### PR TITLE
Refactor gda headless command execution

### DIFF
--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 import typer
 
-from gda.errors import classify_info, classify_run
+from gda.errors import classify_info
 from gda.headless import (
     HeadlessCommand,
     godot_option,
@@ -73,14 +73,12 @@ SCENE_CREATE_COMMAND: HeadlessCommand[SceneCreateResult] = HeadlessCommand(
     operation="scene-create",
     input_model=SceneCreateParams,
     output_model=SceneCreateResult,
-    classify=lambda result, binary: classify_run(result, binary, SceneCreateResult),
 )
 
 SCENE_GET_COMMAND: HeadlessCommand[SceneGetResult] = HeadlessCommand(
     operation="scene-get",
     input_model=SceneGetParams,
     output_model=SceneGetResult,
-    classify=lambda result, binary: classify_run(result, binary, SceneGetResult),
 )
 
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -7,20 +7,21 @@ domain group (issue #18). Every command drives the same headless pipeline:
 binary resolution → runner → sentinel parse → typed model → JSON.
 """
 
-import sys
 from pathlib import Path
-from typing import Callable, NoReturn, Optional, TypeVar
+from typing import Optional
 
 import typer
-from pydantic import BaseModel
 
-from gda.binary import resolve_godot_binary
-from gda.errors import Failure, classify_info, classify_run
-from gda.project import resolve_project_dir
+from gda.errors import classify_info, classify_run
+from gda.headless import (
+    HeadlessCommand,
+    godot_option,
+    json_option,
+    make_subprocess_runner,
+    project_option,
+)
 from gda.models import (
-    CommandSchema,
     EngineVersion,
-    GdaErrorEnvelope,
     InfoParams,
     SceneCreateParams,
     SceneCreateResult,
@@ -28,7 +29,8 @@ from gda.models import (
     SceneGetResult,
     SceneNode,
 )
-from gda.runner import GodotRunner, RunResult, SubprocessGodotRunner
+from gda.project import resolve_project_dir
+from gda.runner import GodotRunner
 
 app = typer.Typer(
     name="gda",
@@ -57,30 +59,29 @@ def _make_runner(binary: Path, project: Optional[Path]) -> GodotRunner:
 
     A seam tests override (via monkeypatch) to inject a fake runner.
     """
-    return SubprocessGodotRunner(binary, project=project)
+    return make_subprocess_runner(binary, project)
 
 
-def _json_option() -> bool:
-    return typer.Option(
-        False, "--json", help="Emit the result as a single JSON object."
-    )
+INFO_COMMAND: HeadlessCommand[EngineVersion] = HeadlessCommand(
+    operation="info",
+    input_model=InfoParams,
+    output_model=EngineVersion,
+    classify=classify_info,
+)
 
+SCENE_CREATE_COMMAND: HeadlessCommand[SceneCreateResult] = HeadlessCommand(
+    operation="scene-create",
+    input_model=SceneCreateParams,
+    output_model=SceneCreateResult,
+    classify=lambda result, binary: classify_run(result, binary, SceneCreateResult),
+)
 
-def _godot_option() -> Optional[str]:
-    return typer.Option(
-        None,
-        "--godot",
-        help="Path to the Godot binary (overrides $GDA_GODOT and the default).",
-    )
-
-
-def _project_option() -> Optional[str]:
-    return typer.Option(
-        None,
-        "--project",
-        help="Godot project directory for res:// resolution "
-        "(overrides $GDA_PROJECT; defaults to the current directory if it is a project).",
-    )
+SCENE_GET_COMMAND: HeadlessCommand[SceneGetResult] = HeadlessCommand(
+    operation="scene-get",
+    input_model=SceneGetParams,
+    output_model=SceneGetResult,
+    classify=lambda result, binary: classify_run(result, binary, SceneGetResult),
+)
 
 
 def _normalize_path(path: str) -> str:
@@ -101,78 +102,6 @@ def _derive_scene_root_name(path: str) -> str:
     if "." in filename:
         return filename.rsplit(".", 1)[0]
     return filename
-
-
-def _schema_option(
-    input_model: type[BaseModel], output_model: type[BaseModel]
-) -> bool:
-    """A ``--schema`` flag wired to its own emission (ADR-0004, issue #18).
-
-    Declaring the flag IS the implementation: an eager callback emits the
-    command's model-derived ``{input, output}`` contract and exits before any
-    other parameter — required arguments included — is validated, and before
-    any engine path (binary resolution, runner) is touched. One declaration
-    per command replaces the per-command ``if schema:`` block, so a command
-    cannot ship the flag without its mandated behavior.
-    """
-
-    def emit(value: bool) -> None:
-        if value:
-            typer.echo(CommandSchema.of(input_model, output_model).model_dump_json())
-            raise typer.Exit()
-
-    return typer.Option(
-        False,
-        "--schema",
-        help="Emit this command's input/output JSON Schemas; no Godot is spawned.",
-        callback=emit,
-        is_eager=True,
-    )
-
-
-def _fail(failure: Failure) -> NoReturn:
-    """Emit a structured error to stdout and exit non-zero (issue #3).
-
-    The error JSON is the stdout contract for the failure path (always emitted,
-    independent of ``--json``); the process exit code distinguishes categories.
-    ``NoReturn`` lets the type checker prove the caller's fallthrough narrows
-    the classification to the success model.
-    """
-    typer.echo(GdaErrorEnvelope(error=failure.error).model_dump_json())
-    raise typer.Exit(code=failure.exit_code)
-
-
-M = TypeVar("M", bound=BaseModel)
-
-
-def _run_classified(
-    operation: str,
-    params: BaseModel,
-    classify: Callable[[RunResult, Path], M | Failure],
-    godot: Optional[str],
-    project: Optional[Path] = None,
-) -> M:
-    """Drive the shared headless pipeline to a typed success model.
-
-    Resolve the binary, run ``operation`` with the typed params against the
-    resolved ``project`` (``None`` runs projectless), surface engine/script
-    diagnostics on stderr (ADR-0002), classify the raw result, and on failure
-    emit the structured error and exit — so each command body is reduced to its
-    params, its classifier, and its output rendering.
-    """
-    binary = resolve_godot_binary(godot)
-    runner = _make_runner(binary, project)
-    result = runner.run(operation, params.model_dump())
-
-    # stdout carries only the result payload; engine/script diagnostics are
-    # surfaced on stderr (ADR-0002).
-    if result.stderr:
-        print(result.stderr, end="", file=sys.stderr)
-
-    outcome = classify(result, binary)
-    if isinstance(outcome, Failure):
-        _fail(outcome)
-    return outcome
 
 
 def _render_tree(node: SceneNode, depth: int = 0) -> str:
@@ -198,15 +127,14 @@ def create(
             "its final extension."
         ),
     ),
-    json_output: bool = _json_option(),
-    schema: bool = _schema_option(SceneCreateParams, SceneCreateResult),
-    godot: Optional[str] = _godot_option(),
-    project: Optional[str] = _project_option(),
+    json_output: bool = json_option(),
+    schema: bool = SCENE_CREATE_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
 ) -> None:
     """Create a new .tscn scene file with the given root node type."""
     normalized_path = _normalize_path(path)
