### PR TITLE
docs(adr): ADR-0009 Phase-1 trust boundary — trusted project (#61, #62)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,6 +62,20 @@ The structured failure result that distinguishes a failed command from a
 successful result.
 _Avoid_: error blob, failure JSON
 
+### Trust model
+
+**Trusted project**:
+The target project `gda` operates on — including its autoloads and scene
+scripts — is assumed trustworthy; Phase 1 does not defend against a malicious or
+untrusted project (ADR-0009).
+_Avoid_: safe project, sandboxed project
+
+**Project-code execution surface**:
+The set of points where a single `gda` run triggers the target project's own
+code to run: autoload constructors at engine startup (every `--project` op), and
+the `_init` of scripts on nodes that an instantiating operation constructs.
+_Avoid_: attack surface, code-execution risk
+
 ### Delivery phases
 
 The order in which **capabilities** are delivered. This is distinct from ADR-0000's

--- a/docs/adr/0009-trust-boundary-trusted-project.md
+++ b/docs/adr/0009-trust-boundary-trusted-project.md
@@ -1,0 +1,70 @@
+---
+status: accepted
+---
+
+# Phase-1 trust boundary: gda operates on a trusted project
+
+Issue #30 established that *reading* a scene must not execute project code, and
+the read operations honour it at the operation level: `scene get`, `node list`,
+and `scene list` walk `SceneState` (`packed.get_state()`) without instantiating
+anything (`src/gda/ops/operations.gd`). But two findings showed that "no project
+code runs" was never true of a whole `gda` invocation:
+
+- **Autoloads run on every `--project` operation (#61).** The runner passes the
+  resolved project as `--path` uniformly for every command (`src/gda/runner.py`),
+  and `operations.gd` is a `SceneTree` main loop. The engine therefore constructs
+  the project's autoload singletons during startup — running their `_init`/`_ready`
+  — *before* our operation script gets control, on read-only commands included.
+- **Instantiating operations run scene scripts' `_init` (#62).** Mutating a scene
+  requires a real node tree: `_load_for_mutation()` calls `PackedScene.instantiate()`,
+  which constructs every node and runs the `_init` of any attached non-`@tool`
+  script. This is unavoidable on the mutate path given the one-shot headless design
+  (ADR-0001). `node get` is a *read* command that also instantiates (to report
+  runtime property defaults `SceneState` does not store), so it sits on the same
+  surface despite not mutating.
+
+## Decision
+
+**Phase 1 assumes the target project is trusted.** `gda` operates on the project
+the agent is building (resolved via `--project`/`$GDA_PROJECT`/cwd, ADR-0006); it
+does not defend against a malicious or untrusted project. Executing that project's
+own autoload and scene-script constructors is therefore expected behaviour, not a
+vulnerability, and we **accept and document** it rather than harden in Phase 1.
+
+The documented [project-code execution surface](../../CONTEXT.md) is classified by
+**mechanism**, on two orthogonal axes — not by a read/mutate split, because
+`node get` is a read that instantiates:
+
+- **Process startup (every `--project` op):** the engine constructs the project's
+  autoloads and runs their `_init`/`_ready`, regardless of which command runs.
+- **Operation level:**
+  - *State-read operations* walk `SceneState` and execute **no** project code at the
+    operation level — `scene get`, `node list`, `scene list`.
+  - *Instantiating operations* call `PackedScene.instantiate()` and execute the
+    `_init` of scripts attached to the scene's nodes — `node add`, `node set`,
+    future mutate operations, **and** `node get`.
+
+A forged result sentinel emitted by an executed script does not produce a silently
+believed result: a second `<<<GDA:RESULT>>>` payload on stdout makes the command
+fail loudly with `contract_violation` (exit 5, ADR-0002).
+
+## Consequences
+
+- **#30 is rescoped, honestly.** Its "reading executes no project code" guarantee
+  holds at the operation level *for state-read operations only*. It does not cover
+  process-startup autoloads (#61), and it does not cover instantiating reads like
+  `node get` (#62). The claim is scoped to *that mechanism*, not to all of `gda`.
+- **Autoload suppression is a possible future robustness enhancement, not a security
+  fix.** The file-level Phase-1 operations never need the project's autoloads, so a
+  broken or heavyweight autoload `_init` only adds noise or can fail an unrelated
+  read. Suppressing autoloads in one-shot headless runs (if feasible — feasibility
+  is itself unestablished) would improve robustness; it carries no security
+  obligation under this trust boundary and is not committed here. It would be its
+  own slice with its own justification.
+- **Untrusted-project safety is explicitly out of scope for Phase 1.** Hardening
+  directions (OS-level sandboxing, text-level `.tscn` editing that bypasses engine
+  semantics) are heavy and were rejected for Phase 1; if a use case for operating on
+  untrusted projects emerges, it warrants its own ADR rather than an incremental
+  patch.
+- The factual user-facing warning (README) and the characterization tests that pin
+  this surface are tracked by #63.


### PR DESCRIPTION
## What

Records the security posture for `gda`'s **project-code execution surface**, settling the two `needs-triage` security findings #61 and #62 (resolved via a `/grill-with-docs` session).

- **New ADR-0009** — *Phase-1 trust boundary: gda operates on a trusted project*.
- **CONTEXT.md** — new "Trust model" terms: *Trusted project*, *Project-code execution surface*.

## Decision

**Phase 1 assumes the target project is trusted.** `gda` operates on the project the agent is building; it does not defend against a malicious/untrusted project. Executing that project's own autoload and scene-script constructors is therefore **expected behaviour**, and we **accept-and-document** rather than harden.

The documented execution surface is classified **by mechanism** (not by read/mutate, because `node get` is a read that instantiates), on two orthogonal axes:

- **Process startup** — autoloads run on every `--project` op (#61).
- **Operation level** — *state-read* ops (`scene get` / `node list` / `scene list`) execute no project code; *instantiating* ops (`node add` / `node set` / `node get` / future mutates) run the `_init` of attached scene scripts (#62).

## Consequences

- Rescopes the #30 read guarantee honestly (operation-level, state-read mechanism only).
- Autoload suppression noted as a *possible future robustness enhancement* (non-security, not committed).
- Untrusted-project sandboxing explicitly out of scope for Phase 1.
- User-facing README warning + characterization tests remain tracked by #63 (its brief is corrected in a comment to add a `node get` test and adopt the by-mechanism framing).

Closes #61, #62
