### PR TITLE
Fix operation error reporting contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,28 @@ in-place state (e.g. inspect the live scene tree, runtime inspection, UndoRedo,
 input simulation). Served through `gda-daemon`, not by a one-shot headless call.
 _Avoid_: realtime op, online op
 
+### Failure reporting
+
+**Gda error code**:
+A stable machine-readable code on a `GdaError`, used by agents to branch on a
+specific failure mode without parsing prose.
+_Avoid_: error string, status code
+
+**Operation-reported error code**:
+A `Gda error code` reported by a headless operation itself. It names a failure
+the operation understood and chose to report.
+_Avoid_: script error code, raw engine error
+
+**Classifier error code**:
+A `Gda error code` assigned by `gda` after classifying a runner, parser,
+version, crash, or fallback operation failure.
+_Avoid_: wrapper error code, Python error code
+
+**Error envelope**:
+The structured failure result that distinguishes a failed command from a
+successful result.
+_Avoid_: error blob, failure JSON
+
 ### Delivery phases
 
 The order in which **capabilities** are delivered. This is distinct from ADR-0000's

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -13,19 +13,76 @@ For [headless operations](../../CONTEXT.md) we define a result contract:
 
 - The GDScript emits **exactly one** result payload to **stdout**, wrapped in unique
   sentinels: `<<<GDA:RESULT>>>{...json...}<<<GDA:END>>>`.
+- On success, the sentinel payload is the command's result object and the process
+  exits `0`.
+- On operation failure, the sentinel payload is a minimal error envelope with an
+  operation-reported error code and message, and the process exits non-zero. `gda`
+  validates the reported code, assigns the `operation` category, and attaches
+  stderr diagnostics before emitting the public `GdaError`.
 - The GDScript routes **all** of its own diagnostics (logs, warnings, progress) to
-  **stderr**. stdout carries nothing but the contract.
+  **stderr**. stderr is diagnostic only; it is never parsed for stable error codes.
 - `gda` extracts the bytes between the sentinels and parses that as the result;
   everything else on stdout is ignored, and stderr is surfaced for diagnostics.
 - A **result file** (a path passed in by `gda`, written by the GDScript) is reserved
   as an escape hatch for large or binary payloads that should not stream through
   stdout.
 
+## Failure contract
+
+The process exit code selects the success/failure channel; the sentinel payload
+provides the structured detail for that channel:
+
+- `exit_code == 0` plus a success payload means success.
+- `exit_code == 0` plus an error envelope is a structured-output contract
+  violation.
+- `exit_code != 0` plus a valid, registered operation error envelope means an
+  `operation` failure with the reported code and message.
+- `exit_code != 0` without a valid operation error envelope falls back to
+  `operation_failed`.
+
+An operation failure payload has this wire shape:
+
+```json
+{"error":{"code":"path_not_found","message":"scene file does not exist: res://missing.tscn"}}
+```
+
+The GDScript payload owns only `code` and `message`. `gda` owns the public
+`GdaError` wrapper: it validates that the code is registered, assigns the
+`operation` category, preserves the message, and copies stderr into diagnostics.
+
+## `GdaError.code` registry
+
+`GdaError.code` values are a public ABI for agents. Their authoritative source is
+the Python registry in `src/gda/error_codes.py`; the table below mirrors that
+source and is checked by tests. GDScript mirrors only the rows whose source is
+`operation`, because only those codes can be reported by headless operations.
+
+| Code | Category | Source | Meaning |
+| --- | --- | --- | --- |
+| `binary_not_found` | `environment` | `runner` | The Godot binary could not be launched. |
+| `launch_timeout` | `environment` | `runner` | Godot launched but did not return before the runner timeout. |
+| `unsupported_version` | `version` | `version_gate` | The detected Godot version is below the supported minimum. |
+| `engine_crashed` | `operation` | `classifier` | Godot terminated abnormally, such as by signal death. |
+| `operation_failed` | `operation` | `classifier` | The engine or operation failed without a valid registered operation error envelope. |
+| `usage_error` | `operation` | `operation` | The operation dispatcher was invoked without the required operation name. |
+| `unknown_operation` | `operation` | `operation` | The operation dispatcher received an unknown operation name. |
+| `invalid_params` | `operation` | `operation` | The operation dispatcher received params that are not a JSON object. |
+| `invalid_path` | `operation` | `operation` | A required path parameter is missing or invalid. |
+| `invalid_root_type` | `operation` | `operation` | A requested Godot root node type cannot be instantiated as a `Node`. |
+| `save_failed` | `operation` | `operation` | A scene could not be packed or saved. |
+| `path_not_found` | `operation` | `operation` | A requested scene file does not exist. |
+| `not_a_scene` | `operation` | `operation` | A requested file cannot be loaded as a `PackedScene`. |
+| `contract_violation` | `parse` | `parser` | The process claimed success but violated the structured-output contract. |
+
 ## Considered options
 
 - **Sentinel-delimited JSON on stdout** (chosen) — simplest, streamable, and the
   unique marker isolates the result from engine noise. Generalises to the
   per-message protocol the daemon will need in Phase 2.
