### PR TITLE
docs: fix broken Status badge (bust poisoned camo cache)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > An agent-first **CLI and MCP server** that lets AI agents drive the [Godot Engine](https://godotengine.org) to build games — with **structured output** built for programmatic consumption.
 
-[![Status](https://img.shields.io/badge/status-Phase%201%20headless%20surface%20complete-brightgreen)](#project-status)
+[![Status](https://img.shields.io/badge/status-Phase%201%20headless%20surface%20complete-brightgreen?cacheSeconds=3600)](#project-status)
 [![CI](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
 [![Python](https://img.shields.io/badge/python-3.13%2B-blue)](https://www.python.org/)
 [![Godot](https://img.shields.io/badge/godot-4.4%2B%20(tested%204.6)-478CBF)](https://godotengine.org)


### PR DESCRIPTION
## Symptom

The **Status** badge renders as a broken image on the GitHub repo homepage, while the other badges (Python, Godot, License, …) render fine.

## Diagnosis — not a URL error

The shields.io URL is correct. The breakage is in **GitHub's camo image proxy** (`camo.githubusercontent.com`), which had cached a failed fetch for this badge's specific camo hash:

| Fetch | Result |
| ----- | ------ |
| shields.io URL directly | **200**, valid `image/svg+xml` ✅ |
| Status badge via camo proxy | **504 / 502** `Error Fetching Resource` ❌ |
| Python badge via camo proxy (control) | **200** ✅ |

camo → shields.io is working in general (the control badge proxies fine); only this badge's cache entry was poisoned by a transient fetch failure, and it was not self-healing (3 consecutive retries all 502). Each badge has its own independent camo cache entry, which is why only this one broke.

## Fix

Append `?cacheSeconds=3600` to the canonical shields.io URL. This:

- changes the canonical URL → GitHub mints a **new camo hash** → forces a fresh fetch (shields.io is currently 200, so it caches a success);
- sets an hourly refresh so the entry self-heals from any future transient failures.

The badge's **text and color are unchanged** — purely a cache-bust. Verified the new URL returns `HTTP 200` from shields.io.

Docs-only; no code touched.
