### PR TITLE
fix(errors): classify environment failures by typed launch_failure, not exit code

### DIFF
--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -16,8 +16,9 @@ is exercised by injecting a crafted ``RunResult`` without touching a real
 engine. The decision tree, top to bottom (``code`` in parentheses; the four
 ``ErrorCategory`` buckets fan out to finer codes):
 
-- exit 127  → environment / binary_not_found      (runner could not launch it)
-- exit 124  → environment / launch_timeout        (launched, hung past timeout)
+- launch NOT_FOUND → environment / binary_not_found  (runner could not launch it)
+- launch TIMEOUT   → environment / launch_timeout     (runner launched it but it
+  hung past the timeout)
 - exit < 0  → operation   / engine_crashed         (engine killed by a signal)
 - exit ≠ 0  → operation   / <operation code>        (operation reported a structured
   failure via the ADR-0002 error envelope — e.g. path_not_found)
@@ -27,10 +28,12 @@ engine. The decision tree, top to bottom (``code`` in parentheses; the four
 - old       → version     / unsupported_version     (below the ADR-0003 minimum,
   ``info``'s per-command layer)
 
-Exit codes come from the single registry in ``gda.exit_codes``: environment
-reuses the runner's shell-convention codes (124/127); version/operation/parse
-get distinct small codes so a shell consumer can tell categories apart without
-parsing the JSON error.
+Environment failures are keyed on the runner's typed ``launch_failure`` reason,
+not the exit code, so an engine (or shell/AppImage wrapper) that *genuinely*
+returns 124/127 is classified as ``operation`` rather than mislabelled
+environment (issue #15). The synthesized environment failures still *exit* with
+the shell-convention codes 124/127; version/operation/parse get distinct small
+codes so a shell consumer can tell categories apart without parsing the JSON error.
 """
 
 from dataclasses import dataclass
@@ -49,7 +52,7 @@ from gda.exit_codes import (
 )
 from gda.models import EngineVersion, ErrorCategory, GdaError, OperationErrorEnvelope
 from gda.parser import parse_result
-from gda.runner import RunResult
+from gda.runner import LaunchFailure, RunResult
 
 # The minimum supported Godot version (ADR-0003): the floor where the modern
 # features gda relies on exist. Resolved from the version gda info reports.
@@ -113,7 +116,7 @@ def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | 
     Command-agnostic: owns the env/operation/parse decision tree shared by all
     commands. Per-command classifiers layer their specific checks on top.
     """
-    if result.exit_code == EXIT_NOT_FOUND:
+    if result.launch_failure is LaunchFailure.NOT_FOUND:
         return _failure(
             ErrorCategory.ENVIRONMENT,
             "binary_not_found",
@@ -121,7 +124,7 @@ def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | 
             EXIT_NOT_FOUND,
             result.stderr,
         )
-    if result.exit_code == EXIT_TIMEOUT:
+    if result.launch_failure is LaunchFailure.TIMEOUT:
         return _failure(
             ErrorCategory.ENVIRONMENT,
             "launch_timeout",

--- a/src/gda/exit_codes.py
+++ b/src/gda/exit_codes.py
@@ -6,8 +6,11 @@ split across ``runner`` and ``errors`` — so the whole contract is reviewable a
 glance and new codes cannot silently collide.
 
 - ``EXIT_NOT_FOUND`` / ``EXIT_TIMEOUT`` follow shell conventions (127 = command
-  not found, 124 = timed out) and are also what the runner *synthesizes* when it
-  cannot get a result from the engine; the CLI maps both to ``environment``.
+  not found, 124 = timed out) and are what the runner *synthesizes* when it
+  cannot get a result from the engine. The CLI maps those synthesized cases to
+  ``environment`` — keyed on the runner's typed ``RunResult.launch_failure``, not
+  the exit code, so an engine that genuinely returns 124/127 is an ``operation``
+  failure, not mislabelled environment (issue #15).
 - ``EXIT_VERSION`` / ``EXIT_OPERATION`` / ``EXIT_PARSE`` are distinct small codes
   the CLI assigns to failures the engine signalled differently or not at all.
 """

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -6,6 +6,7 @@ Given an operation name and JSON params, a runner spawns a one-shot
 exercised against a fake runner without touching a real engine (ADR-0001).
 """
 
+import enum
 import json
 import subprocess
 from dataclasses import dataclass
@@ -25,6 +26,19 @@ OPERATIONS_GD = Path(__file__).parent / "ops" / "operations.gd"
 DEFAULT_TIMEOUT_SECONDS = 60.0
 
 
+class LaunchFailure(enum.Enum):
+    """Why the runner never obtained a result from the engine (issue #15).
+
+    Set *only* by the runner when it synthesizes a result without the engine
+    returning one, so classification keys environment failures on this typed
+    reason rather than on shell-convention exit codes that a real engine or
+    wrapper can itself genuinely return.
+    """
+
+    NOT_FOUND = "not_found"  # the binary could not be launched
+    TIMEOUT = "timeout"  # launched, but did not return before the runner timeout
+
+
 @dataclass
 class RunResult:
     """The raw result of a one-shot headless Godot invocation."""
@@ -32,6 +46,10 @@ class RunResult:
     stdout: str
     stderr: str
     exit_code: int
+    # Set only when the runner synthesized this result (binary missing, timed
+    # out) instead of the engine returning one; ``None`` means the exit_code is
+    # the engine's own (issue #15).
+    launch_failure: "LaunchFailure | None" = None
 
 
 class GodotRunner(Protocol):
@@ -79,12 +97,14 @@ class SubprocessGodotRunner:
                 stdout="",
                 stderr=f"gda: Godot timed out after {self.timeout}s\n",
                 exit_code=EXIT_TIMEOUT,
+                launch_failure=LaunchFailure.TIMEOUT,
             )
         except FileNotFoundError:
             return RunResult(
                 stdout="",
                 stderr=f"gda: Godot binary not found: {self.binary}\n",
                 exit_code=EXIT_NOT_FOUND,
+                launch_failure=LaunchFailure.NOT_FOUND,
             )
         return RunResult(
             stdout=proc.stdout, stderr=proc.stderr, exit_code=proc.returncode

--- a/tests/test_classify_run.py
+++ b/tests/test_classify_run.py
@@ -17,8 +17,9 @@ import pytest
 from pydantic import BaseModel
 
 from gda.errors import Failure, classify_run
+from gda.exit_codes import EXIT_OPERATION
 from gda.models import ErrorCategory
-from gda.runner import RunResult
+from gda.runner import LaunchFailure, RunResult
 
 BINARY = Path("/x/Godot")
 
@@ -58,7 +59,10 @@ def test_synthesized_not_found_maps_to_environment_failure():
     # The runner synthesizes exit 127 + a not-found diagnostic when the binary
     # is missing (#2 convention) — an environment failure naming the binary.
     result = RunResult(
-        stdout="", stderr="gda: Godot binary not found: /x/Godot\n", exit_code=127
+        stdout="",
+        stderr="gda: Godot binary not found: /x/Godot\n",
+        exit_code=127,
+        launch_failure=LaunchFailure.NOT_FOUND,
     )
 
     outcome = classify_run(result, BINARY, SceneSummary)
@@ -76,7 +80,10 @@ def test_synthesized_timeout_maps_to_environment_failure_distinct_from_not_found
     # A launched-but-hung engine is bounded by the runner's timeout: exit 124
     # (#2). Still environment, but distinguishable from binary-not-found.
     result = RunResult(
-        stdout="", stderr="gda: Godot timed out after 60.0s\n", exit_code=124
+        stdout="",
+        stderr="gda: Godot timed out after 60.0s\n",
+        exit_code=124,
+        launch_failure=LaunchFailure.TIMEOUT,
     )
 
     outcome = classify_run(result, BINARY, SceneSummary)
@@ -85,6 +92,34 @@ def test_synthesized_timeout_maps_to_environment_failure_distinct_from_not_found
     assert outcome.exit_code == 124
     assert outcome.error.category == ErrorCategory.ENVIRONMENT
     assert outcome.error.code == "launch_timeout"
+
+
+def test_engine_returned_127_is_operation_not_environment():
+    # A genuine engine/wrapper exit of 127 — with NO runner-synthesized launch
+    # failure — is the engine's own result, not a binary-not-found. It must
+    # classify as operation, never environment (issue #15).
+    result = RunResult(stdout="", stderr="engine said boom\n", exit_code=127)
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.category == ErrorCategory.OPERATION
+    assert outcome.error.code != "binary_not_found"
+    assert outcome.exit_code == EXIT_OPERATION
+
+
+def test_engine_returned_124_is_operation_not_environment():
+    # Symmetric to 127: a genuine engine/wrapper exit of 124 with no runner-
+    # synthesized launch failure is the engine's own result, not a launch
+    # timeout (issue #15).
+    result = RunResult(stdout="", stderr="engine said 124\n", exit_code=124)
+
+    outcome = classify_run(result, BINARY, SceneSummary)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.category == ErrorCategory.OPERATION
+    assert outcome.error.code != "launch_timeout"
+    assert outcome.exit_code == EXIT_OPERATION
 
 
 def test_signal_death_maps_to_operation_failure_naming_the_signal():

--- a/tests/test_headless_command.py
+++ b/tests/test_headless_command.py
@@ -8,7 +8,7 @@ import typer
 
 from gda.headless import HeadlessCommand
 from gda.models import EngineVersion, InfoParams
-from gda.runner import RunResult
+from gda.runner import LaunchFailure, RunResult
 from tests.support import FakeRunner, sentinel
 
 VERSION_INFO = {
@@ -63,6 +63,7 @@ def test_headless_command_emit_owns_structured_failure_output(capsys):
             stdout="",
             stderr="gda: Godot binary not found: /tmp/missing\n",
             exit_code=127,
+            launch_failure=LaunchFailure.NOT_FOUND,
         )
     )
 

--- a/tests/test_info_errors.py
+++ b/tests/test_info_errors.py
@@ -13,7 +13,7 @@ import json
 from typer.testing import CliRunner
 
 from gda.cli import app
-from gda.runner import RunResult
+from gda.runner import LaunchFailure, RunResult
 from tests.support import inject_runner as _inject
 
 
@@ -26,6 +26,7 @@ def test_binary_not_found_maps_to_environment_error(monkeypatch):
             stdout="",
             stderr="gda: Godot binary not found: /x/Godot\n",
             exit_code=127,
+            launch_failure=LaunchFailure.NOT_FOUND,
         ),
     )
 
@@ -49,6 +50,7 @@ def test_launch_timeout_maps_to_environment_error_distinct_from_not_found(monkey
             stdout="",
             stderr="gda: Godot timed out after 60.0s\n",
             exit_code=124,
+            launch_failure=LaunchFailure.TIMEOUT,
         ),
     )
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -8,7 +8,8 @@ CLI already handles via its exit-code path.
 import subprocess
 from pathlib import Path
 
