### PR TITLE
fix(scene): harden scene create integrity

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -69,6 +69,8 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 | `invalid_params` | `operation` | `operation` | The operation dispatcher received params that are not a JSON object. |
 | `invalid_path` | `operation` | `operation` | A required path parameter is missing or invalid. |
 | `invalid_root_type` | `operation` | `operation` | A requested Godot root node type cannot be instantiated as a `Node`. |
+| `invalid_root_name` | `operation` | `operation` | A requested root node name is empty or would be rewritten by Godot. |
+| `already_exists` | `operation` | `operation` | A create operation target already exists and will not be overwritten. |
 | `save_failed` | `operation` | `operation` | A scene could not be packed or saved. |
 | `path_not_found` | `operation` | `operation` | A requested scene file does not exist. |
 | `not_a_scene` | `operation` | `operation` | A requested file cannot be loaded as a `PackedScene`. |

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -95,6 +95,14 @@ def _normalize_path(path: str) -> str:
     return str(Path(path).expanduser())
 
 
+def _derive_scene_root_name(path: str) -> str:
+    """Derive the default scene root name from the target file name."""
+    filename = path.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
+    if "." in filename:
+        return filename.rsplit(".", 1)[0]
+    return filename
+
+
 def _schema_option(
     input_model: type[BaseModel], output_model: type[BaseModel]
 ) -> bool:
@@ -182,15 +190,30 @@ def create(
         "--root-type",
         help="Godot node class of the new scene's root (e.g. Node2D).",
     ),
+    root_name: Optional[str] = typer.Option(
+        None,
+        "--root-name",
+        help=(
+            "Root node name to write. Defaults to the target filename without "
+            "its final extension."
+        ),
+    ),
     json_output: bool = _json_option(),
     schema: bool = _schema_option(SceneCreateParams, SceneCreateResult),
     godot: Optional[str] = _godot_option(),
     project: Optional[str] = _project_option(),
 ) -> None:
     """Create a new .tscn scene file with the given root node type."""
