### PR TITLE
feat(info): structured JSON errors and distinct exit codes for every failure mode (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,14 @@ for the full picture.
 
 - ✅ `gda info` / `gda info --json` — report the Godot engine version through the full Phase-1
   pipeline (binary resolution → headless one-shot runner → sentinel contract → typed model → JSON).
+- ✅ Structured errors for every `gda info` failure mode — a stable `{"error": {category, code,
+  message, diagnostics}}` JSON object on stdout plus a category-distinguishing non-zero exit code
+  (environment 127/124, version 3, operation 4, parse 5); stderr carries engine diagnostics.
 - ✅ `gda --help`, `gda info --help`.
 - ✅ Godot binary resolution via flag / environment variable / default.
 
 **On the roadmap** (designed, not yet implemented)
 
-- 🔜 Structured errors and stable non-zero exit codes for every failure mode.
 - 🔜 `--schema` self-description for each command.
 - 🔜 Domain command groups: `scene`, `node`, `script`, `project`, `resource`, `export`, …
 - 🔜 `gda-mcp`, a thin [Model Context Protocol](https://modelcontextprotocol.io) adapter generated

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -7,7 +7,7 @@ bullet: it runs the headless ``info`` operation and reports the engine version.
 
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import NoReturn, Optional
 
 import typer
 
@@ -40,11 +40,13 @@ def _make_runner(binary: Path) -> GodotRunner:
     return SubprocessGodotRunner(binary)
 
 
-def _fail(failure: Failure) -> None:
+def _fail(failure: Failure) -> NoReturn:
     """Emit a structured error to stdout and exit non-zero (issue #3).
 
     The error JSON is the stdout contract for the failure path (always emitted,
     independent of ``--json``); the process exit code distinguishes categories.
+    ``NoReturn`` lets the type checker prove the caller's fallthrough narrows
+    the classification to the success model.
     """
     typer.echo(GdaErrorEnvelope(error=failure.error).model_dump_json())
     raise typer.Exit(code=failure.exit_code)

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -12,8 +12,8 @@ from typing import Optional
 import typer
 
 from gda.binary import resolve_godot_binary
-from gda.models import EngineVersion
-from gda.parser import parse_result
+from gda.errors import Failure, classify_info
+from gda.models import GdaErrorEnvelope
 from gda.runner import GodotRunner, SubprocessGodotRunner
 
 app = typer.Typer(
@@ -40,6 +40,16 @@ def _make_runner(binary: Path) -> GodotRunner:
     return SubprocessGodotRunner(binary)
 
 
+def _fail(failure: Failure) -> None:
+    """Emit a structured error to stdout and exit non-zero (issue #3).
+
+    The error JSON is the stdout contract for the failure path (always emitted,
+    independent of ``--json``); the process exit code distinguishes categories.
+    """
+    typer.echo(GdaErrorEnvelope(error=failure.error).model_dump_json())
+    raise typer.Exit(code=failure.exit_code)
+
+
 @app.command()
 def info(
     json_output: bool = typer.Option(
@@ -60,10 +70,11 @@ def info(
     # surfaced on stderr (ADR-0002).
     if result.stderr:
         print(result.stderr, end="", file=sys.stderr)
-    if result.exit_code != 0:
-        raise typer.Exit(code=1)
 
-    version = EngineVersion.model_validate(parse_result(result.stdout))
+    outcome = classify_info(result, binary)
+    if isinstance(outcome, Failure):
+        _fail(outcome)
+    version = outcome
 
     if json_output:
         typer.echo(version.model_dump_json())

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -7,17 +7,20 @@ either the parsed success result (``EngineVersion``) or a ``Failure`` — a stab
 
 The classification is a pure function of the raw result, so every failure mode
 is exercised by injecting a crafted ``RunResult`` without touching a real
-engine. The decision tree, top to bottom:
+engine. The decision tree, top to bottom (``code`` in parentheses; the four
+``ErrorCategory`` buckets fan out to finer codes):
 
-- exit 127 → environment / binary_not_found   (runner could not launch it)
-- exit 124 → environment / launch_timeout      (launched, hung past the timeout)
-- exit ≠ 0 → operation  / operation_failed      (engine ran, operation errored)
-- contract → parse      / contract_violation    (sentinel missing/malformed JSON)
-- old      → version    / unsupported_version   (below the ADR-0003 minimum)
+- exit 127  → environment / binary_not_found      (runner could not launch it)
+- exit 124  → environment / launch_timeout        (launched, hung past timeout)
+- exit < 0  → operation   / engine_crashed         (engine killed by a signal)
+- exit ≠ 0  → operation   / operation_failed        (engine ran, operation errored)
+- contract  → parse       / contract_violation      (sentinel/JSON/shape invalid)
+- old       → version     / unsupported_version     (below the ADR-0003 minimum)
 
-Exit codes: environment reuses the runner's shell-convention codes (124/127);
-version/operation/parse get distinct small codes so a shell consumer can tell
-categories apart without parsing the JSON error.
+Exit codes come from the single registry in ``gda.exit_codes``: environment
+reuses the runner's shell-convention codes (124/127); version/operation/parse
+get distinct small codes so a shell consumer can tell categories apart without
+parsing the JSON error.
 """
 
 from dataclasses import dataclass
@@ -25,13 +28,16 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
+from gda.exit_codes import (
+    EXIT_NOT_FOUND,
+    EXIT_OPERATION,
+    EXIT_PARSE,
+    EXIT_TIMEOUT,
+    EXIT_VERSION,
+)
 from gda.models import EngineVersion, ErrorCategory, GdaError
 from gda.parser import parse_result
-from gda.runner import EXIT_NOT_FOUND, EXIT_TIMEOUT, RunResult
-
-EXIT_VERSION = 3
-EXIT_OPERATION = 4
-EXIT_PARSE = 5
+from gda.runner import RunResult
 
 # The minimum supported Godot version (ADR-0003): the floor where the modern
 # features gda relies on exist. Resolved from the version gda info reports.
@@ -46,39 +52,63 @@ class Failure:
     exit_code: int
 
 
+def _failure(
+    category: ErrorCategory,
+    code: str,
+    message: str,
+    exit_code: int,
+    stderr: str,
+) -> Failure:
+    """Build a ``Failure`` from the four parts that actually vary per failure.
+
+    The ``GdaError`` wrapping and ``diagnostics=stderr`` are identical at every
+    call site, so they live here once: the call sites then read as the taxonomy
+    itself — a (category, code, message, exit_code) row per failure mode.
+    """
+    return Failure(
+        GdaError(category=category, code=code, message=message, diagnostics=stderr),
+        exit_code=exit_code,
+    )
+
+
 def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
     """Classify the raw ``info`` result into a success model or a ``Failure``."""
     if result.exit_code == EXIT_NOT_FOUND:
-        return Failure(
-            GdaError(
-                category=ErrorCategory.ENVIRONMENT,
-                code="binary_not_found",
-                message=f"Godot binary could not be launched: {binary}",
-                diagnostics=result.stderr,
-            ),
-            exit_code=EXIT_NOT_FOUND,
+        return _failure(
+            ErrorCategory.ENVIRONMENT,
+            "binary_not_found",
+            f"Godot binary could not be launched: {binary}",
+            EXIT_NOT_FOUND,
+            result.stderr,
         )
     if result.exit_code == EXIT_TIMEOUT:
-        return Failure(
-            GdaError(
-                category=ErrorCategory.ENVIRONMENT,
-                code="launch_timeout",
-                message="Godot launched but did not return before the timeout",
-                diagnostics=result.stderr,
-            ),
-            exit_code=EXIT_TIMEOUT,
+        return _failure(
+            ErrorCategory.ENVIRONMENT,
+            "launch_timeout",
+            "Godot launched but did not return before the timeout",
+            EXIT_TIMEOUT,
+            result.stderr,
+        )
+    if result.exit_code < 0:
+        # subprocess reports a signal death as a negative return code; the
+        # engine ran but was killed (e.g. SIGSEGV crash, OOM SIGKILL) rather
+        # than the operation cleanly reporting an error.
+        return _failure(
+            ErrorCategory.OPERATION,
+            "engine_crashed",
+            f"Godot terminated abnormally (signal {-result.exit_code})",
+            EXIT_OPERATION,
+            result.stderr,
         )
     if result.exit_code != 0:
         # The engine ran but the operation itself reported an error and quit
         # non-zero (its own exit, not the runner's synthetic 124/127).
-        return Failure(
-            GdaError(
-                category=ErrorCategory.OPERATION,
-                code="operation_failed",
-                message="the headless operation reported an error",
-                diagnostics=result.stderr,
-            ),
-            exit_code=EXIT_OPERATION,
+        return _failure(
+            ErrorCategory.OPERATION,
+            "operation_failed",
+            "the headless operation reported an error",
+            EXIT_OPERATION,
+            result.stderr,
         )
 
     try:
@@ -91,14 +121,12 @@ def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
         # rather than escape as a traceback.
         version = EngineVersion.model_validate(parse_result(result.stdout))
     except (ValueError, ValidationError) as exc:
-        return Failure(
-            GdaError(
-                category=ErrorCategory.PARSE,
-                code="contract_violation",
-                message=f"structured-output contract violated: {exc}",
-                diagnostics=result.stderr,
-            ),
-            exit_code=EXIT_PARSE,
+        return _failure(
+            ErrorCategory.PARSE,
+            "contract_violation",
+            f"structured-output contract violated: {exc}",
+            EXIT_PARSE,
+            result.stderr,
         )
 
     if (version.major, version.minor) < MIN_GODOT_VERSION:
@@ -106,17 +134,12 @@ def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
         # "version too old" a programmatically detectable failure rather than an
         # implicit one — distinct from the environment-error case.
         minimum = ".".join(str(part) for part in MIN_GODOT_VERSION)
-        return Failure(
-            GdaError(
-                category=ErrorCategory.VERSION,
-                code="unsupported_version",
-                message=(
-                    f"Godot {version.string} is below the minimum "
-                    f"supported version {minimum}"
-                ),
-                diagnostics=result.stderr,
-            ),
-            exit_code=EXIT_VERSION,
+        return _failure(
+            ErrorCategory.VERSION,
+            "unsupported_version",
+            f"Godot {version.string} is below the minimum supported version {minimum}",
+            EXIT_VERSION,
+            result.stderr,
         )
 
     return version

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -1,0 +1,118 @@
+"""Failure classification for the headless ``info`` operation (issue #3).
+
+This is the single home of ``gda``'s failure taxonomy: given the raw
+``RunResult`` of a one-shot headless invocation, ``classify_info`` returns
+either the parsed success result (``EngineVersion``) or a ``Failure`` — a stable
+``GdaError`` plus the process exit code that distinguishes its category.
+
+The classification is a pure function of the raw result, so every failure mode
+is exercised by injecting a crafted ``RunResult`` without touching a real
+engine. The decision tree, top to bottom:
+
+- exit 127 → environment / binary_not_found   (runner could not launch it)
+- exit 124 → environment / launch_timeout      (launched, hung past the timeout)
+- exit ≠ 0 → operation  / operation_failed      (engine ran, operation errored)
+- contract → parse      / contract_violation    (sentinel missing/malformed JSON)
+- old      → version    / unsupported_version   (below the ADR-0003 minimum)
+
+Exit codes: environment reuses the runner's shell-convention codes (124/127);
+version/operation/parse get distinct small codes so a shell consumer can tell
+categories apart without parsing the JSON error.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from gda.models import EngineVersion, ErrorCategory, GdaError
+from gda.parser import parse_result
+from gda.runner import EXIT_NOT_FOUND, EXIT_TIMEOUT, RunResult
+
+EXIT_VERSION = 3
+EXIT_OPERATION = 4
+EXIT_PARSE = 5
+
+# The minimum supported Godot version (ADR-0003): the floor where the modern
+# features gda relies on exist. Resolved from the version gda info reports.
+MIN_GODOT_VERSION = (4, 4)
+
+
+@dataclass
+class Failure:
+    """A classified failure: the stable error shape plus its process exit code."""
+
+    error: GdaError
+    exit_code: int
+
+
+def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
+    """Classify the raw ``info`` result into a success model or a ``Failure``."""
+    if result.exit_code == EXIT_NOT_FOUND:
+        return Failure(
+            GdaError(
+                category=ErrorCategory.ENVIRONMENT,
+                code="binary_not_found",
+                message=f"Godot binary could not be launched: {binary}",
+                diagnostics=result.stderr,
+            ),
+            exit_code=EXIT_NOT_FOUND,
+        )
+    if result.exit_code == EXIT_TIMEOUT:
+        return Failure(
+            GdaError(
+                category=ErrorCategory.ENVIRONMENT,
+                code="launch_timeout",
+                message="Godot launched but did not return before the timeout",
+                diagnostics=result.stderr,
+            ),
+            exit_code=EXIT_TIMEOUT,
+        )
+    if result.exit_code != 0:
+        # The engine ran but the operation itself reported an error and quit
+        # non-zero (its own exit, not the runner's synthetic 124/127).
+        return Failure(
+            GdaError(
+                category=ErrorCategory.OPERATION,
+                code="operation_failed",
+                message="the headless operation reported an error",
+                diagnostics=result.stderr,
+            ),
+            exit_code=EXIT_OPERATION,
+        )
+
+    try:
+        payload = parse_result(result.stdout)
+    except ValueError as exc:
+        # The sentinel block is missing, or the payload between sentinels is
+        # malformed JSON — a violation of the structured-output contract
+        # (ADR-0002), distinct from an operation error.
+        return Failure(
+            GdaError(
+                category=ErrorCategory.PARSE,
+                code="contract_violation",
+                message=f"structured-output contract violated: {exc}",
+                diagnostics=result.stderr,
+            ),
+            exit_code=EXIT_PARSE,
+        )
+
+    version = EngineVersion.model_validate(payload)
+
+    if (version.major, version.minor) < MIN_GODOT_VERSION:
+        # The engine ran fine but is older than gda supports (ADR-0003), making
+        # "version too old" a programmatically detectable failure rather than an
+        # implicit one — distinct from the environment-error case.
+        minimum = ".".join(str(part) for part in MIN_GODOT_VERSION)
+        return Failure(
+            GdaError(
+                category=ErrorCategory.VERSION,
+                code="unsupported_version",
+                message=(
+                    f"Godot {version.string} is below the minimum "
+                    f"supported version {minimum}"
+                ),
+                diagnostics=result.stderr,
+            ),
+            exit_code=EXIT_VERSION,
+        )
+
+    return version

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -23,6 +23,8 @@ categories apart without parsing the JSON error.
 from dataclasses import dataclass
 from pathlib import Path
 
+from pydantic import ValidationError
+
 from gda.models import EngineVersion, ErrorCategory, GdaError
 from gda.parser import parse_result
 from gda.runner import EXIT_NOT_FOUND, EXIT_TIMEOUT, RunResult
@@ -80,11 +82,15 @@ def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
         )
 
     try:
-        payload = parse_result(result.stdout)
-    except ValueError as exc:
-        # The sentinel block is missing, or the payload between sentinels is
-        # malformed JSON — a violation of the structured-output contract
-        # (ADR-0002), distinct from an operation error.
+        # The sentinel block must be present, hold valid JSON, AND match the
+        # result shape. A missing/empty sentinel or malformed JSON raises
+        # ValueError from parse_result; a well-formed-JSON-but-wrong-shape
+        # payload raises pydantic ValidationError. All three are the same
+        # violation of the structured-output contract (ADR-0002), distinct from
+        # an operation error — and must surface as a structured parse error
+        # rather than escape as a traceback.
+        version = EngineVersion.model_validate(parse_result(result.stdout))
+    except (ValueError, ValidationError) as exc:
         return Failure(
             GdaError(
                 category=ErrorCategory.PARSE,
@@ -94,8 +100,6 @@ def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
             ),
             exit_code=EXIT_PARSE,
         )
-
-    version = EngineVersion.model_validate(payload)
 
     if (version.major, version.minor) < MIN_GODOT_VERSION:
         # The engine ran fine but is older than gda supports (ADR-0003), making

--- a/src/gda/exit_codes.py
+++ b/src/gda/exit_codes.py
@@ -1,0 +1,19 @@
+"""The single registry of ``gda`` process exit codes (issue #3).
+
+These are the public CLI ABI an agent or shell keys on to tell failure
+categories apart *without* parsing the JSON error. Kept in one leaf module — not
+split across ``runner`` and ``errors`` — so the whole contract is reviewable at a
+glance and new codes cannot silently collide.
+
+- ``EXIT_NOT_FOUND`` / ``EXIT_TIMEOUT`` follow shell conventions (127 = command
+  not found, 124 = timed out) and are also what the runner *synthesizes* when it
+  cannot get a result from the engine; the CLI maps both to ``environment``.
+- ``EXIT_VERSION`` / ``EXIT_OPERATION`` / ``EXIT_PARSE`` are distinct small codes
+  the CLI assigns to failures the engine signalled differently or not at all.
+"""
+
+EXIT_NOT_FOUND = 127
+EXIT_TIMEOUT = 124
+EXIT_VERSION = 3
+EXIT_OPERATION = 4
+EXIT_PARSE = 5

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -6,7 +6,50 @@ the ``--schema`` document later (``model_json_schema()``) without
 hand-maintaining the contract twice.
 """
 
+from enum import Enum
+
 from pydantic import BaseModel
+
+
+class ErrorCategory(str, Enum):
+    """The four distinguishable ways a ``gda`` operation can fail (issue #3).
+
+    ENVIRONMENT covers everything before the operation produces a result — the
+    binary not launching, or launching and hanging past the timeout. VERSION is
+    a launched engine below the supported minimum (ADR-0003). OPERATION is the
+    headless operation itself reporting an error. PARSE is a violation of the
+    structured-output contract (ADR-0002): a missing or malformed sentinel.
+    """
+
+    ENVIRONMENT = "environment"
+    VERSION = "version"
+    OPERATION = "operation"
+    PARSE = "parse"
+
+
+class GdaError(BaseModel):
+    """A structured, stable failure of a ``gda`` operation (issue #3).
+
+    Emitted as ``{"error": <this>}`` on stdout so an agent reacts to failure
+    modes programmatically without parsing prose. ``category`` is the coarse,
+    process-exit-code-aligned bucket; ``code`` is the finer, stable identifier;
+    ``diagnostics`` carries the engine/script stderr surfaced per ADR-0002.
+    """
+
+    category: ErrorCategory
+    code: str
+    message: str
+    diagnostics: str = ""
+
+
+class GdaErrorEnvelope(BaseModel):
+    """The ``{"error": {...}}`` wrapper that discriminates a failure from a result.
+
+    The success result (``EngineVersion``) is emitted bare, so the presence of
+    the top-level ``error`` key is the stable success/failure discriminator.
+    """
+
+    error: GdaError
 
 
 class EngineVersion(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -12,13 +12,19 @@ from pydantic import BaseModel
 
 
 class ErrorCategory(str, Enum):
-    """The four distinguishable ways a ``gda`` operation can fail (issue #3).
+    """The four coarse buckets a ``gda`` operation can fail into (issue #3).
+
+    This is the coarse axis; each category fans out to one or more finer,
+    stable ``GdaError.code`` values (e.g. ENVIRONMENT → ``binary_not_found`` /
+    ``launch_timeout``; OPERATION → ``operation_failed`` / ``engine_crashed``).
+    See ``gda.errors.classify_info`` for the category→code decision tree.
 
     ENVIRONMENT covers everything before the operation produces a result — the
     binary not launching, or launching and hanging past the timeout. VERSION is
-    a launched engine below the supported minimum (ADR-0003). OPERATION is the
-    headless operation itself reporting an error. PARSE is a violation of the
-    structured-output contract (ADR-0002): a missing or malformed sentinel.
+    a launched engine below the supported minimum (ADR-0003). OPERATION is a
+    launched engine that failed to deliver a result (the operation reported an
+    error, or the engine crashed). PARSE is a violation of the structured-output
+    contract (ADR-0002): a missing/malformed sentinel or a wrong-shape payload.
     """
 
     ENVIRONMENT = "environment"

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -20,9 +20,11 @@ OPERATIONS_GD = Path(__file__).parent / "ops" / "operations.gd"
 DEFAULT_TIMEOUT_SECONDS = 60.0
 
 # Non-zero exit codes used when the engine never produced its own (shell
-# conventions: 124 = timed out, 127 = command not found).
-_EXIT_TIMEOUT = 124
-_EXIT_NOT_FOUND = 127
+# conventions: 124 = timed out, 127 = command not found). Public because they
+# are the cross-module contract the CLI keys on to classify environment
+# failures (issue #3).
+EXIT_TIMEOUT = 124
+EXIT_NOT_FOUND = 127
 
 
 @dataclass
@@ -74,13 +76,13 @@ class SubprocessGodotRunner:
             return RunResult(
                 stdout="",
                 stderr=f"gda: Godot timed out after {self.timeout}s\n",
-                exit_code=_EXIT_TIMEOUT,
+                exit_code=EXIT_TIMEOUT,
             )
         except FileNotFoundError:
             return RunResult(
                 stdout="",
                 stderr=f"gda: Godot binary not found: {self.binary}\n",
-                exit_code=_EXIT_NOT_FOUND,
+                exit_code=EXIT_NOT_FOUND,
             )
         return RunResult(
             stdout=proc.stdout, stderr=proc.stderr, exit_code=proc.returncode

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -12,19 +12,17 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
+# The codes the runner synthesizes when it never got a result from the engine.
+# Defined once in gda.exit_codes (the full exit-code ABI); imported here because
+# the runner is what produces them (issue #3).
+from gda.exit_codes import EXIT_NOT_FOUND, EXIT_TIMEOUT
+
 # The bundled GDScript operations payload, dispatched by operation name.
 OPERATIONS_GD = Path(__file__).parent / "ops" / "operations.gd"
 
 # A headless one-shot operation should be quick; this bounds a hung engine so
 # the CLI fails loudly instead of blocking forever.
 DEFAULT_TIMEOUT_SECONDS = 60.0
-
-# Non-zero exit codes used when the engine never produced its own (shell
-# conventions: 124 = timed out, 127 = command not found). Public because they
-# are the cross-module contract the CLI keys on to classify environment
-# failures (issue #3).
-EXIT_TIMEOUT = 124
-EXIT_NOT_FOUND = 127
 
 
 @dataclass

--- a/tests/test_e2e_info.py
+++ b/tests/test_e2e_info.py
@@ -41,3 +41,26 @@ def test_gda_info_json_against_real_godot():
     assert isinstance(data["string"], str)
     # The reported version satisfies the minimum supported version (ADR-0003).
     assert (data["major"], data["minor"]) >= (4, 4)
+
+
+@pytest.mark.e2e
+def test_gda_info_missing_binary_yields_structured_error_end_to_end():
+    # The failure path through the whole stack (issue #3): a real subprocess
+    # against a binary that cannot launch. No installed engine required — the
+    # point is that the path does NOT exist. The runner synthesizes exit 127,
+    # the CLI emits a structured JSON error on stdout.
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+
+    proc = subprocess.run(
+        [gda_bin, "info", "--godot", "/nonexistent/Godot"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode == 127
+    err = json.loads(proc.stdout)["error"]
+    assert err["category"] == "environment"
+    assert err["code"] == "binary_not_found"
+    # Engine/script diagnostics are surfaced on stderr (ADR-0002).
+    assert "/nonexistent/Godot" in proc.stderr

--- a/tests/test_info_errors.py
+++ b/tests/test_info_errors.py
@@ -1,0 +1,191 @@
+"""S3: gda info failure modes map to structured JSON errors + distinct exit codes.
+
+Each failure mode is exercised by injecting a fake Godot runner (or crafted raw
+stdout for the parse case). The contract under test (issue #3):
+
+- stdout carries a single ``{"error": {...}}`` JSON object — the stable error shape.
+- the process exits non-zero with a code that distinguishes the failure category.
+- engine/script diagnostics are surfaced on stderr (ADR-0002).
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+
+
+class FakeRunner:
+    """A fakeable GodotRunner that returns a canned raw RunResult."""
+
+    def __init__(self, result: RunResult) -> None:
+        self.result = result
+        self.calls: list[tuple[str, dict]] = []
+
+    def run(self, operation: str, params: dict) -> RunResult:
+        self.calls.append((operation, params))
+        return self.result
+
+
+def _inject(monkeypatch, result: RunResult) -> FakeRunner:
+    fake = FakeRunner(result)
+    monkeypatch.setattr("gda.cli._make_runner", lambda binary: fake)
+    return fake
+
+
+def test_binary_not_found_maps_to_environment_error(monkeypatch):
+    # The runner synthesizes exit 127 + a not-found diagnostic on stderr when
+    # the binary is missing (#2 convention; ADR-0002 surfaces stderr).
+    _inject(
+        monkeypatch,
+        RunResult(
+            stdout="",
+            stderr="gda: Godot binary not found: /x/Godot\n",
+            exit_code=127,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["info"])
+
+    assert result.exit_code == 127
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "environment"
+    assert err["code"] == "binary_not_found"
+    # Engine/script diagnostics are surfaced on stderr for inspection.
+    assert "not found" in result.stderr
+
+
+def test_launch_timeout_maps_to_environment_error_distinct_from_not_found(monkeypatch):
+    # A launched-but-hung engine is bounded by the runner's timeout: exit 124
+    # with a timeout diagnostic (#2). It is still an environment failure but
+    # must be distinguishable from binary-not-found.
+    _inject(
+        monkeypatch,
+        RunResult(
+            stdout="",
+            stderr="gda: Godot timed out after 60.0s\n",
+            exit_code=124,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["info"])
+
+    assert result.exit_code == 124
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "environment"
+    # Distinguishable from the binary-not-found case via a distinct code.
+    assert err["code"] == "launch_timeout"
+    assert "timed out" in result.stderr
+
+
+def test_operation_failure_maps_to_operation_error_distinct_from_environment(monkeypatch):
+    # The engine launched and ran but the GDScript operation reported an error
+    # and quit non-zero (no synthetic 124/127, no result sentinel). This is an
+    # operation failure, distinct from the environment-error case.
+    _inject(
+        monkeypatch,
+        RunResult(
+            stdout="",
+            stderr="gda: unknown operation: bogus\n",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["info"])
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "operation_failed"
+    assert "unknown operation" in result.stderr
+
+
+def test_missing_sentinel_maps_to_parse_error_distinct_from_operation(monkeypatch):
+    # The engine exited 0 but stdout carries no result sentinel — a violation
+    # of the structured-output contract (ADR-0002), distinct from an operation
+    # error (which exits non-zero).
+    _inject(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.stable\nno sentinel here\n",
+            stderr="engine noise\n",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["info"])
+
+    assert result.exit_code == 5
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "parse"
+    assert err["code"] == "contract_violation"
+
+
+def _version_payload(major: int, minor: int) -> str:
+    info = {
+        "major": major,
+        "minor": minor,
+        "patch": 0,
+        "hex": (major << 16) | (minor << 8),
+        "status": "stable",
+        "build": "official",
+        "hash": "0" * 40,
+        "string": f"{major}.{minor}.0-stable (official)",
+        "timestamp": 0,
+    }
+    return f"<<<GDA:RESULT>>>{json.dumps(info)}<<<GDA:END>>>\n"
+
+
+def test_version_below_minimum_maps_to_version_error_distinct_from_environment(monkeypatch):
+    # The engine launched and reported its version successfully, but it is below
+    # the minimum supported version of 4.4 (ADR-0003). This is a version error,
+    # distinct from the environment-error case.
+    _inject(
+        monkeypatch,
+        RunResult(stdout=_version_payload(4, 3), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(app, ["info"])
+
+    assert result.exit_code == 3
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "version"
+    assert err["code"] == "unsupported_version"
+    # The detected version is surfaced in the message for diagnosis.
+    assert "4.3" in err["message"]
+
+
+def test_version_at_minimum_succeeds(monkeypatch):
+    # 4.4 is exactly the floor — it must NOT be reported as unsupported.
+    _inject(
+        monkeypatch,
+        RunResult(stdout=_version_payload(4, 4), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(app, ["info", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert (data["major"], data["minor"]) == (4, 4)
+
+
+def test_malformed_sentinel_json_maps_to_parse_error(monkeypatch):
+    # Sentinels are present but the payload between them is not valid JSON —
+    # also a contract violation, surfaced as a parse error rather than an
+    # opaque JSONDecodeError traceback.
+    _inject(
+        monkeypatch,
+        RunResult(
+            stdout="<<<GDA:RESULT>>>{not valid json}<<<GDA:END>>>\n",
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["info"])
+
+    assert result.exit_code == 5
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "parse"
+    assert err["code"] == "contract_violation"

--- a/tests/test_info_errors.py
+++ b/tests/test_info_errors.py
@@ -101,6 +101,25 @@ def test_operation_failure_maps_to_operation_error_distinct_from_environment(mon
     assert "unknown operation" in result.stderr
 
 
+def test_engine_signal_crash_maps_to_operation_error_distinct_from_clean_exit(monkeypatch):
+    # subprocess reports a signal death as a NEGATIVE return code. The engine
+    # ran but was killed (e.g. SIGSEGV) — surfaced as an engine_crashed code,
+    # distinct from a clean non-zero operation exit, never a raw negative code.
+    _inject(
+        monkeypatch,
+        RunResult(stdout="", stderr="", exit_code=-11),
+    )
+
+    result = CliRunner().invoke(app, ["info"])
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "engine_crashed"
+    # The signal number is surfaced for diagnosis.
+    assert "11" in err["message"]
+
+
 def test_missing_sentinel_maps_to_parse_error_distinct_from_operation(monkeypatch):
     # The engine exited 0 but stdout carries no result sentinel — a violation
     # of the structured-output contract (ADR-0002), distinct from an operation

--- a/tests/test_info_errors.py
+++ b/tests/test_info_errors.py
@@ -122,6 +122,31 @@ def test_missing_sentinel_maps_to_parse_error_distinct_from_operation(monkeypatc
     assert err["code"] == "contract_violation"
 
 
+def test_wrong_shape_sentinel_payload_maps_to_parse_error(monkeypatch):
+    # Sentinels present, payload is valid JSON, but it does not match the
+    # EngineVersion shape (e.g. the GDScript emitted a partial/renamed payload,
+    # or a non-object). This is still a contract violation — it must surface as
+    # a structured parse error, NOT an unhandled pydantic ValidationError that
+    # escapes as a traceback with exit 1.
+    _inject(
+        monkeypatch,
+        RunResult(
+            stdout='<<<GDA:RESULT>>>{"major": 4, "minor": 4}<<<GDA:END>>>\n',
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["info"])
+
+    # A clean exit (SystemExit via typer.Exit), NOT an escaped ValidationError.
+    assert isinstance(result.exception, SystemExit)
+    assert result.exit_code == 5
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "parse"
+    assert err["code"] == "contract_violation"
+
+
 def _version_payload(major: int, minor: int) -> str:
     info = {
         "major": major,


### PR DESCRIPTION
Closes #3.

Implements the failure-path vertical slice for `gda info`: every way the operation can fail now produces a stable `{"error": {category, code, message, diagnostics}}` JSON object on stdout and a category-distinguishing non-zero exit code, so an agent reacts to failures programmatically without parsing prose.

## Failure taxonomy

`gda.errors.classify_info` — a pure `RunResult -> EngineVersion | Failure` classifier, the single home of the taxonomy:

| category / code | exit | trigger |
|---|---|---|
| environment / binary_not_found | 127 | runner could not launch the binary |
| environment / launch_timeout | 124 | launched, hung past the timeout |
| operation / engine_crashed | 4 | engine killed by a signal (negative return code) |
| operation / operation_failed | 4 | engine ran, operation reported an error (non-zero exit) |
| parse / contract_violation | 5 | sentinel missing, malformed JSON, **or** wrong-shape payload |
| version / unsupported_version | 3 | below the ADR-0003 minimum 4.4 |

The error JSON is always emitted on stdout (independent of `--json`); stderr keeps carrying engine diagnostics (ADR-0002). The success result (`EngineVersion`) stays bare, so the top-level `error` key is the success/failure discriminator. Exit-code ABI lives in one leaf module, `gda.exit_codes`.

## Approach

Built test-first (TDD tracer bullets), one failure mode per RED→GREEN cycle. Then a `/code-review` (high) pass found and fixed a real regression before merge.

## Notable fix from review

A payload that was **valid JSON but the wrong shape** slipped past the contract guard (`model_validate` sat outside the `try`), escaping as an uncaught `ValidationError` traceback with exit 1 — defeating the slice's goal for that reachable path. Now caught and surfaced as `parse / contract_violation`. (commit `fce4346`)

## Commits

- `66e6527` feat: structured errors + distinct exit codes (main implementation)
- `fce4346` fix: wrong-shape payload → structured parse error; `_fail` typed `NoReturn`
- `81decfe` refactor: dedup failure construction, single-source exit codes, classify signal crashes

## Follow-ups (filed, deferred)

- #14 — generalize into a command-agnostic `classify_run` (YAGNI until a second command lands)
- #15 — runner should expose a typed failure reason so a genuine engine 124/127 isn't mislabelled `environment`

## Tests

23 unit + e2e tests pass (`uv run pytest`); `ruff check` clean. Each failure mode has an S3 unit test injecting a fake runner / crafted stdout; one e2e confirms the missing-binary path through the whole stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)