-from gda.runner import SubprocessGodotRunner
+from gda.exit_codes import EXIT_NOT_FOUND, EXIT_TIMEOUT
+from gda.runner import LaunchFailure, SubprocessGodotRunner
 
 
 def test_missing_binary_maps_to_nonzero_result_not_traceback():
@@ -16,9 +17,12 @@ def test_missing_binary_maps_to_nonzero_result_not_traceback():
 
     result = runner.run("info", {})
 
-    assert result.exit_code != 0
+    assert result.exit_code == EXIT_NOT_FOUND
     assert "/nonexistent/Godot" in result.stderr
     assert result.stdout == ""
+    # The runner flags this as a synthesized launch failure so the classifier
+    # keys environment on the typed reason, not the overloaded exit code (#15).
+    assert result.launch_failure is LaunchFailure.NOT_FOUND
 
 
 def test_timeout_maps_to_nonzero_result(monkeypatch):
@@ -30,8 +34,9 @@ def test_timeout_maps_to_nonzero_result(monkeypatch):
 
     result = runner.run("info", {})
 
-    assert result.exit_code != 0
+    assert result.exit_code == EXIT_TIMEOUT
     assert "timed out" in result.stderr.lower()
+    assert result.launch_failure is LaunchFailure.TIMEOUT
 
 
 def test_timeout_is_passed_through_to_subprocess(monkeypatch):