+    normalized_path = _normalize_path(path)
     created = _run_classified(
         "scene-create",
-        SceneCreateParams(path=_normalize_path(path), root_type=root_type),
+        SceneCreateParams(
+            path=normalized_path,
+            root_type=root_type,
+            root_name=root_name
+            if root_name is not None
+            else _derive_scene_root_name(normalized_path),
+        ),
         lambda result, binary: classify_run(result, binary, SceneCreateResult),
         godot,
         resolve_project_dir(project),

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -94,6 +94,18 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A requested Godot root node type cannot be instantiated as a Node.",
     ),
     ErrorCodeSpec(
+        "invalid_root_name",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A requested root node name is empty or would be rewritten by Godot.",
+    ),
+    ErrorCodeSpec(
+        "already_exists",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A create operation target already exists and will not be overwritten.",
+    ),
+    ErrorCodeSpec(
         "save_failed",
         ErrorCategory.OPERATION,
         ErrorCodeSource.OPERATION,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -9,7 +9,7 @@ hand-maintaining the contract twice.
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ErrorCategory(str, Enum):
@@ -118,23 +118,41 @@ class SceneCreateParams(BaseModel):
     """The operation params of ``gda scene create`` (issue #18).
 
     ``path`` is the target ``.tscn`` file; ``root_type`` the Godot node class
-    of the new scene's root (e.g. ``Node2D``).
+    of the new scene's root (e.g. ``Node2D``). ``root_name`` is explicit so the
+    operation never silently derives a name Godot later sanitizes; when the CLI
+    caller omits ``--root-name``, it derives this from the target filename
+    without the final extension.
     """
 
     path: str
     root_type: str
+    root_name: str | None = Field(
+        default=None,
+        description=(
+            "Root node name to write. If omitted by the CLI, it is derived from "
+            "the target filename without its final extension. Must be non-empty "
+            "and must not contain '.', ':', '@', '/', '\"', or '%'."
+        ),
+    )
 
 
 class SceneCreateResult(BaseModel):
     """The result of ``gda scene create``: what was written where.
 
     Echoes the saved path and the root node the operation actually created, so
-    an agent can assert the effect without a second call.
+    an agent can assert the effect without a second call. ``created_dirs`` lists
+    parent directories the operation created before saving, from outermost to
+    innermost.
     """
 
     path: str
     root_name: str
     root_type: str
+    created_dirs: list[str] = Field(
+        description=(
+            "Parent directories created before saving, from outermost to innermost."
+        )
+    )
 
 
 class SceneNode(BaseModel):

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -29,9 +29,13 @@ const OP_ERROR_UNKNOWN_OPERATION := "unknown_operation"
 const OP_ERROR_INVALID_PARAMS := "invalid_params"
 const OP_ERROR_INVALID_PATH := "invalid_path"
 const OP_ERROR_INVALID_ROOT_TYPE := "invalid_root_type"
+const OP_ERROR_INVALID_ROOT_NAME := "invalid_root_name"
+const OP_ERROR_ALREADY_EXISTS := "already_exists"
 const OP_ERROR_SAVE_FAILED := "save_failed"
 const OP_ERROR_PATH_NOT_FOUND := "path_not_found"
 const OP_ERROR_NOT_A_SCENE := "not_a_scene"
+
+const ROOT_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
 
 # The exit code the process will use. Defaults to failure, so an operation that
 # aborts before recording an outcome (e.g. an uncaught runtime error) still
@@ -101,10 +105,21 @@ func _op_scene_create(params: Dictionary) -> void:
 			or not ClassDB.is_parent_class(root_type, "Node"):
 		_fail(OP_ERROR_INVALID_ROOT_TYPE, "not an instantiable Node class: " + root_type)
 		return
+	var root_name := _string_param(params, "root_name")
+	if not _is_valid_root_name(root_name):
+		_fail(OP_ERROR_INVALID_ROOT_NAME, "invalid root_name: " + root_name)
+		return
+	if FileAccess.file_exists(path) or DirAccess.dir_exists_absolute(path):
+		_fail(OP_ERROR_ALREADY_EXISTS, "scene target already exists: " + path)
+		return
 
 	var root: Node = ClassDB.instantiate(root_type)
-	root.name = path.get_file().get_basename()
-	var root_name := String(root.name)
+	root.name = root_name
+	var actual_root_name := String(root.name)
+	if actual_root_name != root_name:
+		root.free()
+		_fail(OP_ERROR_INVALID_ROOT_NAME, "Godot rewrote root_name from " + root_name + " to " + actual_root_name)
+		return
 
 	var packed := PackedScene.new()
 	var pack_err := packed.pack(root)
@@ -112,16 +127,21 @@ func _op_scene_create(params: Dictionary) -> void:
 		root.free()
 		_fail(OP_ERROR_SAVE_FAILED, "failed to pack scene: " + error_string(pack_err))
 		return
+	var created_dirs: Variant = _ensure_parent_dirs(path)
+	if created_dirs == null:
+		root.free()
+		return
 	var save_err := ResourceSaver.save(packed, path)
 	root.free()
 	if save_err != OK:
-		_fail(OP_ERROR_SAVE_FAILED, "failed to save scene to " + path + ": " + error_string(save_err))
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message(path, save_err))
 		return
 
 	_succeed({
 		"path": path,
-		"root_name": root_name,
+		"root_name": actual_root_name,
 		"root_type": root_type,
+		"created_dirs": created_dirs,
 	})
 
 
@@ -185,6 +205,59 @@ func _string_param(params: Dictionary, key: String) -> String:
 	if value is String:
 		return value
 	return ""
