### PR TITLE
docs: issue tracker is the backlog; catalog is a feature map

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,12 @@ for the full picture.
   from `--schema`.
 - 🔜 `gda-daemon` for *live operations* against a running engine (Phase 2).
 
-Per-command status (shipped / Phase-1 candidate / parked) is tracked in the
-[command catalog](docs/command-catalog.md) — the single source of truth this section deliberately
-does not duplicate. See also the [roadmap](#roadmap) and the
-[issue tracker](https://github.com/aigengame/godot-agent/issues).
+The active backlog and per-command status live in the
+[issue tracker](https://github.com/aigengame/godot-agent/issues) — the headless increment is
+grouped under the [**Phase 1 — headless operations** milestone](https://github.com/aigengame/godot-agent/milestone/1).
+The [command catalog](docs/command-catalog.md) maps the whole command surface (a non-binding
+*feature map*, not a status tracker); this section deliberately duplicates neither. See also the
+[roadmap](#roadmap).
 
 ---
 
@@ -218,9 +220,10 @@ gda <meta-command> [options]        # meta commands about gda/the engine, e.g. g
 | `set`                    | Mutate a property                                                |
 | domain verbs             | `play`, `run`, `export`, `import`, … kept with their natural meaning |
 
-> The surface grows one vertical slice at a time; `gda --help` lists what is installed, and
-> per-command status is tracked in the [command catalog](docs/command-catalog.md). The taxonomy
-> and naming rules are specified in [ADR-0005](docs/adr/0005-cli-command-taxonomy.md).
+> The surface grows one vertical slice at a time; `gda --help` lists what is installed, and the
+> active backlog / per-command status lives in the
+> [issue tracker](https://github.com/aigengame/godot-agent/issues) (the Phase 1 milestone). The
+> taxonomy and naming rules are specified in [ADR-0005](docs/adr/0005-cli-command-taxonomy.md).
 
 ### Global flags
 

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -1,10 +1,11 @@
 # gda command catalog
 
-A **non-binding roadmap** of the `gda` command surface (ADR-0005). This is a *map, not
-a commitment*: it shows the territory each command group will eventually cover so we
-can prioritise and so agents can see the shape of the whole — but a command becomes a
-commitment only when its slice is picked up as an issue. Commands are delivered one
-vertical slice at a time (ADR-0000); this file is refined as we go.
+A **non-binding roadmap** of the `gda` command surface (ADR-0005). This is a *feature
+map, not a task tracker*: it shows the territory each command group covers so we can
+prioritise and so agents can see the shape of the whole. **What is committed, in flight,
+or done lives in the issue tracker** — for the headless increment, the **Phase 1 —
+headless operations** milestone. Commands are delivered one vertical slice at a time
+(ADR-0000); this file is refined as we go.
 
 Seeded from the `godot-mcp-pro` taxonomy (the reference whose grouping ADR-0005
 adopts), re-expressed in `gda`'s grouped command form (`gda <group> <command>`) and
@@ -22,19 +23,22 @@ when they only touch a scene/resource *file*. `gda` classifies by CONTEXT.md ins
   in-place state (runtime scene tree, runtime properties, input simulation, play/stop,
   screenshots of a running game, editor diagnostics). Served by `gda-daemon`. **Parked.**
 
-Status legend: ✅ shipped · 🔜 Phase-1 candidate · ⏸ Phase-2 (parked). A trailing
-issue ref (e.g. `🔜 (#53)`) marks a candidate already committed as an open slice issue.
+This catalog does **not** carry a per-command status column — that would duplicate, and
+drift from, the issue tracker. For the live backlog (what is committed, in flight, and
+done) open the **Phase 1 — headless operations** milestone. Inline references to issues
+in the prose below (e.g. "established by #53") cite the slice that defined a behavior;
+they are provenance, not status markers.
 
 ---
 
 ## Meta commands (top-level, ungrouped — ADR-0005)
 
-| Command | Description | Phase | Status |
-| --- | --- | --- | --- |
-| `gda info` | Report Godot engine version info | 1 | ✅ |
-| `gda version` | Report `gda`'s own version | — (local) | 🔜 |
-| `gda help` | Usage help | — (local) | ✅ (`--help`) |
-| `gda <command> --schema` | Emit a command's input/output JSON Schema (ADR-0004) | — (local) | ✅ (`info` #4; `scene create`/`scene get` #18; `scene list`/`scene delete` #54; `node add`/`node list` #53; `node get`/`node set` #55) |
+| Command | Description | Phase |
+| --- | --- | --- |
+| `gda info` | Report Godot engine version info | 1 |
+| `gda version` | Report `gda`'s own version | — (local) |
+| `gda help` | Usage help | — (local) |
+| `gda <command> --schema` | Emit a command's input/output JSON Schema (ADR-0004) | — (local) |
 
 > `--schema` is a per-command flag, not a command, and ships with **every** domain
 > command as a hard gate (ADR-0004). It is local introspection — no Godot process.
@@ -45,13 +49,13 @@ issue ref (e.g. `🔜 (#53)`) marks a candidate already committed as an open sli
 
 ### `scene`
 
-| Command | Description | Status |
-| --- | --- | --- |
-| `gda scene create` | Create a new `.tscn` with a given root node type | ✅ (#18) |
-| `gda scene delete` | Delete a scene file | ✅ (#54) |
-| `gda scene get` | Read a scene's structured tree from its file on disk | ✅ (#18) |
-| `gda scene list` | Enumerate scenes in the project | ✅ (#54) |
-| `gda scene get-exports` | List `@export` properties declared by a scene's nodes | 🔜 (#58) |
+| Command | Description |
+| --- | --- |
+| `gda scene create` | Create a new `.tscn` with a given root node type |
+| `gda scene delete` | Delete a scene file |
+| `gda scene get` | Read a scene's structured tree from its file on disk |
+| `gda scene list` | Enumerate scenes in the project |
+| `gda scene get-exports` | List `@export` properties declared by a scene's nodes |
 
 ### `node`
 
@@ -117,74 +121,74 @@ Whitespace around a value or a component is tolerated. A property of any other t
 reported by `node get` (its value degrades to a string projection), but `node set` cannot coerce
 to it yet and refuses with `uncoercible_value` — the coercible set grows as later slices need it.
 
-| Command | Description | Status |
-| --- | --- | --- |
-| `gda node add` | Add a node (by type or `class_name` script) into a scene | ✅ (#53) |
-| `gda node remove` | Remove a node from a scene | 🔜 (#56) |
-| `gda node get` | Read a node's properties (typed JSON) | ✅ (#55) |
-| `gda node list` | List nodes in a scene (optionally filtered by type/group) | ✅ (#53) |
-| `gda node set` | Set a node property (type-coerced) | ✅ (#55) |
-| `gda node move` | Reparent a node | 🔜 (#56) |
-| `gda node duplicate` | Duplicate a node | 🔜 (#56) |
-| `gda node connect-signal` / `disconnect-signal` | Wire / unwire a signal to a method | 🔜 (#57) |
+| Command | Description |
+| --- | --- |
+| `gda node add` | Add a node (by type or `class_name` script) into a scene |
+| `gda node remove` | Remove a node from a scene |
+| `gda node get` | Read a node's properties (typed JSON) |
+| `gda node list` | List nodes in a scene (optionally filtered by type/group) |
+| `gda node set` | Set a node property (type-coerced) |
+| `gda node move` | Reparent a node |
+| `gda node duplicate` | Duplicate a node |
+| `gda node connect-signal` / `disconnect-signal` | Wire / unwire a signal to a method |
 
 ### `script`
 
-| Command | Description | Status |
-| --- | --- | --- |
-| `gda script create` | Create a `.gd`/`.cs` script (template or content) | 🔜 |
-| `gda script delete` | Delete a script file | 🔜 |
-| `gda script get` | Read script source | 🔜 |
-| `gda script list` | Enumerate scripts (with `class_name`/`extends` metadata) | 🔜 |
-| `gda script set` | Edit script (search-replace / line-range / full) | 🔜 |
-| `gda script attach` | Attach a script to a node in a scene | 🔜 |
-| `gda script validate` | Syntax/compile check | 🔜 |
+| Command | Description |
+| --- | --- |
+| `gda script create` | Create a `.gd`/`.cs` script (template or content) |
+| `gda script delete` | Delete a script file |
+| `gda script get` | Read script source |
+| `gda script list` | Enumerate scripts (with `class_name`/`extends` metadata) |
+| `gda script set` | Edit script (search-replace / line-range / full) |
+| `gda script attach` | Attach a script to a node in a scene |
+| `gda script validate` | Syntax/compile check |
 
 ### `project`
 
-| Command | Description | Status |
-| --- | --- | --- |
-| `gda project info` | Project metadata (name, viewport, Godot version) | 🔜 |
-| `gda project get` | Read a project setting by section/key | 🔜 |
-| `gda project set` | Modify a project setting (type-aware) | 🔜 |
-| `gda project add-autoload` / `remove-autoload` | Register / unregister an autoload singleton | 🔜 |
+| Command | Description |
+| --- | --- |
+| `gda project info` | Project metadata (name, viewport, Godot version) |
+| `gda project get` | Read a project setting by section/key |
+| `gda project set` | Modify a project setting (type-aware) |
+| `gda project add-autoload` / `remove-autoload` | Register / unregister an autoload singleton |
 
 ### `resource`
 
-| Command | Description | Status |
-| --- | --- | --- |
-| `gda resource create` | Create a `.tres` resource file | 🔜 |
-| `gda resource delete` | Delete a resource file | 🔜 |
-| `gda resource get` | Load and inspect a resource | 🔜 |
-| `gda resource set` | Edit a resource file | 🔜 |
-| `gda resource uid` | Resolve UID ↔ resource path (both directions) | 🔜 |
+| Command | Description |
+| --- | --- |
+| `gda resource create` | Create a `.tres` resource file |
+| `gda resource delete` | Delete a resource file |
+| `gda resource get` | Load and inspect a resource |
+| `gda resource set` | Edit a resource file |
+| `gda resource uid` | Resolve UID ↔ resource path (both directions) |
 
 ### `export`
 
-| Command | Description | Status |
-| --- | --- | --- |
-| `gda export list` | Enumerate export presets | 🔜 |
-| `gda export run` | Run an export preset via headless CLI | 🔜 |
-| `gda export get` | Export-template install status / preset info | 🔜 |
+| Command | Description |
+| --- | --- |
+| `gda export list` | Enumerate export presets |
+| `gda export run` | Run an export preset via headless CLI |
+| `gda export get` | Export-template install status / preset info |
 
 ### Asset-file groups (create/edit files; headless)
 
 These create or edit resource files (`.gdshader`, `.tres`) and so are headless.
 *Applying* them to a live node is Phase 2.
 
-| Command | Description | Status |
-| --- | --- | --- |
-| `gda shader create` / `get` / `set` | Create / read / edit a `.gdshader` file | 🔜 |
-| `gda theme create` | Create a `.tres` Theme resource | 🔜 |
+| Command | Description |
+| --- | --- |
+| `gda shader create` / `get` / `set` | Create / read / edit a `.gdshader` file |
+| `gda theme create` | Create a `.tres` Theme resource |
 
 ### Static analysis (read-only, headless)
 
-| Command | Description | Status |
-| --- | --- | --- |
-| `gda project find-unused-resources` | Find unreferenced resource files | 🔜 |
-| `gda project find-references` | Find references to a script/class | 🔜 |
-| `gda project dependencies` | Map scene → scene references | 🔜 |
-| `gda project statistics` | File/line counts, autoloads, plugins | 🔜 |
+| Command | Description |
+| --- | --- |
+| `gda project find-unused-resources` | Find unreferenced resource files |
+| `gda project find-references` | Find references to a script/class |
+| `gda project dependencies` | Map scene → scene references |
+| `gda project statistics` | File/line counts, autoloads, plugins |
 
 ---
 


### PR DESCRIPTION
## Summary

Reconciles the docs after a policy decision: **the issue tracker (the "Phase 1 — headless operations" milestone) is the authoritative backlog; the command catalog is a feature map, not a task tracker.**

Context: we created `ready-for-agent` slice issues (#110–#121) for the remaining Phase-1 domain commands from PRD #17 (script / project / resource / export / asset-file / static-analysis groups). With those committed to the tracker under the Phase 1 milestone, the catalog's per-command status column (`✅`/`🔜`) became a second, drift-prone source of truth — and finding "what's next" meant re-deriving it from catalog prose rather than a single milestone query.

## Changes

- **`docs/command-catalog.md`**: drop the per-command **Status** column from every group table and the `✅/🔜/⏸` status legend; reframe the intro as a *feature map, not a task tracker*; point readers at the **Phase 1 milestone** for the live backlog. Inline issue citations in the prose (e.g. "established by #53") are kept as design provenance, not status markers.
- **`README.md`**: the two pointers that named the catalog as the per-command status source now point at the issue tracker / Phase 1 milestone.

## Companion change (not in this PR)

PRD #17's body is updated separately (it's a GitHub issue, not a repo file) to reverse the old "the catalog is the authoritative backlog, promote one slice at a time" policy paragraphs to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
