### PR TITLE
refactor: consolidate remaining test payloads into support.py (#178)

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -127,3 +127,235 @@ SCENE_DELETE_RESULT = {
     "root_name": "old",
     "root_type": "Node2D",
 }
+
+# Canned ``gda node <command> --json`` result payloads. Defined here so the node
+# command tests and the --schema sample-validation tests share one source rather
+# than the latter importing them from the former (issue #178).
+NODE_ADD_RESULT = {
+    "scene_path": "/tmp/proj/main.tscn",
+    "path": "Hero",
+    "name": "Hero",
+    "type": "Sprite2D",
+    "script_class": None,
+}
+
+NODE_LIST_RESULT = {
+    "scene_path": "/tmp/proj/main.tscn",
+    "root": {
+        "name": "main",
+        "type": "Node2D",
+        "path": ".",
+        "children": [
+            {
+                "name": "Hero",
+                "type": "Sprite2D",
+                "path": "Hero",
+                "children": [
+                    {
+                        "name": "Hitbox",
+                        "type": "Area2D",
+                        "path": "Hero/Hitbox",
+                        "children": [],
+                    }
+                ],
+            }
+        ],
+    },
+}
+
+NODE_GET_RESULT = {
+    "scene_path": "/tmp/proj/main.tscn",
+    "path": "Hero",
+    "name": "Hero",
+    "type": "Sprite2D",
+    "properties": [
+        {"name": "position", "type": "Vector2", "value": [10.0, 20.0]},
+        {"name": "visible", "type": "bool", "value": True},
+    ],
+}
+
+NODE_SET_RESULT = {
+    "scene_path": "/tmp/proj/main.tscn",
+    "path": "Hero",
+    "property": "position",
+    "type": "Vector2",
+    "value": [3.0, 4.0],
+}
+
+NODE_REMOVE_RESULT = {
+    "scene_path": "/tmp/proj/main.tscn",
+    "path": "Hero",
+    "name": "Hero",
+    "type": "Sprite2D",
+}
+
+NODE_DUPLICATE_RESULT = {
+    "scene_path": "/tmp/proj/main.tscn",
+    "source_path": "Hero",
+    "path": "Hero2",
+    "name": "Hero2",
+    "type": "Sprite2D",
+}
+
+NODE_MOVE_RESULT = {
+    "scene_path": "/tmp/proj/main.tscn",
+    "source_path": "Hero",
+    "new_parent": "Enemies",
+    "path": "Enemies/Hero",
+    "name": "Hero",
+    "type": "Sprite2D",
+}
+
+NODE_CONNECT_RESULT = {
+    "scene_path": "/tmp/proj/main.tscn",
+    "from": "Emitter",
+    "signal": "timeout",
+    "to": "Receiver",
+    "method": "on_timeout",
+}
+
+# Canned ``gda script <command> --json`` result payloads (issue #178).
+SCRIPT_CREATE_RESULT = {
+    "path": "/tmp/proj/hero.gd",
+    "class_name": "Hero",
+    "extends": "Node2D",
+    "created_dirs": [],
+}
+
+SCRIPT_GET_RESULT = {
+    "path": "/tmp/proj/hero.gd",
+    "source": "class_name Hero\nextends Node2D\n",
+    "class_name": "Hero",
+    "extends": "Node2D",
+}
+
+SCRIPT_LIST_RESULT = {
+    "scripts": [
+        {"path": "res://hero.gd", "class_name": "Hero", "extends": "Node2D"},
+        {"path": "res://util.gd", "class_name": None, "extends": "RefCounted"},
+        {"path": "res://empty.gd", "class_name": None, "extends": None},
+    ]
+}
+
+SCRIPT_SET_RESULT = {
+    "path": "/tmp/proj/hero.gd",
+    "class_name": "Hero",
+    "extends": "Node2D",
+}
+
+# Canned ``gda resource <command> --json`` result payloads (issue #178). For
+# ``resource uid``, both directions converge on one ``{queried, uid, path}``
+# shape, so ``UID``/``PATH`` are shared constants too.
+RESOURCE_CREATE_RESULT = {
+    "path": "/tmp/proj/palette.tres",
+    "type": "Gradient",
+    "created_dirs": [],
+}
+
+RESOURCE_GET_RESULT = {
+    "path": "/tmp/proj/palette.tres",
+    "type": "Gradient",
+    "properties": [
+        {"name": "resource_name", "type": "String", "value": ""},
+        {"name": "interpolation_mode", "type": "int", "value": 0},
+    ],
+}
+
+RESOURCE_SET_RESULT = {
+    "path": "/tmp/proj/palette.tres",
+    "property": "interpolation_mode",
+    "type": "int",
+    "value": 1,
+}
+
+RESOURCE_DELETE_RESULT = {
+    "path": "/tmp/proj/palette.tres",
+    "type": "Gradient",
+}
+
+UID = "uid://caax1gby1api1"
+PATH = "res://data.tres"
+
+UID_TO_PATH_RESULT = {"queried": "uid", "uid": UID, "path": PATH}
+PATH_TO_UID_RESULT = {"queried": "path", "uid": UID, "path": PATH}
+
+# Canned ``gda export <command> --json`` result payloads (issue #178).
+EXPORT_LIST_RESULT = {
+    "presets": [
+        {"index": 0, "name": "Linux/X11", "platform": "Linux/X11", "runnable": True},
+        {"index": 1, "name": "Web", "platform": "Web", "runnable": False},
+    ]
+}
+
+EXPORT_GET_RESULT = {
+    "index": 1,
+    "name": "Web",
+    "platform": "Web",
+    "runnable": False,
+    "export_path": "build/index.html",
+    "templates_installed": True,
+    "templates_version": "4.6.3.stable",
+}
+
+# Canned ``gda project <command> --json`` analysis result payloads (issue #178).
+DEPENDENCIES_RESULT = {
+    "dependencies": [
+        {
+            "path": "res://main.tscn",
+            "depends_on": [
+                {"path": "res://hero.tscn", "kind": "ext_resource"},
+                {"path": "res://icon.png", "kind": "ext_resource"},
+            ],
+        },
+        {"path": "res://hero.tscn", "depends_on": []},
+    ]
+}
+
+FIND_REFERENCES_RESULT = {
+    "target": "res://hero.gd",
+    "references": [
+        {
+            "path": "res://hero.tscn",
+            "kind": "ext_resource",
+            "context": 'res://hero.gd type="Script"',
+        }
+    ],
+}
+
+UNUSED_RESULT = {"unused": ["res://orphan.png", "res://orphan.tres"]}
+
+STATISTICS_RESULT = {
+    "total_files": 5,
+    "total_lines": 120,
+    "by_extension": [
+        {"extension": "gd", "files": 2, "lines": 100},
+        {"extension": "tscn", "files": 2, "lines": 20},
+    ],
+    "autoloads": [{"name": "GameState", "path": "res://game_state.gd"}],
+    "plugins": ["res://addons/widget/plugin.cfg"],
+    "scene_count": 2,
+    "script_count": 2,
+    "resource_count": 1,
+}
+
+# Canned ``gda shader``/``gda theme`` asset-file ``--json`` result payloads
+# (issue #178).
+SHADER_CREATE_RESULT = {
+    "path": "/tmp/proj/wave.gdshader",
+    "shader_type": "canvas_item",
+    "created_dirs": [],
+}
+
+SHADER_GET_RESULT = {
+    "path": "/tmp/proj/wave.gdshader",
+    "source": "shader_type canvas_item;\n",
+    "shader_type": "canvas_item",
+}
+
+SHADER_SET_RESULT = {"path": "/tmp/proj/wave.gdshader", "shader_type": "spatial"}
+
+THEME_CREATE_RESULT = {
+    "path": "/tmp/proj/ui.tres",
+    "type": "Theme",
+    "created_dirs": [],
+}

--- a/tests/test_asset_file_commands.py
+++ b/tests/test_asset_file_commands.py
@@ -15,15 +15,16 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.models import ScriptSetMode
 from gda.runner import RunResult
-from tests.support import inject_runner, sentinel
+from tests.support import (
+    SHADER_CREATE_RESULT,
+    SHADER_GET_RESULT,
+    SHADER_SET_RESULT,
+    THEME_CREATE_RESULT,
+    inject_runner,
+    sentinel,
+)
 
 # --- shader create ---------------------------------------------------------
-
-SHADER_CREATE_RESULT = {
-    "path": "/tmp/proj/wave.gdshader",
-    "shader_type": "canvas_item",
-    "created_dirs": [],
-}
 
 
 def test_shader_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
@@ -140,12 +141,6 @@ def test_shader_create_content_and_type_are_mutually_exclusive(monkeypatch):
 
 # --- shader get ------------------------------------------------------------
 
-SHADER_GET_RESULT = {
-    "path": "/tmp/proj/wave.gdshader",
-    "source": "shader_type canvas_item;\n",
-    "shader_type": "canvas_item",
-}
-
 
 def test_shader_get_json_emits_source_and_metadata_and_exit_zero(monkeypatch):
     # shader get is the verifier (issue #115): it reads a shader's source back as
@@ -163,8 +158,6 @@ def test_shader_get_json_emits_source_and_metadata_and_exit_zero(monkeypatch):
 
 
 # --- shader set: reuses the script set edit-mode interface (issue #115) -----
-
-SHADER_SET_RESULT = {"path": "/tmp/proj/wave.gdshader", "shader_type": "spatial"}
 
 
 def test_shader_set_search_replace_dispatches_search_and_replace(monkeypatch):
@@ -325,12 +318,6 @@ def test_shader_set_search_replace_and_content_are_mutually_exclusive(monkeypatc
 
 
 # --- theme create: engine-backed .tres -------------------------------------
-
-THEME_CREATE_RESULT = {
-    "path": "/tmp/proj/ui.tres",
-    "type": "Theme",
-    "created_dirs": [],
-}
 
 
 def test_theme_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):

--- a/tests/test_export_commands.py
+++ b/tests/test_export_commands.py
@@ -14,24 +14,13 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
-from tests.support import FakeRunner, inject_runner, sentinel
-
-LIST_RESULT = {
-    "presets": [
-        {"index": 0, "name": "Linux/X11", "platform": "Linux/X11", "runnable": True},
-        {"index": 1, "name": "Web", "platform": "Web", "runnable": False},
-    ]
-}
-
-GET_RESULT = {
-    "index": 1,
-    "name": "Web",
-    "platform": "Web",
-    "runnable": False,
-    "export_path": "build/index.html",
-    "templates_installed": True,
-    "templates_version": "4.6.3.stable",
-}
+from tests.support import (
+    EXPORT_GET_RESULT as GET_RESULT,
+    EXPORT_LIST_RESULT as LIST_RESULT,
+    FakeRunner,
+    inject_runner,
+    sentinel,
+)
 
 
 def test_export_list_json_enumerates_presets_and_exit_zero(monkeypatch, tmp_path):

--- a/tests/test_node_commands.py
+++ b/tests/test_node_commands.py
@@ -12,15 +12,18 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
-from tests.support import inject_runner, sentinel
-
-ADD_RESULT = {
-    "scene_path": "/tmp/proj/main.tscn",
-    "path": "Hero",
-    "name": "Hero",
-    "type": "Sprite2D",
-    "script_class": None,
-}
+from tests.support import (
+    NODE_ADD_RESULT as ADD_RESULT,
+    NODE_CONNECT_RESULT as CONNECT_RESULT,
+    NODE_DUPLICATE_RESULT as DUPLICATE_RESULT,
+    NODE_GET_RESULT as GET_RESULT,
+    NODE_LIST_RESULT as LIST_RESULT,
+    NODE_MOVE_RESULT as MOVE_RESULT,
+    NODE_REMOVE_RESULT as REMOVE_RESULT,
+    NODE_SET_RESULT as SET_RESULT,
+    inject_runner,
+    sentinel,
+)
 
 
 def test_node_add_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
@@ -71,31 +74,6 @@ def test_node_add_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     assert "engine diagnostic" in result.stderr
 
 
-LIST_RESULT = {
-    "scene_path": "/tmp/proj/main.tscn",
-    "root": {
-        "name": "main",
-        "type": "Node2D",
-        "path": ".",
-        "children": [
-            {
-                "name": "Hero",
-                "type": "Sprite2D",
-                "path": "Hero",
-                "children": [
-                    {
-                        "name": "Hitbox",
-                        "type": "Area2D",
-                        "path": "Hero/Hitbox",
-                        "children": [],
-                    }
-                ],
-            }
-        ],
-    },
-}
-
-
 def test_node_list_json_emits_node_tree_with_paths_and_exit_zero(monkeypatch):
     # node list is the node-group verifier (issue #53): it reports the scene's
     # tree like scene get, but each node carries its node path — the address an
@@ -114,18 +92,6 @@ def test_node_list_json_emits_node_tree_with_paths_and_exit_zero(monkeypatch):
     assert (hero["name"], hero["type"], hero["path"]) == ("Hero", "Sprite2D", "Hero")
     assert hero["children"][0]["path"] == "Hero/Hitbox"
     assert fake.calls == [("node-list", {"path": "/tmp/proj/main.tscn"})]
-
-
-GET_RESULT = {
-    "scene_path": "/tmp/proj/main.tscn",
-    "path": "Hero",
-    "name": "Hero",
-    "type": "Sprite2D",
-    "properties": [
-        {"name": "position", "type": "Vector2", "value": [10.0, 20.0]},
-        {"name": "visible", "type": "bool", "value": True},
-    ],
-}
 
 
 def test_node_get_json_emits_typed_properties_and_exit_zero(monkeypatch):
@@ -153,15 +119,6 @@ def test_node_get_json_emits_typed_properties_and_exit_zero(monkeypatch):
     assert fake.calls == [
         ("node-get", {"path": "/tmp/proj/main.tscn", "node": "Hero"})
     ]
-
-
-SET_RESULT = {
-    "scene_path": "/tmp/proj/main.tscn",
-    "path": "Hero",
-    "property": "position",
-    "type": "Vector2",
-    "value": [3.0, 4.0],
-}
 
 
 def test_node_set_json_echoes_the_coerced_property_and_exit_zero(monkeypatch):
@@ -209,14 +166,6 @@ def test_node_set_json_echoes_the_coerced_property_and_exit_zero(monkeypatch):
     ]
 
 
