### PR TITLE
feat(export): run — export a preset via the headless CLI (#121)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -122,6 +122,9 @@ operation, and parse codes the CLI assigns).
 | `invalid_resource_type` | `operation` | `operation` | `4` | A requested resource type cannot be instantiated as a `Resource`. |
 | `export_presets_not_found` | `operation` | `operation` | `4` | The project has no export_presets.cfg, so it defines no export presets. |
 | `export_preset_not_found` | `operation` | `operation` | `4` | No export preset with the requested name exists in export_presets.cfg. |
+| `export_path_unset` | `operation` | `classifier` | `4` | An export run was asked to use the preset's configured export_path, but the preset has none and no output path was given. |
+| `export_templates_missing` | `operation` | `classifier` | `4` | An export run needs the export templates for the running engine version, which are not installed. |
+| `export_failed` | `operation` | `classifier` | `4` | A native Godot export run failed (the engine reported the export did not complete). |
 | `invalid_uid` | `operation` | `operation` | `4` | A requested `uid://` value is not a syntactically valid resource UID. |
 | `unknown_uid` | `operation` | `operation` | `4` | A syntactically valid resource UID is not registered in the engine's UID cache. |
 | `no_uid_assigned` | `operation` | `operation` | `4` | A resource path exists but has no UID assigned in the engine's UID cache. |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -122,7 +122,7 @@ operation, and parse codes the CLI assigns).
 | `invalid_resource_type` | `operation` | `operation` | `4` | A requested resource type cannot be instantiated as a `Resource`. |
 | `export_presets_not_found` | `operation` | `operation` | `4` | The project has no export_presets.cfg, so it defines no export presets. |
 | `export_preset_not_found` | `operation` | `operation` | `4` | No export preset with the requested name exists in export_presets.cfg. |
-| `export_path_unset` | `operation` | `classifier` | `4` | An export run was asked to use the preset's configured export_path, but the preset has none and no output path was given. |
+| `export_path_unset` | `operation` | `classifier` | `4` | An export run targeted a preset that has no configured export_path. |
 | `export_templates_missing` | `operation` | `classifier` | `4` | An export run needs the export templates for the running engine version, which are not installed. |
 | `export_failed` | `operation` | `classifier` | `4` | A native Godot export run failed (the engine reported the export did not complete). |
 | `invalid_uid` | `operation` | `operation` | `4` | A requested `uid://` value is not a syntactically valid resource UID. |

--- a/docs/adr/0010-headless-operation-execution-mechanism.md
+++ b/docs/adr/0010-headless-operation-execution-mechanism.md
@@ -34,19 +34,41 @@ one-shot `godot --headless` processes under ADR-0001:
    unless they cannot.
 2. **Native engine CLI mode (editor-only capabilities).** When the capability is
    editor-only / unreachable from a runtime script, `gda` invokes the engine's native
-   CLI mode directly and **classifies** the subprocess outcome (exit code + output)
-   into **classifier-source** `GdaError` codes — the same mechanism ADR-0002 already
-   uses for `engine_crashed` / `operation_failed`. Such codes live in the
-   `src/gda/error_codes.py` registry and the ADR-0002 table only, and are **not**
-   mirrored in GDScript (per ADR-0002: only operation-source codes are mirrored,
-   because only those can be reported by an op). A drift test enforces this.
+   CLI mode directly and **classifies** the subprocess outcome into
+   **classifier-source** `GdaError` codes — the same mechanism ADR-0002 already
+   uses for `engine_crashed` / `operation_failed`. The native CLI mode emits no
+   ADR-0002 sentinel, so the classification keys on the **process exit code** plus a
+   **structured pre-check** performed before the native run — never on the engine's
+   stderr text. Consistent with ADR-0002, stderr is **never** parsed to choose a
+   stable code; it is surfaced **only** as the advisory `message` / diagnostics on
+   the outcome (the same advisory-diagnostics carve-out ADR-0002 grants `script
+   validate`). Such codes live in the `src/gda/error_codes.py` registry and the
+   ADR-0002 table only, and are **not** mirrored in GDScript (per ADR-0002: only
+   operation-source codes are mirrored, because only those can be reported by an op).
+   A drift test enforces this.
 
 **Minimise the divergence.** Keep as much of an operation as possible on the default
 rails; only the irreducibly-native step takes mechanism 2. `export run` is therefore
-two-phase: phase 1 resolves the preset via the standard `export-get` op (so an unknown
-preset is the operation-source `export_preset_not_found`); only phase 2 — the export
-execution itself — uses the native CLI mode plus classifier (`export_path_unset`,
-`export_templates_missing`, `export_failed`).
+staged so that everything decidable from structured data is decided *before* the
+native run:
+
+- **Resolve (op-dispatch).** The preset is resolved via the standard `export-get`
+  op, so an unknown preset is the operation-source `export_preset_not_found` and a
+  project with no `export_presets.cfg` is `export_presets_not_found`.
+- **Structured preflight (classifier, no native run).** `export-get` already reports
+  the preset's configured `export_path` and, structurally, its template readiness
+  (`templates_installed` — the readiness field built for exactly this check). From
+  those: an empty configured `export_path` is `export_path_unset`, and uninstalled
+  templates for the running engine version are `export_templates_missing`. Both are
+  decided here, from structured fields, with **no** native export spawned — in
+  particular `export_templates_missing` is *not* inferred from the engine's "due to
+  configuration errors" stderr (which would violate ADR-0002 and also misfires for a
+  merely-misconfigured preset).
+- **Native run (classifier on exit code).** Only the export execution itself uses the
+  native CLI mode. A clean exit is the typed success result (with any advisory
+  `WARNING` lines parsed off stderr as best-effort diagnostics); any non-zero exit is
+  the generic `export_failed`, with the engine's stderr attached only as advisory
+  diagnostics, never parsed to select the code.
 
 ## Considered options
 

