### PR TITLE
feat(export): run — add --mode + --output overrides (#170)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -122,8 +122,8 @@ operation, and parse codes the CLI assigns).
 | `invalid_resource_type` | `operation` | `operation` | `4` | A requested resource type cannot be instantiated as a `Resource`. |
 | `export_presets_not_found` | `operation` | `operation` | `4` | The project has no export_presets.cfg, so it defines no export presets. |
 | `export_preset_not_found` | `operation` | `operation` | `4` | No export preset with the requested name exists in export_presets.cfg. |
-| `export_path_unset` | `operation` | `classifier` | `4` | An export run targeted a preset that has no configured export_path. |
-| `export_templates_missing` | `operation` | `classifier` | `4` | An export run needs the export templates for the running engine version, which are not installed. |
+| `export_path_unset` | `operation` | `classifier` | `4` | An export run has no destination — neither a `--output` override nor a configured `export_path` (#170). |
+| `export_templates_missing` | `operation` | `classifier` | `4` | A release/debug export needs the export templates for the running engine version, which are not installed (pack needs no platform templates and is exempt; #170). |
 | `export_failed` | `operation` | `classifier` | `4` | A native Godot export run failed (the engine reported the export did not complete). |
 | `invalid_uid` | `operation` | `operation` | `4` | A requested `uid://` value is not a syntactically valid resource UID. |
 | `unknown_uid` | `operation` | `operation` | `4` | A syntactically valid resource UID is not registered in the engine's UID cache. |

--- a/docs/adr/0010-headless-operation-execution-mechanism.md
+++ b/docs/adr/0010-headless-operation-execution-mechanism.md
@@ -58,11 +58,15 @@ native run:
 - **Structured preflight (classifier, no native run).** `export-get` already reports
   the preset's configured `export_path` and, structurally, its template readiness
   (`templates_installed` — the readiness field built for exactly this check). From
-  those: an empty configured `export_path` is `export_path_unset`, and uninstalled
-  templates for the running engine version are `export_templates_missing`. Both are
-  decided here, from structured fields, with **no** native export spawned — in
-  particular `export_templates_missing` is *not* inferred from the engine's "due to
-  configuration errors" stderr (which would violate ADR-0002 and also misfires for a
+  those: no **effective destination** — neither a `--output` override (#170) nor a
+  configured `export_path` — is `export_path_unset`; and uninstalled templates for the
+  running engine version are `export_templates_missing`. The destination check applies
+  to **every** mode, but the template check is for **release/debug only** — `pack`
+  produces project data (a PCK/ZIP via Godot's native `--export-pack`) and needs no
+  platform templates, so it is exempt (#170). Both checks are decided here, from
+  structured fields, with **no** native export spawned — in particular
+  `export_templates_missing` is *not* inferred from the engine's "due to configuration
+  errors" stderr (which would violate ADR-0002 and also misfires for a
   merely-misconfigured preset).
 - **Native run (classifier on exit code).** Only the export execution itself uses the
   native CLI mode. A clean exit is the typed success result (with any advisory

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -1625,31 +1625,47 @@ def run_export(
         "--preset",
         help="The export preset's display name, as 'gda export list' reports it.",
     ),
-    # NOTE: --mode (release/debug/pack) and --output (path override) are
-    # deferred to follow-up issue #170. Issue #121 asks only to export a named
-    # preset in RELEASE mode to its CONFIGURED export_path, so this command
-    # exposes neither flag; the result still carries `mode` (always "release")
-    # to document the mode that ran.
+    # --mode (#170): select the export flavor. A closed Enum so an unrecognized
+    # value is a Typer usage error (exit 2) rather than reaching the runner;
+    # release is the default, preserving #121's behavior when --mode is omitted.
+    mode: ExportRunMode = typer.Option(
+        ExportRunMode.RELEASE,
+        "--mode",
+        help="The export flavor to run (release/debug/pack); default release.",
+    ),
+    # --output (#170): override the preset's configured export_path. A filesystem
+    # path normalized ONCE at the CLI layer (ADR-0006: ~ expanded), like every
+    # other path-taking command.
+    output: Optional[str] = typer.Option(
+        None,
+        "--output",
+        help="Override the preset's configured export_path; write the artifact here instead.",
+    ),
     json_output: bool = json_option(),
     schema: bool = EXPORT_RUN_COMMAND.schema_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Export a named preset (release mode) to its configured path and report the artifact.
+    """Export a named preset to a destination and report the artifact.
 
-    Unlike every other command, the export itself is a native ``--export-release``
+    Unlike every other command, the export itself is a native ``--export-<mode>``
     invocation (the export subsystem is editor-only, so it cannot run through
     operations.gd). The command orchestrates three phases by hand: ``export get``
     resolves the preset's platform + configured ``export_path`` + template
     readiness (reusing #114's clean preset/project errors), a structured preflight
-    fails fast when templates are missing or the path is unset, then the native
-    ``ExportRunner`` performs the export and ``classify_export_run`` synthesizes
-    the typed result from the subprocess's exit code.
+    fails fast when templates are missing or there is no destination, then the
+    native ``ExportRunner`` performs the export and ``classify_export_run``
+    synthesizes the typed result from the subprocess's exit code.
+
+    ``--mode`` selects the export flavor (release/debug/pack; default release) and
+    ``--output`` overrides the preset's configured ``export_path``; both are
+    reflected in the native invocation and the reported result (#170).
     """
     resolved_project = resolve_project_dir(project)
     binary = resolve_godot_binary(godot)
-    # #121 fixes the export flavor to release; --mode is deferred to #170.
-    mode = ExportRunMode.RELEASE
+    # --output is a filesystem path: normalize it ONCE here (ADR-0006, ~-expanded)
+    # so the runner and the reported result both see the effective destination.
+    override_output = _normalize_path(output) if output is not None else None
 
     # Phase 1: resolve the preset via the existing export-get sentinel op. This
     # reuses #114's clean structured errors — an unknown preset is
@@ -1663,22 +1679,26 @@ def run_export(
         make_runner=_make_runner,
     )
 
+    # Resolve the effective destination: --output (already CLI-normalized) wins
+    # over the preset's configured export_path (#170). This is what the native
+    # export writes to AND what the result reports as output_path.
+    output_path = override_output if override_output is not None else got.export_path
+
     # Phase 2: structured preflight, BEFORE any native run (ADR-0010). Two
     # fail-fast checks, both decided from export get's structured fields rather
     # than from the engine's stderr (which ADR-0002 forbids parsing for codes):
     #
-    #  - The configured export_path must be set. A --output override is deferred
-    #    to #170, so an empty configured path means there is nowhere to write —
-    #    export_path_unset. Checked first because it is a per-preset config error
-    #    independent of the engine's template state, so it stays deterministic
-    #    whether or not templates happen to be installed.
+    #  - There must be a destination. --output supplies one directly (#170); only
+    #    when no override is given AND the configured export_path is empty is there
+    #    nowhere to write — export_path_unset. Checked first because it is a
+    #    config/argument error independent of the engine's template state, so it
+    #    stays deterministic whether or not templates happen to be installed.
     #  - Templates for the running engine version must be installed. export get
     #    reports that structurally (templates_installed) — the readiness check
     #    built for exactly this — so an export against an uninstalled template
     #    version is the distinct export_templates_missing, decided here rather
     #    than by string-matching the engine's "due to configuration errors"
     #    stderr (which also fires for a merely-misconfigured preset).
-    output_path = got.export_path
     if not output_path:
         emit_failure(export_path_unset_failure(got.name))
     if not got.templates_installed:

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -1688,20 +1688,28 @@ def run_export(
     # fail-fast checks, both decided from export get's structured fields rather
     # than from the engine's stderr (which ADR-0002 forbids parsing for codes):
     #
-    #  - There must be a destination. --output supplies one directly (#170); only
-    #    when no override is given AND the configured export_path is empty is there
-    #    nowhere to write — export_path_unset. Checked first because it is a
-    #    config/argument error independent of the engine's template state, so it
-    #    stays deterministic whether or not templates happen to be installed.
-    #  - Templates for the running engine version must be installed. export get
-    #    reports that structurally (templates_installed) — the readiness check
-    #    built for exactly this — so an export against an uninstalled template
-    #    version is the distinct export_templates_missing, decided here rather
-    #    than by string-matching the engine's "due to configuration errors"
-    #    stderr (which also fires for a merely-misconfigured preset).
+    #  - There must be a destination, for EVERY mode. --output supplies one
+    #    directly (#170); only when no override is given AND the configured
+    #    export_path is empty is there nowhere to write — export_path_unset.
+    #    Checked first because it is a config/argument error independent of the
+    #    engine's template state, so it stays deterministic whether or not
+    #    templates happen to be installed.
+    #  - Templates for the running engine version must be installed — but ONLY
+    #    for release/debug, never for pack (#170). release/debug produce a full
+    #    platform binary and need the matching platform export templates; pack
+    #    produces project data only (a PCK/ZIP via Godot's native --export-pack)
+    #    and needs no platform templates (ExportRunMode's docstring; confirmed on
+    #    Godot 4.6.3, where a template-less --export-pack writes a .pck). Gating
+    #    pack out lets template-less environments use the mode that works there.
+    #    export get reports template readiness structurally (templates_installed)
+    #    — the readiness check built for exactly this — so a release/debug export
+    #    against an uninstalled template version is the distinct
+    #    export_templates_missing, decided here rather than by string-matching the
+    #    engine's "due to configuration errors" stderr (which also fires for a
+    #    merely-misconfigured preset).
     if not output_path:
         emit_failure(export_path_unset_failure(got.name))
-    if not got.templates_installed:
+    if mode is not ExportRunMode.PACK and not got.templates_installed:
         emit_failure(export_templates_missing_failure(got.name, got.templates_version))
 
     # Phase 3: run the native export and classify its raw outcome. The export-get

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -412,33 +412,37 @@ def classify_export_run(
 
 
 def export_path_unset_failure(preset: str) -> Failure:
-    """The ``export_path_unset`` failure for a preset with no configured path (issue #121).
+    """The ``export_path_unset`` failure for a preset with no effective destination (issue #121, #170).
 
-    ``export run`` writes the artifact to the preset's own configured
-    ``export_path`` (a ``--output`` override is deferred to #170). When the preset
-    has no configured ``export_path`` there is nowhere to write, so gda fails
+    ``export run`` writes the artifact to the effective destination: the
+    ``--output`` override if given (#170), else the preset's own configured
+    ``export_path``. When neither supplies a destination — no ``--output`` AND an
+    empty configured ``export_path`` — there is nowhere to write, so gda fails
     *before* spawning the export rather than letting the engine error obscurely.
-    A pre-run classifier decision (the path is resolved at the CLI from
-    ``export get``'s ``export_path``), kept here beside the other export failures
-    so the whole taxonomy reads from one place.
+    A pre-run classifier decision (the destination is resolved at the CLI from
+    ``--output`` / ``export get``'s ``export_path``), kept here beside the other
+    export failures so the whole taxonomy reads from one place.
     """
     return _failure(
         "export_path_unset",
-        f'export preset "{preset}" has no configured export_path',
+        f'export preset "{preset}" has no destination: '
+        "pass --output or set the preset's export_path",
         "",
     )
 
 
 def export_templates_missing_failure(preset: str, templates_version: str) -> Failure:
-    """The ``export_templates_missing`` failure from the structured preflight (issue #121).
+    """The ``export_templates_missing`` failure from the structured preflight (issue #121, #170).
 
-    A release export needs the export templates for the running engine version
-    installed. ``export get`` already reports that structurally
-    (``templates_installed``) — the readiness check built for exactly this — so
-    gda decides this *before* spawning the native export, rather than
-    string-matching the engine's "due to configuration errors" stderr (which
-    ADR-0002 forbids, and which also fires for a merely-misconfigured preset).
-    Names the ``templates_version`` directory the agent must install.
+    A release/debug export needs the platform export templates for the running
+    engine version installed (``pack`` does not — it produces project data only,
+    so the preflight skips this check for ``--mode pack``; #170). ``export get``
+    already reports template readiness structurally (``templates_installed``) —
+    the readiness check built for exactly this — so gda decides this *before*
+    spawning the native export, rather than string-matching the engine's "due to
+    configuration errors" stderr (which ADR-0002 forbids, and which also fires for
+    a merely-misconfigured preset). Names the ``templates_version`` directory the
+    agent must install.
     """
     return _failure(
         "export_templates_missing",

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -1360,17 +1360,16 @@ class ExportGetResult(BaseModel):
 
 
 class ExportRunMode(str, Enum):
-    """The export flavor ``gda export run`` produces (issue #121).
+    """The export flavor ``gda export run`` produces (issue #121, selectable #170).
 
     Maps to Godot's native export flags (ADR-0001). ``release``/``debug`` produce
     a full platform binary and require the matching export templates to be
     installed; ``pack`` produces project data only — a PCK/ZIP, chosen by the
     output path's extension — and needs no platform templates.
 
-    Issue #121 fixes the mode to ``release`` (the common intent — a complete
-    export), exposing no ``--mode`` flag; selecting ``debug``/``pack`` is deferred
-    to follow-up #170. The enum keeps all three flavors so the result field can
-    document the mode that ran and #170 can wire the flag without reshaping it.
+    Issue #121 fixed the mode to ``release`` (the common intent — a complete
+    export); follow-up #170 exposes ``--mode`` so an agent can select
+    ``debug``/``pack``. ``release`` stays the default.
     """
 
     RELEASE = "release"
@@ -1379,19 +1378,27 @@ class ExportRunMode(str, Enum):
 
 
 class ExportRunParams(BaseModel):
-    """The operation params of ``gda export run`` (issue #121).
+    """The operation params of ``gda export run`` (issue #121, overrides #170).
 
     ``preset`` addresses the export preset by its display name (as ``export
     list`` reports it); an unknown name is the ``export_preset_not_found``
-    failure. The export runs in ``release`` mode to the preset's *configured*
-    ``export_path`` (an empty configured path is the ``export_path_unset``
-    failure). A ``--mode`` selector and an ``--output`` path override are deferred
-    to follow-up #170, so this command takes only ``preset``. The project is
-    process context (``--project``, ADR-0006).
+    failure. ``mode`` selects the export flavor (``release`` default; #170).
+    ``output`` overrides the preset's *configured* ``export_path`` (#170); when
+    omitted the export targets the configured path (an empty configured path with
+    no override is the ``export_path_unset`` failure). The project is process
+    context (``--project``, ADR-0006).
     """
 
     preset: str = Field(
         description="The export preset's display name, as 'gda export list' reports it."
+    )
+    mode: ExportRunMode = Field(
+        default=ExportRunMode.RELEASE,
+        description="The export flavor to run (release/debug/pack); default release.",
+    )
+    output: str | None = Field(
+        default=None,
+        description="Override the preset's configured export_path; write the artifact here instead.",
     )
 
 
@@ -1399,9 +1406,10 @@ class ExportRunResult(BaseModel):
     """The result of ``gda export run``: the artifact that was produced (issue #121).
 
     Echoes the addressed preset's ``preset`` name and target ``platform`` (read
-    from ``export_presets.cfg``), the ``mode`` that was run (always ``release``
-    in #121 — ``--mode`` is deferred to #170), and the ``output_path`` the
-    artifact was written to — the preset's *configured* ``export_path``.
+    from ``export_presets.cfg``), the ``mode`` that was run (the selected flavor,
+    ``release`` by default; #170), and the ``output_path`` the artifact was
+    written to — the effective destination, i.e. the ``--output`` override when
+    given, else the preset's *configured* ``export_path`` (#170).
     ``warnings`` carries the engine's non-fatal export warnings (e.g. a missing
     optional icon), parsed best-effort from the export's stderr; an export that
     succeeds cleanly reports ``warnings == []``. Unlike the sentinel operations,

--- a/tests/test_classify_export_run.py
+++ b/tests/test_classify_export_run.py
@@ -142,13 +142,18 @@ def test_other_nonzero_maps_to_generic_export_failed():
 
 
 def test_export_path_unset_failure_builder():
-    # The pre-run path-unset failure names the preset and the registered code.
+    # The pre-run path-unset failure names the preset and the registered code, and
+    # points at the two ways to supply a destination (#170): --output or the
+    # preset's export_path — no longer claiming "no configured export_path", since
+    # --output can now supply one.
     failure = export_path_unset_failure("Linux/X11")
 
     assert isinstance(failure, Failure)
     assert failure.error.code == "export_path_unset"
     assert failure.exit_code == EXIT_OPERATION
     assert "Linux/X11" in failure.error.message
+    assert "--output" in failure.error.message
+    assert "export_path" in failure.error.message
 
 
 def test_parse_export_warnings_is_empty_when_clean():

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -167,3 +167,47 @@ def test_export_run_writes_to_configured_export_path(godot_project):
     assert isinstance(data["warnings"], list)
     # (a) The artifact was actually written to the configured path on disk.
     assert artifact.exists(), f"expected artifact at configured path {artifact}"
+
+
+@pytest.mark.e2e
+def test_export_run_output_override_and_mode_write_to_overridden_path(godot_project):
+    # #170 overrides: `--mode pack --output <path>` runs the native --export-pack
+    # to the OVERRIDDEN path (not the preset's configured build/game.x86_64) and
+    # reports mode == "pack" with output_path == the override. A pack export still
+    # needs the engine's templates, so this follows the same template-presence
+    # policy: when templates are absent, gda's structured preflight fails fast with
+    # export_templates_missing before any native run — assert that live, then skip
+    # only the success assertion.
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    override_rel = "dist/packed.pck"
+    artifact = godot_project / override_rel
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    configured = godot_project / "build/game.x86_64"
+    gda = _gda_project(godot_project)
+
+    run = gda(
+        "export", "run", "--preset", "Linux/X11",
+        "--mode", "pack", "--output", override_rel, "--json",
+    )
+
+    if not _templates_installed(gda):
+        assert run.returncode == 4, run.stdout + run.stderr
+        err = json.loads(run.stdout)["error"]
+        assert err["code"] == "export_templates_missing", run.stdout + run.stderr
+        assert not artifact.exists(), "no artifact when the preflight fails fast"
+        pytest.skip(
+            "export templates for the running engine version are not installed; "
+            "skipping the successful-override assertion (the structured "
+            "export_templates_missing preflight was verified instead)"
+        )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    data = json.loads(run.stdout)
+    assert data["mode"] == "pack"
+    # The reported output_path is the override, and the artifact lands there —
+    # NOT at the preset's configured export_path.
+    assert data["output_path"] == override_rel
+    assert artifact.exists(), f"expected artifact at the override path {artifact}"
+    assert not configured.exists(), "the override must not write the configured path"

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -9,15 +9,21 @@ real Godot, classified by the real ``classify_export_run`` — plus the real
 ``export get`` structured template-readiness preflight.
 
 The acceptance behavior is exporting to the preset's **configured** ``export_path``
-(no ``--output``). A successful export needs the export templates for the running
-engine version installed; the test machine may not have them, so the configured-
-path happy-path test **auto-skips** when ``export get`` reports the templates are
-missing — the same template-presence policy the read-only export e2e (issue #114)
-observes. Crucially, missing templates are now caught by gda's STRUCTURED preflight
-(export get's ``templates_installed``) *before* any native run, so when templates
-are absent this test asserts the structured ``export_templates_missing`` path live
-and then skips only the success assertion. The structured-failure paths that need
-no templates (unknown preset, unset path) run unconditionally.
+(no ``--output``). A successful *release* export needs the export templates for the
+running engine version installed; the test machine may not have them, so the
+configured-path release happy-path test **auto-skips** when ``export get`` reports
+the templates are missing — the same template-presence policy the read-only export
+e2e (issue #114) observes. Crucially, missing templates are caught by gda's
+STRUCTURED preflight (export get's ``templates_installed``) *before* any native run,
+so when templates are absent that release test asserts the structured
+``export_templates_missing`` path live and then skips only the success assertion.
+
+``--mode pack`` is different (#170): Godot's native ``--export-pack`` produces
+project data only (a PCK/ZIP) and needs **no** platform export templates, so the
+pack test must RUN — not skip — on a template-less machine: it asserts exit 0 and
+the ``.pck`` on disk, giving the on-disk verification a release export cannot give
+here. The structured-failure paths that need no templates (unknown preset, unset
+path) run unconditionally.
 """
 
 import json
@@ -41,6 +47,8 @@ platform="Linux/X11"
 runnable=true
 custom_features=""
 export_filter="all_resources"
+include_filter=""
+exclude_filter=""
 export_path="build/game.x86_64"
 
 [preset.0.options]
@@ -54,6 +62,8 @@ platform="Linux/X11"
 runnable=false
 custom_features=""
 export_filter="all_resources"
+include_filter=""
+exclude_filter=""
 export_path=""
 
 [preset.1.options]
@@ -170,16 +180,23 @@ def test_export_run_writes_to_configured_export_path(godot_project):
 
 
 @pytest.mark.e2e
-def test_export_run_output_override_and_mode_write_to_overridden_path(godot_project):
-    # #170 overrides: `--mode pack --output <path>` runs the native --export-pack
-    # to the OVERRIDDEN path (not the preset's configured build/game.x86_64) and
-    # reports mode == "pack" with output_path == the override. A pack export still
-    # needs the engine's templates, so this follows the same template-presence
-    # policy: when templates are absent, gda's structured preflight fails fast with
-    # export_templates_missing before any native run — assert that live, then skip
-    # only the success assertion.
+def test_export_run_pack_writes_pck_without_templates(godot_project):
+    # #170 PROOF: `--mode pack --output <path>.pck` runs Godot's native
+    # --export-pack to the OVERRIDDEN path (not the preset's configured
+    # build/game.x86_64) and writes a .pck — WITHOUT installed export templates.
+    # pack produces project data only, so unlike release/debug it needs no platform
+    # templates and gda's preflight must NOT block it. This test therefore does NOT
+    # skip on a template-less machine: it asserts exit 0 and the artifact on disk,
+    # the on-disk verification a release export cannot give here. (If this machine
+    # DOES have templates, the same assertions hold.)
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    # all_resources packs every res:// resource, so the project needs at least one
+    # exportable file — a bare project.godot alone yields Godot's "Must select at
+    # least one file to export." A trivial script suffices as pack content.
+    (godot_project / "main.gd").write_text(
+        "extends Node\n\nfunc _ready() -> void:\n\tpass\n", encoding="utf-8"
     )
     override_rel = "dist/packed.pck"
     artifact = godot_project / override_rel
@@ -192,22 +209,12 @@ def test_export_run_output_override_and_mode_write_to_overridden_path(godot_proj
         "--mode", "pack", "--output", override_rel, "--json",
     )
 
-    if not _templates_installed(gda):
-        assert run.returncode == 4, run.stdout + run.stderr
-        err = json.loads(run.stdout)["error"]
-        assert err["code"] == "export_templates_missing", run.stdout + run.stderr
-        assert not artifact.exists(), "no artifact when the preflight fails fast"
-        pytest.skip(
-            "export templates for the running engine version are not installed; "
-            "skipping the successful-override assertion (the structured "
-            "export_templates_missing preflight was verified instead)"
-        )
-
+    # No skip: pack must RUN to completion regardless of template presence.
     assert run.returncode == 0, run.stdout + run.stderr
     data = json.loads(run.stdout)
     assert data["mode"] == "pack"
-    # The reported output_path is the override, and the artifact lands there —
+    # The reported output_path is the override, and the .pck lands there on disk —
     # NOT at the preset's configured export_path.
     assert data["output_path"] == override_rel
-    assert artifact.exists(), f"expected artifact at the override path {artifact}"
+    assert artifact.exists(), f"expected .pck at the override path {artifact}"
     assert not configured.exists(), "the override must not write the configured path"

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -286,6 +286,61 @@ def test_export_run_missing_templates_is_structured_preflight(monkeypatch, tmp_p
     assert export_runner.calls == []
 
 
+def test_export_run_pack_skips_template_preflight_when_missing(monkeypatch, tmp_path):
+    # #170: --mode pack produces project data only (Godot's native --export-pack)
+    # and needs NO platform export templates. So when export get reports
+    # templates_installed=False, pack must NOT emit export_templates_missing — it
+    # proceeds straight to the native runner. (release/debug, which DO need
+    # templates, still fail fast — asserted by the parametric test below.)
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    get = {**GET_RESULT, "templates_installed": False, "templates_version": "4.6.3.stable"}
+    _, export_runner = _inject(monkeypatch, get=get)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "export", "run", "--preset", "Linux/X11",
+            "--mode", "pack",
+            "--project", str(tmp_path), "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["mode"] == "pack"
+    # The preflight was skipped for pack: the native export actually ran.
+    assert export_runner.calls == [("Linux/X11", "pack", "build/game.x86_64")]
+
+
+def test_export_run_release_debug_still_require_templates_when_missing(monkeypatch, tmp_path):
+    # The counterpart guard: release and debug DO need platform templates, so with
+    # templates_installed=False they still fail fast with export_templates_missing
+    # before any native run — only pack is exempt (#170).
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    for mode in ("release", "debug"):
+        get = {
+            **GET_RESULT,
+            "templates_installed": False,
+            "templates_version": "4.6.3.stable",
+        }
+        _, export_runner = _inject(monkeypatch, get=get)
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "export", "run", "--preset", "Linux/X11",
+                "--mode", mode,
+                "--project", str(tmp_path), "--json",
+            ],
+        )
+
+        assert result.exit_code == 4, f"{mode}: {result.stdout + result.stderr}"
+        error = _error(result)
+        assert error["code"] == "export_templates_missing", f"{mode}: {result.stdout}"
+        # The preflight fired before any native run.
+        assert export_runner.calls == [], mode
+
+
 def test_export_run_generic_failure_is_structured(monkeypatch, tmp_path):
     # A non-zero export with no recognized stderr signature is the generic
     # export_failed code; the engine's stderr is preserved as diagnostics.

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -24,6 +24,7 @@ Typer → resolve → preflight → export → classify → JSON pipeline runs e
 """
 
 import json
+from pathlib import Path
 
 from typer.testing import CliRunner
 
@@ -92,24 +93,139 @@ def test_export_run_json_reports_configured_path_and_exit_zero(monkeypatch, tmp_
     assert export_runner.calls == [("Linux/X11", "release", "build/game.x86_64")]
 
 
-def test_export_run_has_no_mode_or_output_flags(monkeypatch, tmp_path):
-    # #121 trims the surface to the issue's ask: --mode and --output are deferred
-    # to #170, so passing either is an unknown-option usage error (Typer exits 2),
-    # and no engine is ever spawned.
+def test_export_run_default_mode_is_release(monkeypatch, tmp_path):
+    # #170 adds --mode but keeps release the default: omitting --mode runs the
+    # native --export-release invocation and reports mode == "release", the #121
+    # behavior preserved.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    _, export_runner = _inject(monkeypatch)
+
+    result = CliRunner().invoke(
+        app,
+        ["export", "run", "--preset", "Linux/X11", "--project", str(tmp_path), "--json"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout)["mode"] == "release"
+    assert export_runner.calls == [("Linux/X11", "release", "build/game.x86_64")]
+
+
+def test_export_run_mode_selects_export_flavor(monkeypatch, tmp_path):
+    # --mode (issue #170) selects the export flavor, reflected in BOTH the native
+    # invocation (the mode string the runner is asked to export) and the result's
+    # `mode` field. Each of debug/pack flows end-to-end through the pipeline.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    for mode in ("debug", "pack"):
+        _, export_runner = _inject(monkeypatch)
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "export", "run", "--preset", "Linux/X11",
+                "--mode", mode,
+                "--project", str(tmp_path), "--json",
+            ],
+        )
+
+        assert result.exit_code == 0, f"{mode}: {result.stdout + result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["mode"] == mode
+        # The native export was driven with the selected mode, to the configured path.
+        assert export_runner.calls == [("Linux/X11", mode, "build/game.x86_64")]
+
+
+def test_export_run_rejects_unknown_mode(monkeypatch, tmp_path):
+    # --mode is a closed set (release/debug/pack); an unrecognized value is a
+    # Typer usage error (exit 2) and spawns no engine.
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
 
     def _boom(*args, **kwargs):
-        raise AssertionError("a rejected flag must not spawn any engine")
+        raise AssertionError("a rejected --mode must not spawn any engine")
 
     monkeypatch.setattr("gda.cli._make_runner", _boom)
     monkeypatch.setattr("gda.cli._make_export_runner", _boom)
 
-    for bad in (["--mode", "debug"], ["--output", "dist/game.x86_64"]):
-        result = CliRunner().invoke(
-            app,
-            ["export", "run", "--preset", "Linux/X11", *bad, "--project", str(tmp_path)],
-        )
-        assert result.exit_code == 2, f"{bad}: {result.stdout + result.stderr}"
+    result = CliRunner().invoke(
+        app,
+        [
+            "export", "run", "--preset", "Linux/X11",
+            "--mode", "nonsense",
+            "--project", str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 2, result.stdout + result.stderr
+
+
+def test_export_run_output_overrides_configured_path(monkeypatch, tmp_path):
+    # --output (issue #170) overrides the preset's configured export_path: the
+    # native export is driven to the override, NOT the configured "build/game.x86_64",
+    # and the result's output_path reports the effective destination.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    _, export_runner = _inject(monkeypatch)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "export", "run", "--preset", "Linux/X11",
+            "--output", "dist/custom.x86_64",
+            "--project", str(tmp_path), "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    # The reported output_path is the override (the effective destination).
+    assert data["output_path"] == "dist/custom.x86_64"
+    assert data["mode"] == "release"
+    assert export_runner.calls == [("Linux/X11", "release", "dist/custom.x86_64")]
+
+
+def test_export_run_output_expands_leading_tilde(monkeypatch, tmp_path):
+    # ADR-0006: --output is a filesystem path normalized ONCE at the CLI layer, so
+    # a literal `~` is expanded to the user's home before it reaches the runner —
+    # the artifact lands in $HOME, not a literal "~" directory.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    _, export_runner = _inject(monkeypatch)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "export", "run", "--preset", "Linux/X11",
+            "--output", "~/builds/game.x86_64",
+            "--project", str(tmp_path), "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    expanded = str((Path.home() / "builds/game.x86_64"))
+    data = json.loads(result.stdout)
+    # Both the native invocation and the reported destination carry the expanded path.
+    assert data["output_path"] == expanded
+    assert export_runner.calls == [("Linux/X11", "release", expanded)]
+
+
+def test_export_run_output_overrides_unset_configured_path(monkeypatch, tmp_path):
+    # --output supplies a destination even when the preset's configured export_path
+    # is empty: the export_path_unset preflight no longer fires (there IS a place to
+    # write), and the export runs to the override.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    get = {**GET_RESULT, "export_path": ""}
+    _, export_runner = _inject(monkeypatch, get=get)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "export", "run", "--preset", "Linux/X11",
+            "--output", "dist/custom.x86_64",
+            "--project", str(tmp_path), "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["output_path"] == "dist/custom.x86_64"
+    assert export_runner.calls == [("Linux/X11", "release", "dist/custom.x86_64")]
 
 
 def test_export_run_surfaces_advisory_warnings(monkeypatch, tmp_path):
@@ -258,11 +374,11 @@ def test_export_run_schema_emits_contract_without_engine(monkeypatch):
     assert result.exit_code == 0, result.stdout + result.stderr
     schema = json.loads(result.stdout)
     assert set(schema) == {"input", "output", "error"}
-    # The input schema carries only the command's single param (--mode / --output
-    # are deferred to #170); the output schema carries the result.
+    # The input schema carries the command's params, now including the #170
+    # --mode and --output overrides; the output schema carries the result.
     assert "preset" in schema["input"]["properties"]
-    assert "mode" not in schema["input"]["properties"]
-    assert "output_path" not in schema["input"]["properties"]
+    assert "mode" in schema["input"]["properties"]
+    assert "output" in schema["input"]["properties"]
     assert "output_path" in schema["output"]["properties"]
     assert "warnings" in schema["output"]["properties"]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,8 @@ from gda.models import (
     EngineVersion,
     ExportGetResult,
     ExportListResult,
+    ExportRunMode,
+    ExportRunResult,
     GdaError,
     GdaErrorEnvelope,
     NodeAddResult,
@@ -576,6 +578,46 @@ def test_export_get_result_round_trips_missing_templates():
     assert got.templates_installed is False
     assert got.export_path == ""
     assert json.loads(got.model_dump_json()) == payload
+
+
+def test_export_run_result_round_trips_each_mode():
+    # The result's `mode` reflects the selected export flavor (issue #170): each
+    # of release/debug/pack round-trips to its native-flag string, so a result
+    # serialized for any --mode reports the mode that ran.
+    for mode in (ExportRunMode.RELEASE, ExportRunMode.DEBUG, ExportRunMode.PACK):
+        payload = {
+            "preset": "Linux/X11",
+            "platform": "Linux/X11",
+            "mode": mode.value,
+            "output_path": "build/game.x86_64",
+            "warnings": [],
+        }
+
+        ran = ExportRunResult.model_validate(payload)
+
+        assert ran.mode is mode
+        assert ran.output_path == "build/game.x86_64"
+        assert json.loads(ran.model_dump_json()) == payload
+
+
+def test_export_run_result_reports_overridden_output_path():
+    # With --output (issue #170) the result's output_path is the EFFECTIVE
+    # destination — the override, not the preset's configured export_path — so an
+    # agent reads back where the artifact actually landed.
+    payload = {
+        "preset": "Linux/X11",
+        "platform": "Linux/X11",
+        "mode": "pack",
+        "output_path": "/tmp/dist/game.pck",
+        "warnings": ["No export template found at the expected icon path."],
+    }
+
+    ran = ExportRunResult.model_validate(payload)
+
+    assert ran.mode is ExportRunMode.PACK
+    assert ran.output_path == "/tmp/dist/game.pck"
+    assert ran.warnings == ["No export template found at the expected icon path."]
+    assert json.loads(ran.model_dump_json()) == payload
 
 
 def test_node_set_result_round_trips_the_coerced_property():


### PR DESCRIPTION
## What

Rounds out `gda export run` (#121) with the two optional overrides de-scoped from that slice:

- `--mode release|debug|pack` — selects the export flavor (maps to Godot's native `--export-release`/`--export-debug`/`--export-pack`). A closed Typer `Enum`, so an unknown value is a usage error (exit 2) before reaching the runner. Default `release`, preserving #121's behavior when omitted.
- `--output PATH` — overrides the preset's configured `export_path`. Normalized **once** at the CLI layer via `_normalize_path` (ADR-0006: `~` expanded), like every other path-taking command.

The result keeps its shape: `mode` reflects the selected flavor; `output_path` reports the effective destination (override when given, else the configured path).

## How

- `ExportRunParams` gains `mode` (default `release`) and `output` (default `None`) so the ADR-0004 `--schema` gate advertises both.
- Changes are localized to the `run_export` command body: `mode`/`output_path` were already the locals the native invocation + result consume, so this only changes where they come from. The `export_path_unset` preflight now fires only when there is neither an override nor a configured path.
- No shared registries, enums, dispatch tables, or other commands touched.

## Tests (TDD: failing tests first, then implementation)

- **S2** (`test_models.py`): mode round-trip per flavor; result reports the overridden `output_path`.
- **S3** (`test_export_run_commands.py`, `FakeExportRunner`): default mode is release; mode selects the flavor; unknown mode rejected (exit 2); output overrides configured path; **leading-`~` expansion** (ADR-0006); output overrides even an unset configured path; `--schema` now advertises `mode` + `output`.
- **S1 e2e** (`test_e2e_export_run.py`): `--mode pack --output …` writes to the overridden path, following the existing template-presence auto-skip policy.

## Results & known limitation

- Engine-free full suite: **489 passed**. `--schema` ADR-0004 gate verified (emits `mode`/`output` in `input.properties`, no engine spawned).
- e2e on the real engine: the two **success-path** e2e tests (configured-path and the new `--output`/`--mode pack` override) **auto-skip** because this machine has no export templates for the running engine version installed — each verifies the structured `export_templates_missing` preflight live before skipping. So the on-disk-artifact assertions could not be exercised here; reviewer with templates installed can confirm.

Closes #170.
