### PR TITLE
fix(release): single-authority version model — retire escape hatch, keep uv.lock in lockstep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,36 +4,24 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Existing tag to release manually (escape hatch), e.g. v0.1.0"
-        required: true
-        type: string
-      draft:
-        description: "Create the manual release as a draft"
-        required: true
-        default: true
-        type: boolean
-      prerelease:
-        description: "Mark the manual release as a prerelease"
-        required: true
-        default: false
-        type: boolean
 
 permissions:
   contents: read
 
-# Serialize push-triggered release runs among themselves (never cancel an
-# in-flight build). workflow_dispatch gets a per-run lane (keyed on run_id) so
-# a manual recovery run is never queue-cancelled by an ordinary push — they
-# would otherwise share refs/heads/main and only one pending run survives (#85).
+# Serialize release runs among themselves (never cancel an in-flight build).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-# Toolchain versions (Python, Godot) live in the shared composite actions under
-# .github/actions, so CI and Release pin them in one place.
+# release-please is the single authority for the version (ADR-0008): every
+# version-bearing file — pyproject.toml, the manifest, uv.lock, the tag,
+# CHANGELOG.md — is a release-please-authored output, and a release happens
+# only by merging the Release PR. There is no manual escape hatch; forcing a
+# specific version uses release-please's `release-as` and recovering a failed
+# release uses "Re-run failed jobs" (ADR-0007).
+
+# Toolchain versions (Python, Godot) remain the single source pinned in the
+# shared composite actions under .github/actions, so CI and Release agree.
 
 # release-please runs twice, bracketing the verify-and-build chain: a draft
 # release carries no git tag until published, and release-please's lookback is
@@ -48,7 +36,6 @@ jobs:
   cut-release:
     name: Cut draft release for a merged Release PR
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     permissions:
       contents: write
       # Load-bearing despite skip-github-pull-request: release-please relabels
@@ -74,33 +61,17 @@ jobs:
     name: Build, verify, and publish release artifacts
     runs-on: ubuntu-latest
     needs: cut-release
-    # Run when release-please just cut a release (draft), or on the manual
-    # escape hatch (the cut-release job is skipped on workflow_dispatch).
+    # Run when release-please just cut a release (draft).
     if: >-
       !failure() && !cancelled() &&
-      (needs.cut-release.outputs.release_created == 'true' ||
-       github.event_name == 'workflow_dispatch')
+      needs.cut-release.outputs.release_created == 'true'
     permissions:
       contents: write
 
     env:
-      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || needs.cut-release.outputs.tag_name }}
-      RELEASE_DRAFT: ${{ inputs.draft || false }}
-      RELEASE_PRERELEASE: ${{ inputs.prerelease || false }}
+      RELEASE_TAG: ${{ needs.cut-release.outputs.tag_name }}
 
     steps:
-      - name: Validate manual tag input
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          INPUT_TAG: ${{ inputs.tag }}
-        run: |
-          # The web UI enforces required inputs, but an API/`gh -f tag=`
-          # dispatch can pass an empty string; fail fast before any build.
-          if [[ -z "$INPUT_TAG" ]]; then
-            echo "::error title=Missing tag::The 'tag' input is required for a manual release."
-            exit 1
-          fi
-
       - name: Checkout release commit
         uses: actions/checkout@v6
         with:
@@ -109,7 +80,7 @@ jobs:
           # push's run can cut an earlier merged Release PR, so github.sha may
           # be ahead of the tagged commit and the version check would not catch
           # it (the version is unchanged across the intervening commits) (#83).
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || needs.cut-release.outputs.sha }}
+          ref: ${{ needs.cut-release.outputs.sha }}
 
       - name: Set up Python environment
         uses: ./.github/actions/setup-python-env
