### PR TITLE
fix(script): preserve sibling scripts on re-pack in unimported projects (#164)

### DIFF
--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3158,6 +3158,16 @@ func _repack_and_save(root: Node, path: String) -> bool:
 	# dropping the sibling's `script = ExtResource(...)` line (or re-embedding it as
 	# a sub_resource). Re-anchoring repoints every node at the single cache owner
 	# for its path, so the saver sees one consistent ext_resource per path.
+	#
+	# This is the CENTRAL shared-mutation hardening point. Because it runs from the
+	# shared pack-and-save tail, it hardens every mutating re-pack op (node
+	# add/set/remove/duplicate/move, signal connect/disconnect) — not only `script
+	# attach` (issue #164's reported path). That broader reach is correct, not
+	# overreach: _reanchor_external_scripts only repoints a node that STILL carries
+	# its captured script (siblings preserved); it leaves a node the op
+	# intentionally re-scripted to a different non-empty path alone; and it skips
+	# nodes that vanished since capture (remove/move). `node add` is covered by
+	# test_node_add_preserves_sibling_script_on_repack_when_unimported.
 	_reanchor_external_scripts(root)
 	var repacked := PackedScene.new()
 	var pack_err := repacked.pack(root)

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3126,6 +3126,10 @@ func _load_for_mutation(params: Dictionary) -> Node:
 		_fail(OP_ERROR_MISSING_DEPENDENCY, "scene nodes vanished or degraded on load: "
 				+ ", ".join(unmaterialized) + " — re-saving would silently drop or downgrade them; check the scene's dependencies and --project")
 		return null
+	# Snapshot every node's external script path NOW — the instant after
+	# instantiate, before any op-specific load can evict a sibling's script object
+	# (issue #164). _repack_and_save re-anchors from this snapshot on the way out.
+	_capture_external_scripts(root)
 	return root
 
 
@@ -3141,6 +3145,20 @@ func _load_for_mutation(params: Dictionary) -> Node:
 # before calling, as the tree is gone once this returns; for scene create the caller
 # also creates any missing parent dirs first, since this tail only packs and saves.
 func _repack_and_save(root: Node, path: String) -> bool:
+	# Re-anchor every external script captured at load time to the one canonical
+	# cached resource for its res:// path BEFORE packing (issue #164). On the
+	# editor build gda drives, the text scene saver dedups ext_resources through a
+	# PATH-keyed cache (ResourceCache::resource_path_cache), not object identity. A
+	# re-attach can leave two distinct in-memory Script objects sharing one res://
+	# path: the engine's GDScriptCache upgrades a shallow script to a full one via
+	# set_path(take_over=true), which evicts the previously cached object WITHOUT
+	# freeing it, so a sibling node still holds the evicted orphan. With an
+	# UNIMPORTED script the path string is the only identity (no uid://), so the
+	# path-keyed dedup collapses the two same-path objects on save — silently
+	# dropping the sibling's `script = ExtResource(...)` line (or re-embedding it as
+	# a sub_resource). Re-anchoring repoints every node at the single cache owner
+	# for its path, so the saver sees one consistent ext_resource per path.
+	_reanchor_external_scripts(root)
 	var repacked := PackedScene.new()
 	var pack_err := repacked.pack(root)
 	if pack_err != OK:
@@ -3153,6 +3171,79 @@ func _repack_and_save(root: Node, path: String) -> bool:
 		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message("scene", path, save_err))
 		return false
 	return true
