### PR TITLE
refactor(render): extract presentation module, close result-model leaks (#140)

### DIFF
--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -7,7 +7,6 @@ domain group (issue #18). Every command drives the same headless pipeline:
 binary resolution → runner → sentinel parse → typed model → JSON.
 """
 
-import json
 from importlib.metadata import version as package_version
 from pathlib import Path
 from typing import Optional
@@ -28,8 +27,6 @@ from gda.headless import (
 from gda.models import (
     EngineVersion,
     InfoParams,
-    ListedNode,
-    ListedScript,
     NodeAddParams,
     NodeAddResult,
     NodeGetParams,
@@ -46,7 +43,6 @@ from gda.models import (
     SceneGetResult,
     SceneListParams,
     SceneListResult,
-    SceneNode,
     ScriptAttachParams,
     ScriptAttachResult,
     ScriptCreateParams,
@@ -63,6 +59,7 @@ from gda.models import (
     ScriptValidateResult,
 )
 from gda.project import resolve_project_dir
+from gda.render import render
 from gda.runner import GodotRunner
 
 app = typer.Typer(
@@ -320,13 +317,6 @@ def _derive_scene_root_name(path: str) -> str:
     return filename
 
 
-def _render_tree(node: "SceneNode | ListedNode", depth: int = 0) -> str:
-    """Render a node tree as an indented ``name (Type)`` outline for humans."""
-    lines = [f"{'  ' * depth}{node.name} ({node.type})"]
-    lines += (_render_tree(child, depth + 1) for child in node.children)
-    return "\n".join(lines)
-
-
 @scene_app.command(cls=SCENE_CREATE_COMMAND.command_class())
 def create(
     path: str = typer.Argument(..., help="Target .tscn path to write."),
@@ -362,9 +352,7 @@ def create(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=lambda created: (
-            f"created {created.path} (root {created.root_type})"
-        ),
+        render=render,
     )
 
 
@@ -383,21 +371,8 @@ def get(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=lambda scene: _render_tree(scene.root),
+        render=render,
     )
-
-
-def _render_scene_list(listed: "SceneListResult") -> str:
-    """Render the enumerated scenes as ``path (root_name: root_type)`` lines."""
-    if not listed.scenes:
-        return "(no scenes)"
-    lines = []
-    for scene in listed.scenes:
-        if scene.root_name is not None and scene.root_type is not None:
-            lines.append(f"{scene.path} ({scene.root_name}: {scene.root_type})")
-        else:
-            lines.append(f"{scene.path} (unreadable)")
-    return "\n".join(lines)
 
 
 @scene_app.command(name="list", cls=SCENE_LIST_COMMAND.command_class())
@@ -414,7 +389,7 @@ def list_scenes(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=_render_scene_list,
+        render=render,
     )
 
 
@@ -433,9 +408,7 @@ def delete(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=lambda removed: (
-            f"deleted {removed.path} (root {removed.root_name}: {removed.root_type})"
-        ),
+        render=render,
     )
 
 
@@ -480,9 +453,7 @@ def add(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=lambda added: (
-            f"added {added.path} ({added.type}) to {added.scene_path}"
-        ),
+        render=render,
     )
 
 
@@ -501,18 +472,8 @@ def list_nodes(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=lambda listed: _render_tree(listed.root),
+        render=render,
     )
-
-
-def _render_node_properties(got: "NodeGetResult") -> str:
-    """Render a node's properties as ``name (Type) = value`` lines for humans."""
-    header = f"{got.path} ({got.type})"
-    lines = [
-        f"  {prop.name} ({prop.type}) = {json.dumps(prop.value)}"
-        for prop in got.properties
-    ]
-    return "\n".join([header, *lines])
 
 
 @node_app.command(cls=NODE_GET_COMMAND.command_class())
@@ -538,7 +499,7 @@ def get(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=_render_node_properties,
+        render=render,
     )
 
 
@@ -578,25 +539,8 @@ def set_property(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=lambda was_set: (
-            f"set {was_set.path}.{was_set.property} ({was_set.type}) = "
-            f"{json.dumps(was_set.value)}"
-        ),
+        render=render,
     )
-
-
-def _render_script_metadata(
-    script: "ScriptCreateResult | ScriptGetResult | ListedScript | ScriptDeleteResult | ScriptSetResult",
-) -> str:
-    """Render a script's path plus its class_name/extends for humans."""
-    meta = []
-    if script.extends is not None:
-        meta.append(f"extends {script.extends}")
-    if script.class_name is not None:
-        meta.append(f"class_name {script.class_name}")
-    if not meta:
-        return script.path
-    return f"{script.path} ({', '.join(meta)})"
 
 
 @script_app.command(cls=SCRIPT_CREATE_COMMAND.command_class())
@@ -636,7 +580,7 @@ def create(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=lambda created: f"created {_render_script_metadata(created)}",
+        render=render,
     )
 
 
@@ -655,17 +599,8 @@ def get_script(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=lambda got: "\n".join(
-            [_render_script_metadata(got), got.source]
-        ),
+        render=render,
     )
-
-
-def _render_script_list(listed: "ScriptListResult") -> str:
-    """Render the enumerated scripts as ``path (extends X, class_name Y)`` lines."""
-    if not listed.scripts:
-        return "(no scripts)"
-    return "\n".join(_render_script_metadata(script) for script in listed.scripts)
 
 
 @script_app.command(name="list", cls=SCRIPT_LIST_COMMAND.command_class())
@@ -682,7 +617,7 @@ def list_scripts(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=_render_script_list,
+        render=render,
     )
 
 
@@ -701,7 +636,7 @@ def delete_script(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=lambda removed: f"deleted {_render_script_metadata(removed)}",
+        render=render,
     )
 
 
@@ -765,7 +700,7 @@ def set_script(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=lambda edited: f"set {_render_script_metadata(edited)}",
+        render=render,
     )
 
 
@@ -840,23 +775,8 @@ def attach_script(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=lambda attached: (
-            f"attached {attached.script} to {attached.node} in {attached.scene_path}"
-        ),
+        render=render,
     )
-
-
-def _render_validate(validated: "ScriptValidateResult") -> str:
-    """Render a validate result: valid/invalid plus best-effort diagnostics."""
-    if validated.valid:
-        return f"valid {validated.path}"
-    lines = [f"invalid {validated.path}"]
-    if validated.error_string is not None:
-        lines.append(f"  {validated.error_string}")
-    for diag in validated.diagnostics:
-        location = f"line {diag.line}" if diag.line is not None else "unknown line"
-        lines.append(f"  {location}: {diag.message}")
-    return "\n".join(lines)
 
 
 @script_app.command(name="validate", cls=SCRIPT_VALIDATE_COMMAND.command_class())
@@ -874,7 +794,7 @@ def validate_script(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=_render_validate,
+        render=render,
     )
 
 
@@ -890,5 +810,5 @@ def info(
         InfoParams(),
         json_output=json_output,
         godot=godot,
-        render=lambda version: version.string,
+        render=render,
     )

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -1,0 +1,244 @@
+"""Human-readable rendering for ``gda`` results — the presentation layer.
+
+The result models (``gda.models``) are pure ``--schema`` / ``--json`` data
+contracts (ADR-0004); presentation does not live in them. This module owns the
+human-readable text path: one renderer per result type, selected by result type
+via :func:`render`, plus the typed helpers that keep the presentation layer from
+reaching into a model's value shape or across a union of result types.
+
+Two seams are deliberately funnelled through one place here:
+
+- **Value-to-text.** A node property's ``value`` is arbitrary JSON (every Godot
+  type carried uniformly, :class:`~gda.models.NodeProperty`). :func:`format_value`
+  owns the JSON projection so no renderer reaches into ``.value`` with a raw
+  ``json.dumps``.
+- **Script metadata.** Five script result types share the same human-facing
+  ``path``/``class_name``/``extends`` surface. :class:`ScriptMetadata` is the
+  structural interface the metadata renderer reads, so the renderer types against
+  one surface rather than a five-way union.
+"""
+
+import json
+from typing import Any, Protocol, runtime_checkable
+
+from gda.models import (
+    EngineVersion,
+    ListedNode,
+    NodeAddResult,
+    NodeGetResult,
+    NodeListResult,
+    NodeSetResult,
+    SceneCreateResult,
+    SceneDeleteResult,
+    SceneGetResult,
+    SceneListResult,
+    SceneNode,
+    ScriptAttachResult,
+    ScriptCreateResult,
+    ScriptDeleteResult,
+    ScriptGetResult,
+    ScriptListResult,
+    ScriptSetResult,
+    ScriptValidateResult,
+)
+
+
+@runtime_checkable
+class ScriptMetadata(Protocol):
+    """The shared human-facing surface of every script result type.
+
+    A structural (typing-only) interface — fields, no methods — over the
+    ``path``/``class_name``/``extends`` that :class:`~gda.models.ScriptCreateResult`,
+    :class:`~gda.models.ScriptGetResult`, :class:`~gda.models.ListedScript`,
+    :class:`~gda.models.ScriptDeleteResult` and :class:`~gda.models.ScriptSetResult`
+    all carry. The metadata renderer types against this surface, so adding a
+    script result type that carries the same fields needs no renderer change and
+    the renderer never reads across a union. It is a ``Protocol`` rather than a
+    shared base model so it imposes nothing on the models' JSON Schema or field
+    order (the ``--schema`` contract stays byte-for-byte unchanged).
+    """
+
+    path: str
+    class_name: str | None
+    extends: str | None
+
+
+def format_value(value: Any) -> str:
+    """Render a node property value (arbitrary JSON) as text.
+
+    The one place value-to-text formatting lives, so no renderer reaches into a
+    model's ``.value`` with a raw ``json.dumps``: a node property's value is the
+    JSON projection of a Godot type (a scalar stays a scalar, a Vector2 becomes
+    ``[x, y]``), and this owns that projection for the human path.
+    """
+    return json.dumps(value)
+
+
+def render_node_tree(node: "SceneNode | ListedNode", depth: int = 0) -> str:
+    """Render a node tree as an indented ``name (Type)`` outline for humans."""
+    lines = [f"{'  ' * depth}{node.name} ({node.type})"]
+    lines += (render_node_tree(child, depth + 1) for child in node.children)
+    return "\n".join(lines)
+
+
+def render_scene_metadata(scene: "SceneCreateResult") -> str:
+    """Render a created scene as ``created <path> (root <type>)``."""
+    return f"created {scene.path} (root {scene.root_type})"
+
+
+def render_scene_tree(scene: "SceneGetResult") -> str:
+    """Render a read scene's node tree."""
+    return render_node_tree(scene.root)
+
+
+def render_scene_list(listed: "SceneListResult") -> str:
+    """Render the enumerated scenes as ``path (root_name: root_type)`` lines."""
+    if not listed.scenes:
+        return "(no scenes)"
+    lines = []
+    for scene in listed.scenes:
+        if scene.root_name is not None and scene.root_type is not None:
+            lines.append(f"{scene.path} ({scene.root_name}: {scene.root_type})")
+        else:
+            lines.append(f"{scene.path} (unreadable)")
+    return "\n".join(lines)
+
+
+def render_scene_delete(removed: "SceneDeleteResult") -> str:
+    """Render a deleted scene as ``deleted <path> (root <name>: <type>)``."""
+    return f"deleted {removed.path} (root {removed.root_name}: {removed.root_type})"
+
+
+def render_node_add(added: "NodeAddResult") -> str:
+    """Render an added node as ``added <path> (<type>) to <scene>``."""
+    return f"added {added.path} ({added.type}) to {added.scene_path}"
+
+
+def render_node_list(listed: "NodeListResult") -> str:
+    """Render a listed scene's node tree (with node paths)."""
+    return render_node_tree(listed.root)
+
+
+def render_node_properties(got: "NodeGetResult") -> str:
+    """Render a node's properties as ``name (Type) = value`` lines for humans."""
+    header = f"{got.path} ({got.type})"
+    lines = [
+        f"  {prop.name} ({prop.type}) = {format_value(prop.value)}"
+        for prop in got.properties
+    ]
+    return "\n".join([header, *lines])
+
+
+def render_node_set(was_set: "NodeSetResult") -> str:
+    """Render a set property as ``set <path>.<prop> (<type>) = <value>``."""
+    return (
+        f"set {was_set.path}.{was_set.property} ({was_set.type}) = "
+        f"{format_value(was_set.value)}"
+    )
+
+
+def render_script_metadata(script: ScriptMetadata) -> str:
+    """Render a script's path plus its class_name/extends for humans.
+
+    Reads the shared :class:`ScriptMetadata` surface, so it serves every script
+    result type without naming the union.
+    """
+    meta = []
+    if script.extends is not None:
+        meta.append(f"extends {script.extends}")
+    if script.class_name is not None:
+        meta.append(f"class_name {script.class_name}")
+    if not meta:
+        return script.path
+    return f"{script.path} ({', '.join(meta)})"
+
+
+def render_script_create(created: "ScriptCreateResult") -> str:
+    """Render a created script as ``created <metadata>``."""
+    return f"created {render_script_metadata(created)}"
+
+
+def render_script_get(got: "ScriptGetResult") -> str:
+    """Render a read script as its metadata line followed by its source."""
+    return "\n".join([render_script_metadata(got), got.source])
+
+
+def render_script_list(listed: "ScriptListResult") -> str:
+    """Render the enumerated scripts as ``path (extends X, class_name Y)`` lines."""
+    if not listed.scripts:
+        return "(no scripts)"
+    return "\n".join(render_script_metadata(script) for script in listed.scripts)
+
+
+def render_script_delete(removed: "ScriptDeleteResult") -> str:
+    """Render a deleted script as ``deleted <metadata>``."""
+    return f"deleted {render_script_metadata(removed)}"
+
+
+def render_script_set(edited: "ScriptSetResult") -> str:
+    """Render an edited script as ``set <metadata>``."""
+    return f"set {render_script_metadata(edited)}"
+
+
+def render_script_attach(attached: "ScriptAttachResult") -> str:
+    """Render an attached script as ``attached <script> to <node> in <scene>``."""
+    return (
+        f"attached {attached.script} to {attached.node} in {attached.scene_path}"
+    )
+
+
+def render_script_validate(validated: "ScriptValidateResult") -> str:
+    """Render a validate result: valid/invalid plus best-effort diagnostics."""
+    if validated.valid:
+        return f"valid {validated.path}"
+    lines = [f"invalid {validated.path}"]
+    if validated.error_string is not None:
+        lines.append(f"  {validated.error_string}")
+    for diag in validated.diagnostics:
+        location = f"line {diag.line}" if diag.line is not None else "unknown line"
+        lines.append(f"  {location}: {diag.message}")
+    return "\n".join(lines)
+
+
+def render_engine_version(version: "EngineVersion") -> str:
+    """Render the engine version as its one-line version string."""
+    return version.string
+
+
+# Renderer selection keyed by result type: each result model maps to the one
+# renderer that turns it into human-readable text. :func:`render` dispatches on
+# ``type(result)``, so a command sources its renderer from this module by its
+# result type rather than carrying an inline closure (composes with #139's
+# ``render`` dispatch parameter).
+_RENDERERS = {
+    SceneCreateResult: render_scene_metadata,
+    SceneGetResult: render_scene_tree,
+    SceneListResult: render_scene_list,
+    SceneDeleteResult: render_scene_delete,
+    NodeAddResult: render_node_add,
+    NodeListResult: render_node_list,
+    NodeGetResult: render_node_properties,
+    NodeSetResult: render_node_set,
+    ScriptCreateResult: render_script_create,
+    ScriptGetResult: render_script_get,
+    ScriptListResult: render_script_list,
+    ScriptDeleteResult: render_script_delete,
+    ScriptSetResult: render_script_set,
+    ScriptAttachResult: render_script_attach,
+    ScriptValidateResult: render_script_validate,
+    EngineVersion: render_engine_version,
+}
+
+
+def render(result: Any) -> str:
+    """Render any ``gda`` result to human-readable text, keyed by its type.
+
+    Looks the result's concrete type up in the type → renderer table and applies
+    the matching renderer. A result type with no registered renderer is a
+    programming error (a new command wired without a renderer), not a runtime
+    user error, so it raises rather than guessing a format.
+    """
+    renderer = _RENDERERS.get(type(result))
+    if renderer is None:
+        raise KeyError(f"no renderer registered for result type {type(result)!r}")
+    return renderer(result)

--- a/tests/test_human_output.py
+++ b/tests/test_human_output.py
@@ -1,0 +1,331 @@
+"""End-to-end human-mode CLI output for every command (issue #140 follow-up).
+
+PR #143 extracted human rendering into ``gda.render`` and pinned the renderers
+in isolation (``test_render.py``). But the command-level *human* output path —
+invoking a command WITHOUT ``--json`` through the real Typer CLI and asserting
+the exact ``stdout`` text — was only covered for ``script validate/attach/set``.
+This closes that gap: one parameterized test drives every command in human mode
+against a fake runner and pins the exact bytes the CLI prints, so #139's
+``render`` dispatch + #140's ``gda.render`` renderers are behavior-pinned
+end-to-end, not just unit-tested in isolation.
+
+The canned success payloads mirror the per-command ``--json`` tests
+(``test_scene_commands.py``, ``test_node_commands.py``, ``test_script_commands.py``,
+``test_info_command.py``) so the faked results match each command's result-model
+shape. The expected strings are transcribed directly from ``gda.render``: a
+renderer produces a newline-free string and the CLI's ``typer.echo`` appends
+exactly one trailing newline, so each case asserts ``stdout == expected + "\n"``.
+
+These run engine-free (FakeRunner) under ``-m "not e2e"``.
+"""
+
+import pytest
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import inject_runner, sentinel
+
+# Each case: (id, argv-without-`--json`, success-payload, expected-stdout-text).
+# The payload is wrapped in the result sentinel as operations.gd emits it; the
+# expected text is what the matching renderer in gda.render produces (the CLI
+# adds the trailing newline). Every NEW-coverage command is here; the already
+# human-pinned script validate/attach/set are included for uniformity.
+HUMAN_CASES = [
+    # --- scene group --------------------------------------------------------
+    (
+        "scene-create",
+        ["scene", "create", "/tmp/proj/main.tscn", "--root-type", "Node2D"],
+        {
+            "path": "/tmp/proj/main.tscn",
+            "root_name": "main",
+            "root_type": "Node2D",
+            "created_dirs": [],
+        },
+        "created /tmp/proj/main.tscn (root Node2D)",
+    ),
+    (
+        "scene-get",
+        ["scene", "get", "/tmp/proj/main.tscn"],
+        {
+            "path": "/tmp/proj/main.tscn",
+            "root": {
+                "name": "main",
+                "type": "Node2D",
+                "children": [
+                    {
+                        "name": "Hero",
+                        "type": "Sprite2D",
+                        "children": [
+                            {"name": "Hitbox", "type": "Area2D", "children": []}
+                        ],
+                    }
+                ],
+            },
+        },
+        # render_node_tree: an indented `name (Type)` outline, two-space depth.
+        "main (Node2D)\n  Hero (Sprite2D)\n    Hitbox (Area2D)",
+    ),
+    (
+        "scene-list",
+        ["scene", "list"],
+        {
+            "scenes": [
+                {
+                    "path": "res://main.tscn",
+                    "root_name": "main",
+                    "root_type": "Node2D",
+                },
+                {
+                    "path": "res://ui/menu.tscn",
+                    "root_name": "Menu",
+                    "root_type": "Control",
+                },
+                # both root fields null -> the `(unreadable)` branch.
+                {"path": "res://broken.tscn", "root_name": None, "root_type": None},
+            ]
+        },
+        "res://main.tscn (main: Node2D)\n"
+        "res://ui/menu.tscn (Menu: Control)\n"
+        "res://broken.tscn (unreadable)",
+    ),
+    (
+        "scene-list-empty",
+        ["scene", "list"],
+        {"scenes": []},
+        "(no scenes)",
+    ),
+    (
+        "scene-delete",
+        ["scene", "delete", "/tmp/proj/old.tscn"],
+        {"path": "/tmp/proj/old.tscn", "root_name": "old", "root_type": "Node2D"},
+        "deleted /tmp/proj/old.tscn (root old: Node2D)",
+    ),
+    # --- node group ---------------------------------------------------------
+    (
+        "node-add",
+        ["node", "add", "/tmp/proj/main.tscn", "--type", "Sprite2D", "--name", "Hero"],
+        {
+            "scene_path": "/tmp/proj/main.tscn",
+            "path": "Hero",
+            "name": "Hero",
+            "type": "Sprite2D",
+            "script_class": None,
+        },
+        "added Hero (Sprite2D) to /tmp/proj/main.tscn",
+    ),
+    (
+        "node-list",
+        ["node", "list", "/tmp/proj/main.tscn"],
+        {
+            "scene_path": "/tmp/proj/main.tscn",
+            "root": {
+                "name": "main",
+                "type": "Node2D",
+                "path": ".",
+                "children": [
+                    {
+                        "name": "Hero",
+                        "type": "Sprite2D",
+                        "path": "Hero",
+                        "children": [
+                            {
+                                "name": "Hitbox",
+                                "type": "Area2D",
+                                "path": "Hero/Hitbox",
+                                "children": [],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        # render_node_tree renders name (Type), NOT the node path.
+        "main (Node2D)\n  Hero (Sprite2D)\n    Hitbox (Area2D)",
+    ),
+    (
+        # node get whose Vector2 value exercises format_value (-> [x, y]); the
+        # bool property pins the JSON `true` projection too.
+        "node-get",
+        ["node", "get", "/tmp/proj/main.tscn", "--node", "Hero"],
+        {
+            "scene_path": "/tmp/proj/main.tscn",
+            "path": "Hero",
+            "name": "Hero",
+            "type": "Sprite2D",
+            "properties": [
+                {"name": "position", "type": "Vector2", "value": [10.0, 20.0]},
+                {"name": "visible", "type": "bool", "value": True},
+            ],
+        },
+        "Hero (Sprite2D)\n"
+        "  position (Vector2) = [10.0, 20.0]\n"
+        "  visible (bool) = true",
+    ),
+    (
+        # node set whose Vector2 value exercises format_value (-> [x, y]).
+        "node-set",
+        [
+            "node",
+            "set",
+            "/tmp/proj/main.tscn",
+            "--node",
+            "Hero",
+            "--property",
+            "position",
+            "--value",
+            "3,4",
+        ],
+        {
+            "scene_path": "/tmp/proj/main.tscn",
+            "path": "Hero",
+            "property": "position",
+            "type": "Vector2",
+            "value": [3.0, 4.0],
+        },
+        "set Hero.position (Vector2) = [3.0, 4.0]",
+    ),
+    # --- script group -------------------------------------------------------
+    (
+        # script create WITH class_name + extends -> both metadata fragments,
+        # extends first then class_name (render_script_metadata ordering).
+        "script-create",
+        ["script", "create", "/tmp/proj/hero.gd", "--extends", "Node2D"],
+        {
+            "path": "/tmp/proj/hero.gd",
+            "class_name": "Hero",
+            "extends": "Node2D",
+            "created_dirs": [],
+        },
+        "created /tmp/proj/hero.gd (extends Node2D, class_name Hero)",
+    ),
+    (
+        # script create with NO metadata -> bare path (the no-meta branch).
+        "script-create-bare",
+        ["script", "create", "/tmp/proj/util.gd", "--content", "extends RefCounted\n"],
+        {
+            "path": "/tmp/proj/util.gd",
+            "class_name": None,
+            "extends": None,
+            "created_dirs": [],
+        },
+        "created /tmp/proj/util.gd",
+    ),
+    (
+        "script-get",
+        ["script", "get", "/tmp/proj/hero.gd"],
+        {
+            "path": "/tmp/proj/hero.gd",
+            "source": "class_name Hero\nextends Node2D\n",
+            "class_name": "Hero",
+            "extends": "Node2D",
+        },
+        # render_script_get: the metadata line then the raw source.
+        "/tmp/proj/hero.gd (extends Node2D, class_name Hero)\n"
+        "class_name Hero\nextends Node2D\n",
+    ),
+    (
+        "script-list",
+        ["script", "list"],
+        {
+            "scripts": [
+                {"path": "res://hero.gd", "class_name": "Hero", "extends": "Node2D"},
+                # extends only, no class_name.
+                {
+                    "path": "res://util.gd",
+                    "class_name": None,
+                    "extends": "RefCounted",
+                },
+                # neither -> bare path.
+                {"path": "res://empty.gd", "class_name": None, "extends": None},
+            ]
+        },
+        "res://hero.gd (extends Node2D, class_name Hero)\n"
+        "res://util.gd (extends RefCounted)\n"
+        "res://empty.gd",
+    ),
+    (
+        "script-list-empty",
+        ["script", "list"],
+        {"scripts": []},
+        "(no scripts)",
+    ),
+    (
+        "script-delete",
+        ["script", "delete", "/tmp/proj/hero.gd"],
+        {"path": "/tmp/proj/hero.gd", "class_name": "Hero", "extends": "Node2D"},
+        "deleted /tmp/proj/hero.gd (extends Node2D, class_name Hero)",
+    ),
+    (
+        # script set (already human-pinned elsewhere; included for uniformity).
+        "script-set",
+        ["script", "set", "/tmp/proj/hero.gd", "--content", "x"],
+        {"path": "/tmp/proj/hero.gd", "class_name": "Hero", "extends": "Node2D"},
+        "set /tmp/proj/hero.gd (extends Node2D, class_name Hero)",
+    ),
+    (
+        # script attach (already human-pinned elsewhere; included for uniformity).
+        "script-attach",
+        [
+            "script",
+            "attach",
+            "/tmp/proj/main.tscn",
+            "--node",
+            "Hero",
+            "--script",
+            "/tmp/proj/hero.gd",
+        ],
+        {
+            "scene_path": "/tmp/proj/main.tscn",
+            "node": "Hero",
+            "script": "/tmp/proj/hero.gd",
+            "class_name": "Hero",
+        },
+        "attached /tmp/proj/hero.gd to Hero in /tmp/proj/main.tscn",
+    ),
+    (
+        # script validate valid (already human-pinned elsewhere; for uniformity).
+        "script-validate-valid",
+        ["script", "validate", "/tmp/proj/ok.gd"],
+        {"path": "/tmp/proj/ok.gd", "valid": True, "error_string": None},
+        "valid /tmp/proj/ok.gd",
+    ),
+    # --- meta ---------------------------------------------------------------
+    (
+        "info",
+        ["info"],
+        {
+            "major": 4,
+            "minor": 6,
+            "patch": 3,
+            "hex": 0x040603,
+            "status": "stable",
+            "build": "official",
+            "hash": "7d41c59c457bd5a245092b4e7eb2d833e3b3f8c3",
+            "string": "4.6.3-stable (official)",
+            "timestamp": 0,
+        },
+        # render_engine_version: the one-line version string.
+        "4.6.3-stable (official)",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("argv", "payload", "expected"),
+    [(argv, payload, expected) for _id, argv, payload, expected in HUMAN_CASES],
+    ids=[case[0] for case in HUMAN_CASES],
+)
+def test_human_mode_cli_output_is_exactly_the_rendered_text(
+    monkeypatch, argv, payload, expected
+):
+    # Invoke the command in HUMAN mode (no --json) through the real Typer CLI
+    # with a fake runner, and assert the exact stdout: the renderer's text plus
+    # the single trailing newline typer.echo adds. This pins #139's render
+    # dispatch + #140's gda.render end-to-end, per command.
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, argv)
+
+    assert result.exit_code == 0
+    assert result.stdout == expected + "\n"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,132 @@
+"""The presentation layer (``gda.render``) — issue #140.
+
+Human rendering lives in a dedicated module, selected by result type, and reads
+typed surfaces (a value helper, a shared script-metadata interface) rather than
+reaching into a model's ``.value`` or across a union of result types. These are
+unit tests on the presentation module itself; the end-to-end human-output text
+per command is pinned by the existing command tests, which still pass unchanged.
+"""
+
+import pytest
+
+from gda import render as render_mod
+from gda.models import (
+    EngineVersion,
+    ListedScript,
+    NodeGetResult,
+    NodeProperty,
+    NodeSetResult,
+    ScriptCreateResult,
+    ScriptDeleteResult,
+    ScriptGetResult,
+    ScriptSetResult,
+)
+from gda.render import ScriptMetadata, format_value, render
+
+# The five script result types the metadata renderer used to read as a union.
+SCRIPT_METADATA_MODELS = [
+    ScriptCreateResult,
+    ScriptGetResult,
+    ListedScript,
+    ScriptDeleteResult,
+    ScriptSetResult,
+]
+
+
+@pytest.mark.parametrize("model", SCRIPT_METADATA_MODELS)
+def test_script_result_types_satisfy_the_shared_metadata_interface(model):
+    # Each script result type structurally matches ScriptMetadata, so the
+    # metadata renderer reads ONE typed surface, not a five-way union.
+    instance = model.model_construct(path="res://s.gd", class_name=None, extends=None)
+    assert isinstance(instance, ScriptMetadata)
+
+
+@pytest.mark.parametrize(
+    "model",
+    SCRIPT_METADATA_MODELS,
+    ids=[m.__name__ for m in SCRIPT_METADATA_MODELS],
+)
+def test_metadata_interface_declares_the_three_human_facing_fields(model):
+    # The interface names exactly the fields the renderer reads; every model
+    # carries them, so adding a script result type needs no renderer change.
+    fields = set(model.model_fields)
+    assert {"path", "class_name", "extends"} <= fields
+
+
+def test_metadata_interface_is_a_protocol_so_models_keep_their_schema():
+    # ScriptMetadata is a structural Protocol, not a base the models inherit, so
+    # it imposes nothing on a model's JSON Schema or field order (the --schema
+    # contract is unchanged). A model inheriting it would have reordered fields;
+    # confirm none of them subclass it.
+    for model in SCRIPT_METADATA_MODELS:
+        assert ScriptMetadata not in model.__mro__
+
+
+def test_format_value_owns_value_to_text():
+    # The single typed value-to-text helper: a scalar stays a scalar, a packed
+    # Godot type its JSON list projection — the same projection node set accepts.
+    assert format_value(3) == "3"
+    assert format_value([1.0, 2.0]) == "[1.0, 2.0]"
+    assert format_value(True) == "true"
+
+
+def test_render_node_properties_routes_value_through_the_helper():
+    result = NodeGetResult(
+        scene_path="res://s.tscn",
+        path=".",
+        name="Root",
+        type="Node2D",
+        properties=[NodeProperty(name="position", type="Vector2", value=[1.0, 2.0])],
+    )
+    rendered = render(result)
+    assert rendered == ". (Node2D)\n  position (Vector2) = [1.0, 2.0]"
+
+
+def test_render_node_set_routes_value_through_the_helper():
+    result = NodeSetResult(
+        scene_path="res://s.tscn",
+        path=".",
+        property="visible",
+        type="bool",
+        value=False,
+    )
+    assert render(result) == "set ..visible (bool) = false"
+
+
+def test_render_is_keyed_by_result_type():
+    # render() selects the renderer by the result's concrete type, so a command
+    # sources its renderer from the module by result type, not an inline closure.
+    version = EngineVersion(
+        major=4,
+        minor=6,
+        patch=3,
+        hex=0x040603,
+        status="stable",
+        build="official",
+        hash="abc",
+        string="4.6.3-stable (official)",
+        timestamp=0,
+    )
+    assert render(version) == "4.6.3-stable (official)"
+
+
+def test_render_rejects_an_unregistered_result_type():
+    # An unrecognized result type is a programming error (a command wired with no
+    # renderer), surfaced loudly rather than silently mis-formatted.
+    with pytest.raises(KeyError):
+        render(object())
+
+
+def test_every_command_result_type_has_a_renderer():
+    # The type → renderer table covers every result type a command emits, so the
+    # keyed dispatch never falls through for a real command.
+    from gda import cli
+
+    output_models = {
+        cmd.output_model
+        for name in dir(cli)
+        if name.endswith("_COMMAND")
+        for cmd in [getattr(cli, name)]
+    }
+    registered = set(render_mod._RENDERERS)
+    assert output_models <= registered


### PR DESCRIPTION
## What

Extract human rendering out of the CLI into a dedicated presentation module (`src/gda/render.py`), keyed by result type, and close the two leaks the architecture review found. Behavior-preserving — architecture deepening candidate 2 (variant C).

- **Presentation module.** All `_render_*` logic and inline render closures move to `render.py`; `render(result)` dispatches on `type(result)` via a `result-type -> renderer` table. Each command now passes `render=render` to #139's `_dispatch`/`_dispatch_meta`. An unregistered result type raises (loud wiring bug, not silent mis-format).
- **`.value` leak closed.** A single typed `format_value()` owns the JSON projection; no renderer reaches into a model's `.value` with a raw `json.dumps`.
- **Five-way union closed.** A `ScriptMetadata` `Protocol` (fields-only: `path`/`class_name`/`extends`) is the surface the script-metadata renderer reads, instead of a five-way union. A Protocol, not a shared base model — so it imposes nothing on field order and the `--schema` contract stays byte-for-byte identical.

## Why

The renderers lived in the CLI file and reached across the seam into model internals (`json.dumps(.value)` in two places; `.path/.class_name/.extends` over a union). Presentation now lives in one module; the result models stay pure `--schema`/`--json` data contracts (ADR-0004) with no presentation methods.

## Behavior preservation

- `src/gda/models.py` **untouched** (empty diff); no model gained a presentation method.
- `--schema` captured for all 7 affected commands and diffed before/after — **byte-for-byte identical**. `--json` (`model_dump_json`) unchanged.
- Human render text is identical for every command (renderers reproduce the exact prior strings).
- No existing test assertion changed; no test import edit needed. Added `tests/test_render.py` (17 tests) pinning the new typed seams.
- Full suite: **331 passed** (e2e against real Godot included). Targeted schema/render/command tests independently re-run on review: **86 passed**.

## Note

Stacked on #139 (PR #142) — base is `refactor/cli-dispatch-helper`. Rebase onto `main` once #139 merges.

Closes #140.
