### PR TITLE
feat(cli): add root version option

### DIFF
--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -7,6 +7,7 @@ domain group (issue #18). Every command drives the same headless pipeline:
 binary resolution → runner → sentinel parse → typed model → JSON.
 """
 
+from importlib.metadata import version as package_version
 from pathlib import Path
 from typing import Optional
 
@@ -46,8 +47,22 @@ scene_app = typer.Typer(
 app.add_typer(scene_app, name="scene")
 
 
+def _version_callback(value: Optional[bool]) -> None:
+    if value:
+        typer.echo(f"gda {package_version('gda')}")
+        raise typer.Exit()
+
+
 @app.callback()
-def main() -> None:
+def main(
+    show_version: Optional[bool] = typer.Option(
+        None,
+        "--version",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the installed gda version and exit.",
+    ),
+) -> None:
     """An agent-facing Godot CLI with structured output."""
     # A no-op callback keeps gda a command *group* so meta commands like
     # `gda info` stay named subcommands (ADR-0005) rather than collapsing to

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,44 @@
+"""Root CLI metadata options."""
+
+import tomllib
+from importlib.metadata import version
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_root_version_option_prints_package_version():
+    result = CliRunner().invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.stdout == f"gda {version('gda')}\n"
+    assert result.stderr == ""
+
+
+def test_root_help_advertises_version_option():
+    result = CliRunner().invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "--version" in result.stdout
+
+
+def test_root_version_option_does_not_require_godot(monkeypatch):
+    monkeypatch.setenv("GDA_GODOT", "/definitely/missing/Godot")
+
+    result = CliRunner().invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.stdout == f"gda {version('gda')}\n"
+    assert result.stderr == ""
+
+
+def test_package_metadata_version_matches_pyproject():
+    pyproject = tomllib.loads(
+        (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+
+    assert version("gda") == pyproject["project"]["version"]

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,5 +1,6 @@
 """Root CLI metadata options."""
 
+import re
 import tomllib
 from importlib.metadata import version
 from pathlib import Path
@@ -9,6 +10,11 @@ from typer.testing import CliRunner
 from gda.cli import app
 
 ROOT = Path(__file__).resolve().parents[1]
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _plain(text: str) -> str:
+    return ANSI_ESCAPE.sub("", text)
 
 
 def test_root_version_option_prints_package_version():
@@ -23,7 +29,7 @@ def test_root_help_advertises_version_option():
     result = CliRunner().invoke(app, ["--help"])
 
     assert result.exit_code == 0
-    assert "--version" in result.stdout
+    assert "--version" in _plain(result.stdout)
 
 
 def test_root_version_option_does_not_require_godot(monkeypatch):


### PR DESCRIPTION
## Summary

- Add a root-level `--version` option that prints the installed `gda` package version and exits.
- Keep the version path independent from Godot binary resolution or command execution.
- Cover package metadata consistency with `pyproject.toml` and root help exposure in tests.

## Tests

- `uv run pytest -q` -> `94 passed`
- `uv run gda --version` -> `gda 0.1.0`
- `uv run gda --help` shows `--version`

Closes #48