### PR TITLE
fix(script): validate at the script's real res:// path (#131)

### DIFF
--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -776,10 +776,11 @@ func _op_script_attach(params: Dictionary) -> void:
 
 
 # script-validate: syntax/compile-check a .gd script (issue #118). Read the file
-# text, set it on a fresh GDScript, and reload() it: err == OK means it compiles.
-# Validating an INVALID script is a SUCCESSFUL operation — the op exits 0 with
-# valid=false; the op only FAILS (non-zero) for op errors (empty/non-.gd path →
-# invalid_path, missing/unreadable file → path_not_found).
+# text, set it on a fresh GDScript at the script's REAL res:// path, and reload()
+# it: err == OK means it compiles. Validating an INVALID script is a SUCCESSFUL
+# operation — the op exits 0 with valid=false; the op only FAILS (non-zero) for op
+# errors (empty/non-.gd path → invalid_path, missing/unreadable file →
+# path_not_found).
 #
 # Unlike the other script-file ops, validate DOES compile the script (reload
 # parses and compiles it), but it never INSTANTIATES it, so it does not run the
@@ -787,6 +788,22 @@ func _op_script_attach(params: Dictionary) -> void:
 # from any bound API (is_valid() is not even callable from GDScript) — only from
 # the engine's stderr — so the op emits just {path, valid, error_string} in the
 # sentinel and gda parses the advisory line/message diagnostics from stderr.
+#
+# The compile context must match how the engine actually loads the file (issue
+# #131). Compiling an ANONYMOUS in-memory GDScript gives it a synthetic
+# `gdscript://` resource path, so a relative `preload("sibling.gd")` resolves
+# against that synthetic base and fails — a false negative for a script that loads
+# fine in-engine. take_over_path claims the script's real res:// path on the fresh
+# GDScript BEFORE reload(), so relative preloads and other path-dependent
+# resolution resolve against the script's own res:// location exactly as in-engine.
+# take_over_path (not `resource_path =`) is used deliberately: in the rare case the
+# path is already in the resource cache (an autoload pulled it in at startup), it
+# cleanly claims the cache slot, whereas assigning resource_path logs a spurious
+# "Another resource is loaded ... cyclic resource inclusion" error. Either way the
+# claim is harmless in this one-shot headless process: validate is a leaf op that
+# loads nothing at that path afterward, so the swapped cache entry cannot leak.
+# reload() stays the verdict, so the stderr still carries the GDScript::reload
+# frame the diagnostics parser pairs (the frame now names the real res:// path).
 func _op_script_validate(params: Dictionary) -> void:
 	_diag("running operation: script-validate")
 	var path := _string_param(params, "path")
@@ -800,10 +817,13 @@ func _op_script_validate(params: Dictionary) -> void:
 	if source == null:
 		return  # _read_script_source already recorded the failure
 
-	# Compile-check without instantiating: set the source on a fresh GDScript and
-	# reload() it. The reload error (and its diagnostics on stderr) is the verdict.
+	# Compile-check without instantiating: set the source on a fresh GDScript at the
+	# script's real res:// path and reload() it. The reload error (and its
+	# diagnostics on stderr) is the verdict; the real path makes relative preloads
+	# resolve as in-engine (issue #131).
 	var script := GDScript.new()
 	script.source_code = source