-    created = _run_classified(
-        "scene-create",
+    SCENE_CREATE_COMMAND.emit(
         SceneCreateParams(
             path=normalized_path,
             root_type=root_type,
@@ -214,50 +142,46 @@ def create(
             if root_name is not None
             else _derive_scene_root_name(normalized_path),
         ),
-        lambda result, binary: classify_run(result, binary, SceneCreateResult),
-        godot,
-        resolve_project_dir(project),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=lambda created: (
+            f"created {created.path} (root {created.root_type})"
+        ),
+        make_runner=_make_runner,
     )
-
-    if json_output:
-        typer.echo(created.model_dump_json())
-    else:
-        typer.echo(f"created {created.path} (root {created.root_type})")
 
 
 @scene_app.command()
 def get(
     path: str = typer.Argument(..., help="The .tscn scene file to read."),
-    json_output: bool = _json_option(),
-    schema: bool = _schema_option(SceneGetParams, SceneGetResult),
-    godot: Optional[str] = _godot_option(),
-    project: Optional[str] = _project_option(),
+    json_output: bool = json_option(),
+    schema: bool = SCENE_GET_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
 ) -> None:
     """Read a scene file and report its structured node tree."""
-    scene = _run_classified(
-        "scene-get",
+    SCENE_GET_COMMAND.emit(
         SceneGetParams(path=_normalize_path(path)),
-        lambda result, binary: classify_run(result, binary, SceneGetResult),
-        godot,
-        resolve_project_dir(project),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=lambda scene: _render_tree(scene.root),
+        make_runner=_make_runner,
     )
-
-    if json_output:
-        typer.echo(scene.model_dump_json())
-    else:
-        typer.echo(_render_tree(scene.root))
 
 
 @app.command()
 def info(
-    json_output: bool = _json_option(),
-    schema: bool = _schema_option(InfoParams, EngineVersion),
-    godot: Optional[str] = _godot_option(),
+    json_output: bool = json_option(),
+    schema: bool = INFO_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
 ) -> None:
     """Report the Godot engine version info."""
-    version = _run_classified("info", InfoParams(), classify_info, godot)
-
-    if json_output:
-        typer.echo(version.model_dump_json())
-    else:
-        typer.echo(version.string)
+    INFO_COMMAND.emit(
+        InfoParams(),
+        godot=godot,
+        json_output=json_output,
+        render_text=lambda version: version.string,
+        make_runner=_make_runner,
+    )

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -1,0 +1,149 @@
+"""Headless command execution for ``gda``.
+
+A headless command declares the small interface that varies per command:
+operation name, input model, output model, classifier, and human rendering.
+This module owns the shared implementation behind that interface: schema
+emission, Godot binary resolution, runner construction, diagnostics forwarding,
+failure output, and JSON rendering.
+"""
+
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Generic, NoReturn, Optional, TypeVar
+
+import typer
+from pydantic import BaseModel
+
+from gda.binary import resolve_godot_binary
+from gda.errors import Failure
+from gda.models import CommandSchema, GdaErrorEnvelope
+from gda.runner import GodotRunner, RunResult, SubprocessGodotRunner
+
+M = TypeVar("M", bound=BaseModel)
+
+Classifier = Callable[[RunResult, Path], M | Failure]
+RunnerFactory = Callable[[Path, Optional[Path]], GodotRunner]
+HumanRenderer = Callable[[M], str]
+
+
+def make_subprocess_runner(binary: Path, project: Optional[Path] = None) -> GodotRunner:
+    """Build the default real Godot runner for ``binary`` and ``project``."""
+    return SubprocessGodotRunner(binary, project=project)
+
+
+def json_option() -> bool:
+    return typer.Option(
+        False, "--json", help="Emit the result as a single JSON object."
+    )
+
+
+def godot_option() -> Optional[str]:
+    return typer.Option(
+        None,
+        "--godot",
+        help="Path to the Godot binary (overrides $GDA_GODOT and the default).",
+    )
+
+
+def project_option() -> Optional[str]:
+    return typer.Option(
+        None,
+        "--project",
+        help="Godot project directory for res:// resolution "
+        "(overrides $GDA_PROJECT; defaults to the current directory if it is a project).",
+    )
+
+
+def schema_option(
+    input_model: type[BaseModel], output_model: type[BaseModel]
+) -> bool:
+    """A ``--schema`` flag wired to model-derived command self-description.
+
+    The eager callback emits the command's ``{input, output}`` contract and
+    exits before required arguments are validated or any engine path is touched
+    (ADR-0004).
+    """
+
+    def emit(value: bool) -> None:
+        if value:
+            typer.echo(CommandSchema.of(input_model, output_model).model_dump_json())
+            raise typer.Exit()
+
+    return typer.Option(
+        False,
+        "--schema",
+        help="Emit this command's input/output JSON Schemas; no Godot is spawned.",
+        callback=emit,
+        is_eager=True,
+    )
+
+
+def _fail(failure: Failure) -> NoReturn:
+    """Emit a structured error to stdout and exit non-zero."""
+    typer.echo(GdaErrorEnvelope(error=failure.error).model_dump_json())
+    raise typer.Exit(code=failure.exit_code)
+
+
+@dataclass(frozen=True)
+class HeadlessCommand(Generic[M]):
+    """A deep module for one Phase-1 headless operation.
+
+    The interface is intentionally small: command modules supply the pieces that
+    are actually command-specific, while this implementation preserves the
+    shared ADR-0001/0002/0004 execution contract in one place.
+    """
+
+    operation: str
+    input_model: type[BaseModel]
+    output_model: type[M]
+    classify: Classifier[M]
+
+    def schema_option(self) -> bool:
+        """Return the Typer ``--schema`` option for this command."""
+        return schema_option(self.input_model, self.output_model)
+
+    def run(
+        self,
+        params: BaseModel,
+        *,
+        godot: Optional[str],
+        project: Optional[Path] = None,
+        make_runner: RunnerFactory = make_subprocess_runner,
+    ) -> M:
+        """Run the command and return its typed success model.
+
+        Diagnostics are forwarded to stderr. Failures are emitted as the public
+        structured error envelope and terminate via Typer's exit path.
+        """
+        binary = resolve_godot_binary(godot)
+        runner = make_runner(binary, project)
+        result = runner.run(self.operation, params.model_dump())
+
+        if result.stderr:
+            print(result.stderr, end="", file=sys.stderr)
+
+        outcome = self.classify(result, binary)
+        if isinstance(outcome, Failure):
+            _fail(outcome)
+        return outcome
+
+    def emit(
+        self,
+        params: BaseModel,
+        *,
+        godot: Optional[str],
+        project: Optional[Path] = None,
+        json_output: bool,
+        render_text: HumanRenderer[M],
+        make_runner: RunnerFactory = make_subprocess_runner,
+    ) -> None:
+        """Run the command and emit either JSON or human-readable output."""
+        result = self.run(
+            params, godot=godot, project=project, make_runner=make_runner
+        )
+        if json_output:
+            typer.echo(result.model_dump_json())
+        else:
+            typer.echo(render_text(result))

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -1,10 +1,10 @@
 """Headless command execution for ``gda``.
 
 A headless command declares the small interface that varies per command:
-operation name, input model, output model, classifier, and human rendering.
+operation name, input model, output model, and human rendering.
 This module owns the shared implementation behind that interface: schema
 emission, Godot binary resolution, runner construction, diagnostics forwarding,
-failure output, and JSON rendering.
+classification, failure output, and JSON rendering.
 """
 
 import sys
@@ -17,7 +17,7 @@ import typer
 from pydantic import BaseModel
 
 from gda.binary import resolve_godot_binary
-from gda.errors import Failure
+from gda.errors import Failure, classify_run
 from gda.models import CommandSchema, GdaErrorEnvelope
 from gda.runner import GodotRunner, RunResult, SubprocessGodotRunner
 
@@ -98,7 +98,7 @@ class HeadlessCommand(Generic[M]):
     operation: str
     input_model: type[BaseModel]
     output_model: type[M]
-    classify: Classifier[M]
+    classify: Classifier[M] | None = None
 
     def schema_option(self) -> bool:
         """Return the Typer ``--schema`` option for this command."""
@@ -124,7 +124,11 @@ class HeadlessCommand(Generic[M]):
         if result.stderr:
             print(result.stderr, end="", file=sys.stderr)
 
-        outcome = self.classify(result, binary)
+        outcome = (
+            self.classify(result, binary)
+            if self.classify is not None
+            else classify_run(result, binary, self.output_model)
+        )
         if isinstance(outcome, Failure):
             _fail(outcome)
         return outcome

--- a/tests/test_headless_command.py
+++ b/tests/test_headless_command.py
@@ -1,0 +1,94 @@
+"""The headless command module owns the shared command execution interface."""
+
+import json
+from pathlib import Path
+
+import pytest
+import typer
+
+from gda.errors import classify_info
+from gda.headless import HeadlessCommand
+from gda.models import EngineVersion, InfoParams
+from gda.runner import RunResult
+from tests.support import FakeRunner, sentinel
+
+VERSION_INFO = {
+    "major": 4,
+    "minor": 6,
+    "patch": 3,
+    "hex": 0x040603,
+    "status": "stable",
+    "build": "official",
+    "hash": "7d41c59c457bd5a245092b4e7eb2d833e3b3f8c3",
+    "string": "4.6.3-stable (official)",
+    "timestamp": 0,
+}
+
+
+def test_headless_command_emit_owns_runner_classification_and_json_output(capsys):
+    fake = FakeRunner(
+        RunResult(stdout=sentinel(VERSION_INFO), stderr="engine diagnostic\n", exit_code=0)
+    )
+    seen: dict[str, Path | None] = {}
+
+    def make_runner(binary: Path, project: Path | None):
+        seen["binary"] = binary
+        seen["project"] = project
+        return fake
+
+    command: HeadlessCommand[EngineVersion] = HeadlessCommand(
+        operation="info",
+        input_model=InfoParams,
+        output_model=EngineVersion,
+        classify=classify_info,
+    )
+
+    command.emit(
+        InfoParams(),
+        godot="/tmp/Godot",
+        project=Path("/tmp/project"),
+        json_output=True,
+        render_text=lambda version: version.string,
+        make_runner=make_runner,
+    )
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["string"] == "4.6.3-stable (official)"
+    assert "engine diagnostic" in captured.err
+    assert fake.calls == [("info", {})]
+    assert seen == {"binary": Path("/tmp/Godot"), "project": Path("/tmp/project")}
+
+
+def test_headless_command_emit_owns_structured_failure_output(capsys):
+    fake = FakeRunner(
+        RunResult(
+            stdout="",
+            stderr="gda: Godot binary not found: /tmp/missing\n",
+            exit_code=127,
+        )
+    )
+
+    def make_runner(binary: Path, project: Path | None):
+        return fake
+
+    command: HeadlessCommand[EngineVersion] = HeadlessCommand(
+        operation="info",
+        input_model=InfoParams,
+        output_model=EngineVersion,
+        classify=classify_info,
+    )
+
+    with pytest.raises(typer.Exit) as raised:
+        command.emit(
+            InfoParams(),
+            godot="/tmp/missing",
+            project=None,
+            json_output=False,
+            render_text=lambda version: version.string,
+            make_runner=make_runner,
+        )
+
+    captured = capsys.readouterr()
+    assert raised.value.exit_code == 127
+    assert json.loads(captured.out)["error"]["code"] == "binary_not_found"
+    assert "not found" in captured.err

--- a/tests/test_headless_command.py
+++ b/tests/test_headless_command.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import pytest
 import typer
 
-from gda.errors import classify_info
 from gda.headless import HeadlessCommand
 from gda.models import EngineVersion, InfoParams
 from gda.runner import RunResult
@@ -40,7 +39,6 @@ def test_headless_command_emit_owns_runner_classification_and_json_output(capsys
         operation="info",
         input_model=InfoParams,
         output_model=EngineVersion,
-        classify=classify_info,
     )
 
     command.emit(
@@ -75,7 +73,6 @@ def test_headless_command_emit_owns_structured_failure_output(capsys):
         operation="info",
         input_model=InfoParams,
         output_model=EngineVersion,
-        classify=classify_info,
     )
 
     with pytest.raises(typer.Exit) as raised:

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -71,7 +71,7 @@ def test_schema_spawns_no_godot(monkeypatch):
     def boom(*args, **kwargs):
         raise AssertionError("--schema must not touch the engine")
 
-    monkeypatch.setattr("gda.cli.resolve_godot_binary", boom)
+    monkeypatch.setattr("gda.headless.resolve_godot_binary", boom)
     monkeypatch.setattr("gda.cli._make_runner", boom)
 
     result = CliRunner().invoke(app, ["info", "--schema"])
@@ -140,7 +140,7 @@ def test_scene_schema_spawns_no_godot(monkeypatch):
     def boom(*args, **kwargs):
         raise AssertionError("--schema must not touch the engine")
 
-    monkeypatch.setattr("gda.cli.resolve_godot_binary", boom)
+    monkeypatch.setattr("gda.headless.resolve_godot_binary", boom)
     monkeypatch.setattr("gda.cli._make_runner", boom)
 
     for command in (["scene", "create"], ["scene", "get"]):


### PR DESCRIPTION
## Summary

- Add a `HeadlessCommand` module that owns schema emission, runner construction, diagnostics forwarding, classification, structured failure output, and JSON/human rendering.
- Keep `gda info`, `gda scene create`, and `gda scene get` behavior unchanged while making the CLI layer a thin Typer adapter.
- Bind default classification to each command's declared output model, with an optional classifier override for command-specific checks such as the `info` version gate.

## Tests

- `uv run pytest`

Closes #46
