### PR TITLE
fix(runner): map launch failures + non-UTF-8 output to structured errors (#33)

### DIFF
--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -125,6 +125,24 @@ def _operation_error_from_payload(result: RunResult) -> tuple[str, str] | None:
     return envelope.error.code, envelope.error.message
 
 
+def unresolvable_binary_failure(reason: str) -> Failure:
+    """The ``binary_not_found`` failure when the binary cannot even be resolved (issue #33).
+
+    Binary resolution runs *before* a runner is built, so an unresolvable
+    ``--godot`` value (an empty ``--godot ""`` / ``$GDA_GODOT`` mistake) raises
+    instead of producing a launchable path. There is no engine to run — the same
+    environment outcome the runner reports as ``LaunchFailure.NOT_FOUND`` — so it
+    reuses the ``binary_not_found`` code rather than minting a new one (ADR-0002:
+    reuse the exit code; discriminate via the envelope). Kept here beside the
+    other environment failures so the whole taxonomy reads from one place.
+    """
+    return _failure(
+        "binary_not_found",
+        f"Godot binary could not be resolved: {reason}",
+        "",
+    )
+
+
 def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | Failure:
     """Classify a raw headless run into the command's typed model or a ``Failure``.
 

--- a/src/gda/export_runner.py
+++ b/src/gda/export_runner.py
@@ -92,8 +92,12 @@ class SubprocessExportRunner:
             cmd += ["--path", str(self.project)]
         cmd += [flag, preset, output_path]
         try:
+            # Capture raw bytes (no ``text=True``): like the sentinel runner,
+            # the native export channel must not decode with the host locale,
+            # which mojibakes or raises ``UnicodeDecodeError`` on a non-UTF-8
+            # locale. We decode UTF-8 explicitly below (issue #33).
             proc = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=self.timeout, cwd=cwd
+                cmd, capture_output=True, timeout=self.timeout, cwd=cwd
             )
         except subprocess.TimeoutExpired:
             return ExportRunOutput(
@@ -102,15 +106,29 @@ class SubprocessExportRunner:
                 exit_code=EXIT_TIMEOUT,
                 launch_failure=LaunchFailure.TIMEOUT,
             )
-        except FileNotFoundError:
+        except OSError as exc:
+            # The configured binary could not be launched: ``FileNotFoundError``
+            # (missing), ``PermissionError`` (a directory like ``Godot.app`` or a
+            # non-executable file), and any other ``OSError`` from ``exec`` are
+            # one environment failure — there was no engine to run (issue #33).
+            # Mirrors ``SubprocessGodotRunner`` so both runners close the same
+            # raw-launch-failure surface. ``OSError`` does not subsume
+            # ``TimeoutExpired`` (a ``SubprocessError``), so the timeout path
+            # above is preserved.
             return ExportRunOutput(
                 stdout="",
-                stderr=f"gda: Godot binary not found: {self.binary}\n",
+                stderr=f"gda: Godot binary could not be launched: {self.binary} ({exc})\n",
                 exit_code=EXIT_NOT_FOUND,
                 launch_failure=LaunchFailure.NOT_FOUND,
             )
         return ExportRunOutput(
-            stdout=proc.stdout, stderr=proc.stderr, exit_code=proc.returncode
+            # Decode the engine's bytes as UTF-8 with a replacement policy, like
+            # the sentinel runner: a well-behaved export emits valid UTF-8, so
+            # ``replace`` only fires on genuinely malformed bytes and the runner
+            # never crashes on engine output (issue #33).
+            stdout=proc.stdout.decode("utf-8", errors="replace"),
+            stderr=proc.stderr.decode("utf-8", errors="replace"),
+            exit_code=proc.returncode,
         )
 
 

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel
 from typer.core import TyperCommand
 
 from gda.binary import resolve_godot_binary
-from gda.errors import Failure, classify_run
+from gda.errors import Failure, classify_run, unresolvable_binary_failure
 from gda.models import CommandSchema, GdaErrorEnvelope
 from gda.runner import GodotRunner, RunResult, SubprocessGodotRunner
 
@@ -160,7 +160,15 @@ class HeadlessCommand(Generic[M]):
         Diagnostics are forwarded to stderr. Failures are emitted as the public
         structured error envelope and terminate via Typer's exit path.
         """
-        binary = resolve_godot_binary(godot)
+        try:
+            binary = resolve_godot_binary(godot)
+        except ValueError as exc:
+            # An empty ``--godot ""`` (a natural $GDA_GODOT mistake) makes
+            # resolution raise *before* a runner exists — there is no binary to
+            # launch, the same environment failure as a missing one. Map it to
+            # the structured ``binary_not_found`` envelope so it never escapes as
+            # a raw traceback (issue #33), mirroring the runner's NOT_FOUND path.
+            _fail(unresolvable_binary_failure(str(exc)))
         runner = make_runner(binary, project)
         result = runner.run(self.operation, params.model_dump())
 

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -89,9 +89,13 @@ class SubprocessGodotRunner:
             json.dumps(params),
         ]
         try:
