### PR TITLE
feat(scene): add scene list + scene delete to round out scene-file CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ for the full picture.
 **Working today**
 
 - ✅ A first working command surface: the `info` meta command and the first domain command groups —
-  `gda scene create` / `gda scene get` and `gda node add` / `gda node list`
+  `gda scene create` / `gda scene get` / `gda scene list` / `gda scene delete` and
+  `gda node add` / `gda node list`
   ([ADR-0005](docs/adr/0005-cli-command-taxonomy.md)).
 - ✅ The contract every shipped command carries: structured `--json` output, model-derived
   `--schema` self-description ([ADR-0004](docs/adr/0004-schema-flag-self-description.md)), and
@@ -171,6 +172,17 @@ gda node add game/main.tscn --type Sprite2D --name Hero --json
 
 gda node list game/main.tscn --json
 # {"scene_path":"game/main.tscn","root":{"name":"main","type":"Node2D","path":".","children":[{"name":"Hero","type":"Sprite2D","path":"Hero","children":[]}]}}
+```
+
+Enumerate a project's scenes, then delete one — `scene list` walks the project's `res://` tree, so it
+needs a project context (`--project`, `$GDA_PROJECT`, or a cwd that is a project):
+
+```bash
+gda scene list --project game --json
+# {"scenes":[{"path":"res://main.tscn","root_name":"main","root_type":"Node2D"}]}
+
+gda scene delete res://main.tscn --project game --json
+# {"path":"res://main.tscn","root_name":"main","root_type":"Node2D"}
 ```
 
 ---

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -78,6 +78,7 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 | `invalid_root_name` | `operation` | `operation` | A requested root node name is empty or would be rewritten by Godot. |
 | `already_exists` | `operation` | `operation` | A create operation target already exists and will not be overwritten. |
 | `save_failed` | `operation` | `operation` | A scene could not be packed or saved. |
+| `project_not_found` | `operation` | `operation` | An operation that enumerates a project's `res://` tree ran without a resolved Godot project. |
 | `path_not_found` | `operation` | `operation` | A requested scene file does not exist. |
 | `not_a_scene` | `operation` | `operation` | A requested file cannot be loaded as a `PackedScene`. |
 | `parent_not_found` | `operation` | `operation` | A requested parent node path does not resolve to a node in the scene. |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -78,6 +78,7 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 | `invalid_root_name` | `operation` | `operation` | A requested root node name is empty or would be rewritten by Godot. |
 | `already_exists` | `operation` | `operation` | A create operation target already exists and will not be overwritten. |
 | `save_failed` | `operation` | `operation` | A scene could not be packed or saved. |
+| `delete_failed` | `operation` | `operation` | A scene file could not be removed from disk. |
 | `project_not_found` | `operation` | `operation` | An operation that enumerates a project's `res://` tree ran without a resolved Godot project. |
 | `path_not_found` | `operation` | `operation` | A requested scene file does not exist. |
 | `not_a_scene` | `operation` | `operation` | A requested file cannot be loaded as a `PackedScene`. |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -34,7 +34,7 @@ issue ref (e.g. `🔜 (#53)`) marks a candidate already committed as an open sli
 | `gda info` | Report Godot engine version info | 1 | ✅ |
 | `gda version` | Report `gda`'s own version | — (local) | 🔜 |
 | `gda help` | Usage help | — (local) | ✅ (`--help`) |
-| `gda <command> --schema` | Emit a command's input/output JSON Schema (ADR-0004) | — (local) | ✅ (`info` #4; `scene create`/`scene get` #18; `node add`/`node list` #53) |
+| `gda <command> --schema` | Emit a command's input/output JSON Schema (ADR-0004) | — (local) | ✅ (`info` #4; `scene create`/`scene get` #18; `scene list`/`scene delete` #54; `node add`/`node list` #53) |
 
 > `--schema` is a per-command flag, not a command, and ships with **every** domain
 > command as a hard gate (ADR-0004). It is local introspection — no Godot process.
