### PR TITLE
feat(script): script set + script validate + script attach — edit, compile-check, bind (#118)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -91,6 +91,8 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 | `node_not_found` | `operation` | `operation` | A requested node path does not resolve to a node in the scene. |
 | `unknown_property` | `operation` | `operation` | A requested property does not exist as a settable property on the node. |
 | `uncoercible_value` | `operation` | `operation` | A supplied value cannot be coerced to the property's declared Godot type. |
+| `no_search_match` | `operation` | `operation` | A search-replace script edit found no occurrence of the search string. |
+| `invalid_line_range` | `operation` | `operation` | A line-range script edit specified lines outside the script's bounds, or end before start. |
 | `contract_violation` | `parse` | `parser` | The process claimed success but violated the structured-output contract. |
 
 ## Considered options

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -106,6 +106,7 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 | `uncoercible_value` | `operation` | `operation` | A supplied value cannot be coerced to the property's declared Godot type. |
 | `no_search_match` | `operation` | `operation` | A search-replace script edit found no occurrence of the search string. |
 | `invalid_line_range` | `operation` | `operation` | A line-range script edit specified lines outside the script's bounds, or end before start. |
+| `script_compile_failed` | `operation` | `operation` | A script could not be attached to a node because it does not compile. |
 | `contract_violation` | `parse` | `parser` | The process claimed success but violated the structured-output contract. |
 
 ## Considered options

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -56,6 +56,19 @@ The GDScript payload owns only `code` and `message`. `gda` owns the public
 `GdaError` wrapper: it validates that the code is registered, assigns the
 `operation` category, preserves the message, and copies stderr into diagnostics.
 
+### stderr as advisory diagnostics
+
+stderr is still **never** parsed for the success/failure *outcome* or for stable
+error codes — those come only from the exit code and the stdout sentinel, as
+above. A command **may**, however, surface engine error text from stderr as
+**advisory, best-effort diagnostics** on its *success* result, when a useful
+detail is available nowhere else. `script validate` (#118) is the established
+case: when it reports `valid=false`, the per-error `line` and `message` exist
+only in the engine's stderr (no bound API exposes them), so `gda` parses them
+into the result's `diagnostics`. This stays within the contract: the diagnostics
+are advisory (they may hold only the first error, and `column` is unavailable on
+the standard build), and they never determine the outcome or a stable code.
+
 ## `GdaError.code` registry
 
 `GdaError.code` values are a public ABI for agents. Their authoritative source is

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -181,6 +181,26 @@ boundary as the rest of the group — only a `.gd` path is removed (a non-`.gd` 
 with `invalid_path`, never erasing an arbitrary file), and a missing target is `path_not_found`.
 The lifecycle round-trips: `create` → `list` shows it → `delete` → `list` no longer shows it.
 
+**Editing source** (established by #118): `gda script set PATH` edits an **existing** `.gd`
+script as **raw text** — it never compiles or loads the script, so editing one never runs
+project code (the read trust boundary of #30). It edits only a script that exists; a missing
+target is `path_not_found`, never a silent create. Exactly one of three mutually-exclusive
+modes is selected at the CLI (a missing or mixed mode is a usage error, exit 2):
+
+- **search-replace** — `--search <old> --replace <new>`: replace **every** literal (not regex)
+  occurrence of `<old>` with `<new>`. A search string the source does not contain is refused
+  with `no_search_match` (the edit landed nowhere; the file is left untouched). `--search` and
+  `--replace` are required together and cannot be combined with the other modes' flags.
+- **line-range** — `--start-line N [--end-line M] --content <text>`: replace lines `N..M`
+  (1-based, **inclusive**; `M` defaults to `N`) with `<text>`. **Lines are the parts of the
+  source split on `\n`**, so a trailing newline yields a final empty part — `"a\nb\n"` is **3**
+  lines (`["a", "b", ""]`). The valid range is `1..N` where `N` is that part count; a range
+  outside the bounds, or `end` before `start`, is refused with `invalid_line_range`.
+- **full** — `--content <text>` with no `--start-line`: overwrite the entire file.
+
+`script set` re-parses the **written** source's `class_name`/`extends` and returns them, so an
+edit round-trips through `script get` (the verifier).
+
 | Command | Description |
 | --- | --- |
 | `gda script create` | Create a `.gd` script (template or content) |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -201,6 +201,21 @@ modes is selected at the CLI (a missing or mixed mode is a usage error, exit 2):
 `script set` re-parses the **written** source's `class_name`/`extends` and returns them, so an
 edit round-trips through `script get` (the verifier).
 
+**Attaching to a node** (established by #118): `gda script attach SCENE --node <node-path>
+--script <gd-path>` binds a `.gd` script to a node inside a `.tscn`. It reuses the node group's
+**node-path addressing** (#53): `--node .` is the scene root, `--node A/B` a descendant — exactly
+the form `node list` reports. Unlike the other script-file ops, `attach` is a **scene mutation**:
+it loads and **instantiates** the scene (so it runs the `_init` of scripts already in the scene —
+the inherent trust boundary of `node set`, ADR-0009), attaches the script via `set_script`, and
+re-packs and saves; loading the `.gd` to attach compiles it but never runs an instance of it. It
+reuses existing codes (no new ones): a missing/unloadable `.gd` is `path_not_found`/`invalid_path`,
+a non-`.gd` script is `invalid_path`, a node path that resolves to nothing is `node_not_found`, a
+missing or non-scene file is `path_not_found`/`not_a_scene`, and a scene whose instances vanish or
+degrade on load is `missing_dependency` (the mutation-integrity boundary, #64). The result echoes
+the scene, node, script, and the attached script's `class_name` (null when it declares none),
+verifiable by reading the saved `.tscn` back: the script now appears as an `ext_resource` the node
+references.
+
 | Command | Description |
 | --- | --- |
 | `gda script create` | Create a `.gd` script (template or content) |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -206,12 +206,16 @@ edit round-trips through `script get` (the verifier).
 **node-path addressing** (#53): `--node .` is the scene root, `--node A/B` a descendant — exactly
 the form `node list` reports. Unlike the other script-file ops, `attach` is a **scene mutation**:
 it loads and **instantiates** the scene (so it runs the `_init` of scripts already in the scene —
-the inherent trust boundary of `node set`, ADR-0009), attaches the script via `set_script`, and
-re-packs and saves; loading the `.gd` to attach compiles it but never runs an instance of it. It
-reuses existing codes (no new ones): a missing/unloadable `.gd` is `path_not_found`/`invalid_path`,
-a non-`.gd` script is `invalid_path`, a node path that resolves to nothing is `node_not_found`, a
-missing or non-scene file is `path_not_found`/`not_a_scene`, and a scene whose instances vanish or
-degrade on load is `missing_dependency` (the mutation-integrity boundary, #64). The result echoes
+the inherent trust boundary of `node set`, ADR-0009), attaches the script via `set_script` (which,
+for a script that compiles, constructs an instance of the newly-attached script, running *its*
+`_init` too), and re-packs and saves. The attached script **must compile**: the headless engine
+silently rejects a non-compiling script from `set_script` (the node's script stays null and a
+re-pack saves no script), so attach **refuses** one with `script_compile_failed` rather than report
+a phantom success over a scene with nothing attached — check a script with `script validate` first.
+Other failures reuse existing codes: a missing script is `path_not_found`, a non-`.gd` script is
+`invalid_path`, a node path that resolves to nothing is `node_not_found`, a missing or non-scene
+file is `path_not_found`/`not_a_scene`, and a scene whose instances vanish or degrade on load is
+`missing_dependency` (the mutation-integrity boundary, #64). The result echoes
 the scene, node, script, and the attached script's `class_name` (null when it declares none),
 verifiable by reading the saved `.tscn` back: the script now appears as an `ext_resource` the node
 references.

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -216,6 +216,22 @@ the scene, node, script, and the attached script's `class_name` (null when it de
 verifiable by reading the saved `.tscn` back: the script now appears as an `ext_resource` the node
 references.
 
+**Validating** (established by #118): `gda script validate PATH` syntax/compile-checks a `.gd`
+script. **Mechanism**: it reads the file text, sets it on a fresh `GDScript`, and calls
+`reload()` — `OK` means the script compiles. It compiles the script (`reload` parses and
+compiles), but never **instantiates** it, so it does not run the script's instance code. Pass
+`--project` when the script `extends` a project `class_name` or preloads a project resource and so
+needs project context to compile; a self-contained `extends Node` script validates projectless.
+
+A **`valid=false` result is a successful operation** — `validate` exits `0` with
+`{valid: false, error_string, diagnostics}` for a script that does not compile. The op only
+*fails* (non-zero, `invalid_path`/`path_not_found`) for op errors (empty/non-`.gd` path, missing
+or unreadable file). `diagnostics` are **best-effort advisory** `{line, message}` pairs: the line
+and message are not available from any bound API — only from the engine's stderr — so they are
+parsed Python-side and may carry only the **first** error. **`column` is always null** on the
+standard Godot build (the engine exposes no column for a parse error). `validate` reuses existing
+codes only (no new ones).
+
 | Command | Description |
 | --- | --- |
 | `gda script create` | Create a `.gd` script (template or content) |

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 import typer
 
-from gda.errors import classify_info
+from gda.errors import classify_info, classify_script_validate
 from gda.headless import (
     HeadlessCommand,
     godot_option,
@@ -44,6 +44,8 @@ from gda.models import (
     SceneListParams,
     SceneListResult,
     SceneNode,
+    ScriptAttachParams,
+    ScriptAttachResult,
     ScriptCreateParams,
     ScriptCreateResult,
     ScriptDeleteParams,
@@ -52,6 +54,10 @@ from gda.models import (
     ScriptGetResult,
     ScriptListParams,
     ScriptListResult,
+    ScriptSetParams,
+    ScriptSetResult,
+    ScriptValidateParams,
+    ScriptValidateResult,
 )
 from gda.project import resolve_project_dir
 from gda.runner import GodotRunner
@@ -191,6 +197,25 @@ SCRIPT_DELETE_COMMAND: HeadlessCommand[ScriptDeleteResult] = HeadlessCommand(
     operation="script-delete",
     input_model=ScriptDeleteParams,
     output_model=ScriptDeleteResult,
+)
+
+SCRIPT_SET_COMMAND: HeadlessCommand[ScriptSetResult] = HeadlessCommand(
+    operation="script-set",
+    input_model=ScriptSetParams,
+    output_model=ScriptSetResult,
+)
+
+SCRIPT_ATTACH_COMMAND: HeadlessCommand[ScriptAttachResult] = HeadlessCommand(
+    operation="script-attach",
+    input_model=ScriptAttachParams,
+    output_model=ScriptAttachResult,
+)
+
+SCRIPT_VALIDATE_COMMAND: HeadlessCommand[ScriptValidateResult] = HeadlessCommand(
+    operation="script-validate",
+    input_model=ScriptValidateParams,
+    output_model=ScriptValidateResult,
+    classify=classify_script_validate,
 )
 
 
@@ -480,7 +505,7 @@ def set_property(
 
 
 def _render_script_metadata(
-    script: "ScriptCreateResult | ScriptGetResult | ListedScript | ScriptDeleteResult",
+    script: "ScriptCreateResult | ScriptGetResult | ListedScript | ScriptDeleteResult | ScriptSetResult",
 ) -> str:
     """Render a script's path plus its class_name/extends for humans."""
     meta = []
@@ -595,6 +620,179 @@ def delete_script(
         project=resolve_project_dir(project),
         json_output=json_output,
         render_text=lambda removed: f"deleted {_render_script_metadata(removed)}",
+        make_runner=_make_runner,
+    )
+
+
+@script_app.command(name="set", cls=SCRIPT_SET_COMMAND.command_class())
+def set_script(
+    path: str = typer.Argument(..., help="The .gd script file to edit."),
+    search: Optional[str] = typer.Option(
+        None,
+        "--search",
+        help=(
+            "search-replace mode: literal substring to find (not regex); all "
+            "occurrences are replaced. Requires --replace."
+        ),
+    ),
+    replace: Optional[str] = typer.Option(
+        None,
+        "--replace",
+        help="search-replace mode: literal replacement text. Requires --search.",
+    ),
+    start_line: Optional[int] = typer.Option(
+        None,
+        "--start-line",
+        help=(
+            "line-range mode: first line to replace (1-based, inclusive). "
+            "Requires --content."
+        ),
+    ),
+    end_line: Optional[int] = typer.Option(
+        None,
+        "--end-line",
+        help=(
+            "line-range mode: last line to replace (1-based, inclusive); "
+            "defaults to --start-line. Requires --content and --start-line."
+        ),
+    ),
+    content: Optional[str] = typer.Option(
+        None,
+        "--content",
+        help=(
+            "Replacement text: the line span in line-range mode, or the whole "
+            "file (full mode) when --start-line is omitted."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = SCRIPT_SET_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Edit a .gd script via search-replace, line-range, or full overwrite."""
+    _validate_set_mode(search, replace, start_line, end_line, content)
+    SCRIPT_SET_COMMAND.emit(
+        ScriptSetParams(
+            path=_normalize_path(path),
+            search=search,
+            replace=replace,
+            start_line=start_line,
+            end_line=end_line,
+            content=content,
+        ),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=lambda edited: f"set {_render_script_metadata(edited)}",
+        make_runner=_make_runner,
+    )
+
+
+def _validate_set_mode(
+    search: Optional[str],
+    replace: Optional[str],
+    start_line: Optional[int],
+    end_line: Optional[int],
+    content: Optional[str],
+) -> None:
+    """Enforce that ``script set`` selects exactly one edit mode (issue #118).
+
+    Validated at the CLI layer (before any dispatch, like ``script create``'s
+    mutual exclusion), so the operation is always handed exactly one well-formed
+    mode and never has to defend against "no mode" or a mixed-mode combination.
+    A violation is a usage error (exit 2).
+    """
+    has_search = search is not None or replace is not None
+    has_line_range = start_line is not None or end_line is not None
+
+    if has_search:
+        if search is None or replace is None:
+            raise typer.BadParameter("--search and --replace must be used together.")
+        if content is not None or has_line_range:
+            raise typer.BadParameter(
+                "--search/--replace cannot be combined with --content, "
+                "--start-line, or --end-line."
+            )
+        return
+
+    if has_line_range:
+        if content is None:
+            raise typer.BadParameter("--start-line/--end-line require --content.")
+        if start_line is None:
+            raise typer.BadParameter("--end-line requires --start-line.")
+        return
+
+    if content is None:
+        raise typer.BadParameter(
+            "script set needs an edit: --search/--replace, --start-line "
+            "(+ --content), or --content (full overwrite)."
+        )
+
+
+@script_app.command(name="attach", cls=SCRIPT_ATTACH_COMMAND.command_class())
+def attach_script(
+    path: str = typer.Argument(..., help="The .tscn scene file to mutate."),
+    node: str = typer.Option(
+        ...,
+        "--node",
+        help=(
+            "Node path, relative to the scene root: '.' addresses the root "
+            "itself, 'Player/Arm' a nested node."
+        ),
+    ),
+    script: str = typer.Option(
+        ..., "--script", help="The .gd script file to attach to the node."
+    ),
+    json_output: bool = json_option(),
+    schema: bool = SCRIPT_ATTACH_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Attach a .gd script to a node (by node path) in a scene and save."""
+    SCRIPT_ATTACH_COMMAND.emit(
+        ScriptAttachParams(
+            path=_normalize_path(path),
+            node=node,
+            script=_normalize_path(script),
+        ),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=lambda attached: (
+            f"attached {attached.script} to {attached.node} in {attached.scene_path}"
+        ),
+        make_runner=_make_runner,
+    )
+
+
+def _render_validate(validated: "ScriptValidateResult") -> str:
+    """Render a validate result: valid/invalid plus best-effort diagnostics."""
+    if validated.valid:
+        return f"valid {validated.path}"
+    lines = [f"invalid {validated.path}"]
+    if validated.error_string is not None:
+        lines.append(f"  {validated.error_string}")
+    for diag in validated.diagnostics:
+        location = f"line {diag.line}" if diag.line is not None else "unknown line"
+        lines.append(f"  {location}: {diag.message}")
+    return "\n".join(lines)
+
+
+@script_app.command(name="validate", cls=SCRIPT_VALIDATE_COMMAND.command_class())
+def validate_script(
+    path: str = typer.Argument(..., help="The .gd script file to validate."),
+    json_output: bool = json_option(),
+    schema: bool = SCRIPT_VALIDATE_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Syntax/compile-check a .gd script; an invalid script is a successful op."""
+    SCRIPT_VALIDATE_COMMAND.emit(
+        ScriptValidateParams(path=_normalize_path(path)),
+        godot=godot,
+        project=resolve_project_dir(project),
+        json_output=json_output,
+        render_text=_render_validate,
         make_runner=_make_runner,
     )
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -193,6 +193,18 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A supplied value cannot be coerced to the property's declared Godot type.",
     ),
     ErrorCodeSpec(
+        "no_search_match",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A search-replace script edit found no occurrence of the search string.",
+    ),
+    ErrorCodeSpec(
+        "invalid_line_range",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A line-range script edit specified lines outside the script's bounds, or end before start.",
+    ),
+    ErrorCodeSpec(
         "contract_violation",
         ErrorCategory.PARSE,
         ErrorCodeSource.PARSER,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -205,6 +205,12 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A line-range script edit specified lines outside the script's bounds, or end before start.",
     ),
     ErrorCodeSpec(
+        "script_compile_failed",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A script could not be attached to a node because it does not compile.",
+    ),
+    ErrorCodeSpec(
         "contract_violation",
         ErrorCategory.PARSE,
         ErrorCodeSource.PARSER,

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -204,10 +204,14 @@ def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | 
 # A `SCRIPT ERROR: <message>` line and the `GDScript::reload (...:<line>)` frame
 # that follows it carry, between them, the one advisory diagnostic the engine
 # emits for a failed validate (issue #118). The line number is the final `:`
-# part of the reload frame; there is NO column on the standard build. Backtrace
-# frames (`[n] _initialize (...)`) are operations.gd's own lines, not the
-# validated script's, so they are deliberately not matched.
-_SCRIPT_ERROR_LINE = re.compile(r"^\s*SCRIPT ERROR:\s*(?P<message>.*?)\s*$", re.MULTILINE)
+# part of the reload frame; there is NO column on the standard build.
+# `[ \t]` (not `\s`) bounds the message capture so it cannot span newlines — an
+# empty SCRIPT ERROR message must not swallow the following reload frame.
+# Backtrace frames (`[n] _initialize (...)`) are operations.gd's own lines, not
+# the validated script's, so they are deliberately not matched.
+_SCRIPT_ERROR_LINE = re.compile(
+    r"^[ \t]*SCRIPT ERROR:[ \t]*(?P<message>.*?)[ \t]*$", re.MULTILINE
+)
 _RELOAD_FRAME = re.compile(r"GDScript::reload \([^)]*:(?P<line>\d+)\)")
 
 
@@ -218,18 +222,35 @@ def parse_validate_diagnostics(stderr: str) -> list[ScriptDiagnostic]:
     ``GDScript.reload()`` are available only from stderr, not from any bound API
     (ADR-0002's stderr is advisory only — it is never parsed for the stable
     success/failure outcome or error codes, only surfaced here as best-effort
-    diagnostics). Each ``SCRIPT ERROR: <message>`` line is paired with the line
-    number from its following ``GDScript::reload (...:<line>)`` frame; ``column``
-    is always null (the engine exposes none). Returns ``[]`` when nothing parses.
+    diagnostics). ``column`` is always null (the engine exposes none).
+
+    The validate op does exactly ONE ``reload()``, so the only legitimate
+    ``GDScript::reload`` frame in stderr is the validated script's. Each
+    ``SCRIPT ERROR: <message>`` line is paired with a reload frame found ONLY in
+    the window up to the next ``SCRIPT ERROR`` line, and a ``SCRIPT ERROR`` with
+    no reload frame in that window is dropped: bounding the search keeps a later
+    error's frame from being mis-attributed to an earlier message, and the
+    frame requirement excludes unrelated engine ``SCRIPT ERROR`` noise — e.g. an
+    autoload's own startup error under ``--project``, whose frame is its
+    ``_init``/``_ready``, not ``GDScript::reload``. Returns ``[]`` when nothing
+    matches.
     """
+    matches = list(_SCRIPT_ERROR_LINE.finditer(stderr))
     diagnostics: list[ScriptDiagnostic] = []
-    for match in _SCRIPT_ERROR_LINE.finditer(stderr):
-        message = match.group("message")
-        # The reload frame, when present, follows the SCRIPT ERROR line; look
-        # for the next one after this match to read its line number.
-        frame = _RELOAD_FRAME.search(stderr, match.end())
-        line = int(frame.group("line")) if frame is not None else None
-        diagnostics.append(ScriptDiagnostic(line=line, column=None, message=message))
+    for index, match in enumerate(matches):
+        window_end = (
+            matches[index + 1].start() if index + 1 < len(matches) else len(stderr)
+        )
+        frame = _RELOAD_FRAME.search(stderr, match.end(), window_end)
+        if frame is None:
+            continue
+        diagnostics.append(
+            ScriptDiagnostic(
+                line=int(frame.group("line")),
+                column=None,
+                message=match.group("message"),
+            )
+        )
     return diagnostics
 
 

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -36,6 +36,7 @@ the shell-convention codes 124/127; version/operation/parse get distinct small
 codes so a shell consumer can tell categories apart without parsing the JSON error.
 """
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeVar
@@ -50,7 +51,14 @@ from gda.exit_codes import (
     EXIT_TIMEOUT,
     EXIT_VERSION,
 )
-from gda.models import EngineVersion, ErrorCategory, GdaError, OperationErrorEnvelope
+from gda.models import (
+    EngineVersion,
+    ErrorCategory,
+    GdaError,
+    OperationErrorEnvelope,
+    ScriptDiagnostic,
+    ScriptValidateResult,
+)
 from gda.parser import parse_result
 from gda.runner import LaunchFailure, RunResult
 
@@ -191,6 +199,58 @@ def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | 
             EXIT_PARSE,
             result.stderr,
         )
+
+
+# A `SCRIPT ERROR: <message>` line and the `GDScript::reload (...:<line>)` frame
+# that follows it carry, between them, the one advisory diagnostic the engine
+# emits for a failed validate (issue #118). The line number is the final `:`
+# part of the reload frame; there is NO column on the standard build. Backtrace
+# frames (`[n] _initialize (...)`) are operations.gd's own lines, not the
+# validated script's, so they are deliberately not matched.
+_SCRIPT_ERROR_LINE = re.compile(r"^\s*SCRIPT ERROR:\s*(?P<message>.*?)\s*$", re.MULTILINE)
+_RELOAD_FRAME = re.compile(r"GDScript::reload \([^)]*:(?P<line>\d+)\)")
+
+
+def parse_validate_diagnostics(stderr: str) -> list[ScriptDiagnostic]:
+    """Parse advisory ``script validate`` diagnostics from the engine's stderr.
+
+    A pure function (no engine, no I/O): the line/message of a failed
+    ``GDScript.reload()`` are available only from stderr, not from any bound API
+    (ADR-0002's stderr is advisory only — it is never parsed for the stable
+    success/failure outcome or error codes, only surfaced here as best-effort
+    diagnostics). Each ``SCRIPT ERROR: <message>`` line is paired with the line
+    number from its following ``GDScript::reload (...:<line>)`` frame; ``column``
+    is always null (the engine exposes none). Returns ``[]`` when nothing parses.
+    """
+    diagnostics: list[ScriptDiagnostic] = []
+    for match in _SCRIPT_ERROR_LINE.finditer(stderr):
+        message = match.group("message")
+        # The reload frame, when present, follows the SCRIPT ERROR line; look
+        # for the next one after this match to read its line number.
+        frame = _RELOAD_FRAME.search(stderr, match.end())
+        line = int(frame.group("line")) if frame is not None else None
+        diagnostics.append(ScriptDiagnostic(line=line, column=None, message=message))
+    return diagnostics
+
+
+def classify_script_validate(
+    result: RunResult, binary: Path
+) -> ScriptValidateResult | Failure:
+    """Classify the raw ``script validate`` result (issue #118).
+
+    The per-command layer for ``script validate``: the shared decision tree comes
+    from ``classify_run`` (an op error — missing path, wrong extension,
+    unreadable file — is still a ``Failure``). For a SUCCESSFUL op reporting an
+    invalid script (``valid=false``), the line/message diagnostics are not in the
+    sentinel — they live only in the engine's stderr — so this layer parses them
+    in and attaches them to the result.
+    """
+    outcome = classify_run(result, binary, ScriptValidateResult)
+    if isinstance(outcome, Failure):
+        return outcome
+    if not outcome.valid:
+        outcome.diagnostics = parse_validate_diagnostics(result.stderr)
+    return outcome
 
 
 def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -607,6 +607,210 @@ class ScriptDeleteResult(BaseModel):
     )
 
 
+class ScriptSetParams(BaseModel):
+    """The operation params of ``gda script set`` (issue #118).
+
+    Edits an existing ``.gd`` script on disk as RAW TEXT — it never compiles or
+    loads the script, so editing one can never run project code (the read trust
+    boundary of issue #30). ``path`` addresses the script by its ``res://`` or
+    filesystem path. The remaining params select one of three mutually-exclusive
+    edit modes (the CLI guarantees exactly one is supplied); the operation infers
+    the mode by presence, with precedence search → line-range → full:
+
+    - **search-replace** — ``search``/``replace`` both present: every literal
+      (not regex) occurrence of ``search`` is replaced with ``replace``.
+    - **line-range** — ``start_line`` (+ optional ``end_line``) with ``content``:
+      the given 1-based, inclusive line span is replaced with ``content``.
+    - **full** — only ``content`` present: the whole file is overwritten.
+    """
+
+    path: str
+    search: str | None = Field(
+        default=None,
+        description=(
+            "search-replace mode: the literal substring to find (NOT a regex). "
+            "Every occurrence is replaced with 'replace'. Requires 'replace'."
+        ),
+    )
+    replace: str | None = Field(
+        default=None,
+        description=(
+            "search-replace mode: the literal text each occurrence of 'search' "
+            "is replaced with. Requires 'search'."
+        ),
+    )
+    start_line: int | None = Field(
+        default=None,
+        description=(
+            "line-range mode: the first line to replace, 1-based and inclusive. "
+            "Lines are the parts of the source split on '\\n', so a trailing "
+            "newline yields a final empty part: 'a\\nb\\n' is 3 lines "
+            "(['a', 'b', '']). Valid range is 1..N where N is that part count. "
+            "Requires 'content'."
+        ),
+    )
+    end_line: int | None = Field(
+        default=None,
+        description=(
+            "line-range mode: the last line to replace, 1-based and inclusive; "
+            "defaults to 'start_line' (a single-line replace). Must satisfy "
+            "start_line <= end_line <= N (the line count). Requires 'content'."
+        ),
+    )
+    content: str | None = Field(
+        default=None,
+        description=(
+            "The replacement text. In line-range mode it replaces the "
+            "start_line..end_line span; with no 'start_line' it overwrites the "
+            "entire file (full mode)."
+        ),
+    )
+
+
+class ScriptSetResult(BaseModel):
+    """The result of ``gda script set``: the edited script's metadata (issue #118).
+
+    Echoes the saved ``path`` and the ``class_name``/``extends`` re-parsed from
+    the source as written, so an edit round-trips through ``script get`` (the
+    verifier) without a second call — and an agent can assert the post-edit
+    metadata directly.
+    """
+
+    path: str
+    class_name: str | None = Field(
+        default=None,
+        description=(
+            "The class_name the edited source declares, or null when it "
+            "declares none."
+        ),
+    )
+    extends: str | None = Field(
+        default=None,
+        description=(
+            "The base class the edited source extends, or null when it "
+            "declares none."
+        ),
+    )
+
+
+class ScriptAttachParams(BaseModel):
+    """The operation params of ``gda script attach`` (issue #118).
+
+    Binds a ``.gd`` script to a node inside a ``.tscn`` scene: load the scene,
+    resolve the node by node path, attach the script, then re-pack and save. As a
+    scene mutation it instantiates the scene (the same inherent trust boundary as
+    ``node set``, ADR-0009): instantiating runs the ``_init`` of scripts already
+    attached in the scene. ``path`` is the scene; ``script`` is the ``.gd`` to
+    attach (loading it compiles the script but never runs an instance of it).
+    """
+
+    path: str = Field(
+        description="The .tscn scene file to mutate."
+    )
+    node: str = Field(
+        description=(
+            "Node path relative to the scene root: '.' addresses the root "
+            "itself, 'Player/Arm' a nested node."
+        )
+    )
+    script: str = Field(
+        description="The .gd script file to attach to the node."
+    )
+
+
+class ScriptAttachResult(BaseModel):
+    """The result of ``gda script attach``: what was bound where (issue #118).
+
+    Echoes the ``scene_path``, the addressed ``node``, and the attached
+    ``script``, plus the script's ``class_name`` when it declares a global one —
+    the result an agent asserts to confirm the binding took effect, verifiable by
+    reading the saved scene back (the script now appears on the node).
+    """
+
+    scene_path: str
+    node: str = Field(
+        description="The node path the script was attached to, relative to the scene root."
+    )
+    script: str = Field(description="The .gd script that was attached.")
+    class_name: str | None = Field(
+        default=None,
+        description=(
+            "The global class_name the attached script declares, or null when "
+            "it declares none."
+        ),
+    )
+
+
+class ScriptDiagnostic(BaseModel):
+    """One advisory diagnostic from ``gda script validate`` (issue #118).
+
+    Best-effort: parsed from the engine's stderr, not from a bound API, so it may
+    carry only the FIRST parse error. ``line`` is 1-based when the engine
+    reported it; ``column`` is ALWAYS null on the standard Godot build — the
+    engine does not expose a column for a parse error — and is kept as a field
+    only so the shape is stable if a future build ever does. ``message`` is the
+    engine's error text with its ``SCRIPT ERROR:`` prefix stripped.
+    """
+
+    line: int | None = Field(
+        default=None,
+        description="The 1-based source line the error was reported at, or null when unknown.",
+    )
+    column: int | None = Field(
+        default=None,
+        description=(
+            "Always null on the standard Godot build: the engine does not "
+            "expose a column for a parse error."
+        ),
+    )
+    message: str
+
+
+class ScriptValidateParams(BaseModel):
+    """The operation params of ``gda script validate``: the script to check (issue #118).
+
+    ``path`` addresses the ``.gd`` script by its ``res://`` or filesystem path.
+    Unlike the other script-file ops, validate DOES compile the script (it sets
+    the source on a fresh ``GDScript`` and reloads it to learn whether it parses),
+    but it never instantiates the script, so it does not run instance code. Pass
+    ``--project`` when the script extends a project ``class_name`` or preloads a
+    project resource and so needs project context to compile.
+    """
+
+    path: str
+
+
+class ScriptValidateResult(BaseModel):
+    """The result of ``gda script validate``: whether the script compiles (issue #118).
+
+    Validating an INVALID script is a SUCCESSFUL operation — the command exits 0
+    and reports ``valid=false`` rather than failing. ``error_string`` carries the
+    engine's one-line summary of the compile error (null when valid).
+    ``diagnostics`` is a best-effort list parsed from the engine's stderr (the
+    only place line/message are available); it may hold only the first error, and
+    is empty when the script is valid or nothing could be parsed.
+    """
+
+    path: str
+    valid: bool = Field(
+        description="True when the script compiles (GDScript.reload() == OK), false otherwise."
+    )
+    error_string: str | None = Field(
+        default=None,
+        description=(
+            "The engine's one-line summary of the compile failure, or null when "
+            "the script is valid."
+        ),
+    )
+    diagnostics: list[ScriptDiagnostic] = Field(
+        default_factory=list,
+        description=(
+            "Best-effort advisory diagnostics parsed from the engine's stderr "
+            "(line + message). May hold only the first error; empty when valid."
+        ),
+    )
+
+
 class EngineVersion(BaseModel):
     """The Godot engine version, as reported by ``Engine.get_version_info()``.
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -700,8 +700,13 @@ class ScriptAttachParams(BaseModel):
     resolve the node by node path, attach the script, then re-pack and save. As a
     scene mutation it instantiates the scene (the same inherent trust boundary as
     ``node set``, ADR-0009): instantiating runs the ``_init`` of scripts already
-    attached in the scene. ``path`` is the scene; ``script`` is the ``.gd`` to
-    attach (loading it compiles the script but never runs an instance of it).
+    attached in the scene, and for a script that compiles ``set_script``
+    constructs an instance of the newly-attached script, running its ``_init``
+    too. ``path`` is the scene; ``script`` is the ``.gd`` to attach. The script
+    must COMPILE: the headless engine silently rejects a non-compiling script
+    from ``set_script`` (it cannot be persisted into the scene), so attach
+    refuses one with ``script_compile_failed`` rather than report a phantom
+    success — check a script with ``script validate`` first.
     """
 
     path: str = Field(

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -47,6 +47,7 @@ const OP_ERROR_UNKNOWN_PROPERTY := "unknown_property"
 const OP_ERROR_UNCOERCIBLE_VALUE := "uncoercible_value"
 const OP_ERROR_NO_SEARCH_MATCH := "no_search_match"
 const OP_ERROR_INVALID_LINE_RANGE := "invalid_line_range"
+const OP_ERROR_SCRIPT_COMPILE_FAILED := "script_compile_failed"
 
 const NODE_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
 
@@ -752,8 +753,19 @@ func _apply_line_range(source: String, params: Dictionary) -> Variant:
 # → unmaterialized-node guard, the same as node set), so it honors the
 # mutation-integrity boundary (issue #64) and instantiates the scene — running
 # the _init of scripts already attached in the scene (the inherent trust
-# boundary of ADR-0009). Loading the .gd to attach compiles it but never runs an
-# instance of it.
+# boundary of ADR-0009). For a script that compiles, set_script constructs an
+# instance of the attached .gd, which RUNS that script's _init too — attach's
+# project-code execution surface is both already-attached scripts and the
+# newly-attached one.
+#
+# attach requires the script to COMPILE. On the standard headless build,
+# set_script silently REJECTS a non-compiling script — the node's script stays
+# null and a re-pack saves no script at all — so attach cannot honor a request
+# to bind a broken script (verified: ResourceLoader.load returns a non-null
+# Script for a .gd with a parse error, but get_script() is null after
+# set_script). Rather than report a phantom success over a scene with no script
+# attached, attach verifies the bind took effect and refuses a non-compiling
+# script with script_compile_failed — fix it (or check with script validate).
 func _op_script_attach(params: Dictionary) -> void:
 	_diag("running operation: script-attach")
 	var path := _string_param(params, "path")
@@ -777,14 +789,25 @@ func _op_script_attach(params: Dictionary) -> void:
 		_fail_node_not_found(node_path)
 		return
 
+	# load returns a non-null Script even for a .gd that does not compile (compile
+	# errors go to stderr; the resource still loads), so a null here is a genuine
+	# resource-load failure (e.g. no format loader), not a compile verdict — guard
+	# it so set_script is never handed null (which would clear the node's script).
 	var script := ResourceLoader.load(script_path) as Script
 	if script == null:
 		root.free()
-		_fail(OP_ERROR_INVALID_PATH, "file could not be loaded as a GDScript: " + script_path
-				+ " — it may not compile")
+		_fail(OP_ERROR_INVALID_PATH, "file could not be loaded as a GDScript resource: " + script_path)
 		return
 
 	node.set_script(script)
+	# set_script silently rejects a non-compiling script: get_script() stays null
+	# and a re-pack would save no script. Verify the bind took effect rather than
+	# report a phantom success over a scene with nothing attached.
+	if node.get_script() == null:
+		root.free()
+		_fail(OP_ERROR_SCRIPT_COMPILE_FAILED, "script does not compile, so it cannot be attached: "
+				+ script_path + " — fix it, or check it with `gda script validate`")
+		return
 
 	var repacked := PackedScene.new()
 	var pack_err := repacked.pack(root)

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -807,10 +807,52 @@ func _op_script_attach(params: Dictionary) -> void:
 	})
 
 
-# script-validate: filled in for issue #118's validate slice.
+# script-validate: syntax/compile-check a .gd script (issue #118). Read the file
+# text, set it on a fresh GDScript, and reload() it: err == OK means it compiles.
+# Validating an INVALID script is a SUCCESSFUL operation — the op exits 0 with
+# valid=false; the op only FAILS (non-zero) for op errors (empty/non-.gd path →
+# invalid_path, missing/unreadable file → path_not_found).
+#
+# Unlike the other script-file ops, validate DOES compile the script (reload
+# parses and compiles it), but it never INSTANTIATES it, so it does not run the
+# script's instance code. The line/message of a compile error are not available
+# from any bound API (is_valid() is not even callable from GDScript) — only from
+# the engine's stderr — so the op emits just {path, valid, error_string} in the
+# sentinel and gda parses the advisory line/message diagnostics from stderr.
 func _op_script_validate(params: Dictionary) -> void:
 	_diag("running operation: script-validate")
-	_fail(OP_ERROR_UNKNOWN_OPERATION, "script-validate not yet implemented")
+	var path := _string_param(params, "path")
+	if path.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
+		return
+	if not _is_script_path(path):
+		_fail(OP_ERROR_INVALID_PATH, "script path must end in .gd: " + path)
+		return
+	if not FileAccess.file_exists(path):
+		_fail(OP_ERROR_PATH_NOT_FOUND, "script file does not exist: " + path)
+		return
+
+	var source := FileAccess.get_file_as_string(path)
+	# get_file_as_string returns "" both for an empty file and on an open error;
+	# disambiguate via the open-error code so an unreadable file is path_not_found
+	# rather than validated as empty (mirrors script-get). An empty .gd compiles.
+	if source.is_empty():
+		var open_err := FileAccess.get_open_error()
+		if open_err != OK:
+			_fail(OP_ERROR_PATH_NOT_FOUND, "script file could not be read: " + path
+					+ ": " + error_string(open_err))
+			return
+
+	# Compile-check without instantiating: set the source on a fresh GDScript and
+	# reload() it. The reload error (and its diagnostics on stderr) is the verdict.
+	var script := GDScript.new()
+	script.source_code = source
+	var err := script.reload()
+	_succeed({
+		"path": path,
+		"valid": err == OK,
+		"error_string": null if err == OK else error_string(err),
+	})
 
 
 # Whether a path names a script file the script group operates on: a .gd

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -743,10 +743,68 @@ func _apply_line_range(source: String, params: Dictionary) -> Variant:
 	return "\n".join(PackedStringArray(rebuilt))
 
 
-# script-attach: filled in for issue #118's attach slice.
+# script-attach: bind a .gd script to a node in a .tscn (issue #118). Load the
+# scene → resolve the node by node path (the #53 addressing: '.' = root, 'A/B' =
+# descendant) → load the .gd as a Script resource → node.set_script(script) →
+# re-pack and save.
+#
+# As a scene MUTATION it goes through the shared mutate-entry (load → instantiate
+# → unmaterialized-node guard, the same as node set), so it honors the
+# mutation-integrity boundary (issue #64) and instantiates the scene — running
+# the _init of scripts already attached in the scene (the inherent trust
+# boundary of ADR-0009). Loading the .gd to attach compiles it but never runs an
+# instance of it.
 func _op_script_attach(params: Dictionary) -> void:
 	_diag("running operation: script-attach")
-	_fail(OP_ERROR_UNKNOWN_OPERATION, "script-attach not yet implemented")
+	var path := _string_param(params, "path")
+
+	# Cheap script-path shape checks first, before the costlier scene load.
+	var script_path := _string_param(params, "script")
+	if not _is_script_path(script_path):
+		_fail(OP_ERROR_INVALID_PATH, "script path must end in .gd: " + script_path)
+		return
+	if not FileAccess.file_exists(script_path):
+		_fail(OP_ERROR_PATH_NOT_FOUND, "script file does not exist: " + script_path)
+		return
+
+	var root: Node = _load_for_mutation(params)
+	if root == null:
+		return  # _load_for_mutation already recorded the failure
+	var node_path := _string_param(params, "node")
+	var node := _resolve_node(root, node_path)
+	if node == null:
+		root.free()
+		_fail_node_not_found(node_path)
+		return
+
+	var script := ResourceLoader.load(script_path) as Script
+	if script == null:
+		root.free()
+		_fail(OP_ERROR_INVALID_PATH, "file could not be loaded as a GDScript: " + script_path
+				+ " — it may not compile")
+		return
+
+	node.set_script(script)
+
+	var repacked := PackedScene.new()
+	var pack_err := repacked.pack(root)
+	if pack_err != OK:
+		root.free()
+		_fail(OP_ERROR_SAVE_FAILED, "failed to pack scene: " + error_string(pack_err))
+		return
+	var class_name_value: Variant = _script_class_of(node)
+	var save_err := ResourceSaver.save(repacked, path)
+	root.free()
+	if save_err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message("scene", path, save_err))
+		return
+
+	_succeed({
+		"scene_path": path,
+		"node": node_path,
+		"script": script_path,
+		"class_name": class_name_value,
+	})
 
 
 # script-validate: filled in for issue #118's validate slice.

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -719,13 +719,19 @@ func _apply_search_replace(source: String, params: Dictionary) -> Variant:
 
 
 # line-range edit: replace the 1-based, inclusive line span [start_line,
-# end_line] with `content`. Lines are the parts of the source split on "\n", so
-# a trailing newline yields a final empty part ("a\nb\n" → ["a","b",""], N=3);
-# the valid range is 1..N. end_line defaults to start_line (a single-line edit).
-# A range outside the bounds, or end before start, is invalid_line_range.
-# Returns null after recording the failure.
+# end_line] with `content`. Lines are the parts of the source split on its
+# newline, so a trailing newline yields a final empty part ("a\nb\n" →
+# ["a","b",""], N=3); the valid range is 1..N. end_line defaults to start_line
+# (a single-line edit). A range outside the bounds, or end before start, is
+# invalid_line_range. Returns null after recording the failure.
+#
+# The file's own newline (CRLF when the source uses it, else LF) is used to both
+# split and rejoin, and the replacement `content` is normalized onto it, so
+# editing a CRLF script preserves CRLF instead of corrupting the edited span to
+# mixed endings. A mixed-ending file is pathological and resolves to CRLF.
 func _apply_line_range(source: String, params: Dictionary) -> Variant:
-	var lines := source.split("\n")
+	var newline := "\r\n" if source.contains("\r\n") else "\n"
+	var lines := source.split(newline)
 	var line_count := lines.size()
 	var start_line := int(params.get("start_line", 0))
 	var end_line: int = int(params.get("end_line", start_line)) if params.get("end_line", null) != null else start_line
@@ -736,12 +742,14 @@ func _apply_line_range(source: String, params: Dictionary) -> Variant:
 	var content := _string_param(params, "content")
 	var before := lines.slice(0, start_line - 1)
 	var after := lines.slice(end_line)
-	var replacement := content.split("\n")
+	# Normalize the replacement's own newlines onto the file's so the whole edited
+	# file keeps one consistent ending.
+	var replacement := content.replace("\r\n", "\n").split("\n")
 	var rebuilt: Array = []
 	rebuilt.append_array(before)
 	rebuilt.append_array(replacement)
 	rebuilt.append_array(after)
-	return "\n".join(PackedStringArray(rebuilt))
+	return newline.join(PackedStringArray(rebuilt))
 
 
 # script-attach: bind a .gd script to a node in a .tscn (issue #118). Load the

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -45,6 +45,8 @@ const OP_ERROR_UNINSTANTIABLE_SCRIPT := "uninstantiable_script"
 const OP_ERROR_NODE_NOT_FOUND := "node_not_found"
 const OP_ERROR_UNKNOWN_PROPERTY := "unknown_property"
 const OP_ERROR_UNCOERCIBLE_VALUE := "uncoercible_value"
+const OP_ERROR_NO_SEARCH_MATCH := "no_search_match"
+const OP_ERROR_INVALID_LINE_RANGE := "invalid_line_range"
 
 const NODE_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
 
@@ -94,6 +96,12 @@ func _initialize() -> void:
 			_op_script_list(params)
 		"script-delete":
 			_op_script_delete(params)
+		"script-set":
+			_op_script_set(params)
+		"script-attach":
+			_op_script_attach(params)
+		"script-validate":
+			_op_script_validate(params)
 		_:
 			_fail(OP_ERROR_UNKNOWN_OPERATION, "unknown operation: " + operation)
 
@@ -622,6 +630,129 @@ func _op_script_delete(params: Dictionary) -> void:
 		"class_name": meta["class_name"],
 		"extends": meta["extends"],
 	})
+
+
+# script-set: edit an EXISTING .gd script on disk as RAW TEXT (issue #118) — it
+# never compiles or loads the script, so editing it cannot run project code (the
+# read trust boundary of issue #30, the same one create/get/delete honor). Three
+# mutually-exclusive edit modes, inferred by param presence with precedence
+# search → line-range → full (the CLI guarantees exactly one is supplied):
+# - search-replace: replace EVERY literal (not regex) occurrence of `search`.
+# - line-range: replace the 1-based, inclusive line span [start_line, end_line]
+#   with `content`. Lines are the parts of the source split on "\n", so a
+#   trailing newline yields a final empty part ("a\nb\n" → ["a","b",""], 3 lines).
+# - full: overwrite the whole file with `content`.
+# set edits an existing script; it never creates — a missing target is
+# path_not_found, not a silent create.
+func _op_script_set(params: Dictionary) -> void:
+	_diag("running operation: script-set")
+	var path := _string_param(params, "path")
+	if path.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
+		return
+	if not _is_script_path(path):
+		_fail(OP_ERROR_INVALID_PATH, "script path must end in .gd: " + path)
+		return
+	if not FileAccess.file_exists(path):
+		_fail(OP_ERROR_PATH_NOT_FOUND, "script file does not exist: " + path)
+		return
+
+	var source := FileAccess.get_file_as_string(path)
+	# get_file_as_string returns "" both for an empty file and on an open error;
+	# disambiguate via the open-error code so an unreadable file is not edited as
+	# if it were empty (mirrors script-get). An empty .gd is legal source.
+	if source.is_empty():
+		var open_err := FileAccess.get_open_error()
+		if open_err != OK:
+			_fail(OP_ERROR_PATH_NOT_FOUND, "script file could not be read: " + path
+					+ ": " + error_string(open_err))
+			return
+
+	# Infer the mode by presence, precedence search → line-range → full.
+	var new_source: Variant
+	if params.get("search", null) is String:
+		new_source = _apply_search_replace(source, params)
+	elif params.get("start_line", null) != null:
+		new_source = _apply_line_range(source, params)
+	else:
+		# full overwrite: content is guaranteed present by the CLI's mode check.
+		new_source = _string_param(params, "content")
+	if new_source == null:
+		return  # the apply helper already recorded the failure
+
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	if file == null:
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message("script", path, FileAccess.get_open_error()))
+		return
+	file.store_string(new_source)
+	# A successful open does not guarantee a successful write (mirrors
+	# script-create): capture a disk-full/I/O error before close() invalidates
+	# the handle, so a failed write is save_failed, not a phantom success.
+	var write_err := file.get_error()
+	file.close()
+	if write_err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message("script", path, write_err))
+		return
+
+	# Re-parse the written source so set round-trips through script get.
+	var meta := _script_metadata(new_source)
+	_succeed({
+		"path": path,
+		"class_name": meta["class_name"],
+		"extends": meta["extends"],
+	})
+
+
+# search-replace edit: replace every literal occurrence of `search` with
+# `replace`. An empty or absent search string can never be located, and a search
+# string the source does not contain is a no_search_match failure (so an agent
+# learns the edit landed nowhere rather than silently writing the file back
+# unchanged). Returns null after recording the failure.
+func _apply_search_replace(source: String, params: Dictionary) -> Variant:
+	var search := _string_param(params, "search")
+	var replace := _string_param(params, "replace")
+	if search.is_empty() or not source.contains(search):
+		_fail(OP_ERROR_NO_SEARCH_MATCH, "search string not found in script: " + search.c_escape())
+		return null
+	return source.replace(search, replace)
+
+
+# line-range edit: replace the 1-based, inclusive line span [start_line,
+# end_line] with `content`. Lines are the parts of the source split on "\n", so
+# a trailing newline yields a final empty part ("a\nb\n" → ["a","b",""], N=3);
+# the valid range is 1..N. end_line defaults to start_line (a single-line edit).
+# A range outside the bounds, or end before start, is invalid_line_range.
+# Returns null after recording the failure.
+func _apply_line_range(source: String, params: Dictionary) -> Variant:
+	var lines := source.split("\n")
+	var line_count := lines.size()
+	var start_line := int(params.get("start_line", 0))
+	var end_line: int = int(params.get("end_line", start_line)) if params.get("end_line", null) != null else start_line
+	if start_line < 1 or start_line > line_count or end_line < start_line or end_line > line_count:
+		_fail(OP_ERROR_INVALID_LINE_RANGE, "line range " + str(start_line) + ".." + str(end_line)
+				+ " is outside the script's bounds (1.." + str(line_count) + ") or ends before it starts")
+		return null
+	var content := _string_param(params, "content")
+	var before := lines.slice(0, start_line - 1)
+	var after := lines.slice(end_line)
+	var replacement := content.split("\n")
+	var rebuilt: Array = []
+	rebuilt.append_array(before)
+	rebuilt.append_array(replacement)
+	rebuilt.append_array(after)
+	return "\n".join(PackedStringArray(rebuilt))
+
+
+# script-attach: filled in for issue #118's attach slice.
+func _op_script_attach(params: Dictionary) -> void:
+	_diag("running operation: script-attach")
+	_fail(OP_ERROR_UNKNOWN_OPERATION, "script-attach not yet implemented")
+
+
+# script-validate: filled in for issue #118's validate slice.
+func _op_script_validate(params: Dictionary) -> void:
+	_diag("running operation: script-validate")
+	_fail(OP_ERROR_UNKNOWN_OPERATION, "script-validate not yet implemented")
 
 
 # Whether a path names a script file the script group operates on: a .gd

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -521,6 +521,24 @@ def test_script_set_line_range_defaults_end_to_start_for_a_single_line(godot_pro
 
 
 @pytest.mark.e2e
+def test_script_set_line_range_preserves_crlf_line_endings(godot_project):
+    # line-range splits/rejoins on the file's OWN newline, so editing a CRLF
+    # script keeps CRLF (not a mixed-ending span). The replacement text's own
+    # endings are normalized onto the file's.
+    script_path = godot_project / "crlf.gd"
+    script_path.write_bytes(b"extends Node\r\nvar a := 1\r\nvar b := 2\r\n")
+
+    edited = _gda(
+        "script", "set", str(script_path),
+        "--start-line", "2", "--content", "var x := 9", "--json",
+    )
+
+    assert edited.returncode == 0, edited.stdout + edited.stderr
+    # CRLF preserved on every line, including the untouched ones — no LF/CRLF mix.
+    assert script_path.read_bytes() == b"extends Node\r\nvar x := 9\r\nvar b := 2\r\n"
+
+
+@pytest.mark.e2e
 def test_script_set_full_overwrites_the_whole_file_and_round_trips_via_get(godot_project):
     # full mode: --content with no --start-line overwrites the entire file.
     script_path = godot_project / "full.gd"

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -634,10 +634,12 @@ def test_script_validate_broken_script_is_success_with_a_real_diagnostic(godot_p
     data = json.loads(validated.stdout)
     assert data["valid"] is False
     assert data["error_string"] is not None
-    assert len(data["diagnostics"]) >= 1
+    # Exactly one diagnostic, at the error's real source line (3: `var x =`) —
+    # pinned (not just `len>=1`/`line>=1`) so a regression in the stderr pairing
+    # (a borrowed/duplicated frame line) fails this real-engine gate.
+    assert len(data["diagnostics"]) == 1
     diag = data["diagnostics"][0]
-    assert isinstance(diag["line"], int)
-    assert diag["line"] >= 1
+    assert diag["line"] == 3
     assert diag["message"]
     # Column is unavailable on the standard build.
     assert diag["column"] is None
@@ -762,6 +764,41 @@ def test_script_attach_no_class_name_echoes_null_class_name(godot_project):
 
     assert attached.returncode == 0, attached.stdout + attached.stderr
     assert json.loads(attached.stdout)["class_name"] is None
+
+
+@pytest.mark.e2e
+def test_script_attach_non_compiling_script_yields_script_compile_failed(godot_project):
+    # attach REQUIRES the script to compile: the headless engine silently rejects
+    # a non-compiling script from set_script (the bind never takes, a re-pack
+    # saves no script), so attach must refuse with script_compile_failed rather
+    # than report a phantom success over a scene with nothing attached. The scene
+    # is left untouched.
+    gda = _gda_project(godot_project)
+    assert (
+        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
+        .returncode
+        == 0
+    )
+    # `var x =` has no initializer — a genuine parse error; the script does not
+    # compile. script validate would report valid=false on it.
+    assert (
+        gda(
+            "script", "create", "res://broken.gd",
+            "--content", "extends Node2D\n\nvar x =\n", "--json",
+        ).returncode
+        == 0
+    )
+    before = (godot_project / "main.tscn").read_text(encoding="utf-8")
+
+    attached = gda(
+        "script", "attach", "res://main.tscn",
+        "--node", ".", "--script", "res://broken.gd", "--json",
+    )
+
+    err = _assert_operation_error(attached, "script_compile_failed")
+    assert "broken.gd" in err["message"]
+    # The refusal leaves the scene exactly as it was — no half-applied mutation.
+    assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -455,6 +455,143 @@ def test_script_delete_wrong_extension_yields_invalid_path_and_leaves_it(godot_p
 
 
 @pytest.mark.e2e
+def test_script_set_search_replace_edits_in_place_and_round_trips_via_get(godot_project):
+    # search-replace mode (issue #118): every literal occurrence of --search is
+    # replaced with --replace; script get round-trips the edited source on disk.
+    script_path = godot_project / "hero.gd"
+    _gda(
+        "script", "create", str(script_path),
+        "--content", "extends Node\nvar a := Node\n", "--json",
+    )
+
+    edited = _gda(
+        "script", "set", str(script_path),
+        "--search", "Node", "--replace", "Node2D", "--json",
+    )
+
+    assert edited.returncode == 0, edited.stdout + edited.stderr
+    assert json.loads(edited.stdout)["extends"] == "Node2D"
+    got = _gda("script", "get", str(script_path), "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    # Both occurrences replaced; the edited source IS what get reports.
+    assert json.loads(got.stdout)["source"] == "extends Node2D\nvar a := Node2D\n"
+    assert script_path.read_text(encoding="utf-8") == "extends Node2D\nvar a := Node2D\n"
+
+
+@pytest.mark.e2e
+def test_script_set_line_range_replaces_the_span_and_round_trips_via_get(godot_project):
+    # line-range mode: replace lines 2..3 (1-based, inclusive) with new content;
+    # the rest of the file is untouched. Lines are the parts split on "\n".
+    script_path = godot_project / "actor.gd"
+    _gda(
+        "script", "create", str(script_path),
+        "--content", "extends Node\nvar a := 1\nvar b := 2\nfunc f(): pass\n", "--json",
+    )
+
+    edited = _gda(
+        "script", "set", str(script_path),
+        "--start-line", "2", "--end-line", "3", "--content", "var x := 9", "--json",
+    )
+
+    assert edited.returncode == 0, edited.stdout + edited.stderr
+    got = _gda("script", "get", str(script_path), "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["source"] == (
+        "extends Node\nvar x := 9\nfunc f(): pass\n"
+    )
+
+
+@pytest.mark.e2e
+def test_script_set_line_range_defaults_end_to_start_for_a_single_line(godot_project):
+    # --end-line defaults to --start-line: a single-line replace.
+    script_path = godot_project / "single.gd"
+    _gda(
+        "script", "create", str(script_path),
+        "--content", "extends Node\nvar a := 1\nvar b := 2\n", "--json",
+    )
+
+    edited = _gda(
+        "script", "set", str(script_path),
+        "--start-line", "2", "--content", "var a := 99", "--json",
+    )
+
+    assert edited.returncode == 0, edited.stdout + edited.stderr
+    got = _gda("script", "get", str(script_path), "--json")
+    assert json.loads(got.stdout)["source"] == "extends Node\nvar a := 99\nvar b := 2\n"
+
+
+@pytest.mark.e2e
+def test_script_set_full_overwrites_the_whole_file_and_round_trips_via_get(godot_project):
+    # full mode: --content with no --start-line overwrites the entire file.
+    script_path = godot_project / "full.gd"
+    _gda("script", "create", str(script_path), "--content", "extends Node\n", "--json")
+
+    new_source = "class_name Hero\nextends Node2D\n\nvar speed := 100\n"
+    edited = _gda("script", "set", str(script_path), "--content", new_source, "--json")
+
+    assert edited.returncode == 0, edited.stdout + edited.stderr
+    data = json.loads(edited.stdout)
+    assert data["class_name"] == "Hero"
+    assert data["extends"] == "Node2D"
+    got = _gda("script", "get", str(script_path), "--json")
+    assert json.loads(got.stdout)["source"] == new_source
+
+
+@pytest.mark.e2e
+def test_script_set_no_search_match_is_refused_and_leaves_file_untouched(godot_project):
+    # A search string the source does not contain is refused with no_search_match
+    # and the file is left exactly as it was — the edit landed nowhere.
+    script_path = godot_project / "hero.gd"
+    _gda("script", "create", str(script_path), "--content", "extends Node\n", "--json")
+    before = script_path.read_text(encoding="utf-8")
+
+    edited = _gda(
+        "script", "set", str(script_path),
+        "--search", "Sprite2D", "--replace", "Node2D", "--json",
+    )
+
+    _assert_operation_error(edited, "no_search_match")
+    assert script_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_script_set_out_of_bounds_line_range_is_refused_and_leaves_file_untouched(
+    godot_project,
+):
+    # A line range past the file's bounds is refused with invalid_line_range and
+    # the file is left untouched.
+    script_path = godot_project / "hero.gd"
+    _gda(
+        "script", "create", str(script_path),
+        "--content", "extends Node\nvar a := 1\n", "--json",
+    )
+    before = script_path.read_text(encoding="utf-8")
+
+    edited = _gda(
+        "script", "set", str(script_path),
+        "--start-line", "9", "--content", "var x := 0", "--json",
+    )
+
+    _assert_operation_error(edited, "invalid_line_range")
+    assert script_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_script_set_missing_file_yields_path_not_found(godot_project):
+    # set edits an existing script; a missing target is path_not_found, never a
+    # silent create.
+    missing = godot_project / "nope.gd"
+
+    edited = _gda(
+        "script", "set", str(missing), "--content", "extends Node\n", "--json"
+    )
+
+    err = _assert_operation_error(edited, "path_not_found")
+    assert str(missing) in err["message"]
+    assert not missing.exists()
+
+
+@pytest.mark.e2e
 def test_script_create_empty_content_round_trips_as_empty_source(godot_project):
     # An empty file is legal source: --content "" writes an empty script, and get
     # reads it back as empty (the get_file_as_string empty-vs-error disambiguation

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -591,6 +591,185 @@ def test_script_set_missing_file_yields_path_not_found(godot_project):
     assert not missing.exists()
 
 
+# --- script attach (issue #118) ---
+
+
+@pytest.mark.e2e
+def test_script_attach_binds_script_to_node_and_scene_references_it(godot_project):
+    # script attach (issue #118) loads a scene, resolves a node by node path,
+    # attaches a .gd, and saves. Verify by reading the saved .tscn back: the
+    # script path now appears as an ext_resource the node references, the result
+    # echoes the script's class_name, and the scene still re-loads (node list).
+    gda = _gda_project(godot_project)
+    assert (
+        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
+        .returncode
+        == 0
+    )
+    assert (
+        gda(
+            "script", "create", "res://hero.gd",
+            "--content", "class_name Hero\nextends Node2D\n", "--json",
+        ).returncode
+        == 0
+    )
+
+    attached = gda(
+        "script", "attach", "res://main.tscn",
+        "--node", ".", "--script", "res://hero.gd", "--json",
+    )
+
+    assert attached.returncode == 0, attached.stdout + attached.stderr
+    data = json.loads(attached.stdout)
+    assert data["node"] == "."
+    assert data["script"] == "res://hero.gd"
+    assert data["class_name"] == "Hero"
+    # The saved .tscn now references the script as an ext_resource on the root.
+    saved = (godot_project / "main.tscn").read_text(encoding="utf-8")
+    assert "hero.gd" in saved
+    assert 'type="Script"' in saved
+    # The scene still re-loads after the mutation.
+    listed = gda("node", "list", "res://main.tscn", "--json")
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+
+
+@pytest.mark.e2e
+def test_script_attach_to_a_descendant_node(godot_project):
+    # Attach addresses the node by the #53 node path: a descendant, not just the
+    # root. The script lands on that exact node.
+    gda = _gda_project(godot_project)
+    assert (
+        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
+        .returncode
+        == 0
+    )
+    assert (
+        gda("node", "add", "res://main.tscn", "--type", "Sprite2D", "--name", "Hero",
+            "--json").returncode
+        == 0
+    )
+    assert (
+        gda("script", "create", "res://hero.gd", "--extends", "Sprite2D", "--json")
+        .returncode
+        == 0
+    )
+
+    attached = gda(
+        "script", "attach", "res://main.tscn",
+        "--node", "Hero", "--script", "res://hero.gd", "--json",
+    )
+
+    assert attached.returncode == 0, attached.stdout + attached.stderr
+    assert json.loads(attached.stdout)["node"] == "Hero"
+    saved = (godot_project / "main.tscn").read_text(encoding="utf-8")
+    assert "hero.gd" in saved
+
+
+@pytest.mark.e2e
+def test_script_attach_no_class_name_echoes_null_class_name(godot_project):
+    # A script with no class_name attaches fine and the result carries null.
+    gda = _gda_project(godot_project)
+    assert (
+        gda("scene", "create", "res://main.tscn", "--root-type", "Node", "--json")
+        .returncode
+        == 0
+    )
+    assert (
+        gda("script", "create", "res://plain.gd", "--extends", "Node", "--json")
+        .returncode
+        == 0
+    )
+
+    attached = gda(
+        "script", "attach", "res://main.tscn",
+        "--node", ".", "--script", "res://plain.gd", "--json",
+    )
+
+    assert attached.returncode == 0, attached.stdout + attached.stderr
+    assert json.loads(attached.stdout)["class_name"] is None
+
+
+@pytest.mark.e2e
+def test_script_attach_missing_script_yields_path_not_found(godot_project):
+    gda = _gda_project(godot_project)
+    assert (
+        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
+        .returncode
+        == 0
+    )
+
+    attached = gda(
+        "script", "attach", "res://main.tscn",
+        "--node", ".", "--script", "res://nope.gd", "--json",
+    )
+
+    err = _assert_operation_error(attached, "path_not_found")
+    assert "nope.gd" in err["message"]
+
+
+@pytest.mark.e2e
+def test_script_attach_wrong_script_extension_yields_invalid_path(godot_project):
+    gda = _gda_project(godot_project)
+    assert (
+        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
+        .returncode
+        == 0
+    )
+    (godot_project / "notes.txt").write_text("not a script\n", encoding="utf-8")
+
+    attached = gda(
+        "script", "attach", "res://main.tscn",
+        "--node", ".", "--script", "res://notes.txt", "--json",
+    )
+
+    err = _assert_operation_error(attached, "invalid_path")
+    assert ".gd" in err["message"]
+
+
+@pytest.mark.e2e
+def test_script_attach_missing_node_yields_node_not_found_and_leaves_scene(godot_project):
+    gda = _gda_project(godot_project)
+    assert (
+        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
+        .returncode
+        == 0
+    )
+    assert (
+        gda("script", "create", "res://hero.gd", "--extends", "Node2D", "--json")
+        .returncode
+        == 0
+    )
+    before = (godot_project / "main.tscn").read_text(encoding="utf-8")
+
+    attached = gda(
+        "script", "attach", "res://main.tscn",
+        "--node", "Bogus", "--script", "res://hero.gd", "--json",
+    )
+
+    err = _assert_operation_error(attached, "node_not_found")
+    assert "Bogus" in err["message"]
+    # The refusal leaves the scene untouched.
+    assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_script_attach_missing_scene_yields_path_not_found(godot_project):
+    gda = _gda_project(godot_project)
+    assert (
+        gda("script", "create", "res://hero.gd", "--extends", "Node2D", "--json")
+        .returncode
+        == 0
+    )
+
+    attached = gda(
+        "script", "attach", "res://missing.tscn",
+        "--node", ".", "--script", "res://hero.gd", "--json",
+    )
+
+    err = _assert_operation_error(attached, "path_not_found")
+    assert "missing.tscn" in err["message"]
+
+
 @pytest.mark.e2e
 def test_script_create_empty_content_round_trips_as_empty_source(godot_project):
     # An empty file is legal source: --content "" writes an empty script, and get

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -591,6 +591,81 @@ def test_script_set_missing_file_yields_path_not_found(godot_project):
     assert not missing.exists()
 
 
+# --- script validate (issue #118) ---
+
+
+@pytest.mark.e2e
+def test_script_validate_valid_script_reports_valid_true_no_diagnostics(godot_project):
+    # The mechanism gate (issue #118): a self-contained `extends Node` script
+    # compiles (GDScript.reload() == OK) projectless, so validate reports valid=
+    # true, no error_string, no diagnostics — exit 0.
+    script_path = godot_project / "ok.gd"
+    _gda(
+        "script", "create", str(script_path),
+        "--content", "extends Node\n\nfunc greet() -> String:\n\treturn \"hi\"\n",
+        "--json",
+    )
+
+    validated = _gda("script", "validate", str(script_path), "--json")
+
+    assert validated.returncode == 0, validated.stdout + validated.stderr
+    data = json.loads(validated.stdout)
+    assert data["valid"] is True
+    assert data["error_string"] is None
+    assert data["diagnostics"] == []
+
+
+@pytest.mark.e2e
+def test_script_validate_broken_script_is_success_with_a_real_diagnostic(godot_project):
+    # The mechanism gate's hard half: a deliberately BROKEN script is a SUCCESSFUL
+    # op (exit 0) reporting valid=false, and at least one diagnostic with a real
+    # `line` and non-empty `message` — proving the stderr-parsing regex against
+    # the REAL engine output, not a fixture.
+    script_path = godot_project / "broken.gd"
+    # `var x =` with no initializer is a parse error the engine reports on its line.
+    _gda(
+        "script", "create", str(script_path),
+        "--content", "extends Node\n\nvar x =\n", "--json",
+    )
+
+    validated = _gda("script", "validate", str(script_path), "--json")
+
+    assert validated.returncode == 0, validated.stdout + validated.stderr
+    data = json.loads(validated.stdout)
+    assert data["valid"] is False
+    assert data["error_string"] is not None
+    assert len(data["diagnostics"]) >= 1
+    diag = data["diagnostics"][0]
+    assert isinstance(diag["line"], int)
+    assert diag["line"] >= 1
+    assert diag["message"]
+    # Column is unavailable on the standard build.
+    assert diag["column"] is None
+
+
+@pytest.mark.e2e
+def test_script_validate_missing_file_yields_path_not_found(godot_project):
+    # validate only op-fails for op errors: a missing file is path_not_found, NOT
+    # a valid=false success.
+    missing = godot_project / "nope.gd"
+
+    validated = _gda("script", "validate", str(missing), "--json")
+
+    err = _assert_operation_error(validated, "path_not_found")
+    assert str(missing) in err["message"]
+
+
+@pytest.mark.e2e
+def test_script_validate_wrong_extension_yields_invalid_path(godot_project):
+    notes = godot_project / "notes.txt"
+    notes.write_text("not a script\n", encoding="utf-8")
+
+    validated = _gda("script", "validate", str(notes), "--json")
+
+    err = _assert_operation_error(validated, "invalid_path")
+    assert ".gd" in err["message"]
+
+
 # --- script attach (issue #118) ---
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,8 +19,10 @@ from gda.models import (
     ScriptCreateResult,
     ScriptDeleteResult,
     ScriptGetResult,
+    ScriptAttachResult,
     ScriptListResult,
     ScriptSetResult,
+    ScriptValidateResult,
 )
 
 
@@ -399,6 +401,40 @@ def test_script_set_result_round_trips_metadata():
     assert edited.class_name == "Hero"
     assert edited.extends == "Node2D"
     assert json.loads(edited.model_dump_json()) == payload
+
+
+def test_script_attach_result_round_trips_with_class_name():
+    # script attach (issue #118) echoes the scene, node, attached script, and the
+    # script's declared class_name — the result an agent asserts to confirm the
+    # binding took effect.
+    payload = {
+        "scene_path": "res://main.tscn",
+        "node": "Hero",
+        "script": "res://hero.gd",
+        "class_name": "Hero",
+    }
+
+    attached = ScriptAttachResult.model_validate(payload)
+
+    assert attached.node == "Hero"
+    assert attached.script == "res://hero.gd"
+    assert attached.class_name == "Hero"
+    assert json.loads(attached.model_dump_json()) == payload
+
+
+def test_script_attach_result_round_trips_null_class_name():
+    # A script with no class_name attaches fine; the result carries null.
+    payload = {
+        "scene_path": "res://main.tscn",
+        "node": ".",
+        "script": "res://util.gd",
+        "class_name": None,
+    }
+
+    attached = ScriptAttachResult.model_validate(payload)
+
+    assert attached.class_name is None
+    assert json.loads(attached.model_dump_json()) == payload
 
 
 def test_node_set_result_round_trips_the_coerced_property():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -437,6 +437,46 @@ def test_script_attach_result_round_trips_null_class_name():
     assert json.loads(attached.model_dump_json()) == payload
 
 
+def test_script_validate_result_round_trips_a_valid_script():
+    # A valid script (issue #118): valid=true, no error_string, no diagnostics —
+    # the successful-op shape.
+    payload = {
+        "path": "res://ok.gd",
+        "valid": True,
+        "error_string": None,
+        "diagnostics": [],
+    }
+
+    validated = ScriptValidateResult.model_validate(payload)
+
+    assert validated.valid is True
+    assert validated.error_string is None
+    assert validated.diagnostics == []
+    assert json.loads(validated.model_dump_json()) == payload
+
+
+def test_script_validate_result_round_trips_an_invalid_script_with_diagnostics():
+    # An invalid script carries valid=false, the engine's one-line summary, and a
+    # best-effort diagnostic (line + message; column always null on the standard
+    # build).
+    payload = {
+        "path": "res://broken.gd",
+        "valid": False,
+        "error_string": "Parse error.",
+        "diagnostics": [
+            {"line": 3, "column": None, "message": "Parse Error: bad token."}
+        ],
+    }
+
+    validated = ScriptValidateResult.model_validate(payload)
+
+    assert validated.valid is False
+    assert validated.diagnostics[0].line == 3
+    assert validated.diagnostics[0].column is None
+    assert validated.diagnostics[0].message == "Parse Error: bad token."
+    assert json.loads(validated.model_dump_json()) == payload
+
+
 def test_node_set_result_round_trips_the_coerced_property():
     # node set echoes the one property it changed (issue #55): its name, the
     # property's declared type the CLI value was coerced to, and the coerced

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,6 +20,7 @@ from gda.models import (
     ScriptDeleteResult,
     ScriptGetResult,
     ScriptListResult,
+    ScriptSetResult,
 )
 
 
@@ -381,6 +382,23 @@ def test_script_delete_result_round_trips():
     assert deleted.class_name == "Hero"
     assert deleted.extends == "Node2D"
     assert json.loads(deleted.model_dump_json()) == payload
+
+
+def test_script_set_result_round_trips_metadata():
+    # script set re-parses the written source's class_name/extends (issue #118),
+    # so an edit round-trips through script get: the metadata dumps back faithfully.
+    payload = {
+        "path": "res://hero.gd",
+        "class_name": "Hero",
+        "extends": "Node2D",
+    }
+
+    edited = ScriptSetResult.model_validate(payload)
+
+    assert edited.path == "res://hero.gd"
+    assert edited.class_name == "Hero"
+    assert edited.extends == "Node2D"
+    assert json.loads(edited.model_dump_json()) == payload
 
 
 def test_node_set_result_round_trips_the_coerced_property():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -88,11 +88,13 @@ def test_parse_validate_diagnostics_ignores_operations_own_backtrace_frames():
     # A failed reload also prints a GDScript backtrace of operations.gd's OWN
     # frames ([n] _initialize (...)). Those are not the validated script's lines,
     # so they must not become diagnostics — only the SCRIPT ERROR + reload frame.
+    # This is the backtrace shape the standard build actually emits.
     stderr = (
         'SCRIPT ERROR: Parse Error: Unexpected "Identifier" in class body.\n'
         "          at: GDScript::reload (gdscript://-123.gd:5)\n"
-        "   0: [gdscript] operations.gd:_op_script_validate(...) at line 700\n"
-        "   1: [gdscript] operations.gd:_initialize(...) at line 60\n"
+        "          GDScript backtrace (most recent call first):\n"
+        "              [0] _op_script_validate (res://ops/operations.gd:864)\n"
+        "              [1] _initialize (res://ops/operations.gd:60)\n"
     )
 
     diagnostics = parse_validate_diagnostics(stderr)
@@ -100,3 +102,56 @@ def test_parse_validate_diagnostics_ignores_operations_own_backtrace_frames():
     assert len(diagnostics) == 1
     assert diagnostics[0].line == 5
     assert diagnostics[0].message == 'Parse Error: Unexpected "Identifier" in class body.'
+
+
+def test_parse_validate_diagnostics_does_not_borrow_a_later_errors_reload_line():
+    # Bounded pairing: a SCRIPT ERROR with NO reload frame in its own window must
+    # not steal the line of a later, unrelated error's reload frame. The first
+    # SCRIPT ERROR is dropped (no reload frame before the next one); only the
+    # second — which owns a reload frame — is reported, at ITS line.
+    stderr = (
+        "SCRIPT ERROR: Method failed. Returning: null\n"
+        "SCRIPT ERROR: Parse Error: the real parse error.\n"
+        "          at: GDScript::reload (gdscript://-1.gd:7)\n"
+    )
+
+    diagnostics = parse_validate_diagnostics(stderr)
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].line == 7
+    assert diagnostics[0].message == "Parse Error: the real parse error."
+
+
+def test_parse_validate_diagnostics_empty_message_keeps_line_and_does_not_spill():
+    # An empty SCRIPT ERROR message must not swallow the following reload frame
+    # (the `[ \t]` bound keeps the capture on its own line): the diagnostic still
+    # gets the frame's line, with an empty message rather than the frame text.
+    stderr = (
+        "SCRIPT ERROR: \n"
+        "          at: GDScript::reload (gdscript://-1.gd:4)\n"
+    )
+
+    diagnostics = parse_validate_diagnostics(stderr)
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].line == 4
+    assert diagnostics[0].message == ""
+
+
+def test_parse_validate_diagnostics_ignores_unrelated_autoload_script_errors():
+    # Under --project the engine may print an autoload's OWN startup error to the
+    # same stderr; its frame is the autoload's _ready/_init, not GDScript::reload.
+    # That error is not the validated script's, so it is dropped — only the
+    # reload-framed diagnostic survives.
+    stderr = (
+        "SCRIPT ERROR: Some autoload blew up at startup.\n"
+        "          at: GameState._ready (res://game_state.gd:12)\n"
+        "SCRIPT ERROR: Parse Error: the validated script error.\n"
+        "          at: GDScript::reload (gdscript://-1.gd:9)\n"
+    )
+
+    diagnostics = parse_validate_diagnostics(stderr)
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].line == 9
+    assert diagnostics[0].message == "Parse Error: the validated script error."

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+from gda.errors import parse_validate_diagnostics
 from gda.parser import parse_result
 
 
@@ -43,3 +44,59 @@ def test_payload_containing_end_sentinel_round_trips():
     stdout = f"<<<GDA:RESULT>>>{json.dumps(payload)}<<<GDA:END>>>\n"
 
     assert parse_result(stdout) == payload
+
+
+# --- script validate diagnostics (issue #118) ---
+#
+# The line/message of a failed GDScript.reload() are available ONLY from the
+# engine's stderr, never from a bound API, so they are parsed Python-side. This
+# is the exact stderr shape the standard Godot build emits.
+REAL_VALIDATE_STDERR = (
+    'SCRIPT ERROR: Parse Error: Expected expression for variable initial value after "=".\n'
+    "          at: GDScript::reload (gdscript://-9223371888644840980.gd:3)\n"
+)
+
+
+def test_parse_validate_diagnostics_extracts_line_and_message():
+    # The mechanism gate's parser half: a SCRIPT ERROR line + its reload frame
+    # yield one diagnostic with the 1-based line and the message (the prefix
+    # stripped). There is no column on the standard build, so it is null.
+    diagnostics = parse_validate_diagnostics(REAL_VALIDATE_STDERR)
+
+    assert len(diagnostics) == 1
+    diag = diagnostics[0]
+    assert diag.line == 3
+    assert diag.column is None
+    assert (
+        diag.message
+        == 'Parse Error: Expected expression for variable initial value after "=".'
+    )
+
+
+def test_parse_validate_diagnostics_empty_when_no_script_error():
+    # Valid-script stderr (engine banner / progress noise only) parses to no
+    # diagnostics — there is nothing to advise on.
+    stderr = (
+        "Godot Engine v4.6.3.stable.official - https://godotengine.org\n"
+        "gda: running operation: script-validate\n"
+    )
+
+    assert parse_validate_diagnostics(stderr) == []
+
+
+def test_parse_validate_diagnostics_ignores_operations_own_backtrace_frames():
+    # A failed reload also prints a GDScript backtrace of operations.gd's OWN
+    # frames ([n] _initialize (...)). Those are not the validated script's lines,
+    # so they must not become diagnostics — only the SCRIPT ERROR + reload frame.
+    stderr = (
+        'SCRIPT ERROR: Parse Error: Unexpected "Identifier" in class body.\n'
+        "          at: GDScript::reload (gdscript://-123.gd:5)\n"
+        "   0: [gdscript] operations.gd:_op_script_validate(...) at line 700\n"
+        "   1: [gdscript] operations.gd:_initialize(...) at line 60\n"
+    )
+
+    diagnostics = parse_validate_diagnostics(stderr)
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].line == 5
+    assert diagnostics[0].message == 'Parse Error: Unexpected "Identifier" in class body.'

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -395,10 +395,71 @@ def test_script_delete_schema_emits_model_derived_contract_without_other_args():
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
 
+def test_script_set_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for script set (issue #118): the bare --schema flag —
+    # no path, no edit mode — short-circuits into the self-description, derived
+    # from the same typed models that back --json. The line-range 1-based-over-
+    # split rule is documented in the contract itself.
+    from gda.models import ScriptSetParams, ScriptSetResult
+
+    result = CliRunner().invoke(app, ["script", "set", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ScriptSetParams.model_json_schema()
+    assert doc["output"] == ScriptSetResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "search" in doc["input"]["properties"]
+    assert "start_line" in doc["input"]["properties"]
+    assert "content" in doc["input"]["properties"]
+    # The line-range addressing rule (1-based over the '\n'-split parts) is in
+    # the contract, not just the prose.
+    assert "1-based" in doc["input"]["properties"]["start_line"]["description"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_script_attach_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for script attach (issue #118): the node param
+    # documents the root-relative node-path addressing agents must use.
+    from gda.models import ScriptAttachParams, ScriptAttachResult
+
+    result = CliRunner().invoke(app, ["script", "attach", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ScriptAttachParams.model_json_schema()
+    assert doc["output"] == ScriptAttachResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    node_description = doc["input"]["properties"]["node"]["description"]
+    assert "scene root" in node_description
+    assert "'.'" in node_description
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_script_validate_schema_emits_model_derived_contract_without_other_args():
+    from gda.models import ScriptValidateParams, ScriptValidateResult
+
+    result = CliRunner().invoke(app, ["script", "validate", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ScriptValidateParams.model_json_schema()
+    assert doc["output"] == ScriptValidateResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "valid" in doc["output"]["properties"]
+    assert "diagnostics" in doc["output"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
 def test_sample_script_results_validate_against_emitted_output_schemas():
     # A sample --json payload of each script command satisfies the contract its
     # --schema emits (the other half of the ADR-0004 hard gate, issues #110, #117).
     from tests.test_script_commands import CREATE_RESULT, GET_RESULT, LIST_RESULT
+
+    from tests.test_script_commands import SET_RESULT
 
     create_doc = json.loads(
         CliRunner().invoke(app, ["script", "create", "--schema"]).stdout
@@ -410,6 +471,13 @@ def test_sample_script_results_validate_against_emitted_output_schemas():
     delete_doc = json.loads(
         CliRunner().invoke(app, ["script", "delete", "--schema"]).stdout
     )
+    set_doc = json.loads(CliRunner().invoke(app, ["script", "set", "--schema"]).stdout)
+    attach_doc = json.loads(
+        CliRunner().invoke(app, ["script", "attach", "--schema"]).stdout
+    )
+    validate_doc = json.loads(
+        CliRunner().invoke(app, ["script", "validate", "--schema"]).stdout
+    )
 
     jsonschema.validate(instance=CREATE_RESULT, schema=create_doc["output"])
     jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
@@ -418,6 +486,26 @@ def test_sample_script_results_validate_against_emitted_output_schemas():
     jsonschema.validate(
         instance={"path": "res://hero.gd", "class_name": "Hero", "extends": "Node2D"},
         schema=delete_doc["output"],
+    )
+    jsonschema.validate(instance=SET_RESULT, schema=set_doc["output"])
+    # Sample attach / validate payloads, shaped as the operations emit them.
+    jsonschema.validate(
+        instance={
+            "scene_path": "res://main.tscn",
+            "node": "Hero",
+            "script": "res://hero.gd",
+            "class_name": "Hero",
+        },
+        schema=attach_doc["output"],
+    )
+    jsonschema.validate(
+        instance={
+            "path": "res://broken.gd",
+            "valid": False,
+            "error_string": "Parse error.",
+            "diagnostics": [{"line": 3, "column": None, "message": "Parse Error: ..."}],
+        },
+        schema=validate_doc["output"],
     )
 
 
@@ -433,6 +521,9 @@ def test_script_schema_spawns_no_godot(monkeypatch):
         ["script", "get"],
         ["script", "list"],
         ["script", "delete"],
+        ["script", "set"],
+        ["script", "attach"],
+        ["script", "validate"],
     ):
         result = CliRunner().invoke(app, [*command, "--schema"])
         assert result.exit_code == 0

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -209,3 +209,237 @@ def test_script_list_passes_resolved_project_to_the_runner(monkeypatch, tmp_path
 
     assert result.exit_code == 0
     assert seen["project"] == tmp_path
+
+
+SET_RESULT = {
+    "path": "/tmp/proj/hero.gd",
+    "class_name": "Hero",
+    "extends": "Node2D",
+}
+
+
+def test_script_set_search_replace_dispatches_search_and_replace(monkeypatch):
+    # search-replace mode (issue #118): --search/--replace ride through as the
+    # search/replace params; the other mode params pass as null. The result
+    # re-parses the written source's class_name/extends, so set round-trips
+    # through get.
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(SET_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "set",
+            "/tmp/proj/hero.gd",
+            "--search",
+            "Node",
+            "--replace",
+            "Node2D",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["path"] == "/tmp/proj/hero.gd"
+    assert data["class_name"] == "Hero"
+    assert data["extends"] == "Node2D"
+    assert fake.calls == [
+        (
+            "script-set",
+            {
+                "path": "/tmp/proj/hero.gd",
+                "search": "Node",
+                "replace": "Node2D",
+                "start_line": None,
+                "end_line": None,
+                "content": None,
+            },
+        )
+    ]
+    assert "engine diagnostic" in result.stderr
+
+
+def test_script_set_line_range_dispatches_start_end_and_content(monkeypatch):
+    # line-range mode: --start-line/--end-line + --content ride through; the
+    # search-replace params pass as null.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "set",
+            "/tmp/proj/hero.gd",
+            "--start-line",
+            "2",
+            "--end-line",
+            "3",
+            "--content",
+            "extends Node2D",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        (
+            "script-set",
+            {
+                "path": "/tmp/proj/hero.gd",
+                "search": None,
+                "replace": None,
+                "start_line": 2,
+                "end_line": 3,
+                "content": "extends Node2D",
+            },
+        )
+    ]
+
+
+def test_script_set_full_overwrite_dispatches_content_only(monkeypatch):
+    # full mode: --content with no --start-line overwrites the whole file; every
+    # other mode param passes as null.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "set",
+            "/tmp/proj/hero.gd",
+            "--content",
+            "extends Node\n",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        (
+            "script-set",
+            {
+                "path": "/tmp/proj/hero.gd",
+                "search": None,
+                "replace": None,
+                "start_line": None,
+                "end_line": None,
+                "content": "extends Node\n",
+            },
+        )
+    ]
+
+
+def _assert_set_usage_error(fake, result):
+    # A mode-validation error is a usage error (exit 2) that fires before any
+    # dispatch — the engine is never reached.
+    assert result.exit_code == 2
+    assert fake.calls == []
+
+
+def test_script_set_no_flags_is_a_usage_error(monkeypatch):
+    # No edit mode at all is a usage error: set always needs exactly one mode.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["script", "set", "/tmp/proj/hero.gd", "--json"])
+
+    _assert_set_usage_error(fake, result)
+
+
+def test_script_set_search_without_replace_is_a_usage_error(monkeypatch):
+    # --search requires --replace (and vice versa) — a half-specified
+    # search-replace is a usage error, never a silent default.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["script", "set", "/tmp/proj/hero.gd", "--search", "Node", "--json"]
+    )
+
+    _assert_set_usage_error(fake, result)
+
+
+def test_script_set_replace_without_search_is_a_usage_error(monkeypatch):
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["script", "set", "/tmp/proj/hero.gd", "--replace", "Node2D", "--json"]
+    )
+
+    _assert_set_usage_error(fake, result)
+
+
+def test_script_set_search_replace_and_content_are_mutually_exclusive(monkeypatch):
+    # Mixing search-replace with a line-range/full param (--content) is a usage
+    # error: the modes are mutually exclusive.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "set",
+            "/tmp/proj/hero.gd",
+            "--search",
+            "Node",
+            "--replace",
+            "Node2D",
+            "--content",
+            "x",
+            "--json",
+        ],
+    )
+
+    _assert_set_usage_error(fake, result)
+
+
+def test_script_set_start_line_without_content_is_a_usage_error(monkeypatch):
+    # --start-line/--end-line require --content: a line range with no replacement
+    # text is a usage error.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["script", "set", "/tmp/proj/hero.gd", "--start-line", "2", "--json"]
+    )
+
+    _assert_set_usage_error(fake, result)
+
+
+def test_script_set_end_line_without_start_line_is_a_usage_error(monkeypatch):
+    # --end-line alone (with --content) is a usage error: end without a start has
+    # no anchor.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "set",
+            "/tmp/proj/hero.gd",
+            "--end-line",
+            "3",
+            "--content",
+            "x",
+            "--json",
+        ],
+    )
+
+    _assert_set_usage_error(fake, result)

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -545,3 +545,71 @@ def test_script_set_end_line_without_start_line_is_a_usage_error(monkeypatch):
     )
 
     _assert_set_usage_error(fake, result)
+
+
+# --- human-readable output (no --json): the render_text paths (issue #118) ---
+
+
+def test_script_validate_human_output_valid(monkeypatch):
+    # Without --json, a valid result renders a one-line 'valid <path>'.
+    payload = {"path": "/tmp/proj/ok.gd", "valid": True, "error_string": None}
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["script", "validate", "/tmp/proj/ok.gd"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "valid /tmp/proj/ok.gd"
+
+
+def test_script_validate_human_output_invalid_lists_diagnostics(monkeypatch):
+    # An invalid result renders 'invalid <path>', the error_string, and each
+    # advisory diagnostic as 'line N: message' (parsed from stderr).
+    payload = {
+        "path": "/tmp/proj/broken.gd",
+        "valid": False,
+        "error_string": "Parse error.",
+    }
+    stderr = (
+        "SCRIPT ERROR: Parse Error: the message.\n"
+        "          at: GDScript::reload (gdscript://-1.gd:3)\n"
+    )
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(payload), stderr=stderr, exit_code=0))
+
+    result = CliRunner().invoke(app, ["script", "validate", "/tmp/proj/broken.gd"])
+
+    assert result.exit_code == 0
+    assert "invalid /tmp/proj/broken.gd" in result.stdout
+    assert "Parse error." in result.stdout
+    assert "line 3: Parse Error: the message." in result.stdout
+
+
+def test_script_attach_human_output(monkeypatch):
+    # Without --json, attach renders 'attached <script> to <node> in <scene>'.
+    payload = {
+        "scene_path": "/tmp/proj/main.tscn",
+        "node": "Hero",
+        "script": "/tmp/proj/hero.gd",
+        "class_name": "Hero",
+    }
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        ["script", "attach", "/tmp/proj/main.tscn", "--node", "Hero", "--script", "/tmp/proj/hero.gd"],
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "attached /tmp/proj/hero.gd to Hero in /tmp/proj/main.tscn"
+
+
+def test_script_set_human_output_renders_metadata(monkeypatch):
+    # Without --json, set reuses the shared script-metadata renderer.
+    payload = {"path": "/tmp/proj/hero.gd", "class_name": "Hero", "extends": "Node2D"}
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app, ["script", "set", "/tmp/proj/hero.gd", "--content", "x"]
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "set /tmp/proj/hero.gd (extends Node2D, class_name Hero)"

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -457,6 +457,58 @@ def test_script_attach_dispatches_scene_node_and_script(monkeypatch):
     assert "engine diagnostic" in result.stderr
 
 
+def test_script_validate_valid_script_reports_valid_true_no_diagnostics(monkeypatch):
+    # script validate (issue #118): a valid script is a successful op (exit 0)
+    # reporting valid=true, no error_string, and no diagnostics.
+    payload = {"path": "/tmp/proj/ok.gd", "valid": True, "error_string": None}
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(payload)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["script", "validate", "/tmp/proj/ok.gd", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["valid"] is True
+    assert data["error_string"] is None
+    assert data["diagnostics"] == []
+    assert fake.calls == [("script-validate", {"path": "/tmp/proj/ok.gd"})]
+
+
+def test_script_validate_invalid_script_is_success_with_parsed_diagnostics(monkeypatch):
+    # Validating an INVALID script is a SUCCESSFUL op (exit 0): the sentinel says
+    # valid=false, and the per-command classifier parses the line/message
+    # diagnostics from stderr (the only place they live) into the result.
+    payload = {
+        "path": "/tmp/proj/broken.gd",
+        "valid": False,
+        "error_string": "Parse error.",
+    }
+    stderr = (
+        'SCRIPT ERROR: Parse Error: Expected expression for variable initial '
+        'value after "=".\n'
+        "          at: GDScript::reload (gdscript://-9223371888644840980.gd:3)\n"
+    )
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(payload)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr=stderr, exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["script", "validate", "/tmp/proj/broken.gd", "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["valid"] is False
+    assert data["error_string"] == "Parse error."
+    # The advisory diagnostics were parsed from stderr (line + message, no column).
+    assert len(data["diagnostics"]) == 1
+    assert data["diagnostics"][0]["line"] == 3
+    assert data["diagnostics"][0]["column"] is None
+    assert "Expected expression" in data["diagnostics"][0]["message"]
+    assert fake.calls == [("script-validate", {"path": "/tmp/proj/broken.gd"})]
+
+
 def test_script_set_start_line_without_content_is_a_usage_error(monkeypatch):
     # --start-line/--end-line require --content: a line range with no replacement
     # text is a usage error.

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -407,6 +407,56 @@ def test_script_set_search_replace_and_content_are_mutually_exclusive(monkeypatc
     _assert_set_usage_error(fake, result)
 
 
+ATTACH_RESULT = {
+    "scene_path": "/tmp/proj/main.tscn",
+    "node": "Hero",
+    "script": "/tmp/proj/hero.gd",
+    "class_name": "Hero",
+}
+
+
+def test_script_attach_dispatches_scene_node_and_script(monkeypatch):
+    # script attach (issue #118) binds a .gd to a node in a scene: the scene
+    # path, the node path, and the script path ride through as the typed params;
+    # the result echoes the attached script's class_name.
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(ATTACH_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "attach",
+            "/tmp/proj/main.tscn",
+            "--node",
+            "Hero",
+            "--script",
+            "/tmp/proj/hero.gd",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["scene_path"] == "/tmp/proj/main.tscn"
+    assert data["node"] == "Hero"
+    assert data["script"] == "/tmp/proj/hero.gd"
+    assert data["class_name"] == "Hero"
+    assert fake.calls == [
+        (
+            "script-attach",
+            {
+                "path": "/tmp/proj/main.tscn",
+                "node": "Hero",
+                "script": "/tmp/proj/hero.gd",
+            },
+        )
+    ]
+    assert "engine diagnostic" in result.stderr
+
+
 def test_script_set_start_line_without_content_is_a_usage_error(monkeypatch):
     # --start-line/--end-line require --content: a line range with no replacement
     # text is a usage error.

--- a/tests/test_script_errors.py
+++ b/tests/test_script_errors.py
@@ -216,3 +216,80 @@ def test_script_delete_unlink_failure_reuses_stable_delete_failed_code(monkeypat
     assert err["category"] == "operation"
     assert err["code"] == "delete_failed"
     assert "/x/hero.gd" in err["message"]
+
+
+def _invoke_script_set(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: script-set\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(
+        app,
+        ["script", "set", "/x/hero.gd", "--search", "a", "--replace", "b", "--json"],
+    )
+
+
+def test_script_set_no_search_match_maps_to_stable_no_search_match_code(monkeypatch):
+    # search-replace mode (issue #118): a search string the source does not
+    # contain is a new no_search_match code, so an agent learns the edit landed
+    # nowhere (and the file was left untouched) rather than parsing prose.
+    result = _invoke_script_set(
+        monkeypatch, "no_search_match", "search string not found in script: \"xyzzy\""
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "no_search_match"
+    assert "xyzzy" in err["message"]
+    assert err["diagnostics"] == "gda: running operation: script-set\n"
+
+
+def test_script_set_invalid_line_range_maps_to_stable_invalid_line_range_code(
+    monkeypatch,
+):
+    # line-range mode: a range outside the script's bounds (or end before start)
+    # is a new invalid_line_range code, distinct from no_search_match, so an
+    # agent knows the line numbers — not the search string — are the problem.
+    result = _invoke_script_set(
+        monkeypatch,
+        "invalid_line_range",
+        "line range 5..9 is outside the script's bounds (1..3) or ends before it starts",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_line_range"
+    assert "1..3" in err["message"]
+
+
+def test_script_set_missing_file_reuses_stable_path_not_found_code(monkeypatch):
+    # set edits an existing script; a missing target is path_not_found (the same
+    # one get/delete use), never a silent create.
+    result = _invoke_script_set(
+        monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert "/x/hero.gd" in err["message"]
+
+
+def test_script_set_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
+    result = _invoke_script_set(
+        monkeypatch, "invalid_path", "script path must end in .gd: /x/notes.txt"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_path"
+    assert ".gd" in err["message"]

--- a/tests/test_script_errors.py
+++ b/tests/test_script_errors.py
@@ -380,20 +380,38 @@ def test_script_attach_missing_scene_reuses_stable_path_not_found_code(monkeypat
     assert "/x/main.tscn" in err["message"]
 
 
-def test_script_attach_unloadable_script_reuses_stable_invalid_path_code(monkeypatch):
-    # A .gd that exists but cannot be loaded as a Script (it does not compile) is
-    # refused with invalid_path naming the path; loading it compiles but never
-    # runs an instance of it.
+def test_script_attach_unloadable_resource_reuses_stable_invalid_path_code(monkeypatch):
+    # A .gd that cannot even be loaded AS A RESOURCE (a genuine load failure, not
+    # a compile error — load returns non-null for a non-compiling script) is the
+    # defensive invalid_path branch, naming the path.
     result = _invoke_script_attach(
         monkeypatch,
         "invalid_path",
-        "file could not be loaded as a GDScript: /x/hero.gd — it may not compile",
+        "file could not be loaded as a GDScript resource: /x/hero.gd",
     )
 
     assert result.exit_code == 4
     err = json.loads(result.stdout)["error"]
     assert err["category"] == "operation"
     assert err["code"] == "invalid_path"
+    assert "/x/hero.gd" in err["message"]
+
+
+def test_script_attach_non_compiling_script_uses_script_compile_failed_code(monkeypatch):
+    # A .gd that loads but does not COMPILE cannot be bound: the headless engine
+    # silently rejects it from set_script, so attach refuses with the focused
+    # script_compile_failed code rather than report a phantom success over a
+    # scene with nothing attached.
+    result = _invoke_script_attach(
+        monkeypatch,
+        "script_compile_failed",
+        "script does not compile, so it cannot be attached: /x/hero.gd",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "script_compile_failed"
     assert "/x/hero.gd" in err["message"]
 
 

--- a/tests/test_script_errors.py
+++ b/tests/test_script_errors.py
@@ -395,3 +395,44 @@ def test_script_attach_unloadable_script_reuses_stable_invalid_path_code(monkeyp
     assert err["category"] == "operation"
     assert err["code"] == "invalid_path"
     assert "/x/hero.gd" in err["message"]
+
+
+def _invoke_script_validate(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: script-validate\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(app, ["script", "validate", "/x/hero.gd", "--json"])
+
+
+def test_script_validate_missing_file_reuses_stable_path_not_found_code(monkeypatch):
+    # validate only op-fails (non-zero) for op errors. A missing file is
+    # path_not_found (the same one get/set use); an INVALID script is NOT a
+    # failure — it is a successful op reporting valid=false (covered in S3 success).
+    result = _invoke_script_validate(
+        monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert "/x/hero.gd" in err["message"]
+    assert err["diagnostics"] == "gda: running operation: script-validate\n"
+
+
+def test_script_validate_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
+    result = _invoke_script_validate(
+        monkeypatch, "invalid_path", "script path must end in .gd: /x/notes.txt"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_path"
+    assert ".gd" in err["message"]

--- a/tests/test_script_errors.py
+++ b/tests/test_script_errors.py
@@ -293,3 +293,105 @@ def test_script_set_wrong_extension_reuses_stable_invalid_path_code(monkeypatch)
     assert err["category"] == "operation"
     assert err["code"] == "invalid_path"
     assert ".gd" in err["message"]
+
+
+def _invoke_script_attach(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: script-attach\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(
+        app,
+        [
+            "script",
+            "attach",
+            "/x/main.tscn",
+            "--node",
+            "Hero",
+            "--script",
+            "/x/hero.gd",
+            "--json",
+        ],
+    )
+
+
+def test_script_attach_missing_script_reuses_stable_path_not_found_code(monkeypatch):
+    # attach binds an existing script; a missing .gd is path_not_found (the same
+    # one script get uses) so an agent knows the script file, not the scene, is
+    # the thing that's missing.
+    result = _invoke_script_attach(
+        monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert "/x/hero.gd" in err["message"]
+    assert err["diagnostics"] == "gda: running operation: script-attach\n"
+
+
+def test_script_attach_wrong_script_extension_reuses_stable_invalid_path_code(
+    monkeypatch,
+):
+    # A non-.gd script target is refused with invalid_path — the same addressing
+    # boundary the rest of the script group uses.
+    result = _invoke_script_attach(
+        monkeypatch, "invalid_path", "script path must end in .gd: /x/notes.txt"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_path"
+    assert ".gd" in err["message"]
+
+
+def test_script_attach_missing_node_reuses_stable_node_not_found_code(monkeypatch):
+    # The scene loaded but the node path resolves to nothing — node_not_found
+    # (the same one node get/set use), distinct from the file-level path_not_found.
+    result = _invoke_script_attach(
+        monkeypatch, "node_not_found", "node not found in scene: Hero"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "node_not_found"
+    assert "Hero" in err["message"]
+
+
+def test_script_attach_missing_scene_reuses_stable_path_not_found_code(monkeypatch):
+    # The scene-file-level failure reuses the registered scene code; attach
+    # introduces no parallel code for the same mode.
+    result = _invoke_script_attach(
+        monkeypatch, "path_not_found", "scene file does not exist: /x/main.tscn"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert "/x/main.tscn" in err["message"]
+
+
+def test_script_attach_unloadable_script_reuses_stable_invalid_path_code(monkeypatch):
+    # A .gd that exists but cannot be loaded as a Script (it does not compile) is
+    # refused with invalid_path naming the path; loading it compiles but never
+    # runs an instance of it.
+    result = _invoke_script_attach(
+        monkeypatch,
+        "invalid_path",
+        "file could not be loaded as a GDScript: /x/hero.gd — it may not compile",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_path"
+    assert "/x/hero.gd" in err["message"]


### PR DESCRIPTION
## What

Closes #118 (parent PRD #17). Rounds out the `script` group's write/verify/bind operations, reusing the script-file plumbing from #110 and the node-path addressing from #53.

- **`gda script set`** — edit an existing `.gd` as **raw text** (never compiles/loads it) via one of three mutually-exclusive modes:
  - search-replace: `--search <old> --replace <new>` (literal, replace-all)
  - line-range: `--start-line N [--end-line M] --content <text>` (1-based, inclusive; `M` defaults to `N`)
  - full: `--content <text>` (overwrite)
  CLI enforces exactly one mode (usage error/exit 2 otherwise). Re-parses the written source's `class_name`/`extends` so an edit round-trips through `script get`. Edits only an existing script — a missing target is `path_not_found`, never a silent create.
- **`gda script attach SCENE --node <path> --script <gd>`** — bind a `.gd` to a node. Reuses the #53 node-path addressing (`.` = root, `A/B` = descendant) and the shared mutate-entry (`_load_for_mutation`, so it honors the #64 mutation-integrity boundary like `node set`): load → resolve node → `set_script` → re-pack → save. Echoes the attached script's `class_name`.
- **`gda script validate PATH`** — syntax/compile-check. Mechanism: read text → `GDScript.new()` + `source_code` + `reload()` (`OK` ⇒ compiles). Compiles but never **instantiates**, so it doesn't run instance code. A **`valid=false` result is a successful op** (exit 0) — it only op-fails for `invalid_path`/`path_not_found`.

## Design notes

- **Error codes (public ABI):** mints two focused operation codes — `no_search_match`, `invalid_line_range` — synced across all three mirrors (Python registry, ADR-0002 table, GDScript `OP_ERROR_*` consts; drift tests enforce). `attach`/`validate` reuse existing codes only.
- **`validate` diagnostics — the hard constraint:** on the standard Godot build there is **no bound API** for structured parse diagnostics. `GDScript.reload()` returns only an `Error`; `is_valid()` is not callable from GDScript; `--check-only` is unreliable (exits 0 on broken scripts). The per-error `line`/`message` exist only in the engine's stderr (**no column**, typically first error only). So `validate` reports `valid`/`error_string` structurally via the sentinel, and a per-command classifier parses **best-effort, advisory** `{line, message}` diagnostics from stderr. ADR-0002 is refined to legitimize this: stderr is still **never** parsed for the success/failure outcome or stable codes — only surfaced as advisory diagnostics.
- `ScriptValidateResult` intentionally exposes `valid` + `error_string` + `diagnostics`; the raw Godot `Error` int is omitted as an unstable engine internal (not a stable gda ABI).

## Tests

All three tiers, behavior-focused (round-trips, on-disk state, untouched-on-failure, descendant addressing). The riskiest path — `validate`'s stderr diagnostics parsing — is covered at S2 (pure parser, incl. ignoring `operations.gd`'s own backtrace frames), S3 (FakeRunner fed the exact engine stderr), and S1 (real engine).

- `uv run pytest -m "not e2e"` → **192 passed** (was 158)
- `uv run pytest -m e2e` → **110 passed** (was 92), real Godot 4.6.3

## Docs

- ADR-0002: 2 new registry rows + a new "stderr as advisory diagnostics" subsection.
- `command-catalog.md`: prose for `script set` (3 modes + the 1-based-over-`\n`-split line rule), `script attach`, `script validate`.
