### PR TITLE
refactor(export): lift export run's recipe into a deep ExportRun operation (#187)

### DIFF
--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -14,20 +14,22 @@ from typing import Optional
 import typer
 from pydantic import BaseModel
 
-from gda.binary import resolve_godot_binary
 from gda.errors import (
     Failure,
-    classify_export_run,
     classify_info,
     classify_script_validate,
-    export_path_unset_failure,
-    export_templates_missing_failure,
+)
+from gda.export_run import (
+    EXPORT_GET_COMMAND,
+    EXPORT_RUN_COMMAND,
+    run_export_operation,
 )
 from gda.export_runner import ExportRunner, make_subprocess_export_runner
 from gda.headless import (
     HeadlessCommand,
     M,
     emit_failure,
+    emit_result,
     godot_option,
     json_option,
     make_subprocess_runner,
@@ -36,12 +38,9 @@ from gda.headless import (
 from gda.models import (
     EngineVersion,
     ExportGetParams,
-    ExportGetResult,
     ExportListParams,
     ExportListResult,
     ExportRunMode,
-    ExportRunParams,
-    ExportRunResult,
     InfoParams,
     ProjectDependenciesParams,
     ProjectDependenciesResult,
@@ -124,7 +123,6 @@ from gda.models import (
     ThemeCreateResult,
 )
 from gda.project import resolve_project_dir
-from gda.render import render
 from gda.runner import GodotRunner
 
 app = typer.Typer(
@@ -484,25 +482,10 @@ EXPORT_LIST_COMMAND: HeadlessCommand[ExportListResult] = HeadlessCommand(
     output_model=ExportListResult,
 )
 
-EXPORT_GET_COMMAND: HeadlessCommand[ExportGetResult] = HeadlessCommand(
-    operation="export-get",
-    input_model=ExportGetParams,
-    output_model=ExportGetResult,
-)
-
-# export run is the one command that does NOT route through operations.gd: the
-# Godot export subsystem is editor-only C++, unreachable from a --script
-# SceneTree run, so the export itself is a native --export-<mode> invocation
-# (gda.export_runner). This HeadlessCommand is used only for its --schema /
-# --json model plumbing; the command body (run_export) drives the two phases by
-# hand — export-get resolves the preset + path, the native ExportRunner exports,
-# classify_export_run turns the subprocess outcome into the typed result — rather
-# than the shared sentinel pipeline.
-EXPORT_RUN_COMMAND: HeadlessCommand[ExportRunResult] = HeadlessCommand(
-    operation="export-run",
-    input_model=ExportRunParams,
-    output_model=ExportRunResult,
-)
+# EXPORT_GET_COMMAND / EXPORT_RUN_COMMAND live in gda.export_run (imported above):
+# they are co-located with run_export_operation, which drives export-get to
+# resolve the preset, so the recipe can reuse them without an export_run ↔ cli
+# import cycle (issue #187).
 
 RESOURCE_UID_COMMAND: HeadlessCommand[ResourceUidResult] = HeadlessCommand(
     operation="resource-uid",
@@ -1611,89 +1594,35 @@ def run_export(
 
     Unlike every other command, the export itself is a native ``--export-<mode>``
     invocation (the export subsystem is editor-only, so it cannot run through
-    operations.gd). The command orchestrates three phases by hand: ``export get``
-    resolves the preset's platform + configured ``export_path`` + template
-    readiness (reusing #114's clean preset/project errors), a structured preflight
-    fails fast when templates are missing or there is no destination, then the
-    native ``ExportRunner`` performs the export and ``classify_export_run``
-    synthesizes the typed result from the subprocess's exit code.
+    operations.gd). The recipe — ``export get`` resolves the preset's platform +
+    configured ``export_path`` + template readiness (reusing #114's clean
+    preset/project errors), a structured preflight fails fast when templates are
+    missing or there is no destination, then the native ``ExportRunner`` performs
+    the export and ``classify_export_run`` synthesizes the typed result from the
+    subprocess's exit code — is owned by :func:`gda.export_run.run_export_operation`
+    (issue #187), so this command is the same thin shape as every other: build
+    params → invoke the operation → emit.
 
     ``--mode`` selects the export flavor (release/debug/pack; default release) and
     ``--output`` overrides the preset's configured ``export_path``; both are
     reflected in the native invocation and the reported result (#170).
     """
-    resolved_project = resolve_project_dir(project)
-    binary = resolve_godot_binary(godot)
     # --output is a filesystem path: normalize it ONCE here (ADR-0006, ~-expanded)
-    # so the runner and the reported result both see the effective destination.
+    # at the CLI layer before it reaches the operation, like every other
+    # path-taking command. The operation receives the already-normalized override.
     override_output = _normalize_path(output) if output is not None else None
-
-    # Phase 1: resolve the preset via the existing export-get sentinel op. This
-    # reuses #114's clean structured errors — an unknown preset is
-    # export_preset_not_found, a project with no export_presets.cfg is
-    # export_presets_not_found — and emits + exits on any of them via the shared
-    # failure channel, before any native export is attempted.
-    got = EXPORT_GET_COMMAND.run(
-        ExportGetParams(preset=preset),
-        godot=godot,
-        project=resolved_project,
-        make_runner=_make_runner,
-    )
-
-    # Resolve the effective destination: --output (already CLI-normalized) wins
-    # over the preset's configured export_path (#170). This is what the native
-    # export writes to AND what the result reports as output_path.
-    output_path = override_output if override_output is not None else got.export_path
-
-    # Phase 2: structured preflight, BEFORE any native run (ADR-0010). Two
-    # fail-fast checks, both decided from export get's structured fields rather
-    # than from the engine's stderr (which ADR-0002 forbids parsing for codes):
-    #
-    #  - There must be a destination, for EVERY mode. --output supplies one
-    #    directly (#170); only when no override is given AND the configured
-    #    export_path is empty is there nowhere to write — export_path_unset.
-    #    Checked first because it is a config/argument error independent of the
-    #    engine's template state, so it stays deterministic whether or not
-    #    templates happen to be installed.
-    #  - Templates for the running engine version must be installed — but ONLY
-    #    for release/debug, never for pack (#170). release/debug produce a full
-    #    platform binary and need the matching platform export templates; pack
-    #    produces project data only (a PCK/ZIP via Godot's native --export-pack)
-    #    and needs no platform templates (ExportRunMode's docstring; confirmed on
-    #    Godot 4.6.3, where a template-less --export-pack writes a .pck). Gating
-    #    pack out lets template-less environments use the mode that works there.
-    #    export get reports template readiness structurally (templates_installed)
-    #    — the readiness check built for exactly this — so a release/debug export
-    #    against an uninstalled template version is the distinct
-    #    export_templates_missing, decided here rather than by string-matching the
-    #    engine's "due to configuration errors" stderr (which also fires for a
-    #    merely-misconfigured preset).
-    if not output_path:
-        emit_failure(export_path_unset_failure(got.name))
-    if mode is not ExportRunMode.PACK and not got.templates_installed:
-        emit_failure(export_templates_missing_failure(got.name, got.templates_version))
-
-    # Phase 3: run the native export and classify its raw outcome. The export-get
-    # resolved name (got.name) is authoritative throughout — it is what the engine
-    # exports and what the result echoes — so the native invocation, not the raw
-    # --preset string, is keyed on it.
-    export_runner = _make_export_runner(binary, resolved_project)
-    export_output = export_runner.run(got.name, mode.value, output_path)
-    outcome = classify_export_run(
-        export_output,
-        binary,
-        preset=got.name,
-        platform=got.platform,
+    outcome = run_export_operation(
+        preset=preset,
         mode=mode,
-        output_path=output_path,
+        output_override=override_output,
+        godot=godot,
+        project=resolve_project_dir(project),
+        make_runner=_make_runner,
+        make_export_runner=_make_export_runner,
     )
     if isinstance(outcome, Failure):
         emit_failure(outcome)
-
-    if json_output:
-        typer.echo(outcome.model_dump_json())
-    else:
-        typer.echo(render(outcome))
+    emit_result(outcome, json_output)
 
 
 @resource_app.command(name="uid", cls=RESOURCE_UID_COMMAND.command_class())

--- a/src/gda/export_run.py
+++ b/src/gda/export_run.py
@@ -1,0 +1,158 @@
+"""The ExportRun operation — ``gda export run``'s resolve → preflight → run recipe.
+
+Unlike every other Phase-1 capability, an export cannot run through
+``operations.gd``: the Godot export subsystem is editor-only C++, unreachable
+from a ``--headless --script`` SceneTree run, so the export itself is a native
+``--export-<mode>`` invocation (ADR-0010, :mod:`gda.export_runner`). ``export
+run`` therefore hand-orchestrates a multi-phase recipe rather than the shared
+sentinel pipeline:
+
+1. **resolve** the preset via the existing ``export-get`` sentinel op — reusing
+   #114's clean preset/project errors;
+2. **structured preflight** (effective destination + template readiness,
+   ADR-0010) that fails fast — ``export_path_unset`` / ``export_templates_missing``
+   — with NO native run;
+3. the native ``--export-<mode>`` run, whose raw outcome
+   :func:`gda.errors.classify_export_run` turns into the typed result.
+
+This module is the recipe's home. :func:`run_export_operation` is a PURE function
+that RETURNS the outcome (``ExportRunResult | Failure``) — it never emits or
+exits — so the CLI command (``gda.cli.run_export``) shrinks to the same thin
+shape as every other command and the recipe gets its own engine-free test
+surface (driven with the two injected seams; see
+``tests/test_export_run_operation.py``).
+
+The two ``EXPORT_GET_COMMAND`` / ``EXPORT_RUN_COMMAND`` :class:`HeadlessCommand`
+definitions live here, not in ``cli.py``, so the operation can drive ``export
+get`` without an ``export_run ↔ cli`` import cycle; ``cli.py`` imports both from
+here.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Optional
+
+from gda.binary import resolve_godot_binary
+from gda.errors import (
+    Failure,
+    classify_export_run,
+    export_path_unset_failure,
+    export_templates_missing_failure,
+)
+from gda.export_runner import ExportRunner, make_subprocess_export_runner
+from gda.headless import HeadlessCommand, RunnerFactory, make_subprocess_runner
+from gda.models import (
+    ExportGetParams,
+    ExportGetResult,
+    ExportRunMode,
+    ExportRunParams,
+    ExportRunResult,
+)
+
+# The factory seam for the native export runner — the ``export run``-only twin of
+# the sentinel channel's ``RunnerFactory``. Spelled here (not in ``headless``)
+# because only the export recipe spawns a native ``--export-<mode>`` process.
+ExportRunnerFactory = Callable[[Path, Optional[Path]], ExportRunner]
+
+EXPORT_GET_COMMAND: HeadlessCommand[ExportGetResult] = HeadlessCommand(
+    operation="export-get",
+    input_model=ExportGetParams,
+    output_model=ExportGetResult,
+)
+
+# export run is the one command that does NOT route through operations.gd: the
+# Godot export subsystem is editor-only C++, unreachable from a --script
+# SceneTree run, so the export itself is a native --export-<mode> invocation
+# (gda.export_runner). This HeadlessCommand is used only for its --schema /
+# --json model plumbing; the recipe is run by run_export_operation below —
+# export-get resolves the preset + path, the native ExportRunner exports,
+# classify_export_run turns the subprocess outcome into the typed result —
+# rather than the shared sentinel pipeline.
+EXPORT_RUN_COMMAND: HeadlessCommand[ExportRunResult] = HeadlessCommand(
+    operation="export-run",
+    input_model=ExportRunParams,
+    output_model=ExportRunResult,
+)
+
+
+def run_export_operation(
+    *,
+    preset: str,
+    mode: ExportRunMode,
+    output_override: Optional[str],
+    godot: Optional[str],
+    project: Optional[Path],
+    make_runner: RunnerFactory = make_subprocess_runner,
+    make_export_runner: ExportRunnerFactory = make_subprocess_export_runner,
+) -> ExportRunResult | Failure:
+    """Run ``export run``'s resolve → preflight → native-run → classify recipe.
+
+    A PURE function: it RETURNS the typed ``ExportRunResult`` on success or a
+    ``Failure`` at any phase, and never emits or exits — the CLI layer owns the
+    public emit/exit channel. ``output_override`` is the already-CLI-normalized
+    ``--output`` value (ADR-0006 path normalization stays at the CLI); both
+    engine-touching seams (``make_runner`` for ``export-get``, ``make_export_runner``
+    for the native export) are injected, so the recipe is fully testable without a
+    real engine.
+    """
+    # Phase 1 (resolve): the preset via the existing export-get sentinel op. This
+    # reuses #114's clean structured errors — an unknown preset is
+    # export_preset_not_found, a project with no export_presets.cfg is
+    # export_presets_not_found — returned as a Failure before any native export.
+    got = EXPORT_GET_COMMAND.execute(
+        ExportGetParams(preset=preset),
+        godot=godot,
+        project=project,
+        make_runner=make_runner,
+    )
+    if isinstance(got, Failure):
+        return got
+
+    # Resolve the effective destination: --output (already CLI-normalized) wins
+    # over the preset's configured export_path (#170). This is what the native
+    # export writes to AND what the result reports as output_path.
+    output_path = output_override if output_override is not None else got.export_path
+
+    # Phase 2 (structured preflight, BEFORE any native run; ADR-0010). Two
+    # fail-fast checks, both decided from export get's structured fields rather
+    # than from the engine's stderr (which ADR-0002 forbids parsing for codes):
+    #
+    #  - There must be a destination, for EVERY mode. --output supplies one
+    #    directly (#170); only when no override is given AND the configured
+    #    export_path is empty is there nowhere to write — export_path_unset.
+    #    Checked first because it is a config/argument error independent of the
+    #    engine's template state, so it stays deterministic whether or not
+    #    templates happen to be installed.
+    #  - Templates for the running engine version must be installed — but ONLY
+    #    for release/debug, never for pack (#170). release/debug produce a full
+    #    platform binary and need the matching platform export templates; pack
+    #    produces project data only (a PCK/ZIP via Godot's native --export-pack)
+    #    and needs no platform templates (ExportRunMode's docstring; confirmed on
+    #    Godot 4.6.3, where a template-less --export-pack writes a .pck). Gating
+    #    pack out lets template-less environments use the mode that works there.
+    #    export get reports template readiness structurally (templates_installed)
+    #    — the readiness check built for exactly this — so a release/debug export
+    #    against an uninstalled template version is the distinct
+    #    export_templates_missing, decided here rather than by string-matching the
+    #    engine's "due to configuration errors" stderr (which also fires for a
+    #    merely-misconfigured preset).
+    if not output_path:
+        return export_path_unset_failure(got.name)
+    if mode is not ExportRunMode.PACK and not got.templates_installed:
+        return export_templates_missing_failure(got.name, got.templates_version)
+
+    # Phase 3 (native run + classify): run the native export and classify its raw
+    # outcome. The export-get resolved name (got.name) is authoritative throughout
+    # — it is what the engine exports and what the result echoes — so the native
+    # invocation, not the raw --preset string, is keyed on it.
+    binary = resolve_godot_binary(godot)
+    export_runner = make_export_runner(binary, project)
+    export_output = export_runner.run(got.name, mode.value, output_path)
+    return classify_export_run(
+        export_output,
+        binary,
+        preset=got.name,
+        platform=got.platform,
+        mode=mode,
+        output_path=output_path,
+    )

--- a/src/gda/export_run.py
+++ b/src/gda/export_run.py
@@ -15,12 +15,15 @@ sentinel pipeline:
 3. the native ``--export-<mode>`` run, whose raw outcome
    :func:`gda.errors.classify_export_run` turns into the typed result.
 
-This module is the recipe's home. :func:`run_export_operation` is a PURE function
-that RETURNS the outcome (``ExportRunResult | Failure``) — it never emits or
-exits — so the CLI command (``gda.cli.run_export``) shrinks to the same thin
+This module is the recipe's home. :func:`run_export_operation` RETURNS its
+outcome (``ExportRunResult | Failure``) instead of emitting the public result or
+exiting — so the CLI command (``gda.cli.run_export``) shrinks to the same thin
 shape as every other command and the recipe gets its own engine-free test
 surface (driven with the two injected seams; see
-``tests/test_export_run_operation.py``).
+``tests/test_export_run_operation.py``). It is not side-effect-free: phase 1's
+``HeadlessCommand.execute`` still forwards the ``export-get`` engine stderr to
+this process's stderr as advisory diagnostics; only the public result/error
+envelope and the process exit are deferred to the CLI caller.
 
 The two ``EXPORT_GET_COMMAND`` / ``EXPORT_RUN_COMMAND`` :class:`HeadlessCommand`
 definitions live here, not in ``cli.py``, so the operation can drive ``export
@@ -87,9 +90,13 @@ def run_export_operation(
 ) -> ExportRunResult | Failure:
     """Run ``export run``'s resolve → preflight → native-run → classify recipe.
 
-    A PURE function: it RETURNS the typed ``ExportRunResult`` on success or a
-    ``Failure`` at any phase, and never emits or exits — the CLI layer owns the
-    public emit/exit channel. ``output_override`` is the already-CLI-normalized
+    Returns its outcome instead of emitting or exiting: the typed
+    ``ExportRunResult`` on success or a ``Failure`` at any phase — the CLI layer
+    owns the public emit/exit channel. Not side-effect-free, though: phase 1's
+    ``HeadlessCommand.execute`` still forwards the ``export-get`` engine stderr to
+    this process's stderr as advisory diagnostics; only the public result/error
+    envelope and the exit are deferred to the caller. ``output_override`` is the
+    already-CLI-normalized
     ``--output`` value (ADR-0006 path normalization stays at the CLI); both
     engine-touching seams (``make_runner`` for ``export-get``, ``make_export_runner``
     for the native export) are injected, so the recipe is fully testable without a

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -125,6 +125,21 @@ def emit_failure(failure: Failure) -> NoReturn:
 _fail = emit_failure
 
 
+def emit_result(result: BaseModel, json_output: bool) -> None:
+    """Emit a typed success result as JSON or human-readable text.
+
+    The single home for the public success channel: a result model becomes its
+    ``--json`` serialization when ``json_output``, else the type-dispatched
+    human rendering by :func:`gda.render.render` (issue #186). Shared by the
+    sentinel-pipeline commands (via :meth:`HeadlessCommand.emit`) and the
+    native-export command (``export run``), so both render success identically.
+    """
+    if json_output:
+        typer.echo(result.model_dump_json())
+    else:
+        typer.echo(render(result))
+
+
 @dataclass(frozen=True)
 class HeadlessCommand(Generic[M]):
     """A deep module for one Phase-1 headless operation.
@@ -147,6 +162,43 @@ class HeadlessCommand(Generic[M]):
         """Return the Typer command class that owns this command's ``--schema``."""
         return schema_command_class(self.input_model, self.output_model)
 
+    def execute(
+        self,
+        params: BaseModel,
+        *,
+        godot: Optional[str],
+        project: Optional[Path] = None,
+        make_runner: RunnerFactory = make_subprocess_runner,
+    ) -> M | Failure:
+        """Run the command and RETURN its typed success model or a ``Failure``.
+
+        The pure outcome step: it resolves the binary, runs the operation,
+        forwards diagnostics to stderr, and classifies the raw result — but it
+        never emits or exits. A failure is *returned* as a :class:`Failure`, so
+        a caller composing a multi-phase recipe (``export run``) can branch on
+        it. :meth:`run` adds the emit-and-exit-on-failure behavior on top.
+        """
+        try:
+            binary = resolve_godot_binary(godot)
+        except ValueError as exc:
+            # An empty ``--godot ""`` (a natural $GDA_GODOT mistake) makes
+            # resolution raise *before* a runner exists — there is no binary to
+            # launch, the same environment failure as a missing one. Map it to
+            # the structured ``binary_not_found`` envelope so it never escapes as
+            # a raw traceback (issue #33), mirroring the runner's NOT_FOUND path.
+            return unresolvable_binary_failure(str(exc))
+        runner = make_runner(binary, project)
+        result = runner.run(self.operation, params.model_dump())
+
+        if result.stderr:
+            print(result.stderr, end="", file=sys.stderr)
+
+        return (
+            self.classify(result, binary)
+            if self.classify is not None
+            else classify_run(result, binary, self.output_model)
+        )
+
     def run(
         self,
         params: BaseModel,
@@ -158,27 +210,12 @@ class HeadlessCommand(Generic[M]):
         """Run the command and return its typed success model.
 
         Diagnostics are forwarded to stderr. Failures are emitted as the public
-        structured error envelope and terminate via Typer's exit path.
+        structured error envelope and terminate via Typer's exit path. The pure
+        outcome is produced by :meth:`execute`; this method adds the
+        emit-and-exit-on-failure behavior shared by every CLI command.
         """
-        try:
-            binary = resolve_godot_binary(godot)
-        except ValueError as exc:
-            # An empty ``--godot ""`` (a natural $GDA_GODOT mistake) makes
-            # resolution raise *before* a runner exists — there is no binary to
-            # launch, the same environment failure as a missing one. Map it to
-            # the structured ``binary_not_found`` envelope so it never escapes as
-            # a raw traceback (issue #33), mirroring the runner's NOT_FOUND path.
-            _fail(unresolvable_binary_failure(str(exc)))
-        runner = make_runner(binary, project)
-        result = runner.run(self.operation, params.model_dump())
-
-        if result.stderr:
-            print(result.stderr, end="", file=sys.stderr)
-
-        outcome = (
-            self.classify(result, binary)
-            if self.classify is not None
-            else classify_run(result, binary, self.output_model)
+        outcome = self.execute(
+            params, godot=godot, project=project, make_runner=make_runner
         )
         if isinstance(outcome, Failure):
             _fail(outcome)
@@ -203,7 +240,4 @@ class HeadlessCommand(Generic[M]):
         result = self.run(
             params, godot=godot, project=project, make_runner=make_runner
         )
-        if json_output:
-            typer.echo(result.model_dump_json())
-        else:
-            typer.echo(render(result))
+        emit_result(result, json_output)

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -172,11 +172,14 @@ class HeadlessCommand(Generic[M]):
     ) -> M | Failure:
         """Run the command and RETURN its typed success model or a ``Failure``.
 
-        The pure outcome step: it resolves the binary, runs the operation,
-        forwards diagnostics to stderr, and classifies the raw result — but it
-        never emits or exits. A failure is *returned* as a :class:`Failure`, so
-        a caller composing a multi-phase recipe (``export run``) can branch on
-        it. :meth:`run` adds the emit-and-exit-on-failure behavior on top.
+        The outcome step: it resolves the binary, runs the operation, forwards
+        engine diagnostics to stderr, and classifies the raw result — but it
+        never emits the public result/error envelope or exits. (Forwarding the
+        engine's stderr is its one side effect; the public emit and the process
+        exit are deferred to :meth:`run`.) A failure is *returned* as a
+        :class:`Failure`, so a caller composing a multi-phase recipe
+        (``export run``) can branch on it. :meth:`run` adds the
+        emit-and-exit-on-failure behavior on top.
         """
         try:
             binary = resolve_godot_binary(godot)
@@ -210,7 +213,7 @@ class HeadlessCommand(Generic[M]):
         """Run the command and return its typed success model.
 
         Diagnostics are forwarded to stderr. Failures are emitted as the public
-        structured error envelope and terminate via Typer's exit path. The pure
+        structured error envelope and terminate via Typer's exit path. The
         outcome is produced by :meth:`execute`; this method adds the
         emit-and-exit-on-failure behavior shared by every CLI command.
         """

--- a/tests/test_export_run_operation.py
+++ b/tests/test_export_run_operation.py
@@ -1,0 +1,211 @@
+"""Direct tests for the ExportRun operation (issue #187).
+
+``export run`` is the one command whose recipe — resolve the preset via
+``export-get`` → structured preflight (effective destination + template
+readiness, ADR-0010) → native ``--export-<mode>`` run → classify — used to live
+inside the Typer function and could only be exercised through a CliRunner. The
+recipe now lives in :func:`gda.export_run.run_export_operation`, a PURE function
+that RETURNS the outcome (never emits/exits).
+
+These tests drive that function directly with the two injected seams — a
+``FakeRunner`` for the ``export-get`` resolve and a ``FakeExportRunner`` for the
+native export — so the phase sequencing and each preflight branch are asserted
+without a real engine and without CliRunner. They are the recipe's own test
+surface, complementary to the command tests in
+``tests/test_export_run_commands.py`` (the zero-behavior-change safety net).
+"""
+
+from pathlib import Path
+
+from gda.errors import Failure
+from gda.export_run import run_export_operation
+from gda.models import ExportRunMode, ExportRunResult
+from gda.runner import RunResult
+from tests.support import FakeExportRunner, FakeRunner, error_sentinel, sentinel
+
+GET_RESULT = {
+    "index": 0,
+    "name": "Linux/X11",
+    "platform": "Linux/X11",
+    "runnable": True,
+    "export_path": "build/game.x86_64",
+    "templates_installed": True,
+    "templates_version": "4.6.3.stable",
+}
+
+
+def _get_runner(get=GET_RESULT) -> FakeRunner:
+    """A FakeRunner that returns ``get`` wrapped in an ADR-0002 success sentinel."""
+    return FakeRunner(
+        RunResult(
+            stdout="Godot Engine v4.6.3.stable.official\n" + sentinel(get),
+            stderr="",
+            exit_code=0,
+        )
+    )
+
+
+def _run(
+    *,
+    get_runner: FakeRunner,
+    export_runner: FakeExportRunner,
+    preset: str = "Linux/X11",
+    mode: ExportRunMode = ExportRunMode.RELEASE,
+    output_override: str | None = None,
+):
+    """Invoke the operation with both seams pinned to the given fakes."""
+    return run_export_operation(
+        preset=preset,
+        mode=mode,
+        output_override=output_override,
+        godot="/tmp/Godot",
+        project=Path("/tmp/project"),
+        make_runner=lambda binary, project=None: get_runner,
+        make_export_runner=lambda binary, project=None: export_runner,
+    )
+
+
+def test_success_returns_typed_result_to_configured_path():
+    # The happy path: export-get resolves the preset, the preflight passes, the
+    # native export exits clean, and the operation RETURNS the typed
+    # ExportRunResult (not an emitted envelope) targeting the configured path.
+    get_runner = _get_runner()
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+    outcome = _run(get_runner=get_runner, export_runner=export_runner)
+
+    assert isinstance(outcome, ExportRunResult)
+    assert outcome.preset == "Linux/X11"
+    assert outcome.platform == "Linux/X11"
+    assert outcome.mode is ExportRunMode.RELEASE
+    assert outcome.output_path == "build/game.x86_64"
+    assert outcome.warnings == []
+    # Phase sequencing: export-get ran first, then the native export to the
+    # configured path keyed on the export-get-resolved name.
+    assert get_runner.calls == [("export-get", {"preset": "Linux/X11"})]
+    assert export_runner.calls == [("Linux/X11", "release", "build/game.x86_64")]
+
+
+def test_phase1_failure_returns_the_failure():
+    # An unknown preset surfaces export-get's clean export_preset_not_found,
+    # RETURNED verbatim as a Failure (Phase 1 short-circuits) — and no native
+    # export is attempted.
+    get_runner = FakeRunner(
+        RunResult(
+            stdout=error_sentinel("export_preset_not_found", "no such preset"),
+            stderr="",
+            exit_code=4,
+        )
+    )
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+    outcome = _run(
+        get_runner=get_runner, export_runner=export_runner, preset="Nope"
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "export_preset_not_found"
+    assert export_runner.calls == []
+
+
+def test_export_path_unset_when_no_override_and_empty_configured_path():
+    # No --output override AND an empty configured export_path means there is
+    # nowhere to write: the operation RETURNS export_path_unset before the native
+    # run, named on the export-get-resolved preset name.
+    get_runner = _get_runner({**GET_RESULT, "export_path": ""})
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+    outcome = _run(get_runner=get_runner, export_runner=export_runner)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "export_path_unset"
+    assert "Linux/X11" in outcome.error.message
+    assert export_runner.calls == []
+
+
+def test_output_override_supplies_destination_when_configured_path_empty():
+    # An --output override supplies a destination even when the configured
+    # export_path is empty: the unset preflight does NOT fire and the export runs
+    # to the override (override-wins-over-configured).
+    get_runner = _get_runner({**GET_RESULT, "export_path": ""})
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+    outcome = _run(
+        get_runner=get_runner,
+        export_runner=export_runner,
+        output_override="dist/custom.x86_64",
+    )
+
+    assert isinstance(outcome, ExportRunResult)
+    assert outcome.output_path == "dist/custom.x86_64"
+    assert export_runner.calls == [("Linux/X11", "release", "dist/custom.x86_64")]
+
+
+def test_output_override_wins_over_configured_path():
+    # When BOTH a configured export_path and an --output override exist, the
+    # override wins, for both the native invocation and the reported output_path.
+    get_runner = _get_runner()
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+    outcome = _run(
+        get_runner=get_runner,
+        export_runner=export_runner,
+        output_override="dist/custom.x86_64",
+    )
+
+    assert isinstance(outcome, ExportRunResult)
+    assert outcome.output_path == "dist/custom.x86_64"
+    assert export_runner.calls == [("Linux/X11", "release", "dist/custom.x86_64")]
+
+
+def test_templates_missing_for_release_and_debug():
+    # release/debug produce a full platform binary and need the matching export
+    # templates: when export-get reports templates_installed=False, the operation
+    # RETURNS export_templates_missing BEFORE any native run, for each of them.
+    for mode in (ExportRunMode.RELEASE, ExportRunMode.DEBUG):
+        get_runner = _get_runner({**GET_RESULT, "templates_installed": False})
+        export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+        outcome = _run(
+            get_runner=get_runner, export_runner=export_runner, mode=mode
+        )
+
+        assert isinstance(outcome, Failure), mode
+        assert outcome.error.code == "export_templates_missing", mode
+        assert "4.6.3.stable" in outcome.error.message, mode
+        # The preflight fired before any native run.
+        assert export_runner.calls == [], mode
+
+
+def test_pack_is_exempt_from_templates_preflight():
+    # --mode pack produces project data only and needs NO platform templates: with
+    # templates_installed=False, pack does NOT emit export_templates_missing — it
+    # proceeds straight to the native runner.
+    get_runner = _get_runner({**GET_RESULT, "templates_installed": False})
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+    outcome = _run(
+        get_runner=get_runner, export_runner=export_runner, mode=ExportRunMode.PACK
+    )
+
+    assert isinstance(outcome, ExportRunResult)
+    assert outcome.mode is ExportRunMode.PACK
+    assert export_runner.calls == [("Linux/X11", "pack", "build/game.x86_64")]
+
+
+def test_native_nonzero_exit_returns_export_failed():
+    # A non-zero native export with no recognized stderr signature is classified
+    # as the generic export_failed Failure; the engine's stderr is preserved as
+    # advisory diagnostics.
+    get_runner = _get_runner()
+    export_runner = FakeExportRunner(
+        RunResult(
+            stdout="", stderr="ERROR: could not write artifact to disk.\n", exit_code=1
+        )
+    )
+
+    outcome = _run(get_runner=get_runner, export_runner=export_runner)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "export_failed"
+    assert "could not write artifact" in outcome.error.diagnostics


### PR DESCRIPTION
Closes #187.

Lift `gda export run`'s multi-phase recipe into a deep, pure **ExportRun operation**,
so the lone special-case command becomes as thin as every other command and the
recipe gets its own engine-free test surface. **Pure refactor — zero behavior change**
(identical `--json`, `--schema`, exit codes, error envelope, human output).

## What changed
- **`HeadlessCommand` split** (`headless.py`): new pure `execute(...) -> M | Failure`
  (the old `run` body, but *returns* the `Failure` instead of emit+exit); `run` is now
  `execute` + emit-and-exit-on-failure — external behavior unchanged for all callers.
  Plus a module-level `emit_result(result, json_output)` (JSON or type-dispatched
  `render`), now shared by `HeadlessCommand.emit` and the export command.
- **New `src/gda/export_run.py`**: `run_export_operation(...)` owns the three phases
  (export-get resolve via `.execute` → structured preflight → native run + classify) as a
  PURE function returning `ExportRunResult | Failure`, with both engine seams injected.
  `EXPORT_GET_COMMAND` / `EXPORT_RUN_COMMAND` moved here so the operation can drive
  `export get` without an `export_run ↔ cli` import cycle; `cli.py` imports all three.
- **`run_export` thinned** (`cli.py`): normalize `--output` once (ADR-0006) → invoke the
  operation → `emit_failure` on `Failure` else `emit_result`. The re-implemented
  `if json_output … else render(…)` branch is gone.

Preserved every detail: `got.name` authoritative throughout, the pack template-exemption,
override-wins-over-configured destination, exact preflight failure builders/codes.

## Verification (independently re-run by reviewer)
- No import cycle (`import gda.cli; from gda.export_run import …` → OK).
- New direct tests (`tests/test_export_run_operation.py`, no CliRunner, two fakes) cover
  every branch: phase-1 failure, `export_path_unset`, override-wins, `export_templates_missing`
  for release/debug + PACK exemption, success, native `export_failed`.
- Existing `test_export_run_commands.py` (CliRunner) and `test_e2e_export_run.py` are
  untouched — the zero-behavior-change safety net.
- Fast tier: `505 passed`. e2e tier: `233 passed, 1 skipped` (serial, isolated).

Builds on #185 (merged): the operation drives the unified launch primitive via the two
runner seams.