+
+
+# {NodePath (root-relative) -> script res:// path} for every node that carried a
+# file-backed script when the tree was first instantiated (issue #164). Captured
+# by _capture_external_scripts the instant _load_for_mutation finishes
+# instantiating — BEFORE any subsequent load (e.g. attach's --script) can run the
+# GDScriptCache shallow→full upgrade that evicts a sibling's script object and
+# clears its resource_path. Consumed by _reanchor_external_scripts at re-pack
+# time, where the orphan's own resource_path is already empty and useless: the
+# captured path is the only surviving anchor back to the script the node should
+# carry. A single member is safe here — operations.gd is a one-shot process that
+# runs exactly one operation, so there is no cross-operation state to leak.
+var _captured_external_scripts: Dictionary = {}
+
+
+# Record {NodePath -> script res:// path} for every node in the freshly
+# instantiated tree that carries a file-backed script, so a later load that
+# evicts one of those scripts can be undone before re-pack (issue #164). Read off
+# the LIVE script object while its resource_path is still intact; a script with
+# no resource_path (an embedded/sub-resource script) has no external identity to
+# anchor and is skipped. Paths are root-relative (get_path_to) so they survive
+# the round-trip to _reanchor_external_scripts regardless of the root's own name.
+func _capture_external_scripts(root: Node) -> void:
+	_captured_external_scripts = {}
+	_capture_external_scripts_into(root, root)
+
+
+func _capture_external_scripts_into(node: Node, root: Node) -> void:
+	var script: Variant = node.get_script()
+	if script is Script:
+		var script_path: String = (script as Script).resource_path
+		if not script_path.is_empty():
+			_captured_external_scripts[root.get_path_to(node)] = script_path
+	for child in node.get_children():
+		_capture_external_scripts_into(child, root)
+
+
+# Repoint every captured node that STILL carries its captured script at the
+# SINGLE canonical cached resource for that script's res:// path, so a re-pack/save
+# never serializes two distinct in-memory objects under one path (issue #164 root
+# cause). For each captured {NodePath -> script_path}: re-load that path with
+# CACHE_MODE_REPLACE — which installs one object as the sole ResourceCache owner of
+# the path — and set_script it back onto the node, collapsing any evicted-but-alive
+# orphan (the second same-path object the GDScriptCache shallow→full upgrade leaves
+# behind) onto the canonical one.
+#
+# Re-anchor ONLY when the node was NOT intentionally re-scripted by the op in
+# between. The discriminator is the node's CURRENT script resource_path:
+#   - equals the captured path -> still the same script (possibly the corrupted
+#     orphan instance); re-anchor to canonicalize.
+#   - empty -> the orphan whose set_path(take_over) eviction cleared its path (the
+#     exact #164 corruption signature); re-anchor to restore the captured binding.
+#   - a DIFFERENT non-empty path -> the op deliberately overwrote this node's
+#     script (e.g. script attach replacing one binding with another, issue #132);
+#     leave it, or the re-anchor would silently undo the requested change.
+# Idempotent: when a node already holds the canonical object, set_script re-binds
+# the same resource, a no-op. A node that vanished since capture (a remove/move op
+# may have detached or freed it) is skipped — its capture entry is stale.
+func _reanchor_external_scripts(root: Node) -> void:
+	for node_path: NodePath in _captured_external_scripts:
+		var node := root.get_node_or_null(node_path)
+		if node == null:
+			continue
+		var captured_path: String = _captured_external_scripts[node_path]
+		var current: Variant = node.get_script()
+		if current is Script:
+			var current_path: String = (current as Script).resource_path
+			if not current_path.is_empty() and current_path != captured_path:
+				continue  # op intentionally replaced this node's script — leave it
+		var canonical: Resource = ResourceLoader.load(
+				captured_path, "Script", ResourceLoader.CACHE_MODE_REPLACE)
+		if canonical is Script:
+			node.set_script(canonical)
 
 
 # Node paths declared in the scene's state that did not materialize faithfully

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -15,6 +15,7 @@ import subprocess
 import pytest
 
 from gda.binary import resolve_godot_binary
+from gda.runner import OPERATIONS_GD
 
 GODOT = resolve_godot_binary()
 
@@ -1145,3 +1146,155 @@ def test_script_create_empty_content_round_trips_as_empty_source(godot_project):
     assert got_data["source"] == ""
     assert got_data["class_name"] is None
     assert got_data["extends"] is None
