### PR TITLE
fix(release): isolate workflow_dispatch from the push concurrency lane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,12 @@ on:
 permissions:
   contents: read
 
-# Serialize release runs; never cancel an in-flight release build.
+# Serialize push-triggered release runs among themselves (never cancel an
+# in-flight build). workflow_dispatch gets a per-run lane (keyed on run_id) so
+# a manual recovery run is never queue-cancelled by an ordinary push — they
+# would otherwise share refs/heads/main and only one pending run survives (#85).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
Closes #85 · part of #81

## Problem

The concurrency group was keyed on `workflow + ref`, and push + manual-dispatch runs on the default branch share `refs/heads/main` → the same group. GitHub keeps at most one **pending** run per group (a newer queued run replaces an older pending one even with `cancel-in-progress: false`). So a pending manual escape-hatch run — precisely the recovery operation, most likely issued while fix pushes are landing — can be silently cancelled by a push and never execute. Queue-replacement of a pending run was observed in this repo (run 27410536584).

## Fix

Key the group on `event_name`, and give `workflow_dispatch` a **per-run lane** (`run_id`):

```
group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
```

- push → `Release-push-refs/heads/main` (serialized among pushes, as before)
- dispatch → `Release-workflow_dispatch-<run_id>` (unique → never contended, never cancelled)

## Verification

- Workflow validates against the GitHub workflow JSON schema.
- Push-triggered runs remain serialized among themselves; manual runs are no longer droppable by a push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)