### PR TITLE
ci: restrict release-triggering commits to feat/fix/deps/revert

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,20 @@
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": false,
   "draft": true,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "deps", "section": "Dependencies" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "perf", "section": "Performance Improvements", "hidden": true },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+    { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build System", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+  ],
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
Closes #102

## Root cause

release-please opens a Release PR only when the generated release notes are non-empty (verified against the release-please source: a Release PR is skipped when the release-notes body is empty). Those notes are built from the **non-hidden** `changelog-sections`. The `python` release-type's default marks only `style`/`chore`/`refactor`/`test`/`build`/`ci` as hidden — leaving `docs`, `perf`, `deps`, `revert` visible and release-triggering. `release-please-config.json` had **no `changelog-sections` override**, so it inherited that default. That is why the `docs(adr):` commit in #100 produced a non-empty "Documentation" changelog and triggered the spurious 0.1.6 Release PR #101 (closed).

## Fix

Explicit `changelog-sections` in `release-please-config.json`:

| Release-triggering (visible) | Hidden (no release on their own) |
|---|---|
| `feat`, `fix`, `deps`, `revert` | `perf`, `docs`, `style`, `chore`, `refactor`, `test`, `build`, `ci` |

`deps` and `revert` kept visible per maintainer decision (a security dependency bump or a revert should be able to ship on its own).

## Verification

- JSON valid; passes the official release-please config JSON schema.
- Mechanism confirmed from source (changelog-empty → no Release PR).
- **Live validation after merge:** the next `docs`/`ci`/`chore` push to `main` should NOT open a Release PR; the next `feat`/`fix`/`deps`/`revert` should. This PR's own squash title is `ci:`, so merging it will not cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)