+
+
+func _is_valid_root_name(root_name: String) -> bool:
+	if root_name.is_empty():
+		return false
+	for invalid_char in ROOT_NAME_INVALID_CHARS:
+		if root_name.contains(String(invalid_char)):
+			return false
+	return true
+
+
+func _ensure_parent_dirs(path: String) -> Variant:
+	var parent := path.get_base_dir()
+	if parent.is_empty() or DirAccess.dir_exists_absolute(parent):
+		return []
+
+	var missing: Array[String] = []
+	var current := parent
+	while not current.is_empty() and not DirAccess.dir_exists_absolute(current):
+		missing.push_front(current)
+		var next := current.get_base_dir()
+		if next == current:
+			break
+		current = next
+
+	var err := DirAccess.make_dir_recursive_absolute(parent)
+	if err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, "failed to create parent directory " + parent + ": " + error_string(err))
+		return null
+	return missing
+
+
+func _save_failure_message(path: String, save_err: Error) -> String:
+	var parent := path.get_base_dir()
+	var message := "failed to save scene to " + path
+	if not parent.is_empty():
+		message += " in parent directory " + parent
+	message += ": " + error_string(save_err)
+
+	var probe_dir := "."
+	if not parent.is_empty():
+		probe_dir = parent
+	var probe_name := ".gda-write-check.tmp"
+	var probe_path := probe_dir.path_join(probe_name)
+	var probe := FileAccess.open(probe_path, FileAccess.WRITE)
+	if probe == null:
+		message += "; write probe " + probe_path + " failed: " + error_string(FileAccess.get_open_error())
+	else:
+		probe.close()
+		var dir := DirAccess.open(probe_dir)
+		if dir != null:
+			dir.remove(probe_name)
+	return message
 
 
 # Record a successful result: emit it through the sentinel contract and mark

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -83,6 +83,161 @@ def test_scene_create_then_get_round_trip(godot_project):
     assert tree["root"]["children"] == []
 
 
