### PR TITLE
feat(project): static-analysis reads — find-references, dependencies, find-unused-resources, statistics (#116)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -126,6 +126,7 @@ operation, and parse codes the CLI assigns).
 | `unknown_uid` | `operation` | `operation` | `4` | A syntactically valid resource UID is not registered in the engine's UID cache. |
 | `no_uid_assigned` | `operation` | `operation` | `4` | A resource path exists but has no UID assigned in the engine's UID cache. |
 | `unknown_setting` | `operation` | `operation` | `4` | A requested project setting does not exist in the project's ProjectSettings. |
+| `invalid_target` | `operation` | `operation` | `4` | A project find-references target is empty or not a valid `res://` path or `class_name`. |
 | `contract_violation` | `parse` | `parser` | `5` | The process claimed success but violated the structured-output contract. |
 | `tree_too_deep` | `parse` | `classifier` | `5` | The engine emitted a valid result tree that nests past gda's recursion limit; the payload is contract-conformant, the limit is wrapper-side (shares the `parse` exit code; the `code` distinguishes it from `contract_violation`). |
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -31,6 +31,14 @@ from gda.models import (
     ExportListParams,
     ExportListResult,
     InfoParams,
+    ProjectDependenciesParams,
+    ProjectDependenciesResult,
+    ProjectFindReferencesParams,
+    ProjectFindReferencesResult,
+    ProjectFindUnusedResourcesParams,
+    ProjectFindUnusedResourcesResult,
+    ProjectStatisticsParams,
+    ProjectStatisticsResult,
     NodeAddParams,
     NodeAddResult,
     NodeConnectSignalParams,
@@ -143,14 +151,17 @@ export_app = typer.Typer(
 )
 app.add_typer(export_app, name="export")
 
-# The project command group (issue #111): commands that read and write the
-# resolved project's project.godot / ProjectSettings headlessly. Every project
-# command runs against an explicit project context (--project), so — like any
-# --project op — it runs the project's autoloads at engine startup (#61,
-# ADR-0009); reading/writing settings never instantiates a scene, so it is a
-# state-read at the operation level.
+# The project command group: commands acting on the Godot project as a whole.
+# The project-settings read/write commands (info/get/set, issue #111) read and
+# write the resolved project's project.godot / ProjectSettings headlessly. Issue
+# #116 adds the read-only, project-wide static-analysis reads (find-references,
+# dependencies, find-unused-resources, statistics), all backed by a single static
+# project scan that parses files as text — never instantiating a scene or loading
+# a script (issue #30). Every project command runs against an explicit project
+# context (--project), so — like any --project op — it runs the project's
+# autoloads at engine startup (#61, ADR-0009).
 project_app = typer.Typer(
-    help="Read and write the project's project.godot settings.", no_args_is_help=True
+    help="Act on the Godot project as a whole.", no_args_is_help=True
 )
 app.add_typer(project_app, name="project")
 
@@ -487,6 +498,36 @@ THEME_CREATE_COMMAND: HeadlessCommand[ThemeCreateResult] = HeadlessCommand(
     operation="theme-create",
     input_model=ThemeCreateParams,
     output_model=ThemeCreateResult,
+)
+
+PROJECT_FIND_REFERENCES_COMMAND: HeadlessCommand[ProjectFindReferencesResult] = (
+    HeadlessCommand(
+        operation="project-find-references",
+        input_model=ProjectFindReferencesParams,
+        output_model=ProjectFindReferencesResult,
+    )
+)
+
+PROJECT_DEPENDENCIES_COMMAND: HeadlessCommand[ProjectDependenciesResult] = (
+    HeadlessCommand(
+        operation="project-dependencies",
+        input_model=ProjectDependenciesParams,
+        output_model=ProjectDependenciesResult,
+    )
+)
+
+PROJECT_FIND_UNUSED_RESOURCES_COMMAND: HeadlessCommand[
+    ProjectFindUnusedResourcesResult
+] = HeadlessCommand(
+    operation="project-find-unused-resources",
+    input_model=ProjectFindUnusedResourcesParams,
+    output_model=ProjectFindUnusedResourcesResult,
+)
+
+PROJECT_STATISTICS_COMMAND: HeadlessCommand[ProjectStatisticsResult] = HeadlessCommand(
+    operation="project-statistics",
+    input_model=ProjectStatisticsParams,
+    output_model=ProjectStatisticsResult,
 )
 
 
@@ -1263,6 +1304,33 @@ def project_get(
     )
 
 
+@project_app.command(
+    name="find-references", cls=PROJECT_FIND_REFERENCES_COMMAND.command_class()
+)
+def find_references(
+    target: str = typer.Argument(
+        ...,
+        help=(
+            "What to find references to: a resource's res:// path (scene, "
+            "script, image, .tres, …) or a script class_name."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = PROJECT_FIND_REFERENCES_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Find every project file that references a given resource path or class_name."""
+    _dispatch(
+        PROJECT_FIND_REFERENCES_COMMAND,
+        ProjectFindReferencesParams(target=_normalize_path(target)),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
 @shader_app.command(cls=SHADER_CREATE_COMMAND.command_class())
 def create(
     path: str = typer.Argument(..., help="Target .gdshader path to write."),
@@ -1346,6 +1414,26 @@ def get_shader(
     )
 
 
+@project_app.command(
+    name="dependencies", cls=PROJECT_DEPENDENCIES_COMMAND.command_class()
+)
+def dependencies(
+    json_output: bool = json_option(),
+    schema: bool = PROJECT_DEPENDENCIES_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Map each scene/resource in the project to the resources it references."""
+    _dispatch(
+        PROJECT_DEPENDENCIES_COMMAND,
+        ProjectDependenciesParams(),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
 @export_app.command(name="list", cls=EXPORT_LIST_COMMAND.command_class())
 def list_presets(
     json_output: bool = json_option(),
@@ -1357,6 +1445,27 @@ def list_presets(
     _dispatch(
         EXPORT_LIST_COMMAND,
         ExportListParams(),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@project_app.command(
+    name="find-unused-resources",
+    cls=PROJECT_FIND_UNUSED_RESOURCES_COMMAND.command_class(),
+)
+def find_unused_resources(
+    json_output: bool = json_option(),
+    schema: bool = PROJECT_FIND_UNUSED_RESOURCES_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Find resource files that nothing references (built on the reference graph)."""
+    _dispatch(
+        PROJECT_FIND_UNUSED_RESOURCES_COMMAND,
+        ProjectFindUnusedResourcesParams(),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -1521,6 +1630,24 @@ def create_theme(
     _dispatch(
         THEME_CREATE_COMMAND,
         ThemeCreateParams(path=_normalize_path(path)),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@project_app.command(name="statistics", cls=PROJECT_STATISTICS_COMMAND.command_class())
+def statistics(
+    json_output: bool = json_option(),
+    schema: bool = PROJECT_STATISTICS_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Report the project's file/line counts, autoloads and plugins."""
+    _dispatch(
+        PROJECT_STATISTICS_COMMAND,
+        ProjectStatisticsParams(),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -350,6 +350,13 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A requested project setting does not exist in the project's ProjectSettings.",
     ),
     ErrorCodeSpec(
+        "invalid_target",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A project find-references target is empty or not a valid res:// path or class_name.",
+    ),
+    ErrorCodeSpec(
         "contract_violation",
         ErrorCategory.PARSE,
         EXIT_PARSE,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -1231,6 +1231,36 @@ class ResourceUidParams(BaseModel):
     )
 
 
+# --- project static-analysis reads (issue #116) -----------------------------
+#
+# Four read-only, project-wide analysis commands, all backed by a single static
+# project scan: find-references, dependencies, find-unused-resources, statistics.
+# The scan parses files as TEXT (.tscn/.tres ext_resource paths, .gd
+# preload/load/class_name references) — it never instantiates a scene or loads a
+# script, so it honors the read trust boundary (issue #30). The only residual
+# project-code execution is the engine constructing the project's autoloads at
+# startup, inherent to any ``--project`` op (issue #61), documented on the params.
+
+
+class ProjectFindReferencesParams(BaseModel):
+    """The operation params of ``gda project find-references`` (issue #116).
+
+    ``target`` is what to find references TO: a resource's ``res://`` path (a
+    scene, script, image, ``.tres`` resource — anything addressable by path), or
+    a script ``class_name``. The scan reads project files as TEXT and never
+    instantiates a scene or loads a script (issue #30); the only project code that
+    runs is the project's autoloads, constructed by the engine at startup on any
+    ``--project`` op (issue #61).
+    """
+
+    target: str = Field(
+        description=(
+            "What to find references to: a resource's res:// path (scene, script, "
+            "image, .tres, …) or a script class_name."
+        )
+    )
+
+
 class ExportListParams(BaseModel):
     """The operation params of ``gda export list`` — none (ADR-0004).
 
@@ -1615,6 +1645,179 @@ class ThemeCreateResult(BaseModel):
             "Parent directories created before saving, from outermost to innermost."
         )
     )
+
+
+class ResourceReference(BaseModel):
+    """One referencing site found by ``gda project find-references`` (issue #116).
+
+    ``path`` is the ``res://`` path of the file that references the target — or
+    ``project.godot`` for a project-level reference (an autoload or the main
+    scene). ``kind`` names how it references it: ``ext_resource`` (a
+    scene/resource ext_resource entry), ``preload``/``load`` (a script load
+    call), ``class_extends`` (a script extending a base-class-by-path),
+    ``class_reference`` (a ``.gd`` file using the target ``class_name`` as a bare
+    identifier — best-effort, whole-word), or ``autoload``/``main_scene`` (a
+    project-level reference in ``project.godot``). ``context`` is the matched
+    line/snippet, best-effort, so an agent can locate the reference without
+    re-reading the file.
+    """
+
+    path: str = Field(
+        description=(
+            "The res:// path of the referencing file, or 'project.godot' for a "
+            "project-level reference."
+        )
+    )
+    kind: str = Field(
+        description=(
+            "How the file references the target: ext_resource, preload, load, "
+            "class_extends, class_reference, autoload, or main_scene."
+        )
+    )
+    context: str = Field(
+        description="The matched line or snippet that holds the reference."
+    )
+
+
+class ProjectFindReferencesResult(BaseModel):
+    """The result of ``gda project find-references``: every site referencing the target.
+
+    Echoes the ``target`` and the list of referencing sites. A target nothing
+    references is a valid, empty result (``references == []``), not a failure —
+    that emptiness is exactly what ``find-unused-resources`` keys on, so the two
+    stay consistent (same reference graph).
+    """
+
+    target: str
+    references: list[ResourceReference]
+
+
+class ProjectDependenciesParams(BaseModel):
+    """The operation params of ``gda project dependencies`` — none (ADR-0004).
+
+    ``dependencies`` maps every scene/resource in the resolved project to the
+    resources it references (its ``[ext_resource]`` entries). The project is
+    process context (``--project``), not an operation param (ADR-0006), so the
+    ``input`` schema is trivially empty.
+    """
+
+
+class Dependency(BaseModel):
+    """One outgoing reference of a scene/resource (issue #116).
+
+    ``path`` is the referenced resource's ``res://`` path; ``kind`` names how it
+    is referenced (``ext_resource`` for a ``[ext_resource]`` entry).
+    """
+
+    path: str = Field(description="The res:// path of the referenced resource.")
+    kind: str = Field(
+        description="How the resource is referenced (ext_resource)."
+    )
+
+
+class ResourceDependencies(BaseModel):
+    """One scene/resource and the resources it references (issue #116).
+
+    ``path`` is the scene/resource's own ``res://`` path; ``depends_on`` lists the
+    resources it references. A scene with no external references is reported with
+    an empty ``depends_on``, not dropped.
+    """
+
+    path: str = Field(description="The res:// path of the scene/resource.")
+    depends_on: list[Dependency]
+
+
+class ProjectDependenciesResult(BaseModel):
+    """The result of ``gda project dependencies``: the scene/resource → resource map.
+
+    An empty project is a valid, empty map (``dependencies == []``), not a
+    failure. Built from the same ext_resource parse as ``find-references``, so the
+    two views of the reference graph stay consistent.
+    """
+
+    dependencies: list[ResourceDependencies]
+
+
+class ProjectFindUnusedResourcesParams(BaseModel):
+    """The operation params of ``gda project find-unused-resources`` — none (ADR-0004).
+
+    Reports resource files that nothing references, built on the SAME reference
+    graph as ``find-references``/``dependencies`` (acceptance criterion: the three
+    must agree). The project is process context (``--project``), not an operation
+    param (ADR-0006), so the ``input`` schema is trivially empty.
+    """
+
+
+class ProjectFindUnusedResourcesResult(BaseModel):
+    """The result of ``gda project find-unused-resources``: the unreferenced resources.
+
+    ``unused`` lists the ``res://`` paths of resource files that no other file
+    references AND that are not project entry points (the main scene, an autoload
+    script). A resource is unused exactly when ``find-references`` for it would
+    return an empty list — the consistency the issue requires. An empty list means
+    every resource is referenced (or an entry point).
+    """
+
+    unused: list[str]
+
+
+class ProjectStatisticsParams(BaseModel):
+    """The operation params of ``gda project statistics`` — none (ADR-0004).
+
+    Reports file/line counts, autoloads and plugins for the resolved project. The
+    project is process context (``--project``), not an operation param (ADR-0006),
+    so the ``input`` schema is trivially empty.
+    """
+
+
+class ExtensionCount(BaseModel):
+    """File/line counts for one file extension (issue #116).
+
+    ``extension`` is the lowercased extension without the dot (``gd``, ``tscn``);
+    ``files`` is how many files carry it; ``lines`` is their summed line count.
+    """
+
+    extension: str = Field(
+        description="The lowercased file extension without the dot (e.g. gd, tscn)."
+    )
+    files: int
+    lines: int
+
+
+class Autoload(BaseModel):
+    """One project autoload singleton (issue #116).
+
+    ``name`` is the singleton name; ``path`` its ``res://`` script/scene path
+    (with any leading ``*`` enable marker stripped). Read from ProjectSettings,
+    not by executing the autoload.
+    """
+
+    name: str
+    path: str = Field(description="The autoload's res:// path (enable marker stripped).")
+
+
+class ProjectStatisticsResult(BaseModel):
+    """The result of ``gda project statistics``: file/line counts, autoloads, plugins.
+
+    ``total_files``/``total_lines`` are the project-wide totals; ``by_extension``
+    breaks them down per extension. ``autoloads`` lists the project's autoload
+    singletons (name + path, read from ProjectSettings); ``plugins`` lists the
+    enabled editor plugins' ``plugin.cfg`` ``res://`` paths. ``scene_count`` /
+    ``script_count`` / ``resource_count`` are convenience counts of ``.tscn`` /
+    ``.gd`` / other-resource files. Line counts cover text files only; binary
+    assets contribute to file counts but not line counts.
+    """
+
+    total_files: int
+    total_lines: int
+    by_extension: list[ExtensionCount]
+    autoloads: list[Autoload]
+    plugins: list[str] = Field(
+        description="The res:// paths of the enabled editor plugins' plugin.cfg files."
+    )
+    scene_count: int
+    script_count: int
+    resource_count: int
 
 
 class EngineVersion(BaseModel):

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -2352,9 +2352,9 @@ func _collect_all_file_paths(dir_path: String, out: Array[String]) -> void:
 # resource: a scene, a resource, a script, or a leaf asset — anything except the
 # import sidecars and the project file the .godot cache and the engine own. Kept
 # deliberately inclusive so an asset (an image, a font) referenced by a scene is
-# itself a node in the graph and a candidate for find-unused. Named distinctly
-# from the resource group's .tres-only _is_resource_path (issue #112): the two
-# answer different questions and must not collide.
+# itself a node in the graph and a candidate for find-unused. Distinct from the
+# resource group's _is_resource_path (a strict .tres check): this is the project
+# scan's graph-eligibility test, hence the separate name.
 func _is_graph_resource_path(path: String) -> bool:
 	var ext := path.get_extension().to_lower()
 	if ext == "import" or ext == "godot" or ext == "cfg" or ext == "uid":
@@ -2479,7 +2479,14 @@ func _collect_references_from(path: String, target_paths: Dictionary, target_cla
 			# A class_name target used as a bare identifier token (extends Name,
 			# `var x: Name`, `Name.new()`, …). Best-effort: a whole-word token
 			# match, so a substring of a longer identifier is not a false hit.
-			if not target_class.is_empty() and _line_uses_token(stripped, target_class):
+			# Skip the target's OWN `class_name <target>` declaration line: that is
+			# the definition site, not a reference (issue #116 review). Without this
+			# guard the class's defining file reports itself as a class_reference.
+			if (
+				not target_class.is_empty()
+				and not _is_class_name_declaration_of(stripped, target_class)
+				and _line_uses_token(stripped, target_class)
+			):
 				references.append({"path": path, "kind": "class_reference", "context": stripped})
 
 
@@ -2581,8 +2588,16 @@ func _project_plugins() -> Array[String]:
 # Count the lines of a TEXT file (issue #116): the number of newline-separated
 # parts of its content, treating a binary/unreadable file as 0 lines. A trailing
 # newline does not add a phantom empty final line, so "a\nb\n" is 2 lines. Only
-# called on files statistics counts; a file that fails to read contributes 0.
+# called on files statistics counts.
+#
+# Line-count ONLY known text extensions (issue #116 review): a binary asset (an
+# image, a font, audio) must contribute to the file count but NOT the line count
+# — statistics' documented contract. Reading every file as text counted a binary
+# asset's stray newline bytes as lines, inflating total_lines. An unknown
+# extension is treated as binary (0 lines) rather than read as text.
 func _count_lines(path: String) -> int:
+	if not _is_text_extension(path.get_extension().to_lower()):
+		return 0
 	var text := FileAccess.get_file_as_string(path)
 	if text.is_empty():
 		return 0
@@ -2593,6 +2608,18 @@ func _count_lines(path: String) -> int:
 	if count > 0 and parts[count - 1].is_empty():
 		count -= 1
 	return count
+
+
+# The file extensions statistics treats as text for line counting (issue #116
+# review). Covers Godot's text formats (.gd/.tscn/.tres scenes & resources, the
+# .godot/.cfg/.import config files, .gdshader) plus common plain-text companions
+# (docs, data, the C# source). Anything else — images, audio, fonts, .res binary
+# resources — is binary: it counts as a file but contributes 0 lines.
+func _is_text_extension(ext: String) -> bool:
+	return ext in [
+		"gd", "tscn", "tres", "godot", "cfg", "import", "gdshader", "gdshaderinc",
+		"cs", "json", "txt", "md", "xml", "csv", "ini", "po", "pot", "gdextension",
+	]
 
 
 # The value of a quoted attribute (e.g. path="res://x") in a line, or "" when the
@@ -2649,6 +2676,18 @@ func _line_uses_token(line: String, token: String) -> bool:
 
 func _is_identifier_char(ch: String) -> bool:
 	return ch == "_" or (ch >= "a" and ch <= "z") or (ch >= "A" and ch <= "Z") or (ch >= "0" and ch <= "9")
+
+
+# Whether an already-stripped .gd line is the `class_name <target>` declaration
+# of the find-references target — the definition site, not a reference. Matches
+# the same `class_name ` prefix _parse_script_meta keys on, with the first token
+# of the remainder equal to the target class (so `class_name HeroSpawner` is not
+# treated as Hero's declaration). Lets find-references exclude a class's own
+# defining line from its class_reference hits (issue #116 review).
+func _is_class_name_declaration_of(line: String, target_class: String) -> bool:
+	if not line.begins_with("class_name "):
+		return false
+	return _first_token(line.substr("class_name ".length())) == target_class
 
 
 # Whether a path names a script file the script group operates on: a .gd

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -61,6 +61,7 @@ const OP_ERROR_INVALID_UID := "invalid_uid"
 const OP_ERROR_UNKNOWN_UID := "unknown_uid"
 const OP_ERROR_NO_UID_ASSIGNED := "no_uid_assigned"
 const OP_ERROR_UNKNOWN_SETTING := "unknown_setting"
+const OP_ERROR_INVALID_TARGET := "invalid_target"
 
 const NODE_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
 
@@ -160,6 +161,14 @@ func _initialize() -> void:
 			_op_shader_set(params)
 		"theme-create":
 			_op_theme_create(params)
+		"project-find-references":
+			_op_project_find_references(params)
+		"project-dependencies":
+			_op_project_dependencies(params)
+		"project-find-unused-resources":
+			_op_project_find_unused_resources(params)
+		"project-statistics":
+			_op_project_statistics(params)
 		_:
 			_fail(OP_ERROR_UNKNOWN_OPERATION, "unknown operation: " + operation)
 
@@ -2075,6 +2084,571 @@ func _write_text_file(path: String, source: String, noun: String) -> bool:
 		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message(noun, path, write_err))
 		return false
 	return true
+
+
+# --- project static-analysis reads (issue #116) -----------------------------
+#
+# Four read-only, project-wide reads, all backed by a SINGLE static project scan
+# (_scan_project). The scan reads files as TEXT — it parses each .tscn/.tres for
+# its [ext_resource path="..."] entries and each .gd for its preload/load/extends
+# references — and never instantiates a scene or loads/compiles a script (the
+# read trust boundary of issue #30). Reads still run under --project, so the
+# engine constructs the project's autoloads at startup before _initialize (the
+# residual project-code execution of issue #61); the scan itself adds none.
+#
+# All four share one reference graph so they stay consistent (acceptance
+# criterion): find-references reports the incoming references of one target;
+# dependencies reports the outgoing references of every scene/resource;
+# find-unused-resources reports the resources with no incoming reference (and not
+# an entry point). A resource is "unused" exactly when find-references for it
+# would return empty — the same graph, one truth.
+
+
+# project-find-references: find every project file that references the target — a
+# resource res:// path, or a script class_name (issue #116). Walks the project's
+# res:// tree, parsing each file's references as text (no instantiation), and
+# reports each referencing site (path + kind + matched context). A target nothing
+# references is a SUCCESSFUL empty result, not a failure.
+func _op_project_find_references(params: Dictionary) -> void:
+	_diag("running operation: project-find-references")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "project find-references requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+	var target := _string_param(params, "target")
+	if target.is_empty():
+		_fail(OP_ERROR_INVALID_TARGET, "missing required param: target")
+		return
+
+	# Resolve the target to the set of strings a reference can name it by. A
+	# res:// path names a resource directly; a class_name names both the class
+	# token (used in .gd as `extends Name` / type annotations) AND the script
+	# path it registers (used as an ext_resource/preload). A bare token that is
+	# neither a res:// path nor a registered class_name is rejected: a filesystem
+	# path (or a typo) could never appear in a res://-addressed reference, so
+	# scanning for it would only ever return a misleading empty result.
+	var target_paths := {}  # res:// paths a reference may name the target by
+	var target_class := ""  # class_name token a .gd reference may name it by
+	if target.begins_with("res://"):
+		target_paths[target] = true
+	else:
+		var script_path := _class_name_script_path(target)
+		if script_path.is_empty():
+			_fail(OP_ERROR_INVALID_TARGET, "find-references target is not a res:// path or a registered class_name: " + target)
+			return
+		target_class = target
+		target_paths[script_path] = true
+
+	var paths: Array[String] = []
+	_collect_resource_paths("res://", paths)
+	paths.sort()
+
+	var references: Array = []
+	for path in paths:
+		_collect_references_from(path, target_paths, target_class, references)
+	# Project-level references (autoloads, the main scene) live in
+	# project.godot, not in a scanned file — add them from ProjectSettings.
+	_collect_project_level_references(target_paths, references)
+
+	_succeed({
+		"target": target,
+		"references": references,
+	})
+
+
+# project-dependencies: map every scene/resource in the project to the resources
+# it references — its outgoing [ext_resource] / preload references (issue #116).
+# A scene/resource with no external references is reported with an empty
+# depends_on, not dropped.
+func _op_project_dependencies(_params: Dictionary) -> void:
+	_diag("running operation: project-dependencies")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "project dependencies requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+
+	var paths: Array[String] = []
+	_collect_resource_paths("res://", paths)
+	paths.sort()
+
+	var dependencies: Array = []
+	for path in paths:
+		# Only resources that can declare ext_resource dependencies (.tscn/.tres)
+		# and scripts (.gd, via preload/load) are reported as dependency sources;
+		# a leaf asset (an image) has no outgoing references to map.
+		if not _has_outgoing_references(path):
+			continue
+		var depends_on := _outgoing_references_of(path)
+		dependencies.append({
+			"path": path,
+			"depends_on": depends_on,
+		})
+
+	_succeed({"dependencies": dependencies})
+
+
+# project-find-unused-resources: resources nothing references (issue #116). Built
+# on the SAME reference graph as find-references/dependencies (acceptance
+# criterion): a resource is unused exactly when no other file references it AND it
+# is not a project entry point (the main scene, or an autoload's script/scene).
+# Scripts (.gd) are excluded from the "unused resource" report — an unreferenced
+# script is dead CODE, a different concern from an unused resource asset, and a
+# project's scripts are routinely referenced only dynamically; reporting them
+# would be noise. .tscn scenes and .tres/asset resources are the resources this
+# reports.
+func _op_project_find_unused_resources(_params: Dictionary) -> void:
+	_diag("running operation: project-find-unused-resources")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "project find-unused-resources requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+
+	var paths: Array[String] = []
+	_collect_resource_paths("res://", paths)
+	paths.sort()
+
+	# Build the set of every res:// path that ANY file references — the union of
+	# all outgoing references across the project, the exact graph find-references
+	# reads one target at a time. A path absent from this set has zero incoming
+	# references (find-references would return empty for it), the consistency the
+	# issue requires.
+	var referenced := {}
+	for path in paths:
+		for dep in _outgoing_references_of(path):
+			referenced[dep["path"]] = true
+	# Project-level entry points are "referenced" too, so they are never reported
+	# unused: the main scene and the autoloads are entered directly, not via a
+	# file reference.
+	for entry in _project_entry_points():
+		referenced[entry] = true
+
+	var unused: Array = []
+	for path in paths:
+		# A script is dead CODE, not an unused resource asset (see the op note).
+		if _is_script_path(path):
+			continue
+		if not referenced.has(path):
+			unused.append(path)
+
+	_succeed({"unused": unused})
+
+
+# project-statistics: file/line counts, autoloads, plugins (issue #116). Counts
+# every file under res:// (skipping the engine's .godot cache) by extension; sums
+# line counts for text files (binary assets count as files but contribute no
+# lines). Autoloads and plugins are read from ProjectSettings — never executed.
+func _op_project_statistics(_params: Dictionary) -> void:
+	_diag("running operation: project-statistics")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "project statistics requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+
+	var paths: Array[String] = []
+	_collect_all_file_paths("res://", paths)
+	paths.sort()
+
+	var total_files := 0
+	var total_lines := 0
+	var by_ext := {}  # extension -> {"files": int, "lines": int}
+	var scene_count := 0
+	var script_count := 0
+	var resource_count := 0
+	for path in paths:
+		total_files += 1
+		var ext := path.get_extension().to_lower()
+		if not by_ext.has(ext):
+			by_ext[ext] = {"files": 0, "lines": 0}
+		by_ext[ext]["files"] += 1
+		var lines := _count_lines(path)
+		by_ext[ext]["lines"] += lines
+		total_lines += lines
+		match ext:
+			"tscn":
+				scene_count += 1
+			"gd":
+				script_count += 1
+			"png", "jpg", "jpeg", "webp", "svg", "ogg", "wav", "mp3", "ttf", "otf", "import", "godot", "cfg":
+				# import sidecars, the project file, and binary/asset files are not
+				# "resource" files in the .tres sense; they still count as files.
+				pass
+			_:
+				resource_count += 1
+
+	var extensions: Array = []
+	var ext_keys := by_ext.keys()
+	ext_keys.sort()
+	for ext in ext_keys:
+		extensions.append({
+			"extension": ext,
+			"files": by_ext[ext]["files"],
+			"lines": by_ext[ext]["lines"],
+		})
+
+	_succeed({
+		"total_files": total_files,
+		"total_lines": total_lines,
+		"by_extension": extensions,
+		"autoloads": _project_autoloads(),
+		"plugins": _project_plugins(),
+		"scene_count": scene_count,
+		"script_count": script_count,
+		"resource_count": resource_count,
+	})
+
+
+# The script res:// path a registered class_name resolves to, or "" if no such
+# class_name is registered. Read from the project's global class list (the same
+# registry node-add resolves class_name nodes through) — never compiled.
+func _class_name_script_path(class_token: String) -> String:
+	for entry in ProjectSettings.get_global_class_list():
+		if String(entry.get("class", "")) == class_token:
+			return String(entry.get("path", ""))
+	return ""
+
+
+# Recursively collect every RESOURCE-bearing file under res:// — the files that
+# can carry references (.tscn/.tres scenes & resources, .gd scripts) AND the leaf
+# asset resources (everything else except import sidecars, the project file, and
+# the .godot cache). Mirrors _collect_scene_paths: hidden entries enumerated,
+# navigational entries off, res://.godot skipped. This is the universe both the
+# reference graph and find-unused range over.
+func _collect_resource_paths(dir_path: String, out: Array[String]) -> void:
+	var dir := DirAccess.open(dir_path)
+	if dir == null:
+		return
+	dir.include_hidden = true
+	dir.list_dir_begin()
+	var entry := dir.get_next()
+	while not entry.is_empty():
+		var child := dir_path.path_join(entry)
+		if dir.current_is_dir():
+			if entry != ".godot":
+				_collect_resource_paths(child, out)
+		elif _is_graph_resource_path(child):
+			out.append(child)
+		entry = dir.get_next()
+	dir.list_dir_end()
+
+
+# Recursively collect EVERY file under res:// (skipping only the .godot cache) for
+# the statistics counts — unlike _collect_resource_paths this keeps import
+# sidecars, project.godot and every asset, since statistics counts all files.
+func _collect_all_file_paths(dir_path: String, out: Array[String]) -> void:
+	var dir := DirAccess.open(dir_path)
+	if dir == null:
+		return
+	dir.include_hidden = true
+	dir.list_dir_begin()
+	var entry := dir.get_next()
+	while not entry.is_empty():
+		var child := dir_path.path_join(entry)
+		if dir.current_is_dir():
+			if entry != ".godot":
+				_collect_all_file_paths(child, out)
+		else:
+			out.append(child)
+		entry = dir.get_next()
+	dir.list_dir_end()
+
+
+# Whether a path names a file the reference graph / find-unused treat as a
+# resource: a scene, a resource, a script, or a leaf asset — anything except the
+# import sidecars and the project file the .godot cache and the engine own. Kept
+# deliberately inclusive so an asset (an image, a font) referenced by a scene is
+# itself a node in the graph and a candidate for find-unused. Named distinctly
+# from the resource group's .tres-only _is_resource_path (issue #112): the two
+# answer different questions and must not collide.
+func _is_graph_resource_path(path: String) -> bool:
+	var ext := path.get_extension().to_lower()
+	if ext == "import" or ext == "godot" or ext == "cfg" or ext == "uid":
+		return false
+	return not ext.is_empty()
+
+
+# Whether this file can declare OUTGOING references (so dependencies reports it as
+# a source row): a scene/resource (.tscn/.tres, via [ext_resource]) or a script
+# (.gd, via preload/load/extends). A leaf asset declares none.
+func _has_outgoing_references(path: String) -> bool:
+	var ext := path.get_extension().to_lower()
+	return ext == "tscn" or ext == "tres" or ext == "gd"
+
+
+# The outgoing references of one file as a list of {path, kind} entries, in the
+# order they appear, de-duplicated. A .tscn/.tres yields its [ext_resource]
+# paths; a .gd yields its preload/load/extends-by-path references. The referenced
+# path is always a res:// path (a relative .gd preload is resolved against the
+# file's own directory). Reading is pure text — no load/instantiate (issue #30).
+func _outgoing_references_of(path: String) -> Array:
+	var ext := path.get_extension().to_lower()
+	var seen := {}
+	var out: Array = []
+	if ext == "tscn" or ext == "tres":
+		for ref_path in _ext_resource_paths(path):
+			# Dedup the ext_resource form on path+kind, the same key
+			# find-references matches by, so the two views of the graph agree
+			# exactly (issue #116 consistency criterion).
+			var key: String = ref_path + "\next_resource"
+			if not seen.has(key):
+				seen[key] = true
+				out.append({"path": ref_path, "kind": "ext_resource"})
+	elif ext == "gd":
+		for ref in _script_outgoing_references(path):
+			# Dedup on path+KIND, not path alone: the same target reached by both
+			# preload() and load() is two distinct references, and find-references
+			# reports both — so dependencies must too, or the graphs disagree
+			# (issue #116 review). A newline joins the pair into a collision-free
+			# key — it can appear in neither a res:// path nor a kind token.
+			var key: String = String(ref["path"]) + "\n" + String(ref["kind"])
+			if not seen.has(key):
+				seen[key] = true
+				out.append(ref)
+	return out
+
+
+# The res:// paths an [ext_resource ... path="res://..."] line names in a
+# .tscn/.tres file — the file's external dependencies. Parsed by text: each
+# ext_resource line carries a path="..." attribute (Godot 4 also carries a uid,
+# but always the path too). Returns res:// paths in line order.
+func _ext_resource_paths(path: String) -> Array[String]:
+	var out: Array[String] = []
+	var text := FileAccess.get_file_as_string(path)
+	if text.is_empty():
+		return out
+	for line in text.split("\n"):
+		var stripped := line.strip_edges()
+		if not stripped.begins_with("[ext_resource"):
+			continue
+		var ref := _quoted_attr(stripped, "path=")
+		if not ref.is_empty():
+			out.append(ref)
+	return out
+
+
+# A .gd script's outgoing references as {path, kind} entries: preload("res://…")
+# and load("res://…") calls (kind preload / load), and an `extends "res://Base.gd"`
+# base-class-by-path (kind class_extends). A relative path argument is resolved
+# against the script's own directory so it becomes a res:// path comparable to the
+# rest of the graph. Parsed by text — the script is never compiled (issue #30).
+func _script_outgoing_references(path: String) -> Array:
+	var out: Array = []
+	var text := FileAccess.get_file_as_string(path)
+	if text.is_empty():
+		return out
+	var base_dir := path.get_base_dir()
+	for line in text.split("\n"):
+		var stripped := line.strip_edges()
+		out.append_array(_script_outgoing_references_in_line(stripped, base_dir))
+	return out
+
+
+# Resolve a reference-path argument to a res:// path: a res:// (or uid://) path is
+# already absolute; a relative path is joined onto the referencing file's base
+# directory and simplified, so "../shared/util.gd" from res://a/b.gd becomes
+# res://shared/util.gd. uid:// references are left as-is (they round-trip through
+# Godot's UID system, not the path graph).
+func _resolve_ref_path(ref: String, base_dir: String) -> String:
+	if ref.begins_with("res://") or ref.begins_with("uid://") or ref.begins_with("user://"):
+		return ref
+	return base_dir.path_join(ref).simplify_path()
+
+
+# Find every reference to the target inside one file, appending {path, kind,
+# context} entries to `references`. A .tscn/.tres references the target when an
+# [ext_resource] names one of the target's res:// paths; a .gd references it when
+# a preload/load/extends names one of those paths, or — when the target is a
+# class_name — when the file uses the class token as an identifier. The context is
+# the matched line, trimmed, so an agent locates the reference without re-reading.
+func _collect_references_from(path: String, target_paths: Dictionary, target_class: String, references: Array) -> void:
+	var ext := path.get_extension().to_lower()
+	var text := FileAccess.get_file_as_string(path)
+	if text.is_empty():
+		return
+	if ext == "tscn" or ext == "tres":
+		for line in text.split("\n"):
+			var stripped := line.strip_edges()
+			if not stripped.begins_with("[ext_resource"):
+				continue
+			var ref := _quoted_attr(stripped, "path=")
+			if target_paths.has(ref):
+				references.append({"path": path, "kind": "ext_resource", "context": stripped})
+	elif ext == "gd":
+		var base_dir := path.get_base_dir()
+		for line in text.split("\n"):
+			var stripped := line.strip_edges()
+			# A preload/load/extends-by-path naming one of the target's paths.
+			for ref in _script_outgoing_references_in_line(stripped, base_dir):
+				if target_paths.has(ref["path"]):
+					references.append({"path": path, "kind": ref["kind"], "context": stripped})
+			# A class_name target used as a bare identifier token (extends Name,
+			# `var x: Name`, `Name.new()`, …). Best-effort: a whole-word token
+			# match, so a substring of a longer identifier is not a false hit.
+			if not target_class.is_empty() and _line_uses_token(stripped, target_class):
+				references.append({"path": path, "kind": "class_reference", "context": stripped})
+
+
+# The {path, kind} references in a SINGLE already-stripped .gd line — the
+# per-line core _script_outgoing_references loops over, factored out so
+# find-references can match a target path AND keep the matched line as context.
+# Finds EVERY preload(...)/load(...) call on the line (not just the first), so a
+# line with two calls is fully captured; each call's marker is matched on a word
+# boundary so `load(` INSIDE `preload(` is not double-counted as its own load
+# reference (the markers overlap as substrings, issue #116 review).
+func _script_outgoing_references_in_line(stripped: String, base_dir: String) -> Array:
+	var out: Array = []
+	var markers: Array[String] = ["preload", "load"]
+	for marker in markers:
+		var call: String = marker + "("
+		var from := 0
+		while true:
+			var idx := stripped.find(call, from)
+			if idx == -1:
+				break
+			from = idx + call.length()
+			# Word boundary on the left: the char before the marker must not be an
+			# identifier char, or this is a longer identifier ending in the marker
+			# (the `load(` inside `preload(`, or a user `myload(`), not a call to it.
+			if idx > 0 and _is_identifier_char(stripped[idx - 1]):
+				continue
+			var arg := _first_quoted_after(stripped, idx + call.length())
+			if arg.is_empty():
+				continue
+			out.append({"path": _resolve_ref_path(arg, base_dir), "kind": marker})
+	if stripped.begins_with("extends ") and stripped.find("\"") != -1:
+		var ext_arg := _first_quoted_after(stripped, "extends ".length())
+		if not ext_arg.is_empty():
+			out.append({"path": _resolve_ref_path(ext_arg, base_dir), "kind": "class_extends"})
+	return out
+
+
+# Project-level references to the target that live in project.godot rather than a
+# scanned file (issue #116): the main scene (run/main_scene) and the autoloads
+# (autoload/*). These reference a resource by path the way a file's ext_resource
+# does, so find-references must surface them or the target would look less
+# referenced than it is.
+func _collect_project_level_references(target_paths: Dictionary, references: Array) -> void:
+	var main_scene := _main_scene_path()
+	if not main_scene.is_empty() and target_paths.has(main_scene):
+		references.append({"path": "project.godot", "kind": "main_scene", "context": "application/run/main_scene=" + main_scene})
+	for autoload in _project_autoloads():
+		if target_paths.has(autoload["path"]):
+			references.append({"path": "project.godot", "kind": "autoload", "context": "autoload/" + autoload["name"] + "=" + autoload["path"]})
+
+
+# The project entry points — paths that are "reached" without a file reference, so
+# find-unused must never flag them: the main scene plus every autoload's path.
+func _project_entry_points() -> Array[String]:
+	var out: Array[String] = []
+	var main_scene := _main_scene_path()
+	if not main_scene.is_empty():
+		out.append(main_scene)
+	for autoload in _project_autoloads():
+		out.append(autoload["path"])
+	return out
+
+
+# The project's main scene res:// path, or "" when none is set. Read from
+# ProjectSettings — never run.
+func _main_scene_path() -> String:
+	var value: Variant = ProjectSettings.get_setting("application/run/main_scene", "")
+	return String(value)
+
+
+# The project's autoload singletons as {name, path} entries, read from
+# ProjectSettings's autoload/* keys (never executed). The stored value carries a
+# leading "*" enable marker for an enabled singleton; it is stripped so the path
+# is the bare res:// path the rest of the graph compares against.
+func _project_autoloads() -> Array:
+	var out: Array = []
+	for setting in ProjectSettings.get_property_list():
+		var key := String(setting.get("name", ""))
+		if not key.begins_with("autoload/"):
+			continue
+		var autoload_name: String = key.substr("autoload/".length())
+		var value := String(ProjectSettings.get_setting(key, ""))
+		out.append({"name": autoload_name, "path": value.trim_prefix("*")})
+	return out
+
+
+# The enabled editor plugins' plugin.cfg res:// paths (issue #116). Read from
+# editor_plugins/enabled in ProjectSettings; each entry is already a
+# res://addons/<name>/plugin.cfg path. Empty when the project enables none.
+func _project_plugins() -> Array[String]:
+	var out: Array[String] = []
+	var enabled: Variant = ProjectSettings.get_setting("editor_plugins/enabled", PackedStringArray())
+	if enabled is PackedStringArray or enabled is Array:
+		for entry in enabled:
+			out.append(String(entry))
+	return out
+
+
+# Count the lines of a TEXT file (issue #116): the number of newline-separated
+# parts of its content, treating a binary/unreadable file as 0 lines. A trailing
+# newline does not add a phantom empty final line, so "a\nb\n" is 2 lines. Only
+# called on files statistics counts; a file that fails to read contributes 0.
+func _count_lines(path: String) -> int:
+	var text := FileAccess.get_file_as_string(path)
+	if text.is_empty():
+		return 0
+	var normalized := text.replace("\r\n", "\n")
+	var parts := normalized.split("\n")
+	var count := parts.size()
+	# A trailing newline yields a final empty part; do not count it as a line.
+	if count > 0 and parts[count - 1].is_empty():
+		count -= 1
+	return count
+
+
+# The value of a quoted attribute (e.g. path="res://x") in a line, or "" when the
+# attribute is absent. `attr` includes the trailing '=' ("path="). Returns the
+# text between the first pair of double quotes after the attribute.
+func _quoted_attr(line: String, attr: String) -> String:
+	var idx := line.find(attr)
+	if idx == -1:
+		return ""
+	return _first_quoted_after(line, idx + attr.length())
+
+
+# The contents of the first quoted string (single or double quotes) at/after
+# `from` in `text`, or "" when there is none. Used to pull the literal-string
+# argument out of preload("...") / load("...") / path="..." without compiling.
+func _first_quoted_after(text: String, from: int) -> String:
+	var dq := text.find("\"", from)
+	var sq := text.find("'", from)
+	var open := -1
+	var quote := "\""
+	if dq != -1 and (sq == -1 or dq < sq):
+		open = dq
+		quote = "\""
+	elif sq != -1:
+		open = sq
+		quote = "'"
+	if open == -1:
+		return ""
+	var close := text.find(quote, open + 1)
+	if close == -1:
+		return ""
+	return text.substr(open + 1, close - open - 1)
+
+
+# Whether a line uses `token` as a WHOLE-WORD identifier — bounded by a non
+# identifier character (or the line edge) on both sides — so a class_name match
+# is not a false positive on a substring of a longer name (Hero vs HeroSpawner)
+# or inside another word. Best-effort static check for class_name references that
+# carry no res:// path (extends Name, type annotations, Name.new()).
+func _line_uses_token(line: String, token: String) -> bool:
+	var from := 0
+	while true:
+		var idx := line.find(token, from)
+		if idx == -1:
+			return false
+		var before_ok := idx == 0 or not _is_identifier_char(line[idx - 1])
+		var after_index := idx + token.length()
+		var after_ok := after_index >= line.length() or not _is_identifier_char(line[after_index])
+		if before_ok and after_ok:
+			return true
+		from = idx + 1
+	return false
+
+
+func _is_identifier_char(ch: String) -> bool:
+	return ch == "_" or (ch >= "a" and ch <= "z") or (ch >= "A" and ch <= "Z") or (ch >= "0" and ch <= "9")
 
 
 # Whether a path names a script file the script group operates on: a .gd

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -57,6 +57,10 @@ from gda.models import (
     ShaderGetResult,
     ShaderSetResult,
     ThemeCreateResult,
+    ProjectDependenciesResult,
+    ProjectFindReferencesResult,
+    ProjectFindUnusedResourcesResult,
+    ProjectStatisticsResult,
 )
 
 
@@ -407,6 +411,55 @@ def render_theme_create(created: "ThemeCreateResult") -> str:
     return f"created {created.path} ({created.type})"
 
 
+def render_project_find_references(found: "ProjectFindReferencesResult") -> str:
+    """Render find-references as ``<target>`` then one ``path (kind)`` line each."""
+    if not found.references:
+        return f"{found.target} (no references)"
+    lines = [found.target]
+    lines += [f"  {ref.path} ({ref.kind})" for ref in found.references]
+    return "\n".join(lines)
+
+
+def render_project_dependencies(deps: "ProjectDependenciesResult") -> str:
+    """Render the dependency map as ``<scene>`` then indented ``-> <dep>`` lines."""
+    if not deps.dependencies:
+        return "(no scenes or resources)"
+    lines = []
+    for resource in deps.dependencies:
+        lines.append(resource.path)
+        lines += [f"  -> {dep.path} ({dep.kind})" for dep in resource.depends_on]
+    return "\n".join(lines)
+
+
+def render_project_find_unused_resources(
+    unused: "ProjectFindUnusedResourcesResult",
+) -> str:
+    """Render the unreferenced resources, one path per line."""
+    if not unused.unused:
+        return "(no unused resources)"
+    return "\n".join(unused.unused)
+
+
+def render_project_statistics(stats: "ProjectStatisticsResult") -> str:
+    """Render the project statistics as a human-readable summary."""
+    lines = [
+        f"{stats.total_files} files, {stats.total_lines} lines",
+        (
+            f"  scenes: {stats.scene_count}, scripts: {stats.script_count}, "
+            f"resources: {stats.resource_count}"
+        ),
+    ]
+    for ext in stats.by_extension:
+        lines.append(f"  .{ext.extension}: {ext.files} files, {ext.lines} lines")
+    if stats.autoloads:
+        lines.append("autoloads:")
+        lines += [f"  {a.name} = {a.path}" for a in stats.autoloads]
+    if stats.plugins:
+        lines.append("plugins:")
+        lines += [f"  {p}" for p in stats.plugins]
+    return "\n".join(lines)
+
+
 def render_engine_version(version: "EngineVersion") -> str:
     """Render the engine version as its one-line version string."""
     return version.string
@@ -451,6 +504,10 @@ _RENDERERS = {
     ShaderGetResult: render_shader_get,
     ShaderSetResult: render_shader_set,
     ThemeCreateResult: render_theme_create,
+    ProjectFindReferencesResult: render_project_find_references,
+    ProjectDependenciesResult: render_project_dependencies,
+    ProjectFindUnusedResourcesResult: render_project_find_unused_resources,
+    ProjectStatisticsResult: render_project_statistics,
     EngineVersion: render_engine_version,
 }
 

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -1,0 +1,294 @@
+"""S1 (e2e): the project static-analysis reads against the real Godot engine (issue #116).
+
+The four read-only, project-wide analysis commands — find-references,
+dependencies, find-unused-resources, statistics — backed by a single static scan
+that parses files as text (no instantiation, issue #30). These tests build a
+small fixture project WITH cross-references (a main scene that ext_resources a
+sub-scene, a script and an image; a script that preloads a sibling; an autoload;
+an unreferenced resource) and assert each command reports it correctly off the
+real engine. find-unused-resources must agree with find-references (the
+acceptance criterion: the same reference graph backs both).
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+GODOT = resolve_godot_binary()
+
+
+# A project.godot with an autoload, a main scene, and an enabled editor plugin —
+# the project-level references and the statistics fields the commands report.
+PROJECT_GODOT = """\
+config_version=5
+
+[application]
+
+config/name="gda-refgraph-fixture"
+run/main_scene="res://main.tscn"
+
+[autoload]
+
+GameState="*res://game_state.gd"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/widget/plugin.cfg")
+"""
+
+# A main scene that ext_resources a sub-scene, a script and an image — three
+# outgoing references, the shape Godot 4 writes.
+MAIN_TSCN = """\
+[gd_scene load_steps=4 format=3 uid="uid://bmain"]
+
+[ext_resource type="PackedScene" uid="uid://bhero" path="res://hero.tscn" id="1_hero"]
+[ext_resource type="Script" path="res://main.gd" id="2_main"]
+[ext_resource type="Texture2D" uid="uid://bicon" path="res://icon.png" id="3_icon"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("2_main")
+
+[node name="Hero" parent="." instance=ExtResource("1_hero")]
+
+[node name="Sprite" type="Sprite2D" parent="."]
+texture = ExtResource("3_icon")
+"""
+
+# A sub-scene with no external references.
+HERO_TSCN = """\
+[gd_scene format=3 uid="uid://bhero"]
+
+[node name="Hero" type="CharacterBody2D"]
+"""
+
+# main.gd preloads a sibling script — a .gd → .gd reference via preload.
+MAIN_GD = """\
+extends Node2D
+
+const Util = preload("res://util.gd")
+
+func _ready() -> void:
+	Util.greet()
+"""
+
+UTIL_GD = """\
+extends RefCounted
+
+static func greet() -> void:
+	print("hi")
+"""
+
+GAME_STATE_GD = """\
+extends Node
+
+var score := 0
+"""
+
+# A .tres resource that nothing references — the unused resource the report finds.
+ORPHAN_TRES = """\
+[gd_resource type="Resource" format=3]
+
+[resource]
+"""
+
+PLUGIN_CFG = """\
+[plugin]
+
+name="Widget"
+script="plugin.gd"
+"""
+
+
+@pytest.fixture
+def refgraph_project(tmp_path):
+    """A fixture project with real cross-references for the analysis commands."""
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "hero.tscn").write_text(HERO_TSCN, encoding="utf-8")
+    (tmp_path / "main.gd").write_text(MAIN_GD, encoding="utf-8")
+    (tmp_path / "util.gd").write_text(UTIL_GD, encoding="utf-8")
+    (tmp_path / "game_state.gd").write_text(GAME_STATE_GD, encoding="utf-8")
+    (tmp_path / "icon.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+    (tmp_path / "orphan.tres").write_text(ORPHAN_TRES, encoding="utf-8")
+    addons = tmp_path / "addons" / "widget"
+    addons.mkdir(parents=True)
+    (addons / "plugin.cfg").write_text(PLUGIN_CFG, encoding="utf-8")
+    return tmp_path
+
+
+def _gda(project, *args: str) -> subprocess.CompletedProcess:
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+    return subprocess.run(
+        [gda_bin, *args, "--godot", str(GODOT), "--project", str(project)],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.e2e
+def test_dependencies_maps_each_scene_to_its_ext_resources(refgraph_project):
+    proc = _gda(refgraph_project, "project", "dependencies", "--json")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    data = json.loads(proc.stdout)
+    by_path = {d["path"]: d for d in data["dependencies"]}
+
+    # main.tscn references the sub-scene, the script and the image.
+    main_deps = {d["path"] for d in by_path["res://main.tscn"]["depends_on"]}
+    assert main_deps == {"res://hero.tscn", "res://main.gd", "res://icon.png"}
+    # main.gd preloads util.gd — a .gd → .gd reference is in the graph too.
+    main_gd_deps = {d["path"] for d in by_path["res://main.gd"]["depends_on"]}
+    assert "res://util.gd" in main_gd_deps
+    # hero.tscn has no external references — reported with an empty depends_on,
+    # not dropped.
+    assert by_path["res://hero.tscn"]["depends_on"] == []
+
+
+@pytest.mark.e2e
+def test_find_references_to_a_script_finds_every_referencing_site(refgraph_project):
+    proc = _gda(
+        refgraph_project, "project", "find-references", "res://util.gd", "--json"
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    data = json.loads(proc.stdout)
+    assert data["target"] == "res://util.gd"
+    referencing = {(r["path"], r["kind"]) for r in data["references"]}
+    # main.gd preloads util.gd.
+    assert ("res://main.gd", "preload") in referencing
+
+
+@pytest.mark.e2e
+def test_find_references_to_a_scene_finds_the_ext_resource(refgraph_project):
+    proc = _gda(
+        refgraph_project, "project", "find-references", "res://hero.tscn", "--json"
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    refs = json.loads(proc.stdout)["references"]
+    referencing = {(r["path"], r["kind"]) for r in refs}
+    assert ("res://main.tscn", "ext_resource") in referencing
+
+
+@pytest.mark.e2e
+def test_find_references_to_the_main_scene_includes_the_project_level_reference(
+    refgraph_project,
+):
+    proc = _gda(
+        refgraph_project, "project", "find-references", "res://main.tscn", "--json"
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    refs = json.loads(proc.stdout)["references"]
+    # The main scene is referenced by project.godot's run/main_scene, not a file.
+    assert any(
+        r["path"] == "project.godot" and r["kind"] == "main_scene" for r in refs
+    )
+
+
+@pytest.mark.e2e
+def test_find_references_to_an_unreferenced_resource_is_empty(refgraph_project):
+    proc = _gda(
+        refgraph_project, "project", "find-references", "res://orphan.tres", "--json"
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert json.loads(proc.stdout)["references"] == []
+
+
+@pytest.mark.e2e
+def test_find_unused_resources_reports_the_orphan_and_is_consistent_with_find_references(
+    refgraph_project,
+):
+    proc = _gda(
+        refgraph_project, "project", "find-unused-resources", "--json"
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    unused = json.loads(proc.stdout)["unused"]
+
+    # The orphan .tres nothing references is reported unused.
+    assert "res://orphan.tres" in unused
+    # Referenced resources are NOT reported unused.
+    assert "res://hero.tscn" not in unused
+    assert "res://icon.png" not in unused
+    # The main scene is an entry point (project.godot run/main_scene), never unused.
+    assert "res://main.tscn" not in unused
+
+    # Consistency (the acceptance criterion): a resource is unused exactly when
+    # find-references for it returns empty, and a referenced one returns non-empty.
+    for path in unused:
+        refs = json.loads(
+            _gda(
+                refgraph_project, "project", "find-references", path, "--json"
+            ).stdout
+        )["references"]
+        assert refs == [], f"{path} reported unused but has references {refs}"
+
+    hero_refs = json.loads(
+        _gda(
+            refgraph_project, "project", "find-references", "res://hero.tscn", "--json"
+        ).stdout
+    )["references"]
+    assert hero_refs != []  # referenced, hence not in unused
+
+
+@pytest.mark.e2e
+def test_statistics_reports_counts_autoloads_and_plugins(refgraph_project):
+    proc = _gda(refgraph_project, "project", "statistics", "--json")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    data = json.loads(proc.stdout)
+
+    # File/line counts: at least the files the fixture wrote, with positive lines.
+    assert data["total_files"] >= 8
+    assert data["total_lines"] > 0
+    assert data["scene_count"] == 2  # main.tscn, hero.tscn
+    assert data["script_count"] >= 3  # main.gd, util.gd, game_state.gd (+ plugin.gd? no)
+    by_ext = {e["extension"]: e for e in data["by_extension"]}
+    assert by_ext["gd"]["files"] >= 3
+    assert by_ext["gd"]["lines"] > 0
+
+    # Autoloads read from ProjectSettings (the '*' enable marker stripped).
+    autoloads = {a["name"]: a["path"] for a in data["autoloads"]}
+    assert autoloads["GameState"] == "res://game_state.gd"
+
+    # Enabled plugins read from editor_plugins/enabled.
+    assert "res://addons/widget/plugin.cfg" in data["plugins"]
+
+
+@pytest.mark.e2e
+def test_find_references_bad_target_is_invalid_target(refgraph_project):
+    # A target that is neither a res:// path nor a registered class_name is a
+    # structured invalid_target operation error (exit 4), not an empty result.
+    proc = _gda(
+        refgraph_project, "project", "find-references", "/abs/not/a/target", "--json"
+    )
+
+    assert proc.returncode == 4, proc.stdout + proc.stderr
+    err = json.loads(proc.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_target"
+
+
+@pytest.mark.e2e
+def test_dependencies_without_project_is_project_not_found(tmp_path):
+    # Run projectless (no --project, cwd is not a project): the res:// scan has no
+    # tree to walk, so it refuses with the registered project_not_found code.
+    gda_bin = shutil.which("gda")
+    assert gda_bin
+    proc = subprocess.run(
+        [gda_bin, "project", "dependencies", "--godot", str(GODOT), "--json"],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+
+    assert proc.returncode == 4, proc.stdout + proc.stderr
+    err = json.loads(proc.stdout)["error"]
+    assert err["code"] == "project_not_found"

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -276,6 +276,162 @@ def test_find_references_bad_target_is_invalid_target(refgraph_project):
     assert err["code"] == "invalid_target"
 
 
+# --- class_name find-references fixture (issue #116 review) -----------------
+#
+# A project whose only references to a class are by its class_name token: a
+# defining script (`class_name Hero`, no other use of the token), genuine
+# consumers (`extends Hero`, a `var x: Hero` annotation, `Hero.new()`), and an
+# UNREFERENCED class (`class_name Lonely`) nothing names. find-references for
+# Hero must report the consumers but NOT Hero's own `class_name Hero` declaration
+# line (the definition site, not a reference); find-references for Lonely must be
+# empty.
+CLASSNAME_PROJECT_GODOT = """\
+config_version=5
+
+[application]
+
+config/name="gda-classname-fixture"
+"""
+
+HERO_GD = """\
+extends Node
+
+class_name Hero
+
+func greet() -> void:
+	print("hero")
+"""
+
+VILLAIN_GD = """\
+extends Hero
+
+func taunt() -> void:
+	print("villain")
+"""
+
+SPAWNER_GD = """\
+extends Node
+
+func make() -> void:
+	var h: Hero = Hero.new()
+	h.greet()
+"""
+
+LONELY_GD = """\
+extends Node
+
+class_name Lonely
+
+func sigh() -> void:
+	print("nobody references me")
+"""
+
+
+def _import_project(project) -> None:
+    # class_name registration lives in the project's global class list, which only
+    # a project scan produces — run the engine's headless import step the way a CI
+    # pipeline would before resolving a find-references target by class_name.
+    imported = subprocess.run(
+        [str(GODOT), "--headless", "--path", str(project), "--import"],
+        capture_output=True,
+        text=True,
+    )
+    assert imported.returncode == 0, imported.stdout + imported.stderr
+
+
+@pytest.fixture
+def classname_project(tmp_path):
+    """A project where a class is referenced only by its class_name token."""
+    (tmp_path / "project.godot").write_text(CLASSNAME_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "hero.gd").write_text(HERO_GD, encoding="utf-8")
+    (tmp_path / "villain.gd").write_text(VILLAIN_GD, encoding="utf-8")
+    (tmp_path / "spawner.gd").write_text(SPAWNER_GD, encoding="utf-8")
+    (tmp_path / "lonely.gd").write_text(LONELY_GD, encoding="utf-8")
+    _import_project(tmp_path)
+    return tmp_path
+
+
+@pytest.mark.e2e
+def test_find_references_to_a_class_name_excludes_its_own_declaration(
+    classname_project,
+):
+    # find-references Hero must report the genuine consumers (extends Hero, a
+    # `var x: Hero` annotation, Hero.new()) but NEVER hero.gd's own
+    # `class_name Hero` declaration line — that is the definition site, not a
+    # reference (issue #116 review: false positive).
+    proc = _gda(
+        classname_project, "project", "find-references", "Hero", "--json"
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    data = json.loads(proc.stdout)
+    assert data["target"] == "Hero"
+    referencing = {(r["path"], r["kind"]) for r in data["references"]}
+    # Genuine consumers are reported as class_reference hits.
+    assert ("res://villain.gd", "class_reference") in referencing
+    assert ("res://spawner.gd", "class_reference") in referencing
+    # The defining file's `class_name Hero` line is NOT reported as a reference.
+    hero_class_refs = [
+        r
+        for r in data["references"]
+        if r["path"] == "res://hero.gd"
+        and r["kind"] == "class_reference"
+        and r["context"].strip().startswith("class_name ")
+    ]
+    assert hero_class_refs == [], (
+        f"the class_name declaration is reported as a self-reference: {hero_class_refs}"
+    )
+
+
+@pytest.mark.e2e
+def test_find_references_to_an_unreferenced_class_name_is_empty(classname_project):
+    # A class declared via class_name that NOTHING consumes returns an empty
+    # reference set — its own declaration line must not count as a reference.
+    proc = _gda(
+        classname_project, "project", "find-references", "Lonely", "--json"
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert json.loads(proc.stdout)["references"] == []
+
+
+@pytest.mark.e2e
+def test_statistics_counts_binary_assets_as_files_but_not_lines(tmp_path):
+    # A binary asset whose bytes happen to contain newlines must contribute to
+    # the file count but NOT the line count — statistics' documented contract
+    # ("binary assets contribute to file counts but not line counts"). Issue #116
+    # review: _count_lines previously read every file as text, so a binary asset's
+    # newline bytes inflated total_lines.
+    (tmp_path / "project.godot").write_text(
+        'config_version=5\n\n[application]\n\nconfig/name="gda-binary-fixture"\n',
+        encoding="utf-8",
+    )
+    # A two-line .gd: a real text file contributing 2 lines.
+    (tmp_path / "code.gd").write_text("extends Node\n\n", encoding="utf-8")
+    # A binary .png with many newline (0x0A) bytes — text-decoded it would look
+    # like dozens of lines, but as a binary asset it must contribute 0 lines.
+    (tmp_path / "blob.png").write_bytes(
+        b"\x89PNG\r\n\x1a\n" + (b"\n" * 50) + b"\x00\xff\x10binary\n"
+    )
+
+    proc = _gda(tmp_path, "project", "statistics", "--json")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    data = json.loads(proc.stdout)
+    by_ext = {e["extension"]: e for e in data["by_extension"]}
+
+    # The binary asset is counted as a file...
+    assert by_ext["png"]["files"] == 1
+    # ...but contributes 0 lines despite its ~52 newline bytes.
+    assert by_ext["png"]["lines"] == 0
+    # The text .gd contributes its 2 lines.
+    assert by_ext["gd"]["lines"] == 2
+    # total_lines is exactly the sum of the per-extension (text-only) line counts;
+    # the binary png's newline bytes are not in it (far below the 52 it carries).
+    assert data["total_lines"] == sum(e["lines"] for e in data["by_extension"])
+    assert data["total_lines"] < 50
+
+
 @pytest.mark.e2e
 def test_dependencies_without_project_is_project_not_found(tmp_path):
     # Run projectless (no --project, cwd is not a project): the res:// scan has no

--- a/tests/test_project_analysis_commands.py
+++ b/tests/test_project_analysis_commands.py
@@ -1,0 +1,167 @@
+"""S3: gda project static-analysis reads against a fake runner (issue #116).
+
+The project analysis group — find-references, dependencies,
+find-unused-resources, statistics — are read-only, project-wide reads backed by
+a single static scan, all headless. These tests drive the same proven pipeline
+as the scene/node/script groups — Typer → binary resolution → runner → sentinel
+parse → typed model → JSON — with canned engine output, no real Godot.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import FakeRunner, inject_runner, sentinel
+
+DEPENDENCIES_RESULT = {
+    "dependencies": [
+        {
+            "path": "res://main.tscn",
+            "depends_on": [
+                {"path": "res://hero.tscn", "kind": "ext_resource"},
+                {"path": "res://icon.png", "kind": "ext_resource"},
+            ],
+        },
+        {"path": "res://hero.tscn", "depends_on": []},
+    ]
+}
+
+FIND_REFERENCES_RESULT = {
+    "target": "res://hero.gd",
+    "references": [
+        {
+            "path": "res://hero.tscn",
+            "kind": "ext_resource",
+            "context": 'res://hero.gd type="Script"',
+        }
+    ],
+}
+
+UNUSED_RESULT = {"unused": ["res://orphan.png", "res://orphan.tres"]}
+
+STATISTICS_RESULT = {
+    "total_files": 5,
+    "total_lines": 120,
+    "by_extension": [
+        {"extension": "gd", "files": 2, "lines": 100},
+        {"extension": "tscn", "files": 2, "lines": 20},
+    ],
+    "autoloads": [{"name": "GameState", "path": "res://game_state.gd"}],
+    "plugins": ["res://addons/widget/plugin.cfg"],
+    "scene_count": 2,
+    "script_count": 2,
+    "resource_count": 1,
+}
+
+
+def test_dependencies_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(DEPENDENCIES_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["project", "dependencies", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["dependencies"][0]["path"] == "res://main.tscn"
+    assert data["dependencies"][0]["depends_on"][0]["path"] == "res://hero.tscn"
+    # dependencies takes no operation params — the project is process context.
+    assert fake.calls == [("project-dependencies", {})]
+    assert "engine diagnostic" in result.stderr
+
+
+def test_dependencies_human_output_lists_each_scene_and_its_deps(monkeypatch):
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(DEPENDENCIES_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(app, ["project", "dependencies"])
+
+    assert result.exit_code == 0
+    assert "res://main.tscn" in result.stdout
+    assert "res://hero.tscn" in result.stdout
+
+
+def test_find_references_passes_target_param(monkeypatch):
+    stdout = sentinel(FIND_REFERENCES_RESULT)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app, ["project", "find-references", "res://hero.gd", "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["target"] == "res://hero.gd"
+    assert data["references"][0]["path"] == "res://hero.tscn"
+    assert data["references"][0]["kind"] == "ext_resource"
+    # The target rides through as the one operation param.
+    assert fake.calls == [("project-find-references", {"target": "res://hero.gd"})]
+
+
+def test_find_references_normalizes_filesystem_target_but_not_res_path(monkeypatch):
+    # A res:// virtual path passes through untouched (the engine resolves it);
+    # a class_name target (no '://') is left as-is too, not treated as a file.
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel({"target": "Hero", "references": []}),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app, ["project", "find-references", "Hero", "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [("project-find-references", {"target": "Hero"})]
+
+
+def test_find_unused_resources_json(monkeypatch):
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(UNUSED_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["project", "find-unused-resources", "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["unused"] == ["res://orphan.png", "res://orphan.tres"]
+    assert fake.calls == [("project-find-unused-resources", {})]
+
+
+def test_statistics_json(monkeypatch):
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(STATISTICS_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(app, ["project", "statistics", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["total_files"] == 5
+    assert data["autoloads"][0]["name"] == "GameState"
+    assert data["plugins"] == ["res://addons/widget/plugin.cfg"]
+    assert fake.calls == [("project-statistics", {})]
+
+
+def test_statistics_human_output_summarizes_counts(monkeypatch):
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(STATISTICS_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(app, ["project", "statistics"])
+
+    assert result.exit_code == 0
+    assert "5" in result.stdout  # total files
+    assert "GameState" in result.stdout

--- a/tests/test_project_analysis_errors.py
+++ b/tests/test_project_analysis_errors.py
@@ -1,0 +1,113 @@
+"""S3: gda project static-analysis failure modes map to structured GdaErrors (issue #116).
+
+Issue #116's acceptance: failures (missing/invalid project, bad target for
+find-references) surface as structured ``GdaError``s with registered operation
+codes (ADR-0002) — exit 4 for the operation category, finer stable codes so an
+agent branches on the mode without parsing prose. The project group reuses
+``project_not_found`` (the res:// enumeration code scene/script list already use)
+and mints ``invalid_target`` for a bad find-references target.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import error_sentinel, inject_runner
+
+
+def _assert_structured_operation_error(result, code: str) -> None:
+    assert result.exit_code == 4, result.stdout
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == code
+
+
+def test_dependencies_without_project_is_project_not_found(monkeypatch):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(
+                "project_not_found",
+                "project dependencies requires a Godot project; none was resolved",
+            ),
+            stderr="gda: running operation: project-dependencies\n",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["project", "dependencies", "--json"])
+
+    _assert_structured_operation_error(result, "project_not_found")
+
+
+def test_find_unused_without_project_is_project_not_found(monkeypatch):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("project_not_found", "no project resolved"),
+            stderr="",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["project", "find-unused-resources", "--json"])
+
+    _assert_structured_operation_error(result, "project_not_found")
+
+
+def test_statistics_without_project_is_project_not_found(monkeypatch):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("project_not_found", "no project resolved"),
+            stderr="",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["project", "statistics", "--json"])
+
+    _assert_structured_operation_error(result, "project_not_found")
+
+
+def test_find_references_without_project_is_project_not_found(monkeypatch):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("project_not_found", "no project resolved"),
+            stderr="",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app, ["project", "find-references", "res://hero.gd", "--json"]
+    )
+
+    _assert_structured_operation_error(result, "project_not_found")
+
+
+def test_find_references_bad_target_is_invalid_target(monkeypatch):
+    # A bad find-references target (empty, or not a res:// path / class_name)
+    # surfaces as the registered invalid_target operation code.
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(
+                "invalid_target",
+                "find-references target is not a res:// path or class_name: /abs/path",
+            ),
+            stderr="gda: running operation: project-find-references\n",
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app, ["project", "find-references", "/abs/path", "--json"]
+    )
+
+    _assert_structured_operation_error(result, "invalid_target")

--- a/tests/test_project_analysis_models.py
+++ b/tests/test_project_analysis_models.py
@@ -1,0 +1,148 @@
+"""S2: the project static-analysis result models (issue #116).
+
+The four read-only project-wide analysis commands — find-references,
+dependencies, find-unused-resources, statistics — each carry their result in a
+typed model (ADR-0004), so the same model backs ``--json`` and ``--schema``.
+These unit tests validate each model from the dict shape its operation emits
+through the sentinel, exactly as the existing model tests do.
+"""
+
+import json
+
+import jsonschema
+
+from gda.models import (
+    ProjectDependenciesResult,
+    ProjectFindReferencesResult,
+    ProjectFindUnusedResourcesResult,
+    ProjectStatisticsResult,
+)
+
+
+def test_find_references_validates_from_operation_payload():
+    payload = {
+        "target": "res://hero.gd",
+        "references": [
+            {
+                "path": "res://main.tscn",
+                "kind": "ext_resource",
+                "context": 'res://main.tscn type="Script"',
+            },
+            {
+                "path": "res://enemy.gd",
+                "kind": "preload",
+                "context": 'preload("res://hero.gd")',
+            },
+        ],
+    }
+
+    result = ProjectFindReferencesResult.model_validate(payload)
+
+    assert result.target == "res://hero.gd"
+    assert len(result.references) == 2
+    assert result.references[0].path == "res://main.tscn"
+    assert result.references[0].kind == "ext_resource"
+    assert result.references[1].kind == "preload"
+
+
+def test_find_references_empty_is_a_valid_result_not_a_failure():
+    # A target nothing references is a valid, empty result.
+    result = ProjectFindReferencesResult.model_validate(
+        {"target": "res://orphan.gd", "references": []}
+    )
+    assert result.references == []
+
+
+def test_dependencies_validates_from_operation_payload():
+    payload = {
+        "dependencies": [
+            {
+                "path": "res://main.tscn",
+                "depends_on": [
+                    {"path": "res://hero.tscn", "kind": "ext_resource"},
+                    {"path": "res://icon.png", "kind": "ext_resource"},
+                ],
+            },
+            {"path": "res://hero.tscn", "depends_on": []},
+        ]
+    }
+
+    result = ProjectDependenciesResult.model_validate(payload)
+
+    assert len(result.dependencies) == 2
+    main = result.dependencies[0]
+    assert main.path == "res://main.tscn"
+    assert [d.path for d in main.depends_on] == ["res://hero.tscn", "res://icon.png"]
+    assert result.dependencies[1].depends_on == []
+
+
+def test_find_unused_resources_validates_from_operation_payload():
+    payload = {
+        "unused": [
+            "res://unused_sprite.png",
+            "res://orphan.tres",
+        ]
+    }
+
+    result = ProjectFindUnusedResourcesResult.model_validate(payload)
+
+    assert result.unused == ["res://unused_sprite.png", "res://orphan.tres"]
+
+
+def test_statistics_validates_from_operation_payload():
+    payload = {
+        "total_files": 12,
+        "total_lines": 340,
+        "by_extension": [
+            {"extension": "gd", "files": 4, "lines": 300},
+            {"extension": "tscn", "files": 3, "lines": 40},
+        ],
+        "autoloads": [
+            {"name": "GameState", "path": "res://game_state.gd"},
+        ],
+        "plugins": ["res://addons/my_plugin/plugin.cfg"],
+        "scene_count": 3,
+        "script_count": 4,
+        "resource_count": 5,
+    }
+
+    result = ProjectStatisticsResult.model_validate(payload)
+
+    assert result.total_files == 12
+    assert result.total_lines == 340
+    assert result.by_extension[0].extension == "gd"
+    assert result.by_extension[0].files == 4
+    assert result.autoloads[0].name == "GameState"
+    assert result.autoloads[0].path == "res://game_state.gd"
+    assert result.plugins == ["res://addons/my_plugin/plugin.cfg"]
+    assert result.scene_count == 3
+
+
+def test_all_four_models_round_trip_to_json_objects():
+    # Each model serializes to a JSON object that re-validates — the --json
+    # contract round-trips.
+    refs = ProjectFindReferencesResult(target="res://a.gd", references=[])
+    deps = ProjectDependenciesResult(dependencies=[])
+    unused = ProjectFindUnusedResourcesResult(unused=[])
+    stats = ProjectStatisticsResult(
+        total_files=0,
+        total_lines=0,
+        by_extension=[],
+        autoloads=[],
+        plugins=[],
+        scene_count=0,
+        script_count=0,
+        resource_count=0,
+    )
+    for model in (refs, deps, unused, stats):
+        assert json.loads(model.model_dump_json()) == model.model_dump()
+
+
+def test_emitted_schemas_are_valid_json_schema():
+    for model in (
+        ProjectFindReferencesResult,
+        ProjectDependenciesResult,
+        ProjectFindUnusedResourcesResult,
+        ProjectStatisticsResult,
+    ):
+        jsonschema.Draft202012Validator.check_schema(model.model_json_schema())

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -758,6 +758,31 @@ def test_resource_create_schema_emits_model_derived_contract_without_other_args(
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
 
+def test_project_find_references_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for project find-references (issue #116): the bare
+    # --schema flag — no target — short-circuits into the self-description,
+    # derived from the same typed models that back --json. The target param
+    # documents the res://-path-or-class_name addressing agents must use.
+    from gda.models import (
+        ProjectFindReferencesParams,
+        ProjectFindReferencesResult,
+    )
+
+    result = CliRunner().invoke(app, ["project", "find-references", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ProjectFindReferencesParams.model_json_schema()
+    assert doc["output"] == ProjectFindReferencesResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "target" in doc["input"]["properties"]
+    assert "references" in doc["output"]["properties"]
+    target_description = doc["input"]["properties"]["target"]["description"]
+    assert "class_name" in target_description
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
 def test_export_list_schema_emits_model_derived_contract_without_a_project():
     # The ADR-0004 hard gate for export list (issue #114): the bare --schema flag
     # — no --project — short-circuits into the self-description, derived from the
@@ -772,6 +797,23 @@ def test_export_list_schema_emits_model_derived_contract_without_a_project():
     doc = json.loads(result.stdout)
     assert doc["input"] == ExportListParams.model_json_schema()
     assert doc["output"] == ExportListResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert doc["input"].get("properties", {}) == {}
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_project_dependencies_schema_emits_model_derived_contract_without_a_project():
+    # dependencies takes no operation params — the project is process context
+    # (ADR-0006) — so its input schema is trivially empty, exactly like scene list.
+    from gda.models import ProjectDependenciesParams, ProjectDependenciesResult
+
+    result = CliRunner().invoke(app, ["project", "dependencies", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ProjectDependenciesParams.model_json_schema()
+    assert doc["output"] == ProjectDependenciesResult.model_json_schema()
     assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     assert doc["input"].get("properties", {}) == {}
     jsonschema.Draft202012Validator.check_schema(doc["input"])
@@ -793,6 +835,27 @@ def test_resource_get_schema_emits_model_derived_contract_without_other_args():
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
 
+def test_project_find_unused_resources_schema_emits_model_derived_contract():
+    from gda.models import (
+        ProjectFindUnusedResourcesParams,
+        ProjectFindUnusedResourcesResult,
+    )
+
+    result = CliRunner().invoke(
+        app, ["project", "find-unused-resources", "--schema"]
+    )
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ProjectFindUnusedResourcesParams.model_json_schema()
+    assert doc["output"] == ProjectFindUnusedResourcesResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert doc["input"].get("properties", {}) == {}
+    assert "unused" in doc["output"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
 def test_export_get_schema_emits_model_derived_contract_without_other_args():
     # The ADR-0004 hard gate for export get (issue #114): the bare --schema flag —
     # no --preset — short-circuits into the self-description. The preset param
@@ -810,6 +873,23 @@ def test_export_get_schema_emits_model_derived_contract_without_other_args():
     assert "preset" in doc["input"]["properties"]
     assert "templates_installed" in doc["output"]["properties"]
     assert "templates_version" in doc["output"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_project_statistics_schema_emits_model_derived_contract():
+    from gda.models import ProjectStatisticsParams, ProjectStatisticsResult
+
+    result = CliRunner().invoke(app, ["project", "statistics", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ProjectStatisticsParams.model_json_schema()
+    assert doc["output"] == ProjectStatisticsResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert doc["input"].get("properties", {}) == {}
+    for key in ("total_files", "total_lines", "autoloads", "plugins"):
+        assert key in doc["output"]["properties"]
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
@@ -844,7 +924,38 @@ def test_sample_export_results_validate_against_emitted_output_schemas():
     jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
 
 
-def test_schema_spawns_no_godot(monkeypatch):
+def test_sample_project_results_validate_against_emitted_output_schemas():
+    # A sample --json payload of each project analysis command satisfies the
+    # contract its --schema emits (the other half of the ADR-0004 hard gate).
+    from tests.test_project_analysis_commands import (
+        DEPENDENCIES_RESULT,
+        FIND_REFERENCES_RESULT,
+        STATISTICS_RESULT,
+        UNUSED_RESULT,
+    )
+
+    refs_doc = json.loads(
+        CliRunner().invoke(app, ["project", "find-references", "--schema"]).stdout
+    )
+    deps_doc = json.loads(
+        CliRunner().invoke(app, ["project", "dependencies", "--schema"]).stdout
+    )
+    unused_doc = json.loads(
+        CliRunner()
+        .invoke(app, ["project", "find-unused-resources", "--schema"])
+        .stdout
+    )
+    stats_doc = json.loads(
+        CliRunner().invoke(app, ["project", "statistics", "--schema"]).stdout
+    )
+
+    jsonschema.validate(instance=FIND_REFERENCES_RESULT, schema=refs_doc["output"])
+    jsonschema.validate(instance=DEPENDENCIES_RESULT, schema=deps_doc["output"])
+    jsonschema.validate(instance=UNUSED_RESULT, schema=unused_doc["output"])
+    jsonschema.validate(instance=STATISTICS_RESULT, schema=stats_doc["output"])
+
+
+def test_grouped_command_schema_spawns_no_godot(monkeypatch):
     def boom(*args, **kwargs):
         raise AssertionError("--schema must not touch the engine")
 
@@ -856,6 +967,10 @@ def test_schema_spawns_no_godot(monkeypatch):
         ["resource", "get"],
         ["export", "list"],
         ["export", "get"],
+        ["project", "find-references"],
+        ["project", "dependencies"],
+        ["project", "find-unused-resources"],
+        ["project", "statistics"],
     ):
         result = CliRunner().invoke(app, [*command, "--schema"])
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Establishes the read-only static-analysis reads for the `project` group (issue #116), all backed by a single **text-only** project scan (no load/instantiate, per #30/#61):

- `gda project find-references <target>` — every site referencing a given script/class/resource
- `gda project dependencies` — scene → scene/resource reference graph
- `gda project find-unused-resources` — orphaned resources, **consistent with the same reference graph**
- `gda project statistics` — file/line counts, autoloads, plugins

All ship `--json` and the ADR-0004 `--schema` hard gate via the shared skeleton.

## Error codes

New: `invalid_target` (`operation` / exit `4`) — registered in the Python registry, the ADR-0002 table, and the GDScript mirror (drift tests green). A missing/invalid project reuses `project_not_found`.

## Tests

- S2 model units, S3 CLI-with-FakeRunner + structured errors + `--schema` gate, S1 e2e on a fixture project with cross-references.
- Full suite: **457 passed** (incl. all e2e against real Godot 4.6.3); `uv build` succeeds.

## Notes

- This slice was implemented by a worktree subagent interrupted by a session limit before committing. Its `operations.gd` edit contained two **raw NUL bytes** (an intended NUL key-separator written as literal `0x00`) that made the GDScript fail to parse — invisible to the FakeRunner unit tier but caught by the e2e gate. Fixed by switching the dedup-key separator to `\n` (impossible in a `res://` path or kind token).
- **Merge order:** this and the `project` tracer #111 (PR #160) both establish the `project` group scaffolding (branched from `main` in parallel). Land **#160 first**, then rebase this onto it.

Closes #116
