### PR TITLE
fix(node): report a broken registered class_name as uninstantiable_script

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -85,6 +85,7 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 | `invalid_node_name` | `operation` | `operation` | A requested node name is empty or would be rewritten by Godot. |
 | `duplicate_node_name` | `operation` | `operation` | The parent node already has a child with the requested name. |
 | `missing_dependency` | `operation` | `operation` | A scene's declared nodes vanished or degraded on load — an unresolvable instanced sub-scene or an unavailable node class; re-saving would silently drop or downgrade them. |
+| `uninstantiable_script` | `operation` | `operation` | A registered `class_name`'s script can no longer be loaded, compiled, or constructed, so it cannot be instantiated as a node. |
 | `contract_violation` | `parse` | `parser` | The process claimed success but violated the structured-output contract. |
 
 ## Considered options

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -77,6 +77,15 @@ registered `missing_dependency` error (exit 4), leaving the file untouched. Rela
 of scripts already attached in the scene (#62) — treat headless mutation of an untrusted scene
 as running its code.
 
+**Type resolution** (sharpened by #65): `node add --type` resolves a built-in `Node` class
+first, then a `class_name` from the project's global class list (which exists only after a
+project import — pass `--project`). A type that resolves to neither is refused with
+`invalid_node_type`. A `class_name` that is still registered but whose script has broken since
+the scan — it fails to load, no longer compiles, or its `_init` requires constructor
+arguments — is a script problem, not an unknown type, and is refused with the distinct
+`uninstantiable_script` error (exit 4) naming the script: repair the script (or re-import),
+don't change the type name. Either way the scene file is left untouched.
+
 | Command | Description | Status |
 | --- | --- | --- |
 | `gda node add` | Add a node (by type or `class_name` script) into a scene | ✅ (#53) |

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -156,6 +156,13 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         " re-saving would silently drop or downgrade them.",
     ),
     ErrorCodeSpec(
+        "uninstantiable_script",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A registered class_name's script can no longer be loaded, compiled,"
+        " or constructed, so it cannot be instantiated as a node.",
+    ),
+    ErrorCodeSpec(
         "contract_violation",
         ErrorCategory.PARSE,
         ErrorCodeSource.PARSER,

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -39,6 +39,7 @@ const OP_ERROR_INVALID_NODE_TYPE := "invalid_node_type"
 const OP_ERROR_INVALID_NODE_NAME := "invalid_node_name"
 const OP_ERROR_DUPLICATE_NODE_NAME := "duplicate_node_name"
 const OP_ERROR_MISSING_DEPENDENCY := "missing_dependency"
+const OP_ERROR_UNINSTANTIABLE_SCRIPT := "uninstantiable_script"
 
 const NODE_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
 
@@ -224,8 +225,7 @@ func _op_node_add(params: Dictionary) -> void:
 	var node := _instantiate_node_type(type)
 	if node == null:
 		root.free()
-		_fail(OP_ERROR_INVALID_NODE_TYPE, "not an instantiable Node class or registered class_name: " + type)
-		return
+		return  # _instantiate_node_type already recorded the failure
 
 	node.name = node_name
 	var actual_name := String(node.name)
@@ -343,26 +343,58 @@ func _resolve_parent(root: Node, parent_path: String) -> Node:
 
 # Instantiate a node by type: a built-in Node class first, then a class_name
 # from the project's global class list (script classes register only once the
-# project has been imported/scanned). Returns null when the type resolves to
-# nothing instantiable as a Node.
+# project has been imported/scanned). Records the failure itself and returns
+# null when the type resolves to nothing instantiable as a Node, telling apart
+# the two distinct failure modes (issue #65): a type that resolves to nothing
+# is invalid_node_type, while a registered class_name whose script broke since
+# registration is uninstantiable_script — repair the script, not the type name.
 func _instantiate_node_type(type: String) -> Node:
-	if type.is_empty():
-		return null
-	if ClassDB.can_instantiate(type) and ClassDB.is_parent_class(type, "Node"):
+	if not type.is_empty() and ClassDB.can_instantiate(type) and ClassDB.is_parent_class(type, "Node"):
 		return ClassDB.instantiate(type)
 	for entry in ProjectSettings.get_global_class_list():
-		if String(entry.get("class", "")) != type:
-			continue
-		var script := ResourceLoader.load(String(entry.get("path", ""))) as Script
-		if script == null:
-			return null
-		var instance: Variant = script.new()
-		if instance is Node:
-			return instance
-		if instance is Object and not (instance is RefCounted):
-			instance.free()
-		return null
+		if String(entry.get("class", "")) == type:
+			return _instantiate_script_class(type, String(entry.get("path", "")))
+	_fail(OP_ERROR_INVALID_NODE_TYPE, "not an instantiable Node class or registered class_name: " + type)
 	return null
+
+
+# Instantiate a registered class_name from its script. Registration only
+# proves the script was valid when the project was last scanned — the script
+# on disk may have broken since (issue #65), so each step is checked and a
+# failure reported as the script problem it is, never as an unknown type.
+func _instantiate_script_class(type: String, script_path: String) -> Node:
+	var script := ResourceLoader.load(script_path) as Script
+	if script == null:
+		_fail(OP_ERROR_UNINSTANTIABLE_SCRIPT, "registered class_name " + type
+				+ " script failed to load: " + script_path
+				+ " — broken or removed since the project scan; see diagnostics")
+		return null
+	if not script.can_instantiate():
+		_fail(OP_ERROR_UNINSTANTIABLE_SCRIPT, "registered class_name " + type
+				+ " script cannot be instantiated: " + script_path
+				+ " — it no longer compiles; see diagnostics")
+		return null
+	var instance: Variant = _new_script_instance(script)
+	if instance == null:
+		_fail(OP_ERROR_UNINSTANTIABLE_SCRIPT, "registered class_name " + type
+				+ " script constructor failed: " + script_path
+				+ " — its _init may require arguments; see diagnostics")
+		return null
+	if instance is Node:
+		return instance
+	if instance is Object and not (instance is RefCounted):
+		instance.free()
+	_fail(OP_ERROR_INVALID_NODE_TYPE, "registered class_name " + type
+			+ " is not a Node-derived script: " + script_path)
+	return null
+
+
+# Isolated so an engine-raised call error from Script.new() — a constructor
+# that needs arguments, or a script broken in a way can_instantiate() does not
+# catch — aborts only this helper frame; the caller observes null and reports
+# the failure structurally instead of degrading into an unstructured abort.
+func _new_script_instance(script: Script) -> Variant:
+	return script.new()
 
 
 # The class_name of the node's attached script, or null for a plain built-in

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -179,6 +179,41 @@ def test_node_add_name_collision_yields_duplicate_node_name(godot_project):
 
 @pytest.mark.e2e
 @requires_godot
+def test_node_add_collision_with_internal_child_yields_duplicate_node_name(
+    godot_project,
+):
+    # Issue #65's internal-child mode, pinned as a regression test: some node
+    # classes construct INTERNAL children in their constructor (ScrollContainer
+    # builds scrollbars named "_h_scroll"/"_v_scroll"), which never appear in
+    # the scene file or node list. A name collision with one must still be the
+    # accurate duplicate_node_name — not invalid_node_name ("Godot rewrote
+    # name") and never a silent engine rename saved into the file. Verified
+    # correct on Godot 4.6.3: get_node_or_null resolves through the engine's
+    # child-name map, which includes internal children.
+    scene_path = godot_project / "ui.tscn"
+    created = _gda(
+        "scene", "create", str(scene_path), "--root-type", "Control", "--json"
+    )
+    assert created.returncode == 0, created.stdout + created.stderr
+    added = _gda(
+        "node", "add", str(scene_path),
+        "--type", "ScrollContainer", "--name", "Scroll", "--json",
+    )
+    assert added.returncode == 0, added.stdout + added.stderr
+    before = scene_path.read_text(encoding="utf-8")
+
+    colliding = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Control", "--name", "_h_scroll", "--parent", "Scroll", "--json",
+    )
+
+    err = _assert_operation_error(colliding, "duplicate_node_name")
+    assert "_h_scroll" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+@requires_godot
 def test_node_add_unknown_type_yields_invalid_node_type(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -492,3 +492,79 @@ def test_node_add_by_unregistered_class_name_yields_invalid_node_type(godot_proj
 
     err = _assert_operation_error(added, "invalid_node_type")
     assert "Hero" in err["message"]
+
+
+# The same class_name, broken AFTER registration: a parse error the import-time
+# scan never saw, so the stale global class list still maps Hero to this script.
+BROKEN_HERO_GD = """\
+class_name Hero
+extends Node2D
+func broken( -> void:
+"""
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_by_registered_but_broken_class_name_names_the_script(godot_project):
+    # Issue #65's broken-class_name mode: the class_name IS in the global class
+    # list (the import scanned a then-valid script), but the script on disk has
+    # since broken. Reporting invalid_node_type ("not a registered class_name")
+    # misdiagnoses a script problem as an unknown type — the agent fix is to
+    # repair the script, not the type name. The failure must surface as the
+    # distinct uninstantiable_script code naming the script, with the scene
+    # file left unchanged.
+    (godot_project / "hero.gd").write_text(HERO_GD, encoding="utf-8")
+    _import_project(godot_project)
+    (godot_project / "hero.gd").write_text(BROKEN_HERO_GD, encoding="utf-8")
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    before = scene_path.read_text(encoding="utf-8")
+
+    added = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Hero", "--project", str(godot_project), "--json",
+    )
+
+    err = _assert_operation_error(added, "uninstantiable_script")
+    assert "Hero" in err["message"]
+    assert "hero.gd" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+# A class_name that compiles and registers fine but cannot be constructed
+# without arguments: script.new() has no args to give _init.
+NEEDS_ARGS_HERO_GD = """\
+class_name Hero
+extends Node2D
+
+
+func _init(speed: float) -> void:
+\tpass
+"""
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_by_class_name_whose_init_requires_args_names_the_constructor(
+    godot_project,
+):
+    # The other half of issue #65's broken-class_name mode: the script is
+    # valid and registered, but its _init requires constructor args, so
+    # script.new() cannot construct it. Same misdiagnosis risk as the broken
+    # script: the type IS registered, the constructor is the problem.
+    (godot_project / "hero.gd").write_text(NEEDS_ARGS_HERO_GD, encoding="utf-8")
+    _import_project(godot_project)
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    before = scene_path.read_text(encoding="utf-8")
+
+    added = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Hero", "--project", str(godot_project), "--json",
+    )
+
+    err = _assert_operation_error(added, "uninstantiable_script")
+    assert "Hero" in err["message"]
+    assert "hero.gd" in err["message"]
+    assert "_init" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -566,6 +566,39 @@ def test_node_add_by_registered_but_broken_class_name_names_the_script(godot_pro
     assert scene_path.read_text(encoding="utf-8") == before
 
 
+# A perfectly healthy class_name that just is not a node: instantiable, but
+# never addable to a scene tree.
+LOOT_GD = """\
+class_name Loot
+extends Resource
+"""
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_node_add_by_non_node_class_name_yields_invalid_node_type(godot_project):
+    # The boundary of issue #65's distinction: a registered class_name whose
+    # script is fine but not Node-derived is a true type error — it stays
+    # invalid_node_type (not uninstantiable_script), with a message naming the
+    # script and the real cause rather than "not a registered class_name".
+    (godot_project / "loot.gd").write_text(LOOT_GD, encoding="utf-8")
+    _import_project(godot_project)
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    before = scene_path.read_text(encoding="utf-8")
+
+    added = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Loot", "--project", str(godot_project), "--json",
+    )
+
+    err = _assert_operation_error(added, "invalid_node_type")
+    assert "Loot" in err["message"]
+    assert "not a Node-derived script" in err["message"]
+    assert "loot.gd" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
 # A class_name that compiles and registers fine but cannot be constructed
 # without arguments: script.new() has no args to give _init.
 NEEDS_ARGS_HERO_GD = """\

--- a/tests/test_node_errors.py
+++ b/tests/test_node_errors.py
@@ -125,6 +125,27 @@ def test_node_add_substituted_class_maps_to_stable_missing_dependency_code(monke
     assert "declared TotallyMissingClass, materialized Node" in err["message"]
 
 
+def test_node_add_broken_class_name_maps_to_stable_uninstantiable_script_code(
+    monkeypatch,
+):
+    # Issue #65: a class_name still present in the global class list but whose
+    # script broke after registration is a script problem, not an unknown type.
+    # The refusal surfaces as the registered uninstantiable_script code so an
+    # agent knows to repair the script rather than the type name.
+    result = _invoke_node_add(
+        monkeypatch,
+        "uninstantiable_script",
+        "registered class_name Hero script cannot be instantiated: "
+        "res://hero.gd — it no longer compiles; see diagnostics",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "uninstantiable_script"
+    assert "res://hero.gd" in err["message"]
+
+
 def test_node_add_missing_scene_reuses_stable_path_not_found_code(monkeypatch):
     # The scene-file-level failure reuses the registered scene code: the
     # node group introduces no parallel code for the same mode.


### PR DESCRIPTION
## Summary

Issue #65 listed three mutate-path failure modes on `gda node add`; empirical re-verification against current main (Godot 4.6.3) gave each a different fate — full write-up in https://github.com/aigengame/godot-agent/issues/65#issuecomment-4680190396:

- **Null instantiate — already fixed by #68**: `missing_dependency` refusal, pinned by an existing e2e test. Nothing re-implemented here.
- **Registered-but-broken `class_name` — fixed here**: previously misclassified as `invalid_node_type` ("not an instantiable Node class or registered class_name"), steering agents to fix the type name when the real problem is the script. Type resolution now routes registered class_names through `load` → `Script.can_instantiate()` → a one-line constructor barrier `_new_script_instance` (an engine-call abort is confined to its own GDScript frame, so the caller observes null and fails structurally), reporting the new registered code **`uninstantiable_script`** with a message naming the script path and real cause, file untouched. A healthy but non-Node `class_name` (e.g. `extends Resource`) stays `invalid_node_type` with a precise message.
- **Internal-child name collision — premise does not reproduce on 4.6.3**: `get_node_or_null` resolves through `Node::data.children`, which includes internal children (engine-source verified); the collision already yields `duplicate_node_name`. Behavior regression-pinned, no change.

## Changes

- `src/gda/ops/operations.gd`: `_instantiate_node_type` records its own failures; new `_instantiate_script_class` (load / can_instantiate / constructor checks → `uninstantiable_script`; non-Node → precise `invalid_node_type` message); `_new_script_instance` abort barrier; new `OP_ERROR_UNINSTANTIABLE_SCRIPT` const.
- `src/gda/error_codes.py` + ADR-0002 table: `uninstantiable_script` registered (category `operation`); three-mirror drift tests enforce sync.
- `docs/command-catalog.md`: "Type resolution" paragraph under `node`.
- Tests: 4 new e2e (parse-error script red→green, `_init`-args script red→green, internal-child collision pin, non-Node class_name pin) + 1 S3 envelope-mapping test; file-unchanged asserted on every failure path.

## Test plan

- [x] Full suite: 140 passed, 0 failed (e2e against real Godot 4.6.3.stable.official; main baseline was 135)

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)