@@ -50,6 +55,9 @@ def test_timeout_is_passed_through_to_subprocess(monkeypatch):
     monkeypatch.setattr(subprocess, "run", fake_run)
     runner = SubprocessGodotRunner(Path("/any/Godot"), timeout=42.0)
 
-    runner.run("info", {})
+    result = runner.run("info", {})
 
     assert captured["timeout"] == 42.0
+    # An engine that actually returned has no synthesized launch failure, so its
+    # exit code is classified as the engine's own result (#15).
+    assert result.launch_failure is None

--- a/tests/test_scene_errors.py
+++ b/tests/test_scene_errors.py
@@ -12,7 +12,7 @@ import json
 from typer.testing import CliRunner
 
 from gda.cli import app
-from gda.runner import RunResult
+from gda.runner import LaunchFailure, RunResult
 from tests.support import error_sentinel, inject_runner
 
 
@@ -141,7 +141,10 @@ def test_scene_create_missing_binary_maps_to_environment_error(monkeypatch):
     inject_runner(
         monkeypatch,
         RunResult(
-            stdout="", stderr="gda: Godot binary not found: /x/Godot\n", exit_code=127
+            stdout="",
+            stderr="gda: Godot binary not found: /x/Godot\n",
+            exit_code=127,
+            launch_failure=LaunchFailure.NOT_FOUND,
         ),
     )
 


