### PR TITLE
test(e2e): fail-fast on a missing engine; drop the "fakeable seams" README framing (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,10 @@ uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
 uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
 ```
 
-The `e2e` tests auto-skip if no Godot binary is found at the resolved path.
+The `e2e` tier runs by default with `uv run pytest`, and **fails loudly** — naming the
+resolved path and how to fix it — if no Godot binary is found there, rather than skipping.
+Deselect the whole tier with `-m "not e2e"` (CI's per-PR job uses exactly this) when you
+have no engine; use `-m e2e` to run only the e2e tests.
 
 ### Project layout
 
@@ -306,8 +309,9 @@ docs/adr/           # architecture decision records
 CONTEXT.md          # the project's shared domain language
 ```
 
-The codebase is intentionally built around **fakeable seams** (e.g. the `GodotRunner` Protocol) so
-commands can be tested without launching a real engine.
+The only external boundary — spawning a Godot process — sits behind the `GodotRunner` Protocol
+(`runner.py`). Fast unit and CLI tests inject a canned result through that boundary; the e2e suite
+drives a real engine. Everything between the CLI and the runner runs as real code in both tiers.
 
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,36 @@
 ``godot_project`` is the reusable e2e scaffold (issue #18): a throwaway Godot
 project for slices whose operations act on files inside a project. Later
 domain slices (node, script, …) reuse it rather than growing their own.
+
+``_require_godot_engine`` is the single missing-engine gate for the whole e2e
+tier (issue #106): any ``e2e``-marked test selected without a resolvable Godot
+binary fails loudly here, naming the resolved path, rather than silently
+skipping per-module.
 """
 
 import pytest
+
+from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
+
+
+@pytest.fixture(autouse=True)
+def _require_godot_engine(request):
+    """Fail any selected e2e test loudly when no Godot engine resolves.
+
+    Keyed on the ``e2e`` marker, so it is a no-op for the fake-based S2/S3
+    tiers. The binary is resolved here (not at import time) so a runtime
+    ``$GDA_GODOT`` override is honored, and a missing engine is a loud failure
+    instead of a silent skip — the e2e tier is a mandatory local gate.
+    """
+    if request.node.get_closest_marker("e2e") is None:
+        return
+    godot = resolve_godot_binary()
+    if not godot.exists():
+        pytest.fail(
+            f"e2e tests need a real Godot engine, but none was found at {godot}. "
+            f"Install Godot at that path or set ${GODOT_BIN_ENV} to a 4.4+ binary."
+        )
+
 
 # The minimal project.godot a Godot 4 engine accepts as a project root.
 PROJECT_GODOT = """\

--- a/tests/test_e2e_info.py
+++ b/tests/test_e2e_info.py
@@ -16,13 +16,8 @@ from gda.binary import resolve_godot_binary
 
 GODOT = resolve_godot_binary()
 
-requires_godot = pytest.mark.skipif(
-    not GODOT.exists(), reason=f"real Godot binary not found at {GODOT}"
-)
-
 
 @pytest.mark.e2e
-@requires_godot
 def test_gda_info_json_against_real_godot():
     gda_bin = shutil.which("gda")
     assert gda_bin, "the `gda` console script is not on PATH"

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -16,10 +16,6 @@ from gda.binary import resolve_godot_binary
 
 GODOT = resolve_godot_binary()
 
-requires_godot = pytest.mark.skipif(
-    not GODOT.exists(), reason=f"real Godot binary not found at {GODOT}"
-)
-
 
 def _gda(*args: str) -> subprocess.CompletedProcess:
     gda_bin = shutil.which("gda")
@@ -37,7 +33,6 @@ def _create_scene(scene_path) -> None:
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_then_list_round_trip(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
@@ -69,7 +64,6 @@ def test_node_add_then_list_round_trip(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_under_nested_parent_path(godot_project):
     # Node-path addressing end-to-end (issue #53): the path node list reports
     # for a node ("Hero") is exactly the address node add accepts as --parent,
@@ -104,7 +98,6 @@ def test_node_add_under_nested_parent_path(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_default_name_is_the_type_name(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
@@ -126,7 +119,6 @@ def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dic
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_to_missing_scene_yields_path_not_found(godot_project):
     missing = godot_project / "missing.tscn"
 
@@ -137,7 +129,6 @@ def test_node_add_to_missing_scene_yields_path_not_found(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_bad_parent_yields_parent_not_found_and_leaves_file_unchanged(
     godot_project,
 ):
@@ -170,7 +161,6 @@ def _scene_with_nested_children(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 @pytest.mark.parametrize("form", ["..", "../A", "/root/A"])
 def test_node_add_parent_path_escaping_or_absolute_stays_rejected(
     godot_project, form
@@ -194,7 +184,6 @@ def test_node_add_parent_path_escaping_or_absolute_stays_rejected(
 
 
 @pytest.mark.e2e
-@requires_godot
 @pytest.mark.parametrize(
     "form", ["A/..", "A/", "A/B/", "A//B", "./A", "A/./B", "A:position"]
 )
@@ -220,7 +209,6 @@ def test_node_add_rejects_non_canonical_parent_path(godot_project, form):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_explicit_dot_parent_addresses_the_root(godot_project):
     # The canonical root address: '.' must keep working verbatim — it is the
     # form node list reports for the root, and the CLI's --parent default.
@@ -236,7 +224,6 @@ def test_node_add_explicit_dot_parent_addresses_the_root(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_name_collision_yields_duplicate_node_name(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
@@ -258,7 +245,6 @@ def test_node_add_name_collision_yields_duplicate_node_name(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_collision_with_internal_child_yields_duplicate_node_name(
     godot_project,
 ):
@@ -293,7 +279,6 @@ def test_node_add_collision_with_internal_child_yields_duplicate_node_name(
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_unknown_type_yields_invalid_node_type(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
@@ -307,7 +292,6 @@ def test_node_add_unknown_type_yields_invalid_node_type(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_rejects_name_godot_would_rewrite(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
@@ -322,7 +306,6 @@ def test_node_add_rejects_name_godot_would_rewrite(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_list_missing_scene_yields_path_not_found(godot_project):
     missing = godot_project / "missing.tscn"
 
@@ -333,7 +316,6 @@ def test_node_list_missing_scene_yields_path_not_found(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_list_non_scene_file_yields_not_a_scene(godot_project):
     notes = godot_project / "notes.txt"
     notes.write_text("not a scene\n", encoding="utf-8")
@@ -390,7 +372,6 @@ def _write_instance_fixture(
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_preserves_editable_instance_overrides(godot_project):
     # Issue #64's data-integrity contract, pinned as a regression test: the
     # load → instantiate → edit → pack → save round-trip must keep every kind
@@ -426,7 +407,6 @@ def test_node_add_preserves_editable_instance_overrides(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_without_project_context_refuses_rather_than_drops_instances(
     godot_project,
 ):
@@ -446,7 +426,6 @@ def test_node_add_without_project_context_refuses_rather_than_drops_instances(
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
     # The real data-loss mode of issue #64: when an instanced sub-scene cannot
     # be resolved on load (broken dependency), instantiate drops the whole
@@ -481,7 +460,6 @@ UNINSTANTIABLE_CHILD_TSCN = """\
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_refuses_scene_that_instantiates_to_null(godot_project):
     # The nested-null mode of issue #64: the sub-scene resource loads fine but
     # instantiates to nothing, and the parent scene's instantiate() returns
@@ -516,7 +494,6 @@ MISSING_CLASS_TSCN = """\
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_refuses_scene_whose_declared_class_is_substituted(godot_project):
     # The degraded-node mode of issue #64: when a declared class is unavailable
     # at instantiate time, the engine warns and substitutes a placeholder node
@@ -557,7 +534,6 @@ def _import_project(project) -> None:
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_by_class_name_attaches_the_script(godot_project):
     # The second half of --type's contract (issue #53): a class_name registered
     # in the project's global class list resolves like a built-in type. The
@@ -592,7 +568,6 @@ def test_node_add_by_class_name_attaches_the_script(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_by_unregistered_class_name_yields_invalid_node_type(godot_project):
     # Without a project import there is no global class list: the class_name
     # cannot resolve, and the failure must be the structured invalid_node_type,
@@ -619,7 +594,6 @@ func broken( -> void:
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_by_registered_but_broken_class_name_names_the_script(godot_project):
     # Issue #65's broken-class_name mode: the class_name IS in the global class
     # list (the import scanned a then-valid script), but the script on disk has
@@ -655,7 +629,6 @@ extends Resource
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_by_non_node_class_name_yields_invalid_node_type(godot_project):
     # The boundary of issue #65's distinction: a registered class_name whose
     # script is fine but not Node-derived is a true type error — it stays
@@ -692,7 +665,6 @@ func _init(speed: float) -> void:
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_node_add_by_class_name_whose_init_requires_args_names_the_constructor(
     godot_project,
 ):

--- a/tests/test_e2e_op_robustness.py
+++ b/tests/test_e2e_op_robustness.py
@@ -21,13 +21,8 @@ from gda.runner import OPERATIONS_GD, RunResult, SubprocessGodotRunner
 
 GODOT = resolve_godot_binary()
 
-requires_godot = pytest.mark.skipif(
-    not GODOT.exists(), reason=f"real Godot binary not found at {GODOT}"
-)
-
 
 @pytest.mark.e2e
-@requires_godot
 def test_malformed_param_fails_promptly_not_as_timeout():
     # A non-string path is the input that previously crashed the GDScript's
     # typed assignment and hung the process until the 60s runner timeout, then
@@ -46,7 +41,6 @@ def test_malformed_param_fails_promptly_not_as_timeout():
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_unknown_operation_yields_stable_code():
     runner = SubprocessGodotRunner(GODOT)
     result = runner.run("bogus-op", {})
@@ -58,7 +52,6 @@ def test_unknown_operation_yields_stable_code():
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_non_json_params_yield_stable_code():
     # Bypass the runner (which json.dumps its params) to hand the op a
     # syntactically invalid params payload directly.

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -17,10 +17,6 @@ from gda.binary import resolve_godot_binary
 
 GODOT = resolve_godot_binary()
 
-requires_godot = pytest.mark.skipif(
-    not GODOT.exists(), reason=f"real Godot binary not found at {GODOT}"
-)
-
 
 def _gda(*args: str) -> subprocess.CompletedProcess:
     gda_bin = shutil.which("gda")
@@ -31,7 +27,6 @@ def _gda(*args: str) -> subprocess.CompletedProcess:
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_res_path_round_trip_against_the_project_fixture(godot_project):
     # The project context (issue #32): with --project pointing at the temp
     # project fixture, a res:// path resolves against it — proving the fixture
@@ -60,7 +55,6 @@ def test_res_path_round_trip_against_the_project_fixture(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_create_then_get_round_trip(godot_project):
     scene_path = godot_project / "main.tscn"
 
@@ -86,7 +80,6 @@ def test_scene_create_then_get_round_trip(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_path_containing_end_sentinel_round_trips(godot_project):
     # issue #34: the result payload echoes the target path verbatim. A path
     # containing the literal end sentinel must round-trip, not be truncated into
@@ -117,7 +110,6 @@ def test_scene_path_containing_end_sentinel_round_trips(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_create_creates_missing_parent_directories(godot_project):
     scene_path = godot_project / "levels" / "demo" / "main.tscn"
 
@@ -140,7 +132,6 @@ def test_scene_create_creates_missing_parent_directories(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_create_creates_relative_parent_directories_against_project(
     godot_project,
 ):
@@ -173,7 +164,6 @@ def test_scene_create_creates_relative_parent_directories_against_project(
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_create_existing_path_yields_already_exists_without_overwriting(
     godot_project,
 ):
@@ -194,7 +184,6 @@ def test_scene_create_existing_path_yields_already_exists_without_overwriting(
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_create_empty_root_name_yields_structured_error(godot_project):
     scene_path = godot_project / ".tscn"
 
@@ -211,7 +200,6 @@ def test_scene_create_empty_root_name_yields_structured_error(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_create_rejects_root_name_godot_would_rewrite(godot_project):
     scene_path = godot_project / "bad-name.tscn"
 
@@ -235,7 +223,6 @@ def test_scene_create_rejects_root_name_godot_would_rewrite(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_create_rejects_dotted_default_root_name_but_allows_override(
     godot_project,
 ):
@@ -284,7 +271,6 @@ NESTED_TSCN = """\
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_get_reports_nested_tree(godot_project):
     # Guards the SceneState parent/child reconstruction (issue #30): a scene
     # read without instantiation must still report nested structure correctly.
@@ -303,7 +289,6 @@ def test_scene_get_reports_nested_tree(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_get_missing_file_yields_structured_error_end_to_end(godot_project):
     # The finer operation code (issue #18) survives the whole real stack: the
     # GDScript op reports path_not_found through the ADR-0002 error envelope,
@@ -321,7 +306,6 @@ def test_scene_get_missing_file_yields_structured_error_end_to_end(godot_project
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_create_unwritable_directory_yields_structured_save_failed(godot_project):
     # The residual save-failure contract (issue #35): when the destination
     # cannot be written, the engine's ERR_CANT_OPEN surfaces as the stable
@@ -352,7 +336,6 @@ def test_scene_create_unwritable_directory_yields_structured_save_failed(godot_p
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_create_unknown_root_type_yields_structured_error_end_to_end(
     godot_project,
 ):
@@ -383,7 +366,6 @@ def _gda_project(project) -> "callable":
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_list_enumerates_created_scenes(godot_project):
     # scene list (issue #54) enumerates the project's .tscn scenes by walking
     # res://: two scenes created at different depths both appear, each with its
@@ -415,7 +397,6 @@ def test_scene_list_enumerates_created_scenes(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_list_enumerates_dot_prefixed_scenes_but_skips_godot_cache(godot_project):
     # scene list promises to enumerate every .tscn in the project, so a
     # dot-prefixed scene (a hidden file, or one under a hidden directory) must
@@ -468,7 +449,6 @@ def test_scene_list_enumerates_dot_prefixed_scenes_but_skips_godot_cache(godot_p
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_list_on_empty_project_is_an_empty_listing(godot_project):
     # A project with no scenes is a valid, empty listing — not an error (the
     # res://.godot import cache must not leak in as a phantom scene).
@@ -481,7 +461,6 @@ def test_scene_list_on_empty_project_is_an_empty_listing(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_list_without_project_yields_project_not_found(tmp_path):
     # scene list cannot enumerate res:// projectless: run from a non-project
     # directory with no --project, it must refuse with the structured
@@ -504,7 +483,6 @@ def test_scene_list_without_project_yields_project_not_found(tmp_path):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_delete_removes_a_scene_and_names_what_was_removed(godot_project):
     # scene delete (issue #54) removes a scene file and names the removed root.
     # The round-trip verifier: scene list before shows the scene, delete reports
@@ -532,7 +510,6 @@ def test_scene_delete_removes_a_scene_and_names_what_was_removed(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_delete_missing_file_yields_path_not_found(godot_project):
     missing = godot_project / "missing.tscn"
 
@@ -546,7 +523,6 @@ def test_scene_delete_missing_file_yields_path_not_found(godot_project):
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_delete_refuses_non_scene_file_and_leaves_it_on_disk(godot_project):
     # The delete safety boundary (issue #54): delete only removes a file that
     # loads as a PackedScene, so a stray non-scene file is refused with

--- a/tests/test_e2e_scene_security.py
+++ b/tests/test_e2e_scene_security.py
@@ -22,9 +22,6 @@ from gda.binary import resolve_godot_binary
 
 GODOT = resolve_godot_binary()
 
-requires_godot = pytest.mark.skipif(
-    not GODOT.exists(), reason=f"real Godot binary not found at {GODOT}"
-)
 
 # A root script whose _init has a side effect AND prints a forged result block.
 # If `scene get` instantiates the scene, _init runs: pwned.txt appears and the
@@ -53,7 +50,6 @@ script = ExtResource("1")
 
 
 @pytest.mark.e2e
-@requires_godot
 def test_scene_get_does_not_execute_scene_code(godot_project):
     (godot_project / "evil.gd").write_text(EVIL_GD, encoding="utf-8")
     (godot_project / "evil.tscn").write_text(EVIL_TSCN, encoding="utf-8")


### PR DESCRIPTION
## What & why

Closes #106.

Makes the Godot `e2e` test tier a **mandatory local gate** instead of a silently-skippable one, and drops the "built around fakeable seams" framing from the README.

### Behavior change — e2e fails loudly on a missing engine

Before, each e2e module guarded its tests with a per-file `pytest.mark.skipif(not <resolved Godot>.exists(), ...)`, so a developer with no engine got an all-green run in which the e2e tier never executed — a silent false pass. Now a missing engine is a loud failure:

- A single autouse fixture in `tests/conftest.py`, keyed on the `e2e` marker, resolves the Godot binary **at fixture-run time** (so a runtime `$GDA_GODOT` override is honored) and calls `pytest.fail(...)` — naming the resolved path and how to fix it — when no engine is found. It is a no-op for non-e2e tests.
- The duplicated per-file `requires_godot = skipif(...)` definitions and all 49 `@requires_godot` decorators are removed (this also advances the consolidation tracked in #39).
- The `@pytest.mark.e2e` marker is preserved on all 50 e2e tests, so `-m "not e2e"` / `-m e2e` selection is unchanged.

Net effect: plain `uv run pytest` runs e2e by default and hard-fails locally without an engine; `-m "not e2e"` still deselects the tier. **CI is not changed** — its per-PR job already runs `-m "not e2e"` and its scheduled job installs an engine before `-m e2e`, so both lanes keep working untouched. The FakeRunner and the S2/S3 fake-based tests are retained.

### Docs change

The README Development section no longer frames the whole codebase as "intentionally built around fakeable seams" (it overclaimed a single DI boundary as an architectural philosophy). It now describes the `GodotRunner` boundary plainly, and the e2e docs state the tier runs by default and **fails** (not skips) on a missing engine.

## Testing

- `uv run pytest -m "not e2e" -q` → **117 passed, 58 deselected** (fast lane / CI per-PR job unaffected, no engine needed).
- `uv run pytest -q` (full, real engine present) → **175 passed**, zero skips.
- `GDA_GODOT=/nonexistent/godot uv run pytest -m e2e -q -x` → **1 error**, `e2e tests need a real Godot engine, but none was found at /nonexistent/godot. Install Godot at that path or set $GDA_GODOT to a 4.4+ binary.` — fails loudly, does not skip.

Note: because the guard fires from a setup fixture, pytest classifies the missing-engine outcome as `ERROR` (not `FAILED`). It is still a loud, non-zero-exit, non-skipping failure with an explicit message; keeping the check centralized (one fixture) was preferred over moving it into every test body.

## Acceptance criteria (#106)

- [x] Missing engine on a selected e2e test fails loudly (names path + fix), does not skip.
- [x] Check defined once (shared autouse fixture keyed on the `e2e` marker); per-file `skipif`/`requires_godot` guards removed from every `test_e2e_*` module.
- [x] `@pytest.mark.e2e` preserved; `-m "not e2e"` still deselects the tier and passes without an engine.
- [x] Full `uv run pytest` (including e2e) passes with a real engine present.
- [x] CI workflows unchanged; both jobs still behave correctly.
- [x] README drops the "fakeable seams" framing and describes the boundary plainly; e2e docs say it runs by default and fails (not skips) on a missing engine.
- [x] FakeRunner and S2/S3 fake-based tests retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
