### PR TITLE
test(scene): cover the save_failed error path

### DIFF
--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -7,6 +7,7 @@ structured-level verification of ``scene create``'s effect.
 """
 
 import json
+import os
 import shutil
 import subprocess
 
@@ -128,6 +129,33 @@ def test_scene_get_missing_file_yields_structured_error_end_to_end(godot_project
     assert err["category"] == "operation"
     assert err["code"] == "path_not_found"
     assert str(missing) in err["message"]
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_create_unwritable_directory_yields_structured_save_failed(godot_project):
+    # The residual save-failure contract (issue #35): when the destination
+    # cannot be written, the engine's ERR_CANT_OPEN surfaces as the stable
+    # save_failed code. An existing-but-unwritable directory triggers it, so
+    # this stays valid once #35 auto-creates missing parent directories.
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("directory write permissions do not bind as root")
+    locked = godot_project / "locked"
+    locked.mkdir()
+    target = locked / "main.tscn"
+    locked.chmod(0o500)
+    try:
+        created = _gda("scene", "create", str(target), "--root-type", "Node2D", "--json")
+    finally:
+        locked.chmod(0o700)
+
+    assert created.returncode == 4
+    err = json.loads(created.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "save_failed"
+    # The message names the destination the caller must fix.
+    assert str(target) in err["message"]
+    assert not target.exists()
 
 
 @pytest.mark.e2e

--- a/tests/test_scene_errors.py
+++ b/tests/test_scene_errors.py
@@ -83,6 +83,31 @@ def test_scene_create_unknown_root_type_maps_to_stable_invalid_root_type_code(
     assert "Foo" in err["message"]
 
 
+def test_scene_create_save_failure_maps_to_stable_save_failed_code(monkeypatch):
+    # The op built the scene but could not write it (unwritable destination,
+    # read-only filesystem): the structured marker maps to the stable
+    # save_failed code so an agent can tell "fix the destination" apart from
+    # "fix the request" (issue #35).
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="",
+            stderr="gda-error:save_failed: failed to save scene to /x/demo/main.tscn: Can't open\n",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app, ["scene", "create", "/x/demo/main.tscn", "--root-type", "Node2D"]
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "save_failed"
+    assert "/x/demo/main.tscn" in err["message"]
+
+
 def test_scene_get_broken_sentinel_maps_to_parse_error(monkeypatch):
     # Exit 0 but no result sentinel: the structured-output contract (ADR-0002)
     # was violated — the shared parse classification applies to scene commands


### PR DESCRIPTION
## Summary

Pins the previously-untested `save_failed` branch of `scene create` at both levels:

- **Unit** (`test_scene_errors.py`): a `gda-error:save_failed:` stderr marker maps to exit 4, `operation` category, the stable `save_failed` code, with the destination named in the message.
- **E2E** (`test_e2e_scene.py`): against the real engine, an existing-but-unwritable target directory (chmod 0500) triggers `ERR_CANT_OPEN` and surfaces as the structured `save_failed` error, leaving no file behind.

The unwritable-directory trigger (rather than a missing parent directory) keeps both tests valid once #35 implements parent-directory auto-creation — they pin the *residual* save-failure contract, not the behavior #35 will change.

## Not included

This PR is preparatory regression coverage only. None of #35's behavior changes are implemented here (no-clobber, root-name validation, parent-directory auto-creation + `created_dirs` reporting). #35 stays open; see its decision-record comment for the plan this PR is part of.

Refs #35 — intentionally not a closing keyword.

## Test plan

- `uv run pytest` — 71 passed, including the real-Godot e2e run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
