### PR TITLE
feat(export): list + get — read-only export-preset discovery (#114)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -120,6 +120,8 @@ operation, and parse codes the CLI assigns).
 | `already_connected` | `operation` | `operation` | `4` | A signal is already connected to the target node's method. |
 | `connection_not_found` | `operation` | `operation` | `4` | A requested signal-to-method connection does not exist on the source node. |
 | `invalid_resource_type` | `operation` | `operation` | `4` | A requested resource type cannot be instantiated as a `Resource`. |
+| `export_presets_not_found` | `operation` | `operation` | `4` | The project has no export_presets.cfg, so it defines no export presets. |
+| `export_preset_not_found` | `operation` | `operation` | `4` | No export preset with the requested name exists in export_presets.cfg. |
 | `contract_violation` | `parse` | `parser` | `5` | The process claimed success but violated the structured-output contract. |
 | `tree_too_deep` | `parse` | `classifier` | `5` | The engine emitted a valid result tree that nests past gda's recursion limit; the payload is contract-conformant, the limit is wrapper-side (shares the `parse` exit code; the `code` distinguishes it from `contract_violation`). |
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -26,6 +26,10 @@ from gda.headless import (
 )
 from gda.models import (
     EngineVersion,
+    ExportGetParams,
+    ExportGetResult,
+    ExportListParams,
+    ExportListResult,
     InfoParams,
     NodeAddParams,
     NodeAddResult,
@@ -113,6 +117,15 @@ resource_app = typer.Typer(
     help="Act on resource files (.tres).", no_args_is_help=True
 )
 app.add_typer(resource_app, name="resource")
+
+# The export command group (issue #114): read-only discovery of the project's
+# export presets (from export_presets.cfg) and export-template readiness. These
+# stay headless — they parse a config file and check the filesystem, never
+# running an actual export (that is a later slice, issue #121).
+export_app = typer.Typer(
+    help="Discover export presets and export-template status.", no_args_is_help=True
+)
+app.add_typer(export_app, name="export")
 
 
 def _version_callback(value: Optional[bool]) -> None:
@@ -369,6 +382,18 @@ RESOURCE_GET_COMMAND: HeadlessCommand[ResourceGetResult] = HeadlessCommand(
     operation="resource-get",
     input_model=ResourceGetParams,
     output_model=ResourceGetResult,
+)
+
+EXPORT_LIST_COMMAND: HeadlessCommand[ExportListResult] = HeadlessCommand(
+    operation="export-list",
+    input_model=ExportListParams,
+    output_model=ExportListResult,
+)
+
+EXPORT_GET_COMMAND: HeadlessCommand[ExportGetResult] = HeadlessCommand(
+    operation="export-get",
+    input_model=ExportGetParams,
+    output_model=ExportGetResult,
 )
 
 
@@ -1118,6 +1143,47 @@ def get_resource(
     _dispatch(
         RESOURCE_GET_COMMAND,
         ResourceGetParams(path=_normalize_path(path)),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@export_app.command(name="list", cls=EXPORT_LIST_COMMAND.command_class())
+def list_presets(
+    json_output: bool = json_option(),
+    schema: bool = EXPORT_LIST_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Enumerate the resolved project's export presets (name, platform, runnable)."""
+    _dispatch(
+        EXPORT_LIST_COMMAND,
+        ExportListParams(),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@export_app.command(name="get", cls=EXPORT_GET_COMMAND.command_class())
+def get_preset(
+    preset: str = typer.Option(
+        ...,
+        "--preset",
+        help="The export preset's display name, as 'gda export list' reports it.",
+    ),
+    json_output: bool = json_option(),
+    schema: bool = EXPORT_GET_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Report one preset's details plus export-template install status."""
+    _dispatch(
+        EXPORT_GET_COMMAND,
+        ExportGetParams(preset=preset),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -308,6 +308,20 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A requested resource type cannot be instantiated as a Resource.",
     ),
     ErrorCodeSpec(
+        "export_presets_not_found",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "The project has no export_presets.cfg, so it defines no export presets.",
+    ),
+    ErrorCodeSpec(
+        "export_preset_not_found",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "No export preset with the requested name exists in export_presets.cfg.",
+    ),
+    ErrorCodeSpec(
         "contract_violation",
         ErrorCategory.PARSE,
         EXIT_PARSE,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -1205,6 +1205,104 @@ class ResourceCreateParams(BaseModel):
     )
 
 
+class ExportListParams(BaseModel):
+    """The operation params of ``gda export list`` — none (ADR-0004).
+
+    ``export list`` enumerates the export presets defined in the resolved
+    project's ``export_presets.cfg``; the project is process context
+    (``--project``), not an operation param (ADR-0006), so the ``input`` schema
+    is trivially empty, exactly like ``scene list`` / ``script list``.
+    """
+
+
+class ListedPreset(BaseModel):
+    """One enumerated export preset of ``gda export list`` (issue #114).
+
+    Read cheaply from ``export_presets.cfg`` (a ``ConfigFile`` parse, no engine
+    export run): ``name`` is the preset's display name — the address an agent
+    feeds back into ``gda export get`` — ``platform`` the target platform (e.g.
+    ``Linux/X11``, ``Web``), and ``runnable`` whether the preset is marked
+    runnable (one-click deploy). ``index`` is the preset's 0-based position in
+    the file (its ``preset.N`` section number), stable across a single read.
+    """
+
+    index: int = Field(
+        description="The preset's 0-based position in export_presets.cfg (its preset.N section number)."
+    )
+    name: str = Field(description="The preset's display name.")
+    platform: str = Field(
+        description="The preset's target platform (e.g. Linux/X11, Web, macOS)."
+    )
+    runnable: bool = Field(
+        description="Whether the preset is marked runnable (one-click deploy)."
+    )
+
+
+class ExportListResult(BaseModel):
+    """The result of ``gda export list``: the project's enumerated export presets.
+
+    A project whose ``export_presets.cfg`` exists but defines no presets is a
+    valid, empty listing — ``presets == []`` — not a failure. A project with no
+    ``export_presets.cfg`` at all is the ``export_presets_not_found`` failure
+    (it has no export configuration), distinct from an empty one.
+    """
+
+    presets: list[ListedPreset]
+
+
+class ExportGetParams(BaseModel):
+    """The operation params of ``gda export get`` (issue #114).
+
+    ``preset`` addresses an export preset by its display name (as ``export
+    list`` reports it). An unknown name is the ``export_preset_not_found``
+    failure. The project is process context (``--project``, ADR-0006).
+    """
+
+    preset: str = Field(
+        description="The export preset's display name, as 'gda export list' reports it."
+    )
+
+
+class ExportGetResult(BaseModel):
+    """The result of ``gda export get``: one preset's details + template readiness (issue #114).
+
+    Echoes the addressed preset's ``index``/``name``/``platform``/``runnable``
+    (read from ``export_presets.cfg``) plus its ``export_path`` (the output path
+    the preset writes to, empty when unset). ``templates_installed`` reports
+    whether the export templates for the running engine version are installed —
+    the readiness check an agent makes before a future ``export run`` (issue
+    #121); ``templates_version`` names the version directory that was checked
+    (e.g. ``4.6.3.stable``), so the agent knows which templates to install when
+    they are missing.
+    """
+
+    index: int = Field(
+        description="The preset's 0-based position in export_presets.cfg (its preset.N section number)."
+    )
+    name: str = Field(description="The preset's display name.")
+    platform: str = Field(
+        description="The preset's target platform (e.g. Linux/X11, Web, macOS)."
+    )
+    runnable: bool = Field(
+        description="Whether the preset is marked runnable (one-click deploy)."
+    )
+    export_path: str = Field(
+        description="The output path the preset exports to, or empty when unset."
+    )
+    templates_installed: bool = Field(
+        description=(
+            "Whether the export templates for the running engine version are "
+            "installed — the readiness check before an export run."
+        )
+    )
+    templates_version: str = Field(
+        description=(
+            "The export-templates version directory checked for installation "
+            "(e.g. 4.6.3.stable), matching the running engine version."
+        )
+    )
+
+
 class ResourceCreateResult(BaseModel):
     """The result of ``gda resource create``: what was written where (issue #112).
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -55,6 +55,8 @@ const OP_ERROR_SIGNAL_NOT_FOUND := "signal_not_found"
 const OP_ERROR_ALREADY_CONNECTED := "already_connected"
 const OP_ERROR_CONNECTION_NOT_FOUND := "connection_not_found"
 const OP_ERROR_INVALID_RESOURCE_TYPE := "invalid_resource_type"
+const OP_ERROR_EXPORT_PRESETS_NOT_FOUND := "export_presets_not_found"
+const OP_ERROR_EXPORT_PRESET_NOT_FOUND := "export_preset_not_found"
 
 const NODE_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
 
@@ -126,6 +128,10 @@ func _initialize() -> void:
 			_op_resource_create(params)
 		"resource-get":
 			_op_resource_get(params)
+		"export-list":
+			_op_export_list(params)
+		"export-get":
+			_op_export_get(params)
 		_:
 			_fail(OP_ERROR_UNKNOWN_OPERATION, "unknown operation: " + operation)
 
@@ -1489,6 +1495,133 @@ func _require_existing_resource(path: String) -> bool:
 		_fail(OP_ERROR_PATH_NOT_FOUND, "resource file does not exist: " + path)
 		return false
 	return true
+
+
+# export-list: enumerate the project's export presets (issue #114). Reads the
+# project's res://export_presets.cfg with ConfigFile — a cheap config parse, not
+# an export run (issue #121 owns running an export) — and reports each preset's
+# index/name/platform/runnable. Like scene-list / script-list this needs a
+# project (project_not_found otherwise); a project that has never configured an
+# export has no export_presets.cfg, which is the distinct export_presets_not_found
+# failure rather than a misleading empty listing.
+func _op_export_list(_params: Dictionary) -> void:
+	_diag("running operation: export-list")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "export list requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+
+	var config := _load_export_presets()
+	if config == null:
+		return  # _load_export_presets already recorded the failure
+
+	var presets: Array = []
+	for entry in _export_preset_sections(config):
+		presets.append(_export_preset_summary(config, entry["section"], entry["index"]))
+
+	_succeed({"presets": presets})
+
+
+# export-get: report one export preset's details plus export-template install
+# status (issue #114). Addresses the preset by its display NAME (as export-list
+# reports it); an unknown name is the export_preset_not_found failure. Beyond the
+# preset's own fields it reports whether the export templates for the running
+# engine version are installed — the readiness check an agent makes before a
+# future export run (issue #121) — and the version directory it checked.
+func _op_export_get(params: Dictionary) -> void:
+	_diag("running operation: export-get")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "export get requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+
+	var preset_name := _string_param(params, "preset")
+	if preset_name.is_empty():
+		_fail(OP_ERROR_INVALID_PARAMS, "missing required param: preset")
+		return
+
+	var config := _load_export_presets()
+	if config == null:
+		return  # _load_export_presets already recorded the failure
+
+	for entry in _export_preset_sections(config):
+		var section: String = entry["section"]
+		if String(config.get_value(section, "name", "")) == preset_name:
+			var summary := _export_preset_summary(config, section, entry["index"])
+			summary["export_path"] = String(config.get_value(section, "export_path", ""))
+			var version_dir := _export_templates_version_dir()
+			summary["templates_version"] = version_dir
+			summary["templates_installed"] = _export_templates_installed(version_dir)
+			_succeed(summary)
+			return
+
+	_fail(OP_ERROR_EXPORT_PRESET_NOT_FOUND, "no export preset named: " + preset_name)
+
+
+# Load the project's export_presets.cfg as a ConfigFile, or record a failure and
+# return null (the caller must stop). A project with no export_presets.cfg has
+# never configured an export, so it is the distinct export_presets_not_found
+# failure; a present-but-unparseable file is a save_failed-style read error.
+func _load_export_presets() -> ConfigFile:
+	var presets_path := "res://export_presets.cfg"
+	if not FileAccess.file_exists(presets_path):
+		_fail(OP_ERROR_EXPORT_PRESETS_NOT_FOUND, "project has no export_presets.cfg; no export presets are defined")
+		return null
+	var config := ConfigFile.new()
+	var err := config.load(presets_path)
+	if err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, "failed to read export_presets.cfg: " + error_string(err))
+		return null
+	return config
+
+
+# The export-preset sections of an export_presets.cfg, in file order, each as
+# {"section": "preset.N", "index": N}. A preset is stored as a "preset.N" section
+# with a sibling "preset.N.options" section; only the bare "preset.N" is a preset,
+# so the ".options" companions are filtered out. The index is the preset's N, the
+# stable 0-based position the file assigns it.
+func _export_preset_sections(config: ConfigFile) -> Array:
+	var sections: Array = []
+	for section in config.get_sections():
+		if not section.begins_with("preset."):
+			continue
+		var rest := section.substr("preset.".length())
+		if not rest.is_valid_int():
+			continue  # skip "preset.N.options" and any non-numeric suffix
+		sections.append({"section": section, "index": int(rest)})
+	return sections
+
+
+# Summarize one export preset for the listing: its index/name/platform plus
+# whether it is marked runnable. Read straight from the ConfigFile, never running
+# an export. Missing keys degrade to safe defaults so a hand-edited file still
+# lists rather than crashing.
+func _export_preset_summary(config: ConfigFile, section: String, index: int) -> Dictionary:
+	return {
+		"index": index,
+		"name": String(config.get_value(section, "name", "")),
+		"platform": String(config.get_value(section, "platform", "")),
+		"runnable": bool(config.get_value(section, "runnable", false)),
+	}
+
+
+# The export-templates version directory name for the running engine, e.g.
+# "4.6.3.stable" — major.minor.patch.status, matching how the editor names the
+# per-version templates folder under <data_dir>/Godot/export_templates/.
+func _export_templates_version_dir() -> String:
+	var v := Engine.get_version_info()
+	return "%d.%d.%d.%s" % [v.major, v.minor, v.patch, v.status]
+
+
+# Whether the export templates for the running engine version are installed:
+# their per-version directory exists under the user data dir's
+# Godot/export_templates/. Headless --script runs have no EditorPaths singleton,
+# so the path is derived from OS.get_data_dir() (the same root the editor uses)
+# plus the fixed "Godot/export_templates/<version>" layout. This is the readiness
+# signal an agent checks before a future export run (issue #121); it does not
+# verify per-platform template files, only that the version's templates are
+# present at all.
+func _export_templates_installed(version_dir: String) -> bool:
+	var templates_root := OS.get_data_dir().path_join("Godot").path_join("export_templates")
+	return DirAccess.dir_exists_absolute(templates_root.path_join(version_dir))
 
 
 # Whether a path names a script file the script group operates on: a .gd

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -23,6 +23,8 @@ from typing import Any, Protocol, runtime_checkable
 
 from gda.models import (
     EngineVersion,
+    ExportGetResult,
+    ExportListResult,
     NodeAddResult,
     NodeConnectSignalResult,
     NodeDisconnectSignalResult,
@@ -300,6 +302,29 @@ def render_resource_properties(got: "ResourceGetResult") -> str:
     return "\n".join([header, *lines])
 
 
+def render_export_list(listed: "ExportListResult") -> str:
+    """Render the enumerated presets as ``name (platform) [runnable]`` lines."""
+    if not listed.presets:
+        return "(no presets)"
+    lines = []
+    for preset in listed.presets:
+        runnable = " [runnable]" if preset.runnable else ""
+        lines.append(f"{preset.name} ({preset.platform}){runnable}")
+    return "\n".join(lines)
+
+
+def render_export_get(got: "ExportGetResult") -> str:
+    """Render one preset's details plus its export-template readiness."""
+    runnable = " [runnable]" if got.runnable else ""
+    header = f"{got.name} ({got.platform}){runnable}"
+    templates = (
+        f"templates installed ({got.templates_version})"
+        if got.templates_installed
+        else f"templates missing ({got.templates_version})"
+    )
+    return "\n".join([header, f"  export_path: {got.export_path}", f"  {templates}"])
+
+
 def render_engine_version(version: "EngineVersion") -> str:
     """Render the engine version as its one-line version string."""
     return version.string
@@ -334,6 +359,8 @@ _RENDERERS = {
     ScriptValidateResult: render_script_validate,
     ResourceCreateResult: render_resource_create,
     ResourceGetResult: render_resource_properties,
+    ExportListResult: render_export_list,
+    ExportGetResult: render_export_get,
     EngineVersion: render_engine_version,
 }
 

--- a/tests/test_e2e_export.py
+++ b/tests/test_e2e_export.py
@@ -1,0 +1,223 @@
+"""S1 (e2e): export discovery against the real Godot engine (issue #114).
+
+The export-group tracer: ``gda export list`` parses the project's
+export_presets.cfg and enumerates its presets (name, platform, runnable);
+``gda export get`` reports one named preset's details plus export-template
+install status — the readiness check before a future ``export run`` (issue #121).
+
+This slice is READ-ONLY: it parses a config file and checks the filesystem, it
+never runs an actual export, so it needs no installed export templates to pass.
+The template-install status is reported as-is (whatever the test machine has),
+so these tests assert its SHAPE (a bool, plus the running engine's version dir),
+not a fixed value.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+GODOT = resolve_godot_binary()
+
+# Two presets in the canonical format Godot writes export_presets.cfg: a
+# runnable Linux preset and a non-runnable Web preset, each with its sibling
+# `.options` sub-section (which export list/get must filter out — only the bare
+# `preset.N` sections are presets).
+EXPORT_PRESETS_CFG = """\
+[preset.0]
+
+name="Linux/X11"
+platform="Linux/X11"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+export_path="build/game.x86_64"
+
+[preset.0.options]
+
+binary_format/embed_pck=false
+
+[preset.1]
+
+name="Web"
+platform="Web"
+runnable=false
+custom_features=""
+export_filter="all_resources"
+export_path=""
+
+[preset.1.options]
+
+html/export_icon=true
+"""
+
+# The export-templates version-directory pattern: major.minor.patch.status,
+# e.g. 4.6.3.stable — what export get reports as templates_version.
+VERSION_DIR = re.compile(r"^\d+\.\d+\.\d+\.[a-z0-9]+$")
+
+
+def _gda_project(project) -> "callable":
+    """A ``gda`` bound to ``--project`` for res:// resolution of the cfg."""
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+
+    def gda(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [gda_bin, *args, "--godot", str(GODOT), "--project", str(project)],
+            capture_output=True,
+            text=True,
+        )
+
+    return gda
+
+
+def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
+    assert proc.returncode == 4, proc.stdout + proc.stderr
+    err = json.loads(proc.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == code
+    return err
+
+
+@pytest.mark.e2e
+def test_export_list_enumerates_presets_from_export_presets_cfg(godot_project):
+    # export list parses export_presets.cfg and reports each preset's index, name,
+    # platform, and runnable flag — filtering out the `.options` sub-sections. The
+    # listing IS the structured-level verification of the project's export config.
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    gda = _gda_project(godot_project)
+
+    listed = gda("export", "list", "--json")
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    presets = json.loads(listed.stdout)["presets"]
+    by_name = {p["name"]: p for p in presets}
+    assert set(by_name) == {"Linux/X11", "Web"}
+    assert by_name["Linux/X11"]["index"] == 0
+    assert by_name["Linux/X11"]["platform"] == "Linux/X11"
+    assert by_name["Linux/X11"]["runnable"] is True
+    assert by_name["Web"]["index"] == 1
+    assert by_name["Web"]["runnable"] is False
+
+
+@pytest.mark.e2e
+def test_export_list_empty_cfg_is_an_empty_listing(godot_project):
+    # An export_presets.cfg that defines no presets is a valid, empty listing —
+    # not an error (distinct from no cfg at all).
+    (godot_project / "export_presets.cfg").write_text("", encoding="utf-8")
+    gda = _gda_project(godot_project)
+
+    listed = gda("export", "list", "--json")
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    assert json.loads(listed.stdout)["presets"] == []
+
+
+@pytest.mark.e2e
+def test_export_list_no_cfg_yields_export_presets_not_found(godot_project):
+    # A project that has never configured an export has no export_presets.cfg:
+    # export list refuses with the structured export_presets_not_found code rather
+    # than a misleading empty listing, so an agent knows the project defines no
+    # presets.
+    gda = _gda_project(godot_project)
+
+    listed = gda("export", "list", "--json")
+
+    err = _assert_operation_error(listed, "export_presets_not_found")
+    assert "export_presets.cfg" in err["message"]
+
+
+@pytest.mark.e2e
+def test_export_list_without_project_yields_project_not_found(tmp_path):
+    # export list reads export_presets.cfg in a project, so it cannot run
+    # projectless: run from a non-project directory with no --project, it refuses
+    # with project_not_found rather than returning a misleading empty listing.
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+
+    listed = subprocess.run(
+        [gda_bin, "export", "list", "--json", "--godot", str(GODOT)],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+
+    err = _assert_operation_error(listed, "project_not_found")
+    assert "--project" in err["message"]
+
+
+@pytest.mark.e2e
+def test_export_get_reports_preset_details_and_template_status(godot_project):
+    # export get reports one named preset's details plus export-template install
+    # status. The preset's own fields come from export_presets.cfg; the template
+    # status reflects the test machine as-is, so we assert its SHAPE: a bool, plus
+    # the running engine's version directory (major.minor.patch.status).
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    gda = _gda_project(godot_project)
+
+    got = gda("export", "get", "--preset", "Web", "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    data = json.loads(got.stdout)
+    assert data["index"] == 1
+    assert data["name"] == "Web"
+    assert data["platform"] == "Web"
+    assert data["runnable"] is False
+    assert data["export_path"] == ""
+    # Template readiness: a bool verdict plus the version dir it checked, matching
+    # the running engine's major.minor.patch.status.
+    assert isinstance(data["templates_installed"], bool)
+    assert VERSION_DIR.match(data["templates_version"]), data["templates_version"]
+
+
+@pytest.mark.e2e
+def test_export_get_reports_export_path_of_a_preset_with_one(godot_project):
+    # A preset with an export_path reports it verbatim (the Linux preset writes to
+    # build/game.x86_64), so an agent learns where an export would land.
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    gda = _gda_project(godot_project)
+
+    got = gda("export", "get", "--preset", "Linux/X11", "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    data = json.loads(got.stdout)
+    assert data["runnable"] is True
+    assert data["export_path"] == "build/game.x86_64"
+
+
+@pytest.mark.e2e
+def test_export_get_unknown_preset_yields_export_preset_not_found(godot_project):
+    # A preset name not present in export_presets.cfg is the structured
+    # export_preset_not_found code, naming the requested preset, so an agent can
+    # re-list to find the real names rather than parse prose.
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    gda = _gda_project(godot_project)
+
+    got = gda("export", "get", "--preset", "Nope", "--json")
+
+    err = _assert_operation_error(got, "export_preset_not_found")
+    assert "Nope" in err["message"]
+
+
+@pytest.mark.e2e
+def test_export_get_no_cfg_yields_export_presets_not_found(godot_project):
+    # export get over a project with no export_presets.cfg reports the same
+    # export_presets_not_found mode as export list — there is nothing to address.
+    gda = _gda_project(godot_project)
+
+    got = gda("export", "get", "--preset", "Web", "--json")
+
+    err = _assert_operation_error(got, "export_presets_not_found")
+    assert "export_presets.cfg" in err["message"]

--- a/tests/test_export_commands.py
+++ b/tests/test_export_commands.py
@@ -1,0 +1,132 @@
+"""S3: gda export list / export get success paths against a fake runner (issue #114).
+
+The export command group is read-only discovery: ``export list`` enumerates the
+project's export presets (from export_presets.cfg) and ``export get`` reports one
+preset's details plus export-template install status. These tests drive the same
+proven pipeline as the scene/node/script groups — Typer → binary resolution →
+runner → sentinel parse → typed model → JSON — with canned engine output, no
+real Godot. This slice never runs an actual export (that is issue #121).
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import FakeRunner, inject_runner, sentinel
+
+LIST_RESULT = {
+    "presets": [
+        {"index": 0, "name": "Linux/X11", "platform": "Linux/X11", "runnable": True},
+        {"index": 1, "name": "Web", "platform": "Web", "runnable": False},
+    ]
+}
+
+GET_RESULT = {
+    "index": 1,
+    "name": "Web",
+    "platform": "Web",
+    "runnable": False,
+    "export_path": "build/index.html",
+    "templates_installed": True,
+    "templates_version": "4.6.3.stable",
+}
+
+
+def test_export_list_json_enumerates_presets_and_exit_zero(monkeypatch, tmp_path):
+    # export list enumerates the resolved project's export presets (issue #114):
+    # each entry carries its index, name, platform, and runnable flag, read
+    # cheaply from export_presets.cfg.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(LIST_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["export", "list", "--project", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert [p["name"] for p in data["presets"]] == ["Linux/X11", "Web"]
+    assert data["presets"][0]["platform"] == "Linux/X11"
+    assert data["presets"][0]["runnable"] is True
+    assert data["presets"][1]["index"] == 1
+    assert data["presets"][1]["runnable"] is False
+    # export list takes no operation params: the project is process context.
+    assert fake.calls == [("export-list", {})]
+    assert "engine diagnostic" in result.stderr
+
+
+def test_export_list_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
+    # export list reads export_presets.cfg in the resolved project, so --project
+    # must reach the runner (which hands it to the engine as --path, issue #32).
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    seen: dict = {}
+
+    def record(binary, project):
+        seen["project"] = project
+        return FakeRunner(RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0))
+
+    monkeypatch.setattr("gda.cli._make_runner", record)
+
+    result = CliRunner().invoke(
+        app, ["export", "list", "--project", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert seen["project"] == tmp_path
+
+
+def test_export_get_json_reports_preset_details_and_template_status(monkeypatch):
+    # export get reports a named preset's details plus export-template readiness
+    # (issue #114): the preset is addressed by --preset (its display name), and
+    # the result carries templates_installed/templates_version so an agent can
+    # check readiness before an export run.
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app, ["export", "get", "--preset", "Web", "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["name"] == "Web"
+    assert data["platform"] == "Web"
+    assert data["export_path"] == "build/index.html"
+    assert data["templates_installed"] is True
+    assert data["templates_version"] == "4.6.3.stable"
+    # The preset name rides through as the typed param.
+    assert fake.calls == [("export-get", {"preset": "Web"})]
+
+
+def test_export_get_missing_preset_flag_is_a_usage_error(monkeypatch):
+    # --preset is required: export get always needs a preset to address. Its
+    # absence is a usage error (exit 2) that fires before any dispatch.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["export", "get", "--json"])
+
+    assert result.exit_code == 2
+    assert fake.calls == []
+
+
+def test_export_get_templates_missing_rides_through_false(monkeypatch):
+    # When the running engine version's templates are not installed,
+    # templates_installed=false rides through to the result so the agent knows it
+    # must install templates before an export run.
+    payload = {**GET_RESULT, "templates_installed": False, "export_path": ""}
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(payload)
+    inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["export", "get", "--preset", "Web", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["templates_installed"] is False
+    assert data["templates_version"] == "4.6.3.stable"

--- a/tests/test_export_errors.py
+++ b/tests/test_export_errors.py
@@ -1,0 +1,127 @@
+"""S3: gda export failure modes map to structured JSON errors + stable exit codes.
+
+Issue #114's acceptance: export-command failures (no export_presets.cfg, unknown
+preset, no resolvable project) surface as structured ``GdaError``s with
+registered operation codes (ADR-0002) — exit 4 for the operation category, finer
+stable codes so an agent can branch on the mode without parsing prose. The export
+group mints two new codes for the modes that had no existing code
+(``export_presets_not_found``, ``export_preset_not_found``) and reuses the shared
+``project_not_found`` for the projectless mode.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import error_sentinel, inject_runner
+
+
+def _invoke_export_list(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: export-list\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(app, ["export", "list", "--json"])
+
+
+def _invoke_export_get(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: export-get\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(app, ["export", "get", "--preset", "Web", "--json"])
+
+
+def test_export_list_no_export_presets_maps_to_export_presets_not_found(monkeypatch):
+    # A project that has never configured an export has no export_presets.cfg:
+    # this is the new export_presets_not_found code (distinct from a generic
+    # missing-path), so an agent knows the project defines no presets rather than
+    # mistaking it for an empty listing.
+    result = _invoke_export_list(
+        monkeypatch,
+        "export_presets_not_found",
+        "project has no export_presets.cfg; no export presets are defined",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "export_presets_not_found"
+    assert "export_presets.cfg" in err["message"]
+    # The raw stderr still rides along as diagnostics (ADR-0002).
+    assert err["diagnostics"] == "gda: running operation: export-list\n"
+
+
+def test_export_list_without_project_reuses_stable_project_not_found_code(monkeypatch):
+    # export list reads export_presets.cfg in a project, so it cannot run
+    # projectless: with no resolvable project, the operation reuses the registered
+    # project_not_found code (the same one scene/script list use) so an agent
+    # knows to pass --project rather than retry.
+    result = _invoke_export_list(
+        monkeypatch,
+        "project_not_found",
+        "export list requires a Godot project; none was resolved — pass --project",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "project_not_found"
+    assert "--project" in err["message"]
+
+
+def test_export_get_unknown_preset_maps_to_export_preset_not_found(monkeypatch):
+    # A preset name not present in export_presets.cfg is the new
+    # export_preset_not_found code, so an agent branches on the unknown-preset
+    # mode (and re-lists to find the real names) without parsing prose.
+    result = _invoke_export_get(
+        monkeypatch, "export_preset_not_found", "no export preset named: Web"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "export_preset_not_found"
+    assert "Web" in err["message"]
+    assert err["diagnostics"] == "gda: running operation: export-get\n"
+
+
+def test_export_get_no_export_presets_maps_to_export_presets_not_found(monkeypatch):
+    # export get over a project with no export_presets.cfg reports the same
+    # export_presets_not_found mode as export list — there is nothing to address.
+    result = _invoke_export_get(
+        monkeypatch,
+        "export_presets_not_found",
+        "project has no export_presets.cfg; no export presets are defined",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "export_presets_not_found"
+
+
+def test_export_get_without_project_reuses_stable_project_not_found_code(monkeypatch):
+    result = _invoke_export_get(
+        monkeypatch,
+        "project_not_found",
+        "export get requires a Godot project; none was resolved — pass --project",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "project_not_found"
+    assert "--project" in err["message"]

--- a/tests/test_human_output.py
+++ b/tests/test_human_output.py
@@ -381,6 +381,63 @@ HUMAN_CASES = [
         {"path": "/tmp/proj/ok.gd", "valid": True, "error_string": None},
         "valid /tmp/proj/ok.gd",
     ),
+    # --- export group -------------------------------------------------------
+    (
+        "export-list",
+        ["export", "list"],
+        {
+            "presets": [
+                {
+                    "index": 0,
+                    "name": "Linux/X11",
+                    "platform": "Linux/X11",
+                    "runnable": True,
+                },
+                # not runnable -> no [runnable] suffix.
+                {"index": 1, "name": "Web", "platform": "Web", "runnable": False},
+            ]
+        },
+        "Linux/X11 (Linux/X11) [runnable]\nWeb (Web)",
+    ),
+    (
+        "export-list-empty",
+        ["export", "list"],
+        {"presets": []},
+        "(no presets)",
+    ),
+    (
+        "export-get",
+        ["export", "get", "--preset", "Web"],
+        {
+            "index": 1,
+            "name": "Web",
+            "platform": "Web",
+            "runnable": False,
+            "export_path": "build/index.html",
+            "templates_installed": True,
+            "templates_version": "4.6.3.stable",
+        },
+        "Web (Web)\n"
+        "  export_path: build/index.html\n"
+        "  templates installed (4.6.3.stable)",
+    ),
+    (
+        # templates missing branch + runnable suffix.
+        "export-get-missing-templates",
+        ["export", "get", "--preset", "Linux/X11"],
+        {
+            "index": 0,
+            "name": "Linux/X11",
+            "platform": "Linux/X11",
+            "runnable": True,
+            "export_path": "",
+            "templates_installed": False,
+            "templates_version": "4.6.3.stable",
+        },
+        "Linux/X11 (Linux/X11) [runnable]\n"
+        "  export_path: \n"
+        "  templates missing (4.6.3.stable)",
+    ),
     # --- meta ---------------------------------------------------------------
     (
         "info",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,6 +6,8 @@ import jsonschema
 
 from gda.models import (
     EngineVersion,
+    ExportGetResult,
+    ExportListResult,
     GdaError,
     GdaErrorEnvelope,
     NodeAddResult,
@@ -489,6 +491,86 @@ def test_script_validate_result_round_trips_an_invalid_script_with_diagnostics()
     assert validated.diagnostics[0].column is None
     assert validated.diagnostics[0].message == "Parse Error: bad token."
     assert json.loads(validated.model_dump_json()) == payload
+
+
+def test_export_list_result_round_trips_enumerated_presets():
+    # The export-list operation enumerates the project's export presets (issue
+    # #114) read from export_presets.cfg: each entry carries its 0-based index,
+    # display name, target platform, and runnable flag. A non-runnable preset
+    # carries runnable=false, so the listing names every preset the file defines.
+    payload = {
+        "presets": [
+            {"index": 0, "name": "Linux/X11", "platform": "Linux/X11", "runnable": True},
+            {"index": 1, "name": "Web", "platform": "Web", "runnable": False},
+        ]
+    }
+
+    listed = ExportListResult.model_validate(payload)
+
+    assert listed.presets[0].index == 0
+    assert listed.presets[0].name == "Linux/X11"
+    assert listed.presets[0].runnable is True
+    assert listed.presets[1].platform == "Web"
+    assert listed.presets[1].runnable is False
+    assert json.loads(listed.model_dump_json()) == payload
+
+
+def test_export_list_result_round_trips_a_project_with_no_presets():
+    # A project whose export_presets.cfg defines no presets is a valid, empty
+    # listing — not an error (distinct from a project with no cfg at all, which
+    # is the export_presets_not_found failure).
+    payload = {"presets": []}
+
+    listed = ExportListResult.model_validate(payload)
+
+    assert listed.presets == []
+    assert json.loads(listed.model_dump_json()) == payload
+
+
+def test_export_get_result_round_trips_preset_details_and_template_status():
+    # export get reports one preset's details plus export-template readiness
+    # (issue #114): the preset's index/name/platform/runnable and export_path,
+    # then whether the running engine version's templates are installed and which
+    # version directory was checked — the readiness an agent asserts before an
+    # export run.
+    payload = {
+        "index": 1,
+        "name": "Web",
+        "platform": "Web",
+        "runnable": False,
+        "export_path": "build/index.html",
+        "templates_installed": True,
+        "templates_version": "4.6.3.stable",
+    }
+
+    got = ExportGetResult.model_validate(payload)
+
+    assert got.index == 1
+    assert got.name == "Web"
+    assert got.export_path == "build/index.html"
+    assert got.templates_installed is True
+    assert got.templates_version == "4.6.3.stable"
+    assert json.loads(got.model_dump_json()) == payload
+
+
+def test_export_get_result_round_trips_missing_templates():
+    # Templates not installed: templates_installed=false carries the version
+    # directory the agent should install, and export_path may be empty (unset).
+    payload = {
+        "index": 0,
+        "name": "Linux/X11",
+        "platform": "Linux/X11",
+        "runnable": True,
+        "export_path": "",
+        "templates_installed": False,
+        "templates_version": "4.6.3.stable",
+    }
+
+    got = ExportGetResult.model_validate(payload)
+
+    assert got.templates_installed is False
+    assert got.export_path == ""
+    assert json.loads(got.model_dump_json()) == payload
 
 
 def test_node_set_result_round_trips_the_coerced_property():

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -712,6 +712,26 @@ def test_resource_create_schema_emits_model_derived_contract_without_other_args(
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
 
+def test_export_list_schema_emits_model_derived_contract_without_a_project():
+    # The ADR-0004 hard gate for export list (issue #114): the bare --schema flag
+    # — no --project — short-circuits into the self-description, derived from the
+    # same typed models that back --json. export list takes no operation params,
+    # so its input schema is trivially empty (the project is process context,
+    # ADR-0006), exactly like scene list / script list.
+    from gda.models import ExportListParams, ExportListResult
+
+    result = CliRunner().invoke(app, ["export", "list", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ExportListParams.model_json_schema()
+    assert doc["output"] == ExportListResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert doc["input"].get("properties", {}) == {}
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
 def test_resource_get_schema_emits_model_derived_contract_without_other_args():
     from gda.models import ResourceGetParams, ResourceGetResult
 
@@ -723,6 +743,27 @@ def test_resource_get_schema_emits_model_derived_contract_without_other_args():
     assert doc["output"] == ResourceGetResult.model_json_schema()
     assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     assert "properties" in doc["output"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_export_get_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for export get (issue #114): the bare --schema flag —
+    # no --preset — short-circuits into the self-description. The preset param
+    # documents name-based addressing, and the output advertises the
+    # template-readiness fields agents check before an export run.
+    from gda.models import ExportGetParams, ExportGetResult
+
+    result = CliRunner().invoke(app, ["export", "get", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ExportGetParams.model_json_schema()
+    assert doc["output"] == ExportGetResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "preset" in doc["input"]["properties"]
+    assert "templates_installed" in doc["output"]["properties"]
+    assert "templates_version" in doc["output"]["properties"]
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
@@ -743,7 +784,21 @@ def test_sample_resource_results_validate_against_emitted_output_schemas():
     jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
 
 
-def test_resource_schema_spawns_no_godot(monkeypatch):
+def test_sample_export_results_validate_against_emitted_output_schemas():
+    # A sample --json payload of each export command satisfies the contract its
+    # --schema emits (the other half of the ADR-0004 hard gate, issue #114).
+    from tests.test_export_commands import GET_RESULT, LIST_RESULT
+
+    list_doc = json.loads(
+        CliRunner().invoke(app, ["export", "list", "--schema"]).stdout
+    )
+    get_doc = json.loads(CliRunner().invoke(app, ["export", "get", "--schema"]).stdout)
+
+    jsonschema.validate(instance=LIST_RESULT, schema=list_doc["output"])
+    jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
+
+
+def test_schema_spawns_no_godot(monkeypatch):
     def boom(*args, **kwargs):
         raise AssertionError("--schema must not touch the engine")
 
@@ -753,6 +808,8 @@ def test_resource_schema_spawns_no_godot(monkeypatch):
     for command in (
         ["resource", "create"],
         ["resource", "get"],
+        ["export", "list"],
+        ["export", "get"],
     ):
         result = CliRunner().invoke(app, [*command, "--schema"])
         assert result.exit_code == 0


### PR DESCRIPTION
## What

Establish the `export` command group with two **read-only** domain commands so an agent can learn what a project can export and whether the environment is ready — before a future `export run` (#121). This slice never runs an actual export.

- **`gda export list`** — enumerates the project's export presets from `export_presets.cfg` (index, name, platform, runnable), parsed with `ConfigFile`. Project-scoped like `scene list` / `script list`.
- **`gda export get`** — reports one preset's details (addressed by `--preset <name>`) plus **export-template install status**: `templates_installed` (the readiness check before an export run) and `templates_version` (the per-version templates directory `<major>.<minor>.<patch>.<status>`). Headless `--script` runs have no `EditorPaths` singleton, so the templates path is derived from `OS.get_data_dir()` + the fixed `Godot/export_templates/<version>` layout.

Both ship `--json` and the ADR-0004 `--schema` hard gate via the shared `HeadlessCommand` skeleton, model-derived from typed Pydantic models.

## Error codes

Two new registered operation codes for the modes that had no existing code, mirrored across the Python registry, the ADR-0002 table, and the GDScript op constants (drift-checked by `test_error_registry.py`):

- `export_presets_not_found` — project has no `export_presets.cfg` (distinct from an empty listing).
- `export_preset_not_found` — no preset with the requested name.

The projectless mode reuses the shared `project_not_found`.

## Acceptance criteria

- [x] `gda export list` enumerates the project's export presets as typed JSON.
- [x] `gda export get` reports a named preset's details + export-template install status as typed JSON.
- [x] Both ship `--json` and the ADR-0004 `--schema` hard gate via the shared skeleton.
- [x] Failure modes (no `export_presets.cfg`, unknown preset) surface as structured `GdaError`s with registered codes (Python registry + ADR-0002 table + GDScript mirror).
- [x] Tests: S2 model unit, S3 CLI-with-FakeRunner, S1 e2e.

## Tests

Strict TDD across all three layers — S2 model round-trips (`test_models.py`), S3 CLI-with-FakeRunner success + every failure mode (`test_export_commands.py`, `test_export_errors.py`), S1 e2e against the real engine (`test_e2e_export.py`: preset enumeration, empty/missing cfg, unknown preset, template-status shape), plus the `--schema` hard-gate (`test_schema_command.py`) and human-render dispatch coverage (`test_human_output.py`).

**Full suite: 453 passed, 0 failed, 0 skipped** (includes the e2e tier against Godot 4.6.3).

Closes #114