-REMOVE_RESULT = {
-    "scene_path": "/tmp/proj/main.tscn",
-    "path": "Hero",
-    "name": "Hero",
-    "type": "Sprite2D",
-}
-
-
 def test_node_remove_json_echoes_the_removed_node_and_exit_zero(monkeypatch):
     # node remove is the first structural edit (issue #56): it deletes a node
     # and its subtree, echoing the removed node's address/name/type — the result
@@ -237,15 +186,6 @@ def test_node_remove_json_echoes_the_removed_node_and_exit_zero(monkeypatch):
     ]
 
 
-DUPLICATE_RESULT = {
-    "scene_path": "/tmp/proj/main.tscn",
-    "source_path": "Hero",
-    "path": "Hero2",
-    "name": "Hero2",
-    "type": "Sprite2D",
-}
-
-
 def test_node_duplicate_json_echoes_the_new_copy_and_exit_zero(monkeypatch):
     # node duplicate (issue #56) copies a node and its subtree under the source's
     # own parent with a fresh name, echoing the source and the new copy's
@@ -264,16 +204,6 @@ def test_node_duplicate_json_echoes_the_new_copy_and_exit_zero(monkeypatch):
     assert fake.calls == [
         ("node-duplicate", {"path": "/tmp/proj/main.tscn", "node": "Hero"})
     ]