+- **Separate `gda-error:<code>:` marker on stderr for operation failures** —
+  rejected; stderr is also where engine and script diagnostics appear, so parsing
+  it for stable codes is spoofable. Regex capture also truncates multiline
+  messages. Success and failure should share one structured channel instead.
 - **Result file always** — strongest isolation from stdout noise, but adds temp-file
   lifecycle and cannot stream; kept only as the large-payload escape hatch.
 - **Raw passthrough** (like `godot-mcp`) — rejected; it abandons the structured-output
@@ -37,3 +94,9 @@ For [headless operations](../../CONTEXT.md) we define a result contract:
   outside the sentinels is a contract violation that corrupts results.
 - The sentinel strings are part of the wire contract between `gda` and its GDScript
   payloads, and changing them is a breaking change.
+- Adding or changing a `GdaError.code` requires updating the Python registry, this
+  ADR's registry table, and any GDScript operation-code mirror. Tests must reject
+  drift between those copies.
+- `gda <command> --schema` currently describes the success result model. Whether
+  command output schemas should include failure envelopes is a separate decision
+  tracked in #43.

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -1,0 +1,126 @@
+"""Authoritative registry of public ``GdaError.code`` values.
+
+The registry is the machine-readable companion to ADR-0002's table. Every code
+emitted in a public ``GdaError`` must be declared here; GDScript mirrors only
+the ``operation`` source subset because only those codes are reported by
+headless operations.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+from gda.models import ErrorCategory
+
+
+class ErrorCodeSource(str, Enum):
+    """Where a public ``GdaError.code`` originates."""
+
+    RUNNER = "runner"
+    CLASSIFIER = "classifier"
+    OPERATION = "operation"
+    PARSER = "parser"
+    VERSION_GATE = "version_gate"
+
+
+@dataclass(frozen=True)
+class ErrorCodeSpec:
+    """One public ``GdaError.code`` registry entry."""
+
+    code: str
+    category: ErrorCategory
+    source: ErrorCodeSource
+    description: str
+
+
+ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
+    ErrorCodeSpec(
+        "binary_not_found",
+        ErrorCategory.ENVIRONMENT,
+        ErrorCodeSource.RUNNER,
+        "The Godot binary could not be launched.",
+    ),
+    ErrorCodeSpec(
+        "launch_timeout",
+        ErrorCategory.ENVIRONMENT,
+        ErrorCodeSource.RUNNER,
+        "Godot launched but did not return before the runner timeout.",
+    ),
+    ErrorCodeSpec(
+        "unsupported_version",
+        ErrorCategory.VERSION,
+        ErrorCodeSource.VERSION_GATE,
+        "The detected Godot version is below the supported minimum.",
+    ),
+    ErrorCodeSpec(
+        "engine_crashed",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.CLASSIFIER,
+        "Godot terminated abnormally, such as by signal death.",
+    ),
+    ErrorCodeSpec(
+        "operation_failed",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.CLASSIFIER,
+        "The engine or operation failed without a valid registered operation error envelope.",
+    ),
+    ErrorCodeSpec(
+        "usage_error",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "The operation dispatcher was invoked without the required operation name.",
+    ),
+    ErrorCodeSpec(
+        "unknown_operation",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "The operation dispatcher received an unknown operation name.",
+    ),
+    ErrorCodeSpec(
+        "invalid_params",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "The operation dispatcher received params that are not a JSON object.",
+    ),
+    ErrorCodeSpec(
+        "invalid_path",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A required path parameter is missing or invalid.",
+    ),
+    ErrorCodeSpec(
+        "invalid_root_type",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A requested Godot root node type cannot be instantiated as a Node.",
+    ),
+    ErrorCodeSpec(
+        "save_failed",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A scene could not be packed or saved.",
+    ),
+    ErrorCodeSpec(
+        "path_not_found",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A requested scene file does not exist.",
+    ),
+    ErrorCodeSpec(
+        "not_a_scene",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A requested file cannot be loaded as a PackedScene.",
+    ),
+    ErrorCodeSpec(
+        "contract_violation",
+        ErrorCategory.PARSE,
+        ErrorCodeSource.PARSER,
+        "The process claimed success but violated the structured-output contract.",
+    ),
+)
+
+ERROR_CODE_BY_CODE: dict[str, ErrorCodeSpec] = {spec.code: spec for spec in ERROR_CODES}
+
+OPERATION_ERROR_CODES: frozenset[str] = frozenset(
+    spec.code for spec in ERROR_CODES if spec.source is ErrorCodeSource.OPERATION
+)

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -19,9 +19,10 @@ engine. The decision tree, top to bottom (``code`` in parentheses; the four
 - exit 127  → environment / binary_not_found      (runner could not launch it)
 - exit 124  → environment / launch_timeout        (launched, hung past timeout)
 - exit < 0  → operation   / engine_crashed         (engine killed by a signal)
-- exit ≠ 0  → operation   / <marker code>           (operation reported a structured
-  failure via the ``gda-error:<code>:`` stderr marker — e.g. path_not_found)
-- exit ≠ 0  → operation   / operation_failed        (engine ran, operation errored)
+- exit ≠ 0  → operation   / <operation code>        (operation reported a structured
+  failure via the ADR-0002 error envelope — e.g. path_not_found)
+- exit ≠ 0  → operation   / operation_failed        (engine ran, operation errored
+  without a valid registered error envelope)
 - contract  → parse       / contract_violation      (sentinel/JSON/shape invalid)
 - old       → version     / unsupported_version     (below the ADR-0003 minimum,
   ``info``'s per-command layer)
@@ -32,13 +33,13 @@ get distinct small codes so a shell consumer can tell categories apart without
 parsing the JSON error.
 """
 
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeVar
 
 from pydantic import BaseModel, ValidationError
 
