### PR TITLE
feat(asset-file): shader create/get/set + theme create — headless asset-file authoring (#115)

### DIFF
--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -86,6 +86,14 @@ from gda.models import (
     ScriptSetResult,
     ScriptValidateParams,
     ScriptValidateResult,
+    ShaderCreateParams,
+    ShaderCreateResult,
+    ShaderGetParams,
+    ShaderGetResult,
+    ShaderSetParams,
+    ShaderSetResult,
+    ThemeCreateParams,
+    ThemeCreateResult,
 )
 from gda.project import resolve_project_dir
 from gda.render import render
@@ -145,6 +153,21 @@ project_app = typer.Typer(
     help="Read and write the project's project.godot settings.", no_args_is_help=True
 )
 app.add_typer(project_app, name="project")
+
+# The asset-file groups (issue #115): headless authoring of the asset-file types.
+# A .gdshader is plain shader source authored as text (create / get / set are
+# pure file authoring, no engine needed), while theme create produces a loadable
+# .tres Theme resource (engine-backed) — the same file-level vs engine-backed
+# split the script group draws between create/get/set and attach/validate.
+shader_app = typer.Typer(
+    help="Act on shader files (.gdshader).", no_args_is_help=True
+)
+app.add_typer(shader_app, name="shader")
+
+theme_app = typer.Typer(
+    help="Act on theme resource files (.tres).", no_args_is_help=True
+)
+app.add_typer(theme_app, name="theme")
 
 
 def _version_callback(value: Optional[bool]) -> None:
@@ -437,6 +460,30 @@ PROJECT_SET_COMMAND: HeadlessCommand[ProjectSetResult] = HeadlessCommand(
     operation="project-set",
     input_model=ProjectSetParams,
     output_model=ProjectSetResult,
+)
+
+SHADER_CREATE_COMMAND: HeadlessCommand[ShaderCreateResult] = HeadlessCommand(
+    operation="shader-create",
+    input_model=ShaderCreateParams,
+    output_model=ShaderCreateResult,
+)
+
+SHADER_GET_COMMAND: HeadlessCommand[ShaderGetResult] = HeadlessCommand(
+    operation="shader-get",
+    input_model=ShaderGetParams,
+    output_model=ShaderGetResult,
+)
+
+SHADER_SET_COMMAND: HeadlessCommand[ShaderSetResult] = HeadlessCommand(
+    operation="shader-set",
+    input_model=ShaderSetParams,
+    output_model=ShaderSetResult,
+)
+
+THEME_CREATE_COMMAND: HeadlessCommand[ThemeCreateResult] = HeadlessCommand(
+    operation="theme-create",
+    input_model=ThemeCreateParams,
+    output_model=ThemeCreateResult,
 )
 
 
@@ -1213,6 +1260,51 @@ def project_get(
     )
 
 
+@shader_app.command(cls=SHADER_CREATE_COMMAND.command_class())
+def create(
+    path: str = typer.Argument(..., help="Target .gdshader path to write."),
+    content: Optional[str] = typer.Option(
+        None,
+        "--content",
+        help=(
+            "Verbatim shader source to write. Mutually exclusive with "
+            "--shader-type; when omitted, a minimal template declaring the "
+            "--shader-type is written."
+        ),
+    ),
+    shader_type: Optional[str] = typer.Option(
+        None,
+        "--shader-type",
+        help=(
+            "Shader type for the built-in template's 'shader_type' line (e.g. "
+            "canvas_item, spatial). Defaults to canvas_item. Ignored — and "
+            "rejected — with --content."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = SHADER_CREATE_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Create a new .gdshader from a template or verbatim --content."""
+    if content is not None and shader_type is not None:
+        raise typer.BadParameter(
+            "--content and --shader-type are mutually exclusive."
+        )
+    _dispatch(
+        SHADER_CREATE_COMMAND,
+        ShaderCreateParams(
+            path=_normalize_path(path),
+            content=content,
+            shader_type=shader_type,
+        ),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
 @resource_app.command(name="get", cls=RESOURCE_GET_COMMAND.command_class())
 def get_resource(
     path: str = typer.Argument(..., help="The .tres resource file to read."),
@@ -1225,6 +1317,25 @@ def get_resource(
     _dispatch(
         RESOURCE_GET_COMMAND,
         ResourceGetParams(path=_normalize_path(path)),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@shader_app.command(name="get", cls=SHADER_GET_COMMAND.command_class())
+def get_shader(
+    path: str = typer.Argument(..., help="The .gdshader file to read."),
+    json_output: bool = json_option(),
+    schema: bool = SHADER_GET_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Read a shader's source and report its shader_type metadata."""
+    _dispatch(
+        SHADER_GET_COMMAND,
+        ShaderGetParams(path=_normalize_path(path)),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -1299,6 +1410,73 @@ def resolve_uid(
     )
 
 
+@shader_app.command(name="set", cls=SHADER_SET_COMMAND.command_class())
+def set_shader(
+    path: str = typer.Argument(..., help="The .gdshader file to edit."),
+    search: Optional[str] = typer.Option(
+        None,
+        "--search",
+        help=(
+            "search-replace mode: literal substring to find (not regex); all "
+            "occurrences are replaced. Requires --replace."
+        ),
+    ),
+    replace: Optional[str] = typer.Option(
+        None,
+        "--replace",
+        help="search-replace mode: literal replacement text. Requires --search.",
+    ),
+    start_line: Optional[int] = typer.Option(
+        None,
+        "--start-line",
+        help=(
+            "line-range mode: first line to replace (1-based, inclusive). "
+            "Requires --content."
+        ),
+    ),
+    end_line: Optional[int] = typer.Option(
+        None,
+        "--end-line",
+        help=(
+            "line-range mode: last line to replace (1-based, inclusive); "
+            "defaults to --start-line. Requires --content and --start-line."
+        ),
+    ),
+    content: Optional[str] = typer.Option(
+        None,
+        "--content",
+        help=(
+            "Replacement text: the line span in line-range mode, or the whole "
+            "file (full mode) when --start-line is omitted."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = SHADER_SET_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Edit a .gdshader via search-replace, line-range, or full overwrite."""
+    # shader set reuses the script set edit-mode interface (issue #115): the same
+    # mutual-exclusion resolver decides the single ScriptSetMode discriminator.
+    mode = _resolve_set_mode(search, replace, start_line, end_line, content)
+    _dispatch(
+        SHADER_SET_COMMAND,
+        ShaderSetParams(
+            path=_normalize_path(path),
+            mode=mode,
+            search=search,
+            replace=replace,
+            start_line=start_line,
+            end_line=end_line,
+            content=content,
+        ),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
 @project_app.command(name="set", cls=PROJECT_SET_COMMAND.command_class())
 def project_set(
     setting: str = typer.Argument(
@@ -1321,6 +1499,25 @@ def project_set(
     _dispatch(
         PROJECT_SET_COMMAND,
         ProjectSetParams(setting=setting, value=value),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@theme_app.command(name="create", cls=THEME_CREATE_COMMAND.command_class())
+def create_theme(
+    path: str = typer.Argument(..., help="Target .tres Theme path to write."),
+    json_output: bool = json_option(),
+    schema: bool = THEME_CREATE_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Create a new, loadable .tres Theme resource (no-clobber)."""
+    _dispatch(
+        THEME_CREATE_COMMAND,
+        ThemeCreateParams(path=_normalize_path(path)),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -155,10 +155,13 @@ project_app = typer.Typer(
 app.add_typer(project_app, name="project")
 
 # The asset-file groups (issue #115): headless authoring of the asset-file types.
-# A .gdshader is plain shader source authored as text (create / get / set are
-# pure file authoring, no engine needed), while theme create produces a loadable
-# .tres Theme resource (engine-backed) — the same file-level vs engine-backed
-# split the script group draws between create/get/set and attach/validate.
+# A .gdshader is plain shader source authored as text (create / get / set author
+# the file directly and never load or compile the shader at the operation level),
+# while theme create produces a loadable .tres Theme resource (engine-backed) —
+# the same file-level vs engine-backed split the script group draws between
+# create/get/set and attach/validate. This bounds the operation, not the run:
+# every command still goes through the headless runner, so resolving --project
+# still constructs the project's autoloads at engine startup (ADR-0009).
 shader_app = typer.Typer(
     help="Act on shader files (.gdshader).", no_args_is_help=True
 )

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -1347,6 +1347,62 @@ class ResourceCreateResult(BaseModel):
     )
 
 
+class ShaderCreateParams(BaseModel):
+    """The operation params of ``gda shader create`` (issue #115).
+
+    ``path`` is the target ``.gdshader`` file, addressed by its ``res://`` or
+    filesystem path. A ``.gdshader`` is plain shader source authored as RAW
+    TEXT — no engine compilation is needed to create, read or edit it, so the
+    create/get/set trio is pure file authoring (the same file-level boundary the
+    script group's create/get/set honor, issue #30). ``content`` supplies
+    verbatim shader source; when omitted, the operation writes a minimal
+    ``shader_type`` template.
+    """
+
+    path: str
+    content: str | None = Field(
+        default=None,
+        description=(
+            "Verbatim shader source to write. When omitted, a minimal template "
+            "declaring 'shader_type canvas_item' is written instead. Mutually "
+            "exclusive with the template's shader type."
+        ),
+    )
+    shader_type: str | None = Field(
+        default=None,
+        description=(
+            "Shader type for the built-in template's 'shader_type' line (e.g. "
+            "canvas_item, spatial, particles). Ignored when 'content' is "
+            "supplied; defaults to 'canvas_item' when neither is given."
+        ),
+    )
+
+
+class ShaderCreateResult(BaseModel):
+    """The result of ``gda shader create``: what was written where (issue #115).
+
+    Echoes the saved ``path`` and the ``shader_type`` the written source
+    declares, so an agent can assert the effect without a second call.
+    ``created_dirs`` lists parent directories the operation created before
+    saving, from outermost to innermost. The ``shader_type`` is parsed from the
+    written source.
+    """
+
+    path: str
+    shader_type: str | None = Field(
+        default=None,
+        description=(
+            "The shader_type the written shader declares, or null when it "
+            "declares none."
+        ),
+    )
+    created_dirs: list[str] = Field(
+        description=(
+            "Parent directories created before saving, from outermost to innermost."
+        )
+    )
+
+
 class ResourceGetParams(BaseModel):
     """The operation params of ``gda resource get``: the ``.tres`` to read (issue #112).
 
@@ -1354,6 +1410,17 @@ class ResourceGetParams(BaseModel):
     a ``.tres`` instantiates the resource (the same trust boundary every load
     carries, ADR-0009), but a plain resource file holds data, not a script that
     runs on load.
+    """
+
+    path: str
+
+
+class ShaderGetParams(BaseModel):
+    """The operation params of ``gda shader get``: the shader file to read (issue #115).
+
+    ``path`` addresses the ``.gdshader`` by its ``res://`` or filesystem path.
+    The source is read as raw text — the shader is never loaded or compiled, so
+    reading it can never run project code (the read boundary of issue #30).
     """
 
     path: str
@@ -1394,6 +1461,151 @@ class ResourceUidResult(BaseModel):
     )
     uid: str = Field(description="The resource's 'uid://…' value.")
     path: str = Field(description="The resource's 'res://…' path the UID maps to.")
+
+
+class ShaderGetResult(BaseModel):
+    """The result of ``gda shader get``: a shader's source and metadata (issue #115).
+
+    Echoes the ``path``, the full ``source`` read as raw text, and the
+    ``shader_type`` the source declares (parsed from the text). Carrying the
+    source verbatim makes a ``create`` verifiable end-to-end: ``create`` then
+    ``get`` returns the same source.
+    """
+
+    path: str
+    source: str
+    shader_type: str | None = Field(
+        default=None,
+        description=(
+            "The shader_type the shader declares, or null when it declares none."
+        ),
+    )
+
+
+class ShaderSetParams(BaseModel):
+    """The operation params of ``gda shader set`` (issue #115).
+
+    Edits an existing ``.gdshader`` on disk as RAW TEXT — it never compiles or
+    loads the shader, so editing one can never run project code (the read
+    boundary of issue #30). ``path`` addresses the shader by its ``res://`` or
+    filesystem path. The remaining params carry the SAME three mutually-exclusive
+    edit modes as ``script set`` (issue #118) — the shader group reuses that edit
+    interface rather than re-deriving it. The CLI resolves which mode and stamps
+    it on ``mode`` (issue #133), so the operation dispatches on that explicit
+    discriminator rather than re-inferring it from which params are present:
+
+    - **search-replace** (``mode = search_replace``) — ``search``/``replace`` both
+      present: every literal (not regex) occurrence of ``search`` is replaced with
+      ``replace``.
+    - **line-range** (``mode = line_range``) — ``start_line`` (+ optional
+      ``end_line``) with ``content``: the given 1-based, inclusive line span is
+      replaced with ``content``.
+    - **full** (``mode = full``) — only ``content`` present: the whole file is
+      overwritten.
+    """
+
+    path: str
+    mode: ScriptSetMode = Field(
+        description=(
+            "The resolved edit mode, the single source of truth the operation "
+            "dispatches on (issue #133). Set by the CLI from the supplied flags, "
+            "not inferred by the operation from param presence. The same edit "
+            "modes as script set (issue #118), reused here."
+        ),
+    )
+    search: str | None = Field(
+        default=None,
+        description=(
+            "search-replace mode: the literal substring to find (NOT a regex). "
+            "Every occurrence is replaced with 'replace'. Requires 'replace'."
+        ),
+    )
+    replace: str | None = Field(
+        default=None,
+        description=(
+            "search-replace mode: the literal text each occurrence of 'search' "
+            "is replaced with. Requires 'search'."
+        ),
+    )
+    start_line: int | None = Field(
+        default=None,
+        description=(
+            "line-range mode: the first line to replace, 1-based and inclusive. "
+            "Lines are the parts of the source split on '\\n', so a trailing "
+            "newline yields a final empty part: 'a\\nb\\n' is 3 lines "
+            "(['a', 'b', '']). Valid range is 1..N where N is that part count. "
+            "Requires 'content'."
+        ),
+    )
+    end_line: int | None = Field(
+        default=None,
+        description=(
+            "line-range mode: the last line to replace, 1-based and inclusive; "
+            "defaults to 'start_line' (a single-line replace). Must satisfy "
+            "start_line <= end_line <= N (the line count). Requires 'content'."
+        ),
+    )
+    content: str | None = Field(
+        default=None,
+        description=(
+            "The replacement text. In line-range mode it replaces the "
+            "start_line..end_line span; with no 'start_line' it overwrites the "
+            "entire file (full mode)."
+        ),
+    )
+
+
+class ShaderSetResult(BaseModel):
+    """The result of ``gda shader set``: the edited shader's metadata (issue #115).
+
+    Echoes the saved ``path`` and the ``shader_type`` re-parsed from the source
+    as written, so an edit round-trips through ``shader get`` (the verifier)
+    without a second call — and an agent can assert the post-edit metadata
+    directly.
+    """
+
+    path: str
+    shader_type: str | None = Field(
+        default=None,
+        description=(
+            "The shader_type the edited source declares, or null when it "
+            "declares none."
+        ),
+    )
+
+
+class ThemeCreateParams(BaseModel):
+    """The operation params of ``gda theme create`` (issue #115).
+
+    ``path`` is the target ``.tres`` file. Unlike the shader trio (plain
+    file authoring), a Theme is an ENGINE-BACKED resource: the operation
+    constructs a ``Theme`` and writes it through ``ResourceSaver`` so the result
+    is a genuine, loadable ``.tres`` (verified by loading it back), not hand-
+    written text. The split mirrors the script group: file-level ops author text;
+    a resource-producing op goes through the engine.
+    """
+
+    path: str
+
+
+class ThemeCreateResult(BaseModel):
+    """The result of ``gda theme create``: the created Theme resource (issue #115).
+
+    Echoes the saved ``path`` and the resource ``type`` written (``Theme``), so
+    an agent can assert the effect without a second call. ``created_dirs`` lists
+    parent directories the operation created before saving, from outermost to
+    innermost.
+    """
+
+    path: str
+    type: str = Field(
+        description="The resource type written to the .tres (Theme)."
+    )
+    created_dirs: list[str] = Field(
+        description=(
+            "Parent directories created before saving, from outermost to innermost."
+        )
+    )
 
 
 class EngineVersion(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -1352,11 +1352,13 @@ class ShaderCreateParams(BaseModel):
 
     ``path`` is the target ``.gdshader`` file, addressed by its ``res://`` or
     filesystem path. A ``.gdshader`` is plain shader source authored as RAW
-    TEXT — no engine compilation is needed to create, read or edit it, so the
-    create/get/set trio is pure file authoring (the same file-level boundary the
-    script group's create/get/set honor, issue #30). ``content`` supplies
-    verbatim shader source; when omitted, the operation writes a minimal
-    ``shader_type`` template.
+    TEXT — the create/get/set trio authors the file directly and never loads or
+    compiles the shader AT THE OPERATION LEVEL (the same file-level boundary the
+    script group's create/get/set honor, issue #30). This bounds the operation,
+    not the run: like every command, a ``shader`` op still goes through the
+    headless runner, so resolving ``--project`` still constructs the project's
+    autoloads at engine startup (ADR-0009). ``content`` supplies verbatim shader
+    source; when omitted, the operation writes a minimal ``shader_type`` template.
     """
 
     path: str
@@ -1372,8 +1374,9 @@ class ShaderCreateParams(BaseModel):
         default=None,
         description=(
             "Shader type for the built-in template's 'shader_type' line (e.g. "
-            "canvas_item, spatial, particles). Ignored when 'content' is "
-            "supplied; defaults to 'canvas_item' when neither is given."
+            "canvas_item, spatial, particles). Mutually exclusive with 'content' "
+            "(supplying both is rejected); defaults to 'canvas_item' when neither "
+            "is given."
         ),
     )
 
@@ -1419,8 +1422,11 @@ class ShaderGetParams(BaseModel):
     """The operation params of ``gda shader get``: the shader file to read (issue #115).
 
     ``path`` addresses the ``.gdshader`` by its ``res://`` or filesystem path.
-    The source is read as raw text — the shader is never loaded or compiled, so
-    reading it can never run project code (the read boundary of issue #30).
+    The source is read as raw text — the operation itself never loads or compiles
+    the shader (the read boundary of issue #30). That bounds the operation, not
+    the run: like every command it goes through the headless runner, so resolving
+    ``--project`` still constructs the project's autoloads at engine startup
+    (ADR-0009).
     """
 
     path: str
@@ -1485,14 +1491,17 @@ class ShaderGetResult(BaseModel):
 class ShaderSetParams(BaseModel):
     """The operation params of ``gda shader set`` (issue #115).
 
-    Edits an existing ``.gdshader`` on disk as RAW TEXT — it never compiles or
-    loads the shader, so editing one can never run project code (the read
-    boundary of issue #30). ``path`` addresses the shader by its ``res://`` or
-    filesystem path. The remaining params carry the SAME three mutually-exclusive
-    edit modes as ``script set`` (issue #118) — the shader group reuses that edit
-    interface rather than re-deriving it. The CLI resolves which mode and stamps
-    it on ``mode`` (issue #133), so the operation dispatches on that explicit
-    discriminator rather than re-inferring it from which params are present:
+    Edits an existing ``.gdshader`` on disk as RAW TEXT — the operation itself
+    never compiles or loads the shader (the edit boundary of issue #30). That
+    bounds the operation, not the run: like every command it goes through the
+    headless runner, so resolving ``--project`` still constructs the project's
+    autoloads at engine startup (ADR-0009). ``path`` addresses the shader by its
+    ``res://`` or filesystem path. The remaining params carry the SAME three
+    mutually-exclusive edit modes as ``script set`` (issue #118) — the shader
+    group reuses that edit interface rather than re-deriving it. The CLI resolves
+    which mode and stamps it on ``mode`` (issue #133), so the operation dispatches
+    on that explicit discriminator rather than re-inferring it from which params
+    are present:
 
     - **search-replace** (``mode = search_replace``) — ``search``/``replace`` both
       present: every literal (not regex) occurrence of ``search`` is replaced with

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -152,6 +152,14 @@ func _initialize() -> void:
 			_op_project_get(params)
 		"project-set":
 			_op_project_set(params)
+		"shader-create":
+			_op_shader_create(params)
+		"shader-get":
+			_op_shader_get(params)
+		"shader-set":
+			_op_shader_set(params)
+		"theme-create":
+			_op_theme_create(params)
 		_:
 			_fail(OP_ERROR_UNKNOWN_OPERATION, "unknown operation: " + operation)
 
@@ -1161,9 +1169,9 @@ func _op_script_set(params: Dictionary) -> void:
 	var new_source: Variant
 	match mode:
 		"search_replace":
-			new_source = _apply_search_replace(source, params)
+			new_source = _apply_search_replace(source, params, "script")
 		"line_range":
-			new_source = _apply_line_range(source, params)
+			new_source = _apply_line_range(source, params, "script")
 		"full":
 			# full overwrite: content is guaranteed present by the CLI's mode check.
 			new_source = _string_param(params, "content")
@@ -1192,11 +1200,11 @@ func _op_script_set(params: Dictionary) -> void:
 # string the source does not contain is a no_search_match failure (so an agent
 # learns the edit landed nowhere rather than silently writing the file back
 # unchanged). Returns null after recording the failure.
-func _apply_search_replace(source: String, params: Dictionary) -> Variant:
+func _apply_search_replace(source: String, params: Dictionary, noun: String) -> Variant:
 	var search := _string_param(params, "search")
 	var replace := _string_param(params, "replace")
 	if search.is_empty() or not source.contains(search):
-		_fail(OP_ERROR_NO_SEARCH_MATCH, "search string not found in script: " + search.c_escape())
+		_fail(OP_ERROR_NO_SEARCH_MATCH, "search string not found in " + noun + ": " + search.c_escape())
 		return null
 	return source.replace(search, replace)
 
@@ -1212,7 +1220,7 @@ func _apply_search_replace(source: String, params: Dictionary) -> Variant:
 # split and rejoin, and the replacement `content` is normalized onto it, so
 # editing a CRLF script preserves CRLF instead of corrupting the edited span to
 # mixed endings. A mixed-ending file is pathological and resolves to CRLF.
-func _apply_line_range(source: String, params: Dictionary) -> Variant:
+func _apply_line_range(source: String, params: Dictionary, noun: String) -> Variant:
 	var newline := "\r\n" if source.contains("\r\n") else "\n"
 	var lines := source.split(newline)
 	var line_count := lines.size()
@@ -1220,7 +1228,7 @@ func _apply_line_range(source: String, params: Dictionary) -> Variant:
 	var end_line: int = int(params.get("end_line", start_line)) if params.get("end_line", null) != null else start_line
 	if start_line < 1 or start_line > line_count or end_line < start_line or end_line > line_count:
 		_fail(OP_ERROR_INVALID_LINE_RANGE, "line range " + str(start_line) + ".." + str(end_line)
-				+ " is outside the script's bounds (1.." + str(line_count) + ") or ends before it starts")
+				+ " is outside the " + noun + "'s bounds (1.." + str(line_count) + ") or ends before it starts")
 		return null
 	var content := _string_param(params, "content")
 	var before := lines.slice(0, start_line - 1)
@@ -1454,6 +1462,50 @@ func _op_resource_create(params: Dictionary) -> void:
 	})
 
 
+# shader-create: author a new .gdshader as RAW TEXT (issue #115). A .gdshader is
+# plain shader source — no engine compilation is needed to write it — so create
+# is pure file authoring, exactly like script-create (issue #110): no-clobber
+# (a target that exists is already_exists), and verbatim --content wins over the
+# built-in shader_type template. The created file is verifiable end-to-end by
+# shader-get (create → get returns the source).
+func _op_shader_create(params: Dictionary) -> void:
+	_diag("running operation: shader-create")
+	var path := _string_param(params, "path")
+	if path.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
+		return
+	if not _is_shader_path(path):
+		_fail(OP_ERROR_INVALID_PATH, "shader path must end in .gdshader: " + path)
+		return
+	if FileAccess.file_exists(path) or DirAccess.dir_exists_absolute(path):
+		_fail(OP_ERROR_ALREADY_EXISTS, "shader target already exists: " + path)
+		return
+
+	# Verbatim content wins; otherwise write a minimal template declaring the
+	# requested shader_type (defaulting to canvas_item).
+	var source: String
+	var content: Variant = params.get("content", null)
+	if content is String:
+		source = content
+	else:
+		var shader_type := _string_param(params, "shader_type")
+		if shader_type.is_empty():
+			shader_type = "canvas_item"
+		source = "shader_type " + shader_type + ";\n"
+
+	var created_dirs: Variant = _ensure_parent_dirs(path)
+	if created_dirs == null:
+		return  # _ensure_parent_dirs already recorded the failure
+	if not _write_text_file(path, source, "shader"):
+		return  # _write_text_file already recorded the failure
+
+	_succeed({
+		"path": path,
+		"shader_type": _shader_metadata(source),
+		"created_dirs": created_dirs,
+	})
+
+
 # resource-get: load a .tres and emit its storage properties as typed JSON — the
 # resource group's verifier (issue #112), which makes a resource-create
 # verifiable end-to-end (create → get reports the resource). Reports the same
@@ -1513,6 +1565,144 @@ func _require_existing_resource(path: String) -> bool:
 		return false
 	if not FileAccess.file_exists(path):
 		_fail(OP_ERROR_PATH_NOT_FOUND, "resource file does not exist: " + path)
+		return false
+	return true
+
+
+# shader-get: read a shader's source back as RAW TEXT and report it with the
+# shader_type the source declares — the read half of issue #115, which makes a
+# shader-create verifiable end-to-end (create → get returns the source). Like
+# script-get, it never load()s/compiles the shader, so reading it can never run
+# project code (issue #30).
+func _op_shader_get(params: Dictionary) -> void:
+	_diag("running operation: shader-get")
+	var path := _string_param(params, "path")
+	if path.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
+		return
+	if not _require_existing_shader(path):
+		return  # _require_existing_shader already recorded the failure
+
+	var source: Variant = _read_text_file(path, "shader")
+	if source == null:
+		return  # _read_text_file already recorded the failure
+
+	_succeed({
+		"path": path,
+		"source": source,
+		"shader_type": _shader_metadata(source),
+	})
+
+
+# shader-set: edit an EXISTING .gdshader on disk as RAW TEXT (issue #115). It
+# REUSES the script-set edit-mode interface (issue #118): the same three
+# mutually-exclusive modes (search-replace / line-range / full), the same apply
+# helpers, dispatched on the same explicit `mode` discriminator the CLI resolves
+# (issue #133). It never compiles or loads the shader, so editing it cannot run
+# project code (issue #30). set edits an existing shader; a missing target is
+# path_not_found, never a silent create.
+func _op_shader_set(params: Dictionary) -> void:
+	_diag("running operation: shader-set")
+	var path := _string_param(params, "path")
+	if path.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
+		return
+	if not _require_existing_shader(path):
+		return  # _require_existing_shader already recorded the failure
+
+	var source: Variant = _read_text_file(path, "shader")
+	if source == null:
+		return  # _read_text_file already recorded the failure
+
+	var mode := _string_param(params, "mode")
+	var new_source: Variant
+	match mode:
+		"search_replace":
+			new_source = _apply_search_replace(source, params, "shader")
+		"line_range":
+			new_source = _apply_line_range(source, params, "shader")
+		"full":
+			# full overwrite: content is guaranteed present by the CLI's mode check.
+			new_source = _string_param(params, "content")
+		_:
+			# The CLI always supplies one of the three modes; a missing/unknown mode
+			# means a malformed direct op invocation, not a reachable CLI path.
+			_fail(OP_ERROR_INVALID_PARAMS, "unknown shader-set mode: " + mode)
+			return
+	if new_source == null:
+		return  # the apply helper already recorded the failure
+
+	if not _write_text_file(path, new_source, "shader"):
+		return  # _write_text_file already recorded the failure
+
+	# Re-parse the written source so set round-trips through shader get.
+	_succeed({
+		"path": path,
+		"shader_type": _shader_metadata(new_source),
+	})
+
+
+# theme-create: produce a loadable .tres Theme resource (issue #115). Unlike the
+# shader trio (plain file authoring), a Theme is an ENGINE-BACKED resource: it is
+# constructed as a Theme and written through ResourceSaver so the .tres is a
+# genuine, loadable resource (the same ResourceSaver path scene-create uses for a
+# PackedScene), not hand-written text — the file-level vs engine-backed split the
+# script group draws between create/get/set and attach/validate. No-clobber: a
+# target that exists is already_exists.
+func _op_theme_create(params: Dictionary) -> void:
+	_diag("running operation: theme-create")
+	var path := _string_param(params, "path")
+	if path.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
+		return
+	if not _is_theme_path(path):
+		_fail(OP_ERROR_INVALID_PATH, "theme path must end in .tres: " + path)
+		return
+	if FileAccess.file_exists(path) or DirAccess.dir_exists_absolute(path):
+		_fail(OP_ERROR_ALREADY_EXISTS, "theme target already exists: " + path)
+		return
+
+	var theme := Theme.new()
+	var created_dirs: Variant = _ensure_parent_dirs(path)
+	if created_dirs == null:
+		return  # _ensure_parent_dirs already recorded the failure
+	var save_err := ResourceSaver.save(theme, path)
+	if save_err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message("theme", path, save_err))
+		return
+
+	_succeed({
+		"path": path,
+		"type": "Theme",
+		"created_dirs": created_dirs,
+	})
+
+
+# Whether a path names a shader file the shader group operates on: a .gdshader
+# (Godot shader) file. Shader-file addressing is by extension, the same way
+# script addressing keys on .gd and scene addressing on .tscn.
+func _is_shader_path(path: String) -> bool:
+	return path.get_extension().to_lower() == "gdshader"
+
+
+# Whether a path names a theme resource file: a .tres. theme-create writes a
+# Theme resource, addressed by extension like the rest of the asset-file groups.
+func _is_theme_path(path: String) -> bool:
+	return path.get_extension().to_lower() == "tres"
+
+
+# Clear the shader group's addressing boundary for an EXISTING shader: the path
+# must be a .gdshader (invalid_path otherwise) and the file must exist on disk
+# (path_not_found otherwise). Returns true to proceed, or false after recording
+# the failure (the caller must stop). Mirrors _require_existing_script: shared by
+# shader get and set so they refuse a non-.gdshader target and a missing file
+# identically.
+func _require_existing_shader(path: String) -> bool:
+	if not _is_shader_path(path):
+		_fail(OP_ERROR_INVALID_PATH, "shader path must end in .gdshader: " + path)
+		return false
+	if not FileAccess.file_exists(path):
+		_fail(OP_ERROR_PATH_NOT_FOUND, "shader file does not exist: " + path)
 		return false
 	return true
 
@@ -1831,6 +2021,60 @@ func _op_project_set(params: Dictionary) -> void:
 		"type": _type_name(declared_type),
 		"value": stored_value,
 	})
+# Extract a .gdshader's declared shader_type from its raw source by lightweight
+# line-by-line parsing — never compiling the shader (issue #30). Null when absent.
+# A .gdshader leads with `shader_type <type>;`, after optional blank/comment
+# lines; scan that header, capture the first shader_type, and stop at the first
+# real statement so a shader_type-shaped token deeper in the body is never
+# mistaken for the declaration.
+func _shader_metadata(source: String) -> Variant:
+	for raw_line in source.split("\n"):
+		var line := raw_line.strip_edges()
+		if line.is_empty() or line.begins_with("//"):
+			continue
+		if line.begins_with("shader_type "):
+			# Drop the trailing ';' and any inline comment, keep the first token.
+			var rest := line.substr("shader_type ".length())
+			var semicolon := rest.find(";")
+			if semicolon != -1:
+				rest = rest.substr(0, semicolon)
+			return _first_token(rest)
+		# The first real line past the header: no shader_type can legally appear
+		# after it, so stop scanning.
+		break
+	return null
+
+
+# Read a text asset's source back as RAW TEXT, disambiguating an empty file from
+# an unreadable one — the same trick as _read_script_source. Shared by the shader
+# get/set ops; `noun` names the asset in the failure message.
+func _read_text_file(path: String, noun: String) -> Variant:
+	var source := FileAccess.get_file_as_string(path)
+	if source.is_empty():
+		var open_err := FileAccess.get_open_error()
+		if open_err != OK:
+			_fail(OP_ERROR_PATH_NOT_FOUND, noun + " file could not be read: " + path
+					+ ": " + error_string(open_err))
+			return null
+	return source
+
+
+# Write `source` to a text asset file as RAW TEXT, reporting both failure modes
+# as save_failed — the generic twin of _write_script_file (which names "script"
+# in its diagnostic). Returns true on a clean write, or false after recording the
+# failure (the caller must stop). `noun` names the asset in the diagnostic.
+func _write_text_file(path: String, source: String, noun: String) -> bool:
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	if file == null:
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message(noun, path, FileAccess.get_open_error()))
+		return false
+	file.store_string(source)
+	var write_err := file.get_error()
+	file.close()
+	if write_err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message(noun, path, write_err))
+		return false
+	return true
 
 
 # Whether a path names a script file the script group operates on: a .gd

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -53,6 +53,10 @@ from gda.models import (
     ScriptListResult,
     ScriptSetResult,
     ScriptValidateResult,
+    ShaderCreateResult,
+    ShaderGetResult,
+    ShaderSetResult,
+    ThemeCreateResult,
 )
 
 
@@ -357,6 +361,52 @@ def render_project_set(was_set: "ProjectSetResult") -> str:
     return f"set {was_set.setting} ({was_set.type}) = {format_value(was_set.value)}"
 
 
+@runtime_checkable
+class ShaderMetadata(Protocol):
+    """The shared human-facing surface of every shader result type.
+
+    A structural (typing-only) interface over the ``path``/``shader_type`` that
+    :class:`~gda.models.ShaderCreateResult`, :class:`~gda.models.ShaderGetResult`
+    and :class:`~gda.models.ShaderSetResult` all carry, so the shader-metadata
+    renderer types against one surface rather than a three-way union (mirrors
+    :class:`ScriptMetadata`).
+    """
+
+    path: str
+    shader_type: str | None
+
+
+def render_shader_metadata(shader: ShaderMetadata) -> str:
+    """Render a shader's path plus its shader_type for humans.
+
+    Reads the shared :class:`ShaderMetadata` surface, so it serves every shader
+    result type without naming the union.
+    """
+    if shader.shader_type is not None:
+        return f"{shader.path} (shader_type {shader.shader_type})"
+    return shader.path
+
+
+def render_shader_create(created: "ShaderCreateResult") -> str:
+    """Render a created shader as ``created <metadata>``."""
+    return f"created {render_shader_metadata(created)}"
+
+
+def render_shader_get(got: "ShaderGetResult") -> str:
+    """Render a read shader as its metadata line followed by its source."""
+    return "\n".join([render_shader_metadata(got), got.source])
+
+
+def render_shader_set(edited: "ShaderSetResult") -> str:
+    """Render an edited shader as ``set <metadata>``."""
+    return f"set {render_shader_metadata(edited)}"
+
+
+def render_theme_create(created: "ThemeCreateResult") -> str:
+    """Render a created theme as ``created <path> (<type>)``."""
+    return f"created {created.path} ({created.type})"
+
+
 def render_engine_version(version: "EngineVersion") -> str:
     """Render the engine version as its one-line version string."""
     return version.string
@@ -397,6 +447,10 @@ _RENDERERS = {
     ProjectInfoResult: render_project_info,
     ProjectGetResult: render_project_get,
     ProjectSetResult: render_project_set,
+    ShaderCreateResult: render_shader_create,
+    ShaderGetResult: render_shader_get,
+    ShaderSetResult: render_shader_set,
+    ThemeCreateResult: render_theme_create,
     EngineVersion: render_engine_version,
 }
 

--- a/tests/test_asset_file_commands.py
+++ b/tests/test_asset_file_commands.py
@@ -1,0 +1,399 @@
+"""S3: gda shader create/get/set + theme create success paths (issue #115).
+
+The asset-file groups author the asset-file types headlessly: a .gdshader is
+plain shader source authored/read/edited as text, while theme create produces a
+loadable .tres Theme. These tests drive the same proven pipeline as the scene,
+node and script groups — Typer → binary resolution → runner → sentinel parse →
+typed model → JSON — with canned engine output, no real Godot. The shader set
+edit-mode interface is the script set interface (issue #118), reused here.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.models import ScriptSetMode
+from gda.runner import RunResult
+from tests.support import inject_runner, sentinel
+
+# --- shader create ---------------------------------------------------------
+
+SHADER_CREATE_RESULT = {
+    "path": "/tmp/proj/wave.gdshader",
+    "shader_type": "canvas_item",
+    "created_dirs": [],
+}
+
+
+def test_shader_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
+    # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(SHADER_CREATE_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["shader", "create", "/tmp/proj/wave.gdshader", "--shader-type", "canvas_item", "--json"],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["path"] == "/tmp/proj/wave.gdshader"
+    assert data["shader_type"] == "canvas_item"
+    # Dispatched by name with the typed params; with --shader-type and no
+    # --content, content is null.
+    assert fake.calls == [
+        (
+            "shader-create",
+            {
+                "path": "/tmp/proj/wave.gdshader",
+                "content": None,
+                "shader_type": "canvas_item",
+            },
+        )
+    ]
+    assert "engine diagnostic" in result.stderr
+
+
+def test_shader_create_default_template_passes_null_content_and_type(monkeypatch):
+    # The bare template: no --content, no --shader-type. Both pass through as
+    # null, so the operation writes its default canvas_item template.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["shader", "create", "/tmp/proj/wave.gdshader", "--json"])
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        (
+            "shader-create",
+            {"path": "/tmp/proj/wave.gdshader", "content": None, "shader_type": None},
+        )
+    ]
+
+
+def test_shader_create_content_passes_verbatim_source(monkeypatch):
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel(
+                {"path": "/tmp/proj/x.gdshader", "shader_type": "spatial", "created_dirs": []}
+            ),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "shader",
+            "create",
+            "/tmp/proj/x.gdshader",
+            "--content",
+            "shader_type spatial;\n",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        (
+            "shader-create",
+            {
+                "path": "/tmp/proj/x.gdshader",
+                "content": "shader_type spatial;\n",
+                "shader_type": None,
+            },
+        )
+    ]
+
+
+def test_shader_create_content_and_type_are_mutually_exclusive(monkeypatch):
+    # Verbatim content is not templated, so a shader_type has nowhere to go;
+    # supplying both is a usage error (exit 2), never a silent precedence rule.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "shader",
+            "create",
+            "/tmp/proj/wave.gdshader",
+            "--content",
+            "shader_type canvas_item;\n",
+            "--shader-type",
+            "spatial",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2
+    # The usage error fires before any dispatch — the engine is never reached.
+    assert fake.calls == []
+
+
+# --- shader get ------------------------------------------------------------
+
+SHADER_GET_RESULT = {
+    "path": "/tmp/proj/wave.gdshader",
+    "source": "shader_type canvas_item;\n",
+    "shader_type": "canvas_item",
+}
+
+
+def test_shader_get_json_emits_source_and_metadata_and_exit_zero(monkeypatch):
+    # shader get is the verifier (issue #115): it reads a shader's source back as
+    # raw text with its shader_type, so a create round-trips.
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(SHADER_GET_RESULT)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["shader", "get", "/tmp/proj/wave.gdshader", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["source"] == "shader_type canvas_item;\n"
+    assert data["shader_type"] == "canvas_item"
+    assert fake.calls == [("shader-get", {"path": "/tmp/proj/wave.gdshader"})]
+
+
+# --- shader set: reuses the script set edit-mode interface (issue #115) -----
+
+SHADER_SET_RESULT = {"path": "/tmp/proj/wave.gdshader", "shader_type": "spatial"}
+
+
+def test_shader_set_search_replace_dispatches_search_and_replace(monkeypatch):
+    # search-replace mode: --search/--replace ride through; the other mode params
+    # pass as null. The CLI resolves the edit mode once and stamps the explicit
+    # `mode` discriminator (issue #133) — the SAME ScriptSetMode as script set.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "shader",
+            "set",
+            "/tmp/proj/wave.gdshader",
+            "--search",
+            "canvas_item",
+            "--replace",
+            "spatial",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        (
+            "shader-set",
+            {
+                "path": "/tmp/proj/wave.gdshader",
+                "mode": ScriptSetMode.SEARCH_REPLACE,
+                "search": "canvas_item",
+                "replace": "spatial",
+                "start_line": None,
+                "end_line": None,
+                "content": None,
+            },
+        )
+    ]
+
+
+def test_shader_set_line_range_dispatches_start_end_and_content(monkeypatch):
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "shader",
+            "set",
+            "/tmp/proj/wave.gdshader",
+            "--start-line",
+            "1",
+            "--end-line",
+            "1",
+            "--content",
+            "shader_type spatial;",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        (
+            "shader-set",
+            {
+                "path": "/tmp/proj/wave.gdshader",
+                "mode": ScriptSetMode.LINE_RANGE,
+                "search": None,
+                "replace": None,
+                "start_line": 1,
+                "end_line": 1,
+                "content": "shader_type spatial;",
+            },
+        )
+    ]
+
+
+def test_shader_set_full_overwrite_dispatches_content_only(monkeypatch):
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["shader", "set", "/tmp/proj/wave.gdshader", "--content", "shader_type spatial;\n", "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        (
+            "shader-set",
+            {
+                "path": "/tmp/proj/wave.gdshader",
+                "mode": ScriptSetMode.FULL,
+                "search": None,
+                "replace": None,
+                "start_line": None,
+                "end_line": None,
+                "content": "shader_type spatial;\n",
+            },
+        )
+    ]
+
+
+def _assert_set_usage_error(fake, result):
+    # A mode-validation error is a usage error (exit 2) that fires before any
+    # dispatch — the engine is never reached. Reuses the script set rule.
+    assert result.exit_code == 2
+    assert fake.calls == []
+
+
+def test_shader_set_no_flags_is_a_usage_error(monkeypatch):
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["shader", "set", "/tmp/proj/wave.gdshader", "--json"])
+
+    _assert_set_usage_error(fake, result)
+
+
+def test_shader_set_search_without_replace_is_a_usage_error(monkeypatch):
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["shader", "set", "/tmp/proj/wave.gdshader", "--search", "x", "--json"]
+    )
+
+    _assert_set_usage_error(fake, result)
+
+
+def test_shader_set_search_replace_and_content_are_mutually_exclusive(monkeypatch):
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "shader",
+            "set",
+            "/tmp/proj/wave.gdshader",
+            "--search",
+            "x",
+            "--replace",
+            "y",
+            "--content",
+            "z",
+            "--json",
+        ],
+    )
+
+    _assert_set_usage_error(fake, result)
+
+
+# --- theme create: engine-backed .tres -------------------------------------
+
+THEME_CREATE_RESULT = {
+    "path": "/tmp/proj/ui.tres",
+    "type": "Theme",
+    "created_dirs": [],
+}
+
+
+def test_theme_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(THEME_CREATE_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["theme", "create", "/tmp/proj/ui.tres", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["path"] == "/tmp/proj/ui.tres"
+    assert data["type"] == "Theme"
+    assert fake.calls == [("theme-create", {"path": "/tmp/proj/ui.tres"})]
+    assert "engine diagnostic" in result.stderr
+
+
+# --- human-readable output (no --json) -------------------------------------
+
+
+def test_shader_create_human_output(monkeypatch):
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["shader", "create", "/tmp/proj/wave.gdshader"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "created /tmp/proj/wave.gdshader (shader_type canvas_item)"
+
+
+def test_shader_get_human_output_renders_metadata_then_source(monkeypatch):
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SHADER_GET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["shader", "get", "/tmp/proj/wave.gdshader"])
+
+    assert result.exit_code == 0
+    assert "/tmp/proj/wave.gdshader (shader_type canvas_item)" in result.stdout
+    assert "shader_type canvas_item;" in result.stdout
+
+
+def test_shader_set_human_output_renders_metadata(monkeypatch):
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["shader", "set", "/tmp/proj/wave.gdshader", "--content", "x"]
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "set /tmp/proj/wave.gdshader (shader_type spatial)"
+
+
+def test_theme_create_human_output(monkeypatch):
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(THEME_CREATE_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["theme", "create", "/tmp/proj/ui.tres"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "created /tmp/proj/ui.tres (Theme)"

--- a/tests/test_asset_file_errors.py
+++ b/tests/test_asset_file_errors.py
@@ -1,0 +1,197 @@
+"""S3: gda shader/theme failure modes map to structured JSON errors + exit codes.
+
+Issue #115's acceptance: asset-file failures (path collision on create, file not
+found on get/set, bad edit range / no search-replace match, wrong extension)
+surface as structured ``GdaError``s with registered operation codes (ADR-0002) —
+exit 4 for the operation category, finer stable codes so an agent can branch on
+the mode without parsing prose. The asset-file groups REUSE the existing
+file-level codes (already_exists / path_not_found / invalid_path / save_failed /
+no_search_match / invalid_line_range) rather than minting parallel ones, exactly
+as the script group did.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import error_sentinel, inject_runner
+
+
+def _invoke(monkeypatch, argv, code, message, op):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n" + error_sentinel(code, message),
+            stderr=f"gda: running operation: {op}\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(app, argv)
+
+
+def _create_argv():
+    return ["shader", "create", "/x/wave.gdshader", "--json"]
+
+
+def _get_argv():
+    return ["shader", "get", "/x/wave.gdshader", "--json"]
+
+
+def _set_argv():
+    return ["shader", "set", "/x/wave.gdshader", "--search", "a", "--replace", "b", "--json"]
+
+
+def _theme_argv():
+    return ["theme", "create", "/x/ui.tres", "--json"]
+
+
+# --- shader create: path collision (no-clobber) + wrong extension ----------
+
+
+def test_shader_create_collision_reuses_stable_already_exists_code(monkeypatch):
+    # No-clobber: a create whose target already exists reuses the registered
+    # already_exists code (the same one scene/script create use), leaving the
+    # file untouched — the shader group mints no parallel collision code.
+    result = _invoke(
+        monkeypatch, _create_argv(), "already_exists",
+        "shader target already exists: /x/wave.gdshader", "shader-create",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "already_exists"
+    assert "/x/wave.gdshader" in err["message"]
+    assert err["diagnostics"] == "gda: running operation: shader-create\n"
+
+
+def test_shader_create_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
+    result = _invoke(
+        monkeypatch, _create_argv(), "invalid_path",
+        "shader path must end in .gdshader: /x/wave.txt", "shader-create",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "invalid_path"
+    assert ".gdshader" in err["message"]
+
+
+def test_shader_create_unwritable_target_reuses_stable_save_failed_code(monkeypatch):
+    result = _invoke(
+        monkeypatch, _create_argv(), "save_failed",
+        "failed to save shader to /x/wave.gdshader", "shader-create",
+    )
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout)["error"]["code"] == "save_failed"
+
+
+# --- shader get/set: file not found + wrong extension ----------------------
+
+
+def test_shader_get_missing_file_reuses_stable_path_not_found_code(monkeypatch):
+    result = _invoke(
+        monkeypatch, _get_argv(), "path_not_found",
+        "shader file does not exist: /x/wave.gdshader", "shader-get",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert "/x/wave.gdshader" in err["message"]
+
+
+def test_shader_get_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
+    result = _invoke(
+        monkeypatch, _get_argv(), "invalid_path",
+        "shader path must end in .gdshader: /x/notes.txt", "shader-get",
+    )
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_path"
+
+
+def test_shader_set_missing_file_reuses_stable_path_not_found_code(monkeypatch):
+    # set edits an existing shader; a missing target is path_not_found, never a
+    # silent create (the same rule as script set).
+    result = _invoke(
+        monkeypatch, _set_argv(), "path_not_found",
+        "shader file does not exist: /x/wave.gdshader", "shader-set",
+    )
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout)["error"]["code"] == "path_not_found"
+
+
+# --- shader set: bad edit range / no search-replace match (reused codes) ----
+
+
+def test_shader_set_no_search_match_maps_to_stable_no_search_match_code(monkeypatch):
+    # search-replace mode: a search string the source does not contain is the
+    # registered no_search_match code (reused from script set), so an agent
+    # learns the edit landed nowhere rather than parsing prose.
+    result = _invoke(
+        monkeypatch, _set_argv(), "no_search_match",
+        'search string not found in shader: "xyzzy"', "shader-set",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "no_search_match"
+    assert "xyzzy" in err["message"]
+
+
+def test_shader_set_invalid_line_range_maps_to_stable_invalid_line_range_code(monkeypatch):
+    result = _invoke(
+        monkeypatch, _set_argv(), "invalid_line_range",
+        "line range 5..9 is outside the shader's bounds (1..3) or ends before it starts",
+        "shader-set",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "invalid_line_range"
+    assert "1..3" in err["message"]
+
+
+# --- theme create: path collision + wrong extension ------------------------
+
+
+def test_theme_create_collision_reuses_stable_already_exists_code(monkeypatch):
+    result = _invoke(
+        monkeypatch, _theme_argv(), "already_exists",
+        "theme target already exists: /x/ui.tres", "theme-create",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "already_exists"
+    assert "/x/ui.tres" in err["message"]
+
+
+def test_theme_create_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
+    result = _invoke(
+        monkeypatch, _theme_argv(), "invalid_path",
+        "theme path must end in .tres: /x/ui.txt", "theme-create",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "invalid_path"
+    assert ".tres" in err["message"]
+
+
+def test_theme_create_unwritable_target_reuses_stable_save_failed_code(monkeypatch):
+    result = _invoke(
+        monkeypatch, _theme_argv(), "save_failed",
+        "failed to save theme to /x/ui.tres", "theme-create",
+    )
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout)["error"]["code"] == "save_failed"

--- a/tests/test_e2e_asset_file.py
+++ b/tests/test_e2e_asset_file.py
@@ -1,0 +1,252 @@
+"""S1 (e2e): asset-file authoring against the real Godot engine (issue #115).
+
+The asset-file tracer: ``gda shader create`` → ``shader get`` → ``shader set``
+round-trips a ``.gdshader`` (plain text authoring), and ``gda theme create``
+produces a genuinely LOADABLE ``.tres`` Theme resource — verified here by loading
+it back through the engine, which is the structured-level proof that the create
+produced a real resource, not hand-written text.
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+GODOT = resolve_godot_binary()
+
+
+def _gda(*args: str) -> subprocess.CompletedProcess:
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+    return subprocess.run(
+        [gda_bin, *args, "--godot", str(GODOT)], capture_output=True, text=True
+    )
+
+
+def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
+    assert proc.returncode == 4, proc.stdout + proc.stderr
+    err = json.loads(proc.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == code
+    return err
+
+
+# --- shader create → get → set round-trip ----------------------------------
+
+
+@pytest.mark.e2e
+def test_shader_create_default_template_then_get_round_trip(godot_project):
+    # The bare template: create writes `shader_type canvas_item;`, get reads it
+    # back. The source on disk IS what get reports — the round-trip proves the
+    # write.
+    shader_path = godot_project / "wave.gdshader"
+
+    created = _gda("shader", "create", str(shader_path), "--json")
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    data = json.loads(created.stdout)
+    assert data["path"] == str(shader_path)
+    assert data["shader_type"] == "canvas_item"
+    assert shader_path.exists()
+
+    got = _gda("shader", "get", str(shader_path), "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    got_data = json.loads(got.stdout)
+    # Round-trip: get returns exactly the source create wrote to disk.
+    assert got_data["source"] == shader_path.read_text(encoding="utf-8")
+    assert got_data["source"] == "shader_type canvas_item;\n"
+    assert got_data["shader_type"] == "canvas_item"
+
+
+@pytest.mark.e2e
+def test_shader_create_with_type_parameterizes_the_template(godot_project):
+    shader_path = godot_project / "world.gdshader"
+
+    created = _gda(
+        "shader", "create", str(shader_path), "--shader-type", "spatial", "--json"
+    )
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    assert json.loads(created.stdout)["shader_type"] == "spatial"
+
+    got = _gda("shader", "get", str(shader_path), "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["shader_type"] == "spatial"
+
+
+@pytest.mark.e2e
+def test_shader_create_with_content_round_trips_verbatim_source(godot_project):
+    # --content supplies verbatim source; get reports it byte-identical and
+    # parses the shader_type — without ever compiling the shader (issue #30).
+    shader_path = godot_project / "blur.gdshader"
+    source = (
+        "shader_type canvas_item;\n\n"
+        "void fragment() {\n"
+        "\tCOLOR = texture(TEXTURE, UV) * 0.5;\n"
+        "}\n"
+    )
+
+    created = _gda("shader", "create", str(shader_path), "--content", source, "--json")
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    assert json.loads(created.stdout)["shader_type"] == "canvas_item"
+
+    got = _gda("shader", "get", str(shader_path), "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["source"] == source
+
+
+@pytest.mark.e2e
+def test_shader_set_search_replace_round_trips_through_get(godot_project):
+    # The full create → get → set round-trip, set's search-replace mode (the
+    # reused script-set interface, issue #115): edit the shader_type and read it
+    # back changed.
+    shader_path = godot_project / "edit.gdshader"
+    _gda("shader", "create", str(shader_path), "--json")
+
+    edited = _gda(
+        "shader", "set", str(shader_path),
+        "--search", "canvas_item", "--replace", "spatial", "--json",
+    )
+
+    assert edited.returncode == 0, edited.stdout + edited.stderr
+    assert json.loads(edited.stdout)["shader_type"] == "spatial"
+
+    got = _gda("shader", "get", str(shader_path), "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["source"] == "shader_type spatial;\n"
+
+
+@pytest.mark.e2e
+def test_shader_set_full_overwrite_round_trips_through_get(godot_project):
+    shader_path = godot_project / "full.gdshader"
+    _gda("shader", "create", str(shader_path), "--json")
+    new_source = "shader_type particles;\n"
+
+    edited = _gda("shader", "set", str(shader_path), "--content", new_source, "--json")
+
+    assert edited.returncode == 0, edited.stdout + edited.stderr
+    got = _gda("shader", "get", str(shader_path), "--json")
+    assert json.loads(got.stdout)["source"] == new_source
+
+
+# --- shader failure modes (against the real engine) ------------------------
+
+
+@pytest.mark.e2e
+def test_shader_create_no_clobber_existing_file(godot_project):
+    shader_path = godot_project / "once.gdshader"
+    assert _gda("shader", "create", str(shader_path), "--json").returncode == 0
+    before = shader_path.read_text(encoding="utf-8")
+
+    again = _gda(
+        "shader", "create", str(shader_path), "--content", "shader_type spatial;\n", "--json"
+    )
+
+    _assert_operation_error(again, "already_exists")
+    # The original file is untouched — no-clobber.
+    assert shader_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_shader_get_missing_file_is_path_not_found(godot_project):
+    missing = _gda("shader", "get", str(godot_project / "nope.gdshader"), "--json")
+    _assert_operation_error(missing, "path_not_found")
+
+
+@pytest.mark.e2e
+def test_shader_set_no_search_match_leaves_file_untouched(godot_project):
+    shader_path = godot_project / "nomatch.gdshader"
+    _gda("shader", "create", str(shader_path), "--json")
+    before = shader_path.read_text(encoding="utf-8")
+
+    edited = _gda(
+        "shader", "set", str(shader_path), "--search", "xyzzy", "--replace", "z", "--json"
+    )
+
+    _assert_operation_error(edited, "no_search_match")
+    assert shader_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_shader_set_invalid_line_range_is_invalid_line_range(godot_project):
+    shader_path = godot_project / "range.gdshader"
+    _gda("shader", "create", str(shader_path), "--json")
+
+    edited = _gda(
+        "shader", "set", str(shader_path),
+        "--start-line", "50", "--end-line", "99", "--content", "x", "--json",
+    )
+
+    _assert_operation_error(edited, "invalid_line_range")
+
+
+# --- theme create: a genuinely LOADABLE .tres ------------------------------
+
+
+@pytest.mark.e2e
+def test_theme_create_produces_a_loadable_tres(godot_project):
+    # The acceptance core: theme create must produce a LOADABLE Theme resource,
+    # not hand-written text. Create it, then load it back through the engine and
+    # assert the loaded resource is a Theme — the structured-level proof.
+    theme_path = godot_project / "ui.tres"
+
+    created = _gda("theme", "create", str(theme_path), "--json")
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    data = json.loads(created.stdout)
+    assert data["path"] == str(theme_path)
+    assert data["type"] == "Theme"
+    assert theme_path.exists()
+
+    # Load the saved .tres back through Godot and confirm it is a real Theme.
+    loaded = _load_resource_class(theme_path)
+    assert loaded == "Theme", f"loaded class was {loaded!r}, expected Theme"
+
+
+@pytest.mark.e2e
+def test_theme_create_no_clobber_existing_file(godot_project):
+    theme_path = godot_project / "dup.tres"
+    assert _gda("theme", "create", str(theme_path), "--json").returncode == 0
+
+    again = _gda("theme", "create", str(theme_path), "--json")
+
+    _assert_operation_error(again, "already_exists")
+
+
+@pytest.mark.e2e
+def test_theme_create_wrong_extension_is_invalid_path(godot_project):
+    bad = _gda("theme", "create", str(godot_project / "ui.txt"), "--json")
+    _assert_operation_error(bad, "invalid_path")
+
+
+def _load_resource_class(resource_path) -> str:
+    """Load ``resource_path`` through a one-shot headless Godot and report its class.
+
+    A direct engine probe (separate from gda's own pipeline): proves theme create
+    wrote a genuinely loadable resource by having the engine load it back.
+    """
+    probe = resource_path.parent / "_probe_load.gd"
+    probe.write_text(
+        "extends SceneTree\n"
+        "func _initialize() -> void:\n"
+        f'\tvar r := ResourceLoader.load("{resource_path}")\n'
+        '\tprint("<<<CLASS>>>" + (r.get_class() if r != null else "NULL") + "<<<END>>>")\n'
+        "func _process(_d):\n"
+        "\tquit(0)\n"
+        "\treturn true\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [str(GODOT), "--headless", "--script", str(probe)],
+        capture_output=True,
+        text=True,
+    )
+    out = proc.stdout
+    start = out.find("<<<CLASS>>>") + len("<<<CLASS>>>")
+    end = out.find("<<<END>>>", start)
+    return out[start:end]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -891,3 +891,89 @@ def test_project_set_result_round_trips_the_coerced_setting():
     assert was_set.type == "String"
     assert was_set.value == "Renamed Game"
     assert json.loads(was_set.model_dump_json()) == payload
+
+
+def test_shader_create_result_round_trips_path_and_metadata():
+    # shader create echoes what it wrote (issue #115): the saved path, the
+    # shader_type parsed from the written source, and the parent dirs created —
+    # so an agent asserts the effect without a second call.
+    from gda.models import ShaderCreateResult
+
+    payload = {
+        "path": "/p/wave.gdshader",
+        "shader_type": "canvas_item",
+        "created_dirs": ["/p/shaders"],
+    }
+
+    created = ShaderCreateResult.model_validate(payload)
+
+    assert created.path == "/p/wave.gdshader"
+    assert created.shader_type == "canvas_item"
+    assert created.created_dirs == ["/p/shaders"]
+    assert json.loads(created.model_dump_json()) == payload
+
+
+def test_shader_get_result_carries_source_verbatim():
+    # shader get is the verifier (issue #115): it echoes the source byte-for-byte
+    # plus the shader_type the source declares, so a create round-trips.
+    from gda.models import ShaderGetResult
+
+    payload = {
+        "path": "/p/wave.gdshader",
+        "source": "shader_type canvas_item;\n",
+        "shader_type": "canvas_item",
+    }
+
+    got = ShaderGetResult.model_validate(payload)
+
+    assert got.source == "shader_type canvas_item;\n"
+    assert got.shader_type == "canvas_item"
+    assert json.loads(got.model_dump_json()) == payload
+
+
+def test_shader_set_params_reuse_the_script_set_edit_mode_enum():
+    # shader set reuses the script set edit-mode interface (issue #115): the mode
+    # discriminator is the SAME ScriptSetMode enum, not a parallel one.
+    from gda.models import ScriptSetMode, ShaderSetParams
+
+    params = ShaderSetParams(
+        path="/p/wave.gdshader",
+        mode=ScriptSetMode.SEARCH_REPLACE,
+        search="0.5",
+        replace="1.0",
+    )
+
+    assert params.mode is ScriptSetMode.SEARCH_REPLACE
+    assert params.search == "0.5"
+    assert params.replace == "1.0"
+
+
+def test_shader_set_result_round_trips_path_and_metadata():
+    from gda.models import ShaderSetResult
+
+    payload = {"path": "/p/wave.gdshader", "shader_type": "spatial"}
+
+    edited = ShaderSetResult.model_validate(payload)
+
+    assert edited.path == "/p/wave.gdshader"
+    assert edited.shader_type == "spatial"
+    assert json.loads(edited.model_dump_json()) == payload
+
+
+def test_theme_create_result_round_trips_path_type_and_dirs():
+    # theme create echoes the saved .tres path, the resource type written
+    # (Theme), and the parent dirs created (issue #115).
+    from gda.models import ThemeCreateResult
+
+    payload = {
+        "path": "/p/ui.tres",
+        "type": "Theme",
+        "created_dirs": [],
+    }
+
+    created = ThemeCreateResult.model_validate(payload)
+
+    assert created.path == "/p/ui.tres"
+    assert created.type == "Theme"
+    assert created.created_dirs == []
+    assert json.loads(created.model_dump_json()) == payload

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -915,3 +915,115 @@ def test_schema_flag_binds_false_not_none_when_absent():
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "schema=False"
+
+
+def test_shader_create_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for the shader group (issue #115): the bare --schema
+    # flag — no path — short-circuits into the self-description, derived from the
+    # same typed models that back --json.
+    from gda.models import ShaderCreateParams, ShaderCreateResult
+
+    result = CliRunner().invoke(app, ["shader", "create", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ShaderCreateParams.model_json_schema()
+    assert doc["output"] == ShaderCreateResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "content" in doc["input"]["properties"]
+    assert "shader_type" in doc["input"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_shader_get_schema_emits_model_derived_contract_without_other_args():
+    from gda.models import ShaderGetParams, ShaderGetResult
+
+    result = CliRunner().invoke(app, ["shader", "get", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ShaderGetParams.model_json_schema()
+    assert doc["output"] == ShaderGetResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "source" in doc["output"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_shader_set_schema_emits_model_derived_contract_without_other_args():
+    # The shader set edit-mode interface is the script set interface reused
+    # (issue #115); the line-range 1-based rule is documented in the contract.
+    from gda.models import ShaderSetParams, ShaderSetResult
+
+    result = CliRunner().invoke(app, ["shader", "set", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ShaderSetParams.model_json_schema()
+    assert doc["output"] == ShaderSetResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "search" in doc["input"]["properties"]
+    assert "start_line" in doc["input"]["properties"]
+    assert "content" in doc["input"]["properties"]
+    assert "1-based" in doc["input"]["properties"]["start_line"]["description"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_theme_create_schema_emits_model_derived_contract_without_other_args():
+    from gda.models import ThemeCreateParams, ThemeCreateResult
+
+    result = CliRunner().invoke(app, ["theme", "create", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ThemeCreateParams.model_json_schema()
+    assert doc["output"] == ThemeCreateResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "type" in doc["output"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_sample_asset_file_results_validate_against_emitted_output_schemas():
+    # A sample --json payload of each asset-file command satisfies the contract
+    # its --schema emits (the other half of the ADR-0004 hard gate, issue #115).
+    from tests.test_asset_file_commands import (
+        SHADER_CREATE_RESULT,
+        SHADER_GET_RESULT,
+        SHADER_SET_RESULT,
+        THEME_CREATE_RESULT,
+    )
+
+    create_doc = json.loads(
+        CliRunner().invoke(app, ["shader", "create", "--schema"]).stdout
+    )
+    get_doc = json.loads(CliRunner().invoke(app, ["shader", "get", "--schema"]).stdout)
+    set_doc = json.loads(CliRunner().invoke(app, ["shader", "set", "--schema"]).stdout)
+    theme_doc = json.loads(
+        CliRunner().invoke(app, ["theme", "create", "--schema"]).stdout
+    )
+
+    jsonschema.validate(instance=SHADER_CREATE_RESULT, schema=create_doc["output"])
+    jsonschema.validate(instance=SHADER_GET_RESULT, schema=get_doc["output"])
+    jsonschema.validate(instance=SHADER_SET_RESULT, schema=set_doc["output"])
+    jsonschema.validate(instance=THEME_CREATE_RESULT, schema=theme_doc["output"])
+
+
+def test_asset_file_schema_spawns_no_godot(monkeypatch):
+    def boom(*args, **kwargs):
+        raise AssertionError("--schema must not touch the engine")
+
+    monkeypatch.setattr("gda.headless.resolve_godot_binary", boom)
+    monkeypatch.setattr("gda.cli._make_runner", boom)
+
+    for command in (
+        ["shader", "create"],
+        ["shader", "get"],
+        ["shader", "set"],
+        ["theme", "create"],
+    ):
+        result = CliRunner().invoke(app, [*command, "--schema"])
+        assert result.exit_code == 0
+        assert set(json.loads(result.stdout)) >= {"input", "output", "error"}


### PR DESCRIPTION
## What

Headless authoring of the asset-file types catalogued under the asset-file group: shaders (`.gdshader`) and themes (`.tres`).

- `gda shader create` / `get` / `set` — author, read, and edit a `.gdshader` as RAW TEXT (no engine compilation needed), the same file-level boundary the script group's create/get/set honor (issue #30). **create → get → set round-trips.**
- `gda shader set` **reuses the `script set` edit-mode interface** (#118) rather than re-deriving it: the same three mutually-exclusive modes (search-replace / line-range / full), the same `ScriptSetMode` discriminator resolved by the shared CLI mutual-exclusion check (#133), and the same apply helpers (now noun-parameterized so the diagnostics name "shader" vs "script").
- `gda theme create` — constructs a `Theme` and writes it through `ResourceSaver` so the `.tres` is a **genuinely loadable** resource (engine-backed). The file-level vs engine-backed split mirrors how the script group splits create/get/set (text) from attach/validate (engine).

## Contract

All four ship `--json` and the ADR-0004 `--schema` hard gate via the shared `HeadlessCommand` skeleton — schemas are model-derived from the same Pydantic models that back `--json`.

## Failure modes

Structured `GdaError`s with registered codes (ADR-0002), **reusing existing file-level codes** — no new codes minted, exactly as the script group did:

| Mode | Code |
| --- | --- |
| path collision (no-clobber) | `already_exists` |
| file not found (get/set) | `path_not_found` |
| wrong extension | `invalid_path` |
| unwritable target | `save_failed` |
| no search-replace match | `no_search_match` |
| bad edit range | `invalid_line_range` |

Because no codes were added, the Python registry / ADR-0002 table / GDScript mirror stay in sync (drift test passes).

## Tests (TDD: red → green)

- **S2** model unit (`tests/test_models.py`)
- **S3** CLI-with-FakeRunner (`tests/test_asset_file_commands.py`), structured errors (`tests/test_asset_file_errors.py`), and the ADR-0004 `--schema` gate (`tests/test_schema_command.py`)
- **S1** e2e against a real engine (`tests/test_e2e_asset_file.py`) — the full shader create → get → set round-trip, and the `.tres` is **loaded back through Godot to prove it is a real `Theme`**; `@pytest.mark.e2e`, auto-skips when no engine resolves.

**Full suite: 473 passed (0 failed, 0 skipped — engine present).**

Closes #115
