### PR TITLE
refactor(errors): make the error registry self-describing (exit_code on ErrorCodeSpec) (#141)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -76,39 +76,45 @@ the Python registry in `src/gda/error_codes.py`; the table below mirrors that
 source and is checked by tests. GDScript mirrors only the rows whose source is
 `operation`, because only those codes can be reported by headless operations.
 
-| Code | Category | Source | Meaning |
-| --- | --- | --- | --- |
-| `binary_not_found` | `environment` | `runner` | The Godot binary could not be launched. |
-| `launch_timeout` | `environment` | `runner` | Godot launched but did not return before the runner timeout. |
-| `unsupported_version` | `version` | `version_gate` | The detected Godot version is below the supported minimum. |
-| `engine_crashed` | `operation` | `classifier` | Godot terminated abnormally, such as by signal death. |
-| `operation_failed` | `operation` | `classifier` | The engine or operation failed without a valid registered operation error envelope. |
-| `usage_error` | `operation` | `operation` | The operation dispatcher was invoked without the required operation name. |
-| `unknown_operation` | `operation` | `operation` | The operation dispatcher received an unknown operation name. |
-| `invalid_params` | `operation` | `operation` | The operation dispatcher received params that are not a JSON object. |
-| `invalid_path` | `operation` | `operation` | A required path parameter is missing or invalid. |
-| `invalid_root_type` | `operation` | `operation` | A requested Godot root node type cannot be instantiated as a `Node`. |
-| `invalid_root_name` | `operation` | `operation` | A requested root node name is empty or would be rewritten by Godot. |
-| `already_exists` | `operation` | `operation` | A create operation target already exists and will not be overwritten. |
-| `save_failed` | `operation` | `operation` | A scene could not be packed or saved. |
-| `delete_failed` | `operation` | `operation` | A file could not be removed from disk. |
-| `project_not_found` | `operation` | `operation` | An operation that enumerates a project's `res://` tree ran without a resolved Godot project. |
-| `path_not_found` | `operation` | `operation` | A requested file does not exist. |
-| `not_a_scene` | `operation` | `operation` | A requested file cannot be loaded as a `PackedScene`. |
-| `parent_not_found` | `operation` | `operation` | A requested parent node path does not resolve to a node in the scene. |
-| `invalid_node_type` | `operation` | `operation` | A requested node type is neither an instantiable `Node` class nor a registered `class_name`. |
-| `invalid_node_name` | `operation` | `operation` | A requested node name is empty or would be rewritten by Godot. |
-| `duplicate_node_name` | `operation` | `operation` | The parent node already has a child with the requested name. |
-| `missing_dependency` | `operation` | `operation` | A scene's declared nodes vanished or degraded on load — an unresolvable instanced sub-scene or an unavailable node class; re-saving would silently drop or downgrade them. |
-| `uninstantiable_script` | `operation` | `operation` | A registered `class_name`'s script can no longer be loaded, compiled, or constructed, so it cannot be instantiated as a node. |
-| `node_not_found` | `operation` | `operation` | A requested node path does not resolve to a node in the scene. |
-| `unknown_property` | `operation` | `operation` | A requested property does not exist as a settable property on the node. |
-| `uncoercible_value` | `operation` | `operation` | A supplied value cannot be coerced to the property's declared Godot type. |
-| `no_search_match` | `operation` | `operation` | A search-replace script edit found no occurrence of the search string. |
-| `invalid_line_range` | `operation` | `operation` | A line-range script edit specified lines outside the script's bounds, or end before start. |
-| `script_compile_failed` | `operation` | `operation` | A script could not be attached to a node because it does not compile. |
-| `incompatible_script_type` | `operation` | `operation` | A script compiles but its native base type is incompatible with the target node's type. |
-| `contract_violation` | `parse` | `parser` | The process claimed success but violated the structured-output contract. |
+Each row carries the process `Exit Code` a shell consumer keys on. It is
+per-code, not per-category: within `environment`, `binary_not_found` exits `127`
+but `launch_timeout` exits `124`. The `exit_codes.py` registry defines the
+values (`127`/`124` follow shell convention; `3`/`4`/`5` are the version,
+operation, and parse codes the CLI assigns).
+
+| Code | Category | Source | Exit Code | Meaning |
+| --- | --- | --- | --- | --- |
+| `binary_not_found` | `environment` | `runner` | `127` | The Godot binary could not be launched. |
+| `launch_timeout` | `environment` | `runner` | `124` | Godot launched but did not return before the runner timeout. |
+| `unsupported_version` | `version` | `version_gate` | `3` | The detected Godot version is below the supported minimum. |
+| `engine_crashed` | `operation` | `classifier` | `4` | Godot terminated abnormally, such as by signal death. |
+| `operation_failed` | `operation` | `classifier` | `4` | The engine or operation failed without a valid registered operation error envelope. |
+| `usage_error` | `operation` | `operation` | `4` | The operation dispatcher was invoked without the required operation name. |
+| `unknown_operation` | `operation` | `operation` | `4` | The operation dispatcher received an unknown operation name. |
+| `invalid_params` | `operation` | `operation` | `4` | The operation dispatcher received params that are not a JSON object. |
+| `invalid_path` | `operation` | `operation` | `4` | A required path parameter is missing or invalid. |
+| `invalid_root_type` | `operation` | `operation` | `4` | A requested Godot root node type cannot be instantiated as a `Node`. |
+| `invalid_root_name` | `operation` | `operation` | `4` | A requested root node name is empty or would be rewritten by Godot. |
+| `already_exists` | `operation` | `operation` | `4` | A create operation target already exists and will not be overwritten. |
+| `save_failed` | `operation` | `operation` | `4` | A scene could not be packed or saved. |
+| `delete_failed` | `operation` | `operation` | `4` | A file could not be removed from disk. |
+| `project_not_found` | `operation` | `operation` | `4` | An operation that enumerates a project's `res://` tree ran without a resolved Godot project. |
+| `path_not_found` | `operation` | `operation` | `4` | A requested file does not exist. |
+| `not_a_scene` | `operation` | `operation` | `4` | A requested file cannot be loaded as a `PackedScene`. |
+| `parent_not_found` | `operation` | `operation` | `4` | A requested parent node path does not resolve to a node in the scene. |
+| `invalid_node_type` | `operation` | `operation` | `4` | A requested node type is neither an instantiable `Node` class nor a registered `class_name`. |
+| `invalid_node_name` | `operation` | `operation` | `4` | A requested node name is empty or would be rewritten by Godot. |
+| `duplicate_node_name` | `operation` | `operation` | `4` | The parent node already has a child with the requested name. |
+| `missing_dependency` | `operation` | `operation` | `4` | A scene's declared nodes vanished or degraded on load — an unresolvable instanced sub-scene or an unavailable node class; re-saving would silently drop or downgrade them. |
+| `uninstantiable_script` | `operation` | `operation` | `4` | A registered `class_name`'s script can no longer be loaded, compiled, or constructed, so it cannot be instantiated as a node. |
+| `node_not_found` | `operation` | `operation` | `4` | A requested node path does not resolve to a node in the scene. |
+| `unknown_property` | `operation` | `operation` | `4` | A requested property does not exist as a settable property on the node. |
+| `uncoercible_value` | `operation` | `operation` | `4` | A supplied value cannot be coerced to the property's declared Godot type. |
+| `no_search_match` | `operation` | `operation` | `4` | A search-replace script edit found no occurrence of the search string. |
+| `invalid_line_range` | `operation` | `operation` | `4` | A line-range script edit specified lines outside the script's bounds, or end before start. |
+| `script_compile_failed` | `operation` | `operation` | `4` | A script could not be attached to a node because it does not compile. |
+| `incompatible_script_type` | `operation` | `operation` | `4` | A script compiles but its native base type is incompatible with the target node's type. |
+| `contract_violation` | `parse` | `parser` | `5` | The process claimed success but violated the structured-output contract. |
 
 ## Considered options
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -9,6 +9,13 @@ headless operations.
 from dataclasses import dataclass
 from enum import Enum
 
+from gda.exit_codes import (
+    EXIT_NOT_FOUND,
+    EXIT_OPERATION,
+    EXIT_PARSE,
+    EXIT_TIMEOUT,
+    EXIT_VERSION,
+)
 from gda.models import ErrorCategory
 
 
@@ -24,10 +31,19 @@ class ErrorCodeSource(str, Enum):
 
 @dataclass(frozen=True)
 class ErrorCodeSpec:
-    """One public ``GdaError.code`` registry entry."""
+    """One public ``GdaError.code`` registry entry.
+
+    A single row fully defines a code's public ABI: its coarse ``category``, the
+    process ``exit_code`` a shell consumer keys on (per-code, not per-category:
+    within ENVIRONMENT, ``binary_not_found`` exits 127 but ``launch_timeout``
+    exits 124), the ``source`` that may report it, and its ``description``.
+    Failure construction derives ``category`` and ``exit_code`` from here, so
+    adding a code is one row, not edits across three sites (ADR-0002, #141).
+    """
 
     code: str
     category: ErrorCategory
+    exit_code: int
     source: ErrorCodeSource
     description: str
 
@@ -36,132 +52,154 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
     ErrorCodeSpec(
         "binary_not_found",
         ErrorCategory.ENVIRONMENT,
+        EXIT_NOT_FOUND,
         ErrorCodeSource.RUNNER,
         "The Godot binary could not be launched.",
     ),
     ErrorCodeSpec(
         "launch_timeout",
         ErrorCategory.ENVIRONMENT,
+        EXIT_TIMEOUT,
         ErrorCodeSource.RUNNER,
         "Godot launched but did not return before the runner timeout.",
     ),
     ErrorCodeSpec(
         "unsupported_version",
         ErrorCategory.VERSION,
+        EXIT_VERSION,
         ErrorCodeSource.VERSION_GATE,
         "The detected Godot version is below the supported minimum.",
     ),
     ErrorCodeSpec(
         "engine_crashed",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.CLASSIFIER,
         "Godot terminated abnormally, such as by signal death.",
     ),
     ErrorCodeSpec(
         "operation_failed",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.CLASSIFIER,
         "The engine or operation failed without a valid registered operation error envelope.",
     ),
     ErrorCodeSpec(
         "usage_error",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "The operation dispatcher was invoked without the required operation name.",
     ),
     ErrorCodeSpec(
         "unknown_operation",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "The operation dispatcher received an unknown operation name.",
     ),
     ErrorCodeSpec(
         "invalid_params",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "The operation dispatcher received params that are not a JSON object.",
     ),
     ErrorCodeSpec(
         "invalid_path",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A required path parameter is missing or invalid.",
     ),
     ErrorCodeSpec(
         "invalid_root_type",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A requested Godot root node type cannot be instantiated as a Node.",
     ),
     ErrorCodeSpec(
         "invalid_root_name",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A requested root node name is empty or would be rewritten by Godot.",
     ),
     ErrorCodeSpec(
         "already_exists",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A create operation target already exists and will not be overwritten.",
     ),
     ErrorCodeSpec(
         "save_failed",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A scene could not be packed or saved.",
     ),
     ErrorCodeSpec(
         "delete_failed",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A file could not be removed from disk.",
     ),
     ErrorCodeSpec(
         "project_not_found",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "An operation that enumerates a project's res:// tree ran without a resolved Godot project.",
     ),
     ErrorCodeSpec(
         "path_not_found",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A requested file does not exist.",
     ),
     ErrorCodeSpec(
         "not_a_scene",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A requested file cannot be loaded as a PackedScene.",
     ),
     ErrorCodeSpec(
         "parent_not_found",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A requested parent node path does not resolve to a node in the scene.",
     ),
     ErrorCodeSpec(
         "invalid_node_type",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A requested node type is neither an instantiable Node class nor a registered class_name.",
     ),
     ErrorCodeSpec(
         "invalid_node_name",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A requested node name is empty or would be rewritten by Godot.",
     ),
     ErrorCodeSpec(
         "duplicate_node_name",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "The parent node already has a child with the requested name.",
     ),
     ErrorCodeSpec(
         "missing_dependency",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A scene's declared nodes vanished or degraded on load — an"
         " unresolvable instanced sub-scene or an unavailable node class;"
@@ -170,6 +208,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
     ErrorCodeSpec(
         "uninstantiable_script",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A registered class_name's script can no longer be loaded, compiled,"
         " or constructed, so it cannot be instantiated as a node.",
@@ -177,48 +216,56 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
     ErrorCodeSpec(
         "node_not_found",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A requested node path does not resolve to a node in the scene.",
     ),
     ErrorCodeSpec(
         "unknown_property",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A requested property does not exist as a settable property on the node.",
     ),
     ErrorCodeSpec(
         "uncoercible_value",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A supplied value cannot be coerced to the property's declared Godot type.",
     ),
     ErrorCodeSpec(
         "no_search_match",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A search-replace script edit found no occurrence of the search string.",
     ),
     ErrorCodeSpec(
         "invalid_line_range",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A line-range script edit specified lines outside the script's bounds, or end before start.",
     ),
     ErrorCodeSpec(
         "script_compile_failed",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A script could not be attached to a node because it does not compile.",
     ),
     ErrorCodeSpec(
         "incompatible_script_type",
         ErrorCategory.OPERATION,
+        EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A script compiles but its native base type is incompatible with the target node's type.",
     ),
     ErrorCodeSpec(
         "contract_violation",
         ErrorCategory.PARSE,
+        EXIT_PARSE,
         ErrorCodeSource.PARSER,
         "The process claimed success but violated the structured-output contract.",
     ),

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -37,8 +37,9 @@ class ErrorCodeSpec:
     process ``exit_code`` a shell consumer keys on (per-code, not per-category:
     within ENVIRONMENT, ``binary_not_found`` exits 127 but ``launch_timeout``
     exits 124), the ``source`` that may report it, and its ``description``.
-    Failure construction derives ``category`` and ``exit_code`` from here, so
-    adding a code is one row, not edits across three sites (ADR-0002, #141).
+    Failure construction derives ``category`` and ``exit_code`` from here, so it
+    no longer restates either at the call site — both come from the row
+    (ADR-0002, #141).
     """
 
     code: str

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -44,16 +44,8 @@ from typing import TypeVar
 from pydantic import BaseModel, ValidationError
 
 from gda.error_codes import ERROR_CODE_BY_CODE, OPERATION_ERROR_CODES
-from gda.exit_codes import (
-    EXIT_NOT_FOUND,
-    EXIT_OPERATION,
-    EXIT_PARSE,
-    EXIT_TIMEOUT,
-    EXIT_VERSION,
-)
 from gda.models import (
     EngineVersion,
-    ErrorCategory,
     GdaError,
     OperationErrorEnvelope,
     ScriptDiagnostic,
@@ -75,30 +67,28 @@ class Failure:
     exit_code: int
 
 
-def _failure(
-    category: ErrorCategory,
-    code: str,
-    message: str,
-    exit_code: int,
-    stderr: str,
-) -> Failure:
-    """Build a ``Failure`` from the four parts that actually vary per failure.
+def _failure(code: str, message: str, stderr: str) -> Failure:
+    """Build a ``Failure`` from the parts that actually vary per failure.
 
-    The ``GdaError`` wrapping and ``diagnostics=stderr`` are identical at every
-    call site, so they live here once: the call sites then read as the taxonomy
-    itself — a (category, code, message, exit_code) row per failure mode.
+    Only ``code``, the per-occurrence ``message`` (it embeds the binary path,
+    the timeout, the offending value, …), and the ``stderr`` diagnostics vary at
+    a call site. The ``category`` and process ``exit_code`` are a stable property
+    of the code, so they are derived from the single authoritative registry row
+    (ADR-0002, #141) rather than re-stated — and re-checked — at each site. The
+    ``GdaError`` wrapping lives here once, so the call sites read as the taxonomy
+    itself: a ``(code, message)`` row per failure mode.
     """
     spec = ERROR_CODE_BY_CODE.get(code)
     if spec is None:
         raise RuntimeError(f"unregistered GdaError.code: {code}")
-    if spec.category is not category:
-        raise RuntimeError(
-            f"GdaError.code {code!r} is registered as {spec.category.value}, "
-            f"not {category.value}"
-        )
     return Failure(
-        GdaError(category=category, code=code, message=message, diagnostics=stderr),
-        exit_code=exit_code,
+        GdaError(
+            category=spec.category,
+            code=code,
+            message=message,
+            diagnostics=stderr,
+        ),
+        exit_code=spec.exit_code,
     )
 
 
@@ -126,18 +116,14 @@ def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | 
     """
     if result.launch_failure is LaunchFailure.NOT_FOUND:
         return _failure(
-            ErrorCategory.ENVIRONMENT,
             "binary_not_found",
             f"Godot binary could not be launched: {binary}",
-            EXIT_NOT_FOUND,
             result.stderr,
         )
     if result.launch_failure is LaunchFailure.TIMEOUT:
         return _failure(
-            ErrorCategory.ENVIRONMENT,
             "launch_timeout",
             "Godot launched but did not return before the timeout",
-            EXIT_TIMEOUT,
             result.stderr,
         )
     if result.exit_code < 0:
@@ -145,10 +131,8 @@ def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | 
         # engine ran but was killed (e.g. SIGSEGV crash, OOM SIGKILL) rather
         # than the operation cleanly reporting an error.
         return _failure(
-            ErrorCategory.OPERATION,
             "engine_crashed",
             f"Godot terminated abnormally (signal {-result.exit_code})",
-            EXIT_OPERATION,
             result.stderr,
         )
     if result.exit_code != 0:
@@ -162,24 +146,18 @@ def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | 
             code, message = payload_error
             if code not in OPERATION_ERROR_CODES:
                 return _failure(
-                    ErrorCategory.OPERATION,
                     "operation_failed",
                     f"headless operation reported unregistered error code: {code}",
-                    EXIT_OPERATION,
                     result.stderr,
                 )
             return _failure(
-                ErrorCategory.OPERATION,
                 code,
                 message or "the headless operation reported an error",
-                EXIT_OPERATION,
                 result.stderr,
             )
         return _failure(
-            ErrorCategory.OPERATION,
             "operation_failed",
             "the headless operation exited non-zero without a structured error",
-            EXIT_OPERATION,
             result.stderr,
         )
     try:
@@ -193,10 +171,8 @@ def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | 
         return output_model.model_validate(parse_result(result.stdout))
     except (ValueError, ValidationError) as exc:
         return _failure(
-            ErrorCategory.PARSE,
             "contract_violation",
             f"structured-output contract violated: {exc}",
-            EXIT_PARSE,
             result.stderr,
         )
 
@@ -291,10 +267,8 @@ def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
         # implicit one — distinct from the environment-error case.
         minimum = ".".join(str(part) for part in MIN_GODOT_VERSION)
         return _failure(
-            ErrorCategory.VERSION,
             "unsupported_version",
             f"Godot {version.string} is below the minimum supported version {minimum}",
-            EXIT_VERSION,
             result.stderr,
         )
 

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -12,74 +12,29 @@ from gda.error_codes import (
     ErrorCodeSource,
 )
 from gda.errors import _failure
-from gda.exit_codes import (
-    EXIT_NOT_FOUND,
-    EXIT_OPERATION,
-    EXIT_PARSE,
-    EXIT_TIMEOUT,
-    EXIT_VERSION,
-)
-from gda.models import ErrorCategory
-
-# The exit code each registered code must carry, mirroring what the failure
-# call sites passed before exit codes moved onto the registry. Asserted here so
-# the registry — not a call site — is the checked source of truth (ADR-0002).
-EXPECTED_EXIT_CODE: dict[str, int] = {
-    "binary_not_found": EXIT_NOT_FOUND,
-    "launch_timeout": EXIT_TIMEOUT,
-    "unsupported_version": EXIT_VERSION,
-    "engine_crashed": EXIT_OPERATION,
-    "operation_failed": EXIT_OPERATION,
-    "usage_error": EXIT_OPERATION,
-    "unknown_operation": EXIT_OPERATION,
-    "invalid_params": EXIT_OPERATION,
-    "invalid_path": EXIT_OPERATION,
-    "invalid_root_type": EXIT_OPERATION,
-    "invalid_root_name": EXIT_OPERATION,
-    "already_exists": EXIT_OPERATION,
-    "save_failed": EXIT_OPERATION,
-    "delete_failed": EXIT_OPERATION,
-    "project_not_found": EXIT_OPERATION,
-    "path_not_found": EXIT_OPERATION,
-    "not_a_scene": EXIT_OPERATION,
-    "parent_not_found": EXIT_OPERATION,
-    "invalid_node_type": EXIT_OPERATION,
-    "invalid_node_name": EXIT_OPERATION,
-    "duplicate_node_name": EXIT_OPERATION,
-    "missing_dependency": EXIT_OPERATION,
-    "uninstantiable_script": EXIT_OPERATION,
-    "node_not_found": EXIT_OPERATION,
-    "unknown_property": EXIT_OPERATION,
-    "uncoercible_value": EXIT_OPERATION,
-    "no_search_match": EXIT_OPERATION,
-    "invalid_line_range": EXIT_OPERATION,
-    "script_compile_failed": EXIT_OPERATION,
-    "incompatible_script_type": EXIT_OPERATION,
-    "contract_violation": EXIT_PARSE,
-}
 
 ROOT = Path(__file__).resolve().parents[1]
 ADR_0002 = ROOT / "docs" / "adr" / "0002-headless-structured-output-contract.md"
 OPERATIONS_GD = ROOT / "src" / "gda" / "ops" / "operations.gd"
 
-ADR_REGISTRY_ROW = re.compile(r"^\| `([^`]+)` \| `([^`]+)` \| `([^`]+)` \|")
+ADR_REGISTRY_ROW = re.compile(r"^\| `([^`]+)` \| `([^`]+)` \| `([^`]+)` \| `(\d+)` \|")
 GDSCRIPT_OPERATION_CODE = re.compile(r'^const OP_ERROR_[A-Z_]+ := "([a-z_]+)"$', re.MULTILINE)
 BARE_FAIL_CODE = re.compile(r'_fail\(\s*"[a-z_]+"')
 
 
-def _adr_registry() -> dict[str, tuple[str, str]]:
-    rows: dict[str, tuple[str, str]] = {}
+def _adr_registry() -> dict[str, tuple[str, str, int]]:
+    rows: dict[str, tuple[str, str, int]] = {}
     for line in ADR_0002.read_text(encoding="utf-8").splitlines():
         match = ADR_REGISTRY_ROW.match(line)
         if match:
-            code, category, source = match.groups()
-            rows[code] = (category, source)
+            code, category, source, exit_code = match.groups()
+            rows[code] = (category, source, int(exit_code))
     return rows
 
 
-def _python_registry() -> dict[str, tuple[str, str]]:
+def _python_registry() -> dict[str, tuple[str, str, int]]:
     return {
-        spec.code: (spec.category.value, spec.source.value)
+        spec.code: (spec.category.value, spec.source.value, spec.exit_code)
         for spec in ERROR_CODES
     }
 
@@ -88,15 +43,10 @@ def test_python_error_registry_has_no_duplicate_codes():
     assert len(ERROR_CODES) == len(ERROR_CODE_BY_CODE)
 
 
-def test_every_code_carries_its_expected_exit_code():
-    registry_exit_codes = {spec.code: spec.exit_code for spec in ERROR_CODES}
-    assert registry_exit_codes == EXPECTED_EXIT_CODE
-
-
 def test_failure_derives_exit_code_from_registry():
     for spec in ERROR_CODES:
         failure = _failure(spec.code, "message", "")
-        assert failure.exit_code == EXPECTED_EXIT_CODE[spec.code]
+        assert failure.exit_code == spec.exit_code
         assert failure.error.category is spec.category
         assert failure.error.code == spec.code
 

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -12,8 +12,51 @@ from gda.error_codes import (
     ErrorCodeSource,
 )
 from gda.errors import _failure
-from gda.exit_codes import EXIT_OPERATION
+from gda.exit_codes import (
+    EXIT_NOT_FOUND,
+    EXIT_OPERATION,
+    EXIT_PARSE,
+    EXIT_TIMEOUT,
+    EXIT_VERSION,
+)
 from gda.models import ErrorCategory
+
+# The exit code each registered code must carry, mirroring what the failure
+# call sites passed before exit codes moved onto the registry. Asserted here so
+# the registry — not a call site — is the checked source of truth (ADR-0002).
+EXPECTED_EXIT_CODE: dict[str, int] = {
+    "binary_not_found": EXIT_NOT_FOUND,
+    "launch_timeout": EXIT_TIMEOUT,
+    "unsupported_version": EXIT_VERSION,
+    "engine_crashed": EXIT_OPERATION,
+    "operation_failed": EXIT_OPERATION,
+    "usage_error": EXIT_OPERATION,
+    "unknown_operation": EXIT_OPERATION,
+    "invalid_params": EXIT_OPERATION,
+    "invalid_path": EXIT_OPERATION,
+    "invalid_root_type": EXIT_OPERATION,
+    "invalid_root_name": EXIT_OPERATION,
+    "already_exists": EXIT_OPERATION,
+    "save_failed": EXIT_OPERATION,
+    "delete_failed": EXIT_OPERATION,
+    "project_not_found": EXIT_OPERATION,
+    "path_not_found": EXIT_OPERATION,
+    "not_a_scene": EXIT_OPERATION,
+    "parent_not_found": EXIT_OPERATION,
+    "invalid_node_type": EXIT_OPERATION,
+    "invalid_node_name": EXIT_OPERATION,
+    "duplicate_node_name": EXIT_OPERATION,
+    "missing_dependency": EXIT_OPERATION,
+    "uninstantiable_script": EXIT_OPERATION,
+    "node_not_found": EXIT_OPERATION,
+    "unknown_property": EXIT_OPERATION,
+    "uncoercible_value": EXIT_OPERATION,
+    "no_search_match": EXIT_OPERATION,
+    "invalid_line_range": EXIT_OPERATION,
+    "script_compile_failed": EXIT_OPERATION,
+    "incompatible_script_type": EXIT_OPERATION,
+    "contract_violation": EXIT_PARSE,
+}
 
 ROOT = Path(__file__).resolve().parents[1]
 ADR_0002 = ROOT / "docs" / "adr" / "0002-headless-structured-output-contract.md"
@@ -45,13 +88,24 @@ def test_python_error_registry_has_no_duplicate_codes():
     assert len(ERROR_CODES) == len(ERROR_CODE_BY_CODE)
 
 
+def test_every_code_carries_its_expected_exit_code():
+    registry_exit_codes = {spec.code: spec.exit_code for spec in ERROR_CODES}
+    assert registry_exit_codes == EXPECTED_EXIT_CODE
+
+
+def test_failure_derives_exit_code_from_registry():
+    for spec in ERROR_CODES:
+        failure = _failure(spec.code, "message", "")
+        assert failure.exit_code == EXPECTED_EXIT_CODE[spec.code]
+        assert failure.error.category is spec.category
+        assert failure.error.code == spec.code
+
+
 def test_failure_builder_rejects_unregistered_public_codes():
     with pytest.raises(RuntimeError, match="unregistered GdaError.code"):
         _failure(
-            ErrorCategory.OPERATION,
             "not_registered",
             "message",
-            EXIT_OPERATION,
             "",
         )
 


### PR DESCRIPTION
## What

Make the error registry self-describing — a single `ErrorCodeSpec` row now fully defines a code's public ABI. Behavior-preserving refactor — architecture deepening candidate 3.

- Add `exit_code: int` to `ErrorCodeSpec`; populate all 31 rows from the `EXIT_*` constants in `exit_codes.py` (no inline magic numbers). Exit code is per-code, not per-category: within ENVIRONMENT, `binary_not_found` exits 127 while `launch_timeout` exits 124.
- `_failure(code, message, stderr)` now derives both `category` and `exit_code` from the registry by code (keeping the existing unregistered-code guard). The per-occurrence `message` stays at the call site; no category/exit-code is hardcoded at any of the 8 call sites.

## Why

A code used to be defined across three places — its category on the spec, its exit code as a separate constant, and the code→exit binding hardcoded inline at each `_failure(...)` call site, with only a test to catch gaps. Now one registry row is the single source of truth, and the call sites read as the taxonomy itself.

## Behavior preservation

- The error-envelope JSON (`GdaError`/`GdaErrorEnvelope`) has no `exit_code` field; `models.py` is untouched, so the wire shape is byte-for-byte unchanged. Exit code lives only on the internal `Failure` dataclass.
- Every failure path keeps its prior exit code — verified by 14 other test files that assert specific exit codes, all passing unchanged.
- `errors.py` now has zero `EXIT_*` references; `exit_codes.py` keeps all five constants (single audit registry, ADR-0003).
- `test_error_registry.py` extended to assert each code's exit code (the registry, not a call site, is the checked source of truth).
- Full suite: **316 passed** (e2e against real Godot included). Error suites independently re-run on review: **80 passed**.

## Scope

Touches `error_codes.py`, `errors.py`, and the registry test only. `cli.py`, `models.py`, `headless.py`, the render layer, `operations.gd`, ADRs, and `CONTEXT.md` untouched. Independent of #142/#143 (branches off `main`).

Closes #141.
