### PR TITLE
refactor(cli): fold the single-adapter render seam into HeadlessCommand.emit (#186)

### DIFF
--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -26,7 +26,6 @@ from gda.errors import (
 from gda.export_runner import ExportRunner, make_subprocess_export_runner
 from gda.headless import (
     HeadlessCommand,
-    HumanRenderer,
     M,
     emit_failure,
     godot_option,
@@ -252,7 +251,6 @@ def _emit(
     json_output: bool,
     godot: Optional[str],
     project: Optional[Path],
-    render: HumanRenderer[M],
 ) -> None:
     """Drive ``cmd.emit`` with the shared CLI execution tail.
 
@@ -267,7 +265,6 @@ def _emit(
         godot=godot,
         project=project,
         json_output=json_output,
-        render_text=render,
         make_runner=_make_runner,
     )
 
@@ -279,15 +276,16 @@ def _dispatch(
     json_output: bool,
     godot: Optional[str],
     project: Optional[str],
-    render: HumanRenderer[M],
 ) -> None:
     """Run a domain command through the shared CLI execution tail.
 
     Owns the per-command-repeated wiring: project resolution
     (``resolve_project_dir``, kept at the CLI layer per ADR-0006), the runner
     seam, the ``json_output`` pass-through, and the JSON-vs-text branch. Each
-    command keeps its own Typer signature, params construction, ``render``, and
-    pre-dispatch validation; only this execution tail is shared.
+    command keeps its own Typer signature, params construction, and
+    pre-dispatch validation; only this execution tail is shared. Human
+    rendering is type-dispatched by :func:`gda.render.render` inside
+    ``cmd.emit`` (issue #186), so no renderer is threaded here.
     """
     _emit(
         cmd,
@@ -295,7 +293,6 @@ def _dispatch(
         json_output=json_output,
         godot=godot,
         project=resolve_project_dir(project),
-        render=render,
     )
 
 
@@ -305,7 +302,6 @@ def _dispatch_meta(
     *,
     json_output: bool,
     godot: Optional[str],
-    render: HumanRenderer[M],
 ) -> None:
     """Run a meta command (no ``--project``, ADR-0005) through the shared tail.
 
@@ -319,7 +315,6 @@ def _dispatch_meta(
         json_output=json_output,
         godot=godot,
         project=None,
-        render=render,
     )
 
 
@@ -657,7 +652,6 @@ def create(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -676,7 +670,6 @@ def get(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -695,7 +688,6 @@ def get_exports(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -713,7 +705,6 @@ def list_scenes(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -732,7 +723,6 @@ def delete(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -777,7 +767,6 @@ def add(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -796,7 +785,6 @@ def list_nodes(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -823,7 +811,6 @@ def get(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -863,7 +850,6 @@ def set_property(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -890,7 +876,6 @@ def remove_node(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -918,7 +903,6 @@ def duplicate_node(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -954,7 +938,6 @@ def move_node(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1018,7 +1001,6 @@ def connect_signal(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1049,7 +1031,6 @@ def disconnect_signal(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1090,7 +1071,6 @@ def create(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1109,7 +1089,6 @@ def get_script(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1127,7 +1106,6 @@ def list_scripts(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1146,7 +1124,6 @@ def delete_script(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1211,7 +1188,6 @@ def set_script(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1289,7 +1265,6 @@ def attach_script(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1308,7 +1283,6 @@ def validate_script(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1332,7 +1306,6 @@ def create(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1350,7 +1323,6 @@ def project_info(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1371,7 +1343,6 @@ def project_get(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1398,7 +1369,6 @@ def find_references(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1443,7 +1413,6 @@ def create(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1462,7 +1431,6 @@ def get_resource(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1494,7 +1462,6 @@ def set_resource(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1513,7 +1480,6 @@ def delete_resource(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1532,7 +1498,6 @@ def get_shader(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1552,7 +1517,6 @@ def dependencies(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1570,7 +1534,6 @@ def list_presets(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1591,7 +1554,6 @@ def find_unused_resources(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1614,7 +1576,6 @@ def get_preset(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1757,7 +1718,6 @@ def resolve_uid(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1824,7 +1784,6 @@ def set_shader(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1853,7 +1812,6 @@ def project_set(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1879,7 +1837,6 @@ def project_add_autoload(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1902,7 +1859,6 @@ def project_remove_autoload(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1921,7 +1877,6 @@ def create_theme(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1939,7 +1894,6 @@ def statistics(
         json_output=json_output,
         godot=godot,
         project=project,
-        render=render,
     )
 
 
@@ -1955,5 +1909,4 @@ def info(
         InfoParams(),
         json_output=json_output,
         godot=godot,
-        render=render,
     )

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -20,13 +20,13 @@ from typer.core import TyperCommand
 from gda.binary import resolve_godot_binary
 from gda.errors import Failure, classify_run, unresolvable_binary_failure
 from gda.models import CommandSchema, GdaErrorEnvelope
+from gda.render import render
 from gda.runner import GodotRunner, RunResult, SubprocessGodotRunner
 
 M = TypeVar("M", bound=BaseModel)
 
 Classifier = Callable[[RunResult, Path], M | Failure]
 RunnerFactory = Callable[[Path, Optional[Path]], GodotRunner]
-HumanRenderer = Callable[[M], str]
 
 
 def make_subprocess_runner(binary: Path, project: Optional[Path] = None) -> GodotRunner:
@@ -191,14 +191,19 @@ class HeadlessCommand(Generic[M]):
         godot: Optional[str],
         project: Optional[Path] = None,
         json_output: bool,
-        render_text: HumanRenderer[M],
         make_runner: RunnerFactory = make_subprocess_runner,
     ) -> None:
-        """Run the command and emit either JSON or human-readable output."""
+        """Run the command and emit either JSON or human-readable output.
+
+        Human output is rendered by the module-level :func:`gda.render.render`,
+        which dispatches on the result type — there is no per-command renderer
+        seam to thread, since every command renders through the same type-keyed
+        table (issue #186).
+        """
         result = self.run(
             params, godot=godot, project=project, make_runner=make_runner
         )
         if json_output:
             typer.echo(result.model_dump_json())
         else:
-            typer.echo(render_text(result))
+            typer.echo(render(result))

--- a/tests/test_headless_command.py
+++ b/tests/test_headless_command.py
@@ -34,7 +34,6 @@ def test_headless_command_emit_owns_runner_classification_and_json_output(capsys
         godot="/tmp/Godot",
         project=Path("/tmp/project"),
         json_output=True,
-        render_text=lambda version: version.string,
         make_runner=make_runner,
     )
 
@@ -70,7 +69,6 @@ def test_headless_command_emit_owns_structured_failure_output(capsys):
             godot="/tmp/missing",
             project=None,
             json_output=False,
-            render_text=lambda version: version.string,
             make_runner=make_runner,
         )
 
@@ -99,7 +97,6 @@ def test_empty_godot_path_maps_to_structured_binary_not_found(capsys):
             godot="",
             project=None,
             json_output=False,
-            render_text=lambda version: version.string,
             make_runner=make_runner,
         )
 


### PR DESCRIPTION
Closes #186.

Fold the single-adapter `render` seam into `HeadlessCommand.emit`.
Every command passed the same global `render` callable threaded through
`_dispatch` → `_emit` → `emit(render_text=…)` at 44 call sites — a seam with one
adapter, since `render()` dispatches by `type(result)` internally and never varies.
**Pure refactor — zero behavior change** (identical text and `--json` output).

## What changed
- `headless.py`: `HeadlessCommand.emit` calls the module-level `gda.render.render()`
  directly; removed the `render_text` parameter and the `HumanRenderer` alias.
- `cli.py`: removed the `render` parameter from `_dispatch` / `_emit` / `_dispatch_meta`;
  deleted all 44 `render=render` arguments and the `HumanRenderer` import. `export run`
  still calls the module-level `render(outcome)` directly.
- `test_headless_command.py`: dropped three `render_text=lambda …` call-site args to match
  the new signature — all three cases emit JSON or fail (binary-not-found) **before** any
  rendering, so no rendering assertion is weakened. Human rendering stays covered by the
  unchanged `test_human_output.py`.

No import cycle: `headless → render → models` stays acyclic (`models` is a leaf).

Independent of #185 (no file overlap) — can merge in either order.

## Verification (independently re-run by reviewer)
- Fast tier: `491 passed` (identical to baseline, incl. `test_human_output.py` + all
  `--json` assertions).
- e2e tier: `233 passed, 1 skipped` (run serially, isolated to avoid parallel-e2e contention).
