### PR TITLE
feat(gda): uniform --params-json structured params-input + normalization parity

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -89,9 +89,9 @@ operation, and parse codes the CLI assigns).
 | `unsupported_version` | `version` | `version_gate` | `3` | The detected Godot version is below the supported minimum. |
 | `engine_crashed` | `operation` | `classifier` | `4` | Godot terminated abnormally, such as by signal death. |
 | `operation_failed` | `operation` | `classifier` | `4` | The engine or operation failed without a valid registered operation error envelope. |
-| `usage_error` | `operation` | `operation` | `4` | The operation dispatcher was invoked without the required operation name. |
+| `usage_error` | `operation` | `operation` | `4` | The command was invoked incorrectly: the operation dispatcher received no operation name, or the CLI received `--params-json` together with the individual arguments (ADR-0015). |
 | `unknown_operation` | `operation` | `operation` | `4` | The operation dispatcher received an unknown operation name. |
-| `invalid_params` | `operation` | `operation` | `4` | The operation dispatcher received params that are not a JSON object. |
+| `invalid_params` | `operation` | `operation` | `4` | Params do not match the command's contract: the operation dispatcher received non-object params, or a `--params-json` object was malformed or schema-invalid (ADR-0015). |
 | `invalid_path` | `operation` | `operation` | `4` | A required path parameter is missing or invalid. |
 | `invalid_root_type` | `operation` | `operation` | `4` | A requested Godot root node type cannot be instantiated as a `Node`. |
 | `invalid_root_name` | `operation` | `operation` | `4` | A requested root node name is empty or would be rewritten by Godot. |

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -619,9 +619,14 @@ PROJECT_STATISTICS_COMMAND: HeadlessCommand[ProjectStatisticsResult] = HeadlessC
 )
 
 
-# Path normalization now lives in the models (ADR-0015), the single home shared
-# by the argv and ``--params-json`` paths. Commands not yet migrated to model-side
-# normalization still call this alias in their bodies.
+# Path normalization now lives in the models (ADR-0015) via the NormalizedPath
+# field type, the single home shared by the argv and ``--params-json`` paths —
+# every domain command's body passes its raw path straight to the params model.
+# The one exception is ``export run`` (issue #187): its argv body does NOT build
+# an ``ExportRunParams`` (it passes preset/mode/output straight to
+# ``run_export_operation``), so the model's NormalizedPath on ``output`` only
+# fires on the ``--params-json`` path. The argv ``--output`` is therefore still
+# normalized here, via this alias, to keep both export-run paths consistent.
 _normalize_path = normalize_path
 
 
