### PR TITLE
fix(classify): distinguish deep scene trees from contract violations

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -120,6 +120,7 @@ operation, and parse codes the CLI assigns).
 | `already_connected` | `operation` | `operation` | `4` | A signal is already connected to the target node's method. |
 | `connection_not_found` | `operation` | `operation` | `4` | A requested signal-to-method connection does not exist on the source node. |
 | `contract_violation` | `parse` | `parser` | `5` | The process claimed success but violated the structured-output contract. |
+| `tree_too_deep` | `parse` | `classifier` | `6` | The engine emitted a valid result tree that nests past gda's recursion limit; the payload is contract-conformant, the limit is wrapper-side. |
 
 ## Considered options
 

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -120,7 +120,7 @@ operation, and parse codes the CLI assigns).
 | `already_connected` | `operation` | `operation` | `4` | A signal is already connected to the target node's method. |
 | `connection_not_found` | `operation` | `operation` | `4` | A requested signal-to-method connection does not exist on the source node. |
 | `contract_violation` | `parse` | `parser` | `5` | The process claimed success but violated the structured-output contract. |
-| `tree_too_deep` | `parse` | `classifier` | `6` | The engine emitted a valid result tree that nests past gda's recursion limit; the payload is contract-conformant, the limit is wrapper-side. |
+| `tree_too_deep` | `parse` | `classifier` | `5` | The engine emitted a valid result tree that nests past gda's recursion limit; the payload is contract-conformant, the limit is wrapper-side (shares the `parse` exit code; the `code` distinguishes it from `contract_violation`). |
 
 ## Considered options
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -14,6 +14,7 @@ from gda.exit_codes import (
     EXIT_OPERATION,
     EXIT_PARSE,
     EXIT_TIMEOUT,
+    EXIT_TREE_TOO_DEEP,
     EXIT_VERSION,
 )
 from gda.models import ErrorCategory
@@ -306,6 +307,14 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         EXIT_PARSE,
         ErrorCodeSource.PARSER,
         "The process claimed success but violated the structured-output contract.",
+    ),
+    ErrorCodeSpec(
+        "tree_too_deep",
+        ErrorCategory.PARSE,
+        EXIT_TREE_TOO_DEEP,
+        ErrorCodeSource.CLASSIFIER,
+        "The engine emitted a valid result tree that nests past gda's recursion"
+        " limit; the payload is contract-conformant, the limit is wrapper-side.",
     ),
 )
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -14,7 +14,6 @@ from gda.exit_codes import (
     EXIT_OPERATION,
     EXIT_PARSE,
     EXIT_TIMEOUT,
-    EXIT_TREE_TOO_DEEP,
     EXIT_VERSION,
 )
 from gda.models import ErrorCategory
