### PR TITLE
refactor(runner): unify the sentinel and native-export channels onto one headless-launch primitive (#185)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,25 @@ in-place state (e.g. inspect the live scene tree, runtime inspection, UndoRedo,
 input simulation). Served through `gda-daemon`, not by a one-shot headless call.
 _Avoid_: realtime op, online op
 
+**Headless launch**:
+The one-shot `godot --headless` spawn primitive that both Phase-1 channels — the
+sentinel op-dispatch runner and the native-export runner — share. Given the
+binary, an argv tail, an optional working directory, and a timeout, it builds
+`[binary, --headless, *args]`, captures bytes with the timeout, and normalizes
+the outcome into a `Raw run` (the single home of the spawn / timeout / launch-
+failure / UTF-8-decode handling). Each channel contributes only its argv tail and
+the export-only cwd.
+_Avoid_: spawn helper, subprocess wrapper
+
+**Raw run**:
+The normalized outcome a `Headless launch` returns — `{stdout, stderr, exit_code,
+launch_failure}`, unparsed — before any classification. `launch_failure` is set
+only when the primitive synthesized the result (binary missing, timed out) rather
+than the engine returning one, so the classifier keys environment failures on
+that typed reason, not on the overloaded exit code. Both channels return the one
+`RunResult` shape.
+_Avoid_: run output, export output
+
 ### Failure reporting
 
 **Gda error code**:

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -44,7 +44,6 @@ from typing import TypeVar
 from pydantic import BaseModel, ValidationError
 
 from gda.error_codes import ERROR_CODE_BY_CODE, OPERATION_ERROR_CODES
-from gda.export_runner import ExportRunOutput
 from gda.models import (
     EngineVersion,
     ExportRunMode,
@@ -143,33 +142,55 @@ def unresolvable_binary_failure(reason: str) -> Failure:
     )
 
 
+def classify_launch_or_crash(raw: RunResult, binary: Path) -> Failure | None:
+    """The env/crash classifier prefix shared by both headless channels (#185).
+
+    The single home of the launch-failure and signal-death mapping that the
+    sentinel channel (``classify_run``) and the native-export channel
+    (``classify_export_run``) both open with, so a missing binary, a hung run,
+    or a signal death is classified identically across both (ADR-0010 — reuse
+    the machinery rather than duplicate it). Returns the env/crash ``Failure``
+    for the three modes below, or ``None`` to let the caller's channel-specific
+    tail (sentinel parse+validate vs synthesize-from-exit-code) take over.
+
+    Environment failures key on the runner's typed ``launch_failure`` reason,
+    not the exit code, so an engine (or shell/AppImage wrapper) that *genuinely*
+    returns 124/127 is classified as ``operation`` by the tail rather than
+    mislabelled environment (issue #15).
+    """
+    if raw.launch_failure is LaunchFailure.NOT_FOUND:
+        return _failure(
+            "binary_not_found",
+            f"Godot binary could not be launched: {binary}",
+            raw.stderr,
+        )
+    if raw.launch_failure is LaunchFailure.TIMEOUT:
+        return _failure(
+            "launch_timeout",
+            "Godot launched but did not return before the timeout",
+            raw.stderr,
+        )
+    if raw.exit_code < 0:
+        # subprocess reports a signal death as a negative return code; the
+        # engine ran but was killed (e.g. SIGSEGV crash, OOM SIGKILL) rather
+        # than the operation cleanly reporting an error.
+        return _failure(
+            "engine_crashed",
+            f"Godot terminated abnormally (signal {-raw.exit_code})",
+            raw.stderr,
+        )
+    return None
+
+
 def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | Failure:
     """Classify a raw headless run into the command's typed model or a ``Failure``.
 
     Command-agnostic: owns the env/operation/parse decision tree shared by all
     commands. Per-command classifiers layer their specific checks on top.
     """
-    if result.launch_failure is LaunchFailure.NOT_FOUND:
-        return _failure(
-            "binary_not_found",
-            f"Godot binary could not be launched: {binary}",
-            result.stderr,
-        )
-    if result.launch_failure is LaunchFailure.TIMEOUT:
-        return _failure(
-            "launch_timeout",
-            "Godot launched but did not return before the timeout",
-            result.stderr,
-        )
-    if result.exit_code < 0:
-        # subprocess reports a signal death as a negative return code; the
-        # engine ran but was killed (e.g. SIGSEGV crash, OOM SIGKILL) rather
-        # than the operation cleanly reporting an error.
-        return _failure(
-            "engine_crashed",
-            f"Godot terminated abnormally (signal {-result.exit_code})",
-            result.stderr,
-        )
+    prefix = classify_launch_or_crash(result, binary)
+    if prefix is not None:
+        return prefix
     if result.exit_code != 0:
         # The engine ran but the operation itself reported an error and quit
         # non-zero (its own exit, not the runner's synthetic 124/127). When the
