### PR TITLE
docs(adr): record gda-mcp architecture (ADR-0011..0014)

### DIFF
--- a/docs/adr/0011-gda-mcp-integration-mechanism.md
+++ b/docs/adr/0011-gda-mcp-integration-mechanism.md
@@ -22,11 +22,27 @@ gda-daemon exists in Phase 2 — the topology of {gda-mcp, gda, gda-daemon}.
 ## Decision
 
 **gda-mcp wraps `gda` as a subprocess.** It shells out to the installed `gda`
-console script (`gda <group> <command> --json …`, and `gda <group> <command>
---schema` for tool generation) and consumes only `gda`'s **public ABI**: the
-ADR-0002 sentinel-delimited JSON result / error envelope on stdout, the ADR-0002
-exit-code categories, and the ADR-0004 `--schema` self-description. It does **not**
+console script and consumes only `gda`'s **public CLI ABI** — *not* the internal
+sentinel protocol ADR-0002 defines **between** `gda` and its headless operation
+subprocesses (which `gda` already parses away before emitting its public output, and
+which ADR-0010's native-CLI-mode operations do not emit at all). That public ABI is:
+the `--json` success output, the structured `GdaError` envelope on a non-zero exit
+(the uniform `GdaErrorEnvelope` of ADR-0004), the exit-code categories, and the
+`--schema` self-description (ADR-0004). Operations are invoked per-command as
+`gda <group> <command> --json …`; the **tool surface is enumerated from the aggregate
+schema dump** (ADR-0012), *not* a per-command `--schema` fan-out. gda-mcp does **not**
 import `gda`'s Python modules or depend on any internal symbol.
+
+**Error mapping is part of this mechanism, and is lossless.** gda-mcp keys on `gda`'s
+exit code: exit 0 is success — the `--json` result becomes the tool's
+`structuredContent` (validated against its `outputSchema`); any non-zero exit becomes
+`CallToolResult(is_error=True)` carrying the **full** `GdaError` envelope
+`{code, category, message, diagnostics}` **losslessly** as JSON in the result content.
+The envelope is **never** flattened to a prose string — the stable `code` exists
+precisely so an agent branches on it without parsing prose — and the `error` schema
+stays out of `outputSchema` (ADR-0004). All non-zero categories (environment /
+version / operation / parse / contract_violation, including launch failures) map
+uniformly to `isError`; `category` / `code` distinguish them.
 
 **Phase-2 topology — gda-daemon sits *below* `gda`, not beside gda-mcp.** This ADR
 records the load-bearing assumption that makes ADR-0001's "gda-mcp follows `gda` into
@@ -36,7 +52,7 @@ Phase 2 automatically" literally true:
   them, internally, to gda-daemon over its IPC channel; gda-daemon owns the
   persistent engine and therefore the cross-call state (the subject of #5).
 - Each `gda` invocation stays a one-shot, stateless RPC to the daemon and emits the
-  **same** ADR-0002 contract a headless op does.
+  **same** public `--json` / `GdaError` contract a headless op does.
 - **gda-mcp always wraps the CLI and never speaks to gda-daemon directly.** The
   headless/live distinction stays invisible to gda-mcp exactly as ADR-0005 keeps it
   invisible in the command tree. gda-mcp therefore needs no IPC client and no
@@ -47,7 +63,7 @@ Phase 2 automatically" literally true:
 
 - **In-process import (rejected).** gda-mcp imports `gda` and calls its
   functions/models directly. Rejected because: (1) it couples gda-mcp to `gda`'s
-  internals instead of the frozen public ABI that `--schema` / ADR-0002 exist to
+  internals instead of the frozen public CLI ABI that `--schema` (ADR-0004) exists to
   expose; (2) its only real upside is per-call speed, which is illusory in Phase 1 —
   every call's latency is dominated by Godot's own `--headless` spawn (60 s / 600 s
   timeouts), beside which a `gda` process start is noise; (3) it gets *worse* under
@@ -78,6 +94,6 @@ Phase 2 automatically" literally true:
   design (#5, #7): the daemon backs the CLI, and "state consistency" (#5) is a
   property of the daemon holding the engine across one-shot CLI calls — gda-mcp does
   not participate in it.
-- gda-mcp's packaging, tool-generation strategy, transport, and error-mapping
-  fidelity are deliberately out of scope here; they are downstream of this mechanism
-  and decided separately.
+- This ADR owns the integration mechanism **and its error mapping**. gda-mcp's
+  packaging, tool-generation strategy, and transport are downstream and decided
+  separately (ADR-0013, ADR-0012, and the PRD respectively).

--- a/docs/adr/0011-gda-mcp-integration-mechanism.md
+++ b/docs/adr/0011-gda-mcp-integration-mechanism.md
@@ -1,0 +1,83 @@
+---
+status: accepted
+---
+
+# gda-mcp integration mechanism: a subprocess adapter over the gda CLI
+
+ADR-0000 fixes the component order `gda → gda-mcp → gda-daemon` and frames
+[gda-mcp](../../CONTEXT.md) as "a thin protocol adapter that wraps `gda`". ADR-0001
+makes gda-mcp orthogonal to the delivery phases — first delivered on Phase 1,
+following `gda` into Phase 2 automatically via the `--schema` self-description
+(ADR-0004), never itself a phase. ADR-0004 / ADR-0005 specify the mechanical mapping
+that lets gda-mcp generate its tool surface rather than hand-write it:
+`gda <group> <command>` → MCP tool `<group>_<command>`, and `--schema`'s
+`input` / `output` → the tool's `inputSchema` / `outputSchema`, with the uniform
+`error` envelope routed to MCP's `isError` channel.
+
+What ADR-0000 leaves open is *how* gda-mcp wraps `gda`: by invoking the CLI as an
+external process (consuming its public ABI), or by importing `gda` in-process and
+calling its Python symbols. The choice fixes gda-mcp's coupling to `gda` and — once
+gda-daemon exists in Phase 2 — the topology of {gda-mcp, gda, gda-daemon}.
+
+## Decision
+
+**gda-mcp wraps `gda` as a subprocess.** It shells out to the installed `gda`
+console script (`gda <group> <command> --json …`, and `gda <group> <command>
+--schema` for tool generation) and consumes only `gda`'s **public ABI**: the
+ADR-0002 sentinel-delimited JSON result / error envelope on stdout, the ADR-0002
+exit-code categories, and the ADR-0004 `--schema` self-description. It does **not**
+import `gda`'s Python modules or depend on any internal symbol.
+
+**Phase-2 topology — gda-daemon sits *below* `gda`, not beside gda-mcp.** This ADR
+records the load-bearing assumption that makes ADR-0001's "gda-mcp follows `gda` into
+Phase 2 automatically" literally true:
+
+- In Phase 2 the **CLI `gda`** gains [live operations](../../CONTEXT.md) and routes
+  them, internally, to gda-daemon over its IPC channel; gda-daemon owns the
+  persistent engine and therefore the cross-call state (the subject of #5).
+- Each `gda` invocation stays a one-shot, stateless RPC to the daemon and emits the
+  **same** ADR-0002 contract a headless op does.
+- **gda-mcp always wraps the CLI and never speaks to gda-daemon directly.** The
+  headless/live distinction stays invisible to gda-mcp exactly as ADR-0005 keeps it
+  invisible in the command tree. gda-mcp therefore needs no IPC client and no
+  per-phase work to cover live operations — it is a client of the daemon only
+  transitively, through the CLI.
+
+## Considered options
+
+- **In-process import (rejected).** gda-mcp imports `gda` and calls its
+  functions/models directly. Rejected because: (1) it couples gda-mcp to `gda`'s
+  internals instead of the frozen public ABI that `--schema` / ADR-0002 exist to
+  expose; (2) its only real upside is per-call speed, which is illusory in Phase 1 —
+  every call's latency is dominated by Godot's own `--headless` spawn (60 s / 600 s
+  timeouts), beside which a `gda` process start is noise; (3) it gets *worse* under
+  the daemon — serving live ops in-process would pull gda-daemon's IPC-client code
+  and connection lifecycle into the gda-mcp process, splitting ownership of the live
+  session between gda-mcp and the CLI.
+- **gda-mcp as a direct gda-daemon client (rejected).** Keep subprocess for headless
+  ops but open a private IPC channel to gda-daemon for live ops. Rejected: it
+  duplicates the daemon-client the CLI already carries, and it contradicts ADR-0001's
+  "never itself a phase" by forcing per-phase transport work into gda-mcp.
+- **gda-mcp hosting/embedding gda-daemon (rejected).** The daemon must serve every
+  client (the CLI, other automation, multiple mcp sessions); it cannot live inside one
+  mcp process. gda-mcp is a *client* of the daemon, never its host.
+- **Subprocess adapter over the gda CLI (chosen).**
+
+## Consequences
+
+- gda-mcp's only dependency on `gda` is the public ABI. `gda` internals can change
+  freely; as long as the ABI holds, gda-mcp is unaffected. gda-mcp also becomes the
+  first real consumer of `--schema`, surfacing any contract gaps while the Phase-1
+  surface is still fresh.
+- A live op in Phase 2 has no Godot spawn to amortise the `gda` process start, so
+  subprocess per-call latency becomes visible there. Accepted: it is a CLI-layer
+  concern (it affects all `gda` automation, not just gda-mcp), to be solved at the
+  gda / daemon layer if it ever bites; and at the MCP layer the consumer is an LLM
+  agent whose model-in-the-loop latency dwarfs a process start.
+- The Phase-2 topology above becomes a constraint on the still-parked gda-daemon
+  design (#5, #7): the daemon backs the CLI, and "state consistency" (#5) is a
+  property of the daemon holding the engine across one-shot CLI calls — gda-mcp does
+  not participate in it.
+- gda-mcp's packaging, tool-generation strategy, transport, and error-mapping
+  fidelity are deliberately out of scope here; they are downstream of this mechanism
+  and decided separately.

--- a/docs/adr/0012-gda-mcp-tool-surface-generation.md
+++ b/docs/adr/0012-gda-mcp-tool-surface-generation.md
@@ -1,0 +1,72 @@
+---
+status: accepted
+---
+
+# gda-mcp tool-surface generation: runtime introspection of a whole-surface schema dump, no hand-curated profiles
+
+ADR-0011 fixes [gda-mcp](../../CONTEXT.md) as a subprocess adapter that consumes
+`gda`'s public ABI. ADR-0004 / ADR-0005 make each command self-describing
+(`--schema` → `{input, output, error}`) and give a deterministic CLI→MCP name map
+(`gda <group> <command>` → `<group>_<command>`). This ADR fixes *how* gda-mcp turns
+that self-description into its registered MCP tool surface, and how (not) it manages
+the surface's size.
+
+## Decision
+
+**Generate the tool surface at runtime by introspection, not at build time by
+codegen.** On startup gda-mcp shells out **once** to a new `gda` aggregate-schema
+meta command that emits, in a single process, the whole surface as one JSON
+document — every command's `{name, description, input, output, error}` — and
+registers one MCP tool per entry (`description` ← the command's help text,
+`inputSchema` ← `input` carrying per-field descriptions from the Pydantic `Field`s,
+`outputSchema` ← `output`, failures via the `isError` channel per ADR-0011). gda-mcp
+is therefore, at any moment, a faithful
+mirror of the installed `gda`: a new command appears as a new tool the next time the
+server starts — no codegen step, no release-pipeline coupling, no drift.
+
+- The aggregate dump is the whole-surface generalisation of ADR-0004's per-command
+  `--schema`; it belongs to `gda` (the self-describing layer), not to gda-mcp.
+  Because it describes `gda` itself rather than a Godot domain object, it is a **meta
+  command** in ADR-0005 terms — top-level and ungrouped, a sibling of `gda info`
+  (exact surface form — a `gda schema`-style subcommand vs a top-level `--schema-all`
+  flag — is a taxonomy detail left to the PRD). gda-mcp **never parses `gda --help`
+  prose** to enumerate the surface.
+
+**Expose the full surface; do not ship hand-curated profiles.** gda-mcp registers
+every tool the dump reports. It explicitly does **not** provide named tiers (full /
+lite / minimal). If a tool-count-limited client ever needs a smaller surface, the
+sanctioned mechanism is **config-driven group/tool filtering** — an allowlist /
+denylist keyed on the ADR-0005 groups the surface already has, applied to the dump
+before registration, defaulting to "all". The user decides what to drop; gda-mcp
+does not decide for them.
+
+## Considered options
+
+- **Build-time codegen of a static tool manifest (rejected).** Fast startup and an
+  inspectable artifact, but the manifest lags the `gda` actually installed on the
+  user's machine (drift), needs a release-pipeline step, and contradicts ADR-0004's
+  zero-touch-sync goal.
+- **Per-command `--schema` fan-out at startup (rejected as the enumeration path).**
+  Correct, but spawns ~one `gda` process per command (dozens) on every startup; the
+  aggregate dump gets the same data in one process.
+- **Hand-curated named profiles à la godot-mcp-pro (rejected).** full / lite /
+  minimal require a maintained central membership list — a centralised-registry
+  append hotspot — and break zero-touch: every new command forces a "which tier?"
+  decision, reintroducing the manual sync ADR-0004 / ADR-0011 exist to remove.
+- **Runtime introspection of a whole-surface dump + optional config filtering
+  (chosen).**
+
+## Consequences
+
+- `gda` gains one new meta command (the aggregate schema dump). It is small, belongs
+  to the self-describing layer, and is independently useful as the machine-readable
+  manifest of the whole surface. It is a **prerequisite of the first gda-mcp slice**:
+  build the dump in `gda` first, then have gda-mcp consume it.
+- gda-mcp startup cost is one `gda` subprocess plus schema parsing — negligible, and
+  independent of command count.
+- The first gda-mcp delivery exposes all ~42 tools. Whether that count strains any
+  client is left to be measured; if it does, group/tool filtering — not named tiers —
+  is the agreed response, and it composes cleanly with runtime introspection (filter
+  the dump, then register).
+- gda-mcp carries no per-command knowledge: it is a pure schema→tool transformation,
+  so it stays correct as the `gda` surface grows without edits to gda-mcp.

--- a/docs/adr/0013-gda-mcp-packaging-and-launch.md
+++ b/docs/adr/0013-gda-mcp-packaging-and-launch.md
@@ -1,0 +1,61 @@
+---
+status: accepted
+---
+
+# gda-mcp packaging and launch: one distribution behind a `[mcp]` extra, launched as a stdio command
+
+ADR-0011 makes [gda-mcp](../../CONTEXT.md) a subprocess adapter over the `gda` CLI;
+ADR-0008 makes release-please the single authoritative version source for the one
+`gda` distribution. This ADR fixes how gda-mcp is packaged and how an agent launches
+it.
+
+## Decision
+
+**One distribution, MCP behind an optional `[mcp]` extra.** gda-mcp ships inside the
+existing `gda` distribution, not as a separate package. The `mcp` SDK and the
+`gda-mcp` console-script entry point are gated behind a `gda[mcp]` extra, so a plain
+`gda` install stays lean (pydantic + typer) and only `gda[mcp]` pulls the MCP SDK.
+This keeps a **single version** (ADR-0008) shared by the CLI and its adapter —
+structurally eliminating any CLI/adapter version skew — and one release pipeline
+(ADR-0007 / ADR-0008), at the cost of declaring the `gda-mcp` entry point even when
+the extra is absent (running it without the extra fails with a clear "install
+`gda[mcp]`" message).
+
+**Launched as a stdio command.** gda-mcp is the `gda-mcp` console script — an `mcp`
+**low-level** stdio server. The portable registration vector across every surveyed
+agent (Claude Code, Codex, Claude Desktop, Cursor) is a stdio server described by
+`command` + `args` (+ optional `env`); gda-mcp targets exactly that shape. Two
+invocations are supported: the installed console script `gda-mcp`, and a zero-install
+`uvx --from "gda[mcp]" gda-mcp`.
+
+**Per-agent registration recipes are a shipped deliverable** (user- and
+project-scope) — not left to the user to derive — because the agents diverge in
+config location and format (`.mcp.json` / `~/.claude.json`; `~/.codex/config.toml`
+plus repo-local `.codex/config.toml`; `claude_desktop_config.json`; `.cursor/mcp.json`
+/ `~/.cursor/mcp.json`).
+
+## Considered options
+
+- **Separate `gda-mcp` distribution depending on `gda` (rejected).** Cleaner
+  dependency isolation, but introduces a second version line that can skew against the
+  installed `gda` and a second release pipeline — both at odds with ADR-0008's
+  single-version authority. Co-distribution behind an extra gets the isolation (lean
+  default install) without the skew.
+- **gda-mcp in the core dependency set, no extra (rejected).** Would force the `mcp`
+  SDK onto every CLI-only user.
+- **One distribution + `[mcp]` extra + stdio console script (chosen).**
+
+## Consequences
+
+- A known cross-agent constraint, recorded so the recipes account for it:
+  GUI-launched agents (Claude Desktop, Cursor) spawn servers with a **minimal PATH**
+  that often excludes `~/.local/bin`, so a bare `command = "uvx"` / `"gda-mcp"` may
+  not resolve. Recipes for those agents use an **absolute path** to the executable (or
+  inject a full `PATH` via `env`); the CLI agents (Claude Code, Codex) inherit a normal
+  shell PATH and are unaffected.
+- Do **not** depend on the launch working directory (see ADR-0014): Claude Code
+  ignores a configured `cwd` (claude-code#17565), Cursor / Claude Desktop leave it at
+  the launch location or undefined, and `uvx` can further skew `os.getcwd()`
+  (python-sdk#1520).
+- The `gda-mcp` entry point exists in every install; without the `[mcp]` extra it
+  errors on a missing `mcp` import with an actionable message.

--- a/docs/adr/0014-gda-mcp-project-context-resolution.md
+++ b/docs/adr/0014-gda-mcp-project-context-resolution.md
@@ -1,0 +1,60 @@
+---
+status: accepted
+---
+
+# gda-mcp project-context resolution: server context, not a tool parameter; resolved by a portable precedence because cwd is unreliable
+
+ADR-0006 makes the target project **process context** for `gda`
+(`--project` flag → `$GDA_PROJECT` → cwd), deliberately kept out of `--schema` input
+and therefore out of any tool's inputSchema. ADR-0012 makes [gda-mcp](../../CONTEXT.md)
+a pure schema→tool transform. This ADR fixes how gda-mcp — a long-lived server serving
+many calls — determines which Godot project its `gda` subprocesses act on, without
+breaking either decision.
+
+## Decision
+
+**The target project is server context, not a per-call tool parameter.** gda-mcp does
+**not** inject a `project` field into any tool's inputSchema; the tool surface stays a
+faithful mirror of `--schema` (ADR-0012), and `gda` still receives the project exactly
+as ADR-0006 specifies. gda-mcp resolves one target project for the server and passes
+it as `--project` to every `gda` subprocess it spawns.
+
+**Resolution is by a portable precedence, with cwd only as a last resort** — because
+the launch working directory is not reliably the project across agents (Claude Code
+ignores a configured `cwd`, claude-code#17565; Cursor / Claude Desktop leave it at the
+launch dir or undefined `/`; only Codex sets it reliably). gda-mcp resolves, first hit
+wins:
+
+1. an explicit **`GDA_PROJECT`** in the server's environment (the user pins it in any
+   agent's `env` / TOML; Cursor can inject `${workspaceFolder}`),
+2. **`CLAUDE_PROJECT_DIR`** (Claude Code sets this in the server env to the project
+   root, for free),
+3. the MCP **`roots/list`** the client advertises (Claude Code populates it with the
+   launch dir),
+4. the process **cwd**, as a last-resort fallback.
+
+The resolved path is passed as `gda --project <dir>`.
+
+## Considered options
+
+- **Per-call `project` tool parameter (rejected for now).** Lets one user-scoped
+  server target any project per call, but (a) deviates from ADR-0006 (project becomes
+  an operation parameter) and (b) breaks ADR-0012's pure transform — gda-mcp would
+  synthesize a field absent from `--schema` into every tool. Not worth it for the
+  first delivery; project-scoped registration covers the common workflow.
+- **cwd as the primary signal (rejected).** The obvious choice, but unusable: three of
+  four agents can't set it or leave it undefined. Demoted to last-resort fallback.
+- **Server context via a portable precedence (chosen).**
+
+## Consequences
+
+- **Recommended registration is project-scoped** (or with `GDA_PROJECT` pinned),
+  giving one server : one project — the clean, ADR-0006-aligned mode.
+- A **user-scoped** server with nothing pinned falls back through `CLAUDE_PROJECT_DIR`
+  / `roots/list` / cwd; it works for the single-active-project workflow but cannot, in
+  this first delivery, follow a user juggling several projects in one session.
+- **Future multi-project without a tool parameter:** honour MCP `roots/list_changed`
+  to re-resolve when the client's active root changes — the MCP-native path to
+  multi-project support that still keeps the project out of the tool surface. Deferred
+  until a concrete need appears. (The startup `roots/list` read at precedence 3 may
+  itself be staged after the env-based resolution in the first slice.)

--- a/docs/adr/0014-gda-mcp-project-context-resolution.md
+++ b/docs/adr/0014-gda-mcp-project-context-resolution.md
@@ -33,7 +33,16 @@ wins:
    launch dir),
 4. the process **cwd**, as a last-resort fallback.
 
-The resolved path is passed as `gda --project <dir>`.
+**A candidate is asserted as an explicit project only when it is a valid Godot
+project** (it contains `project.godot`). gda-mcp does **not** promote an unvalidated
+cwd or root into an explicit `--project`, because ADR-0006 gives `--project` /
+`$GDA_PROJECT` strict semantics (must be a real project) while leaving cwd lenient.
+So an explicit `GDA_PROJECT` / `CLAUDE_PROJECT_DIR`, and any validated `roots`/cwd
+candidate, are passed as `gda --project <dir>`; if nothing resolves to a valid
+project, gda-mcp passes **no** `--project` and lets `gda` apply its own ADR-0006 cwd
+resolution — including running projectless when the cwd is not a project. gda-mcp
+does not itself reject projectless operation; an op that requires a project surfaces
+`gda`'s own typed error, relayed unchanged.
 
 ## Considered options
 
@@ -53,8 +62,10 @@ The resolved path is passed as `gda --project <dir>`.
 - A **user-scoped** server with nothing pinned falls back through `CLAUDE_PROJECT_DIR`
   / `roots/list` / cwd; it works for the single-active-project workflow but cannot, in
   this first delivery, follow a user juggling several projects in one session.
+- The startup `roots/list` read (precedence 3) is part of the resolution contract,
+  not a staged extra — the first delivery implements the full precedence above.
 - **Future multi-project without a tool parameter:** honour MCP `roots/list_changed`
   to re-resolve when the client's active root changes — the MCP-native path to
-  multi-project support that still keeps the project out of the tool surface. Deferred
-  until a concrete need appears. (The startup `roots/list` read at precedence 3 may
-  itself be staged after the env-based resolution in the first slice.)
+  multi-project support that still keeps the project out of the tool surface. This
+  *dynamic* re-resolution (not the static `roots/list` read) is the piece deferred
+  until a concrete need appears, and is out of scope for the first delivery per PRD #8.


### PR DESCRIPTION
## What

Records the architecture decisions for `gda-mcp`, aligned in a grill-with-docs session and anchoring PRD #8.

- **ADR-0011 — integration mechanism:** `gda-mcp` wraps the `gda` CLI as a subprocess (public ABI only, no in-process import). `gda-daemon` sits below `gda`; `gda-mcp` always wraps the CLI and never speaks to the daemon directly, so it follows `gda` into Phase 2 with zero per-phase work.
- **ADR-0012 — tool-surface generation:** runtime introspection of a single whole-surface `gda` schema dump (incl. descriptions); one MCP tool per command (`<group>_<command>`); full surface, no hand-curated profiles (config-driven group filtering reserved if needed).
- **ADR-0013 — packaging & launch:** one distribution, MCP behind a `gda[mcp]` extra; `gda-mcp` stdio console script on the `mcp` low-level Server; per-agent registration recipes as a deliverable.
- **ADR-0014 — project-context resolution:** target project is server context, not a tool parameter (honors ADR-0006); resolved by a portable precedence (`GDA_PROJECT` → `CLAUDE_PROJECT_DIR` → `roots/list` → cwd) because cwd is unreliable across agents.

## Why

These ADRs are the authoritative anchors referenced by **PRD #8** (`gda-mcp`). Landing them keeps the issue / doc / code reference chain consistent before the implementation slices are filed via `/to-issues`.

Docs-only change.

Refs #8
