### PR TITLE
docs: restore the exit-code ABI in the user-facing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ for the full picture.
   ([ADR-0005](docs/adr/0005-cli-command-taxonomy.md)).
 - ✅ The contract every shipped command carries: structured `--json` output, model-derived
   `--schema` self-description ([ADR-0004](docs/adr/0004-schema-flag-self-description.md)), and
-  structured `{"error": {category, code, …}}` failures with category-distinguishing exit codes.
+  structured `{"error": {category, code, …}}` failures with category-distinguishing
+  [exit codes](#exit-codes-the-cli-abi).
 - ✅ The engine plumbing underneath: Godot binary resolution (flag / env var / default) and the
   bounded one-shot `godot --headless` runner with its sentinel output contract
   ([ADR-0002](docs/adr/0002-headless-structured-output-contract.md)).
@@ -289,6 +290,27 @@ with a sentinel contract ([ADR-0002](docs/adr/0002-headless-structured-output-co
 This is what makes `gda`'s output safe to consume programmatically, and it generalizes to the
 per-message protocol the daemon will use in Phase 2.
 
+### Exit codes (the CLI ABI)
+
+A failed `gda` run exits with a small, stable code so a shell or agent can branch on the failure
+**category without parsing the JSON error**:
+
+| Exit code | Category      | When                                                                  |
+| --------- | ------------- | --------------------------------------------------------------------- |
+| `0`       | —             | Success.                                                              |
+| `127`     | `environment` | The Godot binary could not be launched (shell convention: not found). |
+| `124`     | `environment` | Godot launched but did not return before the runner timeout (shell convention: timed out). |
+| `3`       | `version`     | The detected Godot version is below the supported minimum.            |
+| `4`       | `operation`   | The engine ran but the operation failed — a registered operation error, an engine crash, or an unstructured non-zero exit. |
+| `5`       | `parse`       | The process claimed success but violated the structured-output contract. |
+
+These values are the public ABI; their authoritative source is
+[`src/gda/exit_codes.py`](src/gda/exit_codes.py) — that registry, not this table, defines them.
+The `{"error": {category, code, …}}` envelope carries a **finer `code`** within each category
+(e.g. `path_not_found`, `already_exists`, and `node_not_found` all sit under `operation` / exit `4`).
+The full code → category → exit-code registry, kept in sync with the code by tests, lives in
+[ADR-0002’s `GdaError.code` registry table](docs/adr/0002-headless-structured-output-contract.md#gdaerrorcode-registry).
+
 ---
 
 ## Development
@@ -316,6 +338,7 @@ src/gda/
   parser.py         # sentinel-contract result parser (ADR-0002)
   models.py         # typed I/O models (Pydantic) backing --json and --schema (ADR-0004)
   errors.py         # failure classification: shared classify_run + per-command layers
+  error_codes.py    # the registry of public GdaError.code values (ADR-0002 companion)
   exit_codes.py     # the single registry of process exit codes (the CLI ABI)
   ops/operations.gd # GDScript payload, dispatched by operation name
 tests/              # unit tests + e2e tests against a real engine (shared fixtures in conftest.py)


### PR DESCRIPTION
## What

Restores the user-facing statement of the exit-code ABI that a README rewrite of the "Project status" section dropped. The category exit codes (`environment` 127/124, `version` 3, `operation` 4, `parse` 5) had become documented nowhere outside `src/gda/exit_codes.py`.

## Changes

- Add an **"Exit codes (the CLI ABI)"** subsection under *The structured-output contract* in the README, with a category → exit-code table (0/127/124/3/4/5).
- The table names [`src/gda/exit_codes.py`](src/gda/exit_codes.py) as the authoritative source and links to [ADR-0002's `GdaError.code` registry table](docs/adr/0002-headless-structured-output-contract.md#gdaerrorcode-registry) for the full, test-enforced per-operation-code mapping (the #38 operation-error-code registry) — rather than duplicating those 30+ rows in a drift-prone way (RULES.md: single source of truth, one-directional references).
- Link the "Project status" failures bullet to the new table.
- List `error_codes.py` (the #38 registry) in the project-layout block.

## Verification

- Codes verified against `src/gda/exit_codes.py` and `src/gda/error_codes.py`; the operation-code link points at the ADR-0002 table that `tests/test_error_registry.py` keeps in lockstep with the Python registry.
- Docs-only; no test changes. Full suite run (incl. e2e against a real Godot 4.6): **423 passed**.

Closes #40
