### PR TITLE
fix(node): refuse node add when instanced sub-scenes vanish on load

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -84,6 +84,7 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 | `invalid_node_type` | `operation` | `operation` | A requested node type is neither an instantiable `Node` class nor a registered `class_name`. |
 | `invalid_node_name` | `operation` | `operation` | A requested node name is empty or would be rewritten by Godot. |
 | `duplicate_node_name` | `operation` | `operation` | The parent node already has a child with the requested name. |
+| `missing_dependency` | `operation` | `operation` | A scene's declared nodes vanished on load, typically an unresolvable instanced sub-scene; re-saving would silently drop them. |
 | `contract_violation` | `parse` | `parser` | The process claimed success but violated the structured-output contract. |
 
 ## Considered options

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -84,7 +84,7 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 | `invalid_node_type` | `operation` | `operation` | A requested node type is neither an instantiable `Node` class nor a registered `class_name`. |
 | `invalid_node_name` | `operation` | `operation` | A requested node name is empty or would be rewritten by Godot. |
 | `duplicate_node_name` | `operation` | `operation` | The parent node already has a child with the requested name. |
-| `missing_dependency` | `operation` | `operation` | A scene's declared nodes vanished on load, typically an unresolvable instanced sub-scene; re-saving would silently drop them. |
+| `missing_dependency` | `operation` | `operation` | A scene's declared nodes vanished or degraded on load — an unresolvable instanced sub-scene or an unavailable node class; re-saving would silently drop or downgrade them. |
 | `contract_violation` | `parse` | `parser` | The process claimed success but violated the structured-output contract. |
 
 ## Considered options

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -63,6 +63,18 @@ Absolute paths (`/root/…`) are rejected. `gda node list` reports every node's 
 this form, so a listed path can be fed straight back into other node commands (e.g.
 `node add --parent`).
 
