### PR TITLE
feat(schema): emit a uniform error envelope in --schema (#43)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -113,6 +113,8 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 - Adding or changing a `GdaError.code` requires updating the Python registry, this
   ADR's registry table, and any GDScript operation-code mirror. Tests must reject
   drift between those copies.
-- `gda <command> --schema` currently describes the success result model. Whether
-  command output schemas should include failure envelopes is a separate decision
-  tracked in #43.
+- `gda <command> --schema` describes the success result model under its `output`
+  key. Whether command schemas should include the failure envelope was resolved in
+  #43: `--schema` now also carries a uniform `error` key holding this ADR's failure
+  envelope (the shared `GdaErrorEnvelope` schema), kept separate from `output` so the
+  success result and the failure envelope stay distinct channels. See ADR-0004.

--- a/docs/adr/0004-schema-flag-self-description.md
+++ b/docs/adr/0004-schema-flag-self-description.md
@@ -10,18 +10,41 @@ semantics here, and deliberately scope out an overloaded interpretation.
 ## Decision
 
 - **`gda <command> --schema` emits the command's own machine-readable contract**: a
-  JSON object containing both an `input` JSON Schema (the command's arguments/params)
-  and an `output` JSON Schema (the shape of its `--json` result). The contract is
-  owned by `gda`; the flag only *emits*, it never *accepts*, a schema.
+  JSON object with three keys — an `input` JSON Schema (the command's
+  arguments/params), an `output` JSON Schema (the shape of its **success** `--json`
+  result), and an `error` JSON Schema (the **uniform** failure envelope, #43). The
+  contract is owned by `gda`; the flag only *emits*, it never *accepts*, a schema.
+
+- **`output` describes only the success result; `error` describes the failure
+  envelope** (#43). `output` is the command's own success result model, exactly as
+  before — it is *not* turned into a success/failure union. `error` is the shared
+  `GdaErrorEnvelope` schema, **identical for every command**, that `gda` emits on a
+  non-zero exit. Keeping the two halves separate mirrors how the result reaches the
+  caller: a successful `--json` result on exit 0, a structured error envelope on a
+  non-zero exit. The change is a strict superset of the old `{input, output}`
+  contract — `output` is untouched — so it is backward compatible.
 
 - **Schemas are model-driven.** Each command's input and output are defined as typed
   models (Pydantic/msgspec on the Python 3.13 stack). The same model both serializes
   / validates the `--json` result and produces the `--schema` document
-  (`model_json_schema()`), so the contract is never hand-maintained twice.
+  (`model_json_schema()`), so the contract is never hand-maintained twice. The
+  `error` half is derived the same way from the one shared `GdaErrorEnvelope` model,
+  so it costs **zero per-command maintenance** — every command's `error` is byte-for-byte
+  the same schema.
 
 - **`gda-mcp` derives tool definitions mechanically** from `--schema`: `inputSchema`
-  from `input`, `outputSchema` from `output`. This is what makes `gda-mcp` a thin
-  adapter (ADR-0001) rather than a parallel hand-written surface.
+  from `input`, `outputSchema` from `output`. The success/failure split maps onto
+  MCP's two channels: `output` → MCP `outputSchema` (a tool's success result /
+  `structuredContent`), while a `gda` non-zero-exit failure maps to MCP's separate
+  `isError` channel. The `error` schema makes that failure envelope **discoverable**
+  but is deliberately kept **out of `outputSchema`** — the future adapter must not
+  fold `error` into `outputSchema`. This is what makes `gda-mcp` a thin adapter
+  (ADR-0001) rather than a parallel hand-written surface.
+
+- **Per-command *operation* error codes are out of scope for the `error` key.** The
+  `error` schema is the uniform envelope shape, not an enumeration of which
+  `GdaError.code` values a given command can report. Whether `--schema` should also
+  advertise a command's specific operation error codes is a separate, later question.
 
 - **`--schema` does not accept a custom schema.** Making one flag both emit the
   output contract and accept an input contract overloads two opposite directions onto
@@ -45,8 +68,13 @@ semantics here, and deliberately scope out an overloaded interpretation.
 
 ## Considered options
 
-- **Emit input + output contract** (chosen) — fully self-describing; lets `gda-mcp`
-  generate tool definitions for free.
+- **Emit input + output + error contract** (chosen) — fully self-describing; lets
+  `gda-mcp` generate tool definitions for free, and makes the uniform failure
+  envelope discoverable for the `isError` channel without per-command cost (#43).
+- **Fold the failure envelope into `output` as a success/failure union** (rejected)
+  — conflates the two MCP channels: `output` should map to `outputSchema` (success /
+  `structuredContent`) only, while failures belong to `isError`. A `oneOf` union
+  would force the adapter to discriminate success from failure inside `outputSchema`.
 - **Emit output only / input only** — narrower; insufficient for `gda-mcp` to derive
   both `inputSchema` and `outputSchema`.
 - **Accept a custom schema on `--schema`** (rejected) — overloads the flag with the

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -67,7 +67,7 @@ def schema_option() -> bool:
     return typer.Option(
         False,
         "--schema",
-        help="Emit this command's input/output JSON Schemas; no Godot is spawned.",
+        help="Emit this command's input/output/error JSON Schemas; no Godot is spawned.",
     )
 
 
@@ -77,10 +77,11 @@ def schema_command_class(
     """A Typer command that owns ``--schema`` handling (ADR-0004).
 
     ``--schema`` is an introspection probe: it emits the command's
-    ``{input, output}`` contract without spawning Godot and without requiring the
-    command's operational arguments. It must still surface a structurally invalid
-    command line — unknown options or extra positional args — as a usage error,
-    and must always yield to ``--help`` (issue #36).
+    ``{input, output, error}`` contract without spawning Godot and without
+    requiring the command's operational arguments. ``error`` is the uniform
+    failure envelope shared by every command (#43). It must still surface a
+    structurally invalid command line — unknown options or extra positional
+    args — as a usage error, and must always yield to ``--help`` (issue #36).
     """
 
     class _SchemaCommand(TyperCommand):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -91,26 +91,39 @@ class InfoParams(BaseModel):
 
 
 class CommandSchema(BaseModel):
-    """A command's self-description: its ``input`` and ``output`` JSON Schemas (ADR-0004).
+    """A command's self-description: its ``input``, ``output`` and ``error`` JSON Schemas (ADR-0004).
 
-    ``--schema`` emits this. Both halves are derived from the command's typed
-    models via :meth:`of`, so the contract is never hand-maintained: ``input``
-    from the params model, ``output`` from the same result model that backs
-    ``--json``. ``gda-mcp`` later maps ``input`` → ``inputSchema`` and ``output``
-    → ``outputSchema`` mechanically.
+    ``--schema`` emits this. ``input`` and ``output`` are derived from the
+    command's own typed models via :meth:`of`, so the contract is never
+    hand-maintained: ``input`` from the params model, ``output`` from the same
+    *success* result model that backs ``--json``. ``error`` is the **uniform**
+    failure-envelope schema, identical for every command, produced from the one
+    shared :class:`GdaErrorEnvelope` model — zero per-command maintenance (#43).
+
+    ``gda-mcp`` later maps ``input`` → ``inputSchema`` and ``output`` →
+    ``outputSchema`` (success / structuredContent) mechanically. The ``error``
+    half is kept OUT of ``output``: a non-zero-exit failure maps to MCP's
+    separate ``isError`` channel, so the future adapter must not fold ``error``
+    into ``outputSchema``.
     """
 
     input: dict[str, Any]
     output: dict[str, Any]
+    error: dict[str, Any]
 
     @classmethod
     def of(
         cls, input_model: type[BaseModel], output_model: type[BaseModel]
     ) -> "CommandSchema":
-        """Derive the contract from a command's params and result models."""
+        """Derive the contract from a command's params and result models.
+
+        ``error`` is the shared failure-envelope schema, the same for every
+        command, so it takes no per-command model argument.
+        """
         return cls(
             input=input_model.model_json_schema(),
             output=output_model.model_json_schema(),
+            error=GdaErrorEnvelope.model_json_schema(),
         )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,8 +2,12 @@
 
 import json
 
+import jsonschema
+
 from gda.models import (
     EngineVersion,
+    GdaError,
+    GdaErrorEnvelope,
     NodeAddResult,
     NodeListResult,
     SceneCreateResult,
@@ -56,6 +60,34 @@ def test_round_trips_to_json_object():
     assert dumped["major"] == 4
     assert dumped["minor"] == 6
     assert dumped["string"] == "4.6.3-stable (official)"
+
+
+def test_error_envelope_schema_is_well_formed_json_schema():
+    # The uniform `error` half of the --schema contract (#43) is produced from
+    # this one shared model. check_schema raises if it is not itself valid JSON
+    # Schema, so every command's emitted `error` is well-formed by construction.
+    schema = GdaErrorEnvelope.model_json_schema()
+
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+
+def test_error_envelope_round_trips_a_failure():
+    # A real failure envelope validates against its own model — the wire shape
+    # an agent branches on (the top-level `error` key discriminates failure).
+    payload = {
+        "error": {
+            "category": "operation",
+            "code": "path_not_found",
+            "message": "scene file does not exist: res://missing.tscn",
+            "diagnostics": "",
+        }
+    }
+
+    envelope = GdaErrorEnvelope.model_validate(payload)
+
+    assert isinstance(envelope.error, GdaError)
+    assert envelope.error.code == "path_not_found"
+    assert json.loads(envelope.model_dump_json()) == payload
 
 
 def test_scene_create_result_round_trips():

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -11,7 +11,7 @@ import jsonschema
 from typer.testing import CliRunner
 
 from gda.cli import app
-from gda.models import EngineVersion, InfoParams
+from gda.models import EngineVersion, GdaErrorEnvelope, InfoParams
 
 # A sample `gda info` result, shaped as Engine.get_version_info() reports it.
 VERSION_INFO = {
@@ -45,6 +45,17 @@ def test_info_output_schema_is_derived_from_the_info_result_model():
 
     doc = json.loads(result.stdout)
     assert doc["output"] == EngineVersion.model_json_schema()
+
+
+def test_info_error_schema_is_the_uniform_failure_envelope():
+    # issue #43 / ADR-0004: --schema now carries a third key, `error`, holding the uniform
+    # failure-envelope schema shared by every command (GdaErrorEnvelope). It is
+    # the same for all commands and kept OUT of `output` so gda-mcp can map
+    # `output` → outputSchema (success) and `error` → the isError channel.
+    result = CliRunner().invoke(app, ["info", "--schema"])
+
+    doc = json.loads(result.stdout)
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
 
 
 def test_emitted_schemas_are_valid_json_schema():

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -27,15 +27,17 @@ VERSION_INFO = {
 }
 
 
-def test_info_schema_emits_json_object_with_input_and_output():
+def test_info_schema_emits_json_object_with_input_output_and_error():
     result = CliRunner().invoke(app, ["info", "--schema"])
 
     assert result.exit_code == 0
     doc = json.loads(result.stdout)
-    assert set(doc) >= {"input", "output"}
-    # Both halves are JSON Schema objects (have a "type"/"properties" shape).
+    # The contract is the three-key {input, output, error} object (#43).
+    assert set(doc) >= {"input", "output", "error"}
+    # All three halves are JSON Schema objects (have a "type"/"properties" shape).
     assert isinstance(doc["input"], dict)
     assert isinstance(doc["output"], dict)
+    assert isinstance(doc["error"], dict)
 
 
 def test_info_output_schema_is_derived_from_the_info_result_model():
@@ -65,6 +67,8 @@ def test_emitted_schemas_are_valid_json_schema():
     # check_schema raises if the document is not itself a valid JSON Schema.
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
+    # The uniform error envelope is itself well-formed JSON Schema too (#43).
+    jsonschema.Draft202012Validator.check_schema(doc["error"])
 
 
 def test_sample_info_result_validates_against_emitted_output_schema():
@@ -88,7 +92,7 @@ def test_schema_spawns_no_godot(monkeypatch):
     result = CliRunner().invoke(app, ["info", "--schema"])
 
     assert result.exit_code == 0
-    assert set(json.loads(result.stdout)) >= {"input", "output"}
+    assert set(json.loads(result.stdout)) >= {"input", "output", "error"}
 
 
 def test_schema_is_emit_only_and_rejects_a_supplied_value():
@@ -111,6 +115,7 @@ def test_scene_create_schema_emits_model_derived_contract_without_other_args():
     doc = json.loads(result.stdout)
     assert doc["input"] == SceneCreateParams.model_json_schema()
     assert doc["output"] == SceneCreateResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     assert "root_name" in doc["input"]["properties"]
     assert "created_dirs" in doc["output"]["properties"]
     root_name_description = doc["input"]["properties"]["root_name"]["description"]
@@ -129,6 +134,7 @@ def test_scene_get_schema_emits_model_derived_contract_without_other_args():
     doc = json.loads(result.stdout)
     assert doc["input"] == SceneGetParams.model_json_schema()
     assert doc["output"] == SceneGetResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
@@ -147,6 +153,7 @@ def test_scene_list_schema_emits_model_derived_contract_without_a_project():
     doc = json.loads(result.stdout)
     assert doc["input"] == SceneListParams.model_json_schema()
     assert doc["output"] == SceneListResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     assert doc["input"].get("properties", {}) == {}
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
@@ -161,6 +168,7 @@ def test_scene_delete_schema_emits_model_derived_contract_without_other_args():
     doc = json.loads(result.stdout)
     assert doc["input"] == SceneDeleteParams.model_json_schema()
     assert doc["output"] == SceneDeleteResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
@@ -208,7 +216,7 @@ def test_scene_schema_spawns_no_godot(monkeypatch):
     ):
         result = CliRunner().invoke(app, [*command, "--schema"])
         assert result.exit_code == 0
-        assert set(json.loads(result.stdout)) >= {"input", "output"}
+        assert set(json.loads(result.stdout)) >= {"input", "output", "error"}
 
 
 def test_node_add_schema_emits_model_derived_contract_without_other_args():
@@ -223,6 +231,7 @@ def test_node_add_schema_emits_model_derived_contract_without_other_args():
     doc = json.loads(result.stdout)
     assert doc["input"] == NodeAddParams.model_json_schema()
     assert doc["output"] == NodeAddResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     # Node-path addressing is defined in the contract itself: the parent param
     # documents the root-relative convention agents must use.
     parent_description = doc["input"]["properties"]["parent"]["description"]
@@ -241,6 +250,7 @@ def test_node_list_schema_emits_model_derived_contract_without_other_args():
     doc = json.loads(result.stdout)
     assert doc["input"] == NodeListParams.model_json_schema()
     assert doc["output"] == NodeListResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
@@ -267,7 +277,7 @@ def test_node_schema_spawns_no_godot(monkeypatch):
     for command in (["node", "add"], ["node", "list"]):
         result = CliRunner().invoke(app, [*command, "--schema"])
         assert result.exit_code == 0
-        assert set(json.loads(result.stdout)) >= {"input", "output"}
+        assert set(json.loads(result.stdout)) >= {"input", "output", "error"}
 
 
 def test_info_input_schema_is_derived_from_the_params_model():


### PR DESCRIPTION
## What & why

Implements the ratified decision for #43 (Option C): per-command `gda <cmd> --schema` now emits a **three-key** contract `{input, output, error}`.

- `input` / `output` — unchanged. `output` stays the command's **success** result schema only (deliberately **not** a `oneOf` success/failure union).
- `error` — NEW: the **uniform** failure-envelope schema (`GdaErrorEnvelope.model_json_schema()`), identical for every command, generated from the one shared model at **zero per-command cost**.

### Decision rationale

MCP tool semantics map a command's `output` to a tool's `outputSchema` (success / `structuredContent`), and map a `gda` non-zero-exit failure to MCP's separate `isError` channel. Folding the envelope into `output` as a union would make `gda-mcp`'s mechanical `outputSchema ← output` mapping describe failures MCP already models via `isError`, breaking the thin-adapter property (ADR-0004). Keeping `error` as a separate, discoverable key preserves a clean mapping while making the failure shape machine-readable. The change is a **strict superset** of the old `{input, output}` contract (`output` is byte-for-byte unchanged), so it is backward compatible.

Full decision record: https://github.com/aigengame/godot-agent/issues/43#issuecomment-4697698814

## Changes

- `src/gda/models.py` — `CommandSchema` gains an `error` field; `CommandSchema.of()` populates it from `GdaErrorEnvelope.model_json_schema()`.
- `src/gda/headless.py` — `--schema` help text + `schema_command_class` docstring updated to the three-key contract.
- `docs/adr/0004-schema-flag-self-description.md` — contract updated to `{input, output, error}`; documents `output → MCP outputSchema` / failure `→ isError`; records that the adapter must **not** fold `error` into `outputSchema`; adds the rejected union option; notes per-command *operation error codes* stay out of scope.
- `docs/adr/0002-headless-structured-output-contract.md` — the line deferring to #43 now records the resolution and points to ADR-0004.
- `tests/test_schema_command.py`, `tests/test_models.py` — every command's `--schema` is asserted to carry `error == GdaErrorEnvelope.model_json_schema()`; envelope schema well-formedness + failure-payload round-trip added.

## How it was built

TDD (red-green-refactor). Pure-Python slice — no Godot engine involved.

## Testing

`uv run pytest -m "not e2e" -q` → **117 passed, 58 deselected**.

Before: `{"input": {...}, "output": {...}}`
After:  `{"input": {...}, "output": {...}, "error": {...}}`  (`output` unchanged)

## Acceptance criteria (#43)

- [x] Decision recorded on whether command output schemas include failure envelopes.
- [x] ADR-0004 updated for the schema contract change.
- [x] Schema tests cover the chosen behavior.
- [x] `gda-mcp` output-schema mapping expectations documented (failures → `isError`, not `outputSchema`).

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)
