### PR TITLE
ci: drop the stale tag-push trigger from the pre-release-please era

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
       run-e2e:


### PR DESCRIPTION
Closes #86 · part of #81

## Problem

`ci.yml` still triggered on `push: tags: 'v*'`. Under the release-please flow, tags are created only by the default token (cutting/publishing), and token-created refs never trigger workflows (recursion guard) — so this trigger never fired on the automated path. Verified: none of v0.1.1/v0.1.2/v0.1.3 produced a tag-ref CI run; only the pre-release-please v0.1.0 human tag push did. It only fires when a human pushes a tag with personal credentials (the manual flow ADR-0007 abolished), burning a duplicate CI run, and implies tags get CI validation they never receive.

## Fix

Remove the `tags: 'v*'` entry. CI still runs on pull requests, pushes to `main`, manual dispatch, and the weekly schedule.

## Verification

- Workflow validates against the GitHub workflow JSON schema.
- Trigger surface now matches ADR-0007's stated release paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)