### PR TITLE
feat(resource): create + get — establish the .tres resource tracer (#112)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -119,6 +119,7 @@ operation, and parse codes the CLI assigns).
 | `signal_not_found` | `operation` | `operation` | `4` | A requested signal does not exist on the source node. |
 | `already_connected` | `operation` | `operation` | `4` | A signal is already connected to the target node's method. |
 | `connection_not_found` | `operation` | `operation` | `4` | A requested signal-to-method connection does not exist on the source node. |
+| `invalid_resource_type` | `operation` | `operation` | `4` | A requested resource type cannot be instantiated as a `Resource`. |
 | `contract_violation` | `parse` | `parser` | `5` | The process claimed success but violated the structured-output contract. |
 
 ## Considered options

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -45,6 +45,10 @@ from gda.models import (
     NodeRemoveResult,
     NodeSetParams,
     NodeSetResult,
+    ResourceCreateParams,
+    ResourceCreateResult,
+    ResourceGetParams,
+    ResourceGetResult,
     SceneCreateParams,
     SceneCreateResult,
     SceneDeleteParams,
@@ -99,6 +103,14 @@ script_app = typer.Typer(
     help="Act on script files (.gd).", no_args_is_help=True
 )
 app.add_typer(script_app, name="script")
+
+# The resource command group (issue #112): commands acting on .tres resource
+# files on disk (load/save plumbing), so they stay headless. The group is a
+# .tres tracer; the binary .res form is out of scope for this slice.
+resource_app = typer.Typer(
+    help="Act on resource files (.tres).", no_args_is_help=True
+)
+app.add_typer(resource_app, name="resource")
 
 
 def _version_callback(value: Optional[bool]) -> None:
@@ -337,6 +349,18 @@ SCRIPT_VALIDATE_COMMAND: HeadlessCommand[ScriptValidateResult] = HeadlessCommand
     input_model=ScriptValidateParams,
     output_model=ScriptValidateResult,
     classify=classify_script_validate,
+)
+
+RESOURCE_CREATE_COMMAND: HeadlessCommand[ResourceCreateResult] = HeadlessCommand(
+    operation="resource-create",
+    input_model=ResourceCreateParams,
+    output_model=ResourceCreateResult,
+)
+
+RESOURCE_GET_COMMAND: HeadlessCommand[ResourceGetResult] = HeadlessCommand(
+    operation="resource-get",
+    input_model=ResourceGetParams,
+    output_model=ResourceGetResult,
 )
 
 
@@ -1024,6 +1048,49 @@ def validate_script(
     _dispatch(
         SCRIPT_VALIDATE_COMMAND,
         ScriptValidateParams(path=_normalize_path(path)),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@resource_app.command(cls=RESOURCE_CREATE_COMMAND.command_class())
+def create(
+    path: str = typer.Argument(..., help="Target .tres resource path to write."),
+    resource_type: str = typer.Option(
+        ...,
+        "--type",
+        help="Godot resource class of the new .tres (e.g. Gradient, Curve).",
+    ),
+    json_output: bool = json_option(),
+    schema: bool = RESOURCE_CREATE_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Create a new .tres resource file of the given resource type."""
+    _dispatch(
+        RESOURCE_CREATE_COMMAND,
+        ResourceCreateParams(path=_normalize_path(path), type=resource_type),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@resource_app.command(name="get", cls=RESOURCE_GET_COMMAND.command_class())
+def get_resource(
+    path: str = typer.Argument(..., help="The .tres resource file to read."),
+    json_output: bool = json_option(),
+    schema: bool = RESOURCE_GET_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Read a .tres resource and report its properties as typed JSON."""
+    _dispatch(
+        RESOURCE_GET_COMMAND,
+        ResourceGetParams(path=_normalize_path(path)),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -301,6 +301,13 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A requested signal-to-method connection does not exist on the source node.",
     ),
     ErrorCodeSpec(
+        "invalid_resource_type",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A requested resource type cannot be instantiated as a Resource.",
+    ),
+    ErrorCodeSpec(
         "contract_violation",
         ErrorCategory.PARSE,
         EXIT_PARSE,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -1100,6 +1100,70 @@ class ScriptValidateResult(BaseModel):
     )
 
 
+class ResourceCreateParams(BaseModel):
+    """The operation params of ``gda resource create`` (issue #112).
+
+    ``path`` is the target ``.tres`` resource file, addressed by its ``res://``
+    or filesystem path (resource-file addressing — by file path). ``type`` is
+    the Godot resource class to instantiate and save (e.g. ``Gradient``,
+    ``Curve``); it must be an instantiable ``Resource`` subclass, mirroring
+    ``scene create``'s ``root_type`` check against ``Node``.
+    """
+
+    path: str
+    type: str = Field(
+        description=(
+            "The Godot resource class to create (e.g. Gradient, Curve). Must be "
+            "an instantiable Resource subclass."
+        )
+    )
+
+
+class ResourceCreateResult(BaseModel):
+    """The result of ``gda resource create``: what was written where (issue #112).
+
+    Echoes the saved ``path`` and the ``type`` of the resource it created, so an
+    agent can assert the effect (path + type) without a second call.
+    ``created_dirs`` lists parent directories the operation created before
+    saving, from outermost to innermost (mirrors ``scene``/``script`` create).
+    """
+
+    path: str
+    type: str = Field(description="The Godot resource class that was created.")
+    created_dirs: list[str] = Field(
+        description=(
+            "Parent directories created before saving, from outermost to innermost."
+        )
+    )
+
+
+class ResourceGetParams(BaseModel):
+    """The operation params of ``gda resource get``: the ``.tres`` to read (issue #112).
+
+    ``path`` addresses the resource by its ``res://`` or filesystem path. Loading
+    a ``.tres`` instantiates the resource (the same trust boundary every load
+    carries, ADR-0009), but a plain resource file holds data, not a script that
+    runs on load.
+    """
+
+    path: str
+
+
+class ResourceGetResult(BaseModel):
+    """The result of ``gda resource get``: a resource's properties as typed JSON (issue #112).
+
+    Echoes the ``path``, the resource's ``type`` (its engine class), and its
+    storage properties — the ones that serialize into the ``.tres`` — each as a
+    typed :class:`NodeProperty` (the same projection ``node get`` reports), so a
+    ``resource create`` round-trips: ``create`` then ``get`` reports the
+    resource it wrote.
+    """
+
+    path: str
+    type: str = Field(description="The resource's engine class (e.g. Gradient).")
+    properties: list[NodeProperty]
+
+
 class EngineVersion(BaseModel):
     """The Godot engine version, as reported by ``Engine.get_version_info()``.
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -54,6 +54,7 @@ const OP_ERROR_INCOMPATIBLE_SCRIPT_TYPE := "incompatible_script_type"
 const OP_ERROR_SIGNAL_NOT_FOUND := "signal_not_found"
 const OP_ERROR_ALREADY_CONNECTED := "already_connected"
 const OP_ERROR_CONNECTION_NOT_FOUND := "connection_not_found"
+const OP_ERROR_INVALID_RESOURCE_TYPE := "invalid_resource_type"
 
 const NODE_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
 
@@ -119,6 +120,10 @@ func _initialize() -> void:
 			_op_script_attach(params)
 		"script-validate":
 			_op_script_validate(params)
+		"resource-create":
+			_op_resource_create(params)
+		"resource-get":
+			_op_resource_get(params)
 		_:
 			_fail(OP_ERROR_UNKNOWN_OPERATION, "unknown operation: " + operation)
 
@@ -1261,6 +1266,113 @@ func _op_script_validate(params: Dictionary) -> void:
 		"valid": err == OK,
 		"error_string": null if err == OK else error_string(err),
 	})
+
+
+# resource-create: instantiate a Resource of the requested type and save it as a
+# .tres at the requested path — the resource group's save tracer (issue #112).
+# Establishes the .tres load/save plumbing the rest of the group reuses.
+#
+# No-clobber: an existing target is refused with already_exists, leaving it
+# untouched (mirrors scene-create / script-create). The type must be an
+# instantiable Resource subclass — an unknown type or a non-Resource class (e.g.
+# a Node) is refused with invalid_resource_type, parallel to scene-create's
+# invalid_root_type check against Node. A plain Resource holds data, so creating
+# one runs no project code (it constructs an engine class, not a script).
+func _op_resource_create(params: Dictionary) -> void:
+	_diag("running operation: resource-create")
+	var path := _string_param(params, "path")
+	if path.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
+		return
+	if not _is_resource_path(path):
+		_fail(OP_ERROR_INVALID_PATH, "resource path must end in .tres: " + path)
+		return
+	var type := _string_param(params, "type")
+	if type.is_empty() or not ClassDB.can_instantiate(type) \
+			or not ClassDB.is_parent_class(type, "Resource"):
+		_fail(OP_ERROR_INVALID_RESOURCE_TYPE, "not an instantiable Resource class: " + type)
+		return
+	if FileAccess.file_exists(path) or DirAccess.dir_exists_absolute(path):
+		_fail(OP_ERROR_ALREADY_EXISTS, "resource target already exists: " + path)
+		return
+
+	var resource: Resource = ClassDB.instantiate(type)
+	var created_dirs: Variant = _ensure_parent_dirs(path)
+	if created_dirs == null:
+		return  # _ensure_parent_dirs already recorded the failure
+	var save_err := ResourceSaver.save(resource, path)
+	if save_err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message("resource", path, save_err))
+		return
+
+	_succeed({
+		"path": path,
+		"type": type,
+		"created_dirs": created_dirs,
+	})
+
+
+# resource-get: load a .tres and emit its storage properties as typed JSON — the
+# resource group's verifier (issue #112), which makes a resource-create
+# verifiable end-to-end (create → get reports the resource). Reports the same
+# typed projection node-get uses (name / declared Godot type / JSON value), so
+# the two groups read property values through one shape.
+#
+# A .tres must exist and load as a Resource: a missing file is path_not_found, a
+# non-.tres path invalid_path (the resource group's addressing boundary), and a
+# file that does not load as a Resource is not a resource the group can report.
+func _op_resource_get(params: Dictionary) -> void:
+	_diag("running operation: resource-get")
+	var path := _string_param(params, "path")
+	if path.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
+		return
+	if not _require_existing_resource(path):
+		return  # _require_existing_resource already recorded the failure
+
+	var resource := ResourceLoader.load(path) as Resource
+	if resource == null:
+		_fail(OP_ERROR_INVALID_PATH, "file could not be loaded as a Resource: " + path)
+		return
+
+	var properties: Array = []
+	for prop in resource.get_property_list():
+		if not _is_storage_property(prop):
+			continue
+		var prop_name := String(prop.get("name", ""))
+		properties.append({
+			"name": prop_name,
+			"type": _type_name(int(prop.get("type", TYPE_NIL))),
+			"value": _jsonify(resource.get(prop_name)),
+		})
+
+	_succeed({
+		"path": path,
+		"type": resource.get_class(),
+		"properties": properties,
+	})
+
+
+# Whether a path names a resource file the resource group operates on: a .tres
+# (text resource) file. Resource-file addressing is by extension, the same way
+# scene addressing keys on .tscn and script addressing on .gd. The binary .res
+# form is out of scope for this slice — the group is a .tres tracer (issue #112).
+func _is_resource_path(path: String) -> bool:
+	return path.get_extension().to_lower() == "tres"
+
+
+# The resource group's addressing boundary for an EXISTING resource: the path
+# must be a .tres (invalid_path otherwise) and the file must exist on disk
+# (path_not_found otherwise). Returns true to proceed, or false after recording
+# the failure (the caller must stop). Mirrors _require_existing_script.
+func _require_existing_resource(path: String) -> bool:
+	if not _is_resource_path(path):
+		_fail(OP_ERROR_INVALID_PATH, "resource path must end in .tres: " + path)
+		return false
+	if not FileAccess.file_exists(path):
+		_fail(OP_ERROR_PATH_NOT_FOUND, "resource file does not exist: " + path)
+		return false
+	return true
 
 
 # Whether a path names a script file the script group operates on: a .gd

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -32,6 +32,8 @@ from gda.models import (
     NodeMoveResult,
     NodeRemoveResult,
     NodeSetResult,
+    ResourceCreateResult,
+    ResourceGetResult,
     SceneCreateResult,
     SceneDeleteResult,
     SceneGetResult,
@@ -244,6 +246,26 @@ def render_script_validate(validated: "ScriptValidateResult") -> str:
     return "\n".join(lines)
 
 
+def render_resource_create(created: "ResourceCreateResult") -> str:
+    """Render a created resource as ``created <path> (<type>)``."""
+    return f"created {created.path} ({created.type})"
+
+
+def render_resource_properties(got: "ResourceGetResult") -> str:
+    """Render a resource's properties as ``name (Type) = value`` lines for humans.
+
+    Mirrors :func:`render_node_properties`: a header naming the resource and its
+    type, then one typed line per storage property — the same human surface a
+    node's properties get, since both read the shared :class:`NodeProperty`.
+    """
+    header = f"{got.path} ({got.type})"
+    lines = [
+        f"  {prop.name} ({prop.type}) = {format_value(prop.value)}"
+        for prop in got.properties
+    ]
+    return "\n".join([header, *lines])
+
+
 def render_engine_version(version: "EngineVersion") -> str:
     """Render the engine version as its one-line version string."""
     return version.string
@@ -275,6 +297,8 @@ _RENDERERS = {
     ScriptSetResult: render_script_set,
     ScriptAttachResult: render_script_attach,
     ScriptValidateResult: render_script_validate,
+    ResourceCreateResult: render_resource_create,
+    ResourceGetResult: render_resource_properties,
     EngineVersion: render_engine_version,
 }
 

--- a/tests/test_e2e_resource.py
+++ b/tests/test_e2e_resource.py
@@ -1,0 +1,165 @@
+"""S1 (e2e): the resource create → get round-trip against the real Godot engine.
+
+The resource-group tracer (issue #112): ``gda resource create`` writes a .tres
+resource of a given type, no-clobber; ``gda resource get`` loads it and reports
+its properties as typed JSON — ``resource get`` IS the structured-level
+verification of ``resource create``'s effect (create → get reports the
+resource). Establishes the .tres load/save plumbing the rest of the group
+reuses.
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+GODOT = resolve_godot_binary()
+
+
+def _gda(*args: str) -> subprocess.CompletedProcess:
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+    return subprocess.run(
+        [gda_bin, *args, "--godot", str(GODOT)], capture_output=True, text=True
+    )
+
+
+def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
+    assert proc.returncode == 4, proc.stdout + proc.stderr
+    err = json.loads(proc.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == code
+    return err
+
+
+@pytest.mark.e2e
+def test_resource_create_then_get_round_trip(godot_project):
+    # create writes a .tres of the requested type; get loads it back and reports
+    # its type + properties. The round-trip proves the save: get reports the
+    # resource create wrote.
+    resource_path = godot_project / "palette.tres"
+
+    created = _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    data = json.loads(created.stdout)
+    assert data["path"] == str(resource_path)
+    assert data["type"] == "Gradient"
+    assert resource_path.exists()
+    # The written file is a real Godot .tres declaring the resource type.
+    assert 'type="Gradient"' in resource_path.read_text(encoding="utf-8")
+
+    got = _gda("resource", "get", str(resource_path), "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    got_data = json.loads(got.stdout)
+    # Round-trip: get reports the same type create wrote, plus typed properties.
+    assert got_data["path"] == str(resource_path)
+    assert got_data["type"] == "Gradient"
+    by_name = {p["name"]: p for p in got_data["properties"]}
+    # A Gradient declares these storage properties, each with its declared Godot
+    # type — the same typed projection node get reports.
+    assert by_name["interpolation_mode"]["type"] == "int"
+    assert by_name["resource_name"]["type"] == "String"
+
+
+@pytest.mark.e2e
+def test_resource_create_into_nested_dir_reports_created_dirs(godot_project):
+    # create makes missing parent directories before saving and reports them,
+    # outermost to innermost (mirrors scene/script create).
+    resource_path = godot_project / "art" / "palettes" / "sunset.tres"
+
+    created = _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    data = json.loads(created.stdout)
+    assert resource_path.exists()
+    assert data["created_dirs"] == [
+        str(godot_project / "art"),
+        str(godot_project / "art" / "palettes"),
+    ]
+
+
+@pytest.mark.e2e
+def test_resource_create_no_clobber_yields_already_exists(godot_project):
+    # No-clobber: a create whose target already exists is refused with
+    # already_exists, leaving the existing file untouched.
+    resource_path = godot_project / "palette.tres"
+    first = _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    assert first.returncode == 0, first.stdout + first.stderr
+    before = resource_path.read_text(encoding="utf-8")
+
+    second = _gda(
+        "resource", "create", str(resource_path), "--type", "Curve", "--json"
+    )
+
+    err = _assert_operation_error(second, "already_exists")
+    assert str(resource_path) in err["message"]
+    # The original file is untouched — the clobber never happened.
+    assert resource_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_resource_create_unknown_type_yields_invalid_resource_type(godot_project):
+    resource_path = godot_project / "palette.tres"
+
+    created = _gda(
+        "resource", "create", str(resource_path), "--type", "Bogus", "--json"
+    )
+
+    err = _assert_operation_error(created, "invalid_resource_type")
+    assert "Bogus" in err["message"]
+    # Nothing was written for the rejected type.
+    assert not resource_path.exists()
+
+
+@pytest.mark.e2e
+def test_resource_create_non_resource_type_yields_invalid_resource_type(godot_project):
+    # A real Godot class that is NOT a Resource (a Node) cannot be saved as a
+    # .tres, so it is refused with the same code as an unknown type.
+    resource_path = godot_project / "thing.tres"
+
+    created = _gda(
+        "resource", "create", str(resource_path), "--type", "Node2D", "--json"
+    )
+
+    err = _assert_operation_error(created, "invalid_resource_type")
+    assert "Node2D" in err["message"]
+    assert not resource_path.exists()
+
+
+@pytest.mark.e2e
+def test_resource_create_non_tres_path_yields_invalid_path(godot_project):
+    bad_path = godot_project / "palette.txt"
+
+    created = _gda(
+        "resource", "create", str(bad_path), "--type", "Gradient", "--json"
+    )
+
+    err = _assert_operation_error(created, "invalid_path")
+    assert ".tres" in err["message"]
+    assert not bad_path.exists()
+
+
+@pytest.mark.e2e
+def test_resource_get_missing_yields_path_not_found(godot_project):
+    missing = godot_project / "nope.tres"
+
+    got = _gda("resource", "get", str(missing), "--json")
+
+    err = _assert_operation_error(got, "path_not_found")
+    assert str(missing) in err["message"]
+
+
+@pytest.mark.e2e
+def test_resource_get_non_tres_path_yields_invalid_path(godot_project):
+    bad_path = godot_project / "palette.txt"
+    bad_path.write_text("not a resource", encoding="utf-8")
+
+    got = _gda("resource", "get", str(bad_path), "--json")
+
+    err = _assert_operation_error(got, "invalid_path")
+    assert ".tres" in err["message"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,6 +17,8 @@ from gda.models import (
     NodeMoveResult,
     NodeRemoveResult,
     NodeSetResult,
+    ResourceCreateResult,
+    ResourceGetResult,
     SceneCreateResult,
     SceneDeleteResult,
     SceneGetResult,
@@ -615,3 +617,48 @@ def test_node_disconnect_signal_result_round_trips_the_removed_connection():
     assert (disconnected.from_node, disconnected.signal) == ("Emitter", "timeout")
     assert (disconnected.to, disconnected.method) == ("Receiver", "on_timeout")
     assert json.loads(disconnected.model_dump_json(by_alias=True)) == payload
+
+
+def test_resource_create_result_round_trips_with_type_and_dirs():
+    # resource create echoes the saved path and the resource type it wrote
+    # (issue #112), plus any parent directories created before saving — so an
+    # agent verifies the effect (path + type) without a second call.
+    payload = {
+        "path": "res://palette.tres",
+        "type": "Gradient",
+        "created_dirs": ["res://art"],
+    }
+
+    created = ResourceCreateResult.model_validate(payload)
+
+    assert created.path == "res://palette.tres"
+    assert created.type == "Gradient"
+    assert created.created_dirs == ["res://art"]
+    assert json.loads(created.model_dump_json()) == payload
+
+
+def test_resource_get_result_round_trips_typed_properties():
+    # resource get reports a resource's storage properties as typed JSON (issue
+    # #112), reusing the same NodeProperty projection as node get: each property
+    # carries its name, declared Godot type, and value as arbitrary JSON, so the
+    # model carries every Godot type uniformly without a per-type field. A
+    # resource get round-trips a create (create → get reports the resource).
+    payload = {
+        "path": "res://palette.tres",
+        "type": "Gradient",
+        "properties": [
+            {"name": "resource_name", "type": "String", "value": "Sunset"},
+            {"name": "interpolation_mode", "type": "int", "value": 0},
+            {"name": "offsets", "type": "PackedFloat32Array", "value": "[0, 1]"},
+        ],
+    }
+
+    got = ResourceGetResult.model_validate(payload)
+
+    assert got.path == "res://palette.tres"
+    assert got.type == "Gradient"
+    assert got.properties[0].name == "resource_name"
+    assert got.properties[0].type == "String"
+    assert got.properties[0].value == "Sunset"
+    assert got.properties[1].value == 0
+    assert json.loads(got.model_dump_json()) == payload

--- a/tests/test_resource_commands.py
+++ b/tests/test_resource_commands.py
@@ -1,0 +1,134 @@
+"""S3: gda resource create / resource get success paths against a fake runner (issue #112).
+
+The resource command group acts on .tres resource files on disk (load/save
+plumbing), staying headless. These tests drive the same proven pipeline as the
+scene/node/script groups — Typer → binary resolution → runner → sentinel parse
+→ typed model → JSON — with canned engine output, no real Godot.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import FakeRunner, inject_runner, sentinel
+
+CREATE_RESULT = {
+    "path": "/tmp/proj/palette.tres",
+    "type": "Gradient",
+    "created_dirs": [],
+}
+
+GET_RESULT = {
+    "path": "/tmp/proj/palette.tres",
+    "type": "Gradient",
+    "properties": [
+        {"name": "resource_name", "type": "String", "value": ""},
+        {"name": "interpolation_mode", "type": "int", "value": 0},
+    ],
+}
+
+
+def test_resource_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
+    # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(CREATE_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "resource",
+            "create",
+            "/tmp/proj/palette.tres",
+            "--type",
+            "Gradient",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    # stdout carries ONLY the result payload — a single valid JSON object.
+    data = json.loads(result.stdout)
+    assert data["path"] == "/tmp/proj/palette.tres"
+    # The created resource's type, echoed so an agent verifies the effect
+    # (path + type) without a second call.
+    assert data["type"] == "Gradient"
+    # The operation was dispatched by name with the command's typed params.
+    assert fake.calls == [
+        ("resource-create", {"path": "/tmp/proj/palette.tres", "type": "Gradient"})
+    ]
+    assert "engine diagnostic" in result.stderr
+
+
+def test_resource_create_human_output_reports_path_and_type(monkeypatch):
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app, ["resource", "create", "/tmp/proj/palette.tres", "--type", "Gradient"]
+    )
+
+    assert result.exit_code == 0
+    # The human path names what was created and where (mirrors scene create).
+    assert "created /tmp/proj/palette.tres" in result.stdout
+    assert "Gradient" in result.stdout
+
+
+def test_resource_get_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app, ["resource", "get", "/tmp/proj/palette.tres", "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["path"] == "/tmp/proj/palette.tres"
+    assert data["type"] == "Gradient"
+    # The typed property projection (same shape as node get): name/type/value.
+    by_name = {p["name"]: p for p in data["properties"]}
+    assert by_name["interpolation_mode"]["type"] == "int"
+    assert by_name["interpolation_mode"]["value"] == 0
+    assert fake.calls == [("resource-get", {"path": "/tmp/proj/palette.tres"})]
+
+
+def test_resource_get_human_output_lists_typed_properties(monkeypatch):
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["resource", "get", "/tmp/proj/palette.tres"])
+
+    assert result.exit_code == 0
+    # The header names the resource and its type; each property is a typed line.
+    assert "/tmp/proj/palette.tres (Gradient)" in result.stdout
+    assert "interpolation_mode (int) = 0" in result.stdout
+
+
+def test_resource_create_expands_user_home_in_filesystem_path(monkeypatch):
+    # A filesystem path gets ~ expanded at the CLI layer (issue #32); res://
+    # virtual paths pass through untouched. Exercise the expansion seam.
+    fake = FakeRunner(RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0))
+    monkeypatch.setattr("gda.cli._make_runner", lambda binary, project=None: fake)
+
+    result = CliRunner().invoke(
+        app, ["resource", "create", "~/palette.tres", "--type", "Gradient", "--json"]
+    )
+
+    assert result.exit_code == 0
+    sent_path = fake.calls[0][1]["path"]
+    assert "~" not in sent_path
+    assert sent_path.endswith("/palette.tres")
+
+
+def test_resource_get_res_path_passes_through_untouched(monkeypatch):
+    fake = FakeRunner(RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0))
+    monkeypatch.setattr("gda.cli._make_runner", lambda binary, project=None: fake)
+
+    result = CliRunner().invoke(
+        app, ["resource", "get", "res://palette.tres", "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [("resource-get", {"path": "res://palette.tres"})]

--- a/tests/test_resource_errors.py
+++ b/tests/test_resource_errors.py
@@ -1,0 +1,107 @@
+"""S3: gda resource failure modes map to structured JSON errors + stable exit codes.
+
+Issue #112's acceptance: resource-command failures surface as structured
+``GdaError``s with registered operation codes (ADR-0002) — exit 4 for the
+operation category, finer stable codes so an agent can branch on the mode
+without parsing prose:
+
+- path collision on create → ``already_exists`` (reused, like scene/script create)
+- resource not found on get → ``path_not_found`` (reused)
+- non-.tres target path → ``invalid_path`` (reused)
+- invalid/unknown resource type on create → ``invalid_resource_type`` (NEW, #112)
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import error_sentinel, inject_runner
+
+
+def _invoke_resource_create(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: resource-create\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(
+        app, ["resource", "create", "/x/palette.tres", "--type", "Gradient", "--json"]
+    )
+
+
+def _invoke_resource_get(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: resource-get\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(app, ["resource", "get", "/x/palette.tres", "--json"])
+
+
+def test_resource_create_collision_reuses_stable_already_exists_code(monkeypatch):
+    # No-clobber: a create whose target already exists reuses the registered
+    # already_exists code (the same one scene/script create use), leaving the
+    # file untouched — the resource group mints no parallel collision code.
+    result = _invoke_resource_create(
+        monkeypatch, "already_exists", "resource target already exists: /x/palette.tres"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "already_exists"
+    assert "/x/palette.tres" in err["message"]
+    # The raw stderr still rides along as diagnostics (ADR-0002).
+    assert err["diagnostics"] == "gda: running operation: resource-create\n"
+
+
+def test_resource_create_invalid_type_yields_invalid_resource_type(monkeypatch):
+    # An unknown or non-Resource type cannot be saved as a .tres, so create
+    # refuses it with the resource group's own invalid_resource_type code —
+    # parallel to scene create's invalid_root_type and node add's
+    # invalid_node_type, but for the Resource hierarchy.
+    result = _invoke_resource_create(
+        monkeypatch,
+        "invalid_resource_type",
+        "not an instantiable Resource class: Bogus",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_resource_type"
+    assert "Bogus" in err["message"]
+
+
+def test_resource_create_non_tres_path_yields_invalid_path(monkeypatch):
+    result = _invoke_resource_create(
+        monkeypatch, "invalid_path", "resource path must end in .tres: /x/palette.txt"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "invalid_path"
+
+
+def test_resource_get_missing_yields_path_not_found(monkeypatch):
+    # A get on a path with no resource file reuses the registered path_not_found
+    # code (the same one scene/script get use for a missing file).
+    result = _invoke_resource_get(
+        monkeypatch, "path_not_found", "resource file does not exist: /x/palette.tres"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert "/x/palette.tres" in err["message"]

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -674,6 +674,73 @@ def test_script_schema_spawns_no_godot(monkeypatch):
         assert set(json.loads(result.stdout)) >= {"input", "output", "error"}
 
 
+def test_resource_create_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for the resource group (issue #112): the bare
+    # --schema flag — no path, no --type — short-circuits into the
+    # self-description, derived from the same typed models that back --json.
+    from gda.models import ResourceCreateParams, ResourceCreateResult
+
+    result = CliRunner().invoke(app, ["resource", "create", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ResourceCreateParams.model_json_schema()
+    assert doc["output"] == ResourceCreateResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "type" in doc["input"]["properties"]
+    assert "type" in doc["output"]["properties"]
+    assert "created_dirs" in doc["output"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_resource_get_schema_emits_model_derived_contract_without_other_args():
+    from gda.models import ResourceGetParams, ResourceGetResult
+
+    result = CliRunner().invoke(app, ["resource", "get", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ResourceGetParams.model_json_schema()
+    assert doc["output"] == ResourceGetResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "properties" in doc["output"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_sample_resource_results_validate_against_emitted_output_schemas():
+    # A sample --json payload of each resource command satisfies the contract
+    # its --schema emits (the other half of the ADR-0004 hard gate, issue #112).
+    from tests.test_resource_commands import CREATE_RESULT, GET_RESULT
+
+    create_doc = json.loads(
+        CliRunner().invoke(app, ["resource", "create", "--schema"]).stdout
+    )
+    get_doc = json.loads(
+        CliRunner().invoke(app, ["resource", "get", "--schema"]).stdout
+    )
+
+    jsonschema.validate(instance=CREATE_RESULT, schema=create_doc["output"])
+    jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
+
+
+def test_resource_schema_spawns_no_godot(monkeypatch):
+    def boom(*args, **kwargs):
+        raise AssertionError("--schema must not touch the engine")
+
+    monkeypatch.setattr("gda.headless.resolve_godot_binary", boom)
+    monkeypatch.setattr("gda.cli._make_runner", boom)
+
+    for command in (
+        ["resource", "create"],
+        ["resource", "get"],
+    ):
+        result = CliRunner().invoke(app, [*command, "--schema"])
+        assert result.exit_code == 0
+        assert set(json.loads(result.stdout)) >= {"input", "output", "error"}
+
+
 def test_info_input_schema_is_derived_from_the_params_model():
     # info takes no operation params, so its input schema is trivially empty —
     # expected, not an error — and still derived model-side (ADR-0004).


### PR DESCRIPTION
## What

Establishes the `resource` command group — a `.tres` resource-file tracer that mirrors the scene/node/script tracers and lays down the load/save plumbing the rest of the group reuses (resource `uid`/`delete`/`set` build on it).

- **`gda resource create`** — instantiates a `Resource` of a given `--type`, saves it as a `.tres` (no-clobber), and returns the created `path` + `type` as typed JSON, plus `created_dirs`. The type must be an instantiable `Resource` subclass — parallel to `scene create`'s `root_type` check against `Node`.
- **`gda resource get`** — loads a `.tres` and reports its storage properties as typed JSON, reusing the **same `NodeProperty` projection as `node get`** (name / declared Godot type / JSON value), so a `create` round-trips: create → get reports the resource.
- Both ship `--json` and the ADR-0004 `--schema` hard gate via the shared `HeadlessCommand` skeleton + renderers.

## Error codes

Failure modes surface as registered `GdaError`s with stable codes (ADR-0002):

| Mode | Code | Status |
| --- | --- | --- |
| path collision on create | `already_exists` | reused |
| resource not found on get | `path_not_found` | reused |
| non-`.tres` target path | `invalid_path` | reused |
| invalid/unknown resource type on create | **`invalid_resource_type`** | **NEW** |

`invalid_resource_type` is registered across the Python registry (`error_codes.py`), the ADR-0002 table, and the GDScript mirror (`operations.gd`) — the drift tests in `test_error_registry.py` enforce all three stay in sync.

## Tests

Three layers per the acceptance criteria:

- **S2** model/parser unit (`test_models.py`): `ResourceCreateResult` / `ResourceGetResult` round-trips, typed-property projection.
- **S3** CLI-with-FakeRunner (`test_resource_commands.py`, `test_resource_errors.py`, `test_schema_command.py`): success paths, human + JSON output, path normalization, the four failure modes, and the `--schema` hard gate (model-derived contract + no-Godot locality).
- **S1** e2e (`test_e2e_resource.py`, `@pytest.mark.e2e`, auto-skips when the engine is absent): the create → get round-trip, no-clobber, nested-dir `created_dirs`, invalid type, non-`Resource` type (Node2D), non-`.tres` path, not-found — against a real Godot 4.6.3 engine.

**Full suite: 447 passed, 0 failed** (290 non-e2e + 157 e2e against the real engine). Re-verified after rebasing onto current `main` (which picked up the node-group cleanup #154 touching the same files): non-e2e + resource e2e green, `operations.gd` compiles, registry drift tests pass.

## Concurrency note

Scaffolding (the `resource` Typer group + dispatcher `match` arms) is kept minimal and localized so a concurrent `resource uid` (#113) addition to the same group rebases cleanly — the only shared edits are the group registration block and the dispatcher, both small.

Closes #112
