### PR TITLE
feat(script): script create + script get — script-group tracer (#110)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -80,7 +80,7 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 | `save_failed` | `operation` | `operation` | A scene could not be packed or saved. |
 | `delete_failed` | `operation` | `operation` | A scene file could not be removed from disk. |
 | `project_not_found` | `operation` | `operation` | An operation that enumerates a project's `res://` tree ran without a resolved Godot project. |
-| `path_not_found` | `operation` | `operation` | A requested scene file does not exist. |
+| `path_not_found` | `operation` | `operation` | A requested file does not exist. |
 | `not_a_scene` | `operation` | `operation` | A requested file cannot be loaded as a `PackedScene`. |
 | `parent_not_found` | `operation` | `operation` | A requested parent node path does not resolve to a node in the scene. |
 | `invalid_node_type` | `operation` | `operation` | A requested node type is neither an instantiable `Node` class nor a registered `class_name`. |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -134,6 +134,34 @@ to it yet and refuses with `uncoercible_value` — the coercible set grows as la
 
 ### `script`
 
+Operates on **script files** (`.gd`/`.cs`) on disk — writing source text and reading it back —
+so headless: `script create` writes raw text, `script get` reads raw text. Neither ever
+`load()`s or compiles the script, so creating or reading a script never runs project code (the
+read trust boundary of #30): a script's text is data, not something to execute.
+
+**Script-file addressing** (established by #110): a script is addressed by its **file path** —
+a `res://` or filesystem path ending in `.gd` or `.cs` — exactly the way a scene is addressed
+by its `.tscn` path, *not* by its `class_name`. A `res://` path resolves against the project
+(`--project`); a filesystem path is used as given (`~` is expanded). A path whose extension is
+not `.gd`/`.cs` is refused with `invalid_path` rather than being treated as a script.
+
+**Create: template or content** (established by #110): `gda script create PATH` writes a
+minimal built-in template, `extends Node\n`; `--extends <Base>` parameterizes the template's
+base class (e.g. `--extends Node2D` → `extends Node2D\n`), mirroring `scene create --root-type`.
+`--content "<source>"` instead writes verbatim source and is **mutually exclusive** with
+`--extends` (verbatim content is not templated, so a base class would have nowhere to go;
+supplying both is a usage error). Create is **no-clobber**: an existing target is refused with
+`already_exists`, leaving the file untouched (mirrors `scene create`). Missing parent
+directories are created before the write (reported in `created_dirs`, outermost to innermost).
+
+**Class metadata** (established by #110): both `script create` and `script get` report the
+`class_name` and `extends` the source declares, as `{class_name, extends}` (each null when
+absent), parsed by lightweight line scanning of the **raw text** — never by compiling the
+script. For `.cs` scripts both are reported as **null**: C#'s class/base semantics differ from
+GDScript's leading `class_name`/`extends` declarations, so this tracer does not parse them and
+lets the source itself round-trip. `script get` additionally returns the full `source`, so a
+`create` is verifiable end-to-end: `create` then `get` returns the same source.
+
 | Command | Description |
 | --- | --- |
 | `gda script create` | Create a `.gd`/`.cs` script (template or content) |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -134,16 +134,22 @@ to it yet and refuses with `uncoercible_value` — the coercible set grows as la
 
 ### `script`
 
-Operates on **script files** (`.gd`/`.cs`) on disk — writing source text and reading it back —
+Operates on **GDScript files** (`.gd`) on disk — writing source text and reading it back —
 so headless: `script create` writes raw text, `script get` reads raw text. Neither ever
 `load()`s or compiles the script, so creating or reading a script never runs project code (the
 read trust boundary of #30): a script's text is data, not something to execute.
 
+> **C# (`.cs`) is out of scope for now.** It needs the .NET build of Godot, whereas ADR-0003
+> targets the **standard** build (4.4+ / 4.6 baseline), and supporting it is a decision in its
+> own right (class/base semantics differ from GDScript's leading `class_name`/`extends`). Until
+> a `.NET`-build target and a dedicated decision exist, the `script` group is GDScript-only — a
+> non-`.gd` path is refused as `invalid_path` rather than half-supported as opaque text.
+
 **Script-file addressing** (established by #110): a script is addressed by its **file path** —
-a `res://` or filesystem path ending in `.gd` or `.cs` — exactly the way a scene is addressed
-by its `.tscn` path, *not* by its `class_name`. A `res://` path resolves against the project
+a `res://` or filesystem path ending in `.gd` — exactly the way a scene is addressed by its
+`.tscn` path, *not* by its `class_name`. A `res://` path resolves against the project
 (`--project`); a filesystem path is used as given (`~` is expanded). A path whose extension is
-not `.gd`/`.cs` is refused with `invalid_path` rather than being treated as a script.
+not `.gd` is refused with `invalid_path` rather than being treated as a script.
 
 **Create: template or content** (established by #110): `gda script create PATH` writes a
 minimal built-in template, `extends Node\n`; `--extends <Base>` parameterizes the template's
@@ -153,21 +159,18 @@ base class (e.g. `--extends Node2D` → `extends Node2D\n`), mirroring `scene cr
 supplying both is a usage error). Create is **no-clobber**: an existing target is refused with
 `already_exists`, leaving the file untouched (mirrors `scene create`). Missing parent
 directories are created before the write (reported in `created_dirs`, outermost to innermost).
-The built-in template is GDScript (`extends`-based), so a `.cs` target requires `--content`:
-creating a `.cs` without it is a usage error rather than a GDScript template written into a C#
-file.
 
 **Class metadata** (established by #110): both `script create` and `script get` report the
 `class_name` and `extends` the source declares, as `{class_name, extends}` (each null when
 absent), parsed by lightweight line scanning of the **raw text** — never by compiling the
-script. For `.cs` scripts both are reported as **null**: C#'s class/base semantics differ from
-GDScript's leading `class_name`/`extends` declarations, so this tracer does not parse them and
-lets the source itself round-trip. `script get` additionally returns the full `source`, so a
-`create` is verifiable end-to-end: `create` then `get` returns the same source.
+script. The scan reads only the GDScript header (skipping leading `@tool`/`@icon(...)`
+annotations) and stops at the first real statement, so declaration-shaped text deeper in the
+body cannot be mistaken for the declaration. `script get` additionally returns the full
+`source`, so a `create` is verifiable end-to-end: `create` then `get` returns the same source.
 
 | Command | Description |
 | --- | --- |
-| `gda script create` | Create a `.gd`/`.cs` script (template or content) |
+| `gda script create` | Create a `.gd` script (template or content) |
 | `gda script delete` | Delete a script file |
 | `gda script get` | Read script source |
 | `gda script list` | Enumerate scripts (with `class_name`/`extends` metadata) |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -143,7 +143,8 @@ read trust boundary of #30): a script's text is data, not something to execute.
 > targets the **standard** build (4.4+ / 4.6 baseline), and supporting it is a decision in its
 > own right (class/base semantics differ from GDScript's leading `class_name`/`extends`). Until
 > a `.NET`-build target and a dedicated decision exist, the `script` group is GDScript-only — a
-> non-`.gd` path is refused as `invalid_path` rather than half-supported as opaque text.
+> non-`.gd` path is refused as `invalid_path` rather than half-supported as opaque text. The
+> deferral — whether/how to support the .NET build and C# — is tracked in #124.
 
 **Script-file addressing** (established by #110): a script is addressed by its **file path** —
 a `res://` or filesystem path ending in `.gd` — exactly the way a scene is addressed by its

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -153,6 +153,9 @@ base class (e.g. `--extends Node2D` → `extends Node2D\n`), mirroring `scene cr
 supplying both is a usage error). Create is **no-clobber**: an existing target is refused with
 `already_exists`, leaving the file untouched (mirrors `scene create`). Missing parent
 directories are created before the write (reported in `created_dirs`, outermost to innermost).
+The built-in template is GDScript (`extends`-based), so a `.cs` target requires `--content`:
+creating a `.cs` without it is a usage error rather than a GDScript template written into a C#
+file.
 
 **Class metadata** (established by #110): both `script create` and `script get` report the
 `class_name` and `extends` the source declares, as `{class_name, extends}` (each null when

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -43,6 +43,10 @@ from gda.models import (
     SceneListParams,
     SceneListResult,
     SceneNode,
+    ScriptCreateParams,
+    ScriptCreateResult,
+    ScriptGetParams,
+    ScriptGetResult,
 )
 from gda.project import resolve_project_dir
 from gda.runner import GodotRunner
@@ -64,6 +68,13 @@ node_app = typer.Typer(
     help="Act on nodes within a scene file (.tscn).", no_args_is_help=True
 )
 app.add_typer(node_app, name="node")
+
+# The script command group (issue #110): commands acting on .gd/.cs script
+# files on disk (write text / read text back), so they stay headless.
+script_app = typer.Typer(
+    help="Act on script files (.gd/.cs).", no_args_is_help=True
+)
+app.add_typer(script_app, name="script")
 
 
 def _version_callback(value: Optional[bool]) -> None:
@@ -149,6 +160,18 @@ NODE_SET_COMMAND: HeadlessCommand[NodeSetResult] = HeadlessCommand(
     operation="node-set",
     input_model=NodeSetParams,
     output_model=NodeSetResult,
+)
+
+SCRIPT_CREATE_COMMAND: HeadlessCommand[ScriptCreateResult] = HeadlessCommand(
+    operation="script-create",
+    input_model=ScriptCreateParams,
+    output_model=ScriptCreateResult,
+)
+
+SCRIPT_GET_COMMAND: HeadlessCommand[ScriptGetResult] = HeadlessCommand(
+    operation="script-get",
+    input_model=ScriptGetParams,
+    output_model=ScriptGetResult,
 )
 
 
@@ -432,6 +455,80 @@ def set_property(
         render_text=lambda was_set: (
             f"set {was_set.path}.{was_set.property} ({was_set.type}) = "
             f"{json.dumps(was_set.value)}"
+        ),
+        make_runner=_make_runner,
+    )
+
+
+def _render_script_metadata(script: "ScriptCreateResult | ScriptGetResult") -> str:
+    """Render a script's path plus its class_name/extends for humans."""
+    meta = []
+    if script.extends is not None:
+        meta.append(f"extends {script.extends}")
+    if script.class_name is not None:
+        meta.append(f"class_name {script.class_name}")
+    if not meta:
+        return script.path
+    return f"{script.path} ({', '.join(meta)})"
+
+
+@script_app.command(cls=SCRIPT_CREATE_COMMAND.command_class())
+def create(  # noqa: F811 — same command name in a different Typer group
+    path: str = typer.Argument(..., help="Target .gd/.cs script path to write."),
+    content: Optional[str] = typer.Option(
+        None,
+        "--content",
+        help=(
+            "Verbatim script source to write. Mutually exclusive with --extends; "
+            "when omitted, a minimal template extending --extends is written."
+        ),
+    ),
+    extends_type: Optional[str] = typer.Option(
+        None,
+        "--extends",
+        help=(
+            "Base class for the built-in template's 'extends' line (e.g. Node, "
+            "Node2D). Defaults to Node. Ignored — and rejected — with --content."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = SCRIPT_CREATE_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Create a new .gd/.cs script from a template or verbatim --content."""
+    if content is not None and extends_type is not None:
+        raise typer.BadParameter("--content and --extends are mutually exclusive.")
+    SCRIPT_CREATE_COMMAND.emit(
+        ScriptCreateParams(
+            path=_normalize_path(path),
+            content=content,
+            extends_type=extends_type,
+        ),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=lambda created: f"created {_render_script_metadata(created)}",
+        make_runner=_make_runner,
+    )
+
+
+@script_app.command(name="get", cls=SCRIPT_GET_COMMAND.command_class())
+def get_script(
+    path: str = typer.Argument(..., help="The .gd/.cs script file to read."),
+    json_output: bool = json_option(),
+    schema: bool = SCRIPT_GET_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Read a script's source and report its class_name/extends metadata."""
+    SCRIPT_GET_COMMAND.emit(
+        ScriptGetParams(path=_normalize_path(path)),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=lambda got: "\n".join(
+            [_render_script_metadata(got), got.source]
         ),
         make_runner=_make_runner,
     )

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -473,7 +473,7 @@ def _render_script_metadata(script: "ScriptCreateResult | ScriptGetResult") -> s
 
 
 @script_app.command(cls=SCRIPT_CREATE_COMMAND.command_class())
-def create(  # noqa: F811 — same command name in a different Typer group
+def create(
     path: str = typer.Argument(..., help="Target .gd/.cs script path to write."),
     content: Optional[str] = typer.Option(
         None,
@@ -499,9 +499,17 @@ def create(  # noqa: F811 — same command name in a different Typer group
     """Create a new .gd/.cs script from a template or verbatim --content."""
     if content is not None and extends_type is not None:
         raise typer.BadParameter("--content and --extends are mutually exclusive.")
+    normalized_path = _normalize_path(path)
+    # The built-in template is GDScript (`extends`-based); it is meaningless as
+    # C#, so a .cs target must supply its source verbatim via --content rather
+    # than get a GDScript-shaped template written into a .cs file.
+    if content is None and normalized_path.lower().endswith(".cs"):
+        raise typer.BadParameter(
+            "a .cs script needs --content; the built-in template is GDScript-only."
+        )
     SCRIPT_CREATE_COMMAND.emit(
         ScriptCreateParams(
-            path=_normalize_path(path),
+            path=normalized_path,
             content=content,
             extends_type=extends_type,
         ),

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -69,10 +69,12 @@ node_app = typer.Typer(
 )
 app.add_typer(node_app, name="node")
 
-# The script command group (issue #110): commands acting on .gd/.cs script
-# files on disk (write text / read text back), so they stay headless.
+# The script command group (issue #110): commands acting on .gd script files on
+# disk (write text / read text back), so they stay headless. C# (.cs) is out of
+# scope for now — it needs the .NET build of Godot (ADR-0003 targets the standard
+# build) and a dedicated decision.
 script_app = typer.Typer(
-    help="Act on script files (.gd/.cs).", no_args_is_help=True
+    help="Act on script files (.gd).", no_args_is_help=True
 )
 app.add_typer(script_app, name="script")
 
@@ -474,7 +476,7 @@ def _render_script_metadata(script: "ScriptCreateResult | ScriptGetResult") -> s
 
 @script_app.command(cls=SCRIPT_CREATE_COMMAND.command_class())
 def create(
-    path: str = typer.Argument(..., help="Target .gd/.cs script path to write."),
+    path: str = typer.Argument(..., help="Target .gd script path to write."),
     content: Optional[str] = typer.Option(
         None,
         "--content",
@@ -496,20 +498,12 @@ def create(
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Create a new .gd/.cs script from a template or verbatim --content."""
+    """Create a new .gd script from a template or verbatim --content."""
     if content is not None and extends_type is not None:
         raise typer.BadParameter("--content and --extends are mutually exclusive.")
-    normalized_path = _normalize_path(path)
-    # The built-in template is GDScript (`extends`-based); it is meaningless as
-    # C#, so a .cs target must supply its source verbatim via --content rather
-    # than get a GDScript-shaped template written into a .cs file.
-    if content is None and normalized_path.lower().endswith(".cs"):
-        raise typer.BadParameter(
-            "a .cs script needs --content; the built-in template is GDScript-only."
-        )
     SCRIPT_CREATE_COMMAND.emit(
         ScriptCreateParams(
-            path=normalized_path,
+            path=_normalize_path(path),
             content=content,
             extends_type=extends_type,
         ),
@@ -523,7 +517,7 @@ def create(
 
 @script_app.command(name="get", cls=SCRIPT_GET_COMMAND.command_class())
 def get_script(
-    path: str = typer.Argument(..., help="The .gd/.cs script file to read."),
+    path: str = typer.Argument(..., help="The .gd script file to read."),
     json_output: bool = json_option(),
     schema: bool = SCRIPT_GET_COMMAND.schema_option(),
     godot: Optional[str] = godot_option(),

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -127,7 +127,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "path_not_found",
         ErrorCategory.OPERATION,
         ErrorCodeSource.OPERATION,
-        "A requested scene file does not exist.",
+        "A requested file does not exist.",
     ),
     ErrorCodeSpec(
         "not_a_scene",

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -444,6 +444,108 @@ class NodeSetResult(BaseModel):
     )
 
 
+class ScriptCreateParams(BaseModel):
+    """The operation params of ``gda script create`` (issue #110).
+
+    ``path`` is the target ``.gd``/``.cs`` script file, addressed by its
+    ``res://`` or filesystem path (script-file addressing — by file path, not by
+    ``class_name``). ``content`` supplies verbatim source; when omitted, the
+    operation writes a minimal built-in template extending ``extends_type``.
+    ``content`` and ``extends_type`` are mutually exclusive at the CLI: verbatim
+    content is not templated, so a base class would have nowhere to go.
+    """
+
+    path: str
+    content: str | None = Field(
+        default=None,
+        description=(
+            "Verbatim script source to write. When omitted, a minimal built-in "
+            "template extending 'extends_type' is written instead. Mutually "
+            "exclusive with the template's base class."
+        ),
+    )
+    extends_type: str | None = Field(
+        default=None,
+        description=(
+            "Base class for the built-in template's 'extends' line (e.g. Node, "
+            "Node2D). Ignored when 'content' is supplied; defaults to 'Node' "
+            "when neither is given. Only meaningful for .gd scripts."
+        ),
+    )
+
+
+class ScriptCreateResult(BaseModel):
+    """The result of ``gda script create``: what was written where (issue #110).
+
+    Echoes the saved ``path`` and the ``class_name``/``extends`` the written
+    source declares, so an agent can assert the effect without a second call.
+    ``created_dirs`` lists parent directories the operation created before
+    saving, from outermost to innermost. For a ``.gd`` script the metadata is
+    parsed from the written source; for ``.cs`` both are null (C# class/base
+    semantics differ — the source still round-trips).
+    """
+
+    path: str
+    class_name: str | None = Field(
+        default=None,
+        description=(
+            "The class_name the written script declares, or null when it "
+            "declares none (always null for .cs)."
+        ),
+    )
+    extends: str | None = Field(
+        default=None,
+        description=(
+            "The base class the written script extends, or null when it "
+            "declares none (always null for .cs)."
+        ),
+    )
+    created_dirs: list[str] = Field(
+        description=(
+            "Parent directories created before saving, from outermost to innermost."
+        )
+    )
+
+
+class ScriptGetParams(BaseModel):
+    """The operation params of ``gda script get``: the script file to read (issue #110).
+
+    ``path`` addresses the ``.gd``/``.cs`` script by its ``res://`` or
+    filesystem path. The source is read as raw text — the script is never
+    loaded or compiled, so reading it can never run project code (issue #30).
+    """
+
+    path: str
+
+
+class ScriptGetResult(BaseModel):
+    """The result of ``gda script get``: a script's source and metadata (issue #110).
+
+    Echoes the ``path``, the full ``source`` read as raw text, and the
+    ``class_name``/``extends`` the source declares (parsed from the text for
+    ``.gd``; both null for ``.cs``). Carrying the source verbatim makes a
+    ``create`` verifiable end-to-end: ``create`` then ``get`` returns the same
+    source.
+    """
+
+    path: str
+    source: str
+    class_name: str | None = Field(
+        default=None,
+        description=(
+            "The class_name the script declares, or null when it declares none "
+            "(always null for .cs)."
+        ),
+    )
+    extends: str | None = Field(
+        default=None,
+        description=(
+            "The base class the script extends, or null when it declares none "
+            "(always null for .cs)."
+        ),
+    )
+
+
 class EngineVersion(BaseModel):
     """The Godot engine version, as reported by ``Engine.get_version_info()``.
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -447,8 +447,8 @@ class NodeSetResult(BaseModel):
 class ScriptCreateParams(BaseModel):
     """The operation params of ``gda script create`` (issue #110).
 
-    ``path`` is the target ``.gd``/``.cs`` script file, addressed by its
-    ``res://`` or filesystem path (script-file addressing — by file path, not by
+    ``path`` is the target ``.gd`` script file, addressed by its ``res://`` or
+    filesystem path (script-file addressing — by file path, not by
     ``class_name``). ``content`` supplies verbatim source; when omitted, the
     operation writes a minimal built-in template extending ``extends_type``.
     ``content`` and ``extends_type`` are mutually exclusive at the CLI: verbatim
@@ -469,7 +469,7 @@ class ScriptCreateParams(BaseModel):
         description=(
             "Base class for the built-in template's 'extends' line (e.g. Node, "
             "Node2D). Ignored when 'content' is supplied; defaults to 'Node' "
-            "when neither is given. Only meaningful for .gd scripts."
+            "when neither is given."
         ),
     )
 
@@ -480,9 +480,8 @@ class ScriptCreateResult(BaseModel):
     Echoes the saved ``path`` and the ``class_name``/``extends`` the written
     source declares, so an agent can assert the effect without a second call.
     ``created_dirs`` lists parent directories the operation created before
-    saving, from outermost to innermost. For a ``.gd`` script the metadata is
-    parsed from the written source; for ``.cs`` both are null (C# class/base
-    semantics differ — the source still round-trips).
+    saving, from outermost to innermost. The ``class_name``/``extends`` are
+    parsed from the written source.
     """
 
     path: str
@@ -490,14 +489,14 @@ class ScriptCreateResult(BaseModel):
         default=None,
         description=(
             "The class_name the written script declares, or null when it "
-            "declares none (always null for .cs)."
+            "declares none."
         ),
     )
     extends: str | None = Field(
         default=None,
         description=(
             "The base class the written script extends, or null when it "
-            "declares none (always null for .cs)."
+            "declares none."
         ),
     )
     created_dirs: list[str] = Field(
@@ -510,9 +509,9 @@ class ScriptCreateResult(BaseModel):
 class ScriptGetParams(BaseModel):
     """The operation params of ``gda script get``: the script file to read (issue #110).
 
-    ``path`` addresses the ``.gd``/``.cs`` script by its ``res://`` or
-    filesystem path. The source is read as raw text — the script is never
-    loaded or compiled, so reading it can never run project code (issue #30).
+    ``path`` addresses the ``.gd`` script by its ``res://`` or filesystem path.
+    The source is read as raw text — the script is never loaded or compiled, so
+    reading it can never run project code (issue #30).
     """
 
     path: str
@@ -522,10 +521,9 @@ class ScriptGetResult(BaseModel):
     """The result of ``gda script get``: a script's source and metadata (issue #110).
 
     Echoes the ``path``, the full ``source`` read as raw text, and the
-    ``class_name``/``extends`` the source declares (parsed from the text for
-    ``.gd``; both null for ``.cs``). Carrying the source verbatim makes a
-    ``create`` verifiable end-to-end: ``create`` then ``get`` returns the same
-    source.
+    ``class_name``/``extends`` the source declares (parsed from the text).
+    Carrying the source verbatim makes a ``create`` verifiable end-to-end:
+    ``create`` then ``get`` returns the same source.
     """
 
     path: str
@@ -533,15 +531,13 @@ class ScriptGetResult(BaseModel):
     class_name: str | None = Field(
         default=None,
         description=(
-            "The class_name the script declares, or null when it declares none "
-            "(always null for .cs)."
+            "The class_name the script declares, or null when it declares none."
         ),
     )
     extends: str | None = Field(
         default=None,
         description=(
-            "The base class the script extends, or null when it declares none "
-            "(always null for .cs)."
+            "The base class the script extends, or null when it declares none."
         ),
     )
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -161,7 +161,7 @@ func _op_scene_create(params: Dictionary) -> void:
 	var save_err := ResourceSaver.save(packed, path)
 	root.free()
 	if save_err != OK:
-		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message(path, save_err))
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message("scene", path, save_err))
 		return
 
 	_succeed({
@@ -311,7 +311,7 @@ func _op_node_add(params: Dictionary) -> void:
 	var save_err := ResourceSaver.save(repacked, path)
 	root.free()
 	if save_err != OK:
-		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message(path, save_err))
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message("scene", path, save_err))
 		return
 
 	_succeed({
@@ -442,7 +442,7 @@ func _op_node_set(params: Dictionary) -> void:
 	var stored_value: Variant = _jsonify(node.get(prop_name))
 	root.free()
 	if save_err != OK:
-		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message(path, save_err))
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message("scene", path, save_err))
 		return
 
 	_succeed({
@@ -493,10 +493,18 @@ func _op_script_create(params: Dictionary) -> void:
 		return  # _ensure_parent_dirs already recorded the failure
 	var file := FileAccess.open(path, FileAccess.WRITE)
 	if file == null:
-		_fail(OP_ERROR_SAVE_FAILED, _script_save_failure_message(path, FileAccess.get_open_error()))
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message("script", path, FileAccess.get_open_error()))
 		return
 	file.store_string(source)
+	# A successful open does not guarantee a successful write: a disk-full or I/O
+	# error surfaces here, not at open. Capture it before close() invalidates the
+	# handle, so a failed write is reported as save_failed rather than a phantom
+	# success over a partial or empty file (mirrors scene-create checking save).
+	var write_err := file.get_error()
 	file.close()
+	if write_err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message("script", path, write_err))
+		return
 
 	var meta := _script_metadata(source)
 	_succeed({
@@ -588,29 +596,26 @@ func _script_metadata(source: String) -> Dictionary:
 	return {"class_name": class_name_value, "extends": extends_value}
 
 
-# The first whitespace-delimited token of a declaration's remainder — the
-# class_name or base-class identifier — with a trailing inline comment dropped.
-# e.g. "Hero # the hero" → "Hero", "Node2D" → "Node2D".
+# The first token of a declaration's remainder — the class_name or base-class
+# identifier. A bare identifier drops a trailing inline comment and stops at the
+# first whitespace: "Hero # the hero" → "Hero", "Node2D" → "Node2D". The quoted
+# base-class-by-path form (extends "res://Base.gd") is kept whole up to its
+# closing quote — including any '#' inside the path, which is part of the string,
+# not an inline comment.
 func _first_token(rest: String) -> Variant:
 	var trimmed := rest.strip_edges()
 	if trimmed.is_empty():
 		return null
+	if trimmed.begins_with("\"") or trimmed.begins_with("'"):
+		var quote := trimmed[0]
+		var close := trimmed.find(quote, 1)
+		# An unterminated quote is reported as-is rather than silently truncated.
+		return trimmed.substr(0, close + 1) if close != -1 else trimmed
 	var comment := trimmed.find("#")
 	if comment != -1:
 		trimmed = trimmed.substr(0, comment).strip_edges()
 	var token := trimmed.split(" ", false)[0]
 	return token if not token.is_empty() else null
-
-
-# A save-failure message for a raw-text script write, mirroring the scene
-# variant's write-probe diagnostic so an unwritable target reports why.
-func _script_save_failure_message(path: String, open_err: Error) -> String:
-	var parent := path.get_base_dir()
-	var message := "failed to save script to " + path
-	if not parent.is_empty():
-		message += " in parent directory " + parent
-	message += ": " + error_string(open_err)
-	return message
 
 
 # Whether this headless process is running against a Godot project. A project
@@ -1100,9 +1105,13 @@ func _ensure_parent_dirs(path: String) -> Variant:
 	return missing
 
 
-func _save_failure_message(path: String, save_err: Error) -> String:
+# Build a save-failure diagnostic for a `noun` (scene / script) written to
+# `path`: the error, the parent directory, and a write-probe that names why the
+# directory is unwritable when that is the cause. Shared by every save path so
+# the diagnostic (and the probe) stays identical across groups.
+func _save_failure_message(noun: String, path: String, save_err: Error) -> String:
 	var parent := path.get_base_dir()
-	var message := "failed to save scene to " + path
+	var message := "failed to save " + noun + " to " + path
 	if not parent.is_empty():
 		message += " in parent directory " + parent
 	message += ": " + error_string(save_err)

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -454,10 +454,10 @@ func _op_node_set(params: Dictionary) -> void:
 	})
 
 
-# script-create: write a new .gd/.cs script at the requested path — from
-# verbatim content or a minimal built-in template — and report the saved path
-# plus the class_name/extends the written source declares (issue #110). The
-# script group addresses scripts by FILE PATH, not by class_name.
+# script-create: write a new .gd script at the requested path — from verbatim
+# content or a minimal built-in template — and report the saved path plus the
+# class_name/extends the written source declares (issue #110). The script group
+# addresses scripts by FILE PATH, not by class_name.
 #
 # This writes raw text (FileAccess), never compiling or loading the script:
 # creating a script must not run project code, the same trust boundary the read
@@ -470,15 +470,14 @@ func _op_script_create(params: Dictionary) -> void:
 		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
 		return
 	if not _is_script_path(path):
-		_fail(OP_ERROR_INVALID_PATH, "script path must end in .gd or .cs: " + path)
+		_fail(OP_ERROR_INVALID_PATH, "script path must end in .gd: " + path)
 		return
 	if FileAccess.file_exists(path) or DirAccess.dir_exists_absolute(path):
 		_fail(OP_ERROR_ALREADY_EXISTS, "script target already exists: " + path)
 		return
 
 	# Verbatim content wins; otherwise write a minimal template extending the
-	# requested base class (defaulting to Node). The template is GDScript-shaped;
-	# for a .cs target an explicit --content is the way to supply real C# source.
+	# requested base class (defaulting to Node).
 	var source: String
 	var content: Variant = params.get("content", null)
 	if content is String:
@@ -499,7 +498,7 @@ func _op_script_create(params: Dictionary) -> void:
 	file.store_string(source)
 	file.close()
 
-	var meta := _script_metadata(path, source)
+	var meta := _script_metadata(source)
 	_succeed({
 		"path": path,
 		"class_name": meta["class_name"],
@@ -515,7 +514,7 @@ func _op_script_create(params: Dictionary) -> void:
 # Reads via FileAccess.get_file_as_string (which resolves res:// against the
 # project) and parses the metadata from the text — it never load()s/compiles the
 # script, so reading a script can never run or even parse-execute project code
-# (issue #30). The metadata is parsed only for .gd; .cs returns nulls.
+# (issue #30).
 func _op_script_get(params: Dictionary) -> void:
 	_diag("running operation: script-get")
 	var path := _string_param(params, "path")
@@ -523,7 +522,7 @@ func _op_script_get(params: Dictionary) -> void:
 		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
 		return
 	if not _is_script_path(path):
-		_fail(OP_ERROR_INVALID_PATH, "script path must end in .gd or .cs: " + path)
+		_fail(OP_ERROR_INVALID_PATH, "script path must end in .gd: " + path)
 		return
 	if not FileAccess.file_exists(path):
 		_fail(OP_ERROR_PATH_NOT_FOUND, "script file does not exist: " + path)
@@ -540,7 +539,7 @@ func _op_script_get(params: Dictionary) -> void:
 					+ ": " + error_string(open_err))
 			return
 
-	var meta := _script_metadata(path, source)
+	var meta := _script_metadata(source)
 	_succeed({
 		"path": path,
 		"source": source,
@@ -550,21 +549,18 @@ func _op_script_get(params: Dictionary) -> void:
 
 
 # Whether a path names a script file the script group operates on: a .gd
-# (GDScript) or .cs (C#) file. Script-file addressing is by extension, the same
-# way scene addressing keys on .tscn.
+# (GDScript) file. Script-file addressing is by extension, the same way scene
+# addressing keys on .tscn. C# (.cs) is out of scope for now — it needs the .NET
+# build of Godot (ADR-0003 targets the standard build) and a dedicated decision.
 func _is_script_path(path: String) -> bool:
-	var ext := path.get_extension().to_lower()
-	return ext == "gd" or ext == "cs"
+	return path.get_extension().to_lower() == "gd"
 
 
-# Extract a .gd script's declared class_name and extends from its raw source by
+# Extract a GDScript's declared class_name and extends from its raw source by
 # lightweight line-by-line parsing — never compiling the script (issue #30).
-# Both are null when absent. For a .cs script both are null: C# class/base
-# semantics differ from GDScript's leading declarations, so this tracer reports
-# nulls for .cs and lets the source itself round-trip (issue #110).
-func _script_metadata(path: String, source: String) -> Dictionary:
-	if path.get_extension().to_lower() != "gd":
-		return {"class_name": null, "extends": null}
+# Both are null when absent. Only .gd scripts reach here (the entry points reject
+# any other extension as invalid_path), so this keys off GDScript syntax alone.
+func _script_metadata(source: String) -> Dictionary:
 	var class_name_value: Variant = null
 	var extends_value: Variant = null
 	# class_name and extends, when present, lead a GDScript file: they sit in the

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -86,6 +86,10 @@ func _initialize() -> void:
 			_op_node_get(params)
 		"node-set":
 			_op_node_set(params)
+		"script-create":
+			_op_script_create(params)
+		"script-get":
+			_op_script_get(params)
 		_:
 			_fail(OP_ERROR_UNKNOWN_OPERATION, "unknown operation: " + operation)
 
@@ -448,6 +452,160 @@ func _op_node_set(params: Dictionary) -> void:
 		"type": _type_name(declared_type),
 		"value": stored_value,
 	})
+
+
+# script-create: write a new .gd/.cs script at the requested path — from
+# verbatim content or a minimal built-in template — and report the saved path
+# plus the class_name/extends the written source declares (issue #110). The
+# script group addresses scripts by FILE PATH, not by class_name.
+#
+# This writes raw text (FileAccess), never compiling or loading the script:
+# creating a script must not run project code, the same trust boundary the read
+# ops honor (issue #30). No-clobber: an existing target is refused with
+# already_exists, leaving it untouched (mirrors scene-create).
+func _op_script_create(params: Dictionary) -> void:
+	_diag("running operation: script-create")
+	var path := _string_param(params, "path")
+	if path.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
+		return
+	if not _is_script_path(path):
+		_fail(OP_ERROR_INVALID_PATH, "script path must end in .gd or .cs: " + path)
+		return
+	if FileAccess.file_exists(path) or DirAccess.dir_exists_absolute(path):
+		_fail(OP_ERROR_ALREADY_EXISTS, "script target already exists: " + path)
+		return
+
+	# Verbatim content wins; otherwise write a minimal template extending the
+	# requested base class (defaulting to Node). The template is GDScript-shaped;
+	# for a .cs target an explicit --content is the way to supply real C# source.
+	var source: String
+	var content: Variant = params.get("content", null)
+	if content is String:
+		source = content
+	else:
+		var base := _string_param(params, "extends_type")
+		if base.is_empty():
+			base = "Node"
+		source = "extends " + base + "\n"
+
+	var created_dirs: Variant = _ensure_parent_dirs(path)
+	if created_dirs == null:
+		return  # _ensure_parent_dirs already recorded the failure
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	if file == null:
+		_fail(OP_ERROR_SAVE_FAILED, _script_save_failure_message(path, FileAccess.get_open_error()))
+		return
+	file.store_string(source)
+	file.close()
+
+	var meta := _script_metadata(path, source)
+	_succeed({
+		"path": path,
+		"class_name": meta["class_name"],
+		"extends": meta["extends"],
+		"created_dirs": created_dirs,
+	})
+
+
+# script-get: read a script's source back as RAW TEXT and report it with the
+# class_name/extends the source declares — the read half of issue #110, which
+# makes a script-create verifiable end-to-end (create → get returns the source).
+#
+# Reads via FileAccess.get_file_as_string (which resolves res:// against the
+# project) and parses the metadata from the text — it never load()s/compiles the
+# script, so reading a script can never run or even parse-execute project code
+# (issue #30). The metadata is parsed only for .gd; .cs returns nulls.
+func _op_script_get(params: Dictionary) -> void:
+	_diag("running operation: script-get")
+	var path := _string_param(params, "path")
+	if path.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
+		return
+	if not _is_script_path(path):
+		_fail(OP_ERROR_INVALID_PATH, "script path must end in .gd or .cs: " + path)
+		return
+	if not FileAccess.file_exists(path):
+		_fail(OP_ERROR_PATH_NOT_FOUND, "script file does not exist: " + path)
+		return
+
+	var source := FileAccess.get_file_as_string(path)
+	# get_file_as_string returns "" both for an empty file and on an open error;
+	# disambiguate via the open-error code so an unreadable file is not reported
+	# as empty source. An empty .gd is legal and reads back as empty.
+	if source.is_empty():
+		var open_err := FileAccess.get_open_error()
+		if open_err != OK:
+			_fail(OP_ERROR_PATH_NOT_FOUND, "script file could not be read: " + path
+					+ ": " + error_string(open_err))
+			return
+
+	var meta := _script_metadata(path, source)
+	_succeed({
+		"path": path,
+		"source": source,
+		"class_name": meta["class_name"],
+		"extends": meta["extends"],
+	})
+
+
+# Whether a path names a script file the script group operates on: a .gd
+# (GDScript) or .cs (C#) file. Script-file addressing is by extension, the same
+# way scene addressing keys on .tscn.
+func _is_script_path(path: String) -> bool:
+	var ext := path.get_extension().to_lower()
+	return ext == "gd" or ext == "cs"
+
+
+# Extract a .gd script's declared class_name and extends from its raw source by
+# lightweight line-by-line parsing — never compiling the script (issue #30).
+# Both are null when absent. For a .cs script both are null: C# class/base
+# semantics differ from GDScript's leading declarations, so this tracer reports
+# nulls for .cs and lets the source itself round-trip (issue #110).
+func _script_metadata(path: String, source: String) -> Dictionary:
+	if path.get_extension().to_lower() != "gd":
+		return {"class_name": null, "extends": null}
+	var class_name_value: Variant = null
+	var extends_value: Variant = null
+	for raw_line in source.split("\n"):
+		var line := raw_line.strip_edges()
+		if line.is_empty() or line.begins_with("#"):
+			continue
+		if class_name_value == null and line.begins_with("class_name "):
+			class_name_value = _first_token(line.substr("class_name ".length()))
+		elif extends_value == null and line.begins_with("extends "):
+			extends_value = _first_token(line.substr("extends ".length()))
+		# Once a real statement past the declarations is reached, stop: class_name
+		# and extends, when present, lead a GDScript file. Keep scanning only while
+		# we still might find one of them.
+		if class_name_value != null and extends_value != null:
+			break
+	return {"class_name": class_name_value, "extends": extends_value}
+
+
+# The first whitespace-delimited token of a declaration's remainder — the
+# class_name or base-class identifier — with a trailing inline comment dropped.
+# e.g. "Hero # the hero" → "Hero", "Node2D" → "Node2D".
+func _first_token(rest: String) -> Variant:
+	var trimmed := rest.strip_edges()
+	if trimmed.is_empty():
+		return null
+	var comment := trimmed.find("#")
+	if comment != -1:
+		trimmed = trimmed.substr(0, comment).strip_edges()
+	var token := trimmed.split(" ", false)[0]
+	return token if not token.is_empty() else null
+
+
+# A save-failure message for a raw-text script write, mirroring the scene
+# variant's write-probe diagnostic so an unwritable target reports why.
+func _script_save_failure_message(path: String, open_err: Error) -> String:
+	var parent := path.get_base_dir()
+	var message := "failed to save script to " + path
+	if not parent.is_empty():
+		message += " in parent directory " + parent
+	message += ": " + error_string(open_err)
+	return message
 
 
 # Whether this headless process is running against a Godot project. A project

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -567,19 +567,28 @@ func _script_metadata(path: String, source: String) -> Dictionary:
 		return {"class_name": null, "extends": null}
 	var class_name_value: Variant = null
 	var extends_value: Variant = null
+	# class_name and extends, when present, lead a GDScript file: they sit in the
+	# header, after the optional annotation lines (@tool, @icon(...), …) and
+	# before the first real statement. Scan only that header — skip blanks,
+	# comments and annotations, capture the first of each declaration, and STOP at
+	# the first line that is neither. Stopping is what keeps a class_name/extends-
+	# shaped line deeper in the body (e.g. inside a multiline string) from ever
+	# being mistaken for the declaration.
 	for raw_line in source.split("\n"):
 		var line := raw_line.strip_edges()
-		if line.is_empty() or line.begins_with("#"):
+		if line.is_empty() or line.begins_with("#") or line.begins_with("@"):
 			continue
-		if class_name_value == null and line.begins_with("class_name "):
-			class_name_value = _first_token(line.substr("class_name ".length()))
-		elif extends_value == null and line.begins_with("extends "):
-			extends_value = _first_token(line.substr("extends ".length()))
-		# Once a real statement past the declarations is reached, stop: class_name
-		# and extends, when present, lead a GDScript file. Keep scanning only while
-		# we still might find one of them.
-		if class_name_value != null and extends_value != null:
-			break
+		if line.begins_with("class_name "):
+			if class_name_value == null:
+				class_name_value = _first_token(line.substr("class_name ".length()))
+			continue
+		if line.begins_with("extends "):
+			if extends_value == null:
+				extends_value = _first_token(line.substr("extends ".length()))
+			continue
+		# The first real statement past the header: no further class_name/extends
+		# declaration can legally appear, so stop scanning.
+		break
 	return {"class_name": class_name_value, "extends": extends_value}
 
 

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -1,6 +1,6 @@
 """S1 (e2e): the script create → get round-trip against the real Godot engine.
 
-The script-group tracer (issue #110): ``gda script create`` writes a .gd/.cs
+The script-group tracer (issue #110): ``gda script create`` writes a .gd
 script (from a template or verbatim --content), no-clobber; ``gda script get``
 reads its source back with class_name/extends metadata — ``script get`` IS the
 structured-level verification of ``script create``'s effect (create → get
@@ -157,14 +157,29 @@ def test_script_create_existing_path_yields_already_exists_without_overwriting(
 
 @pytest.mark.e2e
 def test_script_create_wrong_extension_yields_invalid_path(godot_project):
-    # A target that is not a .gd/.cs script is an invalid path param; nothing is
+    # A target that is not a .gd script is an invalid path param; nothing is
     # written.
     target = godot_project / "notes.txt"
 
     created = _gda("script", "create", str(target), "--json")
 
     err = _assert_operation_error(created, "invalid_path")
-    assert ".gd or .cs" in err["message"]
+    assert ".gd" in err["message"]
+    assert not target.exists()
+
+
+@pytest.mark.e2e
+def test_script_create_cs_extension_is_refused(godot_project):
+    # C# is out of scope for now (it needs the .NET build of Godot, ADR-0003
+    # targets the standard build): a .cs target is refused as invalid_path, the
+    # same as any non-.gd path, and nothing is written — never half-supported as
+    # opaque text.
+    target = godot_project / "Player.cs"
+
+    created = _gda("script", "create", str(target), "--json")
+
+    err = _assert_operation_error(created, "invalid_path")
+    assert ".gd" in err["message"]
     assert not target.exists()
 
 
@@ -186,36 +201,7 @@ def test_script_get_wrong_extension_yields_invalid_path(godot_project):
     got = _gda("script", "get", str(notes), "--json")
 
     err = _assert_operation_error(got, "invalid_path")
-    assert ".gd or .cs" in err["message"]
-
-
-@pytest.mark.e2e
-def test_script_create_cs_round_trips_source_with_null_metadata(godot_project):
-    # .cs handling (issue #110): a C# script created via --content round-trips
-    # its source verbatim, but class_name/extends are null — C# class/base
-    # semantics differ from GDScript's leading declarations, so this tracer
-    # reports nulls for .cs rather than mis-parsing it as GDScript.
-    script_path = godot_project / "Player.cs"
-    source = (
-        "using Godot;\n\npublic partial class Player : Node2D\n{\n}\n"
-    )
-
-    created = _gda(
-        "script", "create", str(script_path), "--content", source, "--json"
-    )
-
-    assert created.returncode == 0, created.stdout + created.stderr
-    create_data = json.loads(created.stdout)
-    assert create_data["class_name"] is None
-    assert create_data["extends"] is None
-
-    got = _gda("script", "get", str(script_path), "--json")
-
-    assert got.returncode == 0, got.stdout + got.stderr
-    got_data = json.loads(got.stdout)
-    assert got_data["source"] == source
-    assert got_data["class_name"] is None
-    assert got_data["extends"] is None
+    assert ".gd" in err["message"]
 
 
 @pytest.mark.e2e
@@ -324,16 +310,3 @@ def test_script_create_empty_content_round_trips_as_empty_source(godot_project):
     assert got_data["source"] == ""
     assert got_data["class_name"] is None
     assert got_data["extends"] is None
-
-
-@pytest.mark.e2e
-def test_script_create_cs_without_content_is_refused_without_writing(godot_project):
-    # The built-in template is GDScript; a .cs target without --content is a usage
-    # error (exit 2), and nothing is written — a GDScript template must never land
-    # in a .cs file.
-    script_path = godot_project / "Player.cs"
-
-    created = _gda("script", "create", str(script_path), "--json")
-
-    assert created.returncode == 2, created.stdout + created.stderr
-    assert not script_path.exists()

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -235,3 +235,105 @@ def test_script_create_then_get_preserves_a_path_containing_the_end_sentinel(
     got = _gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["source"] == "extends Node\n"
+
+
+@pytest.mark.e2e
+def test_script_get_parses_metadata_past_a_leading_annotation_header(godot_project):
+    # class_name/extends lead a GDScript file, but the optional annotation header
+    # (@tool, @icon(...)) comes first. The lightweight parser must skip those
+    # header lines and still report the real class_name/extends — not give up at
+    # the first @-line.
+    script_path = godot_project / "widget.gd"
+    source = (
+        "@tool\n"
+        '@icon("res://icon.svg")\n'
+        "class_name Widget\n"
+        "extends Control\n"
+        "\n"
+        "func _ready() -> void:\n"
+        "\tpass\n"
+    )
+
+    created = _gda("script", "create", str(script_path), "--content", source, "--json")
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    create_data = json.loads(created.stdout)
+    assert create_data["class_name"] == "Widget"
+    assert create_data["extends"] == "Control"
+
+    got = _gda("script", "get", str(script_path), "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    got_data = json.loads(got.stdout)
+    assert got_data["class_name"] == "Widget"
+    assert got_data["extends"] == "Control"
+
+
+@pytest.mark.e2e
+def test_script_get_does_not_mistake_declaration_shaped_body_text_for_metadata(
+    godot_project,
+):
+    # The parser scans only the header and stops at the first real statement, so
+    # a `class_name`/`extends`-shaped line deeper in the body (here inside a
+    # multiline string) is never mistaken for the declaration: the real extends
+    # is reported, and class_name stays null.
+    script_path = godot_project / "doc.gd"
+    source = (
+        "extends Node\n"
+        "\n"
+        'var doc := """\n'
+        "class_name Injected\n"
+        "extends Injected\n"
+        '"""\n'
+    )
+
+    created = _gda("script", "create", str(script_path), "--content", source, "--json")
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    create_data = json.loads(created.stdout)
+    assert create_data["extends"] == "Node"
+    assert create_data["class_name"] is None
+
+    got = _gda("script", "get", str(script_path), "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    got_data = json.loads(got.stdout)
+    assert got_data["source"] == source
+    assert got_data["extends"] == "Node"
+    assert got_data["class_name"] is None
+
+
+@pytest.mark.e2e
+def test_script_create_empty_content_round_trips_as_empty_source(godot_project):
+    # An empty file is legal source: --content "" writes an empty script, and get
+    # reads it back as empty (the get_file_as_string empty-vs-error disambiguation
+    # treats a readable empty file as empty source, not a read failure), with null
+    # metadata.
+    script_path = godot_project / "empty.gd"
+
+    created = _gda("script", "create", str(script_path), "--content", "", "--json")
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    create_data = json.loads(created.stdout)
+    assert create_data["class_name"] is None
+    assert create_data["extends"] is None
+    assert script_path.read_text(encoding="utf-8") == ""
+
+    got = _gda("script", "get", str(script_path), "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    got_data = json.loads(got.stdout)
+    assert got_data["source"] == ""
+    assert got_data["class_name"] is None
+    assert got_data["extends"] is None
+
+
+@pytest.mark.e2e
+def test_script_create_cs_without_content_is_refused_without_writing(godot_project):
+    # The built-in template is GDScript; a .cs target without --content is a usage
+    # error (exit 2), and nothing is written — a GDScript template must never land
+    # in a .cs file.
+    script_path = godot_project / "Player.cs"
+
+    created = _gda("script", "create", str(script_path), "--json")
+
+    assert created.returncode == 2, created.stdout + created.stderr
+    assert not script_path.exists()

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -165,6 +165,7 @@ def test_script_create_wrong_extension_yields_invalid_path(godot_project):
 
     err = _assert_operation_error(created, "invalid_path")
     assert ".gd" in err["message"]
+    assert str(target) in err["message"]
     assert not target.exists()
 
 
@@ -180,6 +181,7 @@ def test_script_create_cs_extension_is_refused(godot_project):
 
     err = _assert_operation_error(created, "invalid_path")
     assert ".gd" in err["message"]
+    assert str(target) in err["message"]
     assert not target.exists()
 
 
@@ -202,6 +204,7 @@ def test_script_get_wrong_extension_yields_invalid_path(godot_project):
 
     err = _assert_operation_error(got, "invalid_path")
     assert ".gd" in err["message"]
+    assert str(notes) in err["message"]
 
 
 @pytest.mark.e2e
@@ -285,6 +288,25 @@ def test_script_get_does_not_mistake_declaration_shaped_body_text_for_metadata(
     assert got_data["source"] == source
     assert got_data["extends"] == "Node"
     assert got_data["class_name"] is None
+
+
+@pytest.mark.e2e
+def test_script_get_keeps_a_quoted_base_class_path_intact(godot_project):
+    # `extends "res://Base.gd"` (base-class-by-path) is legal GDScript. The
+    # metadata parser keeps the quoted string whole up to its closing quote —
+    # including a '#' inside the path, which is part of the string, not an inline
+    # comment — rather than truncating at the '#' or splitting on whitespace.
+    script_path = godot_project / "derived.gd"
+    source = 'extends "res://weapons/a#b.gd"\n'
+
+    created = _gda("script", "create", str(script_path), "--content", source, "--json")
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    assert json.loads(created.stdout)["extends"] == '"res://weapons/a#b.gd"'
+
+    got = _gda("script", "get", str(script_path), "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["extends"] == '"res://weapons/a#b.gd"'
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -1,0 +1,237 @@
+"""S1 (e2e): the script create → get round-trip against the real Godot engine.
+
+The script-group tracer (issue #110): ``gda script create`` writes a .gd/.cs
+script (from a template or verbatim --content), no-clobber; ``gda script get``
+reads its source back with class_name/extends metadata — ``script get`` IS the
+structured-level verification of ``script create``'s effect (create → get
+returns the source).
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+GODOT = resolve_godot_binary()
+
+
+def _gda(*args: str) -> subprocess.CompletedProcess:
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+    return subprocess.run(
+        [gda_bin, *args, "--godot", str(GODOT)], capture_output=True, text=True
+    )
+
+
+def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
+    assert proc.returncode == 4, proc.stdout + proc.stderr
+    err = json.loads(proc.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == code
+    return err
+
+
+@pytest.mark.e2e
+def test_script_create_default_template_then_get_round_trip(godot_project):
+    # The bare template: create writes `extends Node`, get reads it back. The
+    # source on disk IS what get reports — the round-trip proves the write.
+    script_path = godot_project / "actor.gd"
+
+    created = _gda("script", "create", str(script_path), "--json")
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    data = json.loads(created.stdout)
+    assert data["path"] == str(script_path)
+    assert data["extends"] == "Node"
+    assert data["class_name"] is None
+    assert script_path.exists()
+
+    got = _gda("script", "get", str(script_path), "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    got_data = json.loads(got.stdout)
+    # Round-trip: get returns exactly the source create wrote to disk.
+    assert got_data["source"] == script_path.read_text(encoding="utf-8")
+    assert got_data["source"] == "extends Node\n"
+    assert got_data["extends"] == "Node"
+    assert got_data["class_name"] is None
+
+
+@pytest.mark.e2e
+def test_script_create_with_extends_parameterizes_the_template(godot_project):
+    # --extends parameterizes the template's base class (mirrors scene create
+    # --root-type), and get reports it back from the parsed source.
+    script_path = godot_project / "sprite.gd"
+
+    created = _gda("script", "create", str(script_path), "--extends", "Node2D", "--json")
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    assert json.loads(created.stdout)["extends"] == "Node2D"
+
+    got = _gda("script", "get", str(script_path), "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["extends"] == "Node2D"
+
+
+@pytest.mark.e2e
+def test_script_create_with_content_round_trips_verbatim_source_and_metadata(
+    godot_project,
+):
+    # --content supplies verbatim source; get reports it byte-identical and
+    # parses the class_name/extends the source declares — without ever compiling
+    # the script (issue #30: reading a script must never run it).
+    script_path = godot_project / "hero.gd"
+    source = "class_name Hero\nextends Node2D\n\nvar speed := 100\n"
+
+    created = _gda(
+        "script", "create", str(script_path), "--content", source, "--json"
+    )
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    create_data = json.loads(created.stdout)
+    assert create_data["class_name"] == "Hero"
+    assert create_data["extends"] == "Node2D"
+
+    got = _gda("script", "get", str(script_path), "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    got_data = json.loads(got.stdout)
+    assert got_data["source"] == source
+    assert got_data["class_name"] == "Hero"
+    assert got_data["extends"] == "Node2D"
+
+
+@pytest.mark.e2e
+def test_script_create_resolves_res_path_against_the_project(godot_project):
+    # Script-file addressing via res:// resolves against --project, exactly like
+    # scene create (issue #32): the script lands inside the project and reads
+    # back through res://.
+    def gda(*args: str) -> subprocess.CompletedProcess:
+        return _gda(*args, "--project", str(godot_project))
+
+    created = gda("script", "create", "res://hero.gd", "--extends", "Node2D", "--json")
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    assert (godot_project / "hero.gd").exists()
+
+    got = gda("script", "get", "res://hero.gd", "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["extends"] == "Node2D"
+
+
+@pytest.mark.e2e
+def test_script_create_creates_missing_parent_directories(godot_project):
+    # Parent dirs are created before the write (mirrors scene create), reported
+    # in created_dirs from outermost to innermost.
+    script_path = godot_project / "actors" / "enemies" / "goblin.gd"
+
+    created = _gda("script", "create", str(script_path), "--json")
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    assert script_path.exists()
+    assert json.loads(created.stdout)["created_dirs"] == [
+        str(godot_project / "actors"),
+        str(godot_project / "actors" / "enemies"),
+    ]
+
+
+@pytest.mark.e2e
+def test_script_create_existing_path_yields_already_exists_without_overwriting(
+    godot_project,
+):
+    # No-clobber: a second create on the same path is refused with already_exists
+    # and the original content is left untouched.
+    script_path = godot_project / "hero.gd"
+    _gda("script", "create", str(script_path), "--extends", "Node2D", "--json")
+    before = script_path.read_text(encoding="utf-8")
+
+    again = _gda("script", "create", str(script_path), "--extends", "Sprite2D", "--json")
+
+    err = _assert_operation_error(again, "already_exists")
+    assert str(script_path) in err["message"]
+    assert script_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_script_create_wrong_extension_yields_invalid_path(godot_project):
+    # A target that is not a .gd/.cs script is an invalid path param; nothing is
+    # written.
+    target = godot_project / "notes.txt"
+
+    created = _gda("script", "create", str(target), "--json")
+
+    err = _assert_operation_error(created, "invalid_path")
+    assert ".gd or .cs" in err["message"]
+    assert not target.exists()
+
+
+@pytest.mark.e2e
+def test_script_get_missing_file_yields_path_not_found(godot_project):
+    missing = godot_project / "nope.gd"
+
+    got = _gda("script", "get", str(missing), "--json")
+
+    err = _assert_operation_error(got, "path_not_found")
+    assert str(missing) in err["message"]
+
+
+@pytest.mark.e2e
+def test_script_get_wrong_extension_yields_invalid_path(godot_project):
+    notes = godot_project / "notes.txt"
+    notes.write_text("not a script\n", encoding="utf-8")
+
+    got = _gda("script", "get", str(notes), "--json")
+
+    err = _assert_operation_error(got, "invalid_path")
+    assert ".gd or .cs" in err["message"]
+
+
+@pytest.mark.e2e
+def test_script_create_cs_round_trips_source_with_null_metadata(godot_project):
+    # .cs handling (issue #110): a C# script created via --content round-trips
+    # its source verbatim, but class_name/extends are null — C# class/base
+    # semantics differ from GDScript's leading declarations, so this tracer
+    # reports nulls for .cs rather than mis-parsing it as GDScript.
+    script_path = godot_project / "Player.cs"
+    source = (
+        "using Godot;\n\npublic partial class Player : Node2D\n{\n}\n"
+    )
+
+    created = _gda(
+        "script", "create", str(script_path), "--content", source, "--json"
+    )
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    create_data = json.loads(created.stdout)
+    assert create_data["class_name"] is None
+    assert create_data["extends"] is None
+
+    got = _gda("script", "get", str(script_path), "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    got_data = json.loads(got.stdout)
+    assert got_data["source"] == source
+    assert got_data["class_name"] is None
+    assert got_data["extends"] is None
+
+
+@pytest.mark.e2e
+def test_script_create_then_get_preserves_a_path_containing_the_end_sentinel(
+    godot_project,
+):
+    # issue #34 parallel: the result echoes the path verbatim and carries the
+    # source as a JSON string, so a path or source containing the literal end
+    # sentinel must round-trip, not truncate into a parse error.
+    script_path = godot_project / "weird<<<GDA:END>>>name.gd"
+
+    created = _gda("script", "create", str(script_path), "--json")
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    assert json.loads(created.stdout)["path"] == str(script_path)
+
+    got = _gda("script", "get", str(script_path), "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["source"] == "extends Node\n"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,6 +16,8 @@ from gda.models import (
     SceneDeleteResult,
     SceneGetResult,
     SceneListResult,
+    ScriptCreateResult,
+    ScriptGetResult,
 )
 
 
@@ -270,6 +272,61 @@ def test_node_get_result_round_trips_typed_properties():
     assert got.properties[0].name == "position"
     assert got.properties[0].type == "Vector2"
     assert got.properties[0].value == [10.0, 20.0]
+    assert json.loads(got.model_dump_json()) == payload
+
+
+def test_script_create_result_round_trips_with_metadata():
+    # script create echoes the saved path plus the class_name/extends the
+    # written source declares (issue #110), so an agent verifies the effect
+    # without a second call.
+    payload = {
+        "path": "res://hero.gd",
+        "class_name": "Hero",
+        "extends": "Node2D",
+        "created_dirs": ["res://scripts"],
+    }
+
+    created = ScriptCreateResult.model_validate(payload)
+
+    assert created.path == "res://hero.gd"
+    assert created.class_name == "Hero"
+    assert created.extends == "Node2D"
+    assert json.loads(created.model_dump_json()) == payload
+
+
+def test_script_create_result_round_trips_null_metadata():
+    # A template script with no class_name (or a .cs target) carries null
+    # class_name/extends; the null metadata round-trips faithfully.
+    payload = {
+        "path": "res://util.cs",
+        "class_name": None,
+        "extends": None,
+        "created_dirs": [],
+    }
+
+    created = ScriptCreateResult.model_validate(payload)
+
+    assert created.class_name is None
+    assert created.extends is None
+    assert json.loads(created.model_dump_json()) == payload
+
+
+def test_script_get_result_round_trips_source_and_metadata():
+    # script get carries the source verbatim alongside the parsed metadata, so a
+    # create round-trips through a get (issue #110): the source dumps back
+    # byte-identical, including its trailing newline.
+    payload = {
+        "path": "res://hero.gd",
+        "source": "class_name Hero\nextends Node2D\n\nfunc _ready() -> void:\n\tpass\n",
+        "class_name": "Hero",
+        "extends": "Node2D",
+    }
+
+    got = ScriptGetResult.model_validate(payload)
+
+    assert got.source.endswith("pass\n")
+    assert got.class_name == "Hero"
+    assert got.extends == "Node2D"
     assert json.loads(got.model_dump_json()) == payload
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -295,10 +295,10 @@ def test_script_create_result_round_trips_with_metadata():
 
 
 def test_script_create_result_round_trips_null_metadata():
-    # A template script with no class_name (or a .cs target) carries null
-    # class_name/extends; the null metadata round-trips faithfully.
+    # A template script with no class_name carries null class_name/extends; the
+    # null metadata round-trips faithfully.
     payload = {
-        "path": "res://util.cs",
+        "path": "res://util.gd",
         "class_name": None,
         "extends": None,
         "created_dirs": [],

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -325,6 +325,69 @@ def test_node_schema_spawns_no_godot(monkeypatch):
         assert set(json.loads(result.stdout)) >= {"input", "output", "error"}
 
 
+def test_script_create_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for the script group (issue #110): the bare
+    # --schema flag — no path — short-circuits into the self-description,
+    # derived from the same typed models that back --json.
+    from gda.models import ScriptCreateParams, ScriptCreateResult
+
+    result = CliRunner().invoke(app, ["script", "create", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ScriptCreateParams.model_json_schema()
+    assert doc["output"] == ScriptCreateResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    # The template/content surface is in the contract itself.
+    assert "content" in doc["input"]["properties"]
+    assert "extends_type" in doc["input"]["properties"]
+    assert "class_name" in doc["output"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_script_get_schema_emits_model_derived_contract_without_other_args():
+    from gda.models import ScriptGetParams, ScriptGetResult
+
+    result = CliRunner().invoke(app, ["script", "get", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ScriptGetParams.model_json_schema()
+    assert doc["output"] == ScriptGetResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "source" in doc["output"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_sample_script_results_validate_against_emitted_output_schemas():
+    # A sample --json payload of each script command satisfies the contract its
+    # --schema emits (the other half of the ADR-0004 hard gate, issue #110).
+    from tests.test_script_commands import CREATE_RESULT, GET_RESULT
+
+    create_doc = json.loads(
+        CliRunner().invoke(app, ["script", "create", "--schema"]).stdout
+    )
+    get_doc = json.loads(CliRunner().invoke(app, ["script", "get", "--schema"]).stdout)
+
+    jsonschema.validate(instance=CREATE_RESULT, schema=create_doc["output"])
+    jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
+
+
+def test_script_schema_spawns_no_godot(monkeypatch):
+    def boom(*args, **kwargs):
+        raise AssertionError("--schema must not touch the engine")
+
+    monkeypatch.setattr("gda.headless.resolve_godot_binary", boom)
+    monkeypatch.setattr("gda.cli._make_runner", boom)
+
+    for command in (["script", "create"], ["script", "get"]):
+        result = CliRunner().invoke(app, [*command, "--schema"])
+        assert result.exit_code == 0
+        assert set(json.loads(result.stdout)) >= {"input", "output", "error"}
+
+
 def test_info_input_schema_is_derived_from_the_params_model():
     # info takes no operation params, so its input schema is trivially empty —
     # expected, not an error — and still derived model-side (ADR-0004).

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -1,6 +1,6 @@
 """S3: gda script create / script get success paths against a fake runner (issue #110).
 
-The script command group acts on .gd/.cs script files on disk (write text /
+The script command group acts on .gd script files on disk (write text /
 read text back), staying headless. These tests drive the same proven pipeline
 as the scene and node groups — Typer → binary resolution → runner → sentinel
 parse → typed model → JSON — with canned engine output, no real Godot.
@@ -123,17 +123,6 @@ def test_script_create_content_and_extends_are_mutually_exclusive(monkeypatch):
             "--json",
         ],
     )
-
-    assert result.exit_code == 2
-
-
-def test_script_create_cs_without_content_is_a_usage_error(monkeypatch):
-    # The built-in template is GDScript; writing it into a .cs file is
-    # meaningless, so a .cs target without --content is a usage error (exit 2)
-    # rather than a GDScript template silently landing in a C# file.
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0))
-
-    result = CliRunner().invoke(app, ["script", "create", "/tmp/proj/Player.cs", "--json"])
 
     assert result.exit_code == 2
 

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -127,6 +127,17 @@ def test_script_create_content_and_extends_are_mutually_exclusive(monkeypatch):
     assert result.exit_code == 2
 
 
+def test_script_create_cs_without_content_is_a_usage_error(monkeypatch):
+    # The built-in template is GDScript; writing it into a .cs file is
+    # meaningless, so a .cs target without --content is a usage error (exit 2)
+    # rather than a GDScript template silently landing in a C# file.
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["script", "create", "/tmp/proj/Player.cs", "--json"])
+
+    assert result.exit_code == 2
+
+
 GET_RESULT = {
     "path": "/tmp/proj/hero.gd",
     "source": "class_name Hero\nextends Node2D\n",

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -108,7 +108,7 @@ def test_script_create_content_passes_verbatim_source(monkeypatch):
 def test_script_create_content_and_extends_are_mutually_exclusive(monkeypatch):
     # Verbatim content is not templated, so a base class has nowhere to go;
     # supplying both is a usage error (exit 2), never a silent precedence rule.
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0))
+    fake = inject_runner(monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0))
 
     result = CliRunner().invoke(
         app,
@@ -125,6 +125,8 @@ def test_script_create_content_and_extends_are_mutually_exclusive(monkeypatch):
     )
 
     assert result.exit_code == 2
+    # The usage error fires before any dispatch — the engine is never reached.
+    assert fake.calls == []
 
 
 GET_RESULT = {

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -1,0 +1,152 @@
+"""S3: gda script create / script get success paths against a fake runner (issue #110).
+
+The script command group acts on .gd/.cs script files on disk (write text /
+read text back), staying headless. These tests drive the same proven pipeline
+as the scene and node groups — Typer → binary resolution → runner → sentinel
+parse → typed model → JSON — with canned engine output, no real Godot.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import inject_runner, sentinel
+
+CREATE_RESULT = {
+    "path": "/tmp/proj/hero.gd",
+    "class_name": "Hero",
+    "extends": "Node2D",
+    "created_dirs": [],
+}
+
+
+def test_script_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
+    # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(CREATE_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["script", "create", "/tmp/proj/hero.gd", "--extends", "Node2D", "--json"],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["path"] == "/tmp/proj/hero.gd"
+    # The created script's declared metadata, echoed so an agent verifies the
+    # effect without a second call.
+    assert data["class_name"] == "Hero"
+    assert data["extends"] == "Node2D"
+    # The operation was dispatched by name with the command's typed params. With
+    # --extends and no --content, content is null.
+    assert fake.calls == [
+        (
+            "script-create",
+            {
+                "path": "/tmp/proj/hero.gd",
+                "content": None,
+                "extends_type": "Node2D",
+            },
+        )
+    ]
+    assert "engine diagnostic" in result.stderr
+
+
+def test_script_create_default_template_passes_null_content_and_extends(monkeypatch):
+    # The bare template: no --content, no --extends. Both pass through as null,
+    # so the operation writes its default minimal template.
+    stdout = sentinel({**CREATE_RESULT, "extends": "Node"})
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["script", "create", "/tmp/proj/hero.gd", "--json"])
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        (
+            "script-create",
+            {"path": "/tmp/proj/hero.gd", "content": None, "extends_type": None},
+        )
+    ]
+
+
+def test_script_create_content_passes_verbatim_source(monkeypatch):
+    # --content supplies verbatim source; it rides through as the content param.
+    stdout = sentinel(
+        {"path": "/tmp/proj/util.gd", "class_name": None, "extends": None, "created_dirs": []}
+    )
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "create",
+            "/tmp/proj/util.gd",
+            "--content",
+            "extends RefCounted\n",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        (
+            "script-create",
+            {
+                "path": "/tmp/proj/util.gd",
+                "content": "extends RefCounted\n",
+                "extends_type": None,
+            },
+        )
+    ]
+
+
+def test_script_create_content_and_extends_are_mutually_exclusive(monkeypatch):
+    # Verbatim content is not templated, so a base class has nowhere to go;
+    # supplying both is a usage error (exit 2), never a silent precedence rule.
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "create",
+            "/tmp/proj/hero.gd",
+            "--content",
+            "extends Node\n",
+            "--extends",
+            "Node2D",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2
+
+
+GET_RESULT = {
+    "path": "/tmp/proj/hero.gd",
+    "source": "class_name Hero\nextends Node2D\n",
+    "class_name": "Hero",
+    "extends": "Node2D",
+}
+
+
+def test_script_get_json_emits_source_and_metadata_and_exit_zero(monkeypatch):
+    # script get is the verifier (issue #110): it reads a script's source back
+    # as raw text with its class_name/extends, so a create round-trips.
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["script", "get", "/tmp/proj/hero.gd", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["path"] == "/tmp/proj/hero.gd"
+    assert data["source"] == "class_name Hero\nextends Node2D\n"
+    assert data["class_name"] == "Hero"
+    assert data["extends"] == "Node2D"
+    assert fake.calls == [("script-get", {"path": "/tmp/proj/hero.gd"})]

--- a/tests/test_script_errors.py
+++ b/tests/test_script_errors.py
@@ -1,0 +1,127 @@
+"""S3: gda script failure modes map to structured JSON errors + stable exit codes.
+
+Issue #110's acceptance: script-command failures (path collision on create,
+script not found on get, invalid target path / wrong extension) surface as
+structured ``GdaError``s with registered operation codes (ADR-0002) — exit 4
+for the operation category, finer stable codes so an agent can branch on the
+mode without parsing prose. The script group reuses the existing file-level
+codes rather than minting parallel ones.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import error_sentinel, inject_runner
+
+
+def _invoke_script_create(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: script-create\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(
+        app, ["script", "create", "/x/hero.gd", "--json"]
+    )
+
+
+def _invoke_script_get(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: script-get\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(app, ["script", "get", "/x/hero.gd", "--json"])
+
+
+def test_script_create_collision_reuses_stable_already_exists_code(monkeypatch):
+    # No-clobber: a create whose target already exists reuses the registered
+    # already_exists code (the same one scene create uses), leaving the file
+    # untouched — the script group mints no parallel collision code.
+    result = _invoke_script_create(
+        monkeypatch, "already_exists", "script target already exists: /x/hero.gd"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "already_exists"
+    assert "/x/hero.gd" in err["message"]
+    # The raw stderr still rides along as diagnostics (ADR-0002).
+    assert err["diagnostics"] == "gda: running operation: script-create\n"
+
+
+def test_script_create_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
+    # A target that is not a .gd/.cs script is an invalid path param — reuse the
+    # registered invalid_path code rather than a focused per-group code.
+    result = _invoke_script_create(
+        monkeypatch,
+        "invalid_path",
+        "script path must end in .gd or .cs: /x/hero.txt",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_path"
+    assert ".gd or .cs" in err["message"]
+
+
+def test_script_create_missing_path_reuses_stable_invalid_path_code(monkeypatch):
+    result = _invoke_script_create(
+        monkeypatch, "invalid_path", "missing required param: path"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "invalid_path"
+
+
+def test_script_create_unwritable_target_reuses_stable_save_failed_code(monkeypatch):
+    result = _invoke_script_create(
+        monkeypatch, "save_failed", "failed to save script to /x/hero.gd"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "save_failed"
+    assert "/x/hero.gd" in err["message"]
+
+
+def test_script_get_missing_file_reuses_stable_path_not_found_code(monkeypatch):
+    # A script that does not exist reuses the registered path_not_found code
+    # (now generalized in the registry from scene-specific to any file), so an
+    # agent branches on the missing-file mode without a new code.
+    result = _invoke_script_get(
+        monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert "/x/hero.gd" in err["message"]
+
+
+def test_script_get_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
+    result = _invoke_script_get(
+        monkeypatch,
+        "invalid_path",
+        "script path must end in .gd or .cs: /x/notes.txt",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "invalid_path"
+    assert ".gd or .cs" in err["message"]

--- a/tests/test_script_errors.py
+++ b/tests/test_script_errors.py
@@ -63,19 +63,19 @@ def test_script_create_collision_reuses_stable_already_exists_code(monkeypatch):
 
 
 def test_script_create_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
-    # A target that is not a .gd/.cs script is an invalid path param — reuse the
+    # A target that is not a .gd script is an invalid path param — reuse the
     # registered invalid_path code rather than a focused per-group code.
     result = _invoke_script_create(
         monkeypatch,
         "invalid_path",
-        "script path must end in .gd or .cs: /x/hero.txt",
+        "script path must end in .gd: /x/hero.txt",
     )
 
     assert result.exit_code == 4
     err = json.loads(result.stdout)["error"]
     assert err["category"] == "operation"
     assert err["code"] == "invalid_path"
-    assert ".gd or .cs" in err["message"]
+    assert ".gd" in err["message"]
 
 
 def test_script_create_missing_path_reuses_stable_invalid_path_code(monkeypatch):
@@ -118,10 +118,10 @@ def test_script_get_wrong_extension_reuses_stable_invalid_path_code(monkeypatch)
     result = _invoke_script_get(
         monkeypatch,
         "invalid_path",
-        "script path must end in .gd or .cs: /x/notes.txt",
+        "script path must end in .gd: /x/notes.txt",
     )
 
     assert result.exit_code == 4
     err = json.loads(result.stdout)["error"]
     assert err["code"] == "invalid_path"
-    assert ".gd or .cs" in err["message"]
+    assert ".gd" in err["message"]


### PR DESCRIPTION
## What

Establishes the `script` command group, acting on **GDScript** (`.gd`) script files on disk (headless, one-shot `godot --headless`), mirroring the `scene` (#18) and `node` (#53) tracers. Closes #110.

- **`gda script create PATH`** — writes a new script from a minimal built-in template (`extends Node`, parameterized by `--extends`) or verbatim `--content` (the two are mutually exclusive). No-clobber, creates missing parent dirs, and returns the saved path plus the `class_name`/`extends` the written source declares, as typed JSON.
- **`gda script get PATH`** — reads the source back as **raw text** with its `class_name`/`extends` metadata, so a `create` is verifiable end-to-end (create → get returns the same source).

## Key decisions

- **Script-file addressing** is by file path (`.gd`), not by `class_name` — the same way scenes are addressed by `.tscn` path. Documented in `docs/command-catalog.md`.
- **Read trust boundary (#30):** `script get` reads via `FileAccess.get_file_as_string` and parses metadata by lightweight **header** scanning (skips leading `@tool`/`@icon` annotations, stops at the first real statement, so declaration-shaped text in a body string is never misread) — it **never `load()`s/compiles** the script, so reading one can never run project code. `script create` likewise writes raw text.
- **Error codes:** zero new codes — reuses `already_exists` (collision), `invalid_path` (missing path / non-`.gd` extension), `save_failed` (unwritable), `path_not_found` (not found on get). `path_not_found`'s registry + ADR-0002 description was generalized from scene-specific to "A requested file does not exist." so the reuse is honest (drift test stays green).
- **Scope — GDScript only (narrowed during review).** The issue/catalog originally said `.gd`/`.cs`, seeded from the godot-mcp-pro taxonomy without an explicit decision. C# (`.cs`) is **deferred**: it needs the .NET build of Godot, whereas ADR-0003 targets the **standard** build (the local 4.6.3 engine can't compile C# at all), and it is a decision of its own. A non-`.gd` path is now refused as `invalid_path` rather than half-supported as opaque text. issue #110's acceptance criteria were narrowed to match.

## Tests

S2 model round-trips, S3 CLI-with-FakeRunner (success + every failure mode), S1 e2e create→get round-trip + failure modes against real Godot, and the ADR-0004 `--schema` hard gate. **Full suite green: 232 passed (incl. e2e) locally.**

## Commits

- `feat(script): …` — the slice (delegated, TDD).
- `fix(script): …` — review follow-up: tightened the `class_name`/`extends` header parser, with added tests.
- `refactor(script): …` — narrow the group to GDScript (`.gd`), defer C# (`.cs`), and sync code/tests/catalog/issue.
