### PR TITLE
fix(cli): make --schema yield to --help, reject malformed argv, and bind a bool

### DIFF
--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -124,7 +124,7 @@ def _render_tree(node: SceneNode, depth: int = 0) -> str:
     return "\n".join(lines)
 
 
-@scene_app.command()
+@scene_app.command(cls=SCENE_CREATE_COMMAND.command_class())
 def create(
     path: str = typer.Argument(..., help="Target .tscn path to write."),
     root_type: str = typer.Option(
@@ -165,7 +165,7 @@ def create(
     )
 
 
-@scene_app.command()
+@scene_app.command(cls=SCENE_GET_COMMAND.command_class())
 def get(
     path: str = typer.Argument(..., help="The .tscn scene file to read."),
     json_output: bool = json_option(),
@@ -184,7 +184,7 @@ def get(
     )
 
 
-@app.command()
+@app.command(cls=INFO_COMMAND.command_class())
 def info(
     json_output: bool = json_option(),
     schema: bool = INFO_COMMAND.schema_option(),

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -15,6 +15,7 @@ from typing import Generic, NoReturn, Optional, TypeVar
 
 import typer
 from pydantic import BaseModel
+from typer.core import TyperCommand
 
 from gda.binary import resolve_godot_binary
 from gda.errors import Failure, classify_run
@@ -56,28 +57,54 @@ def project_option() -> Optional[str]:
     )
 
 
-def schema_option(
-    input_model: type[BaseModel], output_model: type[BaseModel]
-) -> bool:
-    """A ``--schema`` flag wired to model-derived command self-description.
+def schema_option() -> bool:
+    """A plain ``--schema`` boolean flag.
 
-    The eager callback emits the command's ``{input, output}`` contract and
-    exits before required arguments are validated or any engine path is touched
-    (ADR-0004).
+    Emission is owned by the command class (:func:`schema_command_class`), not an
+    eager callback: a bare ``bool`` binds ``False`` when absent (not ``None``)
+    and yields to an eager ``--help`` (issue #36).
     """
-
-    def emit(value: bool) -> None:
-        if value:
-            typer.echo(CommandSchema.of(input_model, output_model).model_dump_json())
-            raise typer.Exit()
-
     return typer.Option(
         False,
         "--schema",
         help="Emit this command's input/output JSON Schemas; no Godot is spawned.",
-        callback=emit,
-        is_eager=True,
     )
+
+
+def schema_command_class(
+    input_model: type[BaseModel], output_model: type[BaseModel]
+) -> type[TyperCommand]:
+    """A Typer command that owns ``--schema`` handling (ADR-0004).
+
+    ``--schema`` is an introspection probe: it emits the command's
+    ``{input, output}`` contract without spawning Godot and without requiring the
+    command's operational arguments. It must still surface a structurally invalid
+    command line — unknown options or extra positional args — as a usage error,
+    and must always yield to ``--help`` (issue #36).
+    """
+
+    class _SchemaCommand(TyperCommand):
+        def parse_args(self, ctx: typer.Context, args: list[str]) -> list[str]:
+            if "--schema" not in args:
+                return super().parse_args(ctx, args)
+
+            # Relax required args so a bare ``--schema`` probe succeeds, while
+            # Click still rejects unknown options / extra positional args and an
+            # eager ``--help`` still wins. Restore afterwards: Typer reuses the
+            # command object across invocations.
+            relaxed = [(param, param.required) for param in self.params]
+            try:
+                for param, _ in relaxed:
+                    param.required = False
+                super().parse_args(ctx, list(args))
+            finally:
+                for param, required in relaxed:
+                    param.required = required
+
+            typer.echo(CommandSchema.of(input_model, output_model).model_dump_json())
+            raise typer.Exit()
+
+    return _SchemaCommand
 
 
 def _fail(failure: Failure) -> NoReturn:
@@ -101,8 +128,12 @@ class HeadlessCommand(Generic[M]):
     classify: Classifier[M] | None = None
 
     def schema_option(self) -> bool:
-        """Return the Typer ``--schema`` option for this command."""
-        return schema_option(self.input_model, self.output_model)
+        """Return the Typer ``--schema`` flag for this command."""
+        return schema_option()
+
+    def command_class(self) -> type[TyperCommand]:
+        """Return the Typer command class that owns this command's ``--schema``."""
+        return schema_command_class(self.input_model, self.output_model)
 
     def run(
         self,

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -157,3 +157,48 @@ def test_info_input_schema_is_derived_from_the_params_model():
     doc = json.loads(result.stdout)
     assert doc["input"] == InfoParams.model_json_schema()
     assert doc["input"].get("properties", {}) == {}
+
+
+def test_help_takes_precedence_over_schema_regardless_of_argv_order():
+    # issue #36 (1): both --schema and --help were eager, so the winner
+    # depended on argv order. --help must always win, either order.
+    runner = CliRunner()
+
+    schema_first = runner.invoke(app, ["info", "--schema", "--help"])
+    help_first = runner.invoke(app, ["info", "--help", "--schema"])
+
+    for result in (schema_first, help_first):
+        assert result.exit_code == 0
+        assert "Usage" in result.stdout
+        # The help screen, not the schema document.
+        assert not result.stdout.lstrip().startswith("{")
+
+
+def test_extra_positional_args_are_a_usage_error_even_with_schema():
+    # issue #36 (2): --schema must not swallow a malformed command line. Extra
+    # positional args still fail with a usage error (exit 2), not exit 0 + schema.
+    result = CliRunner().invoke(app, ["scene", "create", "--schema", "a", "b", "c"])
+
+    assert result.exit_code == 2
+    # No schema document was emitted for the malformed invocation.
+    assert not result.stdout.lstrip().startswith("{")
+
+
+def test_schema_flag_binds_false_not_none_when_absent():
+    # issue #36 (3): the flag must bind a real bool default (False), not None,
+    # so a command body reads a correct boolean. Exercise the shared option in a
+    # throwaway app and observe the value the body receives.
+    import typer
+
+    from gda.headless import schema_option
+
+    probe = typer.Typer()
+
+    @probe.command()
+    def run(schema: bool = schema_option()) -> None:
+        typer.echo(f"schema={schema!r}")
+
+    result = CliRunner().invoke(probe, [])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "schema=False"


### PR DESCRIPTION
## Summary

Fixes the three `--schema` eager-callback regressions found in the #18 review (#36). The shared `--schema` flag was an eager, exiting callback, which caused:

- **Precedence vs `--help`** — both were eager, so the winner depended on argv order (`gda info --schema --help` emitted schema instead of help).
- **Swallowed usage errors** — the callback exited 0 before Click validated args, so a malformed argv that happened to include `--schema` (e.g. `gda scene create --schema a b c`) returned exit 0 + schema instead of a usage error (exit 2).
- **Wrong value binding** — the callback returned `None` on the non-emitting path, so command bodies bound `schema=None` instead of the declared `bool` default `False`.

## Approach

Emission moves out of the eager callback into the command class (the skeleton mechanism every domain command inherits):

- `schema_option()` becomes a plain `bool` flag → binds `False` when absent.
- New `schema_command_class()` / `HeadlessCommand.command_class()` own `--schema` in `TyperCommand.parse_args`: it relaxes required args so a **bare** `--schema` probe still self-describes (ADR-0004 hard gate), while letting Click reject unknown options / extra positional args as usage errors, and letting an eager `--help` always win regardless of argv order.
- `cli.py` wires `cls=…_COMMAND.command_class()` on the three commands. Future commands follow `@grp.command(cls=CMD.command_class())` + `schema: bool = CMD.schema_option()`.

## Acceptance criteria (#36)

- [x] `--help` takes precedence over `--schema` regardless of argv order.
- [x] An invocation with extra/unknown positional args still fails with a usage error even when `--schema` is present.
- [x] Command bodies receive `schema=False` (not `None`) when the flag is absent.
- [x] Existing `--schema` emission behavior preserved (model-derived `{input, output}`, no Godot spawned), with a test for each fix.

## Testing

- 3 new TDD tests in `tests/test_schema_command.py` (one per fix).
- Full suite green: **79 non-e2e + 18 e2e** (real Godot) pass; the existing 12 `--schema` tests (incl. the bare-`--schema` ADR-0004 gate) stay green.

## Notes

No ADR change needed — ADR-0004 specifies `--schema` *semantics* (emit input+output, model-driven, emit-only, hard gate), all preserved. The introspection-probe nuance (tolerate missing required, reject structural errors) is documented in the new `schema_command_class` docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)