+	script.take_over_path(path)
 	var err := script.reload()
 	_succeed({
 		"path": path,

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -687,6 +687,72 @@ def test_script_validate_broken_script_is_success_with_a_real_diagnostic(godot_p
 
 
 @pytest.mark.e2e
+def test_script_validate_relative_preload_resolves_at_the_real_res_path(godot_project):
+    # The #131 fix: validate compiles the script AT ITS REAL res:// path, so a
+    # relative `preload("sibling.gd")` resolves against the script's own res://
+    # location exactly as the engine loads it. The sibling is present and compiles,
+    # so the dependent script is valid=true under --project — not a false negative
+    # from compiling an anonymous in-memory GDScript that has no res:// location to
+    # resolve the relative reference against.
+    gda = _gda_project(godot_project)
+    assert (
+        gda(
+            "script", "create", "res://sibling.gd",
+            "--content", "extends Node\nclass_name Sibling\n", "--json",
+        ).returncode
+        == 0
+    )
+    assert (
+        gda(
+            "script", "create", "res://uses_sibling.gd",
+            "--content",
+            'extends Node\n\nconst S = preload("sibling.gd")\n\n'
+            "func use() -> void:\n\tvar _x = S.new()\n",
+            "--json",
+        ).returncode
+        == 0
+    )
+
+    validated = gda("script", "validate", "res://uses_sibling.gd", "--json")
+
+    assert validated.returncode == 0, validated.stdout + validated.stderr
+    data = json.loads(validated.stdout)
+    assert data["valid"] is True
+    assert data["error_string"] is None
+    assert data["diagnostics"] == []
+
+
+@pytest.mark.e2e
+def test_script_validate_broken_script_under_project_still_reports_diagnostics(godot_project):
+    # The #131 regression guard: compiling at the real res:// path must not break a
+    # genuinely broken script's verdict — it is still a SUCCESSFUL op (exit 0)
+    # reporting valid=false, and the stderr-parsed line/message diagnostic still
+    # works under --project (the reload frame now names the real res:// path, which
+    # the diagnostics parser pairs exactly as before).
+    gda = _gda_project(godot_project)
+    # `var x =` with no initializer is a parse error the engine reports on its line.
+    assert (
+        gda(
+            "script", "create", "res://broken.gd",
+            "--content", "extends Node\n\nvar x =\n", "--json",
+        ).returncode
+        == 0
+    )
+
+    validated = gda("script", "validate", "res://broken.gd", "--json")
+
+    assert validated.returncode == 0, validated.stdout + validated.stderr
+    data = json.loads(validated.stdout)
+    assert data["valid"] is False
+    assert data["error_string"] is not None
+    assert len(data["diagnostics"]) == 1
+    diag = data["diagnostics"][0]
+    assert diag["line"] == 3
+    assert diag["message"]
+    assert diag["column"] is None
+
+
+@pytest.mark.e2e
 def test_script_validate_missing_file_yields_path_not_found(godot_project):
     # validate only op-fails for op errors: a missing file is path_not_found, NOT
     # a valid=false success.


### PR DESCRIPTION
## What

`gda script validate` compiled an **anonymous** in-memory GDScript (no resource path), so a script using a **relative** `preload("sibling.gd")` was wrongly reported `valid=false` though it loads fine in-engine — a false negative.

Fix: claim the script's **real `res://` path** on the fresh `GDScript` (`take_over_path(path)`) **before** `reload()`, so relative `preload`s and other path-dependent resolution resolve against the script's own location exactly as the engine loads it.

Closes #131.

## Why `take_over_path`, why `reload` stays the verdict

- **Real path fixes it:** an anonymous GDScript gets a synthetic `gdscript://…` path; a relative preload resolves against that synthetic base and fails. Claiming the real `res://` path makes it resolve as in-engine.
- **`take_over_path` over `resource_path =`:** when the path is already cached (e.g. an autoload pulled it in at startup), assigning `resource_path` logs a spurious *"Another resource is loaded … cyclic resource inclusion"* and fails to take the slot; `take_over_path` claims it cleanly. Probed against a real engine (`cached_is_ours=true`, no spurious error).
- **`reload()` stays the verdict** (not `ResourceLoader.load`): it preserves the `GDScript::reload (…:<line>)` stderr frame the advisory diagnostics parser pairs — the frame now names the real `res://` path, which the existing regex still matches.
- **No cache contamination:** each call is a one-shot `godot --headless` process and validate loads nothing at that path afterward, so the swapped cache entry cannot leak within the run.

## Behavior preserved

- The "`valid=false` is a SUCCESSFUL op" contract is unchanged; the op only fails (non-zero) for op errors.
- Advisory line/message diagnostics for a broken script intact (line/message present, `column` null).
- Projectless self-contained `extends Node` validate still works.

## Tests

Two e2e fixtures added in `tests/test_e2e_script.py`:
- `…relative_preload_resolves_at_the_real_res_path` — sibling present + compiles, dependent uses relative `preload`, `valid=true` under `--project`. **Written first, red pre-fix** (`valid` was `False`), green post-fix.
- `…broken_script_under_project_still_reports_diagnostics` — broken script under `--project` still `valid=false` with `line==3` diagnostic (regression guard).

Full suite: `uv run pytest -q` → **354 passed**. Reviewer independently re-ran the validate e2e subset → **6 passed**.
