### PR TITLE
gda scene create + scene get: first headless file-mutation tracer (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,16 @@ for the full picture.
   ([ADR-0004](docs/adr/0004-schema-flag-self-description.md)).
 - ✅ `gda --help`, `gda info --help`.
 - ✅ Godot binary resolution via flag / environment variable / default.
+- ✅ `gda scene create <path> --root-type <Type>` / `gda scene get <path>` — the first domain
+  command group ([ADR-0005](docs/adr/0005-cli-command-taxonomy.md)): create a `.tscn` headlessly
+  and read its structured node tree back, with `--json`, `--schema`, structured errors with
+  stable operation codes (`path_not_found`, `not_a_scene`, `invalid_root_type`, `save_failed`),
+  and an e2e-verified create → get round-trip.
 
 **On the roadmap** (designed, not yet implemented)
 
-- 🔜 Domain command groups: `scene`, `node`, `script`, `project`, `resource`, `export`, …
+- 🔜 Further domain command groups and commands: `node`, `script`, `project`, `resource`,
+  `export`, … (see the [command catalog](docs/command-catalog.md)).
 - 🔜 `gda-mcp`, a thin [Model Context Protocol](https://modelcontextprotocol.io) adapter generated
   from `--schema`.
 - 🔜 `gda-daemon` for *live operations* against a running engine (Phase 2).
@@ -149,6 +155,16 @@ All engine and script diagnostics go to **stderr**, so stdout is always clean JS
 gda info --json | jq .major   # → 4
 ```
 
+Create a scene headlessly and read its structured tree back:
+
+```bash
+gda scene create game/main.tscn --root-type Node2D --json
+# {"path":"game/main.tscn","root_name":"main","root_type":"Node2D"}
+
+gda scene get game/main.tscn --json
+# {"path":"game/main.tscn","root":{"name":"main","type":"Node2D","children":[]}}
+```
+
 ---
 
 ## Usage
@@ -171,8 +187,10 @@ gda <meta-command> [options]        # meta commands about gda/the engine, e.g. g
 | `set`                    | Mutate a property                                                |
 | domain verbs             | `play`, `run`, `export`, `import`, … kept with their natural meaning |
 
-> Today only the `info` meta command is implemented. The domain command groups
-> (`scene`, `node`, `script`, …) are on the [roadmap](#roadmap). The taxonomy and naming rules are
+> Today the `info` meta command and the first domain commands — `gda scene create` and
+> `gda scene get` — are implemented. The remaining groups and commands
+> (`node`, `script`, …) are on the [roadmap](#roadmap); the full territory is mapped in the
+> [command catalog](docs/command-catalog.md). The taxonomy and naming rules are
 > specified in [ADR-0005](docs/adr/0005-cli-command-taxonomy.md).
 
 ### Global flags

--- a/README.md
+++ b/README.md
@@ -49,37 +49,33 @@ for the full picture.
 ## Project status
 
 > **`gda` is in active early development (Phase 1).** The architecture and contracts are settled
-> (see [`CONTEXT.md`](CONTEXT.md) and [`docs/adr/`](docs/adr/)), and the first end-to-end slice ships
-> today. This README documents the working surface *and* the roadmap, and is explicit about which
-> is which.
+> (see [`CONTEXT.md`](CONTEXT.md) and [`docs/adr/`](docs/adr/)), and the headless pipeline is live
+> end-to-end. This README documents the working surface *and* the roadmap, and is explicit about
+> which is which.
 
 **Working today**
 
-- ✅ `gda info` / `gda info --json` — report the Godot engine version through the full Phase-1
-  pipeline (binary resolution → headless one-shot runner → sentinel contract → typed model → JSON).
-- ✅ Structured errors for every `gda info` failure mode — a stable `{"error": {category, code,
-  message, diagnostics}}` JSON object on stdout plus a category-distinguishing non-zero exit code
-  (environment 127/124, version 3, operation 4, parse 5); stderr carries engine diagnostics.
-- ✅ `gda info --schema` — model-driven self-description: emits the command's `input` and `output`
-  JSON Schemas, derived from the same typed models that back `--json`, without spawning Godot
-  ([ADR-0004](docs/adr/0004-schema-flag-self-description.md)).
-- ✅ `gda --help`, `gda info --help`.
-- ✅ Godot binary resolution via flag / environment variable / default.
-- ✅ `gda scene create <path> --root-type <Type>` / `gda scene get <path>` — the first domain
-  command group ([ADR-0005](docs/adr/0005-cli-command-taxonomy.md)): create a `.tscn` headlessly
-  and read its structured node tree back, with `--json`, `--schema`, structured errors with
-  stable operation codes (`path_not_found`, `not_a_scene`, `invalid_root_type`, `save_failed`),
-  and an e2e-verified create → get round-trip.
+- ✅ A first working command surface: the `info` meta command and the first domain command group,
+  `gda scene create` / `gda scene get` ([ADR-0005](docs/adr/0005-cli-command-taxonomy.md)).
+- ✅ The contract every shipped command carries: structured `--json` output, model-derived
+  `--schema` self-description ([ADR-0004](docs/adr/0004-schema-flag-self-description.md)), and
+  structured `{"error": {category, code, …}}` failures with category-distinguishing exit codes.
+- ✅ The engine plumbing underneath: Godot binary resolution (flag / env var / default) and the
+  bounded one-shot `godot --headless` runner with its sentinel output contract
+  ([ADR-0002](docs/adr/0002-headless-structured-output-contract.md)).
 
 **On the roadmap** (designed, not yet implemented)
 
-- 🔜 Further domain command groups and commands: `node`, `script`, `project`, `resource`,
-  `export`, … (see the [command catalog](docs/command-catalog.md)).
+- 🔜 The remaining domain command groups and commands: `node`, `script`, `project`, `resource`,
+  `export`, …
 - 🔜 `gda-mcp`, a thin [Model Context Protocol](https://modelcontextprotocol.io) adapter generated
   from `--schema`.
 - 🔜 `gda-daemon` for *live operations* against a running engine (Phase 2).
 
-See the [roadmap](#roadmap) and the [issue tracker](https://github.com/aigengame/godot-agent/issues).
+Per-command status (shipped / Phase-1 candidate / parked) is tracked in the
+[command catalog](docs/command-catalog.md) — the single source of truth this section deliberately
+does not duplicate. See also the [roadmap](#roadmap) and the
+[issue tracker](https://github.com/aigengame/godot-agent/issues).
 
 ---
 
@@ -187,11 +183,9 @@ gda <meta-command> [options]        # meta commands about gda/the engine, e.g. g
 | `set`                    | Mutate a property                                                |
 | domain verbs             | `play`, `run`, `export`, `import`, … kept with their natural meaning |
 
-> Today the `info` meta command and the first domain commands — `gda scene create` and
-> `gda scene get` — are implemented. The remaining groups and commands
-> (`node`, `script`, …) are on the [roadmap](#roadmap); the full territory is mapped in the
-> [command catalog](docs/command-catalog.md). The taxonomy and naming rules are
-> specified in [ADR-0005](docs/adr/0005-cli-command-taxonomy.md).
+> The surface grows one vertical slice at a time; `gda --help` lists what is installed, and
+> per-command status is tracked in the [command catalog](docs/command-catalog.md). The taxonomy
+> and naming rules are specified in [ADR-0005](docs/adr/0005-cli-command-taxonomy.md).
 
 ### Global flags
 
@@ -243,24 +237,26 @@ per-message protocol the daemon will use in Phase 2.
 ```bash
 uv sync                       # set up the environment
 
-uv run pytest                 # run the full suite (includes an e2e test against a real Godot)
+uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
 uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
-uv run pytest -m e2e          # only the end-to-end test (needs Godot 4.4+ on this machine)
+uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
 ```
 
-The `e2e` test auto-skips if no Godot binary is found at the resolved path.
+The `e2e` tests auto-skip if no Godot binary is found at the resolved path.
 
 ### Project layout
 
 ```
 src/gda/
-  cli.py            # CLI entrypoint (Typer); commands, --json, binary override
+  cli.py            # CLI entrypoint (Typer); command groups, --json/--schema, binary override
   binary.py         # Godot binary resolution (flag > $GDA_GODOT > default)
   runner.py         # GodotRunner seam (Protocol) + SubprocessGodotRunner (one-shot headless)
   parser.py         # sentinel-contract result parser (ADR-0002)
-  models.py         # typed result models (Pydantic) backing --json and --schema (ADR-0004)
+  models.py         # typed I/O models (Pydantic) backing --json and --schema (ADR-0004)
+  errors.py         # failure classification: shared classify_run + per-command layers
+  exit_codes.py     # the single registry of process exit codes (the CLI ABI)
   ops/operations.gd # GDScript payload, dispatched by operation name
-tests/              # unit tests + an e2e test against a real engine
+tests/              # unit tests + e2e tests against a real engine (shared fixtures in conftest.py)
 docs/adr/           # architecture decision records
 CONTEXT.md          # the project's shared domain language
 ```

--- a/README.md
+++ b/README.md
@@ -191,9 +191,11 @@ gda <meta-command> [options]        # meta commands about gda/the engine, e.g. g
 
 | Flag       | Description                                                          |
 | ---------- | ------------------------------------------------------------------- |
-| `--json`   | Emit the result as a single JSON object on stdout. Without it, commands print a concise human-readable rendering. |
-| `--schema` | Emit the command's input/output JSON Schema contract (no Godot spawned). |
-| `--help`   | Show usage for `gda` or any command.                                |
+| `--json`    | Emit the result as a single JSON object on stdout. Without it, commands print a concise human-readable rendering. |
+| `--schema`  | Emit the command's input/output JSON Schema contract (no Godot spawned). |
+| `--godot`   | Path to the Godot binary (overrides `$GDA_GODOT` and the default). |
+| `--project` | Godot project directory for `res://` resolution (overrides `$GDA_PROJECT`; defaults to the current directory if it is a project). Domain commands only. |
+| `--help`    | Show usage for `gda` or any command.                                |
 
 ---
 
@@ -208,6 +210,25 @@ gda <meta-command> [options]        # meta commands about gda/the engine, e.g. g
 
 ```bash
 gda info --godot "/Applications/Godot.app/Contents/MacOS/Godot" --json
+```
+
+### Project context
+
+Domain commands resolve a **Godot project** so that `res://` paths and a scene's
+inter-resource references resolve deterministically, in this order (highest precedence first):
+
+1. The **`--project <dir>`** flag.
+2. The **`GDA_PROJECT`** environment variable.
+3. The **current directory**, when it is a Godot project (contains `project.godot`).
+
+A named directory must be a project, or `gda` reports it as an error. When none resolves, `gda`
+runs **projectless** — only filesystem paths (absolute or cwd-relative) resolve, not `res://`.
+Path normalization happens once at the CLI layer: `res://` / `user://` / `uid://` pass through to
+the engine; filesystem paths get `~` expanded. See
+[ADR-0006](docs/adr/0006-project-context-and-path-resolution.md).
+
+```bash
+gda scene get res://main.tscn --project ~/game --json
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ gda <meta-command> [options]        # meta commands about gda/the engine, e.g. g
 
 | Flag       | Description                                                          |
 | ---------- | ------------------------------------------------------------------- |
-| `--json`   | Emit the result as a single JSON object on stdout.                  |
+| `--json`   | Emit the result as a single JSON object on stdout. Without it, commands print a concise human-readable rendering. |
 | `--schema` | Emit the command's input/output JSON Schema contract (no Godot spawned). |
 | `--help`   | Show usage for `gda` or any command.                                |
 

--- a/docs/adr/0006-project-context-and-path-resolution.md
+++ b/docs/adr/0006-project-context-and-path-resolution.md
@@ -1,0 +1,65 @@
+---
+status: accepted
+---
+
+# Project context and path resolution for headless operations
+
+Headless operations act on files addressed by path. Godot resolves `res://`
+paths — and inter-resource references inside a scene/resource — against the
+*project* it was launched with. A one-shot `godot --headless --script` process
+launched with no `--path` infers its project from the current working
+directory, so the same command run from a different directory resolves `res://`
+differently, or runs projectless. That made results silently cwd-dependent and
+left no defined home for path semantics as the command surface grows
+(`node`, `script`, `resource`, … all take paths).
+
+## Decision
+
+**`gda` resolves a project directory and passes it to the engine as `--path`.**
+Resolution precedence, mirroring the `--godot` binary resolution (`gda.binary`):
+
+1. The `--project <dir>` flag.
+2. The `GDA_PROJECT` environment variable.
+3. The current working directory.
+
+An explicitly named directory (flag or env) **must** be a Godot project (hold a
+`project.godot`) or `gda` surfaces it as an error rather than running against
+the wrong context. The cwd fallback counts as a project only when it holds the
+marker; otherwise resolution yields *no project* and the engine runs
+**projectless** — the pre-existing behaviour, under which only filesystem paths
+(absolute or cwd-relative) resolve. This keeps project context opt-in for
+callers who pass absolute paths and never touch `res://`.
+
+**Path normalization happens once, at the CLI layer**, before a path reaches an
+operation: engine-resolved virtual paths (`res://`, `user://`, `uid://`) pass
+through untouched (the engine resolves them against the project), and a
+filesystem path has `~` expanded. Operations therefore receive a path whose
+resolution rule is already fixed and documented, rather than each operation
+inventing its own.
+
+This applies to every path-taking command, not just `scene` — it is the project
+of record for the whole Phase-1 surface.
+
+## Consequences
+
+- `res://` resolves deterministically against the chosen project regardless of
+  `gda`'s cwd; a scene's inter-resource references resolve in their own project.
+- Meta commands (`gda info`) take no path and no project — they run projectless.
+- The test suite's temp-project fixture is exercised for real by passing
+  `--project`, rather than being a directory the engine never sees.
+- `--project`/`$GDA_PROJECT` is process context, not an operation parameter, so
+  it does not appear in a command's `--schema` input contract (ADR-0004) — the
+  same treatment as `--godot`.
+
+## Considered options
+
+- **`--project` flag, projectless fallback** (chosen) — explicit and
+  agent-controllable, mirrors `--godot`, and preserves absolute-path usage with
+  no project.
+- **Derive the project from the target path** (walk up to the nearest
+  `project.godot`) — zero-config, but undefined when the target is outside any
+  project, and a single call spanning multiple paths could imply different
+  roots.
+- **Filesystem paths only, no `res://`** — simplest, but `res://` is core Godot
+  vocabulary that later slices (`node`, `script`, `resource`) need, so this only
+  defers the decision.

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -33,7 +33,7 @@ Status legend: ✅ shipped · 🔜 Phase-1 candidate · ⏸ Phase-2 (parked).
 | `gda info` | Report Godot engine version info | 1 | ✅ |
 | `gda version` | Report `gda`'s own version | — (local) | 🔜 |
 | `gda help` | Usage help | — (local) | ✅ (`--help`) |
-| `gda <command> --schema` | Emit a command's input/output JSON Schema (ADR-0004) | — (local) | ✅ (`info`, #4) |
+| `gda <command> --schema` | Emit a command's input/output JSON Schema (ADR-0004) | — (local) | ✅ (`info` #4; `scene create`/`scene get` #18) |
 
 > `--schema` is a per-command flag, not a command, and ships with **every** domain
 > command as a hard gate (ADR-0004). It is local introspection — no Godot process.
@@ -46,9 +46,9 @@ Status legend: ✅ shipped · 🔜 Phase-1 candidate · ⏸ Phase-2 (parked).
 
 | Command | Description | Status |
 | --- | --- | --- |
-| `gda scene create` | Create a new `.tscn` with a given root node type | 🔜 |
+| `gda scene create` | Create a new `.tscn` with a given root node type | ✅ (#18) |
 | `gda scene delete` | Delete a scene file | 🔜 |
-| `gda scene get` | Read a scene's structured tree from its file on disk | 🔜 |
+| `gda scene get` | Read a scene's structured tree from its file on disk | ✅ (#18) |
 | `gda scene list` | Enumerate scenes in the project | 🔜 |
 | `gda scene get-exports` | List `@export` properties declared by a scene's nodes | 🔜 |
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -10,10 +10,21 @@ from pathlib import Path
 from typing import NoReturn, Optional
 
 import typer
+from pydantic import BaseModel
 
 from gda.binary import resolve_godot_binary
-from gda.errors import Failure, classify_info
-from gda.models import CommandSchema, EngineVersion, GdaErrorEnvelope, InfoParams
+from gda.errors import Failure, classify_info, classify_run
+from gda.models import (
+    CommandSchema,
+    EngineVersion,
+    GdaErrorEnvelope,
+    InfoParams,
+    SceneCreateParams,
+    SceneCreateResult,
+    SceneGetParams,
+    SceneGetResult,
+    SceneNode,
+)
 from gda.runner import GodotRunner, SubprocessGodotRunner
 
 app = typer.Typer(
@@ -22,6 +33,12 @@ app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
 )
+
+# The first domain command group (ADR-0005): commands acting on scene files.
+scene_app = typer.Typer(
+    help="Act on Godot scene files (.tscn).", no_args_is_help=True
+)
+app.add_typer(scene_app, name="scene")
 
 
 @app.callback()
@@ -40,6 +57,33 @@ def _make_runner(binary: Path) -> GodotRunner:
     return SubprocessGodotRunner(binary)
 
 
+def _schema_option(
+    input_model: type[BaseModel], output_model: type[BaseModel]
+) -> bool:
+    """A ``--schema`` flag wired to its own emission (ADR-0004, issue #18).
+
+    Declaring the flag IS the implementation: an eager callback emits the
+    command's model-derived ``{input, output}`` contract and exits before any
+    other parameter — required arguments included — is validated, and before
+    any engine path (binary resolution, runner) is touched. One declaration
+    per command replaces the per-command ``if schema:`` block, so a command
+    cannot ship the flag without its mandated behavior.
+    """
+
+    def emit(value: bool) -> None:
+        if value:
+            typer.echo(CommandSchema.of(input_model, output_model).model_dump_json())
+            raise typer.Exit()
+
+    return typer.Option(
+        False,
+        "--schema",
+        help="Emit this command's input/output JSON Schemas; no Godot is spawned.",
+        callback=emit,
+        is_eager=True,
+    )
+
+
 def _fail(failure: Failure) -> NoReturn:
     """Emit a structured error to stdout and exit non-zero (issue #3).
 
@@ -52,16 +96,90 @@ def _fail(failure: Failure) -> NoReturn:
     raise typer.Exit(code=failure.exit_code)
 
 
+@scene_app.command()
+def create(
+    path: str = typer.Argument(..., help="Target .tscn path to write."),
+    root_type: str = typer.Option(
+        ...,
+        "--root-type",
+        help="Godot node class of the new scene's root (e.g. Node2D).",
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit the result as a single JSON object."
+    ),
+    schema: bool = _schema_option(SceneCreateParams, SceneCreateResult),
+    godot: Optional[str] = typer.Option(
+        None,
+        "--godot",
+        help="Path to the Godot binary (overrides $GDA_GODOT and the default).",
+    ),
+) -> None:
+    """Create a new .tscn scene file with the given root node type."""
+    binary = resolve_godot_binary(godot)
+    runner = _make_runner(binary)
+    params = SceneCreateParams(path=path, root_type=root_type)
+    result = runner.run("scene-create", params.model_dump())
+
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+
+    outcome = classify_run(result, binary, SceneCreateResult)
+    if isinstance(outcome, Failure):
+        _fail(outcome)
+    created = outcome
+
+    if json_output:
+        typer.echo(created.model_dump_json())
+    else:
+        typer.echo(f"created {created.path} (root {created.root_type})")
+
+
+def _render_tree(node: SceneNode, depth: int = 0) -> str:
+    """Render a node tree as an indented ``name (Type)`` outline for humans."""
+    lines = [f"{'  ' * depth}{node.name} ({node.type})"]
+    lines += (_render_tree(child, depth + 1) for child in node.children)
+    return "\n".join(lines)
+
+
+@scene_app.command()
+def get(
+    path: str = typer.Argument(..., help="The .tscn scene file to read."),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit the result as a single JSON object."
+    ),
+    schema: bool = _schema_option(SceneGetParams, SceneGetResult),
+    godot: Optional[str] = typer.Option(
+        None,
+        "--godot",
+        help="Path to the Godot binary (overrides $GDA_GODOT and the default).",
+    ),
+) -> None:
+    """Read a scene file and report its structured node tree."""
+    binary = resolve_godot_binary(godot)
+    runner = _make_runner(binary)
+    params = SceneGetParams(path=path)
+    result = runner.run("scene-get", params.model_dump())
+
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+
+    outcome = classify_run(result, binary, SceneGetResult)
+    if isinstance(outcome, Failure):
+        _fail(outcome)
+    scene = outcome
+
+    if json_output:
+        typer.echo(scene.model_dump_json())
+    else:
+        typer.echo(_render_tree(scene.root))
+
+
 @app.command()
 def info(
     json_output: bool = typer.Option(
         False, "--json", help="Emit the result as a single JSON object."
     ),
-    schema: bool = typer.Option(
-        False,
-        "--schema",
-        help="Emit this command's input/output JSON Schemas; no Godot is spawned.",
-    ),
+    schema: bool = _schema_option(InfoParams, EngineVersion),
     godot: Optional[str] = typer.Option(
         None,
         "--godot",
@@ -69,13 +187,6 @@ def info(
     ),
 ) -> None:
     """Report the Godot engine version info."""
-    if schema:
-        # Local, no-Godot self-description (ADR-0004): derived from the same
-        # typed models that back --json. Short-circuit before touching the
-        # engine — no binary resolution, no process spawned.
-        typer.echo(CommandSchema.of(InfoParams, EngineVersion).model_dump_json())
-        return
-
     binary = resolve_godot_binary(godot)
     runner = _make_runner(binary)
     result = runner.run("info", {})

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -1,13 +1,15 @@
 """The ``gda`` CLI entrypoint.
 
-Meta commands (about ``gda`` or the engine itself) sit at the top level
-(ADR-0005). ``gda info`` is the first such command and the Phase-1 tracer
-bullet: it runs the headless ``info`` operation and reports the engine version.
+Meta commands (about ``gda`` or the engine itself) sit at the top level;
+domain commands are grouped under their Godot domain object (ADR-0005).
+``gda info`` is the Phase-1 tracer bullet; the ``scene`` group is the first
+domain group (issue #18). Every command drives the same headless pipeline:
+binary resolution → runner → sentinel parse → typed model → JSON.
 """
 
 import sys
 from pathlib import Path
-from typing import NoReturn, Optional
+from typing import Callable, NoReturn, Optional, TypeVar
 
 import typer
 from pydantic import BaseModel
@@ -25,7 +27,7 @@ from gda.models import (
     SceneGetResult,
     SceneNode,
 )
-from gda.runner import GodotRunner, SubprocessGodotRunner
+from gda.runner import GodotRunner, RunResult, SubprocessGodotRunner
 
 app = typer.Typer(
     name="gda",
@@ -55,6 +57,20 @@ def _make_runner(binary: Path) -> GodotRunner:
     A seam tests override (via monkeypatch) to inject a fake runner.
     """
     return SubprocessGodotRunner(binary)
+
+
+def _json_option() -> bool:
+    return typer.Option(
+        False, "--json", help="Emit the result as a single JSON object."
+    )
+
+
+def _godot_option() -> Optional[str]:
+    return typer.Option(
+        None,
+        "--godot",
+        help="Path to the Godot binary (overrides $GDA_GODOT and the default).",
+    )
 
 
 def _schema_option(
@@ -96,42 +112,35 @@ def _fail(failure: Failure) -> NoReturn:
     raise typer.Exit(code=failure.exit_code)
 
 
-@scene_app.command()
-def create(
-    path: str = typer.Argument(..., help="Target .tscn path to write."),
-    root_type: str = typer.Option(
-        ...,
-        "--root-type",
-        help="Godot node class of the new scene's root (e.g. Node2D).",
-    ),
-    json_output: bool = typer.Option(
-        False, "--json", help="Emit the result as a single JSON object."
-    ),
-    schema: bool = _schema_option(SceneCreateParams, SceneCreateResult),
-    godot: Optional[str] = typer.Option(
-        None,
-        "--godot",
-        help="Path to the Godot binary (overrides $GDA_GODOT and the default).",
-    ),
-) -> None:
-    """Create a new .tscn scene file with the given root node type."""
+M = TypeVar("M", bound=BaseModel)
+
+
+def _run_classified(
+    operation: str,
+    params: BaseModel,
+    classify: Callable[[RunResult, Path], M | Failure],
+    godot: Optional[str],
+) -> M:
+    """Drive the shared headless pipeline to a typed success model.
+
+    Resolve the binary, run ``operation`` with the typed params, surface
+    engine/script diagnostics on stderr (ADR-0002), classify the raw result,
+    and on failure emit the structured error and exit — so each command body
+    is reduced to its params, its classifier, and its output rendering.
+    """
     binary = resolve_godot_binary(godot)
     runner = _make_runner(binary)
-    params = SceneCreateParams(path=path, root_type=root_type)
-    result = runner.run("scene-create", params.model_dump())
+    result = runner.run(operation, params.model_dump())
 
+    # stdout carries only the result payload; engine/script diagnostics are
+    # surfaced on stderr (ADR-0002).
     if result.stderr:
         print(result.stderr, end="", file=sys.stderr)
 
-    outcome = classify_run(result, binary, SceneCreateResult)
+    outcome = classify(result, binary)
     if isinstance(outcome, Failure):
         _fail(outcome)
-    created = outcome
-
-    if json_output:
-        typer.echo(created.model_dump_json())
-    else:
-        typer.echo(f"created {created.path} (root {created.root_type})")
+    return outcome
 
 
 def _render_tree(node: SceneNode, depth: int = 0) -> str:
@@ -142,31 +151,45 @@ def _render_tree(node: SceneNode, depth: int = 0) -> str:
 
 
 @scene_app.command()
+def create(
+    path: str = typer.Argument(..., help="Target .tscn path to write."),
+    root_type: str = typer.Option(
+        ...,
+        "--root-type",
+        help="Godot node class of the new scene's root (e.g. Node2D).",
+    ),
+    json_output: bool = _json_option(),
+    schema: bool = _schema_option(SceneCreateParams, SceneCreateResult),
+    godot: Optional[str] = _godot_option(),
+) -> None:
+    """Create a new .tscn scene file with the given root node type."""
+    created = _run_classified(
+        "scene-create",
+        SceneCreateParams(path=path, root_type=root_type),
+        lambda result, binary: classify_run(result, binary, SceneCreateResult),
+        godot,
+    )
+
+    if json_output:
+        typer.echo(created.model_dump_json())
+    else:
+        typer.echo(f"created {created.path} (root {created.root_type})")
+
+
+@scene_app.command()
 def get(
     path: str = typer.Argument(..., help="The .tscn scene file to read."),
-    json_output: bool = typer.Option(
-        False, "--json", help="Emit the result as a single JSON object."
-    ),
+    json_output: bool = _json_option(),
     schema: bool = _schema_option(SceneGetParams, SceneGetResult),
-    godot: Optional[str] = typer.Option(
-        None,
-        "--godot",
-        help="Path to the Godot binary (overrides $GDA_GODOT and the default).",
-    ),
+    godot: Optional[str] = _godot_option(),
 ) -> None:
     """Read a scene file and report its structured node tree."""
-    binary = resolve_godot_binary(godot)
-    runner = _make_runner(binary)
-    params = SceneGetParams(path=path)
-    result = runner.run("scene-get", params.model_dump())
-
-    if result.stderr:
-        print(result.stderr, end="", file=sys.stderr)
-
-    outcome = classify_run(result, binary, SceneGetResult)
-    if isinstance(outcome, Failure):
-        _fail(outcome)
-    scene = outcome
+    scene = _run_classified(
+        "scene-get",
+        SceneGetParams(path=path),
+        lambda result, binary: classify_run(result, binary, SceneGetResult),
+        godot,
+    )
 
     if json_output:
         typer.echo(scene.model_dump_json())
@@ -176,30 +199,12 @@ def get(
 
 @app.command()
 def info(
-    json_output: bool = typer.Option(
-        False, "--json", help="Emit the result as a single JSON object."
-    ),
+    json_output: bool = _json_option(),
     schema: bool = _schema_option(InfoParams, EngineVersion),
-    godot: Optional[str] = typer.Option(
-        None,
-        "--godot",
-        help="Path to the Godot binary (overrides $GDA_GODOT and the default).",
-    ),
+    godot: Optional[str] = _godot_option(),
 ) -> None:
     """Report the Godot engine version info."""
-    binary = resolve_godot_binary(godot)
-    runner = _make_runner(binary)
-    result = runner.run("info", {})
-
-    # stdout carries only the result payload; engine/script diagnostics are
-    # surfaced on stderr (ADR-0002).
-    if result.stderr:
-        print(result.stderr, end="", file=sys.stderr)
-
-    outcome = classify_info(result, binary)
-    if isinstance(outcome, Failure):
-        _fail(outcome)
-    version = outcome
+    version = _run_classified("info", InfoParams(), classify_info, godot)
 
     if json_output:
         typer.echo(version.model_dump_json())

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 
 from gda.binary import resolve_godot_binary
 from gda.errors import Failure, classify_info, classify_run
+from gda.project import resolve_project_dir
 from gda.models import (
     CommandSchema,
     EngineVersion,
@@ -51,12 +52,12 @@ def main() -> None:
     # the top level, as Typer does for a single-command app.
 
 
-def _make_runner(binary: Path) -> GodotRunner:
-    """Build the default (real) Godot runner for ``binary``.
+def _make_runner(binary: Path, project: Optional[Path]) -> GodotRunner:
+    """Build the default (real) Godot runner for ``binary`` and ``project``.
 
     A seam tests override (via monkeypatch) to inject a fake runner.
     """
-    return SubprocessGodotRunner(binary)
+    return SubprocessGodotRunner(binary, project=project)
 
 
 def _json_option() -> bool:
@@ -71,6 +72,27 @@ def _godot_option() -> Optional[str]:
         "--godot",
         help="Path to the Godot binary (overrides $GDA_GODOT and the default).",
     )
+
+
+def _project_option() -> Optional[str]:
+    return typer.Option(
+        None,
+        "--project",
+        help="Godot project directory for res:// resolution "
+        "(overrides $GDA_PROJECT; defaults to the current directory if it is a project).",
+    )
+
+
+def _normalize_path(path: str) -> str:
+    """Normalize a path argument at the CLI layer (issue #32).
+
+    Engine-resolved virtual paths (``res://``, ``user://``, ``uid://``) pass
+    through untouched — the engine resolves them against the project. A
+    filesystem path gets ``~`` expanded so a literal ``~`` works without a shell.
+    """
+    if "://" in path:
+        return path
+    return str(Path(path).expanduser())
 
 
 def _schema_option(
@@ -120,16 +142,18 @@ def _run_classified(
     params: BaseModel,
     classify: Callable[[RunResult, Path], M | Failure],
     godot: Optional[str],
+    project: Optional[Path] = None,
 ) -> M:
     """Drive the shared headless pipeline to a typed success model.
 
-    Resolve the binary, run ``operation`` with the typed params, surface
-    engine/script diagnostics on stderr (ADR-0002), classify the raw result,
-    and on failure emit the structured error and exit — so each command body
-    is reduced to its params, its classifier, and its output rendering.
+    Resolve the binary, run ``operation`` with the typed params against the
+    resolved ``project`` (``None`` runs projectless), surface engine/script
+    diagnostics on stderr (ADR-0002), classify the raw result, and on failure
+    emit the structured error and exit — so each command body is reduced to its
+    params, its classifier, and its output rendering.
     """
     binary = resolve_godot_binary(godot)
-    runner = _make_runner(binary)
+    runner = _make_runner(binary, project)
     result = runner.run(operation, params.model_dump())
 
     # stdout carries only the result payload; engine/script diagnostics are
@@ -161,13 +185,15 @@ def create(
     json_output: bool = _json_option(),
     schema: bool = _schema_option(SceneCreateParams, SceneCreateResult),
     godot: Optional[str] = _godot_option(),
+    project: Optional[str] = _project_option(),
 ) -> None:
     """Create a new .tscn scene file with the given root node type."""
     created = _run_classified(
         "scene-create",
-        SceneCreateParams(path=path, root_type=root_type),
+        SceneCreateParams(path=_normalize_path(path), root_type=root_type),
         lambda result, binary: classify_run(result, binary, SceneCreateResult),
         godot,
+        resolve_project_dir(project),
     )
 
     if json_output:
@@ -182,13 +208,15 @@ def get(
     json_output: bool = _json_option(),
     schema: bool = _schema_option(SceneGetParams, SceneGetResult),
     godot: Optional[str] = _godot_option(),
+    project: Optional[str] = _project_option(),
 ) -> None:
     """Read a scene file and report its structured node tree."""
     scene = _run_classified(
         "scene-get",
-        SceneGetParams(path=path),
+        SceneGetParams(path=_normalize_path(path)),
         lambda result, binary: classify_run(result, binary, SceneGetResult),
         godot,
+        resolve_project_dir(project),
     )
 
     if json_output:

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -19,6 +19,8 @@ engine. The decision tree, top to bottom (``code`` in parentheses; the four
 - exit 127  → environment / binary_not_found      (runner could not launch it)
 - exit 124  → environment / launch_timeout        (launched, hung past timeout)
 - exit < 0  → operation   / engine_crashed         (engine killed by a signal)
+- exit ≠ 0  → operation   / <marker code>           (operation reported a structured
+  failure via the ``gda-error:<code>:`` stderr marker — e.g. path_not_found)
 - exit ≠ 0  → operation   / operation_failed        (engine ran, operation errored)
 - contract  → parse       / contract_violation      (sentinel/JSON/shape invalid)
 - old       → version     / unsupported_version     (below the ADR-0003 minimum,
@@ -30,6 +32,7 @@ get distinct small codes so a shell consumer can tell categories apart without
 parsing the JSON error.
 """
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeVar
@@ -50,6 +53,12 @@ from gda.runner import RunResult
 # The minimum supported Godot version (ADR-0003): the floor where the modern
 # features gda relies on exist. Resolved from the version gda info reports.
 MIN_GODOT_VERSION = (4, 4)
+
+# A structured operation failure, as the operations payload reports it on
+# stderr: ``gda-error:<code>: <message>``. The marker refines the generic
+# operation_failed bucket into the operation's own stable, finer code
+# (e.g. path_not_found, not_a_scene) — same category, same exit code.
+_OP_ERROR_MARKER = re.compile(r"^gda-error:([a-z_]+): ?(.*)$", re.MULTILINE)
 
 
 @dataclass
@@ -117,7 +126,19 @@ def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | 
         )
     if result.exit_code != 0:
         # The engine ran but the operation itself reported an error and quit
-        # non-zero (its own exit, not the runner's synthetic 124/127).
+        # non-zero (its own exit, not the runner's synthetic 124/127). When the
+        # operation reported the failure *structurally* via the gda-error
+        # stderr marker, surface its finer stable code; otherwise fall back to
+        # the generic operation_failed.
+        marker = _OP_ERROR_MARKER.search(result.stderr)
+        if marker:
+            return _failure(
+                ErrorCategory.OPERATION,
+                marker.group(1),
+                marker.group(2) or "the headless operation reported an error",
+                EXIT_OPERATION,
+                result.stderr,
+            )
         return _failure(
             ErrorCategory.OPERATION,
             "operation_failed",

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -92,6 +92,54 @@ class CommandSchema(BaseModel):
         )
 
 
+class SceneCreateParams(BaseModel):
+    """The operation params of ``gda scene create`` (issue #18).
+
+    ``path`` is the target ``.tscn`` file; ``root_type`` the Godot node class
+    of the new scene's root (e.g. ``Node2D``).
+    """
+
+    path: str
+    root_type: str
+
+
+class SceneCreateResult(BaseModel):
+    """The result of ``gda scene create``: what was written where.
+
+    Echoes the saved path and the root node the operation actually created, so
+    an agent can assert the effect without a second call.
+    """
+
+    path: str
+    root_name: str
+    root_type: str
+
+
+class SceneNode(BaseModel):
+    """One node of a scene's structured tree: name, type, nested children.
+
+    Recursive on purpose — the tree IS the contract: ``gda scene get`` reports
+    arbitrarily nested scenes through this one shape.
+    """
+
+    name: str
+    type: str
+    children: list["SceneNode"] = []
+
+
+class SceneGetParams(BaseModel):
+    """The operation params of ``gda scene get``: the ``.tscn`` file to read."""
+
+    path: str
+
+
+class SceneGetResult(BaseModel):
+    """The result of ``gda scene get``: the scene file's structured node tree."""
+
+    path: str
+    root: SceneNode
+
+
 class EngineVersion(BaseModel):
     """The Godot engine version, as reported by ``Engine.get_version_info()``.
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -10,68 +10,88 @@ extends SceneTree
 # nothing but the sentinel-delimited result; everything else is engine noise.
 #
 # An operation that fails reports it structurally on stderr as
-# `gda-error:<code>: <message>` and quits non-zero; gda's shared classifier
-# surfaces <code> as the stable GdaError.code (issue #18).
+# `gda-error:<code>: <message>`; gda's shared classifier surfaces <code> as the
+# stable GdaError.code (issue #18).
+#
+# Control flow (issue #31): all work happens in _initialize, but the process is
+# quit from _process — which runs on the first idle frame regardless of whether
+# _initialize completed. So even an uncaught runtime error mid-operation, which
+# aborts _initialize, still exits promptly and non-zero (the default _exit_code)
+# instead of leaving the headless main loop spinning forever. An operation never
+# calls quit() itself: it records its outcome via _succeed / _fail, and the
+# single quit() lives in _process — no path can quit twice or clobber the code.
 
 const RESULT_BEGIN := "<<<GDA:RESULT>>>"
 const RESULT_END := "<<<GDA:END>>>"
 
+# The exit code the process will use. Defaults to failure, so an operation that
+# aborts before recording an outcome (e.g. an uncaught runtime error) still
+# exits non-zero rather than reporting a phantom success.
+var _exit_code := 1
 
-func _init() -> void:
+
+func _initialize() -> void:
 	# Everything after `--` on the Godot command line — i.e. <operation>
 	# [params_json] — arrives here, independent of engine argument ordering.
 	var args := OS.get_cmdline_user_args()
 	if args.is_empty():
-		_fail("usage: godot --headless --script operations.gd -- <operation> [params_json]")
+		_fail("usage_error", "usage: godot --headless --script operations.gd -- <operation> [params_json]")
 		return
 
-	var operation := args[0]
+	var operation: String = args[0]
+	var params: Variant = _parse_params(args)
+	if params == null:
+		return  # _parse_params already recorded the failure
 
-	var params: Dictionary = {}
-	if args.size() > 1:
-		var parsed: Variant = JSON.parse_string(args[1])
-		if parsed == null or not (parsed is Dictionary):
-			_fail("params is not a JSON object: " + args[1])
-			return
-		params = parsed
-
-	# Each op returns whether it succeeded; a failing op has already quit(1),
-	# so only a successful run may reach the final quit() — quitting twice
-	# would overwrite the failure exit code.
-	var ok: bool
 	match operation:
 		"info":
-			ok = _op_info()
+			_op_info()
 		"scene-create":
-			ok = _op_scene_create(params)
+			_op_scene_create(params)
 		"scene-get":
-			ok = _op_scene_get(params)
+			_op_scene_get(params)
 		_:
-			_fail("unknown operation: " + operation)
-			return
+			_fail("unknown_operation", "unknown operation: " + operation)
 
-	if ok:
-		quit()
+
+# Quit on the first idle frame, whatever happened during _initialize — this is
+# the single exit point and the watchdog against a hung main loop (issue #31).
+func _process(_delta: float) -> bool:
+	quit(_exit_code)
+	return true
+
+
+# Parse the optional params JSON into a Dictionary; null signals a recorded
+# failure (the caller must stop). A missing payload is an empty Dictionary.
+func _parse_params(args: PackedStringArray) -> Variant:
+	if args.size() <= 1:
+		return {}
+	var parsed: Variant = JSON.parse_string(args[1])
+	if not (parsed is Dictionary):
+		_fail("invalid_params", "params is not a JSON object: " + args[1])
+		return null
+	return parsed
 
 
 # info: emit Engine.get_version_info() through the structured-output contract.
-func _op_info() -> bool:
+func _op_info() -> void:
 	_diag("running operation: info")
-	_emit_result(JSON.stringify(Engine.get_version_info()))
-	return true
+	_succeed(Engine.get_version_info())
 
 
 # scene-create: instantiate a root node of the requested type, pack it, save
 # it as a .tscn at the requested path (issue #18).
-func _op_scene_create(params: Dictionary) -> bool:
+func _op_scene_create(params: Dictionary) -> void:
 	_diag("running operation: scene-create")
-	var path: String = params.get("path", "")
+	var path := _string_param(params, "path")
 	if path.is_empty():
-		return _fail_op("invalid_path", "missing required param: path")
-	var root_type: String = params.get("root_type", "")
+		_fail("invalid_path", "missing required param: path")
+		return
+	var root_type := _string_param(params, "root_type")
 	if root_type.is_empty() or not ClassDB.can_instantiate(root_type) \
 			or not ClassDB.is_parent_class(root_type, "Node"):
-		return _fail_op("invalid_root_type", "not an instantiable Node class: " + root_type)
+		_fail("invalid_root_type", "not an instantiable Node class: " + root_type)
+		return
 
 	var root: Node = ClassDB.instantiate(root_type)
 	root.name = path.get_file().get_basename()
@@ -81,18 +101,19 @@ func _op_scene_create(params: Dictionary) -> bool:
 	var pack_err := packed.pack(root)
 	if pack_err != OK:
 		root.free()
-		return _fail_op("save_failed", "failed to pack scene: " + error_string(pack_err))
+		_fail("save_failed", "failed to pack scene: " + error_string(pack_err))
+		return
 	var save_err := ResourceSaver.save(packed, path)
 	root.free()
 	if save_err != OK:
-		return _fail_op("save_failed", "failed to save scene to " + path + ": " + error_string(save_err))
+		_fail("save_failed", "failed to save scene to " + path + ": " + error_string(save_err))
+		return
 
-	_emit_result(JSON.stringify({
+	_succeed({
 		"path": path,
 		"root_name": root_name,
 		"root_type": root_type,
-	}))
-	return true
+	})
 
 
 # scene-get: load a .tscn from disk and emit its structured node tree.
@@ -102,23 +123,26 @@ func _op_scene_create(params: Dictionary) -> bool:
 # arbitrary project code merely to read a scene, and letting that code print a
 # forged result onto stdout (issue #30). SceneState exposes the declared tree
 # without constructing a single node.
-func _op_scene_get(params: Dictionary) -> bool:
+func _op_scene_get(params: Dictionary) -> void:
 	_diag("running operation: scene-get")
-	var path: String = params.get("path", "")
+	var path := _string_param(params, "path")
 	if path.is_empty():
-		return _fail_op("invalid_path", "missing required param: path")
+		_fail("invalid_path", "missing required param: path")
+		return
 	if not FileAccess.file_exists(path):
-		return _fail_op("path_not_found", "scene file does not exist: " + path)
+		_fail("path_not_found", "scene file does not exist: " + path)
+		return
 
 	var packed := ResourceLoader.load(path, "PackedScene") as PackedScene
 	if packed == null:
-		return _fail_op("not_a_scene", "failed to load as a scene: " + path)
+		_fail("not_a_scene", "failed to load as a scene: " + path)
+		return
 	var state := packed.get_state()
 	if state == null or state.get_node_count() == 0:
-		return _fail_op("not_a_scene", "scene declares no root node: " + path)
+		_fail("not_a_scene", "scene declares no root node: " + path)
+		return
 
-	_emit_result(JSON.stringify({"path": path, "root": _tree_from_state(state)}))
-	return true
+	_succeed({"path": path, "root": _tree_from_state(state)})
 
 
 # Build the structured node tree from a SceneState. The state lists nodes in
@@ -144,22 +168,29 @@ func _tree_from_state(state: SceneState) -> Dictionary:
 	return root
 
 
-func _emit_result(json_payload: String) -> void:
-	print(RESULT_BEGIN + json_payload + RESULT_END)
+# Read a string param defensively: a non-string value (the params arrive as
+# arbitrary JSON) is treated as absent rather than crashing a typed assignment,
+# so a malformed param surfaces as a structured failure, not a runtime error.
+func _string_param(params: Dictionary, key: String) -> String:
+	var value: Variant = params.get(key, "")
+	if value is String:
+		return value
+	return ""
+
+
+# Record a successful result: emit it through the sentinel contract and mark
+# the process to exit 0. The single quit() lives in _process.
+func _succeed(payload: Dictionary) -> void:
+	print(RESULT_BEGIN + JSON.stringify(payload) + RESULT_END)
+	_exit_code = 0
 
 
 func _diag(message: String) -> void:
 	printerr("gda: " + message)
 
 
-# A structured operation failure: the stable finer code rides the stderr
-# marker; returns false so the caller can stop without reaching quit().
-func _fail_op(code: String, message: String) -> bool:
+# Record a structured failure: the stable finer code rides the stderr marker
+# (issue #18) and the process is left to exit non-zero via _process.
+func _fail(code: String, message: String) -> void:
 	printerr("gda-error:" + code + ": " + message)
-	quit(1)
-	return false
-
-
-func _fail(message: String) -> void:
-	_diag(message)
-	quit(1)
+	_exit_code = 1

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -8,6 +8,10 @@ extends SceneTree
 # Each operation emits EXACTLY ONE result to stdout, wrapped in the GDA
 # sentinels, and routes all of its own diagnostics to stderr. stdout carries
 # nothing but the sentinel-delimited result; everything else is engine noise.
+#
+# An operation that fails reports it structurally on stderr as
+# `gda-error:<code>: <message>` and quits non-zero; gda's shared classifier
+# surfaces <code> as the stable GdaError.code (issue #18).
 
 const RESULT_BEGIN := "<<<GDA:RESULT>>>"
 const RESULT_END := "<<<GDA:END>>>"
@@ -23,20 +27,101 @@ func _init() -> void:
 
 	var operation := args[0]
 
+	var params: Dictionary = {}
+	if args.size() > 1:
+		var parsed: Variant = JSON.parse_string(args[1])
+		if parsed == null or not (parsed is Dictionary):
+			_fail("params is not a JSON object: " + args[1])
+			return
+		params = parsed
+
+	# Each op returns whether it succeeded; a failing op has already quit(1),
+	# so only a successful run may reach the final quit() — quitting twice
+	# would overwrite the failure exit code.
+	var ok: bool
 	match operation:
 		"info":
-			_op_info()
+			ok = _op_info()
+		"scene-create":
+			ok = _op_scene_create(params)
+		"scene-get":
+			ok = _op_scene_get(params)
 		_:
 			_fail("unknown operation: " + operation)
 			return
 
-	quit()
+	if ok:
+		quit()
 
 
 # info: emit Engine.get_version_info() through the structured-output contract.
-func _op_info() -> void:
+func _op_info() -> bool:
 	_diag("running operation: info")
 	_emit_result(JSON.stringify(Engine.get_version_info()))
+	return true
+
+
+# scene-create: instantiate a root node of the requested type, pack it, save
+# it as a .tscn at the requested path (issue #18).
+func _op_scene_create(params: Dictionary) -> bool:
+	_diag("running operation: scene-create")
+	var path: String = params.get("path", "")
+	if path.is_empty():
+		return _fail_op("invalid_path", "missing required param: path")
+	var root_type: String = params.get("root_type", "")
+	if root_type.is_empty() or not ClassDB.can_instantiate(root_type) \
+			or not ClassDB.is_parent_class(root_type, "Node"):
+		return _fail_op("invalid_root_type", "not an instantiable Node class: " + root_type)
+
+	var root: Node = ClassDB.instantiate(root_type)
+	root.name = path.get_file().get_basename()
+	var root_name := String(root.name)
+
+	var packed := PackedScene.new()
+	var pack_err := packed.pack(root)
+	if pack_err != OK:
+		root.free()
+		return _fail_op("save_failed", "failed to pack scene: " + error_string(pack_err))
+	var save_err := ResourceSaver.save(packed, path)
+	root.free()
+	if save_err != OK:
+		return _fail_op("save_failed", "failed to save scene to " + path + ": " + error_string(save_err))
+
+	_emit_result(JSON.stringify({
+		"path": path,
+		"root_name": root_name,
+		"root_type": root_type,
+	}))
+	return true
+
+
+# scene-get: load a .tscn from disk and emit its structured node tree.
+func _op_scene_get(params: Dictionary) -> bool:
+	_diag("running operation: scene-get")
+	var path: String = params.get("path", "")
+	if path.is_empty():
+		return _fail_op("invalid_path", "missing required param: path")
+	if not FileAccess.file_exists(path):
+		return _fail_op("path_not_found", "scene file does not exist: " + path)
+
+	var packed := ResourceLoader.load(path, "PackedScene") as PackedScene
+	if packed == null:
+		return _fail_op("not_a_scene", "failed to load as a scene: " + path)
+	var root := packed.instantiate()
+	if root == null:
+		return _fail_op("not_a_scene", "scene has no instantiable root: " + path)
+
+	var tree := _node_dict(root)
+	root.free()
+	_emit_result(JSON.stringify({"path": path, "root": tree}))
+	return true
+
+
+func _node_dict(node: Node) -> Dictionary:
+	var children: Array = []
+	for child in node.get_children():
+		children.append(_node_dict(child))
+	return {"name": String(node.name), "type": node.get_class(), "children": children}
 
 
 func _emit_result(json_payload: String) -> void:
@@ -45,6 +130,14 @@ func _emit_result(json_payload: String) -> void:
 
 func _diag(message: String) -> void:
 	printerr("gda: " + message)
+
+
+# A structured operation failure: the stable finer code rides the stderr
+# marker; returns false so the caller can stop without reaching quit().
+func _fail_op(code: String, message: String) -> bool:
+	printerr("gda-error:" + code + ": " + message)
+	quit(1)
+	return false
 
 
 func _fail(message: String) -> void:

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -96,6 +96,12 @@ func _op_scene_create(params: Dictionary) -> bool:
 
 
 # scene-get: load a .tscn from disk and emit its structured node tree.
+#
+# Reads the packed scene's STORED STATE (SceneState) rather than instantiating
+# it. Instantiating would run the _init of any attached script — executing
+# arbitrary project code merely to read a scene, and letting that code print a
+# forged result onto stdout (issue #30). SceneState exposes the declared tree
+# without constructing a single node.
 func _op_scene_get(params: Dictionary) -> bool:
 	_diag("running operation: scene-get")
 	var path: String = params.get("path", "")
@@ -107,21 +113,35 @@ func _op_scene_get(params: Dictionary) -> bool:
 	var packed := ResourceLoader.load(path, "PackedScene") as PackedScene
 	if packed == null:
 		return _fail_op("not_a_scene", "failed to load as a scene: " + path)
-	var root := packed.instantiate()
-	if root == null:
-		return _fail_op("not_a_scene", "scene has no instantiable root: " + path)
+	var state := packed.get_state()
+	if state == null or state.get_node_count() == 0:
+		return _fail_op("not_a_scene", "scene declares no root node: " + path)
 
-	var tree := _node_dict(root)
-	root.free()
-	_emit_result(JSON.stringify({"path": path, "root": tree}))
+	_emit_result(JSON.stringify({"path": path, "root": _tree_from_state(state)}))
 	return true
 
 
-func _node_dict(node: Node) -> Dictionary:
-	var children: Array = []
-	for child in node.get_children():
-		children.append(_node_dict(child))
-	return {"name": String(node.name), "type": node.get_class(), "children": children}
+# Build the structured node tree from a SceneState. The state lists nodes in
+# tree order; each carries a node path ("." for the root, "Hero/Hitbox" for a
+# descendant) and the path to its parent, which is enough to reconstruct the
+# parent/child structure without instantiating anything.
+func _tree_from_state(state: SceneState) -> Dictionary:
+	var by_path := {}
+	var root: Dictionary = {}
+	for i in state.get_node_count():
+		var node := {
+			"name": String(state.get_node_name(i)),
+			"type": String(state.get_node_type(i)),
+			"children": [],
+		}
+		by_path[String(state.get_node_path(i))] = node
+		if i == 0:
+			root = node
+		else:
+			var parent: Variant = by_path.get(String(state.get_node_path(i, true)))
+			if parent != null:
+				parent["children"].append(node)
+	return root
 
 
 func _emit_result(json_payload: String) -> void:

--- a/src/gda/project.py
+++ b/src/gda/project.py
@@ -1,0 +1,71 @@
+"""Godot project resolution (issue #32).
+
+A scene operation runs against a Godot *project* so that ``res://`` paths and
+inter-resource references resolve deterministically. The resolved directory is
+handed to the engine as ``--path``; without it the engine's project — hence
+``res://`` resolution — would depend on gda's current working directory.
+
+Resolution precedence (highest first), mirroring ``gda.binary``:
+
+1. An explicit path passed by the caller (the ``--project`` flag).
+2. The ``GDA_PROJECT`` environment variable.
+3. The current working directory.
+
+An explicitly named directory (flag or env) must actually be a Godot project —
+hold a ``project.godot`` — or it is a mistake we surface rather than run in the
+wrong context. The cwd fallback counts as a project only when it holds the
+marker; otherwise resolution yields ``None`` and gda runs *projectless*
+(filesystem paths only), the behaviour before project context existed.
+"""
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+GDA_PROJECT_ENV = "GDA_PROJECT"
+
+# The file Godot uses to mark a directory as a project root.
+PROJECT_MARKER = "project.godot"
+
+
+def _project_or_raise(raw: str, source: str) -> Path:
+    """Expand ``raw`` to a project directory, or raise if it is not one."""
+    candidate = Path(raw).expanduser()
+    if not (candidate / PROJECT_MARKER).exists():
+        raise ValueError(
+            f"{source} is not a Godot project (no {PROJECT_MARKER}): {candidate}"
+        )
+    return candidate
+
+
+def resolve_project_dir(
+    explicit: str | None = None,
+    env: Mapping[str, str] | None = None,
+    cwd: Path | None = None,
+) -> Path | None:
+    """Resolve the Godot project directory using flag > env > cwd precedence.
+
+    Returns the project root to pass as ``--path``, or ``None`` to run
+    projectless. Raises ``ValueError`` if an explicitly named directory (flag
+    or env) is empty or is not a Godot project.
+    """
+    if env is None:
+        env = os.environ
+    if cwd is None:
+        cwd = Path.cwd()
+
+    if explicit is not None:
+        # An explicit (even if empty) value is a deliberate choice; an empty
+        # one is a mistake we surface rather than silently fall through.
+        if not explicit:
+            raise ValueError("explicit project path is empty")
+        return _project_or_raise(explicit, "--project")
+
+    env_value = env.get(GDA_PROJECT_ENV)
+    if env_value:
+        return _project_or_raise(env_value, f"${GDA_PROJECT_ENV}")
+
+    cwd = Path(cwd)
+    if (cwd / PROJECT_MARKER).exists():
+        return cwd
+    return None

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -46,10 +46,13 @@ class SubprocessGodotRunner:
 
     It dispatches the operation to the bundled ``operations.gd`` payload and
     returns the process's raw stdout/stderr/exit code unparsed — extracting the
-    result from the noise is the parser's job (ADR-0002).
+    result from the noise is the parser's job (ADR-0002). When ``project`` is
+    set it is passed as ``--path`` so the engine runs against that project and
+    ``res://`` resolves there (issue #32); otherwise the engine runs projectless.
     """
 
     binary: Path
+    project: Path | None = None
     script: Path = OPERATIONS_GD
     timeout: float = DEFAULT_TIMEOUT_SECONDS
 
@@ -57,9 +60,10 @@ class SubprocessGodotRunner:
         # Everything after `--` is delivered to the script verbatim via
         # OS.get_cmdline_user_args(), so the payload is decoupled from however
         # Godot orders its own engine arguments.
-        cmd = [
-            str(self.binary),
-            "--headless",
+        cmd = [str(self.binary), "--headless"]
+        if self.project is not None:
+            cmd += ["--path", str(self.project)]
+        cmd += [
             "--script",
             str(self.script),
             "--",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Shared pytest fixtures for gda's test tiers.
+
+``godot_project`` is the reusable e2e scaffold (issue #18): a throwaway Godot
+project for slices whose operations act on files inside a project. Later
+domain slices (node, script, …) reuse it rather than growing their own.
+"""
+
+import pytest
+
+# The minimal project.godot a Godot 4 engine accepts as a project root.
+PROJECT_GODOT = """\
+config_version=5
+
+[application]
+
+config/name="gda-e2e-fixture"
+"""
+
+
+@pytest.fixture
+def godot_project(tmp_path):
+    """A temp Godot project dir: ``project.godot`` scaffolded, cleanup owned by pytest."""
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    return tmp_path

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,0 +1,36 @@
+"""Shared test support for driving gda commands without a real engine (S3).
+
+``FakeRunner`` satisfies the ``GodotRunner`` protocol with a canned raw
+``RunResult`` and records dispatched ``(operation, params)`` calls, so command
+tests exercise the full Typer→classify→JSON pipeline engine-free. ``sentinel``
+wraps a payload in the ADR-0002 result sentinels the way ``operations.gd``
+emits it.
+"""
+
+import json
+
+from gda.runner import RunResult
+
+
+class FakeRunner:
+    """A fakeable GodotRunner that records its calls and returns a canned result."""
+
+    def __init__(self, result: RunResult) -> None:
+        self.result = result
+        self.calls: list[tuple[str, dict]] = []
+
+    def run(self, operation: str, params: dict) -> RunResult:
+        self.calls.append((operation, params))
+        return self.result
+
+
+def sentinel(payload: dict) -> str:
+    """Wrap ``payload`` in the ADR-0002 result sentinels, as operations.gd emits."""
+    return f"<<<GDA:RESULT>>>{json.dumps(payload)}<<<GDA:END>>>\n"
+
+
+def inject_runner(monkeypatch, result: RunResult) -> FakeRunner:
+    """Swap the CLI's runner seam for a ``FakeRunner`` returning ``result``."""
+    fake = FakeRunner(result)
+    monkeypatch.setattr("gda.cli._make_runner", lambda binary: fake)
+    return fake

--- a/tests/support.py
+++ b/tests/support.py
@@ -32,5 +32,5 @@ def sentinel(payload: dict) -> str:
 def inject_runner(monkeypatch, result: RunResult) -> FakeRunner:
     """Swap the CLI's runner seam for a ``FakeRunner`` returning ``result``."""
     fake = FakeRunner(result)
-    monkeypatch.setattr("gda.cli._make_runner", lambda binary: fake)
+    monkeypatch.setattr("gda.cli._make_runner", lambda binary, project=None: fake)
     return fake

--- a/tests/test_classify_run.py
+++ b/tests/test_classify_run.py
@@ -113,6 +113,29 @@ def test_engine_nonzero_exit_maps_to_operation_failure():
     assert outcome.error.code == "operation_failed"
 
 
+def test_structured_op_failure_marker_refines_the_operation_code():
+    # An operation that reports its failure structurally — the
+    # ``gda-error:<code>: <message>`` stderr marker (issue #18) — surfaces its
+    # own stable finer code instead of the generic operation_failed, with the
+    # same operation category and exit code. Command-agnostic: the refinement
+    # lives in the shared tree, not in any per-command classifier.
+    result = RunResult(
+        stdout="Godot Engine v4.6.stable\n",
+        stderr="gda: running operation: scene-get\n"
+        "gda-error:path_not_found: scene file does not exist: /x/a.tscn\n",
+        exit_code=1,
+    )
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.exit_code == 4
+    assert outcome.error.category == ErrorCategory.OPERATION
+    assert outcome.error.code == "path_not_found"
+    assert outcome.error.message == "scene file does not exist: /x/a.tscn"
+    assert outcome.error.diagnostics == result.stderr
+
+
 @pytest.mark.parametrize(
     "stdout",
     [

--- a/tests/test_e2e_op_robustness.py
+++ b/tests/test_e2e_op_robustness.py
@@ -1,0 +1,76 @@
+"""S1 (e2e): the headless op dispatcher always exits, structured (issue #31).
+
+These drive operations.gd below the CLI/pydantic layer (which would reject the
+inputs first), proving the GDScript dispatch itself never hangs and reports a
+stable code: a malformed param that once crashed a typed assignment and left
+the main loop spinning is now a prompt operation failure, and dispatcher-level
+errors (unknown operation, non-JSON params) carry their own stable codes rather
+than the generic operation_failed.
+"""
+
+import shutil
+import subprocess
+import time
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+from gda.errors import Failure, classify_run
+from gda.models import EngineVersion
+from gda.runner import OPERATIONS_GD, RunResult, SubprocessGodotRunner
+
+GODOT = resolve_godot_binary()
+
+requires_godot = pytest.mark.skipif(
+    not GODOT.exists(), reason=f"real Godot binary not found at {GODOT}"
+)
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_malformed_param_fails_promptly_not_as_timeout():
+    # A non-string path is the input that previously crashed the GDScript's
+    # typed assignment and hung the process until the 60s runner timeout, then
+    # was misclassified as environment/launch_timeout (exit 124). It must now
+    # be a prompt, structured operation failure.
+    runner = SubprocessGodotRunner(GODOT)
+    start = time.monotonic()
+    result = runner.run("scene-get", {"path": 123})
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 30, "the op hung instead of exiting promptly"
+    outcome = classify_run(result, GODOT, EngineVersion)
+    assert isinstance(outcome, Failure)
+    assert outcome.error.category.value == "operation"
+    assert outcome.exit_code != 124  # never the launch_timeout misclassification
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_unknown_operation_yields_stable_code():
+    runner = SubprocessGodotRunner(GODOT)
+    result = runner.run("bogus-op", {})
+
+    outcome = classify_run(result, GODOT, EngineVersion)
+    assert isinstance(outcome, Failure)
+    assert outcome.error.category.value == "operation"
+    assert outcome.error.code == "unknown_operation"
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_non_json_params_yield_stable_code():
+    # Bypass the runner (which json.dumps its params) to hand the op a
+    # syntactically invalid params payload directly.
+    proc = subprocess.run(
+        [str(GODOT), "--headless", "--script", str(OPERATIONS_GD), "--", "info", "{not json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    result = RunResult(stdout=proc.stdout, stderr=proc.stderr, exit_code=proc.returncode)
+
+    outcome = classify_run(result, GODOT, EngineVersion)
+    assert isinstance(outcome, Failure)
+    assert outcome.error.category.value == "operation"
+    assert outcome.error.code == "invalid_params"

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -55,6 +55,37 @@ def test_scene_create_then_get_round_trip(godot_project):
     assert tree["root"]["children"] == []
 
 
+# A hand-written nested scene: Root → Hero → Hitbox, distinct node types.
+NESTED_TSCN = """\
+[gd_scene format=3]
+
+[node name="Root" type="Node2D"]
+
+[node name="Hero" type="Sprite2D" parent="."]
+
+[node name="Hitbox" type="Area2D" parent="Hero"]
+"""
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_get_reports_nested_tree(godot_project):
+    # Guards the SceneState parent/child reconstruction (issue #30): a scene
+    # read without instantiation must still report nested structure correctly.
+    scene_path = godot_project / "nested.tscn"
+    scene_path.write_text(NESTED_TSCN, encoding="utf-8")
+
+    got = _gda("scene", "get", str(scene_path), "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    root = json.loads(got.stdout)["root"]
+    assert (root["name"], root["type"]) == ("Root", "Node2D")
+    hero = root["children"][0]
+    assert (hero["name"], hero["type"]) == ("Hero", "Sprite2D")
+    hitbox = hero["children"][0]
+    assert (hitbox["name"], hitbox["type"]) == ("Hitbox", "Area2D")
+
+
 @pytest.mark.e2e
 @requires_godot
 def test_scene_get_missing_file_yields_structured_error_end_to_end(godot_project):

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -31,6 +31,33 @@ def _gda(*args: str) -> subprocess.CompletedProcess:
 
 @pytest.mark.e2e
 @requires_godot
+def test_res_path_round_trip_against_the_project_fixture(godot_project):
+    # The project context (issue #32): with --project pointing at the temp
+    # project fixture, a res:// path resolves against it — proving the fixture
+    # is actually handed to the engine (it previously never reached it). The
+    # created scene lands inside the project and reads back through res://.
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+
+    def gda(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [gda_bin, *args, "--godot", str(GODOT), "--project", str(godot_project)],
+            capture_output=True,
+            text=True,
+        )
+
+    created = gda("scene", "create", "res://hero.tscn", "--root-type", "Node2D", "--json")
+    assert created.returncode == 0, created.stdout + created.stderr
+    # res:// resolved against the fixture project, not gda's cwd.
+    assert (godot_project / "hero.tscn").exists()
+
+    got = gda("scene", "get", "res://hero.tscn", "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["root"]["type"] == "Node2D"
+
+
+@pytest.mark.e2e
+@requires_godot
 def test_scene_create_then_get_round_trip(godot_project):
     scene_path = godot_project / "main.tscn"
 

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -1,0 +1,88 @@
+"""S1 (e2e): the scene create → get round-trip against the real Godot engine.
+
+The tracer for headless file mutation (issue #18): ``gda scene create`` writes
+a ``.tscn`` into a temp Godot project, ``gda scene get`` reads it back, and the
+structured tree it reports must match what was requested — ``scene get`` IS the
+structured-level verification of ``scene create``'s effect.
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+GODOT = resolve_godot_binary()
+
+requires_godot = pytest.mark.skipif(
+    not GODOT.exists(), reason=f"real Godot binary not found at {GODOT}"
+)
+
+
+def _gda(*args: str) -> subprocess.CompletedProcess:
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+    return subprocess.run(
+        [gda_bin, *args, "--godot", str(GODOT)], capture_output=True, text=True
+    )
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_create_then_get_round_trip(godot_project):
+    scene_path = godot_project / "main.tscn"
+
+    created = _gda(
+        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
+    )
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    data = json.loads(created.stdout)
+    assert data["root_type"] == "Node2D"
+    # The .tscn landed on disk inside the temp project.
+    assert scene_path.exists()
+
+    got = _gda("scene", "get", str(scene_path), "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    tree = json.loads(got.stdout)
+    # Round-trip: the engine loaded the created scene and reports the
+    # requested root type back — the scene file is loadable, not just present.
+    assert tree["root"]["type"] == "Node2D"
+    assert tree["root"]["name"] == "main"
+    assert tree["root"]["children"] == []
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_get_missing_file_yields_structured_error_end_to_end(godot_project):
+    # The finer operation code (issue #18) survives the whole real stack: the
+    # GDScript op reports path_not_found on stderr, the shared classifier
+    # surfaces it as the stable code with the operation exit code.
+    missing = godot_project / "missing.tscn"
+
+    got = _gda("scene", "get", str(missing), "--json")
+
+    assert got.returncode == 4
+    err = json.loads(got.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert str(missing) in err["message"]
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_create_unknown_root_type_yields_structured_error_end_to_end(
+    godot_project,
+):
+    target = godot_project / "bogus.tscn"
+
+    created = _gda("scene", "create", str(target), "--root-type", "NotAClass", "--json")
+
+    assert created.returncode == 4
+    err = json.loads(created.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_root_type"
+    assert not target.exists()

--- a/tests/test_e2e_scene_security.py
+++ b/tests/test_e2e_scene_security.py
@@ -1,0 +1,78 @@
+"""S1 (e2e): reading a scene must not execute the scene's code (issue #30).
+
+``gda scene get`` reports a scene's structured tree by inspecting the packed
+scene's stored state, NOT by instantiating it. Instantiating would run the
+``_init`` of any attached script, so merely *reading* a scene would execute
+arbitrary project code — and a script that prints a sentinel-shaped line could
+forge the command's result (the parser takes the first sentinel match).
+
+This test plants a root script whose ``_init`` both writes a marker file (an
+observable side effect) and prints a forged result block, then asserts neither
+happened: the real tree is reported and the side-effect file does not exist.
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+GODOT = resolve_godot_binary()
+
+requires_godot = pytest.mark.skipif(
+    not GODOT.exists(), reason=f"real Godot binary not found at {GODOT}"
+)
+
+# A root script whose _init has a side effect AND prints a forged result block.
+# If `scene get` instantiates the scene, _init runs: pwned.txt appears and the
+# forged sentinel lands on stdout before the real one.
+EVIL_GD = """\
+extends Node2D
+
+
+func _init() -> void:
+	var f := FileAccess.open("res://pwned.txt", FileAccess.WRITE)
+	if f:
+		f.store_string("executed")
+		f.close()
+	print('<<<GDA:RESULT>>>{"path":"forged","root":{"name":"FORGED","type":"Node","children":[]}}<<<GDA:END>>>')
+"""
+
+# A scene attaching that script to its Node2D root (hand-written .tscn).
+EVIL_TSCN = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://evil.gd" id="1"]
+
+[node name="Root" type="Node2D"]
+script = ExtResource("1")
+"""
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_get_does_not_execute_scene_code(godot_project):
+    (godot_project / "evil.gd").write_text(EVIL_GD, encoding="utf-8")
+    (godot_project / "evil.tscn").write_text(EVIL_TSCN, encoding="utf-8")
+
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+    # Run from inside the project so res://evil.gd resolves — the condition
+    # under which the script would load and (on the buggy path) execute.
+    proc = subprocess.run(
+        [gda_bin, "scene", "get", "evil.tscn", "--json", "--godot", str(GODOT)],
+        capture_output=True,
+        text=True,
+        cwd=str(godot_project),
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    tree = json.loads(proc.stdout)
+    # The real tree, not the script-forged one.
+    assert tree["root"]["name"] == "Root"
+    assert tree["root"]["type"] == "Node2D"
+    assert tree["path"] != "forged"
+    # The script's _init never ran: no side-effect file.
+    assert not (godot_project / "pwned.txt").exists()

--- a/tests/test_info_command.py
+++ b/tests/test_info_command.py
@@ -6,6 +6,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
+from tests.support import inject_runner, sentinel
 
 VERSION_INFO = {
     "major": 4,
@@ -20,27 +21,15 @@ VERSION_INFO = {
 }
 
 
-class FakeRunner:
-    """A fakeable GodotRunner that records its calls and returns a canned result."""
-
-    def __init__(self, result: RunResult) -> None:
-        self.result = result
-        self.calls: list[tuple[str, dict]] = []
-
-    def run(self, operation: str, params: dict) -> RunResult:
-        self.calls.append((operation, params))
-        return self.result
-
-
 def test_info_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner / warnings around the sentinel, plus diagnostics on stderr.
     stdout = (
         "Godot Engine v4.6.3.stable.official\n"
-        "WARNING: benign\n"
-        "<<<GDA:RESULT>>>" + json.dumps(VERSION_INFO) + "<<<GDA:END>>>\n"
+        "WARNING: benign\n" + sentinel(VERSION_INFO)
     )
-    fake = FakeRunner(RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0))
-    monkeypatch.setattr("gda.cli._make_runner", lambda binary: fake)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
 
     result = CliRunner().invoke(app, ["info", "--json"])
 

--- a/tests/test_info_errors.py
+++ b/tests/test_info_errors.py
@@ -14,24 +14,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
-
-
-class FakeRunner:
-    """A fakeable GodotRunner that returns a canned raw RunResult."""
-
-    def __init__(self, result: RunResult) -> None:
-        self.result = result
-        self.calls: list[tuple[str, dict]] = []
-
-    def run(self, operation: str, params: dict) -> RunResult:
-        self.calls.append((operation, params))
-        return self.result
-
-
-def _inject(monkeypatch, result: RunResult) -> FakeRunner:
-    fake = FakeRunner(result)
-    monkeypatch.setattr("gda.cli._make_runner", lambda binary: fake)
-    return fake
+from tests.support import inject_runner as _inject
 
 
 def test_binary_not_found_maps_to_environment_error(monkeypatch):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,8 @@
-"""The gda info result is carried by a typed model (ADR-0004)."""
+"""The gda command results are carried by typed models (ADR-0004)."""
 
 import json
 
-from gda.models import EngineVersion
+from gda.models import EngineVersion, SceneCreateResult, SceneGetResult
 
 
 def test_validates_from_engine_get_version_info_dict():
@@ -48,3 +48,37 @@ def test_round_trips_to_json_object():
     assert dumped["major"] == 4
     assert dumped["minor"] == 6
     assert dumped["string"] == "4.6.3-stable (official)"
+
+
+def test_scene_create_result_round_trips():
+    payload = {"path": "/p/main.tscn", "root_name": "main", "root_type": "Node2D"}
+
+    created = SceneCreateResult.model_validate(payload)
+
+    assert json.loads(created.model_dump_json()) == payload
+
+
+def test_scene_get_result_round_trips_a_nested_tree():
+    # The recursive SceneNode shape, as the scene-get operation emits it: a
+    # validated nested tree must dump back to the identical payload (S2).
+    payload = {
+        "path": "/p/main.tscn",
+        "root": {
+            "name": "main",
+            "type": "Node2D",
+            "children": [
+                {
+                    "name": "Hero",
+                    "type": "Sprite2D",
+                    "children": [
+                        {"name": "Hitbox", "type": "Area2D", "children": []}
+                    ],
+                }
+            ],
+        },
+    }
+
+    scene = SceneGetResult.model_validate(payload)
+
+    assert scene.root.children[0].children[0].name == "Hitbox"
+    assert json.loads(scene.model_dump_json()) == payload

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,66 @@
+"""Godot project resolution: explicit flag > env override > cwd (issue #32).
+
+The resolved directory becomes the engine's ``--path`` so ``res://`` resolves
+deterministically there. An explicitly named directory must actually be a Godot
+project (hold a ``project.godot``); the cwd fallback only counts as a project
+when it holds one, otherwise gda runs projectless (filesystem paths only) — the
+behaviour before project context existed.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from gda.project import GDA_PROJECT_ENV, PROJECT_MARKER, resolve_project_dir
+
+
+def _make_project(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / PROJECT_MARKER).write_text("config_version=5\n", encoding="utf-8")
+    return path
+
+
+def test_explicit_project_wins_over_env_and_cwd(tmp_path):
+    proj = _make_project(tmp_path / "explicit")
+    env = {GDA_PROJECT_ENV: str(_make_project(tmp_path / "env"))}
+
+    resolved = resolve_project_dir(str(proj), env=env, cwd=tmp_path)
+
+    assert resolved == proj
+
+
+def test_env_override_used_when_no_explicit(tmp_path):
+    env_proj = _make_project(tmp_path / "env")
+    env = {GDA_PROJECT_ENV: str(env_proj)}
+
+    resolved = resolve_project_dir(None, env=env, cwd=tmp_path)
+
+    assert resolved == env_proj
+
+
+def test_cwd_used_when_it_is_a_project(tmp_path):
+    proj = _make_project(tmp_path)
+
+    resolved = resolve_project_dir(None, env={}, cwd=proj)
+
+    assert resolved == proj
+
+
+def test_projectless_when_cwd_has_no_project_marker(tmp_path):
+    # No flag, no env, and the cwd is not a project: gda runs projectless
+    # (filesystem paths only), preserving pre-project-context behaviour.
+    resolved = resolve_project_dir(None, env={}, cwd=tmp_path)
+
+    assert resolved is None
+
+
+def test_explicit_non_project_dir_is_rejected(tmp_path):
+    # A named directory that is not a Godot project is a mistake we surface,
+    # not silently treat as projectless.
+    with pytest.raises(ValueError):
+        resolve_project_dir(str(tmp_path), env={}, cwd=tmp_path)
+
+
+def test_explicit_empty_string_is_not_silently_swallowed(tmp_path):
+    with pytest.raises(ValueError):
+        resolve_project_dir("", env={GDA_PROJECT_ENV: str(_make_project(tmp_path))})

--- a/tests/test_scene_commands.py
+++ b/tests/test_scene_commands.py
@@ -1,0 +1,78 @@
+"""S3: gda scene create / scene get success paths against a fake runner (issue #18).
+
+The first domain command group (ADR-0005): each command drives the proven
+headless pipeline — Typer → binary resolution → runner → sentinel parse →
+typed model → JSON — exercised here with canned engine output, no real Godot.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import inject_runner, sentinel
+
+CREATE_RESULT = {
+    "path": "/tmp/proj/main.tscn",
+    "root_name": "main",
+    "root_type": "Node2D",
+}
+
+
+def test_scene_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
+    # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(CREATE_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["scene", "create", "/tmp/proj/main.tscn", "--root-type", "Node2D", "--json"],
+    )
+
+    assert result.exit_code == 0
+    # stdout carries ONLY the result payload — a single valid JSON object.
+    data = json.loads(result.stdout)
+    assert data["path"] == "/tmp/proj/main.tscn"
+    assert data["root_type"] == "Node2D"
+    assert data["root_name"] == "main"
+    # The operation was dispatched by name with the command's typed params.
+    assert fake.calls == [
+        ("scene-create", {"path": "/tmp/proj/main.tscn", "root_type": "Node2D"})
+    ]
+    # Engine/script diagnostics are surfaced on stderr, not stdout.
+    assert "engine diagnostic" in result.stderr
+
+
+GET_RESULT = {
+    "path": "/tmp/proj/main.tscn",
+    "root": {
+        "name": "main",
+        "type": "Node2D",
+        "children": [
+            {
+                "name": "Hero",
+                "type": "Sprite2D",
+                "children": [{"name": "Hitbox", "type": "Area2D", "children": []}],
+            }
+        ],
+    },
+}
+
+
+def test_scene_get_json_emits_structured_node_tree_and_exit_zero(monkeypatch):
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["scene", "get", "/tmp/proj/main.tscn", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    # Root node name + type, nested children where present (issue #18).
+    assert data["root"]["name"] == "main"
+    assert data["root"]["type"] == "Node2D"
+    assert data["root"]["children"][0]["type"] == "Sprite2D"
+    assert data["root"]["children"][0]["children"][0]["name"] == "Hitbox"
+    assert fake.calls == [("scene-get", {"path": "/tmp/proj/main.tscn"})]

--- a/tests/test_scene_commands.py
+++ b/tests/test_scene_commands.py
@@ -11,7 +11,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
-from tests.support import inject_runner, sentinel
+from tests.support import FakeRunner, inject_runner, sentinel
 
 CREATE_RESULT = {
     "path": "/tmp/proj/main.tscn",
@@ -76,3 +76,37 @@ def test_scene_get_json_emits_structured_node_tree_and_exit_zero(monkeypatch):
     assert data["root"]["children"][0]["type"] == "Sprite2D"
     assert data["root"]["children"][0]["children"][0]["name"] == "Hitbox"
     assert fake.calls == [("scene-get", {"path": "/tmp/proj/main.tscn"})]
+
+
+def test_scene_get_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
+    # --project resolves to a project dir and is handed to the runner (which
+    # turns it into the engine's --path so res:// resolves there, issue #32).
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    seen: dict = {}
+
+    def record(binary, project):
+        seen["project"] = project
+        return FakeRunner(RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0))
+
+    monkeypatch.setattr("gda.cli._make_runner", record)
+
+    result = CliRunner().invoke(
+        app, ["scene", "get", "res://main.tscn", "--project", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert seen["project"] == tmp_path
+
+
+def test_scene_get_expands_user_home_in_filesystem_path_but_not_res(monkeypatch):
+    # Path normalization lives at the CLI layer (issue #32): a filesystem path
+    # gets ~ expanded; an engine-resolved res:// path passes through untouched.
+    fake = inject_runner(monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0))
+
+    CliRunner().invoke(app, ["scene", "get", "~/game/main.tscn", "--json"])
+    assert "~" not in fake.calls[0][1]["path"]
+    assert fake.calls[0][1]["path"].endswith("/game/main.tscn")
+
+    fake.calls.clear()
+    CliRunner().invoke(app, ["scene", "get", "res://main.tscn", "--json"])
+    assert fake.calls[0][1]["path"] == "res://main.tscn"

--- a/tests/test_scene_errors.py
+++ b/tests/test_scene_errors.py
@@ -1,0 +1,120 @@
+"""S3: gda scene failure modes map to structured JSON errors + stable exit codes.
+
+Issue #18's acceptance: scene-command failures reuse the shared classification
+(no parallel decision tree) and are distinguishable — environment vs operation
+vs parse by exit code, finer modes (missing path, not-a-scene, bad root type)
+by stable ``GdaError.code`` values. The finer codes ride the ``gda-error:``
+stderr marker the operations payload emits on a structured failure.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import inject_runner
+
+
+def test_scene_get_missing_file_maps_to_stable_path_not_found_code(monkeypatch):
+    # The operation found no file at the target path and reported a structured
+    # failure: exit 4 (operation category), but a finer stable code than the
+    # generic operation_failed so an agent can react to the mode specifically.
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n",
+            stderr="gda-error:path_not_found: scene file does not exist: /x/missing.tscn\n",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["scene", "get", "/x/missing.tscn"])
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert "/x/missing.tscn" in err["message"]
+    # The raw stderr still rides along as diagnostics (ADR-0002).
+    assert "path_not_found" in err["diagnostics"]
+
+
+def test_scene_get_unloadable_file_maps_to_stable_not_a_scene_code(monkeypatch):
+    # The file exists but Godot cannot load it as a PackedScene — distinct
+    # stable code, same operation category and exit code.
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="",
+            stderr="gda-error:not_a_scene: failed to load as a scene: /x/notes.txt\n",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["scene", "get", "/x/notes.txt"])
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "not_a_scene"
+
+
+def test_scene_create_unknown_root_type_maps_to_stable_invalid_root_type_code(
+    monkeypatch,
+):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="",
+            stderr="gda-error:invalid_root_type: not an instantiable Node class: Foo\n",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app, ["scene", "create", "/x/main.tscn", "--root-type", "Foo"]
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_root_type"
+    assert "Foo" in err["message"]
+
+
+def test_scene_get_broken_sentinel_maps_to_parse_error(monkeypatch):
+    # Exit 0 but no result sentinel: the structured-output contract (ADR-0002)
+    # was violated — the shared parse classification applies to scene commands
+    # exactly as it does to info.
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout="no sentinel here\n", stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(app, ["scene", "get", "/x/main.tscn"])
+
+    assert result.exit_code == 5
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "parse"
+    assert err["code"] == "contract_violation"
+
+
+def test_scene_create_missing_binary_maps_to_environment_error(monkeypatch):
+    # The runner's synthetic exit 127 flows through the same shared environment
+    # branch for scene commands as for info.
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="", stderr="gda: Godot binary not found: /x/Godot\n", exit_code=127
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app, ["scene", "create", "/x/main.tscn", "--root-type", "Node2D"]
+    )
+
+    assert result.exit_code == 127
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "environment"
+    assert err["code"] == "binary_not_found"

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -88,6 +88,62 @@ def test_schema_is_emit_only_and_rejects_a_supplied_value():
     assert result.exit_code != 0
 
 
+def test_scene_create_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for the first domain commands (issue #18): the
+    # bare `--schema` flag — no path, no --root-type — short-circuits into the
+    # self-description, derived from the same typed models that back --json.
+    from gda.models import SceneCreateParams, SceneCreateResult
+
+    result = CliRunner().invoke(app, ["scene", "create", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == SceneCreateParams.model_json_schema()
+    assert doc["output"] == SceneCreateResult.model_json_schema()
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_scene_get_schema_emits_model_derived_contract_without_other_args():
+    from gda.models import SceneGetParams, SceneGetResult
+
+    result = CliRunner().invoke(app, ["scene", "get", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == SceneGetParams.model_json_schema()
+    assert doc["output"] == SceneGetResult.model_json_schema()
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_sample_scene_results_validate_against_emitted_output_schemas():
+    # The other half of the ADR-0004 hard gate (issue #18): a sample --json
+    # payload of each scene command satisfies the contract its --schema emits.
+    from tests.test_scene_commands import CREATE_RESULT, GET_RESULT
+
+    create_doc = json.loads(CliRunner().invoke(app, ["scene", "create", "--schema"]).stdout)
+    get_doc = json.loads(CliRunner().invoke(app, ["scene", "get", "--schema"]).stdout)
+
+    jsonschema.validate(instance=CREATE_RESULT, schema=create_doc["output"])
+    jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
+
+
+def test_scene_schema_spawns_no_godot(monkeypatch):
+    # Same locality guarantee the info flag established: --schema must
+    # short-circuit before binary resolution or any runner construction.
+    def boom(*args, **kwargs):
+        raise AssertionError("--schema must not touch the engine")
+
+    monkeypatch.setattr("gda.cli.resolve_godot_binary", boom)
+    monkeypatch.setattr("gda.cli._make_runner", boom)
+
+    for command in (["scene", "create"], ["scene", "get"]):
+        result = CliRunner().invoke(app, [*command, "--schema"])
+        assert result.exit_code == 0
+        assert set(json.loads(result.stdout)) >= {"input", "output"}
+
+
 def test_info_input_schema_is_derived_from_the_params_model():
     # info takes no operation params, so its input schema is trivially empty —
     # expected, not an error — and still derived model-side (ADR-0004).


### PR DESCRIPTION
## What this delivers

The first domain command group (ADR-0005): `gda scene create` writes a new `.tscn` with a chosen root node type, and `gda scene get` reads a scene file back as a structured node tree. Both reuse the pipeline proven by `gda info` (binary resolution → headless one-shot runner → ADR-0002 sentinel parse → typed models → shared `classify_run` → JSON), and ship self-describing via `--schema` (ADR-0004, hard gate).

Implements **#18**. The `if schema:` block was extracted into a shared eager-callback emission helper (per the #18 review note), and `gda info` was migrated onto it plus the shared `_run_classified` pipeline.

## Review-driven hardening

This branch was reviewed at high effort before merge; the three must-fix correctness findings are fixed here, each TDD with e2e coverage against real Godot 4.6:

- **#30 — read without executing scene code.** `scene get` read the tree by `instantiate()`, which runs attached scripts' `_init` — arbitrary code execution on read, and a script could print a forged result. Now reads `PackedScene.get_state()` (SceneState) without constructing any node.
- **#31 — guaranteed single clean exit.** An op hitting a runtime error aborted `_init` before `quit()`, hanging the headless loop until the 60s timeout (then mis-classified `launch_timeout`). Work moved to `_initialize`; `quit()` is owned solely by `_process` (first idle frame), so an aborted op still exits promptly and non-zero. Params read defensively; dispatcher errors get stable codes; `_fail`/`_fail_op` unified.
- **#32 — explicit project context.** The runner passed no `--path`, so `res://` resolution was cwd-dependent and the e2e project fixture never reached the engine. Added `--project` resolution (`--project` > `$GDA_PROJECT` > cwd), passed as `--path`; path normalization centralized at the CLI layer. Decision recorded in **ADR-0006**.

## Tests

69 passing (unit + e2e). The e2e tier auto-skips without a Godot binary.

## Follow-ups (filed, not blocking)

Remaining review findings are tracked as #33–#40 under epic #17 (runner robustness, sentinel-content escaping, create overwrite/root-name, `--schema` callback edge cases, deep-tree recursion, the structured-failure-channel ADR decision, exit-code-ABI docs, test-support dedup).

Closes #18
Closes #30
Closes #31
Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)