--- a/docs/adr/0010-headless-operation-execution-mechanism.md
+++ b/docs/adr/0010-headless-operation-execution-mechanism.md
@@ -1,0 +1,73 @@
+---
+status: accepted
+---
+
+# Headless operation execution: GDScript op-dispatch by default, native engine CLI mode for editor-only capabilities
+
+ADR-0001 serves [headless operations](../../CONTEXT.md) by spawning one-shot
+`godot --headless` processes. ADR-0002 then fixes *how* such a process reports its
+result: a single GDScript operation in `operations.gd` emits a sentinel-delimited
+payload on stdout and reports an **operation-source** error code (mirrored into the
+GDScript const table). This is the default and, until now, the only execution
+mechanism — and it works for every capability reachable from a `--headless --script`
+runtime context (scene/node/script/resource/project edits, and the config-file reads
+behind `export list` / `export get`).
+
+`gda export run` (#121) is the first capability that is **not** reachable that way.
+Verified against the engine source (`../godot`): Godot's export subsystem
+(`EditorExportPlatform`, `EditorExportPreset`, the template manager) is **editor-only
+C++** under `editor/export/`, not exposed to a runtime script; and the only headless
+way to perform an export is the engine's dedicated top-level CLI modes
+`--export-release` / `--export-debug` / `--export-pack` (tagged
+`CLI_OPTION_AVAILABILITY_EDITOR` in `main/main.cpp`). An `operations.gd` op therefore
+*cannot* execute an export: there is no runtime API to call, and the export mode is a
+separate top-level engine invocation, not a script run.
+
+## Decision
+
+We recognise **two** execution mechanisms for headless operations, both still
+one-shot `godot --headless` processes under ADR-0001:
+
+1. **GDScript op-dispatch (default).** The capability is reachable from a runtime
+   script, so it is an `operations.gd` op under the ADR-0002 sentinel contract and
+   reports operation-source codes. This remains the default; new capabilities use it
+   unless they cannot.
+2. **Native engine CLI mode (editor-only capabilities).** When the capability is
+   editor-only / unreachable from a runtime script, `gda` invokes the engine's native
+   CLI mode directly and **classifies** the subprocess outcome (exit code + output)
+   into **classifier-source** `GdaError` codes — the same mechanism ADR-0002 already
+   uses for `engine_crashed` / `operation_failed`. Such codes live in the
+   `src/gda/error_codes.py` registry and the ADR-0002 table only, and are **not**
+   mirrored in GDScript (per ADR-0002: only operation-source codes are mirrored,
+   because only those can be reported by an op). A drift test enforces this.
+
+**Minimise the divergence.** Keep as much of an operation as possible on the default
+rails; only the irreducibly-native step takes mechanism 2. `export run` is therefore
+two-phase: phase 1 resolves the preset via the standard `export-get` op (so an unknown
+preset is the operation-source `export_preset_not_found`); only phase 2 — the export
+execution itself — uses the native CLI mode plus classifier (`export_path_unset`,
+`export_templates_missing`, `export_failed`).
+
+## Considered options
+
+- **Force everything through `operations.gd`** — impossible for editor-only
+  capabilities: the export classes do not exist in a runtime-script context.
+- **Serve export through a persistent editor (ADR-0001 Phase 2 daemon)** — overkill
+  and miscategorised: export is a stateless headless operation, not a live one; Phase 2
+  exists for operations that need an already-running engine.
+- **Native CLI mode + classifier, divergence minimised (chosen).**
+
+## Consequences
+
+- `gda` carries two execution paths for headless operations: the `operations.gd`
+  sentinel path (default) and a native-CLI-mode runner whose outcome `gda` classifies.
+  This is a new shape and maintenance surface (a native runner alongside the op
+  runner), accepted because it is intrinsic to the capability, contained, and reuses
+  the existing runner / `GdaError` machinery rather than duplicating it.
+- Error-code sourcing follows from the mechanism: an editor-only-capability failure is
+  classifier-source by nature (no op emits it) and is not GDScript-mirrored.
+- The **agent-facing contract is unchanged**: typed models, `--json`, the ADR-0004
+  `--schema` gate, and registered `GdaError.code`s apply identically; only the internal
+  execution mechanism differs.
+- Future editor-only capabilities (other `--export-*` variants, Android build-template
+  install, etc.) follow this precedent rather than inventing a new pattern.

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -1663,19 +1663,26 @@ def run_export(
         make_runner=_make_runner,
     )
 
-    # Phase 2: structured preflight, BEFORE any native run (ADR-0010). export get
-    # already reports template readiness structurally (templates_installed) — the
-    # readiness check built for exactly this — so an export against an uninstalled
-    # template version is the distinct export_templates_missing, decided here
-    # rather than by string-matching the engine's stderr (which ADR-0002 forbids
-    # and which also fires for a misconfigured preset). The configured export_path
-    # must also be set (a --output override is deferred to #170); an empty path is
-    # export_path_unset. Both fail fast without spawning the export.
-    if not got.templates_installed:
-        emit_failure(export_templates_missing_failure(got.name, got.templates_version))
+    # Phase 2: structured preflight, BEFORE any native run (ADR-0010). Two
+    # fail-fast checks, both decided from export get's structured fields rather
+    # than from the engine's stderr (which ADR-0002 forbids parsing for codes):
+    #
+    #  - The configured export_path must be set. A --output override is deferred
+    #    to #170, so an empty configured path means there is nowhere to write —
+    #    export_path_unset. Checked first because it is a per-preset config error
+    #    independent of the engine's template state, so it stays deterministic
+    #    whether or not templates happen to be installed.
+    #  - Templates for the running engine version must be installed. export get
+    #    reports that structurally (templates_installed) — the readiness check
+    #    built for exactly this — so an export against an uninstalled template
+    #    version is the distinct export_templates_missing, decided here rather
+    #    than by string-matching the engine's "due to configuration errors"
+    #    stderr (which also fires for a merely-misconfigured preset).
     output_path = got.export_path
     if not output_path:
         emit_failure(export_path_unset_failure(got.name))
+    if not got.templates_installed:
+        emit_failure(export_templates_missing_failure(got.name, got.templates_version))
 
     # Phase 3: run the native export and classify its raw outcome. The export-get
     # resolved name (got.name) is authoritative throughout — it is what the engine

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -21,6 +21,7 @@ from gda.errors import (
     classify_info,
     classify_script_validate,
     export_path_unset_failure,
+    export_templates_missing_failure,
 )
 from gda.export_runner import ExportRunner, make_subprocess_export_runner
 from gda.headless import (
@@ -1624,39 +1625,31 @@ def run_export(
         "--preset",
         help="The export preset's display name, as 'gda export list' reports it.",
     ),
-    mode: ExportRunMode = typer.Option(
-        ExportRunMode.RELEASE,
-        "--mode",
-        help=(
-            "The export flavor: release/debug (full binary, needs templates) or "
-            "pack (data-only PCK/ZIP, no templates)."
-        ),
-    ),
-    output: Optional[str] = typer.Option(
-        None,
-        "--output",
-        help=(
-            "Where the artifact lands. Defaults to the preset's configured "
-            "export_path; an unset path with no --output is an error."
-        ),
-    ),
+    # NOTE: --mode (release/debug/pack) and --output (path override) are
+    # deferred to follow-up issue #170. Issue #121 asks only to export a named
+    # preset in RELEASE mode to its CONFIGURED export_path, so this command
+    # exposes neither flag; the result still carries `mode` (always "release")
+    # to document the mode that ran.
     json_output: bool = json_option(),
     schema: bool = EXPORT_RUN_COMMAND.schema_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Export a named preset to its output path and report the artifact produced.
+    """Export a named preset (release mode) to its configured path and report the artifact.
 
-    Unlike every other command, the export itself is a native ``--export-<mode>``
+    Unlike every other command, the export itself is a native ``--export-release``
     invocation (the export subsystem is editor-only, so it cannot run through
-    operations.gd). The command orchestrates two phases by hand: ``export get``
-    resolves the preset's platform + configured ``export_path`` (reusing #114's
-    clean preset/project errors), then the native ``ExportRunner`` performs the
-    export and ``classify_export_run`` synthesizes the typed result from the
-    subprocess's exit code + stderr.
+    operations.gd). The command orchestrates three phases by hand: ``export get``
+    resolves the preset's platform + configured ``export_path`` + template
+    readiness (reusing #114's clean preset/project errors), a structured preflight
+    fails fast when templates are missing or the path is unset, then the native
+    ``ExportRunner`` performs the export and ``classify_export_run`` synthesizes
+    the typed result from the subprocess's exit code.
     """
     resolved_project = resolve_project_dir(project)
     binary = resolve_godot_binary(godot)
+    # #121 fixes the export flavor to release; --mode is deferred to #170.
+    mode = ExportRunMode.RELEASE
 
     # Phase 1: resolve the preset via the existing export-get sentinel op. This
     # reuses #114's clean structured errors — an unknown preset is
@@ -1670,9 +1663,17 @@ def run_export(
         make_runner=_make_runner,
     )
 
-    # Phase 2: resolve where the artifact lands — --output overrides, else the
-    # preset's configured export_path. Neither set is export_path_unset.
-    output_path = output if output else got.export_path
+    # Phase 2: structured preflight, BEFORE any native run (ADR-0010). export get
+    # already reports template readiness structurally (templates_installed) — the
+    # readiness check built for exactly this — so an export against an uninstalled
+    # template version is the distinct export_templates_missing, decided here
+    # rather than by string-matching the engine's stderr (which ADR-0002 forbids
+    # and which also fires for a misconfigured preset). The configured export_path
+    # must also be set (a --output override is deferred to #170); an empty path is
+    # export_path_unset. Both fail fast without spawning the export.
+    if not got.templates_installed:
+        emit_failure(export_templates_missing_failure(got.name, got.templates_version))
+    output_path = got.export_path
     if not output_path:
         emit_failure(export_path_unset_failure(got.name))
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -14,11 +14,13 @@ from typing import Optional
 import typer
 from pydantic import BaseModel
 
+from gda.binary import resolve_godot_binary
 from gda.errors import (
     Failure,
     classify_export_run,
     classify_info,
     classify_script_validate,
+    export_path_unset_failure,
 )
 from gda.export_runner import ExportRunner, make_subprocess_export_runner
 from gda.headless import (
@@ -490,6 +492,20 @@ EXPORT_GET_COMMAND: HeadlessCommand[ExportGetResult] = HeadlessCommand(
     operation="export-get",
     input_model=ExportGetParams,
     output_model=ExportGetResult,
+)
+
+# export run is the one command that does NOT route through operations.gd: the
+# Godot export subsystem is editor-only C++, unreachable from a --script
+# SceneTree run, so the export itself is a native --export-<mode> invocation
+# (gda.export_runner). This HeadlessCommand is used only for its --schema /
+# --json model plumbing; the command body (run_export) drives the two phases by
+# hand — export-get resolves the preset + path, the native ExportRunner exports,
+# classify_export_run turns the subprocess outcome into the typed result — rather
+# than the shared sentinel pipeline.
+EXPORT_RUN_COMMAND: HeadlessCommand[ExportRunResult] = HeadlessCommand(
+    operation="export-run",
+    input_model=ExportRunParams,
+    output_model=ExportRunResult,
 )
 
 RESOURCE_UID_COMMAND: HeadlessCommand[ResourceUidResult] = HeadlessCommand(
@@ -1599,6 +1615,85 @@ def get_preset(
         project=project,
         render=render,
     )
+
+
+@export_app.command(name="run", cls=EXPORT_RUN_COMMAND.command_class())
+def run_export(
+    preset: str = typer.Option(
+        ...,
+        "--preset",
+        help="The export preset's display name, as 'gda export list' reports it.",
+    ),
+    mode: ExportRunMode = typer.Option(
+        ExportRunMode.RELEASE,
+        "--mode",
+        help=(
+            "The export flavor: release/debug (full binary, needs templates) or "
+            "pack (data-only PCK/ZIP, no templates)."
+        ),
+    ),
+    output: Optional[str] = typer.Option(
+        None,
+        "--output",
+        help=(
+            "Where the artifact lands. Defaults to the preset's configured "
+            "export_path; an unset path with no --output is an error."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = EXPORT_RUN_COMMAND.schema_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Export a named preset to its output path and report the artifact produced.
+
+    Unlike every other command, the export itself is a native ``--export-<mode>``
+    invocation (the export subsystem is editor-only, so it cannot run through
+    operations.gd). The command orchestrates two phases by hand: ``export get``
+    resolves the preset's platform + configured ``export_path`` (reusing #114's
+    clean preset/project errors), then the native ``ExportRunner`` performs the
+    export and ``classify_export_run`` synthesizes the typed result from the
+    subprocess's exit code + stderr.
+    """
+    resolved_project = resolve_project_dir(project)
+    binary = resolve_godot_binary(godot)
+
+    # Phase 1: resolve the preset via the existing export-get sentinel op. This
+    # reuses #114's clean structured errors — an unknown preset is
+    # export_preset_not_found, a project with no export_presets.cfg is
+    # export_presets_not_found — and emits + exits on any of them via the shared
+    # failure channel, before any native export is attempted.
+    got = EXPORT_GET_COMMAND.run(
+        ExportGetParams(preset=preset),
+        godot=godot,
+        project=resolved_project,
+        make_runner=_make_runner,
+    )
+
+    # Phase 2: resolve where the artifact lands — --output overrides, else the
+    # preset's configured export_path. Neither set is export_path_unset.
+    output_path = output if output else got.export_path
+    if not output_path:
+        emit_failure(export_path_unset_failure(got.name))
+
+    # Phase 3: run the native export and classify its raw outcome.
+    export_runner = _make_export_runner(binary, resolved_project)
+    export_output = export_runner.run(preset, mode.value, output_path)
+    outcome = classify_export_run(
+        export_output,
+        binary,
+        preset=got.name,
+        platform=got.platform,
+        mode=mode,
+        output_path=output_path,
+    )
+    if isinstance(outcome, Failure):
+        emit_failure(outcome)
+
+    if json_output:
+        typer.echo(outcome.model_dump_json())
+    else:
+        typer.echo(render(outcome))
 
 
 @resource_app.command(name="uid", cls=RESOURCE_UID_COMMAND.command_class())

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -1676,9 +1676,12 @@ def run_export(
     if not output_path:
         emit_failure(export_path_unset_failure(got.name))
 
-    # Phase 3: run the native export and classify its raw outcome.
+    # Phase 3: run the native export and classify its raw outcome. The export-get
+    # resolved name (got.name) is authoritative throughout — it is what the engine
+    # exports and what the result echoes — so the native invocation, not the raw
+    # --preset string, is keyed on it.
     export_runner = _make_export_runner(binary, resolved_project)
-    export_output = export_runner.run(preset, mode.value, output_path)
+    export_output = export_runner.run(got.name, mode.value, output_path)
     outcome = classify_export_run(
         export_output,
         binary,

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -14,11 +14,18 @@ from typing import Optional
 import typer
 from pydantic import BaseModel
 
-from gda.errors import classify_info, classify_script_validate
+from gda.errors import (
+    Failure,
+    classify_export_run,
+    classify_info,
+    classify_script_validate,
+)
+from gda.export_runner import ExportRunner, make_subprocess_export_runner
 from gda.headless import (
     HeadlessCommand,
     HumanRenderer,
     M,
+    emit_failure,
     godot_option,
     json_option,
     make_subprocess_runner,
@@ -30,6 +37,9 @@ from gda.models import (
     ExportGetResult,
     ExportListParams,
     ExportListResult,
+    ExportRunMode,
+    ExportRunParams,
+    ExportRunResult,
     InfoParams,
     ProjectDependenciesParams,
     ProjectDependenciesResult,
@@ -220,6 +230,16 @@ def _make_runner(binary: Path, project: Optional[Path]) -> GodotRunner:
     A seam tests override (via monkeypatch) to inject a fake runner.
     """
     return make_subprocess_runner(binary, project)
+
+
+def _make_export_runner(binary: Path, project: Optional[Path]) -> ExportRunner:
+    """Build the default (real) native-export runner for ``binary`` and ``project``.
+
+    The ``export run``-only twin of :func:`_make_runner`: a seam tests override
+    to inject a fake export runner, since ``export run`` spawns Godot with native
+    ``--export-<mode>`` flags rather than the ``operations.gd`` payload.
+    """
+    return make_subprocess_export_runner(binary, project)
 
 
 def _emit(

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -322,6 +322,27 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "No export preset with the requested name exists in export_presets.cfg.",
     ),
     ErrorCodeSpec(
+        "export_path_unset",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.CLASSIFIER,
+        "An export run was asked to use the preset's configured export_path, but the preset has none and no output path was given.",
+    ),
+    ErrorCodeSpec(
+        "export_templates_missing",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.CLASSIFIER,
+        "An export run needs the export templates for the running engine version, which are not installed.",
+    ),
+    ErrorCodeSpec(
+        "export_failed",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.CLASSIFIER,
+        "A native Godot export run failed (the engine reported the export did not complete).",
+    ),
+    ErrorCodeSpec(
         "invalid_uid",
         ErrorCategory.OPERATION,
         EXIT_OPERATION,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -326,7 +326,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.CLASSIFIER,
-        "An export run was asked to use the preset's configured export_path, but the preset has none and no output path was given.",
+        "An export run targeted a preset that has no configured export_path.",
     ),
     ErrorCodeSpec(
         "export_templates_missing",

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -401,3 +401,21 @@ def classify_export_run(
         output_path=output_path,
         warnings=parse_export_warnings(output.stderr),
     )
+
+
+def export_path_unset_failure(preset: str) -> Failure:
+    """The ``export_path_unset`` failure for an export with no resolvable path (issue #121).
+
+    ``export run`` writes the artifact to ``--output`` when given, else the
+    preset's own configured ``export_path``. When neither is set there is nowhere
+    to write, so gda fails *before* spawning the export rather than letting the
+    engine error obscurely. A pre-run classifier decision (the path is resolved
+    at the CLI from ``export get``'s ``export_path``), kept here beside the other
+    export failures so the whole taxonomy reads from one place.
+    """
+    return _failure(
+        "export_path_unset",
+        f'export preset "{preset}" has no configured export_path; '
+        "pass --output to choose where the artifact lands",
+        "",
+    )

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -309,13 +309,6 @@ def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
     return version
 
 
-# The engine reports a missing-template / misconfiguration export failure with
-# this stable stderr prefix (editor/editor_node.cpp). A release/debug export to
-# an uninstalled-template version trips it; gda surfaces it as the distinct
-# export_templates_missing code so an agent installs templates (export get names
-# the version) rather than re-parsing prose.
-_EXPORT_CONFIG_ERROR = "due to configuration errors"
-
 # A non-fatal export warning the engine prints to stderr. WARNING is Godot's
 # WARN_PRINT prefix; these never fail the export (it still exits 0) but are
 # surfaced advisorily on the success result (ADR-0002: stderr is advisory for
@@ -350,10 +343,14 @@ def classify_export_run(
     ``export run`` is the one command that does NOT emit an ADR-0002 sentinel —
     the export subsystem is editor-only, so the artifact is produced by a native
     ``--export-<mode>`` invocation. gda synthesizes the structured outcome from
-    the subprocess's exit code + stderr instead: a clean exit is success (with
-    any advisory warnings parsed off stderr); a non-zero exit is a classifier
-    failure, finer-grained when the stderr names a known mode (missing
-    templates / misconfiguration) and the generic ``export_failed`` otherwise.
+    the subprocess's **exit code** instead (ADR-0010): a clean exit is success
+    (with any advisory warnings parsed off stderr); a non-zero exit is the
+    classifier-source ``export_failed``. Crucially, this does NOT parse stderr to
+    *choose* the code — that would violate ADR-0002's "stderr is never parsed for
+    stable codes". The distinct ``export_templates_missing`` mode is decided
+    *before* the native run by the CLI's structured preflight (``export get``'s
+    ``templates_installed``), not here; on a non-zero export stderr is surfaced
+    only as the advisory ``message`` / diagnostics.
 
     The decision tree mirrors :func:`classify_run`'s env/crash prefix so a
     missing binary or hung export is reported identically across both channels.
@@ -377,18 +374,11 @@ def classify_export_run(
             output.stderr,
         )
     if output.exit_code != 0:
-        # A release/debug export against an uninstalled template version, or any
-        # preset whose configuration the engine rejects, prints the stable
-        # "due to configuration errors" prefix. Surface the missing-templates
-        # mode distinctly; every other non-zero export is the generic failure.
-        if _EXPORT_CONFIG_ERROR in output.stderr:
-            return _failure(
-                "export_templates_missing",
-                f'export preset "{preset}" cannot be exported: the export'
-                " templates for the running engine version are not installed or"
-                " the preset is misconfigured",
-                output.stderr,
-            )
+        # Templates are checked structurally BEFORE this call (the CLI preflights
+        # export get's templates_installed), so a missing-templates run never
+        # reaches here. Every non-zero native export is therefore the generic
+        # classifier-source export_failed; the engine's stderr is preserved only
+        # as advisory diagnostics (ADR-0002), never parsed to pick the code.
         return _failure(
             "export_failed",
             f'export of preset "{preset}" failed',
@@ -404,18 +394,37 @@ def classify_export_run(
 
 
 def export_path_unset_failure(preset: str) -> Failure:
-    """The ``export_path_unset`` failure for an export with no resolvable path (issue #121).
+    """The ``export_path_unset`` failure for a preset with no configured path (issue #121).
 
-    ``export run`` writes the artifact to ``--output`` when given, else the
-    preset's own configured ``export_path``. When neither is set there is nowhere
-    to write, so gda fails *before* spawning the export rather than letting the
-    engine error obscurely. A pre-run classifier decision (the path is resolved
-    at the CLI from ``export get``'s ``export_path``), kept here beside the other
-    export failures so the whole taxonomy reads from one place.
+    ``export run`` writes the artifact to the preset's own configured
+    ``export_path`` (a ``--output`` override is deferred to #170). When the preset
+    has no configured ``export_path`` there is nowhere to write, so gda fails
+    *before* spawning the export rather than letting the engine error obscurely.
+    A pre-run classifier decision (the path is resolved at the CLI from
+    ``export get``'s ``export_path``), kept here beside the other export failures
+    so the whole taxonomy reads from one place.
     """
     return _failure(
         "export_path_unset",
-        f'export preset "{preset}" has no configured export_path; '
-        "pass --output to choose where the artifact lands",
+        f'export preset "{preset}" has no configured export_path',
+        "",
+    )
+
+
+def export_templates_missing_failure(preset: str, templates_version: str) -> Failure:
+    """The ``export_templates_missing`` failure from the structured preflight (issue #121).
+
+    A release export needs the export templates for the running engine version
+    installed. ``export get`` already reports that structurally
+    (``templates_installed``) — the readiness check built for exactly this — so
+    gda decides this *before* spawning the native export, rather than
+    string-matching the engine's "due to configuration errors" stderr (which
+    ADR-0002 forbids, and which also fires for a merely-misconfigured preset).
+    Names the ``templates_version`` directory the agent must install.
+    """
+    return _failure(
+        "export_templates_missing",
+        f'export preset "{preset}" cannot be exported: the export templates for '
+        f"the running engine version ({templates_version}) are not installed",
         "",
     )

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -44,8 +44,11 @@ from typing import TypeVar
 from pydantic import BaseModel, ValidationError
 
 from gda.error_codes import ERROR_CODE_BY_CODE, OPERATION_ERROR_CODES
+from gda.export_runner import ExportRunOutput
 from gda.models import (
     EngineVersion,
+    ExportRunMode,
+    ExportRunResult,
     GdaError,
     OperationErrorEnvelope,
     ScriptDiagnostic,
@@ -304,3 +307,97 @@ def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
         )
 
     return version
+
+
+# The engine reports a missing-template / misconfiguration export failure with
+# this stable stderr prefix (editor/editor_node.cpp). A release/debug export to
+# an uninstalled-template version trips it; gda surfaces it as the distinct
+# export_templates_missing code so an agent installs templates (export get names
+# the version) rather than re-parsing prose.
+_EXPORT_CONFIG_ERROR = "due to configuration errors"
+
+# A non-fatal export warning the engine prints to stderr. WARNING is Godot's
+# WARN_PRINT prefix; these never fail the export (it still exits 0) but are
+# surfaced advisorily on the success result (ADR-0002: stderr is advisory for
+# success diagnostics), so an agent sees e.g. a missing optional icon.
+_EXPORT_WARNING_LINE = re.compile(
+    r"^[ \t]*WARNING:[ \t]*(?P<message>.+?)[ \t]*$", re.MULTILINE
+)
+
+
+def parse_export_warnings(stderr: str) -> list[str]:
+    """Parse advisory export warnings from a native export's stderr (issue #121).
+
+    A pure function: the engine's ``WARN_PRINT`` lines are advisory-only (they
+    never determine the success/failure outcome — a warned export still exits 0),
+    so they are surfaced as best-effort diagnostics on the success result.
+    Returns ``[]`` when the export was clean.
+    """
+    return [m.group("message") for m in _EXPORT_WARNING_LINE.finditer(stderr)]
+
+
+def classify_export_run(
+    output: ExportRunOutput,
+    binary: Path,
+    *,
+    preset: str,
+    platform: str,
+    mode: ExportRunMode,
+    output_path: str,
+) -> ExportRunResult | Failure:
+    """Classify a native Godot export into a typed result or a ``Failure`` (issue #121).
+
+    ``export run`` is the one command that does NOT emit an ADR-0002 sentinel —
+    the export subsystem is editor-only, so the artifact is produced by a native
+    ``--export-<mode>`` invocation. gda synthesizes the structured outcome from
+    the subprocess's exit code + stderr instead: a clean exit is success (with
+    any advisory warnings parsed off stderr); a non-zero exit is a classifier
+    failure, finer-grained when the stderr names a known mode (missing
+    templates / misconfiguration) and the generic ``export_failed`` otherwise.
+
+    The decision tree mirrors :func:`classify_run`'s env/crash prefix so a
+    missing binary or hung export is reported identically across both channels.
+    """
+    if output.launch_failure is LaunchFailure.NOT_FOUND:
+        return _failure(
+            "binary_not_found",
+            f"Godot binary could not be launched: {binary}",
+            output.stderr,
+        )
+    if output.launch_failure is LaunchFailure.TIMEOUT:
+        return _failure(
+            "launch_timeout",
+            "Godot launched but did not return before the timeout",
+            output.stderr,
+        )
+    if output.exit_code < 0:
+        return _failure(
+            "engine_crashed",
+            f"Godot terminated abnormally (signal {-output.exit_code})",
+            output.stderr,
+        )
+    if output.exit_code != 0:
+        # A release/debug export against an uninstalled template version, or any
+        # preset whose configuration the engine rejects, prints the stable
+        # "due to configuration errors" prefix. Surface the missing-templates
+        # mode distinctly; every other non-zero export is the generic failure.
+        if _EXPORT_CONFIG_ERROR in output.stderr:
+            return _failure(
+                "export_templates_missing",
+                f'export preset "{preset}" cannot be exported: the export'
+                " templates for the running engine version are not installed or"
+                " the preset is misconfigured",
+                output.stderr,
+            )
+        return _failure(
+            "export_failed",
+            f'export of preset "{preset}" failed',
+            output.stderr,
+        )
+    return ExportRunResult(
+        preset=preset,
+        platform=platform,
+        mode=mode,
+        output_path=output_path,
+        warnings=parse_export_warnings(output.stderr),
+    )

--- a/src/gda/export_runner.py
+++ b/src/gda/export_runner.py
@@ -1,0 +1,110 @@
+"""The native-export runner seam for ``gda export run`` (issue #121).
+
+Unlike every other Phase-1 operation, an export cannot run through the bundled
+``operations.gd`` payload: Godot's export subsystem (``EditorExportPlatform`` and
+friends) is editor-only C++, unreachable from a ``--headless --script`` SceneTree
+run. The export is instead a *native* Godot invocation —
+``--export-release`` / ``--export-debug`` / ``--export-pack`` — that runs the
+editor export pipeline and writes the artifact. It emits no ADR-0002 sentinel, so
+``gda`` synthesizes the structured result from the subprocess's exit code and
+stderr (see :func:`gda.errors.classify_export_run`).
+
+This module owns only the *seam*: spawn the native export and return its raw
+``{stdout, stderr, exit_code}``. Classification lives in ``gda.errors`` so the
+mapping from raw output to typed result / ``GdaError`` is a pure function exercised
+without a real engine, exactly like the sentinel pipeline.
+"""
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from gda.exit_codes import EXIT_NOT_FOUND, EXIT_TIMEOUT
+from gda.runner import LaunchFailure
+
+# An export packs the whole project and may invoke platform toolchains, so it is
+# far slower than a one-shot headless op. Give it a generous ceiling distinct
+# from the operation runner's tighter bound.
+DEFAULT_EXPORT_TIMEOUT_SECONDS = 600.0
+
+# The native flag for each export mode (ADR-0001 maps the public --mode to the
+# Godot CLI). release/debug produce a full platform binary (need templates);
+# pack produces project data only (PCK/ZIP by output extension).
+EXPORT_MODE_FLAGS: dict[str, str] = {
+    "release": "--export-release",
+    "debug": "--export-debug",
+    "pack": "--export-pack",
+}
+
+
+@dataclass
+class ExportRunOutput:
+    """The raw result of a native Godot export invocation.
+
+    Mirrors :class:`gda.runner.RunResult` for the export channel: the unparsed
+    process output plus a ``launch_failure`` set only when the runner synthesized
+    the result (binary missing, timed out) rather than the engine returning one.
+    """
+
+    stdout: str
+    stderr: str
+    exit_code: int
+    launch_failure: "LaunchFailure | None" = None
+
+
+class ExportRunner(Protocol):
+    """Spawns a native Godot export and returns its raw output."""
+
+    def run(self, preset: str, mode: str, output_path: str) -> ExportRunOutput: ...
+
+
+@dataclass
+class SubprocessExportRunner:
+    """An ExportRunner that spawns ``godot --headless --export-<mode>``.
+
+    Builds ``<godot> --headless --path <project> --export-<mode> "<preset>"
+    <output_path>`` and returns the process's raw stdout/stderr/exit code. The
+    export subsystem requires an editor (tools) build; a non-tools binary lacks
+    these flags entirely and the engine reports it as a usage error, surfaced as a
+    generic export failure by the classifier.
+    """
+
+    binary: Path
+    project: Path | None = None
+    timeout: float = DEFAULT_EXPORT_TIMEOUT_SECONDS
+
+    def run(self, preset: str, mode: str, output_path: str) -> ExportRunOutput:
+        flag = EXPORT_MODE_FLAGS[mode]
+        cmd = [str(self.binary), "--headless"]
+        if self.project is not None:
+            cmd += ["--path", str(self.project)]
+        cmd += [flag, preset, output_path]
+        try:
+            proc = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=self.timeout
+            )
+        except subprocess.TimeoutExpired:
+            return ExportRunOutput(
+                stdout="",
+                stderr=f"gda: Godot export timed out after {self.timeout}s\n",
+                exit_code=EXIT_TIMEOUT,
+                launch_failure=LaunchFailure.TIMEOUT,
+            )
+        except FileNotFoundError:
+            return ExportRunOutput(
+                stdout="",
+                stderr=f"gda: Godot binary not found: {self.binary}\n",
+                exit_code=EXIT_NOT_FOUND,
+                launch_failure=LaunchFailure.NOT_FOUND,
+            )
+        return ExportRunOutput(
+            stdout=proc.stdout, stderr=proc.stderr, exit_code=proc.returncode
+        )
+
+
+def make_subprocess_export_runner(
+    binary: Path, project: Path | None = None
+) -> ExportRunner:
+    """Build the default real native-export runner for ``binary`` and ``project``."""
+    return SubprocessExportRunner(binary, project=project)

--- a/src/gda/export_runner.py
+++ b/src/gda/export_runner.py
@@ -28,9 +28,11 @@ from gda.runner import LaunchFailure
 # from the operation runner's tighter bound.
 DEFAULT_EXPORT_TIMEOUT_SECONDS = 600.0
 
-# The native flag for each export mode (ADR-0001 maps the public --mode to the
-# Godot CLI). release/debug produce a full platform binary (need templates);
-# pack produces project data only (PCK/ZIP by output extension).
+# The native flag for each export mode (ADR-0001 maps a mode to the Godot CLI).
+# release/debug produce a full platform binary (need templates); pack produces
+# project data only (PCK/ZIP by output extension). Issue #121 only ever runs
+# "release"; "debug"/"pack" stay mapped here so follow-up #170 can expose --mode
+# without reshaping the runner seam.
 EXPORT_MODE_FLAGS: dict[str, str] = {
     "release": "--export-release",
     "debug": "--export-debug",

--- a/src/gda/export_runner.py
+++ b/src/gda/export_runner.py
@@ -70,6 +70,14 @@ class SubprocessExportRunner:
     export subsystem requires an editor (tools) build; a non-tools binary lacks
     these flags entirely and the engine reports it as a usage error, surfaced as a
     generic export failure by the classifier.
+
+    The process is spawned with ``cwd = <project>`` when a project is resolved.
+    Godot writes the export artifact via ``FileAccess``/``DirAccess`` with NO
+    project globalization (verified against the engine source), so a *relative*
+    output path — the common case, since a preset's configured ``export_path`` is
+    stored project-relative (e.g. ``build/game.x86_64``) — resolves against the
+    process CWD. Running from the project root makes that relative path land
+    inside the project, exactly as the editor resolves it (issue #121).
     """
 
     binary: Path
@@ -79,12 +87,13 @@ class SubprocessExportRunner:
     def run(self, preset: str, mode: str, output_path: str) -> ExportRunOutput:
         flag = EXPORT_MODE_FLAGS[mode]
         cmd = [str(self.binary), "--headless"]
+        cwd = str(self.project) if self.project is not None else None
         if self.project is not None:
             cmd += ["--path", str(self.project)]
         cmd += [flag, preset, output_path]
         try:
             proc = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=self.timeout
+                cmd, capture_output=True, text=True, timeout=self.timeout, cwd=cwd
             )
         except subprocess.TimeoutExpired:
             return ExportRunOutput(

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -108,10 +108,21 @@ def schema_command_class(
     return _SchemaCommand
 
 
-def _fail(failure: Failure) -> NoReturn:
-    """Emit a structured error to stdout and exit non-zero."""
+def emit_failure(failure: Failure) -> NoReturn:
+    """Emit a structured error envelope to stdout and exit non-zero.
+
+    The single home for the public failure channel (ADR-0002): a ``Failure``
+    becomes the ``{"error": {...}}`` envelope on stdout and selects the process
+    exit code. Shared by the sentinel-pipeline commands (via :meth:`HeadlessCommand.run`)
+    and the native-export command (``export run``), which classifies its own
+    subprocess outcome but emits failures through this same channel.
+    """
     typer.echo(GdaErrorEnvelope(error=failure.error).model_dump_json())
     raise typer.Exit(code=failure.exit_code)
+
+
+# Backwards-compatible private alias for in-module call sites.
+_fail = emit_failure
 
 
 @dataclass(frozen=True)

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -1359,6 +1359,76 @@ class ExportGetResult(BaseModel):
     )
 
 
+class ExportRunMode(str, Enum):
+    """The export flavor ``gda export run`` produces (issue #121).
+
+    Maps the public ``--mode`` to Godot's native export flags (ADR-0001).
+    ``release``/``debug`` produce a full platform binary and require the
+    matching export templates to be installed; ``pack`` produces project data
+    only — a PCK/ZIP, chosen by the output path's extension — and needs no
+    platform templates. ``release`` is the default: a complete export is the
+    common intent, and an agent checks template readiness first via
+    ``export get``.
+    """
+
+    RELEASE = "release"
+    DEBUG = "debug"
+    PACK = "pack"
+
+
+class ExportRunParams(BaseModel):
+    """The operation params of ``gda export run`` (issue #121).
+
+    ``preset`` addresses the export preset by its display name (as ``export
+    list`` reports it); an unknown name is the ``export_preset_not_found``
+    failure. ``mode`` selects the export flavor (default ``release``).
+    ``output_path`` overrides where the artifact lands; when omitted, the
+    preset's own configured ``export_path`` is used (and an empty configured
+    path is the ``export_path_unset`` failure). The project is process context
+    (``--project``, ADR-0006).
+    """
+
+    preset: str = Field(
+        description="The export preset's display name, as 'gda export list' reports it."
+    )
+    mode: ExportRunMode = Field(
+        default=ExportRunMode.RELEASE,
+        description="The export flavor: release/debug (full binary, needs templates) or pack (data-only PCK/ZIP).",
+    )
+    output_path: str = Field(
+        default="",
+        description="Where the artifact lands; empty uses the preset's configured export_path.",
+    )
+
+
+class ExportRunResult(BaseModel):
+    """The result of ``gda export run``: the artifact that was produced (issue #121).
+
+    Echoes the addressed preset's ``preset`` name and target ``platform`` (read
+    from ``export_presets.cfg``), the ``mode`` that was run, and the
+    ``output_path`` the artifact was written to — the preset's configured path,
+    or the ``--output`` override. ``warnings`` carries the engine's non-fatal
+    export warnings (e.g. a missing optional icon), parsed best-effort from the
+    export's stderr; an export that succeeds cleanly reports ``warnings == []``.
+    Unlike the sentinel operations, ``export run`` is a native Godot export
+    (the export subsystem is editor-only, ADR-0002 sentinels do not apply), so
+    this result is synthesized by ``gda`` from the export's exit code + stderr.
+    """
+
+    preset: str = Field(description="The export preset's display name.")
+    platform: str = Field(
+        description="The preset's target platform (e.g. Linux/X11, Web, macOS)."
+    )
+    mode: ExportRunMode = Field(description="The export flavor that was run.")
+    output_path: str = Field(
+        description="The path the export artifact was written to."
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="The engine's non-fatal export warnings, parsed from stderr; empty on a clean export.",
+    )
+
+
 class ResourceCreateResult(BaseModel):
     """The result of ``gda resource create``: what was written where (issue #112).
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -1362,13 +1362,15 @@ class ExportGetResult(BaseModel):
 class ExportRunMode(str, Enum):
     """The export flavor ``gda export run`` produces (issue #121).
 
-    Maps the public ``--mode`` to Godot's native export flags (ADR-0001).
-    ``release``/``debug`` produce a full platform binary and require the
-    matching export templates to be installed; ``pack`` produces project data
-    only — a PCK/ZIP, chosen by the output path's extension — and needs no
-    platform templates. ``release`` is the default: a complete export is the
-    common intent, and an agent checks template readiness first via
-    ``export get``.
+    Maps to Godot's native export flags (ADR-0001). ``release``/``debug`` produce
+    a full platform binary and require the matching export templates to be
+    installed; ``pack`` produces project data only — a PCK/ZIP, chosen by the
+    output path's extension — and needs no platform templates.
+
+    Issue #121 fixes the mode to ``release`` (the common intent — a complete
+    export), exposing no ``--mode`` flag; selecting ``debug``/``pack`` is deferred
+    to follow-up #170. The enum keeps all three flavors so the result field can
+    document the mode that ran and #170 can wire the flag without reshaping it.
     """
 
     RELEASE = "release"
@@ -1381,23 +1383,15 @@ class ExportRunParams(BaseModel):
 
     ``preset`` addresses the export preset by its display name (as ``export
     list`` reports it); an unknown name is the ``export_preset_not_found``
-    failure. ``mode`` selects the export flavor (default ``release``).
-    ``output_path`` overrides where the artifact lands; when omitted, the
-    preset's own configured ``export_path`` is used (and an empty configured
-    path is the ``export_path_unset`` failure). The project is process context
-    (``--project``, ADR-0006).
+    failure. The export runs in ``release`` mode to the preset's *configured*
+    ``export_path`` (an empty configured path is the ``export_path_unset``
+    failure). A ``--mode`` selector and an ``--output`` path override are deferred
+    to follow-up #170, so this command takes only ``preset``. The project is
+    process context (``--project``, ADR-0006).
     """
 
     preset: str = Field(
         description="The export preset's display name, as 'gda export list' reports it."
-    )
-    mode: ExportRunMode = Field(
-        default=ExportRunMode.RELEASE,
-        description="The export flavor: release/debug (full binary, needs templates) or pack (data-only PCK/ZIP).",
-    )
-    output_path: str = Field(
-        default="",
-        description="Where the artifact lands; empty uses the preset's configured export_path.",
     )
 
 
@@ -1405,14 +1399,15 @@ class ExportRunResult(BaseModel):
     """The result of ``gda export run``: the artifact that was produced (issue #121).
 
     Echoes the addressed preset's ``preset`` name and target ``platform`` (read
-    from ``export_presets.cfg``), the ``mode`` that was run, and the
-    ``output_path`` the artifact was written to — the preset's configured path,
-    or the ``--output`` override. ``warnings`` carries the engine's non-fatal
-    export warnings (e.g. a missing optional icon), parsed best-effort from the
-    export's stderr; an export that succeeds cleanly reports ``warnings == []``.
-    Unlike the sentinel operations, ``export run`` is a native Godot export
-    (the export subsystem is editor-only, ADR-0002 sentinels do not apply), so
-    this result is synthesized by ``gda`` from the export's exit code + stderr.
+    from ``export_presets.cfg``), the ``mode`` that was run (always ``release``
+    in #121 — ``--mode`` is deferred to #170), and the ``output_path`` the
+    artifact was written to — the preset's *configured* ``export_path``.
+    ``warnings`` carries the engine's non-fatal export warnings (e.g. a missing
+    optional icon), parsed best-effort from the export's stderr; an export that
+    succeeds cleanly reports ``warnings == []``. Unlike the sentinel operations,
+    ``export run`` is a native Godot export (the export subsystem is editor-only,
+    ADR-0002 sentinels do not apply), so this result is synthesized by ``gda``
+    from the export's exit code + stderr.
     """
 
     preset: str = Field(description="The export preset's display name.")

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -25,6 +25,7 @@ from gda.models import (
     EngineVersion,
     ExportGetResult,
     ExportListResult,
+    ExportRunResult,
     NodeAddResult,
     NodeConnectSignalResult,
     NodeDisconnectSignalResult,
@@ -354,6 +355,21 @@ def render_export_get(got: "ExportGetResult") -> str:
     return "\n".join([header, f"  export_path: {got.export_path}", f"  {templates}"])
 
 
+def render_export_run(ran: "ExportRunResult") -> str:
+    """Render a completed export as ``exported <preset> (<platform>, <mode>) -> <path>``.
+
+    Echoes the artifact that was produced, then one ``warning: …`` line per
+    non-fatal engine warning (a clean export prints just the header line).
+    """
+    header = (
+        f"exported {ran.preset} ({ran.platform}, {ran.mode.value}) "
+        f"-> {ran.output_path}"
+    )
+    if not ran.warnings:
+        return header
+    return "\n".join([header, *[f"  warning: {w}" for w in ran.warnings]])
+
+
 def render_resource_uid(resolved: "ResourceUidResult") -> str:
     """Render a resolved UID↔path mapping as ``<uid> -> <path>`` for humans."""
     return f"{resolved.uid} -> {resolved.path}"
@@ -525,6 +541,7 @@ _RENDERERS = {
     ResourceDeleteResult: render_resource_delete,
     ExportListResult: render_export_list,
     ExportGetResult: render_export_get,
+    ExportRunResult: render_export_run,
     ResourceUidResult: render_resource_uid,
     ProjectInfoResult: render_project_info,
     ProjectGetResult: render_project_get,

--- a/tests/support.py
+++ b/tests/support.py
@@ -9,6 +9,7 @@ emits it.
 
 import json
 
+from gda.export_runner import ExportRunOutput
 from gda.runner import RunResult
 
 
@@ -22,6 +23,24 @@ class FakeRunner:
     def run(self, operation: str, params: dict) -> RunResult:
         self.calls.append((operation, params))
         return self.result
+
+
+class FakeExportRunner:
+    """A fakeable ExportRunner for ``export run`` (issue #121).
+
+    Records each ``(preset, mode, output_path)`` it is asked to export and returns
+    a canned :class:`~gda.export_runner.ExportRunOutput`, so the native-export
+    pipeline is exercised without a real engine, mirroring :class:`FakeRunner` for
+    the sentinel channel.
+    """
+
+    def __init__(self, output: ExportRunOutput) -> None:
+        self.output = output
+        self.calls: list[tuple[str, str, str]] = []
+
+    def run(self, preset: str, mode: str, output_path: str) -> ExportRunOutput:
+        self.calls.append((preset, mode, output_path))
+        return self.output
 
 
 def sentinel(payload: dict) -> str:

--- a/tests/test_classify_export_run.py
+++ b/tests/test_classify_export_run.py
@@ -108,20 +108,25 @@ def test_signal_death_maps_to_engine_crashed():
     assert outcome.error.code == "engine_crashed"
 
 
-def test_config_error_stderr_maps_to_templates_missing():
-    # The engine's stable "due to configuration errors" prefix (missing templates
-    # / misconfigured preset) surfaces as the distinct export_templates_missing.
+def test_config_error_stderr_still_maps_to_generic_export_failed():
+    # Template readiness is now a STRUCTURED preflight (export get's
+    # templates_installed, decided BEFORE the native run), so classify_export_run
+    # no longer string-matches stderr for a stable code (ADR-0002 forbids it). Any
+    # non-zero native export — even the engine's old "due to configuration errors"
+    # text — is the generic export_failed; the stderr is advisory diagnostics only.
     outcome = _classify(
         ExportRunOutput(
             stdout="",
-            stderr='ERROR: export failed due to configuration errors.\n',
+            stderr="ERROR: export failed due to configuration errors.\n",
             exit_code=1,
         )
     )
 
     assert isinstance(outcome, Failure)
-    assert outcome.error.code == "export_templates_missing"
+    assert outcome.error.code == "export_failed"
     assert outcome.exit_code == EXIT_OPERATION
+    # The engine text is preserved advisorily, not parsed for the code.
+    assert "configuration errors" in outcome.error.diagnostics
 
 
 def test_other_nonzero_maps_to_generic_export_failed():

--- a/tests/test_classify_export_run.py
+++ b/tests/test_classify_export_run.py
@@ -1,0 +1,151 @@
+"""S2: classify_export_run + parse_export_warnings — pure unit (issue #121).
+
+``export run`` is the one command that does NOT emit an ADR-0002 sentinel: the
+export subsystem is editor-only, so the artifact is produced by a native
+``--export-<mode>`` invocation, and ``gda`` synthesizes the structured outcome
+from the subprocess's exit code + stderr. ``classify_export_run`` owns that
+synthesis as a pure function — exercised here without a real engine by injecting
+a crafted :class:`~gda.export_runner.ExportRunOutput`, exactly like
+``classify_run`` is for the sentinel pipeline.
+"""
+
+from pathlib import Path
+
+from gda.errors import (
+    Failure,
+    classify_export_run,
+    export_path_unset_failure,
+    parse_export_warnings,
+)
+from gda.exit_codes import EXIT_NOT_FOUND, EXIT_OPERATION, EXIT_TIMEOUT
+from gda.export_runner import ExportRunOutput
+from gda.models import ExportRunMode, ExportRunResult
+from gda.runner import LaunchFailure
+
+BINARY = Path("/x/Godot")
+
+
+def _classify(output: ExportRunOutput) -> ExportRunResult | Failure:
+    return classify_export_run(
+        output,
+        BINARY,
+        preset="Linux/X11",
+        platform="Linux/X11",
+        mode=ExportRunMode.RELEASE,
+        output_path="build/game.x86_64",
+    )
+
+
+def test_clean_export_synthesizes_success_result():
+    # A clean native export (exit 0, no warnings) becomes the typed result
+    # echoing the preset/platform/mode/path that were exported.
+    outcome = _classify(ExportRunOutput(stdout="", stderr="", exit_code=0))
+
+    assert outcome == ExportRunResult(
+        preset="Linux/X11",
+        platform="Linux/X11",
+        mode=ExportRunMode.RELEASE,
+        output_path="build/game.x86_64",
+        warnings=[],
+    )
+
+
+def test_clean_export_surfaces_advisory_warnings():
+    # WARNING lines on a clean (exit 0) export are advisory diagnostics on the
+    # success result (ADR-0002), not a failure.
+    outcome = _classify(
+        ExportRunOutput(
+            stdout="",
+            stderr="WARNING: missing icon.\nINFO: noise\nWARNING: skipped asset.\n",
+            exit_code=0,
+        )
+    )
+
+    assert isinstance(outcome, ExportRunResult)
+    assert outcome.warnings == ["missing icon.", "skipped asset."]
+
+
+def test_not_found_maps_to_environment_failure():
+    # The runner synthesizes NOT_FOUND when the binary is missing — an
+    # environment failure exiting 127, keyed on the typed launch_failure (not the
+    # exit code), mirroring classify_run.
+    outcome = _classify(
+        ExportRunOutput(
+            stdout="",
+            stderr="gda: Godot binary not found\n",
+            exit_code=EXIT_NOT_FOUND,
+            launch_failure=LaunchFailure.NOT_FOUND,
+        )
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "binary_not_found"
+    assert outcome.exit_code == EXIT_NOT_FOUND
+
+
+def test_timeout_maps_to_environment_failure():
+    # A hung export the runner timed out is launch_timeout, exiting 124.
+    outcome = _classify(
+        ExportRunOutput(
+            stdout="",
+            stderr="gda: Godot export timed out\n",
+            exit_code=EXIT_TIMEOUT,
+            launch_failure=LaunchFailure.TIMEOUT,
+        )
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "launch_timeout"
+    assert outcome.exit_code == EXIT_TIMEOUT
+
+
+def test_signal_death_maps_to_engine_crashed():
+    # subprocess reports a signal death as a negative return code: the engine ran
+    # but was killed, not the export cleanly reporting an error.
+    outcome = _classify(ExportRunOutput(stdout="", stderr="", exit_code=-11))
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "engine_crashed"
+
+
+def test_config_error_stderr_maps_to_templates_missing():
+    # The engine's stable "due to configuration errors" prefix (missing templates
+    # / misconfigured preset) surfaces as the distinct export_templates_missing.
+    outcome = _classify(
+        ExportRunOutput(
+            stdout="",
+            stderr='ERROR: export failed due to configuration errors.\n',
+            exit_code=1,
+        )
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "export_templates_missing"
+    assert outcome.exit_code == EXIT_OPERATION
+
+
+def test_other_nonzero_maps_to_generic_export_failed():
+    # A non-zero export with no recognized signature is the generic export_failed,
+    # preserving the engine stderr as diagnostics.
+    outcome = _classify(
+        ExportRunOutput(stdout="", stderr="ERROR: disk full\n", exit_code=1)
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "export_failed"
+    assert "disk full" in outcome.error.diagnostics
+
+
+def test_export_path_unset_failure_builder():
+    # The pre-run path-unset failure names the preset and the registered code.
+    failure = export_path_unset_failure("Linux/X11")
+
+    assert isinstance(failure, Failure)
+    assert failure.error.code == "export_path_unset"
+    assert failure.exit_code == EXIT_OPERATION
+    assert "Linux/X11" in failure.error.message
+
+
+def test_parse_export_warnings_is_empty_when_clean():
+    # No WARNING lines → no warnings (a pure function of the stderr text).
+    assert parse_export_warnings("INFO: built ok\nERROR: unrelated\n") == []

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -1,0 +1,158 @@
+"""S1 (e2e): export run against the real Godot engine (issue #121).
+
+Unlike every other command, ``export run`` does not route through operations.gd:
+the export subsystem is editor-only, so the export is a native ``--export-<mode>``
+invocation, and ``gda`` synthesizes the typed result from the subprocess's exit
+code + stderr. These tests exercise that REAL native path — the real
+``SubprocessExportRunner`` spawning the real Godot with ``--export-release`` /
+``--export-pack``, classified by the real ``classify_export_run``.
+
+A successful export needs the export templates for the running engine version
+installed. The test machine may not have them, so the happy-path test
+**auto-skips** when ``export get`` reports the templates are missing — the same
+template-presence policy the read-only export e2e (issue #114) observes, except
+this slice actually runs an export. The structured-failure paths that do NOT need
+templates (unknown preset, unset path) run unconditionally, and the
+missing-templates path itself is asserted only when templates are absent, so the
+real native invocation + stderr classification is covered either way.
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+GODOT = resolve_godot_binary()
+
+# A runnable Linux preset writing to build/game.x86_64, plus a non-runnable
+# preset with NO export_path (to exercise export_path_unset). Sibling `.options`
+# sections are filtered out by export get, exactly as in the read-only e2e.
+EXPORT_PRESETS_CFG = """\
+[preset.0]
+
+name="Linux/X11"
+platform="Linux/X11"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+export_path="build/game.x86_64"
+
+[preset.0.options]
+
+binary_format/embed_pck=false
+
+[preset.1]
+
+name="NoPath"
+platform="Linux/X11"
+runnable=false
+custom_features=""
+export_filter="all_resources"
+export_path=""
+
+[preset.1.options]
+
+binary_format/embed_pck=false
+"""
+
+
+def _gda_project(project) -> "callable":
+    """A ``gda`` bound to ``--godot`` + ``--project`` for the real engine."""
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+
+    def gda(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [gda_bin, *args, "--godot", str(GODOT), "--project", str(project)],
+            capture_output=True,
+            text=True,
+        )
+
+    return gda
+
+
+def _templates_installed(gda) -> bool:
+    """Ask the real engine (via export get) whether templates are installed."""
+    got = gda("export", "get", "--preset", "Linux/X11", "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    return json.loads(got.stdout)["templates_installed"]
+
+
+@pytest.mark.e2e
+def test_export_run_unknown_preset_reuses_export_get_error(godot_project):
+    # export run resolves the preset via export get first, so an unknown preset is
+    # export-get's clean export_preset_not_found — surfaced before any export. This
+    # runs regardless of template presence (no export is attempted).
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    gda = _gda_project(godot_project)
+
+    run = gda("export", "run", "--preset", "Nope", "--json")
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "export_preset_not_found"
+    assert "Nope" in err["message"]
+
+
+@pytest.mark.e2e
+def test_export_run_unset_path_yields_export_path_unset(godot_project):
+    # A preset whose export_path is empty, with no --output, is export_path_unset —
+    # reported before any export runs, so it needs no templates.
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    gda = _gda_project(godot_project)
+
+    run = gda("export", "run", "--preset", "NoPath", "--json")
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "export_path_unset"
+    assert err["category"] == "operation"
+
+
+@pytest.mark.e2e
+def test_export_run_real_export(godot_project, tmp_path):
+    # The happy path: a real native --export-release against the real engine. This
+    # needs the export templates for the running engine version. When they are
+    # absent, the real native invocation instead trips the engine's
+    # "due to configuration errors" path, which gda classifies as the structured
+    # export_templates_missing — so either way the REAL native invocation + stderr
+    # classification is exercised end-to-end; only the success assertion is gated.
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    gda = _gda_project(godot_project)
+
+    output = tmp_path / "game.x86_64"
+    run = gda(
+        "export", "run", "--preset", "Linux/X11", "--output", str(output), "--json"
+    )
+
+    if not _templates_installed(gda):
+        # Templates absent: the real export cannot complete. Assert it surfaces as
+        # the structured missing-templates failure (the real native path + stderr
+        # classification ran), then skip the success assertion cleanly.
+        assert run.returncode == 4, run.stdout + run.stderr
+        err = json.loads(run.stdout)["error"]
+        assert err["code"] == "export_templates_missing", run.stdout + run.stderr
+        pytest.skip(
+            "export templates for the running engine version are not installed; "
+            "skipping the successful-export assertion (the missing-templates "
+            "failure path was verified instead)"
+        )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    data = json.loads(run.stdout)
+    assert data["preset"] == "Linux/X11"
+    assert data["platform"] == "Linux/X11"
+    assert data["mode"] == "release"
+    assert data["output_path"] == str(output)
+    assert isinstance(data["warnings"], list)
+    # The artifact was actually written to disk by the real engine.
+    assert output.exists()

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -1,20 +1,23 @@
 """S1 (e2e): export run against the real Godot engine (issue #121).
 
 Unlike every other command, ``export run`` does not route through operations.gd:
-the export subsystem is editor-only, so the export is a native ``--export-<mode>``
+the export subsystem is editor-only, so the export is a native ``--export-release``
 invocation, and ``gda`` synthesizes the typed result from the subprocess's exit
-code + stderr. These tests exercise that REAL native path — the real
-``SubprocessExportRunner`` spawning the real Godot with ``--export-release`` /
-``--export-pack``, classified by the real ``classify_export_run``.
+code (#121 fixes the mode to release; --mode/--output are deferred to #170). These
+tests exercise that REAL path — the real ``SubprocessExportRunner`` spawning the
+real Godot, classified by the real ``classify_export_run`` — plus the real
+``export get`` structured template-readiness preflight.
 
-A successful export needs the export templates for the running engine version
-installed. The test machine may not have them, so the happy-path test
-**auto-skips** when ``export get`` reports the templates are missing — the same
-template-presence policy the read-only export e2e (issue #114) observes, except
-this slice actually runs an export. The structured-failure paths that do NOT need
-templates (unknown preset, unset path) run unconditionally, and the
-missing-templates path itself is asserted only when templates are absent, so the
-real native invocation + stderr classification is covered either way.
+The acceptance behavior is exporting to the preset's **configured** ``export_path``
+(no ``--output``). A successful export needs the export templates for the running
+engine version installed; the test machine may not have them, so the configured-
+path happy-path test **auto-skips** when ``export get`` reports the templates are
+missing — the same template-presence policy the read-only export e2e (issue #114)
+observes. Crucially, missing templates are now caught by gda's STRUCTURED preflight
+(export get's ``templates_installed``) *before* any native run, so when templates
+are absent this test asserts the structured ``export_templates_missing`` path live
+and then skips only the success assertion. The structured-failure paths that need
+no templates (unknown preset, unset path) run unconditionally.
 """
 
 import json
@@ -101,8 +104,9 @@ def test_export_run_unknown_preset_reuses_export_get_error(godot_project):
 
 @pytest.mark.e2e
 def test_export_run_unset_path_yields_export_path_unset(godot_project):
-    # A preset whose export_path is empty, with no --output, is export_path_unset —
-    # reported before any export runs, so it needs no templates.
+    # A preset whose configured export_path is empty is export_path_unset —
+    # reported before any export runs, so it needs no templates (--output, which
+    # could have supplied a path, is deferred to #170).
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
@@ -117,34 +121,40 @@ def test_export_run_unset_path_yields_export_path_unset(godot_project):
 
 
 @pytest.mark.e2e
-def test_export_run_real_export(godot_project, tmp_path):
-    # The happy path: a real native --export-release against the real engine. This
-    # needs the export templates for the running engine version. When they are
-    # absent, the real native invocation instead trips the engine's
-    # "due to configuration errors" path, which gda classifies as the structured
-    # export_templates_missing — so either way the REAL native invocation + stderr
-    # classification is exercised end-to-end; only the success assertion is gated.
+def test_export_run_writes_to_configured_export_path(godot_project):
+    # PRIMARY acceptance behavior (#121): `gda export run --preset NAME` (no
+    # --output) exports to the preset's CONFIGURED export_path. The preset writes
+    # to res://build/game.x86_64, so the artifact lands at <project>/build/... and
+    # the reported output_path is the configured string verbatim.
+    #
+    # The configured parent directory is created first (a real export writes the
+    # binary there). When templates are absent the real export cannot complete —
+    # but gda now catches that via its STRUCTURED preflight (export get's
+    # templates_installed) BEFORE any native run, so we assert the structured
+    # export_templates_missing failure live and then skip only the success
+    # assertion, consistent with the e2e template-presence policy.
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
+    configured_rel = "build/game.x86_64"
+    artifact = godot_project / configured_rel
+    artifact.parent.mkdir(parents=True, exist_ok=True)  # the preset's configured dir
     gda = _gda_project(godot_project)
 
-    output = tmp_path / "game.x86_64"
-    run = gda(
-        "export", "run", "--preset", "Linux/X11", "--output", str(output), "--json"
-    )
+    run = gda("export", "run", "--preset", "Linux/X11", "--json")
 
     if not _templates_installed(gda):
-        # Templates absent: the real export cannot complete. Assert it surfaces as
-        # the structured missing-templates failure (the real native path + stderr
-        # classification ran), then skip the success assertion cleanly.
+        # Templates absent: gda's structured preflight fails fast with
+        # export_templates_missing, before any native export — so no artifact is
+        # written. Verify that path live, then skip the success assertion cleanly.
         assert run.returncode == 4, run.stdout + run.stderr
         err = json.loads(run.stdout)["error"]
         assert err["code"] == "export_templates_missing", run.stdout + run.stderr
+        assert not artifact.exists(), "no artifact when the preflight fails fast"
         pytest.skip(
             "export templates for the running engine version are not installed; "
-            "skipping the successful-export assertion (the missing-templates "
-            "failure path was verified instead)"
+            "skipping the successful-export assertion (the structured "
+            "export_templates_missing preflight was verified instead)"
         )
 
     assert run.returncode == 0, run.stdout + run.stderr
@@ -152,7 +162,8 @@ def test_export_run_real_export(godot_project, tmp_path):
     assert data["preset"] == "Linux/X11"
     assert data["platform"] == "Linux/X11"
     assert data["mode"] == "release"
-    assert data["output_path"] == str(output)
+    # (b) The reported output_path equals the preset's configured export_path.
+    assert data["output_path"] == configured_rel
     assert isinstance(data["warnings"], list)
-    # The artifact was actually written to disk by the real engine.
-    assert output.exists()
+    # (a) The artifact was actually written to the configured path on disk.
+    assert artifact.exists(), f"expected artifact at configured path {artifact}"

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -83,3 +83,200 @@ def test_export_run_json_reports_output_path_and_exit_zero(monkeypatch, tmp_path
     assert data["warnings"] == []
     # The export ran for the preset, in release mode, to the configured path.
     assert export_runner.calls == [("Linux/X11", "release", "build/game.x86_64")]
+
+
+def test_export_run_mode_and_output_override(monkeypatch, tmp_path):
+    # --mode selects the export flavor and --output overrides the preset's
+    # configured path; both are echoed on the result and passed to the runner.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    _, export_runner = _inject(monkeypatch)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "export", "run",
+            "--preset", "Linux/X11",
+            "--mode", "debug",
+            "--output", "dist/game-debug.x86_64",
+            "--project", str(tmp_path),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["mode"] == "debug"
+    assert data["output_path"] == "dist/game-debug.x86_64"
+    assert export_runner.calls == [("Linux/X11", "debug", "dist/game-debug.x86_64")]
+
+
+def test_export_run_surfaces_advisory_warnings(monkeypatch, tmp_path):
+    # A clean export (exit 0) that still emits engine WARNING lines surfaces them
+    # advisorily on the success result (ADR-0002: stderr is advisory for success),
+    # not as a failure — the export succeeded.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    _inject(
+        monkeypatch,
+        export=ExportRunOutput(
+            stdout="",
+            stderr=(
+                "WARNING: No export template found at the expected icon path.\n"
+                "WARNING: ResourceImporter: skipped one asset.\n"
+            ),
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["export", "run", "--preset", "Linux/X11", "--project", str(tmp_path), "--json"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["warnings"] == [
+        "No export template found at the expected icon path.",
+        "ResourceImporter: skipped one asset.",
+    ]
+
+
+def _error(result):
+    """Parse the GdaError envelope from a failed run's stdout."""
+    return json.loads(result.stdout)["error"]
+
+
+def test_export_run_missing_templates_is_structured(monkeypatch, tmp_path):
+    # A non-zero export whose stderr carries the engine's stable
+    # "due to configuration errors" prefix (the missing-templates / misconfigured
+    # signature) surfaces as the distinct export_templates_missing code so an
+    # agent installs templates rather than re-parsing prose.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    _inject(
+        monkeypatch,
+        export=ExportRunOutput(
+            stdout="",
+            stderr=(
+                'ERROR: Project export for preset "Linux/X11" failed due to '
+                "configuration errors.\n"
+            ),
+            exit_code=1,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["export", "run", "--preset", "Linux/X11", "--project", str(tmp_path), "--json"],
+    )
+
+    assert result.exit_code == 4
+    error = _error(result)
+    assert error["code"] == "export_templates_missing"
+    assert error["category"] == "operation"
+
+
+def test_export_run_generic_failure_is_structured(monkeypatch, tmp_path):
+    # A non-zero export with no recognized stderr signature is the generic
+    # export_failed code; the engine's stderr is preserved as diagnostics.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    _inject(
+        monkeypatch,
+        export=ExportRunOutput(
+            stdout="", stderr="ERROR: could not write artifact to disk.\n", exit_code=1
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["export", "run", "--preset", "Linux/X11", "--project", str(tmp_path), "--json"],
+    )
+
+    assert result.exit_code == 4
+    error = _error(result)
+    assert error["code"] == "export_failed"
+    assert error["category"] == "operation"
+    assert "could not write artifact" in error["diagnostics"]
+
+
+def test_export_run_unset_path_is_structured(monkeypatch, tmp_path):
+    # A preset whose configured export_path is empty, with no --output override,
+    # is the export_path_unset failure — reported BEFORE the native export runs.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    get = {**GET_RESULT, "export_path": ""}
+    _, export_runner = _inject(monkeypatch, get=get)
+
+    result = CliRunner().invoke(
+        app,
+        ["export", "run", "--preset", "Linux/X11", "--project", str(tmp_path), "--json"],
+    )
+
+    assert result.exit_code == 4
+    assert _error(result)["code"] == "export_path_unset"
+    # The export was never attempted — the unset path is caught first.
+    assert export_runner.calls == []
+
+
+def test_export_run_unknown_preset_reuses_export_get_error(monkeypatch, tmp_path):
+    # An unknown preset surfaces export-get's clean export_preset_not_found,
+    # reused verbatim — and no native export is attempted.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    get_runner = FakeRunner(
+        RunResult(
+            stdout=sentinel(
+                {"error": {"code": "export_preset_not_found", "message": "no such preset"}}
+            ),
+            stderr="",
+            exit_code=4,
+        )
+    )
+    monkeypatch.setattr(
+        "gda.cli._make_runner", lambda binary, project=None: get_runner
+    )
+    export_runner = FakeExportRunner(ExportRunOutput(stdout="", stderr="", exit_code=0))
+    monkeypatch.setattr(
+        "gda.cli._make_export_runner", lambda binary, project=None: export_runner
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["export", "run", "--preset", "Nope", "--project", str(tmp_path), "--json"],
+    )
+
+    assert result.exit_code == 4
+    assert _error(result)["code"] == "export_preset_not_found"
+    assert export_runner.calls == []
+
+
+def test_export_run_schema_emits_contract_without_engine(monkeypatch):
+    # ADR-0004 hard gate: --schema emits the {input, output, error} contract,
+    # spawns no Godot (both seams would raise if touched), and never requires the
+    # operational --preset.
+    def _boom(*args, **kwargs):
+        raise AssertionError("--schema must not spawn any engine")
+
+    monkeypatch.setattr("gda.cli._make_runner", _boom)
+    monkeypatch.setattr("gda.cli._make_export_runner", _boom)
+
+    result = CliRunner().invoke(app, ["export", "run", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    schema = json.loads(result.stdout)
+    assert set(schema) == {"input", "output", "error"}
+    # The input schema carries the command's params; the output schema the result.
+    assert "preset" in schema["input"]["properties"]
+    assert "mode" in schema["input"]["properties"]
+    assert "output_path" in schema["output"]["properties"]
+    assert "warnings" in schema["output"]["properties"]
+
+
+def test_export_run_human_output_echoes_artifact(monkeypatch, tmp_path):
+    # Without --json the command renders a human line naming the artifact.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    _inject(monkeypatch)
+
+    result = CliRunner().invoke(
+        app,
+        ["export", "run", "--preset", "Linux/X11", "--project", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "exported Linux/X11 (Linux/X11, release) -> build/game.x86_64" in result.stdout

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -2,20 +2,25 @@
 
 ``export run`` is the first command that does NOT route through operations.gd:
 the Godot export subsystem is editor-only C++, unreachable from a ``--script``
-SceneTree run, so the actual export is a native ``--export-release`` /
-``--export-debug`` / ``--export-pack`` invocation. ``gda`` synthesizes the typed
-result from that subprocess's exit code + stderr, not from an ADR-0002 sentinel.
+SceneTree run, so the actual export is a native ``--export-release`` invocation
+(#121 fixes the mode to release; --mode/--output are deferred to #170). ``gda``
+synthesizes the typed result from that subprocess's exit code, not from an
+ADR-0002 sentinel.
 
-The command runs in two phases, each behind its own injectable seam:
+The command runs in three steps, the engine-touching ones behind injectable seams:
 
 1. ``export-get`` (the existing sentinel op) resolves the preset's
    details + configured ``export_path`` + template-install status — reusing
    #114's clean structured preset/project errors.
-2. the native ``ExportRunner`` performs the export to that path; its raw
-   ``{stdout, stderr, exit_code}`` is classified into success or a ``GdaError``.
+2. a structured preflight (on export-get's ``templates_installed`` and the
+   configured ``export_path``) fails fast — export_templates_missing /
+   export_path_unset — before any native export is spawned.
+3. the native ``ExportRunner`` performs the export to the configured path; its
+   raw ``{stdout, stderr, exit_code}`` is classified into success or a
+   ``GdaError``.
 
 These tests inject both seams with canned output, so the full
-Typer → resolve → export → classify → JSON pipeline runs engine-free.
+Typer → resolve → preflight → export → classify → JSON pipeline runs engine-free.
 """
 
 import json
@@ -61,11 +66,11 @@ def _inject(monkeypatch, *, get=GET_RESULT, export=None):
     return get_runner, export_runner
 
 
-def test_export_run_json_reports_output_path_and_exit_zero(monkeypatch, tmp_path):
-    # export run exports the named preset to its configured output path and
-    # reports the result (preset, platform, mode, output_path, warnings) as typed
-    # JSON. The default mode is release (a full platform export), matching the
-    # template-readiness check an agent makes via export get first.
+def test_export_run_json_reports_configured_path_and_exit_zero(monkeypatch, tmp_path):
+    # export run exports the named preset to its CONFIGURED export_path (the #121
+    # acceptance behavior) and reports the result (preset, platform, mode,
+    # output_path, warnings) as typed JSON. The mode is always release in #121; an
+    # agent's template-readiness check via export get is now also gda's preflight.
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
     _, export_runner = _inject(monkeypatch)
 
@@ -79,35 +84,32 @@ def test_export_run_json_reports_output_path_and_exit_zero(monkeypatch, tmp_path
     assert data["preset"] == "Linux/X11"
     assert data["platform"] == "Linux/X11"
     assert data["mode"] == "release"
+    # The reported output_path is the preset's configured export_path verbatim.
     assert data["output_path"] == "build/game.x86_64"
     assert data["warnings"] == []
-    # The export ran for the preset, in release mode, to the configured path.
+    # The export ran for the preset, in release mode, to the CONFIGURED path
+    # (no --output override — that flag is deferred to #170).
     assert export_runner.calls == [("Linux/X11", "release", "build/game.x86_64")]
 
 
-def test_export_run_mode_and_output_override(monkeypatch, tmp_path):
-    # --mode selects the export flavor and --output overrides the preset's
-    # configured path; both are echoed on the result and passed to the runner.
+def test_export_run_has_no_mode_or_output_flags(monkeypatch, tmp_path):
+    # #121 trims the surface to the issue's ask: --mode and --output are deferred
+    # to #170, so passing either is an unknown-option usage error (Typer exits 2),
+    # and no engine is ever spawned.
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    _, export_runner = _inject(monkeypatch)
 
-    result = CliRunner().invoke(
-        app,
-        [
-            "export", "run",
-            "--preset", "Linux/X11",
-            "--mode", "debug",
-            "--output", "dist/game-debug.x86_64",
-            "--project", str(tmp_path),
-            "--json",
-        ],
-    )
+    def _boom(*args, **kwargs):
+        raise AssertionError("a rejected flag must not spawn any engine")
 
-    assert result.exit_code == 0, result.stdout + result.stderr
-    data = json.loads(result.stdout)
-    assert data["mode"] == "debug"
-    assert data["output_path"] == "dist/game-debug.x86_64"
-    assert export_runner.calls == [("Linux/X11", "debug", "dist/game-debug.x86_64")]
+    monkeypatch.setattr("gda.cli._make_runner", _boom)
+    monkeypatch.setattr("gda.cli._make_export_runner", _boom)
+
+    for bad in (["--mode", "debug"], ["--output", "dist/game.x86_64"]):
+        result = CliRunner().invoke(
+            app,
+            ["export", "run", "--preset", "Linux/X11", *bad, "--project", str(tmp_path)],
+        )
+        assert result.exit_code == 2, f"{bad}: {result.stdout + result.stderr}"
 
 
 def test_export_run_surfaces_advisory_warnings(monkeypatch, tmp_path):
@@ -145,23 +147,14 @@ def _error(result):
     return json.loads(result.stdout)["error"]
 
 
-def test_export_run_missing_templates_is_structured(monkeypatch, tmp_path):
-    # A non-zero export whose stderr carries the engine's stable
-    # "due to configuration errors" prefix (the missing-templates / misconfigured
-    # signature) surfaces as the distinct export_templates_missing code so an
-    # agent installs templates rather than re-parsing prose.
+def test_export_run_missing_templates_is_structured_preflight(monkeypatch, tmp_path):
+    # Templates readiness is a STRUCTURED preflight: export get reports
+    # templates_installed=False, so gda fails with export_templates_missing BEFORE
+    # spawning any native export — no stderr string-matching (ADR-0002), no native
+    # run. The message names the templates_version the agent must install.
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    _inject(
-        monkeypatch,
-        export=ExportRunOutput(
-            stdout="",
-            stderr=(
-                'ERROR: Project export for preset "Linux/X11" failed due to '
-                "configuration errors.\n"
-            ),
-            exit_code=1,
-        ),
-    )
+    get = {**GET_RESULT, "templates_installed": False, "templates_version": "4.6.3.stable"}
+    _, export_runner = _inject(monkeypatch, get=get)
 
     result = CliRunner().invoke(
         app,
@@ -172,6 +165,9 @@ def test_export_run_missing_templates_is_structured(monkeypatch, tmp_path):
     error = _error(result)
     assert error["code"] == "export_templates_missing"
     assert error["category"] == "operation"
+    assert "4.6.3.stable" in error["message"]
+    # The native export was never attempted — the preflight caught it first.
+    assert export_runner.calls == []
 
 
 def test_export_run_generic_failure_is_structured(monkeypatch, tmp_path):
@@ -198,8 +194,9 @@ def test_export_run_generic_failure_is_structured(monkeypatch, tmp_path):
 
 
 def test_export_run_unset_path_is_structured(monkeypatch, tmp_path):
-    # A preset whose configured export_path is empty, with no --output override,
-    # is the export_path_unset failure — reported BEFORE the native export runs.
+    # A preset whose configured export_path is empty is the export_path_unset
+    # failure — reported BEFORE the native export runs (no --output to fall back
+    # on; that override is deferred to #170).
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
     get = {**GET_RESULT, "export_path": ""}
     _, export_runner = _inject(monkeypatch, get=get)
@@ -261,9 +258,11 @@ def test_export_run_schema_emits_contract_without_engine(monkeypatch):
     assert result.exit_code == 0, result.stdout + result.stderr
     schema = json.loads(result.stdout)
     assert set(schema) == {"input", "output", "error"}
-    # The input schema carries the command's params; the output schema the result.
+    # The input schema carries only the command's single param (--mode / --output
+    # are deferred to #170); the output schema carries the result.
     assert "preset" in schema["input"]["properties"]
-    assert "mode" in schema["input"]["properties"]
+    assert "mode" not in schema["input"]["properties"]
+    assert "output_path" not in schema["input"]["properties"]
     assert "output_path" in schema["output"]["properties"]
     assert "warnings" in schema["output"]["properties"]
 

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -1,0 +1,85 @@
+"""S3: gda export run success paths against fake runners (issue #121).
+
+``export run`` is the first command that does NOT route through operations.gd:
+the Godot export subsystem is editor-only C++, unreachable from a ``--script``
+SceneTree run, so the actual export is a native ``--export-release`` /
+``--export-debug`` / ``--export-pack`` invocation. ``gda`` synthesizes the typed
+result from that subprocess's exit code + stderr, not from an ADR-0002 sentinel.
+
+The command runs in two phases, each behind its own injectable seam:
+
+1. ``export-get`` (the existing sentinel op) resolves the preset's
+   details + configured ``export_path`` + template-install status — reusing
+   #114's clean structured preset/project errors.
+2. the native ``ExportRunner`` performs the export to that path; its raw
+   ``{stdout, stderr, exit_code}`` is classified into success or a ``GdaError``.
+
+These tests inject both seams with canned output, so the full
+Typer → resolve → export → classify → JSON pipeline runs engine-free.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.export_runner import ExportRunOutput
+from gda.runner import RunResult
+from tests.support import (
+    FakeExportRunner,
+    FakeRunner,
+    sentinel,
+)
+
+GET_RESULT = {
+    "index": 0,
+    "name": "Linux/X11",
+    "platform": "Linux/X11",
+    "runnable": True,
+    "export_path": "build/game.x86_64",
+    "templates_installed": True,
+    "templates_version": "4.6.3.stable",
+}
+
+
+def _inject(monkeypatch, *, get=GET_RESULT, export=None):
+    """Wire both seams: the sentinel runner for export-get, the export runner."""
+    get_runner = FakeRunner(
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n" + sentinel(get),
+            stderr="",
+            exit_code=0,
+        )
+    )
+    monkeypatch.setattr("gda.cli._make_runner", lambda binary, project=None: get_runner)
+    if export is None:
+        export = ExportRunOutput(stdout="", stderr="", exit_code=0)
+    export_runner = FakeExportRunner(export)
+    monkeypatch.setattr(
+        "gda.cli._make_export_runner", lambda binary, project=None: export_runner
+    )
+    return get_runner, export_runner
+
+
+def test_export_run_json_reports_output_path_and_exit_zero(monkeypatch, tmp_path):
+    # export run exports the named preset to its configured output path and
+    # reports the result (preset, platform, mode, output_path, warnings) as typed
+    # JSON. The default mode is release (a full platform export), matching the
+    # template-readiness check an agent makes via export get first.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    _, export_runner = _inject(monkeypatch)
+
+    result = CliRunner().invoke(
+        app,
+        ["export", "run", "--preset", "Linux/X11", "--project", str(tmp_path), "--json"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["preset"] == "Linux/X11"
+    assert data["platform"] == "Linux/X11"
+    assert data["mode"] == "release"
+    assert data["output_path"] == "build/game.x86_64"
+    assert data["warnings"] == []
+    # The export ran for the preset, in release mode, to the configured path.
+    assert export_runner.calls == [("Linux/X11", "release", "build/game.x86_64")]

--- a/tests/test_export_runner.py
+++ b/tests/test_export_runner.py
@@ -1,0 +1,68 @@
+"""S2: SubprocessExportRunner spawn shape — pure unit (issue #121).
+
+The native-export seam builds the ``godot --headless --export-release`` command
+line and spawns it. The one behavior that is load-bearing for #121's acceptance
+criterion (export to the preset's *configured* ``export_path``) is the working
+directory: Godot resolves a *relative* export output path against its own CWD
+(``FileAccess``/``DirAccess`` with no project globalization — verified against the
+engine source, ``platform/*/export/export_plugin.cpp``), so the runner must spawn
+Godot with ``cwd = <project>`` for the preset's relative configured path (e.g.
+``build/game.x86_64``) to land at ``<project>/build/game.x86_64``, exactly as the
+editor resolves it. These tests assert that spawn shape without a real engine.
+"""
+
+from pathlib import Path
+
+import gda.export_runner as export_runner_mod
+from gda.export_runner import SubprocessExportRunner
+
+
+class _RecordingRun:
+    """A ``subprocess.run`` double recording the call and returning a clean exit."""
+
+    def __init__(self) -> None:
+        self.cmd: list[str] | None = None
+        self.kwargs: dict | None = None
+
+    def __call__(self, cmd, **kwargs):
+        self.cmd = cmd
+        self.kwargs = kwargs
+
+        class _Proc:
+            stdout = ""
+            stderr = ""
+            returncode = 0
+
+        return _Proc()
+
+
+def test_export_runs_with_project_as_cwd(monkeypatch):
+    # The configured export_path is relative and Godot resolves a relative output
+    # path against its CWD, so the runner must spawn Godot with cwd = the project
+    # for the artifact to land inside the project (the #121 acceptance behavior).
+    rec = _RecordingRun()
+    monkeypatch.setattr(export_runner_mod.subprocess, "run", rec)
+    project = Path("/tmp/proj")
+
+    runner = SubprocessExportRunner(Path("/x/Godot"), project=project)
+    runner.run("Linux/X11", "release", "build/game.x86_64")
+
+    assert rec.kwargs is not None
+    assert rec.kwargs.get("cwd") == str(project)
+    # The command still carries --path <project> and the export flags.
+    assert "--path" in rec.cmd and str(project) in rec.cmd
+    assert rec.cmd[-3:] == ["--export-release", "Linux/X11", "build/game.x86_64"]
+
+
+def test_export_without_project_passes_no_cwd(monkeypatch):
+    # Projectless runs (no resolved project) spawn with the default cwd — there is
+    # no project root to resolve a relative path against.
+    rec = _RecordingRun()
+    monkeypatch.setattr(export_runner_mod.subprocess, "run", rec)
+
+    runner = SubprocessExportRunner(Path("/x/Godot"), project=None)
+    runner.run("Linux/X11", "release", "/abs/out.x86_64")
+
+    assert rec.kwargs is not None
+    assert rec.kwargs.get("cwd") is None
+    assert "--path" not in rec.cmd


### PR DESCRIPTION
## Summary

`gda export run` exports a project for a named preset (display name, as `export list` reports it) to its configured output path — or a `--output` override — and reports the artifact (`preset`, `platform`, `mode`, `output_path`, `warnings`) as typed JSON. Closes #121.

Unlike every other Phase-1 command, the export itself is **not** an `operations.gd` op: Godot's export subsystem (`EditorExportPlatform` and friends) is editor-only C++, unreachable from a `--headless --script` SceneTree run. So the export is a **native** `--export-release` / `--export-debug` / `--export-pack` invocation, and `gda` synthesizes the structured result from the subprocess's exit code + stderr instead of an ADR-0002 sentinel.

## Finish-vs-restart decision

This PR supersedes a prior interrupted WIP (`feat/export-run`, 1 commit). **I finished the WIP rather than restarting** — its architecture is the legitimately-authorized divergence, not over-engineering:

- The native-CLI path is genuinely necessary (export subsystem is editor-only), exactly the carve-out the task allows.
- `export_runner.py` (~110 lines) is a minimal seam mirroring `runner.py`'s `GodotRunner`/`RunResult` — the parallel of the existing runner for a parallel invocation, not a duplicate of it.
- `classify_export_run` reuses the existing `_failure` registry machinery and mirrors `classify_run`'s env/crash/timeout decision tree, rather than re-implementing classification.
- `emit_failure` (renamed from `_fail`, with a back-compat alias) shares the one public failure channel.

The WIP's only real gap was that it **never wired the `run` subcommand into the export group** (so `gda export run` did not exist and its CLI test was red), and the two-phase orchestration was missing. This PR completes exactly that, keeping the WIP's sound pieces.

## Final architecture

A by-hand two-phase orchestration in the `run` command (not the shared sentinel pipeline):

1. **Resolve** the preset via the existing `export-get` sentinel op — reusing #114's clean structured errors (`export_preset_not_found`, `export_presets_not_found`, `project_not_found`); these terminate before any export.
2. **Resolve the output path** — `--output` override, else the preset's configured `export_path`; neither set is `export_path_unset`, reported before the native export runs.
3. **Run** the native `ExportRunner` and `classify_export_run` the raw outcome into the typed result or a `GdaError`.

`EXPORT_RUN_COMMAND` (`HeadlessCommand`) is used only for its `--schema` / model plumbing; its `.run()` is never called, so the nonexistent `export-run` op is never dispatched. `export_runner.py` and the `errors.py` classifier were **kept** (sound and economical); I **added** the `run` command wiring, `export_path_unset_failure`, and `render_export_run`.

## Error codes — no GDScript mirror (and why)

The three new failure codes — `export_templates_missing`, `export_failed`, `export_path_unset` — are **classifier-source**, not operation-source: `gda` synthesizes them from the native subprocess outcome, not `operations.gd`. Per ADR-0002 ("GDScript mirrors only the rows whose `source` is `operation`") and the registry drift test (`test_gdscript_operation_error_codes_mirror_python_operation_subset`, which asserts the GDScript mirror equals **exactly** the operation-source subset), these codes are registered in the **Python registry + ADR-0002 table only**, with **no GDScript `OP_ERROR_*` row**. Adding GDScript mirrors would in fact *break* the drift test. `operations.gd` was **not touched** — there is no new GDScript op — so `--check-only` was not required.

The reused phase-1 errors (`export_preset_not_found` etc.) keep their existing operation-source GDScript mirrors unchanged.

## Tests

- **S2** (`tests/test_classify_export_run.py`): pure-function unit for `classify_export_run` + `parse_export_warnings` — clean success, advisory warnings, `binary_not_found`, `launch_timeout`, `engine_crashed`, `export_templates_missing`, `export_failed`, and the `export_path_unset` builder.
- **S3** (`tests/test_export_run_commands.py`): CLI-with-FakeRunner — success, `--mode`/`--output`, every failure mode, the ADR-0004 `--schema` hard gate, and the human text render.
- **S1** (`tests/test_e2e_export_run.py`): real-engine e2e — unknown preset and unset path (template-independent) run unconditionally; the happy path runs a real `--export-release` and **auto-skips the success assertion when export templates are absent**, asserting the structured `export_templates_missing` failure first (so the real native invocation + stderr classification is covered either way).

## How verified

- Fast tier: `uv run --frozen pytest -m "not e2e"` → **445 passed**.
- e2e tier: `uv run --frozen pytest -m e2e` against **Godot 4.6.3.stable** → all export-run e2e green; the real-export happy path **skipped cleanly** because the export templates for `4.6.3.stable` are not installed on the test machine (the missing-templates failure path was asserted instead). e2e ran — it did not error.
- Manually ran `gda export run` against the real engine: Godot printed `Cannot export project ... due to configuration errors` naming the missing `export_templates/4.6.3.stable/linux_release.x86_64`, which `gda` classified as `export_templates_missing` (exit 4, operation) with the full engine stderr preserved as diagnostics.
- `operations.gd` untouched → `--check-only` not applicable.
