### PR TITLE
refactor(errors): extract command-agnostic classify_run from classify_info

### DIFF
--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -1,9 +1,15 @@
-"""Failure classification for the headless ``info`` operation (issue #3).
+"""Failure classification for headless operations (issues #3, #14).
 
-This is the single home of ``gda``'s failure taxonomy: given the raw
-``RunResult`` of a one-shot headless invocation, ``classify_info`` returns
-either the parsed success result (``EngineVersion``) or a ``Failure`` — a stable
-``GdaError`` plus the process exit code that distinguishes its category.
+This is the single home of ``gda``'s failure taxonomy, split into two layers
+(issue #14):
+
+- ``classify_run`` — command-agnostic: given the raw ``RunResult`` of a
+  one-shot headless invocation and the command's typed output model, it owns
+  the environment/operation/parse decision tree shared by every command and
+  returns either the validated model or a ``Failure`` — a stable ``GdaError``
+  plus the process exit code that distinguishes its category.
+- thin per-command classifiers (``classify_info``) — layer command-specific
+  checks (e.g. ``info``'s ADR-0003 version gate) on top of ``classify_run``.
 
 The classification is a pure function of the raw result, so every failure mode
 is exercised by injecting a crafted ``RunResult`` without touching a real
@@ -15,7 +21,8 @@ engine. The decision tree, top to bottom (``code`` in parentheses; the four
 - exit < 0  → operation   / engine_crashed         (engine killed by a signal)
 - exit ≠ 0  → operation   / operation_failed        (engine ran, operation errored)
 - contract  → parse       / contract_violation      (sentinel/JSON/shape invalid)
-- old       → version     / unsupported_version     (below the ADR-0003 minimum)
+- old       → version     / unsupported_version     (below the ADR-0003 minimum,
+  ``info``'s per-command layer)
 
 Exit codes come from the single registry in ``gda.exit_codes``: environment
 reuses the runner's shell-convention codes (124/127); version/operation/parse
@@ -25,8 +32,9 @@ parsing the JSON error.
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TypeVar
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from gda.exit_codes import (
     EXIT_NOT_FOUND,
@@ -71,8 +79,15 @@ def _failure(
     )
 
 
-def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
-    """Classify the raw ``info`` result into a success model or a ``Failure``."""
+M = TypeVar("M", bound=BaseModel)
+
+
+def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | Failure:
+    """Classify a raw headless run into the command's typed model or a ``Failure``.
+
+    Command-agnostic: owns the env/operation/parse decision tree shared by all
+    commands. Per-command classifiers layer their specific checks on top.
+    """
     if result.exit_code == EXIT_NOT_FOUND:
         return _failure(
             ErrorCategory.ENVIRONMENT,
@@ -110,16 +125,15 @@ def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
             EXIT_OPERATION,
             result.stderr,
         )
-
     try:
         # The sentinel block must be present, hold valid JSON, AND match the
-        # result shape. A missing/empty sentinel or malformed JSON raises
-        # ValueError from parse_result; a well-formed-JSON-but-wrong-shape
+        # command's result shape. A missing/empty sentinel or malformed JSON
+        # raises ValueError from parse_result; a well-formed-JSON-but-wrong-shape
         # payload raises pydantic ValidationError. All three are the same
         # violation of the structured-output contract (ADR-0002), distinct from
-        # an operation error — and must surface as a structured parse error
+        # an operation error — and must surface as a structured parse failure
         # rather than escape as a traceback.
-        version = EngineVersion.model_validate(parse_result(result.stdout))
+        return output_model.model_validate(parse_result(result.stdout))
     except (ValueError, ValidationError) as exc:
         return _failure(
             ErrorCategory.PARSE,
@@ -128,6 +142,18 @@ def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
             EXIT_PARSE,
             result.stderr,
         )
+
+
+def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
+    """Classify the raw ``info`` result into a success model or a ``Failure``.
+
+    The per-command layer for ``info``: the shared decision tree comes from
+    ``classify_run``; only the ADR-0003 minimum-version gate is ``info``'s own.
+    """
+    outcome = classify_run(result, binary, EngineVersion)
+    if isinstance(outcome, Failure):
+        return outcome
+    version = outcome
 
     if (version.major, version.minor) < MIN_GODOT_VERSION:
         # The engine ran fine but is older than gda supports (ADR-0003), making

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -18,7 +18,7 @@ class ErrorCategory(str, Enum):
     This is the coarse axis; each category fans out to one or more finer,
     stable ``GdaError.code`` values (e.g. ENVIRONMENT → ``binary_not_found`` /
     ``launch_timeout``; OPERATION → ``operation_failed`` / ``engine_crashed``).
-    See ``gda.errors.classify_info`` for the category→code decision tree.
+    See ``gda.errors.classify_run`` for the category→code decision tree.
 
     ENVIRONMENT covers everything before the operation produces a result — the
     binary not launching, or launching and hanging past the timeout. VERSION is

--- a/tests/test_classify_run.py
+++ b/tests/test_classify_run.py
@@ -1,0 +1,153 @@
+"""S2: classify_run — the command-agnostic failure classifier (issue #14).
+
+``classify_run`` owns the env/operation/parse decision tree once, for every
+command: given a raw ``RunResult`` and the command's typed output model, it
+returns either the validated model or a stable ``Failure``. Per-command
+classifiers (e.g. ``classify_info``) only layer command-specific checks on top.
+
+The contract is exercised through a *hypothetical second command's* model — the
+issue's acceptance bar: a new command must classify without copying any branch
+of the decision tree.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+from gda.errors import Failure, classify_run
+from gda.models import ErrorCategory
+from gda.runner import RunResult
+
+BINARY = Path("/x/Godot")
+
+
+class SceneSummary(BaseModel):
+    """A hypothetical second command's result model (not ``EngineVersion``)."""
+
+    name: str
+    root_type: str
+
+
+def _sentinel(payload: dict) -> str:
+    return f"<<<GDA:RESULT>>>{json.dumps(payload)}<<<GDA:END>>>\n"
+
+
+def test_clean_run_parses_payload_into_the_commands_typed_model():
+    # The engine exited 0 and stdout carries a sentinel payload matching the
+    # command's model: classify_run returns the validated model instance, with
+    # engine banner noise around the sentinel ignored (ADR-0002).
+    result = RunResult(
+        stdout="Godot Engine v4.6.stable\n"
+        + _sentinel({"name": "Main", "root_type": "Node2D"}),
+        stderr="",
+        exit_code=0,
+    )
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert outcome == SceneSummary(name="Main", root_type="Node2D")
+
+
+def test_synthesized_not_found_maps_to_environment_failure():
+    # The runner synthesizes exit 127 + a not-found diagnostic when the binary
+    # is missing (#2 convention) — an environment failure naming the binary.
+    result = RunResult(
+        stdout="", stderr="gda: Godot binary not found: /x/Godot\n", exit_code=127
+    )
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.exit_code == 127
+    assert outcome.error.category == ErrorCategory.ENVIRONMENT
+    assert outcome.error.code == "binary_not_found"
+    assert str(BINARY) in outcome.error.message
+    # Engine/script stderr is carried as diagnostics (ADR-0002).
+    assert outcome.error.diagnostics == result.stderr
+
+
+def test_synthesized_timeout_maps_to_environment_failure_distinct_from_not_found():
+    # A launched-but-hung engine is bounded by the runner's timeout: exit 124
+    # (#2). Still environment, but distinguishable from binary-not-found.
+    result = RunResult(
+        stdout="", stderr="gda: Godot timed out after 60.0s\n", exit_code=124
+    )
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.exit_code == 124
+    assert outcome.error.category == ErrorCategory.ENVIRONMENT
+    assert outcome.error.code == "launch_timeout"
+
+
+def test_signal_death_maps_to_operation_failure_naming_the_signal():
+    # subprocess reports a signal death as a negative return code: the engine
+    # ran but was killed (e.g. SIGSEGV) — an operation failure, never a raw
+    # negative exit code leaking out.
+    result = RunResult(stdout="", stderr="", exit_code=-11)
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.exit_code == 4
+    assert outcome.error.category == ErrorCategory.OPERATION
+    assert outcome.error.code == "engine_crashed"
+    assert "11" in outcome.error.message
+
+
+def test_engine_nonzero_exit_maps_to_operation_failure():
+    # The engine launched and ran but the operation reported an error and quit
+    # non-zero (its own exit, not the runner's synthetic 124/127).
+    result = RunResult(
+        stdout="", stderr="gda: unknown operation: bogus\n", exit_code=1
+    )
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.exit_code == 4
+    assert outcome.error.category == ErrorCategory.OPERATION
+    assert outcome.error.code == "operation_failed"
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        "Godot Engine v4.6.stable\nno sentinel here\n",
+        "<<<GDA:RESULT>>>{not valid json}<<<GDA:END>>>\n",
+    ],
+    ids=["missing_sentinel", "malformed_json"],
+)
+def test_broken_sentinel_contract_maps_to_parse_failure(stdout):
+    # The engine exited 0 but stdout violates the structured-output contract
+    # (ADR-0002): no sentinel, or non-JSON between the sentinels. Must surface
+    # as a structured parse failure, not escape as a traceback.
+    result = RunResult(stdout=stdout, stderr="engine noise\n", exit_code=0)
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.exit_code == 5
+    assert outcome.error.category == ErrorCategory.PARSE
+    assert outcome.error.code == "contract_violation"
+
+
+def test_wrong_shape_payload_maps_to_parse_failure():
+    # Sentinels present, payload is valid JSON, but it does not match the
+    # command's model — still a contract violation, surfaced as a structured
+    # parse failure, NOT an unhandled pydantic ValidationError.
+    result = RunResult(
+        stdout=_sentinel({"name": "Main"}),  # root_type missing
+        stderr="",
+        exit_code=0,
+    )
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.exit_code == 5
+    assert outcome.error.category == ErrorCategory.PARSE
+    assert outcome.error.code == "contract_violation"


### PR DESCRIPTION
## Summary

Implements #14: splits the failure taxonomy in `gda.errors` into two layers so the env/operation/parse decision tree lives in exactly one place.

- **`classify_run(result, binary, output_model)`** — command-agnostic: owns the environment (127/124), operation (signal / non-zero exit), and parse (sentinel / JSON / shape) branches, validating the sentinel payload into the command's typed model (`TypeVar` bound to `BaseModel`).
- **`classify_info`** — now a thin per-command layer: `classify_run(…, EngineVersion)` plus the ADR-0003 minimum-version gate, which is intrinsically `info`-specific (only `info`'s payload carries the engine version).

`gda info` behavior, error shapes, and exit codes are unchanged — `tests/test_info_errors.py` passes untouched.

## Acceptance criteria (#14)

- [x] env/operation/parse classification lives in exactly one place (`classify_run`), shared by all commands
- [x] `gda info` behavior and its error shapes/exit codes unchanged (existing tests stay green, zero edits)
- [x] A second command requires no copy of the branches — `tests/test_classify_run.py` exercises the seam end-to-end through a hypothetical second command's model (`SceneSummary`), exactly how #18 will consume it: `classify_run(result, binary, SceneResult)`

## Test plan

- [x] TDD: each decision-tree branch driven RED→GREEN through the new public seam with a non-`info` model (8 new unit tests, no Godot required)
- [x] Full suite: 38 passed, including the real-engine e2e tests
- [x] `/code-review` (high effort, 9 finder angles + adversarial verification): 0 correctness bugs; 3 PLAUSIBLE style findings, all resolved as keep-as-is (exit-code literals deliberately pin the CLI ABI per existing test convention; shared test-support extraction is deferred to #18's planned fixture work)

## Notes

- Unblocks #18 (`gda scene create`/`get`), which lists this generalization as its enabling prerequisite.
- Neutral-or-better for #15: the 124/127 keying now lives in one function, so swapping to a typed `RunResult` launch-failure field touches a single predicate.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)