### PR TITLE
test(e2e): characterize the project-code execution surface + README facts (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ gda <meta-command> [options]        # meta commands about gda/the engine, e.g. g
 | `--json`    | Emit the result as a single JSON object on stdout. Without it, commands print a concise human-readable rendering. |
 | `--schema`  | Emit the command's input/output JSON Schema contract (no Godot spawned). |
 | `--godot`   | Path to the Godot binary (overrides `$GDA_GODOT` and the default). |
-| `--project` | Godot project directory for `res://` resolution (overrides `$GDA_PROJECT`; defaults to the current directory if it is a project). Domain commands only. |
+| `--project` | Godot project directory for `res://` resolution (overrides `$GDA_PROJECT`; defaults to the current directory if it is a project). Domain commands only. Resolving a project runs that project's code — see [Project code execution](#project-code-execution). |
 | `--help`    | Show usage for `gda` or any command.                                |
 
 ---
@@ -269,6 +269,31 @@ the engine; filesystem paths get `~` expanded. See
 ```bash
 gda scene get res://main.tscn --project ~/game --json
 ```
+
+### Project code execution
+
+Resolving a project so `res://` paths work runs Godot against that project, and Godot runs
+some of the project's own code as part of that. Concretely:
+
+- **Autoloads run on every `--project` operation.** When a project is resolved, the engine
+  constructs the project's autoload singletons at startup — before the command's own work runs —
+  so their `_init` (and `_ready`) execute on **every** operation, including read-only ones like
+  `scene get` and `node list`. Without a resolved project, no autoloads are registered, so they do
+  not run.
+- **Commands that instantiate a scene execute that scene's attached scripts' constructors.** A
+  command that needs a live node tree — every mutating command (`node add`, `node set`,
+  `node remove`, …), and `node get` (which reports runtime property defaults the stored data does
+  not carry) — loads and instantiates the scene, which constructs each node and runs the `_init` of
+  any script attached to a node in it. Commands that only read the stored scene data
+  (`scene get`, `scene list`, `node list`) walk it without instantiating, so they do not run those
+  scripts.
+
+In short: pointing `gda` at a project executes that project's autoload code on every command, and
+any command that instantiates a scene additionally executes that scene's attached scripts' `_init`.
+The tracked decisions on this are [#61](https://github.com/aigengame/godot-agent/issues/61)
+(autoloads) and [#62](https://github.com/aigengame/godot-agent/issues/62) (scene scripts on
+instantiating operations); see also
+[ADR-0009](docs/adr/0009-trust-boundary-trusted-project.md).
 
 ---
 

--- a/tests/test_e2e_scene_security.py
+++ b/tests/test_e2e_scene_security.py
@@ -3,10 +3,13 @@
 These tests freeze *today's verified contract* for when a single ``gda`` run
 triggers the target project's own code to run (CONTEXT.md "Project-code
 execution surface"). They are deliberate characterization tests for the two
-tracked security findings #61 (autoloads run on every ``--project`` op) and #62
-(mutating commands execute pre-existing scene scripts' ``_init``). They pin the
-facts so that *if hardening ever lands*, the change shows up here as an
-intentional, reviewed test inversion rather than a silent behavior drift.
+tracked findings #61 (autoloads run on every ``--project`` op) and #62
+(instantiating commands execute pre-existing scene scripts' ``_init``). They pin
+the facts so that *if a future behavior/robustness change lands*, the change
+shows up here as an intentional, reviewed test inversion rather than a silent
+behavior drift. ADR-0009 settles the trust-boundary posture: in a Phase-1
+trusted project this constructor execution is expected behavior, and future
+autoload suppression would be a robustness change.
 
 The contract pinned (verified on Godot 4.6.3):
 
@@ -17,10 +20,14 @@ The contract pinned (verified on Godot 4.6.3):
    never runs (issue #30, extended to the node group).
 2. ``test_node_add_executes_pre_existing_scene_script`` — mutation instantiates
    the scene, so a pre-existing scripted node's ``_init`` runs (#62).
-3. ``test_node_add_forged_sentinel_from_scene_script_fails_loudly`` — a scene
+3. ``test_node_get_executes_pre_existing_scene_script`` — ``node get`` is a read
+   that *instantiates* (``operations.gd`` reads it via ``packed.instantiate()``),
+   so it too runs a pre-existing scripted node's ``_init``; the get still
+   succeeds (#62).
+4. ``test_node_add_forged_sentinel_from_scene_script_fails_loudly`` — a scene
    script that forges a result block makes the mutate command fail loudly with
    ``contract_violation`` / exit 5, never a silently accepted forged result (#62).
-4. ``test_autoload_runs_on_scene_get`` — a project's autoload constructor runs
+5. ``test_autoload_runs_on_scene_get`` — a project's autoload constructor runs
    on *every* ``--project`` op, even a read-only ``scene get`` (#61).
 """
 
@@ -99,6 +106,10 @@ def test_scene_get_does_not_execute_scene_code(godot_project):
 
 
 # --- Characterization of the project-code execution surface (issues #61/#62) ---
+# Trust-boundary posture is settled by ADR-0009: in a Phase-1 trusted project the
+# autoload/scene-script constructor execution these tests pin is expected
+# behavior, not a vulnerability. These are characterization tests of that
+# operation-level contract — not security regression tests.
 
 # A scene script whose _init writes an observable marker file. Reused by the
 # read-clean and mutation tests below to detect whether the script ran.
@@ -137,10 +148,10 @@ def _plant_spied_scene(project):
 def test_node_list_does_not_execute_scene_script(godot_project):
     # Characterizes #30's read-clean guarantee, extended to the node group:
     # `node list` (and `scene get`) walk the packed scene's stored state and
-    # never instantiate it, so an attached script's _init never runs. This is a
-    # POSITIVE security property; unlike the #61/#62 contracts below it is NOT a
+    # never instantiate it, so an attached script's _init never runs. This is an
+    # operation-level invariant; unlike the #61/#62 contracts below it is NOT a
     # behavior we expect to invert — if it ever fails, a read started executing
-    # project code and that is a regression, not intentional hardening.
+    # project code and that is a regression, not an intentional behavior change.
     scene = _plant_spied_scene(godot_project)
 
     listed = _gda("node", "list", str(scene), "--project", str(godot_project), "--json")
@@ -166,9 +177,9 @@ def test_node_add_executes_pre_existing_scene_script(godot_project):
     # `node add` on a scene with a pre-existing scripted root EXECUTES that
     # script. The add still succeeds and reports the added node.
     #
-    # If hardening ever lands for #62 (mutate path no longer executes scene
-    # scripts), THIS TEST MUST BE INTENTIONALLY INVERTED: the assertion below
-    # should flip to assert the marker file does NOT appear.
+    # If a future behavior/robustness change lands for #62 (mutate path no longer
+    # executes scene scripts), THIS TEST MUST BE INTENTIONALLY INVERTED: the
+    # assertion below should flip to assert the marker file does NOT appear.
     scene = _plant_spied_scene(godot_project)
 
     added = _gda(
@@ -181,6 +192,39 @@ def test_node_add_executes_pre_existing_scene_script(godot_project):
     data = json.loads(added.stdout)
     assert (data["path"], data["name"], data["type"]) == ("Hero", "Hero", "Sprite2D")
     # Today's contract (#62): the pre-existing scene script's _init ran.
+    assert (godot_project / "spy_ran.txt").exists()
+
+
+@pytest.mark.e2e
+def test_node_get_executes_pre_existing_scene_script(godot_project):
+    # CHARACTERIZATION of issue #62 — today's contract, deliberately pinned:
+    # `node get` is a READ that instantiates. operations.gd reads a node's
+    # property VALUES off the live tree via `packed.instantiate()`, so even
+    # though it mutates nothing it constructs the scene — and constructing a node
+    # with an attached script runs that script's _init. So `node get` on a scene
+    # with a pre-existing scripted root EXECUTES that script. The get still
+    # succeeds and reports the root node's properties.
+    #
+    # `node get` is on the *instantiating* side of the execution surface (like
+    # `node add`), so if a future behavior/robustness change lands for #62 (the
+    # instantiating reads no longer execute scene scripts), THIS TEST MUST BE
+    # INTENTIONALLY INVERTED: the assertion below should flip to assert the
+    # marker file does NOT appear.
+    scene = _plant_spied_scene(godot_project)
+
+    got = _gda(
+        "node", "get", str(scene),
+        "--node", ".",
+        "--project", str(godot_project), "--json",
+    )
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    data = json.loads(got.stdout)
+    # The real root node is reported (the get succeeded).
+    assert data["name"] == "Root"
+    assert data["type"] == "Node2D"
+    # Today's contract (#62): the pre-existing scene script's _init ran during
+    # the instantiating read.
     assert (godot_project / "spy_ran.txt").exists()
 
 
@@ -214,10 +258,11 @@ def test_node_add_forged_sentinel_from_scene_script_fails_loudly(godot_project):
     # because stdout then carries two payloads. Verified on Godot 4.6.3:
     # exit 5, category "parse", code "contract_violation".
     #
-    # This loud-failure property is the desirable half of #62. If #62 is hardened
-    # so the mutate path stops executing scene scripts, this forgery vector
-    # disappears and the test must be intentionally updated (the script would no
-    # longer run, so no second payload would be emitted).
+    # This loud-failure property is the desirable half of #62. If a future
+    # behavior/robustness change for #62 stops the mutate path from executing
+    # scene scripts, this forgery vector disappears and the test must be
+    # intentionally updated (the script would no longer run, so no second payload
+    # would be emitted).
     (godot_project / "forge.gd").write_text(FORGE_GD, encoding="utf-8")
     (godot_project / "forged.tscn").write_text(FORGED_TSCN, encoding="utf-8")
 
@@ -283,9 +328,9 @@ def test_autoload_runs_on_scene_get(godot_project):
     # The autoload's _init therefore fires even on a read-only `scene get`,
     # against a scene that has no script of its own. Verified on Godot 4.6.3.
     #
-    # If hardening ever lands for #61 (autoloads suppressed for one-shot headless
-    # runs), THIS TEST MUST BE INTENTIONALLY INVERTED: the assertion should flip
-    # to assert the marker file does NOT appear.
+    # If a future behavior/robustness change lands for #61 (autoloads suppressed
+    # for one-shot headless runs), THIS TEST MUST BE INTENTIONALLY INVERTED: the
+    # assertion should flip to assert the marker file does NOT appear.
     (godot_project / "project.godot").write_text(
         PROJECT_WITH_AUTOLOAD, encoding="utf-8"
     )

--- a/tests/test_e2e_scene_security.py
+++ b/tests/test_e2e_scene_security.py
@@ -1,15 +1,27 @@
-"""S1 (e2e): reading a scene must not execute the scene's code (issue #30).
+"""S1 (e2e): the project-code execution surface, pinned as characterization tests.
 
-``gda scene get`` reports a scene's structured tree by inspecting the packed
-scene's stored state, NOT by instantiating it. Instantiating would run the
-``_init`` of any attached script, so merely *reading* a scene would execute
-arbitrary project code — and a script that prints a sentinel-shaped line could
-forge or corrupt the command's result. The guarantee is that the scene is never
-instantiated (issue #30), so that line is never emitted in the first place.
+These tests freeze *today's verified contract* for when a single ``gda`` run
+triggers the target project's own code to run (CONTEXT.md "Project-code
+execution surface"). They are deliberate characterization tests for the two
+tracked security findings #61 (autoloads run on every ``--project`` op) and #62
+(mutating commands execute pre-existing scene scripts' ``_init``). They pin the
+facts so that *if hardening ever lands*, the change shows up here as an
+intentional, reviewed test inversion rather than a silent behavior drift.
 
-This test plants a root script whose ``_init`` both writes a marker file (an
-observable side effect) and prints a forged result block, then asserts neither
-happened: the real tree is reported and the side-effect file does not exist.
+The contract pinned (verified on Godot 4.6.3):
+
+1. ``test_node_list_does_not_execute_scene_script`` /
+   ``test_scene_get_does_not_execute_scene_code`` — reads stay clean at the
+   *operation* level: ``node list`` / ``scene get`` walk the packed scene's
+   stored state and never instantiate it, so an attached script's ``_init``
+   never runs (issue #30, extended to the node group).
+2. ``test_node_add_executes_pre_existing_scene_script`` — mutation instantiates
+   the scene, so a pre-existing scripted node's ``_init`` runs (#62).
+3. ``test_node_add_forged_sentinel_from_scene_script_fails_loudly`` — a scene
+   script that forges a result block makes the mutate command fail loudly with
+   ``contract_violation`` / exit 5, never a silently accepted forged result (#62).
+4. ``test_autoload_runs_on_scene_get`` — a project's autoload constructor runs
+   on *every* ``--project`` op, even a read-only ``scene get`` (#61).
 """
 
 import json
@@ -21,6 +33,17 @@ import pytest
 from gda.binary import resolve_godot_binary
 
 GODOT = resolve_godot_binary()
+
+
+def _gda(*args: str, cwd=None) -> subprocess.CompletedProcess:
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+    return subprocess.run(
+        [gda_bin, *args, "--godot", str(GODOT)],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd) if cwd is not None else None,
+    )
 
 
 # A root script whose _init has a side effect AND prints a forged result block.
@@ -73,3 +96,209 @@ def test_scene_get_does_not_execute_scene_code(godot_project):
     assert tree["path"] != "forged"
     # The script's _init never ran: no side-effect file.
     assert not (godot_project / "pwned.txt").exists()
+
+
+# --- Characterization of the project-code execution surface (issues #61/#62) ---
+
+# A scene script whose _init writes an observable marker file. Reused by the
+# read-clean and mutation tests below to detect whether the script ran.
+SPY_GD = """\
+extends Node2D
+
+
+func _init() -> void:
+	var f := FileAccess.open("res://spy_ran.txt", FileAccess.WRITE)
+	if f:
+		f.store_string("executed")
+		f.close()
+	printerr("SPY: _init executed")
+"""
+
+SPIED_TSCN = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://spy.gd" id="1"]
+
+[node name="Root" type="Node2D"]
+script = ExtResource("1")
+"""
+
+
+def _plant_spied_scene(project):
+    """A scene whose root has a script with a side-effecting ``_init`` that
+    writes ``res://spy_ran.txt``. The project fixture has no autoload, so the
+    scene script is the *only* project-code execution surface here."""
+    (project / "spy.gd").write_text(SPY_GD, encoding="utf-8")
+    (project / "spied.tscn").write_text(SPIED_TSCN, encoding="utf-8")
+    return project / "spied.tscn"
+
+
+@pytest.mark.e2e
+def test_node_list_does_not_execute_scene_script(godot_project):
+    # Characterizes #30's read-clean guarantee, extended to the node group:
+    # `node list` (and `scene get`) walk the packed scene's stored state and
+    # never instantiate it, so an attached script's _init never runs. This is a
+    # POSITIVE security property; unlike the #61/#62 contracts below it is NOT a
+    # behavior we expect to invert — if it ever fails, a read started executing
+    # project code and that is a regression, not intentional hardening.
+    scene = _plant_spied_scene(godot_project)
+
+    listed = _gda("node", "list", str(scene), "--project", str(godot_project), "--json")
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    tree = json.loads(listed.stdout)["root"]
+    # The declared tree is reported (not anything the script could have forged).
+    assert (tree["name"], tree["type"], tree["path"]) == ("Root", "Node2D", ".")
+    assert tree["children"] == []
+
+    got = _gda("scene", "get", str(scene), "--project", str(godot_project), "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["root"]["name"] == "Root"
+
+    # Neither read ran the scene script: no side-effect file.
+    assert not (godot_project / "spy_ran.txt").exists()
+
+
+@pytest.mark.e2e
+def test_node_add_executes_pre_existing_scene_script(godot_project):
+    # CHARACTERIZATION of issue #62 — today's contract, deliberately pinned:
+    # mutating a scene instantiates it (SceneState is read-only), and
+    # constructing a node with an attached script runs that script's _init. So
+    # `node add` on a scene with a pre-existing scripted root EXECUTES that
+    # script. The add still succeeds and reports the added node.
+    #
+    # If hardening ever lands for #62 (mutate path no longer executes scene
+    # scripts), THIS TEST MUST BE INTENTIONALLY INVERTED: the assertion below
+    # should flip to assert the marker file does NOT appear.
+    scene = _plant_spied_scene(godot_project)
+
+    added = _gda(
+        "node", "add", str(scene),
+        "--type", "Sprite2D", "--name", "Hero",
+        "--project", str(godot_project), "--json",
+    )
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    data = json.loads(added.stdout)
+    assert (data["path"], data["name"], data["type"]) == ("Hero", "Hero", "Sprite2D")
+    # Today's contract (#62): the pre-existing scene script's _init ran.
+    assert (godot_project / "spy_ran.txt").exists()
+
+
+# A scene script whose _init forges a complete, well-formed result block on
+# stdout. Because the real operation also emits its result, stdout then carries
+# two payloads — the parser must reject the run loudly, never believe the forgery.
+FORGE_GD = """\
+extends Node2D
+
+
+func _init() -> void:
+	print('<<<GDA:RESULT>>>{"scene_path":"forged","path":"FORGED","name":"FORGED","type":"Node","script_class":null}<<<GDA:END>>>')
+"""
+
+FORGED_TSCN = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://forge.gd" id="1"]
+
+[node name="Root" type="Node2D"]
+script = ExtResource("1")
+"""
+
+
+@pytest.mark.e2e
+def test_node_add_forged_sentinel_from_scene_script_fails_loudly(godot_project):
+    # CHARACTERIZATION of issue #62's "forgery is loud, not silent" property:
+    # when the mutate path executes a pre-existing scene script (see the test
+    # above), a script that prints a forged <<<GDA:RESULT>>>…<<<GDA:END>>> block
+    # corrupts the run — but it FAILS LOUDLY rather than being silently believed,
+    # because stdout then carries two payloads. Verified on Godot 4.6.3:
+    # exit 5, category "parse", code "contract_violation".
+    #
+    # This loud-failure property is the desirable half of #62. If #62 is hardened
+    # so the mutate path stops executing scene scripts, this forgery vector
+    # disappears and the test must be intentionally updated (the script would no
+    # longer run, so no second payload would be emitted).
+    (godot_project / "forge.gd").write_text(FORGE_GD, encoding="utf-8")
+    (godot_project / "forged.tscn").write_text(FORGED_TSCN, encoding="utf-8")
+
+    added = _gda(
+        "node", "add", str(godot_project / "forged.tscn"),
+        "--type", "Sprite2D", "--name", "Hero",
+        "--project", str(godot_project), "--json",
+    )
+
+    # The forged result is never accepted: the run fails on the parse boundary.
+    assert added.returncode == 5, added.stdout + added.stderr
+    err = json.loads(added.stdout)["error"]
+    assert err["category"] == "parse"
+    assert err["code"] == "contract_violation"
+    # The forgery surfaces only as a diagnostic, never as a believed result
+    # payload: the envelope is an error, not a success carrying "FORGED".
+    assert "error" in json.loads(added.stdout)
+
+
+# An autoload whose _init writes an observable marker file. The project defines
+# it via [autoload]; the engine constructs it during startup, before gda's own
+# operation script runs — so it fires on ANY --project op, read or write.
+AUTOLOAD_GD = """\
+extends Node
+
+
+func _init() -> void:
+	var f := FileAccess.open("res://autoload_ran.txt", FileAccess.WRITE)
+	if f:
+		f.store_string("executed")
+		f.close()
+	printerr("AUTOLOAD: _init executed")
+"""
+
+# A project.godot that registers the autoload (extends the minimal fixture form).
+PROJECT_WITH_AUTOLOAD = """\
+config_version=5
+
+[application]
+
+config/name="gda-e2e-autoload-fixture"
+
+[autoload]
+
+Spy="*res://autoload.gd"
+"""
+
+# A plain scene with NO attached script, so the only project-code execution
+# surface in this test is the autoload (not a scene script).
+PLAIN_TSCN = """\
+[gd_scene format=3]
+
+[node name="Root" type="Node2D"]
+"""
+
+
+@pytest.mark.e2e
+def test_autoload_runs_on_scene_get(godot_project):
+    # CHARACTERIZATION of issue #61 — today's contract, deliberately pinned:
+    # the runner passes --path <project> for any --project op, and operations.gd
+    # is a SceneTree main loop, so the engine registers and constructs the
+    # project's autoload singletons during startup — BEFORE the operation runs.
+    # The autoload's _init therefore fires even on a read-only `scene get`,
+    # against a scene that has no script of its own. Verified on Godot 4.6.3.
+    #
+    # If hardening ever lands for #61 (autoloads suppressed for one-shot headless
+    # runs), THIS TEST MUST BE INTENTIONALLY INVERTED: the assertion should flip
+    # to assert the marker file does NOT appear.
+    (godot_project / "project.godot").write_text(
+        PROJECT_WITH_AUTOLOAD, encoding="utf-8"
+    )
+    (godot_project / "autoload.gd").write_text(AUTOLOAD_GD, encoding="utf-8")
+    (godot_project / "plain.tscn").write_text(PLAIN_TSCN, encoding="utf-8")
+
+    got = _gda(
+        "scene", "get", str(godot_project / "plain.tscn"),
+        "--project", str(godot_project), "--json",
+    )
+
+    # The read itself succeeds and reports the declared (script-less) tree.
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["root"]["name"] == "Root"
+    # Today's contract (#61): the project's autoload _init ran during the read op.
+    assert (godot_project / "autoload_ran.txt").exists()


### PR DESCRIPTION
## What

Pins **today's verified behavior** of the project-code execution surface (CONTEXT.md) as e2e characterization tests, and states the facts in user-facing docs — so any future hardening shows up as an intentional, reviewed test inversion rather than silent drift. This slice does **not** take a posture; it characterizes the two tracked security findings #61 (autoloads) and #62 (scene scripts on instantiating ops).

## Tests (all pass against real Godot 4.6.3)

Added to `tests/test_e2e_scene_security.py` (kept the existing #30 test → 5 total):

1. `test_node_list_does_not_execute_scene_script` — `node list` / `scene get` on a scripted scene report the declared tree and run **no** scene-script `_init` (extends #30 to the node group). Flagged as a **positive** property — NOT to be inverted; a failure here is a regression.
2. `test_node_add_executes_pre_existing_scene_script` — `node add` succeeds **and** the pre-existing scripted node's `_init` runs (today's #62 contract). Comment flags deliberate inversion if #62 is hardened.
3. `test_node_add_forged_sentinel_from_scene_script_fails_loudly` — a scene script forging a `<<<GDA:RESULT>>>…<<<GDA:END>>>` block makes `node add` fail loudly: **exit 5, category `parse`, code `contract_violation`** — never a silently accepted forgery. Verified against `exit_codes.py`/`error_codes.py`.
4. `test_autoload_runs_on_scene_get` — a project's autoload `_init` runs on **every** `--project` op, even read-only `scene get` (today's #61 contract). Same inversion note.

Each test's comment names the issue it characterizes and states the exact condition under which it must be intentionally updated.

## README

New **"Project code execution"** subsection under "Project context", plus a pointer on the `--project` flag row. States factually that (a) autoloads run on every `--project` op (and not when no project resolves), and (b) any command that **instantiates** a scene — mutating commands **and** `node get` — runs that scene's attached scripts' `_init`, while pure reads (`scene get`, `scene list`, `node list`) do not. Classifies by **mechanism (instantiation)**, not a read/mutate split (corrected after empirically confirming `node get` instantiates). No posture language. Links #61, #62, ADR-0009.

## Results

- Full suite: **711 passed, 1 skipped** (the 1 skip is a pre-existing `test_e2e_export_run.py` template-presence skip, unrelated).
- Note: `ruff` is not installed in this environment, so the configured linter could not be run; the new tests mirror the existing e2e style exactly and pytest collection is clean.

Closes #63. (Leaves #61/#62 posture decisions open by design.)