@@ -348,7 +369,7 @@ def parse_export_warnings(stderr: str) -> list[str]:
 
 
 def classify_export_run(
-    output: ExportRunOutput,
+    output: RunResult,
     binary: Path,
     *,
     preset: str,
@@ -370,27 +391,14 @@ def classify_export_run(
     ``templates_installed``), not here; on a non-zero export stderr is surfaced
     only as the advisory ``message`` / diagnostics.
 
-    The decision tree mirrors :func:`classify_run`'s env/crash prefix so a
-    missing binary or hung export is reported identically across both channels.
+    The decision tree shares :func:`classify_launch_or_crash`'s env/crash prefix
+    so a missing binary or hung export is reported identically across both
+    channels (#185); only the non-zero-exit tail differs from the sentinel
+    channel (synthesize-from-exit-code, no sentinel parse).
     """
-    if output.launch_failure is LaunchFailure.NOT_FOUND:
-        return _failure(
-            "binary_not_found",
-            f"Godot binary could not be launched: {binary}",
-            output.stderr,
-        )
-    if output.launch_failure is LaunchFailure.TIMEOUT:
-        return _failure(
-            "launch_timeout",
-            "Godot launched but did not return before the timeout",
-            output.stderr,
-        )
-    if output.exit_code < 0:
-        return _failure(
-            "engine_crashed",
-            f"Godot terminated abnormally (signal {-output.exit_code})",
-            output.stderr,
-        )
+    prefix = classify_launch_or_crash(output, binary)
+    if prefix is not None:
+        return prefix
     if output.exit_code != 0:
         # Templates are checked structurally BEFORE this call (the CLI preflights
         # export get's templates_installed), so a missing-templates run never

--- a/src/gda/export_runner.py
+++ b/src/gda/export_runner.py
@@ -10,18 +10,17 @@ editor export pipeline and writes the artifact. It emits no ADR-0002 sentinel, s
 stderr (see :func:`gda.errors.classify_export_run`).
 
 This module owns only the *seam*: spawn the native export and return its raw
-``{stdout, stderr, exit_code}``. Classification lives in ``gda.errors`` so the
-mapping from raw output to typed result / ``GdaError`` is a pure function exercised
-without a real engine, exactly like the sentinel pipeline.
+``{stdout, stderr, exit_code}`` as the shared :class:`~gda.runner.RunResult`.
+Classification lives in ``gda.errors`` so the mapping from raw output to typed
+result / ``GdaError`` is a pure function exercised without a real engine, exactly
+like the sentinel pipeline.
 """
 
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
-from gda.exit_codes import EXIT_NOT_FOUND, EXIT_TIMEOUT
-from gda.runner import LaunchFailure
+from gda.runner import RunResult, launch
 
 # An export packs the whole project and may invoke platform toolchains, so it is
 # far slower than a one-shot headless op. Give it a generous ceiling distinct
@@ -40,25 +39,10 @@ EXPORT_MODE_FLAGS: dict[str, str] = {
 }
 
 
-@dataclass
-class ExportRunOutput:
-    """The raw result of a native Godot export invocation.
-
-    Mirrors :class:`gda.runner.RunResult` for the export channel: the unparsed
-    process output plus a ``launch_failure`` set only when the runner synthesized
-    the result (binary missing, timed out) rather than the engine returning one.
-    """
-
-    stdout: str
-    stderr: str
-    exit_code: int
-    launch_failure: "LaunchFailure | None" = None
-
-
 class ExportRunner(Protocol):
     """Spawns a native Godot export and returns its raw output."""
 
-    def run(self, preset: str, mode: str, output_path: str) -> ExportRunOutput: ...
+    def run(self, preset: str, mode: str, output_path: str) -> RunResult: ...
 
 
 @dataclass
@@ -84,52 +68,16 @@ class SubprocessExportRunner:
     project: Path | None = None
     timeout: float = DEFAULT_EXPORT_TIMEOUT_SECONDS
 
-    def run(self, preset: str, mode: str, output_path: str) -> ExportRunOutput:
+    def run(self, preset: str, mode: str, output_path: str) -> RunResult:
+        # Build only this channel's argv tail and the export-only cwd (see the
+        # class docstring), then delegate the spawn / timeout / OSError /
+        # UTF-8-decode handling to the shared launch primitive (#185).
         flag = EXPORT_MODE_FLAGS[mode]
-        cmd = [str(self.binary), "--headless"]
-        cwd = str(self.project) if self.project is not None else None
+        args: list[str] = []
         if self.project is not None:
-            cmd += ["--path", str(self.project)]
-        cmd += [flag, preset, output_path]
-        try:
-            # Capture raw bytes (no ``text=True``): like the sentinel runner,
-            # the native export channel must not decode with the host locale,
-            # which mojibakes or raises ``UnicodeDecodeError`` on a non-UTF-8
-            # locale. We decode UTF-8 explicitly below (issue #33).
-            proc = subprocess.run(
-                cmd, capture_output=True, timeout=self.timeout, cwd=cwd
-            )
-        except subprocess.TimeoutExpired:
-            return ExportRunOutput(
-                stdout="",
-                stderr=f"gda: Godot export timed out after {self.timeout}s\n",
-                exit_code=EXIT_TIMEOUT,
-                launch_failure=LaunchFailure.TIMEOUT,
-            )
-        except OSError as exc:
-            # The configured binary could not be launched: ``FileNotFoundError``
-            # (missing), ``PermissionError`` (a directory like ``Godot.app`` or a
-            # non-executable file), and any other ``OSError`` from ``exec`` are
-            # one environment failure — there was no engine to run (issue #33).
-            # Mirrors ``SubprocessGodotRunner`` so both runners close the same
-            # raw-launch-failure surface. ``OSError`` does not subsume
-            # ``TimeoutExpired`` (a ``SubprocessError``), so the timeout path
-            # above is preserved.
-            return ExportRunOutput(
-                stdout="",
-                stderr=f"gda: Godot binary could not be launched: {self.binary} ({exc})\n",
-                exit_code=EXIT_NOT_FOUND,
-                launch_failure=LaunchFailure.NOT_FOUND,
-            )
-        return ExportRunOutput(
-            # Decode the engine's bytes as UTF-8 with a replacement policy, like
-            # the sentinel runner: a well-behaved export emits valid UTF-8, so
-            # ``replace`` only fires on genuinely malformed bytes and the runner
-            # never crashes on engine output (issue #33).
-            stdout=proc.stdout.decode("utf-8", errors="replace"),
-            stderr=proc.stderr.decode("utf-8", errors="replace"),
-            exit_code=proc.returncode,
-        )
+            args += ["--path", str(self.project)]
+        args += [flag, preset, output_path]
+        return launch(self.binary, args, cwd=self.project, timeout=self.timeout)
 
 
 def make_subprocess_export_runner(

--- a/src/gda/export_runner.py
+++ b/src/gda/export_runner.py
@@ -77,7 +77,17 @@ class SubprocessExportRunner:
         if self.project is not None:
             args += ["--path", str(self.project)]
         args += [flag, preset, output_path]
-        return launch(self.binary, args, cwd=self.project, timeout=self.timeout)
+        # Pass the export-specific timeout label: on a timeout the primitive's
+        # stderr is carried into GdaError.diagnostics and serialized in
+        # `export run --json`, so it is part of the public error envelope and must
+        # stay byte-compatible with the pre-#185 "Godot export timed out" wording.
+        return launch(
+            self.binary,
+            args,
+            cwd=self.project,
+            timeout=self.timeout,
+            timeout_label="Godot export",
+        )
 
 
 def make_subprocess_export_runner(

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -58,6 +58,7 @@ def launch(
     *,
     cwd: Path | None,
     timeout: float,
+    timeout_label: str = "Godot",
 ) -> RunResult:
     """Spawn one ``godot --headless`` process and normalize its raw outcome.
 
@@ -73,7 +74,11 @@ def launch(
 
     - ``subprocess.TimeoutExpired`` → a synthesized ``EXIT_TIMEOUT`` result
       flagged ``LaunchFailure.TIMEOUT``: launched, but did not return before the
-      timeout (a hung engine bounded so the CLI fails loudly, #15);
+      timeout (a hung engine bounded so the CLI fails loudly, #15). The diagnostic
+      names ``timeout_label`` (default ``"Godot"``; the export channel passes
+      ``"Godot export"``) — this stderr is carried into ``GdaError.diagnostics``
+      and serialized in ``--json``, so the per-channel wording is part of the
+      public error envelope and stays byte-compatible across the refactor (#185);
     - ``OSError`` → a synthesized ``EXIT_NOT_FOUND`` result flagged
       ``LaunchFailure.NOT_FOUND``: the configured binary could not be launched —
       ``FileNotFoundError`` (missing), ``PermissionError`` (a directory like
@@ -107,7 +112,7 @@ def launch(
     except subprocess.TimeoutExpired:
         return RunResult(
             stdout="",
-            stderr=f"gda: Godot timed out after {timeout}s\n",
+            stderr=f"gda: {timeout_label} timed out after {timeout}s\n",
             exit_code=EXIT_TIMEOUT,
             launch_failure=LaunchFailure.TIMEOUT,
         )

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -52,6 +52,85 @@ class RunResult:
     launch_failure: "LaunchFailure | None" = None
 
 
+def launch(
+    binary: Path,
+    args: list[str],
+    *,
+    cwd: Path | None,
+    timeout: float,
+) -> RunResult:
+    """Spawn one ``godot --headless`` process and normalize its raw outcome.
+
+    The single home of the headless-launch primitive: it builds
+    ``[binary, --headless, *args]``, runs it with a timeout capturing raw
+    *bytes*, and returns a normalized :class:`RunResult`. Both Phase-1 channels
+    — the sentinel op-dispatch runner and the native-export runner — build only
+    their channel-specific argv tail (and the export-only ``cwd``) and delegate
+    the spawn/timeout/``OSError``/decode handling here, so a launch-handling fix
+    lands in one place rather than two copies (issue #185, ADR-0010).
+
+    The mapping, identical for both channels:
+
+    - ``subprocess.TimeoutExpired`` → a synthesized ``EXIT_TIMEOUT`` result
+      flagged ``LaunchFailure.TIMEOUT``: launched, but did not return before the
+      timeout (a hung engine bounded so the CLI fails loudly, #15);
+    - ``OSError`` → a synthesized ``EXIT_NOT_FOUND`` result flagged
+      ``LaunchFailure.NOT_FOUND``: the configured binary could not be launched —
+      ``FileNotFoundError`` (missing), ``PermissionError`` (a directory like
+      ``Godot.app`` — a natural ``$GDA_GODOT`` mistake — or a non-executable
+      file), and any other ``OSError`` from ``exec`` are the one environment
+      failure of there being no engine to run (#33). The synthesized typed
+      reason lets the classifier key environment on it, not on the overloaded
+      exit code (#15). ``OSError`` does not subsume ``TimeoutExpired`` (a
+      ``SubprocessError``), so the timeout path above is preserved. The OS
+      message is kept as advisory stderr to disambiguate which mode occurred;
+    - otherwise → the engine's own ``returncode`` with ``launch_failure=None``,
+      and stdout/stderr decoded as UTF-8 with ``errors="replace"`` (see below).
+    """
+    cmd = [str(binary), "--headless", *args]
+    try:
+        # Capture raw bytes (no ``text=True``): Godot's ``JSON.stringify`` emits
+        # UTF-8, but ``text=True`` would decode with the host locale, which
+        # mojibakes or raises ``UnicodeDecodeError`` on a non-UTF-8 locale (e.g.
+        # Windows cp1252/cp936) for a non-ASCII node name or echoed path. We
+        # decode UTF-8 explicitly below so user content round-trips regardless of
+        # locale (issue #33).
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            timeout=timeout,
+            # Pass the working directory as a string (not a Path): the export
+            # channel resolves a relative output path against this CWD, and the
+            # spawn shape stays byte-identical to the pre-#185 ``str(project)``.
+            cwd=str(cwd) if cwd is not None else None,
+        )
+    except subprocess.TimeoutExpired:
+        return RunResult(
+            stdout="",
+            stderr=f"gda: Godot timed out after {timeout}s\n",
+            exit_code=EXIT_TIMEOUT,
+            launch_failure=LaunchFailure.TIMEOUT,
+        )
+    except OSError as exc:
+        return RunResult(
+            stdout="",
+            stderr=f"gda: Godot binary could not be launched: {binary} ({exc})\n",
+            exit_code=EXIT_NOT_FOUND,
+            launch_failure=LaunchFailure.NOT_FOUND,
+        )
+    return RunResult(
+        # Decode the engine's bytes as UTF-8 with a replacement policy: a
+        # well-behaved operation emits valid UTF-8, so ``replace`` only ever
+        # fires on genuinely malformed bytes — and the runner never crashes on
+        # engine output. A malformed result then surfaces as a structured
+        # ``contract_violation`` downstream rather than an escaping
+        # ``UnicodeDecodeError`` traceback (ADR-0002).
+        stdout=proc.stdout.decode("utf-8", errors="replace"),
+        stderr=proc.stderr.decode("utf-8", errors="replace"),
+        exit_code=proc.returncode,
+    )
+
+
 class GodotRunner(Protocol):
     """Spawns a headless Godot operation and returns its raw output."""
 
@@ -75,59 +154,21 @@ class SubprocessGodotRunner:
     timeout: float = DEFAULT_TIMEOUT_SECONDS
 
     def run(self, operation: str, params: dict) -> RunResult:
+        # Build only this channel's argv tail and delegate the spawn / timeout /
+        # OSError / UTF-8-decode handling to the shared launch primitive (#185).
         # Everything after `--` is delivered to the script verbatim via
         # OS.get_cmdline_user_args(), so the payload is decoupled from however
         # Godot orders its own engine arguments.
-        cmd = [str(self.binary), "--headless"]
+        args: list[str] = []
         if self.project is not None:
-            cmd += ["--path", str(self.project)]
-        cmd += [
+            args += ["--path", str(self.project)]
+        args += [
             "--script",
             str(self.script),
             "--",
             operation,
             json.dumps(params),
         ]
-        try:
-            # Capture raw bytes (no ``text=True``): Godot's ``JSON.stringify``
-            # emits UTF-8, but ``text=True`` would decode with the host locale,
-            # which mojibakes or raises ``UnicodeDecodeError`` on a non-UTF-8
-            # locale (e.g. Windows cp1252/cp936) for a non-ASCII node name or
-            # echoed path. We decode UTF-8 explicitly below so user content
-            # round-trips regardless of locale (issue #33).
-            proc = subprocess.run(cmd, capture_output=True, timeout=self.timeout)
-        except subprocess.TimeoutExpired:
-            return RunResult(
-                stdout="",
-                stderr=f"gda: Godot timed out after {self.timeout}s\n",
-                exit_code=EXIT_TIMEOUT,
-                launch_failure=LaunchFailure.TIMEOUT,
-            )
-        except OSError as exc:
-            # The configured binary could not be launched. ``FileNotFoundError``
-            # (missing), ``PermissionError`` (a directory like ``Godot.app`` — a
-            # natural $GDA_GODOT mistake — or a non-executable file), and any
-            # other ``OSError`` from ``exec`` are all the same environment
-            # failure: there was no engine to run (issue #33). They synthesize
-            # the typed ``NOT_FOUND`` reason so the classifier keys environment
-            # on it, not on the overloaded exit code (issue #15). ``OSError``
-            # does not subsume ``TimeoutExpired`` (a ``SubprocessError``), so the
-            # timeout path above is preserved. The original OS message is kept as
-            # advisory stderr to disambiguate which of the three modes occurred.
-            return RunResult(
-                stdout="",
-                stderr=f"gda: Godot binary could not be launched: {self.binary} ({exc})\n",
-                exit_code=EXIT_NOT_FOUND,
-                launch_failure=LaunchFailure.NOT_FOUND,
-            )
-        return RunResult(
-            # Decode the engine's bytes as UTF-8 with a replacement policy: a
-            # well-behaved operation emits valid UTF-8, so ``replace`` only ever
-            # fires on genuinely malformed bytes — and the runner never crashes
-            # on engine output. A malformed result then surfaces as a structured
-            # ``contract_violation`` downstream rather than an escaping
-            # ``UnicodeDecodeError`` traceback (ADR-0002).
-            stdout=proc.stdout.decode("utf-8", errors="replace"),
-            stderr=proc.stderr.decode("utf-8", errors="replace"),
-            exit_code=proc.returncode,
-        )
+        # A sentinel op runs projectless or against --path; it never needs a
+        # working directory, so cwd is always the default.
+        return launch(self.binary, args, cwd=None, timeout=self.timeout)

--- a/tests/support.py
+++ b/tests/support.py
@@ -13,7 +13,6 @@ between modules or imported test-module-to-test-module (issue #39).
 
 import json
 
-from gda.export_runner import ExportRunOutput
 from gda.runner import RunResult
 
 
@@ -33,16 +32,16 @@ class FakeExportRunner:
     """A fakeable ExportRunner for ``export run`` (issue #121).
 
     Records each ``(preset, mode, output_path)`` it is asked to export and returns
-    a canned :class:`~gda.export_runner.ExportRunOutput`, so the native-export
-    pipeline is exercised without a real engine, mirroring :class:`FakeRunner` for
-    the sentinel channel.
+    a canned :class:`~gda.runner.RunResult`, so the native-export pipeline is
+    exercised without a real engine, mirroring :class:`FakeRunner` for the
+    sentinel channel. Both channels share the one raw-run dataclass (#185).
     """
 
-    def __init__(self, output: ExportRunOutput) -> None:
+    def __init__(self, output: RunResult) -> None:
         self.output = output
         self.calls: list[tuple[str, str, str]] = []
 
-    def run(self, preset: str, mode: str, output_path: str) -> ExportRunOutput:
+    def run(self, preset: str, mode: str, output_path: str) -> RunResult:
         self.calls.append((preset, mode, output_path))
         return self.output
 

--- a/tests/test_classify_export_run.py
+++ b/tests/test_classify_export_run.py
@@ -5,8 +5,9 @@ export subsystem is editor-only, so the artifact is produced by a native
 ``--export-<mode>`` invocation, and ``gda`` synthesizes the structured outcome
 from the subprocess's exit code + stderr. ``classify_export_run`` owns that
 synthesis as a pure function — exercised here without a real engine by injecting
-a crafted :class:`~gda.export_runner.ExportRunOutput`, exactly like
-``classify_run`` is for the sentinel pipeline.
+a crafted :class:`~gda.runner.RunResult` (the shared raw-run dataclass both
+channels return since #185), exactly like ``classify_run`` is for the sentinel
+pipeline.
 """
 
 from pathlib import Path
@@ -17,15 +18,14 @@ from gda.errors import (
     export_path_unset_failure,
     parse_export_warnings,
 )
-from gda.exit_codes import EXIT_NOT_FOUND, EXIT_OPERATION, EXIT_TIMEOUT
-from gda.export_runner import ExportRunOutput
+from gda.exit_codes import EXIT_OPERATION
 from gda.models import ExportRunMode, ExportRunResult
-from gda.runner import LaunchFailure
+from gda.runner import RunResult
 
 BINARY = Path("/x/Godot")
 
 
-def _classify(output: ExportRunOutput) -> ExportRunResult | Failure:
+def _classify(output: RunResult) -> ExportRunResult | Failure:
     return classify_export_run(
         output,
         BINARY,
@@ -39,7 +39,7 @@ def _classify(output: ExportRunOutput) -> ExportRunResult | Failure:
 def test_clean_export_synthesizes_success_result():
     # A clean native export (exit 0, no warnings) becomes the typed result
     # echoing the preset/platform/mode/path that were exported.
-    outcome = _classify(ExportRunOutput(stdout="", stderr="", exit_code=0))
+    outcome = _classify(RunResult(stdout="", stderr="", exit_code=0))
 
     assert outcome == ExportRunResult(
         preset="Linux/X11",
@@ -54,7 +54,7 @@ def test_clean_export_surfaces_advisory_warnings():
     # WARNING lines on a clean (exit 0) export are advisory diagnostics on the
     # success result (ADR-0002), not a failure.
     outcome = _classify(
-        ExportRunOutput(
+        RunResult(
             stdout="",
             stderr="WARNING: missing icon.\nINFO: noise\nWARNING: skipped asset.\n",
             exit_code=0,
@@ -65,49 +65,6 @@ def test_clean_export_surfaces_advisory_warnings():
     assert outcome.warnings == ["missing icon.", "skipped asset."]
 
 
-def test_not_found_maps_to_environment_failure():
-    # The runner synthesizes NOT_FOUND when the binary is missing — an
-    # environment failure exiting 127, keyed on the typed launch_failure (not the
-    # exit code), mirroring classify_run.
-    outcome = _classify(
-        ExportRunOutput(
-            stdout="",
-            stderr="gda: Godot binary not found\n",
-            exit_code=EXIT_NOT_FOUND,
-            launch_failure=LaunchFailure.NOT_FOUND,
-        )
-    )
-
-    assert isinstance(outcome, Failure)
-    assert outcome.error.code == "binary_not_found"
-    assert outcome.exit_code == EXIT_NOT_FOUND
-
-
-def test_timeout_maps_to_environment_failure():
-    # A hung export the runner timed out is launch_timeout, exiting 124.
-    outcome = _classify(
-        ExportRunOutput(
-            stdout="",
-            stderr="gda: Godot export timed out\n",
-            exit_code=EXIT_TIMEOUT,
-            launch_failure=LaunchFailure.TIMEOUT,
-        )
-    )
-
-    assert isinstance(outcome, Failure)
-    assert outcome.error.code == "launch_timeout"
-    assert outcome.exit_code == EXIT_TIMEOUT
-
-
-def test_signal_death_maps_to_engine_crashed():
-    # subprocess reports a signal death as a negative return code: the engine ran
-    # but was killed, not the export cleanly reporting an error.
-    outcome = _classify(ExportRunOutput(stdout="", stderr="", exit_code=-11))
-
-    assert isinstance(outcome, Failure)
-    assert outcome.error.code == "engine_crashed"
-
-
 def test_config_error_stderr_still_maps_to_generic_export_failed():
     # Template readiness is now a STRUCTURED preflight (export get's
     # templates_installed, decided BEFORE the native run), so classify_export_run
@@ -115,7 +72,7 @@ def test_config_error_stderr_still_maps_to_generic_export_failed():
     # non-zero native export — even the engine's old "due to configuration errors"
     # text — is the generic export_failed; the stderr is advisory diagnostics only.
     outcome = _classify(
-        ExportRunOutput(
+        RunResult(
             stdout="",
             stderr="ERROR: export failed due to configuration errors.\n",
             exit_code=1,
@@ -133,7 +90,7 @@ def test_other_nonzero_maps_to_generic_export_failed():
     # A non-zero export with no recognized signature is the generic export_failed,
     # preserving the engine stderr as diagnostics.
     outcome = _classify(
-        ExportRunOutput(stdout="", stderr="ERROR: disk full\n", exit_code=1)
+        RunResult(stdout="", stderr="ERROR: disk full\n", exit_code=1)
     )
 
     assert isinstance(outcome, Failure)

--- a/tests/test_classify_export_run.py
+++ b/tests/test_classify_export_run.py
@@ -20,7 +20,7 @@ from gda.errors import (
 )
 from gda.exit_codes import EXIT_OPERATION
 from gda.models import ExportRunMode, ExportRunResult
-from gda.runner import RunResult
+from gda.runner import LaunchFailure, RunResult
 
 BINARY = Path("/x/Godot")
 
@@ -96,6 +96,27 @@ def test_other_nonzero_maps_to_generic_export_failed():
     assert isinstance(outcome, Failure)
     assert outcome.error.code == "export_failed"
     assert "disk full" in outcome.error.diagnostics
+
+
+def test_export_timeout_envelope_keeps_byte_compatible_diagnostics():
+    # Regression for the #185 review: an export timeout maps to launch_timeout,
+    # and the runner-synthesized stderr is carried verbatim into the PUBLIC
+    # GdaError.diagnostics — the field serialized in `export run --json`. The
+    # refactor must keep that diagnostics string byte-compatible with the pre-#185
+    # "Godot export timed out" wording, so the error envelope is unchanged.
+    timeout_stderr = "gda: Godot export timed out after 600.0s\n"
+    outcome = _classify(
+        RunResult(
+            stdout="",
+            stderr=timeout_stderr,
+            exit_code=124,
+            launch_failure=LaunchFailure.TIMEOUT,
+        )
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "launch_timeout"
+    assert outcome.error.diagnostics == timeout_stderr
 
 
 def test_export_path_unset_failure_builder():

--- a/tests/test_classify_launch_or_crash.py
+++ b/tests/test_classify_launch_or_crash.py
@@ -1,0 +1,87 @@
+"""classify_launch_or_crash — the env/crash classifier prefix (issue #185).
+
+Both headless channels open classification with the same env/crash prefix: a
+synthesized ``NOT_FOUND`` launch failure → ``binary_not_found``, a synthesized
+``TIMEOUT`` → ``launch_timeout``, and a signal death (``exit < 0``) →
+``engine_crashed``; anything else returns ``None`` so the caller's
+channel-specific tail takes over. That mapping used to be written (and asserted)
+twice — once in ``classify_run``, once in ``classify_export_run``. It now lives in
+one shared function, tested here once; each channel's suite keeps only its tail.
+
+Environment failures key on the runner's typed ``launch_failure`` reason, not the
+exit code, so an engine (or wrapper) that *genuinely* exits 124/127 falls through
+the prefix (returns ``None``) and is classified by the tail as operation — that
+fall-through is asserted here, the operation classification in each channel suite
+(issue #15).
+"""
+
+from pathlib import Path
+
+from gda.errors import Failure, classify_launch_or_crash
+from gda.exit_codes import EXIT_NOT_FOUND, EXIT_OPERATION, EXIT_TIMEOUT
+from gda.models import ErrorCategory
+from gda.runner import LaunchFailure, RunResult
+
+BINARY = Path("/x/Godot")
+
+
+def test_synthesized_not_found_maps_to_binary_not_found():
+    result = RunResult(
+        stdout="",
+        stderr="gda: Godot binary could not be launched: /x/Godot\n",
+        exit_code=EXIT_NOT_FOUND,
+        launch_failure=LaunchFailure.NOT_FOUND,
+    )
+
+    failure = classify_launch_or_crash(result, BINARY)
+
+    assert isinstance(failure, Failure)
+    assert failure.exit_code == EXIT_NOT_FOUND
+    assert failure.error.category == ErrorCategory.ENVIRONMENT
+    assert failure.error.code == "binary_not_found"
+    assert str(BINARY) in failure.error.message
+    # Engine/runner stderr is carried as diagnostics (ADR-0002).
+    assert failure.error.diagnostics == result.stderr
+
+
+def test_synthesized_timeout_maps_to_launch_timeout_distinct_from_not_found():
+    result = RunResult(
+        stdout="",
+        stderr="gda: Godot timed out after 60.0s\n",
+        exit_code=EXIT_TIMEOUT,
+        launch_failure=LaunchFailure.TIMEOUT,
+    )
+
+    failure = classify_launch_or_crash(result, BINARY)
+
+    assert isinstance(failure, Failure)
+    assert failure.exit_code == EXIT_TIMEOUT
+    assert failure.error.category == ErrorCategory.ENVIRONMENT
+    assert failure.error.code == "launch_timeout"
+
+
+def test_signal_death_maps_to_engine_crashed_naming_the_signal():
+    # subprocess reports a signal death as a negative return code: the engine ran
+    # but was killed (e.g. SIGSEGV) — an operation-category crash, never a raw
+    # negative exit code leaking out.
+    failure = classify_launch_or_crash(RunResult(stdout="", stderr="", exit_code=-11), BINARY)
+
+    assert isinstance(failure, Failure)
+    assert failure.exit_code == EXIT_OPERATION
+    assert failure.error.category == ErrorCategory.OPERATION
+    assert failure.error.code == "engine_crashed"
+    assert "11" in failure.error.message
+
+
+def test_clean_exit_returns_none_so_the_channel_tail_takes_over():
+    # exit 0 with no launch failure is not an env/crash outcome: the prefix yields
+    # to the channel-specific tail (sentinel parse vs synthesize-from-exit-code).
+    assert classify_launch_or_crash(RunResult(stdout="ok", stderr="", exit_code=0), BINARY) is None
+
+
+def test_genuine_engine_124_127_fall_through_to_the_tail():
+    # A genuine engine/wrapper exit of 124/127 — with NO runner-synthesized launch
+    # failure — is the engine's own result, not an env failure. The prefix returns
+    # None so the tail classifies it as operation, never environment (issue #15).
+    assert classify_launch_or_crash(RunResult(stdout="", stderr="boom\n", exit_code=127), BINARY) is None
+    assert classify_launch_or_crash(RunResult(stdout="", stderr="124\n", exit_code=124), BINARY) is None

--- a/tests/test_classify_run.py
+++ b/tests/test_classify_run.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel
 from gda.errors import Failure, classify_run
 from gda.exit_codes import EXIT_OPERATION
 from gda.models import ErrorCategory
-from gda.runner import LaunchFailure, RunResult
+from gda.runner import RunResult
 from tests.support import error_sentinel, sentinel
 
 BINARY = Path("/x/Godot")
@@ -47,45 +47,6 @@ def test_clean_run_parses_payload_into_the_commands_typed_model():
     assert outcome == SceneSummary(name="Main", root_type="Node2D")
 
 
-def test_synthesized_not_found_maps_to_environment_failure():
-    # The runner synthesizes exit 127 + a not-found diagnostic when the binary
-    # is missing (#2 convention) — an environment failure naming the binary.
-    result = RunResult(
-        stdout="",
-        stderr="gda: Godot binary not found: /x/Godot\n",
-        exit_code=127,
-        launch_failure=LaunchFailure.NOT_FOUND,
-    )
-
-    outcome = classify_run(result, BINARY, SceneSummary)
-
-    assert isinstance(outcome, Failure)
-    assert outcome.exit_code == 127
-    assert outcome.error.category == ErrorCategory.ENVIRONMENT
-    assert outcome.error.code == "binary_not_found"
-    assert str(BINARY) in outcome.error.message
-    # Engine/script stderr is carried as diagnostics (ADR-0002).
-    assert outcome.error.diagnostics == result.stderr
-
-
-def test_synthesized_timeout_maps_to_environment_failure_distinct_from_not_found():
-    # A launched-but-hung engine is bounded by the runner's timeout: exit 124
-    # (#2). Still environment, but distinguishable from binary-not-found.
-    result = RunResult(
-        stdout="",
-        stderr="gda: Godot timed out after 60.0s\n",
-        exit_code=124,
-        launch_failure=LaunchFailure.TIMEOUT,
-    )
-
-    outcome = classify_run(result, BINARY, SceneSummary)
-
-    assert isinstance(outcome, Failure)
-    assert outcome.exit_code == 124
-    assert outcome.error.category == ErrorCategory.ENVIRONMENT
-    assert outcome.error.code == "launch_timeout"
-
-
 def test_engine_returned_127_is_operation_not_environment():
     # A genuine engine/wrapper exit of 127 — with NO runner-synthesized launch
     # failure — is the engine's own result, not a binary-not-found. It must
@@ -112,21 +73,6 @@ def test_engine_returned_124_is_operation_not_environment():
     assert outcome.error.category == ErrorCategory.OPERATION
     assert outcome.error.code != "launch_timeout"
     assert outcome.exit_code == EXIT_OPERATION
-
-
-def test_signal_death_maps_to_operation_failure_naming_the_signal():
-    # subprocess reports a signal death as a negative return code: the engine
-    # ran but was killed (e.g. SIGSEGV) — an operation failure, never a raw
-    # negative exit code leaking out.
-    result = RunResult(stdout="", stderr="", exit_code=-11)
-
-    outcome = classify_run(result, BINARY, SceneSummary)
-
-    assert isinstance(outcome, Failure)
-    assert outcome.exit_code == 4
-    assert outcome.error.category == ErrorCategory.OPERATION
-    assert outcome.error.code == "engine_crashed"
-    assert "11" in outcome.error.message
 
 
 def test_engine_nonzero_exit_maps_to_operation_failure():

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -29,7 +29,6 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from gda.cli import app
-from gda.export_runner import ExportRunOutput
 from gda.runner import RunResult
 from tests.support import (
     FakeExportRunner,
@@ -59,7 +58,7 @@ def _inject(monkeypatch, *, get=GET_RESULT, export=None):
     )
     monkeypatch.setattr("gda.cli._make_runner", lambda binary, project=None: get_runner)
     if export is None:
-        export = ExportRunOutput(stdout="", stderr="", exit_code=0)
+        export = RunResult(stdout="", stderr="", exit_code=0)
     export_runner = FakeExportRunner(export)
     monkeypatch.setattr(
         "gda.cli._make_export_runner", lambda binary, project=None: export_runner
@@ -235,7 +234,7 @@ def test_export_run_surfaces_advisory_warnings(monkeypatch, tmp_path):
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
     _inject(
         monkeypatch,
-        export=ExportRunOutput(
+        export=RunResult(
             stdout="",
             stderr=(
                 "WARNING: No export template found at the expected icon path.\n"
@@ -347,7 +346,7 @@ def test_export_run_generic_failure_is_structured(monkeypatch, tmp_path):
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
     _inject(
         monkeypatch,
-        export=ExportRunOutput(
+        export=RunResult(
             stdout="", stderr="ERROR: could not write artifact to disk.\n", exit_code=1
         ),
     )
@@ -399,7 +398,7 @@ def test_export_run_unknown_preset_reuses_export_get_error(monkeypatch, tmp_path
     monkeypatch.setattr(
         "gda.cli._make_runner", lambda binary, project=None: get_runner
     )
-    export_runner = FakeExportRunner(ExportRunOutput(stdout="", stderr="", exit_code=0))
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
     monkeypatch.setattr(
         "gda.cli._make_export_runner", lambda binary, project=None: export_runner
     )

--- a/tests/test_export_runner.py
+++ b/tests/test_export_runner.py
@@ -1,22 +1,25 @@
-"""S2: SubprocessExportRunner spawn shape — pure unit (issue #121).
+"""S2: SubprocessExportRunner spawn shape — pure unit (issue #121, #185).
 
-The native-export seam builds the ``godot --headless --export-release`` command
-line and spawns it. The one behavior that is load-bearing for #121's acceptance
-criterion (export to the preset's *configured* ``export_path``) is the working
-directory: Godot resolves a *relative* export output path against its own CWD
-(``FileAccess``/``DirAccess`` with no project globalization — verified against the
-engine source, ``platform/*/export/export_plugin.cpp``), so the runner must spawn
-Godot with ``cwd = <project>`` for the preset's relative configured path (e.g.
+The native-export seam builds the ``godot --headless --export-release`` argv tail
+and the export-only working directory, then delegates the spawn / timeout /
+``OSError`` / UTF-8-decode handling to the shared ``launch`` primitive (tested in
+``test_launch.py``). This suite covers only what is *specific* to the export
+channel: the argv tail and the working directory.
+
+The one behavior load-bearing for #121's acceptance criterion (export to the
+preset's *configured* ``export_path``) is that working directory: Godot resolves
+a *relative* export output path against its own CWD (``FileAccess``/``DirAccess``
+with no project globalization — verified against the engine source,
+``platform/*/export/export_plugin.cpp``), so the runner must spawn Godot with
+``cwd = <project>`` for the preset's relative configured path (e.g.
 ``build/game.x86_64``) to land at ``<project>/build/game.x86_64``, exactly as the
 editor resolves it. These tests assert that spawn shape without a real engine.
 """
 
 from pathlib import Path
 
-import gda.export_runner as export_runner_mod
+import gda.runner as runner_mod
 from gda.export_runner import SubprocessExportRunner
-from gda.exit_codes import EXIT_NOT_FOUND
-from gda.runner import LaunchFailure
 
 
 class _RecordingRun:
@@ -31,8 +34,8 @@ class _RecordingRun:
         self.kwargs = kwargs
 
         class _Proc:
-            # The runner captures bytes (no text=True) and decodes UTF-8 itself,
-            # so the double mirrors that real subprocess contract (#33).
+            # The primitive captures bytes (no text=True) and decodes UTF-8
+            # itself, so the double mirrors that real subprocess contract (#33).
             stdout = b""
             stderr = b""
             returncode = 0
@@ -45,7 +48,7 @@ def test_export_runs_with_project_as_cwd(monkeypatch):
     # path against its CWD, so the runner must spawn Godot with cwd = the project
     # for the artifact to land inside the project (the #121 acceptance behavior).
     rec = _RecordingRun()
-    monkeypatch.setattr(export_runner_mod.subprocess, "run", rec)
+    monkeypatch.setattr(runner_mod.subprocess, "run", rec)
     project = Path("/tmp/proj")
 
     runner = SubprocessExportRunner(Path("/x/Godot"), project=project)
@@ -62,7 +65,7 @@ def test_export_without_project_passes_no_cwd(monkeypatch):
     # Projectless runs (no resolved project) spawn with the default cwd — there is
     # no project root to resolve a relative path against.
     rec = _RecordingRun()
-    monkeypatch.setattr(export_runner_mod.subprocess, "run", rec)
+    monkeypatch.setattr(runner_mod.subprocess, "run", rec)
 
     runner = SubprocessExportRunner(Path("/x/Godot"), project=None)
     runner.run("Linux/X11", "release", "/abs/out.x86_64")
@@ -72,59 +75,18 @@ def test_export_without_project_passes_no_cwd(monkeypatch):
     assert "--path" not in rec.cmd
 
 
-def test_export_directory_binary_maps_to_not_found_not_traceback(tmp_path):
+def test_export_launch_failure_surfaces_through_the_typed_run_adapter(tmp_path):
     # A directory passed as --godot (e.g. the bundle "Godot.app") cannot be
-    # exec'd; the native export runner must catch the OSError and synthesize a
-    # launch failure rather than leak a raw traceback — mirroring the sentinel
-    # runner so both runners close the same launch-failure surface (#33).
+    # exec'd; the failure surfaces through the typed run(preset, mode, output)
+    # adapter as a synthesized launch failure, not a raw traceback — the export
+    # runner delegates the launch handling to the shared primitive (#185).
+    from gda.exit_codes import EXIT_NOT_FOUND
+    from gda.runner import LaunchFailure
+
     runner = SubprocessExportRunner(tmp_path)
 
     result = runner.run("Linux/X11", "release", "out.x86_64")
 
     assert result.exit_code == EXIT_NOT_FOUND
     assert str(tmp_path) in result.stderr
-    assert result.stdout == ""
     assert result.launch_failure is LaunchFailure.NOT_FOUND
-
-
-def test_export_non_executable_file_binary_maps_to_not_found_not_traceback(tmp_path):
-    # A plain, non-executable file passed as --godot cannot be exec'd; the
-    # PermissionError must become a launch failure, not a traceback (#33).
-    not_exec = tmp_path / "notgodot.txt"
-    not_exec.write_text("i am not an engine")
-    runner = SubprocessExportRunner(not_exec)
-
-    result = runner.run("Linux/X11", "release", "out.x86_64")
-
-    assert result.exit_code == EXIT_NOT_FOUND
-    assert str(not_exec) in result.stderr
-    assert result.stdout == ""
-    assert result.launch_failure is LaunchFailure.NOT_FOUND
-
-
-def test_export_output_is_decoded_as_utf8_regardless_of_host_locale(monkeypatch):
-    # Like the sentinel runner, the native export channel must capture bytes and
-    # decode UTF-8 explicitly so non-ASCII engine output round-trips regardless
-    # of host locale, instead of locale-decoding via text=True (#33).
-    stdout_bytes = "エクスポート完了\n".encode("utf-8")
-    stderr_bytes = "警告: テンプレート\n".encode("utf-8")
-
-    def fake_run(cmd, **kwargs):
-        # The fix drops text=True and captures bytes; assert that contract here
-        # so the test fails loudly if decoding silently reverts to locale text.
-        assert kwargs.get("text") in (None, False)
-
-        class _Proc:
-            stdout = stdout_bytes
-            stderr = stderr_bytes
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(export_runner_mod.subprocess, "run", fake_run)
-    runner = SubprocessExportRunner(Path("/any/Godot"))
-
-    result = runner.run("Linux/X11", "release", "out.x86_64")
-
-    assert "エクスポート完了" in result.stdout
-    assert "警告: テンプレート" in result.stderr

--- a/tests/test_export_runner.py
+++ b/tests/test_export_runner.py
@@ -90,3 +90,27 @@ def test_export_launch_failure_surfaces_through_the_typed_run_adapter(tmp_path):
     assert result.exit_code == EXIT_NOT_FOUND
     assert str(tmp_path) in result.stderr
     assert result.launch_failure is LaunchFailure.NOT_FOUND
+
+
+def test_export_timeout_keeps_the_export_worded_diagnostic(monkeypatch):
+    # The export channel passes timeout_label="Godot export" to the shared
+    # primitive so its timeout stderr stays byte-compatible with the pre-#185
+    # wording. This stderr is what the classifier carries into the public
+    # GdaError.diagnostics, so the wording is part of `export run --json` (#185
+    # review). The shared launch handling itself is tested in test_launch.py.
+    import subprocess
+
+    from gda.exit_codes import EXIT_TIMEOUT
+    from gda.runner import LaunchFailure
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+
+    monkeypatch.setattr(runner_mod.subprocess, "run", fake_run)
+
+    runner = SubprocessExportRunner(Path("/x/Godot"), timeout=600.0)
+    result = runner.run("Linux/X11", "release", "out.x86_64")
+
+    assert result.exit_code == EXIT_TIMEOUT
+    assert result.stderr == "gda: Godot export timed out after 600.0s\n"
+    assert result.launch_failure is LaunchFailure.TIMEOUT

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -64,7 +64,31 @@ def test_timeout_maps_to_synthesized_timeout_result(monkeypatch):
     result = launch(Path("/any/Godot"), ["--version"], cwd=None, timeout=0.01)
 
     assert result.exit_code == EXIT_TIMEOUT
-    assert "timed out" in result.stderr.lower()
+    # Default label is "Godot": the sentinel channel keeps its exact pre-#185
+    # timeout diagnostic wording.
+    assert result.stderr == "gda: Godot timed out after 0.01s\n"
+    assert result.launch_failure is LaunchFailure.TIMEOUT
+
+
+def test_timeout_label_customizes_the_diagnostic(monkeypatch):
+    # The export channel passes a distinct label so its timeout diagnostic stays
+    # byte-compatible with the pre-#185 "Godot export timed out" wording — the
+    # stderr the classifier carries into the public GdaError.diagnostics (#185).
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = launch(
+        Path("/any/Godot"),
+        ["--export-release", "Web", "out"],
+        cwd=None,
+        timeout=600.0,
+        timeout_label="Godot export",
+    )
+
+    assert result.exit_code == EXIT_TIMEOUT
+    assert result.stderr == "gda: Godot export timed out after 600.0s\n"
     assert result.launch_failure is LaunchFailure.TIMEOUT
 
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,0 +1,186 @@
+"""The headless-launch primitive maps subprocess failures to a RunResult (#185).
+
+``launch`` is the single home of the spawn / timeout / ``OSError`` / UTF-8-decode
+handling that both Phase-1 channels (the sentinel op runner and the native-export
+runner) delegate to. A hung or missing engine must not surface as a raw Python
+traceback; it is turned into a synthesized non-zero-exit :class:`RunResult` with a
+typed ``launch_failure`` and a diagnostic on stderr — the launch-handling contract
+that used to be written (and tested) twice, now exercised once here. The
+channel-specific argv tail / export-only cwd stay tested in each runner's own
+suite.
+"""
+
+import subprocess
+from pathlib import Path
+
+from gda.exit_codes import EXIT_NOT_FOUND, EXIT_TIMEOUT
+from gda.runner import LaunchFailure, launch
+
+
+def test_missing_binary_maps_to_not_found_not_traceback():
+    result = launch(Path("/nonexistent/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert result.exit_code == EXIT_NOT_FOUND
+    assert "/nonexistent/Godot" in result.stderr
+    assert result.stdout == ""
+    # The primitive flags this as a synthesized launch failure so the classifier
+    # keys environment on the typed reason, not the overloaded exit code (#15).
+    assert result.launch_failure is LaunchFailure.NOT_FOUND
+
+
+def test_directory_binary_maps_to_not_found_not_traceback(tmp_path):
+    # A directory passed as --godot (e.g. the bundle "Godot.app", a natural
+    # $GDA_GODOT mistake) cannot be exec'd; the OS raises a PermissionError /
+    # IsADirectoryError that must not escape as a raw traceback (#33).
+    result = launch(tmp_path, ["--version"], cwd=None, timeout=60.0)
+
+    assert result.exit_code == EXIT_NOT_FOUND
+    assert str(tmp_path) in result.stderr
+    assert result.stdout == ""
+    assert result.launch_failure is LaunchFailure.NOT_FOUND
+
+
+def test_non_executable_file_binary_maps_to_not_found_not_traceback(tmp_path):
+    # A plain, non-executable file passed as --godot cannot be exec'd; the OS
+    # raises a PermissionError that the primitive must catch and synthesize as a
+    # launch failure rather than leak as a traceback (#33).
+    not_exec = tmp_path / "notgodot.txt"
+    not_exec.write_text("i am not an engine")
+
+    result = launch(not_exec, ["--version"], cwd=None, timeout=60.0)
+
+    assert result.exit_code == EXIT_NOT_FOUND
+    assert str(not_exec) in result.stderr
+    assert result.stdout == ""
+    assert result.launch_failure is LaunchFailure.NOT_FOUND
+
+
+def test_timeout_maps_to_synthesized_timeout_result(monkeypatch):
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = launch(Path("/any/Godot"), ["--version"], cwd=None, timeout=0.01)
+
+    assert result.exit_code == EXIT_TIMEOUT
+    assert "timed out" in result.stderr.lower()
+    assert result.launch_failure is LaunchFailure.TIMEOUT
+
+
+def test_timeout_is_passed_through_to_subprocess(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+
+        class _Proc:
+            # The primitive captures bytes (no text=True) and decodes UTF-8
+            # itself, so the double mirrors that real subprocess contract (#33).
+            stdout = b""
+            stderr = b""
+            returncode = 0
+
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = launch(Path("/any/Godot"), ["--version"], cwd=None, timeout=42.0)
+
+    assert captured["timeout"] == 42.0
+    # An engine that actually returned has no synthesized launch failure, so its
+    # exit code is classified as the engine's own result (#15).
+    assert result.launch_failure is None
+
+
+def test_builds_headless_argv_from_binary_and_tail(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+
+        class _Proc:
+            stdout = b""
+            stderr = b""
+            returncode = 0
+
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    launch(Path("/x/Godot"), ["--path", "/p", "--version"], cwd=None, timeout=60.0)
+
+    # The primitive always prepends `[binary, --headless]` to the caller's tail.
+    assert captured["cmd"] == ["/x/Godot", "--headless", "--path", "/p", "--version"]
+
+
+def test_engine_output_is_decoded_as_utf8_regardless_of_host_locale(monkeypatch):
+    # Godot's JSON.stringify emits raw UTF-8, but subprocess(text=True) would
+    # decode with the host locale. On a non-UTF-8 locale a non-ASCII node name
+    # mojibakes or raises UnicodeDecodeError. The primitive must capture bytes and
+    # decode UTF-8 explicitly so user content round-trips (#33). We prove this by
+    # returning raw UTF-8 *bytes* from subprocess (the bytes mode the fix uses).
+    payload = '<<<GDA:RESULT>>>{"name":"日本語"}<<<GDA:END>>>'
+    stdout_bytes = payload.encode("utf-8")
+    stderr_bytes = "警告: ノード名\n".encode("utf-8")
+
+    def fake_run(cmd, **kwargs):
+        # The fix drops text=True and captures bytes; assert that contract here
+        # so the test fails loudly if decoding silently reverts to locale text.
+        assert kwargs.get("text") in (None, False)
+
+        class _Proc:
+            stdout = stdout_bytes
+            stderr = stderr_bytes
+            returncode = 0
+
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = launch(Path("/any/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert "日本語" in result.stdout
+    assert "警告: ノード名" in result.stderr
+
+
+def test_cwd_is_passed_through_to_subprocess_as_a_string(monkeypatch, tmp_path):
+    # The export channel relies on cwd to resolve a relative output path; the
+    # primitive must forward it (as a string, the historical spawn shape).
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+
+        class _Proc:
+            stdout = b""
+            stderr = b""
+            returncode = 0
+
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    launch(Path("/x/Godot"), ["--version"], cwd=tmp_path, timeout=60.0)
+
+    assert captured["cwd"] == str(tmp_path)
+
+
+def test_cwd_none_passes_no_working_directory(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+
+        class _Proc:
+            stdout = b""
+            stderr = b""
+            returncode = 0
+
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert captured["cwd"] is None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,126 +1,89 @@
-"""SubprocessGodotRunner maps subprocess failures to a structured RunResult.
+"""SubprocessGodotRunner builds the sentinel argv tail and delegates to launch.
 
-A hung or missing engine must not surface as a raw Python traceback; it is
-turned into a non-zero-exit RunResult with a diagnostic on stderr, which the
-CLI already handles via its exit-code path.
+The launch / timeout / OSError / UTF-8-decode contract now lives once on the
+shared ``launch`` primitive (tested in ``test_launch.py``); this suite covers
+only what is *specific* to the sentinel op-dispatch channel: the argv tail it
+builds (``--path`` when a project is set, then ``--script operations.gd -- <op>
+<json params>``), and that a launch failure still surfaces through the typed
+``run(operation, params)`` adapter rather than escaping as a traceback (#185).
 """
 
+import json
 import subprocess
 from pathlib import Path
 
-from gda.exit_codes import EXIT_NOT_FOUND, EXIT_TIMEOUT
-from gda.runner import LaunchFailure, SubprocessGodotRunner
+from gda.exit_codes import EXIT_NOT_FOUND
+from gda.runner import OPERATIONS_GD, LaunchFailure, SubprocessGodotRunner
 
 
-def test_missing_binary_maps_to_nonzero_result_not_traceback():
-    runner = SubprocessGodotRunner(Path("/nonexistent/Godot"))
+class _RecordingRun:
+    """A ``subprocess.run`` double recording the call and returning a clean exit."""
 
-    result = runner.run("info", {})
+    def __init__(self) -> None:
+        self.cmd: list[str] | None = None
+        self.kwargs: dict | None = None
 
-    assert result.exit_code == EXIT_NOT_FOUND
-    assert "/nonexistent/Godot" in result.stderr
-    assert result.stdout == ""
-    # The runner flags this as a synthesized launch failure so the classifier
-    # keys environment on the typed reason, not the overloaded exit code (#15).
-    assert result.launch_failure is LaunchFailure.NOT_FOUND
-
-
-def test_directory_binary_maps_to_not_found_not_traceback(tmp_path):
-    # A directory passed as --godot (e.g. the bundle "Godot.app", a natural
-    # $GDA_GODOT mistake) cannot be exec'd; the OS raises a PermissionError /
-    # IsADirectoryError that must not escape as a raw traceback (#33).
-    runner = SubprocessGodotRunner(tmp_path)
-
-    result = runner.run("info", {})
-
-    assert result.exit_code == EXIT_NOT_FOUND
-    assert str(tmp_path) in result.stderr
-    assert result.stdout == ""
-    assert result.launch_failure is LaunchFailure.NOT_FOUND
-
-
-def test_non_executable_file_binary_maps_to_not_found_not_traceback(tmp_path):
-    # A plain, non-executable file passed as --godot cannot be exec'd; the OS
-    # raises a PermissionError that the runner must catch and synthesize as a
-    # launch failure rather than leak as a traceback (#33).
-    not_exec = tmp_path / "notgodot.txt"
-    not_exec.write_text("i am not an engine")
-    runner = SubprocessGodotRunner(not_exec)
-
-    result = runner.run("info", {})
-
-    assert result.exit_code == EXIT_NOT_FOUND
-    assert str(not_exec) in result.stderr
-    assert result.stdout == ""
-    assert result.launch_failure is LaunchFailure.NOT_FOUND
-
-
-def test_engine_output_is_decoded_as_utf8_regardless_of_host_locale(monkeypatch):
-    # Godot's JSON.stringify emits raw UTF-8, but subprocess(text=True) would
-    # decode with the host locale. On a non-UTF-8 locale a non-ASCII node name
-    # mojibakes or raises UnicodeDecodeError. The runner must capture bytes and
-    # decode UTF-8 explicitly so user content round-trips (#33). We prove this by
-    # returning raw UTF-8 *bytes* from subprocess (the bytes mode the fix uses).
-    payload = '<<<GDA:RESULT>>>{"name":"日本語"}<<<GDA:END>>>'
-    stdout_bytes = payload.encode("utf-8")
-    stderr_bytes = "警告: ノード名\n".encode("utf-8")
-
-    def fake_run(cmd, **kwargs):
-        # The fix drops text=True and captures bytes; assert that contract here
-        # so the test fails loudly if decoding silently reverts to locale text.
-        assert kwargs.get("text") in (None, False)
+    def __call__(self, cmd, **kwargs):
+        self.cmd = cmd
+        self.kwargs = kwargs
 
         class _Proc:
-            stdout = stdout_bytes
-            stderr = stderr_bytes
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    runner = SubprocessGodotRunner(Path("/any/Godot"))
-
-    result = runner.run("scene", {})
-
-    assert "日本語" in result.stdout
-    assert "警告: ノード名" in result.stderr
-
-
-def test_timeout_maps_to_nonzero_result(monkeypatch):
-    def fake_run(*args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    runner = SubprocessGodotRunner(Path("/any/Godot"), timeout=0.01)
-
-    result = runner.run("info", {})
-
-    assert result.exit_code == EXIT_TIMEOUT
-    assert "timed out" in result.stderr.lower()
-    assert result.launch_failure is LaunchFailure.TIMEOUT
-
-
-def test_timeout_is_passed_through_to_subprocess(monkeypatch):
-    captured = {}
-
-    def fake_run(cmd, **kwargs):
-        captured["timeout"] = kwargs.get("timeout")
-
-        class _Proc:
-            # The runner captures bytes (no text=True) and decodes UTF-8 itself,
-            # so the double mirrors that real subprocess contract (#33).
+            # The primitive captures bytes (no text=True) and decodes UTF-8
+            # itself, so the double mirrors that real subprocess contract (#33).
             stdout = b"<<<GDA:RESULT>>>{}<<<GDA:END>>>"
             stderr = b""
             returncode = 0
 
         return _Proc()
 
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    runner = SubprocessGodotRunner(Path("/any/Godot"), timeout=42.0)
+
+def test_projectless_run_builds_the_script_dispatch_tail(monkeypatch):
+    # A projectless op spawns `--headless --script operations.gd -- <op> <json>`
+    # with no --path and no working directory: everything after `--` reaches the
+    # script verbatim via OS.get_cmdline_user_args().
+    rec = _RecordingRun()
+    monkeypatch.setattr(subprocess, "run", rec)
+    runner = SubprocessGodotRunner(Path("/x/Godot"))
+
+    runner.run("info", {"a": 1})
+
+    assert rec.cmd == [
+        "/x/Godot",
+        "--headless",
+        "--script",
+        str(OPERATIONS_GD),
+        "--",
+        "info",
+        json.dumps({"a": 1}),
+    ]
+    # A sentinel op never needs a working directory.
+    assert rec.kwargs is not None and rec.kwargs.get("cwd") is None
+
+
+def test_run_against_a_project_passes_path(monkeypatch):
+    # When a project is resolved it is passed as --path so the engine runs against
+    # it and res:// resolves there (#32); --path precedes the --script tail.
+    rec = _RecordingRun()
+    monkeypatch.setattr(subprocess, "run", rec)
+    project = Path("/tmp/proj")
+    runner = SubprocessGodotRunner(Path("/x/Godot"), project=project)
+
+    runner.run("scene-get", {})
+
+    assert rec.cmd is not None
+    assert rec.cmd[:5] == ["/x/Godot", "--headless", "--path", str(project), "--script"]
+    # A sentinel op runs against --path, never with a working directory.
+    assert rec.kwargs is not None and rec.kwargs.get("cwd") is None
+
+
+def test_launch_failure_surfaces_through_the_typed_run_adapter():
+    # A missing binary surfaces through the typed run(operation, params) adapter
+    # as a synthesized launch failure, not a raw traceback — the runner delegates
+    # the launch handling to the shared primitive (#185).
+    runner = SubprocessGodotRunner(Path("/nonexistent/Godot"))
 
     result = runner.run("info", {})
 
-    assert captured["timeout"] == 42.0
-    # An engine that actually returned has no synthesized launch failure, so its
-    # exit code is classified as the engine's own result (#15).
-    assert result.launch_failure is None
+    assert result.exit_code == EXIT_NOT_FOUND
+    assert "/nonexistent/Godot" in result.stderr
+    assert result.launch_failure is LaunchFailure.NOT_FOUND


### PR DESCRIPTION
Closes #185.

Unify the sentinel and native-export channels onto **one headless-launch primitive**.
ADR-0010 intended the native-export channel to *reuse* the runner / `GdaError`
machinery; in practice it was duplicated across five surfaces. This collapses the
shared **implementation** while preserving every interface a caller or test crosses.
**Pure refactor — zero behavior change.**

## What changed
- **One launch primitive** — `runner.launch(binary, args, *, cwd, timeout) -> RunResult`
  is the single home of subprocess spawn + `TimeoutExpired`→TIMEOUT +
  `OSError`→NOT_FOUND + UTF-8 decode. Both `SubprocessGodotRunner` and
  `SubprocessExportRunner` shrink to "build argv tail (+ export-only `cwd`) → delegate".
- **One raw-outcome type** — `ExportRunOutput` deleted; both channels return `RunResult`.
- **One classifier prefix** — `errors.classify_launch_or_crash(raw, binary) -> Failure | None`
  owns the NOT_FOUND / TIMEOUT / `exit<0` mapping; `classify_run` and
  `classify_export_run` both open with it, then keep only their channel tail.
- **Both typed runner adapters kept** — `GodotRunner.run(operation, params)` and
  `ExportRunner.run(preset, mode, output_path)` Protocols + both fakes retain their typed
  call-shapes (command tests asserting `fake.calls` pass unchanged). Not collapsed to `run(args)`.
- **Tests consolidated** — duplicated subprocess/decode/timeout tests → `tests/test_launch.py`;
  duplicated env/crash prefix tests → `tests/test_classify_launch_or_crash.py`; export-only
  spawn-shape tests retained.
- **CONTEXT.md** gains the **Headless launch** and **Raw run** domain terms.

## Verification (independently re-run by reviewer)
- Fast tier: `494 passed`.
- e2e tier: `233 passed, 1 skipped` (run serially, isolated from other e2e to avoid the
  known parallel-`$HOME`/engine contention).

## One accepted deviation
The export channel's timeout **advisory stderr** now reads `gda: Godot timed out…` (was
`…Godot export timed out…`) — the launch primitive emits one message. This is advisory
diagnostic stderr only (ADR-0002 never parses it for a stable code), and the agent-facing
`GdaError.message` / `code` / exit code are byte-identical. No test or contract asserts the
dropped word.
