### PR TITLE
fix(release): build release artifacts from the tagged commit, not push HEAD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,9 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      # The commit release-please tagged the release at — not necessarily the
+      # push HEAD, so github-release builds the right tree under concurrency (#83).
+      sha: ${{ steps.release.outputs.sha }}
     steps:
       - name: Run release-please (release cutting only)
         uses: googleapis/release-please-action@v4
@@ -85,9 +88,12 @@ jobs:
       - name: Checkout release commit
         uses: actions/checkout@v6
         with:
-          # The release-please tag may not exist yet (draft release), but the
-          # push that triggered this run is exactly the tagged release commit.
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.sha }}
+          # Build from the exact commit release-please tagged the release at,
+          # not the push HEAD: under concurrency queue replacement a later
+          # push's run can cut an earlier merged Release PR, so github.sha may
+          # be ahead of the tagged commit and the version check would not catch
+          # it (the version is unchanged across the intervening commits) (#83).
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || needs.cut-release.outputs.sha }}
           fetch-depth: 0
 
       - name: Set up uv


### PR DESCRIPTION
Closes #83 · part of #81

## Problem

`github-release` checked out `github.sha` with a comment asserting it was the tagged release commit. Under GitHub concurrency **queue replacement** (one pending run per group; a newer push cancels an older pending one even with `cancel-in-progress: false`), a later push's run cuts the still-pending merged Release PR — release-please tags it at the Release-PR merge commit — but the job then builds/tests/uploads from the later HEAD. The "Validate release tag" step can't catch it: the manifest version is unchanged across the intervening commits, so `v{version}` still matches. Result: published artifacts contain commits not in the tagged release. Queue-replacement cancellation was observed in this repo (run 27410536584).

## Fix

- `cut-release` now exposes release-please's `sha` output ("SHA that a GitHub release was tagged at" — confirmed against the action's v4 README).
- `github-release` checks out `needs.cut-release.outputs.sha` on the automated path instead of `github.sha`.
- The manual escape hatch still checks out the requested `inputs.tag`.

## Verification

- Workflow validates against the GitHub workflow JSON schema.
- `sha` is a documented root output of `googleapis/release-please-action@v4`.
- On a normal release run `sha` equals the push HEAD, so behavior is identical except in the queue-replacement case this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)