### PR TITLE
feat(script): script list + script delete — round out script-file CRUD (#117)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -78,7 +78,7 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 | `invalid_root_name` | `operation` | `operation` | A requested root node name is empty or would be rewritten by Godot. |
 | `already_exists` | `operation` | `operation` | A create operation target already exists and will not be overwritten. |
 | `save_failed` | `operation` | `operation` | A scene could not be packed or saved. |
-| `delete_failed` | `operation` | `operation` | A scene file could not be removed from disk. |
+| `delete_failed` | `operation` | `operation` | A file could not be removed from disk. |
 | `project_not_found` | `operation` | `operation` | An operation that enumerates a project's `res://` tree ran without a resolved Godot project. |
 | `path_not_found` | `operation` | `operation` | A requested file does not exist. |
 | `not_a_scene` | `operation` | `operation` | A requested file cannot be loaded as a `PackedScene`. |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -169,6 +169,18 @@ annotations) and stops at the first real statement, so declaration-shaped text d
 body cannot be mistaken for the declaration. `script get` additionally returns the full
 `source`, so a `create` is verifiable end-to-end: `create` then `get` returns the same source.
 
+**Discovery and removal** (established by #117, mirrors `scene list` + `scene delete` #54):
+`gda script list` walks the project's `res://` tree and enumerates every `.gd` script, each with
+its `res://` path and the `class_name`/`extends` parsed from the **raw text** (no compilation,
+issue #30) — null when the source declares neither, so the listing names every `.gd` it found.
+Enumeration needs a project, so projectless it is refused with `project_not_found` (pass
+`--project`); an empty project is a valid, empty listing, not an error. `gda script delete`
+removes a script file and reports the removed script's `class_name`/`extends` (parsed before
+deletion), so the result names the content, not just the path. Delete honors the same addressing
+boundary as the rest of the group — only a `.gd` path is removed (a non-`.gd` target is refused
+with `invalid_path`, never erasing an arbitrary file), and a missing target is `path_not_found`.
+The lifecycle round-trips: `create` → `list` shows it → `delete` → `list` no longer shows it.
+
 | Command | Description |
 | --- | --- |
 | `gda script create` | Create a `.gd` script (template or content) |

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -26,6 +26,7 @@ from gda.models import (
     EngineVersion,
     InfoParams,
     ListedNode,
+    ListedScript,
     NodeAddParams,
     NodeAddResult,
     NodeGetParams,
@@ -45,8 +46,12 @@ from gda.models import (
     SceneNode,
     ScriptCreateParams,
     ScriptCreateResult,
+    ScriptDeleteParams,
+    ScriptDeleteResult,
     ScriptGetParams,
     ScriptGetResult,
+    ScriptListParams,
+    ScriptListResult,
 )
 from gda.project import resolve_project_dir
 from gda.runner import GodotRunner
@@ -174,6 +179,18 @@ SCRIPT_GET_COMMAND: HeadlessCommand[ScriptGetResult] = HeadlessCommand(
     operation="script-get",
     input_model=ScriptGetParams,
     output_model=ScriptGetResult,
+)
+
+SCRIPT_LIST_COMMAND: HeadlessCommand[ScriptListResult] = HeadlessCommand(
+    operation="script-list",
+    input_model=ScriptListParams,
+    output_model=ScriptListResult,
+)
+
+SCRIPT_DELETE_COMMAND: HeadlessCommand[ScriptDeleteResult] = HeadlessCommand(
+    operation="script-delete",
+    input_model=ScriptDeleteParams,
+    output_model=ScriptDeleteResult,
 )
 
 
@@ -462,7 +479,9 @@ def set_property(
     )
 
 
-def _render_script_metadata(script: "ScriptCreateResult | ScriptGetResult") -> str:
+def _render_script_metadata(
+    script: "ScriptCreateResult | ScriptGetResult | ListedScript | ScriptDeleteResult",
+) -> str:
     """Render a script's path plus its class_name/extends for humans."""
     meta = []
     if script.extends is not None:
@@ -532,6 +551,50 @@ def get_script(
         render_text=lambda got: "\n".join(
             [_render_script_metadata(got), got.source]
         ),
+        make_runner=_make_runner,
+    )
+
+
+def _render_script_list(listed: "ScriptListResult") -> str:
+    """Render the enumerated scripts as ``path (extends X, class_name Y)`` lines."""
+    if not listed.scripts:
+        return "(no scripts)"
+    return "\n".join(_render_script_metadata(script) for script in listed.scripts)
+
+
+@script_app.command(name="list", cls=SCRIPT_LIST_COMMAND.command_class())
+def list_scripts(
+    json_output: bool = json_option(),
+    schema: bool = SCRIPT_LIST_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Enumerate the .gd scripts in the resolved project."""
+    SCRIPT_LIST_COMMAND.emit(
+        ScriptListParams(),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=_render_script_list,
+        make_runner=_make_runner,
+    )
+
+
+@script_app.command(name="delete", cls=SCRIPT_DELETE_COMMAND.command_class())
+def delete_script(
+    path: str = typer.Argument(..., help="The .gd script file to delete."),
+    json_output: bool = json_option(),
+    schema: bool = SCRIPT_DELETE_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Delete a script file and report what was removed."""
+    SCRIPT_DELETE_COMMAND.emit(
+        ScriptDeleteParams(path=_normalize_path(path)),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=lambda removed: f"deleted {_render_script_metadata(removed)}",
         make_runner=_make_runner,
     )
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -115,7 +115,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "delete_failed",
         ErrorCategory.OPERATION,
         ErrorCodeSource.OPERATION,
-        "A scene file could not be removed from disk.",
+        "A file could not be removed from disk.",
     ),
     ErrorCodeSpec(
         "project_not_found",

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -542,6 +542,71 @@ class ScriptGetResult(BaseModel):
     )
 
 
+class ScriptListParams(BaseModel):
+    """The operation params of ``gda script list`` — none (ADR-0004).
+
+    ``script list`` enumerates the ``.gd`` scripts in the resolved project's
+    ``res://`` tree; the project is process context (``--project``), not an
+    operation param (ADR-0006), so the ``input`` schema is trivially empty.
+    """
+
+
+class ListedScript(BaseModel):
+    """One enumerated script of ``gda script list``: its path and metadata.
+
+    ``path`` is the script's ``res://`` path — the address an agent feeds back
+    into other script commands. ``class_name``/``extends`` are parsed cheaply
+    from the script's raw source (no compilation, issue #30); both are null when
+    the script declares neither, so the entry still names a file the listing
+    found rather than dropping it.
+    """
+
+    path: str
+    class_name: str | None = Field(
+        default=None,
+        description="The class_name the script declares, or null when it declares none.",
+    )
+    extends: str | None = Field(
+        default=None,
+        description="The base class the script extends, or null when it declares none.",
+    )
+
+
+class ScriptListResult(BaseModel):
+    """The result of ``gda script list``: the project's enumerated ``.gd`` scripts.
+
+    An empty project is a valid, empty listing — ``scripts == []`` — not a
+    failure.
+    """
+
+    scripts: list[ListedScript]
+
+
+class ScriptDeleteParams(BaseModel):
+    """The operation params of ``gda script delete``: the ``.gd`` file to remove."""
+
+    path: str
+
+
+class ScriptDeleteResult(BaseModel):
+    """The result of ``gda script delete``: what was removed (issue #117).
+
+    Echoes the deleted script's ``path`` and the ``class_name``/``extends`` its
+    source declared (parsed from the raw text before deletion), so the result
+    names the content removed, not just the file path.
+    """
+
+    path: str
+    class_name: str | None = Field(
+        default=None,
+        description="The class_name the deleted script declared, or null when it declared none.",
+    )
+    extends: str | None = Field(
+        default=None,
+        description="The base class the deleted script extended, or null when it declared none.",
+    )
+
+
 class EngineVersion(BaseModel):
     """The Godot engine version, as reported by ``Engine.get_version_info()``.
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -90,6 +90,10 @@ func _initialize() -> void:
 			_op_script_create(params)
 		"script-get":
 			_op_script_get(params)
+		"script-list":
+			_op_script_list(params)
+		"script-delete":
+			_op_script_delete(params)
 		_:
 			_fail(OP_ERROR_UNKNOWN_OPERATION, "unknown operation: " + operation)
 
@@ -556,6 +560,70 @@ func _op_script_get(params: Dictionary) -> void:
 	})
 
 
+# script-list: enumerate the project's .gd scripts (issue #117). Walks the
+# project's res:// tree, reporting each script's res:// path plus the
+# class_name/extends parsed from its raw source (no compilation, exactly like
+# script-get, issue #30 — listing must not execute project code). Mirrors
+# scene-list (issue #54): a script whose source declares neither is still
+# listed, with null metadata, so the listing names every .gd it found.
+#
+# Enumerating res:// requires a project: a projectless headless process has no
+# res:// tree to walk, so script-list refuses with project_not_found rather than
+# returning a misleading empty listing.
+func _op_script_list(_params: Dictionary) -> void:
+	_diag("running operation: script-list")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "script list requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+
+	var paths: Array[String] = []
+	_collect_script_paths("res://", paths)
+	paths.sort()
+
+	var scripts: Array = []
+	for path in paths:
+		scripts.append(_script_summary(path))
+
+	_succeed({"scripts": scripts})
+
+
+# script-delete: remove a script file and report what was removed (issue #117).
+# Reuses the script group's existing addressing boundary (must be .gd → missing
+# file → path_not_found), exactly as script-get does: delete only removes a .gd
+# script that exists, so a non-.gd target is refused with invalid_path and a
+# stray missing path with path_not_found, never silently deleting an arbitrary
+# file. The class_name/extends are parsed from the raw source before deletion so
+# the result names the content removed, not just the path (mirrors scene-delete).
+func _op_script_delete(params: Dictionary) -> void:
+	_diag("running operation: script-delete")
+	var path := _string_param(params, "path")
+	if path.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
+		return
+	if not _is_script_path(path):
+		_fail(OP_ERROR_INVALID_PATH, "script path must end in .gd: " + path)
+		return
+	if not FileAccess.file_exists(path):
+		_fail(OP_ERROR_PATH_NOT_FOUND, "script file does not exist: " + path)
+		return
+
+	# Read the metadata before deletion so the result names the content removed.
+	# A read error here is non-fatal: the file exists and is about to be deleted,
+	# so fall back to null metadata rather than failing the delete.
+	var meta := _script_metadata(FileAccess.get_file_as_string(path))
+
+	var err := DirAccess.remove_absolute(path)
+	if err != OK:
+		_fail(OP_ERROR_DELETE_FAILED, "failed to delete script " + path + ": " + error_string(err))
+		return
+
+	_succeed({
+		"path": path,
+		"class_name": meta["class_name"],
+		"extends": meta["extends"],
+	})
+
+
 # Whether a path names a script file the script group operates on: a .gd
 # (GDScript) file. Script-file addressing is by extension, the same way scene
 # addressing keys on .tscn. C# (.cs) is out of scope for now — it needs the .NET
@@ -668,6 +736,43 @@ func _scene_summary(path: String) -> Dictionary:
 		"path": path,
 		"root_name": String(state.get_node_name(0)),
 		"root_type": String(state.get_node_type(0)),
+	}
+
+
+# Recursively collect every .gd script under res:// (issue #117), skipping only
+# the engine's own res://.godot cache directory. Mirrors _collect_scene_paths
+# (issue #54): hidden entries are enumerated (a .hidden.gd, or a script under a
+# dot-prefixed directory), navigational entries stay off, and the skip is scoped
+# to res://.godot alone. Paths are returned as res:// paths so they round-trip
+# into other script commands.
+func _collect_script_paths(dir_path: String, out: Array[String]) -> void:
+	var dir := DirAccess.open(dir_path)
+	if dir == null:
+		return
+	dir.include_hidden = true
+	dir.list_dir_begin()
+	var entry := dir.get_next()
+	while not entry.is_empty():
+		var child := dir_path.path_join(entry)
+		if dir.current_is_dir():
+			if entry != ".godot":
+				_collect_script_paths(child, out)
+		elif entry.get_extension().to_lower() == "gd":
+			out.append(child)
+		entry = dir.get_next()
+	dir.list_dir_end()
+
+
+# Summarize one .gd for the listing: its path plus the class_name/extends parsed
+# from its raw source (no compilation, issue #30 — reading a script must never
+# run it). A script whose source declares neither (or could not be read) still
+# appears, with null metadata, rather than being dropped.
+func _script_summary(path: String) -> Dictionary:
+	var meta := _script_metadata(FileAccess.get_file_as_string(path))
+	return {
+		"path": path,
+		"class_name": meta["class_name"],
+		"extends": meta["extends"],
 	}
 
 

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -26,6 +26,21 @@ def _gda(*args: str) -> subprocess.CompletedProcess:
     )
 
 
+def _gda_project(project) -> "callable":
+    """A ``_gda`` bound to ``--project`` for res:// enumeration/resolution."""
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+
+    def gda(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [gda_bin, *args, "--godot", str(GODOT), "--project", str(project)],
+            capture_output=True,
+            text=True,
+        )
+
+    return gda
+
+
 def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
     assert proc.returncode == 4, proc.stdout + proc.stderr
     err = json.loads(proc.stdout)["error"]
@@ -307,6 +322,136 @@ def test_script_get_keeps_a_quoted_base_class_path_intact(godot_project):
     got = _gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["extends"] == '"res://weapons/a#b.gd"'
+
+
+@pytest.mark.e2e
+def test_script_list_enumerates_created_scripts(godot_project):
+    # script list (issue #117) enumerates the project's .gd scripts by walking
+    # res://: two scripts created at different depths both appear, each with its
+    # res:// path and the class_name/extends parsed from raw source. The listing
+    # IS the structured-level verification of what script create wrote.
+    gda = _gda_project(godot_project)
+
+    assert (
+        gda(
+            "script",
+            "create",
+            "res://hero.gd",
+            "--content",
+            "class_name Hero\nextends Node2D\n",
+            "--json",
+        ).returncode
+        == 0
+    )
+    assert (
+        gda(
+            "script", "create", "res://lib/util.gd", "--extends", "RefCounted", "--json"
+        ).returncode
+        == 0
+    )
+
+    listed = gda("script", "list", "--json")
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    scripts = json.loads(listed.stdout)["scripts"]
+    by_path = {s["path"]: s for s in scripts}
+    assert by_path["res://hero.gd"]["class_name"] == "Hero"
+    assert by_path["res://hero.gd"]["extends"] == "Node2D"
+    assert by_path["res://lib/util.gd"]["class_name"] is None
+    assert by_path["res://lib/util.gd"]["extends"] == "RefCounted"
+
+
+@pytest.mark.e2e
+def test_script_list_on_empty_project_is_an_empty_listing(godot_project):
+    # A project with no scripts is a valid, empty listing — not an error (the
+    # res://.godot import cache must not leak in as a phantom script).
+    gda = _gda_project(godot_project)
+
+    listed = gda("script", "list", "--json")
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    assert json.loads(listed.stdout)["scripts"] == []
+
+
+@pytest.mark.e2e
+def test_script_list_without_project_yields_project_not_found(tmp_path):
+    # script list cannot enumerate res:// projectless: run from a non-project
+    # directory with no --project, it must refuse with the structured
+    # project_not_found code rather than return a misleading empty listing.
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+
+    listed = subprocess.run(
+        [gda_bin, "script", "list", "--json", "--godot", str(GODOT)],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+
+    err = _assert_operation_error(listed, "project_not_found")
+    assert "--project" in err["message"]
+
+
+@pytest.mark.e2e
+def test_script_delete_removes_a_script_and_names_what_was_removed(godot_project):
+    # script delete (issue #117) removes a script file and names the removed
+    # script's metadata. The round-trip verifier: script list before shows the
+    # script, delete reports the removed class_name/extends, and script list
+    # after no longer shows it.
+    gda = _gda_project(godot_project)
+    assert (
+        gda(
+            "script",
+            "create",
+            "res://hero.gd",
+            "--content",
+            "class_name Hero\nextends Node2D\n",
+            "--json",
+        ).returncode
+        == 0
+    )
+    script_path = godot_project / "hero.gd"
+    assert script_path.exists()
+    listed_before = json.loads(gda("script", "list", "--json").stdout)["scripts"]
+    assert any(s["path"] == "res://hero.gd" for s in listed_before)
+
+    deleted = gda("script", "delete", "res://hero.gd", "--json")
+
+    assert deleted.returncode == 0, deleted.stdout + deleted.stderr
+    data = json.loads(deleted.stdout)
+    assert data["path"] == "res://hero.gd"
+    assert data["class_name"] == "Hero"
+    assert data["extends"] == "Node2D"
+    # The file is gone from disk, not just from the report.
+    assert not script_path.exists()
+    assert json.loads(gda("script", "list", "--json").stdout)["scripts"] == []
+
+
+@pytest.mark.e2e
+def test_script_delete_missing_file_yields_path_not_found(godot_project):
+    missing = godot_project / "nope.gd"
+
+    deleted = _gda("script", "delete", str(missing), "--json")
+
+    err = _assert_operation_error(deleted, "path_not_found")
+    assert str(missing) in err["message"]
+
+
+@pytest.mark.e2e
+def test_script_delete_wrong_extension_yields_invalid_path_and_leaves_it(godot_project):
+    # The delete safety boundary mirrors create/get: delete only removes a .gd
+    # script, so a non-.gd target is refused with invalid_path and left on disk —
+    # delete never erases arbitrary files.
+    notes = godot_project / "notes.txt"
+    notes.write_text("not a script\n", encoding="utf-8")
+
+    deleted = _gda("script", "delete", str(notes), "--json")
+
+    err = _assert_operation_error(deleted, "invalid_path")
+    assert ".gd" in err["message"]
+    assert str(notes) in err["message"]
+    # The non-script file survives the refusal.
+    assert notes.read_text(encoding="utf-8") == "not a script\n"
 
 
 @pytest.mark.e2e

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,7 +17,9 @@ from gda.models import (
     SceneGetResult,
     SceneListResult,
     ScriptCreateResult,
+    ScriptDeleteResult,
     ScriptGetResult,
+    ScriptListResult,
 )
 
 
@@ -328,6 +330,57 @@ def test_script_get_result_round_trips_source_and_metadata():
     assert got.class_name == "Hero"
     assert got.extends == "Node2D"
     assert json.loads(got.model_dump_json()) == payload
+
+
+def test_script_list_result_round_trips_enumerated_scripts():
+    # The script-list operation enumerates the project's .gd files (issue #117):
+    # each entry carries its res:// path plus the class_name/extends parsed
+    # cheaply from the script's raw source (no compilation, issue #30). A script
+    # that declares neither carries null metadata, so the listing names every
+    # .gd it found.
+    payload = {
+        "scripts": [
+            {"path": "res://hero.gd", "class_name": "Hero", "extends": "Node2D"},
+            {"path": "res://util.gd", "class_name": None, "extends": "RefCounted"},
+            {"path": "res://empty.gd", "class_name": None, "extends": None},
+        ]
+    }
+
+    listed = ScriptListResult.model_validate(payload)
+
+    assert listed.scripts[0].path == "res://hero.gd"
+    assert listed.scripts[0].class_name == "Hero"
+    assert listed.scripts[1].extends == "RefCounted"
+    assert listed.scripts[2].class_name is None
+    assert json.loads(listed.model_dump_json()) == payload
+
+
+def test_script_list_result_round_trips_an_empty_project():
+    # A project with no scripts is a valid, empty listing — not an error.
+    payload = {"scripts": []}
+
+    listed = ScriptListResult.model_validate(payload)
+
+    assert listed.scripts == []
+    assert json.loads(listed.model_dump_json()) == payload
+
+
+def test_script_delete_result_round_trips():
+    # The script-delete operation reports what it removed (issue #117): the path,
+    # and the deleted script's class_name/extends so the result names the content,
+    # not just the file.
+    payload = {
+        "path": "res://hero.gd",
+        "class_name": "Hero",
+        "extends": "Node2D",
+    }
+
+    deleted = ScriptDeleteResult.model_validate(payload)
+
+    assert deleted.path == "res://hero.gd"
+    assert deleted.class_name == "Hero"
+    assert deleted.extends == "Node2D"
+    assert json.loads(deleted.model_dump_json()) == payload
 
 
 def test_node_set_result_round_trips_the_coerced_property():

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -361,18 +361,64 @@ def test_script_get_schema_emits_model_derived_contract_without_other_args():
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
 
+def test_script_list_schema_emits_model_derived_contract_without_a_project():
+    # The ADR-0004 hard gate for script list (issue #117): the bare --schema flag
+    # — no --project — short-circuits into the self-description, derived from the
+    # same typed models that back --json. script list takes no operation params,
+    # so its input schema is trivially empty (the project is process context,
+    # ADR-0006), exactly like scene list.
+    from gda.models import ScriptListParams, ScriptListResult
+
+    result = CliRunner().invoke(app, ["script", "list", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ScriptListParams.model_json_schema()
+    assert doc["output"] == ScriptListResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert doc["input"].get("properties", {}) == {}
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_script_delete_schema_emits_model_derived_contract_without_other_args():
+    from gda.models import ScriptDeleteParams, ScriptDeleteResult
+
+    result = CliRunner().invoke(app, ["script", "delete", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ScriptDeleteParams.model_json_schema()
+    assert doc["output"] == ScriptDeleteResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
 def test_sample_script_results_validate_against_emitted_output_schemas():
     # A sample --json payload of each script command satisfies the contract its
-    # --schema emits (the other half of the ADR-0004 hard gate, issue #110).
-    from tests.test_script_commands import CREATE_RESULT, GET_RESULT
+    # --schema emits (the other half of the ADR-0004 hard gate, issues #110, #117).
+    from tests.test_script_commands import CREATE_RESULT, GET_RESULT, LIST_RESULT
 
     create_doc = json.loads(
         CliRunner().invoke(app, ["script", "create", "--schema"]).stdout
     )
     get_doc = json.loads(CliRunner().invoke(app, ["script", "get", "--schema"]).stdout)
+    list_doc = json.loads(
+        CliRunner().invoke(app, ["script", "list", "--schema"]).stdout
+    )
+    delete_doc = json.loads(
+        CliRunner().invoke(app, ["script", "delete", "--schema"]).stdout
+    )
 
     jsonschema.validate(instance=CREATE_RESULT, schema=create_doc["output"])
     jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
+    jsonschema.validate(instance=LIST_RESULT, schema=list_doc["output"])
+    # A sample delete payload, shaped as the script-delete operation emits it.
+    jsonschema.validate(
+        instance={"path": "res://hero.gd", "class_name": "Hero", "extends": "Node2D"},
+        schema=delete_doc["output"],
+    )
 
 
 def test_script_schema_spawns_no_godot(monkeypatch):
@@ -382,7 +428,12 @@ def test_script_schema_spawns_no_godot(monkeypatch):
     monkeypatch.setattr("gda.headless.resolve_godot_binary", boom)
     monkeypatch.setattr("gda.cli._make_runner", boom)
 
-    for command in (["script", "create"], ["script", "get"]):
+    for command in (
+        ["script", "create"],
+        ["script", "get"],
+        ["script", "list"],
+        ["script", "delete"],
+    ):
         result = CliRunner().invoke(app, [*command, "--schema"])
         assert result.exit_code == 0
         assert set(json.loads(result.stdout)) >= {"input", "output", "error"}

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -12,7 +12,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
-from tests.support import inject_runner, sentinel
+from tests.support import FakeRunner, inject_runner, sentinel
 
 CREATE_RESULT = {
     "path": "/tmp/proj/hero.gd",
@@ -152,3 +152,60 @@ def test_script_get_json_emits_source_and_metadata_and_exit_zero(monkeypatch):
     assert data["class_name"] == "Hero"
     assert data["extends"] == "Node2D"
     assert fake.calls == [("script-get", {"path": "/tmp/proj/hero.gd"})]
+
+
+LIST_RESULT = {
+    "scripts": [
+        {"path": "res://hero.gd", "class_name": "Hero", "extends": "Node2D"},
+        {"path": "res://util.gd", "class_name": None, "extends": "RefCounted"},
+        {"path": "res://empty.gd", "class_name": None, "extends": None},
+    ]
+}
+
+
+def test_script_list_json_enumerates_project_scripts_and_exit_zero(monkeypatch, tmp_path):
+    # script list enumerates the resolved project's .gd files (issue #117): each
+    # entry carries its res:// path plus the class_name/extends parsed cheaply
+    # from the script's raw source.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(LIST_RESULT)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app, ["script", "list", "--project", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert [s["path"] for s in data["scripts"]] == [
+        "res://hero.gd",
+        "res://util.gd",
+        "res://empty.gd",
+    ]
+    assert data["scripts"][0]["class_name"] == "Hero"
+    assert data["scripts"][1]["extends"] == "RefCounted"
+    assert data["scripts"][2]["class_name"] is None
+    # script list takes no operation params: the project is process context.
+    assert fake.calls == [("script-list", {})]
+
+
+def test_script_list_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
+    # script list enumerates res:// in the resolved project, so --project must
+    # reach the runner (which hands it to the engine as --path, issue #32).
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    seen: dict = {}
+
+    def record(binary, project):
+        seen["project"] = project
+        return FakeRunner(
+            RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+        )
+
+    monkeypatch.setattr("gda.cli._make_runner", record)
+
+    result = CliRunner().invoke(
+        app, ["script", "list", "--project", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert seen["project"] == tmp_path

--- a/tests/test_script_errors.py
+++ b/tests/test_script_errors.py
@@ -45,6 +45,32 @@ def _invoke_script_get(monkeypatch, code: str, message: str):
     return CliRunner().invoke(app, ["script", "get", "/x/hero.gd", "--json"])
 
 
+def _invoke_script_list(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: script-list\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(app, ["script", "list", "--json"])
+
+
+def _invoke_script_delete(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: script-delete\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(app, ["script", "delete", "/x/hero.gd", "--json"])
+
+
 def test_script_create_collision_reuses_stable_already_exists_code(monkeypatch):
     # No-clobber: a create whose target already exists reuses the registered
     # already_exists code (the same one scene create uses), leaving the file
@@ -125,3 +151,68 @@ def test_script_get_wrong_extension_reuses_stable_invalid_path_code(monkeypatch)
     err = json.loads(result.stdout)["error"]
     assert err["code"] == "invalid_path"
     assert ".gd" in err["message"]
+
+
+def test_script_list_without_project_reuses_stable_project_not_found_code(monkeypatch):
+    # script list enumerates res:// in a project, so it cannot run projectless
+    # (issue #117): with no resolvable project, the operation reuses the
+    # registered project_not_found code (the same one scene list uses) so an
+    # agent knows to pass --project rather than retry.
+    result = _invoke_script_list(
+        monkeypatch,
+        "project_not_found",
+        "script list requires a Godot project; none was resolved — pass --project",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "project_not_found"
+    assert "--project" in err["message"]
+
+
+def test_script_delete_missing_file_reuses_stable_path_not_found_code(monkeypatch):
+    # A script that does not exist reuses the registered path_not_found code (the
+    # same one script get uses), so an agent branches on the missing-file mode
+    # without a new code.
+    result = _invoke_script_delete(
+        monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert "/x/hero.gd" in err["message"]
+
+
+def test_script_delete_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
+    # delete only removes a .gd script, so a non-.gd target is refused with the
+    # registered invalid_path code — the same addressing boundary create/get use.
+    result = _invoke_script_delete(
+        monkeypatch, "invalid_path", "script path must end in .gd: /x/notes.txt"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_path"
+    assert ".gd" in err["message"]
+
+
+def test_script_delete_unlink_failure_reuses_stable_delete_failed_code(monkeypatch):
+    # The op found the script but the underlying unlink/remove failed (a
+    # read-only filesystem, a permission boundary): this maps to the stable
+    # delete_failed code (the same one scene delete uses) so an agent can tell
+    # "deletion was blocked" apart from other failures.
+    result = _invoke_script_delete(
+        monkeypatch,
+        "delete_failed",
+        "failed to delete script /x/hero.gd: Permission denied",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "delete_failed"
+    assert "/x/hero.gd" in err["message"]


### PR DESCRIPTION
## Summary

Rounds out script-file CRUD with the two discovery/removal commands, the script-group analogue of `scene list` + `scene delete` (#54), reusing the script-file addressing and load/save plumbing from the script-group tracer (#110).

- **`gda script list`** — walks the resolved project's `res://` tree and enumerates every `.gd` script as typed JSON, each with `class_name`/`extends` parsed from **raw source** (no compilation, #30). Output model `ScriptListResult` (`ListedScript{path, class_name, extends}`). Projectless it refuses with `project_not_found`; an empty project is a valid empty listing.
- **`gda script delete PATH`** — removes a `.gd` script and reports the removed script's `class_name`/`extends` (parsed before deletion). Output model `ScriptDeleteResult{path, class_name, extends}`. Honors the group's addressing boundary: only a `.gd` path is removed (non-`.gd` → `invalid_path`, never erasing an arbitrary file), missing target → `path_not_found`.

Lifecycle round-trips: `create` → `list` shows it → `delete` → `list` no longer shows it.

## Error codes

No new codes. List/delete reuse existing `project_not_found`, `path_not_found`, `invalid_path`, `delete_failed`. The `delete_failed` description was generalized ("A scene file…" → "A file…") in both the Python registry and the ADR-0002 table since the code is now shared with `script delete` (mirrors how #110 generalized `path_not_found`). The registry-drift test keeps Python registry / ADR-0002 table / GDScript mirror in sync.

## Tests (all three seams per the PRD)

- **S1 e2e** (real Godot, `@pytest.mark.e2e`): create→list→delete→list round-trip, empty-project listing (guards `.godot` cache leak), projectless refusal, delete safety boundary (non-`.gd` refused and left on disk).
- **S3 CLI+FakeRunner**: flag/JSON shape + failure classification for both commands (4 error cases, each asserting reuse of a stable code).
- **S2 model/parser unit**: output-model round-trips + ADR-0004 `--schema` hard gate (emitted schema equals the model-derived JSON Schema; sample `--json` validates).

Full suite: **250 passed** (`uv run pytest -q`); script e2e: **21 passed** against real Godot (6 new), verified non-skipped.

## Acceptance criteria (#117)

- [x] `gda script list` enumerates scripts with `class_name`/`extends` as typed JSON
- [x] `gda script delete` removes a script and round-trips against `list`
- [x] Both ship `--json` + the ADR-0004 `--schema` hard gate
- [x] Failure modes surface as structured `GdaError`s with registered codes
- [x] Tests at S1/S2/S3

Closes #117.