-            proc = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=self.timeout
-            )
+            # Capture raw bytes (no ``text=True``): Godot's ``JSON.stringify``
+            # emits UTF-8, but ``text=True`` would decode with the host locale,
+            # which mojibakes or raises ``UnicodeDecodeError`` on a non-UTF-8
+            # locale (e.g. Windows cp1252/cp936) for a non-ASCII node name or
+            # echoed path. We decode UTF-8 explicitly below so user content
+            # round-trips regardless of locale (issue #33).
+            proc = subprocess.run(cmd, capture_output=True, timeout=self.timeout)
         except subprocess.TimeoutExpired:
             return RunResult(
                 stdout="",
@@ -99,13 +103,31 @@ class SubprocessGodotRunner:
                 exit_code=EXIT_TIMEOUT,
                 launch_failure=LaunchFailure.TIMEOUT,
             )
-        except FileNotFoundError:
+        except OSError as exc:
+            # The configured binary could not be launched. ``FileNotFoundError``
+            # (missing), ``PermissionError`` (a directory like ``Godot.app`` — a
+            # natural $GDA_GODOT mistake — or a non-executable file), and any
+            # other ``OSError`` from ``exec`` are all the same environment
+            # failure: there was no engine to run (issue #33). They synthesize
+            # the typed ``NOT_FOUND`` reason so the classifier keys environment
+            # on it, not on the overloaded exit code (issue #15). ``OSError``
+            # does not subsume ``TimeoutExpired`` (a ``SubprocessError``), so the
+            # timeout path above is preserved. The original OS message is kept as
+            # advisory stderr to disambiguate which of the three modes occurred.
             return RunResult(
                 stdout="",
-                stderr=f"gda: Godot binary not found: {self.binary}\n",
+                stderr=f"gda: Godot binary could not be launched: {self.binary} ({exc})\n",
                 exit_code=EXIT_NOT_FOUND,
                 launch_failure=LaunchFailure.NOT_FOUND,
             )
         return RunResult(
-            stdout=proc.stdout, stderr=proc.stderr, exit_code=proc.returncode
+            # Decode the engine's bytes as UTF-8 with a replacement policy: a
+            # well-behaved operation emits valid UTF-8, so ``replace`` only ever
+            # fires on genuinely malformed bytes — and the runner never crashes
+            # on engine output. A malformed result then surfaces as a structured
+            # ``contract_violation`` downstream rather than an escaping
+            # ``UnicodeDecodeError`` traceback (ADR-0002).
+            stdout=proc.stdout.decode("utf-8", errors="replace"),
+            stderr=proc.stderr.decode("utf-8", errors="replace"),
+            exit_code=proc.returncode,
         )

--- a/tests/test_export_runner.py
+++ b/tests/test_export_runner.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 import gda.export_runner as export_runner_mod
 from gda.export_runner import SubprocessExportRunner
+from gda.exit_codes import EXIT_NOT_FOUND
+from gda.runner import LaunchFailure
 
 
 class _RecordingRun:
@@ -29,8 +31,10 @@ class _RecordingRun:
         self.kwargs = kwargs
 
         class _Proc:
-            stdout = ""
-            stderr = ""
+            # The runner captures bytes (no text=True) and decodes UTF-8 itself,
+            # so the double mirrors that real subprocess contract (#33).
+            stdout = b""
+            stderr = b""
             returncode = 0
 
         return _Proc()
@@ -66,3 +70,61 @@ def test_export_without_project_passes_no_cwd(monkeypatch):
     assert rec.kwargs is not None
     assert rec.kwargs.get("cwd") is None
     assert "--path" not in rec.cmd