@@ -664,13 +669,14 @@ def get(
     path: str = typer.Argument(..., help="The .tscn scene file to read."),
     json_output: bool = json_option(),
     schema: bool = SCENE_GET_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Read a scene file and report its structured node tree."""
     _dispatch(
         SCENE_GET_COMMAND,
-        SceneGetParams(path=_normalize_path(path)),
+        SceneGetParams(path=path),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -682,13 +688,14 @@ def get_exports(
     path: str = typer.Argument(..., help="The .tscn scene file to read."),
     json_output: bool = json_option(),
     schema: bool = SCENE_GET_EXPORTS_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """List the @export properties a scene's nodes' scripts declare, per node path."""
     _dispatch(
         SCENE_GET_EXPORTS_COMMAND,
-        SceneGetExportsParams(path=_normalize_path(path)),
+        SceneGetExportsParams(path=path),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -699,6 +706,7 @@ def get_exports(
 def list_scenes(
     json_output: bool = json_option(),
     schema: bool = SCENE_LIST_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -717,13 +725,14 @@ def delete(
     path: str = typer.Argument(..., help="The .tscn scene file to delete."),
     json_output: bool = json_option(),
     schema: bool = SCENE_DELETE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Delete a scene file and report what was removed."""
     _dispatch(
         SCENE_DELETE_COMMAND,
-        SceneDeleteParams(path=_normalize_path(path)),
+        SceneDeleteParams(path=path),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -756,6 +765,7 @@ def add(
     ),
     json_output: bool = json_option(),
     schema: bool = NODE_ADD_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -763,7 +773,7 @@ def add(
     _dispatch(
         NODE_ADD_COMMAND,
         NodeAddParams(
-            path=_normalize_path(path),
+            path=path,
             parent=parent,
             type=node_type,
             name=name if name is not None else node_type,
@@ -779,13 +789,14 @@ def list_nodes(
     path: str = typer.Argument(..., help="The .tscn scene file to read."),
     json_output: bool = json_option(),
     schema: bool = NODE_LIST_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """List a scene's node tree with each node's path relative to the root."""
     _dispatch(
         NODE_LIST_COMMAND,
-        NodeListParams(path=_normalize_path(path)),
+        NodeListParams(path=path),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -805,13 +816,14 @@ def get(
     ),
     json_output: bool = json_option(),
     schema: bool = NODE_GET_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Read a node's properties (by node path) as typed JSON."""
     _dispatch(
         NODE_GET_COMMAND,
-        NodeGetParams(path=_normalize_path(path), node=node),
+        NodeGetParams(path=path, node=node),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -842,6 +854,7 @@ def set_property(
     ),
     json_output: bool = json_option(),
     schema: bool = NODE_SET_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -849,7 +862,7 @@ def set_property(
     _dispatch(
         NODE_SET_COMMAND,
         NodeSetParams(
-            path=_normalize_path(path), node=node, property=property, value=value
+            path=path, node=node, property=property, value=value
         ),
         json_output=json_output,
         godot=godot,
@@ -870,13 +883,14 @@ def remove_node(
     ),
     json_output: bool = json_option(),
     schema: bool = NODE_REMOVE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Remove a node (and its subtree) from a scene file by node path."""
     _dispatch(
         NODE_REMOVE_COMMAND,
-        NodeRemoveParams(path=_normalize_path(path), node=node),
+        NodeRemoveParams(path=path, node=node),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -897,13 +911,14 @@ def duplicate_node(
     ),
     json_output: bool = json_option(),
     schema: bool = NODE_DUPLICATE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Duplicate a node (and its subtree) under its parent with a fresh name."""
     _dispatch(
         NODE_DUPLICATE_COMMAND,
-        NodeDuplicateParams(path=_normalize_path(path), node=node),
+        NodeDuplicateParams(path=path, node=node),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -932,13 +947,14 @@ def move_node(
     ),
     json_output: bool = json_option(),
     schema: bool = NODE_MOVE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Reparent a node (and its subtree) under a new parent node path."""
     _dispatch(
         NODE_MOVE_COMMAND,
-        NodeMoveParams(path=_normalize_path(path), node=node, to=to),
+        NodeMoveParams(path=path, node=node, to=to),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -989,6 +1005,7 @@ def connect_signal(
     method: str = _method_option(),
     json_output: bool = json_option(),
     schema: bool = NODE_CONNECT_SIGNAL_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -996,7 +1013,7 @@ def connect_signal(
     _dispatch(
         NODE_CONNECT_SIGNAL_COMMAND,
         NodeConnectSignalParams(
-            path=_normalize_path(path),
+            path=path,
             from_node=from_node,
             signal=signal,
             to=to,
@@ -1019,6 +1036,7 @@ def disconnect_signal(
     method: str = _method_option(),
     json_output: bool = json_option(),
     schema: bool = NODE_DISCONNECT_SIGNAL_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1026,7 +1044,7 @@ def disconnect_signal(
     _dispatch(
         NODE_DISCONNECT_SIGNAL_COMMAND,
         NodeDisconnectSignalParams(
-            path=_normalize_path(path),
+            path=path,
             from_node=from_node,
             signal=signal,
             to=to,
@@ -1059,6 +1077,7 @@ def create(
     ),
     json_output: bool = json_option(),
     schema: bool = SCRIPT_CREATE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1068,7 +1087,7 @@ def create(
     _dispatch(
         SCRIPT_CREATE_COMMAND,
         ScriptCreateParams(
-            path=_normalize_path(path),
+            path=path,
             content=content,
             extends_type=extends_type,
         ),
@@ -1083,13 +1102,14 @@ def get_script(
     path: str = typer.Argument(..., help="The .gd script file to read."),
     json_output: bool = json_option(),
     schema: bool = SCRIPT_GET_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Read a script's source and report its class_name/extends metadata."""
     _dispatch(
         SCRIPT_GET_COMMAND,
-        ScriptGetParams(path=_normalize_path(path)),
+        ScriptGetParams(path=path),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -1100,6 +1120,7 @@ def get_script(
 def list_scripts(
     json_output: bool = json_option(),
     schema: bool = SCRIPT_LIST_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1118,13 +1139,14 @@ def delete_script(
     path: str = typer.Argument(..., help="The .gd script file to delete."),
     json_output: bool = json_option(),
     schema: bool = SCRIPT_DELETE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Delete a script file and report what was removed."""
     _dispatch(
         SCRIPT_DELETE_COMMAND,
-        ScriptDeleteParams(path=_normalize_path(path)),
+        ScriptDeleteParams(path=path),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -1173,6 +1195,7 @@ def set_script(
     ),
     json_output: bool = json_option(),
     schema: bool = SCRIPT_SET_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1181,7 +1204,7 @@ def set_script(
     _dispatch(
         SCRIPT_SET_COMMAND,
         ScriptSetParams(
-            path=_normalize_path(path),
+            path=path,
             mode=mode,
             search=search,
             replace=replace,
@@ -1255,6 +1278,7 @@ def attach_script(
     ),
     json_output: bool = json_option(),
     schema: bool = SCRIPT_ATTACH_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1262,9 +1286,9 @@ def attach_script(
     _dispatch(
         SCRIPT_ATTACH_COMMAND,
         ScriptAttachParams(
-            path=_normalize_path(path),
+            path=path,
             node=node,
-            script=_normalize_path(script),
+            script=script,
         ),
         json_output=json_output,
         godot=godot,
@@ -1277,13 +1301,14 @@ def validate_script(
     path: str = typer.Argument(..., help="The .gd script file to validate."),
     json_output: bool = json_option(),
     schema: bool = SCRIPT_VALIDATE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Syntax/compile-check a .gd script; an invalid script is a successful op."""
     _dispatch(
         SCRIPT_VALIDATE_COMMAND,
-        ScriptValidateParams(path=_normalize_path(path)),
+        ScriptValidateParams(path=path),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -1300,13 +1325,14 @@ def create(
     ),
     json_output: bool = json_option(),
     schema: bool = RESOURCE_CREATE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Create a new .tres resource file of the given resource type."""
     _dispatch(
         RESOURCE_CREATE_COMMAND,
-        ResourceCreateParams(path=_normalize_path(path), type=resource_type),
+        ResourceCreateParams(path=path, type=resource_type),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -1317,6 +1343,7 @@ def create(
 def project_info(
     json_output: bool = json_option(),
     schema: bool = PROJECT_INFO_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1337,6 +1364,7 @@ def project_get(
     ),
     json_output: bool = json_option(),
     schema: bool = PROJECT_GET_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1363,13 +1391,14 @@ def find_references(
     ),
     json_output: bool = json_option(),
     schema: bool = PROJECT_FIND_REFERENCES_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Find every project file that references a given resource path or class_name."""
     _dispatch(
         PROJECT_FIND_REFERENCES_COMMAND,
-        ProjectFindReferencesParams(target=_normalize_path(target)),
+        ProjectFindReferencesParams(target=target),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -1399,6 +1428,7 @@ def create(
     ),
     json_output: bool = json_option(),
     schema: bool = SHADER_CREATE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1410,7 +1440,7 @@ def create(
     _dispatch(
         SHADER_CREATE_COMMAND,
         ShaderCreateParams(
-            path=_normalize_path(path),
+            path=path,
             content=content,
             shader_type=shader_type,
         ),
@@ -1425,13 +1455,14 @@ def get_resource(
     path: str = typer.Argument(..., help="The .tres resource file to read."),
     json_output: bool = json_option(),
     schema: bool = RESOURCE_GET_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Read a .tres resource and report its properties as typed JSON."""
     _dispatch(
         RESOURCE_GET_COMMAND,
-        ResourceGetParams(path=_normalize_path(path)),
+        ResourceGetParams(path=path),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -1454,6 +1485,7 @@ def set_resource(
     ),
     json_output: bool = json_option(),
     schema: bool = RESOURCE_SET_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1461,7 +1493,7 @@ def set_resource(
     _dispatch(
         RESOURCE_SET_COMMAND,
         ResourceSetParams(
-            path=_normalize_path(path), property=property, value=value
+            path=path, property=property, value=value
         ),
         json_output=json_output,
         godot=godot,
@@ -1474,13 +1506,14 @@ def delete_resource(
     path: str = typer.Argument(..., help="The .tres resource file to delete."),
     json_output: bool = json_option(),
     schema: bool = RESOURCE_DELETE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Delete a .tres resource file and report what was removed."""
     _dispatch(
         RESOURCE_DELETE_COMMAND,
-        ResourceDeleteParams(path=_normalize_path(path)),
+        ResourceDeleteParams(path=path),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -1492,13 +1525,14 @@ def get_shader(
     path: str = typer.Argument(..., help="The .gdshader file to read."),
     json_output: bool = json_option(),
     schema: bool = SHADER_GET_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Read a shader's source and report its shader_type metadata."""
     _dispatch(
         SHADER_GET_COMMAND,
-        ShaderGetParams(path=_normalize_path(path)),
+        ShaderGetParams(path=path),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -1511,6 +1545,7 @@ def get_shader(
 def dependencies(
     json_output: bool = json_option(),
     schema: bool = PROJECT_DEPENDENCIES_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1528,6 +1563,7 @@ def dependencies(
 def list_presets(
     json_output: bool = json_option(),
     schema: bool = EXPORT_LIST_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1548,6 +1584,7 @@ def list_presets(
 def find_unused_resources(
     json_output: bool = json_option(),
     schema: bool = PROJECT_FIND_UNUSED_RESOURCES_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1570,6 +1607,7 @@ def get_preset(
     ),
     json_output: bool = json_option(),
     schema: bool = EXPORT_GET_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1608,6 +1646,7 @@ def run_export(
     ),
     json_output: bool = json_option(),
     schema: bool = EXPORT_RUN_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1658,13 +1697,14 @@ def resolve_uid(
     ),
     json_output: bool = json_option(),
     schema: bool = RESOURCE_UID_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Resolve a resource UID to/from its res:// path via the engine's UID cache."""
     _dispatch(
         RESOURCE_UID_COMMAND,
-        ResourceUidParams(target=_normalize_path(target)),
+        ResourceUidParams(target=target),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -1713,6 +1753,7 @@ def set_shader(
     ),
     json_output: bool = json_option(),
     schema: bool = SHADER_SET_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1723,7 +1764,7 @@ def set_shader(
     _dispatch(
         SHADER_SET_COMMAND,
         ShaderSetParams(
-            path=_normalize_path(path),
+            path=path,
             mode=mode,
             search=search,
             replace=replace,
@@ -1752,6 +1793,7 @@ def project_set(
     ),
     json_output: bool = json_option(),
     schema: bool = PROJECT_SET_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1777,13 +1819,14 @@ def project_add_autoload(
     ),
     json_output: bool = json_option(),
     schema: bool = PROJECT_ADD_AUTOLOAD_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Register an autoload singleton (name → script/scene path), then save project.godot."""
     _dispatch(
         PROJECT_ADD_AUTOLOAD_COMMAND,
-        ProjectAddAutoloadParams(name=name, path=_normalize_path(path)),
+        ProjectAddAutoloadParams(name=name, path=path),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -1799,6 +1842,7 @@ def project_remove_autoload(
     ),
     json_output: bool = json_option(),
     schema: bool = PROJECT_REMOVE_AUTOLOAD_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1817,13 +1861,14 @@ def create_theme(
     path: str = typer.Argument(..., help="Target .tres Theme path to write."),
     json_output: bool = json_option(),
     schema: bool = THEME_CREATE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Create a new, loadable .tres Theme resource (no-clobber)."""
     _dispatch(
         THEME_CREATE_COMMAND,
-        ThemeCreateParams(path=_normalize_path(path)),
+        ThemeCreateParams(path=path),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -1834,6 +1879,7 @@ def create_theme(
 def statistics(
     json_output: bool = json_option(),
     schema: bool = PROJECT_STATISTICS_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
@@ -1851,6 +1897,7 @@ def statistics(
 def info(
     json_output: bool = json_option(),
     schema: bool = INFO_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
 ) -> None:
     """Report the Godot engine version info."""

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -33,7 +33,9 @@ from gda.headless import (
     godot_option,
     json_option,
     make_subprocess_runner,
+    params_json_option,
     project_option,
+    register_params_json_dispatch,
     schema_command_class,
     schema_option,
 )
@@ -125,6 +127,7 @@ from gda.models import (
     SurfaceManifest,
     ThemeCreateParams,
     ThemeCreateResult,
+    normalize_path,
 )
 from gda.project import resolve_project_dir
 from gda.runner import GodotRunner
@@ -319,6 +322,37 @@ def _dispatch_meta(
         godot=godot,
         project=None,
     )
+
+
+def _run_params_json(
+    cmd: HeadlessCommand[M], params: BaseModel, ctx: typer.Context
+) -> None:
+    """Dispatch a ``--params-json`` invocation through the shared CLI tail (ADR-0015).
+
+    Registered with :func:`gda.headless.register_params_json_dispatch`. The model
+    is already built from the JSON object by the command class; this only routes
+    it through the *same* project resolution + runner seam the argv path uses, so
+    the two input paths are indistinguishable downstream. The global
+    ``--json`` / ``--godot`` / ``--project`` options parsed alongside
+    ``--params-json`` are honored; a meta command (no ``--project`` option)
+    dispatches projectless, mirroring :func:`_dispatch_meta`.
+    """
+    options = ctx.params
+    json_output = bool(options.get("json_output", False))
+    godot = options.get("godot")
+    if "project" in options:
+        _dispatch(
+            cmd,
+            params,
+            json_output=json_output,
+            godot=godot,
+            project=options.get("project"),
+        )
+    else:
+        _dispatch_meta(cmd, params, json_output=json_output, godot=godot)
+
+
+register_params_json_dispatch(_run_params_json)
 
 
 INFO_COMMAND: HeadlessCommand[EngineVersion] = HeadlessCommand(
@@ -585,24 +619,10 @@ PROJECT_STATISTICS_COMMAND: HeadlessCommand[ProjectStatisticsResult] = HeadlessC
 )
 
 
-def _normalize_path(path: str) -> str:
-    """Normalize a path argument at the CLI layer (issue #32).
-
-    Engine-resolved virtual paths (``res://``, ``user://``, ``uid://``) pass
-    through untouched — the engine resolves them against the project. A
-    filesystem path gets ``~`` expanded so a literal ``~`` works without a shell.
-    """
-    if "://" in path:
-        return path
-    return str(Path(path).expanduser())
-
-
-def _derive_scene_root_name(path: str) -> str:
-    """Derive the default scene root name from the target file name."""
-    filename = path.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
-    if "." in filename:
-        return filename.rsplit(".", 1)[0]
-    return filename
+# Path normalization now lives in the models (ADR-0015), the single home shared
+# by the argv and ``--params-json`` paths. Commands not yet migrated to model-side
+# normalization still call this alias in their bodies.
+_normalize_path = normalize_path
 
 
 @scene_app.command(cls=SCENE_CREATE_COMMAND.command_class())
@@ -623,20 +643,16 @@ def create(
     ),
     json_output: bool = json_option(),
     schema: bool = SCENE_CREATE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
     """Create a new .tscn scene file with the given root node type."""
-    normalized_path = _normalize_path(path)
+    # Normalization + root-name derivation live in SceneCreateParams (ADR-0015),
+    # so this body is a thin argv→model adapter and the --params-json path agrees.
     _dispatch(
         SCENE_CREATE_COMMAND,
-        SceneCreateParams(
-            path=normalized_path,
-            root_type=root_type,
-            root_name=root_name
-            if root_name is not None
-            else _derive_scene_root_name(normalized_path),
-        ),
+        SceneCreateParams(path=path, root_type=root_type, root_name=root_name),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -340,6 +340,25 @@ def _run_params_json(
     options = ctx.params
     json_output = bool(options.get("json_output", False))
     godot = options.get("godot")
+    if cmd is EXPORT_RUN_COMMAND:
+        # export run is the native-export recipe (#187), not the sentinel
+        # pipeline, so it cannot go through cmd.emit. Mirror its body so
+        # --params-json drives the SAME run_export_operation path as the argv
+        # form. params.output is already normalized (ExportRunParams.output is a
+        # NormalizedPath), so no extra normalization is needed here.
+        outcome = run_export_operation(
+            preset=params.preset,
+            mode=params.mode,
+            output_override=params.output,
+            godot=godot,
+            project=resolve_project_dir(options.get("project")),
+            make_runner=_make_runner,
+            make_export_runner=_make_export_runner,
+        )
+        if isinstance(outcome, Failure):
+            emit_failure(outcome)
+        emit_result(outcome, json_output)
+        return
     if "project" in options:
         _dispatch(
             cmd,

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -128,6 +128,7 @@ from gda.models import (
     ThemeCreateParams,
     ThemeCreateResult,
     normalize_path,
+    resolve_set_mode,
 )
 from gda.project import resolve_project_dir
 from gda.runner import GodotRunner
@@ -795,7 +796,7 @@ def add(
             path=path,
             parent=parent,
             type=node_type,
-            name=name if name is not None else node_type,
+            name=name,
         ),
         json_output=json_output,
         godot=godot,
@@ -1244,41 +1245,18 @@ def _resolve_set_mode(
     end_line: Optional[int],
     content: Optional[str],
 ) -> ScriptSetMode:
-    """Resolve ``script set``'s edit mode, the single source of truth (issue #133).
+    """Resolve a set command's edit mode for the argv path (issue #133).
 
-    This is the one place the edit mode is decided: it enforces that exactly one
-    of the three mutually-exclusive modes is supplied (a violation is a usage
-    error, exit 2, like ``script create``'s mutual exclusion) and returns the
-    resolved :class:`ScriptSetMode`. The CLI stamps it onto the op params so the
-    operation dispatches on this explicit discriminator instead of re-inferring
-    the mode from which params are present — the two can no longer drift.
+    The rule itself lives in :func:`gda.models.resolve_set_mode` — the single
+    source shared with ``ScriptSetParams`` / ``ShaderSetParams`` (ADR-0015). This
+    thin wrapper translates its ``ValueError`` into a Click usage error (exit 2)
+    so the argv path keeps its usage-error ergonomics, while ``--params-json``
+    surfaces the same rule as a structured ``invalid_params`` via the model.
     """
-    has_search = search is not None or replace is not None
-    has_line_range = start_line is not None or end_line is not None
-
-    if has_search:
-        if search is None or replace is None:
-            raise typer.BadParameter("--search and --replace must be used together.")
-        if content is not None or has_line_range:
-            raise typer.BadParameter(
-                "--search/--replace cannot be combined with --content, "
-                "--start-line, or --end-line."
-            )
-        return ScriptSetMode.SEARCH_REPLACE
-
-    if has_line_range:
-        if content is None:
-            raise typer.BadParameter("--start-line/--end-line require --content.")
-        if start_line is None:
-            raise typer.BadParameter("--end-line requires --start-line.")
-        return ScriptSetMode.LINE_RANGE
-
-    if content is None:
-        raise typer.BadParameter(
-            "script set needs an edit: --search/--replace, --start-line "
-            "(+ --content), or --content (full overwrite)."
-        )
-    return ScriptSetMode.FULL
+    try:
+        return resolve_set_mode(search, replace, start_line, end_line, content)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 @script_app.command(name="attach", cls=SCRIPT_ATTACH_COMMAND.command_class())

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -90,7 +90,9 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
-        "The operation dispatcher was invoked without the required operation name.",
+        "The command was invoked incorrectly: the operation dispatcher received no "
+        "operation name, or the CLI received --params-json together with the "
+        "individual arguments (ADR-0015).",
     ),
     ErrorCodeSpec(
         "unknown_operation",
@@ -104,7 +106,9 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
-        "The operation dispatcher received params that are not a JSON object.",
+        "Params do not match the command's contract: the operation dispatcher "
+        "received non-object params, or a --params-json object was malformed or "
+        "schema-invalid (ADR-0015).",
     ),
     ErrorCodeSpec(
         "invalid_path",

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -142,6 +142,37 @@ def unresolvable_binary_failure(reason: str) -> Failure:
     )
 
 
+def conflicting_params_input_failure() -> Failure:
+    """``--params-json`` was combined with the individual arguments (ADR-0015).
+
+    A CLI-side usage error reported *before* any engine launch, but the same
+    failure mode the operation dispatcher reports as ``usage_error`` — the
+    command was invoked incorrectly — so it reuses that code rather than minting
+    a new one (ADR-0002: reuse the code; discriminate via the message).
+    """
+    return _failure(
+        "usage_error",
+        "--params-json is mutually exclusive with the individual arguments; "
+        "pass the params as one JSON object OR as individual arguments, not both.",
+        "",
+    )
+
+
+def invalid_params_json_failure(detail: str) -> Failure:
+    """``--params-json`` was not a valid params object for the command (ADR-0015).
+
+    Malformed JSON, or a well-formed object that fails the command's input
+    schema. It is the same failure mode the operation dispatcher reports as
+    ``invalid_params`` — params that do not match the command's contract — just
+    detected CLI-side, so it reuses that code (ADR-0002).
+    """
+    return _failure(
+        "invalid_params",
+        f"--params-json is not a valid params object: {detail}",
+        "",
+    )
+
+
 def classify_launch_or_crash(raw: RunResult, binary: Path) -> Failure | None:
     """The env/crash classifier prefix shared by both headless channels (#185).
 

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -14,11 +14,17 @@ from pathlib import Path
 from typing import Generic, NoReturn, Optional, TypeVar
 
 import typer
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from typer.core import TyperCommand
 
 from gda.binary import resolve_godot_binary
-from gda.errors import Failure, classify_run, unresolvable_binary_failure
+from gda.errors import (
+    Failure,
+    classify_run,
+    conflicting_params_input_failure,
+    invalid_params_json_failure,
+    unresolvable_binary_failure,
+)
 from gda.models import CommandSchema, GdaErrorEnvelope
 from gda.render import render
 from gda.runner import GodotRunner, RunResult, SubprocessGodotRunner
@@ -71,8 +77,59 @@ def schema_option() -> bool:
     )
 
 
+def params_json_option() -> Optional[str]:
+    """A ``--params-json`` option: supply the command's params as one JSON object.
+
+    The value is a JSON object of the command's params, or ``-`` to read the
+    object from stdin (ADR-0015). It is mutually exclusive with the individual
+    arguments; the command class (:func:`schema_command_class`) intercepts it,
+    builds the input model from the JSON, and dispatches through the same
+    execution tail the argv path uses, so ``gda-mcp`` can forward an MCP tool's
+    input object verbatim without reconstructing argv.
+    """
+    return typer.Option(
+        None,
+        "--params-json",
+        help="Supply params as one JSON object (or '-' to read it from stdin); "
+        "mutually exclusive with the individual arguments.",
+    )
+
+
+# A hook registered by gda.cli that runs a command from a params model built off
+# ``--params-json``, through the same project-resolution + runner seam the argv
+# path uses. Held as a hook so this module need not import gda.cli (ADR-0015).
+ParamsJsonDispatch = Callable[["HeadlessCommand", BaseModel, "typer.Context"], None]
+_params_json_dispatch: Optional[ParamsJsonDispatch] = None
+
+
+def register_params_json_dispatch(dispatch: ParamsJsonDispatch) -> None:
+    """Register the CLI-layer dispatcher used by the ``--params-json`` path."""
+    global _params_json_dispatch
+    _params_json_dispatch = dispatch
+
+
+# The cross-cutting options every command shares; they compose with
+# ``--params-json`` rather than counting as the individual operation arguments it
+# is mutually exclusive with (ADR-0015).
+_GLOBAL_OPTION_NAMES = frozenset(
+    {"json_output", "schema", "params_json", "godot", "project"}
+)
+
+
+def _from_command_line(ctx: typer.Context, name: str) -> bool:
+    """True when ``name`` was supplied on the command line, not left at default.
+
+    Compares the Click ``ParameterSource`` by member name so this module need
+    not import Click (a transitive dependency through Typer).
+    """
+    source = ctx.get_parameter_source(name)
+    return source is not None and source.name == "COMMANDLINE"
+
+
 def schema_command_class(
-    input_model: type[BaseModel], output_model: type[BaseModel]
+    input_model: type[BaseModel],
+    output_model: type[BaseModel],
+    command: "Optional[HeadlessCommand]" = None,
 ) -> type[TyperCommand]:
     """A Typer command that owns ``--schema`` handling (ADR-0004).
 
@@ -90,28 +147,70 @@ def schema_command_class(
         # live Typer tree, instead of re-deriving the contract a second way
         # (ADR-0012). The closure above keeps them for `--schema`; these make
         # the same single source readable off the registered command object.
+        # ``gda_command`` carries the full HeadlessCommand so the ``--params-json``
+        # path can dispatch the operation (ADR-0015); None for the bare ``gda
+        # schema`` meta command, which has no operation to run.
         gda_input_model = input_model
         gda_output_model = output_model
+        gda_command = command
 
-        def parse_args(self, ctx: typer.Context, args: list[str]) -> list[str]:
-            if "--schema" not in args:
-                return super().parse_args(ctx, args)
-
-            # Relax required args so a bare ``--schema`` probe succeeds, while
-            # Click still rejects unknown options / extra positional args and an
-            # eager ``--help`` still wins. Restore afterwards: Typer reuses the
-            # command object across invocations.
+        def _parse_relaxed(
+            self, ctx: typer.Context, args: list[str]
+        ) -> list[str]:
+            # Parse with required args relaxed, so a probe that omits the
+            # individual operation args still succeeds, while Click still rejects
+            # unknown options / extra positionals and an eager ``--help`` still
+            # wins. Restore afterwards: Typer reuses the command object across
+            # invocations. Shared by the ``--schema`` and ``--params-json`` paths.
             relaxed = [(param, param.required) for param in self.params]
             try:
                 for param, _ in relaxed:
                     param.required = False
-                super().parse_args(ctx, list(args))
+                return super().parse_args(ctx, list(args))
             finally:
                 for param, required in relaxed:
                     param.required = required
 
-            typer.echo(CommandSchema.of(input_model, output_model).model_dump_json())
-            raise typer.Exit()
+        def parse_args(self, ctx: typer.Context, args: list[str]) -> list[str]:
+            if "--schema" in args:
+                self._parse_relaxed(ctx, args)
+                typer.echo(
+                    CommandSchema.of(input_model, output_model).model_dump_json()
+                )
+                raise typer.Exit()
+            if command is not None and "--params-json" in args:
+                # The individual operation args are absent — supplied by the JSON
+                # object instead; ``invoke`` builds the model and dispatches.
+                return self._parse_relaxed(ctx, args)
+            return super().parse_args(ctx, args)
+
+        def invoke(self, ctx: typer.Context):
+            if command is not None and ctx.params.get("params_json") is not None:
+                # --params-json supplies ALL operation params, so no individual
+                # operation argument may also be given on the command line; the
+                # global flags (--json/--godot/--project/--schema) still compose.
+                if any(
+                    name not in _GLOBAL_OPTION_NAMES
+                    and _from_command_line(ctx, name)
+                    for name in ctx.params
+                ):
+                    emit_failure(conflicting_params_input_failure())
+                raw = ctx.params["params_json"]
+                # ``-`` reads the object from stdin so large payloads avoid OS
+                # argv length limits and process-listing leakage (ADR-0015).
+                text = sys.stdin.read() if raw == "-" else raw
+                try:
+                    model = command.input_model.model_validate_json(text)
+                except ValidationError as exc:
+                    emit_failure(invalid_params_json_failure(str(exc)))
+                if _params_json_dispatch is None:  # pragma: no cover - misconfig
+                    raise RuntimeError(
+                        "no --params-json dispatcher registered; gda.cli must call "
+                        "register_params_json_dispatch()"
+                    )
+                _params_json_dispatch(command, model, ctx)
+                return None
+            return super().invoke(ctx)
 
     return _SchemaCommand
 
@@ -167,8 +266,8 @@ class HeadlessCommand(Generic[M]):
         return schema_option()
 
     def command_class(self) -> type[TyperCommand]:
-        """Return the Typer command class that owns this command's ``--schema``."""
-        return schema_command_class(self.input_model, self.output_model)
+        """Return the Typer command class owning ``--schema`` and ``--params-json``."""
+        return schema_command_class(self.input_model, self.output_model, command=self)
 
     def execute(
         self,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -7,9 +7,10 @@ hand-maintaining the contract twice.
 """
 
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class ErrorCategory(str, Enum):
@@ -167,14 +168,39 @@ class SurfaceManifest(BaseModel):
     commands: list[CommandManifestEntry]
 
 
+def normalize_path(path: str) -> str:
+    """Normalize a path argument (issue #32; ADR-0015 moves it model-side).
+
+    Engine-resolved virtual paths (``res://``, ``user://``, ``uid://``) pass
+    through untouched — the engine resolves them against the project. A
+    filesystem path gets ``~`` expanded so a literal ``~`` works without a shell.
+
+    Lives here, not at the CLI layer, so the argv path and the ``--params-json``
+    path normalize identically (ADR-0015): the model is the single home of
+    normalization, applied wherever the model is constructed.
+    """
+    if "://" in path:
+        return path
+    return str(Path(path).expanduser())
+
+
+def derive_scene_root_name(path: str) -> str:
+    """Derive the default scene root name from the target file name."""
+    filename = path.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
+    if "." in filename:
+        return filename.rsplit(".", 1)[0]
+    return filename
+
+
 class SceneCreateParams(BaseModel):
     """The operation params of ``gda scene create`` (issue #18).
 
     ``path`` is the target ``.tscn`` file; ``root_type`` the Godot node class
     of the new scene's root (e.g. ``Node2D``). ``root_name`` is explicit so the
-    operation never silently derives a name Godot later sanitizes; when the CLI
-    caller omits ``--root-name``, it derives this from the target filename
-    without the final extension.
+    operation never silently derives a name Godot later sanitizes; when omitted,
+    it is derived from the target filename without the final extension. Path
+    normalization and that derivation live in the model (ADR-0015), so the argv
+    and ``--params-json`` paths produce identical params.
     """
 
     path: str = Field(description="Target .tscn path to write.")
@@ -184,11 +210,22 @@ class SceneCreateParams(BaseModel):
     root_name: str | None = Field(
         default=None,
         description=(
-            "Root node name to write. If omitted by the CLI, it is derived from "
-            "the target filename without its final extension. Must be non-empty "
-            "and must not contain '.', ':', '@', '/', '\"', or '%'."
+            "Root node name to write. If omitted, it is derived from the target "
+            "filename without its final extension. Must be non-empty and must not "
+            "contain '.', ':', '@', '/', '\"', or '%'."
         ),
     )
+
+    @field_validator("path")
+    @classmethod
+    def _normalize(cls, value: str) -> str:
+        return normalize_path(value)
+
+    @model_validator(mode="after")
+    def _default_root_name(self) -> "SceneCreateParams":
+        if self.root_name is None:
+            self.root_name = derive_scene_root_name(self.path)
+        return self
 
 
 class SceneCreateResult(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -11,8 +11,8 @@ from pathlib import Path
 from typing import Annotated, Any
 
 from pydantic import (
+    AfterValidator,
     BaseModel,
-    BeforeValidator,
     ConfigDict,
     Field,
     model_validator,
@@ -194,7 +194,11 @@ def normalize_path(path: str) -> str:
 # ``normalize_path`` whenever the model is constructed (ADR-0015). Annotating a
 # field with this is the single normalization mechanism shared by the argv and
 # ``--params-json`` paths — no per-model ``@field_validator`` to maintain.
-NormalizedPath = Annotated[str, BeforeValidator(normalize_path)]
+# ``AfterValidator`` (not Before): the value is validated as a ``str`` FIRST, so a
+# wrong-typed ``--params-json`` value (e.g. ``{"path": 123}``) raises a
+# ``ValidationError`` (→ structured ``invalid_params``) instead of ``normalize_path``
+# hitting a ``TypeError`` on a non-string.
+NormalizedPath = Annotated[str, AfterValidator(normalize_path)]
 
 
 def derive_scene_root_name(path: str) -> str:
@@ -453,11 +457,18 @@ class NodeAddParams(BaseModel):
     name: str | None = Field(
         default=None,
         description=(
-            "Name for the new node. If omitted by the CLI, the type name is "
-            "used. Must be non-empty and must not contain '.', ':', '@', '/', "
-            "'\"', or '%'."
+            "Name for the new node. If omitted, the type name is used. Must be "
+            "non-empty and must not contain '.', ':', '@', '/', '\"', or '%'."
         ),
     )
+
+    @model_validator(mode="after")
+    def _default_name(self) -> "NodeAddParams":
+        # Derive the default node name from the type model-side (ADR-0015), so the
+        # argv and --params-json paths agree instead of the CLI deriving it.
+        if self.name is None:
+            self.name = self.type
+        return self
 
 
 class NodeAddResult(BaseModel):
@@ -892,6 +903,15 @@ class ScriptCreateParams(BaseModel):
         ),
     )
 
+    @model_validator(mode="after")
+    def _content_xor_extends(self) -> "ScriptCreateParams":
+        # Verbatim content is not templated, so a base class has nowhere to go:
+        # the two are mutually exclusive. Enforced model-side (ADR-0015) so the
+        # --params-json path rejects the conflict too, not just argv.
+        if self.content is not None and self.extends_type is not None:
+            raise ValueError("'content' and 'extends_type' are mutually exclusive.")
+        return self
+
 
 class ScriptCreateResult(BaseModel):
     """The result of ``gda script create``: what was written where (issue #110).
@@ -1046,6 +1066,50 @@ class ScriptSetMode(str, Enum):
     FULL = "full"
 
 
+def resolve_set_mode(
+    search: str | None,
+    replace: str | None,
+    start_line: int | None,
+    end_line: int | None,
+    content: str | None,
+) -> ScriptSetMode:
+    """Resolve a script/shader-set edit mode from the supplied params (issue #133).
+
+    The single home of the edit-mode rule, shared by ``script set`` and ``shader
+    set`` and by BOTH input paths (ADR-0015): exactly one of the three
+    mutually-exclusive modes must be supplied. Raises ``ValueError`` on a
+    violation — the CLI wrapper translates it to a usage error (exit 2) for argv,
+    while the params models surface it as the structured ``invalid_params`` for
+    ``--params-json``.
+    """
+    has_search = search is not None or replace is not None
+    has_line_range = start_line is not None or end_line is not None
+
+    if has_search:
+        if search is None or replace is None:
+            raise ValueError("'search' and 'replace' must be used together.")
+        if content is not None or has_line_range:
+            raise ValueError(
+                "'search'/'replace' cannot be combined with 'content', "
+                "'start_line', or 'end_line'."
+            )
+        return ScriptSetMode.SEARCH_REPLACE
+
+    if has_line_range:
+        if content is None:
+            raise ValueError("'start_line'/'end_line' require 'content'.")
+        if start_line is None:
+            raise ValueError("'end_line' requires 'start_line'.")
+        return ScriptSetMode.LINE_RANGE
+
+    if content is None:
+        raise ValueError(
+            "a set command needs an edit: 'search'/'replace', 'start_line' "
+            "(+ 'content'), or 'content' (full overwrite)."
+        )
+    return ScriptSetMode.FULL
+
+
 class ScriptSetParams(BaseModel):
     """The operation params of ``gda script set`` (issue #118).
 
@@ -1068,11 +1132,12 @@ class ScriptSetParams(BaseModel):
     """
 
     path: NormalizedPath = Field(description="The .gd script file to edit.")
-    mode: ScriptSetMode = Field(
+    mode: ScriptSetMode | None = Field(
+        default=None,
         description=(
             "The resolved edit mode, the single source of truth the operation "
-            "dispatches on (issue #133). Set by the CLI from the supplied flags, "
-            "not inferred by the operation from param presence."
+            "dispatches on (issue #133). Derived model-side from the supplied "
+            "edit params (ADR-0015); a value passed in is ignored."
         ),
     )
     search: str | None = Field(
@@ -1115,6 +1180,16 @@ class ScriptSetParams(BaseModel):
             "entire file (full mode)."
         ),
     )
+
+    @model_validator(mode="after")
+    def _resolve_mode(self) -> "ScriptSetParams":
+        # Derive the edit mode from the supplied params (ADR-0015), so the argv
+        # and --params-json paths agree and a JSON caller cannot pass a mode
+        # inconsistent with the other edit fields.
+        self.mode = resolve_set_mode(
+            self.search, self.replace, self.start_line, self.end_line, self.content
+        )
+        return self
 
 
 class ScriptSetResult(BaseModel):
@@ -1577,6 +1652,15 @@ class ShaderCreateParams(BaseModel):
         ),
     )
 
+    @model_validator(mode="after")
+    def _content_xor_shader_type(self) -> "ShaderCreateParams":
+        # Same rule as script create: verbatim content is not templated, so a
+        # shader type has nowhere to go. Enforced model-side (ADR-0015) so the
+        # --params-json path rejects the conflict, not just argv.
+        if self.content is not None and self.shader_type is not None:
+            raise ValueError("'content' and 'shader_type' are mutually exclusive.")
+        return self
+
 
 class ShaderCreateResult(BaseModel):
     """The result of ``gda shader create``: what was written where (issue #115).
@@ -1775,11 +1859,12 @@ class ShaderSetParams(BaseModel):
     """
 
     path: NormalizedPath = Field(description="The .gdshader file to edit.")
-    mode: ScriptSetMode = Field(
+    mode: ScriptSetMode | None = Field(
+        default=None,
         description=(
             "The resolved edit mode, the single source of truth the operation "
-            "dispatches on (issue #133). Set by the CLI from the supplied flags, "
-            "not inferred by the operation from param presence. The same edit "
+            "dispatches on (issue #133). Derived model-side from the supplied "
+            "edit params (ADR-0015); a value passed in is ignored. The same edit "
             "modes as script set (issue #118), reused here."
         ),
     )
@@ -1823,6 +1908,16 @@ class ShaderSetParams(BaseModel):
             "entire file (full mode)."
         ),
     )
+
+    @model_validator(mode="after")
+    def _resolve_mode(self) -> "ShaderSetParams":
+        # Derive the edit mode from the supplied params (ADR-0015), so the argv
+        # and --params-json paths agree and a JSON caller cannot pass a mode
+        # inconsistent with the other edit fields.
+        self.mode = resolve_set_mode(
+            self.search, self.replace, self.start_line, self.end_line, self.content
+        )
+        return self
 
 
 class ShaderSetResult(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -8,9 +8,15 @@ hand-maintaining the contract twice.
 
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    model_validator,
+)
 
 
 class ErrorCategory(str, Enum):
@@ -184,6 +190,13 @@ def normalize_path(path: str) -> str:
     return str(Path(path).expanduser())
 
 
+# The one reusable path-field type: a ``str`` whose value is run through
+# ``normalize_path`` whenever the model is constructed (ADR-0015). Annotating a
+# field with this is the single normalization mechanism shared by the argv and
+# ``--params-json`` paths — no per-model ``@field_validator`` to maintain.
+NormalizedPath = Annotated[str, BeforeValidator(normalize_path)]
+
+
 def derive_scene_root_name(path: str) -> str:
     """Derive the default scene root name from the target file name."""
     filename = path.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
@@ -203,7 +216,7 @@ class SceneCreateParams(BaseModel):
     and ``--params-json`` paths produce identical params.
     """
 
-    path: str = Field(description="Target .tscn path to write.")
+    path: NormalizedPath = Field(description="Target .tscn path to write.")
     root_type: str = Field(
         description="Godot node class of the new scene's root (e.g. Node2D)."
     )
@@ -215,11 +228,6 @@ class SceneCreateParams(BaseModel):
             "contain '.', ':', '@', '/', '\"', or '%'."
         ),
     )
-
-    @field_validator("path")
-    @classmethod
-    def _normalize(cls, value: str) -> str:
-        return normalize_path(value)
 
     @model_validator(mode="after")
     def _default_root_name(self) -> "SceneCreateParams":
@@ -262,7 +270,7 @@ class SceneNode(BaseModel):
 class SceneGetParams(BaseModel):
     """The operation params of ``gda scene get``: the ``.tscn`` file to read."""
 
-    path: str = Field(description="The .tscn scene file to read.")
+    path: NormalizedPath = Field(description="The .tscn scene file to read.")
 
 
 class SceneGetResult(BaseModel):
@@ -340,7 +348,7 @@ class ExportingNode(BaseModel):
 class SceneGetExportsParams(BaseModel):
     """The operation params of ``gda scene get-exports``: the ``.tscn`` file to read (issue #58)."""
 
-    path: str = Field(description="The .tscn scene file to read.")
+    path: NormalizedPath = Field(description="The .tscn scene file to read.")
 
 
 class SceneGetExportsResult(BaseModel):
@@ -401,7 +409,7 @@ class SceneListResult(BaseModel):
 class SceneDeleteParams(BaseModel):
     """The operation params of ``gda scene delete``: the ``.tscn`` file to remove."""
 
-    path: str = Field(description="The .tscn scene file to delete.")
+    path: NormalizedPath = Field(description="The .tscn scene file to delete.")
 
 
 class SceneDeleteResult(BaseModel):
@@ -428,7 +436,7 @@ class NodeAddParams(BaseModel):
     the type name.
     """
 
-    path: str = Field(description="The .tscn scene file to mutate.")
+    path: NormalizedPath = Field(description="The .tscn scene file to mutate.")
     parent: str = Field(
         default=".",
         description=(
@@ -511,7 +519,7 @@ class ListedNode(SceneNode):
 class NodeListParams(BaseModel):
     """The operation params of ``gda node list``: the ``.tscn`` file to read."""
 
-    path: str = Field(description="The .tscn scene file to read.")
+    path: NormalizedPath = Field(description="The .tscn scene file to read.")
 
 
 class NodeListResult(BaseModel):
@@ -550,7 +558,7 @@ class NodeGetParams(BaseModel):
     its node path relative to the scene root ('.' is the root itself).
     """
 
-    path: str = Field(description="The .tscn scene file to read.")
+    path: NormalizedPath = Field(description="The .tscn scene file to read.")
     node: str = Field(
         description=(
             "Node path relative to the scene root: '.' addresses the root "
@@ -586,7 +594,7 @@ class NodeSetParams(BaseModel):
     Godot type by the operation before the scene is re-packed and saved.
     """
 
-    path: str = Field(description="The .tscn scene file to mutate.")
+    path: NormalizedPath = Field(description="The .tscn scene file to mutate.")
     node: str = Field(
         description=(
             "Node path relative to the scene root: '.' addresses the root "
@@ -634,7 +642,7 @@ class NodeRemoveParams(BaseModel):
     emptying the scene.
     """
 
-    path: str = Field(description="The .tscn scene file to mutate.")
+    path: NormalizedPath = Field(description="The .tscn scene file to mutate.")
     node: str = Field(
         description=(
             "Node path relative to the scene root: 'Player/Arm' a nested node. "
@@ -669,7 +677,7 @@ class NodeDuplicateParams(BaseModel):
     copy, so duplicating it is refused.
     """
 
-    path: str = Field(description="The .tscn scene file to mutate.")
+    path: NormalizedPath = Field(description="The .tscn scene file to mutate.")
     node: str = Field(
         description=(
             "Node path relative to the scene root: 'Player/Arm' a nested node. "
@@ -712,7 +720,7 @@ class NodeMoveParams(BaseModel):
     the scene. The scene root ('.') has no parent to be reparented out of.
     """
 
-    path: str = Field(description="The .tscn scene file to mutate.")
+    path: NormalizedPath = Field(description="The .tscn scene file to mutate.")
     node: str = Field(
         description=(
             "Node path of the node to reparent, relative to the scene root: "
@@ -795,7 +803,7 @@ class NodeConnectSignalParams(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
 
-    path: str = Field(description="The .tscn scene file to mutate.")
+    path: NormalizedPath = Field(description="The .tscn scene file to mutate.")
     from_node: str = _FROM_FIELD
     signal: str = _SIGNAL_FIELD
     to: str = _TO_FIELD
@@ -831,7 +839,7 @@ class NodeDisconnectSignalParams(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
 
-    path: str = Field(description="The .tscn scene file to mutate.")
+    path: NormalizedPath = Field(description="The .tscn scene file to mutate.")
     from_node: str = _FROM_FIELD
     signal: str = _SIGNAL_FIELD
     to: str = _TO_FIELD
@@ -866,7 +874,7 @@ class ScriptCreateParams(BaseModel):
     content is not templated, so a base class would have nowhere to go.
     """
 
-    path: str = Field(description="Target .gd script path to write.")
+    path: NormalizedPath = Field(description="Target .gd script path to write.")
     content: str | None = Field(
         default=None,
         description=(
@@ -925,7 +933,7 @@ class ScriptGetParams(BaseModel):
     reading it can never run project code (issue #30).
     """
 
-    path: str = Field(description="The .gd script file to read.")
+    path: NormalizedPath = Field(description="The .gd script file to read.")
 
 
 class ScriptGetResult(BaseModel):
@@ -996,7 +1004,7 @@ class ScriptListResult(BaseModel):
 class ScriptDeleteParams(BaseModel):
     """The operation params of ``gda script delete``: the ``.gd`` file to remove."""
 
-    path: str = Field(description="The .gd script file to delete.")
+    path: NormalizedPath = Field(description="The .gd script file to delete.")
 
 
 class ScriptDeleteResult(BaseModel):
@@ -1059,7 +1067,7 @@ class ScriptSetParams(BaseModel):
       overwritten.
     """
 
-    path: str = Field(description="The .gd script file to edit.")
+    path: NormalizedPath = Field(description="The .gd script file to edit.")
     mode: ScriptSetMode = Field(
         description=(
             "The resolved edit mode, the single source of truth the operation "
@@ -1151,7 +1159,7 @@ class ScriptAttachParams(BaseModel):
     success — check a script with ``script validate`` first.
     """
 
-    path: str = Field(
+    path: NormalizedPath = Field(
         description="The .tscn scene file to mutate."
     )
     node: str = Field(
@@ -1160,7 +1168,7 @@ class ScriptAttachParams(BaseModel):
             "itself, 'Player/Arm' a nested node."
         )
     )
-    script: str = Field(
+    script: NormalizedPath = Field(
         description="The .gd script file to attach to the node."
     )
 
@@ -1238,7 +1246,7 @@ class ScriptValidateParams(BaseModel):
     project resource and so needs project context to compile.
     """
 
-    path: str = Field(description="The .gd script file to validate.")
+    path: NormalizedPath = Field(description="The .gd script file to validate.")
 
 
 class ScriptValidateResult(BaseModel):
@@ -1282,7 +1290,7 @@ class ResourceCreateParams(BaseModel):
     ``scene create``'s ``root_type`` check against ``Node``.
     """
 
-    path: str = Field(description="Target .tres resource path to write.")
+    path: NormalizedPath = Field(description="Target .tres resource path to write.")
     type: str = Field(
         description=(
             "The Godot resource class to create (e.g. Gradient, Curve). Must be "
@@ -1308,7 +1316,7 @@ class ResourceUidParams(BaseModel):
     queries the cache, not a file's contents.
     """
 
-    target: str = Field(
+    target: NormalizedPath = Field(
         description=(
             "The resolution target: a 'uid://…' value to resolve to its res:// "
             "path, or a 'res://…' / filesystem path to resolve to its 'uid://…'. "
@@ -1339,7 +1347,7 @@ class ProjectFindReferencesParams(BaseModel):
     ``--project`` op (issue #61).
     """
 
-    target: str = Field(
+    target: NormalizedPath = Field(
         description=(
             "What to find references to: a resource's res:// path (scene, script, "
             "image, .tres, …) or a script class_name."
@@ -1482,7 +1490,7 @@ class ExportRunParams(BaseModel):
         default=ExportRunMode.RELEASE,
         description="The export flavor to run (release/debug/pack); default release.",
     )
-    output: str | None = Field(
+    output: NormalizedPath | None = Field(
         default=None,
         description="Override the preset's configured export_path; write the artifact here instead.",
     )
@@ -1550,7 +1558,7 @@ class ShaderCreateParams(BaseModel):
     source; when omitted, the operation writes a minimal ``shader_type`` template.
     """
 
-    path: str = Field(description="Target .gdshader path to write.")
+    path: NormalizedPath = Field(description="Target .gdshader path to write.")
     content: str | None = Field(
         default=None,
         description=(
@@ -1604,7 +1612,7 @@ class ResourceGetParams(BaseModel):
     runs on load.
     """
 
-    path: str = Field(description="The .tres resource file to read.")
+    path: NormalizedPath = Field(description="The .tres resource file to read.")
 
 
 class ShaderGetParams(BaseModel):
@@ -1618,7 +1626,7 @@ class ShaderGetParams(BaseModel):
     (ADR-0009).
     """
 
-    path: str = Field(description="The .gdshader file to read.")
+    path: NormalizedPath = Field(description="The .gdshader file to read.")
 
 
 class ResourceGetResult(BaseModel):
@@ -1650,7 +1658,7 @@ class ResourceSetParams(BaseModel):
     round-trip via ``resource get``.
     """
 
-    path: str = Field(description="The .tres resource file to mutate.")
+    path: NormalizedPath = Field(description="The .tres resource file to mutate.")
     property: str = Field(
         description="The resource property to set (e.g. interpolation_mode)."
     )
@@ -1685,7 +1693,7 @@ class ResourceSetResult(BaseModel):
 class ResourceDeleteParams(BaseModel):
     """The operation params of ``gda resource delete``: the ``.tres`` file to remove (issue #120)."""
 
-    path: str = Field(description="The .tres resource file to delete.")
+    path: NormalizedPath = Field(description="The .tres resource file to delete.")
 
 
 class ResourceDeleteResult(BaseModel):
@@ -1766,7 +1774,7 @@ class ShaderSetParams(BaseModel):
       overwritten.
     """
 
-    path: str = Field(description="The .gdshader file to edit.")
+    path: NormalizedPath = Field(description="The .gdshader file to edit.")
     mode: ScriptSetMode = Field(
         description=(
             "The resolved edit mode, the single source of truth the operation "
@@ -1847,7 +1855,7 @@ class ThemeCreateParams(BaseModel):
     a resource-producing op goes through the engine.
     """
 
-    path: str = Field(description="Target .tres Theme path to write.")
+    path: NormalizedPath = Field(description="Target .tres Theme path to write.")
 
 
 class ThemeCreateResult(BaseModel):
@@ -2195,7 +2203,7 @@ class ProjectAddAutoloadParams(BaseModel):
             "and the key under the project's autoload/ section."
         )
     )
-    path: str = Field(
+    path: NormalizedPath = Field(
         description=(
             "The res:// path to the script or scene to autoload, e.g. "
             "res://global.gd."

--- a/tests/test_e2e_params_json.py
+++ b/tests/test_e2e_params_json.py
@@ -1,0 +1,78 @@
+"""S1 (e2e): gda --params-json against the real Godot engine (issue #199, ADR-0015).
+
+Drives the structured params-input ABI through the real installed console script
+and a real Godot process: a JSON params object (on the command line, and via
+stdin) produces the same on-disk effect as the argv form — the ``.tscn`` is
+created and reads back. Per RULES.md DoD the fake-runner fast tests do not count
+toward this gate.
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+GODOT = resolve_godot_binary()
+
+
+@pytest.mark.e2e
+def test_scene_create_via_params_json_creates_the_scene(godot_project):
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+    scene_path = godot_project / "main.tscn"
+    params = json.dumps({"path": str(scene_path), "root_type": "Node2D"})
+
+    created = subprocess.run(
+        [
+            gda_bin,
+            "scene",
+            "create",
+            "--params-json",
+            params,
+            "--json",
+            "--godot",
+            str(GODOT),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    data = json.loads(created.stdout)
+    assert data["root_type"] == "Node2D"
+    # root_name derived model-side from the filename — same as the argv path.
+    assert data["root_name"] == "main"
+    # The .tscn really landed on disk.
+    assert scene_path.exists()
+
+    # And reads back through the engine — the file is loadable, not just present.
+    got = subprocess.run(
+        [gda_bin, "scene", "get", str(scene_path), "--json", "--godot", str(GODOT)],
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["root"]["type"] == "Node2D"
+
+
+@pytest.mark.e2e
+def test_scene_create_via_params_json_stdin_creates_the_scene(godot_project):
+    # `--params-json -` reads the object from stdin through the real chain.
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+    scene_path = godot_project / "fromstdin.tscn"
+    params = json.dumps({"path": str(scene_path), "root_type": "Node2D"})
+
+    created = subprocess.run(
+        [gda_bin, "scene", "create", "--params-json", "-", "--json", "--godot", str(GODOT)],
+        input=params,
+        capture_output=True,
+        text=True,
+    )
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    assert json.loads(created.stdout)["root_name"] == "fromstdin"
+    assert scene_path.exists()

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -66,6 +66,32 @@ def _inject(monkeypatch, *, get=GET_RESULT, export=None):
     return get_runner, export_runner
 
 
+def test_export_run_params_json_drives_the_native_export_runner(monkeypatch, tmp_path):
+    # export run is the native-export recipe (run_export_operation), NOT the
+    # sentinel pipeline. --params-json (ADR-0015) must drive that SAME recipe, so
+    # the export runner is actually invoked — a regression guard against the
+    # generic dispatch hook routing it through the wrong (sentinel) path.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    _, export_runner = _inject(monkeypatch)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "export",
+            "run",
+            "--params-json",
+            '{"preset": "Linux/X11"}',
+            "--project",
+            str(tmp_path),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout)["mode"] == "release"
+    assert export_runner.calls == [("Linux/X11", "release", "build/game.x86_64")]
+
+
 def test_export_run_json_reports_configured_path_and_exit_zero(monkeypatch, tmp_path):
     # export run exports the named preset to its CONFIGURED export_path (the #121
     # acceptance behavior) and reports the result (preset, platform, mode,

--- a/tests/test_params_json.py
+++ b/tests/test_params_json.py
@@ -1,0 +1,184 @@
+"""`gda <group> <command> --params-json` structured params input (issue #199, ADR-0015).
+
+A caller may supply a command's params as one JSON object via `--params-json`
+(or `-` to read the object from stdin) instead of the individual CLI arguments.
+The object is deserialized into the command's input model and dispatched through
+the same runner seam as the argv path, producing identical params (normalization
+included). These are fast tests; one e2e drives a real command via --params-json.
+"""
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+from tests.support import SCENE_CREATE_RESULT, inject_runner, sentinel
+
+
+def test_scene_create_params_json_dispatches_like_argv(monkeypatch):
+    # The --params-json path builds the model from a JSON object and dispatches
+    # through the SAME runner seam as the argv path, applying the same
+    # normalization (~ expanded, root_name derived from the filename). Proves the
+    # central mechanism end-to-end and the argv/JSON parity in one shot.
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "scene",
+            "create",
+            "--params-json",
+            '{"path": "~/proj/main.tscn", "root_type": "Node2D"}',
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert fake.calls == [
+        (
+            "scene-create",
+            {
+                "path": str(Path("~/proj/main.tscn").expanduser()),
+                "root_type": "Node2D",
+                "root_name": "main",
+            },
+        )
+    ]
+
+
+def test_params_json_conflicting_with_individual_args_is_a_structured_usage_error(
+    monkeypatch,
+):
+    # Mutual exclusivity (ADR-0015): --params-json alongside an individual arg is a
+    # registered usage_error (ADR-0002), emitted as a structured GdaError envelope
+    # on a non-zero exit — never an ad-hoc message.
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "scene",
+            "create",
+            "/tmp/proj/main.tscn",
+            "--params-json",
+            '{"path": "/tmp/proj/main.tscn", "root_type": "Node2D"}',
+        ],
+    )
+
+    assert result.exit_code != 0
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "usage_error"
+    assert err["category"] == "operation"
+
+
+def test_invalid_json_params_is_a_structured_error(monkeypatch):
+    # Malformed JSON → a registered invalid_params GdaError, not a traceback.
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(app, ["scene", "create", "--params-json", "{not json"])
+
+    assert result.exit_code != 0
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "invalid_params"
+    assert err["category"] == "operation"
+
+
+def test_schema_invalid_params_object_is_a_structured_error(monkeypatch):
+    # Valid JSON but missing a required field (root_type) → invalid_params.
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app, ["scene", "create", "--params-json", '{"path": "/tmp/proj/main.tscn"}']
+    )
+
+    assert result.exit_code != 0
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "invalid_params"
+
+
+def test_schema_takes_precedence_over_params_json(monkeypatch):
+    # A bare --schema wins: it emits the contract and ignores --params-json,
+    # dispatching nothing (ADR-0015 / ADR-0004).
+    def boom(*args, **kwargs):
+        raise AssertionError("--schema must not dispatch the operation")
+
+    monkeypatch.setattr("gda.cli._make_runner", boom)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "scene",
+            "create",
+            "--params-json",
+            '{"path": "/tmp/proj/main.tscn", "root_type": "Node2D"}',
+            "--schema",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert set(json.loads(result.stdout)) >= {"input", "output", "error"}
+
+
+def test_json_output_composes_with_params_json(monkeypatch):
+    # --json (a result projection) composes with --params-json (an input source):
+    # the success result is emitted as a single JSON object.
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "scene",
+            "create",
+            "--params-json",
+            '{"path": "/tmp/proj/main.tscn", "root_type": "Node2D"}',
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    data = json.loads(result.stdout)
+    assert data["path"] == "/tmp/proj/main.tscn"
+    assert data["root_type"] == "Node2D"
+
+
+def test_params_json_dash_reads_the_object_from_stdin(monkeypatch):
+    # `--params-json -` reads the JSON object from stdin, so large payloads
+    # (script/shader content) avoid argv length limits (ADR-0015).
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["scene", "create", "--params-json", "-"],
+        input='{"path": "/tmp/proj/level.tscn", "root_type": "Node2D"}',
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert fake.calls == [
+        (
+            "scene-create",
+            {
+                "path": "/tmp/proj/level.tscn",
+                "root_type": "Node2D",
+                "root_name": "level",
+            },
+        )
+    ]

--- a/tests/test_params_json.py
+++ b/tests/test_params_json.py
@@ -10,11 +10,20 @@ included). These are fast tests; one e2e drives a real command via --params-json
 import json
 from pathlib import Path
 
+import pytest
+import typer
 from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
-from tests.support import SCENE_CREATE_RESULT, inject_runner, sentinel
+from tests.support import (
+    NODE_GET_RESULT,
+    RESOURCE_CREATE_RESULT,
+    SCENE_CREATE_RESULT,
+    SCENE_GET_RESULT,
+    inject_runner,
+    sentinel,
+)
 
 
 def test_scene_create_params_json_dispatches_like_argv(monkeypatch):
@@ -182,3 +191,130 @@ def test_params_json_dash_reads_the_object_from_stdin(monkeypatch):
             },
         )
     ]
+
+
+def _leaf_commands(command, prefix=()):
+    """Yield ``(name_path, leaf_click_command)`` for every leaf of the Typer tree.
+
+    Recurses the live Click command tree (``typer.main.get_command(app)``),
+    descending into groups (those with a ``.commands`` mapping) and yielding only
+    the leaves — the actual ``gda <group> <command>`` invocables.
+    """
+    sub = getattr(command, "commands", None)
+    if not sub:
+        yield prefix, command
+        return
+    for name, child in sub.items():
+        yield from _leaf_commands(child, prefix + (name,))
+
+
+def _params_json_leaves():
+    """The leaf-command param table for the coverage test, as ``(name, params)``.
+
+    Walks the live Typer tree so a newly-added command that forgot
+    ``--params-json`` is caught here automatically, not only in a hand-kept list.
+    """
+    root = typer.main.get_command(app)
+    return [
+        (" ".join(name), command.params)
+        for name, command in _leaf_commands(root)
+    ]
+
+
+# ``gda schema`` is the one documented exception (ADR-0015): the parameterless
+# manifest emitter has no operation to drive, so it carries no --params-json.
+_PARAMS_JSON_EXEMPT = {"schema"}
+
+
+@pytest.mark.parametrize(
+    "name, params",
+    _params_json_leaves(),
+    ids=lambda value: value if isinstance(value, str) else "",
+)
+def test_every_leaf_command_exposes_params_json(name, params):
+    # Coverage: every leaf command must expose --params-json so gda-mcp can drive
+    # ANY command from a JSON object (ADR-0015), with the single `schema` meta
+    # exception. Driven off the LIVE Typer tree, so a future command that omits
+    # the option fails here without anyone maintaining a list.
+    exposes = any("--params-json" in param.opts for param in params)
+    if name in _PARAMS_JSON_EXEMPT:
+        assert not exposes, f"{name} must NOT expose --params-json (the exception)"
+    else:
+        assert exposes, f"{name} is missing --params-json"
+
+
+# The argv↔JSON parity table: representative commands covering the distinct
+# field shapes (single path; path + node; path + a renamed --type option; two
+# path-like fields; a --target). Each row drives the SAME logical input through
+# BOTH the argv form and the --params-json form with a `~/…`-prefixed path, so a
+# field that did NOT get NormalizedPath would diverge (the argv body passes raw,
+# the model normalizes) — exactly the silent regression this guards. Only
+# ``fake.calls`` is asserted, so any valid canned result works.
+_HOME_TSCN = "~/proj/main.tscn"
+_HOME_GD = "~/proj/hero.gd"
+_HOME_TRES = "~/proj/palette.tres"
+
+_PARITY_TABLE = [
+    # (id, argv-tail, params-json object, canned result)
+    (
+        "scene-get",
+        ["scene", "get", _HOME_TSCN],
+        {"path": _HOME_TSCN},
+        SCENE_GET_RESULT,
+    ),
+    (
+        "node-get",
+        ["node", "get", _HOME_TSCN, "--node", "Hero"],
+        {"path": _HOME_TSCN, "node": "Hero"},
+        NODE_GET_RESULT,
+    ),
+    (
+        "resource-create",
+        ["resource", "create", _HOME_TRES, "--type", "Gradient"],
+        {"path": _HOME_TRES, "type": "Gradient"},
+        RESOURCE_CREATE_RESULT,
+    ),
+    (
+        "script-attach",
+        ["script", "attach", _HOME_TSCN, "--node", "Hero", "--script", _HOME_GD],
+        {"path": _HOME_TSCN, "node": "Hero", "script": _HOME_GD},
+        # Any valid canned result works; only fake.calls is asserted.
+        SCENE_GET_RESULT,
+    ),
+    (
+        "find-references",
+        ["project", "find-references", _HOME_TSCN],
+        {"target": _HOME_TSCN},
+        SCENE_GET_RESULT,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "case_id, argv, params_object, canned",
+    _PARITY_TABLE,
+    ids=[row[0] for row in _PARITY_TABLE],
+)
+def test_argv_and_params_json_dispatch_identically(
+    case_id, argv, params_object, canned, monkeypatch
+):
+    # The argv form and the --params-json form of the SAME command, given the same
+    # logical input (a `~/…` path that normalization must expand), dispatch the
+    # IDENTICAL (operation, params) call. Proves argv ≡ JSON parity and catches
+    # any path-bearing field that did not get NormalizedPath.
+    argv_fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(canned), stderr="", exit_code=0)
+    )
+    CliRunner().invoke(app, argv)
+
+    json_fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(canned), stderr="", exit_code=0)
+    )
+    CliRunner().invoke(
+        app, [argv[0], argv[1], "--params-json", json.dumps(params_object)]
+    )
+
+    assert argv_fake.calls == json_fake.calls, case_id
+    # And the path was actually normalized (~ expanded), so the parity is not a
+    # vacuous "both stayed raw".
+    assert "~" not in json.dumps(json_fake.calls), case_id

--- a/tests/test_params_json.py
+++ b/tests/test_params_json.py
@@ -15,12 +15,17 @@ import typer
 from typer.testing import CliRunner
 
 from gda.cli import app
+from gda.models import ScriptSetMode
 from gda.runner import RunResult
 from tests.support import (
+    NODE_ADD_RESULT,
     NODE_GET_RESULT,
     RESOURCE_CREATE_RESULT,
     SCENE_CREATE_RESULT,
     SCENE_GET_RESULT,
+    SCRIPT_CREATE_RESULT,
+    SCRIPT_SET_RESULT,
+    SHADER_CREATE_RESULT,
     inject_runner,
     sentinel,
 )
@@ -191,6 +196,122 @@ def test_params_json_dash_reads_the_object_from_stdin(monkeypatch):
             },
         )
     ]
+
+
+# --- the model is the single source of input semantics (PR #201 review) --------
+# argv derives/validates in the CLI body; for parity these must live in the model
+# so --params-json gets the SAME derivation/validation, not a wider or divergent API.
+
+
+def test_wrong_typed_path_is_a_structured_error_not_a_traceback(monkeypatch):
+    # A non-string NormalizedPath value must surface as structured invalid_params,
+    # not a TypeError traceback: NormalizedPath uses AfterValidator, so the value is
+    # validated as a str FIRST (ADR-0015). Regression for the BeforeValidator crash.
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app, ["scene", "create", "--params-json", '{"path": 123, "root_type": "Node2D"}']
+    )
+
+    assert result.exit_code != 0
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "invalid_params"
+    assert err["category"] == "operation"
+
+
+def test_node_add_params_json_derives_default_name_like_argv(monkeypatch):
+    # Parity: omitting name derives it from the type model-side, exactly like the
+    # argv path (which used to do this in the CLI body).
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(NODE_ADD_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["node", "add", "--params-json", '{"path": "/tmp/proj/main.tscn", "type": "Sprite2D"}'],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    op, params = fake.calls[0]
+    assert op == "node-add"
+    assert params["name"] == "Sprite2D"
+
+
+def test_script_create_params_json_rejects_content_and_extends(monkeypatch):
+    # The content/extends mutual exclusivity is enforced model-side, so
+    # --params-json cannot bypass it (it is rejected, not silently resolved).
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SCRIPT_CREATE_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "create",
+            "--params-json",
+            '{"path": "/tmp/proj/hero.gd", "content": "extends Node\\n", "extends_type": "Node2D"}',
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+
+
+def test_shader_create_params_json_rejects_content_and_shader_type(monkeypatch):
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "shader",
+            "create",
+            "--params-json",
+            '{"path": "/tmp/proj/wave.gdshader", "content": "shader_type spatial;", "shader_type": "spatial"}',
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+
+
+def test_script_set_params_json_rejects_inconsistent_edit_fields(monkeypatch):
+    # The edit-mode rule is enforced model-side: a half-specified mode (search
+    # without replace) is invalid_params via --params-json, not a silent dispatch.
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SCRIPT_SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["script", "set", "--params-json", '{"path": "/tmp/proj/hero.gd", "search": "a"}'],
+    )
+
+    assert result.exit_code != 0
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+
+
+def test_script_set_params_json_derives_mode_like_argv(monkeypatch):
+    # Parity: the edit mode is derived from the supplied fields model-side, so a
+    # --params-json caller need not (and should not) supply it.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SCRIPT_SET_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["script", "set", "--params-json", '{"path": "/tmp/proj/hero.gd", "content": "extends Node\\n"}'],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    op, params = fake.calls[0]
+    assert op == "script-set"
+    assert params["mode"] == ScriptSetMode.FULL
 
 
 def _leaf_commands(command, prefix=()):


### PR DESCRIPTION
## What & why

Implements **ADR-0015** (#198): a uniform structured params-input ABI so a caller can supply a command's params as **one JSON object** via `gda <group> <command> --params-json <json | ->` (`-` reads the object from stdin), instead of the individual CLI arguments. This is the gda-side prerequisite that lets **gda-mcp (#193)** forward an MCP tool's input object **verbatim** — no argv reconstruction (the dump's `inputSchema` deliberately doesn't encode CLI binding). Closes #199.

## Mechanism

- The command class (which already owns `--schema`) intercepts `--params-json`, builds the input model with `model_validate_json`, and dispatches it through the **same** project-resolution + runner seam the argv path uses (a hook `gda.cli` registers, so `gda.headless` needn't import `gda.cli`). The body is bypassed, staying a thin argv→model adapter.
- **Single source of truth:** normalization moved into the models via a reusable `NormalizedPath = Annotated[str, BeforeValidator(normalize_path)]`, plus scene-create's root-name derivation. The argv and `--params-json` paths therefore produce **identical** params — proven by an argv≡JSON parity test driven with `~/…` paths.
- **`gda schema`'s `inputSchema` is exactly the model `--params-json` accepts**, by construction (ADR-0004's input/output/error separation preserved — `--params-json` adds only an input channel).

## Structured errors (ADR-0002, single-sourced)

- `--params-json` + individual args → `usage_error` (mutually exclusive); malformed/schema-invalid JSON → `invalid_params`. Both are **registered** `GdaError` envelopes (never tracebacks), reusing existing codes; their `error_codes.py` + ADR-0002 descriptions were broadened to note the CLI origin. The ADR-0002 ↔ registry guard test confirms consistency.
- A bare `--schema` still wins (emit-only); `--json` composes with `--params-json`.

## Surface

Every command exposes `--params-json` (coverage test walks the live Typer tree), with the single documented exception of `gda schema` (the parameterless manifest emitter, no operation to drive). `export run` is special-cased: it runs a native-export recipe (`run_export_operation`, #187), not the sentinel pipeline, so its `--params-json` path mirrors that recipe rather than `cmd.emit`.

## Tests

- `tests/test_params_json.py`: mechanism, stdin, structured-error paths, flag composition, a **coverage** test (every command exposes `--params-json`), and an argv≡JSON **parity** table (`~/…` paths, asserts identical dispatch + that `~` actually expanded).
- `tests/test_export_run_commands.py`: regression test that `export run --params-json` drives the **native export runner** (guards the special-case).
- `tests/test_e2e_params_json.py`: **e2e gate** — `scene create --params-json` (inline + stdin) creates a loadable `.tscn` through the real engine.

Verification: `pytest -m "not e2e"` → **571 passed**; full `pytest -m e2e` → **235 passed, 1 skipped** (no regression from moving normalization into models); `uv build` clean.

## Acceptance criteria (#199)

- [x] Every command accepts `--params-json` (inline + stdin); identical to the argv path (normalization parity)
- [x] Invalid/conflicting input → registered structured `GdaError` (not a traceback)
- [x] `--params-json` mutually exclusive with individual args
- [x] Normalization lives in the params models, exercised by both paths
- [x] `--params-json` composes with `--json`; `--schema` precedence preserved
- [x] Fast round-trip parity + full-coverage tests; one real-engine e2e
