### PR TITLE
refactor(node): node-group cleanup + test hardening (#67)

### DIFF
--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -310,7 +310,7 @@ class NodeAddResult(BaseModel):
     )
 
 
-class ListedNode(BaseModel):
+class ListedNode(SceneNode):
     """One node of ``gda node list``'s tree: name, type, node path, children.
 
     Like ``SceneNode`` but each node also carries its node path relative to the
@@ -318,8 +318,12 @@ class ListedNode(BaseModel):
     other node commands (e.g. ``node add --parent``).
     """
 
-    name: str
-    type: str
+    # Subclasses ``SceneNode`` so the recursive tree shape (name/type/children)
+    # has one source of truth; ``children`` is re-declared as ``list[ListedNode]``
+    # — not the inherited ``list[SceneNode]`` — so a listed node's children are
+    # themselves listed nodes (carrying ``path``), keeping the tree self-recursive
+    # on ``ListedNode`` and the ``--json``/``--schema`` output byte-for-byte
+    # unchanged.
     path: str = Field(
         description=(
             "The node's node path relative to the scene root: '.' for the root "

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -322,8 +322,13 @@ class ListedNode(SceneNode):
     # has one source of truth; ``children`` is re-declared as ``list[ListedNode]``
     # — not the inherited ``list[SceneNode]`` — so a listed node's children are
     # themselves listed nodes (carrying ``path``), keeping the tree self-recursive
-    # on ``ListedNode`` and the ``--json``/``--schema`` output byte-for-byte
-    # unchanged.
+    # on ``ListedNode``. The ``--json``/``--schema`` output stays SEMANTICALLY
+    # unchanged (same fields, same ``required``, same recursion) but is NOT byte-
+    # identical: inheriting name/type/children and appending ``path`` orders the
+    # properties name,type,children,path rather than the prior name,type,path,
+    # children. JSON property order is insignificant — consumers parse by key and
+    # the ``--schema`` → MCP generation is order-insensitive — so this is a safe
+    # trade for the single-source-of-truth tree shape.
     path: str = Field(
         description=(
             "The node's node path relative to the scene root: '.' for the root "

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -177,21 +177,17 @@ func _op_scene_create(params: Dictionary) -> void:
 		_fail(OP_ERROR_INVALID_ROOT_NAME, "Godot rewrote root_name from " + root_name + " to " + actual_root_name)
 		return
 
-	var packed := PackedScene.new()
-	var pack_err := packed.pack(root)
-	if pack_err != OK:
-		root.free()
-		_fail(OP_ERROR_SAVE_FAILED, "failed to pack scene: " + error_string(pack_err))
-		return
+	# Create any missing parent dirs BEFORE packing-and-saving. pack() works purely
+	# in memory on root and writes nothing, so making the directories first (rather
+	# than between pack and save) is behavior-equivalent and lets scene-create reuse
+	# the one shared pack-and-save tail (_repack_and_save) the node ops use (#135).
+	# _ensure_parent_dirs does not free root on failure, so free it here on that path.
 	var created_dirs: Variant = _ensure_parent_dirs(path)
 	if created_dirs == null:
 		root.free()
-		return
-	var save_err := ResourceSaver.save(packed, path)
-	root.free()
-	if save_err != OK:
-		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message("scene", path, save_err))
-		return
+		return  # _ensure_parent_dirs already recorded the failure
+	if not _repack_and_save(root, path):
+		return  # _repack_and_save already recorded the failure (and freed root)
 
 	_succeed({
 		"path": path,
@@ -1508,14 +1504,17 @@ func _load_for_mutation(params: Dictionary) -> Node:
 	return root
 
 
-# The single mutate-exit paired with _load_for_mutation: re-pack the (mutated)
-# instantiated `root` and save it back to the .tscn at `path`, then free the
-# tree. Returns true on a clean save, or false after recording save_failed (the
-# caller must stop). root.free() runs on EVERY path — pack failure, save failure,
-# and success alike — so an instantiated scene (the most leak-prone object in the
-# mutating ops) is never leaked. Shared by node add / node set / script attach;
-# the caller captures any result fields it needs OFF THE TREE before calling, as
-# the tree is gone once this returns.
+# The single pack-and-save tail: pack `root` into a PackedScene and save it to the
+# .tscn at `path`, then free the tree. Returns true on a clean save, or false after
+# recording save_failed (the caller must stop). root.free() runs on EVERY path —
+# pack failure, save failure, and success alike — so an instantiated scene (the most
+# leak-prone object in the mutating ops) is never leaked. Shared by every op whose
+# tail packs-and-saves a root: scene create (a freshly-built root) and the mutating
+# ops node add / node set / node remove / node duplicate / node move / connect- &
+# disconnect-signal / script attach (a re-packed instantiated tree, paired with
+# _load_for_mutation). The caller captures any result fields it needs OFF THE TREE
+# before calling, as the tree is gone once this returns; for scene create the caller
+# also creates any missing parent dirs first, since this tail only packs and saves.
 func _repack_and_save(root: Node, path: String) -> bool:
 	var repacked := PackedScene.new()
 	var pack_err := repacked.pack(root)

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -318,13 +318,11 @@ func _op_node_add(params: Dictionary) -> void:
 		root.free()
 		return  # _instantiate_node_type already recorded the failure
 
+	# A parentless node never has its name rewritten: _is_valid_node_name already
+	# rejected the chars Godot sanitizes, and the @-dedup suffix is only appended
+	# inside add_child (already guarded by the duplicate-name check above). So the
+	# assigned name is final; no post-assignment recheck is needed.
 	node.name = node_name
-	var actual_name := String(node.name)
-	if actual_name != node_name:
-		node.free()
-		root.free()
-		_fail(OP_ERROR_INVALID_NODE_NAME, "Godot rewrote name from " + node_name + " to " + actual_name)
-		return
 	parent.add_child(node)
 	node.owner = root
 
@@ -338,7 +336,7 @@ func _op_node_add(params: Dictionary) -> void:
 	_succeed({
 		"scene_path": path,
 		"path": node_path,
-		"name": actual_name,
+		"name": node_name,
 		"type": node_type,
 		"script_class": script_class,
 	})

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -23,7 +23,6 @@ from typing import Any, Protocol, runtime_checkable
 
 from gda.models import (
     EngineVersion,
-    ListedNode,
     NodeAddResult,
     NodeConnectSignalResult,
     NodeDisconnectSignalResult,
@@ -79,8 +78,14 @@ def format_value(value: Any) -> str:
     return json.dumps(value)
 
 
-def render_node_tree(node: "SceneNode | ListedNode", depth: int = 0) -> str:
-    """Render a node tree as an indented ``name (Type)`` outline for humans."""
+def render_node_tree(node: "SceneNode", depth: int = 0) -> str:
+    """Render a node tree as an indented ``name (Type)`` outline for humans.
+
+    Types against ``SceneNode`` alone: ``ListedNode`` is a ``SceneNode`` subclass
+    (one tree shape), so node list's tree flows through here without naming a
+    union — the renderer reads only ``name``/``type``/``children``, which every
+    node in the tree carries.
+    """
     lines = [f"{'  ' * depth}{node.name} ({node.type})"]
     lines += (render_node_tree(child, depth + 1) for child in node.children)
     return "\n".join(lines)

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -507,6 +507,35 @@ def test_node_set_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
 
 
 @pytest.mark.e2e
+def test_node_list_reports_all_siblings_at_one_level_in_tree_order(godot_project):
+    # node list's sibling enumeration and child ordering (issue #53): every other
+    # round-trip fixture has at most one child per parent, so a parent with >1
+    # child is the case that exercises reporting ALL siblings and preserving their
+    # order. Add three distinct-typed children under the root, then assert node
+    # list reports all three, in the order they were added, off the saved file.
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    siblings = [("A", "Node2D"), ("B", "Sprite2D"), ("C", "Area2D")]
+    for name, node_type in siblings:
+        added = _gda(
+            "node", "add", str(scene_path),
+            "--type", node_type, "--name", name, "--json",
+        )
+        assert added.returncode == 0, added.stdout + added.stderr
+
+    listed = _gda("node", "list", str(scene_path), "--json")
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    children = json.loads(listed.stdout)["root"]["children"]
+    # All siblings are reported, in tree order — name, type and node path each.
+    assert [(c["name"], c["type"], c["path"]) for c in children] == [
+        ("A", "Node2D", "A"),
+        ("B", "Sprite2D", "B"),
+        ("C", "Area2D", "C"),
+    ]
+
+
+@pytest.mark.e2e
 def test_node_list_missing_scene_yields_path_not_found(godot_project):
     missing = godot_project / "missing.tscn"
 

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -110,6 +110,28 @@ def test_node_add_default_name_is_the_type_name(godot_project):
     assert data["path"] == "Sprite2D"
 
 
+@pytest.mark.e2e
+def test_node_add_builtin_type_reports_null_script_class(godot_project):
+    # script_class is the class_name of an attached script (issue #53); a plain
+    # built-in type carries no script, so it must be null. Asserted end-to-end
+    # here because every other success test ignores it — a broken
+    # _script_class_of returning garbage for a built-in Sprite2D would otherwise
+    # pass them all. Its counterpart is the by-class_name add, which asserts
+    # script_class == "Hero".
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+
+    added = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Sprite2D", "--name", "Hero", "--json",
+    )
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    data = json.loads(added.stdout)
+    assert data["type"] == "Sprite2D"
+    assert data["script_class"] is None
+
+
 def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
     assert proc.returncode == 4, proc.stdout + proc.stderr
     err = json.loads(proc.stdout)["error"]


### PR DESCRIPTION
## What

Non-functional cleanup + test hardening for the node group, surfaced by the PR #60 review. No behavior change except the two added tests.

Closes #67.

## Cleanup

1. **Removed the dead rewrite guard in `_op_node_add`** — the `actual_name != node_name` recheck after assigning `.name` to a parentless node was unreachable (`_is_valid_node_name` already rejects the sanitized chars, and the `@`-dedup suffix only happens in `add_child`, already guarded by the duplicate-name check). Replaced with a comment; the result now uses the validated `node_name`.

2. **`ListedNode` now subclasses `SceneNode`** (`class ListedNode(SceneNode): path: str`, per the issue) — collapses the `"SceneNode | ListedNode"` union in `render_node_tree` to a single tree type, so the tree shape has one source of truth.
   - **One honest caveat on the "output unchanged" criterion:** the `node list` `--schema`/`--json` are **semantically identical** (same fields, same `required` `["name","type","path"]`, same field definitions and `$ref` recursion; `$defs` holds only `ListedNode`, no `SceneNode` leak) — but the **property declaration order** of `ListedNode` changes: `path` now follows `children` instead of preceding it, because a subclass inherits `name`/`type`/`children` first and appends `path`. This is the inherent consequence of the issue-prescribed `class ListedNode(SceneNode): path: str`. JSON property order is insignificant (agents parse by key; MCP generation from `--schema` is order-insensitive), and the whole suite — including the `--schema` hard-gate — stays green. If strict byte-stability of the schema string is required, the fields can instead be re-declared on `ListedNode` in the original order (at the cost of duplicating the field defs); flagging the trade-off rather than deciding it silently.

3. **Consolidated the pack-and-save tail** — re-scoped: #135 already extracted `_repack_and_save(root, path)` and routed the node ops through it, so **no new helper was created**. `_op_scene_create` still inlined the same tail; routed it through `_repack_and_save` too. `_ensure_parent_dirs` runs **before** the shared tail (pack is purely in-memory, so creating dirs first is equivalent), freeing `root` explicitly on the dir-creation failure path. `created_dirs` and the `save_failed` diagnostics are unchanged.

## Test hardening

4. **e2e asserts `script_class is None` for a built-in-type add** (`node add --type Sprite2D`) — previously only the model round-trip / fake-runner dict asserted it, so a broken `_script_class_of` returning garbage for a plain node would pass every e2e success test.
5. **e2e covers `node list` with >1 sibling at one level** — three distinct-typed children under the root, asserting all are reported with correct `(name, type, path)` in tree order (sibling enumeration / child ordering was previously unverified).

## Tests

Fast: `274 passed`. Full incl. e2e: `425 passed` (+2 = the new e2e tests). Reviewer independently re-ran fast (274) + the scene/node e2e subset (19 passed), verified the dead guard is gone, and diffed the `node list --schema` against `main` (semantically identical; only the `path`/`children` property order differs, as noted above).
