### PR TITLE
ci: share setup via composite actions, cache Godot, and harden publish

### DIFF
--- a/.github/actions/install-godot/action.yml
+++ b/.github/actions/install-godot/action.yml
@@ -1,0 +1,45 @@
+name: Install Godot
+description: >-
+  Download (and cache) a headless Godot binary and export GDA_GODOT for later
+  steps. Single source of truth for the Godot version shared by CI and Release.
+
+inputs:
+  godot-version:
+    description: Godot release to install, e.g. "4.6-stable".
+    required: false
+    default: "4.6-stable"
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve Godot paths
+      shell: bash
+      run: |
+        binary="Godot_v${{ inputs.godot-version }}_linux.x86_64"
+        echo "GODOT_BINARY=${binary}" >> "$GITHUB_ENV"
+        echo "GDA_GODOT=${GITHUB_WORKSPACE}/.godot/${binary}" >> "$GITHUB_ENV"
+
+    - name: Restore cached Godot
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: .godot
+        key: godot-${{ inputs.godot-version }}-linux-x86_64
+
+    - name: Download Godot
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir -p .godot
+        curl --fail --location --show-error \
+          --output .godot/godot.zip \
+          "https://github.com/godotengine/godot/releases/download/${{ inputs.godot-version }}/${GODOT_BINARY}.zip"
+        unzip -q .godot/godot.zip -d .godot
+        # Cache only the binary, not the downloaded archive.
+        rm -f .godot/godot.zip
+
+    - name: Verify Godot
+      shell: bash
+      run: |
+        chmod +x "${GDA_GODOT}"
+        "${GDA_GODOT}" --headless --version

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -1,0 +1,31 @@
+name: Set up Python environment
+description: >-
+  Install uv pinned to the project's Python and sync dev dependencies. Single
+  source of truth for the Python toolchain shared by CI and Release.
+
+inputs:
+  python-version:
+    description: Python version for uv to provide.
+    required: false
+    default: "3.13"
+  save-cache:
+    description: Whether setup-uv should save its dependency cache.
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v8.2.0
+      with:
+        python-version: ${{ inputs.python-version }}
+        enable-cache: true
+        save-cache: ${{ inputs.save-cache }}
+        cache-dependency-glob: |
+          pyproject.toml
+          uv.lock
+
+    - name: Install dependencies
+      shell: bash
+      run: uv sync --frozen --dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  PYTHON_VERSION: "3.13"
-
 jobs:
   python:
     name: Python unit tests and package build
@@ -34,17 +31,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v8.2.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-
-      - name: Install dependencies
-        run: uv sync --frozen --dev
+      - name: Set up Python environment
+        uses: ./.github/actions/setup-python-env
 
       - name: Run unit tests
         run: uv run --frozen pytest -m "not e2e"
@@ -64,36 +52,17 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs['run-e2e']) }}
 
-    env:
-      GODOT_VERSION: "4.6-stable"
-      GDA_GODOT: ${{ github.workspace }}/.godot/Godot_v4.6-stable_linux.x86_64
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v8.2.0
+      - name: Set up Python environment
+        uses: ./.github/actions/setup-python-env
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          enable-cache: true
           save-cache: false
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-
-      - name: Install dependencies
-        run: uv sync --frozen --dev
 
       - name: Install Godot
-        run: |
-          mkdir -p .godot
-          curl --fail --location --show-error \
-            --output .godot/godot.zip \
-            "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_linux.x86_64.zip"
-          unzip -q .godot/godot.zip -d .godot
-          chmod +x "${GDA_GODOT}"
-          "${GDA_GODOT}" --headless --version
+        uses: ./.github/actions/install-godot
 
       - name: Run Godot e2e tests
         run: uv run --frozen pytest -m e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
   cancel-in-progress: false
 
-env:
-  PYTHON_VERSION: "3.13"
-  GODOT_VERSION: "4.6-stable"
-  GDA_GODOT: ${{ github.workspace }}/.godot/Godot_v4.6-stable_linux.x86_64
+# Toolchain versions (Python, Godot) live in the shared composite actions under
+# .github/actions, so CI and Release pin them in one place.
 
 # release-please runs twice, bracketing the verify-and-build chain: a draft
 # release carries no git tag until published, and release-please's lookback is