+
+
+def test_export_directory_binary_maps_to_not_found_not_traceback(tmp_path):
+    # A directory passed as --godot (e.g. the bundle "Godot.app") cannot be
+    # exec'd; the native export runner must catch the OSError and synthesize a
+    # launch failure rather than leak a raw traceback — mirroring the sentinel
+    # runner so both runners close the same launch-failure surface (#33).
+    runner = SubprocessExportRunner(tmp_path)
+
+    result = runner.run("Linux/X11", "release", "out.x86_64")
+
+    assert result.exit_code == EXIT_NOT_FOUND
+    assert str(tmp_path) in result.stderr
+    assert result.stdout == ""
+    assert result.launch_failure is LaunchFailure.NOT_FOUND
+
+
+def test_export_non_executable_file_binary_maps_to_not_found_not_traceback(tmp_path):
+    # A plain, non-executable file passed as --godot cannot be exec'd; the
+    # PermissionError must become a launch failure, not a traceback (#33).
+    not_exec = tmp_path / "notgodot.txt"
+    not_exec.write_text("i am not an engine")
+    runner = SubprocessExportRunner(not_exec)
+
+    result = runner.run("Linux/X11", "release", "out.x86_64")
+
+    assert result.exit_code == EXIT_NOT_FOUND
+    assert str(not_exec) in result.stderr
+    assert result.stdout == ""
+    assert result.launch_failure is LaunchFailure.NOT_FOUND
+
+
+def test_export_output_is_decoded_as_utf8_regardless_of_host_locale(monkeypatch):
+    # Like the sentinel runner, the native export channel must capture bytes and
+    # decode UTF-8 explicitly so non-ASCII engine output round-trips regardless
+    # of host locale, instead of locale-decoding via text=True (#33).
+    stdout_bytes = "エクスポート完了\n".encode("utf-8")
+    stderr_bytes = "警告: テンプレート\n".encode("utf-8")
+
+    def fake_run(cmd, **kwargs):
+        # The fix drops text=True and captures bytes; assert that contract here
+        # so the test fails loudly if decoding silently reverts to locale text.
+        assert kwargs.get("text") in (None, False)
+
+        class _Proc:
+            stdout = stdout_bytes
+            stderr = stderr_bytes
+            returncode = 0
+
+        return _Proc()
+
+    monkeypatch.setattr(export_runner_mod.subprocess, "run", fake_run)
+    runner = SubprocessExportRunner(Path("/any/Godot"))
+
+    result = runner.run("Linux/X11", "release", "out.x86_64")
+
+    assert "エクスポート完了" in result.stdout
+    assert "警告: テンプレート" in result.stderr

--- a/tests/test_headless_command.py
+++ b/tests/test_headless_command.py
@@ -90,3 +90,31 @@ def test_headless_command_emit_owns_structured_failure_output(capsys):
     assert raised.value.exit_code == 127
     assert json.loads(captured.out)["error"]["code"] == "binary_not_found"
     assert "not found" in captured.err
+
+
+def test_empty_godot_path_maps_to_structured_binary_not_found(capsys):
+    # ``--godot ""`` makes binary resolution raise ``ValueError`` *before* a
+    # runner is ever built; that must become the structured ``binary_not_found``
+    # environment envelope (exit 127), not escape as a raw traceback (#33).
+    def make_runner(binary: Path, project: Path | None):  # pragma: no cover
+        raise AssertionError("no runner should be built for an unresolvable binary")
+
+    command: HeadlessCommand[EngineVersion] = HeadlessCommand(
+        operation="info",
+        input_model=InfoParams,
+        output_model=EngineVersion,
+    )
+
+    with pytest.raises(typer.Exit) as raised:
+        command.emit(
+            InfoParams(),
+            godot="",
+            project=None,
+            json_output=False,
+            render_text=lambda version: version.string,
+            make_runner=make_runner,
+        )
+
+    captured = capsys.readouterr()
+    assert raised.value.exit_code == 127
+    assert json.loads(captured.out)["error"]["code"] == "binary_not_found"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -25,6 +25,67 @@ def test_missing_binary_maps_to_nonzero_result_not_traceback():
     assert result.launch_failure is LaunchFailure.NOT_FOUND
 
 
