### PR TITLE
feat(scene): get-exports — list a scene's nodes' @export properties (#58)

### DIFF
--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -57,6 +57,23 @@ they are provenance, not status markers.
 | `gda scene list` | Enumerate scenes in the project |
 | `gda scene get-exports` | List `@export` properties declared by a scene's nodes |
 
+**Export reporting** (established by #58): `gda scene get-exports` loads a scene, instantiates
+it, and reports — per node, keyed by the same canonical node path `node get`/`node set`
+address by (`.` for the root) — the `@export` properties the node's attached script declares:
+each a `{name, type, hint, hint_string, value}` entry, where `type` is the export's declared
+Godot type name, `hint`/`hint_string` are the Godot `PropertyHint` enum value and its companion
+string the `@export` annotation produced, and `value` is the export's current value in the same
+JSON projection `node get` uses (its default on a freshly-loaded node) — the property-value
+introspection is reused from `node get` (#55), not re-implemented. An export is detected by its
+usage flags (`PROPERTY_USAGE_SCRIPT_VARIABLE` + `PROPERTY_USAGE_EDITOR`) on the script's own
+property list, so a node's inherited engine properties and a script's plain (non-`@export`)
+variables are excluded. A node with no script, or whose script declares no exports, is omitted;
+a scene with no exported variables anywhere is a valid, empty listing (`nodes == []`). Like
+`scene get`, get-exports reuses the shared load-failure ladder — a missing file is
+`path_not_found`, a non-scene file `not_a_scene` (both exit 4). It reads but does not save, so
+it skips the re-save mutation-integrity guard; instantiating still runs attached scripts'
+`_init` (the trust boundary of ADR-0009).
+
 ### `node`
 
 Operates on nodes **within a scene file** (load → mutate → pack → save), so headless.

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -53,6 +53,8 @@ from gda.models import (
     SceneCreateResult,
     SceneDeleteParams,
     SceneDeleteResult,
+    SceneGetExportsParams,
+    SceneGetExportsResult,
     SceneGetParams,
     SceneGetResult,
     SceneListParams,
@@ -238,6 +240,12 @@ SCENE_GET_COMMAND: HeadlessCommand[SceneGetResult] = HeadlessCommand(
     operation="scene-get",
     input_model=SceneGetParams,
     output_model=SceneGetResult,
+)
+
+SCENE_GET_EXPORTS_COMMAND: HeadlessCommand[SceneGetExportsResult] = HeadlessCommand(
+    operation="scene-get-exports",
+    input_model=SceneGetExportsParams,
+    output_model=SceneGetExportsResult,
 )
 
 SCENE_LIST_COMMAND: HeadlessCommand[SceneListResult] = HeadlessCommand(
@@ -435,6 +443,25 @@ def get(
     _dispatch(
         SCENE_GET_COMMAND,
         SceneGetParams(path=_normalize_path(path)),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@scene_app.command(name="get-exports", cls=SCENE_GET_EXPORTS_COMMAND.command_class())
+def get_exports(
+    path: str = typer.Argument(..., help="The .tscn scene file to read."),
+    json_output: bool = json_option(),
+    schema: bool = SCENE_GET_EXPORTS_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """List the @export properties a scene's nodes' scripts declare, per node path."""
+    _dispatch(
+        SCENE_GET_EXPORTS_COMMAND,
+        SceneGetExportsParams(path=_normalize_path(path)),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -193,6 +193,92 @@ class SceneGetResult(BaseModel):
     root: SceneNode
 
 
+class SceneExport(BaseModel):
+    """One ``@export`` property a node's attached script declares (issue #58).
+
+    ``type`` is the property's declared Godot type name (``float``, ``String``,
+    ``Vector2``, …), the same spelling :class:`NodeProperty` uses. ``hint`` is the
+    Godot ``PropertyHint`` enum value the ``@export`` annotation produced (e.g. a
+    ``@export_range`` yields ``PROPERTY_HINT_RANGE``); ``hint_string`` is its
+    companion string (the range bounds, the enum members, the file filter, …) —
+    together they capture HOW the export is meant to be edited. ``value`` is the
+    property's current value in the same JSON projection ``node get`` reports — a
+    scalar for a scalar type, a list for a packed type (Vector2 → ``[x, y]``) —
+    which on a freshly-instantiated node is the export's default.
+    """
+
+    name: str
+    type: str = Field(
+        description="The export's declared Godot type name (e.g. float, String, Vector2)."
+    )
+    hint: int = Field(
+        description=(
+            "The Godot PropertyHint enum value the @export annotation produced "
+            "(0 = PROPERTY_HINT_NONE)."
+        )
+    )
+    hint_string: str = Field(
+        description="The PropertyHint's companion string (range bounds, enum members, …); empty when none."
+    )
+    value: Any = Field(
+        description=(
+            "The export's current value as JSON (its default on a freshly-loaded "
+            "node): a scalar for a scalar type, a list for a packed type "
+            "(Vector2 → [x, y], Color → [r, g, b, a])."
+        )
+    )
+
+
+class ExportingNode(BaseModel):
+    """One node of ``gda scene get-exports``: the exports its script declares (issue #58).
+
+    A node appears only when its attached script declares at least one ``@export``
+    property. ``path`` is the node's node path relative to the scene root ('.' for
+    the root), the same addressing ``node get`` uses, so an agent can read or set
+    any export with ``node get``/``node set``. ``script`` is the attached script's
+    ``res://`` path, naming where the exports came from. ``exports`` lists them in
+    declaration order.
+    """
+
+    path: str = Field(
+        description=(
+            "The node's node path relative to the scene root: '.' for the root "
+            "itself, 'Player/Arm' for a nested node."
+        )
+    )
+    name: str
+    type: str = Field(description="The node's engine class (e.g. Node2D).")
+    script: str | None = Field(
+        default=None,
+        description=(
+            "The res:// path of the script that declares these exports, or null "
+            "when the attached script has no resource path (an embedded script)."
+        ),
+    )
+    exports: list[SceneExport]
+
+
+class SceneGetExportsParams(BaseModel):
+    """The operation params of ``gda scene get-exports``: the ``.tscn`` file to read (issue #58)."""
+
+    path: str
+
+
+class SceneGetExportsResult(BaseModel):
+    """The result of ``gda scene get-exports``: each node's declared ``@export``s (issue #58).
+
+    Echoes the scene ``path`` and, per node that declares them, the ``@export``
+    properties its attached script exposes — name, type, hint/hint_string, and
+    current value — as typed JSON. Reuses ``node get``'s property-value
+    projection, so an export's ``value`` reads exactly as ``node get`` would
+    report it. Nodes without an export-declaring script are omitted; a scene with
+    no exported variables anywhere is a valid, empty listing (``nodes == []``).
+    """
+
+    path: str
+    nodes: list[ExportingNode]
+
+
 class SceneListParams(BaseModel):
     """The operation params of ``gda scene list`` — none (ADR-0004).
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -84,6 +84,8 @@ func _initialize() -> void:
 			_op_scene_create(params)
 		"scene-get":
 			_op_scene_get(params)
+		"scene-get-exports":
+			_op_scene_get_exports(params)
 		"scene-list":
 			_op_scene_list(params)
 		"scene-delete":
@@ -219,6 +221,120 @@ func _op_scene_get(params: Dictionary) -> void:
 		"path": _string_param(params, "path"),
 		"root": _tree_from_state(packed.get_state()),
 	})
+
+
+# scene-get-exports: load a .tscn, instantiate it, and emit — per node (by node
+# path) — the @export properties the node's attached script declares (issue #58).
+#
+# Unlike scene-get (which reads SceneState without instantiating, issue #30),
+# reporting an export's TYPE/HINT and current/default VALUE requires the real
+# script and the real node: a script's @export surface is read from
+# Script.get_script_property_list(), and the value off the live node — exactly
+# the introspection node-get reuses (_type_name, _jsonify). Instantiating runs
+# the _init of any attached script (the same trust boundary as node-get,
+# ADR-0009), but get-exports does not re-save, so it skips the unmaterialized-
+# node guard (that boundary protects a re-save from silently dropping data,
+# issue #64 — there is no save here). It reuses _load_scene's failure ladder, so
+# a missing file is path_not_found and a non-scene file not_a_scene.
+#
+# An @export property is a SCRIPT VARIABLE the script exposes to the editor: in
+# the property's usage flags both PROPERTY_USAGE_SCRIPT_VARIABLE (declared in
+# the script, not inherited from the engine class) and PROPERTY_USAGE_EDITOR
+# (exported) are set. Reading the script's own get_script_property_list() — not
+# the node's whole get_property_list() — keeps the listing to the script's
+# declared surface, so an inherited engine property never leaks in.
+func _op_scene_get_exports(params: Dictionary) -> void:
+	_diag("running operation: scene-get-exports")
+	var packed: PackedScene = _load_scene(params)
+	if packed == null:
+		return  # _load_scene already recorded the failure
+	var root: Node = packed.instantiate()
+	if root == null:
+		_fail(OP_ERROR_MISSING_DEPENDENCY, "scene failed to instantiate: "
+				+ _string_param(params, "path")
+				+ " — an instanced sub-scene is unresolvable or empty; check the scene's dependencies and --project")
+		return
+
+	var nodes: Array = []
+	_collect_node_exports(root, root, nodes)
+	# Capture the path before freeing the tree (reading off a freed node errors).
+	var scene_path := _string_param(params, "path")
+	root.free()
+
+	_succeed({
+		"path": scene_path,
+		"nodes": nodes,
+	})
+
+
+# Walk the instantiated subtree rooted at `node`, appending one entry per node
+# whose attached script declares at least one @export property (issue #58). A
+# node with no script, or a script declaring no exports, is omitted — the
+# listing names only nodes that actually export. The node path is the canonical
+# root-relative form node get / node set address by ('.' for the root), so an
+# agent can read or set any reported export afterwards.
+func _collect_node_exports(node: Node, root: Node, out: Array) -> void:
+	var exports := _script_exports_of(node)
+	if not exports.is_empty():
+		var node_path := "." if node == root else String(root.get_path_to(node))
+		out.append({
+			"path": node_path,
+			"name": String(node.name),
+			"type": node.get_class(),
+			"script": _script_resource_path_of(node),
+			"exports": exports,
+		})
+	for child in node.get_children():
+		_collect_node_exports(child, root, out)
+
+
+# The @export properties a node's attached script declares, in declaration
+# order (issue #58). Empty for a scriptless node or a script that exports
+# nothing. Each export reuses node get's introspection: _type_name for the
+# declared Godot type, _jsonify for the value projection (its default on a
+# freshly-instantiated node). hint is the PropertyHint enum value the @export
+# annotation produced, hint_string its companion string.
+func _script_exports_of(node: Node) -> Array:
+	var script := node.get_script() as Script
+	if script == null:
+		return []
+	var exports: Array = []
+	for prop in script.get_script_property_list():
+		if not _is_export_property(prop):
+			continue
+		var prop_name := String(prop.get("name", ""))
+		exports.append({
+			"name": prop_name,
+			"type": _type_name(int(prop.get("type", TYPE_NIL))),
+			"hint": int(prop.get("hint", 0)),
+			"hint_string": String(prop.get("hint_string", "")),
+			"value": _jsonify(node.get(prop_name)),
+		})
+	return exports
+
+
+# Whether a script property-list entry is an @export: a script-declared variable
+# (PROPERTY_USAGE_SCRIPT_VARIABLE) exposed to the editor (PROPERTY_USAGE_EDITOR).
+# Both flags together are exactly what the @export annotation sets — the engine's
+# category/group separators and non-exported script vars (a plain `var`, which
+# carries SCRIPT_VARIABLE but not EDITOR) are excluded.
+func _is_export_property(prop: Dictionary) -> bool:
+	var usage := int(prop.get("usage", 0))
+	return (usage & PROPERTY_USAGE_SCRIPT_VARIABLE) != 0 \
+			and (usage & PROPERTY_USAGE_EDITOR) != 0
+
+
+# The res:// path of the script attached to `node`, naming where its exports
+# came from, or null for a scriptless node or a script with no resource path
+# (an embedded/built-in script). Mirrors _displaced_script_path's null handling.
+func _script_resource_path_of(node: Node) -> Variant:
+	var script := node.get_script() as Script
+	if script == null:
+		return null
+	var resource_path := script.resource_path
+	if resource_path.is_empty():
+		return null
+	return resource_path
 
 
 # scene-list: enumerate the project's .tscn scenes (issue #54). Walks the

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -36,6 +36,7 @@ from gda.models import (
     ResourceGetResult,
     SceneCreateResult,
     SceneDeleteResult,
+    SceneGetExportsResult,
     SceneGetResult,
     SceneListResult,
     SceneNode,
@@ -114,6 +115,26 @@ def render_scene_metadata(scene: "SceneCreateResult") -> str:
 def render_scene_tree(scene: "SceneGetResult") -> str:
     """Render a read scene's node tree."""
     return render_node_tree(scene.root)
+
+
+def render_scene_exports(scene: "SceneGetExportsResult") -> str:
+    """Render a scene's per-node @export properties for humans.
+
+    One ``path (Type)`` header per node that declares exports, then a
+    ``name (Type) = value`` line per export — reusing :func:`format_value` for
+    the value, the same projection ``node get`` renders. An empty listing (no
+    exported variables anywhere) reads as ``(no exports)``.
+    """
+    if not scene.nodes:
+        return "(no exports)"
+    lines = []
+    for node in scene.nodes:
+        lines.append(f"{node.path} ({node.type})")
+        for export in node.exports:
+            lines.append(
+                f"  {export.name} ({export.type}) = {format_value(export.value)}"
+            )
+    return "\n".join(lines)
 
 
 def render_scene_list(listed: "SceneListResult") -> str:
@@ -292,6 +313,7 @@ def render_engine_version(version: "EngineVersion") -> str:
 _RENDERERS = {
     SceneCreateResult: render_scene_metadata,
     SceneGetResult: render_scene_tree,
+    SceneGetExportsResult: render_scene_exports,
     SceneListResult: render_scene_list,
     SceneDeleteResult: render_scene_delete,
     NodeAddResult: render_node_add,

--- a/tests/test_e2e_scene_exports.py
+++ b/tests/test_e2e_scene_exports.py
@@ -1,0 +1,202 @@
+"""S1 (e2e): gda scene get-exports against the real Godot engine (issue #58).
+
+``gda scene get-exports`` loads a scene, instantiates it, and reports — per node
+(by node path) — the ``@export`` properties its attached script declares: name,
+declared Godot type, hint/hint_string, and current (default) value as typed
+JSON. It reuses ``node get``'s property-value introspection, so an export's
+value reads exactly as ``node get`` would report it.
+
+The scene is built end-to-end with the real CLI: ``scene create`` →
+``script create`` (a ``.gd`` with ``@export`` vars) → ``script attach`` →
+``scene get-exports``. Auto-skipped when no engine resolves (conftest gate).
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+GODOT = resolve_godot_binary()
+
+
+def _gda(*args: str) -> subprocess.CompletedProcess:
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+    return subprocess.run(
+        [gda_bin, *args, "--godot", str(GODOT)], capture_output=True, text=True
+    )
+
+
+def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
+    assert proc.returncode == 4, proc.stdout + proc.stderr
+    err = json.loads(proc.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == code
+    return err
+
+
+# A script declaring a representative @export surface: a typed scalar with a
+# default, a string, a packed Vector2, and a hinted range — plus one PLAIN
+# (non-exported) var that must NOT appear in the exports listing.
+EXPORTING_SCRIPT = """\
+extends Node2D
+
+@export var speed: float = 3.5
+@export var title: String = "Hello"
+@export var start: Vector2 = Vector2(1, 2)
+@export_range(0, 100) var max_hp: int = 100
+
+var not_exported: int = 7
+"""
+
+
+def _build_scene_with_exports(project) -> "tuple":
+    """scene create → script create (exports) → script attach to the root."""
+    scene_path = project / "main.tscn"
+    created = _gda(
+        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
+    )
+    assert created.returncode == 0, created.stdout + created.stderr
+
+    script_path = project / "actor.gd"
+    script_path.write_text(EXPORTING_SCRIPT, encoding="utf-8")
+
+    attached = _gda(
+        "script", "attach", str(scene_path),
+        "--node", ".", "--script", str(script_path),
+        "--project", str(project), "--json",
+    )
+    assert attached.returncode == 0, attached.stdout + attached.stderr
+    return scene_path, script_path
+
+
+@pytest.mark.e2e
+def test_scene_get_exports_reports_declared_exports_per_node(godot_project):
+    # The core of issue #58: get-exports loads the scene and reports the @export
+    # properties the root node's attached script declares — each with its name,
+    # declared Godot type, hint/hint_string, and value (its default here), as
+    # typed JSON. A plain (non-@export) var is NOT reported.
+    scene_path, _ = _build_scene_with_exports(godot_project)
+
+    got = _gda(
+        "scene", "get-exports", str(scene_path),
+        "--project", str(godot_project), "--json",
+    )
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    data = json.loads(got.stdout)
+    assert data["path"] == str(scene_path)
+    # The root node, addressed as '.', carries the exports its script declares.
+    nodes = {n["path"]: n for n in data["nodes"]}
+    assert "." in nodes
+    root = nodes["."]
+    assert root["type"] == "Node2D"
+    exports = {e["name"]: e for e in root["exports"]}
+
+    # Each declared @export appears with its declared Godot type and default
+    # value in the same JSON projection node get uses.
+    assert exports["speed"]["type"] == "float"
+    assert exports["speed"]["value"] == 3.5
+    assert exports["title"]["type"] == "String"
+    assert exports["title"]["value"] == "Hello"
+    assert exports["start"]["type"] == "Vector2"
+    assert exports["start"]["value"] == [1.0, 2.0]
+    # The hinted range carries its PropertyHint and companion hint_string.
+    assert exports["max_hp"]["type"] == "int"
+    assert exports["max_hp"]["value"] == 100
+    assert exports["max_hp"]["hint"] != 0
+    assert "100" in exports["max_hp"]["hint_string"]
+
+    # A plain (non-exported) var is excluded — get-exports reports the @export
+    # surface, not the script's whole property list.
+    assert "not_exported" not in exports
+
+
+@pytest.mark.e2e
+def test_scene_get_exports_omits_nodes_without_declared_exports(godot_project):
+    # A node whose script declares no @export, or that carries no script, does
+    # not appear: get-exports lists only nodes that actually declare exports. A
+    # bare scene (no scripts anywhere) is a valid, empty listing.
+    scene_path = godot_project / "bare.tscn"
+    created = _gda(
+        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
+    )
+    assert created.returncode == 0, created.stdout + created.stderr
+
+    got = _gda(
+        "scene", "get-exports", str(scene_path),
+        "--project", str(godot_project), "--json",
+    )
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["nodes"] == []
+
+
+@pytest.mark.e2e
+def test_scene_get_exports_reports_nested_node_by_path(godot_project):
+    # Exports are reported per node by node path: a script attached to a NESTED
+    # node is reported under that node's canonical path ('Child'), the same
+    # addressing node get / node set use, so an agent can read/set the export
+    # afterwards. The root here carries no script, so only the child is listed —
+    # which also pins that a scriptless node is omitted.
+    scene_path = godot_project / "main.tscn"
+    created = _gda(
+        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
+    )
+    assert created.returncode == 0, created.stdout + created.stderr
+    script_path = godot_project / "actor.gd"
+    script_path.write_text(EXPORTING_SCRIPT, encoding="utf-8")
+
+    added = _gda(
+        "node", "add", str(scene_path),
+        "--type", "Node2D", "--name", "Child", "--json",
+    )
+    assert added.returncode == 0, added.stdout + added.stderr
+    attached = _gda(
+        "script", "attach", str(scene_path),
+        "--node", "Child", "--script", str(script_path),
+        "--project", str(godot_project), "--json",
+    )
+    assert attached.returncode == 0, attached.stdout + attached.stderr
+
+    got = _gda(
+        "scene", "get-exports", str(scene_path),
+        "--project", str(godot_project), "--json",
+    )
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    nodes = {n["path"]: n for n in json.loads(got.stdout)["nodes"]}
+    # The nested node is addressed by its canonical node path.
+    assert "Child" in nodes
+    assert {e["name"] for e in nodes["Child"]["exports"]} >= {"speed", "max_hp"}
+    # The scriptless root is omitted: only export-declaring nodes are listed.
+    assert "." not in nodes
+
+
+@pytest.mark.e2e
+def test_scene_get_exports_missing_file_yields_path_not_found(godot_project):
+    got = _gda(
+        "scene", "get-exports", str(godot_project / "nope.tscn"),
+        "--project", str(godot_project), "--json",
+    )
+
+    err = _assert_operation_error(got, "path_not_found")
+    assert "nope.tscn" in err["message"]
+
+
+@pytest.mark.e2e
+def test_scene_get_exports_non_scene_file_yields_not_a_scene(godot_project):
+    # A file that exists but does not load as a PackedScene is refused with the
+    # shared not_a_scene code, exactly like scene get / delete.
+    notes = godot_project / "notes.txt"
+    notes.write_text("not a scene\n", encoding="utf-8")
+
+    got = _gda(
+        "scene", "get-exports", str(notes),
+        "--project", str(godot_project), "--json",
+    )
+
+    _assert_operation_error(got, "not_a_scene")

--- a/tests/test_human_output.py
+++ b/tests/test_human_output.py
@@ -101,6 +101,49 @@ HUMAN_CASES = [
         {"path": "/tmp/proj/old.tscn", "root_name": "old", "root_type": "Node2D"},
         "deleted /tmp/proj/old.tscn (root old: Node2D)",
     ),
+    (
+        # scene get-exports: a `path (Type)` header per node, then each export as
+        # `name (Type) = value` — the value via format_value (float scalar, and
+        # a Vector2 -> [x, y]).
+        "scene-get-exports",
+        ["scene", "get-exports", "/tmp/proj/main.tscn"],
+        {
+            "path": "/tmp/proj/main.tscn",
+            "nodes": [
+                {
+                    "path": ".",
+                    "name": "main",
+                    "type": "Node2D",
+                    "script": "res://main.gd",
+                    "exports": [
+                        {
+                            "name": "speed",
+                            "type": "float",
+                            "hint": 0,
+                            "hint_string": "",
+                            "value": 3.5,
+                        },
+                        {
+                            "name": "start",
+                            "type": "Vector2",
+                            "hint": 0,
+                            "hint_string": "",
+                            "value": [1.0, 2.0],
+                        },
+                    ],
+                }
+            ],
+        },
+        ". (Node2D)\n"
+        "  speed (float) = 3.5\n"
+        "  start (Vector2) = [1.0, 2.0]",
+    ),
+    (
+        "scene-get-exports-empty",
+        ["scene", "get-exports", "/tmp/proj/bare.tscn"],
+        {"path": "/tmp/proj/bare.tscn", "nodes": []},
+        "(no exports)",
+    ),
     # --- node group ---------------------------------------------------------
     (
         "node-add",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,6 +21,7 @@ from gda.models import (
     ResourceGetResult,
     SceneCreateResult,
     SceneDeleteResult,
+    SceneGetExportsResult,
     SceneGetResult,
     SceneListResult,
     ScriptCreateResult,
@@ -661,4 +662,50 @@ def test_resource_get_result_round_trips_typed_properties():
     assert got.properties[0].type == "String"
     assert got.properties[0].value == "Sunset"
     assert got.properties[1].value == 0
+    assert json.loads(got.model_dump_json()) == payload
+
+
+def test_scene_get_exports_result_round_trips_per_node_exports():
+    # scene get-exports reports, per node (by node path), the @export properties
+    # the node's attached script declares (issue #58): each export carries its
+    # name, declared Godot type, hint/hint_string, and current value in the same
+    # JSON projection node get uses. A node carries the script that declares the
+    # exports, so an agent knows where they came from.
+    payload = {
+        "path": "/p/main.tscn",
+        "nodes": [
+            {
+                "path": ".",
+                "name": "main",
+                "type": "Node2D",
+                "script": "res://main.gd",
+                "exports": [
+                    {
+                        "name": "speed",
+                        "type": "float",
+                        "hint": 0,
+                        "hint_string": "",
+                        "value": 3.5,
+                    },
+                    {
+                        "name": "title",
+                        "type": "String",
+                        "hint": 0,
+                        "hint_string": "",
+                        "value": "Hello",
+                    },
+                ],
+            }
+        ],
+    }
+
+    got = SceneGetExportsResult.model_validate(payload)
+
+    assert got.path == "/p/main.tscn"
+    node = got.nodes[0]
+    assert (node.path, node.name, node.type) == (".", "main", "Node2D")
+    assert node.script == "res://main.gd"
+    assert node.exports[0].name == "speed"
+    assert node.exports[0].type == "float"
+    assert node.exports[0].value == 3.5
     assert json.loads(got.model_dump_json()) == payload

--- a/tests/test_scene_commands.py
+++ b/tests/test_scene_commands.py
@@ -158,6 +158,113 @@ def test_scene_get_expands_user_home_in_filesystem_path_but_not_res(monkeypatch)
     assert fake.calls[0][1]["path"] == "res://main.tscn"
 
 
+GET_EXPORTS_RESULT = {
+    "path": "/tmp/proj/main.tscn",
+    "nodes": [
+        {
+            "path": ".",
+            "name": "main",
+            "type": "Node2D",
+            "script": "res://main.gd",
+            "exports": [
+                {
+                    "name": "speed",
+                    "type": "float",
+                    "hint": 0,
+                    "hint_string": "",
+                    "value": 3.5,
+                },
+                {
+                    "name": "title",
+                    "type": "String",
+                    "hint": 0,
+                    "hint_string": "",
+                    "value": "Hello",
+                },
+            ],
+        },
+        {
+            "path": "Hero",
+            "name": "Hero",
+            "type": "Sprite2D",
+            "script": "res://hero.gd",
+            "exports": [
+                {
+                    "name": "max_hp",
+                    "type": "int",
+                    "hint": 1,
+                    "hint_string": "0,100",
+                    "value": 100,
+                }
+            ],
+        },
+    ],
+}
+
+
+def test_scene_get_exports_json_emits_per_node_exports_and_exit_zero(monkeypatch):
+    # scene get-exports loads a scene and reports, per node (by node path), the
+    # @export properties its attached script declares (issue #58): each export's
+    # name, declared type, hint/hint_string, and value as typed JSON.
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_EXPORTS_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["scene", "get-exports", "/tmp/proj/main.tscn", "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["path"] == "/tmp/proj/main.tscn"
+    # The root node, addressed as '.', carries the exports its script declares.
+    root = data["nodes"][0]
+    assert (root["path"], root["name"], root["type"]) == (".", "main", "Node2D")
+    assert root["script"] == "res://main.gd"
+    speed = root["exports"][0]
+    assert (speed["name"], speed["type"], speed["value"]) == ("speed", "float", 3.5)
+    # A descendant node carries its own exports with hint/hint_string.
+    hero = data["nodes"][1]
+    assert hero["path"] == "Hero"
+    assert hero["exports"][0]["hint_string"] == "0,100"
+    # The operation is dispatched by name with the command's typed params.
+    assert fake.calls == [("scene-get-exports", {"path": "/tmp/proj/main.tscn"})]
+    # Engine/script diagnostics are surfaced on stderr, not stdout.
+    assert "engine diagnostic" in result.stderr
+
+
+def test_scene_get_exports_expands_user_home_in_filesystem_path_but_not_res(monkeypatch):
+    # Path normalization at the CLI layer (issue #32) applies to get-exports too:
+    # a filesystem path gets ~ expanded; a res:// path passes through untouched.
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(GET_EXPORTS_RESULT), stderr="", exit_code=0),
+    )
+
+    CliRunner().invoke(app, ["scene", "get-exports", "~/game/main.tscn", "--json"])
+    assert "~" not in fake.calls[0][1]["path"]
+    assert fake.calls[0][1]["path"].endswith("/game/main.tscn")
+
+    fake.calls.clear()
+    CliRunner().invoke(app, ["scene", "get-exports", "res://main.tscn", "--json"])
+    assert fake.calls[0][1]["path"] == "res://main.tscn"
+
+
+def test_scene_get_exports_empty_scene_is_a_valid_empty_listing(monkeypatch):
+    # A scene with no exported variables anywhere is a successful, empty listing
+    # (nodes == []), not a failure.
+    stdout = sentinel({"path": "/tmp/proj/bare.tscn", "nodes": []})
+    inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app, ["scene", "get-exports", "/tmp/proj/bare.tscn", "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["nodes"] == []
+
+
 LIST_RESULT = {
     "scenes": [
         {"path": "res://main.tscn", "root_name": "main", "root_type": "Node2D"},

--- a/tests/test_scene_errors.py
+++ b/tests/test_scene_errors.py
@@ -65,6 +65,54 @@ def test_scene_get_unloadable_file_maps_to_stable_not_a_scene_code(monkeypatch):
     assert err["code"] == "not_a_scene"
 
 
+def test_scene_get_exports_missing_file_maps_to_stable_path_not_found_code(monkeypatch):
+    # scene get-exports reuses the shared load-failure ladder (issue #58): a
+    # target that does not exist is the file-level path_not_found, exit 4, so an
+    # agent can tell "no such scene" apart from other get-exports failures.
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(
+                "path_not_found", "scene file does not exist: /x/missing.tscn"
+            ),
+            stderr="gda: running operation: scene-get-exports\n",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["scene", "get-exports", "/x/missing.tscn"])
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert "/x/missing.tscn" in err["message"]
+
+
+def test_scene_get_exports_unloadable_file_maps_to_stable_not_a_scene_code(monkeypatch):
+    # The file exists but Godot cannot load it as a PackedScene — get-exports
+    # reuses the same stable not_a_scene code scene get / delete report, so a
+    # stray non-scene file is refused rather than mis-handled (issue #58).
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel(
+                "not_a_scene", "failed to load as a scene: /x/notes.txt"
+            ),
+            stderr="",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["scene", "get-exports", "/x/notes.txt"])
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "not_a_scene"
+
+
 def test_scene_create_unknown_root_type_maps_to_stable_invalid_root_type_code(
     monkeypatch,
 ):

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -139,6 +139,23 @@ def test_scene_get_schema_emits_model_derived_contract_without_other_args():
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
 
+def test_scene_get_exports_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for scene get-exports (issue #58): the bare --schema
+    # flag — no path — short-circuits into the self-description, derived from the
+    # same typed models that back --json.
+    from gda.models import SceneGetExportsParams, SceneGetExportsResult
+
+    result = CliRunner().invoke(app, ["scene", "get-exports", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == SceneGetExportsParams.model_json_schema()
+    assert doc["output"] == SceneGetExportsResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
 def test_scene_list_schema_emits_model_derived_contract_without_a_project():
     # The ADR-0004 hard gate for scene list (issue #54): the bare --schema flag
     # — no --project — short-circuits into the self-description, derived from the
@@ -211,6 +228,7 @@ def test_scene_schema_spawns_no_godot(monkeypatch):
     for command in (
         ["scene", "create"],
         ["scene", "get"],
+        ["scene", "get-exports"],
         ["scene", "list"],
         ["scene", "delete"],
     ):


### PR DESCRIPTION
## What

Adds `gda scene get-exports`: loads a `.tscn`, instantiates it, and reports — **per node, by node path** — the `@export` properties the node's attached script declares: each a `{name, type, hint, hint_string, value}` entry, as typed JSON.

- `type` is the export's declared Godot type name (the same spelling `node get` uses).
- `hint`/`hint_string` are the Godot `PropertyHint` enum value and its companion string the `@export` annotation produced (e.g. `@export_range` → `PROPERTY_HINT_RANGE` + `"0,100"`).
- `value` is the export's current value in the same JSON projection `node get` reports (its default on a freshly-loaded node).
- `script` names the attached script's `res://` path (where the exports came from).

## Reuse (not re-implementation)

The GDScript op reuses `node get`'s property/script introspection (issue #55) rather than duplicating it:
- `_type_name` for the declared Godot type, `_jsonify` for the value projection.
- the shared `_load_scene` failure ladder.
- the canonical node-path addressing (`.` for root) via `get_path_to`.

An export is detected by its usage flags (`PROPERTY_USAGE_SCRIPT_VARIABLE` + `PROPERTY_USAGE_EDITOR`) on the script's own `get_script_property_list()`, so inherited engine properties and plain (non-`@export`) script vars are excluded. A node with no export-declaring script is omitted; a scene with no exports anywhere is a valid empty listing (`nodes == []`).

## Skeleton / contract

- `--json` and the ADR-0004 `--schema` hard gate via the shared skeleton (Pydantic models back both).
- Human renderer registered (verified by the existing renderer-coverage invariant test).
- **No new error codes.** Scene-not-found → `path_not_found`, not-a-scene → `not_a_scene` — both already registered, so the Python registry / ADR-0002 table / GDScript mirror need no change (drift tests stay green).

## Tests (strict TDD, red→green per slice)

- **S2** model round-trip (`test_models.py`).
- **S3** CLI-with-FakeRunner: success, path normalization (`~`/`res://`), empty listing (`test_scene_commands.py`); error paths `path_not_found` / `not_a_scene` (`test_scene_errors.py`); `--schema` hard gate (`test_schema_command.py`); human output (`test_human_output.py`).
- **S1** e2e against the real engine (`test_e2e_scene_exports.py`, `@pytest.mark.e2e`, auto-skips when no engine): declared exports per node with types/hint/value, omission of scriptless nodes, nested-node addressing, `path_not_found`, `not_a_scene`.

Local results: `283 passed` (non-e2e); the 5 new e2e tests pass in isolation against Godot 4.6.3.

## Note (out of scope)

While building the e2e fixtures I found a **pre-existing, non-deterministic `script attach` behavior**: re-attaching a script to a second node in a freshly-created project whose `res://` script has not yet been imported can drop a *sibling* node's `script =` line on the re-pack/save. It reproduces only intermittently and is unrelated to get-exports (which faithfully reports whatever is in the scene). The e2e tests here avoid depending on it. Worth a separate issue.

Closes #58