@@ -151,35 +122,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            # Manual escape hatch: create a release from an existing tag.
-            release_args=(
-              --repo "$GITHUB_REPOSITORY"
-              --verify-tag
-              --generate-notes
-            )
-
-            if [[ "$RELEASE_DRAFT" == "true" ]]; then
-              release_args+=(--draft)
-            fi
-
-            if [[ "$RELEASE_PRERELEASE" == "true" ]]; then
-              release_args+=(--prerelease)
-            fi
-
-            gh release create "$RELEASE_TAG" dist/* "${release_args[@]}"
-          else
-            # release-please path: attach artifacts to the draft release it
-            # created, then publish (publishing also creates the git tag).
-            # --clobber makes the upload idempotent so "Re-run failed jobs"
-            # recovers a partial publish instead of erroring on existing
-            # assets and leaving a stranded tag-less draft (#84). Both commands
-            # are no-ops if already done, so re-running converges to published.
-            gh release upload "$RELEASE_TAG" dist/* --clobber --repo "$GITHUB_REPOSITORY"
-            # --latest pins the Latest badge to this release even if an earlier
-            # draft is published out of order (#87).
-            gh release edit "$RELEASE_TAG" --draft=false --latest --repo "$GITHUB_REPOSITORY"
-          fi
+          # Attach artifacts to the draft release release-please created, then
+          # publish (publishing also creates the git tag).
+          # --clobber makes the upload idempotent so "Re-run failed jobs"
+          # recovers a partial publish instead of erroring on existing
+          # assets and leaving a stranded tag-less draft (#84). Both commands
+          # are no-ops if already done, so re-running converges to published.
+          gh release upload "$RELEASE_TAG" dist/* --clobber --repo "$GITHUB_REPOSITORY"
+          # --latest pins the Latest badge to this release even if an earlier
+          # draft is published out of order (#87).
+          gh release edit "$RELEASE_TAG" --draft=false --latest --repo "$GITHUB_REPOSITORY"
 
   release-pr:
     name: Maintain release PR
@@ -196,8 +148,7 @@ jobs:
     # tag exists (#82). On pushes that cut no release the github-release job is
     # skipped and this still runs.
     if: >-
-      !failure() && !cancelled() &&
-      github.event_name == 'push'
+      !failure() && !cancelled()
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,9 +179,55 @@ jobs:
           echo "::warning title=Release pipeline needs recovery::Tag ${tag} for the current manifest version does not exist, so release-PR maintenance is skipped to avoid regenerating a spurious full-history Release PR (#79). A previous release likely failed to publish, leaving a tag-less draft. See ADR-0007 for recovery."
 
       - name: Run release-please (release PR maintenance only)
+        id: release
         if: steps.tag_gate.outputs.tag_present == 'true'
         uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           skip-github-release: true
+
+      # Bring uv.lock under release-please's single version authority (ADR-0008):
+      # release-please bumps pyproject.toml/the manifest but never touches
+      # uv.lock's editable `gda` self-version, so it would drift every release
+      # (#97). Regenerate uv.lock on the Release PR branch so the lock's gda
+      # version tracks the bumped pyproject.toml and both land in the same PR.
+      #
+      # Both steps run only when maintenance ran (tag_present) AND a Release PR
+      # exists (steps.release.outputs.pr is the PullRequest JSON, unset
+      # otherwise), so a normal no-op push that maintains nothing is unaffected.
+      - name: Set up uv
+        if: steps.tag_gate.outputs.tag_present == 'true' && steps.release.outputs.pr
+        uses: astral-sh/setup-uv@v8.2.0
+
+      # release-please force-updates its branch each run, so this re-applies the
+      # lock each run — intended: the branch ends every run with the synced lock.
+      # Pushes with the default GITHUB_TOKEN do not trigger workflows (recursion
+      # guard), which is fine here. uv sync --frozen would NOT rewrite the lock,
+      # so we run uv lock. If uv.lock is unchanged the step is a no-op.
+      - name: Sync uv.lock on the Release PR branch
+        if: steps.tag_gate.outputs.tag_present == 'true' && steps.release.outputs.pr
+        env:
+          RELEASE_PR: ${{ steps.release.outputs.pr }}
+        run: |
+          branch="$(echo "$RELEASE_PR" | python3 -c 'import json, sys; print(json.load(sys.stdin).get("headBranchName", ""))')"
+          if [[ -z "$branch" ]]; then
+            # Fall back to release-please's branch-naming convention.
+            branch="release-please--branches--${GITHUB_REF_NAME}"
+            echo "Release PR JSON had no headBranchName; falling back to ${branch}."
+          fi
+          git fetch origin "$branch"
+          # -B ... FETCH_HEAD is robust regardless of the narrow refspec
+          # actions/checkout configures: a bare `git checkout "$branch"` would
+          # fail because the bare fetch updates only FETCH_HEAD, not origin/$branch.
+          git checkout -B "$branch" FETCH_HEAD
+          uv lock
+          if git diff --quiet -- uv.lock; then
+            echo "uv.lock already in sync with the release version; nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: sync uv.lock with the release version"
+          git push origin "HEAD:${branch}"

--- a/docs/adr/0007-release-automation-with-release-please.md
+++ b/docs/adr/0007-release-automation-with-release-please.md
@@ -62,6 +62,11 @@ a release from that tag. It is deliberately *not* the recovery path for a
 failed automated release (which leaves a tag-less draft) — see "Failure
 handling and recovery" below.
 
+> **Superseded by [ADR-0008](0008-single-authoritative-version-source.md):**
+> the manual escape hatch is retired. release-please is the single version
+> authority and merging the Release PR is the only release path; forcing a
+> version uses `release-as`, and recovery uses "Re-run failed jobs".
+
 ## Consequences
 
 - The version/tag mismatch failure mode is gone by construction; the tag
@@ -73,6 +78,8 @@ handling and recovery" below.
   visible before anything happens.
 - Pushing a `v*` tag no longer triggers a release. The only release paths are
   merging the Release PR and the manual `workflow_dispatch` escape hatch.
+  ([ADR-0008](0008-single-authoritative-version-source.md) retires the escape
+  hatch — merging the Release PR is now the only release path.)
 - CI's `pull_request` jobs do not run on the Release PR (same `GITHUB_TOKEN`
   recursion guard). Acceptable: it touches only version and changelog. If
   branch protection ever requires checks on it, switch the action's token to a
@@ -108,13 +115,10 @@ means a release is wedged.
 use **"Re-run failed jobs"**. The build job rebuilds and the publish is
 idempotent (`--clobber` upload, plus an already-no-op un-draft), so the re-run
 converges to a published release, which creates the tag and unwedges
-maintenance. Do **not**:
-
-- use the `workflow_dispatch` escape hatch — it requires an existing tag, which
-  the wedged draft lacks; or
-- hand-push the tag — `gh release create` would then mint a *second* release
-  for that tag name beside the orphaned draft, leaving two releases sharing one
-  tag.
+maintenance. Do **not** hand-push the tag — `gh release create` would then mint
+a *second* release for that tag name beside the orphaned draft, leaving two
+releases sharing one tag. (Before [ADR-0008](0008-single-authoritative-version-source.md)
+this also warned against the `workflow_dispatch` escape hatch, now retired.)
 
 If the cut release is unwanted, delete the draft release and revert the
 manifest/`CHANGELOG` bump so the Release PR returns to `autorelease: pending`.

--- a/docs/adr/0008-single-authoritative-version-source.md
+++ b/docs/adr/0008-single-authoritative-version-source.md
@@ -1,0 +1,81 @@
+---
+status: accepted
+---
+
+# Single authoritative version source; retire the manual release path
+
+ADR-0007 left two ways to release: the automated release-please path and a
+manual `workflow_dispatch` escape hatch that releases an existing tag. They
+carry **different version authorities**, and the manual one is inconsistent
+with release-please's bookkeeping:
+
+- On the **automated** path release-please is the sole author. It computes the
+  next version from `.release-please-manifest.json` (the ledger of what was
+  last released) plus the conventional commits, and writes that version into
+  `pyproject.toml`, the manifest, and `CHANGELOG.md` together; the tag is
+  derived at publish. Everything is consistent by construction — except
+  `uv.lock`, whose editable `gda` self-version release-please never updates, so
+  it drifts every release (#97).
+- On the **manual** path the human is the authority: they bump `pyproject.toml`
+  and push a matching tag, and the workflow only *validates* `tag == v{version}`.
+  Crucially it **does not touch the manifest**. Since release-please's lookback
+  is tag-based but anchored to the manifest version, a manual release leaves
+  the ledger stale, and the next push makes release-please treat the
+  already-released commits as unreleased and re-propose them.
+
+Two authorities, one of which corrupts the other's ledger, is the root of the
+version-consistency problem — not merely the `uv.lock` drift.
+
+## Decision
+
+**release-please is the single authority for the version, with
+`.release-please-manifest.json` as the ledger; every version-bearing file is a
+release-please-authored output. The manual `workflow_dispatch` escape hatch is
+retired.**
+
+- All version-bearing artifacts — `pyproject.toml`, the manifest, `uv.lock`,
+  the git tag, `CHANGELOG.md` — are produced or derived by release-please. No
+  file is hand-edited to set a version. `uv.lock` is brought under this rule by
+  regenerating it on the Release PR branch so its `gda` self-version tracks the
+  bumped `pyproject.toml` in the same PR (#97).
+- The only release path is **merging the Release PR**. The two needs the manual
+  path historically served are met within the automated model:
+  - *Force a specific version* → release-please's `release-as` (a one-off
+    config entry), not a hand-pushed tag.
+  - *Recover a failed/partial release* → "Re-run failed jobs" on the release
+    run, made reliable by the idempotent publish (ADR-0007, #84).
+- There is no standing manual release path. A genuine break-glass (main or the
+  release-please config itself unusable) is handled by fixing forward; if an
+  out-of-band release is ever unavoidable it must also reconcile the manifest,
+  precisely the coupling this decision removes from the everyday path.
+
+## Consequences
+
+- One authority, one ledger: the manifest-desync failure mode is gone, and the
+  three version sources (`pyproject.toml`, manifest, `uv.lock`) cannot drift.
+- The Release workflow loses its `workflow_dispatch` trigger and the
+  `github-release` branches, inputs, dispatch-only concurrency lane, and
+  empty-tag guard that served it (ADR-0007's #85/#87 hardening of the manual
+  path becomes moot and is removed).
+- ADR-0007's escape-hatch statements are superseded by this ADR: the "only
+  release paths" are now merging the Release PR (the manual path is gone), and
+  the failure-recovery guidance no longer needs to warn against the escape
+  hatch.
+- Releasing an arbitrary historical tag with no GitHub Release is no longer a
+  one-click action; it was never an everyday need and `release-as` covers
+  intentional version targeting.
+
+## Considered options
+
+- **Single authority, retire the manual path** (chosen, Option A) — one author
+  for every version file; `release-as` + re-run cover the manual path's real
+  uses; simplest and removes the desync vector. Cost: no one-click break-glass,
+  accepted as rare and fixable forward.
+- **Keep the manual path but make it consistent** (Option C) — have it also
+  write the manifest, `pyproject.toml`, and `uv.lock`. Preserves break-glass
+  but duplicates release-please's bookkeeping in a second code path that must
+  be kept in lockstep — the maintenance cost the single-authority model exists
+  to avoid.
+- **Keep the manual path, document the caveat** (Option B) — retain it as a
+  break-glass and warn that it desyncs the manifest. Cheapest, but leaves a
+  footgun whose misuse silently re-proposes released commits.

--- a/uv.lock
+++ b/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "gda"
-version = "0.1.0"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Closes #97

Implements ADR-0008 (Option A): **release-please is the single version authority**; every version-bearing file is a release-please-authored output, and the manual escape hatch is retired.

## Background

The version-consistency problem had two layers: (1) `uv.lock`'s editable `gda` self-version drifts (release-please bumps `pyproject.toml`/manifest but not the lock), and (2) deeper — the repo had **two version authorities**, and the manual `workflow_dispatch` escape hatch bypassed the manifest ledger, so a manual release could make release-please re-propose already-released commits. The fix is to make release-please the sole authority and remove the second path.

## Changes (3 commits)

- **`docs(adr)`** — ADR-0008 records the single-authority decision (Option A) with the A/B/C options weighed; reconciles ADR-0007's escape-hatch references with supersession pointers. *(authored directly; the decision)*
- **`ci`** — retire the manual escape hatch in `release.yml`: removed the `workflow_dispatch` trigger + inputs, the `gh release create` manual publish branch, the dispatch-only concurrency lane (#85), the empty-tag guard (#87), and the now-moot event guards. The push/release-please path, `tag_gate` (#82), build-from-tagged-SHA (#83), idempotent `--clobber` publish (#84), and `--latest` (#87) are all retained.
- **`fix(release)`** — keep `uv.lock` in lockstep: after maintenance opens/updates the Release PR, a step regenerates `uv.lock` on that branch (`uv lock`, a clean one-line self-version update) and pushes it, so the bump and lock land in the same PR. Also corrects the existing drift (`gda` `0.1.0` → `0.1.4`).

## Replacements for the retired escape hatch

- Force a specific version → release-please `release-as`.
- Recover a failed release → "Re-run failed jobs" (idempotent publish, ADR-0007).

## Verification

- `release.yml`: workflow JSON schema ✓, `actionlint` ✓, embedded shell `bash -n` ✓.
- `uv.lock` `gda` version now `0.1.4` (matches `pyproject.toml`); `uv sync --frozen --dev` ✓.
- Review caught and fixed a runtime bug in the sync step: a bare `git checkout "$branch"` would fail under actions/checkout's narrow refspec — changed to `git checkout -B "$branch" FETCH_HEAD` with a branch-name fallback.
- **Live validation of the uv.lock-sync step happens on the 0.1.5 Release PR** this merge will open (release-please will maintain it and run the new sync step) — worth watching that the 0.1.5 Release PR carries `uv.lock` at `0.1.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)