+from gda.error_codes import ERROR_CODE_BY_CODE, OPERATION_ERROR_CODES
 from gda.exit_codes import (
     EXIT_NOT_FOUND,
     EXIT_OPERATION,
@@ -46,19 +47,13 @@ from gda.exit_codes import (
     EXIT_TIMEOUT,
     EXIT_VERSION,
 )
-from gda.models import EngineVersion, ErrorCategory, GdaError
+from gda.models import EngineVersion, ErrorCategory, GdaError, OperationErrorEnvelope
 from gda.parser import parse_result
 from gda.runner import RunResult
 
 # The minimum supported Godot version (ADR-0003): the floor where the modern
 # features gda relies on exist. Resolved from the version gda info reports.
 MIN_GODOT_VERSION = (4, 4)
-
-# A structured operation failure, as the operations payload reports it on
-# stderr: ``gda-error:<code>: <message>``. The marker refines the generic
-# operation_failed bucket into the operation's own stable, finer code
-# (e.g. path_not_found, not_a_scene) — same category, same exit code.
-_OP_ERROR_MARKER = re.compile(r"^gda-error:([a-z_]+): ?(.*)$", re.MULTILINE)
 
 
 @dataclass
@@ -82,6 +77,14 @@ def _failure(
     call site, so they live here once: the call sites then read as the taxonomy
     itself — a (category, code, message, exit_code) row per failure mode.
     """
+    spec = ERROR_CODE_BY_CODE.get(code)
+    if spec is None:
+        raise RuntimeError(f"unregistered GdaError.code: {code}")
+    if spec.category is not category:
+        raise RuntimeError(
+            f"GdaError.code {code!r} is registered as {spec.category.value}, "
+            f"not {category.value}"
+        )
     return Failure(
         GdaError(category=category, code=code, message=message, diagnostics=stderr),
         exit_code=exit_code,
@@ -89,6 +92,19 @@ def _failure(
 
 
 M = TypeVar("M", bound=BaseModel)
+
+
+def _operation_error_from_payload(result: RunResult) -> tuple[str, str] | None:
+    """Extract a minimal operation error envelope from stdout, if present."""
+    try:
+        payload = parse_result(result.stdout)
+    except ValueError:
+        return None
+    try:
+        envelope = OperationErrorEnvelope.model_validate(payload)
+    except ValidationError:
+        return None
+    return envelope.error.code, envelope.error.message
 
 
 def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | Failure:
@@ -127,22 +143,31 @@ def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | 
     if result.exit_code != 0:
         # The engine ran but the operation itself reported an error and quit
         # non-zero (its own exit, not the runner's synthetic 124/127). When the
-        # operation reported the failure *structurally* via the gda-error
-        # stderr marker, surface its finer stable code; otherwise fall back to
-        # the generic operation_failed.
-        marker = _OP_ERROR_MARKER.search(result.stderr)
-        if marker:
+        # operation reported the failure structurally via the ADR-0002 sentinel
+        # error envelope, surface its registered finer code; otherwise fall
+        # back to the generic operation_failed.
+        payload_error = _operation_error_from_payload(result)
+        if payload_error is not None:
+            code, message = payload_error
+            if code not in OPERATION_ERROR_CODES:
+                return _failure(
+                    ErrorCategory.OPERATION,
+                    "operation_failed",
+                    f"headless operation reported unregistered error code: {code}",
+                    EXIT_OPERATION,
+                    result.stderr,
+                )
             return _failure(
                 ErrorCategory.OPERATION,
-                marker.group(1),
-                marker.group(2) or "the headless operation reported an error",
+                code,
+                message or "the headless operation reported an error",
                 EXIT_OPERATION,
                 result.stderr,
             )
         return _failure(
             ErrorCategory.OPERATION,
             "operation_failed",
-            "the headless operation reported an error",
+            "the headless operation exited non-zero without a structured error",
             EXIT_OPERATION,
             result.stderr,
         )

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -9,7 +9,7 @@ hand-maintaining the contract twice.
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class ErrorCategory(str, Enum):
@@ -57,6 +57,28 @@ class GdaErrorEnvelope(BaseModel):
     """
 
     error: GdaError
+
+
+class OperationError(BaseModel):
+    """The minimal operation-reported failure payload (ADR-0002).
+
+    Headless operations only report the part they own: a registered operation
+    error ``code`` and a human-readable ``message``. The Python classifier adds
+    category and diagnostics when it builds the public ``GdaError``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    message: str
+
+
+class OperationErrorEnvelope(BaseModel):
+    """The sentinel payload shape for a headless operation failure."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    error: OperationError
 
 
 class InfoParams(BaseModel):

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -9,9 +9,9 @@ extends SceneTree
 # sentinels, and routes all of its own diagnostics to stderr. stdout carries
 # nothing but the sentinel-delimited result; everything else is engine noise.
 #
-# An operation that fails reports it structurally on stderr as
-# `gda-error:<code>: <message>`; gda's shared classifier surfaces <code> as the
-# stable GdaError.code (issue #18).
+# An operation that fails reports it structurally through the same stdout
+# sentinels as success, using a minimal error envelope. gda's shared classifier
+# surfaces the registered code as the stable GdaError.code (ADR-0002).
 #
 # Control flow (issue #31): all work happens in _initialize, but the process is
 # quit from _process — which runs on the first idle frame regardless of whether
@@ -24,6 +24,15 @@ extends SceneTree
 const RESULT_BEGIN := "<<<GDA:RESULT>>>"
 const RESULT_END := "<<<GDA:END>>>"
 
+const OP_ERROR_USAGE := "usage_error"
+const OP_ERROR_UNKNOWN_OPERATION := "unknown_operation"
+const OP_ERROR_INVALID_PARAMS := "invalid_params"
+const OP_ERROR_INVALID_PATH := "invalid_path"
+const OP_ERROR_INVALID_ROOT_TYPE := "invalid_root_type"
+const OP_ERROR_SAVE_FAILED := "save_failed"
+const OP_ERROR_PATH_NOT_FOUND := "path_not_found"
+const OP_ERROR_NOT_A_SCENE := "not_a_scene"
+
 # The exit code the process will use. Defaults to failure, so an operation that
 # aborts before recording an outcome (e.g. an uncaught runtime error) still
 # exits non-zero rather than reporting a phantom success.
@@ -35,7 +44,7 @@ func _initialize() -> void:
 	# [params_json] — arrives here, independent of engine argument ordering.
 	var args := OS.get_cmdline_user_args()
 	if args.is_empty():
-		_fail("usage_error", "usage: godot --headless --script operations.gd -- <operation> [params_json]")
+		_fail(OP_ERROR_USAGE, "usage: godot --headless --script operations.gd -- <operation> [params_json]")
 		return
 
 	var operation: String = args[0]
@@ -51,7 +60,7 @@ func _initialize() -> void:
 		"scene-get":
 			_op_scene_get(params)
 		_:
-			_fail("unknown_operation", "unknown operation: " + operation)
+			_fail(OP_ERROR_UNKNOWN_OPERATION, "unknown operation: " + operation)
 
 
 # Quit on the first idle frame, whatever happened during _initialize — this is
@@ -68,7 +77,7 @@ func _parse_params(args: PackedStringArray) -> Variant:
 		return {}
 	var parsed: Variant = JSON.parse_string(args[1])
 	if not (parsed is Dictionary):
-		_fail("invalid_params", "params is not a JSON object: " + args[1])
+		_fail(OP_ERROR_INVALID_PARAMS, "params is not a JSON object: " + args[1])
 		return null
 	return parsed
 
@@ -85,12 +94,12 @@ func _op_scene_create(params: Dictionary) -> void:
 	_diag("running operation: scene-create")
 	var path := _string_param(params, "path")
 	if path.is_empty():
-		_fail("invalid_path", "missing required param: path")
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
 		return
 	var root_type := _string_param(params, "root_type")
 	if root_type.is_empty() or not ClassDB.can_instantiate(root_type) \
 			or not ClassDB.is_parent_class(root_type, "Node"):
-		_fail("invalid_root_type", "not an instantiable Node class: " + root_type)
+		_fail(OP_ERROR_INVALID_ROOT_TYPE, "not an instantiable Node class: " + root_type)
 		return
 
 	var root: Node = ClassDB.instantiate(root_type)
@@ -101,12 +110,12 @@ func _op_scene_create(params: Dictionary) -> void:
 	var pack_err := packed.pack(root)
 	if pack_err != OK:
 		root.free()
-		_fail("save_failed", "failed to pack scene: " + error_string(pack_err))
+		_fail(OP_ERROR_SAVE_FAILED, "failed to pack scene: " + error_string(pack_err))
 		return
 	var save_err := ResourceSaver.save(packed, path)
 	root.free()
 	if save_err != OK:
-		_fail("save_failed", "failed to save scene to " + path + ": " + error_string(save_err))
+		_fail(OP_ERROR_SAVE_FAILED, "failed to save scene to " + path + ": " + error_string(save_err))
 		return
 
 	_succeed({
@@ -127,19 +136,19 @@ func _op_scene_get(params: Dictionary) -> void:
 	_diag("running operation: scene-get")
 	var path := _string_param(params, "path")
 	if path.is_empty():
-		_fail("invalid_path", "missing required param: path")
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
 		return
 	if not FileAccess.file_exists(path):
-		_fail("path_not_found", "scene file does not exist: " + path)
+		_fail(OP_ERROR_PATH_NOT_FOUND, "scene file does not exist: " + path)
 		return
 
 	var packed := ResourceLoader.load(path, "PackedScene") as PackedScene
 	if packed == null:
-		_fail("not_a_scene", "failed to load as a scene: " + path)
+		_fail(OP_ERROR_NOT_A_SCENE, "failed to load as a scene: " + path)
 		return
 	var state := packed.get_state()
 	if state == null or state.get_node_count() == 0:
-		_fail("not_a_scene", "scene declares no root node: " + path)
+		_fail(OP_ERROR_NOT_A_SCENE, "scene declares no root node: " + path)
 		return
 
 	_succeed({"path": path, "root": _tree_from_state(state)})
@@ -189,8 +198,13 @@ func _diag(message: String) -> void:
 	printerr("gda: " + message)
 
 
-# Record a structured failure: the stable finer code rides the stderr marker
-# (issue #18) and the process is left to exit non-zero via _process.
+# Record a structured failure through the ADR-0002 sentinel contract. The
+# process is left to exit non-zero via _process.
 func _fail(code: String, message: String) -> void:
-	printerr("gda-error:" + code + ": " + message)
+	print(RESULT_BEGIN + JSON.stringify({
+		"error": {
+			"code": code,
+			"message": message,
+		},
+	}) + RESULT_END)
 	_exit_code = 1

--- a/tests/support.py
+++ b/tests/support.py
@@ -29,6 +29,11 @@ def sentinel(payload: dict) -> str:
     return f"<<<GDA:RESULT>>>{json.dumps(payload)}<<<GDA:END>>>\n"
 
 
+def error_sentinel(code: str, message: str) -> str:
+    """Wrap a minimal ADR-0002 operation error envelope in result sentinels."""
+    return sentinel({"error": {"code": code, "message": message}})
+
+
 def inject_runner(monkeypatch, result: RunResult) -> FakeRunner:
     """Swap the CLI's runner seam for a ``FakeRunner`` returning ``result``."""
     fake = FakeRunner(result)

--- a/tests/test_classify_run.py
+++ b/tests/test_classify_run.py
@@ -34,6 +34,10 @@ def _sentinel(payload: dict) -> str:
     return f"<<<GDA:RESULT>>>{json.dumps(payload)}<<<GDA:END>>>\n"
 
 
+def _error_sentinel(code: str, message: str) -> str:
+    return _sentinel({"error": {"code": code, "message": message}})
+
+
 def test_clean_run_parses_payload_into_the_commands_typed_model():
     # The engine exited 0 and stdout carries a sentinel payload matching the
     # command's model: classify_run returns the validated model instance, with
@@ -113,16 +117,11 @@ def test_engine_nonzero_exit_maps_to_operation_failure():
     assert outcome.error.code == "operation_failed"
 
 
-def test_structured_op_failure_marker_refines_the_operation_code():
-    # An operation that reports its failure structurally — the
-    # ``gda-error:<code>: <message>`` stderr marker (issue #18) — surfaces its
-    # own stable finer code instead of the generic operation_failed, with the
-    # same operation category and exit code. Command-agnostic: the refinement
-    # lives in the shared tree, not in any per-command classifier.
+def test_structured_op_failure_envelope_refines_the_operation_code():
     result = RunResult(
-        stdout="Godot Engine v4.6.stable\n",
-        stderr="gda: running operation: scene-get\n"
-        "gda-error:path_not_found: scene file does not exist: /x/a.tscn\n",
+        stdout="Godot Engine v4.6.stable\n"
+        + _error_sentinel("path_not_found", "scene file does not exist: /x/a.tscn"),
+        stderr="gda: running operation: scene-get\n",
         exit_code=1,
     )
 
@@ -134,6 +133,89 @@ def test_structured_op_failure_marker_refines_the_operation_code():
     assert outcome.error.code == "path_not_found"
     assert outcome.error.message == "scene file does not exist: /x/a.tscn"
     assert outcome.error.diagnostics == result.stderr
+
+
+def test_structured_op_failure_message_can_contain_newlines():
+    message = "scene file does not exist: /x/path\nwith-newline.tscn"
+    result = RunResult(
+        stdout=_error_sentinel("path_not_found", message),
+        stderr="",
+        exit_code=1,
+    )
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "path_not_found"
+    assert outcome.error.message == message
+
+
+def test_stderr_marker_spoof_does_not_forge_an_operation_code():
+    result = RunResult(
+        stdout="Godot Engine v4.6.stable\n",
+        stderr="gda-error:path_not_found: forged by engine noise\n",
+        exit_code=1,
+    )
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.category == ErrorCategory.OPERATION
+    assert outcome.error.code == "operation_failed"
+    assert outcome.error.diagnostics == result.stderr
+
+
+def test_unregistered_operation_error_code_falls_back_to_operation_failed():
+    result = RunResult(
+        stdout=_error_sentinel("forged_code", "forged message"),
+        stderr="",
+        exit_code=1,
+    )
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.category == ErrorCategory.OPERATION
+    assert outcome.error.code == "operation_failed"
+    assert "forged_code" in outcome.error.message
+
+
+def test_operation_error_envelope_rejects_public_error_extra_fields():
+    result = RunResult(
+        stdout=_sentinel(
+            {
+                "error": {
+                    "category": "operation",
+                    "code": "path_not_found",
+                    "message": "scene file does not exist",
+                    "diagnostics": "not owned by the operation payload",
+                }
+            }
+        ),
+        stderr="",
+        exit_code=1,
+    )
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.category == ErrorCategory.OPERATION
+    assert outcome.error.code == "operation_failed"
+
+
+def test_error_envelope_with_zero_exit_maps_to_parse_failure():
+    result = RunResult(
+        stdout=_error_sentinel("path_not_found", "scene file does not exist"),
+        stderr="",
+        exit_code=0,
+    )
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.exit_code == 5
+    assert outcome.error.category == ErrorCategory.PARSE
+    assert outcome.error.code == "contract_violation"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -118,8 +118,9 @@ def test_scene_get_reports_nested_tree(godot_project):
 @requires_godot
 def test_scene_get_missing_file_yields_structured_error_end_to_end(godot_project):
     # The finer operation code (issue #18) survives the whole real stack: the
-    # GDScript op reports path_not_found on stderr, the shared classifier
-    # surfaces it as the stable code with the operation exit code.
+    # GDScript op reports path_not_found through the ADR-0002 error envelope,
+    # and the shared classifier surfaces it as the stable code with the
+    # operation exit code.
     missing = godot_project / "missing.tscn"
 
     got = _gda("scene", "get", str(missing), "--json")

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -1,0 +1,78 @@
+"""ADR-0002 error-code registry drift checks."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from gda.error_codes import (
+    ERROR_CODE_BY_CODE,
+    ERROR_CODES,
+    OPERATION_ERROR_CODES,
+    ErrorCodeSource,
+)
+from gda.errors import _failure
+from gda.exit_codes import EXIT_OPERATION
+from gda.models import ErrorCategory
+
+ROOT = Path(__file__).resolve().parents[1]
+ADR_0002 = ROOT / "docs" / "adr" / "0002-headless-structured-output-contract.md"
+OPERATIONS_GD = ROOT / "src" / "gda" / "ops" / "operations.gd"
+
+ADR_REGISTRY_ROW = re.compile(r"^\| `([^`]+)` \| `([^`]+)` \| `([^`]+)` \|")
+GDSCRIPT_OPERATION_CODE = re.compile(r'^const OP_ERROR_[A-Z_]+ := "([a-z_]+)"$', re.MULTILINE)
+BARE_FAIL_CODE = re.compile(r'_fail\(\s*"[a-z_]+"')
+
+
+def _adr_registry() -> dict[str, tuple[str, str]]:
+    rows: dict[str, tuple[str, str]] = {}
+    for line in ADR_0002.read_text(encoding="utf-8").splitlines():
+        match = ADR_REGISTRY_ROW.match(line)
+        if match:
+            code, category, source = match.groups()
+            rows[code] = (category, source)
+    return rows
+
+
+def _python_registry() -> dict[str, tuple[str, str]]:
+    return {
+        spec.code: (spec.category.value, spec.source.value)
+        for spec in ERROR_CODES
+    }
+
+
+def test_python_error_registry_has_no_duplicate_codes():
+    assert len(ERROR_CODES) == len(ERROR_CODE_BY_CODE)
+
+
+def test_failure_builder_rejects_unregistered_public_codes():
+    with pytest.raises(RuntimeError, match="unregistered GdaError.code"):
+        _failure(
+            ErrorCategory.OPERATION,
+            "not_registered",
+            "message",
+            EXIT_OPERATION,
+            "",
+        )
+
+
+def test_adr_registry_matches_python_authoritative_registry():
+    assert _adr_registry() == _python_registry()
+
+
+def test_gdscript_operation_error_codes_mirror_python_operation_subset():
+    gdscript = OPERATIONS_GD.read_text(encoding="utf-8")
+    mirrored_codes = set(GDSCRIPT_OPERATION_CODE.findall(gdscript))
+
+    python_operation_codes = {
+        spec.code for spec in ERROR_CODES if spec.source is ErrorCodeSource.OPERATION
+    }
+
+    assert mirrored_codes == python_operation_codes
+    assert mirrored_codes == set(OPERATION_ERROR_CODES)
+
+
+def test_gdscript_fail_calls_do_not_use_literal_error_codes():
+    gdscript = OPERATIONS_GD.read_text(encoding="utf-8")
+
+    assert not BARE_FAIL_CODE.search(gdscript)

--- a/tests/test_scene_errors.py
+++ b/tests/test_scene_errors.py
@@ -3,8 +3,8 @@
 Issue #18's acceptance: scene-command failures reuse the shared classification
 (no parallel decision tree) and are distinguishable — environment vs operation
 vs parse by exit code, finer modes (missing path, not-a-scene, bad root type)
-by stable ``GdaError.code`` values. The finer codes ride the ``gda-error:``
-stderr marker the operations payload emits on a structured failure.
+by stable ``GdaError.code`` values. The finer codes ride the ADR-0002 error
+envelope the operations payload emits on a structured failure.
 """
 
 import json
@@ -13,7 +13,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
-from tests.support import inject_runner
+from tests.support import error_sentinel, inject_runner
 
 
 def test_scene_get_missing_file_maps_to_stable_path_not_found_code(monkeypatch):
@@ -23,8 +23,11 @@ def test_scene_get_missing_file_maps_to_stable_path_not_found_code(monkeypatch):
     inject_runner(
         monkeypatch,
         RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n",
-            stderr="gda-error:path_not_found: scene file does not exist: /x/missing.tscn\n",
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(
+                "path_not_found", "scene file does not exist: /x/missing.tscn"
+            ),
+            stderr="gda: running operation: scene-get\n",
             exit_code=1,
         ),
     )
@@ -37,7 +40,7 @@ def test_scene_get_missing_file_maps_to_stable_path_not_found_code(monkeypatch):
     assert err["code"] == "path_not_found"
     assert "/x/missing.tscn" in err["message"]
     # The raw stderr still rides along as diagnostics (ADR-0002).
-    assert "path_not_found" in err["diagnostics"]
+    assert err["diagnostics"] == "gda: running operation: scene-get\n"
 
 
 def test_scene_get_unloadable_file_maps_to_stable_not_a_scene_code(monkeypatch):
@@ -46,8 +49,10 @@ def test_scene_get_unloadable_file_maps_to_stable_not_a_scene_code(monkeypatch):
     inject_runner(
         monkeypatch,
         RunResult(
-            stdout="",
-            stderr="gda-error:not_a_scene: failed to load as a scene: /x/notes.txt\n",
+            stdout=error_sentinel(
+                "not_a_scene", "failed to load as a scene: /x/notes.txt"
+            ),
+            stderr="",
             exit_code=1,
         ),
     )
@@ -66,8 +71,10 @@ def test_scene_create_unknown_root_type_maps_to_stable_invalid_root_type_code(
     inject_runner(
         monkeypatch,
         RunResult(
-            stdout="",
-            stderr="gda-error:invalid_root_type: not an instantiable Node class: Foo\n",
+            stdout=error_sentinel(
+                "invalid_root_type", "not an instantiable Node class: Foo"
+            ),
+            stderr="",
             exit_code=1,
         ),
     )
@@ -85,14 +92,17 @@ def test_scene_create_unknown_root_type_maps_to_stable_invalid_root_type_code(
 
 def test_scene_create_save_failure_maps_to_stable_save_failed_code(monkeypatch):
     # The op built the scene but could not write it (unwritable destination,
-    # read-only filesystem): the structured marker maps to the stable
+    # read-only filesystem): the structured error envelope maps to the stable
     # save_failed code so an agent can tell "fix the destination" apart from
     # "fix the request" (issue #35).
     inject_runner(
         monkeypatch,
         RunResult(
-            stdout="",
-            stderr="gda-error:save_failed: failed to save scene to /x/demo/main.tscn: Can't open\n",
+            stdout=error_sentinel(
+                "save_failed",
+                "failed to save scene to /x/demo/main.tscn: Can't open",
+            ),
+            stderr="",
             exit_code=1,
         ),
     )


### PR DESCRIPTION
## Summary

- route headless operation failures through the ADR-0002 sentinel error envelope instead of parsing stderr markers
- add a Python authoritative GdaError.code registry with GDScript operation-code mirrors and drift tests
- update CONTEXT.md and ADR-0002 with the failure-reporting language, registry, and schema follow-up note

## Tests

- uv run pytest -m "not e2e"
- uv run pytest -m e2e

Fixes #38