### PR TITLE
docs(adr): record the squash-only merge strategy in ADR-0007

### DIFF
--- a/docs/adr/0007-release-automation-with-release-please.md
+++ b/docs/adr/0007-release-automation-with-release-please.md
@@ -59,6 +59,13 @@ release from that tag.
   GitHub App token.
 - Release cadence is decoupled from commit cadence: the Release PR accumulates
   changes until someone decides to merge it.
+- PRs are merged **squash-only** (repo setting). With merge commits,
+  release-please counted both the PR title and every conventional commit inside
+  the merge, double-listing each PR in the changelog — the 0.1.1 changelog
+  carries these historical duplicates. The squash commit title is forced to the
+  PR title (which must therefore be a conventional commit message) and the body
+  is left blank, so a squashed body can never be re-parsed into phantom
+  changelog entries. A breaking change is flagged with `!` in the PR title.
 
 ## Considered options
 


### PR DESCRIPTION
Refs #72

## What

Amends ADR-0007's Consequences with the squash-only merge decision and its rationale.

## Context

The first release-please run (Release PR #74) exposed systematic changelog duplication: for every PR merged via a merge commit, release-please counted both the PR title (resolved from the merge commit) and each conventional commit inside the merge. release-please has no dedup option, so the fix is at the merge-strategy level.

Repo settings have been changed (already applied):

- `allow_merge_commit: false`, `allow_rebase_merge: false`, `allow_squash_merge: true`
- `squash_merge_commit_title: PR_TITLE` — the squash commit title is always the PR title, so PR titles must be conventional commit messages (already house practice)
- `squash_merge_commit_message: BLANK` — release-please splits a squashed body containing conventional-looking lines into multiple changelog entries, so a blank body guarantees one entry per PR; breaking changes are flagged with `!` in the PR title

The 0.1.1 changelog (#74) keeps its historical duplicates — history is immutable; releases after this are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)