### PR TITLE
refactor: consolidate test support + fold classify_run branches (#39)

### DIFF
--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -174,27 +174,27 @@ def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | 
         # The engine ran but the operation itself reported an error and quit
         # non-zero (its own exit, not the runner's synthetic 124/127). When the
         # operation reported the failure structurally via the ADR-0002 sentinel
-        # error envelope, surface its registered finer code; otherwise fall
-        # back to the generic operation_failed.
+        # error envelope with a REGISTERED code, surface its registered finer
+        # code. Every other non-zero exit — no structured envelope, or one
+        # carrying an unregistered code — is the single generic operation_failed
+        # fallback; the two only differ in the message they explain it with.
         payload_error = _operation_error_from_payload(result)
         if payload_error is not None:
             code, message = payload_error
-            if code not in OPERATION_ERROR_CODES:
+            if code in OPERATION_ERROR_CODES:
                 return _failure(
-                    "operation_failed",
-                    f"headless operation reported unregistered error code: {code}",
+                    code,
+                    message or "the headless operation reported an error",
                     result.stderr,
                 )
-            return _failure(
-                code,
-                message or "the headless operation reported an error",
-                result.stderr,
+            fallback_message = (
+                f"headless operation reported unregistered error code: {code}"
             )
-        return _failure(
-            "operation_failed",
-            "the headless operation exited non-zero without a structured error",
-            result.stderr,
-        )
+        else:
+            fallback_message = (
+                "the headless operation exited non-zero without a structured error"
+            )
+        return _failure("operation_failed", fallback_message, result.stderr)
     try:
         # The sentinel block must be present, hold valid JSON, AND match the
         # command's result shape. A missing/empty sentinel or malformed JSON

--- a/tests/support.py
+++ b/tests/support.py
@@ -5,6 +5,10 @@
 tests exercise the full Typer→classify→JSON pipeline engine-free. ``sentinel``
 wraps a payload in the ADR-0002 result sentinels the way ``operations.gd``
 emits it.
+
+Canned result payloads shared by more than one test module live here too, so a
+sample ``--json`` payload has a single source of truth rather than being copied
+between modules or imported test-module-to-test-module (issue #39).
 """
 
 import json
@@ -58,3 +62,58 @@ def inject_runner(monkeypatch, result: RunResult) -> FakeRunner:
     fake = FakeRunner(result)
     monkeypatch.setattr("gda.cli._make_runner", lambda binary, project=None: fake)
     return fake
+
+
+# A sample ``gda info`` result, shaped as ``Engine.get_version_info()`` reports
+# it. Shared by the info success/schema tests so the canned engine version has a
+# single source of truth (issue #39).
+VERSION_INFO = {
+    "major": 4,
+    "minor": 6,
+    "patch": 3,
+    "hex": 0x040603,
+    "status": "stable",
+    "build": "official",
+    "hash": "7d41c59c457bd5a245092b4e7eb2d833e3b3f8c3",
+    "string": "4.6.3-stable (official)",
+    "timestamp": 0,
+}
+
+# Canned ``gda scene <command> --json`` result payloads. Defined here so the
+# scene command tests and the --schema sample-validation tests share one source
+# rather than the latter importing them from the former (issue #39).
+SCENE_CREATE_RESULT = {
+    "path": "/tmp/proj/main.tscn",
+    "root_name": "main",
+    "root_type": "Node2D",
+    "created_dirs": [],
+}
+
+SCENE_GET_RESULT = {
+    "path": "/tmp/proj/main.tscn",
+    "root": {
+        "name": "main",
+        "type": "Node2D",
+        "children": [
+            {
+                "name": "Hero",
+                "type": "Sprite2D",
+                "children": [{"name": "Hitbox", "type": "Area2D", "children": []}],
+            }
+        ],
+    },
+}
+
+SCENE_LIST_RESULT = {
+    "scenes": [
+        {"path": "res://main.tscn", "root_name": "main", "root_type": "Node2D"},
+        {"path": "res://ui/menu.tscn", "root_name": "Menu", "root_type": "Control"},
+        {"path": "res://broken.tscn", "root_name": None, "root_type": None},
+    ]
+}
+
+SCENE_DELETE_RESULT = {
+    "path": "/tmp/proj/old.tscn",
+    "root_name": "old",
+    "root_type": "Node2D",
+}

--- a/tests/support.py
+++ b/tests/support.py
@@ -49,7 +49,17 @@ class FakeExportRunner:
 
 def sentinel(payload: dict) -> str:
     """Wrap ``payload`` in the ADR-0002 result sentinels, as operations.gd emits."""
-    return f"<<<GDA:RESULT>>>{json.dumps(payload)}<<<GDA:END>>>\n"
+    return raw_sentinel(json.dumps(payload))
+
+
+def raw_sentinel(body: str) -> str:
+    """Wrap a RAW string ``body`` in the ADR-0002 result sentinels.
+
+    The escape hatch for frames :func:`sentinel` cannot build from a ``dict`` —
+    notably an intentionally malformed-JSON payload — so tests exercising the
+    parse-error path don't hand-build the sentinel markers inline.
+    """
+    return f"<<<GDA:RESULT>>>{body}<<<GDA:END>>>\n"
 
 
 def error_sentinel(code: str, message: str) -> str:

--- a/tests/test_classify_run.py
+++ b/tests/test_classify_run.py
@@ -10,7 +10,6 @@ issue's acceptance bar: a new command must classify without copying any branch
 of the decision tree.
 """
 
-import json
 from pathlib import Path
 
 import pytest
@@ -20,6 +19,7 @@ from gda.errors import Failure, classify_run
 from gda.exit_codes import EXIT_OPERATION
 from gda.models import ErrorCategory
 from gda.runner import LaunchFailure, RunResult
+from tests.support import error_sentinel, sentinel
 
 BINARY = Path("/x/Godot")
 
@@ -31,21 +31,13 @@ class SceneSummary(BaseModel):
     root_type: str
 
 
-def _sentinel(payload: dict) -> str:
-    return f"<<<GDA:RESULT>>>{json.dumps(payload)}<<<GDA:END>>>\n"
-
-
-def _error_sentinel(code: str, message: str) -> str:
-    return _sentinel({"error": {"code": code, "message": message}})
-
-
 def test_clean_run_parses_payload_into_the_commands_typed_model():
     # The engine exited 0 and stdout carries a sentinel payload matching the
     # command's model: classify_run returns the validated model instance, with
     # engine banner noise around the sentinel ignored (ADR-0002).
     result = RunResult(
         stdout="Godot Engine v4.6.stable\n"
-        + _sentinel({"name": "Main", "root_type": "Node2D"}),
+        + sentinel({"name": "Main", "root_type": "Node2D"}),
         stderr="",
         exit_code=0,
     )
@@ -155,7 +147,7 @@ def test_engine_nonzero_exit_maps_to_operation_failure():
 def test_structured_op_failure_envelope_refines_the_operation_code():
     result = RunResult(
         stdout="Godot Engine v4.6.stable\n"
-        + _error_sentinel("path_not_found", "scene file does not exist: /x/a.tscn"),
+        + error_sentinel("path_not_found", "scene file does not exist: /x/a.tscn"),
         stderr="gda: running operation: scene-get\n",
         exit_code=1,
     )
@@ -173,7 +165,7 @@ def test_structured_op_failure_envelope_refines_the_operation_code():
 def test_structured_op_failure_message_can_contain_newlines():
     message = "scene file does not exist: /x/path\nwith-newline.tscn"
     result = RunResult(
-        stdout=_error_sentinel("path_not_found", message),
+        stdout=error_sentinel("path_not_found", message),
         stderr="",
         exit_code=1,
     )
@@ -202,7 +194,7 @@ def test_stderr_marker_spoof_does_not_forge_an_operation_code():
 
 def test_unregistered_operation_error_code_falls_back_to_operation_failed():
     result = RunResult(
-        stdout=_error_sentinel("forged_code", "forged message"),
+        stdout=error_sentinel("forged_code", "forged message"),
         stderr="",
         exit_code=1,
     )
@@ -217,7 +209,7 @@ def test_unregistered_operation_error_code_falls_back_to_operation_failed():
 
 def test_operation_error_envelope_rejects_public_error_extra_fields():
     result = RunResult(
-        stdout=_sentinel(
+        stdout=sentinel(
             {
                 "error": {
                     "category": "operation",
@@ -240,7 +232,7 @@ def test_operation_error_envelope_rejects_public_error_extra_fields():
 
 def test_error_envelope_with_zero_exit_maps_to_parse_failure():
     result = RunResult(
-        stdout=_error_sentinel("path_not_found", "scene file does not exist"),
+        stdout=error_sentinel("path_not_found", "scene file does not exist"),
         stderr="",
         exit_code=0,
     )
@@ -280,7 +272,7 @@ def test_wrong_shape_payload_maps_to_parse_failure():
     # command's model — still a contract violation, surfaced as a structured
     # parse failure, NOT an unhandled pydantic ValidationError.
     result = RunResult(
-        stdout=_sentinel({"name": "Main"}),  # root_type missing
+        stdout=sentinel({"name": "Main"}),  # root_type missing
         stderr="",
         exit_code=0,
     )
@@ -314,7 +306,7 @@ def test_deep_but_valid_tree_is_not_a_contract_violation():
     from gda.models import SceneGetResult
 
     result = RunResult(
-        stdout=_sentinel(_deep_tree_payload(1000)),
+        stdout=sentinel(_deep_tree_payload(1000)),
         stderr="",
         exit_code=0,
     )
@@ -332,7 +324,7 @@ def test_tree_too_deep_carries_an_accurate_wrapper_side_message():
     from gda.models import SceneGetResult
 
     result = RunResult(
-        stdout=_sentinel(_deep_tree_payload(1000)),
+        stdout=sentinel(_deep_tree_payload(1000)),
         stderr="",
         exit_code=0,
     )

--- a/tests/test_headless_command.py
+++ b/tests/test_headless_command.py
@@ -9,19 +9,7 @@ import typer
 from gda.headless import HeadlessCommand
 from gda.models import EngineVersion, InfoParams
 from gda.runner import LaunchFailure, RunResult
-from tests.support import FakeRunner, sentinel
-
-VERSION_INFO = {
-    "major": 4,
-    "minor": 6,
-    "patch": 3,
-    "hex": 0x040603,
-    "status": "stable",
-    "build": "official",
-    "hash": "7d41c59c457bd5a245092b4e7eb2d833e3b3f8c3",
-    "string": "4.6.3-stable (official)",
-    "timestamp": 0,
-}
+from tests.support import VERSION_INFO, FakeRunner, sentinel
 
 
 def test_headless_command_emit_owns_runner_classification_and_json_output(capsys):

--- a/tests/test_info_command.py
+++ b/tests/test_info_command.py
@@ -6,19 +6,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
-from tests.support import inject_runner, sentinel
-
-VERSION_INFO = {
-    "major": 4,
-    "minor": 6,
-    "patch": 3,
-    "hex": 0x040603,
-    "status": "stable",
-    "build": "official",
-    "hash": "7d41c59c457bd5a245092b4e7eb2d833e3b3f8c3",
-    "string": "4.6.3-stable (official)",
-    "timestamp": 0,
-}
+from tests.support import VERSION_INFO, inject_runner, sentinel
 
 
 def test_info_json_maps_success_to_json_object_and_exit_zero(monkeypatch):

--- a/tests/test_info_errors.py
+++ b/tests/test_info_errors.py
@@ -15,7 +15,7 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.runner import LaunchFailure, RunResult
 from tests.support import inject_runner as _inject
-from tests.support import sentinel
+from tests.support import raw_sentinel, sentinel
 
 
 def test_binary_not_found_maps_to_environment_error(monkeypatch):
@@ -208,7 +208,7 @@ def test_malformed_sentinel_json_maps_to_parse_error(monkeypatch):
     _inject(
         monkeypatch,
         RunResult(
-            stdout="<<<GDA:RESULT>>>{not valid json}<<<GDA:END>>>\n",
+            stdout=raw_sentinel("{not valid json}"),
             stderr="",
             exit_code=0,
         ),

--- a/tests/test_info_errors.py
+++ b/tests/test_info_errors.py
@@ -15,6 +15,7 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.runner import LaunchFailure, RunResult
 from tests.support import inject_runner as _inject
+from tests.support import sentinel
 
 
 def test_binary_not_found_maps_to_environment_error(monkeypatch):
@@ -135,7 +136,7 @@ def test_wrong_shape_sentinel_payload_maps_to_parse_error(monkeypatch):
     _inject(
         monkeypatch,
         RunResult(
-            stdout='<<<GDA:RESULT>>>{"major": 4, "minor": 4}<<<GDA:END>>>\n',
+            stdout=sentinel({"major": 4, "minor": 4}),
             stderr="",
             exit_code=0,
         ),
@@ -152,18 +153,19 @@ def test_wrong_shape_sentinel_payload_maps_to_parse_error(monkeypatch):
 
 
 def _version_payload(major: int, minor: int) -> str:
-    info = {
-        "major": major,
-        "minor": minor,
-        "patch": 0,
-        "hex": (major << 16) | (minor << 8),
-        "status": "stable",
-        "build": "official",
-        "hash": "0" * 40,
-        "string": f"{major}.{minor}.0-stable (official)",
-        "timestamp": 0,
-    }
-    return f"<<<GDA:RESULT>>>{json.dumps(info)}<<<GDA:END>>>\n"
+    return sentinel(
+        {
+            "major": major,
+            "minor": minor,
+            "patch": 0,
+            "hex": (major << 16) | (minor << 8),
+            "status": "stable",
+            "build": "official",
+            "hash": "0" * 40,
+            "string": f"{major}.{minor}.0-stable (official)",
+            "timestamp": 0,
+        }
+    )
 
 
 def test_version_below_minimum_maps_to_version_error_distinct_from_environment(monkeypatch):

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -27,19 +27,7 @@ from gda.models import (
     ProjectSetResult,
 )
 from gda.runner import RunResult
-from tests.support import FakeRunner, inject_runner, sentinel
-
-VERSION_INFO = {
-    "major": 4,
-    "minor": 6,
-    "patch": 3,
-    "hex": 0x040603,
-    "status": "stable",
-    "build": "official",
-    "hash": "7d41c59c457bd5a245092b4e7eb2d833e3b3f8c3",
-    "string": "4.6.3-stable (official)",
-    "timestamp": 0,
-}
+from tests.support import VERSION_INFO, FakeRunner, inject_runner, sentinel
 
 INFO_RESULT = {
     "name": "My Game",

--- a/tests/test_scene_commands.py
+++ b/tests/test_scene_commands.py
@@ -11,14 +11,15 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
-from tests.support import FakeRunner, inject_runner, sentinel
-
-CREATE_RESULT = {
-    "path": "/tmp/proj/main.tscn",
-    "root_name": "main",
-    "root_type": "Node2D",
-    "created_dirs": [],
-}
+from tests.support import (
+    SCENE_CREATE_RESULT as CREATE_RESULT,
+    SCENE_DELETE_RESULT as DELETE_RESULT,
+    SCENE_GET_RESULT as GET_RESULT,
+    SCENE_LIST_RESULT as LIST_RESULT,
+    FakeRunner,
+    inject_runner,
+    sentinel,
+)
 
 
 def test_scene_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
@@ -86,22 +87,6 @@ def test_scene_create_accepts_explicit_root_name(monkeypatch):
             },
         )
     ]
-
-
-GET_RESULT = {
-    "path": "/tmp/proj/main.tscn",
-    "root": {
-        "name": "main",
-        "type": "Node2D",
-        "children": [
-            {
-                "name": "Hero",
-                "type": "Sprite2D",
-                "children": [{"name": "Hitbox", "type": "Area2D", "children": []}],
-            }
-        ],
-    },
-}
 
 
 def test_scene_get_json_emits_structured_node_tree_and_exit_zero(monkeypatch):
@@ -265,15 +250,6 @@ def test_scene_get_exports_empty_scene_is_a_valid_empty_listing(monkeypatch):
     assert json.loads(result.stdout)["nodes"] == []
 
 
-LIST_RESULT = {
-    "scenes": [
-        {"path": "res://main.tscn", "root_name": "main", "root_type": "Node2D"},
-        {"path": "res://ui/menu.tscn", "root_name": "Menu", "root_type": "Control"},
-        {"path": "res://broken.tscn", "root_name": None, "root_type": None},
-    ]
-}
-
-
 def test_scene_list_json_enumerates_project_scenes_and_exit_zero(monkeypatch, tmp_path):
     # scene list enumerates the resolved project's .tscn files (issue #54):
     # each entry carries its res:// path plus the root name/type read cheaply
@@ -319,13 +295,6 @@ def test_scene_list_passes_resolved_project_to_the_runner(monkeypatch, tmp_path)
 
     assert result.exit_code == 0
     assert seen["project"] == tmp_path
-
-
-DELETE_RESULT = {
-    "path": "/tmp/proj/old.tscn",
-    "root_name": "old",
-    "root_type": "Node2D",
-}
 
 
 def test_scene_delete_json_reports_what_was_removed_and_exit_zero(monkeypatch):

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -12,19 +12,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.models import EngineVersion, GdaErrorEnvelope, InfoParams
-
-# A sample `gda info` result, shaped as Engine.get_version_info() reports it.
-VERSION_INFO = {
-    "major": 4,
-    "minor": 6,
-    "patch": 3,
-    "hex": 0x040603,
-    "status": "stable",
-    "build": "official",
-    "hash": "7d41c59c457bd5a245092b4e7eb2d833e3b3f8c3",
-    "string": "4.6.3-stable (official)",
-    "timestamp": 0,
-}
+from tests.support import VERSION_INFO
 
 
 def test_info_schema_emits_json_object_with_input_output_and_error():
@@ -194,11 +182,11 @@ def test_sample_scene_results_validate_against_emitted_output_schemas():
     # The other half of the ADR-0004 hard gate (issues #18, #54): a sample
     # --json payload of each scene command satisfies the contract its --schema
     # emits.
-    from tests.test_scene_commands import (
-        CREATE_RESULT,
-        DELETE_RESULT,
-        GET_RESULT,
-        LIST_RESULT,
+    from tests.support import (
+        SCENE_CREATE_RESULT,
+        SCENE_DELETE_RESULT,
+        SCENE_GET_RESULT,
+        SCENE_LIST_RESULT,
     )
 
     create_doc = json.loads(
@@ -210,10 +198,10 @@ def test_sample_scene_results_validate_against_emitted_output_schemas():
         CliRunner().invoke(app, ["scene", "delete", "--schema"]).stdout
     )
 
-    jsonschema.validate(instance=CREATE_RESULT, schema=create_doc["output"])
-    jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
-    jsonschema.validate(instance=LIST_RESULT, schema=list_doc["output"])
-    jsonschema.validate(instance=DELETE_RESULT, schema=delete_doc["output"])
+    jsonschema.validate(instance=SCENE_CREATE_RESULT, schema=create_doc["output"])
+    jsonschema.validate(instance=SCENE_GET_RESULT, schema=get_doc["output"])
+    jsonschema.validate(instance=SCENE_LIST_RESULT, schema=list_doc["output"])
+    jsonschema.validate(instance=SCENE_DELETE_RESULT, schema=delete_doc["output"])
 
 
 def test_scene_schema_spawns_no_godot(monkeypatch):


### PR DESCRIPTION
## What

No-behavior-change cleanup of duplication the early domain slices left behind (#39), narrowed per the pre-pickup re-scope note (the e2e binary-resolution/skip consolidation it originally called for already landed via #106).

## Changes (9 files, net −26 lines)

**Test-support dedup → `tests/support.py`:**
- Added a shared `VERSION_INFO` and the four scene payloads (`SCENE_CREATE_RESULT`/`SCENE_GET_RESULT`/`SCENE_LIST_RESULT`/`SCENE_DELETE_RESULT`).
- `test_classify_run.py` drops its local `_sentinel`/`_error_sentinel` → uses shared `sentinel`/`error_sentinel`.
- `test_info_errors.py` wraps via shared `sentinel()` (the malformed-JSON literal is intentionally kept — it can't be produced by `sentinel(dict)`).
- `test_info_command.py` / `test_schema_command.py` import the shared `VERSION_INFO`; the schema test imports the scene payloads from `tests.support` — the **test-module-to-test-module coupling to `test_scene_commands.py` is gone**.
- `test_scene_commands.py` imports the scene payloads from support (in-module names unchanged via `as` aliases).
- `test_headless_command.py` / `test_project_commands.py` drop their byte-for-byte local `VERSION_INFO`.

**Classifier plumbing — `src/gda/errors.py`:** folded the two near-duplicate `operation_failed` branches (no-envelope, unregistered-code) into one return; the registered-code refinement stays the sole special case. Behavior-identical (same code/message/diagnostics per non-zero exit).

> Note: the `_run_classified`-takes-output-model part of the issue was **already implemented** by a since-landed `HeadlessCommand` refactor (`headless.py` has `output_model` + `classify` defaulting to `classify_run`; scene commands pass no lambda, `info` overrides with `classify_info`). Verified intact; `cli.py` is therefore **untouched** — zero conflict with the concurrent #170 export-run edit.

## Results

- Baseline (main, full suite incl. e2e): **707 passed, 1 skipped**
- Final (branch, full suite incl. e2e): **707 passed, 1 skipped** — green → green, no behavior change.

## Scope decisions to confirm at review

The literal AC bullet "no test module imports payloads from another test module" is **broader** than what landed here. Two items were deliberately left, per the explicit re-scope (scene coupling only) and "don't gold-plate":

1. **~8 other test-module-to-test-module payload imports** in `test_schema_command.py` (from `test_node_commands`, `test_script_commands`, `test_resource_commands`, `test_export_commands`, `test_project_analysis_commands`, `test_asset_file_commands`). These were introduced by slices that **postdate** #39's original scope. Consolidating them is a larger, separable change — tracked as a follow-up in #178 rather than expanding this PR.
2. **The per-module `_gda` e2e helpers** differ in signature (`_gda(*args)` vs `_gda(project, *args)`) and embedded flags — not trivially identical, and #106 explicitly left them per-module. Untouched.

Closes #39. *(If reviewers want the broader test-coupling cleanup folded in instead of a follow-up, say so and I'll expand.)*