-
-
-MOVE_RESULT = {
-    "scene_path": "/tmp/proj/main.tscn",
-    "source_path": "Hero",
-    "new_parent": "Enemies",
-    "path": "Enemies/Hero",
-    "name": "Hero",
-    "type": "Sprite2D",
-}
 
 
 def test_node_move_json_echoes_the_reparented_node_and_exit_zero(monkeypatch):
@@ -333,15 +263,6 @@ def test_node_add_defaults_parent_to_root_and_name_to_type(monkeypatch):
             },
         )
     ]
-
-
-CONNECT_RESULT = {
-    "scene_path": "/tmp/proj/main.tscn",
-    "from": "Emitter",
-    "signal": "timeout",
-    "to": "Receiver",
-    "method": "on_timeout",
-}
 
 
 def test_node_connect_signal_json_dispatches_the_four_part_connection(monkeypatch):

--- a/tests/test_project_analysis_commands.py
+++ b/tests/test_project_analysis_commands.py
@@ -13,47 +13,15 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
-from tests.support import FakeRunner, inject_runner, sentinel
-
-DEPENDENCIES_RESULT = {
-    "dependencies": [
-        {
-            "path": "res://main.tscn",
-            "depends_on": [
-                {"path": "res://hero.tscn", "kind": "ext_resource"},
-                {"path": "res://icon.png", "kind": "ext_resource"},
-            ],
-        },
-        {"path": "res://hero.tscn", "depends_on": []},
-    ]
-}
-
-FIND_REFERENCES_RESULT = {
-    "target": "res://hero.gd",
-    "references": [
-        {
-            "path": "res://hero.tscn",
-            "kind": "ext_resource",
-            "context": 'res://hero.gd type="Script"',
-        }
-    ],
-}
-
-UNUSED_RESULT = {"unused": ["res://orphan.png", "res://orphan.tres"]}
-
-STATISTICS_RESULT = {
-    "total_files": 5,
-    "total_lines": 120,
-    "by_extension": [
-        {"extension": "gd", "files": 2, "lines": 100},
-        {"extension": "tscn", "files": 2, "lines": 20},
-    ],
-    "autoloads": [{"name": "GameState", "path": "res://game_state.gd"}],
-    "plugins": ["res://addons/widget/plugin.cfg"],
-    "scene_count": 2,
-    "script_count": 2,
-    "resource_count": 1,
-}
+from tests.support import (
+    DEPENDENCIES_RESULT,
+    FIND_REFERENCES_RESULT,
+    STATISTICS_RESULT,
+    UNUSED_RESULT,
+    FakeRunner,
+    inject_runner,
+    sentinel,
+)
 
 
 def test_dependencies_json_maps_success_to_json_object_and_exit_zero(monkeypatch):

