### PR TITLE
feat(script): attach overwrites-and-reports the displaced script (#132)

### DIFF
--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -218,10 +218,32 @@ but whose native base is **incompatible** with the node (e.g. an `extends Node3D
 `extends`). Other failures reuse existing codes: a missing script is `path_not_found`, a non-`.gd` script is
 `invalid_path`, a node path that resolves to nothing is `node_not_found`, a missing or non-scene
 file is `path_not_found`/`not_a_scene`, and a scene whose instances vanish or degrade on load is
-`missing_dependency` (the mutation-integrity boundary, #64). The result echoes
-the scene, node, script, and the attached script's `class_name` (null when it declares none),
-verifiable by reading the saved `.tscn` back: the script now appears as an `ext_resource` the node
-references.
+`missing_dependency` (the mutation-integrity boundary, #64).
+
+**Overwrite-and-report** (established by #132): `attach` is a **mutation verb** — it *is*
+`node.set_script()` — so it **overwrites** an existing binding rather than refusing it. (Contrast
+`script create`, a **create verb**: there the file is the entity and a silent overwrite is
+destructive, so it **no-clobbers** with `already_exists`. `attach` does the opposite because there
+is **no `script detach` command** — refusing an already-scripted node would strand it, unable to be
+re-scripted, and re-scripting is a common, legitimate operation.) The overwrite is **not silent**:
+the result's `replaced_script` field names the **displaced** script's `resource_path` **verbatim**
+— including a built-in/embedded script's sub-resource ref (e.g. `res://scene.tscn::GDScript_xxx`),
+so a displacement always reports a **non-null** signal. `replaced_script` is **null only** when the
+node had no prior script. An agent reads it to detect a clobber from the result.
+
+**Scene-before-script ordering** (established by #132): for this scene-mutating command the
+**primary subject** (the scene loads + the addressed node exists) is validated **before** the
+**secondary input** (the `--script` argument) — **one invariant, no exceptions**. Both the
+script's `.gd`-shape check (`invalid_path`) and its existence check (`path_not_found`) run **after**
+the scene load and node resolution, so with **both** the scene and the script missing the **scene**
+problem is reported first. The accepted trade-off: a missing/malformed `--script` now pays the
+scene load+instantiate on the error path — acceptable, since ADR-0009 makes the project trusted
+(running `_init` is not a security concern) and the error path is rare.
+
+The result echoes
+the scene, node, script, the attached script's `class_name` (null when it declares none), and
+`replaced_script` (the displaced script, or null), verifiable by reading the saved `.tscn` back: the
+script now appears as an `ext_resource` the node references.
 
 **Validating** (established by #118): `gda script validate PATH` syntax/compile-checks a `.gd`
 script. **Mechanism**: it reads the file text, sets it on a fresh `GDScript`, and calls

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -761,6 +761,10 @@ class ScriptAttachResult(BaseModel):
     ``script``, plus the script's ``class_name`` when it declares a global one —
     the result an agent asserts to confirm the binding took effect, verifiable by
     reading the saved scene back (the script now appears on the node).
+
+    ``attach`` is a mutation verb: it OVERWRITES an existing binding rather than
+    refusing it (issue #132). ``replaced_script`` makes that displacement visible
+    so the overwrite is never silent — an agent reads it to detect a clobber.
     """
 
     scene_path: str
@@ -773,6 +777,16 @@ class ScriptAttachResult(BaseModel):
         description=(
             "The global class_name the attached script declares, or null when "
             "it declares none."
+        ),
+    )
+    replaced_script: str | None = Field(
+        default=None,
+        description=(
+            "The resource_path of the script this attach DISPLACED, reported "
+            "verbatim — including a built-in/embedded script's sub-resource ref "
+            "(e.g. 'res://scene.tscn::GDScript_xxx'). Non-null whenever the node "
+            "already carried a script (attach overwrites-and-reports, issue "
+            "#132); null only when the node had no prior script."
         ),
     )
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -721,15 +721,29 @@ func _apply_line_range(source: String, params: Dictionary) -> Variant:
 # set_script). Rather than report a phantom success over a scene with no script
 # attached, attach verifies the bind took effect and refuses a non-compiling
 # script with script_compile_failed — fix it (or check with script validate).
+#
+# attach is a MUTATION verb (it is node.set_script): it OVERWRITES an existing
+# binding rather than refusing it (issue #132) — there is no `script detach`, so
+# refusing an already-scripted node would strand it. The overwrite is not silent:
+# the prior script's resource_path is captured BEFORE set_script and reported as
+# replaced_script (null only when the node had no prior script), so an agent can
+# detect a clobber from the result.
+#
+# Error ordering (issue #132, Part 2): the primary subject (the scene loads + the
+# addressed node exists) is validated BEFORE the secondary input (the --script
+# arg). Both the .gd-shape check and the script-existence check (_require_existing_
+# script) run AFTER the scene load and node resolution — one invariant, no
+# exceptions. So with both the scene and the script missing, the scene problem is
+# reported first. The accepted trade-off: a missing/malformed --script now pays
+# the scene load+instantiate on the error path — fine, since ADR-0009 makes the
+# project trusted (running _init is not a security concern) and the error path is
+# rare.
 func _op_script_attach(params: Dictionary) -> void:
 	_diag("running operation: script-attach")
 	var path := _string_param(params, "path")
 
-	# Cheap script-path shape checks first, before the costlier scene load.
-	var script_path := _string_param(params, "script")
-	if not _require_existing_script(script_path):
-		return  # _require_existing_script already recorded the failure
-
+	# Primary subject first: load + instantiate the scene, then resolve the node —
+	# validated before the secondary --script input (issue #132, Part 2).
 	var root: Node = _load_for_mutation(params)
 	if root == null:
 		return  # _load_for_mutation already recorded the failure
@@ -740,6 +754,15 @@ func _op_script_attach(params: Dictionary) -> void:
 		_fail_node_not_found(node_path)
 		return
 
+	# Secondary input: validate the --script arg only now — its .gd shape
+	# (invalid_path) and existence (path_not_found), via the shared #135 helper — so
+	# a scene/node problem is always reported ahead of a script problem (issue #132,
+	# Part 2). The helper records the failure; the caller frees the live tree.
+	var script_path := _string_param(params, "script")
+	if not _require_existing_script(script_path):
+		root.free()
+		return  # _require_existing_script already recorded the failure
+
 	# load returns a non-null Script even for a .gd that does not compile (compile
 	# errors go to stderr; the resource still loads), so a null here is a genuine
 	# resource-load failure (e.g. no format loader), not a compile verdict — guard
@@ -749,6 +772,13 @@ func _op_script_attach(params: Dictionary) -> void:
 		root.free()
 		_fail(OP_ERROR_INVALID_PATH, "file could not be loaded as a GDScript resource: " + script_path)
 		return
+
+	# Capture what this attach is about to DISPLACE before set_script overwrites it
+	# (issue #132). A node that already carries a script yields its prior script's
+	# resource_path verbatim — including a built-in/embedded script's sub-resource
+	# ref (res://scene.tscn::GDScript_xxx) — so a displacement always reports a
+	# non-null signal; a node with no prior script yields null.
+	var replaced_script: Variant = _displaced_script_path(node)
 
 	node.set_script(script)
 	# set_script silently rejects a script it cannot bind: get_script() stays null
@@ -783,6 +813,7 @@ func _op_script_attach(params: Dictionary) -> void:
 		"node": node_path,
 		"script": script_path,
 		"class_name": class_name_value,
+		"replaced_script": replaced_script,
 	})
 
 
@@ -1270,6 +1301,23 @@ func _script_class_of(node: Node) -> Variant:
 	if global_name.is_empty():
 		return null
 	return global_name
+
+
+# The resource_path of the script CURRENTLY bound to the node — the script that an
+# attach is about to DISPLACE (issue #132). Reported verbatim, so a built-in /
+# embedded script keeps its sub-resource ref (res://scene.tscn::GDScript_xxx) and
+# a displacement always yields a non-null signal. null when the node carries no
+# prior script (get_script() == null). The "had a script but resource_path is
+# empty" edge (does not occur for .tscn-embedded scripts, which carry an id) is
+# accepted as reported-null. Captured BEFORE set_script overwrites the binding.
+func _displaced_script_path(node: Node) -> Variant:
+	var script := node.get_script() as Script
+	if script == null:
+		return null
+	var resource_path := script.resource_path
+	if resource_path.is_empty():
+		return null
+	return resource_path
 
 
 # A SceneState node path normalized to the canonical root-relative form the

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -1025,6 +1025,104 @@ def test_script_attach_missing_scene_yields_path_not_found(godot_project):
 
 
 @pytest.mark.e2e
+def test_script_attach_no_prior_script_reports_null_replaced_script(godot_project):
+    # attach is overwrite-and-report (issue #132): a node with no prior script is
+    # bound and replaced_script is null — the signal that nothing was displaced.
+    gda = _gda_project(godot_project)
+    assert (
+        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
+        .returncode
+        == 0
+    )
+    assert (
+        gda("script", "create", "res://hero.gd", "--extends", "Node2D", "--json")
+        .returncode
+        == 0
+    )
+
+    attached = gda(
+        "script", "attach", "res://main.tscn",
+        "--node", ".", "--script", "res://hero.gd", "--json",
+    )
+
+    assert attached.returncode == 0, attached.stdout + attached.stderr
+    assert json.loads(attached.stdout)["replaced_script"] is None
+
+
+@pytest.mark.e2e
+def test_script_attach_overwrites_and_reports_the_displaced_script(godot_project):
+    # The issue #132 core: re-attaching to an ALREADY-scripted node overwrites the
+    # binding (attach is a mutation verb — there is no `script detach`, so refusing
+    # would strand the node) but no longer hides the displacement: replaced_script
+    # names the prior script's res:// path verbatim. The overwrite is real — the
+    # saved .tscn now references the NEW script and no longer the old one.
+    gda = _gda_project(godot_project)
+    assert (
+        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
+        .returncode
+        == 0
+    )
+    assert (
+        gda("script", "create", "res://old.gd", "--extends", "Node2D", "--json")
+        .returncode
+        == 0
+    )
+    assert (
+        gda(
+            "script", "create", "res://new.gd",
+            "--content", "class_name NewHero\nextends Node2D\n", "--json",
+        ).returncode
+        == 0
+    )
+    # First attach binds old.gd — the node is now already-scripted.
+    first = gda(
+        "script", "attach", "res://main.tscn",
+        "--node", ".", "--script", "res://old.gd", "--json",
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+    assert json.loads(first.stdout)["replaced_script"] is None
+
+    # Second attach OVERWRITES old.gd with new.gd and REPORTS the displaced old.gd.
+    second = gda(
+        "script", "attach", "res://main.tscn",
+        "--node", ".", "--script", "res://new.gd", "--json",
+    )
+
+    assert second.returncode == 0, second.stdout + second.stderr
+    data = json.loads(second.stdout)
+    assert data["script"] == "res://new.gd"
+    assert data["class_name"] == "NewHero"
+    # The displaced script is reported verbatim by its resource_path.
+    assert data["replaced_script"] == "res://old.gd"
+    # The overwrite is real: the saved scene references the new script, not the old.
+    saved = (godot_project / "main.tscn").read_text(encoding="utf-8")
+    assert "new.gd" in saved
+    assert "old.gd" not in saved
+
+
+@pytest.mark.e2e
+def test_script_attach_both_scene_and_script_missing_reports_the_scene_first(
+    godot_project,
+):
+    # The scene-before-script ordering acceptance (issue #132, Part 2): with BOTH
+    # the scene and the --script absent, the SCENE problem is reported first — the
+    # primary subject (the scene loads + node exists) is validated before the
+    # secondary input (the --script arg), one invariant with no exceptions. Before
+    # the reorder this surfaced the script's path_not_found and masked the scene.
+    gda = _gda_project(godot_project)
+
+    attached = gda(
+        "script", "attach", "res://missing.tscn",
+        "--node", ".", "--script", "res://also_missing.gd", "--json",
+    )
+
+    err = _assert_operation_error(attached, "path_not_found")
+    # The reported failure names the SCENE, not the script.
+    assert "missing.tscn" in err["message"]
+    assert "also_missing.gd" not in err["message"]
+
+
+@pytest.mark.e2e
 def test_script_create_empty_content_round_trips_as_empty_source(godot_project):
     # An empty file is legal source: --content "" writes an empty script, and get
     # reads it back as empty (the get_file_as_string empty-vs-error disambiguation

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -406,12 +406,14 @@ def test_script_set_result_round_trips_metadata():
 def test_script_attach_result_round_trips_with_class_name():
     # script attach (issue #118) echoes the scene, node, attached script, and the
     # script's declared class_name — the result an agent asserts to confirm the
-    # binding took effect.
+    # binding took effect. attach is overwrite-and-report (issue #132): here the
+    # node already carried a script, so replaced_script names the displaced path.
     payload = {
         "scene_path": "res://main.tscn",
         "node": "Hero",
         "script": "res://hero.gd",
         "class_name": "Hero",
+        "replaced_script": "res://old.gd",
     }
 
     attached = ScriptAttachResult.model_validate(payload)
@@ -419,21 +421,25 @@ def test_script_attach_result_round_trips_with_class_name():
     assert attached.node == "Hero"
     assert attached.script == "res://hero.gd"
     assert attached.class_name == "Hero"
+    assert attached.replaced_script == "res://old.gd"
     assert json.loads(attached.model_dump_json()) == payload
 
 
 def test_script_attach_result_round_trips_null_class_name():
-    # A script with no class_name attaches fine; the result carries null.
+    # A script with no class_name attaches fine; the result carries null. The node
+    # had no prior script, so replaced_script is null (issue #132).
     payload = {
         "scene_path": "res://main.tscn",
         "node": ".",
         "script": "res://util.gd",
         "class_name": None,
+        "replaced_script": None,
     }
 
     attached = ScriptAttachResult.model_validate(payload)
 
     assert attached.class_name is None
+    assert attached.replaced_script is None
     assert json.loads(attached.model_dump_json()) == payload
 
 

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -419,6 +419,7 @@ ATTACH_RESULT = {
     "node": "Hero",
     "script": "/tmp/proj/hero.gd",
     "class_name": "Hero",
+    "replaced_script": None,
 }
 
 
@@ -451,6 +452,9 @@ def test_script_attach_dispatches_scene_node_and_script(monkeypatch):
     assert data["node"] == "Hero"
     assert data["script"] == "/tmp/proj/hero.gd"
     assert data["class_name"] == "Hero"
+    # attach overwrites-and-reports (issue #132): the displaced-script field rides
+    # through to the result; null here means the node had no prior script.
+    assert data["replaced_script"] is None
     assert fake.calls == [
         (
             "script-attach",
@@ -462,6 +466,38 @@ def test_script_attach_dispatches_scene_node_and_script(monkeypatch):
         )
     ]
     assert "engine diagnostic" in result.stderr
+
+
+def test_script_attach_reports_the_displaced_script(monkeypatch):
+    # attach is overwrite-and-report (issue #132): when the node already carried a
+    # script, the result names the displaced script's resource_path verbatim, so an
+    # agent can detect a clobber from the result rather than have it silently hidden.
+    payload = {
+        "scene_path": "/tmp/proj/main.tscn",
+        "node": "Hero",
+        "script": "/tmp/proj/new.gd",
+        "class_name": None,
+        "replaced_script": "res://old.gd",
+    }
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(payload)
+    inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "attach",
+            "/tmp/proj/main.tscn",
+            "--node",
+            "Hero",
+            "--script",
+            "/tmp/proj/new.gd",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["replaced_script"] == "res://old.gd"
 
 
 def test_script_validate_valid_script_reports_valid_true_no_diagnostics(monkeypatch):


### PR DESCRIPTION
## What

Implements the HITL-decided policy for `gda script attach` (recorded in #132's decision comment, settled in a grilling session). Two refinements folded together.

Closes #132.

### 1. Already-scripted-node policy — **overwrite-and-report**

`attach` is a **mutation verb** (it *is* `node.set_script()`), so it overwrites an existing binding rather than refusing it — there is no `script detach`, so refusing would strand an already-scripted node. The overwrite is no longer **silent**: the prior script's `resource_path` is captured **before** `set_script` and reported as a new `replaced_script` field on `ScriptAttachResult`.

- `replaced_script` = the displaced script's `resource_path`, **verbatim** (including a built-in/embedded script's sub-resource ref) — a displacement always yields a **non-null** signal.
- `null` only when the node had no prior script.
- **No new error code** (`node_already_scripted` is deliberately *not* added — that was the rejected refuse path).
- Idempotent re-attach of the same script is not special-cased.

### 2. Scene-before-script error ordering — one invariant

The `--script` shape (`invalid_path`) and existence (`path_not_found`) checks move to **after** scene load + node resolution, so for this scene-mutating command the **primary subject** (scene loads + node exists) is always validated before the **secondary input** (the `--script` arg). With both scene and script missing, the **scene** problem is now reported first (consistent with `node get`/`node set`). Accepted trade-off: a missing/malformed `--script` pays the scene load on the error path — fine under ADR-0009 (trusted project), and the error path is rare.

New order in `_op_script_attach`: load scene → resolve node → script shape/existence → load + `set_script` (compile/incompatible verdict unchanged) → capture `replaced_script` → `_repack_and_save`. `root.free()` runs on every non-success path (audited).

## Docs / ADR

- `docs/command-catalog.md` `script attach`: added **Overwrite-and-report** (the `replaced_script` contract + the asymmetry with `script create`'s no-clobber and why) and **Scene-before-script ordering** (the invariant + trade-off); result-echo updated.
- **No ADR** (the finer clobber/displacement principle has only one data point so far — revisit when `resource set`/`project set` land). `CONTEXT.md` untouched.

## Tests

- e2e (`tests/test_e2e_script.py`): attach to an already-scripted node → `replaced_script` = prior res:// path; no-prior-script → null; **both scene+script missing → scene reported first** (this was red against the old ordering); all existing failure modes still map to their codes.
- S3 (`tests/test_script_commands.py`) + model round-trip (`tests/test_models.py`) carry the new field.

Fast: `239 passed`. Full incl. e2e: `359 passed`. Reviewer independently re-ran fast (239) + the attach e2e subset (12 passed) and audited `root.free()` on all paths.
