### PR TITLE
feat(resource): uid — resolve UID ↔ resource path (both directions) (#113)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -122,6 +122,9 @@ operation, and parse codes the CLI assigns).
 | `invalid_resource_type` | `operation` | `operation` | `4` | A requested resource type cannot be instantiated as a `Resource`. |
 | `export_presets_not_found` | `operation` | `operation` | `4` | The project has no export_presets.cfg, so it defines no export presets. |
 | `export_preset_not_found` | `operation` | `operation` | `4` | No export preset with the requested name exists in export_presets.cfg. |
+| `invalid_uid` | `operation` | `operation` | `4` | A requested `uid://` value is not a syntactically valid resource UID. |
+| `unknown_uid` | `operation` | `operation` | `4` | A syntactically valid resource UID is not registered in the engine's UID cache. |
+| `no_uid_assigned` | `operation` | `operation` | `4` | A resource path exists but has no UID assigned in the engine's UID cache. |
 | `contract_violation` | `parse` | `parser` | `5` | The process claimed success but violated the structured-output contract. |
 | `tree_too_deep` | `parse` | `classifier` | `5` | The engine emitted a valid result tree that nests past gda's recursion limit; the payload is contract-conformant, the limit is wrapper-side (shares the `parse` exit code; the `code` distinguishes it from `contract_violation`). |
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -53,6 +53,8 @@ from gda.models import (
     ResourceCreateResult,
     ResourceGetParams,
     ResourceGetResult,
+    ResourceUidParams,
+    ResourceUidResult,
     SceneCreateParams,
     SceneCreateResult,
     SceneDeleteParams,
@@ -394,6 +396,12 @@ EXPORT_GET_COMMAND: HeadlessCommand[ExportGetResult] = HeadlessCommand(
     operation="export-get",
     input_model=ExportGetParams,
     output_model=ExportGetResult,
+)
+
+RESOURCE_UID_COMMAND: HeadlessCommand[ResourceUidResult] = HeadlessCommand(
+    operation="resource-uid",
+    input_model=ResourceUidParams,
+    output_model=ResourceUidResult,
 )
 
 
@@ -1184,6 +1192,32 @@ def get_preset(
     _dispatch(
         EXPORT_GET_COMMAND,
         ExportGetParams(preset=preset),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@resource_app.command(name="uid", cls=RESOURCE_UID_COMMAND.command_class())
+def resolve_uid(
+    target: str = typer.Argument(
+        ...,
+        help=(
+            "A 'uid://…' value to resolve to its res:// path, or a 'res://…' / "
+            "filesystem path to resolve to its 'uid://…'. The direction is chosen "
+            "by whether the target begins with 'uid://'."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = RESOURCE_UID_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Resolve a resource UID to/from its res:// path via the engine's UID cache."""
+    _dispatch(
+        RESOURCE_UID_COMMAND,
+        ResourceUidParams(target=_normalize_path(target)),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -322,6 +322,27 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "No export preset with the requested name exists in export_presets.cfg.",
     ),
     ErrorCodeSpec(
+        "invalid_uid",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A requested uid:// value is not a syntactically valid resource UID.",
+    ),
+    ErrorCodeSpec(
+        "unknown_uid",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A syntactically valid resource UID is not registered in the engine's UID cache.",
+    ),
+    ErrorCodeSpec(
+        "no_uid_assigned",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A resource path exists but has no UID assigned in the engine's UID cache.",
+    ),
+    ErrorCodeSpec(
         "contract_violation",
         ErrorCategory.PARSE,
         EXIT_PARSE,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -1205,6 +1205,32 @@ class ResourceCreateParams(BaseModel):
     )
 
 
+class ResourceUidParams(BaseModel):
+    """The operation params of ``gda resource uid`` (issue #113).
+
+    Resolves a Godot resource UID to/from its resource path in BOTH directions
+    against the engine's UID cache — read-only, it never mutates the cache or any
+    file. ``target`` is the single addressing argument and selects the direction
+    by its form:
+
+    - a ``uid://…`` value: report the ``res://…`` path it resolves to.
+    - a ``res://…`` (or filesystem) path: report its assigned ``uid://…``.
+
+    The UID cache is the engine's own ``res://.godot/uid_cache.bin``, loaded at
+    startup, so resolution needs project context (``--project``); a projectless
+    run has no cache to query. This is distinct from ``.tres`` file CRUD: it
+    queries the cache, not a file's contents.
+    """
+
+    target: str = Field(
+        description=(
+            "The resolution target: a 'uid://…' value to resolve to its res:// "
+            "path, or a 'res://…' / filesystem path to resolve to its 'uid://…'. "
+            "The direction is chosen by whether 'target' begins with 'uid://'."
+        )
+    )
+
+
 class ExportListParams(BaseModel):
     """The operation params of ``gda export list`` — none (ADR-0004).
 
@@ -1346,6 +1372,28 @@ class ResourceGetResult(BaseModel):
     path: str
     type: str = Field(description="The resource's engine class (e.g. Gradient).")
     properties: list[NodeProperty]
+
+
+class ResourceUidResult(BaseModel):
+    """The result of ``gda resource uid``: the resolved UID↔path pair (issue #113).
+
+    Both directions converge on the same shape — the resolved ``uid`` and the
+    ``path`` it maps to — so an agent always gets both sides of the mapping
+    regardless of which it queried. ``queried`` echoes which direction was
+    resolved, so the result is self-describing: ``uid`` means the target was a
+    ``uid://`` resolved to its path, ``path`` means the target was a path
+    resolved to its UID.
+    """
+
+    queried: str = Field(
+        description=(
+            "Which direction was resolved: 'uid' when the target was a 'uid://' "
+            "value (resolved to its path), 'path' when the target was a path "
+            "(resolved to its UID)."
+        )
+    )
+    uid: str = Field(description="The resource's 'uid://…' value.")
+    path: str = Field(description="The resource's 'res://…' path the UID maps to.")
 
 
 class EngineVersion(BaseModel):

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -57,6 +57,9 @@ const OP_ERROR_CONNECTION_NOT_FOUND := "connection_not_found"
 const OP_ERROR_INVALID_RESOURCE_TYPE := "invalid_resource_type"
 const OP_ERROR_EXPORT_PRESETS_NOT_FOUND := "export_presets_not_found"
 const OP_ERROR_EXPORT_PRESET_NOT_FOUND := "export_preset_not_found"
+const OP_ERROR_INVALID_UID := "invalid_uid"
+const OP_ERROR_UNKNOWN_UID := "unknown_uid"
+const OP_ERROR_NO_UID_ASSIGNED := "no_uid_assigned"
 
 const NODE_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
 
@@ -132,6 +135,8 @@ func _initialize() -> void:
 			_op_export_list(params)
 		"export-get":
 			_op_export_get(params)
+		"resource-uid":
+			_op_resource_uid(params)
 		_:
 			_fail(OP_ERROR_UNKNOWN_OPERATION, "unknown operation: " + operation)
 
@@ -1622,6 +1627,80 @@ func _export_templates_version_dir() -> String:
 func _export_templates_installed(version_dir: String) -> bool:
 	var templates_root := OS.get_data_dir().path_join("Godot").path_join("export_templates")
 	return DirAccess.dir_exists_absolute(templates_root.path_join(version_dir))
+
+
+# resource-uid: resolve a Godot resource UID to/from its resource path in BOTH
+# directions against the engine's UID cache (issue #113). Read-only — it only
+# queries ResourceUID / ResourceLoader, never mutating the cache or any file.
+#
+# The cache is the engine's own res://.godot/uid_cache.bin, loaded at startup
+# (Main loads it via ResourceUID.load_from_cache for every run, and a non-editor
+# run also enables the reverse cache that path->uid resolution reads). So
+# resolution needs a project: a projectless headless run has no cache to query,
+# refused with project_not_found rather than a misleading "no UID" answer.
+#
+# Direction is chosen by the target's form:
+# - target begins with "uid://" -> resolve uid -> path:
+#     text_to_id == INVALID_ID    -> invalid_uid    (malformed uid:// syntax)
+#     not has_id                   -> unknown_uid    (valid syntax, not in cache)
+#     else get_id_path(id)         -> the res:// path
+# - otherwise target is a path -> resolve path -> uid:
+#     not ResourceLoader.exists    -> path_not_found (no such resource)
+#     get_resource_uid == INVALID  -> no_uid_assigned (exists, but no UID)
+#     else id_to_text(id)          -> the uid:// value
+# Both directions converge on the same {queried, uid, path} result, so an agent
+# always gets both sides of the mapping regardless of which it queried.
+func _op_resource_uid(params: Dictionary) -> void:
+	_diag("running operation: resource-uid")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "resource uid requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+
+	var target := _string_param(params, "target")
+	if target.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: target")
+		return
+
+	if target.begins_with("uid://"):
+		_resolve_uid_to_path(target)
+	else:
+		_resolve_path_to_uid(target)
+
+
+# uid -> path: extract the UID value, confirm it is in the cache, and report the
+# path it maps to. A malformed uid:// is invalid_uid (text_to_id == INVALID_ID);
+# a well-formed UID absent from the cache is unknown_uid (has_id false).
+func _resolve_uid_to_path(uid_text: String) -> void:
+	var id := ResourceUID.text_to_id(uid_text)
+	if id == ResourceUID.INVALID_ID:
+		_fail(OP_ERROR_INVALID_UID, "not a valid resource UID: " + uid_text)
+		return
+	if not ResourceUID.has_id(id):
+		_fail(OP_ERROR_UNKNOWN_UID, "UID is not registered in the project's UID cache: " + uid_text)
+		return
+	_succeed({
+		"queried": "uid",
+		"uid": uid_text,
+		"path": ResourceUID.get_id_path(id),
+	})
+
+
+# path -> uid: confirm the resource exists, then report its assigned UID. A path
+# that names no resource is path_not_found; a resource with no UID in the cache
+# is no_uid_assigned (get_resource_uid == INVALID_ID).
+func _resolve_path_to_uid(path: String) -> void:
+	if not ResourceLoader.exists(path):
+		_fail(OP_ERROR_PATH_NOT_FOUND, "no resource at path: " + path)
+		return
+	var id := ResourceLoader.get_resource_uid(path)
+	if id == ResourceUID.INVALID_ID:
+		_fail(OP_ERROR_NO_UID_ASSIGNED, "resource has no UID assigned in the project's UID cache: " + path)
+		return
+	_succeed({
+		"queried": "path",
+		"uid": ResourceUID.id_to_text(id),
+		"path": path,
+	})
 
 
 # Whether a path names a script file the script group operates on: a .gd

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -36,6 +36,7 @@ from gda.models import (
     NodeSetResult,
     ResourceCreateResult,
     ResourceGetResult,
+    ResourceUidResult,
     SceneCreateResult,
     SceneDeleteResult,
     SceneGetExportsResult,
@@ -325,6 +326,11 @@ def render_export_get(got: "ExportGetResult") -> str:
     return "\n".join([header, f"  export_path: {got.export_path}", f"  {templates}"])
 
 
+def render_resource_uid(resolved: "ResourceUidResult") -> str:
+    """Render a resolved UID↔path mapping as ``<uid> -> <path>`` for humans."""
+    return f"{resolved.uid} -> {resolved.path}"
+
+
 def render_engine_version(version: "EngineVersion") -> str:
     """Render the engine version as its one-line version string."""
     return version.string
@@ -361,6 +367,7 @@ _RENDERERS = {
     ResourceGetResult: render_resource_properties,
     ExportListResult: render_export_list,
     ExportGetResult: render_export_get,
+    ResourceUidResult: render_resource_uid,
     EngineVersion: render_engine_version,
 }
 

--- a/tests/test_e2e_resource.py
+++ b/tests/test_e2e_resource.py
@@ -1,4 +1,4 @@
-"""S1 (e2e): the resource create → get round-trip against the real Godot engine.
+"""S1 (e2e): the resource create → get round-trip and resource uid resolution against the real Godot engine.
 
 The resource-group tracer (issue #112): ``gda resource create`` writes a .tres
 resource of a given type, no-clobber; ``gda resource get`` loads it and reports
@@ -6,6 +6,20 @@ its properties as typed JSON — ``resource get`` IS the structured-level
 verification of ``resource create``'s effect (create → get reports the
 resource). Establishes the .tres load/save plumbing the rest of the group
 reuses.
+
+The resource-uid tracer (issue #113): ``gda resource uid`` resolves a Godot
+resource UID to/from its resource path in BOTH directions against the engine's
+read-only UID cache (``res://.godot/uid_cache.bin``).
+
+The cache is populated by a project import scan, so each uid test scaffolds the
+relevant files and runs a one-shot ``godot --headless --import`` to write the
+cache before querying it — that import is the realistic precondition for any UID
+to resolve at all. A ``.gd`` script is auto-assigned a UID on import (a ``.uid``
+sidecar plus a cache entry), which is what makes both resolution directions
+resolve; a ``.tres`` resource imported without a sidecar exists but carries no
+cached UID, which is the realistic ``no_uid_assigned`` case. Both directions,
+plus the unknown-UID / invalid-UID / path-not-found / no-UID-assigned failure
+modes, are exercised end to end.
 """
 
 import json
@@ -18,6 +32,15 @@ from gda.binary import resolve_godot_binary
 
 GODOT = resolve_godot_binary()
 
+# A plain custom Resource .tres. On import (without a .uid sidecar) it exists as
+# a resource but is NOT assigned a UID in the non-editor reverse cache, so it is
+# the realistic no_uid_assigned case.
+DATA_TRES = """\
+[gd_resource type="Resource" format=3]
+
+[resource]
+"""
+
 
 def _gda(*args: str) -> subprocess.CompletedProcess:
     gda_bin = shutil.which("gda")
@@ -27,12 +50,46 @@ def _gda(*args: str) -> subprocess.CompletedProcess:
     )
 
 
+def _import_project(project) -> None:
+    """Run a one-shot headless import so the project's UID cache is written."""
+    subprocess.run(
+        [str(GODOT), "--headless", "--path", str(project), "--import"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def _gda_project(project) -> "callable":
+    """A ``gda`` bound to ``--godot`` and ``--project`` for res:// / UID resolution."""
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+
+    def gda(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [gda_bin, *args, "--godot", str(GODOT), "--project", str(project)],
+            capture_output=True,
+            text=True,
+        )
+
+    return gda
+
+
 def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
     assert proc.returncode == 4, proc.stdout + proc.stderr
     err = json.loads(proc.stdout)["error"]
     assert err["category"] == "operation"
     assert err["code"] == code
     return err
+
+
+@pytest.fixture
+def imported_project(godot_project):
+    """A project fixture with a script (UID-cached) and a .tres (no cached UID)."""
+    (godot_project / "hero.gd").write_text("extends Node\n", encoding="utf-8")
+    (godot_project / "data.tres").write_text(DATA_TRES, encoding="utf-8")
+    _import_project(godot_project)
+    return godot_project
 
 
 @pytest.mark.e2e
@@ -163,3 +220,99 @@ def test_resource_get_non_tres_path_yields_invalid_path(godot_project):
 
     err = _assert_operation_error(got, "invalid_path")
     assert ".tres" in err["message"]
+
+
+@pytest.mark.e2e
+def test_resource_uid_resolves_both_directions_round_trip(imported_project):
+    # path -> uid -> path: the script's import-assigned UID resolves back to the
+    # same path. This is the bidirectional contract: query a path, get its UID;
+    # query that UID, get the path back — proving both directions read one
+    # consistent cache.
+    gda = _gda_project(imported_project)
+
+    path_to_uid = gda("resource", "uid", "res://hero.gd", "--json")
+    assert path_to_uid.returncode == 0, path_to_uid.stdout + path_to_uid.stderr
+    forward = json.loads(path_to_uid.stdout)
+    assert forward["queried"] == "path"
+    assert forward["path"] == "res://hero.gd"
+    assert forward["uid"].startswith("uid://")
+
+    uid = forward["uid"]
+    uid_to_path = gda("resource", "uid", uid, "--json")
+    assert uid_to_path.returncode == 0, uid_to_path.stdout + uid_to_path.stderr
+    back = json.loads(uid_to_path.stdout)
+    assert back["queried"] == "uid"
+    assert back["uid"] == uid
+    # The round-trip closes: the UID resolves back to the original path.
+    assert back["path"] == "res://hero.gd"
+
+
+@pytest.mark.e2e
+def test_resource_uid_human_output_renders_uid_arrow_path(imported_project):
+    # Without --json, a resolved mapping renders as `<uid> -> <path>`.
+    gda = _gda_project(imported_project)
+
+    proc = gda("resource", "uid", "res://hero.gd")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert proc.stdout.strip().endswith("-> res://hero.gd")
+    assert proc.stdout.strip().startswith("uid://")
+
+
+@pytest.mark.e2e
+def test_resource_uid_unknown_uid_is_unknown_uid(imported_project):
+    # A syntactically valid uid:// not in the project's cache is unknown_uid.
+    gda = _gda_project(imported_project)
+
+    proc = gda("resource", "uid", "uid://b00000000000b", "--json")
+
+    _assert_operation_error(proc, "unknown_uid")
+
+
+@pytest.mark.e2e
+def test_resource_uid_invalid_uid_is_invalid_uid(imported_project):
+    # A uid:// whose body holds illegal characters fails text_to_id (INVALID_ID),
+    # reported as invalid_uid — distinct from a well-formed-but-unknown UID.
+    gda = _gda_project(imported_project)
+
+    proc = gda("resource", "uid", "uid://<invalid>", "--json")
+
+    _assert_operation_error(proc, "invalid_uid")
+
+
+@pytest.mark.e2e
+def test_resource_uid_path_not_found_is_path_not_found(imported_project):
+    # A res:// path naming no resource is path_not_found.
+    gda = _gda_project(imported_project)
+
+    proc = gda("resource", "uid", "res://missing.tres", "--json")
+
+    _assert_operation_error(proc, "path_not_found")
+
+
+@pytest.mark.e2e
+def test_resource_uid_path_without_uid_is_no_uid_assigned(imported_project):
+    # A resource that exists but has no UID in the non-editor reverse cache is
+    # no_uid_assigned — distinct from path_not_found (the file is there) and from
+    # a UID-direction failure (the query was a path).
+    gda = _gda_project(imported_project)
+
+    proc = gda("resource", "uid", "res://data.tres", "--json")
+
+    _assert_operation_error(proc, "no_uid_assigned")
+
+
+@pytest.mark.e2e
+def test_resource_uid_projectless_run_is_project_not_found():
+    # Resolution queries the project's UID cache, so a projectless run is refused
+    # with project_not_found rather than a misleading "no UID" answer.
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+
+    proc = subprocess.run(
+        [gda_bin, "resource", "uid", "uid://b00000000000b", "--godot", str(GODOT), "--json"],
+        capture_output=True,
+        text=True,
+    )
+
+    _assert_operation_error(proc, "project_not_found")

--- a/tests/test_resource_commands.py
+++ b/tests/test_resource_commands.py
@@ -1,9 +1,14 @@
-"""S3: gda resource create / resource get success paths against a fake runner (issue #112).
+"""S3: gda resource create / get / uid success paths against a fake runner (issues #112, #113).
 
 The resource command group acts on .tres resource files on disk (load/save
-plumbing), staying headless. These tests drive the same proven pipeline as the
+plumbing), staying headless; `gda resource uid` additionally resolves a Godot
+resource UID to/from its resource path in BOTH directions against the engine's
+read-only UID cache. These tests drive the same proven pipeline as the
 scene/node/script groups — Typer → binary resolution → runner → sentinel parse
-→ typed model → JSON — with canned engine output, no real Godot.
+→ typed model → JSON — with canned engine output, no real Godot. For `uid`, the
+single `target` argument selects the direction by its form (a `uid://` value vs
+a `res://`/filesystem path); both directions converge on one
+`{queried, uid, path}` result.
 """
 
 import json
@@ -13,6 +18,7 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.runner import RunResult
 from tests.support import FakeRunner, inject_runner, sentinel
+
 
 CREATE_RESULT = {
     "path": "/tmp/proj/palette.tres",
@@ -28,6 +34,13 @@ GET_RESULT = {
         {"name": "interpolation_mode", "type": "int", "value": 0},
     ],
 }
+
+
+UID = "uid://caax1gby1api1"
+PATH = "res://data.tres"
+
+UID_TO_PATH_RESULT = {"queried": "uid", "uid": UID, "path": PATH}
+PATH_TO_UID_RESULT = {"queried": "path", "uid": UID, "path": PATH}
 
 
 def test_resource_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
@@ -132,3 +145,108 @@ def test_resource_get_res_path_passes_through_untouched(monkeypatch):
 
     assert result.exit_code == 0
     assert fake.calls == [("resource-get", {"path": "res://palette.tres"})]
+
+
+def test_resource_uid_resolves_uid_to_path_json_and_exit_zero(monkeypatch, tmp_path):
+    # Given a uid://, the command reports the res:// path it resolves to. Engine
+    # banner noise around the sentinel, diagnostics on stderr (ADR-0002).
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(UID_TO_PATH_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["resource", "uid", UID, "--project", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["queried"] == "uid"
+    assert data["uid"] == UID
+    assert data["path"] == PATH
+    # The target rides through verbatim as the typed `target` param; a uid://
+    # value passes through the CLI path normalization untouched (issue #32).
+    assert fake.calls == [("resource-uid", {"target": UID})]
+    assert "engine diagnostic" in result.stderr
+
+
+def test_resource_uid_resolves_path_to_uid_json_and_exit_zero(monkeypatch, tmp_path):
+    # Given a res:// path, the command reports its assigned uid://. The result is
+    # the same shape; only `queried` distinguishes which side was the target.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(PATH_TO_UID_RESULT)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app, ["resource", "uid", PATH, "--project", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["queried"] == "path"
+    assert data["uid"] == UID
+    assert data["path"] == PATH
+    # A res:// path also passes through normalization untouched (issue #32).
+    assert fake.calls == [("resource-uid", {"target": PATH})]
+
+
+def test_resource_uid_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
+    # Resolution queries the project's UID cache, so --project must reach the
+    # runner (which hands it to the engine as --path, issue #32).
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    seen: dict = {}
+
+    def record(binary, project):
+        seen["project"] = project
+        return FakeRunner(
+            RunResult(stdout=sentinel(UID_TO_PATH_RESULT), stderr="", exit_code=0)
+        )
+
+    monkeypatch.setattr("gda.cli._make_runner", record)
+
+    result = CliRunner().invoke(
+        app, ["resource", "uid", UID, "--project", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert seen["project"] == tmp_path
+
+
+def test_resource_uid_expands_tilde_for_a_filesystem_target(monkeypatch, tmp_path):
+    # A filesystem path target gets ~ expanded at the CLI layer so a literal ~
+    # works without a shell (issue #32); a uid:// / res:// target is untouched.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(PATH_TO_UID_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["resource", "uid", "~/data.tres", "--project", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    # The dispatched target is the ~-expanded absolute path, not the literal "~".
+    (operation, params), = fake.calls
+    assert operation == "resource-uid"
+    assert not params["target"].startswith("~")
+    assert params["target"].endswith("/data.tres")
+
+
+# --- human-readable output (no --json): the render_text path (issue #113) ---
+
+
+def test_resource_uid_human_output_renders_uid_arrow_path(monkeypatch, tmp_path):
+    # Without --json, a resolved mapping renders as `<uid> -> <path>`, the same
+    # for both directions since the result shape is identical.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(UID_TO_PATH_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["resource", "uid", UID, "--project", str(tmp_path)]
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == f"{UID} -> {PATH}"

--- a/tests/test_resource_errors.py
+++ b/tests/test_resource_errors.py
@@ -1,4 +1,4 @@
-"""S3: gda resource failure modes map to structured JSON errors + stable exit codes.
+"""S3: gda resource failure modes map to structured JSON errors + stable exit codes (issues #112, #113).
 
 Issue #112's acceptance: resource-command failures surface as structured
 ``GdaError``s with registered operation codes (ADR-0002) — exit 4 for the
@@ -9,6 +9,12 @@ without parsing prose:
 - resource not found on get → ``path_not_found`` (reused)
 - non-.tres target path → ``invalid_path`` (reused)
 - invalid/unknown resource type on create → ``invalid_resource_type`` (NEW, #112)
+
+Issue #113's acceptance: the ``resource uid`` UID-resolution failure modes — an
+unknown UID, a path not found, and a path that exists but has no assigned UID —
+surface the same way (exit 4, registered operation codes). A syntactically
+malformed ``uid://`` adds ``invalid_uid``, and a projectless run reuses the
+shared ``project_not_found``.
 """
 
 import json
@@ -105,3 +111,94 @@ def test_resource_get_missing_yields_path_not_found(monkeypatch):
     assert err["category"] == "operation"
     assert err["code"] == "path_not_found"
     assert "/x/palette.tres" in err["message"]
+
+
+def _invoke_resource_uid(monkeypatch, code: str, message: str, target: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: resource-uid\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(app, ["resource", "uid", target, "--json"])
+
+
+def _assert_operation_error(result, code: str, needle: str) -> dict:
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == code
+    assert needle in err["message"]
+    # The raw stderr still rides along as diagnostics (ADR-0002).
+    assert err["diagnostics"] == "gda: running operation: resource-uid\n"
+    return err
+
+
+def test_resource_uid_unknown_uid_is_structured_error(monkeypatch):
+    # A well-formed uid:// absent from the project's UID cache is unknown_uid —
+    # the agent learns the UID is unregistered, not that the syntax was wrong.
+    result = _invoke_resource_uid(
+        monkeypatch,
+        "unknown_uid",
+        "UID is not registered in the project's UID cache: uid://abc",
+        "uid://abc",
+    )
+
+    _assert_operation_error(result, "unknown_uid", "uid://abc")
+
+
+def test_resource_uid_invalid_uid_is_structured_error(monkeypatch):
+    # A syntactically malformed uid:// (engine text_to_id == INVALID_ID) is
+    # invalid_uid — distinct from an unknown-but-well-formed UID.
+    result = _invoke_resource_uid(
+        monkeypatch,
+        "invalid_uid",
+        "not a valid resource UID: uid://!!!",
+        "uid://!!!",
+    )
+
+    _assert_operation_error(result, "invalid_uid", "uid://!!!")
+
+
+def test_resource_uid_path_not_found_is_structured_error(monkeypatch):
+    # A res:// path naming no resource is path_not_found — the same registered
+    # code the file groups use, not a parallel resource-specific code.
+    result = _invoke_resource_uid(
+        monkeypatch,
+        "path_not_found",
+        "no resource at path: res://missing.tres",
+        "res://missing.tres",
+    )
+
+    _assert_operation_error(result, "path_not_found", "res://missing.tres")
+
+
+def test_resource_uid_no_uid_assigned_is_structured_error(monkeypatch):
+    # A resource that exists but carries no UID in the cache is no_uid_assigned —
+    # distinct from path_not_found (the file is there) and from a UID-direction
+    # failure (the query was a path).
+    result = _invoke_resource_uid(
+        monkeypatch,
+        "no_uid_assigned",
+        "resource has no UID assigned in the project's UID cache: res://plain.txt",
+        "res://plain.txt",
+    )
+
+    _assert_operation_error(result, "no_uid_assigned", "res://plain.txt")
+
+
+def test_resource_uid_projectless_run_is_project_not_found(monkeypatch):
+    # Resolution queries the project's UID cache, so a projectless run has no
+    # cache to query — refused with the shared project_not_found rather than a
+    # misleading "no UID" answer.
+    result = _invoke_resource_uid(
+        monkeypatch,
+        "project_not_found",
+        "resource uid requires a Godot project; none was resolved",
+        "uid://abc",
+    )
+
+    _assert_operation_error(result, "project_not_found", "requires a Godot project")

--- a/tests/test_resource_models.py
+++ b/tests/test_resource_models.py
@@ -1,0 +1,59 @@
+"""S2: the resource uid command's typed models (issue #113, ADR-0004).
+
+`gda resource uid`'s result is carried by `ResourceUidResult` and its params by
+`ResourceUidParams`, so the same models both serialize the `--json` output and
+derive the `--schema` document. These unit tests pin the model shapes — both
+resolution directions converge on one `{queried, uid, path}` result — without a
+real engine.
+"""
+
+import json
+
+import jsonschema
+
+from gda.models import ResourceUidParams, ResourceUidResult
+
+
+def test_params_carry_the_single_target_argument():
+    params = ResourceUidParams(target="uid://caax1gby1api1")
+
+    assert params.target == "uid://caax1gby1api1"
+    # The params serialize to exactly the operation payload the runner dispatches.
+    assert params.model_dump() == {"target": "uid://caax1gby1api1"}
+
+
+def test_result_validates_a_uid_to_path_payload():
+    # The uid->path direction: the sentinel payload the operation emits.
+    payload = {"queried": "uid", "uid": "uid://caax1gby1api1", "path": "res://data.tres"}
+
+    result = ResourceUidResult.model_validate(payload)
+
+    assert result.queried == "uid"
+    assert result.uid == "uid://caax1gby1api1"
+    assert result.path == "res://data.tres"
+
+
+def test_result_validates_a_path_to_uid_payload():
+    # The path->uid direction shares the same shape; only `queried` differs.
+    payload = {"queried": "path", "uid": "uid://caax1gby1api1", "path": "res://data.tres"}
+
+    result = ResourceUidResult.model_validate(payload)
+
+    assert result.queried == "path"
+    assert result.uid == "uid://caax1gby1api1"
+    assert result.path == "res://data.tres"
+
+
+def test_result_round_trips_to_json_object():
+    payload = {"queried": "uid", "uid": "uid://abc", "path": "res://x.tres"}
+
+    result = ResourceUidResult.model_validate(payload)
+
+    assert json.loads(result.model_dump_json()) == payload
+
+
+def test_result_schema_is_valid_json_schema_with_the_three_fields():
+    schema = ResourceUidResult.model_json_schema()
+
+    jsonschema.Draft202012Validator.check_schema(schema)
+    assert {"queried", "uid", "path"} <= set(schema["properties"])

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -671,6 +671,52 @@ def test_sample_script_results_validate_against_emitted_output_schemas():
     )
 
 
+def test_resource_uid_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for resource uid (issue #113): the bare --schema
+    # flag — no target, no --project — short-circuits into the self-description,
+    # derived from the same typed models that back --json.
+    from gda.models import ResourceUidParams, ResourceUidResult
+
+    result = CliRunner().invoke(app, ["resource", "uid", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ResourceUidParams.model_json_schema()
+    assert doc["output"] == ResourceUidResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "target" in doc["input"]["properties"]
+    assert {"queried", "uid", "path"} <= set(doc["output"]["properties"])
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_sample_resource_uid_results_validate_against_emitted_output_schema():
+    # A sample --json payload of resource uid satisfies the contract its --schema
+    # emits — the other half of the ADR-0004 hard gate (issue #113). Both
+    # directions share one result shape, so one sample covers them.
+    from tests.test_resource_commands import PATH_TO_UID_RESULT, UID_TO_PATH_RESULT
+
+    doc = json.loads(CliRunner().invoke(app, ["resource", "uid", "--schema"]).stdout)
+
+    jsonschema.validate(instance=UID_TO_PATH_RESULT, schema=doc["output"])
+    jsonschema.validate(instance=PATH_TO_UID_RESULT, schema=doc["output"])
+
+
+def test_resource_uid_schema_spawns_no_godot(monkeypatch):
+    # --schema is local introspection: resource uid must short-circuit before any
+    # engine path, exactly like the other groups' schema gate.
+    def boom(*args, **kwargs):
+        raise AssertionError("--schema must not touch the engine")
+
+    monkeypatch.setattr("gda.headless.resolve_godot_binary", boom)
+    monkeypatch.setattr("gda.cli._make_runner", boom)
+
+    result = CliRunner().invoke(app, ["resource", "uid", "--schema"])
+
+    assert result.exit_code == 0
+    assert set(json.loads(result.stdout)) >= {"input", "output", "error"}
+
+
 def test_script_schema_spawns_no_godot(monkeypatch):
     def boom(*args, **kwargs):
         raise AssertionError("--schema must not touch the engine")


### PR DESCRIPTION
Closes #113

## What

Adds `gda resource uid <target>`, which resolves a Godot resource UID to/from its resource path in **both directions** against the engine's **read-only** UID cache (`res://.godot/uid_cache.bin`):

- a `uid://…` target → reports the `res://…` path it resolves to
- a `res://…` / filesystem path target → reports its assigned `uid://…`

The direction is chosen by the target's `uid://` prefix. Both directions converge on one self-describing result: `{queried, uid, path}` (`queried` says which side was the target). This queries the UID cache, not a file's contents, so it is distinct from `.tres` CRUD — it ships as its own slice (independent of the resource create/get/set/delete tracer, #112).

## How

- Reuses the existing headless skeleton end-to-end: `ResourceUidParams`/`ResourceUidResult` Pydantic models, a `resource-uid` GDScript operation, the shared classifier, a `render_resource_uid` renderer, and `--json` + the ADR-0004 `--schema` hard gate.
- The GDScript op uses the engine's own `ResourceUID` / `ResourceLoader` API: `text_to_id` → `has_id` → `get_id_path` for uid→path, and `ResourceLoader.exists` → `get_resource_uid` → `id_to_text` for path→uid. It is read-only — it never mutates the cache or any file.
- The `resource` command group is registered **minimally** (this slice only adds `uid`), kept localized so the resource CRUD tracer (#112) rebases cleanly.

## Error codes

Three new operation-source codes, mirrored across the Python registry, the ADR-0002 table, and the GDScript constants (the registry-drift test gates all three):

| Code | When |
| --- | --- |
| `invalid_uid` | a `uid://` value is syntactically malformed (`text_to_id` == `INVALID_ID`) |
| `unknown_uid` | a well-formed UID is not registered in the project's UID cache |
| `no_uid_assigned` | a resource path exists but has no UID in the cache |

A missing path reuses `path_not_found`; a projectless run reuses `project_not_found` (no cache to query).

## Tests

- **S2** model/parser unit (`test_resource_models.py`)
- **S3** CLI-with-FakeRunner success + human-render (`test_resource_commands.py`), structured-error mapping for all failure modes (`test_resource_errors.py`), and the `--schema` hard gate (`test_schema_command.py`)
- **S1** e2e against a real engine (`test_e2e_resource.py`): the path→uid→path round-trip plus every failure mode. Resolution needs a populated UID cache, so the fixture runs a one-shot `godot --headless --import` to write it; auto-skips when no engine is present.

Full suite: **448 passed** (with a real engine present).
