### PR TITLE
feat(node): gda node add + node list — the node-group tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ for the full picture.
 
 **Working today**
 
-- ✅ A first working command surface: the `info` meta command and the first domain command group,
-  `gda scene create` / `gda scene get` ([ADR-0005](docs/adr/0005-cli-command-taxonomy.md)).
+- ✅ A first working command surface: the `info` meta command and the first domain command groups —
+  `gda scene create` / `gda scene get` and `gda node add` / `gda node list`
+  ([ADR-0005](docs/adr/0005-cli-command-taxonomy.md)).
 - ✅ The contract every shipped command carries: structured `--json` output, model-derived
   `--schema` self-description ([ADR-0004](docs/adr/0004-schema-flag-self-description.md)), and
   structured `{"error": {category, code, …}}` failures with category-distinguishing exit codes.
@@ -66,8 +67,8 @@ for the full picture.
 
 **On the roadmap** (designed, not yet implemented)
 
-- 🔜 The remaining domain command groups and commands: `node`, `script`, `project`, `resource`,
-  `export`, …
+- 🔜 The remaining domain command groups and commands: the rest of `node`, `script`, `project`,
+  `resource`, `export`, …
 - 🔜 `gda-mcp`, a thin [Model Context Protocol](https://modelcontextprotocol.io) adapter generated
   from `--schema`.
 - 🔜 `gda-daemon` for *live operations* against a running engine (Phase 2).
@@ -159,6 +160,17 @@ gda scene create game/main.tscn --root-type Node2D --json
 
 gda scene get game/main.tscn --json
 # {"path":"game/main.tscn","root":{"name":"main","type":"Node2D","children":[]}}
+```
+
+Add a node into that scene and verify it landed — nodes are addressed by their path relative to
+the scene root (`.` is the root itself):
+
+```bash
+gda node add game/main.tscn --type Sprite2D --name Hero --json
+# {"scene_path":"game/main.tscn","path":"Hero","name":"Hero","type":"Sprite2D","script_class":null}
+
+gda node list game/main.tscn --json
+# {"scene_path":"game/main.tscn","root":{"name":"main","type":"Node2D","path":".","children":[{"name":"Hero","type":"Sprite2D","path":"Hero","children":[]}]}}
 ```
 
 ---

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -80,6 +80,10 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 | `save_failed` | `operation` | `operation` | A scene could not be packed or saved. |
 | `path_not_found` | `operation` | `operation` | A requested scene file does not exist. |
 | `not_a_scene` | `operation` | `operation` | A requested file cannot be loaded as a `PackedScene`. |
+| `parent_not_found` | `operation` | `operation` | A requested parent node path does not resolve to a node in the scene. |
+| `invalid_node_type` | `operation` | `operation` | A requested node type is neither an instantiable `Node` class nor a registered `class_name`. |
+| `invalid_node_name` | `operation` | `operation` | A requested node name is empty or would be rewritten by Godot. |
+| `duplicate_node_name` | `operation` | `operation` | The parent node already has a child with the requested name. |
 | `contract_violation` | `parse` | `parser` | The process claimed success but violated the structured-output contract. |
 
 ## Considered options

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -34,7 +34,7 @@ issue ref (e.g. `🔜 (#53)`) marks a candidate already committed as an open sli
 | `gda info` | Report Godot engine version info | 1 | ✅ |
 | `gda version` | Report `gda`'s own version | — (local) | 🔜 |
 | `gda help` | Usage help | — (local) | ✅ (`--help`) |
-| `gda <command> --schema` | Emit a command's input/output JSON Schema (ADR-0004) | — (local) | ✅ (`info` #4; `scene create`/`scene get` #18) |
+| `gda <command> --schema` | Emit a command's input/output JSON Schema (ADR-0004) | — (local) | ✅ (`info` #4; `scene create`/`scene get` #18; `node add`/`node list` #53) |
 
 > `--schema` is a per-command flag, not a command, and ships with **every** domain
 > command as a hard gate (ADR-0004). It is local introspection — no Godot process.
@@ -57,12 +57,18 @@ issue ref (e.g. `🔜 (#53)`) marks a candidate already committed as an open sli
 
 Operates on nodes **within a scene file** (load → mutate → pack → save), so headless.
 
+**Node-path addressing** (established by #53): a node within a scene is addressed by its node
+path **relative to the scene root** — `.` is the root itself, `Player/Arm` a nested node.
+Absolute paths (`/root/…`) are rejected. `gda node list` reports every node's path in exactly
+this form, so a listed path can be fed straight back into other node commands (e.g.
+`node add --parent`).
+
 | Command | Description | Status |
 | --- | --- | --- |
-| `gda node add` | Add a node (by type or `class_name` script) into a scene | 🔜 (#53) |
+| `gda node add` | Add a node (by type or `class_name` script) into a scene | ✅ (#53) |
 | `gda node remove` | Remove a node from a scene | 🔜 (#56) |
 | `gda node get` | Read a node's properties | 🔜 (#55) |
-| `gda node list` | List nodes in a scene (optionally filtered by type/group) | 🔜 (#53) |
+| `gda node list` | List nodes in a scene (optionally filtered by type/group) | ✅ (#53) |
 | `gda node set` | Set a node property (type-coerced) | 🔜 (#55) |
 | `gda node move` | Reparent a node | 🔜 (#56) |
 | `gda node duplicate` | Duplicate a node | 🔜 (#56) |

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -24,6 +24,11 @@ from gda.headless import (
 from gda.models import (
     EngineVersion,
     InfoParams,
+    ListedNode,
+    NodeAddParams,
+    NodeAddResult,
+    NodeListParams,
+    NodeListResult,
     SceneCreateParams,
     SceneCreateResult,
     SceneGetParams,
@@ -45,6 +50,13 @@ scene_app = typer.Typer(
     help="Act on Godot scene files (.tscn).", no_args_is_help=True
 )
 app.add_typer(scene_app, name="scene")
+
+# The node command group (issue #53): commands acting on nodes WITHIN a scene
+# file (load → locate → mutate → pack → save), so they stay headless.
+node_app = typer.Typer(
+    help="Act on nodes within a scene file (.tscn).", no_args_is_help=True
+)
+app.add_typer(node_app, name="node")
 
 
 def _version_callback(value: Optional[bool]) -> None:
@@ -96,6 +108,18 @@ SCENE_GET_COMMAND: HeadlessCommand[SceneGetResult] = HeadlessCommand(
     output_model=SceneGetResult,
 )
 
+NODE_ADD_COMMAND: HeadlessCommand[NodeAddResult] = HeadlessCommand(
+    operation="node-add",
+    input_model=NodeAddParams,
+    output_model=NodeAddResult,
+)
+
+NODE_LIST_COMMAND: HeadlessCommand[NodeListResult] = HeadlessCommand(
+    operation="node-list",
+    input_model=NodeListParams,
+    output_model=NodeListResult,
+)
+
 
 def _normalize_path(path: str) -> str:
     """Normalize a path argument at the CLI layer (issue #32).
@@ -117,7 +141,7 @@ def _derive_scene_root_name(path: str) -> str:
     return filename
 
 
-def _render_tree(node: SceneNode, depth: int = 0) -> str:
+def _render_tree(node: "SceneNode | ListedNode", depth: int = 0) -> str:
     """Render a node tree as an indented ``name (Type)`` outline for humans."""
     lines = [f"{'  ' * depth}{node.name} ({node.type})"]
     lines += (_render_tree(child, depth + 1) for child in node.children)
@@ -180,6 +204,72 @@ def get(
         project=resolve_project_dir(project),
         json_output=json_output,
         render_text=lambda scene: _render_tree(scene.root),
+        make_runner=_make_runner,
+    )
+
+
+@node_app.command(cls=NODE_ADD_COMMAND.command_class())
+def add(
+    path: str = typer.Argument(..., help="The .tscn scene file to mutate."),
+    node_type: str = typer.Option(
+        ...,
+        "--type",
+        help=(
+            "Node type to add: a Godot node class (e.g. Sprite2D), or a "
+            "class_name registered in the project's global class list."
+        ),
+    ),
+    parent: str = typer.Option(
+        ".",
+        "--parent",
+        help=(
+            "Parent node path, relative to the scene root: '.' addresses the "
+            "root itself, 'Player/Arm' a nested node."
+        ),
+    ),
+    name: Optional[str] = typer.Option(
+        None,
+        "--name",
+        help="Name for the new node. Defaults to the type name.",
+    ),
+    json_output: bool = json_option(),
+    schema: bool = NODE_ADD_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Add a node to a scene file under the given parent node path."""
+    NODE_ADD_COMMAND.emit(
+        NodeAddParams(
+            path=_normalize_path(path),
+            parent=parent,
+            type=node_type,
+            name=name if name is not None else node_type,
+        ),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=lambda added: (
+            f"added {added.path} ({added.type}) to {added.scene_path}"
+        ),
+        make_runner=_make_runner,
+    )
+
+
+@node_app.command(name="list", cls=NODE_LIST_COMMAND.command_class())
+def list_nodes(
+    path: str = typer.Argument(..., help="The .tscn scene file to read."),
+    json_output: bool = json_option(),
+    schema: bool = NODE_LIST_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """List a scene's node tree with each node's path relative to the root."""
+    NODE_LIST_COMMAND.emit(
+        NodeListParams(path=_normalize_path(path)),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=lambda listed: _render_tree(listed.root),
         make_runner=_make_runner,
     )
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -124,6 +124,30 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A requested file cannot be loaded as a PackedScene.",
     ),
     ErrorCodeSpec(
+        "parent_not_found",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A requested parent node path does not resolve to a node in the scene.",
+    ),
+    ErrorCodeSpec(
+        "invalid_node_type",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A requested node type is neither an instantiable Node class nor a registered class_name.",
+    ),
+    ErrorCodeSpec(
+        "invalid_node_name",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A requested node name is empty or would be rewritten by Godot.",
+    ),
+    ErrorCodeSpec(
+        "duplicate_node_name",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "The parent node already has a child with the requested name.",
+    ),
+    ErrorCodeSpec(
         "contract_violation",
         ErrorCategory.PARSE,
         ErrorCodeSource.PARSER,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -180,6 +180,96 @@ class SceneGetResult(BaseModel):
     root: SceneNode
 
 
+class NodeAddParams(BaseModel):
+    """The operation params of ``gda node add`` (issue #53).
+
+    ``path`` is the ``.tscn`` scene file to mutate. ``parent`` addresses the
+    parent node by node path. ``type`` is resolved first as a built-in Godot
+    node class, then as a ``class_name`` registered in the project's global
+    class list. ``name`` is explicit so the operation never silently derives a
+    name Godot later sanitizes; when the CLI caller omits ``--name``, it uses
+    the type name.
+    """
+
+    path: str
+    parent: str = Field(
+        default=".",
+        description=(
+            "Parent node path, relative to the scene root: '.' addresses the "
+            "root itself, 'Player/Arm' a nested node."
+        ),
+    )
+    type: str
+    name: str | None = Field(
+        default=None,
+        description=(
+            "Name for the new node. If omitted by the CLI, the type name is "
+            "used. Must be non-empty and must not contain '.', ':', '@', '/', "
+            "'\"', or '%'."
+        ),
+    )
+
+
+class NodeAddResult(BaseModel):
+    """The result of ``gda node add``: the created node and where it landed.
+
+    ``path`` is the created node's node path relative to the scene root, so an
+    agent can address the node in follow-up node commands without re-listing.
+    """
+
+    scene_path: str
+    path: str = Field(
+        description="The created node's node path, relative to the scene root."
+    )
+    name: str
+    type: str = Field(
+        description=(
+            "The created node's engine class (e.g. Node2D) — for a class_name "
+            "addition, the script's base class."
+        )
+    )
+    script_class: str | None = Field(
+        default=None,
+        description=(
+            "The class_name of the script attached to the created node, when "
+            "the requested type resolved to a script class; null for a "
+            "built-in type."
+        ),
+    )
+
+
+class ListedNode(BaseModel):
+    """One node of ``gda node list``'s tree: name, type, node path, children.
+
+    Like ``SceneNode`` but each node also carries its node path relative to the
+    scene root ('.' for the root itself) — the address an agent feeds back into
+    other node commands (e.g. ``node add --parent``).
+    """
+
+    name: str
+    type: str
+    path: str = Field(
+        description=(
+            "The node's node path relative to the scene root: '.' for the root "
+            "itself, 'Player/Arm' for a nested node."
+        )
+    )
+    children: list["ListedNode"] = []
+
+
+class NodeListParams(BaseModel):
+    """The operation params of ``gda node list``: the ``.tscn`` file to read."""
+
+    path: str
+
+
+class NodeListResult(BaseModel):
+    """The result of ``gda node list``: the scene's node tree with node paths."""
+
+    scene_path: str
+    root: ListedNode
+
+
 class EngineVersion(BaseModel):
     """The Godot engine version, as reported by ``Engine.get_version_info()``.
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -34,8 +34,12 @@ const OP_ERROR_ALREADY_EXISTS := "already_exists"
 const OP_ERROR_SAVE_FAILED := "save_failed"
 const OP_ERROR_PATH_NOT_FOUND := "path_not_found"
 const OP_ERROR_NOT_A_SCENE := "not_a_scene"
+const OP_ERROR_PARENT_NOT_FOUND := "parent_not_found"
+const OP_ERROR_INVALID_NODE_TYPE := "invalid_node_type"
+const OP_ERROR_INVALID_NODE_NAME := "invalid_node_name"
+const OP_ERROR_DUPLICATE_NODE_NAME := "duplicate_node_name"
 
-const ROOT_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
+const NODE_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
 
 # The exit code the process will use. Defaults to failure, so an operation that
 # aborts before recording an outcome (e.g. an uncaught runtime error) still
@@ -63,6 +67,10 @@ func _initialize() -> void:
 			_op_scene_create(params)
 		"scene-get":
 			_op_scene_get(params)
+		"node-add":
+			_op_node_add(params)
+		"node-list":
+			_op_node_list(params)
 		_:
 			_fail(OP_ERROR_UNKNOWN_OPERATION, "unknown operation: " + operation)
 
@@ -106,7 +114,7 @@ func _op_scene_create(params: Dictionary) -> void:
 		_fail(OP_ERROR_INVALID_ROOT_TYPE, "not an instantiable Node class: " + root_type)
 		return
 	var root_name := _string_param(params, "root_name")
-	if not _is_valid_root_name(root_name):
+	if not _is_valid_node_name(root_name):
 		_fail(OP_ERROR_INVALID_ROOT_NAME, "invalid root_name: " + root_name)
 		return
 	if FileAccess.file_exists(path) or DirAccess.dir_exists_absolute(path):
@@ -154,40 +162,198 @@ func _op_scene_create(params: Dictionary) -> void:
 # without constructing a single node.
 func _op_scene_get(params: Dictionary) -> void:
 	_diag("running operation: scene-get")
+	var packed: PackedScene = _load_scene(params)
+	if packed == null:
+		return  # _load_scene already recorded the failure
+
+	_succeed({
+		"path": _string_param(params, "path"),
+		"root": _tree_from_state(packed.get_state()),
+	})
+
+
+# node-add: load a .tscn, add a child node under a parent node path, pack and
+# save it back — the node-group mutate tracer (issue #53). The parent is
+# addressed by node path relative to the scene root ('.' is the root itself).
+#
+# Unlike the read operations, mutation REQUIRES instantiating the scene — only
+# a real node tree can be edited and re-packed. Instantiating runs the _init
+# of any script attached in the scene, so node-add executes project code where
+# scene-get (issue #30) deliberately does not; likewise creating a class_name
+# node runs that script's constructor. Inherent to headless file mutation.
+func _op_node_add(params: Dictionary) -> void:
+	_diag("running operation: node-add")
+	var packed: PackedScene = _load_scene(params)
+	if packed == null:
+		return  # _load_scene already recorded the failure
+	var path := _string_param(params, "path")
+
+	var node_name := _string_param(params, "name")
+	if not _is_valid_node_name(node_name):
+		_fail(OP_ERROR_INVALID_NODE_NAME, "invalid name: " + node_name)
+		return
+
+	var root: Node = packed.instantiate()
+	var parent_path := _string_param(params, "parent")
+	var parent := _resolve_parent(root, parent_path)
+	if parent == null:
+		root.free()
+		_fail(OP_ERROR_PARENT_NOT_FOUND, "parent node not found in scene: " + parent_path)
+		return
+	if parent.get_node_or_null(NodePath(node_name)) != null:
+		root.free()
+		_fail(OP_ERROR_DUPLICATE_NODE_NAME, "parent " + parent_path + " already has a child named: " + node_name)
+		return
+
+	var type := _string_param(params, "type")
+	var node := _instantiate_node_type(type)
+	if node == null:
+		root.free()
+		_fail(OP_ERROR_INVALID_NODE_TYPE, "not an instantiable Node class or registered class_name: " + type)
+		return
+
+	node.name = node_name
+	var actual_name := String(node.name)
+	if actual_name != node_name:
+		node.free()
+		root.free()
+		_fail(OP_ERROR_INVALID_NODE_NAME, "Godot rewrote name from " + node_name + " to " + actual_name)
+		return
+	parent.add_child(node)
+	node.owner = root
+
+	var repacked := PackedScene.new()
+	var pack_err := repacked.pack(root)
+	if pack_err != OK:
+		root.free()
+		_fail(OP_ERROR_SAVE_FAILED, "failed to pack scene: " + error_string(pack_err))
+		return
+	var node_path := String(root.get_path_to(node))
+	var node_type := node.get_class()
+	var script_class: Variant = _script_class_of(node)
+	var save_err := ResourceSaver.save(repacked, path)
+	root.free()
+	if save_err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message(path, save_err))
+		return
+
+	_succeed({
+		"scene_path": path,
+		"path": node_path,
+		"name": actual_name,
+		"type": node_type,
+		"script_class": script_class,
+	})
+
+
+# node-list: load a .tscn and emit its node tree with per-node paths — the
+# node-group verifier (issue #53): each node carries the address an agent
+# feeds back into node add's --parent. Reads SceneState without instantiating,
+# exactly like scene-get (issue #30): listing must not execute project code.
+func _op_node_list(params: Dictionary) -> void:
+	_diag("running operation: node-list")
+	var packed: PackedScene = _load_scene(params)
+	if packed == null:
+		return  # _load_scene already recorded the failure
+
+	_succeed({
+		"scene_path": _string_param(params, "path"),
+		"root": _tree_from_state(packed.get_state(), true),
+	})
+
+
+# Load the .tscn named by params.path for reading or mutation, validating the
+# shared failure ladder: missing param → missing file → not loadable as a
+# scene → scene without a root. Returns null after recording the failure.
+func _load_scene(params: Dictionary) -> PackedScene:
 	var path := _string_param(params, "path")
 	if path.is_empty():
 		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
-		return
+		return null
 	if not FileAccess.file_exists(path):
 		_fail(OP_ERROR_PATH_NOT_FOUND, "scene file does not exist: " + path)
-		return
-
+		return null
 	var packed := ResourceLoader.load(path, "PackedScene") as PackedScene
 	if packed == null:
 		_fail(OP_ERROR_NOT_A_SCENE, "failed to load as a scene: " + path)
-		return
+		return null
 	var state := packed.get_state()
 	if state == null or state.get_node_count() == 0:
 		_fail(OP_ERROR_NOT_A_SCENE, "scene declares no root node: " + path)
-		return
+		return null
+	return packed
 
-	_succeed({"path": path, "root": _tree_from_state(state)})
+
+# Resolve a parent node path against the scene root. Node-path addressing
+# (issue #53) is relative to the scene root: '.' is the root itself,
+# 'Player/Arm' a descendant. Absolute paths are rejected — they would require
+# the scene to live inside a SceneTree, which a loaded-for-editing tree does not.
+func _resolve_parent(root: Node, parent_path: String) -> Node:
+	if parent_path.is_empty():
+		return null
+	var node_path := NodePath(parent_path)
+	if node_path.is_absolute():
+		return null
+	return root.get_node_or_null(node_path)
+
+
+# Instantiate a node by type: a built-in Node class first, then a class_name
+# from the project's global class list (script classes register only once the
+# project has been imported/scanned). Returns null when the type resolves to
+# nothing instantiable as a Node.
+func _instantiate_node_type(type: String) -> Node:
+	if type.is_empty():
+		return null
+	if ClassDB.can_instantiate(type) and ClassDB.is_parent_class(type, "Node"):
+		return ClassDB.instantiate(type)
+	for entry in ProjectSettings.get_global_class_list():
+		if String(entry.get("class", "")) != type:
+			continue
+		var script := ResourceLoader.load(String(entry.get("path", ""))) as Script
+		if script == null:
+			return null
+		var instance: Variant = script.new()
+		if instance is Node:
+			return instance
+		if instance is Object and not (instance is RefCounted):
+			instance.free()
+		return null
+	return null
+
+
+# The class_name of the node's attached script, or null for a plain built-in
+# node (or a script with no class_name) — the result field an agent asserts to
+# confirm a class_name addition took effect.
+func _script_class_of(node: Node) -> Variant:
+	var script := node.get_script() as Script
+	if script == null:
+		return null
+	var global_name := String(script.get_global_name())
+	if global_name.is_empty():
+		return null
+	return global_name
 
 
 # Build the structured node tree from a SceneState. The state lists nodes in
-# tree order; each carries a node path ("." for the root, "Hero/Hitbox" for a
-# descendant) and the path to its parent, which is enough to reconstruct the
-# parent/child structure without instantiating anything.
-func _tree_from_state(state: SceneState) -> Dictionary:
+# tree order; each carries a node path ("." for the root, "./Hero/Hitbox" for
+# a descendant) and the path to its parent, which is enough to reconstruct the
+# parent/child structure without instantiating anything. with_paths includes
+# each node's path in the emitted tree (node-list's addressing contract),
+# normalized to the root-relative form node add accepts and reports: the
+# state's "./Hero" prefix form becomes "Hero", the root stays ".".
+func _tree_from_state(state: SceneState, with_paths := false) -> Dictionary:
 	var by_path := {}
 	var root: Dictionary = {}
 	for i in state.get_node_count():
+		var state_path := String(state.get_node_path(i))
 		var node := {
 			"name": String(state.get_node_name(i)),
 			"type": String(state.get_node_type(i)),
 			"children": [],
 		}
-		by_path[String(state.get_node_path(i))] = node
+		if with_paths:
+			node["path"] = state_path.trim_prefix("./")
+		by_path[state_path] = node
 		if i == 0:
 			root = node
 		else:
@@ -207,11 +373,11 @@ func _string_param(params: Dictionary, key: String) -> String:
 	return ""
 
 
-func _is_valid_root_name(root_name: String) -> bool:
-	if root_name.is_empty():
+func _is_valid_node_name(node_name: String) -> bool:
+	if node_name.is_empty():
 		return false
-	for invalid_char in ROOT_NAME_INVALID_CHARS:
-		if root_name.contains(String(invalid_char)):
+	for invalid_char in NODE_NAME_INVALID_CHARS:
+		if node_name.contains(String(invalid_char)):
 			return false
 	return true
 

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -1,0 +1,299 @@
+"""S1 (e2e): the node add → list round-trip against the real Godot engine.
+
+The node-group tracer (issue #53): ``gda node add`` loads a ``.tscn``, adds a
+child under a parent node path, packs and saves; ``gda node list`` reads the
+tree back with per-node paths — ``node list`` IS the structured-level
+verification of ``node add``'s effect.
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+GODOT = resolve_godot_binary()
+
+requires_godot = pytest.mark.skipif(
+    not GODOT.exists(), reason=f"real Godot binary not found at {GODOT}"
+)
+
+
+def _gda(*args: str) -> subprocess.CompletedProcess:
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+    return subprocess.run(
+        [gda_bin, *args, "--godot", str(GODOT)], capture_output=True, text=True
+    )
+
+
+def _create_scene(scene_path) -> None:
+    created = _gda(
+        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
+    )
+    assert created.returncode == 0, created.stdout + created.stderr
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_then_list_round_trip(godot_project):
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+
+    added = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Sprite2D", "--name", "Hero", "--json",
+    )
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    data = json.loads(added.stdout)
+    # The created node's address: its node path relative to the scene root.
+    assert data["scene_path"] == str(scene_path)
+    assert data["path"] == "Hero"
+    assert data["name"] == "Hero"
+    assert data["type"] == "Sprite2D"
+
+    listed = _gda("node", "list", str(scene_path), "--json")
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    tree = json.loads(listed.stdout)
+    # Round-trip: the saved scene file declares the added node — the mutation
+    # is on disk, not just in the reporting process.
+    root = tree["root"]
+    assert (root["name"], root["type"], root["path"]) == ("main", "Node2D", ".")
+    hero = root["children"][0]
+    assert (hero["name"], hero["type"], hero["path"]) == ("Hero", "Sprite2D", "Hero")
+    assert hero["children"] == []
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_under_nested_parent_path(godot_project):
+    # Node-path addressing end-to-end (issue #53): the path node list reports
+    # for a node ("Hero") is exactly the address node add accepts as --parent,
+    # and the second mutation must preserve the first (existing children
+    # survive the load → mutate → pack → save round-trip).
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+
+    first = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Sprite2D", "--name", "Hero", "--json",
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+
+    second = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Area2D", "--name", "Hitbox", "--parent", "Hero", "--json",
+    )
+
+    assert second.returncode == 0, second.stdout + second.stderr
+    data = json.loads(second.stdout)
+    assert data["path"] == "Hero/Hitbox"
+    assert data["type"] == "Area2D"
+
+    listed = _gda("node", "list", str(scene_path), "--json")
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    hero = json.loads(listed.stdout)["root"]["children"][0]
+    assert hero["path"] == "Hero"
+    assert hero["children"][0]["path"] == "Hero/Hitbox"
+    assert hero["children"][0]["type"] == "Area2D"
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_default_name_is_the_type_name(godot_project):
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+
+    added = _gda("node", "add", str(scene_path), "--type", "Sprite2D", "--json")
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    data = json.loads(added.stdout)
+    assert data["name"] == "Sprite2D"
+    assert data["path"] == "Sprite2D"
+
+
+def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
+    assert proc.returncode == 4, proc.stdout + proc.stderr
+    err = json.loads(proc.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == code
+    return err
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_to_missing_scene_yields_path_not_found(godot_project):
+    missing = godot_project / "missing.tscn"
+
+    added = _gda("node", "add", str(missing), "--type", "Sprite2D", "--json")
+
+    err = _assert_operation_error(added, "path_not_found")
+    assert str(missing) in err["message"]
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_bad_parent_yields_parent_not_found_and_leaves_file_unchanged(
+    godot_project,
+):
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    before = scene_path.read_text(encoding="utf-8")
+
+    added = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Sprite2D", "--parent", "Bogus/Path", "--json",
+    )
+
+    err = _assert_operation_error(added, "parent_not_found")
+    assert "Bogus/Path" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_name_collision_yields_duplicate_node_name(godot_project):
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    first = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Sprite2D", "--name", "Hero", "--json",
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+    before = scene_path.read_text(encoding="utf-8")
+
+    again = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Area2D", "--name", "Hero", "--json",
+    )
+
+    err = _assert_operation_error(again, "duplicate_node_name")
+    assert "Hero" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_unknown_type_yields_invalid_node_type(godot_project):
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    before = scene_path.read_text(encoding="utf-8")
+
+    added = _gda("node", "add", str(scene_path), "--type", "NotAClass", "--json")
+
+    err = _assert_operation_error(added, "invalid_node_type")
+    assert "NotAClass" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_rejects_name_godot_would_rewrite(godot_project):
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+
+    added = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Sprite2D", "--name", "Bad%Name", "--json",
+    )
+
+    err = _assert_operation_error(added, "invalid_node_name")
+    assert "Bad%Name" in err["message"]
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_list_missing_scene_yields_path_not_found(godot_project):
+    missing = godot_project / "missing.tscn"
+
+    listed = _gda("node", "list", str(missing), "--json")
+
+    err = _assert_operation_error(listed, "path_not_found")
+    assert str(missing) in err["message"]
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_list_non_scene_file_yields_not_a_scene(godot_project):
+    notes = godot_project / "notes.txt"
+    notes.write_text("not a scene\n", encoding="utf-8")
+
+    listed = _gda("node", "list", str(notes), "--json")
+
+    _assert_operation_error(listed, "not_a_scene")
+
+
+HERO_GD = """\
+class_name Hero
+extends Node2D
+"""
+
+
+def _import_project(project) -> None:
+    # class_name registration lives in .godot/global_script_class_list.cfg,
+    # which only a project scan produces — run the engine's headless import
+    # step the way a CI pipeline would before using script classes.
+    imported = subprocess.run(
+        [str(GODOT), "--headless", "--path", str(project), "--import"],
+        capture_output=True,
+        text=True,
+    )
+    assert imported.returncode == 0, imported.stdout + imported.stderr
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_by_class_name_attaches_the_script(godot_project):
+    # The second half of --type's contract (issue #53): a class_name registered
+    # in the project's global class list resolves like a built-in type. The
+    # created node reports its engine class as type and the class_name as
+    # script_class, so an agent can assert the script attach without reading
+    # the .tscn.
+    (godot_project / "hero.gd").write_text(HERO_GD, encoding="utf-8")
+    _import_project(godot_project)
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+
+    added = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Hero", "--project", str(godot_project), "--json",
+    )
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    data = json.loads(added.stdout)
+    assert data["name"] == "Hero"
+    assert data["path"] == "Hero"
+    assert data["type"] == "Node2D"
+    assert data["script_class"] == "Hero"
+
+    listed = _gda("node", "list", str(scene_path), "--json")
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    hero = json.loads(listed.stdout)["root"]["children"][0]
+    # The .tscn stores a scripted node under its engine class; the script ref
+    # itself is in the saved file.
+    assert (hero["name"], hero["type"]) == ("Hero", "Node2D")
+    assert "hero.gd" in scene_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_by_unregistered_class_name_yields_invalid_node_type(godot_project):
+    # Without a project import there is no global class list: the class_name
+    # cannot resolve, and the failure must be the structured invalid_node_type,
+    # not a crash or a silent plain-Node fallback.
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+
+    added = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Hero", "--project", str(godot_project), "--json",
+    )
+
+    err = _assert_operation_error(added, "invalid_node_type")
+    assert "Hero" in err["message"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,13 @@
 
 import json
 
-from gda.models import EngineVersion, SceneCreateResult, SceneGetResult
+from gda.models import (
+    EngineVersion,
+    NodeAddResult,
+    NodeListResult,
+    SceneCreateResult,
+    SceneGetResult,
+)
 
 
 def test_validates_from_engine_get_version_info_dict():
@@ -87,3 +93,72 @@ def test_scene_get_result_round_trips_a_nested_tree():
 
     assert scene.root.children[0].children[0].name == "Hitbox"
     assert json.loads(scene.model_dump_json()) == payload
+
+
+def test_node_add_result_round_trips():
+    # The node-add operation reports the created node's address (issue #53):
+    # its node path relative to the scene root, alongside name and type.
+    # script_class is null for a built-in type, the class_name for a script one.
+    payload = {
+        "scene_path": "/p/main.tscn",
+        "path": "Player/Hero",
+        "name": "Hero",
+        "type": "Sprite2D",
+        "script_class": None,
+    }
+
+    added = NodeAddResult.model_validate(payload)
+
+    assert added.path == "Player/Hero"
+    assert json.loads(added.model_dump_json()) == payload
+
+
+def test_node_add_result_carries_the_class_name_of_a_script_addition():
+    payload = {
+        "scene_path": "/p/main.tscn",
+        "path": "Hero",
+        "name": "Hero",
+        "type": "Node2D",
+        "script_class": "Hero",
+    }
+
+    added = NodeAddResult.model_validate(payload)
+
+    assert added.type == "Node2D"
+    assert added.script_class == "Hero"
+    assert json.loads(added.model_dump_json()) == payload
+
+
+def test_node_list_result_round_trips_a_nested_tree_with_paths():
+    # The recursive ListedNode shape: like SceneNode but every node carries its
+    # node path ('.' for the root), so a validated nested tree must dump back
+    # to the identical payload (S2).
+    payload = {
+        "scene_path": "/p/main.tscn",
+        "root": {
+            "name": "main",
+            "type": "Node2D",
+            "path": ".",
+            "children": [
+                {
+                    "name": "Hero",
+                    "type": "Sprite2D",
+                    "path": "Hero",
+                    "children": [
+                        {
+                            "name": "Hitbox",
+                            "type": "Area2D",
+                            "path": "Hero/Hitbox",
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+
+    listed = NodeListResult.model_validate(payload)
+
+    assert listed.root.path == "."
+    assert listed.root.children[0].children[0].path == "Hero/Hitbox"
+    assert json.loads(listed.model_dump_json()) == payload

--- a/tests/test_node_commands.py
+++ b/tests/test_node_commands.py
@@ -1,0 +1,142 @@
+"""S3: gda node add / node list success paths against a fake runner (issue #53).
+
+The node command group acts on nodes WITHIN a scene file (load → locate →
+mutate → pack → save), staying headless. These tests drive the same proven
+pipeline as the scene group — Typer → binary resolution → runner → sentinel
+parse → typed model → JSON — with canned engine output, no real Godot.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import inject_runner, sentinel
+
+ADD_RESULT = {
+    "scene_path": "/tmp/proj/main.tscn",
+    "path": "Hero",
+    "name": "Hero",
+    "type": "Sprite2D",
+    "script_class": None,
+}
+
+
+def test_node_add_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
+    # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(ADD_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "node",
+            "add",
+            "/tmp/proj/main.tscn",
+            "--type",
+            "Sprite2D",
+            "--parent",
+            ".",
+            "--name",
+            "Hero",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    # stdout carries ONLY the result payload — a single valid JSON object.
+    data = json.loads(result.stdout)
+    assert data["scene_path"] == "/tmp/proj/main.tscn"
+    # The created node's path/name/type (issue #53): path is the node path
+    # relative to the scene root, so an agent can address the node afterwards.
+    assert data["path"] == "Hero"
+    assert data["name"] == "Hero"
+    assert data["type"] == "Sprite2D"
+    # The operation was dispatched by name with the command's typed params.
+    assert fake.calls == [
+        (
+            "node-add",
+            {
+                "path": "/tmp/proj/main.tscn",
+                "parent": ".",
+                "type": "Sprite2D",
+                "name": "Hero",
+            },
+        )
+    ]
+    # Engine/script diagnostics are surfaced on stderr, not stdout.
+    assert "engine diagnostic" in result.stderr
+
+
+LIST_RESULT = {
+    "scene_path": "/tmp/proj/main.tscn",
+    "root": {
+        "name": "main",
+        "type": "Node2D",
+        "path": ".",
+        "children": [
+            {
+                "name": "Hero",
+                "type": "Sprite2D",
+                "path": "Hero",
+                "children": [
+                    {
+                        "name": "Hitbox",
+                        "type": "Area2D",
+                        "path": "Hero/Hitbox",
+                        "children": [],
+                    }
+                ],
+            }
+        ],
+    },
+}
+
+
+def test_node_list_json_emits_node_tree_with_paths_and_exit_zero(monkeypatch):
+    # node list is the node-group verifier (issue #53): it reports the scene's
+    # tree like scene get, but each node carries its node path — the address an
+    # agent feeds back into node add's --parent.
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(LIST_RESULT)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["node", "list", "/tmp/proj/main.tscn", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["scene_path"] == "/tmp/proj/main.tscn"
+    # The root is addressed as '.', matching node add's --parent default.
+    assert data["root"]["path"] == "."
+    hero = data["root"]["children"][0]
+    assert (hero["name"], hero["type"], hero["path"]) == ("Hero", "Sprite2D", "Hero")
+    assert hero["children"][0]["path"] == "Hero/Hitbox"
+    assert fake.calls == [("node-list", {"path": "/tmp/proj/main.tscn"})]
+
+
+def test_node_add_defaults_parent_to_root_and_name_to_type(monkeypatch):
+    # The two ergonomic defaults (issue #53): omitting --parent targets the
+    # scene root ('.'), and omitting --name names the node after its type —
+    # mirroring how the Godot editor names a freshly added node.
+    stdout = sentinel({**ADD_RESULT, "path": "Sprite2D", "name": "Sprite2D"})
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        ["node", "add", "/tmp/proj/main.tscn", "--type", "Sprite2D", "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        (
+            "node-add",
+            {
+                "path": "/tmp/proj/main.tscn",
+                "parent": ".",
+                "type": "Sprite2D",
+                "name": "Sprite2D",
+            },
+        )
+    ]

--- a/tests/test_node_errors.py
+++ b/tests/test_node_errors.py
@@ -1,0 +1,100 @@
+"""S3: gda node failure modes map to structured JSON errors + stable exit codes.
+
+Issue #53's acceptance: node-command failures (scene not found, bad parent
+path, invalid type, name collision) surface as structured ``GdaError``s with
+registered operation codes (ADR-0002) — exit 4 for the operation category,
+finer stable codes so an agent can branch on the mode without parsing prose.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import error_sentinel, inject_runner
+
+
+def _invoke_node_add(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: node-add\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(
+        app,
+        ["node", "add", "/x/main.tscn", "--type", "Sprite2D", "--json"],
+    )
+
+
+def test_node_add_bad_parent_maps_to_stable_parent_not_found_code(monkeypatch):
+    # The scene exists but the requested parent node path resolves to nothing —
+    # a new node-group code, distinct from the file-level path_not_found, so an
+    # agent knows to fix the node path, not the scene path.
+    result = _invoke_node_add(
+        monkeypatch, "parent_not_found", "parent node not found in scene: Bogus/Path"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "parent_not_found"
+    assert "Bogus/Path" in err["message"]
+    # The raw stderr still rides along as diagnostics (ADR-0002).
+    assert err["diagnostics"] == "gda: running operation: node-add\n"
+
+
+def test_node_add_unknown_type_maps_to_stable_invalid_node_type_code(monkeypatch):
+    result = _invoke_node_add(
+        monkeypatch,
+        "invalid_node_type",
+        "not an instantiable Node class or registered class_name: Foo",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_node_type"
+    assert "Foo" in err["message"]
+
+
+def test_node_add_name_collision_maps_to_stable_duplicate_node_name_code(monkeypatch):
+    result = _invoke_node_add(
+        monkeypatch, "duplicate_node_name", "parent already has a child named: Hero"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "duplicate_node_name"
+    assert "Hero" in err["message"]
+
+
+def test_node_add_bad_name_maps_to_stable_invalid_node_name_code(monkeypatch):
+    result = _invoke_node_add(
+        monkeypatch, "invalid_node_name", "invalid name: Bad%Name"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_node_name"
+    assert "Bad%Name" in err["message"]
+
+
+def test_node_add_missing_scene_reuses_stable_path_not_found_code(monkeypatch):
+    # The scene-file-level failure reuses the registered scene code: the
+    # node group introduces no parallel code for the same mode.
+    result = _invoke_node_add(
+        monkeypatch, "path_not_found", "scene file does not exist: /x/main.tscn"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert "/x/main.tscn" in err["message"]

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -149,6 +149,65 @@ def test_scene_schema_spawns_no_godot(monkeypatch):
         assert set(json.loads(result.stdout)) >= {"input", "output"}
 
 
+def test_node_add_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for the node group (issue #53): the bare --schema
+    # flag — no path, no --type — short-circuits into the self-description,
+    # derived from the same typed models that back --json.
+    from gda.models import NodeAddParams, NodeAddResult
+
+    result = CliRunner().invoke(app, ["node", "add", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == NodeAddParams.model_json_schema()
+    assert doc["output"] == NodeAddResult.model_json_schema()
+    # Node-path addressing is defined in the contract itself: the parent param
+    # documents the root-relative convention agents must use.
+    parent_description = doc["input"]["properties"]["parent"]["description"]
+    assert "scene root" in parent_description
+    assert "'.'" in parent_description
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_node_list_schema_emits_model_derived_contract_without_other_args():
+    from gda.models import NodeListParams, NodeListResult
+
+    result = CliRunner().invoke(app, ["node", "list", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == NodeListParams.model_json_schema()
+    assert doc["output"] == NodeListResult.model_json_schema()
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_sample_node_results_validate_against_emitted_output_schemas():
+    # A sample --json payload of each node command satisfies the contract its
+    # --schema emits (the other half of the ADR-0004 hard gate, issue #53).
+    from tests.test_node_commands import ADD_RESULT, LIST_RESULT
+
+    add_doc = json.loads(CliRunner().invoke(app, ["node", "add", "--schema"]).stdout)
+    list_doc = json.loads(CliRunner().invoke(app, ["node", "list", "--schema"]).stdout)
+
+    jsonschema.validate(instance=ADD_RESULT, schema=add_doc["output"])
+    jsonschema.validate(instance=LIST_RESULT, schema=list_doc["output"])
+
+
+def test_node_schema_spawns_no_godot(monkeypatch):
+    def boom(*args, **kwargs):
+        raise AssertionError("--schema must not touch the engine")
+
+    monkeypatch.setattr("gda.headless.resolve_godot_binary", boom)
+    monkeypatch.setattr("gda.cli._make_runner", boom)
+
+    for command in (["node", "add"], ["node", "list"]):
+        result = CliRunner().invoke(app, [*command, "--schema"])
+        assert result.exit_code == 0
+        assert set(json.loads(result.stdout)) >= {"input", "output"}
+
+
 def test_info_input_schema_is_derived_from_the_params_model():
     # info takes no operation params, so its input schema is trivially empty —
     # expected, not an error — and still derived model-side (ADR-0004).


### PR DESCRIPTION
## Summary

Implements #53: establishes the `node` command group — the node-group tracer mirroring the `scene` tracer (#18) — with the load → locate → mutate → pack → save round-trip every other `node` command will reuse.

- **`gda node add`** loads a `.tscn`, adds a child node under a parent node path, names it, packs and saves. `--type` resolves first as a built-in Godot `Node` class, then as a `class_name` from the project's global class list (instantiating the script and attaching it). `--name` defaults to the type name, `--parent` to the scene root. Returns the created node's `path`/`name`/`type` (+ `script_class` for class_name additions) as a typed JSON result.
- **`gda node list`** reports the scene's node tree (name/type/path, nestable) from `SceneState` without instantiating — the structured verifier of `node add` (add → list round-trips), preserving the no-code-execution read property (#30).

## Node-path addressing (established by this slice)

A node within a scene is addressed by its node path **relative to the scene root**: `.` is the root itself, `Player/Arm` a nested node; absolute paths are rejected. `node list` reports every node's path in exactly the form `node add --parent` accepts. Documented in the command catalog and in the `--schema` field descriptions.

## Error contract (ADR-0002)

New operation codes registered in the Python registry + ADR-0002 table + GDScript mirror (drift tests cover all three): `parent_not_found`, `invalid_node_type`, `invalid_node_name`, `duplicate_node_name`. Scene-file failures reuse `path_not_found` / `not_a_scene` / `invalid_path`; failed mutations leave the scene file untouched (asserted e2e).

## Tests (TDD, red→green per slice)

- **S2**: model round-trips for `NodeAddResult` / nested `NodeListResult` trees.
- **S3** (CLI + FakeRunner): success paths, defaults, all five failure modes, `--schema` hard gate (model-derived contracts, sample payloads validate, no Godot spawned).
- **S1** (e2e, real Godot): add → list round-trip, nested parent addressing, default name, all failure modes end-to-end, and class_name resolution against an imported project fixture (`godot --headless --import`).

Full suite: 128 passed (31 e2e against Godot 4.6).

## Known limitation

Mutation requires instantiating the scene, so `node add` on a scene that already contains scripted nodes runs those scripts' `_init` (unlike the read ops, which stay on `SceneState`). Noted in `operations.gd`; inherent to headless file mutation.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)