### PR TITLE
test(e2e): isolate fixtures from user:// log contention (#180)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,23 @@ domain slices (node, script, …) reuse it rather than growing their own.
 tier (issue #106): any ``e2e``-marked test selected without a resolvable Godot
 binary fails loudly here, naming the resolved path, rather than silently
 skipping per-module.
+
+``project_godot`` (issue #180) is the single builder for every e2e
+``project.godot``. It always disables Godot's default desktop file logging, so
+**no** e2e engine launch writes a ``user://logs/godot.log``. Why this matters:
+Godot resolves ``user://`` to ``$HOME/Library/Application Support/Godot/
+app_userdata/<config/name>/`` and, on desktop, attaches a ``RotatedFileLogger``
+that races in ``rotate_file()`` when concurrent launches share one log dir.
+Overlapping e2e runs (parallel agents / a CI matrix) then abort with what looks
+like ``engine_crashed`` but is purely test-infra contention. Removing the log
+write at the source makes the e2e tier reliable by default — no ``fresh-HOME``
+workaround needed. The operative key is the **platform override**
+``debug/file_logging/enable_file_logging.pc``: the base key defaults to
+``false`` but Godot's ``.pc`` feature-tagged override defaults to ``true`` on
+desktop and wins at startup (godot ``main/main.cpp``), so disabling the base
+alone is a no-op — the ``.pc`` override must be set too. Every e2e test that
+needs its own ``project.godot`` must build it through this helper (passing its
+extra sections via ``extra``) so the logging stays disabled.
 """
 
 import pytest
@@ -34,14 +51,37 @@ def _require_godot_engine(request):
         )
 
 
-# The minimal project.godot a Godot 4 engine accepts as a project root.
-PROJECT_GODOT = """\
-config_version=5
+# Disables Godot's default desktop file logging so an e2e launch writes no
+# ``user://logs/godot.log`` (issue #180). The ``.pc`` line is the operative one:
+# on desktop the ``.pc`` feature override (default ``true``) wins over the base
+# key (default ``false``), so both are set off.
+_DEBUG_NO_FILE_LOGGING = """\
+[debug]
 
-[application]
-
-config/name="gda-e2e-fixture"
+file_logging/enable_file_logging=false
+file_logging/enable_file_logging.pc=false
 """
+
+
+def project_godot(name: str = "gda-e2e-fixture", extra: str = "") -> str:
+    """Build a ``project.godot`` with file logging disabled (issue #180).
+
+    The single source of truth for every e2e ``project.godot``. ``name`` sets
+    ``config/name`` (which is also the ``user://`` dir name); ``extra`` appends
+    further sections (``[autoload]``, ``run/main_scene``, ``[editor_plugins]``,
+    …) verbatim. File logging is always disabled so no e2e launch writes to a
+    shared ``user://logs`` dir.
+    """
+    body = f'config_version=5\n\n[application]\n\nconfig/name="{name}"\n'
+    if extra:
+        body += "\n" + extra.rstrip("\n") + "\n"
+    return body + "\n" + _DEBUG_NO_FILE_LOGGING
+
+
+# The minimal project.godot a Godot 4 engine accepts as a project root, with
+# e2e file logging disabled (issue #180). Built through ``project_godot`` so the
+# logging-disable rationale lives in exactly one place.
+PROJECT_GODOT = project_godot()
 
 
 @pytest.fixture

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -18,17 +18,17 @@ import pytest
 
 from gda.binary import resolve_godot_binary
 
+from .conftest import project_godot
+
 GODOT = resolve_godot_binary()
 
 
 # A project.godot with an autoload, a main scene, and an enabled editor plugin —
 # the project-level references and the statistics fields the commands report.
-PROJECT_GODOT = """\
-config_version=5
-
-[application]
-
-config/name="gda-refgraph-fixture"
+# Built through ``project_godot`` so e2e file logging stays disabled (issue #180).
+PROJECT_GODOT = project_godot(
+    name="gda-refgraph-fixture",
+    extra="""\
 run/main_scene="res://main.tscn"
 
 [autoload]
@@ -38,7 +38,8 @@ GameState="*res://game_state.gd"
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/widget/plugin.cfg")
-"""
+""",
+)
 
 # A main scene that ext_resources a sub-scene, a script and an image — three
 # outgoing references, the shape Godot 4 writes.
@@ -285,13 +286,8 @@ def test_find_references_bad_target_is_invalid_target(refgraph_project):
 # Hero must report the consumers but NOT Hero's own `class_name Hero` declaration
 # line (the definition site, not a reference); find-references for Lonely must be
 # empty.
-CLASSNAME_PROJECT_GODOT = """\
-config_version=5
-
-[application]
-
-config/name="gda-classname-fixture"
-"""
+# Built through ``project_godot`` so e2e file logging stays disabled (issue #180).
+CLASSNAME_PROJECT_GODOT = project_godot(name="gda-classname-fixture")
 
 HERO_GD = """\
 extends Node
@@ -402,9 +398,9 @@ def test_statistics_counts_binary_assets_as_files_but_not_lines(tmp_path):
     # ("binary assets contribute to file counts but not line counts"). Issue #116
     # review: _count_lines previously read every file as text, so a binary asset's
     # newline bytes inflated total_lines.
+    # Built through ``project_godot`` so e2e file logging stays disabled (#180).
     (tmp_path / "project.godot").write_text(
-        'config_version=5\n\n[application]\n\nconfig/name="gda-binary-fixture"\n',
-        encoding="utf-8",
+        project_godot(name="gda-binary-fixture"), encoding="utf-8"
     )
     # A two-line .gd: a real text file contributing 2 lines.
     (tmp_path / "code.gd").write_text("extends Node\n\n", encoding="utf-8")

--- a/tests/test_e2e_scene_security.py
+++ b/tests/test_e2e_scene_security.py
@@ -39,6 +39,8 @@ import pytest
 
 from gda.binary import resolve_godot_binary
 
+from .conftest import project_godot
+
 GODOT = resolve_godot_binary()
 
 
@@ -298,17 +300,15 @@ func _init() -> void:
 """
 
 # A project.godot that registers the autoload (extends the minimal fixture form).
-PROJECT_WITH_AUTOLOAD = """\
-config_version=5
-
-[application]
-
-config/name="gda-e2e-autoload-fixture"
-
+# Built through ``project_godot`` so e2e file logging stays disabled (issue #180).
+PROJECT_WITH_AUTOLOAD = project_godot(
+    name="gda-e2e-autoload-fixture",
+    extra="""\
 [autoload]
 
 Spy="*res://autoload.gd"
-"""
+""",
+)
 
 # A plain scene with NO attached script, so the only project-code execution
 # surface in this test is the autoload (not a scene script).


