### PR TITLE
refactor(script): dispatch script set on an explicit mode discriminator (#133)

### DIFF
--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -53,6 +53,7 @@ from gda.models import (
     ScriptGetResult,
     ScriptListParams,
     ScriptListResult,
+    ScriptSetMode,
     ScriptSetParams,
     ScriptSetResult,
     ScriptValidateParams,
@@ -686,11 +687,12 @@ def set_script(
     project: Optional[str] = project_option(),
 ) -> None:
     """Edit a .gd script via search-replace, line-range, or full overwrite."""
-    _validate_set_mode(search, replace, start_line, end_line, content)
+    mode = _resolve_set_mode(search, replace, start_line, end_line, content)
     _dispatch(
         SCRIPT_SET_COMMAND,
         ScriptSetParams(
             path=_normalize_path(path),
+            mode=mode,
             search=search,
             replace=replace,
             start_line=start_line,
@@ -704,19 +706,21 @@ def set_script(
     )
 
 
-def _validate_set_mode(
+def _resolve_set_mode(
     search: Optional[str],
     replace: Optional[str],
     start_line: Optional[int],
     end_line: Optional[int],
     content: Optional[str],
-) -> None:
-    """Enforce that ``script set`` selects exactly one edit mode (issue #118).
+) -> ScriptSetMode:
+    """Resolve ``script set``'s edit mode, the single source of truth (issue #133).
 
-    Validated at the CLI layer (before any dispatch, like ``script create``'s
-    mutual exclusion), so the operation is always handed exactly one well-formed
-    mode and never has to defend against "no mode" or a mixed-mode combination.
-    A violation is a usage error (exit 2).
+    This is the one place the edit mode is decided: it enforces that exactly one
+    of the three mutually-exclusive modes is supplied (a violation is a usage
+    error, exit 2, like ``script create``'s mutual exclusion) and returns the
+    resolved :class:`ScriptSetMode`. The CLI stamps it onto the op params so the
+    operation dispatches on this explicit discriminator instead of re-inferring
+    the mode from which params are present — the two can no longer drift.
     """
     has_search = search is not None or replace is not None
     has_line_range = start_line is not None or end_line is not None
@@ -729,20 +733,21 @@ def _validate_set_mode(
                 "--search/--replace cannot be combined with --content, "
                 "--start-line, or --end-line."
             )
-        return
+        return ScriptSetMode.SEARCH_REPLACE
 
     if has_line_range:
         if content is None:
             raise typer.BadParameter("--start-line/--end-line require --content.")
         if start_line is None:
             raise typer.BadParameter("--end-line requires --start-line.")
-        return
+        return ScriptSetMode.LINE_RANGE
 
     if content is None:
         raise typer.BadParameter(
             "script set needs an edit: --search/--replace, --start-line "
             "(+ --content), or --content (full overwrite)."
         )
+    return ScriptSetMode.FULL
 
 
 @script_app.command(name="attach", cls=SCRIPT_ATTACH_COMMAND.command_class())

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -607,24 +607,55 @@ class ScriptDeleteResult(BaseModel):
     )
 
 
+class ScriptSetMode(str, Enum):
+    """The edit mode of ``gda script set``, the single source of truth (issue #133).
+
+    The CLI resolves exactly one mode from the supplied flags (its mutual-exclusion
+    check) and stamps it here, so the operation dispatches on this explicit
+    discriminator instead of re-inferring the mode from which params are present —
+    the inference precedence can no longer drift from the CLI's exclusivity rule.
+
+    - ``SEARCH_REPLACE`` — ``search``/``replace``: every literal (not regex)
+      occurrence of ``search`` is replaced with ``replace``.
+    - ``LINE_RANGE`` — ``start_line`` (+ optional ``end_line``) with ``content``:
+      the given 1-based, inclusive line span is replaced with ``content``.
+    - ``FULL`` — ``content`` only: the whole file is overwritten.
+    """
+
+    SEARCH_REPLACE = "search_replace"
+    LINE_RANGE = "line_range"
+    FULL = "full"
+
+
 class ScriptSetParams(BaseModel):
     """The operation params of ``gda script set`` (issue #118).
 
     Edits an existing ``.gd`` script on disk as RAW TEXT — it never compiles or
     loads the script, so editing one can never run project code (the read trust
     boundary of issue #30). ``path`` addresses the script by its ``res://`` or
-    filesystem path. The remaining params select one of three mutually-exclusive
-    edit modes (the CLI guarantees exactly one is supplied); the operation infers
-    the mode by presence, with precedence search → line-range → full:
+    filesystem path. The remaining params carry one of three mutually-exclusive
+    edit modes; the CLI resolves which one and stamps it on ``mode`` (issue #133),
+    so the operation dispatches on that explicit discriminator rather than
+    re-inferring it from which params are present:
 
-    - **search-replace** — ``search``/``replace`` both present: every literal
-      (not regex) occurrence of ``search`` is replaced with ``replace``.
-    - **line-range** — ``start_line`` (+ optional ``end_line``) with ``content``:
-      the given 1-based, inclusive line span is replaced with ``content``.
-    - **full** — only ``content`` present: the whole file is overwritten.
+    - **search-replace** (``mode = search_replace``) — ``search``/``replace`` both
+      present: every literal (not regex) occurrence of ``search`` is replaced with
+      ``replace``.
+    - **line-range** (``mode = line_range``) — ``start_line`` (+ optional
+      ``end_line``) with ``content``: the given 1-based, inclusive line span is
+      replaced with ``content``.
+    - **full** (``mode = full``) — only ``content`` present: the whole file is
+      overwritten.
     """
 
     path: str
+    mode: ScriptSetMode = Field(
+        description=(
+            "The resolved edit mode, the single source of truth the operation "
+            "dispatches on (issue #133). Set by the CLI from the supplied flags, "
+            "not inferred by the operation from param presence."
+        ),
+    )
     search: str | None = Field(
         default=None,
         description=(

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -594,8 +594,9 @@ func _op_script_delete(params: Dictionary) -> void:
 # script-set: edit an EXISTING .gd script on disk as RAW TEXT (issue #118) — it
 # never compiles or loads the script, so editing it cannot run project code (the
 # read trust boundary of issue #30, the same one create/get/delete honor). Three
-# mutually-exclusive edit modes, inferred by param presence with precedence
-# search → line-range → full (the CLI guarantees exactly one is supplied):
+# mutually-exclusive edit modes; the CLI resolves exactly one and stamps it on the
+# explicit `mode` discriminator the op dispatches on (issue #133), never re-inferred
+# here from which params are present:
 # - search-replace: replace EVERY literal (not regex) occurrence of `search`.
 # - line-range: replace the 1-based, inclusive line span [start_line, end_line]
 #   with `content`. Lines are the parts of the source split on "\n", so a

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -616,15 +616,25 @@ func _op_script_set(params: Dictionary) -> void:
 	if source == null:
 		return  # _read_script_source already recorded the failure
 
-	# Infer the mode by presence, precedence search → line-range → full.
+	# Dispatch on the explicit mode discriminator the CLI resolved (issue #133):
+	# the edit mode is decided once, at the CLI's mutual-exclusion check, and rides
+	# through on `mode` — the op never re-infers it from which params are present,
+	# so the op's dispatch can no longer drift from the CLI's exclusivity rule.
+	var mode := _string_param(params, "mode")
 	var new_source: Variant
-	if params.get("search", null) is String:
-		new_source = _apply_search_replace(source, params)
-	elif params.get("start_line", null) != null:
-		new_source = _apply_line_range(source, params)
-	else:
-		# full overwrite: content is guaranteed present by the CLI's mode check.
-		new_source = _string_param(params, "content")
+	match mode:
+		"search_replace":
+			new_source = _apply_search_replace(source, params)
+		"line_range":
+			new_source = _apply_line_range(source, params)
+		"full":
+			# full overwrite: content is guaranteed present by the CLI's mode check.
+			new_source = _string_param(params, "content")
+		_:
+			# The CLI always supplies one of the three modes; a missing/unknown mode
+			# means a malformed direct op invocation, not a reachable CLI path.
+			_fail(OP_ERROR_INVALID_PARAMS, "unknown script-set mode: " + mode)
+			return
 	if new_source == null:
 		return  # the apply helper already recorded the failure
 

--- a/tests/test_e2e_op_robustness.py
+++ b/tests/test_e2e_op_robustness.py
@@ -17,6 +17,7 @@ import pytest
 from gda.binary import resolve_godot_binary
 from gda.errors import Failure, classify_run
 from gda.models import EngineVersion
+from gda.parser import parse_result
 from gda.runner import OPERATIONS_GD, RunResult, SubprocessGodotRunner
 
 GODOT = resolve_godot_binary()
@@ -67,3 +68,37 @@ def test_non_json_params_yield_stable_code():
     assert isinstance(outcome, Failure)
     assert outcome.error.category.value == "operation"
     assert outcome.error.code == "invalid_params"
+
+
+@pytest.mark.e2e
+def test_script_set_dispatches_on_the_explicit_mode_not_param_presence(tmp_path):
+    # script-set is decided once at the CLI and the op dispatches on the explicit
+    # `mode` discriminator, NOT by re-inferring from which params are present
+    # (issue #133). Hand the op a params dict the CLI's mutual exclusion would
+    # never produce: mode=full but with start_line ALSO set. Honoring `mode`
+    # overwrites the whole file with `content`; the obsolete presence-inference
+    # (search → line-range → full) would instead apply a line-range edit. The two
+    # produce observably different files, so this pins the dispatch on `mode`.
+    script = tmp_path / "hero.gd"
+    script.write_text("extends Node\nvar a := 1\nvar b := 2\n", encoding="utf-8")
+
+    runner = SubprocessGodotRunner(GODOT)
+    result = runner.run(
+        "script-set",
+        {
+            "path": str(script),
+            "mode": "full",
+            "search": None,
+            "replace": None,
+            "start_line": 1,  # presence-inference would mis-select line_range
+            "end_line": None,
+            "content": "class_name Hero\nextends Node2D\n",
+        },
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    payload = parse_result(result.stdout)
+    assert payload["class_name"] == "Hero"
+    assert payload["extends"] == "Node2D"
+    # The file was fully overwritten (full mode honored), not line-range edited.
+    assert script.read_text(encoding="utf-8") == "class_name Hero\nextends Node2D\n"

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -11,6 +11,7 @@ import json
 from typer.testing import CliRunner
 
 from gda.cli import app
+from gda.models import ScriptSetMode
 from gda.runner import RunResult
 from tests.support import FakeRunner, inject_runner, sentinel
 
@@ -220,9 +221,10 @@ SET_RESULT = {
 
 def test_script_set_search_replace_dispatches_search_and_replace(monkeypatch):
     # search-replace mode (issue #118): --search/--replace ride through as the
-    # search/replace params; the other mode params pass as null. The result
-    # re-parses the written source's class_name/extends, so set round-trips
-    # through get.
+    # search/replace params; the other mode params pass as null. The CLI resolves
+    # the edit mode once and stamps the explicit `mode` discriminator the op
+    # dispatches on (issue #133). The result re-parses the written source's
+    # class_name/extends, so set round-trips through get.
     stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(SET_RESULT)
     fake = inject_runner(
         monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
@@ -252,6 +254,7 @@ def test_script_set_search_replace_dispatches_search_and_replace(monkeypatch):
             "script-set",
             {
                 "path": "/tmp/proj/hero.gd",
+                "mode": ScriptSetMode.SEARCH_REPLACE,
                 "search": "Node",
                 "replace": "Node2D",
                 "start_line": None,
@@ -265,7 +268,8 @@ def test_script_set_search_replace_dispatches_search_and_replace(monkeypatch):
 
 def test_script_set_line_range_dispatches_start_end_and_content(monkeypatch):
     # line-range mode: --start-line/--end-line + --content ride through; the
-    # search-replace params pass as null.
+    # search-replace params pass as null. The CLI stamps the explicit `mode`
+    # discriminator the op dispatches on (issue #133).
     fake = inject_runner(
         monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
     )
@@ -292,6 +296,7 @@ def test_script_set_line_range_dispatches_start_end_and_content(monkeypatch):
             "script-set",
             {
                 "path": "/tmp/proj/hero.gd",
+                "mode": ScriptSetMode.LINE_RANGE,
                 "search": None,
                 "replace": None,
                 "start_line": 2,
@@ -304,7 +309,8 @@ def test_script_set_line_range_dispatches_start_end_and_content(monkeypatch):
 
 def test_script_set_full_overwrite_dispatches_content_only(monkeypatch):
     # full mode: --content with no --start-line overwrites the whole file; every
-    # other mode param passes as null.
+    # other mode param passes as null. The CLI stamps the explicit `mode`
+    # discriminator the op dispatches on (issue #133).
     fake = inject_runner(
         monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
     )
@@ -327,6 +333,7 @@ def test_script_set_full_overwrite_dispatches_content_only(monkeypatch):
             "script-set",
             {
                 "path": "/tmp/proj/hero.gd",
+                "mode": ScriptSetMode.FULL,
                 "search": None,
                 "replace": None,
                 "start_line": None,


### PR DESCRIPTION
## What

`gda script set` decided its edit mode (search-replace / line-range / full) in **two** places that had to stay in lockstep: the CLI's `_validate_set_mode` exclusivity check, and the GDScript op re-inferring the mode by param-presence precedence. The two could drift. This collapses them to a single source of truth.

Closes #133.

## Change

- **CLI is the one decider** — `src/gda/cli.py`: `_validate_set_mode` → `_resolve_set_mode(...) -> ScriptSetMode`. It still enforces exactly-one-of (same `typer.BadParameter` usage errors, exit 2) but now *returns* the resolved mode; `set_script` stamps it onto `ScriptSetParams(mode=...)`.
- **Explicit discriminator** — `src/gda/models.py`: new `ScriptSetMode(str, Enum)` (`search_replace | line_range | full`) and a required `mode` field on `ScriptSetParams`. Model-derived, so `--schema` (ADR-0004) now enumerates `mode` automatically — no hand-written schema to touch.
- **Op dispatches, never infers** — `src/gda/ops/operations.gd`: `_op_script_set` replaces the param-presence `if/elif/else` with `match mode`. A missing/unknown mode (only reachable via a malformed *direct* op call, never via the CLI) fails with the pre-existing, registered `invalid_params`. Keeps using the #135 shared helpers.

## Behavior preserved

- CLI mutual-exclusion is unchanged: missing or mixed mode still exits 2 with the same messages.
- All `script set` behavior preserved exactly: search-replace (`no_search_match`), line-range (1-based inclusive, `\n`-split, `invalid_line_range`), full overwrite, class_name/extends round-trip. No error code or message changes; no new error code.

## Tests

- Updated the three CLI dispatch tests in `tests/test_script_commands.py` to pin the resolved `mode` the CLI stamps.
- Added one op-level test `tests/test_e2e_op_robustness.py::test_script_set_dispatches_on_the_explicit_mode_not_param_presence`: it drives the op below the CLI with a params dict the CLI's exclusivity would never produce (`mode=full` **with** `start_line=1` also set) and asserts a full overwrite. It **fails** against the old presence-inference and **passes** against `match mode` — the regression net for "the op no longer re-infers".

Fast: `238 passed`. Full incl. e2e: `353 passed` (+1 = the new op test). Reviewer independently re-ran fast (238) + the affected e2e subset (12 passed), and confirmed `invalid_params` is a pre-existing registered code.