+
+
+# --- script attach: sibling-script drop on re-pack (issue #164) ---
+
+# A deterministic harness for the issue #164 corruption, run against the real
+# engine. It drives gda's OWN operations.gd payload (loaded as an object, its real
+# _load_scene / _capture_external_scripts / _reanchor_external_scripts / pack /
+# save methods) so the test exercises the product re-pack path — not a re-implementation.
+#
+# Why a harness and not a plain `gda script attach` call: the corruption needs two
+# distinct in-memory Script objects sharing one res:// path. The engine creates
+# that state itself when GDScriptCache upgrades a shallow script to a full one via
+# Resource.set_path(take_over=true) — which evicts the previously cached object
+# WITHOUT freeing it, so a sibling node still references the evicted orphan. That
+# shallow→full eviction is engine-internal and does not fire deterministically
+# from a fresh one-shot `gda` process (each call reuses the resource cache from
+# scratch), so a CLI-only test would be as intermittent as the original bug. The
+# harness reproduces the EXACT engine mechanism (take_over_path, i.e.
+# set_path(take_over=true)) deterministically, in an unimported-project fixture
+# (no .godot import metadata, no .uid sidecar -> scripts carry no uid://), then
+# runs the real product re-pack. Pre-fix the sibling's `script = ExtResource(...)`
+# is dropped; post-fix the capture+reanchor preserves it. has_method guards keep
+# the harness loadable against the pre-fix payload so red→green is on behavior.
+_ATTACH_DROP_HARNESS = r"""
+extends SceneTree
+
+func _emit(ok: bool, detail: String) -> void:
+	print("<<<HARNESS>>>", JSON.stringify({"ok": ok, "detail": detail}), "<<<END>>>")
+
+func _init() -> void:
+	# Sibling-scripted scene on disk: node A carries a.gd, node B is bare. The
+	# scripts are unimported (fresh project, no import pass) -> no uid://.
+	FileAccess.open("res://a.gd", FileAccess.WRITE).store_string("extends Sprite2D\n")
+	FileAccess.open("res://b.gd", FileAccess.WRITE).store_string("extends Sprite2D\n")
+	var build_root := Node2D.new()
+	build_root.name = "main"
+	var build_a := Sprite2D.new(); build_a.name = "A"; build_root.add_child(build_a); build_a.owner = build_root
+	var build_b := Sprite2D.new(); build_b.name = "B"; build_root.add_child(build_b); build_b.owner = build_root
+	build_a.set_script(ResourceLoader.load("res://a.gd"))
+	var seed := PackedScene.new(); seed.pack(build_root); ResourceSaver.save(seed, "res://main.tscn")
+	build_root.free()
+
+	# Drive gda's REAL operations payload.
+	var ops_script: GDScript = load("res://operations.gd")
+	var ops: Object = ops_script.new()
+	var params := {"path": "res://main.tscn", "project": "res://"}
+
+	# Load + instantiate exactly as a mutating op does (_load_for_mutation).
+	var packed: PackedScene = ops.call("_load_scene", params)
+	var live: Node = packed.instantiate()
+
+	# Capture script paths the instant after instantiate, as _load_for_mutation does
+	# post-fix (the product wires this in; the test mirrors the call site). Pre-fix
+	# the method is absent, so capture is skipped and the drop is left to occur.
+	if ops.has_method("_capture_external_scripts"):
+		ops.call("_capture_external_scripts", live)
+
+	# Reproduce the engine's shallow->full eviction deterministically: a second
+	# in-memory object for res://a.gd that take_over_path()s the cache slot, leaving
+	# node A holding the evicted orphan. This is the #164 precondition verbatim.
+	var orphan_maker := GDScript.new()
+	orphan_maker.source_code = "extends Sprite2D\n"
+	orphan_maker.take_over_path("res://a.gd")
+	orphan_maker.reload()
+
+	# Attach b.gd to the sibling node B (the second-node attach the bug needs).
+	live.get_node("B").set_script(ResourceLoader.load("res://b.gd"))
+
+	# Re-anchor before pack, as the product's _repack_and_save now does.
+	if ops.has_method("_reanchor_external_scripts"):
+		ops.call("_reanchor_external_scripts", live)
+
+	var repacked := PackedScene.new()
+	var pack_err := repacked.pack(live)
+	if pack_err != OK:
+		_emit(false, "pack failed: %d" % pack_err)
+		live.free(); ops.free(); quit(); return
+	var save_err := ResourceSaver.save(repacked, "res://main.tscn")
+	live.free(); ops.free()
+	if save_err != OK:
+		_emit(false, "save failed: %d" % save_err)
+		quit(); return
+
+	var saved := FileAccess.get_file_as_string("res://main.tscn")
+	_emit(true, saved)
+	quit()
+"""
+
+
+def _run_harness(project) -> str:
+    """Run the #164 harness in `project` against the real engine; return saved .tscn."""
+    # The harness drives gda's own operations.gd, so ship a copy into the fixture.
+    shutil.copy(OPERATIONS_GD, project / "operations.gd")
+    (project / "attach_drop_harness.gd").write_text(
+        _ATTACH_DROP_HARNESS, encoding="utf-8"
+    )
+    proc = subprocess.run(
+        [
+            str(GODOT),
+            "--headless",
+            "--path",
+            str(project),
+            "--script",
+            "res://attach_drop_harness.gd",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    marker_begin, marker_end = "<<<HARNESS>>>", "<<<END>>>"
+    out = proc.stdout
+    assert marker_begin in out and marker_end in out, (
+        "harness did not emit a result:\n" + proc.stdout + proc.stderr
+    )
+    payload = out.split(marker_begin, 1)[1].split(marker_end, 1)[0].strip()
+    result = json.loads(payload)
+    assert result["ok"], "harness failed: " + result["detail"] + proc.stderr
+    return result["detail"]
+
+
+@pytest.mark.e2e
+def test_script_attach_preserves_sibling_script_on_repack_when_unimported(
+    godot_project,
+):
+    # Issue #164 regression: attaching a script to one node must never drop a
+    # SIBLING node's existing `script =` binding on the re-pack/save — including in
+    # a freshly-created project whose scripts have not been imported (no uid://).
+    #
+    # Root cause: the editor build's text scene saver dedups ext_resources through
+    # a PATH-keyed cache, not object identity. When two distinct in-memory Script
+    # objects share one res:// path (the engine's shallow→full GDScriptCache
+    # upgrade evicts-but-does-not-free the cached object a sibling still holds) and
+    # the script is unimported (path is the only identity), the dedup collapses
+    # them and the sibling's ext_resource is dropped / re-embedded as a sub_resource.
+    #
+    # This drives gda's real operations.gd re-pack path and reproduces the engine
+    # precondition deterministically (see _ATTACH_DROP_HARNESS). It fails pre-fix
+    # (node A's a.gd reference is gone) and passes once _repack_and_save re-anchors.
+    saved = _run_harness(godot_project)
+
+    # Node A's sibling script survives as a clean external reference — not dropped,
+    # not silently re-embedded as an inline sub_resource.
+    assert 'path="res://a.gd"' in saved, (
+        "sibling node A's a.gd ext_resource was DROPPED on re-pack:\n" + saved
+    )
+    assert 'sub_resource type="GDScript"' not in saved, (
+        "sibling node A's script was silently re-embedded as a sub_resource:\n" + saved
+    )
+    # Both nodes keep their script bindings, each referencing its own external script.
+    assert 'path="res://b.gd"' in saved, "the attached b.gd reference is missing:\n" + saved
+    assert saved.count("script = ExtResource(") == 2, (
+        "expected exactly two external script bindings to survive:\n" + saved
+    )

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -1151,9 +1151,15 @@ def test_script_create_empty_content_round_trips_as_empty_source(godot_project):
 # --- script attach: sibling-script drop on re-pack (issue #164) ---
 
 # A deterministic harness for the issue #164 corruption, run against the real
-# engine. It drives gda's OWN operations.gd payload (loaded as an object, its real
-# _load_scene / _capture_external_scripts / _reanchor_external_scripts / pack /
-# save methods) so the test exercises the product re-pack path — not a re-implementation.
+# engine. It drives gda's OWN operations.gd payload through the SAME product entry
+# points a mutating op uses — `_load_for_mutation` (which internally captures the
+# external-script snapshot) and `_repack_and_save` (which internally re-anchors
+# before pack/save). The harness only supplies the deterministic engine
+# precondition and the mutation in between; capture and re-anchor are NOT called by
+# the harness. That is deliberate: it makes the test guard the actual production
+# WIRING, so deleting the `_capture_external_scripts(root)` call in
+# `_load_for_mutation` OR the `_reanchor_external_scripts(root)` call in
+# `_repack_and_save` makes this go red (verified red→green).
 #
 # Why a harness and not a plain `gda script attach` call: the corruption needs two
 # distinct in-memory Script objects sharing one res:// path. The engine creates
@@ -1165,10 +1171,11 @@ def test_script_create_empty_content_round_trips_as_empty_source(godot_project):
 # scratch), so a CLI-only test would be as intermittent as the original bug. The
 # harness reproduces the EXACT engine mechanism (take_over_path, i.e.
 # set_path(take_over=true)) deterministically, in an unimported-project fixture
-# (no .godot import metadata, no .uid sidecar -> scripts carry no uid://), then
-# runs the real product re-pack. Pre-fix the sibling's `script = ExtResource(...)`
-# is dropped; post-fix the capture+reanchor preserves it. has_method guards keep
-# the harness loadable against the pre-fix payload so red→green is on behavior.
+# (no .godot import metadata, no .uid sidecar -> scripts carry no uid://), AFTER
+# `_load_for_mutation` has already taken its snapshot — matching the real ordering
+# where the eviction happens while the op runs. Then it calls `_repack_and_save`,
+# the real product tail. Pre-fix the sibling's `script = ExtResource(...)` is
+# dropped; post-fix the wired capture+reanchor preserves it.
 _ATTACH_DROP_HARNESS = r"""
 extends SceneTree
 
@@ -1188,24 +1195,25 @@ func _init() -> void:
 	var seed := PackedScene.new(); seed.pack(build_root); ResourceSaver.save(seed, "res://main.tscn")
 	build_root.free()
 
-	# Drive gda's REAL operations payload.
+	# Drive gda's REAL operations payload through its REAL mutate entry points.
 	var ops_script: GDScript = load("res://operations.gd")
 	var ops: Object = ops_script.new()
 	var params := {"path": "res://main.tscn", "project": "res://"}
 
-	# Load + instantiate exactly as a mutating op does (_load_for_mutation).
-	var packed: PackedScene = ops.call("_load_scene", params)
-	var live: Node = packed.instantiate()
+	# Load + instantiate via the product's single mutate-entry. _load_for_mutation
+	# is what (post-fix) captures the external-script snapshot the instant after
+	# instantiate — the harness does NOT call _capture_external_scripts, so if that
+	# wiring is removed the snapshot is empty and the drop is left to occur.
+	var live: Node = ops.call("_load_for_mutation", params)
+	if live == null:
+		_emit(false, "_load_for_mutation returned null")
+		ops.free(); quit(); return
 
-	# Capture script paths the instant after instantiate, as _load_for_mutation does
-	# post-fix (the product wires this in; the test mirrors the call site). Pre-fix
-	# the method is absent, so capture is skipped and the drop is left to occur.
-	if ops.has_method("_capture_external_scripts"):
-		ops.call("_capture_external_scripts", live)
-
-	# Reproduce the engine's shallow->full eviction deterministically: a second
-	# in-memory object for res://a.gd that take_over_path()s the cache slot, leaving
-	# node A holding the evicted orphan. This is the #164 precondition verbatim.
+	# Reproduce the engine's shallow->full eviction deterministically, AFTER the
+	# snapshot was taken (matching the real ordering where attach's own --script load
+	# triggers it mid-op): a second in-memory object for res://a.gd that
+	# take_over_path()s the cache slot, leaving node A holding the evicted orphan
+	# whose resource_path is now empty. This is the #164 precondition verbatim.
 	var orphan_maker := GDScript.new()
 	orphan_maker.source_code = "extends Sprite2D\n"
 	orphan_maker.take_over_path("res://a.gd")
@@ -1214,19 +1222,75 @@ func _init() -> void:
 	# Attach b.gd to the sibling node B (the second-node attach the bug needs).
 	live.get_node("B").set_script(ResourceLoader.load("res://b.gd"))
 
-	# Re-anchor before pack, as the product's _repack_and_save now does.
-	if ops.has_method("_reanchor_external_scripts"):
-		ops.call("_reanchor_external_scripts", live)
+	# Re-pack + save via the product's single pack-and-save tail. _repack_and_save
+	# is what (post-fix) re-anchors from the snapshot before packing — the harness
+	# does NOT call _reanchor_external_scripts, so if that wiring is removed the
+	# evicted orphan is serialized and the sibling's ext_resource is dropped.
+	var ok: bool = ops.call("_repack_and_save", live, "res://main.tscn")
+	ops.free()
+	if not ok:
+		_emit(false, "_repack_and_save reported failure")
+		quit(); return
 
-	var repacked := PackedScene.new()
-	var pack_err := repacked.pack(live)
-	if pack_err != OK:
-		_emit(false, "pack failed: %d" % pack_err)
-		live.free(); ops.free(); quit(); return
-	var save_err := ResourceSaver.save(repacked, "res://main.tscn")
-	live.free(); ops.free()
-	if save_err != OK:
-		_emit(false, "save failed: %d" % save_err)
+	var saved := FileAccess.get_file_as_string("res://main.tscn")
+	_emit(true, saved)
+	quit()
+"""
+
+# A broader-surface coverage harness (review finding 2): the fix hooks into the
+# SHARED `_repack_and_save`, so it hardens every mutating re-pack op, not just
+# `script attach`. This drives a representative non-attach mutation — adding a child
+# node via _build_added_node + _repack_and_save — over the same unimported
+# two-node scene with the same take_over_path eviction on the scripted sibling, and
+# asserts the sibling's `script = ExtResource(...)` binding survives the re-pack.
+# It proves the central hardening point holds for the broader surface, not only the
+# attach path. (See the matching code comment at the _reanchor_external_scripts
+# call site in operations.gd.)
+_NODE_ADD_PRESERVES_SIBLING_HARNESS = r"""
+extends SceneTree
+
+func _emit(ok: bool, detail: String) -> void:
+	print("<<<HARNESS>>>", JSON.stringify({"ok": ok, "detail": detail}), "<<<END>>>")
+
+func _init() -> void:
+	# Same unimported sibling-scripted fixture: node A carries a.gd, node B is bare.
+	FileAccess.open("res://a.gd", FileAccess.WRITE).store_string("extends Sprite2D\n")
+	var build_root := Node2D.new()
+	build_root.name = "main"
+	var build_a := Sprite2D.new(); build_a.name = "A"; build_root.add_child(build_a); build_a.owner = build_root
+	var build_b := Sprite2D.new(); build_b.name = "B"; build_root.add_child(build_b); build_b.owner = build_root
+	build_a.set_script(ResourceLoader.load("res://a.gd"))
+	var seed := PackedScene.new(); seed.pack(build_root); ResourceSaver.save(seed, "res://main.tscn")
+	build_root.free()
+
+	var ops_script: GDScript = load("res://operations.gd")
+	var ops: Object = ops_script.new()
+	var params := {"path": "res://main.tscn", "project": "res://"}
+
+	# Same shared mutate entry — captures the snapshot.
+	var live: Node = ops.call("_load_for_mutation", params)
+	if live == null:
+		_emit(false, "_load_for_mutation returned null")
+		ops.free(); quit(); return
+
+	# Same deterministic eviction of the scripted sibling A's cache slot.
+	var orphan_maker := GDScript.new()
+	orphan_maker.source_code = "extends Sprite2D\n"
+	orphan_maker.take_over_path("res://a.gd")
+	orphan_maker.reload()
+
+	# A NON-attach mutation: add a fresh child node (no script). This is the
+	# `node add` shared tail — it touches the same _repack_and_save as attach.
+	var added := Node2D.new()
+	added.name = "C"
+	live.add_child(added)
+	added.owner = live
+
+	# Same shared pack-and-save tail — re-anchors the sibling before packing.
+	var ok: bool = ops.call("_repack_and_save", live, "res://main.tscn")
+	ops.free()
+	if not ok:
+		_emit(false, "_repack_and_save reported failure")
 		quit(); return
 
 	var saved := FileAccess.get_file_as_string("res://main.tscn")
@@ -1235,13 +1299,11 @@ func _init() -> void:
 """
 
 
-def _run_harness(project) -> str:
-    """Run the #164 harness in `project` against the real engine; return saved .tscn."""
+def _run_harness(project, harness: str = _ATTACH_DROP_HARNESS) -> str:
+    """Run a #164 harness in `project` against the real engine; return saved .tscn."""
     # The harness drives gda's own operations.gd, so ship a copy into the fixture.
     shutil.copy(OPERATIONS_GD, project / "operations.gd")
-    (project / "attach_drop_harness.gd").write_text(
-        _ATTACH_DROP_HARNESS, encoding="utf-8"
-    )
+    (project / "attach_drop_harness.gd").write_text(harness, encoding="utf-8")
     proc = subprocess.run(
         [
             str(GODOT),
@@ -1280,9 +1342,12 @@ def test_script_attach_preserves_sibling_script_on_repack_when_unimported(
     # the script is unimported (path is the only identity), the dedup collapses
     # them and the sibling's ext_resource is dropped / re-embedded as a sub_resource.
     #
-    # This drives gda's real operations.gd re-pack path and reproduces the engine
-    # precondition deterministically (see _ATTACH_DROP_HARNESS). It fails pre-fix
-    # (node A's a.gd reference is gone) and passes once _repack_and_save re-anchors.
+    # This drives gda's real operations.gd entry points — `_load_for_mutation`
+    # (captures the snapshot) then `_repack_and_save` (re-anchors before pack) — and
+    # reproduces the engine precondition deterministically in between (see
+    # _ATTACH_DROP_HARNESS). The harness does NOT call _capture_external_scripts or
+    # _reanchor_external_scripts itself, so this guards the production WIRING: it
+    # fails pre-fix and fails if EITHER wiring call is later removed.
     saved = _run_harness(godot_project)
 
     # Node A's sibling script survives as a clean external reference — not dropped,
@@ -1297,4 +1362,27 @@ def test_script_attach_preserves_sibling_script_on_repack_when_unimported(
     assert 'path="res://b.gd"' in saved, "the attached b.gd reference is missing:\n" + saved
     assert saved.count("script = ExtResource(") == 2, (
         "expected exactly two external script bindings to survive:\n" + saved
+    )
+
+
+@pytest.mark.e2e
+def test_node_add_preserves_sibling_script_on_repack_when_unimported(godot_project):
+    # Broader-surface coverage (issue #164, review finding 2): the fix re-anchors
+    # from the SHARED `_repack_and_save` tail, so it hardens every mutating re-pack
+    # op — not only `script attach`. A representative NON-attach mutation (`node
+    # add`) over the same unimported two-node scene, with the same take_over_path
+    # eviction on the scripted sibling A, must likewise preserve A's external script
+    # binding through the shared re-pack. This proves the central hardening point
+    # holds for the broader mutation surface, not just the path #164 reported.
+    saved = _run_harness(godot_project, _NODE_ADD_PRESERVES_SIBLING_HARNESS)
+
+    # The scripted sibling A survives the re-pack as a clean external reference.
+    assert 'path="res://a.gd"' in saved, (
+        "sibling node A's a.gd ext_resource was DROPPED on node-add re-pack:\n" + saved
+    )
+    assert 'sub_resource type="GDScript"' not in saved, (
+        "sibling node A's script was silently re-embedded as a sub_resource:\n" + saved
+    )
+    assert saved.count("script = ExtResource(") == 1, (
+        "expected sibling A's single external script binding to survive:\n" + saved
     )


### PR DESCRIPTION
## The bug

`gda script attach` (and any mutating re-pack op) could **intermittently drop a sibling node's `script =` line** when re-packing a `.tscn` in a freshly-created project whose `.gd` scripts have not yet been imported — silently corrupting the scene (the sibling's external script is dropped or re-embedded as an inline `sub_resource`).

## Root cause (confirmed against the Godot 4.6.x source)

The editor build's text scene saver dedups `ext_resource` entries through a **path-keyed** cache (`ResourceCache::resource_path_cache`), not object identity. An **unimported** `.gd` carries no `uid://` (headless never runs the import pass that assigns one), so its `res://` path string is its only identity. The engine's `GDScriptCache` upgrades a shallow script to a full one via `Resource::set_path(take_over=true)`, which **evicts the previously cached object without freeing it** — a sibling node still holds the evicted orphan, so two distinct in-memory `Script` objects share one `res://` path. On save the path-keyed dedup collapses them and the sibling's binding is lost. Intermittent because it depends on whether the second same-path object is alive at save time.

## Fix (gda-layer hardening, no engine patch)

Re-anchor every external script to the **single canonical cached resource** for its `res://` path before `pack()`:

- `_load_for_mutation` calls `_capture_external_scripts(root)` the instant after instantiate — snapshotting `{NodePath → script res:// path}` for every scripted node, **before** any op-specific load can evict a sibling (the orphan loses its `resource_path` on eviction, so the path must be captured while intact).
- `_repack_and_save` calls `_reanchor_external_scripts(root)` before packing: for each captured node still carrying its captured script (current path equals captured, **or empty** — the orphan signature), re-load the path with `CACHE_MODE_REPLACE` (sole cache owner) and `set_script` it back.

**Preserves existing semantics:** a node the op *intentionally* re-scripted to a **different** path is left untouched (`script attach` overwrite-and-report, #132); a vanished node (remove/move) is skipped; already-canonical is idempotent. This protects every mutating re-pack op, not just `script attach`.

## Test — deterministic regression

`tests/test_e2e_script.py::test_script_attach_preserves_sibling_script_on_repack_when_unimported` (`@pytest.mark.e2e`, real engine, unimported `godot_project` fixture). The pure `gda` CLI cannot reproduce the drop deterministically (each call is a fresh process with a clean cache — measured 0 drops in 30+ runs), so the test drives gda's **own** `operations.gd` payload (real `_load_scene` / `_capture_external_scripts` / `_reanchor_external_scripts` / pack / save) and injects the engine precondition deterministically via `take_over_path` (== `set_path(take_over=true)`). `has_method` guards keep the harness loadable against the pre-fix payload, so red→green is on behavior:

- **RED** (fix stashed): node A's `res://a.gd` ext_resource dropped and re-embedded as `sub_resource type="GDScript"` — the exact corruption.
- **GREEN** (fix applied): both nodes keep clean external bindings; 0 sub_resources.

## Results

- Full suite: **708 passed, 1 skipped** (the 1 skip is a pre-existing, unrelated template-presence skip).
- Displacement reporting (#132), compile/type-incompatibility verdicts, and registry-drift tests stay green.

Closes #164.