### PR DESCRIPTION
## What

Eliminates the `engine_crashed` / `RotatedFileLogger::rotate_file()` flakiness in the e2e tier. Root cause: Godot desktop enables file logging by default; `user://` resolves to `…/app_userdata/<config/name>/`, and the e2e fixtures shared one project name, so concurrent e2e launches (parallel agents / CI matrix) raced in `rotate_file()` against one shared `user://logs` dir and aborted. It looked like a product crash but was test-infra contention. This removes the log write at the source so the e2e tier is reliable by default — no `fresh-HOME` workaround needed.

## How

- New `project_godot(name="gda-e2e-fixture", extra="")` builder in `tests/conftest.py` — the single source of truth for every e2e `project.godot`. It always appends a `[debug]` section disabling file logging; `extra` appends test-specific sections (`[autoload]`, etc.) verbatim. `PROJECT_GODOT` is rebuilt through it.
- Routed every e2e test that writes its own `project.godot` through the builder: `gda-refgraph-fixture`/`gda-classname-fixture`/`gda-binary-fixture` (project-analysis) and `gda-e2e-autoload-fixture` (scene-security). (Export tests write only `export_presets.cfg` over the shared fixture, already covered.)
- Confined to test infra; **no production code changed**. `gda`'s real engine-invocation behavior is unchanged.

## Key finding — the `.pc` override is the operative key

Setting `debug/file_logging/enable_file_logging=false` alone is a **no-op on desktop**: Godot's base key defaults to `false`, but the `.pc` (desktop) feature-tagged override defaults to `true` and wins at startup (`main/main.cpp`). The builder sets **both** `file_logging/enable_file_logging=false` **and** `file_logging/enable_file_logging.pc=false`. Verified empirically: base-key-only still wrote `godot.log`; with the `.pc` override, none.

## Proof & results

- **Deterministic "no log dir" proof:** ran the full e2e suite against a clean throwaway `HOME`, then scanned `app_userdata/` — across all 7 fixture project dirs, `find` reported **0** `godot.log` files and **0** `logs/` directories. The contention source is structurally removed (stronger than reproducing the race).
- **Full suite (e2e included):** **724 passed, 1 skipped, 0 failed** — no `engine_crashed`/`RotatedFileLogger`.
- **Engine-free:** **491 passed**.

Closes #180.
