### PR TITLE
fix(release): gate release-PR maintenance on the manifest version's tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,11 @@ env:
 # release-please runs twice, bracketing the verify-and-build chain: a draft
 # release carries no git tag until published, and release-please's lookback is
 # tag-based, so computing the next Release PR before the publish reads the
-# whole history as unreleased and proposes a spurious release (#79).
+# whole history as unreleased and proposes a spurious release (#79). The
+# release-pr phase additionally gates on the manifest version's tag actually
+# existing: a failed publish leaves a tag-less draft, and without that gate a
+# later ordinary push would run release-please against the missing tag and
+# regenerate the spurious full-history Release PR across runs (#82).
 
 jobs:
   cut-release:
@@ -172,11 +176,14 @@ jobs:
     needs:
       - cut-release
       - github-release
-    # Runs after any cut release is published, so the tag lookback always sees
-    # the new tag. Skipped when the verify-and-build chain fails: computing a
-    # Release PR while the cut release's tag is missing reads the whole
-    # history as unreleased (#79). On pushes that cut no release the
-    # github-release job is skipped and this still runs.
+    # Runs after any cut release is published. The same-run `needs` only sees
+    # this run's job statuses, but the hazard is repo-global and survives the
+    # run: a failed verify-and-build chain leaves a tag-less draft whose merged
+    # Release PR is already labeled "autorelease: tagged", so a later ordinary
+    # push reaches here with everything merely skipped. The tag_gate step below
+    # is the actual guard — it refuses maintenance unless the manifest version's
+    # tag exists (#82). On pushes that cut no release the github-release job is
+    # skipped and this still runs.
     if: >-
       !failure() && !cancelled() &&
       github.event_name == 'push'
@@ -184,7 +191,33 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Check out the release manifest
+        uses: actions/checkout@v6
+
+      - name: Require the manifest version's tag before maintaining the release PR
+        id: tag_gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="$(python3 -c "import json; print(json.load(open('.release-please-manifest.json'))['.'])")"
+          tag="v${version}"
+          # Bounded retry: a tag created by the publish step moments ago may not
+          # be visible immediately (read-after-write), which would otherwise let
+          # an all-green release run still regenerate the spurious PR (#79/#82).
+          for attempt in $(seq 1 6); do
+            if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+              echo "Tag ${tag} is visible; maintaining the release PR."
+              echo "tag_present=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Tag ${tag} not visible yet (attempt ${attempt}/6); waiting 5s..."
+            sleep 5
+          done
+          echo "tag_present=false" >> "$GITHUB_OUTPUT"
+          echo "::warning title=Release pipeline needs recovery::Tag ${tag} for the current manifest version does not exist, so release-PR maintenance is skipped to avoid regenerating a spurious full-history Release PR (#79). A previous release likely failed to publish, leaving a tag-less draft. See ADR-0007 for recovery."
+
       - name: Run release-please (release PR maintenance only)
+        if: steps.tag_gate.outputs.tag_present == 'true'
         uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json


### PR DESCRIPTION
Closes #82 · part of #81

## Problem

#80 fixed the spurious-Release-PR race only within a single run. The hazardous state is repo-global and survives a failed run: a failed verify-and-build chain leaves a tag-less draft whose merged Release PR is already relabeled `autorelease: tagged`, so the **next ordinary push** reaches `release-pr` with `cut-release` finding nothing to cut and `github-release` merely skipped — the run-local `!failure() && !cancelled()` guard passes, maintenance runs, release-please's tag-based lookback misses the manifest version's tag, and the spurious full-history Release PR of #79 reappears. Verified CONFIRMED in the code review (PR #76 was relabeled `tagged` at 10:41:17Z while v0.1.2 published only at 10:43:58Z).

## Fix

Add a `tag_gate` step to `release-pr` that reads the manifest version and runs maintenance **only if `v{version}` exists as a git tag**:

- Checks the git **ref** (`git/ref/tags/<tag>`), not the release object — a tag-less draft must read as absent.
- Bounded retry (6 × 5s) covers the publish step's read-after-write window, which also closes the happy-path eventual-consistency gap (F7).
- On a missing tag: emits a `::warning::` annotation pointing at recovery and skips maintenance; the run stays green so ordinary pushes aren't spuriously failed.

## Verification

- Workflow validates against the GitHub workflow JSON schema.
- `tag_gate` shell: `bash -n` clean; logic exercised against the live repo — existing `v0.1.3` → present, nonexistent `v9.9.9` → absent.
- Normal flow unaffected: on a real release push the just-created tag is present (attempt 1), maintenance runs; on an ordinary push the last release's tag is present, maintenance runs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)