@@ -53,6 +51,9 @@ jobs:
     if: github.event_name == 'push'
     permissions:
       contents: write
+      # Load-bearing despite skip-github-pull-request: release-please relabels
+      # the merged Release PR (autorelease: pending -> tagged) when it cuts the
+      # release. Removing this silently breaks that relabel and re-opens #82.
       pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -88,6 +89,18 @@ jobs:
       RELEASE_PRERELEASE: ${{ inputs.prerelease || false }}
 
     steps:
+      - name: Validate manual tag input
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          # The web UI enforces required inputs, but an API/`gh -f tag=`
+          # dispatch can pass an empty string; fail fast before any build.
+          if [[ -z "$INPUT_TAG" ]]; then
+            echo "::error title=Missing tag::The 'tag' input is required for a manual release."
+            exit 1
+          fi
+
       - name: Checkout release commit
         uses: actions/checkout@v6
         with:
@@ -97,32 +110,15 @@ jobs:
           # be ahead of the tagged commit and the version check would not catch
           # it (the version is unchanged across the intervening commits) (#83).
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || needs.cut-release.outputs.sha }}
-          fetch-depth: 0
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v8.2.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-
-      - name: Install dependencies
-        run: uv sync --frozen --dev
+      - name: Set up Python environment
+        uses: ./.github/actions/setup-python-env
 
       - name: Run unit tests
         run: uv run --frozen pytest -m "not e2e"
 
       - name: Install Godot
-        run: |
-          mkdir -p .godot
-          curl --fail --location --show-error \
-            --output .godot/godot.zip \
-            "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_linux.x86_64.zip"
-          unzip -q .godot/godot.zip -d .godot
-          chmod +x "${GDA_GODOT}"
-          "${GDA_GODOT}" --headless --version
+        uses: ./.github/actions/install-godot
 
       - name: Run Godot e2e tests
         run: uv run --frozen pytest -m e2e
@@ -180,7 +176,9 @@ jobs:
             # assets and leaving a stranded tag-less draft (#84). Both commands
             # are no-ops if already done, so re-running converges to published.
             gh release upload "$RELEASE_TAG" dist/* --clobber --repo "$GITHUB_REPOSITORY"
-            gh release edit "$RELEASE_TAG" --draft=false --repo "$GITHUB_REPOSITORY"
+            # --latest pins the Latest badge to this release even if an earlier
+            # draft is published out of order (#87).
+            gh release edit "$RELEASE_TAG" --draft=false --latest --repo "$GITHUB_REPOSITORY"
           fi
 
   release-pr:


### PR DESCRIPTION
Closes #87 · part of #81

Batch of low-severity hygiene + hardening from the review.

## Changes

- **Composite actions** (`.github/actions/setup-python-env`, `install-godot`): extract the environment setup and Godot install duplicated across `ci.yml` and `release.yml`. The Python and Godot versions are now pinned **in one place** (the action defaults), removing the `GDA_GODOT` path literal and the per-file version env. (C1)
- **Cache Godot** (C3): `install-godot` restores the binary from `actions/cache` keyed on the version instead of re-downloading ~50MB every run — removing a third-party download from the release-critical path.
- **`--latest` on publish** (S1): the release-please publish marks the release latest so an out-of-order/re-run publish can't leave the Latest badge on an older version.
- **Drop `fetch-depth: 0`** (C2): no step in `github-release` reads git history.
- **Document cut-release permission** (S3): a comment marks `pull-requests: write` as load-bearing for the Release-PR relabel, so a future least-privilege trim won't silently re-open #82.
- **Guard empty manual tag** (F8): a dispatch with an empty `tag` input fails fast before any build work, via env (no script injection).

## Verification

- Both workflows + both composite actions validate against their GitHub JSON schemas; `actionlint` clean.
- **The Godot composite action is validated end-to-end by triggering the real e2e run on this branch** (CI `workflow_dispatch` with `run-e2e=true`) — see the linked run; merge gated on it passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)