### PR TITLE
fix(script): attach distinguishes type incompatibility from compile failure (#136)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -107,6 +107,7 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 | `no_search_match` | `operation` | `operation` | A search-replace script edit found no occurrence of the search string. |
 | `invalid_line_range` | `operation` | `operation` | A line-range script edit specified lines outside the script's bounds, or end before start. |
 | `script_compile_failed` | `operation` | `operation` | A script could not be attached to a node because it does not compile. |
+| `incompatible_script_type` | `operation` | `operation` | A script compiles but its native base type is incompatible with the target node's type. |
 | `contract_violation` | `parse` | `parser` | The process claimed success but violated the structured-output contract. |
 
 ## Considered options

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -208,11 +208,14 @@ the form `node list` reports. Unlike the other script-file ops, `attach` is a **
 it loads and **instantiates** the scene (so it runs the `_init` of scripts already in the scene —
 the inherent trust boundary of `node set`, ADR-0009), attaches the script via `set_script` (which,
 for a script that compiles, constructs an instance of the newly-attached script, running *its*
-`_init` too), and re-packs and saves. The attached script **must compile**: the headless engine
-silently rejects a non-compiling script from `set_script` (the node's script stays null and a
-re-pack saves no script), so attach **refuses** one with `script_compile_failed` rather than report
-a phantom success over a scene with nothing attached — check a script with `script validate` first.
-Other failures reuse existing codes: a missing script is `path_not_found`, a non-`.gd` script is
+`_init` too), and re-packs and saves. The attached script **must bind**: the headless engine
+silently rejects a script `set_script` cannot bind (the node's script stays null and a re-pack saves
+no script), so attach **refuses** rather than report a phantom success, distinguishing the two
+rejection modes so an agent gets the right remediation — a script that does **not compile** is
+`script_compile_failed` (fix the syntax; check it with `script validate`), while one that compiles
+but whose native base is **incompatible** with the node (e.g. an `extends Node3D` script on a
+`Node2D`) is `incompatible_script_type` (attach it to a compatible node, or change the script's
+`extends`). Other failures reuse existing codes: a missing script is `path_not_found`, a non-`.gd` script is
 `invalid_path`, a node path that resolves to nothing is `node_not_found`, a missing or non-scene
 file is `path_not_found`/`not_a_scene`, and a scene whose instances vanish or degrade on load is
 `missing_dependency` (the mutation-integrity boundary, #64). The result echoes

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -211,6 +211,12 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A script could not be attached to a node because it does not compile.",
     ),
     ErrorCodeSpec(
+        "incompatible_script_type",
+        ErrorCategory.OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A script compiles but its native base type is incompatible with the target node's type.",
+    ),
+    ErrorCodeSpec(
         "contract_violation",
         ErrorCategory.PARSE,
         ErrorCodeSource.PARSER,

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -48,6 +48,7 @@ const OP_ERROR_UNCOERCIBLE_VALUE := "uncoercible_value"
 const OP_ERROR_NO_SEARCH_MATCH := "no_search_match"
 const OP_ERROR_INVALID_LINE_RANGE := "invalid_line_range"
 const OP_ERROR_SCRIPT_COMPILE_FAILED := "script_compile_failed"
+const OP_ERROR_INCOMPATIBLE_SCRIPT_TYPE := "incompatible_script_type"
 
 const NODE_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
 
@@ -808,13 +809,26 @@ func _op_script_attach(params: Dictionary) -> void:
 		return
 
 	node.set_script(script)
-	# set_script silently rejects a non-compiling script: get_script() stays null
+	# set_script silently rejects a script it cannot bind: get_script() stays null
 	# and a re-pack would save no script. Verify the bind took effect rather than
-	# report a phantom success over a scene with nothing attached.
+	# report a phantom success — and tell the two rejection modes apart so the
+	# agent gets the right remediation: a script that does NOT compile is
+	# script_compile_failed (fix the syntax), while one that compiles but whose
+	# native base is incompatible with the node (e.g. an `extends Node3D` script
+	# on a Node2D — the engine refuses the assignment) is incompatible_script_type
+	# (attach it to a compatible node, or change the script's extends).
 	if node.get_script() == null:
+		var node_class := node.get_class()
+		var script_base := script.get_instance_base_type()
+		var compiles := script.reload() == OK
 		root.free()
-		_fail(OP_ERROR_SCRIPT_COMPILE_FAILED, "script does not compile, so it cannot be attached: "
-				+ script_path + " — fix it, or check it with `gda script validate`")
+		if compiles:
+			_fail(OP_ERROR_INCOMPATIBLE_SCRIPT_TYPE, "script extends " + script_base
+					+ ", which is incompatible with node " + node_path + " of type " + node_class
+					+ " — attach it to a " + script_base + " node, or change the script's extends")
+		else:
+			_fail(OP_ERROR_SCRIPT_COMPILE_FAILED, "script does not compile, so it cannot be attached: "
+					+ script_path + " — fix it, or check it with `gda script validate`")
 		return
 
 	var repacked := PackedScene.new()

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -820,6 +820,41 @@ def test_script_attach_non_compiling_script_yields_script_compile_failed(godot_p
 
 
 @pytest.mark.e2e
+def test_script_attach_incompatible_node_type_yields_incompatible_script_type(godot_project):
+    # A script that COMPILES but whose native base is incompatible with the node
+    # (an `extends Node3D` script onto a Node2D root) is bounced by set_script for
+    # a reason that is NOT a compile error. attach must report the distinct
+    # incompatible_script_type — not script_compile_failed — so the agent fixes
+    # the node/script pairing rather than chasing a non-existent syntax error. The
+    # scene is left untouched.
+    gda = _gda_project(godot_project)
+    assert (
+        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
+        .returncode
+        == 0
+    )
+    # A perfectly valid script — it compiles — but extends Node3D, incompatible
+    # with the Node2D root.
+    assert (
+        gda("script", "create", "res://spatial.gd", "--extends", "Node3D", "--json")
+        .returncode
+        == 0
+    )
+    before = (godot_project / "main.tscn").read_text(encoding="utf-8")
+
+    attached = gda(
+        "script", "attach", "res://main.tscn",
+        "--node", ".", "--script", "res://spatial.gd", "--json",
+    )
+
+    err = _assert_operation_error(attached, "incompatible_script_type")
+    assert "Node3D" in err["message"]
+    assert "Node2D" in err["message"]
+    # The refusal leaves the scene untouched.
+    assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
 def test_script_attach_missing_script_yields_path_not_found(godot_project):
     gda = _gda_project(godot_project)
     assert (

--- a/tests/test_script_errors.py
+++ b/tests/test_script_errors.py
@@ -415,6 +415,26 @@ def test_script_attach_non_compiling_script_uses_script_compile_failed_code(monk
     assert "/x/hero.gd" in err["message"]
 
 
+def test_script_attach_incompatible_type_uses_incompatible_script_type_code(monkeypatch):
+    # A script that COMPILES but whose native base is incompatible with the node
+    # (e.g. an `extends Node3D` script onto a Node2D) is bounced by set_script for
+    # a different reason than a compile error — attach reports the distinct
+    # incompatible_script_type code so the agent fixes the node/script pairing
+    # rather than chasing a non-existent syntax error.
+    result = _invoke_script_attach(
+        monkeypatch,
+        "incompatible_script_type",
+        "script extends Node3D, which is incompatible with node Hero of type Node2D",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "incompatible_script_type"
+    assert "Node3D" in err["message"]
+    assert "Node2D" in err["message"]
+
+
 def _invoke_script_validate(monkeypatch, code: str, message: str):
     inject_runner(
         monkeypatch,


### PR DESCRIPTION
## What

Closes #136. Follow-up to the #129 review (maintainer `qinhaihong-red` reproduced it; independently confirmed against Godot 4.6.3).

`gda script attach`'s post-bind check reported **any** `node.get_script() == null` after `set_script` as `script_compile_failed`. But `set_script` also silently rejects a script that **compiles fine** yet whose native base type is **incompatible** with the target node — e.g. an `extends Node3D` script attached to a `Node2D` (`Script inherits from native type 'Node3D', so it can't be assigned to an object of type 'Node2D'`). Labeling that `script_compile_failed` sends an agent to chase a non-existent syntax error.

attach now distinguishes the two rejection modes:
- script does **not compile** → `script_compile_failed` (existing);
- script **compiles** but is type-incompatible → new **`incompatible_script_type`** (names the script's base type and the node's class, so the agent attaches to a compatible node or changes the script's `extends`).

Disambiguation uses `script.reload() == OK` for the compile signal; the incompatibility is what `ClassDB.is_parent_class(node.get_class(), script.get_instance_base_type())` already shows.

## Tests

- `uv run pytest -m "not e2e"` → **201 passed** (incl. registry drift gates: the new code synced across Python registry / ADR-0002 table / GDScript mirror)
- `uv run pytest -m e2e -k attach` → **10 passed** (real Godot 4.6.3): the new `extends Node3D`-onto-`Node2D` case yields `incompatible_script_type` with the scene untouched, and the existing non-compiling case still yields `script_compile_failed`.
