### PR TITLE
fix(parser): take the last end sentinel so payload content can't truncate the result

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -25,8 +25,10 @@ For [headless operations](../../CONTEXT.md) we define a result contract:
   everything else on stdout is ignored, and stderr is surfaced for diagnostics.
   The payload echoes user-controlled content (a path, and later node names /
   script source) that may itself contain the end sentinel text, so extraction
-  takes the **last** end sentinel as the terminator — the operation emits exactly
-  one result, so sentinel-shaped payload content cannot truncate it (issue #34).
+  takes the **last** end sentinel after the begin sentinel as the terminator.
+  This rests on two invariants below: the operation emits exactly one result and
+  writes nothing else to stdout, so any sentinel-shaped bytes are payload content
+  *before* the real terminator and cannot truncate the result (issue #34).
 - A **result file** (a path passed in by `gda`, written by the GDScript) is reserved
   as an escape hatch for large or binary payloads that should not stream through
   stdout.

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -23,6 +23,10 @@ For [headless operations](../../CONTEXT.md) we define a result contract:
   **stderr**. stderr is diagnostic only; it is never parsed for stable error codes.
 - `gda` extracts the bytes between the sentinels and parses that as the result;
   everything else on stdout is ignored, and stderr is surfaced for diagnostics.
+  The payload echoes user-controlled content (a path, and later node names /
+  script source) that may itself contain the end sentinel text, so extraction
+  takes the **last** end sentinel as the terminator — the operation emits exactly
+  one result, so sentinel-shaped payload content cannot truncate it (issue #34).
 - A **result file** (a path passed in by `gda`, written by the GDScript) is reserved
   as an escape hatch for large or binary payloads that should not stream through
   stdout.

--- a/src/gda/parser.py
+++ b/src/gda/parser.py
@@ -7,7 +7,10 @@ wrapped in unique sentinels::
     <<<GDA:RESULT>>>{...json...}<<<GDA:END>>>
 
 ``parse_result`` extracts the bytes between the sentinels and parses them as
-JSON, ignoring everything else on stdout.
+JSON, ignoring everything else on stdout. The payload echoes user-controlled
+content (a path, and later node names / script source), so it may itself contain
+the literal end sentinel; the real terminator is the *last* end sentinel, since
+the operation emits exactly one result (ADR-0002).
 """
 
 import json
@@ -23,7 +26,10 @@ def parse_result(stdout: str) -> Any:
     if start == -1:
         raise ValueError("no GDA result sentinel found in stdout")
     payload_start = start + len(RESULT_BEGIN)
-    end = stdout.find(RESULT_END, payload_start)
+    # The last end sentinel after the payload start, not the first: the payload
+    # may contain sentinel-shaped content, but the real terminator is last since
+    # exactly one result is emitted (issue #34).
+    end = stdout.rfind(RESULT_END, payload_start)
     if end == -1:
         raise ValueError("unterminated GDA result sentinel in stdout")
     payload = stdout[payload_start:end].strip()

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -85,6 +85,31 @@ def test_scene_create_then_get_round_trip(godot_project):
 
 @pytest.mark.e2e
 @requires_godot
+def test_scene_path_containing_end_sentinel_round_trips(godot_project):
+    # issue #34: the result payload echoes the target path verbatim. A path
+    # containing the literal end sentinel must round-trip, not be truncated into
+    # a parse error (exit 5). root_name is explicit because the sentinel's ':'
+    # is not a legal node-name char, so it cannot be derived from this filename.
+    scene_path = godot_project / "weird<<<GDA:END>>>name.tscn"
+
+    created = _gda(
+        "scene", "create", str(scene_path),
+        "--root-type", "Node2D", "--root-name", "Main", "--json",
+    )
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    assert json.loads(created.stdout)["path"] == str(scene_path)
+
+    got = _gda("scene", "get", str(scene_path), "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    tree = json.loads(got.stdout)
+    assert tree["path"] == str(scene_path)
+    assert tree["root"]["name"] == "Main"
+
+
+@pytest.mark.e2e
+@requires_godot
 def test_scene_create_creates_missing_parent_directories(godot_project):
     scene_path = godot_project / "levels" / "demo" / "main.tscn"
 

--- a/tests/test_e2e_scene_security.py
+++ b/tests/test_e2e_scene_security.py
@@ -4,7 +4,8 @@
 scene's stored state, NOT by instantiating it. Instantiating would run the
 ``_init`` of any attached script, so merely *reading* a scene would execute
 arbitrary project code — and a script that prints a sentinel-shaped line could
-forge the command's result (the parser takes the first sentinel match).
+forge or corrupt the command's result. The guarantee is that the scene is never
+instantiated (issue #30), so that line is never emitted in the first place.
 
 This test plants a root script whose ``_init`` both writes a marker file (an
 observable side effect) and prints a forged result block, then asserts neither

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,7 @@
 """S2: the result parser implements the ADR-0002 sentinel contract."""
 
+import json
+
 import pytest
 
 from gda.parser import parse_result
@@ -30,3 +32,14 @@ def test_empty_payload_raises_descriptive_error():
 
     with pytest.raises(ValueError, match="empty GDA result payload"):
         parse_result(stdout)
+
+
+def test_payload_containing_end_sentinel_round_trips():
+    # issue #34: the result payload echoes user-controlled content (a path, and
+    # later node names / script source). If that content contains the literal
+    # end sentinel, extraction must still recover the whole payload — the real
+    # terminator is the LAST end sentinel, not the first.
+    payload = {"path": "res://weird<<<GDA:END>>>name.tscn", "root_type": "Node2D"}
+    stdout = f"<<<GDA:RESULT>>>{json.dumps(payload)}<<<GDA:END>>>\n"
+
+    assert parse_result(stdout) == payload


### PR DESCRIPTION
## Summary

Fixes #34. The result payload echoes user-controlled content (the target path; later node names / `script get` source) verbatim inside the ADR-0002 sentinel block. JSON does not escape the literal end sentinel `<<<GDA:END>>>`, so when that text appears in the payload the parser — which took the **first** end sentinel — truncated the JSON mid-string, and a valid result was misreported as `parse / contract_violation` (exit 5).

## Approach

The operation emits **exactly one** result, so the real terminator is always the **last** end sentinel after the payload start. Switch `find` → `rfind` (bounded after the begin sentinel): payload-internal sentinel text now falls before the real terminator and is recovered intact.

This is robust to **arbitrary payload content** — the issue's stated requirement — without changing the wire format. So:

- the GDScript emitter (`operations.gd`) is untouched,
- the ~5 existing wire-format mirrors in tests are untouched (zero blast radius),
- `--json` output and `GdaError.code` (the agent-facing ABI) are unchanged.

The only residual gap — sentinel-shaped bytes in stdout *after* the single result — is already precluded by ADR-0002's stdout discipline (one result, all diagnostics to stderr), so base64/length-prefix encoding would be over-engineering here.

## Acceptance criteria (#34)

- [x] A scene whose path contains the literal `<<<GDA:END>>>` is reported correctly, not as a parse error (new e2e against real Godot).
- [x] Unit test feeds sentinel-shaped content through the round-trip (`test_parser.py`).
- [x] ADR-0002 updated to document the last-end-sentinel extraction rule (wire format itself unchanged).

## Testing

- `test_parser.py`: round-trip of a payload whose value contains `<<<GDA:END>>>` (was RED: "Unterminated string").
- `test_e2e_scene.py`: real Godot `scene create` → `get` at a path containing `<<<GDA:END>>>`; the path round-trips through both (exit 0), where it previously truncated to exit 5.
- Full suite green: **99 passed** (81 non-e2e + 18 e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)