### PR TITLE
fix(release): make the release publish idempotent with --clobber

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,11 @@ jobs:
           else
             # release-please path: attach artifacts to the draft release it
             # created, then publish (publishing also creates the git tag).
-            gh release upload "$RELEASE_TAG" dist/* --repo "$GITHUB_REPOSITORY"
+            # --clobber makes the upload idempotent so "Re-run failed jobs"
+            # recovers a partial publish instead of erroring on existing
+            # assets and leaving a stranded tag-less draft (#84). Both commands
+            # are no-ops if already done, so re-running converges to published.
+            gh release upload "$RELEASE_TAG" dist/* --clobber --repo "$GITHUB_REPOSITORY"
             gh release edit "$RELEASE_TAG" --draft=false --repo "$GITHUB_REPOSITORY"
           fi
 


### PR DESCRIPTION
Closes #84 · part of #81

## Problem

`gh release upload` had no `--clobber`, and the step runs under the Actions default `bash -e`. If a first attempt uploaded some of `dist/*` and then the job died (or the publish edit failed), re-running rebuilds `dist` and the upload aborts on the already-existing asset names (`422`) before reaching `gh release edit --draft=false` — so the standard "Re-run failed jobs" recovery can never republish, and the draft stays stranded and tag-less (feeding the cross-run #79 regression). Confirmed in review against the gh CLI source.

## Fix

Add `--clobber` so the upload overwrites same-named assets. The `--draft=false` edit is already a no-op on an already-published release, so a re-run now converges to a published release.

## Verification

- Workflow validates against the GitHub workflow JSON schema.
- `gh release upload --help`: `--clobber   Delete and re-upload existing assets of the same name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)