+@pytest.mark.e2e
+@requires_godot
+def test_scene_create_creates_missing_parent_directories(godot_project):
+    scene_path = godot_project / "levels" / "demo" / "main.tscn"
+
+    created = _gda(
+        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
+    )
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    data = json.loads(created.stdout)
+    assert data["created_dirs"] == [
+        str(godot_project / "levels"),
+        str(godot_project / "levels" / "demo"),
+    ]
+    assert scene_path.exists()
+
+    got = _gda("scene", "get", str(scene_path), "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["root"]["name"] == "main"
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_create_creates_relative_parent_directories_against_project(
+    godot_project,
+):
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+
+    created = subprocess.run(
+        [
+            gda_bin,
+            "scene",
+            "create",
+            "demo/main.tscn",
+            "--root-type",
+            "Node2D",
+            "--project",
+            str(godot_project),
+            "--godot",
+            str(GODOT),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    data = json.loads(created.stdout)
+    assert data["path"] == "demo/main.tscn"
+    assert data["created_dirs"] == ["demo"]
+    assert (godot_project / "demo" / "main.tscn").exists()
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_create_existing_path_yields_already_exists_without_overwriting(
+    godot_project,
+):
+    scene_path = godot_project / "main.tscn"
+    original = "not a scene\n"
+    scene_path.write_text(original, encoding="utf-8")
+
+    created = _gda(
+        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
+    )
+
+    assert created.returncode == 4
+    err = json.loads(created.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "already_exists"
+    assert str(scene_path) in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_create_empty_root_name_yields_structured_error(godot_project):
+    scene_path = godot_project / ".tscn"
+
+    created = _gda(
+        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
+    )
+
+    assert created.returncode == 4
+    err = json.loads(created.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_root_name"
+    assert "root_name" in err["message"]
+    assert not scene_path.exists()
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_create_rejects_root_name_godot_would_rewrite(godot_project):
+    scene_path = godot_project / "bad-name.tscn"
+
+    created = _gda(
+        "scene",
+        "create",
+        str(scene_path),
+        "--root-type",
+        "Node2D",
+        "--root-name",
+        "Bad%Name",
+        "--json",
+    )
+
+    assert created.returncode == 4
+    err = json.loads(created.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_root_name"
+    assert "root_name" in err["message"]
+    assert not scene_path.exists()
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_create_rejects_dotted_default_root_name_but_allows_override(
+    godot_project,
+):
+    scene_path = godot_project / "level.v2.tscn"
+
+    rejected = _gda(
+        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
+    )
+
+    assert rejected.returncode == 4
+    err = json.loads(rejected.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_root_name"
+    assert not scene_path.exists()
+
+    created = _gda(
+        "scene",
+        "create",
+        str(scene_path),
+        "--root-type",
+        "Node2D",
+        "--root-name",
+        "LevelV2",
+        "--json",
+    )
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    assert json.loads(created.stdout)["root_name"] == "LevelV2"
+
+    got = _gda("scene", "get", str(scene_path), "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["root"]["name"] == "LevelV2"
+
+
 # A hand-written nested scene: Root → Hero → Hitbox, distinct node types.
 NESTED_TSCN = """\
 [gd_scene format=3]
@@ -156,6 +311,8 @@ def test_scene_create_unwritable_directory_yields_structured_save_failed(godot_p
     assert err["code"] == "save_failed"
     # The message names the destination the caller must fix.
     assert str(target) in err["message"]
+    assert str(locked) in err["message"]
+    assert "write probe" in err["message"]
     assert not target.exists()
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,7 +51,12 @@ def test_round_trips_to_json_object():
 
 
 def test_scene_create_result_round_trips():
-    payload = {"path": "/p/main.tscn", "root_name": "main", "root_type": "Node2D"}
+    payload = {
+        "path": "/p/main.tscn",
+        "root_name": "main",
+        "root_type": "Node2D",
+        "created_dirs": ["/p"],
+    }
 
     created = SceneCreateResult.model_validate(payload)
 

--- a/tests/test_scene_commands.py
+++ b/tests/test_scene_commands.py
@@ -17,6 +17,7 @@ CREATE_RESULT = {
     "path": "/tmp/proj/main.tscn",
     "root_name": "main",
     "root_type": "Node2D",
+    "created_dirs": [],
 }
 
 
@@ -40,10 +41,51 @@ def test_scene_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch
     assert data["root_name"] == "main"
     # The operation was dispatched by name with the command's typed params.
     assert fake.calls == [
-        ("scene-create", {"path": "/tmp/proj/main.tscn", "root_type": "Node2D"})
+        (
+            "scene-create",
+            {
+                "path": "/tmp/proj/main.tscn",
+                "root_type": "Node2D",
+                "root_name": "main",
+            },
+        )
     ]
     # Engine/script diagnostics are surfaced on stderr, not stdout.
     assert "engine diagnostic" in result.stderr
+
+
+def test_scene_create_accepts_explicit_root_name(monkeypatch):
+    stdout = sentinel(
+        {**CREATE_RESULT, "path": "/tmp/proj/level.v2.tscn", "root_name": "LevelV2"}
+    )
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "scene",
+            "create",
+            "/tmp/proj/level.v2.tscn",
+            "--root-type",
+            "Node2D",
+            "--root-name",
+            "LevelV2",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["root_name"] == "LevelV2"
+    assert fake.calls == [
+        (
+            "scene-create",
+            {
+                "path": "/tmp/proj/level.v2.tscn",
+                "root_type": "Node2D",
+                "root_name": "LevelV2",
+            },
+        )
+    ]
 
 
 GET_RESULT = {

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -100,6 +100,11 @@ def test_scene_create_schema_emits_model_derived_contract_without_other_args():
     doc = json.loads(result.stdout)
     assert doc["input"] == SceneCreateParams.model_json_schema()
     assert doc["output"] == SceneCreateResult.model_json_schema()
+    assert "root_name" in doc["input"]["properties"]
+    assert "created_dirs" in doc["output"]["properties"]
+    root_name_description = doc["input"]["properties"]["root_name"]["description"]
+    assert '"' in root_name_description
+    assert "%" in root_name_description
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 


### PR DESCRIPTION
## Summary
- prevent scene create from silently overwriting existing targets with a structured already_exists error
- make scene root naming explicit through root_name / --root-name and reject names Godot would rewrite
- create missing parent directories before saving and report created_dirs in the typed result
- improve residual save_failed messages with parent-directory and write-probe diagnostics

## Tests
- uv run pytest

Fixes #35