### PR TITLE
docs(adr): reconcile ADR-0007 with the retired manual release path

### DIFF
--- a/docs/adr/0007-release-automation-with-release-please.md
+++ b/docs/adr/0007-release-automation-with-release-please.md
@@ -48,13 +48,16 @@ release (#79). Bracketing alone only fixes the happy path: the hazardous state
 survives a failed run, so maintenance additionally **gates on the manifest
 version's tag actually existing** and is skipped (with a warning annotation)
 when it does not — that gate, not the bracketing, is what stops a later push
-from regenerating the spurious Release PR across runs (#82). Three further
+from regenerating the spurious Release PR across runs (#82). Two further
 guards harden the chain: the build job checks out the exact commit
 release-please tagged rather than the push HEAD, so concurrent pushes cannot
-publish artifacts from the wrong commit (#83); the publish is idempotent so a
-re-run recovers a partial publish (#84); and manual dispatch runs in an
-isolated concurrency lane so an ordinary push cannot cancel a recovery run
-(#85).
+publish artifacts from the wrong commit (#83); and the publish is idempotent so
+a re-run recovers a partial publish (#84).
+(A third guard, an isolated concurrency lane for manual dispatch (#85), is
+[superseded by ADR-0008](0008-single-authoritative-version-source.md): with the
+manual escape hatch retired the lane was removed, and the release workflow's
+concurrency group reverted to the simple `${{ github.workflow }}-${{ github.ref }}`
+form.)
 
 A `workflow_dispatch` escape hatch retains the previous manual semantics:
 given an **existing** tag, it runs the same verify-and-build chain and creates


### PR DESCRIPTION
Output of a `/reconcile` consistency check after the single-authority decision (ADR-0008, #98).

## Finding

ADR-0007's "release-please runs twice" paragraph still claimed, in the present tense, that "manual dispatch runs in an isolated concurrency lane ... (#85)" as one of "Three further guards". PR #98 retired the manual escape hatch and removed that lane (the concurrency group reverted to the simple `${{ github.workflow }}-${{ github.ref }}` form). This was the one spot the #88 amendments missed.

## Fix

"Three further guards" → "Two" (#83 and #84, both still live), with the #85 clause moved into a parenthetical supersession pointer to ADR-0008 — matching the amendment style already used elsewhere in ADR-0007.

## Reconcile scope (everything else verified consistent)

- All issue/PR/ADR cross-references in ADR-0007 and ADR-0008 resolve.
- Docs match the post-#98 workflow (simple concurrency group, no `workflow_dispatch` trigger, idempotent publish, uv.lock lockstep step; ci.yml has no tag trigger).
- **CONTEXT.md**: no change needed (domain language, untouched by release tooling).
- **README.md**: no change needed.
- Closed issues #85/#87 describe later-removed mechanisms — left as historical record; no open issue or doc relies on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)