+def test_directory_binary_maps_to_not_found_not_traceback(tmp_path):
+    # A directory passed as --godot (e.g. the bundle "Godot.app", a natural
+    # $GDA_GODOT mistake) cannot be exec'd; the OS raises a PermissionError /
+    # IsADirectoryError that must not escape as a raw traceback (#33).
+    runner = SubprocessGodotRunner(tmp_path)
+
+    result = runner.run("info", {})
+
+    assert result.exit_code == EXIT_NOT_FOUND
+    assert str(tmp_path) in result.stderr
+    assert result.stdout == ""
+    assert result.launch_failure is LaunchFailure.NOT_FOUND
+
+
+def test_non_executable_file_binary_maps_to_not_found_not_traceback(tmp_path):
+    # A plain, non-executable file passed as --godot cannot be exec'd; the OS
+    # raises a PermissionError that the runner must catch and synthesize as a
+    # launch failure rather than leak as a traceback (#33).
+    not_exec = tmp_path / "notgodot.txt"
+    not_exec.write_text("i am not an engine")
+    runner = SubprocessGodotRunner(not_exec)
+
+    result = runner.run("info", {})
+
+    assert result.exit_code == EXIT_NOT_FOUND
+    assert str(not_exec) in result.stderr
+    assert result.stdout == ""
+    assert result.launch_failure is LaunchFailure.NOT_FOUND
+
+
+def test_engine_output_is_decoded_as_utf8_regardless_of_host_locale(monkeypatch):
+    # Godot's JSON.stringify emits raw UTF-8, but subprocess(text=True) would
+    # decode with the host locale. On a non-UTF-8 locale a non-ASCII node name
+    # mojibakes or raises UnicodeDecodeError. The runner must capture bytes and
+    # decode UTF-8 explicitly so user content round-trips (#33). We prove this by
+    # returning raw UTF-8 *bytes* from subprocess (the bytes mode the fix uses).
+    payload = '<<<GDA:RESULT>>>{"name":"日本語"}<<<GDA:END>>>'
+    stdout_bytes = payload.encode("utf-8")
+    stderr_bytes = "警告: ノード名\n".encode("utf-8")
+
+    def fake_run(cmd, **kwargs):
+        # The fix drops text=True and captures bytes; assert that contract here
+        # so the test fails loudly if decoding silently reverts to locale text.
+        assert kwargs.get("text") in (None, False)
+
+        class _Proc:
+            stdout = stdout_bytes
+            stderr = stderr_bytes
+            returncode = 0
+
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    runner = SubprocessGodotRunner(Path("/any/Godot"))
+
+    result = runner.run("scene", {})
+
+    assert "日本語" in result.stdout
+    assert "警告: ノード名" in result.stderr
+
+
 def test_timeout_maps_to_nonzero_result(monkeypatch):
     def fake_run(*args, **kwargs):
         raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
@@ -46,8 +107,10 @@ def test_timeout_is_passed_through_to_subprocess(monkeypatch):
         captured["timeout"] = kwargs.get("timeout")
 
         class _Proc:
-            stdout = "<<<GDA:RESULT>>>{}<<<GDA:END>>>"
-            stderr = ""
+            # The runner captures bytes (no text=True) and decodes UTF-8 itself,
+            # so the double mirrors that real subprocess contract (#33).
+            stdout = b"<<<GDA:RESULT>>>{}<<<GDA:END>>>"
+            stderr = b""
             returncode = 0
 
         return _Proc()


### PR DESCRIPTION
Closes #33

## What

Three engine-launch failure modes escaped `gda`'s classification layer as raw Python tracebacks (exit 1, no `{"error": …}` envelope), violating ADR-0002's contract that every command failure maps to a structured `GdaError` with a registry exit code. This maps all three into the existing environment-category taxonomy.

- **`--godot <directory>` / `--godot <non-executable file>`** — `subprocess.run` raised an uncaught `PermissionError`; the runner only caught `TimeoutExpired` and `FileNotFoundError`. Broadened the catch to `OSError` (covers missing / directory / non-executable / any `exec` failure) → `LaunchFailure.NOT_FOUND`. `TimeoutExpired` is a `SubprocessError`, not an `OSError`, so the timeout path is preserved.
- **`--godot ""` (empty)** — binary resolution raises `ValueError` *before* a runner is built. `HeadlessCommand.run` now catches it and emits `binary_not_found` through the public failure channel (new `errors.unresolvable_binary_failure` helper).
- **Non-UTF-8 host locale** — `subprocess.run(text=True)` decoded engine stdout with the locale encoding, but Godot's `JSON.stringify` emits raw UTF-8; a non-ASCII node name mojibaked or raised `UnicodeDecodeError` on a non-UTF-8 locale (cp1252/cp936). The runner now captures **bytes** and decodes UTF-8 explicitly (`errors="replace"`: never crash on engine output; a malformed result then surfaces as a structured `contract_violation` downstream).

## Error code

All three reuse the existing **runner-source `binary_not_found`** code (exit 127) — no new code minted (ADR-0002: reuse the exit code, discriminate via the envelope). `error_codes.py`, the ADR-0002 table, and `operations.gd` are therefore untouched.

## Tests

TDD red→green. New unit tests (no real engine needed):

- `test_runner.py`: directory binary, non-executable file → `LaunchFailure.NOT_FOUND` / exit 127; engine output decoded as UTF-8 round-trips a `日本語` node name + stderr regardless of locale (driven by returning raw UTF-8 bytes from a fake subprocess).
- `test_headless_command.py`: `--godot ""` → structured `binary_not_found` envelope (exit 127), no runner ever built.

Updated the pre-existing `test_timeout_is_passed_through_to_subprocess` fake to return bytes, matching the real (no-`text=True`) subprocess contract.

## How verified

`uv run pytest` full suite green (unit + real-engine e2e). Each new test was confirmed failing before the fix and passing after.