### PR DESCRIPTION
## Summary

Fixes #15. `classify_run` distinguished environment from operation failures purely by exit code: `127 → binary_not_found`, `124 → launch_timeout`. But those are shell-convention codes the runner only **synthesizes** when it catches `FileNotFoundError` / `TimeoutExpired`. A real engine — or a shell/AppImage wrapper — that genuinely exits 124 or 127 for an operation reason was mislabelled `environment`, pointing the user at binary resolution when the real fault is downstream.

## Approach

Add a typed `RunResult.launch_failure` (`NOT_FOUND | TIMEOUT | None`), set **only** by the runner when it synthesizes a result without the engine returning one. `classify_run` now keys its environment branches on that field; any engine-returned exit code — including a genuine 124/127 — falls through to the operation branch. The synthesized cases keep their existing #3 error shapes and exit codes.

This is the last of three skeleton fixes inherited by every future domain command; the change is in shared infrastructure (`runner.py` + `errors.py`).

## Acceptance criteria (#15)

- [x] A runner-synthesized not-found/timeout still maps to `environment` / `binary_not_found` | `launch_timeout` (exit 127/124 preserved).
- [x] An engine process that genuinely exits 124 or 127 maps to `operation`, not `environment`.
- [x] Existing #3 error shapes and exit codes preserved for the synthesized cases.
- [x] Unit tests cover "runner synthesized 127" and "engine returned 127" distinctly.

## Testing

- `test_classify_run.py`: new `engine_returned_127`/`engine_returned_124` → operation (RED on the old exit-code keying); the two `synthesized_*` tests now set `launch_failure` and keep asserting environment.
- `test_runner.py`: assert the runner sets `launch_failure = NOT_FOUND`/`TIMEOUT` on the synthesized paths and `None` on a real engine return.
- e2e: `test_e2e_info::binary_not_found` (real runner, missing binary) and `test_e2e_op_robustness` (real op → operation, never 124) validate both halves end-to-end.
- The 6 existing environment-simulating tests updated to the new idiom (set `launch_failure`).
- Full suite green: **101 passed** (83 non-e2e + 18 e2e). Manual: `gda info --godot /nonexistent` → `environment/binary_not_found`, exit 127 (preserved).

## Docs

`errors.py` decision-tree docstring and `exit_codes.py` updated: environment is keyed on the typed `launch_failure`, and a genuine engine 124/127 is an operation failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)