--- a/tests/test_resource_commands.py
+++ b/tests/test_resource_commands.py
@@ -17,43 +17,19 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
-from tests.support import FakeRunner, inject_runner, sentinel
-
-
-CREATE_RESULT = {
-    "path": "/tmp/proj/palette.tres",
-    "type": "Gradient",
-    "created_dirs": [],
-}
-
-GET_RESULT = {
-    "path": "/tmp/proj/palette.tres",
-    "type": "Gradient",
-    "properties": [
-        {"name": "resource_name", "type": "String", "value": ""},
-        {"name": "interpolation_mode", "type": "int", "value": 0},
-    ],
-}
-
-
-SET_RESULT = {
-    "path": "/tmp/proj/palette.tres",
-    "property": "interpolation_mode",
-    "type": "int",
-    "value": 1,
-}
-
-DELETE_RESULT = {
-    "path": "/tmp/proj/palette.tres",
-    "type": "Gradient",
-}
-
-
-UID = "uid://caax1gby1api1"
-PATH = "res://data.tres"
-
-UID_TO_PATH_RESULT = {"queried": "uid", "uid": UID, "path": PATH}
-PATH_TO_UID_RESULT = {"queried": "path", "uid": UID, "path": PATH}
+from tests.support import (
+    RESOURCE_CREATE_RESULT as CREATE_RESULT,
+    RESOURCE_DELETE_RESULT as DELETE_RESULT,
+    RESOURCE_GET_RESULT as GET_RESULT,
+    RESOURCE_SET_RESULT as SET_RESULT,
+    PATH,
+    PATH_TO_UID_RESULT,
+    UID,
+    UID_TO_PATH_RESULT,
+    FakeRunner,
+    inject_runner,
+    sentinel,
+)
 
 
 # --- resource set (issue #120) -------------------------------------------

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -411,15 +411,15 @@ def test_sample_node_results_validate_against_emitted_output_schemas():
     # A sample --json payload of each node command satisfies the contract its
     # --schema emits (the other half of the ADR-0004 hard gate, issues
     # #53/#55/#56/#57).
