### PR TITLE
feat(resource): set + delete — round out resource-file CRUD (#120)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -110,7 +110,7 @@ operation, and parse codes the CLI assigns).
 | `node_not_found` | `operation` | `operation` | `4` | A requested node path does not resolve to a node in the scene. |
 | `cannot_target_root` | `operation` | `operation` | `4` | A structural edit targeted the scene root, which has no parent to be removed from, duplicated alongside, or reparented out of. |
 | `cyclic_target` | `operation` | `operation` | `4` | A node move targeted the node itself or one of its own descendants, which would detach the moved subtree from the scene. |
-| `unknown_property` | `operation` | `operation` | `4` | A requested property does not exist as a settable property on the node. |
+| `unknown_property` | `operation` | `operation` | `4` | A requested property does not exist as a settable property on the target node or resource. |
 | `uncoercible_value` | `operation` | `operation` | `4` | A supplied value cannot be coerced to the property's declared Godot type. |
 | `no_search_match` | `operation` | `operation` | `4` | A search-replace script edit found no occurrence of the search string. |
 | `invalid_line_range` | `operation` | `operation` | `4` | A line-range script edit specified lines outside the script's bounds, or end before start. |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -138,6 +138,13 @@ Whitespace around a value or a component is tolerated. A property of any other t
 reported by `node get` (its value degrades to a string projection), but `node set` cannot coerce
 to it yet and refuses with `uncoercible_value` — the coercible set grows as later slices need it.
 
+This coercion contract — the accepted string forms above, the declared-type target, and the
+`unknown_property` / `uncoercible_value` failures — is **shared by other property-bearing
+commands**, not specific to nodes. `gda resource set` (#120) applies the same #55 coercion to the
+addressed `.tres` resource property's declared type and round-trips through `resource get`, exactly
+as `node set` round-trips through `node get`; here `unknown_property` names a property absent on the
+**resource** rather than a node.
+
 **Structural edits** (established by #56): three commands restructure the node tree within a
 scene file, each a `load → locate → restructure → pack → save` round-trip that reuses the
 node-path addressing and the mutation-integrity boundary above. They share one rule for the

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -69,8 +69,12 @@ from gda.models import (
     ProjectSetResult,
     ResourceCreateParams,
     ResourceCreateResult,
+    ResourceDeleteParams,
+    ResourceDeleteResult,
     ResourceGetParams,
     ResourceGetResult,
+    ResourceSetParams,
+    ResourceSetResult,
     ResourceUidParams,
     ResourceUidResult,
     SceneCreateParams,
@@ -442,6 +446,18 @@ RESOURCE_GET_COMMAND: HeadlessCommand[ResourceGetResult] = HeadlessCommand(
     operation="resource-get",
     input_model=ResourceGetParams,
     output_model=ResourceGetResult,
+)
+
+RESOURCE_SET_COMMAND: HeadlessCommand[ResourceSetResult] = HeadlessCommand(
+    operation="resource-set",
+    input_model=ResourceSetParams,
+    output_model=ResourceSetResult,
+)
+
+RESOURCE_DELETE_COMMAND: HeadlessCommand[ResourceDeleteResult] = HeadlessCommand(
+    operation="resource-delete",
+    input_model=ResourceDeleteParams,
+    output_model=ResourceDeleteResult,
 )
 
 EXPORT_LIST_COMMAND: HeadlessCommand[ExportListResult] = HeadlessCommand(
@@ -1406,6 +1422,57 @@ def get_resource(
     _dispatch(
         RESOURCE_GET_COMMAND,
         ResourceGetParams(path=_normalize_path(path)),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@resource_app.command(name="set", cls=RESOURCE_SET_COMMAND.command_class())
+def set_resource(
+    path: str = typer.Argument(..., help="The .tres resource file to mutate."),
+    property: str = typer.Option(
+        ..., "--property", help="The resource property to set (e.g. interpolation_mode)."
+    ),
+    value: str = typer.Option(
+        ...,
+        "--value",
+        help=(
+            "The value to set, as a string. Coerced to the property's declared "
+            "Godot type; an uncoercible value is a clean error."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = RESOURCE_SET_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Set a .tres property, coercing the value to its declared Godot type, then save."""
+    _dispatch(
+        RESOURCE_SET_COMMAND,
+        ResourceSetParams(
+            path=_normalize_path(path), property=property, value=value
+        ),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        render=render,
+    )
+
+
+@resource_app.command(name="delete", cls=RESOURCE_DELETE_COMMAND.command_class())
+def delete_resource(
+    path: str = typer.Argument(..., help="The .tres resource file to delete."),
+    json_output: bool = json_option(),
+    schema: bool = RESOURCE_DELETE_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Delete a .tres resource file and report what was removed."""
+    _dispatch(
+        RESOURCE_DELETE_COMMAND,
+        ResourceDeleteParams(path=_normalize_path(path)),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -242,7 +242,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
-        "A requested property does not exist as a settable property on the node.",
+        "A requested property does not exist as a settable property on the target node or resource.",
     ),
     ErrorCodeSpec(
         "uncoercible_value",

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -1477,6 +1477,70 @@ class ResourceGetResult(BaseModel):
     properties: list[NodeProperty]
 
 
+class ResourceSetParams(BaseModel):
+    """The operation params of ``gda resource set`` (issue #120).
+
+    ``path`` is the ``.tres`` resource file to mutate, addressed by its ``res://``
+    or filesystem path; ``property`` is the resource property to set; ``value`` is
+    the CLI string value, coerced to the property's declared Godot type by the
+    operation (the same coercion rules as ``node set`` / ``project set``, #55)
+    before the ``.tres`` is re-saved. ``set`` edits an EXISTING property — an
+    unknown property is a clean error, never a silent create — so the declared
+    type to coerce to is always known (read off the resource's property list).
+    Mirrors ``project set`` closely: load → coerce to the declared type → save →
+    round-trip via ``resource get``.
+    """
+
+    path: str
+    property: str = Field(
+        description="The resource property to set (e.g. interpolation_mode)."
+    )
+    value: str = Field(
+        description=(
+            "The value to set, as a string. The operation coerces it to the "
+            "property's declared Godot type (see the command catalog's 'Property "
+            "value coercion'); an uncoercible value is a clean error."
+        )
+    )
+
+
+class ResourceSetResult(BaseModel):
+    """The result of ``gda resource set``: the one property it set (issue #120).
+
+    Echoes the ``path``, the ``property`` set, the declared ``type`` the CLI value
+    was coerced to, and the coerced ``value`` as JSON — the same projection
+    ``resource get`` reports for a storage property, so a ``set`` round-trips
+    through a ``get`` without re-reading the ``.tres``.
+    """
+
+    path: str
+    property: str
+    type: str = Field(
+        description="The property's declared Godot type the value was coerced to."
+    )
+    value: Any = Field(
+        description="The coerced value as JSON, as the resource now holds it."
+    )
+
+
+class ResourceDeleteParams(BaseModel):
+    """The operation params of ``gda resource delete``: the ``.tres`` file to remove (issue #120)."""
+
+    path: str
+
+
+class ResourceDeleteResult(BaseModel):
+    """The result of ``gda resource delete``: what was removed (issue #120).
+
+    Echoes the deleted resource's ``path`` and its ``type`` (the engine class,
+    read from the resource before deletion), so the result names the content
+    removed, not just the file path — mirroring ``scene``/``script delete``.
+    """
+
+    path: str
+    type: str = Field(description="The deleted resource's engine class (e.g. Gradient).")
+
+
 class ResourceUidResult(BaseModel):
     """The result of ``gda resource uid``: the resolved UID↔path pair (issue #113).
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -147,6 +147,10 @@ func _initialize() -> void:
 			_op_resource_create(params)
 		"resource-get":
 			_op_resource_get(params)
+		"resource-set":
+			_op_resource_set(params)
+		"resource-delete":
+			_op_resource_delete(params)
 		"export-list":
 			_op_export_list(params)
 		"export-get":
@@ -1564,6 +1568,103 @@ func _op_resource_get(params: Dictionary) -> void:
 		"type": resource.get_class(),
 		"properties": properties,
 	})
+
+
+# resource-set: load a .tres, coerce a CLI string value to a property's declared
+# Godot type and set it, then re-save the resource (issue #120). Mirrors node-set
+# / project-set: the declared type comes from the property the resource actually
+# declares, never from guessing, and the coerced value is read back off the
+# resource before reporting, so a set round-trips through resource get. set edits
+# an EXISTING property — an unknown property is unknown_property, never a silent
+# create — reusing the #55 codes (unknown_property / uncoercible_value).
+func _op_resource_set(params: Dictionary) -> void:
+	_diag("running operation: resource-set")
+	var path := _string_param(params, "path")
+	if path.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
+		return
+	if not _require_existing_resource(path):
+		return  # _require_existing_resource already recorded the failure
+
+	var resource := ResourceLoader.load(path) as Resource
+	if resource == null:
+		_fail(OP_ERROR_INVALID_PATH, "file could not be loaded as a Resource: " + path)
+		return
+
+	var prop_name := _string_param(params, "property")
+	var declared_type := _resource_property_type(resource, prop_name)
+	if declared_type == TYPE_NIL:
+		_fail(OP_ERROR_UNKNOWN_PROPERTY, "resource " + path
+				+ " has no settable property: " + prop_name)
+		return
+
+	var raw_value := _string_param(params, "value")
+	var coerced: Variant = _coerce_value(raw_value, declared_type)
+	if coerced == null:
+		_fail(OP_ERROR_UNCOERCIBLE_VALUE, "cannot coerce value " + raw_value.c_escape()
+				+ " to " + _type_name(declared_type) + " for property " + prop_name
+				+ " on resource " + path)
+		return
+
+	resource.set(prop_name, coerced)
+	var save_err := ResourceSaver.save(resource, path)
+	if save_err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message("resource", path, save_err))
+		return
+
+	# Read the value back off the resource before reporting — it now holds the
+	# coerced value in its canonical form, the same projection resource get
+	# reports, so a set round-trips through a get.
+	var stored_value: Variant = _jsonify(resource.get(prop_name))
+	_succeed({
+		"path": path,
+		"property": prop_name,
+		"type": _type_name(declared_type),
+		"value": stored_value,
+	})
+
+
+# resource-delete: remove a .tres file from disk, reporting what was removed
+# (path + the resource's engine class, read before deletion), completing the
+# create → get → set → delete lifecycle (issue #120). Mirrors script-delete:
+# validate addressing/existence with _require_existing_resource, capture the
+# identity before delete, then DirAccess.remove_absolute (delete_failed on error).
+func _op_resource_delete(params: Dictionary) -> void:
+	_diag("running operation: resource-delete")
+	var path := _string_param(params, "path")
+	if path.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
+		return
+	if not _require_existing_resource(path):
+		return  # _require_existing_resource already recorded the failure
+
+	# Read the type before deletion so the result names the content removed. A
+	# load failure here is non-fatal: the file exists and is about to be deleted,
+	# so fall back to a generic Resource class rather than failing the delete.
+	var resource := ResourceLoader.load(path) as Resource
+	var type := resource.get_class() if resource != null else "Resource"
+
+	var err := DirAccess.remove_absolute(path)
+	if err != OK:
+		_fail(OP_ERROR_DELETE_FAILED, "failed to delete resource " + path + ": " + error_string(err))
+		return
+
+	_succeed({
+		"path": path,
+		"type": type,
+	})
+
+
+# The declared Godot type of a settable storage property on a resource, or
+# TYPE_NIL if the resource has no storage property by that name. resource set
+# keys coercion off this: the value's target type comes from the property the
+# resource actually declares, never from guessing — the resource counterpart of
+# _property_type (which is typed to Node).
+func _resource_property_type(resource: Resource, prop_name: String) -> int:
+	for prop in resource.get_property_list():
+		if String(prop.get("name", "")) == prop_name and _is_storage_property(prop):
+			return int(prop.get("type", TYPE_NIL))
+	return TYPE_NIL
 
 
 # Whether a path names a resource file the resource group operates on: a .tres

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -40,7 +40,9 @@ from gda.models import (
     ProjectRemoveAutoloadResult,
     ProjectSetResult,
     ResourceCreateResult,
+    ResourceDeleteResult,
     ResourceGetResult,
+    ResourceSetResult,
     ResourceUidResult,
     SceneCreateResult,
     SceneDeleteResult,
@@ -316,6 +318,19 @@ def render_resource_properties(got: "ResourceGetResult") -> str:
     return "\n".join([header, *lines])
 
 
+def render_resource_set(was_set: "ResourceSetResult") -> str:
+    """Render a set property as ``set <path>.<property> (<type>) = <value>``."""
+    return (
+        f"set {was_set.path}.{was_set.property} ({was_set.type}) = "
+        f"{format_value(was_set.value)}"
+    )
+
+
+def render_resource_delete(removed: "ResourceDeleteResult") -> str:
+    """Render a deleted resource as ``deleted <path> (<type>)``."""
+    return f"deleted {removed.path} ({removed.type})"
+
+
 def render_export_list(listed: "ExportListResult") -> str:
     """Render the enumerated presets as ``name (platform) [runnable]`` lines."""
     if not listed.presets:
@@ -506,6 +521,8 @@ _RENDERERS = {
     ScriptValidateResult: render_script_validate,
     ResourceCreateResult: render_resource_create,
     ResourceGetResult: render_resource_properties,
+    ResourceSetResult: render_resource_set,
+    ResourceDeleteResult: render_resource_delete,
     ExportListResult: render_export_list,
     ExportGetResult: render_export_get,
     ResourceUidResult: render_resource_uid,

--- a/tests/test_e2e_resource.py
+++ b/tests/test_e2e_resource.py
@@ -222,6 +222,174 @@ def test_resource_get_non_tres_path_yields_invalid_path(godot_project):
     assert ".tres" in err["message"]
 
 
+# --- resource set / delete: round out .tres CRUD (issue #120) ------------
+
+
+@pytest.mark.e2e
+def test_resource_set_coerces_persists_and_round_trips_via_get(godot_project):
+    # create → set → get: set coerces the CLI string to the property's declared
+    # type, saves the .tres, and get reports the coerced value — resource get IS
+    # the structured-level verification that set persisted.
+    resource_path = godot_project / "palette.tres"
+    created = _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    assert created.returncode == 0, created.stdout + created.stderr
+
+    was_set = _gda(
+        "resource",
+        "set",
+        str(resource_path),
+        "--property",
+        "interpolation_mode",
+        "--value",
+        "1",
+        "--json",
+    )
+
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    set_data = json.loads(was_set.stdout)
+    # The result reports the coerced value (the declared int, not the string).
+    assert set_data["path"] == str(resource_path)
+    assert set_data["property"] == "interpolation_mode"
+    assert set_data["type"] == "int"
+    assert set_data["value"] == 1
+
+    got = _gda("resource", "get", str(resource_path), "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    by_name = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
+    # Round-trip: get reports the value set persisted to the .tres.
+    assert by_name["interpolation_mode"]["value"] == 1
+
+
+@pytest.mark.e2e
+def test_resource_set_string_property_round_trips(godot_project):
+    # A String property coerces trivially and round-trips through get.
+    resource_path = godot_project / "palette.tres"
+    _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+
+    was_set = _gda(
+        "resource",
+        "set",
+        str(resource_path),
+        "--property",
+        "resource_name",
+        "--value",
+        "Sunset",
+        "--json",
+    )
+
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    assert json.loads(was_set.stdout)["type"] == "String"
+
+    got = _gda("resource", "get", str(resource_path), "--json")
+    by_name = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
+    assert by_name["resource_name"]["value"] == "Sunset"
+
+
+@pytest.mark.e2e
+def test_resource_set_unknown_property_is_a_clean_error(godot_project):
+    # set edits an existing property; an unknown property is unknown_property,
+    # never a silent create — the agent fixes the property name.
+    resource_path = godot_project / "palette.tres"
+    _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+
+    was_set = _gda(
+        "resource",
+        "set",
+        str(resource_path),
+        "--property",
+        "bogus_property",
+        "--value",
+        "1",
+        "--json",
+    )
+
+    err = _assert_operation_error(was_set, "unknown_property")
+    assert "bogus_property" in err["message"]
+
+
+@pytest.mark.e2e
+def test_resource_set_uncoercible_value_is_a_clean_error(godot_project):
+    # An int property cannot take a non-numeric string — uncoercible_value (#55),
+    # the .tres left untouched.
+    resource_path = godot_project / "palette.tres"
+    _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    before = resource_path.read_text(encoding="utf-8")
+
+    was_set = _gda(
+        "resource",
+        "set",
+        str(resource_path),
+        "--property",
+        "interpolation_mode",
+        "--value",
+        "not-a-number",
+        "--json",
+    )
+
+    err = _assert_operation_error(was_set, "uncoercible_value")
+    assert "not-a-number" in err["message"]
+    # The file is untouched — the rejected coercion never wrote.
+    assert resource_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_resource_set_missing_yields_path_not_found(godot_project):
+    missing = godot_project / "nope.tres"
+
+    was_set = _gda(
+        "resource", "set", str(missing), "--property", "x", "--value", "1", "--json"
+    )
+
+    err = _assert_operation_error(was_set, "path_not_found")
+    assert str(missing) in err["message"]
+
+
+@pytest.mark.e2e
+def test_resource_delete_removes_file_and_round_trips_against_get(godot_project):
+    # create → delete → get: delete removes the .tres and reports what was removed
+    # (path + type); a subsequent get is now path_not_found, closing the lifecycle.
+    resource_path = godot_project / "palette.tres"
+    created = _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    assert created.returncode == 0, created.stdout + created.stderr
+    assert resource_path.exists()
+
+    deleted = _gda("resource", "delete", str(resource_path), "--json")
+
+    assert deleted.returncode == 0, deleted.stdout + deleted.stderr
+    del_data = json.loads(deleted.stdout)
+    assert del_data["path"] == str(resource_path)
+    assert del_data["type"] == "Gradient"
+    # The file is gone from disk.
+    assert not resource_path.exists()
+
+    # Round-trip: get now reports path_not_found — the lifecycle's now-not-found.
+    got = _gda("resource", "get", str(resource_path), "--json")
+    _assert_operation_error(got, "path_not_found")
+
+
+@pytest.mark.e2e
+def test_resource_delete_missing_yields_path_not_found(godot_project):
+    missing = godot_project / "nope.tres"
+
+    deleted = _gda("resource", "delete", str(missing), "--json")
+
+    err = _assert_operation_error(deleted, "path_not_found")
+    assert str(missing) in err["message"]
+
+
+@pytest.mark.e2e
+def test_resource_delete_non_tres_path_yields_invalid_path(godot_project):
+    bad_path = godot_project / "palette.txt"
+    bad_path.write_text("not a resource", encoding="utf-8")
+
+    deleted = _gda("resource", "delete", str(bad_path), "--json")
+
+    err = _assert_operation_error(deleted, "invalid_path")
+    assert ".tres" in err["message"]
+    # The non-.tres file is untouched — the rejected addressing never deleted.
+    assert bad_path.exists()
+
+
 @pytest.mark.e2e
 def test_resource_uid_resolves_both_directions_round_trip(imported_project):
     # path -> uid -> path: the script's import-assigned UID resolves back to the

--- a/tests/test_resource_commands.py
+++ b/tests/test_resource_commands.py
@@ -36,11 +36,175 @@ GET_RESULT = {
 }
 
 
+SET_RESULT = {
+    "path": "/tmp/proj/palette.tres",
+    "property": "interpolation_mode",
+    "type": "int",
+    "value": 1,
+}
+
+DELETE_RESULT = {
+    "path": "/tmp/proj/palette.tres",
+    "type": "Gradient",
+}
+
+
 UID = "uid://caax1gby1api1"
 PATH = "res://data.tres"
 
 UID_TO_PATH_RESULT = {"queried": "uid", "uid": UID, "path": PATH}
 PATH_TO_UID_RESULT = {"queried": "path", "uid": UID, "path": PATH}
+
+
+# --- resource set (issue #120) -------------------------------------------
+
+
+def test_resource_set_dispatches_path_property_value_and_round_trips(monkeypatch):
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(SET_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "resource",
+            "set",
+            "/tmp/proj/palette.tres",
+            "--property",
+            "interpolation_mode",
+            "--value",
+            "1",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    # The result reports the coerced value in the JSON projection get reports, so
+    # a set round-trips through a get (the declared int type, not the string).
+    assert data["path"] == "/tmp/proj/palette.tres"
+    assert data["property"] == "interpolation_mode"
+    assert data["type"] == "int"
+    assert data["value"] == 1
+    # The CLI value rides through as a string; the operation owns the coercion.
+    assert fake.calls == [
+        (
+            "resource-set",
+            {
+                "path": "/tmp/proj/palette.tres",
+                "property": "interpolation_mode",
+                "value": "1",
+            },
+        )
+    ]
+    assert "engine diagnostic" in result.stderr
+
+
+def test_resource_set_human_output_is_set_path_property_type_value(monkeypatch):
+    inject_runner(monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "resource",
+            "set",
+            "/tmp/proj/palette.tres",
+            "--property",
+            "interpolation_mode",
+            "--value",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert (
+        result.stdout.strip()
+        == "set /tmp/proj/palette.tres.interpolation_mode (int) = 1"
+    )
+
+
+def test_resource_set_requires_value(monkeypatch):
+    # --value is required: a set with no value is a usage error (exit 2), not a
+    # silent no-op or an empty write.
+    fake = FakeRunner(RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0))
+    monkeypatch.setattr("gda.cli._make_runner", lambda binary, project=None: fake)
+
+    result = CliRunner().invoke(
+        app, ["resource", "set", "/tmp/proj/palette.tres", "--property", "x"]
+    )
+
+    assert result.exit_code == 2
+    assert fake.calls == []
+
+
+def test_resource_set_expands_user_home_in_filesystem_path(monkeypatch):
+    fake = FakeRunner(RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0))
+    monkeypatch.setattr("gda.cli._make_runner", lambda binary, project=None: fake)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "resource",
+            "set",
+            "~/palette.tres",
+            "--property",
+            "interpolation_mode",
+            "--value",
+            "1",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    sent_path = fake.calls[0][1]["path"]
+    assert "~" not in sent_path
+    assert sent_path.endswith("/palette.tres")
+
+
+# --- resource delete (issue #120) ----------------------------------------
+
+
+def test_resource_delete_dispatches_path_and_reports_removed(monkeypatch):
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(DELETE_RESULT)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["resource", "delete", "/tmp/proj/palette.tres", "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    # The result names the content removed (path + type), not just the path.
+    assert data["path"] == "/tmp/proj/palette.tres"
+    assert data["type"] == "Gradient"
+    assert fake.calls == [("resource-delete", {"path": "/tmp/proj/palette.tres"})]
+    assert "engine diagnostic" in result.stderr
+
+
+def test_resource_delete_human_output_names_path_and_type(monkeypatch):
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(DELETE_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["resource", "delete", "/tmp/proj/palette.tres"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "deleted /tmp/proj/palette.tres (Gradient)"
+
+
+def test_resource_delete_res_path_passes_through_untouched(monkeypatch):
+    fake = FakeRunner(RunResult(stdout=sentinel(DELETE_RESULT), stderr="", exit_code=0))
+    monkeypatch.setattr("gda.cli._make_runner", lambda binary, project=None: fake)
+
+    result = CliRunner().invoke(
+        app, ["resource", "delete", "res://palette.tres", "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [("resource-delete", {"path": "res://palette.tres"})]
 
 
 def test_resource_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):

--- a/tests/test_resource_errors.py
+++ b/tests/test_resource_errors.py
@@ -113,6 +113,127 @@ def test_resource_get_missing_yields_path_not_found(monkeypatch):
     assert "/x/palette.tres" in err["message"]
 
 
+def _invoke_resource_set(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: resource-set\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(
+        app,
+        [
+            "resource",
+            "set",
+            "/x/palette.tres",
+            "--property",
+            "interpolation_mode",
+            "--value",
+            "1",
+            "--json",
+        ],
+    )
+
+
+def _invoke_resource_delete(monkeypatch, code: str, message: str):
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
+            stderr="gda: running operation: resource-delete\n",
+            exit_code=1,
+        ),
+    )
+    return CliRunner().invoke(
+        app, ["resource", "delete", "/x/palette.tres", "--json"]
+    )
+
+
+def test_resource_set_unknown_property_yields_unknown_property(monkeypatch):
+    # set edits an existing property; an unknown property is unknown_property
+    # (the same #55 code node set uses), never a silent create.
+    result = _invoke_resource_set(
+        monkeypatch,
+        "unknown_property",
+        "resource /x/palette.tres has no settable property: bogus",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "unknown_property"
+    assert "bogus" in err["message"]
+    assert err["diagnostics"] == "gda: running operation: resource-set\n"
+
+
+def test_resource_set_uncoercible_value_yields_uncoercible_value(monkeypatch):
+    # A value that cannot be coerced to the property's declared type reuses the
+    # node-set #55 code: uncoercible_value (exit 4, the .tres untouched).
+    result = _invoke_resource_set(
+        monkeypatch,
+        "uncoercible_value",
+        "cannot coerce value not-a-number to int for property "
+        "interpolation_mode on resource /x/palette.tres",
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "uncoercible_value"
+    assert "not-a-number" in err["message"]
+
+
+def test_resource_set_missing_yields_path_not_found(monkeypatch):
+    # A set on a path with no resource file reuses the registered path_not_found
+    # code (the same one resource get uses for a missing file).
+    result = _invoke_resource_set(
+        monkeypatch, "path_not_found", "resource file does not exist: /x/palette.tres"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "path_not_found"
+    assert "/x/palette.tres" in err["message"]
+
+
+def test_resource_set_non_tres_path_yields_invalid_path(monkeypatch):
+    result = _invoke_resource_set(
+        monkeypatch, "invalid_path", "resource path must end in .tres: /x/palette.txt"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "invalid_path"
+
+
+def test_resource_delete_missing_yields_path_not_found(monkeypatch):
+    # A delete on a path with no resource file reuses path_not_found, so the
+    # lifecycle's now-not-found is the same code a fresh get would report.
+    result = _invoke_resource_delete(
+        monkeypatch, "path_not_found", "resource file does not exist: /x/palette.tres"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "path_not_found"
+    assert "/x/palette.tres" in err["message"]
+
+
+def test_resource_delete_non_tres_path_yields_invalid_path(monkeypatch):
+    result = _invoke_resource_delete(
+        monkeypatch, "invalid_path", "resource path must end in .tres: /x/palette.txt"
+    )
+
+    assert result.exit_code == 4
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "invalid_path"
+
+
 def _invoke_resource_uid(monkeypatch, code: str, message: str, target: str):
     inject_runner(
         monkeypatch,

--- a/tests/test_resource_models.py
+++ b/tests/test_resource_models.py
@@ -11,7 +11,14 @@ import json
 
 import jsonschema
 
-from gda.models import ResourceUidParams, ResourceUidResult
+from gda.models import (
+    ResourceDeleteParams,
+    ResourceDeleteResult,
+    ResourceSetParams,
+    ResourceSetResult,
+    ResourceUidParams,
+    ResourceUidResult,
+)
 
 
 def test_params_carry_the_single_target_argument():
@@ -57,3 +64,53 @@ def test_result_schema_is_valid_json_schema_with_the_three_fields():
 
     jsonschema.Draft202012Validator.check_schema(schema)
     assert {"queried", "uid", "path"} <= set(schema["properties"])
+
+
+# --- resource set / delete models (issue #120) ---------------------------
+
+
+def test_set_params_carry_path_property_and_string_value():
+    params = ResourceSetParams(
+        path="res://palette.tres", property="interpolation_mode", value="1"
+    )
+
+    # The CLI value rides through as a string; the operation owns the coercion.
+    assert params.model_dump() == {
+        "path": "res://palette.tres",
+        "property": "interpolation_mode",
+        "value": "1",
+    }
+
+
+def test_set_result_carries_the_coerced_value_projection():
+    # The result reports the coerced value in the JSON projection get reports, so
+    # a set round-trips through a get (the declared int type, not the string).
+    payload = {
+        "path": "res://palette.tres",
+        "property": "interpolation_mode",
+        "type": "int",
+        "value": 1,
+    }
+
+    result = ResourceSetResult.model_validate(payload)
+
+    assert result.property == "interpolation_mode"
+    assert result.type == "int"
+    assert result.value == 1
+    assert json.loads(result.model_dump_json()) == payload
+
+
+def test_delete_params_carry_the_single_path_argument():
+    params = ResourceDeleteParams(path="res://palette.tres")
+
+    assert params.model_dump() == {"path": "res://palette.tres"}
+
+
+def test_delete_result_names_the_removed_path_and_type():
+    payload = {"path": "res://palette.tres", "type": "Gradient"}
+
+    result = ResourceDeleteResult.model_validate(payload)
+
+    assert result.path == "res://palette.tres"
+    assert result.type == "Gradient"
+    assert json.loads(result.model_dump_json()) == payload

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -835,6 +835,60 @@ def test_resource_get_schema_emits_model_derived_contract_without_other_args():
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
 
+def test_resource_set_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for resource set (issue #120): the bare --schema flag
+    # — no path, no --property/--value — short-circuits into the self-description,
+    # derived from the same typed models that back --json. The value param
+    # documents the type-coercion contract agents must rely on.
+    from gda.models import ResourceSetParams, ResourceSetResult
+
+    result = CliRunner().invoke(app, ["resource", "set", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ResourceSetParams.model_json_schema()
+    assert doc["output"] == ResourceSetResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    value_description = doc["input"]["properties"]["value"]["description"]
+    assert "coerce" in value_description.lower()
+    assert "property" in doc["output"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_resource_delete_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for resource delete (issue #120): the bare --schema
+    # flag — no path — short-circuits into the self-description.
+    from gda.models import ResourceDeleteParams, ResourceDeleteResult
+
+    result = CliRunner().invoke(app, ["resource", "delete", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ResourceDeleteParams.model_json_schema()
+    assert doc["output"] == ResourceDeleteResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "type" in doc["output"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_sample_resource_set_delete_results_validate_against_emitted_output_schemas():
+    # A sample --json payload of each new resource command satisfies the contract
+    # its --schema emits (the other half of the ADR-0004 hard gate, issue #120).
+    from tests.test_resource_commands import DELETE_RESULT, SET_RESULT
+
+    set_doc = json.loads(
+        CliRunner().invoke(app, ["resource", "set", "--schema"]).stdout
+    )
+    delete_doc = json.loads(
+        CliRunner().invoke(app, ["resource", "delete", "--schema"]).stdout
+    )
+
+    jsonschema.validate(instance=SET_RESULT, schema=set_doc["output"])
+    jsonschema.validate(instance=DELETE_RESULT, schema=delete_doc["output"])
+
+
 def test_project_find_unused_resources_schema_emits_model_derived_contract():
     from gda.models import (
         ProjectFindUnusedResourcesParams,


### PR DESCRIPTION
## Summary
Completes the `.tres` lifecycle (create → get → set → delete) on top of the #112 resource tracer.

- `gda resource set <path> --property P --value V` coerces the CLI value to the property's declared Godot type (reusing #55 coercion), saves, and round-trips via `resource get`.
- `gda resource delete <path>` removes a `.tres` and reports what was removed (now-not-found via `resource get`).
- Both ship `--json` + the ADR-0004 `--schema` gate via the shared skeleton.

Failure modes reuse already-registered codes (no new code rows): `unknown_property`, `uncoercible_value`, `invalid_path`, `save_failed`, `delete_failed`.

## Tests / verification
- S2 model round-trip, S3 CLI-with-FakeRunner, S1 e2e (real engine).
- Orchestrator independently re-ran the **full suite incl. e2e**: `uv run pytest` → **665 passed (0:06:53)**. New GDScript ops `_op_resource_set` / `_op_resource_delete` (+ helper `_resource_property_type`) exercised against the real engine.

Closes #120