+**Mutation integrity boundary** (established by #64): mutating a scene instantiates it and
+re-saves the re-packed tree. The round-trip preserves existing instanced sub-scenes and their
+state — the `instance=` reference, `[editable ...]` markers, and node-path-keyed property
+overrides on nodes inside an instance (verified on Godot 4.6.3, regression-pinned in the e2e
+suite). When an instanced sub-scene cannot be resolved on load (a broken dependency, or
+`res://` references without project context — pass `--project`), the engine instantiates the
+scene *without* it, so a re-save would silently erase the instance and all its overrides;
+mutating node commands detect this and refuse with the registered `missing_dependency` error
+(exit 4), leaving the file untouched. Related trust boundary: instantiating executes `_init`
+of scripts already attached in the scene (#62) — treat headless mutation of an untrusted scene
+as running its code.
+
 | Command | Description | Status |
 | --- | --- | --- |
 | `gda node add` | Add a node (by type or `class_name` script) into a scene | ✅ (#53) |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -70,8 +70,10 @@ overrides on nodes inside an instance (verified on Godot 4.6.3, regression-pinne
 suite). When an instanced sub-scene cannot be resolved on load (a broken dependency, or
 `res://` references without project context — pass `--project`), the engine instantiates the
 scene *without* it, so a re-save would silently erase the instance and all its overrides;
-mutating node commands detect this and refuse with the registered `missing_dependency` error
-(exit 4), leaving the file untouched. Related trust boundary: instantiating executes `_init`
+likewise, a declared node class unavailable in the running engine (e.g. an absent
+GDExtension) is silently substituted with a placeholder node, and a re-save would rewrite the
+node under the substitute type. Mutating node commands detect both and refuse with the
+registered `missing_dependency` error (exit 4), leaving the file untouched. Related trust boundary: instantiating executes `_init`
 of scripts already attached in the scene (#62) — treat headless mutation of an untrusted scene
 as running its code.
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -151,8 +151,9 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "missing_dependency",
         ErrorCategory.OPERATION,
         ErrorCodeSource.OPERATION,
-        "A scene's declared nodes vanished on load, typically an unresolvable"
-        " instanced sub-scene; re-saving would silently drop them.",
+        "A scene's declared nodes vanished or degraded on load — an"
+        " unresolvable instanced sub-scene or an unavailable node class;"
+        " re-saving would silently drop or downgrade them.",
     ),
     ErrorCodeSpec(
         "contract_violation",

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -148,6 +148,13 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "The parent node already has a child with the requested name.",
     ),
     ErrorCodeSpec(
+        "missing_dependency",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A scene's declared nodes vanished on load, typically an unresolvable"
+        " instanced sub-scene; re-saving would silently drop them.",
+    ),
+    ErrorCodeSpec(
         "contract_violation",
         ErrorCategory.PARSE,
         ErrorCodeSource.PARSER,

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -195,6 +195,14 @@ func _op_node_add(params: Dictionary) -> void:
 		return
 
 	var root: Node = packed.instantiate()
+	if root == null:
+		# The engine returns null for a scene it cannot instantiate at all —
+		# e.g. an instanced sub-scene whose resource loads but instantiates to
+		# nothing (packed_scene.cpp propagates the nested null). Nothing exists
+		# to edit or save, so refuse with the dependency code.
+		_fail(OP_ERROR_MISSING_DEPENDENCY, "scene failed to instantiate: " + path
+				+ " — an instanced sub-scene is unresolvable or empty; check the scene's dependencies and --project")
+		return
 	var vanished := _vanished_node_paths(packed.get_state(), root)
 	if not vanished.is_empty():
 		root.free()

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -203,11 +203,11 @@ func _op_node_add(params: Dictionary) -> void:
 		_fail(OP_ERROR_MISSING_DEPENDENCY, "scene failed to instantiate: " + path
 				+ " — an instanced sub-scene is unresolvable or empty; check the scene's dependencies and --project")
 		return
-	var vanished := _vanished_node_paths(packed.get_state(), root)
-	if not vanished.is_empty():
+	var unmaterialized := _unmaterialized_node_paths(packed.get_state(), root)
+	if not unmaterialized.is_empty():
 		root.free()
-		_fail(OP_ERROR_MISSING_DEPENDENCY, "scene nodes vanished on load (unresolvable instanced sub-scene?): "
-				+ ", ".join(vanished) + " — re-saving would silently drop them; check the scene's dependencies and --project")
+		_fail(OP_ERROR_MISSING_DEPENDENCY, "scene nodes vanished or degraded on load: "
+				+ ", ".join(unmaterialized) + " — re-saving would silently drop or downgrade them; check the scene's dependencies and --project")
 		return
 	var parent_path := _string_param(params, "parent")
 	var parent := _resolve_parent(root, parent_path)
@@ -299,20 +299,33 @@ func _load_scene(params: Dictionary) -> PackedScene:
 	return packed
 
 
-# Node paths declared in the scene's state that did not materialize in the
-# instantiated tree — typically an instanced sub-scene whose ext_resource
-# could not be resolved (missing file, or res:// without project context).
-# The engine instantiates such a scene WITHOUT the vanished nodes (issue #64),
-# so re-packing and saving would silently erase them — the instance, its
-# overrides, and its editable marker — from the file. Mutation must refuse
-# before saving rather than report success over that data loss.
-func _vanished_node_paths(state: SceneState, root: Node) -> Array[String]:
-	var vanished: Array[String] = []
-	for i in range(1, state.get_node_count()):
+# Node paths declared in the scene's state that did not materialize faithfully
+# in the instantiated tree (issue #64), in the two modes the engine survives
+# silently:
+# - vanished: the node is absent — typically an instanced sub-scene whose
+#   ext_resource could not be resolved (missing file, or res:// without
+#   project context); the instance, its overrides, and its editable marker
+#   would all be erased by a re-save.
+# - degraded: the node exists but as a substitute class — the declared class
+#   was unavailable at instantiate time (e.g. an absent GDExtension/module)
+#   and the engine fell back to a placeholder node at the same path; a re-save
+#   would rewrite the node under the substitute type.
+# Mutation must refuse before saving rather than report success over either
+# data loss. Instance nodes and instance-override entries declare no type in
+# the state, so only nodes this scene itself declares get the class check.
+func _unmaterialized_node_paths(state: SceneState, root: Node) -> Array[String]:
+	var unmaterialized: Array[String] = []
+	for i in state.get_node_count():
 		var state_path := String(state.get_node_path(i)).trim_prefix("./")
-		if root.get_node_or_null(NodePath(state_path)) == null:
-			vanished.append(state_path)
-	return vanished
+		var node := root.get_node_or_null(NodePath(state_path))
+		if node == null:
+			unmaterialized.append(state_path + " (vanished)")
+			continue
+		var declared_type := String(state.get_node_type(i))
+		if not declared_type.is_empty() and node.get_class() != declared_type:
+			unmaterialized.append(state_path + " (declared " + declared_type
+					+ ", materialized " + node.get_class() + ")")
+	return unmaterialized
 
 
 # Resolve a parent node path against the scene root. Node-path addressing

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -38,6 +38,7 @@ const OP_ERROR_PARENT_NOT_FOUND := "parent_not_found"
 const OP_ERROR_INVALID_NODE_TYPE := "invalid_node_type"
 const OP_ERROR_INVALID_NODE_NAME := "invalid_node_name"
 const OP_ERROR_DUPLICATE_NODE_NAME := "duplicate_node_name"
+const OP_ERROR_MISSING_DEPENDENCY := "missing_dependency"
 
 const NODE_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
 
@@ -194,6 +195,12 @@ func _op_node_add(params: Dictionary) -> void:
 		return
 
 	var root: Node = packed.instantiate()
+	var vanished := _vanished_node_paths(packed.get_state(), root)
+	if not vanished.is_empty():
+		root.free()
+		_fail(OP_ERROR_MISSING_DEPENDENCY, "scene nodes vanished on load (unresolvable instanced sub-scene?): "
+				+ ", ".join(vanished) + " — re-saving would silently drop them; check the scene's dependencies and --project")
+		return
 	var parent_path := _string_param(params, "parent")
 	var parent := _resolve_parent(root, parent_path)
 	if parent == null:
@@ -282,6 +289,22 @@ func _load_scene(params: Dictionary) -> PackedScene:
 		_fail(OP_ERROR_NOT_A_SCENE, "scene declares no root node: " + path)
 		return null
 	return packed
+
+
+# Node paths declared in the scene's state that did not materialize in the
+# instantiated tree — typically an instanced sub-scene whose ext_resource
+# could not be resolved (missing file, or res:// without project context).
+# The engine instantiates such a scene WITHOUT the vanished nodes (issue #64),
+# so re-packing and saving would silently erase them — the instance, its
+# overrides, and its editable marker — from the file. Mutation must refuse
+# before saving rather than report success over that data loss.
+func _vanished_node_paths(state: SceneState, root: Node) -> Array[String]:
+	var vanished: Array[String] = []
+	for i in range(1, state.get_node_count()):
+		var state_path := String(state.get_node_path(i)).trim_prefix("./")
+		if root.get_node_or_null(NodePath(state_path)) == null:
+			vanished.append(state_path)
+	return vanished
 
 
 # Resolve a parent node path against the scene root. Node-path addressing

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -264,9 +264,11 @@ position = Vector2(3, 4)
 """
 
 
-def _write_instance_fixture(project, child: str = "child.tscn"):
+def _write_instance_fixture(
+    project, child: str = "child.tscn", child_content: str = CHILD_TSCN
+):
     """Write parent.tscn instancing ``res://<child>`` with editable overrides."""
-    (project / "child.tscn").write_text(CHILD_TSCN, encoding="utf-8")
+    (project / "child.tscn").write_text(child_content, encoding="utf-8")
     parent = project / "parent.tscn"
     parent.write_text(PARENT_TSCN.format(child=child), encoding="utf-8")
     return parent
@@ -348,6 +350,42 @@ def test_node_add_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
 
     err = _assert_operation_error(added, "missing_dependency")
     assert "ChildInstance" in err["message"]
+    assert parent.read_text(encoding="utf-8") == before
+
+
+# A child that loads as a valid PackedScene resource but cannot instantiate:
+# its root illegally declares a parent, which SceneState::instantiate refuses
+# with an engine null. The nested null propagates (packed_scene.cpp fails the
+# instanced node with nullptr), so the PARENT scene's own top-level
+# instantiate() also returns null — there is no tree to diff, edit, or save.
+UNINSTANTIABLE_CHILD_TSCN = """\
+[gd_scene format=3]
+
+[node name="Child" type="Node2D" parent="."]
+"""
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_refuses_scene_that_instantiates_to_null(godot_project):
+    # The nested-null mode of issue #64: the sub-scene resource loads fine but
+    # instantiates to nothing, and the parent scene's instantiate() returns
+    # null. node add must refuse with the structured missing_dependency
+    # envelope — not dereference the null and surface as the unstructured
+    # operation_failed classification.
+    parent = _write_instance_fixture(
+        godot_project, child_content=UNINSTANTIABLE_CHILD_TSCN
+    )
+    before = parent.read_text(encoding="utf-8")
+
+    added = _gda(
+        "node", "add", str(parent),
+        "--type", "Marker2D", "--name", "M",
+        "--project", str(godot_project), "--json",
+    )
+
+    err = _assert_operation_error(added, "missing_dependency")
+    assert str(parent) in err["message"]
     assert parent.read_text(encoding="utf-8") == before
 
 

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -228,6 +228,73 @@ def test_node_list_non_scene_file_yields_not_a_scene(godot_project):
     _assert_operation_error(listed, "not_a_scene")
 
 
+# A legal editable-children fixture, in the engine's own serialization (issue
+# #64): the parent scene instances child.tscn, overrides nodes inside the
+# instance (keyed by node path), adds a node under the editable instance, and
+# carries the `[editable path=...]` marker the editor writes.
+CHILD_TSCN = """\
+[gd_scene format=3]
+
+[node name="Child" type="Node2D"]
+
+[node name="Inner" type="Sprite2D" parent="."]
+
+[node name="Deep" type="Node2D" parent="Inner"]
+"""
+
+PARENT_TSCN = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="PackedScene" path="res://{child}" id="1_child"]
+
+[node name="Parent" type="Node2D"]
+
+[node name="ChildInstance" parent="." instance=ExtResource("1_child")]
+position = Vector2(10, 20)
+
+[node name="Inner" parent="ChildInstance" index="0"]
+modulate = Color(1, 0, 0, 1)
+
+[node name="Deep" parent="ChildInstance/Inner" index="0"]
+position = Vector2(3, 4)
+
+[node name="Extra" type="Marker2D" parent="ChildInstance/Inner"]
+
+[editable path="ChildInstance"]
+"""
+
+
+def _write_instance_fixture(project, child: str = "child.tscn"):
+    """Write parent.tscn instancing ``res://<child>`` with editable overrides."""
+    (project / "child.tscn").write_text(CHILD_TSCN, encoding="utf-8")
+    parent = project / "parent.tscn"
+    parent.write_text(PARENT_TSCN.format(child=child), encoding="utf-8")
+    return parent
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
+    # The real data-loss mode of issue #64: when an instanced sub-scene cannot
+    # be resolved on load (broken dependency), instantiate drops the whole
+    # instance — and a re-save would silently erase the instance, its
+    # overrides, and its editable marker from the file. node add must refuse
+    # with a structured error and leave the file byte-identical instead.
+    parent = _write_instance_fixture(godot_project, child="gone.tscn")
+    (godot_project / "gone.tscn").unlink(missing_ok=True)
+    before = parent.read_text(encoding="utf-8")
+
+    added = _gda(
+        "node", "add", str(parent),
+        "--type", "Marker2D", "--name", "M",
+        "--project", str(godot_project), "--json",
+    )
+
+    err = _assert_operation_error(added, "missing_dependency")
+    assert "ChildInstance" in err["message"]
+    assert parent.read_text(encoding="utf-8") == before
+
+
 HERO_GD = """\
 class_name Hero
 extends Node2D

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -274,6 +274,62 @@ def _write_instance_fixture(project, child: str = "child.tscn"):
 
 @pytest.mark.e2e
 @requires_godot
+def test_node_add_preserves_editable_instance_overrides(godot_project):
+    # Issue #64's data-integrity contract, pinned as a regression test: the
+    # load → instantiate → edit → pack → save round-trip must keep every kind
+    # of instance state the editor writes — the instance reference itself, the
+    # `[editable ...]` marker, property overrides on the instance node and on
+    # nodes inside it (node-path-keyed, at any depth), and nodes added under
+    # the editable instance. Verified to hold on Godot 4.6.3.
+    parent = _write_instance_fixture(godot_project)
+
+    added = _gda(
+        "node", "add", str(parent),
+        "--type", "Marker2D", "--name", "M",
+        "--project", str(godot_project), "--json",
+    )
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    assert json.loads(added.stdout)["path"] == "M"
+    saved = parent.read_text(encoding="utf-8")
+    # The sub-scene is still an instance, not a flattened copy.
+    assert 'instance=ExtResource(' in saved
+    assert '[editable path="ChildInstance"]' in saved
+    # Top-level instance property override.
+    assert "position = Vector2(10, 20)" in saved
+    # Overrides on nodes INSIDE the instance, keyed by node path.
+    assert '[node name="Inner" parent="ChildInstance"' in saved
+    assert "modulate = Color(1, 0, 0, 1)" in saved
+    assert '[node name="Deep" parent="ChildInstance/Inner"' in saved
+    assert "position = Vector2(3, 4)" in saved
+    # A node added under the editable instance.
+    assert '[node name="Extra" type="Marker2D" parent="ChildInstance/Inner"' in saved
+    # And the node this command added.
+    assert '[node name="M" type="Marker2D" parent="."' in saved
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_without_project_context_refuses_rather_than_drops_instances(
+    godot_project,
+):
+    # The same vanish mode from the common invocation mistake: without
+    # --project, res:// ext_resources cannot resolve, so the instance would
+    # vanish from the re-saved file even though every scene file exists.
+    parent = _write_instance_fixture(godot_project)
+    before = parent.read_text(encoding="utf-8")
+
+    added = _gda(
+        "node", "add", str(parent), "--type", "Marker2D", "--name", "M", "--json"
+    )
+
+    err = _assert_operation_error(added, "missing_dependency")
+    assert "ChildInstance" in err["message"]
+    assert parent.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+@requires_godot
 def test_node_add_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
     # The real data-loss mode of issue #64: when an instanced sub-scene cannot
     # be resolved on load (broken dependency), instantiate drops the whole

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -389,6 +389,40 @@ def test_node_add_refuses_scene_that_instantiates_to_null(godot_project):
     assert parent.read_text(encoding="utf-8") == before
 
 
+# A scene declaring a node class that does not exist in a stock 4.6.3 headless
+# engine — the shape of an absent GDExtension/module class.
+MISSING_CLASS_TSCN = """\
+[gd_scene format=3]
+
+[node name="Root" type="Node2D"]
+
+[node name="Widget" type="TotallyMissingClass" parent="."]
+"""
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_refuses_scene_whose_declared_class_is_substituted(godot_project):
+    # The degraded-node mode of issue #64: when a declared class is unavailable
+    # at instantiate time, the engine warns and substitutes a placeholder node
+    # at the same path (observed on 4.6.3 headless: a plain Node), so an
+    # existence check alone passes — but a re-save would rewrite the node as
+    # the substitute type, silently dropping its declared class. node add must
+    # refuse, naming declared vs materialized class, and leave the file alone.
+    scene_path = godot_project / "widget.tscn"
+    scene_path.write_text(MISSING_CLASS_TSCN, encoding="utf-8")
+    before = scene_path.read_text(encoding="utf-8")
+
+    added = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Marker2D", "--name", "M", "--json",
+    )
+
+    err = _assert_operation_error(added, "missing_dependency")
+    assert "Widget (declared TotallyMissingClass, materialized" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
 HERO_GD = """\
 class_name Hero
 extends Node2D

--- a/tests/test_node_errors.py
+++ b/tests/test_node_errors.py
@@ -105,6 +105,26 @@ def test_node_add_vanished_instance_maps_to_stable_missing_dependency_code(monke
     assert "ChildInstance" in err["message"]
 
 
+def test_node_add_substituted_class_maps_to_stable_missing_dependency_code(monkeypatch):
+    # Issue #64's degraded mode: a declared class unavailable in this engine
+    # run materializes as a substitute node, so a re-save would rewrite its
+    # type. The refusal reuses missing_dependency — an unavailable class IS a
+    # missing dependency (extension/module), the same agent fix applies.
+    result = _invoke_node_add(
+        monkeypatch,
+        "missing_dependency",
+        "scene nodes vanished or degraded on load: "
+        "Widget (declared TotallyMissingClass, materialized Node) — "
+        "re-saving would silently drop or downgrade them",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "missing_dependency"
+    assert "declared TotallyMissingClass, materialized Node" in err["message"]
+
+
 def test_node_add_missing_scene_reuses_stable_path_not_found_code(monkeypatch):
     # The scene-file-level failure reuses the registered scene code: the
     # node group introduces no parallel code for the same mode.

--- a/tests/test_node_errors.py
+++ b/tests/test_node_errors.py
@@ -86,6 +86,25 @@ def test_node_add_bad_name_maps_to_stable_invalid_node_name_code(monkeypatch):
     assert "Bad%Name" in err["message"]
 
 
+def test_node_add_vanished_instance_maps_to_stable_missing_dependency_code(monkeypatch):
+    # Issue #64: a scene whose instanced sub-scene cannot be resolved on load
+    # would lose the whole instance on re-save; the refusal surfaces as the
+    # registered missing_dependency code so an agent knows to fix the scene's
+    # dependencies or its project context rather than retry the add.
+    result = _invoke_node_add(
+        monkeypatch,
+        "missing_dependency",
+        "scene nodes vanished on load (unresolvable instanced sub-scene?): "
+        "ChildInstance — re-saving would silently drop them",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "missing_dependency"
+    assert "ChildInstance" in err["message"]
+
+
 def test_node_add_missing_scene_reuses_stable_path_not_found_code(monkeypatch):
     # The scene-file-level failure reuses the registered scene code: the
     # node group introduces no parallel code for the same mode.


### PR DESCRIPTION
## Summary

- Fixes the empirically confirmed data-loss mode of #64: when a scene's instanced sub-scene cannot be resolved on load (broken `ext_resource` dependency, or `res://` paths without `--project`), `instantiate()` silently drops the whole instance — and `node add` re-packed and saved the file with the instance, its overrides, and its editable marker erased, while reporting success. `node add` now detects vanished instances right after `instantiate()` and refuses with the new registered operation code `missing_dependency` (exit 4) before any mutation, leaving the file byte-identical.
- Regression-pins the issue body's original acceptance criteria, which hold on the target engine (verified Godot 4.6.3): after `node add`, the saved scene still carries the instance reference, the `[editable]` marker, top-level instance properties, node-path-keyed overrides at any depth, and nodes added under the editable instance.
- Documents the node-mutation integrity boundary in the command catalog, cross-referencing the #62 trust boundary.

## Root cause (corrects the issue's hypotheses)

The issue's edit-state hypothesis and the follow-up "even a pure round-trip loses the override" finding both failed to reproduce on 4.6.3 — legal editable-children overrides survive the headless round-trip in all three edit states, because `instantiate()` restores `editable_instances` unconditionally (`scene/resources/packed_scene.cpp:693`). The real, reproducible silent loss is the vanished-instance mode above. Full empirical write-up: https://github.com/aigengame/godot-agent/issues/64#issuecomment-4677216065 (deviation from the triage direction confirmed by the maintainer there).

## Changes

- `src/gda/ops/operations.gd`: new `_vanished_node_paths()` diffs the SceneState's declared node paths against the materialized tree; `_op_node_add` refuses with `OP_ERROR_MISSING_DEPENDENCY` before mutating.
- `src/gda/error_codes.py` + ADR-0002 error-code table: `missing_dependency` registered (category `operation`); the existing three-way drift tests enforce Python/ADR/GDScript sync.
- `docs/command-catalog.md`: "Mutation integrity boundary" paragraph under `node`.
- Tests: e2e refusal on broken dependency (red→green: returncode was 0 pre-fix, now exit 4 with the file byte-identical), preservation regression pin, missing-`--project` refusal, and an engine-free S3 envelope-mapping test.

## Test plan

- [x] Full suite: 132 passed, 0 failed (e2e against real Godot 4.6.3.stable.official)

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)
