### PR TITLE
feat(project): info + get + set — read/write project.godot headlessly (#111)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -125,6 +125,7 @@ operation, and parse codes the CLI assigns).
 | `invalid_uid` | `operation` | `operation` | `4` | A requested `uid://` value is not a syntactically valid resource UID. |
 | `unknown_uid` | `operation` | `operation` | `4` | A syntactically valid resource UID is not registered in the engine's UID cache. |
 | `no_uid_assigned` | `operation` | `operation` | `4` | A resource path exists but has no UID assigned in the engine's UID cache. |
+| `unknown_setting` | `operation` | `operation` | `4` | A requested project setting does not exist in the project's ProjectSettings. |
 | `contract_violation` | `parse` | `parser` | `5` | The process claimed success but violated the structured-output contract. |
 | `tree_too_deep` | `parse` | `classifier` | `5` | The engine emitted a valid result tree that nests past gda's recursion limit; the payload is contract-conformant, the limit is wrapper-side (shares the `parse` exit code; the `code` distinguishes it from `contract_violation`). |
 

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -350,11 +350,46 @@ codes only (no new ones).
 
 ### `project`
 
+Reads and writes the resolved project's `project.godot` / `ProjectSettings` headlessly. Every
+project command runs against an **explicit project context** (`--project`/`$GDA_PROJECT`/cwd,
+ADR-0006): `ProjectSettings` without a resolved project reports only the engine's bare defaults,
+not the agent's project, so a projectless run is refused with `project_not_found` (exit 4) rather
+than returning a misleading result.
+
+> **Autoloads run on every `project` command (#61, ADR-0009).** A `project` op is a **state-read**
+> at the operation level — it reads/writes `ProjectSettings` and never instantiates a scene — but it
+> still runs under `--project`, and the engine constructs the project's **autoload singletons**
+> (running their `_init`/`_ready`) at startup, *before* the operation gets control, on `project get`
+> / `info` included. This is the documented **process-startup execution surface** of the trusted-
+> project model (ADR-0009), not re-introduced silently: a `project` read is not zero-execution.
+
+**Project metadata** (established by #111): `gda project info` reports the project's `name` and
+`main_scene` (from `ProjectSettings`), its configured `viewport_width`/`viewport_height`, and the
+`engine_version` the project runs on (the same shape `gda info` reports). `main_scene` is the empty
+string for a project with no main scene set, and the viewport fields fall back to the engine's
+built-in defaults when the project never set them — so a brand-new project still reports a complete,
+valid result.
+
+**Reading and writing settings** (established by #111): `gda project get SECTION/KEY` reads one
+setting by its full `section/key` name (e.g. `application/config/name`) and reports it as a
+`{setting, type, value}` triple — `type` is the setting's declared Godot type name and `value` its
+JSON projection, the **same projection** `node get` reports for a node property. A setting that does
+not exist is a clean `unknown_setting` error (exit 4), distinguishing a typo'd key from a setting
+genuinely holding null. `gda project set SECTION/KEY --value <string>` writes a setting, **coercing**
+the CLI value to the setting's **declared type** — read off the setting's current value, exactly as
+`node set` reads it off the node's property list — using the **same coercion rules** the node group
+established (#55; see "Property value coercion" under [`node`](#node)). It then persists
+`project.godot` (`ProjectSettings.save()`) and reports the coerced value in the same JSON projection
+`project get` uses, so a **`set` round-trips through a `get`**. `set` edits an **existing** setting —
+an unknown key is `unknown_setting`, never a silent create, so the type to coerce to is always known.
+A value that cannot be coerced to the setting's type is `uncoercible_value` (exit 4, the #55 code,
+`project.godot` left untouched); a failed save is `save_failed`.
+
 | Command | Description |
 | --- | --- |
-| `gda project info` | Project metadata (name, viewport, Godot version) |
-| `gda project get` | Read a project setting by section/key |
-| `gda project set` | Modify a project setting (type-aware) |
+| `gda project info` | Project metadata (name, main scene, viewport, engine version) |
+| `gda project get` | Read a project setting by section/key (typed JSON) |
+| `gda project set` | Modify a project setting (value coerced to its declared type) |
 | `gda project add-autoload` / `remove-autoload` | Register / unregister an autoload singleton |
 
 ### `resource`

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -356,12 +356,14 @@ ADR-0006): `ProjectSettings` without a resolved project reports only the engine'
 not the agent's project, so a projectless run is refused with `project_not_found` (exit 4) rather
 than returning a misleading result.
 
-> **Autoloads run on every `project` command (#61, ADR-0009).** A `project` op is a **state-read**
-> at the operation level — it reads/writes `ProjectSettings` and never instantiates a scene — but it
-> still runs under `--project`, and the engine constructs the project's **autoload singletons**
-> (running their `_init`/`_ready`) at startup, *before* the operation gets control, on `project get`
-> / `info` included. This is the documented **process-startup execution surface** of the trusted-
-> project model (ADR-0009), not re-introduced silently: a `project` read is not zero-execution.
+> **Autoloads run on every `project` command (#61, ADR-0009).** `project info` and `project get` are
+> **state-reads** at the operation level — they read `ProjectSettings` and never instantiate a scene;
+> `project set` is a **`ProjectSettings` write** that persists to `project.godot`
+> (`ProjectSettings.save()`) but still never instantiates a scene. Either way, every `project` command
+> runs under `--project`, and the engine constructs the project's **autoload singletons** (running
+> their `_init`/`_ready`) at startup, *before* the operation gets control, on `project info` / `get` /
+> `set` alike. This is the documented **process-startup execution surface** of the trusted-project
+> model (ADR-0009), not re-introduced silently: a `project` op is not zero-execution.
 
 **Project metadata** (established by #111): `gda project info` reports the project's `name` and
 `main_scene` (from `ProjectSettings`), its configured `viewport_width`/`viewport_height`, and the

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -49,6 +49,12 @@ from gda.models import (
     NodeRemoveResult,
     NodeSetParams,
     NodeSetResult,
+    ProjectGetParams,
+    ProjectGetResult,
+    ProjectInfoParams,
+    ProjectInfoResult,
+    ProjectSetParams,
+    ProjectSetResult,
     ResourceCreateParams,
     ResourceCreateResult,
     ResourceGetParams,
@@ -128,6 +134,17 @@ export_app = typer.Typer(
     help="Discover export presets and export-template status.", no_args_is_help=True
 )
 app.add_typer(export_app, name="export")
+
+# The project command group (issue #111): commands that read and write the
+# resolved project's project.godot / ProjectSettings headlessly. Every project
+# command runs against an explicit project context (--project), so — like any
+# --project op — it runs the project's autoloads at engine startup (#61,
+# ADR-0009); reading/writing settings never instantiates a scene, so it is a
+# state-read at the operation level.
+project_app = typer.Typer(
+    help="Read and write the project's project.godot settings.", no_args_is_help=True
+)
+app.add_typer(project_app, name="project")
 
 
 def _version_callback(value: Optional[bool]) -> None:
@@ -402,6 +419,24 @@ RESOURCE_UID_COMMAND: HeadlessCommand[ResourceUidResult] = HeadlessCommand(
     operation="resource-uid",
     input_model=ResourceUidParams,
     output_model=ResourceUidResult,
+)
+
+PROJECT_INFO_COMMAND: HeadlessCommand[ProjectInfoResult] = HeadlessCommand(
+    operation="project-info",
+    input_model=ProjectInfoParams,
+    output_model=ProjectInfoResult,
+)
+
+PROJECT_GET_COMMAND: HeadlessCommand[ProjectGetResult] = HeadlessCommand(
+    operation="project-get",
+    input_model=ProjectGetParams,
+    output_model=ProjectGetResult,
+)
+
+PROJECT_SET_COMMAND: HeadlessCommand[ProjectSetResult] = HeadlessCommand(
+    operation="project-set",
+    input_model=ProjectSetParams,
+    output_model=ProjectSetResult,
 )
 
 
@@ -1139,6 +1174,45 @@ def create(
     )
 
 
+@project_app.command(name="info", cls=PROJECT_INFO_COMMAND.command_class())
+def project_info(
+    json_output: bool = json_option(),
+    schema: bool = PROJECT_INFO_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Report the resolved project's metadata (name, main scene, viewport, engine)."""
+    _dispatch(
+        PROJECT_INFO_COMMAND,
+        ProjectInfoParams(),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@project_app.command(name="get", cls=PROJECT_GET_COMMAND.command_class())
+def project_get(
+    setting: str = typer.Argument(
+        ..., help="The project setting's full section/key name (e.g. application/config/name)."
+    ),
+    json_output: bool = json_option(),
+    schema: bool = PROJECT_GET_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Read a single project setting by section/key as typed JSON."""
+    _dispatch(
+        PROJECT_GET_COMMAND,
+        ProjectGetParams(setting=setting),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
 @resource_app.command(name="get", cls=RESOURCE_GET_COMMAND.command_class())
 def get_resource(
     path: str = typer.Argument(..., help="The .tres resource file to read."),
@@ -1218,6 +1292,35 @@ def resolve_uid(
     _dispatch(
         RESOURCE_UID_COMMAND,
         ResourceUidParams(target=_normalize_path(target)),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@project_app.command(name="set", cls=PROJECT_SET_COMMAND.command_class())
+def project_set(
+    setting: str = typer.Argument(
+        ..., help="The project setting's full section/key name (e.g. application/config/name)."
+    ),
+    value: str = typer.Option(
+        ...,
+        "--value",
+        help=(
+            "The value to set, as a string. Coerced to the setting's declared "
+            "Godot type; an uncoercible value is a clean error."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = PROJECT_SET_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Set a project setting, coercing the value to its declared Godot type, then save."""
+    _dispatch(
+        PROJECT_SET_COMMAND,
+        ProjectSetParams(setting=setting, value=value),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -343,6 +343,13 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A resource path exists but has no UID assigned in the engine's UID cache.",
     ),
     ErrorCodeSpec(
+        "unknown_setting",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A requested project setting does not exist in the project's ProjectSettings.",
+    ),
+    ErrorCodeSpec(
         "contract_violation",
         ErrorCategory.PARSE,
         EXIT_PARSE,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -1399,7 +1399,8 @@ class ResourceUidResult(BaseModel):
 class EngineVersion(BaseModel):
     """The Godot engine version, as reported by ``Engine.get_version_info()``.
 
-    This is the result model of ``gda info``.
+    This is the result model of ``gda info``, and the ``engine_version`` carried
+    by ``gda project info``.
     """
 
     major: int
@@ -1411,3 +1412,120 @@ class EngineVersion(BaseModel):
     hash: str
     string: str
     timestamp: int
+
+
+class ProjectInfoParams(BaseModel):
+    """The operation params of ``gda project info`` — none (ADR-0004).
+
+    ``project info`` reports the resolved project's metadata from its
+    ``ProjectSettings``; the project is process context (``--project``), not an
+    operation param (ADR-0006), so the ``input`` schema is trivially empty.
+    """
+
+
+class ProjectInfoResult(BaseModel):
+    """The result of ``gda project info``: core project metadata (issue #111).
+
+    Reports the project's ``name`` and ``main_scene`` from ``ProjectSettings``,
+    its configured ``viewport_width``/``viewport_height``, and the ``engine_version``
+    the project runs on (the same shape ``gda info`` reports). ``main_scene`` is the
+    empty string for a project that has not set a main scene, and the viewport
+    fields fall back to the engine's built-in defaults when the project never set
+    them, so a brand-new project still reports a complete, valid result.
+    """
+
+    name: str = Field(description="The project name (ProjectSettings application/config/name).")
+    main_scene: str = Field(
+        description=(
+            "The project's main scene path (application/run/main_scene), or the "
+            "empty string when none is set."
+        )
+    )
+    viewport_width: int = Field(
+        description="The configured viewport width (display/window/size/viewport_width)."
+    )
+    viewport_height: int = Field(
+        description="The configured viewport height (display/window/size/viewport_height)."
+    )
+    engine_version: EngineVersion = Field(
+        description="The Godot engine version the project runs on."
+    )
+
+
+class ProjectGetParams(BaseModel):
+    """The operation params of ``gda project get`` (issue #111).
+
+    ``setting`` is the project setting's full ``section/key`` name (e.g.
+    ``application/config/name``). The project is process context (``--project``),
+    not an operation param (ADR-0006), so only ``setting`` is an input.
+    """
+
+    setting: str = Field(
+        description=(
+            "The project setting's full section/key name, e.g. "
+            "application/config/name."
+        )
+    )
+
+
+class ProjectGetResult(BaseModel):
+    """The result of ``gda project get``: one setting as typed JSON (issue #111).
+
+    Echoes the addressed ``setting``, its declared Godot ``type`` name, and its
+    ``value`` in the same JSON projection ``node get`` reports for a node property
+    (a scalar stays a scalar, a Vector2 becomes ``[x, y]``) — the projection
+    ``project set`` accepts back, so a ``set`` round-trips through a ``get``.
+    """
+
+    setting: str
+    type: str = Field(
+        description="The setting's declared Godot type name (e.g. String, int, Vector2)."
+    )
+    value: Any = Field(
+        description=(
+            "The setting's value as JSON: a scalar for a scalar type, a list for "
+            "a packed type (Vector2 → [x, y], Color → [r, g, b, a])."
+        )
+    )
+
+
+class ProjectSetParams(BaseModel):
+    """The operation params of ``gda project set`` (issue #111).
+
+    ``setting`` is the project setting's full ``section/key`` name; ``value`` is
+    the CLI string value, coerced to the setting's declared Godot type by the
+    operation (the same coercion rules as ``node set``, #55) before
+    ``project.godot`` is saved. ``set`` edits an EXISTING setting — an unknown key
+    is a clean error, never a silent create — so the declared type to coerce to is
+    always known (read off the setting's current value).
+    """
+
+    setting: str = Field(
+        description=(
+            "The project setting's full section/key name, e.g. "
+            "application/config/name."
+        )
+    )
+    value: str = Field(
+        description=(
+            "The value to set, as a string. The operation coerces it to the "
+            "setting's declared Godot type (see the command catalog's 'Property "
+            "value coercion'); an uncoercible value is a clean error."
+        )
+    )
+
+
+class ProjectSetResult(BaseModel):
+    """The result of ``gda project set``: the one setting it set (issue #111).
+
+    Echoes the ``setting`` set, the declared ``type`` the CLI value was coerced
+    to, and the coerced ``value`` as JSON — the same projection ``project get``
+    reports, so a ``set`` round-trips through a ``get`` without re-reading
+    ``project.godot``.
+    """
+
+    setting: str
+    type: str = Field(description="The setting's declared Godot type the value was coerced to.")
+    value: Any = Field(
+        description="The coerced value as JSON, as ProjectSettings now holds it."
+    )

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -1791,7 +1791,7 @@ func _op_project_get(params: Dictionary) -> void:
 #
 # Persistence: ProjectSettings.set_setting mutates the in-memory settings, and
 # ProjectSettings.save() writes them back to res://project.godot. A failed save is
-# setting_save_failed. Like every --project op it runs the project's autoloads at
+# save_failed. Like every --project op it runs the project's autoloads at
 # startup (#61, ADR-0009); the set itself never instantiates a scene.
 func _op_project_set(params: Dictionary) -> void:
 	_diag("running operation: project-set")

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -60,8 +60,17 @@ const OP_ERROR_EXPORT_PRESET_NOT_FOUND := "export_preset_not_found"
 const OP_ERROR_INVALID_UID := "invalid_uid"
 const OP_ERROR_UNKNOWN_UID := "unknown_uid"
 const OP_ERROR_NO_UID_ASSIGNED := "no_uid_assigned"
+const OP_ERROR_UNKNOWN_SETTING := "unknown_setting"
 
 const NODE_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
+
+# The project-info settings (issue #111), read with a default so a project that
+# never wrote them still reports a sensible value rather than failing: a new
+# Godot 4 project has no explicit main_scene and inherits viewport defaults.
+const PROJECT_NAME_SETTING := "application/config/name"
+const PROJECT_MAIN_SCENE_SETTING := "application/run/main_scene"
+const PROJECT_VIEWPORT_WIDTH_SETTING := "display/window/size/viewport_width"
+const PROJECT_VIEWPORT_HEIGHT_SETTING := "display/window/size/viewport_height"
 
 # The exit code the process will use. Defaults to failure, so an operation that
 # aborts before recording an outcome (e.g. an uncaught runtime error) still
@@ -137,6 +146,12 @@ func _initialize() -> void:
 			_op_export_get(params)
 		"resource-uid":
 			_op_resource_uid(params)
+		"project-info":
+			_op_project_info(params)
+		"project-get":
+			_op_project_get(params)
+		"project-set":
+			_op_project_set(params)
 		_:
 			_fail(OP_ERROR_UNKNOWN_OPERATION, "unknown operation: " + operation)
 
@@ -1700,6 +1715,121 @@ func _resolve_path_to_uid(path: String) -> void:
 		"queried": "path",
 		"uid": ResourceUID.id_to_text(id),
 		"path": path,
+	})
+
+
+# project-info: report core project metadata — name, main scene, viewport size,
+# and the engine version — as typed JSON (issue #111, the project-group tracer's
+# read half). Reads ProjectSettings, which the engine populates from project.godot
+# at startup; the engine version comes from Engine.get_version_info(), the same
+# source gda info reports. The viewport/main-scene settings are read WITH A DEFAULT
+# so a new project that never wrote them still reports a value (a fresh Godot 4
+# project has no explicit main_scene and inherits the built-in viewport size)
+# rather than failing.
+#
+# project-info needs a project: ProjectSettings without a resolved project would
+# report only the engine's bare defaults, not the agent's project, so a projectless
+# run is refused with project_not_found rather than returning a misleading result.
+# Like every --project op it runs the project's autoloads at engine startup (#61,
+# ADR-0009) — reading settings is a state-read at the operation level (it never
+# instantiates a scene), but the startup autoload execution surface still applies.
+func _op_project_info(_params: Dictionary) -> void:
+	_diag("running operation: project-info")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "project info requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+
+	_succeed({
+		"name": String(ProjectSettings.get_setting(PROJECT_NAME_SETTING, "")),
+		"main_scene": String(ProjectSettings.get_setting(PROJECT_MAIN_SCENE_SETTING, "")),
+		"viewport_width": int(ProjectSettings.get_setting(PROJECT_VIEWPORT_WIDTH_SETTING, 0)),
+		"viewport_height": int(ProjectSettings.get_setting(PROJECT_VIEWPORT_HEIGHT_SETTING, 0)),
+		"engine_version": Engine.get_version_info(),
+	})
+
+
+# project-get: read one project setting by its full "section/key" name and report
+# it as typed JSON (issue #111). The reported `type` is the setting's declared
+# Godot type name and `value` its JSON projection — the same {type, value}
+# projection node get reports for a node property, so project get / set round-trip
+# through the same shape as node get / set. A setting that does not exist is a
+# clean unknown_setting error (not a null value), so a typo'd key is distinguished
+# from a setting genuinely holding null.
+#
+# Like project-info it needs a project (project_not_found otherwise) and runs the
+# project's autoloads at startup (#61, ADR-0009); reading a setting never
+# instantiates a scene, so it is a state-read at the operation level.
+func _op_project_get(params: Dictionary) -> void:
+	_diag("running operation: project-get")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "project get requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+	var setting := _string_param(params, "setting")
+	if setting.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: setting")
+		return
+	if not ProjectSettings.has_setting(setting):
+		_fail(OP_ERROR_UNKNOWN_SETTING, "project setting not found: " + setting)
+		return
+
+	var value: Variant = ProjectSettings.get_setting(setting)
+	_succeed({
+		"setting": setting,
+		"type": _type_name(typeof(value)),
+		"value": _jsonify(value),
+	})
+
+
+# project-set: write one project setting, coercing the CLI string value to the
+# setting's DECLARED Godot type, then persist project.godot (issue #111, the write
+# half — verifiable via project get). The declared type is read off the setting's
+# CURRENT value (typeof), exactly as node set reads it off the node's property
+# list, and the value is coerced with the SAME shared _coerce_value rules (#55):
+# an uncoercible value is a clean uncoercible_value error, leaving project.godot
+# untouched. set only writes a setting that already exists — an unknown key is
+# unknown_setting, not a silent create — so the type to coerce to is always known.
+#
+# Persistence: ProjectSettings.set_setting mutates the in-memory settings, and
+# ProjectSettings.save() writes them back to res://project.godot. A failed save is
+# setting_save_failed. Like every --project op it runs the project's autoloads at
+# startup (#61, ADR-0009); the set itself never instantiates a scene.
+func _op_project_set(params: Dictionary) -> void:
+	_diag("running operation: project-set")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "project set requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+	var setting := _string_param(params, "setting")
+	if setting.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: setting")
+		return
+	if not ProjectSettings.has_setting(setting):
+		_fail(OP_ERROR_UNKNOWN_SETTING, "project setting not found: " + setting
+				+ " — project set edits an existing setting; it never creates one")
+		return
+
+	var declared_type := typeof(ProjectSettings.get_setting(setting))
+	var raw_value := _string_param(params, "value")
+	var coerced: Variant = _coerce_value(raw_value, declared_type)
+	if coerced == null:
+		_fail(OP_ERROR_UNCOERCIBLE_VALUE, "cannot coerce value " + raw_value.c_escape()
+				+ " to " + _type_name(declared_type) + " for project setting " + setting)
+		return
+
+	ProjectSettings.set_setting(setting, coerced)
+	var save_err := ProjectSettings.save()
+	if save_err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, "failed to save project settings after setting "
+				+ setting + ": " + error_string(save_err))
+		return
+
+	# Read the value back off ProjectSettings before reporting — it now holds the
+	# coerced value in its canonical form, the same projection project get reports,
+	# so a set round-trips through a get.
+	var stored_value: Variant = _jsonify(ProjectSettings.get_setting(setting))
+	_succeed({
+		"setting": setting,
+		"type": _type_name(declared_type),
+		"value": stored_value,
 	})
 
 

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -34,6 +34,9 @@ from gda.models import (
     NodeMoveResult,
     NodeRemoveResult,
     NodeSetResult,
+    ProjectGetResult,
+    ProjectInfoResult,
+    ProjectSetResult,
     ResourceCreateResult,
     ResourceGetResult,
     ResourceUidResult,
@@ -331,6 +334,29 @@ def render_resource_uid(resolved: "ResourceUidResult") -> str:
     return f"{resolved.uid} -> {resolved.path}"
 
 
+def render_project_info(info: "ProjectInfoResult") -> str:
+    """Render project metadata as a small ``key: value`` block for humans."""
+    main_scene = info.main_scene if info.main_scene else "(none)"
+    return "\n".join(
+        [
+            f"name: {info.name}",
+            f"main_scene: {main_scene}",
+            f"viewport: {info.viewport_width}x{info.viewport_height}",
+            f"engine: {info.engine_version.string}",
+        ]
+    )
+
+
+def render_project_get(got: "ProjectGetResult") -> str:
+    """Render a read setting as ``<setting> (<type>) = <value>``."""
+    return f"{got.setting} ({got.type}) = {format_value(got.value)}"
+
+
+def render_project_set(was_set: "ProjectSetResult") -> str:
+    """Render a set setting as ``set <setting> (<type>) = <value>``."""
+    return f"set {was_set.setting} ({was_set.type}) = {format_value(was_set.value)}"
+
+
 def render_engine_version(version: "EngineVersion") -> str:
     """Render the engine version as its one-line version string."""
     return version.string
@@ -368,6 +394,9 @@ _RENDERERS = {
     ExportListResult: render_export_list,
     ExportGetResult: render_export_get,
     ResourceUidResult: render_resource_uid,
+    ProjectInfoResult: render_project_info,
+    ProjectGetResult: render_project_get,
+    ProjectSetResult: render_project_set,
     EngineVersion: render_engine_version,
 }
 

--- a/tests/test_e2e_project.py
+++ b/tests/test_e2e_project.py
@@ -1,0 +1,171 @@
+"""S1 (e2e): the project info / get / set round-trip against the real Godot engine.
+
+The project-group tracer (issue #111): ``gda project info`` reports the resolved
+project's metadata from ``ProjectSettings``; ``gda project get`` reads one
+setting; ``gda project set`` coerces a CLI value to the setting's declared type,
+saves ``project.godot``, and is verified by ``project get`` reading the new value
+back — ``project get`` IS the structured-level verification of ``project set``.
+
+Every project op runs against an explicit project context (--project) and so, like
+any --project op, runs the project's autoloads at engine startup (#61, ADR-0009);
+the e2e fixture has none, so that surface is exercised as a no-op here.
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+GODOT = resolve_godot_binary()
+
+
+def _gda(project, *args: str) -> subprocess.CompletedProcess:
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+    return subprocess.run(
+        [gda_bin, *args, "--project", str(project), "--godot", str(GODOT)],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.e2e
+def test_project_info_reports_metadata(godot_project):
+    info = _gda(godot_project, "project", "info", "--json")
+
+    assert info.returncode == 0, info.stdout + info.stderr
+    data = json.loads(info.stdout)
+    # The fixture's project.godot sets config/name to this.
+    assert data["name"] == "gda-e2e-fixture"
+    # A fresh project has no explicit main scene.
+    assert data["main_scene"] == ""
+    # Viewport falls back to the engine's built-in defaults (positive integers).
+    assert isinstance(data["viewport_width"], int) and data["viewport_width"] > 0
+    assert isinstance(data["viewport_height"], int) and data["viewport_height"] > 0
+    # The engine version is the same shape (and minimum, ADR-0003) gda info reports.
+    version = data["engine_version"]
+    assert (version["major"], version["minor"]) >= (4, 4)
+
+
+@pytest.mark.e2e
+def test_project_get_reads_a_setting_as_typed_json(godot_project):
+    got = _gda(godot_project, "project", "get", "application/config/name", "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    data = json.loads(got.stdout)
+    assert data["setting"] == "application/config/name"
+    assert data["type"] == "String"
+    assert data["value"] == "gda-e2e-fixture"
+
+
+@pytest.mark.e2e
+def test_project_set_coerces_persists_and_round_trips_via_get(godot_project):
+    # The CLI value is a STRING; the operation coerces it to the setting's declared
+    # int type, saves project.godot, and the result reports the coerced int (#55
+    # coercion reused). A second get reads it back from the saved file.
+    was_set = _gda(
+        godot_project,
+        "project",
+        "set",
+        "display/window/size/viewport_width",
+        "--value",
+        "1920",
+        "--json",
+    )
+
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    set_data = json.loads(was_set.stdout)
+    assert set_data["setting"] == "display/window/size/viewport_width"
+    assert set_data["type"] == "int"
+    # Coerced to an int, not left as the string "1920".
+    assert set_data["value"] == 1920
+
+    # Round-trip: a fresh process reads the persisted value back from project.godot.
+    got = _gda(
+        godot_project, "project", "get", "display/window/size/viewport_width", "--json"
+    )
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["value"] == 1920
+
+    # And project info reflects the saved viewport width.
+    info = _gda(godot_project, "project", "info", "--json")
+    assert info.returncode == 0, info.stdout + info.stderr
+    assert json.loads(info.stdout)["viewport_width"] == 1920
+
+
+@pytest.mark.e2e
+def test_project_set_string_setting_round_trips(godot_project):
+    # A String-typed setting takes the CLI value verbatim and round-trips.
+    was_set = _gda(
+        godot_project,
+        "project",
+        "set",
+        "application/config/name",
+        "--value",
+        "Renamed Game",
+        "--json",
+    )
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    assert json.loads(was_set.stdout)["value"] == "Renamed Game"
+
+    got = _gda(godot_project, "project", "get", "application/config/name", "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["value"] == "Renamed Game"
+
+
+@pytest.mark.e2e
+def test_project_get_unknown_setting_is_a_clean_error(godot_project):
+    got = _gda(godot_project, "project", "get", "application/bogus/key", "--json")
+
+    assert got.returncode == 4
+    err = json.loads(got.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "unknown_setting"
+    assert "application/bogus/key" in err["message"]
+
+
+@pytest.mark.e2e
+def test_project_set_uncoercible_value_is_a_clean_error(godot_project):
+    # An int setting cannot take a non-numeric string — uncoercible_value (#55),
+    # exit 4, project.godot left untouched.
+    bad = _gda(
+        godot_project,
+        "project",
+        "set",
+        "display/window/size/viewport_width",
+        "--value",
+        "not-a-number",
+        "--json",
+    )
+
+    assert bad.returncode == 4
+    err = json.loads(bad.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "uncoercible_value"
+
+    # The file was untouched: a subsequent get still returns the original value.
+    got = _gda(
+        godot_project, "project", "get", "display/window/size/viewport_width", "--json"
+    )
+    assert got.returncode == 0, got.stdout + got.stderr
+
+
+@pytest.mark.e2e
+def test_project_info_without_project_is_a_clean_error():
+    # Projectless: ProjectSettings would report only the engine's bare defaults,
+    # not the agent's project, so it is refused with project_not_found.
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+    proc = subprocess.run(
+        [gda_bin, "project", "info", "--json", "--godot", str(GODOT)],
+        capture_output=True,
+        text=True,
+        cwd="/tmp",
+    )
+
+    assert proc.returncode == 4
+    err = json.loads(proc.stdout)["error"]
+    assert err["code"] == "project_not_found"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,6 +19,9 @@ from gda.models import (
     NodeMoveResult,
     NodeRemoveResult,
     NodeSetResult,
+    ProjectGetResult,
+    ProjectInfoResult,
+    ProjectSetResult,
     ResourceCreateResult,
     ResourceGetResult,
     SceneCreateResult,
@@ -791,3 +794,100 @@ def test_scene_get_exports_result_round_trips_per_node_exports():
     assert node.exports[0].type == "float"
     assert node.exports[0].value == 3.5
     assert json.loads(got.model_dump_json()) == payload
+
+
+def test_project_info_result_round_trips_metadata_and_engine_version():
+    # project info reports the project's core metadata (issue #111): name and
+    # main scene from ProjectSettings, the configured viewport size, and the
+    # nested engine_version the project runs on (the same shape gda info reports).
+    payload = {
+        "name": "My Game",
+        "main_scene": "res://main.tscn",
+        "viewport_width": 1920,
+        "viewport_height": 1080,
+        "engine_version": {
+            "major": 4,
+            "minor": 6,
+            "patch": 3,
+            "hex": 0x040603,
+            "status": "stable",
+            "build": "official",
+            "hash": "7d41c59c457bd5a245092b4e7eb2d833e3b3f8c3",
+            "string": "4.6.3-stable (official)",
+            "timestamp": 0,
+        },
+    }
+
+    info = ProjectInfoResult.model_validate(payload)
+
+    assert info.name == "My Game"
+    assert info.main_scene == "res://main.tscn"
+    assert (info.viewport_width, info.viewport_height) == (1920, 1080)
+    assert info.engine_version.string == "4.6.3-stable (official)"
+    assert json.loads(info.model_dump_json()) == payload
+
+
+def test_project_info_result_round_trips_a_brand_new_project():
+    # A brand-new project that never set a main scene reports the empty string for
+    # main_scene and the engine's built-in viewport defaults — a complete, valid
+    # result rather than an error.
+    payload = {
+        "name": "",
+        "main_scene": "",
+        "viewport_width": 1152,
+        "viewport_height": 648,
+        "engine_version": {
+            "major": 4,
+            "minor": 6,
+            "patch": 3,
+            "hex": 0x040603,
+            "status": "stable",
+            "build": "official",
+            "hash": "7d41c59c457bd5a245092b4e7eb2d833e3b3f8c3",
+            "string": "4.6.3-stable (official)",
+            "timestamp": 0,
+        },
+    }
+
+    info = ProjectInfoResult.model_validate(payload)
+
+    assert info.main_scene == ""
+    assert (info.viewport_width, info.viewport_height) == (1152, 648)
+    assert json.loads(info.model_dump_json()) == payload
+
+
+def test_project_get_result_round_trips_a_typed_setting():
+    # project get echoes one setting (issue #111): its full section/key name, its
+    # declared Godot type name, and its value in the same JSON projection node get
+    # uses for a property — a packed type projects to a list (Vector2 → [x, y]).
+    payload = {
+        "setting": "display/window/size/viewport_width",
+        "type": "int",
+        "value": 1920,
+    }
+
+    got = ProjectGetResult.model_validate(payload)
+
+    assert got.setting == "display/window/size/viewport_width"
+    assert got.type == "int"
+    assert got.value == 1920
+    assert json.loads(got.model_dump_json()) == payload
+
+
+def test_project_set_result_round_trips_the_coerced_setting():
+    # project set echoes the one setting it wrote (issue #111): the setting name,
+    # the declared type the CLI value was coerced to, and the coerced value as
+    # ProjectSettings now holds it — the same projection project get reports, so a
+    # set round-trips through a get.
+    payload = {
+        "setting": "application/config/name",
+        "type": "String",
+        "value": "Renamed Game",
+    }
+
+    was_set = ProjectSetResult.model_validate(payload)
+
+    assert was_set.setting == "application/config/name"
+    assert was_set.type == "String"
+    assert was_set.value == "Renamed Game"
+    assert json.loads(was_set.model_dump_json()) == payload

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -1,0 +1,288 @@
+"""S3: gda project info / get / set success paths against a fake runner (issue #111).
+
+The project command group reads and writes the resolved project's
+``project.godot`` / ``ProjectSettings`` headlessly. These tests drive the same
+proven pipeline as the scene / node / script groups — Typer → binary resolution
+→ runner → sentinel parse → typed model → JSON — with canned engine output, no
+real Godot.
+"""
+
+import json
+
+import jsonschema
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.models import (
+    GdaErrorEnvelope,
+    ProjectGetParams,
+    ProjectGetResult,
+    ProjectInfoParams,
+    ProjectInfoResult,
+    ProjectSetParams,
+    ProjectSetResult,
+)
+from gda.runner import RunResult
+from tests.support import FakeRunner, inject_runner, sentinel
+
+VERSION_INFO = {
+    "major": 4,
+    "minor": 6,
+    "patch": 3,
+    "hex": 0x040603,
+    "status": "stable",
+    "build": "official",
+    "hash": "7d41c59c457bd5a245092b4e7eb2d833e3b3f8c3",
+    "string": "4.6.3-stable (official)",
+    "timestamp": 0,
+}
+
+INFO_RESULT = {
+    "name": "My Game",
+    "main_scene": "res://main.tscn",
+    "viewport_width": 1152,
+    "viewport_height": 648,
+    "engine_version": VERSION_INFO,
+}
+
+GET_RESULT = {
+    "setting": "application/config/name",
+    "type": "String",
+    "value": "My Game",
+}
+
+SET_RESULT = {
+    "setting": "display/window/size/viewport_width",
+    "type": "int",
+    "value": 1920,
+}
+
+
+# --- project info ---------------------------------------------------------
+
+
+def test_project_info_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
+    # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(INFO_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["project", "info", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["name"] == "My Game"
+    assert data["main_scene"] == "res://main.tscn"
+    assert data["viewport_width"] == 1152
+    assert data["viewport_height"] == 648
+    # The engine version is the same shape gda info reports.
+    assert data["engine_version"]["string"] == "4.6.3-stable (official)"
+    # project info takes no operation params (the project is process context).
+    assert fake.calls == [("project-info", {})]
+    assert "engine diagnostic" in result.stderr
+
+
+def test_project_info_human_output_is_a_readable_block(monkeypatch):
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(INFO_RESULT), stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["project", "info"])
+
+    assert result.exit_code == 0
+    assert "name: My Game" in result.stdout
+    assert "main_scene: res://main.tscn" in result.stdout
+    assert "viewport: 1152x648" in result.stdout
+    assert "4.6.3-stable (official)" in result.stdout
+
+
+def test_project_info_human_output_shows_none_for_empty_main_scene(monkeypatch):
+    # A new project has no main scene; the human block names that explicitly.
+    payload = {**INFO_RESULT, "main_scene": ""}
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["project", "info"])
+
+    assert result.exit_code == 0
+    assert "main_scene: (none)" in result.stdout
+
+
+# --- project get ----------------------------------------------------------
+
+
+def test_project_get_dispatches_setting_param_and_reports_typed_value(monkeypatch):
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["project", "get", "application/config/name", "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data == GET_RESULT
+    # The setting rides through as the one operation param.
+    assert fake.calls == [("project-get", {"setting": "application/config/name"})]
+
+
+def test_project_get_human_output_is_setting_type_value(monkeypatch):
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["project", "get", "application/config/name"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == 'application/config/name (String) = "My Game"'
+
+
+def test_project_get_carries_packed_value_projection(monkeypatch):
+    # A packed-type setting (e.g. a Vector2-ish value) is carried as a JSON list,
+    # the same projection node get reports — so get / set round-trip the shape.
+    payload = {"setting": "some/vec", "type": "Vector2", "value": [10.0, 20.0]}
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["project", "get", "some/vec", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["value"] == [10.0, 20.0]
+
+
+# --- project set ----------------------------------------------------------
+
+
+def test_project_set_dispatches_setting_and_value_and_round_trips(monkeypatch):
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "project",
+            "set",
+            "display/window/size/viewport_width",
+            "--value",
+            "1920",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    # The result reports the coerced value as the JSON projection get reports,
+    # so a set round-trips through a get (the declared int type, not the string).
+    assert data["setting"] == "display/window/size/viewport_width"
+    assert data["type"] == "int"
+    assert data["value"] == 1920
+    # The CLI value is passed as a string; the operation owns the coercion.
+    assert fake.calls == [
+        (
+            "project-set",
+            {"setting": "display/window/size/viewport_width", "value": "1920"},
+        )
+    ]
+
+
+def test_project_set_human_output_is_set_setting_type_value(monkeypatch):
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app, ["project", "set", "display/window/size/viewport_width", "--value", "1920"]
+    )
+
+    assert result.exit_code == 0
+    assert (
+        result.stdout.strip()
+        == "set display/window/size/viewport_width (int) = 1920"
+    )
+
+
+def test_project_set_requires_value(monkeypatch):
+    # --value is required: a set with no value is a usage error (exit 2), not a
+    # silent no-op or an empty write.
+    fake = FakeRunner(RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0))
+    monkeypatch.setattr("gda.cli._make_runner", lambda binary, project=None: fake)
+
+    result = CliRunner().invoke(
+        app, ["project", "set", "application/config/name"]
+    )
+
+    assert result.exit_code == 2
+    assert fake.calls == []
+
+
+# --- ADR-0004 --schema hard gate -----------------------------------------
+
+
+def test_project_info_schema_emits_model_derived_contract_without_a_project():
+    # The ADR-0004 hard gate for project info (issue #111): the bare --schema flag
+    # — no --project — short-circuits into the self-description, derived from the
+    # same typed models that back --json. project info takes no operation params,
+    # so its input schema is trivially empty (the project is process context).
+    result = CliRunner().invoke(app, ["project", "info", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ProjectInfoParams.model_json_schema()
+    assert doc["output"] == ProjectInfoResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert doc["input"].get("properties", {}) == {}
+    assert "engine_version" in doc["output"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_project_get_schema_emits_model_derived_contract_without_other_args():
+    result = CliRunner().invoke(app, ["project", "get", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ProjectGetParams.model_json_schema()
+    assert doc["output"] == ProjectGetResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "section/key" in doc["input"]["properties"]["setting"]["description"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_project_set_schema_emits_model_derived_contract_without_other_args():
+    # The value param documents the type-coercion contract agents must rely on.
+    result = CliRunner().invoke(app, ["project", "set", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ProjectSetParams.model_json_schema()
+    assert doc["output"] == ProjectSetResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    value_description = doc["input"]["properties"]["value"]["description"]
+    assert "coerce" in value_description.lower()
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_sample_project_results_validate_against_emitted_output_schemas():
+    # A sample --json payload of each project command satisfies the contract its
+    # --schema emits (the other half of the ADR-0004 hard gate, issue #111).
+    info_doc = json.loads(CliRunner().invoke(app, ["project", "info", "--schema"]).stdout)
+    get_doc = json.loads(CliRunner().invoke(app, ["project", "get", "--schema"]).stdout)
+    set_doc = json.loads(CliRunner().invoke(app, ["project", "set", "--schema"]).stdout)
+
+    jsonschema.validate(instance=INFO_RESULT, schema=info_doc["output"])
+    jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
+    jsonschema.validate(instance=SET_RESULT, schema=set_doc["output"])
+
+
+def test_project_schema_spawns_no_godot(monkeypatch):
+    def boom(*args, **kwargs):
+        raise AssertionError("--schema must not touch the engine")
+
+    monkeypatch.setattr("gda.headless.resolve_godot_binary", boom)
+    monkeypatch.setattr("gda.cli._make_runner", boom)
+
+    for command in (
+        ["project", "info"],
+        ["project", "get"],
+        ["project", "set"],
+    ):
+        result = CliRunner().invoke(app, [*command, "--schema"])
+        assert result.exit_code == 0
+        assert set(json.loads(result.stdout)) >= {"input", "output", "error"}

--- a/tests/test_project_errors.py
+++ b/tests/test_project_errors.py
@@ -1,0 +1,107 @@
+"""S3: gda project failure modes map to structured JSON errors + stable exit codes.
+
+Issue #111's acceptance: project-command failures (missing/invalid project,
+unknown setting key, uncoercible value) surface as structured ``GdaError``s with
+registered operation codes (ADR-0002) — exit 4 for the operation category, finer
+stable codes so an agent branches on the mode without parsing prose.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import error_sentinel, inject_runner
+
+
+def _invoke(monkeypatch, args, code, message, stderr="gda: running operation\n"):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr=stderr,
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(app, args)
+
+
+def test_project_info_without_project_maps_to_project_not_found(monkeypatch):
+    # project info reads ProjectSettings, so a projectless run would report only
+    # the engine's bare defaults — refused with project_not_found instead.
+    result = _invoke(
+        monkeypatch,
+        ["project", "info", "--json"],
+        "project_not_found",
+        "project info requires a Godot project; none was resolved",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "project_not_found"
+    assert "Godot project" in err["message"]
+    assert err["diagnostics"] == "gda: running operation\n"
+
+
+def test_project_get_unknown_setting_maps_to_stable_unknown_setting_code(monkeypatch):
+    # A typo'd / absent setting key is unknown_setting, distinct from a setting
+    # genuinely holding null — the agent fixes the key, not the value.
+    result = _invoke(
+        monkeypatch,
+        ["project", "get", "application/bogus/key", "--json"],
+        "unknown_setting",
+        "project setting not found: application/bogus/key",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "unknown_setting"
+    assert "application/bogus/key" in err["message"]
+
+
+def test_project_set_unknown_setting_maps_to_stable_unknown_setting_code(monkeypatch):
+    # set edits an existing setting; an unknown key is unknown_setting, never a
+    # silent create.
+    result = _invoke(
+        monkeypatch,
+        ["project", "set", "application/bogus/key", "--value", "1", "--json"],
+        "unknown_setting",
+        "project setting not found: application/bogus/key — project set edits an "
+        "existing setting; it never creates one",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "unknown_setting"
+    assert "never creates" in err["message"]
+
+
+def test_project_set_uncoercible_value_maps_to_stable_uncoercible_value_code(
+    monkeypatch,
+):
+    # A value that cannot be coerced to the setting's declared type reuses the
+    # node-set #55 code: uncoercible_value (exit 4, project.godot untouched).
+    result = _invoke(
+        monkeypatch,
+        [
+            "project",
+            "set",
+            "display/window/size/viewport_width",
+            "--value",
+            "not-a-number",
+            "--json",
+        ],
+        "uncoercible_value",
+        "cannot coerce value not-a-number to int for project setting "
+        "display/window/size/viewport_width",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "uncoercible_value"
+    assert "not-a-number" in err["message"]


### PR DESCRIPTION
## What

Establishes the `project` command group (issue #111), reading and writing the resolved project's `project.godot` / `ProjectSettings` headlessly. This is the **project-group tracer** — it lays down the group scaffolding (`project_app` Typer group, shared `_dispatch`/skeleton reuse) that the peer slices #116 (static-analysis reads) and #119 (autoload management) rebase onto.

- **`gda project info`** — core metadata (name, main scene, viewport size, engine version) as typed JSON. The `engine_version` reuses the `EngineVersion` model `gda info` reports.
- **`gda project get SECTION/KEY`** — reads one setting by its full `section/key` name, reported as a `{setting, type, value}` triple in the **same JSON projection `node get` uses** (a scalar stays a scalar, a packed type becomes a list).
- **`gda project set SECTION/KEY --value <string>`** — coerces the CLI value to the setting's **declared type** (read off the setting's current value, exactly as `node set` reads it off the node's property list), **reusing the #55 coercion rules**, saves `project.godot`, and reports the coerced value — so a **`set` round-trips through a `get`**.

## Acceptance criteria

- [x] `project info` returns metadata (name, main scene, viewport, engine version) as typed JSON.
- [x] `project get` returns a setting value by section/key as typed JSON.
- [x] `project set` coerces the CLI value to the setting's declared type, persists to `project.godot`, and round-trips via `get` (proven e2e).
- [x] Coercion reuses the #55 rules; an uncoercible value is a clean `uncoercible_value` error; the rules are documented (catalog `project` section links the `node` "Property value coercion" table).
- [x] All ship `--json` and the ADR-0004 `--schema` hard gate via the shared skeleton.
- [x] Failure modes surface as registered `GdaError`s: missing/invalid project → `project_not_found`, unknown key → **new** `unknown_setting`, uncoercible value → `uncoercible_value`, failed save → `save_failed`.
- [x] Tests: S2 model-derived schema, S3 CLI-with-FakeRunner, S1 e2e.

## Autoload caveat (#61, ADR-0009)

Every `project` op runs under `--project`, so the engine constructs the project's **autoload singletons** (running their `_init`/`_ready`) at startup, on `project get`/`info` included. A `project` read is a **state-read at the operation level** (it never instantiates a scene) but is **not zero-execution**. This is documented in the catalog's `project` section as the process-startup execution surface — not re-introduced silently.

## New error code

`unknown_setting` — a requested project setting does not exist in the project's `ProjectSettings`. Registered in the Python registry (`error_codes.py`), the ADR-0002 table, and the GDScript mirror; the registry-drift tests pass. (Save reuses `save_failed`; uncoercible value reuses `uncoercible_value` — no other new codes.)

## Tests

- Full suite incl. e2e against a real Godot 4.6.3 engine: **448 passed, 0 failed, 0 skipped**.
- CI-equivalent (`uv run --frozen pytest -m "not e2e"`): 292 passed; `uv build` succeeds.

Closes #111