-    from tests.test_node_commands import (
-        ADD_RESULT,
-        CONNECT_RESULT,
-        DUPLICATE_RESULT,
-        GET_RESULT,
-        LIST_RESULT,
-        MOVE_RESULT,
-        REMOVE_RESULT,
-        SET_RESULT,
+    from tests.support import (
+        NODE_ADD_RESULT as ADD_RESULT,
+        NODE_CONNECT_RESULT as CONNECT_RESULT,
+        NODE_DUPLICATE_RESULT as DUPLICATE_RESULT,
+        NODE_GET_RESULT as GET_RESULT,
+        NODE_LIST_RESULT as LIST_RESULT,
+        NODE_MOVE_RESULT as MOVE_RESULT,
+        NODE_REMOVE_RESULT as REMOVE_RESULT,
+        NODE_SET_RESULT as SET_RESULT,
     )
 
     add_doc = json.loads(CliRunner().invoke(app, ["node", "add", "--schema"]).stdout)
@@ -607,9 +607,12 @@ def test_script_validate_schema_emits_model_derived_contract_without_other_args(
 def test_sample_script_results_validate_against_emitted_output_schemas():
     # A sample --json payload of each script command satisfies the contract its
     # --schema emits (the other half of the ADR-0004 hard gate, issues #110, #117).
-    from tests.test_script_commands import CREATE_RESULT, GET_RESULT, LIST_RESULT
-
-    from tests.test_script_commands import SET_RESULT
+    from tests.support import (
+        SCRIPT_CREATE_RESULT as CREATE_RESULT,
+        SCRIPT_GET_RESULT as GET_RESULT,
+        SCRIPT_LIST_RESULT as LIST_RESULT,
+        SCRIPT_SET_RESULT as SET_RESULT,
+    )
 
     create_doc = json.loads(
         CliRunner().invoke(app, ["script", "create", "--schema"]).stdout
@@ -682,7 +685,7 @@ def test_sample_resource_uid_results_validate_against_emitted_output_schema():
     # A sample --json payload of resource uid satisfies the contract its --schema
     # emits — the other half of the ADR-0004 hard gate (issue #113). Both
     # directions share one result shape, so one sample covers them.
-    from tests.test_resource_commands import PATH_TO_UID_RESULT, UID_TO_PATH_RESULT
+    from tests.support import PATH_TO_UID_RESULT, UID_TO_PATH_RESULT
 
     doc = json.loads(CliRunner().invoke(app, ["resource", "uid", "--schema"]).stdout)
 
@@ -864,7 +867,10 @@ def test_resource_delete_schema_emits_model_derived_contract_without_other_args(
 def test_sample_resource_set_delete_results_validate_against_emitted_output_schemas():
     # A sample --json payload of each new resource command satisfies the contract
     # its --schema emits (the other half of the ADR-0004 hard gate, issue #120).
-    from tests.test_resource_commands import DELETE_RESULT, SET_RESULT
+    from tests.support import (
+        RESOURCE_DELETE_RESULT as DELETE_RESULT,
+        RESOURCE_SET_RESULT as SET_RESULT,
+    )
 
     set_doc = json.loads(
         CliRunner().invoke(app, ["resource", "set", "--schema"]).stdout
@@ -939,7 +945,10 @@ def test_project_statistics_schema_emits_model_derived_contract():
 def test_sample_resource_results_validate_against_emitted_output_schemas():
     # A sample --json payload of each resource command satisfies the contract
     # its --schema emits (the other half of the ADR-0004 hard gate, issue #112).
-    from tests.test_resource_commands import CREATE_RESULT, GET_RESULT
+    from tests.support import (
+        RESOURCE_CREATE_RESULT as CREATE_RESULT,
+        RESOURCE_GET_RESULT as GET_RESULT,
+    )
 
     create_doc = json.loads(
         CliRunner().invoke(app, ["resource", "create", "--schema"]).stdout
@@ -955,7 +964,10 @@ def test_sample_resource_results_validate_against_emitted_output_schemas():
 def test_sample_export_results_validate_against_emitted_output_schemas():
     # A sample --json payload of each export command satisfies the contract its
     # --schema emits (the other half of the ADR-0004 hard gate, issue #114).
-    from tests.test_export_commands import GET_RESULT, LIST_RESULT
+    from tests.support import (
+        EXPORT_GET_RESULT as GET_RESULT,
+        EXPORT_LIST_RESULT as LIST_RESULT,
+    )
 
     list_doc = json.loads(
         CliRunner().invoke(app, ["export", "list", "--schema"]).stdout
@@ -969,7 +981,7 @@ def test_sample_export_results_validate_against_emitted_output_schemas():
 def test_sample_project_results_validate_against_emitted_output_schemas():
     # A sample --json payload of each project analysis command satisfies the
     # contract its --schema emits (the other half of the ADR-0004 hard gate).
-    from tests.test_project_analysis_commands import (
+    from tests.support import (
         DEPENDENCIES_RESULT,
         FIND_REFERENCES_RESULT,
         STATISTICS_RESULT,
@@ -1146,7 +1158,7 @@ def test_theme_create_schema_emits_model_derived_contract_without_other_args():
 def test_sample_asset_file_results_validate_against_emitted_output_schemas():
     # A sample --json payload of each asset-file command satisfies the contract
     # its --schema emits (the other half of the ADR-0004 hard gate, issue #115).
-    from tests.test_asset_file_commands import (
+    from tests.support import (
         SHADER_CREATE_RESULT,
         SHADER_GET_RESULT,
         SHADER_SET_RESULT,

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -13,14 +13,15 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.models import ScriptSetMode
 from gda.runner import RunResult
-from tests.support import FakeRunner, inject_runner, sentinel
-
-CREATE_RESULT = {
-    "path": "/tmp/proj/hero.gd",
-    "class_name": "Hero",
-    "extends": "Node2D",
-    "created_dirs": [],
-}
+from tests.support import (
+    SCRIPT_CREATE_RESULT as CREATE_RESULT,
+    SCRIPT_GET_RESULT as GET_RESULT,
+    SCRIPT_LIST_RESULT as LIST_RESULT,
+    SCRIPT_SET_RESULT as SET_RESULT,
+    FakeRunner,
+    inject_runner,
+    sentinel,
+)
 
 
 def test_script_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
@@ -130,14 +131,6 @@ def test_script_create_content_and_extends_are_mutually_exclusive(monkeypatch):
     assert fake.calls == []
 
 
-GET_RESULT = {
-    "path": "/tmp/proj/hero.gd",
-    "source": "class_name Hero\nextends Node2D\n",
-    "class_name": "Hero",
-    "extends": "Node2D",
-}
-
-
 def test_script_get_json_emits_source_and_metadata_and_exit_zero(monkeypatch):
     # script get is the verifier (issue #110): it reads a script's source back
     # as raw text with its class_name/extends, so a create round-trips.
@@ -153,15 +146,6 @@ def test_script_get_json_emits_source_and_metadata_and_exit_zero(monkeypatch):
     assert data["class_name"] == "Hero"
     assert data["extends"] == "Node2D"
     assert fake.calls == [("script-get", {"path": "/tmp/proj/hero.gd"})]
-
-
-LIST_RESULT = {
-    "scripts": [
-        {"path": "res://hero.gd", "class_name": "Hero", "extends": "Node2D"},
-        {"path": "res://util.gd", "class_name": None, "extends": "RefCounted"},
-        {"path": "res://empty.gd", "class_name": None, "extends": None},
-    ]
-}
 
 
 def test_script_list_json_enumerates_project_scripts_and_exit_zero(monkeypatch, tmp_path):
@@ -210,13 +194,6 @@ def test_script_list_passes_resolved_project_to_the_runner(monkeypatch, tmp_path
 
     assert result.exit_code == 0
     assert seen["project"] == tmp_path
-
-
-SET_RESULT = {
-    "path": "/tmp/proj/hero.gd",
-    "class_name": "Hero",
-    "extends": "Node2D",
-}
 
 
 def test_script_set_search_replace_dispatches_search_and_replace(monkeypatch):


### PR DESCRIPTION
## What

Finishes the test-module decoupling started in #39/#177. `test_schema_command.py` reused other command-test modules' canned `--json` result payloads by importing them directly (`from tests.test_<group>_commands import …`), coupling test module to test module. PR #177 removed this for the **scene** payloads; this applies the exact same pattern to the remaining 6 groups.

## How

For each group — node, script, resource, export, project-analysis, asset-file — moved its canned result payloads into `tests/support.py`, then imported them back from there in **both** the owning command-test module and `test_schema_command.py`. Generic in-module names stay stable via `as` aliases (as #177 did): e.g. support holds `NODE_ADD_RESULT`/`SCRIPT_CREATE_RESULT`/`RESOURCE_GET_RESULT`/`EXPORT_LIST_RESULT`, aliased back to the modules' `ADD_RESULT`/`CREATE_RESULT`/`GET_RESULT`/`LIST_RESULT`. Already-unique names moved without aliasing. The resource module's shared `UID`/`PATH` constants (depended on by the uid payloads) moved too.

Pure data movement — **no production code changed**, all 8 files under `tests/`.

## Result

- **No test module imports a payload from another test module** — `grep -rE "from (tests\.)?test_[a-z_]+ import" tests/` returns nothing (closes the literal #39/#178 acceptance bar).
- Each consolidated payload is defined exactly once (in `tests/support.py`).
- Engine-free suite: **491 passed → 491 passed** (green → green, no behavior change). Pure unit-test refactor; e2e tier untouched.

Out of scope (deliberately deferred, tracked on #178): the per-module `_gda` e2e invocation helper — a concurrent slice (#180) touches `conftest.py`, so this PR stays off e2e infra to remain conflict-free.

Closes #178.
