### PR TITLE
feat(project): add-autoload + remove-autoload — manage singleton autoloads (#119)

### DIFF
--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -57,10 +57,14 @@ from gda.models import (
     NodeRemoveResult,
     NodeSetParams,
     NodeSetResult,
+    ProjectAddAutoloadParams,
+    ProjectAddAutoloadResult,
     ProjectGetParams,
     ProjectGetResult,
     ProjectInfoParams,
     ProjectInfoResult,
+    ProjectRemoveAutoloadParams,
+    ProjectRemoveAutoloadResult,
     ProjectSetParams,
     ProjectSetResult,
     ResourceCreateParams,
@@ -474,6 +478,20 @@ PROJECT_SET_COMMAND: HeadlessCommand[ProjectSetResult] = HeadlessCommand(
     operation="project-set",
     input_model=ProjectSetParams,
     output_model=ProjectSetResult,
+)
+
+PROJECT_ADD_AUTOLOAD_COMMAND: HeadlessCommand[ProjectAddAutoloadResult] = HeadlessCommand(
+    operation="project-add-autoload",
+    input_model=ProjectAddAutoloadParams,
+    output_model=ProjectAddAutoloadResult,
+)
+
+PROJECT_REMOVE_AUTOLOAD_COMMAND: HeadlessCommand[ProjectRemoveAutoloadResult] = (
+    HeadlessCommand(
+        operation="project-remove-autoload",
+        input_model=ProjectRemoveAutoloadParams,
+        output_model=ProjectRemoveAutoloadResult,
+    )
 )
 
 SHADER_CREATE_COMMAND: HeadlessCommand[ShaderCreateResult] = HeadlessCommand(
@@ -1611,6 +1629,55 @@ def project_set(
     _dispatch(
         PROJECT_SET_COMMAND,
         ProjectSetParams(setting=setting, value=value),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@project_app.command(
+    name="add-autoload", cls=PROJECT_ADD_AUTOLOAD_COMMAND.command_class()
+)
+def project_add_autoload(
+    name: str = typer.Argument(
+        ..., help="The autoload singleton's global name (the autoload/<name> key)."
+    ),
+    path: str = typer.Argument(
+        ..., help="The res:// path to the script or scene to autoload (e.g. res://global.gd)."
+    ),
+    json_output: bool = json_option(),
+    schema: bool = PROJECT_ADD_AUTOLOAD_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Register an autoload singleton (name → script/scene path), then save project.godot."""
+    _dispatch(
+        PROJECT_ADD_AUTOLOAD_COMMAND,
+        ProjectAddAutoloadParams(name=name, path=_normalize_path(path)),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@project_app.command(
+    name="remove-autoload", cls=PROJECT_REMOVE_AUTOLOAD_COMMAND.command_class()
+)
+def project_remove_autoload(
+    name: str = typer.Argument(
+        ..., help="The global name of the autoload singleton to unregister."
+    ),
+    json_output: bool = json_option(),
+    schema: bool = PROJECT_REMOVE_AUTOLOAD_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Unregister an autoload singleton by name, then save project.godot."""
+    _dispatch(
+        PROJECT_REMOVE_AUTOLOAD_COMMAND,
+        ProjectRemoveAutoloadParams(name=name),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -1953,3 +1953,71 @@ class ProjectSetResult(BaseModel):
     value: Any = Field(
         description="The coerced value as JSON, as ProjectSettings now holds it."
     )
+
+
+class ProjectAddAutoloadParams(BaseModel):
+    """The operation params of ``gda project add-autoload`` (issue #119).
+
+    Registers an autoload singleton: ``name`` is the global accessor name (the key
+    under the ``autoload/`` section of ``project.godot``); ``path`` is the res://
+    path to the script or scene to autoload. The operation stores it in the
+    enabled-singleton form (a leading ``*`` prefix) and saves ``project.godot``.
+    The project is process context (``--project``), not an operation param
+    (ADR-0006), so only ``name`` and ``path`` are inputs.
+    """
+
+    name: str = Field(
+        description=(
+            "The autoload singleton's global name — the accessor it is reached by "
+            "and the key under the project's autoload/ section."
+        )
+    )
+    path: str = Field(
+        description=(
+            "The res:// path to the script or scene to autoload, e.g. "
+            "res://global.gd."
+        )
+    )
+
+
+class ProjectAddAutoloadResult(BaseModel):
+    """The result of ``gda project add-autoload``: the autoload it registered.
+
+    Echoes the autoload's ``name`` and the ``path`` exactly as it was persisted to
+    ``project.godot`` — the enabled-singleton form with the leading ``*`` prefix
+    (e.g. ``*res://global.gd``), the same value a ``project get`` of
+    ``autoload/<name>`` reads back, so an add round-trips through a get.
+    """
+
+    name: str = Field(description="The registered autoload's global name.")
+    path: str = Field(
+        description=(
+            "The autoload value as persisted to project.godot, in enabled-singleton "
+            "form with the leading * prefix (e.g. *res://global.gd)."
+        )
+    )
+
+
+class ProjectRemoveAutoloadParams(BaseModel):
+    """The operation params of ``gda project remove-autoload`` (issue #119).
+
+    Unregisters an autoload singleton by its global ``name`` (the key under the
+    ``autoload/`` section), then saves ``project.godot``. The project is process
+    context (``--project``), not an operation param (ADR-0006), so only ``name``
+    is an input.
+    """
+
+    name: str = Field(
+        description="The global name of the autoload singleton to unregister."
+    )
+
+
+class ProjectRemoveAutoloadResult(BaseModel):
+    """The result of ``gda project remove-autoload``: the autoload it removed.
+
+    Echoes the ``name`` of the autoload that was unregistered, so an agent can
+    confirm which singleton was removed; a subsequent ``project get`` of
+    ``autoload/<name>`` reports ``unknown_setting``.
+    """
+
+    name: str = Field(description="The unregistered autoload's global name.")

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -73,6 +73,12 @@ const PROJECT_MAIN_SCENE_SETTING := "application/run/main_scene"
 const PROJECT_VIEWPORT_WIDTH_SETTING := "display/window/size/viewport_width"
 const PROJECT_VIEWPORT_HEIGHT_SETTING := "display/window/size/viewport_height"
 
+# Autoload singletons live under the "autoload/<name>" section of project.godot
+# (issue #119). The value is the res:// path optionally prefixed with "*" to mean
+# "enabled as a singleton" — the normal, accessible form gda writes.
+const AUTOLOAD_SETTING_PREFIX := "autoload/"
+const AUTOLOAD_ENABLED_PREFIX := "*"
+
 # The exit code the process will use. Defaults to failure, so an operation that
 # aborts before recording an outcome (e.g. an uncaught runtime error) still
 # exits non-zero rather than reporting a phantom success.
@@ -153,6 +159,10 @@ func _initialize() -> void:
 			_op_project_get(params)
 		"project-set":
 			_op_project_set(params)
+		"project-add-autoload":
+			_op_project_add_autoload(params)
+		"project-remove-autoload":
+			_op_project_remove_autoload(params)
 		"shader-create":
 			_op_shader_create(params)
 		"shader-get":
@@ -2030,6 +2040,93 @@ func _op_project_set(params: Dictionary) -> void:
 		"type": _type_name(declared_type),
 		"value": stored_value,
 	})
+
+
+# project-add-autoload: register an autoload singleton (name -> script/scene path)
+# under the autoload/<name> section of project.godot, then persist (issue #119).
+# The value is stored in the ENABLED-singleton form — the res:// path with a
+# leading "*" — which is the normal, globally-accessible autoload gda writes, the
+# same value a `project get autoload/<name>` reads back so an add round-trips
+# through a get.
+#
+# Failure modes use existing registered codes: an empty name or path is
+# invalid_path; a name already registered is already_exists (add never silently
+# overwrites — use remove + add to replace); a target file that does not exist is
+# path_not_found; a failed save is save_failed. Like every --project op it runs
+# the project's autoloads at startup (#61, ADR-0009); the registration itself
+# never instantiates the autoload.
+func _op_project_add_autoload(params: Dictionary) -> void:
+	_diag("running operation: project-add-autoload")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "project add-autoload requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+	var autoload_name := _string_param(params, "name")
+	if autoload_name.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: name")
+		return
+	var path := _string_param(params, "path")
+	if path.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
+		return
+
+	var setting := AUTOLOAD_SETTING_PREFIX + autoload_name
+	if ProjectSettings.has_setting(setting):
+		_fail(OP_ERROR_ALREADY_EXISTS, "autoload already registered: " + autoload_name
+				+ " — add-autoload never overwrites; remove it first to replace it")
+		return
+	if not (FileAccess.file_exists(path) or ResourceLoader.exists(path)):
+		_fail(OP_ERROR_PATH_NOT_FOUND, "autoload target does not exist: " + path)
+		return
+
+	var stored_path := AUTOLOAD_ENABLED_PREFIX + path
+	ProjectSettings.set_setting(setting, stored_path)
+	var save_err := ProjectSettings.save()
+	if save_err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, "failed to save project settings after registering autoload "
+				+ autoload_name + ": " + error_string(save_err))
+		return
+
+	_succeed({
+		"name": autoload_name,
+		"path": stored_path,
+	})
+
+
+# project-remove-autoload: unregister an autoload singleton by name (clearing the
+# autoload/<name> section), then persist project.godot (issue #119). An autoload
+# that is not registered is a clean unknown_setting error — the same code
+# `project get` of a missing setting reports, since an autoload IS a project
+# setting — not a silent no-op, so a typo'd name is distinguished from a genuine
+# removal. A failed save is save_failed.
+func _op_project_remove_autoload(params: Dictionary) -> void:
+	_diag("running operation: project-remove-autoload")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "project remove-autoload requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+	var autoload_name := _string_param(params, "name")
+	if autoload_name.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: name")
+		return
+
+	var setting := AUTOLOAD_SETTING_PREFIX + autoload_name
+	if not ProjectSettings.has_setting(setting):
+		_fail(OP_ERROR_UNKNOWN_SETTING, "autoload not registered: " + autoload_name)
+		return
+
+	# Clearing the setting (assigning null) removes it from ProjectSettings, so it
+	# is dropped from project.godot on save rather than persisted as an empty key.
+	ProjectSettings.set_setting(setting, null)
+	var save_err := ProjectSettings.save()
+	if save_err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, "failed to save project settings after removing autoload "
+				+ autoload_name + ": " + error_string(save_err))
+		return
+
+	_succeed({
+		"name": autoload_name,
+	})
+
+
 # Extract a .gdshader's declared shader_type from its raw source by lightweight
 # line-by-line parsing — never compiling the shader (issue #30). Null when absent.
 # A .gdshader leads with `shader_type <type>;`, after optional blank/comment

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -34,8 +34,10 @@ from gda.models import (
     NodeMoveResult,
     NodeRemoveResult,
     NodeSetResult,
+    ProjectAddAutoloadResult,
     ProjectGetResult,
     ProjectInfoResult,
+    ProjectRemoveAutoloadResult,
     ProjectSetResult,
     ResourceCreateResult,
     ResourceGetResult,
@@ -365,6 +367,16 @@ def render_project_set(was_set: "ProjectSetResult") -> str:
     return f"set {was_set.setting} ({was_set.type}) = {format_value(was_set.value)}"
 
 
+def render_project_add_autoload(added: "ProjectAddAutoloadResult") -> str:
+    """Render a registered autoload as ``added autoload <name> = <path>``."""
+    return f"added autoload {added.name} = {added.path}"
+
+
+def render_project_remove_autoload(removed: "ProjectRemoveAutoloadResult") -> str:
+    """Render an unregistered autoload as ``removed autoload <name>``."""
+    return f"removed autoload {removed.name}"
+
+
 @runtime_checkable
 class ShaderMetadata(Protocol):
     """The shared human-facing surface of every shader result type.
@@ -500,6 +512,8 @@ _RENDERERS = {
     ProjectInfoResult: render_project_info,
     ProjectGetResult: render_project_get,
     ProjectSetResult: render_project_set,
+    ProjectAddAutoloadResult: render_project_add_autoload,
+    ProjectRemoveAutoloadResult: render_project_remove_autoload,
     ShaderCreateResult: render_shader_create,
     ShaderGetResult: render_shader_get,
     ShaderSetResult: render_shader_set,

--- a/tests/test_e2e_project.py
+++ b/tests/test_e2e_project.py
@@ -154,6 +154,111 @@ def test_project_set_uncoercible_value_is_a_clean_error(godot_project):
 
 
 @pytest.mark.e2e
+def test_project_add_autoload_registers_persists_and_round_trips(godot_project):
+    # A real script to autoload must exist in the project (path_not_found otherwise).
+    (godot_project / "global.gd").write_text(
+        "extends Node\n", encoding="utf-8"
+    )
+
+    added = _gda(
+        godot_project,
+        "project",
+        "add-autoload",
+        "Global",
+        "res://global.gd",
+        "--json",
+    )
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    add_data = json.loads(added.stdout)
+    assert add_data["name"] == "Global"
+    # Persisted in the enabled-singleton form, with the leading * prefix.
+    assert add_data["path"] == "*res://global.gd"
+
+    # Round-trip: a fresh process reads the autoload back from project.godot via get.
+    got = _gda(godot_project, "project", "get", "autoload/Global", "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    got_data = json.loads(got.stdout)
+    assert got_data["setting"] == "autoload/Global"
+    assert got_data["value"] == "*res://global.gd"
+
+
+@pytest.mark.e2e
+def test_project_remove_autoload_unregisters_and_round_trips(godot_project):
+    (godot_project / "global.gd").write_text("extends Node\n", encoding="utf-8")
+    added = _gda(
+        godot_project, "project", "add-autoload", "Global", "res://global.gd", "--json"
+    )
+    assert added.returncode == 0, added.stdout + added.stderr
+
+    removed = _gda(godot_project, "project", "remove-autoload", "Global", "--json")
+    assert removed.returncode == 0, removed.stdout + removed.stderr
+    assert json.loads(removed.stdout) == {"name": "Global"}
+
+    # Round-trip: the autoload is gone from project.godot — a fresh get reports it
+    # as an unknown setting, exit 4.
+    got = _gda(godot_project, "project", "get", "autoload/Global", "--json")
+    assert got.returncode == 4, got.stdout + got.stderr
+    assert json.loads(got.stdout)["error"]["code"] == "unknown_setting"
+
+
+@pytest.mark.e2e
+def test_project_add_autoload_duplicate_name_is_a_clean_error(godot_project):
+    (godot_project / "global.gd").write_text("extends Node\n", encoding="utf-8")
+    first = _gda(
+        godot_project, "project", "add-autoload", "Global", "res://global.gd", "--json"
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+
+    dup = _gda(
+        godot_project, "project", "add-autoload", "Global", "res://global.gd", "--json"
+    )
+    assert dup.returncode == 4
+    err = json.loads(dup.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "already_exists"
+
+    # The original registration is untouched: a get still reads it back.
+    got = _gda(godot_project, "project", "get", "autoload/Global", "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["value"] == "*res://global.gd"
+
+
+@pytest.mark.e2e
+def test_project_add_autoload_missing_target_is_a_clean_error(godot_project):
+    # The target script/scene does not exist — path_not_found, exit 4, nothing saved.
+    bad = _gda(
+        godot_project,
+        "project",
+        "add-autoload",
+        "Global",
+        "res://nope.gd",
+        "--json",
+    )
+
+    assert bad.returncode == 4
+    err = json.loads(bad.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+
+    # Nothing was registered: a get reports the autoload as unknown.
+    got = _gda(godot_project, "project", "get", "autoload/Global", "--json")
+    assert got.returncode == 4
+    assert json.loads(got.stdout)["error"]["code"] == "unknown_setting"
+
+
+@pytest.mark.e2e
+def test_project_remove_autoload_unknown_name_is_a_clean_error(godot_project):
+    bad = _gda(godot_project, "project", "remove-autoload", "Nonexistent", "--json")
+
+    assert bad.returncode == 4
+    err = json.loads(bad.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "unknown_setting"
+    assert "Nonexistent" in err["message"]
+
+
+@pytest.mark.e2e
 def test_project_info_without_project_is_a_clean_error():
     # Projectless: ProjectSettings would report only the engine's bare defaults,
     # not the agent's project, so it is refused with project_not_found.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,8 +19,10 @@ from gda.models import (
     NodeMoveResult,
     NodeRemoveResult,
     NodeSetResult,
+    ProjectAddAutoloadResult,
     ProjectGetResult,
     ProjectInfoResult,
+    ProjectRemoveAutoloadResult,
     ProjectSetResult,
     ResourceCreateResult,
     ResourceGetResult,
@@ -891,6 +893,33 @@ def test_project_set_result_round_trips_the_coerced_setting():
     assert was_set.type == "String"
     assert was_set.value == "Renamed Game"
     assert json.loads(was_set.model_dump_json()) == payload
+
+
+def test_project_add_autoload_result_round_trips_the_registered_autoload():
+    # project add-autoload echoes the autoload it registered (issue #119): the
+    # global name and the path AS PERSISTED — the enabled-singleton form with the
+    # leading * prefix, the same value a project get of autoload/<name> reads back.
+    payload = {
+        "name": "Global",
+        "path": "*res://global.gd",
+    }
+
+    added = ProjectAddAutoloadResult.model_validate(payload)
+
+    assert added.name == "Global"
+    assert added.path == "*res://global.gd"
+    assert json.loads(added.model_dump_json()) == payload
+
+
+def test_project_remove_autoload_result_round_trips_the_unregistered_name():
+    # project remove-autoload echoes the name it unregistered (issue #119), so an
+    # agent can confirm which singleton was removed.
+    payload = {"name": "Global"}
+
+    removed = ProjectRemoveAutoloadResult.model_validate(payload)
+
+    assert removed.name == "Global"
+    assert json.loads(removed.model_dump_json()) == payload
 
 
 def test_shader_create_result_round_trips_path_and_metadata():

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -15,10 +15,14 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.models import (
     GdaErrorEnvelope,
+    ProjectAddAutoloadParams,
+    ProjectAddAutoloadResult,
     ProjectGetParams,
     ProjectGetResult,
     ProjectInfoParams,
     ProjectInfoResult,
+    ProjectRemoveAutoloadParams,
+    ProjectRemoveAutoloadResult,
     ProjectSetParams,
     ProjectSetResult,
 )
@@ -210,6 +214,85 @@ def test_project_set_requires_value(monkeypatch):
     assert fake.calls == []
 
 
+# --- project add-autoload -------------------------------------------------
+
+
+ADD_AUTOLOAD_RESULT = {
+    "name": "Global",
+    "path": "*res://global.gd",
+}
+
+REMOVE_AUTOLOAD_RESULT = {
+    "name": "Global",
+}
+
+
+def test_project_add_autoload_dispatches_name_and_path_and_reports_result(monkeypatch):
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(ADD_AUTOLOAD_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["project", "add-autoload", "Global", "res://global.gd", "--json"],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["name"] == "Global"
+    # The persisted value is the enabled-singleton form (the leading * prefix).
+    assert data["path"] == "*res://global.gd"
+    # name and the res:// path ride through as the two operation params; the CLI
+    # passes the bare path and the operation owns the autoload/ section + * prefix.
+    assert fake.calls == [
+        ("project-add-autoload", {"name": "Global", "path": "res://global.gd"})
+    ]
+
+
+def test_project_add_autoload_human_output_names_the_registered_autoload(monkeypatch):
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(ADD_AUTOLOAD_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(app, ["project", "add-autoload", "Global", "res://global.gd"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "added autoload Global = *res://global.gd"
+
+
+# --- project remove-autoload ----------------------------------------------
+
+
+def test_project_remove_autoload_dispatches_name_and_reports_result(monkeypatch):
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(REMOVE_AUTOLOAD_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app, ["project", "remove-autoload", "Global", "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data == REMOVE_AUTOLOAD_RESULT
+    assert fake.calls == [("project-remove-autoload", {"name": "Global"})]
+
+
+def test_project_remove_autoload_human_output_names_the_unregistered_autoload(monkeypatch):
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(REMOVE_AUTOLOAD_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(app, ["project", "remove-autoload", "Global"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "removed autoload Global"
+
+
 # --- ADR-0004 --schema hard gate -----------------------------------------
 
 
@@ -259,16 +342,51 @@ def test_project_set_schema_emits_model_derived_contract_without_other_args():
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
 
+def test_project_add_autoload_schema_emits_model_derived_contract_without_other_args():
+    result = CliRunner().invoke(app, ["project", "add-autoload", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ProjectAddAutoloadParams.model_json_schema()
+    assert doc["output"] == ProjectAddAutoloadResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "name" in doc["input"]["properties"]
+    assert "path" in doc["input"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_project_remove_autoload_schema_emits_model_derived_contract_without_other_args():
+    result = CliRunner().invoke(app, ["project", "remove-autoload", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ProjectRemoveAutoloadParams.model_json_schema()
+    assert doc["output"] == ProjectRemoveAutoloadResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "name" in doc["input"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
 def test_sample_project_results_validate_against_emitted_output_schemas():
     # A sample --json payload of each project command satisfies the contract its
     # --schema emits (the other half of the ADR-0004 hard gate, issue #111).
     info_doc = json.loads(CliRunner().invoke(app, ["project", "info", "--schema"]).stdout)
     get_doc = json.loads(CliRunner().invoke(app, ["project", "get", "--schema"]).stdout)
     set_doc = json.loads(CliRunner().invoke(app, ["project", "set", "--schema"]).stdout)
+    add_doc = json.loads(
+        CliRunner().invoke(app, ["project", "add-autoload", "--schema"]).stdout
+    )
+    remove_doc = json.loads(
+        CliRunner().invoke(app, ["project", "remove-autoload", "--schema"]).stdout
+    )
 
     jsonschema.validate(instance=INFO_RESULT, schema=info_doc["output"])
     jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
     jsonschema.validate(instance=SET_RESULT, schema=set_doc["output"])
+    jsonschema.validate(instance=ADD_AUTOLOAD_RESULT, schema=add_doc["output"])
+    jsonschema.validate(instance=REMOVE_AUTOLOAD_RESULT, schema=remove_doc["output"])
 
 
 def test_project_schema_spawns_no_godot(monkeypatch):
@@ -282,6 +400,8 @@ def test_project_schema_spawns_no_godot(monkeypatch):
         ["project", "info"],
         ["project", "get"],
         ["project", "set"],
+        ["project", "add-autoload"],
+        ["project", "remove-autoload"],
     ):
         result = CliRunner().invoke(app, [*command, "--schema"])
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary
Rounds out the project group with autoload-singleton management on `project.godot`, reusing the #111 `ProjectSettings` read/write plumbing.

- `gda project add-autoload <name> <path>` registers an autoload (stored in enabled-singleton form, `*res://…`) and saves `project.godot`.
- `gda project remove-autoload <name>` unregisters one (clears the setting so it drops from `project.godot` on save).
- Both round-trip via `project get autoload/<name>` / `project info`; both ship `--json` + the ADR-0004 `--schema` gate via the shared skeleton.

Failure modes reuse already-registered codes (no new code rows): missing project → `project_not_found`; empty name/path → `invalid_path`; duplicate on add → `already_exists` (never overwrites); target missing → `path_not_found`; unknown autoload on remove → `unknown_setting`; save failure → `save_failed`.

## Tests / verification
- S2 model round-trip, S3 CLI-with-FakeRunner, S1 e2e (real engine).
- Orchestrator independently re-ran the **full suite incl. e2e**: `uv run pytest` → **650 passed (0:06:28)**. New GDScript ops `_op_project_add_autoload` / `_op_project_remove_autoload` exercised against the real engine.

Closes #119
