### PR TITLE
feat(node): node get + node set — node property read/write (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ for the full picture.
 
 - ✅ A first working command surface: the `info` meta command and the first domain command groups —
   `gda scene create` / `gda scene get` / `gda scene list` / `gda scene delete` and
-  `gda node add` / `gda node list`
+  `gda node add` / `gda node list` / `gda node get` / `gda node set`
   ([ADR-0005](docs/adr/0005-cli-command-taxonomy.md)).
 - ✅ The contract every shipped command carries: structured `--json` output, model-derived
   `--schema` self-description ([ADR-0004](docs/adr/0004-schema-flag-self-description.md)), and
@@ -172,6 +172,17 @@ gda node add game/main.tscn --type Sprite2D --name Hero --json
 
 gda node list game/main.tscn --json
 # {"scene_path":"game/main.tscn","root":{"name":"main","type":"Node2D","path":".","children":[{"name":"Hero","type":"Sprite2D","path":"Hero","children":[]}]}}
+```
+
+Read a node's properties as typed JSON, set one (the CLI value is coerced to the property's declared
+Godot type), and verify the change round-trips via `get`:
+
+```bash
+gda node set game/main.tscn --node Hero --property position --value 10,20 --json
+# {"scene_path":"game/main.tscn","path":"Hero","property":"position","type":"Vector2","value":[10.0,20.0]}
+
+gda node get game/main.tscn --node Hero --json
+# {"scene_path":"game/main.tscn","path":"Hero","name":"Hero","type":"Sprite2D","properties":[…,{"name":"position","type":"Vector2","value":[10.0,20.0]},…]}
 ```
 
 Enumerate a project's scenes, then delete one — `scene list` walks the project's `res://` tree, so it

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -88,6 +88,9 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 | `duplicate_node_name` | `operation` | `operation` | The parent node already has a child with the requested name. |
 | `missing_dependency` | `operation` | `operation` | A scene's declared nodes vanished or degraded on load — an unresolvable instanced sub-scene or an unavailable node class; re-saving would silently drop or downgrade them. |
 | `uninstantiable_script` | `operation` | `operation` | A registered `class_name`'s script can no longer be loaded, compiled, or constructed, so it cannot be instantiated as a node. |
+| `node_not_found` | `operation` | `operation` | A requested node path does not resolve to a node in the scene. |
+| `unknown_property` | `operation` | `operation` | A requested property does not exist as a settable property on the node. |
+| `uncoercible_value` | `operation` | `operation` | A supplied value cannot be coerced to the property's declared Godot type. |
 | `contract_violation` | `parse` | `parser` | The process claimed success but violated the structured-output contract. |
 
 ## Considered options

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -34,7 +34,7 @@ issue ref (e.g. `🔜 (#53)`) marks a candidate already committed as an open sli
 | `gda info` | Report Godot engine version info | 1 | ✅ |
 | `gda version` | Report `gda`'s own version | — (local) | 🔜 |
 | `gda help` | Usage help | — (local) | ✅ (`--help`) |
-| `gda <command> --schema` | Emit a command's input/output JSON Schema (ADR-0004) | — (local) | ✅ (`info` #4; `scene create`/`scene get` #18; `scene list`/`scene delete` #54; `node add`/`node list` #53) |
+| `gda <command> --schema` | Emit a command's input/output JSON Schema (ADR-0004) | — (local) | ✅ (`info` #4; `scene create`/`scene get` #18; `scene list`/`scene delete` #54; `node add`/`node list` #53; `node get`/`node set` #55) |
 
 > `--schema` is a per-command flag, not a command, and ships with **every** domain
 > command as a hard gate (ADR-0004). It is local introspection — no Godot process.
@@ -91,13 +91,39 @@ arguments — is a script problem, not an unknown type, and is refused with the 
 `uninstantiable_script` error (exit 4) naming the script: repair the script (or re-import),
 don't change the type name. Either way the scene file is left untouched.
 
+**Property reporting and value coercion** (established by #55): `gda node get` instantiates the
+scene and reports the addressed node's **storage** properties (the ones that serialize into the
+`.tscn`) as typed JSON — each a `{name, type, value}` triple where `type` is the property's
+declared Godot type name and `value` is its JSON projection. `gda node set` takes the property's
+declared type as the coercion target and converts the CLI `--value` **string** to it; the value
+the node ends up holding is reported back in the same JSON projection `node get` uses, so a `set`
+round-trips through a `get`. An unknown property is `unknown_property`; a value that cannot be
+coerced to the property's type is `uncoercible_value` (both exit 4, file untouched). `node get`
+reads but does not save, so it skips the re-save guard; `node set` is a mutating op and honors the
+mutation integrity boundary above. The supported target types and the string forms they accept:
+
+| Godot type | Accepted CLI `--value` string | JSON projection (`get` / `set` result) |
+| --- | --- | --- |
+| `bool` | `true` / `false` (case-insensitive) | `true` / `false` |
+| `int` | an integer literal (e.g. `7`, `-3`) | a JSON number |
+| `float` | a number literal (e.g. `1.5`, `3`) | a JSON number |
+| `String` | any string, verbatim | the string |
+| `StringName` | any string, verbatim | the string |
+| `Vector2` | two comma-separated floats: `x,y` (e.g. `10,20`) | `[x, y]` |
+| `Vector2i` | two comma-separated integers: `x,y` | `[x, y]` |
+| `Color` | `#rrggbb` / `#rrggbbaa`, or 3–4 comma-separated floats in 0..1 (`r,g,b[,a]`) | `[r, g, b, a]` |
+
+Whitespace around a value or a component is tolerated. A property of any other type is still
+reported by `node get` (its value degrades to a string projection), but `node set` cannot coerce
+to it yet and refuses with `uncoercible_value` — the coercible set grows as later slices need it.
+
 | Command | Description | Status |
 | --- | --- | --- |
 | `gda node add` | Add a node (by type or `class_name` script) into a scene | ✅ (#53) |
 | `gda node remove` | Remove a node from a scene | 🔜 (#56) |
-| `gda node get` | Read a node's properties | 🔜 (#55) |
+| `gda node get` | Read a node's properties (typed JSON) | ✅ (#55) |
 | `gda node list` | List nodes in a scene (optionally filtered by type/group) | ✅ (#53) |
-| `gda node set` | Set a node property (type-coerced) | 🔜 (#55) |
+| `gda node set` | Set a node property (type-coerced) | ✅ (#55) |
 | `gda node move` | Reparent a node | 🔜 (#56) |
 | `gda node duplicate` | Duplicate a node | 🔜 (#56) |
 | `gda node connect-signal` / `disconnect-signal` | Wire / unwire a signal to a method | 🔜 (#57) |

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -7,6 +7,7 @@ domain group (issue #18). Every command drives the same headless pipeline:
 binary resolution → runner → sentinel parse → typed model → JSON.
 """
 
+import json
 from importlib.metadata import version as package_version
 from pathlib import Path
 from typing import Optional
@@ -27,8 +28,12 @@ from gda.models import (
     ListedNode,
     NodeAddParams,
     NodeAddResult,
+    NodeGetParams,
+    NodeGetResult,
     NodeListParams,
     NodeListResult,
+    NodeSetParams,
+    NodeSetResult,
     SceneCreateParams,
     SceneCreateResult,
     SceneDeleteParams,
@@ -132,6 +137,18 @@ NODE_LIST_COMMAND: HeadlessCommand[NodeListResult] = HeadlessCommand(
     operation="node-list",
     input_model=NodeListParams,
     output_model=NodeListResult,
+)
+
+NODE_GET_COMMAND: HeadlessCommand[NodeGetResult] = HeadlessCommand(
+    operation="node-get",
+    input_model=NodeGetParams,
+    output_model=NodeGetResult,
+)
+
+NODE_SET_COMMAND: HeadlessCommand[NodeSetResult] = HeadlessCommand(
+    operation="node-set",
+    input_model=NodeSetParams,
+    output_model=NodeSetResult,
 )
 
 
@@ -336,6 +353,86 @@ def list_nodes(
         project=resolve_project_dir(project),
         json_output=json_output,
         render_text=lambda listed: _render_tree(listed.root),
+        make_runner=_make_runner,
+    )
+
+
+def _render_node_properties(got: "NodeGetResult") -> str:
+    """Render a node's properties as ``name (Type) = value`` lines for humans."""
+    header = f"{got.path} ({got.type})"
+    lines = [
+        f"  {prop.name} ({prop.type}) = {json.dumps(prop.value)}"
+        for prop in got.properties
+    ]
+    return "\n".join([header, *lines])
+
+
+@node_app.command(cls=NODE_GET_COMMAND.command_class())
+def get(
+    path: str = typer.Argument(..., help="The .tscn scene file to read."),
+    node: str = typer.Option(
+        ...,
+        "--node",
+        help=(
+            "Node path, relative to the scene root: '.' addresses the root "
+            "itself, 'Player/Arm' a nested node."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = NODE_GET_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Read a node's properties (by node path) as typed JSON."""
+    NODE_GET_COMMAND.emit(
+        NodeGetParams(path=_normalize_path(path), node=node),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=_render_node_properties,
+        make_runner=_make_runner,
+    )
+
+
+@node_app.command(name="set", cls=NODE_SET_COMMAND.command_class())
+def set_property(
+    path: str = typer.Argument(..., help="The .tscn scene file to mutate."),
+    node: str = typer.Option(
+        ...,
+        "--node",
+        help=(
+            "Node path, relative to the scene root: '.' addresses the root "
+            "itself, 'Player/Arm' a nested node."
+        ),
+    ),
+    property: str = typer.Option(
+        ..., "--property", help="The property to set (e.g. position, visible)."
+    ),
+    value: str = typer.Option(
+        ...,
+        "--value",
+        help=(
+            "The value to set, as a string. Coerced to the property's declared "
+            "Godot type; an uncoercible value is a clean error."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = NODE_SET_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Set a node property, coercing the value to its declared Godot type."""
+    NODE_SET_COMMAND.emit(
+        NodeSetParams(
+            path=_normalize_path(path), node=node, property=property, value=value
+        ),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=lambda was_set: (
+            f"set {was_set.path}.{was_set.property} ({was_set.type}) = "
+            f"{json.dumps(was_set.value)}"
+        ),
         make_runner=_make_runner,
     )
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -175,6 +175,24 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         " or constructed, so it cannot be instantiated as a node.",
     ),
     ErrorCodeSpec(
+        "node_not_found",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A requested node path does not resolve to a node in the scene.",
+    ),
+    ErrorCodeSpec(
+        "unknown_property",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A requested property does not exist as a settable property on the node.",
+    ),
+    ErrorCodeSpec(
+        "uncoercible_value",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A supplied value cannot be coerced to the property's declared Godot type.",
+    ),
+    ErrorCodeSpec(
         "contract_violation",
         ErrorCategory.PARSE,
         ErrorCodeSource.PARSER,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -342,6 +342,108 @@ class NodeListResult(BaseModel):
     root: ListedNode
 
 
+class NodeProperty(BaseModel):
+    """One of a node's properties as ``gda node get`` reports it (issue #55).
+
+    ``type`` is the property's declared Godot type name (``int``, ``Vector2``,
+    ``Color``, …). ``value`` is the property's value in its JSON projection —
+    left as arbitrary JSON so every Godot type is carried uniformly through one
+    field: a scalar stays a scalar, a Vector2 becomes ``[x, y]``, a Color
+    ``[r, g, b, a]`` — the same projection ``node set`` accepts back.
+    """
+
+    name: str
+    type: str = Field(
+        description="The property's declared Godot type name (e.g. int, Vector2, Color)."
+    )
+    value: Any = Field(
+        description=(
+            "The property's value as JSON: a scalar for a scalar type, a list "
+            "for a packed type (Vector2 → [x, y], Color → [r, g, b, a])."
+        )
+    )
+
+
+class NodeGetParams(BaseModel):
+    """The operation params of ``gda node get`` (issue #55).
+
+    ``path`` is the ``.tscn`` scene file to read; ``node`` addresses the node by
+    its node path relative to the scene root ('.' is the root itself).
+    """
+
+    path: str
+    node: str = Field(
+        description=(
+            "Node path relative to the scene root: '.' addresses the root "
+            "itself, 'Player/Arm' a nested node."
+        )
+    )
+
+
+class NodeGetResult(BaseModel):
+    """The result of ``gda node get``: a node's properties as typed JSON (issue #55).
+
+    Echoes the addressed node (``path``/``name``/``type``) and its storage
+    properties — the ones that serialize into the ``.tscn`` — each as a typed
+    :class:`NodeProperty`, so an agent reads a node's state without parsing the
+    scene file and can feed any property straight back into ``node set``.
+    """
+
+    scene_path: str
+    path: str = Field(
+        description="The addressed node's node path, relative to the scene root."
+    )
+    name: str
+    type: str = Field(description="The node's engine class (e.g. Sprite2D).")
+    properties: list[NodeProperty]
+
+
+class NodeSetParams(BaseModel):
+    """The operation params of ``gda node set`` (issue #55).
+
+    ``path`` is the ``.tscn`` scene file to mutate; ``node`` addresses the node
+    by node path relative to the scene root. ``property`` names the property to
+    set; ``value`` is the CLI string value, coerced to the property's declared
+    Godot type by the operation before the scene is re-packed and saved.
+    """
+
+    path: str
+    node: str = Field(
+        description=(
+            "Node path relative to the scene root: '.' addresses the root "
+            "itself, 'Player/Arm' a nested node."
+        )
+    )
+    property: str
+    value: str = Field(
+        description=(
+            "The value to set, as a string. The operation coerces it to the "
+            "property's declared Godot type (see the command catalog's "
+            "'Property value coercion'); an uncoercible value is a clean error."
+        )
+    )
+
+
+class NodeSetResult(BaseModel):
+    """The result of ``gda node set``: the one property it set (issue #55).
+
+    Echoes the addressed node's ``path``, the ``property`` set, the declared
+    ``type`` the CLI value was coerced to, and the coerced ``value`` as JSON —
+    the projection ``node get`` reports, so a ``set`` round-trips through a
+    ``get`` without re-reading the file.
+    """
+
+    scene_path: str
+    path: str = Field(
+        description="The addressed node's node path, relative to the scene root."
+    )
+    property: str
+    type: str = Field(description="The property's declared Godot type the value was coerced to.")
+    value: Any = Field(
+        description="The coerced value as JSON, as the node now holds it."
+    )
+
+
 class EngineVersion(BaseModel):
     """The Godot engine version, as reported by ``Engine.get_version_info()``.
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -42,6 +42,9 @@ const OP_ERROR_INVALID_NODE_NAME := "invalid_node_name"
 const OP_ERROR_DUPLICATE_NODE_NAME := "duplicate_node_name"
 const OP_ERROR_MISSING_DEPENDENCY := "missing_dependency"
 const OP_ERROR_UNINSTANTIABLE_SCRIPT := "uninstantiable_script"
+const OP_ERROR_NODE_NOT_FOUND := "node_not_found"
+const OP_ERROR_UNKNOWN_PROPERTY := "unknown_property"
+const OP_ERROR_UNCOERCIBLE_VALUE := "uncoercible_value"
 
 const NODE_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
 
@@ -79,6 +82,10 @@ func _initialize() -> void:
 			_op_node_add(params)
 		"node-list":
 			_op_node_list(params)
+		"node-get":
+			_op_node_get(params)
+		"node-set":
+			_op_node_set(params)
 		_:
 			_fail(OP_ERROR_UNKNOWN_OPERATION, "unknown operation: " + operation)
 
@@ -247,9 +254,6 @@ func _op_scene_delete(params: Dictionary) -> void:
 # node runs that script's constructor. Inherent to headless file mutation.
 func _op_node_add(params: Dictionary) -> void:
 	_diag("running operation: node-add")
-	var packed: PackedScene = _load_scene(params)
-	if packed == null:
-		return  # _load_scene already recorded the failure
 	var path := _string_param(params, "path")
 
 	var node_name := _string_param(params, "name")
@@ -257,23 +261,11 @@ func _op_node_add(params: Dictionary) -> void:
 		_fail(OP_ERROR_INVALID_NODE_NAME, "invalid name: " + node_name)
 		return
 
-	var root: Node = packed.instantiate()
+	var root: Node = _load_for_mutation(params)
 	if root == null:
-		# The engine returns null for a scene it cannot instantiate at all —
-		# e.g. an instanced sub-scene whose resource loads but instantiates to
-		# nothing (packed_scene.cpp propagates the nested null). Nothing exists
-		# to edit or save, so refuse with the dependency code.
-		_fail(OP_ERROR_MISSING_DEPENDENCY, "scene failed to instantiate: " + path
-				+ " — an instanced sub-scene is unresolvable or empty; check the scene's dependencies and --project")
-		return
-	var unmaterialized := _unmaterialized_node_paths(packed.get_state(), root)
-	if not unmaterialized.is_empty():
-		root.free()
-		_fail(OP_ERROR_MISSING_DEPENDENCY, "scene nodes vanished or degraded on load: "
-				+ ", ".join(unmaterialized) + " — re-saving would silently drop or downgrade them; check the scene's dependencies and --project")
-		return
+		return  # _load_for_mutation already recorded the failure
 	var parent_path := _string_param(params, "parent")
-	var parent := _resolve_parent(root, parent_path)
+	var parent := _resolve_node(root, parent_path)
 	if parent == null:
 		root.free()
 		if _is_canonical_parent_path(parent_path):
@@ -340,6 +332,121 @@ func _op_node_list(params: Dictionary) -> void:
 	_succeed({
 		"scene_path": _string_param(params, "path"),
 		"root": _tree_from_state(packed.get_state(), true),
+	})
+
+
+# node-get: load a .tscn, resolve a node by node path, and emit its storage
+# properties as typed JSON — the read half of issue #55. Unlike node-list,
+# reporting a node's actual property VALUES requires the instantiated node:
+# SceneState only stores explicitly-overridden values, not defaults, and not in
+# a clean typed projection. Instantiating runs the _init of attached scripts
+# (the same trust boundary as node-add), but node-get does not re-save, so it
+# skips the unmaterialized-node guard (that boundary protects a re-save from
+# silently dropping data, issue #64 — there is no save here to protect). The
+# node still has to exist in the instantiated tree, reported as node_not_found.
+func _op_node_get(params: Dictionary) -> void:
+	_diag("running operation: node-get")
+	var packed: PackedScene = _load_scene(params)
+	if packed == null:
+		return  # _load_scene already recorded the failure
+	var root: Node = packed.instantiate()
+	if root == null:
+		_fail(OP_ERROR_MISSING_DEPENDENCY, "scene failed to instantiate: "
+				+ _string_param(params, "path")
+				+ " — an instanced sub-scene is unresolvable or empty; check the scene's dependencies and --project")
+		return
+	var node_path := _string_param(params, "node")
+	var node := _resolve_node(root, node_path)
+	if node == null:
+		root.free()
+		_fail_node_not_found(node_path)
+		return
+
+	var properties: Array = []
+	for prop in node.get_property_list():
+		if not _is_storage_property(prop):
+			continue
+		var prop_name := String(prop.get("name", ""))
+		properties.append({
+			"name": prop_name,
+			"type": _type_name(int(prop.get("type", TYPE_NIL))),
+			"value": _jsonify(node.get(prop_name)),
+		})
+	# Capture the node's identity before freeing the tree: freeing root frees
+	# node too, and reading off a freed node is a runtime error.
+	var node_name := String(node.name)
+	var node_type := node.get_class()
+	root.free()
+
+	_succeed({
+		"scene_path": _string_param(params, "path"),
+		"path": node_path,
+		"name": node_name,
+		"type": node_type,
+		"properties": properties,
+	})
+
+
+# node-set: load a .tscn, resolve a node by node path, set one property —
+# coercing the CLI string value to the property's declared Godot type — then
+# pack and save (the write half of issue #55, verifiable via node-get). As a
+# mutating op it goes through the shared mutate-entry (load → instantiate →
+# unmaterialized-node guard), so it honors the mutation-integrity boundary the
+# command catalog promises (issue #64): a re-save can never silently drop an
+# unresolvable instance or downgrade a substituted class.
+func _op_node_set(params: Dictionary) -> void:
+	_diag("running operation: node-set")
+	var path := _string_param(params, "path")
+	var root: Node = _load_for_mutation(params)
+	if root == null:
+		return  # _load_for_mutation already recorded the failure
+	var node_path := _string_param(params, "node")
+	var node := _resolve_node(root, node_path)
+	if node == null:
+		root.free()
+		_fail_node_not_found(node_path)
+		return
+
+	var prop_name := _string_param(params, "property")
+	var declared_type := _property_type(node, prop_name)
+	if declared_type == TYPE_NIL:
+		root.free()
+		_fail(OP_ERROR_UNKNOWN_PROPERTY, "node " + node_path
+				+ " has no settable property: " + prop_name)
+		return
+
+	var raw_value := _string_param(params, "value")
+	var coerced: Variant = _coerce_value(raw_value, declared_type)
+	if coerced == null:
+		root.free()
+		_fail(OP_ERROR_UNCOERCIBLE_VALUE, "cannot coerce value " + raw_value.c_escape()
+				+ " to " + _type_name(declared_type) + " for property " + prop_name
+				+ " on node " + node_path)
+		return
+
+	node.set(prop_name, coerced)
+
+	var repacked := PackedScene.new()
+	var pack_err := repacked.pack(root)
+	if pack_err != OK:
+		root.free()
+		_fail(OP_ERROR_SAVE_FAILED, "failed to pack scene: " + error_string(pack_err))
+		return
+	var save_err := ResourceSaver.save(repacked, path)
+	# Read the value back off the node — the node now holds the coerced value in
+	# its canonical form, the same projection node-get reports.
+	var stored_value: Variant = _jsonify(node.get(prop_name))
+	root.free()
+	if save_err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message(path, save_err))
+		return
+
+	_succeed({
+		"scene_path": path,
+		"path": node_path,
+		"property": prop_name,
+		"type": _type_name(declared_type),
+		"value": stored_value,
 	})
 
 
@@ -418,6 +525,39 @@ func _load_scene(params: Dictionary) -> PackedScene:
 	return packed
 
 
+# The single mutate-entry for the node group (issue #55): load the .tscn,
+# instantiate it, and clear the mutation-integrity boundary before any op
+# touches the tree, returning the instantiated root (or null after recording
+# the failure). Mutation REQUIRES instantiating the scene — only a real node
+# tree can be edited and re-packed — which runs the _init of any script
+# attached in the scene, so mutating ops execute project code where the read
+# ops (issue #30) deliberately do not. Centralising load → instantiate → guard
+# here means every current and future mutating op honors the boundary the
+# command catalog promises, rather than re-inlining (and risking forgetting)
+# the unmaterialized-node check (issue #64). The caller owns root.free().
+func _load_for_mutation(params: Dictionary) -> Node:
+	var packed: PackedScene = _load_scene(params)
+	if packed == null:
+		return null  # _load_scene already recorded the failure
+	var path := _string_param(params, "path")
+	var root: Node = packed.instantiate()
+	if root == null:
+		# The engine returns null for a scene it cannot instantiate at all —
+		# e.g. an instanced sub-scene whose resource loads but instantiates to
+		# nothing (packed_scene.cpp propagates the nested null). Nothing exists
+		# to edit or save, so refuse with the dependency code.
+		_fail(OP_ERROR_MISSING_DEPENDENCY, "scene failed to instantiate: " + path
+				+ " — an instanced sub-scene is unresolvable or empty; check the scene's dependencies and --project")
+		return null
+	var unmaterialized := _unmaterialized_node_paths(packed.get_state(), root)
+	if not unmaterialized.is_empty():
+		root.free()
+		_fail(OP_ERROR_MISSING_DEPENDENCY, "scene nodes vanished or degraded on load: "
+				+ ", ".join(unmaterialized) + " — re-saving would silently drop or downgrade them; check the scene's dependencies and --project")
+		return null
+	return root
+
+
 # Node paths declared in the scene's state that did not materialize faithfully
 # in the instantiated tree (issue #64), in the two modes the engine survives
 # silently:
@@ -435,7 +575,7 @@ func _load_scene(params: Dictionary) -> PackedScene:
 func _unmaterialized_node_paths(state: SceneState, root: Node) -> Array[String]:
 	var unmaterialized: Array[String] = []
 	for i in state.get_node_count():
-		var state_path := String(state.get_node_path(i)).trim_prefix("./")
+		var state_path := _normalize_state_path(state, i)
 		var node := root.get_node_or_null(NodePath(state_path))
 		if node == null:
 			unmaterialized.append(state_path + " (vanished)")
@@ -466,17 +606,52 @@ func _is_canonical_parent_path(parent_path: String) -> bool:
 	return true
 
 
-# Resolve a parent node path against the scene root. Node-path addressing
-# (issue #53) is relative to the scene root: '.' is the root itself,
-# 'Player/Arm' a descendant. Only canonical paths resolve (issue #66) — this
-# subsumes rejecting absolute paths ('/root/…' opens with an empty segment),
-# which a loaded-for-editing tree outside any SceneTree could never serve.
-func _resolve_parent(root: Node, parent_path: String) -> Node:
-	if not _is_canonical_parent_path(parent_path):
+# Resolve a node path against the scene root. Node-path addressing (issue #53)
+# is relative to the scene root: '.' is the root itself, 'Player/Arm' a
+# descendant. Only canonical paths resolve (issue #66) — this subsumes
+# rejecting absolute paths ('/root/…' opens with an empty segment), which a
+# loaded-for-editing tree outside any SceneTree could never serve. Shared by
+# node add (its --parent), node get and node set (their --node): one strict
+# resolver so every node-group op addresses nodes identically.
+func _resolve_node(root: Node, node_path: String) -> Node:
+	if not _is_canonical_parent_path(node_path):
 		return null
-	if parent_path == ".":
+	if node_path == ".":
 		return root
-	return root.get_node_or_null(NodePath(parent_path))
+	return root.get_node_or_null(NodePath(node_path))
+
+
+# Record a node-not-found failure for node get / node set, distinguishing the
+# two ways resolution can fail the same way node add does for its parent: a
+# canonical path that names no node, versus a non-canonical path rejected by
+# strict addressing (issue #66) rather than silently resolved elsewhere.
+func _fail_node_not_found(node_path: String) -> void:
+	if _is_canonical_parent_path(node_path):
+		_fail(OP_ERROR_NODE_NOT_FOUND, "node not found in scene: " + node_path)
+	else:
+		_fail(OP_ERROR_NODE_NOT_FOUND, "non-canonical node path: " + node_path
+				+ " — address the node exactly as node list reports it: '.' for the root, 'A/B' for a descendant")
+
+
+# Whether a property-list entry is a STORAGE property — the ones node get
+# reports and node set targets: the properties that serialize into the .tscn,
+# excluding the engine's category headers, group separators, and editor-only
+# (non-storage) entries. This is the same usage flag the scene serializer keys
+# on, so node get reports exactly the surface a saved scene can carry.
+func _is_storage_property(prop: Dictionary) -> bool:
+	var usage := int(prop.get("usage", 0))
+	return (usage & PROPERTY_USAGE_STORAGE) != 0
+
+
+# The declared Godot type of a settable property on the node, or TYPE_NIL if the
+# node has no storage property by that name. node set keys coercion off this:
+# the value's target type comes from the property the node actually declares,
+# never from guessing.
+func _property_type(node: Node, prop_name: String) -> int:
+	for prop in node.get_property_list():
+		if String(prop.get("name", "")) == prop_name and _is_storage_property(prop):
+			return int(prop.get("type", TYPE_NIL))
+	return TYPE_NIL
 
 
 # Instantiate a node by type: a built-in Node class first, then a class_name
@@ -548,6 +723,15 @@ func _script_class_of(node: Node) -> Variant:
 	return global_name
 
 
+# A SceneState node path normalized to the canonical root-relative form the
+# node group addresses by and reports: the state stores "." for the root and a
+# "./Hero/Hitbox" prefix form for a descendant, which becomes "Hero/Hitbox".
+# Shared so the unmaterialized-node guard and the tree builder agree on one
+# normalization rather than re-spelling it (issue #55 review).
+func _normalize_state_path(state: SceneState, index: int) -> String:
+	return String(state.get_node_path(index)).trim_prefix("./")
+
+
 # Build the structured node tree from a SceneState. The state lists nodes in
 # tree order; each carries a node path ("." for the root, "./Hero/Hitbox" for
 # a descendant) and the path to its parent, which is enough to reconstruct the
@@ -566,7 +750,7 @@ func _tree_from_state(state: SceneState, with_paths := false) -> Dictionary:
 			"children": [],
 		}
 		if with_paths:
-			node["path"] = state_path.trim_prefix("./")
+			node["path"] = _normalize_state_path(state, i)
 		by_path[state_path] = node
 		if i == 0:
 			root = node
@@ -585,6 +769,142 @@ func _string_param(params: Dictionary, key: String) -> String:
 	if value is String:
 		return value
 	return ""
+
+
+# The Godot type name for a Variant.Type, as node get / node set report it
+# (the same spelling type_string uses: "int", "Vector2", "Color", …).
+func _type_name(type: int) -> String:
+	return type_string(type)
+
+
+# Project a Godot property value into JSON-safe form for the result payload
+# (issue #55). Scalars pass through; the packed value types node set supports
+# become flat number arrays so node get's output is exactly the projection node
+# set accepts back: Vector2 → [x, y], Vector2i likewise, Color → [r, g, b, a].
+# Any other type degrades to its string form rather than crashing JSON.stringify
+# on an unencodable Variant — node get reports the whole storage surface, but
+# only the coercible types claim a structured projection.
+func _jsonify(value: Variant) -> Variant:
+	match typeof(value):
+		TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING, TYPE_STRING_NAME:
+			return value
+		TYPE_VECTOR2:
+			return [value.x, value.y]
+		TYPE_VECTOR2I:
+			return [value.x, value.y]
+		TYPE_COLOR:
+			return [value.r, value.g, value.b, value.a]
+		_:
+			return str(value)
+
+
+# Coerce a CLI string value to a property's declared Godot type (issue #55).
+# The supported types and their accepted string forms are documented in the
+# command catalog's "Property value coercion" section — keep the two in sync.
+# Returns null when the value cannot be coerced to that type, which the caller
+# reports as the clean uncoercible_value error. null is unambiguous as a
+# failure signal because no supported target type coerces TO null.
+func _coerce_value(raw: String, type: int) -> Variant:
+	match type:
+		TYPE_BOOL:
+			return _coerce_bool(raw)
+		TYPE_INT:
+			return _coerce_int(raw)
+		TYPE_FLOAT:
+			return _coerce_float(raw)
+		TYPE_STRING:
+			return raw
+		TYPE_STRING_NAME:
+			return StringName(raw)
+		TYPE_VECTOR2:
+			var parts: Variant = _coerce_float_list(raw, 2)
+			return Vector2(parts[0], parts[1]) if parts != null else null
+		TYPE_VECTOR2I:
+			var parts: Variant = _coerce_int_list(raw, 2)
+			return Vector2i(parts[0], parts[1]) if parts != null else null
+		TYPE_COLOR:
+			return _coerce_color(raw)
+		_:
+			return null
+
+
+# A bool from "true"/"false" (case-insensitive), nothing else — so a typo never
+# silently becomes false.
+func _coerce_bool(raw: String) -> Variant:
+	var lowered := raw.strip_edges().to_lower()
+	if lowered == "true":
+		return true
+	if lowered == "false":
+		return false
+	return null
+
+
+func _coerce_int(raw: String) -> Variant:
+	var trimmed := raw.strip_edges()
+	if not trimmed.is_valid_int():
+		return null
+	return trimmed.to_int()
+
+
+func _coerce_float(raw: String) -> Variant:
+	var trimmed := raw.strip_edges()
+	# is_valid_float accepts integer spellings too, which is intended: "3" is a
+	# valid float value, and Godot stores it as 3.0.
+	if not trimmed.is_valid_float():
+		return null
+	return trimmed.to_float()
+
+
+# Parse a comma-separated list of exactly `count` floats (e.g. "10,20" for a
+# Vector2). Whitespace around each component is tolerated; a wrong count or a
+# non-numeric component fails the whole coercion.
+func _coerce_float_list(raw: String, count: int) -> Variant:
+	var parts := raw.split(",")
+	if parts.size() != count:
+		return null
+	var out: Array[float] = []
+	for part in parts:
+		var coerced: Variant = _coerce_float(part)
+		if coerced == null:
+			return null
+		out.append(coerced)
+	return out
+
+
+func _coerce_int_list(raw: String, count: int) -> Variant:
+	var parts := raw.split(",")
+	if parts.size() != count:
+		return null
+	var out: Array[int] = []
+	for part in parts:
+		var coerced: Variant = _coerce_int(part)
+		if coerced == null:
+			return null
+		out.append(coerced)
+	return out
+
+
+# A Color from either a "#rrggbb"/"#rrggbbaa" hex string or a comma-separated
+# list of 3 (rgb) or 4 (rgba) floats in 0..1. Godot's Color.html validates the
+# hex form; the float-list form reuses the shared numeric coercion.
+func _coerce_color(raw: String) -> Variant:
+	var trimmed := raw.strip_edges()
+	if trimmed.begins_with("#"):
+		if not Color.html_is_valid(trimmed):
+			return null
+		return Color.html(trimmed)
+	var parts := trimmed.split(",")
+	if parts.size() != 3 and parts.size() != 4:
+		return null
+	var out: Array[float] = []
+	for part in parts:
+		var coerced: Variant = _coerce_float(part)
+		if coerced == null:
+			return null
+		out.append(coerced)
+	if out.size() == 3:
+		return Color(out[0], out[1], out[2])
+	return Color(out[0], out[1], out[2], out[3])
 
 
 func _is_valid_node_name(node_name: String) -> bool:

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -305,6 +305,185 @@ def test_node_add_rejects_name_godot_would_rewrite(godot_project):
     assert "Bad%Name" in err["message"]
 
 
+# --- node get / node set (issue #55) ---
+
+
+def _get_property(scene_path, node: str, name: str):
+    """Read one property dict (by name) off a node via `gda node get --json`."""
+    got = _gda("node", "get", str(scene_path), "--node", node, "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    for prop in json.loads(got.stdout)["properties"]:
+        if prop["name"] == name:
+            return prop
+    return None
+
+
+@pytest.mark.e2e
+def test_node_get_reports_typed_properties(godot_project):
+    # node get is the read half of issue #55: it loads a scene and reports the
+    # addressed node's storage properties as typed JSON — each with its name,
+    # declared Godot type, and value in the JSON projection.
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    added = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Sprite2D", "--name", "Hero", "--json",
+    )
+    assert added.returncode == 0, added.stdout + added.stderr
+
+    got = _gda("node", "get", str(scene_path), "--node", "Hero", "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    data = json.loads(got.stdout)
+    assert (data["path"], data["name"], data["type"]) == ("Hero", "Hero", "Sprite2D")
+    by_name = {p["name"]: p for p in data["properties"]}
+    # A representative scalar, packed, and bool property carry their declared
+    # Godot type and a JSON-projected value.
+    assert by_name["position"]["type"] == "Vector2"
+    assert by_name["position"]["value"] == [0.0, 0.0]
+    assert by_name["visible"] == {"name": "visible", "type": "bool", "value": True}
+    assert by_name["z_index"]["type"] == "int"
+
+
+@pytest.mark.e2e
+def test_node_get_addresses_the_root_with_dot(godot_project):
+    # The canonical root address works for get too: '.' is the root itself,
+    # exactly as node list reports it and node add's --parent default.
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+
+    got = _gda("node", "get", str(scene_path), "--node", ".", "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    data = json.loads(got.stdout)
+    assert (data["path"], data["name"], data["type"]) == (".", "main", "Node2D")
+
+
+@pytest.mark.e2e
+def test_node_get_missing_node_yields_node_not_found(godot_project):
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+
+    got = _gda("node", "get", str(scene_path), "--node", "Bogus", "--json")
+
+    err = _assert_operation_error(got, "node_not_found")
+    assert "Bogus" in err["message"]
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "prop,value,want_type,want_value",
+    [
+        ("position", "3,4", "Vector2", [3.0, 4.0]),
+        ("z_index", "7", "int", 7),
+        ("rotation", "1.5", "float", 1.5),
+        ("visible", "false", "bool", False),
+        ("modulate", "1,0,0,1", "Color", [1.0, 0.0, 0.0, 1.0]),
+        ("modulate", "#ff0000ff", "Color", [1.0, 0.0, 0.0, 1.0]),
+    ],
+)
+def test_node_set_coerces_and_round_trips_via_get(
+    godot_project, prop, value, want_type, want_value
+):
+    # The core of issue #55: node set coerces the CLI string to the property's
+    # declared Godot type, saves, and the change round-trips via node get —
+    # the acceptance criterion "set is verifiable via get", across the coercion
+    # rules documented in the command catalog.
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    _gda("node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json")
+
+    was_set = _gda(
+        "node", "set", str(scene_path),
+        "--node", "Hero", "--property", prop, "--value", value, "--json",
+    )
+
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    set_data = json.loads(was_set.stdout)
+    assert (set_data["property"], set_data["type"]) == (prop, want_type)
+    assert set_data["value"] == want_value
+    # The change is on disk, verified through a fresh get.
+    assert _get_property(scene_path, "Hero", prop)["value"] == want_value
+
+
+@pytest.mark.e2e
+def test_node_set_unknown_property_yields_unknown_property_and_leaves_file_unchanged(
+    godot_project,
+):
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    _gda("node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json")
+    before = scene_path.read_text(encoding="utf-8")
+
+    was_set = _gda(
+        "node", "set", str(scene_path),
+        "--node", "Hero", "--property", "no_such_prop", "--value", "1", "--json",
+    )
+
+    err = _assert_operation_error(was_set, "unknown_property")
+    assert "no_such_prop" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_node_set_uncoercible_value_yields_uncoercible_value_and_leaves_file_unchanged(
+    godot_project,
+):
+    # The type-coercion contract's failure path: a value that cannot become the
+    # property's declared type is a clean error, not a silent wrong value, and
+    # the scene file is left untouched.
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    _gda("node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json")
+    before = scene_path.read_text(encoding="utf-8")
+
+    was_set = _gda(
+        "node", "set", str(scene_path),
+        "--node", "Hero", "--property", "position", "--value", "not_a_vector", "--json",
+    )
+
+    err = _assert_operation_error(was_set, "uncoercible_value")
+    assert "Vector2" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_node_set_missing_node_yields_node_not_found(godot_project):
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    before = scene_path.read_text(encoding="utf-8")
+
+    was_set = _gda(
+        "node", "set", str(scene_path),
+        "--node", "Bogus", "--property", "position", "--value", "1,2", "--json",
+    )
+
+    err = _assert_operation_error(was_set, "node_not_found")
+    assert "Bogus" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_node_set_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
+    # node set is the second mutating op (issue #55), so it must honor the same
+    # mutation-integrity boundary as node add (issue #64): when an instanced
+    # sub-scene cannot resolve on load, set refuses with missing_dependency and
+    # leaves the file byte-identical rather than dropping the instance on save.
+    parent = _write_instance_fixture(godot_project, child="gone.tscn")
+    (godot_project / "gone.tscn").unlink(missing_ok=True)
+    before = parent.read_text(encoding="utf-8")
+
+    was_set = _gda(
+        "node", "set", str(parent),
+        "--node", ".", "--property", "position", "--value", "1,2",
+        "--project", str(godot_project), "--json",
+    )
+
+    err = _assert_operation_error(was_set, "missing_dependency")
+    assert "ChildInstance" in err["message"]
+    assert parent.read_text(encoding="utf-8") == before
+
+
 @pytest.mark.e2e
 def test_node_list_missing_scene_yields_path_not_found(godot_project):
     missing = godot_project / "missing.tscn"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,9 @@ from gda.models import (
     GdaError,
     GdaErrorEnvelope,
     NodeAddResult,
+    NodeGetResult,
     NodeListResult,
+    NodeSetResult,
     SceneCreateResult,
     SceneDeleteResult,
     SceneGetResult,
@@ -242,3 +244,51 @@ def test_node_list_result_round_trips_a_nested_tree_with_paths():
     assert listed.root.path == "."
     assert listed.root.children[0].children[0].path == "Hero/Hitbox"
     assert json.loads(listed.model_dump_json()) == payload
+
+
+def test_node_get_result_round_trips_typed_properties():
+    # node get reports a node's storage properties as typed JSON (issue #55):
+    # each property carries its name, its declared Godot type, and its value in
+    # the JSON projection the operation emits. The value is left as arbitrary
+    # JSON so the model carries every Godot type uniformly (a number, a string,
+    # a list for a Vector2, …) without a per-type field.
+    payload = {
+        "scene_path": "/p/main.tscn",
+        "path": "Hero",
+        "name": "Hero",
+        "type": "Sprite2D",
+        "properties": [
+            {"name": "position", "type": "Vector2", "value": [10.0, 20.0]},
+            {"name": "visible", "type": "bool", "value": True},
+            {"name": "z_index", "type": "int", "value": 3},
+        ],
+    }
+
+    got = NodeGetResult.model_validate(payload)
+
+    assert got.path == "Hero"
+    assert got.properties[0].name == "position"
+    assert got.properties[0].type == "Vector2"
+    assert got.properties[0].value == [10.0, 20.0]
+    assert json.loads(got.model_dump_json()) == payload
+
+
+def test_node_set_result_round_trips_the_coerced_property():
+    # node set echoes the one property it changed (issue #55): its name, the
+    # property's declared type the CLI value was coerced to, and the coerced
+    # value as the node now holds it — the result an agent asserts without a
+    # second `get`.
+    payload = {
+        "scene_path": "/p/main.tscn",
+        "path": "Hero",
+        "property": "position",
+        "type": "Vector2",
+        "value": [3.0, 4.0],
+    }
+
+    was_set = NodeSetResult.model_validate(payload)
+
+    assert was_set.property == "position"
+    assert was_set.type == "Vector2"
+    assert was_set.value == [3.0, 4.0]
+    assert json.loads(was_set.model_dump_json()) == payload

--- a/tests/test_node_commands.py
+++ b/tests/test_node_commands.py
@@ -116,6 +116,99 @@ def test_node_list_json_emits_node_tree_with_paths_and_exit_zero(monkeypatch):
     assert fake.calls == [("node-list", {"path": "/tmp/proj/main.tscn"})]
 
 
+GET_RESULT = {
+    "scene_path": "/tmp/proj/main.tscn",
+    "path": "Hero",
+    "name": "Hero",
+    "type": "Sprite2D",
+    "properties": [
+        {"name": "position", "type": "Vector2", "value": [10.0, 20.0]},
+        {"name": "visible", "type": "bool", "value": True},
+    ],
+}
+
+
+def test_node_get_json_emits_typed_properties_and_exit_zero(monkeypatch):
+    # node get is the read half of issue #55: it loads a scene and reports the
+    # addressed node's properties as typed JSON — the read an agent verifies a
+    # `set` against.
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app, ["node", "get", "/tmp/proj/main.tscn", "--node", "Hero", "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["scene_path"] == "/tmp/proj/main.tscn"
+    assert (data["path"], data["name"], data["type"]) == ("Hero", "Hero", "Sprite2D")
+    position = data["properties"][0]
+    assert (position["name"], position["type"], position["value"]) == (
+        "position",
+        "Vector2",
+        [10.0, 20.0],
+    )
+    # The node is addressed by node path, dispatched by the operation name.
+    assert fake.calls == [
+        ("node-get", {"path": "/tmp/proj/main.tscn", "node": "Hero"})
+    ]
+
+
+SET_RESULT = {
+    "scene_path": "/tmp/proj/main.tscn",
+    "path": "Hero",
+    "property": "position",
+    "type": "Vector2",
+    "value": [3.0, 4.0],
+}
+
+
+def test_node_set_json_echoes_the_coerced_property_and_exit_zero(monkeypatch):
+    # node set is the write half of issue #55: it coerces the CLI string value
+    # to the property's declared type, saves, and echoes the coerced property —
+    # the result an agent asserts (and which round-trips via node get).
+    stdout = sentinel(SET_RESULT)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "node",
+            "set",
+            "/tmp/proj/main.tscn",
+            "--node",
+            "Hero",
+            "--property",
+            "position",
+            "--value",
+            "3,4",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert (data["path"], data["property"], data["type"]) == (
+        "Hero",
+        "position",
+        "Vector2",
+    )
+    assert data["value"] == [3.0, 4.0]
+    # The CLI value is passed as a raw string; coercion is the operation's job.
+    assert fake.calls == [
+        (
+            "node-set",
+            {
+                "path": "/tmp/proj/main.tscn",
+                "node": "Hero",
+                "property": "position",
+                "value": "3,4",
+            },
+        )
+    ]
+
+
 def test_node_add_defaults_parent_to_root_and_name_to_type(monkeypatch):
     # The two ergonomic defaults (issue #53): omitting --parent targets the
     # scene root ('.'), and omitting --name names the node after its type —

--- a/tests/test_node_errors.py
+++ b/tests/test_node_errors.py
@@ -183,3 +183,135 @@ def test_node_add_missing_scene_reuses_stable_path_not_found_code(monkeypatch):
     assert err["category"] == "operation"
     assert err["code"] == "path_not_found"
     assert "/x/main.tscn" in err["message"]
+
+
+def _invoke_node_get(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: node-get\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(
+        app, ["node", "get", "/x/main.tscn", "--node", "Bogus", "--json"]
+    )
+
+
+def _invoke_node_set(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: node-set\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(
+        app,
+        [
+            "node",
+            "set",
+            "/x/main.tscn",
+            "--node",
+            "Hero",
+            "--property",
+            "position",
+            "--value",
+            "3,4",
+            "--json",
+        ],
+    )
+
+
+def test_node_get_missing_node_maps_to_stable_node_not_found_code(monkeypatch):
+    # issue #55: a node path that resolves to nothing is node_not_found —
+    # distinct from the file-level path_not_found and from node add's
+    # parent_not_found, so an agent knows the node, not the file or parent, is
+    # the thing that's missing.
+    result = _invoke_node_get(
+        monkeypatch, "node_not_found", "node not found in scene: Bogus"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "node_not_found"
+    assert "Bogus" in err["message"]
+
+
+def test_node_set_missing_node_maps_to_stable_node_not_found_code(monkeypatch):
+    result = _invoke_node_set(
+        monkeypatch, "node_not_found", "node not found in scene: Hero"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "node_not_found"
+    assert "Hero" in err["message"]
+
+
+def test_node_set_unknown_property_maps_to_stable_unknown_property_code(monkeypatch):
+    # issue #55: setting a property the node does not declare is a clean
+    # unknown_property error, so an agent can branch on a typo'd or absent
+    # property name rather than parsing prose.
+    result = _invoke_node_set(
+        monkeypatch,
+        "unknown_property",
+        "node Hero has no settable property: positon",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "unknown_property"
+    assert "positon" in err["message"]
+
+
+def test_node_set_uncoercible_value_maps_to_stable_uncoercible_value_code(monkeypatch):
+    # issue #55's type-coercion contract: a value that cannot be coerced to the
+    # property's declared Godot type is a clean uncoercible_value error naming
+    # the value, the target type, and the property — never a silent wrong value.
+    result = _invoke_node_set(
+        monkeypatch,
+        "uncoercible_value",
+        'cannot coerce value "nope" to Vector2 for property position on node Hero',
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "uncoercible_value"
+    assert "Vector2" in err["message"]
+
+
+def test_node_set_missing_dependency_maps_to_stable_missing_dependency_code(monkeypatch):
+    # node set is a mutating op, so it honors the mutation-integrity boundary
+    # (issue #64) via the shared mutate-entry: a scene whose instance vanishes
+    # on load is refused with missing_dependency, the same as node add, leaving
+    # the file untouched rather than dropping the instance on re-save.
+    result = _invoke_node_set(
+        monkeypatch,
+        "missing_dependency",
+        "scene nodes vanished or degraded on load: ChildInstance (vanished) — "
+        "re-saving would silently drop or downgrade them",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "missing_dependency"
+    assert "ChildInstance" in err["message"]
+
+
+def test_node_get_missing_scene_reuses_stable_path_not_found_code(monkeypatch):
+    result = _invoke_node_get(
+        monkeypatch, "path_not_found", "scene file does not exist: /x/main.tscn"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "path_not_found"
+    assert "/x/main.tscn" in err["message"]

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -255,16 +255,61 @@ def test_node_list_schema_emits_model_derived_contract_without_other_args():
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
 
+def test_node_get_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for node get (issue #55): the bare --schema flag —
+    # no path, no --node — short-circuits into the self-description.
+    from gda.models import NodeGetParams, NodeGetResult
+
+    result = CliRunner().invoke(app, ["node", "get", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == NodeGetParams.model_json_schema()
+    assert doc["output"] == NodeGetResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    node_description = doc["input"]["properties"]["node"]["description"]
+    assert "scene root" in node_description
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_node_set_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for node set (issue #55): the value param documents
+    # the type-coercion contract agents must rely on.
+    from gda.models import NodeSetParams, NodeSetResult
+
+    result = CliRunner().invoke(app, ["node", "set", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == NodeSetParams.model_json_schema()
+    assert doc["output"] == NodeSetResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    value_description = doc["input"]["properties"]["value"]["description"]
+    assert "coerce" in value_description.lower()
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
 def test_sample_node_results_validate_against_emitted_output_schemas():
     # A sample --json payload of each node command satisfies the contract its
-    # --schema emits (the other half of the ADR-0004 hard gate, issue #53).
-    from tests.test_node_commands import ADD_RESULT, LIST_RESULT
+    # --schema emits (the other half of the ADR-0004 hard gate, issues #53/#55).
+    from tests.test_node_commands import (
+        ADD_RESULT,
+        GET_RESULT,
+        LIST_RESULT,
+        SET_RESULT,
+    )
 
     add_doc = json.loads(CliRunner().invoke(app, ["node", "add", "--schema"]).stdout)
     list_doc = json.loads(CliRunner().invoke(app, ["node", "list", "--schema"]).stdout)
+    get_doc = json.loads(CliRunner().invoke(app, ["node", "get", "--schema"]).stdout)
+    set_doc = json.loads(CliRunner().invoke(app, ["node", "set", "--schema"]).stdout)
 
     jsonschema.validate(instance=ADD_RESULT, schema=add_doc["output"])
     jsonschema.validate(instance=LIST_RESULT, schema=list_doc["output"])
+    jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
+    jsonschema.validate(instance=SET_RESULT, schema=set_doc["output"])
 
 
 def test_node_schema_spawns_no_godot(monkeypatch):
@@ -274,7 +319,7 @@ def test_node_schema_spawns_no_godot(monkeypatch):
     monkeypatch.setattr("gda.headless.resolve_godot_binary", boom)
     monkeypatch.setattr("gda.cli._make_runner", boom)
 
-    for command in (["node", "add"], ["node", "list"]):
+    for command in (["node", "add"], ["node", "list"], ["node", "get"], ["node", "set"]):
         result = CliRunner().invoke(app, [*command, "--schema"])
         assert result.exit_code == 0
         assert set(json.loads(result.stdout)) >= {"input", "output", "error"}


### PR DESCRIPTION
## Summary

Implements #55 — `gda node get` (read) and `gda node set` (write) for node property read/write within a scene file, built on the node-path addressing and load→mutate→save plumbing from #53.

- **`gda node get <scene> --node <path>`** — instantiates the scene, resolves the node by path, and reports its storage properties as typed JSON (`{name, type, value}` per property).
- **`gda node set <scene> --node <path> --property <p> --value <v>`** — coerces the CLI string value to the property's declared Godot type, sets it, packs and saves. Round-trips via `get`.

## Type coercion

CLI values arrive as strings and are coerced to the property's declared type. Covered: `bool` (case-insensitive `true`/`false`), `int`, `float`, `String`, `StringName`, `Vector2`/`Vector2i` (`x,y`), `Color` (`#rrggbb[aa]` or 3–4 floats in 0..1). JSON projection mirrors the input form (packed types flatten to arrays, e.g. `Vector2 → [x, y]`), so `get` output is exactly what `set` accepts. Uncoercible values fail cleanly with `uncoercible_value`. Rules documented in `docs/command-catalog.md` under "Property reporting and value coercion".

## Mutation integrity (carries over the #53 / PR #68 review note)

As the second mutating op, this slice extracts a shared mutate-entry helper `_load_for_mutation()` (load → instantiate → null-check → unmaterialized-node guard). `node add` now routes through it, and `node set` reuses it — so the #64 mutation-integrity boundary is guaranteed in one place. Duplicated SceneState path normalization is folded into `_normalize_state_path`, and parent resolution is generalized to `_resolve_node` (shared by add/get/set). `node get` is read-only: it instantiates but skips the re-save guard (nothing is saved), while still requiring the node to exist (`node_not_found` otherwise).

## Error codes (3 new, operation-sourced, exit 4)

`node_not_found`, `unknown_property`, `uncoercible_value` — mirrored across the Python registry, the ADR-0002 table, and the GDScript constants; the registry-drift test enforces the three-way sync.

## Tests

- S2 model/parser unit, S3 CLI-with-FakeRunner (success + failure modes + `--schema` hard gate), S1 e2e against real Godot.
- **200 passed** locally (129 non-e2e + 71 e2e on Godot 4.6.3), no skips. The #53 add/list e2e regression pins still pass, confirming the refactor is behavior-preserving.

## Acceptance criteria

- [x] `node get` returns a node's properties (by node path) as typed JSON.
- [x] `node set` coerces, packs, saves, and round-trips via `get`.
- [x] Type-coercion rules defined and documented; uncoercible value is a clean error.
- [x] Both ship `--json` and the ADR-0004 `--schema` hard gate via the shared skeleton.
- [x] Failure modes surface as registered `GdaError`s (registry + ADR-0002 table + GDScript mirror).
- [x] Tests: S2 unit, S3 CLI-with-FakeRunner, S1 e2e.

Closes #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