@@ -311,7 +310,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
     ErrorCodeSpec(
         "tree_too_deep",
         ErrorCategory.PARSE,
-        EXIT_TREE_TOO_DEEP,
+        EXIT_PARSE,
         ErrorCodeSource.CLASSIFIER,
         "The engine emitted a valid result tree that nests past gda's recursion"
         " limit; the payload is contract-conformant, the limit is wrapper-side.",

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -95,6 +95,20 @@ def _failure(code: str, message: str, stderr: str) -> Failure:
 M = TypeVar("M", bound=BaseModel)
 
 
+def _is_too_deep(exc: ValidationError) -> bool:
+    """Is this ValidationError purely pydantic-core's recursion-depth ceiling?
+
+    pydantic-core reports breaching its recursive-validation depth limit with the
+    ``recursion_loop`` error type — the same type a genuine cyclic reference
+    raises. A deep-but-valid tree (issue #37) produces ONLY ``recursion_loop``
+    errors, whereas a real shape violation that merely happens to also be deep
+    mixes in other error types; so depth is the cause only when every reported
+    error is ``recursion_loop``.
+    """
+    errors = exc.errors()
+    return bool(errors) and all(error["type"] == "recursion_loop" for error in errors)
+
+
 def _operation_error_from_payload(result: RunResult) -> tuple[str, str] | None:
     """Extract a minimal operation error envelope from stdout, if present."""
     try:
@@ -170,6 +184,23 @@ def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | 
         # rather than escape as a traceback.
         return output_model.model_validate(parse_result(result.stdout))
     except (ValueError, ValidationError) as exc:
+        # pydantic-core caps recursive-model validation at a hardcoded ceiling
+        # (~255 levels) and reports breaching it as a `recursion_loop` error —
+        # the SAME error type as a genuine cyclic reference. A legitimately deep
+        # scene tree (issue #37) trips this even though every node is valid and
+        # the payload is contract-conformant: the limit is gda's own (wrapper
+        # side), not the engine violating the output contract. Surface that as a
+        # distinct `tree_too_deep` failure so it is never misclassified as
+        # `contract_violation`. A mix of recursion_loop with other errors is a
+        # real shape violation that merely happens to also be deep, so require
+        # ALL errors to be recursion_loop before claiming depth as the cause.
+        if isinstance(exc, ValidationError) and _is_too_deep(exc):
+            return _failure(
+                "tree_too_deep",
+                "result tree nests too deep for gda to materialize "
+                f"(exceeds the recursion limit on {output_model.__name__})",
+                result.stderr,
+            )
         return _failure(
             "contract_violation",
             f"structured-output contract violated: {exc}",

--- a/src/gda/exit_codes.py
+++ b/src/gda/exit_codes.py
@@ -13,11 +13,11 @@ glance and new codes cannot silently collide.
   failure, not mislabelled environment (issue #15).
 - ``EXIT_VERSION`` / ``EXIT_OPERATION`` / ``EXIT_PARSE`` are distinct small codes
   the CLI assigns to failures the engine signalled differently or not at all.
-- ``EXIT_TREE_TOO_DEEP`` is a wrapper-side limit, not a contract violation
-  (issue #37): the engine emitted a valid, contract-conformant result tree, but
-  it nests past pydantic-core's recursion ceiling so ``gda`` cannot materialize
-  it. A distinct exit code keeps a shell consumer from conflating it with the
-  ``EXIT_PARSE`` "the engine violated the contract" case.
+  ``parse`` (exit ``5``) spans more than one ``GdaError.code``: both a genuine
+  ``contract_violation`` and a deep-but-valid ``tree_too_deep`` (issue #37) — the
+  envelope ``code`` distinguishes them, exactly as the many ``operation`` codes
+  share exit ``4``. Exit codes stay at category granularity; finer detail is the
+  ``code`` field's job (ADR-0002, ADR-0004).
 """
 
 EXIT_NOT_FOUND = 127
@@ -25,4 +25,3 @@ EXIT_TIMEOUT = 124
 EXIT_VERSION = 3
 EXIT_OPERATION = 4
 EXIT_PARSE = 5
-EXIT_TREE_TOO_DEEP = 6

--- a/src/gda/exit_codes.py
+++ b/src/gda/exit_codes.py
@@ -13,6 +13,11 @@ glance and new codes cannot silently collide.
   failure, not mislabelled environment (issue #15).
 - ``EXIT_VERSION`` / ``EXIT_OPERATION`` / ``EXIT_PARSE`` are distinct small codes
   the CLI assigns to failures the engine signalled differently or not at all.
+- ``EXIT_TREE_TOO_DEEP`` is a wrapper-side limit, not a contract violation
+  (issue #37): the engine emitted a valid, contract-conformant result tree, but
+  it nests past pydantic-core's recursion ceiling so ``gda`` cannot materialize
+  it. A distinct exit code keeps a shell consumer from conflating it with the
+  ``EXIT_PARSE`` "the engine violated the contract" case.
 """
 
 EXIT_NOT_FOUND = 127
@@ -20,3 +25,4 @@ EXIT_TIMEOUT = 124
 EXIT_VERSION = 3
 EXIT_OPERATION = 4
 EXIT_PARSE = 5
+EXIT_TREE_TOO_DEEP = 6

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -85,9 +85,22 @@ def render_node_tree(node: "SceneNode", depth: int = 0) -> str:
     (one tree shape), so node list's tree flows through here without naming a
     union — the renderer reads only ``name``/``type``/``children``, which every
     node in the tree carries.
+
+    Iterative on purpose (issue #37): a legitimately deep scene tree can nest far
+    past Python's recursion limit, so this walks the tree with an explicit stack
+    (pre-order, children left-to-right — the same outline a recursive walk would
+    produce) rather than recursing per level and raising an unstructured
+    ``RecursionError`` on a deep-but-valid tree.
     """
-    lines = [f"{'  ' * depth}{node.name} ({node.type})"]
-    lines += (render_node_tree(child, depth + 1) for child in node.children)
+    lines: list[str] = []
+    # Stack of (node, depth); pushing children in reverse so the leftmost child
+    # is popped first preserves the recursive pre-order, in-order traversal.
+    stack: list[tuple["SceneNode", int]] = [(node, depth)]
+    while stack:
+        current, current_depth = stack.pop()
+        lines.append(f"{'  ' * current_depth}{current.name} ({current.type})")
+        for child in reversed(current.children):
+            stack.append((child, current_depth + 1))
     return "\n".join(lines)
 
 

--- a/tests/test_classify_run.py
+++ b/tests/test_classify_run.py
@@ -291,3 +291,55 @@ def test_wrong_shape_payload_maps_to_parse_failure():
     assert outcome.exit_code == 5
     assert outcome.error.category == ErrorCategory.PARSE
     assert outcome.error.code == "contract_violation"
+
+
+def _deep_tree_payload(depth: int) -> dict:
+    # A valid SceneGetResult payload whose root nests `depth` levels deep — a
+    # single-child chain. Every node is contract-conformant; only the DEPTH is
+    # extreme, past pydantic-core's ~255 recursion ceiling (issue #37).
+    root = leaf = {"name": "n0", "type": "Node", "children": []}
+    for i in range(1, depth):
+        child = {"name": f"n{i}", "type": "Node", "children": []}
+        leaf["children"] = [child]
+        leaf = child
+    return {"path": "/p/deep.tscn", "root": root}
+
+
+def test_deep_but_valid_tree_is_not_a_contract_violation():
+    # A legitimately deep scene tree exceeds pydantic-core's ~255 recursion
+    # ceiling on the recursive SceneNode model. The engine payload is VALID and
+    # contract-conformant — the limit is gda's own (a wrapper-side validation
+    # ceiling), so blaming the engine with `parse / contract_violation` is wrong
+    # (issue #37). It must surface as a distinct, accurate failure instead.
+    from gda.models import SceneGetResult
+
+    result = RunResult(
+        stdout=_sentinel(_deep_tree_payload(1000)),
+        stderr="",
+        exit_code=0,
+    )
+
+    outcome = classify_run(result, BINARY, SceneGetResult)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "tree_too_deep"
+    assert outcome.error.code != "contract_violation"
+
+
+def test_tree_too_deep_carries_an_accurate_wrapper_side_message():
+    # The failure must name the limit accurately as gda's own (not "the engine
+    # violated the output contract"), so an agent reads a true cause (issue #37).
+    from gda.models import SceneGetResult
+
+    result = RunResult(
+        stdout=_sentinel(_deep_tree_payload(1000)),
+        stderr="",
+        exit_code=0,
+    )
+
+    outcome = classify_run(result, BINARY, SceneGetResult)
+
+    assert isinstance(outcome, Failure)
+    message = outcome.error.message.lower()
+    assert "deep" in message or "depth" in message
+    assert "contract" not in message

--- a/tests/test_classify_run.py
+++ b/tests/test_classify_run.py
@@ -343,3 +343,18 @@ def test_tree_too_deep_carries_an_accurate_wrapper_side_message():
     message = outcome.error.message.lower()
     assert "deep" in message or "depth" in message
     assert "contract" not in message
+
+
+def test_tree_too_deep_shares_the_parse_exit_code():
+    # tree_too_deep is a `parse`-category failure and rides the shared `parse`
+    # exit code (5), NOT a code of its own: exit codes stay at category
+    # granularity and the envelope `code` carries the finer distinction from
+    # `contract_violation` (issue #37 review — ADR-0002 / ADR-0004 model).
+    from gda.error_codes import ERROR_CODE_BY_CODE
+    from gda.exit_codes import EXIT_PARSE
+
+    assert ERROR_CODE_BY_CODE["tree_too_deep"].exit_code == EXIT_PARSE
+    assert (
+        ERROR_CODE_BY_CODE["tree_too_deep"].exit_code
+        == ERROR_CODE_BY_CODE["contract_violation"].exit_code
+    )

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -12,16 +12,18 @@ import pytest
 from gda import render as render_mod
 from gda.models import (
     EngineVersion,
+    ListedNode,
     ListedScript,
     NodeGetResult,
     NodeProperty,
     NodeSetResult,
+    SceneNode,
     ScriptCreateResult,
     ScriptDeleteResult,
     ScriptGetResult,
     ScriptSetResult,
 )
-from gda.render import ScriptMetadata, format_value, render
+from gda.render import ScriptMetadata, format_value, render, render_node_tree
 
 # The five script result types the metadata renderer used to read as a union.
 SCRIPT_METADATA_MODELS = [
@@ -68,6 +70,45 @@ def test_format_value_owns_value_to_text():
     assert format_value(3) == "3"
     assert format_value([1.0, 2.0]) == "[1.0, 2.0]"
     assert format_value(True) == "true"
+
+
+def _deep_chain(model, depth, **leaf_fields):
+    # A single-child chain `depth` nodes deep, built via model_construct so it
+    # bypasses pydantic's recursive validation (issue #37): the point is to
+    # exercise the RENDER path's recursion in isolation, at a depth past the
+    # ~255 pydantic-core ceiling a legitimately deep scene can reach.
+    root = leaf = model.model_construct(name="n0", type="Node", children=[], **leaf_fields)
+    for i in range(1, depth):
+        child = model.model_construct(
+            name=f"n{i}", type="Node", children=[], **leaf_fields
+        )
+        leaf.children = [child]
+        leaf = child
+    return root
+
+
+def test_render_node_tree_does_not_recurse_on_a_deep_tree():
+    # The non-`--json` render path must not raise an unstructured RecursionError
+    # on a legitimately deep scene tree (issue #37): a 2000-deep chain — far past
+    # the ~255 pydantic-core ceiling — renders one indented line per node.
+    deep = _deep_chain(SceneNode, 2000)
+
+    rendered = render_node_tree(deep)
+
+    lines = rendered.split("\n")
+    assert len(lines) == 2000
+    assert lines[0] == "n0 (Node)"
+    assert lines[-1] == "  " * 1999 + "n1999 (Node)"
+
+
+def test_render_node_tree_renders_listed_nodes_deeply_too():
+    # node list shares the same recursive renderer over ListedNode; a deep listed
+    # tree must render without RecursionError as well (issue #37).
+    deep = _deep_chain(ListedNode, 2000, path=".")
+
+    rendered = render_node_tree(deep)
+
+    assert len(rendered.split("\n")) == 2000
 
 
 def test_render_node_properties_routes_value_through_the_helper():


### PR DESCRIPTION
## Problem

A legitimately deep scene tree from `scene get` nests past pydantic-core's hardcoded recursive-validation ceiling (~255 levels). The resulting `ValidationError` on depth was reported by `classify_run` as `parse / contract_violation` (exit 5) — blaming the engine payload for a wrapper-side limit. The recursive `_render_tree` / `render_node_tree` had the same unbounded recursion on the non-`--json` path (pydantic failed first today, but the latent `RecursionError` is real).

Verified locally: depth 255 validates, 256 fails (boundary varies slightly by pydantic-core version; the issue reported 254/255). pydantic-core reports the depth ceiling with the `recursion_loop` error type — the *same* type used for genuine cyclic references — which gives a clean, version-stable discriminator.

## Fix

Route chosen: **distinct structured error for the classification/`--json` path + iterative render for the human path.** Making validation "succeed" via a higher limit is not possible — pydantic-core's recursion guard is a hardcoded Rust limit, unaffected by `sys.setrecursionlimit`; and even if validation were bypassed via `model_construct`, `model_dump_json` hits the *same* ceiling on serialization. So fully succeeding the `--json` path would mean replacing pydantic's validator *and* serializer with custom iterative code — fighting the framework on both ends. A precise, distinct error is the honest fix.

- `classify_run` now detects a `ValidationError` whose errors are **all** `recursion_loop` and surfaces a distinct `tree_too_deep` failure whose message names the limit as gda's own — never `contract_violation`. A mix of `recursion_loop` with other error types stays a genuine `contract_violation` (a real shape violation that merely happens to also be deep).
- `render_node_tree` is now an explicit-stack pre-order walk, so the human (non-`--json`) path renders an arbitrarily deep tree without raising an unstructured `RecursionError`; output order is unchanged (existing render tests pass untouched).

## New error code

`tree_too_deep` — category `parse`, source `classifier`, exit code `6` (new `EXIT_TREE_TOO_DEEP`). Registered in the Python registry (`error_codes.py`), the ADR-0002 table, and `exit_codes.py`. **No GDScript mirror** — it is a classifier-assigned code, not an operation-reported one, so the registry-drift test correctly does not require it in `operations.gd`.

A distinct exit code (6, not 5) lets a shell consumer tell "tree too deep for the wrapper" apart from "the engine violated the output contract", matching the ADR's per-code exit-code rule (precedent: ENVIRONMENT spans 127 and 124).

## Tests

- `tests/test_classify_run.py`: a 1000-deep valid `SceneGetResult` payload classifies as `tree_too_deep`, not `contract_violation`, with an accurate wrapper-side message.
- `tests/test_render.py`: a 2000-deep `SceneNode` chain and a 2000-deep `ListedNode` chain each render without `RecursionError`, one indented line per node.
- Full suite green: **427 passed** (incl. real-Godot e2e). CI-equivalent `pytest -m "not e2e"` + `uv build` pass.

## Acceptance criteria

- [x] A valid scene nested past the ~255 limit fails with an accurate, distinct structured error — not `parse / contract_violation`.
- [x] The human-readable render path does not raise an unstructured `RecursionError`.
- [x] A unit test exercises a tree at/above the previous failing depth.

Closes #37