@@ -48,9 +48,9 @@ issue ref (e.g. `🔜 (#53)`) marks a candidate already committed as an open sli
 | Command | Description | Status |
 | --- | --- | --- |
 | `gda scene create` | Create a new `.tscn` with a given root node type | ✅ (#18) |
-| `gda scene delete` | Delete a scene file | 🔜 (#54) |
+| `gda scene delete` | Delete a scene file | ✅ (#54) |
 | `gda scene get` | Read a scene's structured tree from its file on disk | ✅ (#18) |
-| `gda scene list` | Enumerate scenes in the project | 🔜 (#54) |
+| `gda scene list` | Enumerate scenes in the project | ✅ (#54) |
 | `gda scene get-exports` | List `@export` properties declared by a scene's nodes | 🔜 (#58) |
 
 ### `node`

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -31,8 +31,12 @@ from gda.models import (
     NodeListResult,
     SceneCreateParams,
     SceneCreateResult,
+    SceneDeleteParams,
+    SceneDeleteResult,
     SceneGetParams,
     SceneGetResult,
+    SceneListParams,
+    SceneListResult,
     SceneNode,
 )
 from gda.project import resolve_project_dir
@@ -46,9 +50,7 @@ app = typer.Typer(
 )
 
 # The first domain command group (ADR-0005): commands acting on scene files.
-scene_app = typer.Typer(
-    help="Act on Godot scene files (.tscn).", no_args_is_help=True
-)
+scene_app = typer.Typer(help="Act on Godot scene files (.tscn).", no_args_is_help=True)
 app.add_typer(scene_app, name="scene")
 
 # The node command group (issue #53): commands acting on nodes WITHIN a scene
@@ -106,6 +108,18 @@ SCENE_GET_COMMAND: HeadlessCommand[SceneGetResult] = HeadlessCommand(
     operation="scene-get",
     input_model=SceneGetParams,
     output_model=SceneGetResult,
+)
+
+SCENE_LIST_COMMAND: HeadlessCommand[SceneListResult] = HeadlessCommand(
+    operation="scene-list",
+    input_model=SceneListParams,
+    output_model=SceneListResult,
+)
+
+SCENE_DELETE_COMMAND: HeadlessCommand[SceneDeleteResult] = HeadlessCommand(
+    operation="scene-delete",
+    input_model=SceneDeleteParams,
+    output_model=SceneDeleteResult,
 )
 
 NODE_ADD_COMMAND: HeadlessCommand[NodeAddResult] = HeadlessCommand(
@@ -204,6 +218,58 @@ def get(
         project=resolve_project_dir(project),
         json_output=json_output,
         render_text=lambda scene: _render_tree(scene.root),
+        make_runner=_make_runner,
+    )
+
+
+def _render_scene_list(listed: "SceneListResult") -> str:
+    """Render the enumerated scenes as ``path (root_name: root_type)`` lines."""
+    if not listed.scenes:
+        return "(no scenes)"
+    lines = []
+    for scene in listed.scenes:
+        if scene.root_name is not None and scene.root_type is not None:
+            lines.append(f"{scene.path} ({scene.root_name}: {scene.root_type})")
+        else:
+            lines.append(f"{scene.path} (unreadable)")
+    return "\n".join(lines)
+
+
+@scene_app.command(name="list", cls=SCENE_LIST_COMMAND.command_class())
+def list_scenes(
+    json_output: bool = json_option(),
+    schema: bool = SCENE_LIST_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Enumerate the .tscn scenes in the resolved project."""
+    SCENE_LIST_COMMAND.emit(
+        SceneListParams(),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=_render_scene_list,
+        make_runner=_make_runner,
+    )
+
+
+@scene_app.command(cls=SCENE_DELETE_COMMAND.command_class())
+def delete(
+    path: str = typer.Argument(..., help="The .tscn scene file to delete."),
+    json_output: bool = json_option(),
+    schema: bool = SCENE_DELETE_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Delete a scene file and report what was removed."""
+    SCENE_DELETE_COMMAND.emit(
+        SceneDeleteParams(path=_normalize_path(path)),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=lambda removed: (
+            f"deleted {removed.path} (root {removed.root_name}: {removed.root_type})"
+        ),
         make_runner=_make_runner,
     )
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -112,6 +112,12 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A scene could not be packed or saved.",
     ),
     ErrorCodeSpec(
+        "delete_failed",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A scene file could not be removed from disk.",
+    ),
+    ErrorCodeSpec(
         "project_not_found",
         ErrorCategory.OPERATION,
         ErrorCodeSource.OPERATION,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -112,6 +112,12 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A scene could not be packed or saved.",
     ),
     ErrorCodeSpec(
+        "project_not_found",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "An operation that enumerates a project's res:// tree ran without a resolved Godot project.",
+    ),
+    ErrorCodeSpec(
         "path_not_found",
         ErrorCategory.OPERATION,
         ErrorCodeSource.OPERATION,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -180,6 +180,65 @@ class SceneGetResult(BaseModel):
     root: SceneNode
 
 
+class SceneListParams(BaseModel):
+    """The operation params of ``gda scene list`` — none (ADR-0004).
+
+    ``scene list`` enumerates the ``.tscn`` scenes in the resolved project's
+    ``res://`` tree; the project is process context (``--project``), not an
+    operation param (ADR-0006), so the ``input`` schema is trivially empty.
+    """
+
+
+class ListedScene(BaseModel):
+    """One enumerated scene of ``gda scene list``: its path and root summary.
+
+    ``path`` is the scene's ``res://`` path — the address an agent feeds back
+    into other scene commands. ``root_name``/``root_type`` are read cheaply from
+    the scene's stored state (no instantiation, issue #30); both are null when
+    the ``.tscn`` could not be loaded as a scene, so the entry still names a file
+    the listing found rather than dropping it.
+    """
+
+    path: str
+    root_name: str | None = Field(
+        default=None,
+        description="The scene root node's name, or null if the file could not be loaded as a scene.",
+    )
+    root_type: str | None = Field(
+        default=None,
+        description="The scene root node's type, or null if the file could not be loaded as a scene.",
+    )
+
+
+class SceneListResult(BaseModel):
+    """The result of ``gda scene list``: the project's enumerated ``.tscn`` scenes.
+
+    An empty project is a valid, empty listing — ``scenes == []`` — not a
+    failure.
+    """
+
+    scenes: list[ListedScene]
+
+
+class SceneDeleteParams(BaseModel):
+    """The operation params of ``gda scene delete``: the ``.tscn`` file to remove."""
+
+    path: str
+
+
+class SceneDeleteResult(BaseModel):
+    """The result of ``gda scene delete``: what was removed.
+
+    Echoes the deleted scene's path and its root node's name/type (read from the
+    scene's stored state before deletion), so the result names the content
+    removed, not just the file path.
+    """
+
+    path: str
+    root_name: str
+    root_type: str
+
+
 class NodeAddParams(BaseModel):
     """The operation params of ``gda node add`` (issue #53).
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -32,6 +32,7 @@ const OP_ERROR_INVALID_ROOT_TYPE := "invalid_root_type"
 const OP_ERROR_INVALID_ROOT_NAME := "invalid_root_name"
 const OP_ERROR_ALREADY_EXISTS := "already_exists"
 const OP_ERROR_SAVE_FAILED := "save_failed"
+const OP_ERROR_PROJECT_NOT_FOUND := "project_not_found"
 const OP_ERROR_PATH_NOT_FOUND := "path_not_found"
 const OP_ERROR_NOT_A_SCENE := "not_a_scene"
 const OP_ERROR_PARENT_NOT_FOUND := "parent_not_found"
@@ -69,6 +70,10 @@ func _initialize() -> void:
 			_op_scene_create(params)
 		"scene-get":
 			_op_scene_get(params)
+		"scene-list":
+			_op_scene_list(params)
+		"scene-delete":
+			_op_scene_delete(params)
 		"node-add":
 			_op_node_add(params)
 		"node-list":
@@ -171,6 +176,62 @@ func _op_scene_get(params: Dictionary) -> void:
 	_succeed({
 		"path": _string_param(params, "path"),
 		"root": _tree_from_state(packed.get_state()),
+	})
+
+
+# scene-list: enumerate the project's .tscn scenes (issue #54). Walks the
+# project's res:// tree, reporting each scene's res:// path plus its root
+# name/type read from stored state (no instantiation, exactly like scene-get,
+# issue #30 — listing must not execute project code). A .tscn that cannot be
+# loaded as a scene is still listed, with null root info, so the listing names
+# every .tscn it found rather than dropping it.
+#
+# Enumerating res:// requires a project: a projectless headless process has no
+# res:// tree to walk, so scene-list refuses with project_not_found rather than
+# returning a misleading empty listing.
+func _op_scene_list(_params: Dictionary) -> void:
+	_diag("running operation: scene-list")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "scene list requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+
+	var paths: Array[String] = []
+	_collect_scene_paths("res://", paths)
+	paths.sort()
+
+	var scenes: Array = []
+	for path in paths:
+		scenes.append(_scene_summary(path))
+
+	_succeed({"scenes": scenes})
+
+
+# scene-delete: remove a scene file and report what was removed (issue #54).
+# Reuses the shared load-failure ladder (missing → path_not_found, not loadable
+# → not_a_scene): delete only removes a file that loads as a PackedScene, so a
+# stray non-scene file is refused rather than silently deleted. The root
+# name/type are read from stored state before deletion so the result names the
+# content removed, not just the path.
+func _op_scene_delete(params: Dictionary) -> void:
+	_diag("running operation: scene-delete")
+	var packed: PackedScene = _load_scene(params)
+	if packed == null:
+		return  # _load_scene already recorded the failure
+	var path := _string_param(params, "path")
+
+	var state := packed.get_state()
+	var root_name := String(state.get_node_name(0))
+	var root_type := String(state.get_node_type(0))
+
+	var err := DirAccess.remove_absolute(path)
+	if err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, "failed to delete scene " + path + ": " + error_string(err))
+		return
+
+	_succeed({
+		"path": path,
+		"root_name": root_name,
+		"root_type": root_type,
 	})
 
 
@@ -279,6 +340,52 @@ func _op_node_list(params: Dictionary) -> void:
 		"scene_path": _string_param(params, "path"),
 		"root": _tree_from_state(packed.get_state(), true),
 	})
+
+
+# Whether this headless process is running against a Godot project. A project
+# scan writes the resource UID cache under res://.godot; its presence is the
+# marker the engine itself uses, and a projectless --script run (no --path to a
+# project dir) does not have it. scene-list needs a real res:// tree to walk.
+func _has_project() -> bool:
+	return DirAccess.dir_exists_absolute("res://") and FileAccess.file_exists("res://project.godot")
+
+
+# Recursively collect every .tscn under res:// (issue #54), skipping the
+# engine's own res://.godot cache directory (import artifacts, not authored
+# scenes). Paths are returned as res:// paths so they round-trip into other
+# scene commands.
+func _collect_scene_paths(dir_path: String, out: Array[String]) -> void:
+	var dir := DirAccess.open(dir_path)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	var entry := dir.get_next()
+	while not entry.is_empty():
+		if not entry.begins_with("."):
+			var child := dir_path.path_join(entry)
+			if dir.current_is_dir():
+				_collect_scene_paths(child, out)
+			elif entry.get_extension() == "tscn":
+				out.append(child)
+		entry = dir.get_next()
+	dir.list_dir_end()
+
+
+# Summarize one .tscn for the listing: its path plus the root node's name/type
+# from stored state (no instantiation, issue #30). A file that cannot be loaded
+# as a scene still appears, with null root info, rather than being dropped.
+func _scene_summary(path: String) -> Dictionary:
+	var packed := ResourceLoader.load(path, "PackedScene") as PackedScene
+	if packed == null:
+		return {"path": path, "root_name": null, "root_type": null}
+	var state := packed.get_state()
+	if state == null or state.get_node_count() == 0:
+		return {"path": path, "root_name": null, "root_type": null}
+	return {
+		"path": path,
+		"root_name": String(state.get_node_name(0)),
+		"root_type": String(state.get_node_type(0)),
+	}
 
 
 # Load the .tscn named by params.path for reading or mutation, validating the

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -351,23 +351,30 @@ func _has_project() -> bool:
 	return DirAccess.dir_exists_absolute("res://") and FileAccess.file_exists("res://project.godot")
 
 
-# Recursively collect every .tscn under res:// (issue #54), skipping the
+# Recursively collect every .tscn under res:// (issue #54), skipping only the
 # engine's own res://.godot cache directory (import artifacts, not authored
-# scenes). Paths are returned as res:// paths so they round-trip into other
+# scenes). The skip is scoped to that one directory name rather than every
+# dot-prefixed entry, so legitimately hidden scenes (a .hidden.tscn, or a scene
+# under a dot-prefixed directory) are still enumerated as promised (issue #54
+# review). Paths are returned as res:// paths so they round-trip into other
 # scene commands.
 func _collect_scene_paths(dir_path: String, out: Array[String]) -> void:
 	var dir := DirAccess.open(dir_path)
 	if dir == null:
 		return
+	# Hidden entries are off by default; enable them so a .hidden.tscn or a scene
+	# under a dot-prefixed directory is enumerated. Navigational entries ('.',
+	# '..') stay off, so recursion cannot loop back on itself (issue #54 review).
+	dir.include_hidden = true
 	dir.list_dir_begin()
 	var entry := dir.get_next()
 	while not entry.is_empty():
-		if not entry.begins_with("."):
-			var child := dir_path.path_join(entry)
-			if dir.current_is_dir():
+		var child := dir_path.path_join(entry)
+		if dir.current_is_dir():
+			if entry != ".godot":
 				_collect_scene_paths(child, out)
-			elif entry.get_extension() == "tscn":
-				out.append(child)
+		elif entry.get_extension() == "tscn":
+			out.append(child)
 		entry = dir.get_next()
 	dir.list_dir_end()
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -32,6 +32,7 @@ const OP_ERROR_INVALID_ROOT_TYPE := "invalid_root_type"
 const OP_ERROR_INVALID_ROOT_NAME := "invalid_root_name"
 const OP_ERROR_ALREADY_EXISTS := "already_exists"
 const OP_ERROR_SAVE_FAILED := "save_failed"
+const OP_ERROR_DELETE_FAILED := "delete_failed"
 const OP_ERROR_PROJECT_NOT_FOUND := "project_not_found"
 const OP_ERROR_PATH_NOT_FOUND := "path_not_found"
 const OP_ERROR_NOT_A_SCENE := "not_a_scene"
@@ -225,7 +226,7 @@ func _op_scene_delete(params: Dictionary) -> void:
 
 	var err := DirAccess.remove_absolute(path)
 	if err != OK:
-		_fail(OP_ERROR_SAVE_FAILED, "failed to delete scene " + path + ": " + error_string(err))
+		_fail(OP_ERROR_DELETE_FAILED, "failed to delete scene " + path + ": " + error_string(err))
 		return
 
 	_succeed({

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -416,6 +416,59 @@ def test_scene_list_enumerates_created_scenes(godot_project):
 
 @pytest.mark.e2e
 @requires_godot
+def test_scene_list_enumerates_dot_prefixed_scenes_but_skips_godot_cache(godot_project):
+    # scene list promises to enumerate every .tscn in the project, so a
+    # dot-prefixed scene (a hidden file, or one under a hidden directory) must
+    # appear — only the engine's res://.godot import cache is skipped, not every
+    # dot-prefixed entry. The empty-project test already proves res://.godot does
+    # not leak; this proves the skip is scoped to res://.godot, not "anything
+    # starting with a dot".
+    gda = _gda_project(godot_project)
+
+    assert (
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
+        == 0
+    )
+    assert (
+        gda(
+            "scene",
+            "create",
+            "res://.hidden.tscn",
+            "--root-type",
+            "Node2D",
+            "--root-name",
+            "Hidden",
+            "--json",
+        ).returncode
+        == 0
+    )
+    assert (
+        gda(
+            "scene",
+            "create",
+            "res://.config/deep.tscn",
+            "--root-type",
+            "Node2D",
+            "--json",
+        ).returncode
+        == 0
+    )
+
+    listed = gda("scene", "list", "--json")
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    paths = {s["path"] for s in json.loads(listed.stdout)["scenes"]}
+    assert "res://main.tscn" in paths
+    assert "res://.hidden.tscn" in paths
+    assert "res://.config/deep.tscn" in paths
+    # The engine import cache is still excluded — no res://.godot entry leaks in.
+    assert not any(p.startswith("res://.godot") for p in paths)
+
+
+@pytest.mark.e2e
+@requires_godot
 def test_scene_list_on_empty_project_is_an_empty_listing(godot_project):
     # A project with no scenes is a valid, empty listing — not an error (the
     # res://.godot import cache must not leak in as a phantom scene).

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -47,7 +47,9 @@ def test_res_path_round_trip_against_the_project_fixture(godot_project):
             text=True,
         )
 
-    created = gda("scene", "create", "res://hero.tscn", "--root-type", "Node2D", "--json")
+    created = gda(
+        "scene", "create", "res://hero.tscn", "--root-type", "Node2D", "--json"
+    )
     assert created.returncode == 0, created.stdout + created.stderr
     # res:// resolved against the fixture project, not gda's cwd.
     assert (godot_project / "hero.tscn").exists()
@@ -93,8 +95,14 @@ def test_scene_path_containing_end_sentinel_round_trips(godot_project):
     scene_path = godot_project / "weird<<<GDA:END>>>name.tscn"
 
     created = _gda(
-        "scene", "create", str(scene_path),
-        "--root-type", "Node2D", "--root-name", "Main", "--json",
+        "scene",
+        "create",
+        str(scene_path),
+        "--root-type",
+        "Node2D",
+        "--root-name",
+        "Main",
+        "--json",
     )
 
     assert created.returncode == 0, created.stdout + created.stderr
@@ -326,7 +334,9 @@ def test_scene_create_unwritable_directory_yields_structured_save_failed(godot_p
     target = locked / "main.tscn"
     locked.chmod(0o500)
     try:
-        created = _gda("scene", "create", str(target), "--root-type", "Node2D", "--json")
+        created = _gda(
+            "scene", "create", str(target), "--root-type", "Node2D", "--json"
+        )
     finally:
         locked.chmod(0o700)
 
@@ -355,3 +365,147 @@ def test_scene_create_unknown_root_type_yields_structured_error_end_to_end(
     assert err["category"] == "operation"
     assert err["code"] == "invalid_root_type"
     assert not target.exists()
+
+
+def _gda_project(project) -> "callable":
+    """A ``_gda`` bound to ``--project`` for res:// enumeration/resolution."""
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+
+    def gda(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [gda_bin, *args, "--godot", str(GODOT), "--project", str(project)],
+            capture_output=True,
+            text=True,
+        )
+
+    return gda
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_list_enumerates_created_scenes(godot_project):
+    # scene list (issue #54) enumerates the project's .tscn scenes by walking
+    # res://: two scenes created at different depths both appear, each with its
+    # res:// path and the root name/type read from stored state. The listing IS
+    # the structured-level verification of what scene create wrote.
+    gda = _gda_project(godot_project)
+
+    assert (
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
+        == 0
+    )
+    assert (
+        gda(
+            "scene", "create", "res://ui/menu.tscn", "--root-type", "Control", "--json"
+        ).returncode
+        == 0
+    )
+
+    listed = gda("scene", "list", "--json")
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    scenes = json.loads(listed.stdout)["scenes"]
+    by_path = {s["path"]: s for s in scenes}
+    assert by_path["res://main.tscn"]["root_type"] == "Node2D"
+    assert by_path["res://main.tscn"]["root_name"] == "main"
+    assert by_path["res://ui/menu.tscn"]["root_type"] == "Control"
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_list_on_empty_project_is_an_empty_listing(godot_project):
+    # A project with no scenes is a valid, empty listing — not an error (the
+    # res://.godot import cache must not leak in as a phantom scene).
+    gda = _gda_project(godot_project)
+
+    listed = gda("scene", "list", "--json")
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    assert json.loads(listed.stdout)["scenes"] == []
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_list_without_project_yields_project_not_found(tmp_path):
+    # scene list cannot enumerate res:// projectless: run from a non-project
+    # directory with no --project, it must refuse with the structured
+    # project_not_found code rather than return a misleading empty listing.
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+
+    listed = subprocess.run(
+        [gda_bin, "scene", "list", "--json", "--godot", str(GODOT)],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+
+    assert listed.returncode == 4, listed.stdout + listed.stderr
+    err = json.loads(listed.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "project_not_found"
+    assert "--project" in err["message"]
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_delete_removes_a_scene_and_names_what_was_removed(godot_project):
+    # scene delete (issue #54) removes a scene file and names the removed root.
+    # The round-trip verifier: scene list before shows the scene, delete reports
+    # the removed root's name/type, and scene list after no longer shows it.
+    gda = _gda_project(godot_project)
+    assert (
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
+        == 0
+    )
+    scene_path = godot_project / "main.tscn"
+    assert scene_path.exists()
+
+    deleted = gda("scene", "delete", "res://main.tscn", "--json")
+
+    assert deleted.returncode == 0, deleted.stdout + deleted.stderr
+    data = json.loads(deleted.stdout)
+    assert data["path"] == "res://main.tscn"
+    assert data["root_name"] == "main"
+    assert data["root_type"] == "Node2D"
+    # The file is gone from disk, not just from the report.
+    assert not scene_path.exists()
+    assert json.loads(gda("scene", "list", "--json").stdout)["scenes"] == []
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_delete_missing_file_yields_path_not_found(godot_project):
+    missing = godot_project / "missing.tscn"
+
+    deleted = _gda("scene", "delete", str(missing), "--json")
+
+    assert deleted.returncode == 4
+    err = json.loads(deleted.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert str(missing) in err["message"]
+
+
+@pytest.mark.e2e
+@requires_godot
+def test_scene_delete_refuses_non_scene_file_and_leaves_it_on_disk(godot_project):
+    # The delete safety boundary (issue #54): delete only removes a file that
+    # loads as a PackedScene, so a stray non-scene file is refused with
+    # not_a_scene and left untouched — delete never erases arbitrary files.
+    notes = godot_project / "notes.txt"
+    notes.write_text("not a scene\n", encoding="utf-8")
+
+    deleted = _gda("scene", "delete", str(notes), "--json")
+
+    assert deleted.returncode == 4
+    err = json.loads(deleted.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "not_a_scene"
+    # The non-scene file survives the refusal.
+    assert notes.read_text(encoding="utf-8") == "not a scene\n"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,9 @@ from gda.models import (
     NodeAddResult,
     NodeListResult,
     SceneCreateResult,
+    SceneDeleteResult,
     SceneGetResult,
+    SceneListResult,
 )
 
 
@@ -93,6 +95,54 @@ def test_scene_get_result_round_trips_a_nested_tree():
 
     assert scene.root.children[0].children[0].name == "Hitbox"
     assert json.loads(scene.model_dump_json()) == payload
+
+
+def test_scene_list_result_round_trips_enumerated_scenes():
+    # The scene-list operation enumerates the project's .tscn files (issue #54):
+    # each entry carries its res:// path plus the root's name/type read cheaply
+    # from the scene's stored state. A scene that fails to load still appears,
+    # with null root info, so the listing names every .tscn it found.
+    payload = {
+        "scenes": [
+            {"path": "res://main.tscn", "root_name": "main", "root_type": "Node2D"},
+            {"path": "res://ui/menu.tscn", "root_name": "Menu", "root_type": "Control"},
+            {"path": "res://broken.tscn", "root_name": None, "root_type": None},
+        ]
+    }
+
+    listed = SceneListResult.model_validate(payload)
+
+    assert listed.scenes[0].path == "res://main.tscn"
+    assert listed.scenes[1].root_type == "Control"
+    assert listed.scenes[2].root_name is None
+    assert json.loads(listed.model_dump_json()) == payload
+
+
+def test_scene_list_result_round_trips_an_empty_project():
+    # A project with no scenes is a valid, empty listing — not an error.
+    payload = {"scenes": []}
+
+    listed = SceneListResult.model_validate(payload)
+
+    assert listed.scenes == []
+    assert json.loads(listed.model_dump_json()) == payload
+
+
+def test_scene_delete_result_round_trips():
+    # The scene-delete operation reports what it removed (issue #54): the path,
+    # and the deleted scene's root name/type so the result names the content,
+    # not just the file.
+    payload = {
+        "path": "res://main.tscn",
+        "root_name": "main",
+        "root_type": "Node2D",
+    }
+
+    deleted = SceneDeleteResult.model_validate(payload)
+
+    assert deleted.path == "res://main.tscn"
+    assert deleted.root_name == "main"
+    assert json.loads(deleted.model_dump_json()) == payload
 
 
 def test_node_add_result_round_trips():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -83,9 +83,7 @@ def test_scene_get_result_round_trips_a_nested_tree():
                 {
                     "name": "Hero",
                     "type": "Sprite2D",
-                    "children": [
-                        {"name": "Hitbox", "type": "Area2D", "children": []}
-                    ],
+                    "children": [{"name": "Hitbox", "type": "Area2D", "children": []}],
                 }
             ],
         },

--- a/tests/test_scene_commands.py
+++ b/tests/test_scene_commands.py
@@ -128,7 +128,9 @@ def test_scene_get_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
 
     def record(binary, project):
         seen["project"] = project
-        return FakeRunner(RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0))
+        return FakeRunner(
+            RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+        )
 
     monkeypatch.setattr("gda.cli._make_runner", record)
 
@@ -143,7 +145,9 @@ def test_scene_get_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
 def test_scene_get_expands_user_home_in_filesystem_path_but_not_res(monkeypatch):
     # Path normalization lives at the CLI layer (issue #32): a filesystem path
     # gets ~ expanded; an engine-resolved res:// path passes through untouched.
-    fake = inject_runner(monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0))
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    )
 
     CliRunner().invoke(app, ["scene", "get", "~/game/main.tscn", "--json"])
     assert "~" not in fake.calls[0][1]["path"]
@@ -152,3 +156,106 @@ def test_scene_get_expands_user_home_in_filesystem_path_but_not_res(monkeypatch)
     fake.calls.clear()
     CliRunner().invoke(app, ["scene", "get", "res://main.tscn", "--json"])
     assert fake.calls[0][1]["path"] == "res://main.tscn"
+
+
+LIST_RESULT = {
+    "scenes": [
+        {"path": "res://main.tscn", "root_name": "main", "root_type": "Node2D"},
+        {"path": "res://ui/menu.tscn", "root_name": "Menu", "root_type": "Control"},
+        {"path": "res://broken.tscn", "root_name": None, "root_type": None},
+    ]
+}
+
+
+def test_scene_list_json_enumerates_project_scenes_and_exit_zero(monkeypatch, tmp_path):
+    # scene list enumerates the resolved project's .tscn files (issue #54):
+    # each entry carries its res:// path plus the root name/type read cheaply
+    # from the scene's stored state.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(LIST_RESULT)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app, ["scene", "list", "--project", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert [s["path"] for s in data["scenes"]] == [
+        "res://main.tscn",
+        "res://ui/menu.tscn",
+        "res://broken.tscn",
+    ]
+    assert data["scenes"][1]["root_type"] == "Control"
+    assert data["scenes"][2]["root_name"] is None
+    # scene list takes no operation params: the project is process context.
+    assert fake.calls == [("scene-list", {})]
+
+
+def test_scene_list_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
+    # scene list enumerates res:// in the resolved project, so --project must
+    # reach the runner (which hands it to the engine as --path, issue #32).
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    seen: dict = {}
+
+    def record(binary, project):
+        seen["project"] = project
+        return FakeRunner(
+            RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+        )
+
+    monkeypatch.setattr("gda.cli._make_runner", record)
+
+    result = CliRunner().invoke(
+        app, ["scene", "list", "--project", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert seen["project"] == tmp_path
+
+
+DELETE_RESULT = {
+    "path": "/tmp/proj/old.tscn",
+    "root_name": "old",
+    "root_type": "Node2D",
+}
+
+
+def test_scene_delete_json_reports_what_was_removed_and_exit_zero(monkeypatch):
+    # scene delete removes a scene file and names what it deleted (issue #54):
+    # the path plus the removed scene's root name/type, so the result names the
+    # content, not just the file.
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(DELETE_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["scene", "delete", "/tmp/proj/old.tscn", "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["path"] == "/tmp/proj/old.tscn"
+    assert data["root_name"] == "old"
+    assert data["root_type"] == "Node2D"
+    # The operation was dispatched by name with the command's typed params.
+    assert fake.calls == [("scene-delete", {"path": "/tmp/proj/old.tscn"})]
+    # Engine/script diagnostics are surfaced on stderr, not stdout.
+    assert "engine diagnostic" in result.stderr
+
+
+def test_scene_delete_expands_user_home_in_filesystem_path_but_not_res(monkeypatch):
+    # Path normalization at the CLI layer (issue #32) applies to delete too: a
+    # filesystem path gets ~ expanded; a res:// path passes through untouched.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(DELETE_RESULT), stderr="", exit_code=0)
+    )
+
+    CliRunner().invoke(app, ["scene", "delete", "~/game/old.tscn", "--json"])
+    assert "~" not in fake.calls[0][1]["path"]
+    assert fake.calls[0][1]["path"].endswith("/game/old.tscn")
+
+    fake.calls.clear()
+    CliRunner().invoke(app, ["scene", "delete", "res://old.tscn", "--json"])
+    assert fake.calls[0][1]["path"] == "res://old.tscn"

--- a/tests/test_scene_errors.py
+++ b/tests/test_scene_errors.py
@@ -135,6 +135,79 @@ def test_scene_get_broken_sentinel_maps_to_parse_error(monkeypatch):
     assert err["code"] == "contract_violation"
 
 
+def test_scene_delete_missing_file_maps_to_stable_path_not_found_code(monkeypatch):
+    # scene delete reuses the shared load-failure ladder (issue #54): a target
+    # that does not exist is the file-level path_not_found, exit 4, so an agent
+    # can tell "no such scene" apart from other delete failures.
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel(
+                "path_not_found", "scene file does not exist: /x/missing.tscn"
+            ),
+            stderr="",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["scene", "delete", "/x/missing.tscn"])
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert "/x/missing.tscn" in err["message"]
+
+
+def test_scene_delete_non_scene_file_maps_to_stable_not_a_scene_code(monkeypatch):
+    # delete refuses a target that is not loadable as a scene (issue #54): the
+    # safety boundary is that delete only removes things that load as a
+    # PackedScene, so a stray file is not_a_scene rather than silently deleted.
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel(
+                "not_a_scene", "failed to load as a scene: /x/notes.txt"
+            ),
+            stderr="",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["scene", "delete", "/x/notes.txt"])
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "not_a_scene"
+
+
+def test_scene_list_without_project_maps_to_stable_project_not_found_code(monkeypatch):
+    # scene list enumerates res:// in a project, so it cannot run projectless
+    # (issue #54): with no resolvable project, the operation reports the new
+    # project_not_found code — a finer mode than the generic operation_failed so
+    # an agent knows to pass --project rather than retry.
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel(
+                "project_not_found",
+                "scene list requires a Godot project; none was resolved — pass --project",
+            ),
+            stderr="",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["scene", "list"])
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "project_not_found"
+    assert "--project" in err["message"]
+
+
 def test_scene_create_missing_binary_maps_to_environment_error(monkeypatch):
     # The runner's synthetic exit 127 flows through the same shared environment
     # branch for scene commands as for info.

--- a/tests/test_scene_errors.py
+++ b/tests/test_scene_errors.py
@@ -182,6 +182,34 @@ def test_scene_delete_non_scene_file_maps_to_stable_not_a_scene_code(monkeypatch
     assert err["code"] == "not_a_scene"
 
 
+def test_scene_delete_unlink_failure_maps_to_stable_delete_failed_code(monkeypatch):
+    # The op loaded the scene but the underlying unlink/remove failed (a
+    # read-only filesystem, a permission boundary): this is a delete IO failure,
+    # not a save/pack failure, so it maps to the stable delete_failed code rather
+    # than reusing save_failed (whose contract is "a scene could not be packed or
+    # saved"). An agent can then tell "deletion was blocked" apart from "writing
+    # the scene failed".
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel(
+                "delete_failed",
+                "failed to delete scene /x/main.tscn: Permission denied",
+            ),
+            stderr="",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["scene", "delete", "/x/main.tscn"])
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "delete_failed"
+    assert "/x/main.tscn" in err["message"]
+
+
 def test_scene_list_without_project_maps_to_stable_project_not_found_code(monkeypatch):
     # scene list enumerates res:// in a project, so it cannot run projectless
     # (issue #54): with no resolvable project, the operation reports the new

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -122,16 +122,62 @@ def test_scene_get_schema_emits_model_derived_contract_without_other_args():
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
 
-def test_sample_scene_results_validate_against_emitted_output_schemas():
-    # The other half of the ADR-0004 hard gate (issue #18): a sample --json
-    # payload of each scene command satisfies the contract its --schema emits.
-    from tests.test_scene_commands import CREATE_RESULT, GET_RESULT
+def test_scene_list_schema_emits_model_derived_contract_without_a_project():
+    # The ADR-0004 hard gate for scene list (issue #54): the bare --schema flag
+    # — no --project — short-circuits into the self-description, derived from the
+    # same typed models that back --json. scene list takes no operation params,
+    # so its input schema is trivially empty (the project is process context,
+    # ADR-0006), exactly like info.
+    from gda.models import SceneListParams, SceneListResult
 
-    create_doc = json.loads(CliRunner().invoke(app, ["scene", "create", "--schema"]).stdout)
+    result = CliRunner().invoke(app, ["scene", "list", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == SceneListParams.model_json_schema()
+    assert doc["output"] == SceneListResult.model_json_schema()
+    assert doc["input"].get("properties", {}) == {}
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_scene_delete_schema_emits_model_derived_contract_without_other_args():
+    from gda.models import SceneDeleteParams, SceneDeleteResult
+
+    result = CliRunner().invoke(app, ["scene", "delete", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == SceneDeleteParams.model_json_schema()
+    assert doc["output"] == SceneDeleteResult.model_json_schema()
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_sample_scene_results_validate_against_emitted_output_schemas():
+    # The other half of the ADR-0004 hard gate (issues #18, #54): a sample
+    # --json payload of each scene command satisfies the contract its --schema
+    # emits.
+    from tests.test_scene_commands import (
+        CREATE_RESULT,
+        DELETE_RESULT,
+        GET_RESULT,
+        LIST_RESULT,
+    )
+
+    create_doc = json.loads(
+        CliRunner().invoke(app, ["scene", "create", "--schema"]).stdout
+    )
     get_doc = json.loads(CliRunner().invoke(app, ["scene", "get", "--schema"]).stdout)
+    list_doc = json.loads(CliRunner().invoke(app, ["scene", "list", "--schema"]).stdout)
+    delete_doc = json.loads(
+        CliRunner().invoke(app, ["scene", "delete", "--schema"]).stdout
+    )
 
     jsonschema.validate(instance=CREATE_RESULT, schema=create_doc["output"])
     jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
+    jsonschema.validate(instance=LIST_RESULT, schema=list_doc["output"])
+    jsonschema.validate(instance=DELETE_RESULT, schema=delete_doc["output"])
 
 
 def test_scene_schema_spawns_no_godot(monkeypatch):
@@ -143,7 +189,12 @@ def test_scene_schema_spawns_no_godot(monkeypatch):
     monkeypatch.setattr("gda.headless.resolve_godot_binary", boom)
     monkeypatch.setattr("gda.cli._make_runner", boom)
 
-    for command in (["scene", "create"], ["scene", "get"]):
+    for command in (
+        ["scene", "create"],
+        ["scene", "get"],
+        ["scene", "list"],
+        ["scene", "delete"],
+    ):
         result = CliRunner().invoke(app, [*command, "--schema"])
         assert result.exit_code == 0
         assert set(json.loads(result.stdout)) >= {"input", "output"}


### PR DESCRIPTION
## Summary

Completes the basic scene-file CRUD alongside the existing `scene create` / `scene get` (#18), implementing both new commands via the shared headless pipeline and command skeleton (ADR-0001/0002/0004/0005).

- **`gda scene list`** — enumerates every `.tscn` under the resolved project's `res://` tree (project context via `--project` / `GDA_PROJECT` / cwd, ADR-0006) and returns a typed JSON list. Each entry carries `path` (res:// form) plus `root_name` / `root_type` read cheaply from the `SceneState` **without instantiating the scene** (no project code executed). Results are sorted; the engine's own `res://.godot` import cache is skipped; `.tscn` files that fail to load are still listed with null root info.
- **`gda scene delete`** — deletes one scene file and reports what was removed (`path` + root `name` / `type`, read before deletion). It only deletes files that load as a `PackedScene`, so a missing or non-scene target clean-errors and the file is left on disk.

Both ship `--json` and the ADR-0004 `--schema` hard gate through the shared command skeleton.

## Error codes

Two operation-reported codes registered across all three sources (Python registry + ADR-0002 table + GDScript mirror):

- `project_not_found` — `scene list` refuses when no project resolves (no `res://` tree to enumerate).
- `delete_failed` — `scene delete` reports an unlink/remove IO failure (distinct from `save_failed`, which stays scoped to pack/save failures).

`scene delete`'s missing / non-scene targets reuse the existing `path_not_found` / `not_a_scene` codes.

## Tests

- **S2** model/parser unit (`tests/test_models.py`)
- **S3** CLI-with-FakeRunner success + failure paths (`tests/test_scene_commands.py`, `tests/test_scene_errors.py`, `tests/test_schema_command.py`)
- **S1** e2e against real Godot 4.6 (`tests/test_e2e_scene.py`), including hidden-scene enumeration vs `.godot`-cache exclusion

Full suite: **172 passed** (incl. e2e). Changed Python files pass `ruff check` + `format --check`.

## Review fixes folded in

A code review of this branch flagged two issues, both fixed here under TDD:

- **`delete_failed`** — the delete IO-failure path originally reused `save_failed`, whose ADR-0002 contract is "could not be packed or saved" — a semantic ABI mismatch for agents branching on the code. Now reports a dedicated `delete_failed` code (3-place sync) with S3 coverage.
- **`scene list` hidden-scene enumeration** — the dot-prefix skip was broader than intended and silently dropped legitimate hidden `.tscn` files; the real root cause was `DirAccess.include_hidden` defaulting to false. Now scoped to the `.godot` cache directory only, with `include_hidden` enabled and S1 e2e coverage.

Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)