### PR TITLE
feat(gda-mcp): generated stdio MCP server over the gda CLI (#193)

### DIFF
--- a/docs/adr/0011-gda-mcp-integration-mechanism.md
+++ b/docs/adr/0011-gda-mcp-integration-mechanism.md
@@ -21,15 +21,21 @@ gda-daemon exists in Phase 2 — the topology of {gda-mcp, gda, gda-daemon}.
 
 ## Decision
 
-**gda-mcp wraps `gda` as a subprocess.** It shells out to the installed `gda`
-console script and consumes only `gda`'s **public CLI ABI** — *not* the internal
-sentinel protocol ADR-0002 defines **between** `gda` and its headless operation
-subprocesses (which `gda` already parses away before emitting its public output, and
-which ADR-0010's native-CLI-mode operations do not emit at all). That public ABI is:
-the `--json` success output, the structured `GdaError` envelope on a non-zero exit
-(the uniform `GdaErrorEnvelope` of ADR-0004), the exit-code categories, and the
-`--schema` self-description (ADR-0004). Operations are invoked per-command as
-`gda <group> <command> --json …`; the **tool surface is enumerated from the aggregate
+**gda-mcp wraps `gda` as a subprocess.** It shells out to `gda` — invoked as
+`[sys.executable, "-m", "gda", …]`, the *same-distribution* binary paired with the
+running gda-mcp (the `[mcp]` extra), which is deterministic and cannot resolve a
+*wrong global* `gda`, rather than a PATH lookup of the console script (#193 Design
+decision 3; an optional `$GDA_BIN` escape hatch overrides it, ADR-0013) — and
+consumes only `gda`'s **public CLI ABI** — *not* the internal sentinel protocol
+ADR-0002 defines **between** `gda` and its headless operation subprocesses (which
+`gda` already parses away before emitting its public output, and which ADR-0010's
+native-CLI-mode operations do not emit at all). That public ABI is: the `--json`
+success output, the structured `GdaError` envelope on a non-zero exit (the uniform
+`GdaErrorEnvelope` of ADR-0004), the exit-code categories, and the `--schema`
+self-description (ADR-0004). Operations are invoked per-command as
+`python -m gda <group> <command> --params-json - --json`, forwarding the tool's
+input object **verbatim** on stdin (ADR-0015's structured params channel — so
+gda-mcp reconstructs no argv); the **tool surface is enumerated from the aggregate
 schema dump** (ADR-0012), *not* a per-command `--schema` fan-out. gda-mcp does **not**
 import `gda`'s Python modules or depend on any internal symbol.
 

--- a/docs/adr/0012-gda-mcp-tool-surface-generation.md
+++ b/docs/adr/0012-gda-mcp-tool-surface-generation.md
@@ -32,6 +32,22 @@ server starts — no codegen step, no release-pipeline coupling, no drift.
   flag — is a taxonomy detail left to the PRD). gda-mcp **never parses `gda --help`
   prose** to enumerate the surface.
 
+**The dump is the dispatchable-operation surface (refinement, #193).** It carries
+one entry per command that accepts the `--params-json` structured-input channel
+(ADR-0015) — i.e. has a backing operation gda-mcp can actually invoke. A
+*non-dispatchable* meta command (no backing operation, hence no `--params-json`)
+is excluded **at the source**, inside `gda`'s own surface walk, keyed on the one
+fact the command's registration already carries (its backing operation, `None`
+for such a command). `gda schema` is the only such command today: a pure
+self-describer, excluded from the surface it describes (re-listing it would be
+circular), while it still self-describes under its own `--schema`. This keeps the
+sole authority for "is this an MCP-dispatchable operation" in `gda`, so gda-mcp
+stays a pure transform that registers exactly what the dump reports and never
+advertises a tool it cannot fulfil — it holds no exclusion list of its own. This
+exclusion is a **soundness** property (gda-mcp can only serve what it can
+dispatch), distinct from the optional, user-facing group/tool *filtering* below
+(a surface-*size* control).
+
 **Expose the full surface; do not ship hand-curated profiles.** gda-mcp registers
 every tool the dump reports. It explicitly does **not** provide named tiers (full /
 lite / minimal). If a tool-count-limited client ever needs a smaller surface, the

--- a/docs/adr/0013-gda-mcp-packaging-and-launch.md
+++ b/docs/adr/0013-gda-mcp-packaging-and-launch.md
@@ -59,3 +59,15 @@ plus repo-local `.codex/config.toml`; `claude_desktop_config.json`; `.cursor/mcp
   (python-sdk#1520).
 - The `gda-mcp` entry point exists in every install; without the `[mcp]` extra it
   errors on a missing `mcp` import with an actionable message.
+- **Which `gda` gda-mcp shells out to, and the `GDA_BIN` escape hatch (#193).** By
+  default gda-mcp invokes `[sys.executable, "-m", "gda", …]` (ADR-0011) — the
+  interpreter running gda-mcp, hence the *same install*. This preserves this ADR's
+  single-version guarantee **structurally**: the adapter and the CLI are one
+  distribution, so no CLI/adapter skew is possible. An optional `GDA_BIN` env var
+  overrides that command for unusual deployment layouts (e.g. gda installed under a
+  different interpreter); it is an **explicit escape hatch**, analogous to `--godot`
+  overriding engine resolution (ADR-0006). When set, it can point at a *different*
+  `gda` and therefore transfers responsibility for CLI/adapter version alignment to
+  the operator — the structural no-skew guarantee holds only for the default. A
+  binary the override cannot launch is surfaced as a structured `isError`, never an
+  escaping exception (ADR-0011's can't-run edge).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,21 @@ dependencies = [
     "typer>=0.26.7",
 ]
 
+[project.optional-dependencies]
+# The MCP adapter (gda-mcp) ships inside this one distribution, gated behind an
+# optional extra so a plain `gda` install stays lean — only `gda[mcp]` pulls the
+# MCP SDK (ADR-0013). Pinned to the v1 low-level Server API (decorator handlers,
+# camelCase Tool/CallToolResult fields) that gda-mcp targets; <2 fences off the
+# different v2 constructor API.
+mcp = [
+    "mcp>=1.12,<2",
+]
+
 [project.scripts]
 gda = "gda.cli:app"
+# Declared in every install (ADR-0013); without the `[mcp]` extra it errors on a
+# missing `mcp` import with an actionable "install gda[mcp]" message.
+gda-mcp = "gda.mcp:main"
 
 [build-system]
 requires = ["uv_build>=0.11.19,<0.12.0"]
@@ -24,6 +37,9 @@ build-backend = "uv_build"
 dev = [
     "jsonschema>=4.26.0",
     "pytest>=9.0.3",
+    # The MCP SDK is also a dev dependency (not just the `[mcp]` extra) so
+    # `uv run pytest` has it for the gda-mcp fast/e2e tiers (ADR-0013).
+    "mcp>=1.12,<2",
 ]
 
 [tool.pytest.ini_options]

--- a/src/gda/__main__.py
+++ b/src/gda/__main__.py
@@ -1,0 +1,14 @@
+"""Enable ``python -m gda`` (and thus ``sys.executable -m gda``).
+
+gda-mcp invokes the CLI as ``[sys.executable, "-m", "gda", …]`` for a
+deterministic, same-environment binary (ADR-0011, Design decision 3): it runs
+the *exact* gda paired with the running gda-mcp, never a wrong global ``gda`` a
+PATH lookup might resolve. This module is the ``-m gda`` entry point that makes
+that invocation work; it shares the one Typer ``app`` with the ``gda`` console
+script, so both entry points behave identically.
+"""
+
+from gda.cli import app
+
+if __name__ == "__main__":
+    app()

--- a/src/gda/mcp/__init__.py
+++ b/src/gda/mcp/__init__.py
@@ -1,0 +1,48 @@
+"""gda-mcp: a generated stdio MCP server over the gda CLI (issue #193).
+
+gda's MCP adapter (ADR-0011/0012/0013): it introspects gda's aggregate schema
+dump and exposes one MCP tool per command, shelling out to the installed gda for
+each call over gda's public CLI ABI. It ships inside the one ``gda`` distribution
+behind the optional ``gda[mcp]`` extra — gda core never imports ``mcp``, and this
+package's :func:`main` entry point guards the import so ``gda-mcp`` without the
+extra fails with an actionable message rather than an opaque ImportError.
+
+This module stays deliberately lean (no ``mcp`` import at load time): the import
+guard in :func:`main` must run *before* any SDK-dependent code, so all of that
+lives in :mod:`gda.mcp.server`, imported only after the guard passes.
+"""
+
+import sys
+
+# The actionable failure when the optional ``mcp`` SDK is absent (ADR-0013): the
+# ``gda-mcp`` console script is declared in every install, but only ``gda[mcp]``
+# installs the SDK it needs. Point the user at the fix instead of letting a bare
+# ImportError escape.
+_MISSING_MCP_MESSAGE = (
+    "gda-mcp requires the optional 'mcp' extra, which is not installed.\n"
+    "Install it with:    pip install 'gda[mcp]'\n"
+    "or run without installing:    uvx --from 'gda[mcp]' gda-mcp\n"
+)
+
+
+def main() -> int:
+    """The ``gda-mcp`` console-script entry point (ADR-0013).
+
+    Lean by design: it guards the optional ``mcp`` import (so a plain ``gda``
+    install fails with an actionable message, not an opaque traceback), then
+    hands off to the server, which owns all the SDK-dependent logic. Returns the
+    process exit code; ``console_scripts`` wraps the return value in
+    ``sys.exit``.
+    """
+    try:
+        import mcp  # noqa: F401
+    except ImportError:
+        sys.stderr.write(_MISSING_MCP_MESSAGE)
+        return 1
+    # Imported lazily, AFTER the guard: gda.mcp.server imports the SDK at module
+    # load, so importing it before the guard would surface the bare ImportError
+    # this guard exists to replace.
+    from gda.mcp.server import run_stdio
+
+    run_stdio()
+    return 0

--- a/src/gda/mcp/runner.py
+++ b/src/gda/mcp/runner.py
@@ -1,0 +1,87 @@
+"""The single subprocess seam gda-mcp runs ``gda`` through (ADR-0011).
+
+One low-level seam: given an argv tail (and optional stdin), it spawns the
+installed ``gda`` and returns the *raw* ``{stdout, stderr, returncode}`` —
+unparsed. BOTH startup dump-introspection (``gda schema``) and per-tool dispatch
+(``gda <group> <command> --params-json -``) go through it, so the success/error
+mapping lives ABOVE the seam and is unit-testable by injecting a fake (Design
+decision 2). Keeping the seam raw mirrors gda's own ``RunResult`` discipline one
+layer down.
+
+The binary is ``[sys.executable, "-m", "gda"]`` — the exact gda paired with the
+running gda-mcp (same distribution, the ``[mcp]`` extra), NOT a PATH lookup that
+could resolve a *wrong global* ``gda`` (Design decision 3; the PR #196 review
+lesson, ``shutil.which`` deliberately rejected). An optional ``$GDA_BIN`` env var
+overrides it for deployments that need a specific command line.
+"""
+
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+# Override the default ``-m gda`` invocation with an explicit command line.
+GDA_BIN_ENV = "GDA_BIN"
+
+
+@dataclass(frozen=True)
+class GdaResult:
+    """The raw outcome of one ``gda`` subprocess run — unparsed (ADR-0011)."""
+
+    stdout: str
+    stderr: str
+    returncode: int
+
+
+class GdaRunner(Protocol):
+    """Runs ``gda`` with an argv tail and optional stdin, returns raw output.
+
+    A Protocol so fast tests inject a fake seam (mirroring gda's own
+    ``FakeRunner``, one layer up) and exercise the whole introspect/dispatch +
+    result/error mapping engine-free.
+    """
+
+    def run(self, args: list[str], *, stdin: Optional[str] = None) -> GdaResult: ...
+
+
+def gda_command() -> list[str]:
+    """The base argv that invokes gda (Design decision 3).
+
+    ``$GDA_BIN`` (shell-split) when set, else ``[sys.executable, "-m", "gda"]`` —
+    the same interpreter running gda-mcp, so gda-mcp and gda are guaranteed the
+    one distribution rather than whatever ``gda`` a PATH search might surface.
+    """
+    override = os.environ.get(GDA_BIN_ENV)
+    if override:
+        return shlex.split(override)
+    return [sys.executable, "-m", "gda"]
+
+
+@dataclass(frozen=True)
+class SubprocessGdaRunner:
+    """The real :class:`GdaRunner`: spawns ``gda`` as a one-shot subprocess."""
+
+    command: list[str]
+
+    @classmethod
+    def default(cls) -> "SubprocessGdaRunner":
+        """Build the runner from the resolved :func:`gda_command`."""
+        return cls(command=gda_command())
+
+    def run(self, args: list[str], *, stdin: Optional[str] = None) -> GdaResult:
+        # Capture raw bytes (no ``text=True``) and decode UTF-8 explicitly, like
+        # gda's own runner (issue #33): gda emits its ``--json`` result as UTF-8
+        # via pydantic, which can carry non-ASCII (e.g. a CJK node name); a
+        # locale-based decode would mojibake it on a non-UTF-8 locale.
+        proc = subprocess.run(
+            [*self.command, *args],
+            input=stdin.encode("utf-8") if stdin is not None else None,
+            capture_output=True,
+        )
+        return GdaResult(
+            stdout=proc.stdout.decode("utf-8", errors="replace"),
+            stderr=proc.stderr.decode("utf-8", errors="replace"),
+            returncode=proc.returncode,
+        )

--- a/src/gda/mcp/runner.py
+++ b/src/gda/mcp/runner.py
@@ -25,6 +25,12 @@ from typing import Optional, Protocol
 # Override the default ``-m gda`` invocation with an explicit command line.
 GDA_BIN_ENV = "GDA_BIN"
 
+# The exit code synthesized when the gda command itself cannot be launched (the
+# binary is missing / not executable) — the shell "command not found" convention,
+# matching gda's own runner (gda.exit_codes.EXIT_NOT_FOUND). The value only has to
+# be non-zero for the layer above to treat it as a failure; 127 keeps it legible.
+_LAUNCH_FAILURE_EXIT = 127
+
 
 @dataclass(frozen=True)
 class GdaResult:
@@ -75,11 +81,24 @@ class SubprocessGdaRunner:
         # gda's own runner (issue #33): gda emits its ``--json`` result as UTF-8
         # via pydantic, which can carry non-ASCII (e.g. a CJK node name); a
         # locale-based decode would mojibake it on a non-UTF-8 locale.
-        proc = subprocess.run(
-            [*self.command, *args],
-            input=stdin.encode("utf-8") if stdin is not None else None,
-            capture_output=True,
-        )
+        try:
+            proc = subprocess.run(
+                [*self.command, *args],
+                input=stdin.encode("utf-8") if stdin is not None else None,
+                capture_output=True,
+            )
+        except OSError as exc:
+            # The gda command itself could not be launched — e.g. a ``$GDA_BIN``
+            # override pointing at a missing / non-executable path. Mirror gda's
+            # own runner (gda.runner.launch): never let the OSError escape;
+            # synthesize a non-zero raw result so the layer above turns it into a
+            # structured ``isError`` (ADR-0011's "can't-run" edge, synthesized by
+            # gda-mcp) rather than a traceback crossing the MCP boundary.
+            return GdaResult(
+                stdout="",
+                stderr=f"gda could not be launched: {self.command!r} ({exc})",
+                returncode=_LAUNCH_FAILURE_EXIT,
+            )
         return GdaResult(
             stdout=proc.stdout.decode("utf-8", errors="replace"),
             stderr=proc.stderr.decode("utf-8", errors="replace"),

--- a/src/gda/mcp/server.py
+++ b/src/gda/mcp/server.py
@@ -1,0 +1,243 @@
+"""The gda-mcp low-level stdio Server (ADR-0011/0012/0013, issue #193).
+
+A *generated* server: at startup it introspects gda's aggregate schema dump
+(``gda schema``) and registers one MCP tool per command — name
+``<group>_<command>``, ``description`` ← the command's help, ``inputSchema`` /
+``outputSchema`` ← the command's input/output schemas (ADR-0012's faithful
+mirror). On a tool call it shells out to the installed gda, forwarding the tool
+input *verbatim* via ``gda <group> <command> --params-json -`` (the object on
+stdin; ADR-0015), and maps the result mechanically off gda's exit code
+(ADR-0011):
+
+- **exit 0** → the ``--json`` result dict; the SDK validates it against the
+  tool's ``outputSchema`` and wraps it as ``structuredContent`` (Design
+  decision 5 — gda-mcp does NOT re-validate: gda's result and its ``outputSchema``
+  share one Pydantic model, so conformance is by construction);
+- **exit ≠ 0** → ``CallToolResult(isError=True)`` carrying the full ``GdaError``
+  envelope *verbatim* as JSON content — lossless, never flattened to prose, and
+  kept out of ``structuredContent`` / ``outputSchema``.
+
+Why the low-level ``Server`` and not FastMCP: our schemas come *from* gda (not
+from Python signatures), tools are discovered at runtime and served by one
+generic dispatcher, and we need direct control of the result/error channels —
+the inverse of FastMCP's "one tool = one decorated Python function" assumption.
+
+gda-mcp consumes only gda's public CLI ABI (``--json`` / exit code / ``GdaError``
+envelope); it never imports a gda internal symbol.
+"""
+
+import json
+from importlib.metadata import version
+from typing import Any, Optional
+
+import mcp.server.stdio
+import mcp.types as types
+from mcp.server.lowlevel import NotificationOptions, Server
+from mcp.server.models import InitializationOptions
+
+from gda.mcp.runner import GdaResult, GdaRunner, SubprocessGdaRunner
+
+SERVER_NAME = "gda-mcp"
+
+# The category/code gda-mcp stamps on an error it had to synthesize itself —
+# distinct from gda's own four categories so an agent can tell a gda-mcp-level
+# failure (gda could not run, or emitted non-envelope output) from a gda one.
+_ADAPTER_ERROR_CATEGORY = "adapter"
+_ADAPTER_ERROR_CODE = "gda_invocation_failed"
+
+
+def tool_name(command_name: str) -> str:
+    """Map a manifest command name to its MCP tool name (ADR-0005).
+
+    ``<group> <command>`` → ``<group>_<command>``: the space (group separator)
+    and any hyphen (within a multi-word command like ``get-exports``) both become
+    underscores, so ``scene get-exports`` → ``scene_get_exports`` while the bare
+    meta command ``info`` stays ``info``.
+    """
+    return command_name.replace(" ", "_").replace("-", "_")
+
+
+def _load_commands(runner: GdaRunner) -> list[dict[str, Any]]:
+    """Introspect gda's whole-surface dump through the seam (ADR-0012).
+
+    Spawns ``gda schema`` exactly once at startup and returns its per-command
+    entries. A non-zero exit is fatal: without the dump there is no tool surface
+    to serve, so fail loudly with gda's diagnostics rather than start empty.
+    """
+    result = runner.run(["schema"])
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"`gda schema` failed (exit {result.returncode}); gda-mcp cannot "
+            f"build its tool surface.\n{result.stderr}"
+        )
+    return json.loads(result.stdout)["commands"]
+
+
+def _parse_error_envelope(stdout: str) -> Optional[dict[str, Any]]:
+    """Return gda's ``GdaError`` envelope if ``stdout`` is one, else ``None``.
+
+    The discriminator for the ADR-0011 edge: a genuine non-zero gda failure emits
+    ``{"error": {category, code, message, diagnostics}}`` on stdout, which is
+    relayed verbatim; anything else (a Click usage error to stderr, a crash before
+    the envelope, an unrelated string) is *not* an envelope and is synthesized by
+    gda-mcp instead.
+    """
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    error = payload.get("error")
+    if not isinstance(error, dict) or "code" not in error or "category" not in error:
+        return None
+    return payload
+
+
+def _synthesized_error(message: str, result: GdaResult) -> types.CallToolResult:
+    """gda-mcp's own ``isError`` result when gda produced no usable envelope.
+
+    The edge of ADR-0011: gda failed to even run (e.g. ``-m gda`` import failure)
+    or emitted non-envelope output. gda-mcp synthesizes a structured error in the
+    same ``{category, code, message, diagnostics}`` shape as a ``GdaError`` —
+    stamped with the distinct ``adapter`` category — preserving gda's raw
+    stderr/stdout as diagnostics so nothing is silently swallowed.
+    """
+    body = {
+        "error": {
+            "category": _ADAPTER_ERROR_CATEGORY,
+            "code": _ADAPTER_ERROR_CODE,
+            "message": message,
+            "diagnostics": (result.stderr or result.stdout).strip(),
+        }
+    }
+    return types.CallToolResult(
+        content=[types.TextContent(type="text", text=json.dumps(body))],
+        isError=True,
+    )
+
+
+def dispatch(
+    runner: GdaRunner, argv: list[str], arguments: dict[str, Any]
+) -> dict[str, Any] | types.CallToolResult:
+    """Forward one MCP tool call to gda and map the outcome (ADR-0011/0015).
+
+    Returns the success result *dict* (the SDK validates it against the tool's
+    ``outputSchema`` and wraps it as ``structuredContent``) or a
+    :class:`~mcp.types.CallToolResult` for a failure. Never raises for a gda
+    failure: the low-level SDK flattens an exception to a prose ``isError``
+    string, which would lose the structured envelope, so failures are *returned*
+    as a ``CallToolResult`` instead.
+    """
+    params_json = json.dumps(arguments)
+    # Verbatim passthrough (ADR-0015): the input object goes to gda on stdin via
+    # ``--params-json -``; ``--json`` makes gda emit the machine-readable result.
+    # gda-mcp builds no per-command argv beyond the command name — no binding
+    # knowledge — so new commands/params reach the surface with no gda-mcp change.
+    result = runner.run([*argv, "--params-json", "-", "--json"], stdin=params_json)
+
+    if result.returncode == 0:
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError:
+            # exit 0 but non-JSON stdout: gda could not have honored ``--json``.
+            # Treat as the can't-run / non-envelope edge rather than crash.
+            return _synthesized_error(
+                "gda exited 0 but did not emit a JSON result for "
+                f"{' '.join(argv)!r}",
+                result,
+            )
+
+    envelope = _parse_error_envelope(result.stdout)
+    if envelope is None:
+        return _synthesized_error(
+            f"gda failed (exit {result.returncode}) without a structured error "
+            f"envelope for {' '.join(argv)!r}",
+            result,
+        )
+    # Relay gda's envelope verbatim and losslessly (ADR-0011): the exact JSON gda
+    # emitted, carrying {category, code, message, diagnostics}, kept out of
+    # structuredContent / outputSchema.
+    return types.CallToolResult(
+        content=[types.TextContent(type="text", text=result.stdout.strip())],
+        isError=True,
+    )
+
+
+def build_server(runner: GdaRunner) -> Server:
+    """Introspect the dump → register one tool per command → wire the dispatcher.
+
+    The pure schema→tool transform (ADR-0012): gda-mcp carries no per-command
+    knowledge, so it stays correct as gda's surface grows without edits here.
+    """
+    commands = _load_commands(runner)
+    tools = [
+        types.Tool(
+            name=tool_name(entry["name"]),
+            description=entry["description"],
+            inputSchema=entry["input"],
+            outputSchema=entry["output"],
+        )
+        for entry in commands
+    ]
+    # Map each MCP tool name back to its gda command argv. Built from the dump's
+    # own ``name`` (split on spaces), NOT by reversing tool_name — that mapping is
+    # not injective (an underscore could have been a space OR a hyphen), so the
+    # dump's name is the only exact source of the argv to dispatch.
+    argv_by_tool = {
+        tool_name(entry["name"]): entry["name"].split(" ") for entry in commands
+    }
+
+    server: Server = Server(SERVER_NAME)
+
+    @server.list_tools()
+    async def list_tools() -> list[types.Tool]:
+        return tools
+
+    # validate_input=False: gda owns input validation (ADR-0015 — gda-mcp forwards
+    # verbatim and gda's params model validates), so invalid params surface as
+    # gda's structured ``invalid_params`` envelope, not the SDK's prose error.
+    @server.call_tool(validate_input=False)
+    async def call_tool(name: str, arguments: dict[str, Any]):
+        argv = argv_by_tool.get(name)
+        if argv is None:
+            # The SDK only routes registered tool names here; this is defensive.
+            return types.CallToolResult(
+                content=[
+                    types.TextContent(type="text", text=f"unknown tool: {name!r}")
+                ],
+                isError=True,
+            )
+        return dispatch(runner, argv, arguments or {})
+
+    return server
+
+
+def run_stdio() -> None:
+    """Serve gda-mcp over stdio (ADR-0013): the console-script run loop.
+
+    Builds the server once (introspecting the dump — ADR-0012's single startup
+    ``gda`` subprocess) and serves it over the stdio transport every surveyed
+    agent registers (``command`` + ``args``). gda and gda-mcp share one version
+    (ADR-0008), so the advertised ``server_version`` is gda's.
+    """
+    import anyio
+
+    server = build_server(SubprocessGdaRunner.default())
+
+    async def _serve() -> None:
+        async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
+            await server.run(
+                read_stream,
+                write_stream,
+                InitializationOptions(
+                    server_name=SERVER_NAME,
+                    server_version=version("gda"),
+                    capabilities=server.get_capabilities(
+                        notification_options=NotificationOptions(),
+                        experimental_capabilities={},
+                    ),
+                ),
+            )
+
+    anyio.run(_serve)

--- a/src/gda/surface.py
+++ b/src/gda/surface.py
@@ -2,13 +2,23 @@
 
 The whole-surface generalisation of per-command ``--schema`` (ADR-0004):
 :func:`build_surface_manifest` walks the *live* Typer command tree and emits one
-:class:`~gda.models.CommandManifestEntry` per command. Walking the registered
-tree — rather than a hand-maintained list — keeps the manifest a faithful mirror
-of the installed ``gda``: a newly registered command appears automatically, with
-no central registry to update (ADR-0012's zero-touch sync). Each entry's
-``input`` / ``output`` / ``error`` is derived through the same
+:class:`~gda.models.CommandManifestEntry` per **dispatchable** command. Walking
+the registered tree — rather than a hand-maintained list — keeps the manifest a
+faithful mirror of the installed ``gda``: a newly registered command appears
+automatically, with no central registry to update (ADR-0012's zero-touch sync).
+Each entry's ``input`` / ``output`` / ``error`` is derived through the same
 :meth:`~gda.models.CommandSchema.of` that backs a single command's ``--schema``,
 so there is one source of truth for a command's contract.
+
+The manifest is the **dispatchable-operation surface**: a non-dispatchable meta
+command — one with no backing operation, so it does not accept ``--params-json``
+(ADR-0015) — is excluded. ``gda schema`` itself is the only such command today:
+it is a pure self-describer, not an operation, and re-listing it inside the
+surface it describes would be circular. Excluding it at the source keeps the one
+authority for "is this an MCP-dispatchable operation" in ``gda`` (a command's own
+registration), so gda-mcp stays a pure schema→tool transform that registers
+exactly what the dump reports — no per-command knowledge, nothing it cannot
+dispatch (ADR-0011/0012).
 """
 
 import typer
@@ -37,6 +47,8 @@ def _collect(
     ``path`` is the chain of command names from the root *excluding* the root
     itself, so a top-level meta command (``info``) yields a bare ``name`` while a
     grouped command yields the ``<group> <command>`` MCP mapping basis (ADR-0005).
+    A non-dispatchable leaf (``gda_command is None``, e.g. ``gda schema``) is
+    skipped — the manifest is the dispatchable-operation surface (see module doc).
 
     A group is identified by its ``commands`` mapping (Click groups have one, leaf
     commands do not) — a duck-type that avoids importing Click, which is only a
@@ -59,6 +71,16 @@ def _collect(
             f"command {' '.join(path)!r} exposes no --schema models; every command "
             "must be registered via HeadlessCommand.command_class() (ADR-0004)."
         )
+    # Exclude non-dispatchable meta commands from the surface (Plan A). The
+    # command class carries the backing ``HeadlessCommand`` as ``gda_command``,
+    # set to ``None`` for the bare ``gda schema`` meta command "which has no
+    # operation to run" (gda.headless.schema_command_class). That is the SAME
+    # single fact the ``--params-json`` dispatch keys on, so a ``None`` here means
+    # the command cannot be driven via ``--params-json`` (ADR-0015) and therefore
+    # is not part of the dispatchable-operation surface gda-mcp serves. Reading it
+    # off the command object reuses that one authority rather than re-deriving it.
+    if getattr(command, "gda_command", None) is None:
+        return
     schema = CommandSchema.of(input_model, output_model)
     description = (command.help or command.short_help or "").strip()
     entries.append(

--- a/tests/mcp_support.py
+++ b/tests/mcp_support.py
@@ -1,0 +1,92 @@
+"""Shared test support for driving gda-mcp without a real engine (issue #193).
+
+The gda-mcp analogue of :mod:`tests.support`, one layer up: where ``support.py``
+fakes gda's ``GodotRunner`` (gda ↔ engine), this fakes gda-mcp's ``GdaRunner``
+seam (gda-mcp ↔ gda). :class:`FakeGdaRunner` satisfies the seam with a canned
+:class:`~gda.mcp.runner.GdaResult` per invocation and records every
+``(args, stdin)`` it is asked to run, so the whole introspect → register →
+dispatch → result/error-map pipeline is exercised over an **in-memory MCP
+client → in-process server** with no ``gda`` subprocess and no Godot (Design
+decision 2 / 6).
+
+The fast tiers drive the surface from the **real** aggregate dump
+(:func:`real_manifest_json`), built in-process — so registration coverage is a
+true mirror of the live ``gda`` surface, not a hand-stubbed subset.
+"""
+
+from typing import Callable, Optional
+
+import anyio
+
+from gda.cli import app
+from gda.mcp.runner import GdaResult
+from gda.surface import build_surface_manifest
+
+# A responder maps one seam invocation ``(args, stdin)`` to its canned result.
+Responder = Callable[[list[str], Optional[str]], GdaResult]
+
+
+class FakeGdaRunner:
+    """A fake ``GdaRunner``: routes each invocation through a responder, records calls."""
+
+    def __init__(self, responder: Responder) -> None:
+        self.responder = responder
+        self.calls: list[tuple[list[str], Optional[str]]] = []
+
+    def run(self, args: list[str], *, stdin: Optional[str] = None) -> GdaResult:
+        self.calls.append((args, stdin))
+        return self.responder(args, stdin)
+
+
+def real_manifest_json() -> str:
+    """The live ``gda schema`` manifest as JSON, built in-process (no subprocess).
+
+    ``gda schema`` spawns no Godot (ADR-0012), so the manifest is produced
+    directly from the Typer tree — giving the fake seam the *real* whole surface
+    to register against.
+    """
+    return build_surface_manifest(app).model_dump_json()
+
+
+def schema_then(dispatch: Responder) -> Responder:
+    """A responder that serves the real dump for ``gda schema``, else ``dispatch``.
+
+    Startup introspection (``["schema"]``) gets the real manifest so the full
+    tool surface registers; every other invocation (a per-tool dispatch) is
+    delegated to ``dispatch``.
+    """
+    manifest = real_manifest_json()
+
+    def responder(args: list[str], stdin: Optional[str]) -> GdaResult:
+        if args[:1] == ["schema"]:
+            return GdaResult(stdout=manifest, stderr="", returncode=0)
+        return dispatch(args, stdin)
+
+    return responder
+
+
+def gda_result(stdout: str = "", stderr: str = "", returncode: int = 0) -> GdaResult:
+    """Terse :class:`GdaResult` factory for canned seam responses."""
+    return GdaResult(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def list_tools(server):
+    """Open an in-memory MCP session and return the server's ``list_tools`` result."""
+    from mcp.shared.memory import create_connected_server_and_client_session as connect
+
+    async def _inner():
+        async with connect(server) as session:
+            return await session.list_tools()
+
+    return anyio.run(_inner)
+
+
+def call_tool(server, name: str, arguments: dict):
+    """Open an in-memory MCP session, call one tool, return its ``CallToolResult``."""
+    from mcp.shared.memory import create_connected_server_and_client_session as connect
+
+    async def _inner():
+        async with connect(server) as session:
+            return await session.call_tool(name, arguments)
+
+    return anyio.run(_inner)

--- a/tests/test_e2e_mcp_stdio.py
+++ b/tests/test_e2e_mcp_stdio.py
@@ -1,0 +1,72 @@
+"""S6 (e2e): the non-negotiable gda-mcp stdio gate (issue #193, ADR-0013).
+
+The real chain over the wire it ships on: a real MCP client → the real
+``gda-mcp`` **console script** over **stdio** → the real ``gda`` subprocess → a
+real Godot engine. This is what validates ADR-0013 packaging + launch (the
+console script actually starts and speaks MCP), so the fake seam does NOT count
+toward this gate (RULES.md DoD). Representative tools: ``info`` (reports the
+engine version — #199-independent) and ``scene_create`` (creates a scene file on
+disk — exercises the ADR-0015 ``--params-json`` dispatch).
+
+Godot is pinned via ``$GDA_GODOT`` in the *server's* env — the same vector a real
+MCP registration uses — since gda-mcp resolves Godot by gda's own precedence and
+never hardcodes it (Design decision 1).
+"""
+
+import os
+import shutil
+
+import anyio
+import pytest
+from mcp import StdioServerParameters
+from mcp.client.session import ClientSession
+from mcp.client.stdio import stdio_client
+
+from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
+
+GODOT = resolve_godot_binary()
+
+
+def _server_params() -> StdioServerParameters:
+    gda_mcp = shutil.which("gda-mcp")
+    assert gda_mcp, "the `gda-mcp` console script is not on PATH"
+    # Full env + a pinned Godot, so the server's nested `-m gda` resolves the
+    # same engine deterministically.
+    env = {**os.environ, GODOT_BIN_ENV: str(GODOT)}
+    return StdioServerParameters(command=gda_mcp, args=[], env=env)
+
+
+def _call(tool: str, arguments: dict):
+    """Spawn the real gda-mcp over stdio, call one tool, return its result."""
+
+    async def _drive():
+        async with stdio_client(_server_params()) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                return await session.call_tool(tool, arguments)
+
+    return anyio.run(_drive)
+
+
+@pytest.mark.e2e
+def test_info_over_stdio_reports_engine_version():
+    result = _call("info", {})
+
+    assert result.isError is False, result.content
+    assert result.structuredContent["major"] == 4
+    assert (result.structuredContent["major"], result.structuredContent["minor"]) >= (4, 4)
+
+
+@pytest.mark.e2e
+def test_scene_create_over_stdio_creates_a_scene_file(tmp_path):
+    scene = tmp_path / "main.tscn"
+
+    result = _call("scene_create", {"path": str(scene), "root_type": "Node2D"})
+
+    assert result.isError is False, result.content
+    # The verbatim --params-json dispatch produced gda's typed result…
+    assert result.structuredContent["root_type"] == "Node2D"
+    # root_name derived model-side from the filename, same as the argv path.
+    assert result.structuredContent["root_name"] == "main"
+    # …and the .tscn really landed on disk (the real outcome, not a fake).
+    assert scene.exists()

--- a/tests/test_e2e_mcp_tracer.py
+++ b/tests/test_e2e_mcp_tracer.py
@@ -1,0 +1,47 @@
+"""S1 (e2e): the gda-mcp `info` tracer — the real chain end to end (issue #193).
+
+The tracer bullet: an in-memory MCP client → in-process low-level Server → the
+real ``-m gda info`` subprocess → a real Godot engine. It proves the whole spine
+composes (SDK + subprocess seam + dump-introspection + engine) before breadth or
+polish. Godot is resolved by gda's OWN precedence — gda-mcp never hardcodes it
+(Design decision 1) — so we pin ``$GDA_GODOT`` for determinism; the e2e marker
+reuses the shared ``_require_godot_engine`` gate.
+"""
+
+import anyio
+import pytest
+from mcp.shared.memory import create_connected_server_and_client_session as connect
+
+from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
+from gda.mcp.runner import SubprocessGdaRunner
+from gda.mcp.server import build_server
+
+GODOT = resolve_godot_binary()
+
+
+@pytest.mark.e2e
+def test_info_tracer_real_chain(monkeypatch):
+    # Pin Godot for the nested `-m gda` via gda's own env precedence (never
+    # hardcoded in gda-mcp). The in-process server introspects the real dump at
+    # build time, then the info call shells out through the real seam to a real
+    # engine.
+    monkeypatch.setenv(GODOT_BIN_ENV, str(GODOT))
+    server = build_server(SubprocessGdaRunner.default())
+
+    async def _drive():
+        async with connect(server) as session:
+            tools = await session.list_tools()
+            result = await session.call_tool("info", {})
+            return tools, result
+
+    tools, result = anyio.run(_drive)
+
+    # Startup registered the real surface, including the info tracer tool.
+    assert "info" in {t.name for t in tools.tools}
+    # The call succeeded and the engine version came back as validated
+    # structuredContent (the SDK checked it against info's outputSchema).
+    assert result.isError is False, result.content
+    version = result.structuredContent
+    assert version["major"] == 4
+    assert (version["major"], version["minor"]) >= (4, 4)  # ADR-0003 minimum
+    assert isinstance(version["string"], str)

--- a/tests/test_mcp_dispatch.py
+++ b/tests/test_mcp_dispatch.py
@@ -1,0 +1,67 @@
+"""S5 (fast): gda-mcp parametrized dispatch + success mapping (issue #193, ADR-0015).
+
+A tool call forwards its input object *verbatim* to gda via
+``gda <group> <command> --params-json -`` (object on stdin) and relays the
+success: gda's ``--json`` dict becomes the tool's ``structuredContent``, which
+the SDK validates against the tool's ``outputSchema`` (Design decision 5). These
+drive the real surface through a fake seam (no gda subprocess, no Godot) over an
+in-memory MCP client, asserting both the seam invocation and the relayed result.
+"""
+
+import json
+
+from gda.mcp.server import build_server
+from tests.mcp_support import FakeGdaRunner, call_tool, gda_result, schema_then
+from tests.support import SCENE_CREATE_RESULT, VERSION_INFO
+
+
+def test_scene_create_input_object_builds_params_json_dispatch():
+    # The canonical S5 case: scene_create's input object → the exact gda argv +
+    # the object on stdin; the canned --json result relays as structuredContent.
+    runner = FakeGdaRunner(
+        schema_then(lambda args, stdin: gda_result(json.dumps(SCENE_CREATE_RESULT)))
+    )
+    server = build_server(runner)
+    arguments = {"path": "/tmp/proj/main.tscn", "root_type": "Node2D"}
+
+    result = call_tool(server, "scene_create", arguments)
+
+    # Success relayed as structuredContent, validated against the real outputSchema.
+    assert result.isError is False
+    assert result.structuredContent == SCENE_CREATE_RESULT
+    # The seam was driven with the gda command argv + verbatim object on stdin.
+    dispatch_args, dispatch_stdin = runner.calls[-1]
+    assert dispatch_args == ["scene", "create", "--params-json", "-", "--json"]
+    assert json.loads(dispatch_stdin) == arguments
+
+
+def test_multiword_command_name_maps_back_to_the_right_argv():
+    # The MCP tool name `scene_get_exports` must dispatch to `scene get-exports`
+    # (hyphen restored), proving the argv comes from the dump's own name — not a
+    # lossy reverse of the underscored tool name.
+    runner = FakeGdaRunner(
+        schema_then(lambda args, stdin: gda_result(json.dumps({"path": "x", "exports": []})))
+    )
+    server = build_server(runner)
+
+    call_tool(server, "scene_get_exports", {"path": "res://main.tscn"})
+
+    dispatch_args, _ = runner.calls[-1]
+    assert dispatch_args[:2] == ["scene", "get-exports"]
+
+
+def test_no_param_tool_dispatches_an_empty_params_object():
+    # A no-arg tool (info) still goes through --params-json with `{}` on stdin —
+    # the uniform passthrough, no special-casing of param-less commands.
+    runner = FakeGdaRunner(
+        schema_then(lambda args, stdin: gda_result(json.dumps(VERSION_INFO)))
+    )
+    server = build_server(runner)
+
+    result = call_tool(server, "info", {})
+
+    assert result.isError is False
+    assert result.structuredContent["string"] == VERSION_INFO["string"]
+    dispatch_args, dispatch_stdin = runner.calls[-1]
+    assert dispatch_args == ["info", "--params-json", "-", "--json"]
+    assert json.loads(dispatch_stdin) == {}

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -1,0 +1,126 @@
+"""S3 (fast): gda-mcp error channel + the can't-run / non-envelope edge (issue #193).
+
+A failing gda call (non-zero exit) maps to ``CallToolResult(isError=True)``
+carrying gda's ``GdaError`` envelope **verbatim and losslessly** as JSON content
+(never flattened to prose, never folded into ``structuredContent`` /
+``outputSchema``) — ADR-0011. The stable ``code`` survives for every non-zero
+category: environment / version / operation / parse, including the launch codes
+(``binary_not_found`` / ``launch_timeout``) and the parse-category
+``contract_violation``. The edge — gda could not even run, or emitted
+non-envelope output — is synthesized by gda-mcp itself.
+
+These drive the real surface through a fake seam (no gda subprocess, no Godot)
+over an in-memory MCP client.
+"""
+
+import json
+
+import pytest
+
+from gda.error_codes import ERROR_CODE_BY_CODE
+from gda.mcp.server import build_server
+from gda.models import GdaError, GdaErrorEnvelope
+from tests.mcp_support import FakeGdaRunner, call_tool, gda_result, schema_then
+
+
+def _gda_envelope_json(code: str) -> str:
+    """The exact stdout gda emits for ``code`` — the real envelope, real shape."""
+    spec = ERROR_CODE_BY_CODE[code]
+    error = GdaError(
+        category=spec.category,
+        code=code,
+        message=f"{code} happened",
+        diagnostics="engine stderr noise",
+    )
+    return GdaErrorEnvelope(error=error).model_dump_json()
+
+
+def _failing_server(code: str):
+    """A server whose every dispatch fails with gda's real envelope for ``code``."""
+    spec = ERROR_CODE_BY_CODE[code]
+    stdout = _gda_envelope_json(code)
+    runner = FakeGdaRunner(
+        schema_then(lambda args, stdin: gda_result(stdout, returncode=spec.exit_code))
+    )
+    return build_server(runner)
+
+
+# One representative code per non-zero category, spanning the two launch codes
+# and the parse-category contract_violation the AC calls out explicitly.
+@pytest.mark.parametrize(
+    "code",
+    [
+        "binary_not_found",  # environment (launch, exit 127)
+        "launch_timeout",  # environment (launch, exit 124)
+        "unsupported_version",  # version
+        "operation_failed",  # operation
+        "path_not_found",  # operation (an operation-reported code)
+        "contract_violation",  # parse
+    ],
+)
+def test_each_category_relays_losslessly_as_is_error(code):
+    result = call_tool(_failing_server(code), "scene_create", {"path": "x", "root_type": "Node2D"})
+
+    # The failure channel: isError, and the error stays OUT of structuredContent.
+    assert result.isError is True
+    assert result.structuredContent is None
+    # Lossless: the single content block parses back to gda's exact envelope —
+    # all four fields, and crucially the stable code, preserved verbatim.
+    assert len(result.content) == 1
+    relayed = json.loads(result.content[0].text)
+    assert relayed == json.loads(_gda_envelope_json(code))
+    assert relayed["error"]["code"] == code
+    assert relayed["error"]["category"] == ERROR_CODE_BY_CODE[code].category.value
+
+
+def test_relayed_content_is_not_flattened_to_prose():
+    # ADR-0011: the envelope must arrive as JSON an agent can branch on, never a
+    # prose string the SDK would synthesize from a raised exception.
+    result = call_tool(_failing_server("path_not_found"), "scene_create", {"path": "x"})
+    text = result.content[0].text
+    parsed = json.loads(text)  # must be valid JSON, not prose
+    assert set(parsed["error"]) >= {"category", "code", "message", "diagnostics"}
+
+
+def test_cannot_run_edge_is_synthesized_by_gda_mcp():
+    # gda could not even run (e.g. `-m gda` import failure): no stdout, a traceback
+    # on stderr, non-zero exit. gda-mcp synthesizes its OWN structured isError,
+    # preserving gda's stderr as diagnostics rather than crashing or going silent.
+    runner = FakeGdaRunner(
+        schema_then(
+            lambda args, stdin: gda_result(
+                stdout="", stderr="Traceback: ModuleNotFoundError: No module named 'gda'", returncode=1
+            )
+        )
+    )
+    result = call_tool(build_server(runner), "info", {})
+
+    assert result.isError is True
+    assert result.structuredContent is None
+    body = json.loads(result.content[0].text)
+    assert body["error"]["category"] == "adapter"  # gda-mcp's own, not a gda category
+    assert "ModuleNotFoundError" in body["error"]["diagnostics"]
+
+
+def test_non_envelope_output_edge_is_synthesized():
+    # Non-zero exit but stdout is not a GdaError envelope (a Click usage error, a
+    # bare string, JSON missing the error shape): also synthesized by gda-mcp.
+    runner = FakeGdaRunner(
+        schema_then(lambda args, stdin: gda_result(stdout='{"not":"an envelope"}', returncode=2))
+    )
+    result = call_tool(build_server(runner), "info", {})
+
+    assert result.isError is True
+    assert json.loads(result.content[0].text)["error"]["category"] == "adapter"
+
+
+def test_exit_zero_but_non_json_stdout_edge_is_synthesized():
+    # The success-path edge: gda exits 0 yet stdout is not JSON (so --json could
+    # not have been honored). gda-mcp treats it as an adapter error, not a crash.
+    runner = FakeGdaRunner(
+        schema_then(lambda args, stdin: gda_result(stdout="not json at all", returncode=0))
+    )
+    result = call_tool(build_server(runner), "info", {})
+
+    assert result.isError is True
+    assert json.loads(result.content[0].text)["error"]["category"] == "adapter"

--- a/tests/test_mcp_packaging.py
+++ b/tests/test_mcp_packaging.py
@@ -1,0 +1,51 @@
+"""S4 (fast): gda-mcp packaging guard + lean core (issue #193, ADR-0013).
+
+The ``gda-mcp`` console script is declared in every install, but the ``mcp`` SDK
+only ships with the ``gda[mcp]`` extra. Without it, ``gda-mcp`` must fail with an
+actionable "install ``gda[mcp]``" message and a non-zero exit — not an opaque
+ImportError (AC1). And gda *core* must never import ``mcp``, so a plain ``gda``
+install stays lean. These are fast (no Godot, no MCP session).
+"""
+
+import subprocess
+import sys
+
+import gda.mcp
+
+
+def test_missing_mcp_extra_fails_with_actionable_message(monkeypatch, capsys):
+    # Simulate the extra being absent: a ``None`` entry in sys.modules makes
+    # ``import mcp`` raise ImportError, exactly as a missing install would.
+    monkeypatch.setitem(sys.modules, "mcp", None)
+
+    rc = gda.mcp.main()
+
+    assert rc != 0  # non-zero exit (AC1)
+    err = capsys.readouterr().err
+    assert "gda[mcp]" in err  # names the fix
+    assert "mcp" in err
+
+
+def test_present_mcp_hands_off_to_the_server(monkeypatch):
+    # With the extra present, main() guards successfully and hands off to the
+    # server's run loop (stubbed here so no real stdio server starts).
+    calls = []
+    monkeypatch.setattr("gda.mcp.server.run_stdio", lambda: calls.append(True))
+
+    rc = gda.mcp.main()
+
+    assert rc == 0
+    assert calls == [True]
+
+
+def test_gda_core_does_not_import_mcp():
+    # ADR-0013: gda core never imports the MCP SDK, so a CLI-only install pays no
+    # MCP cost. Checked in a fresh interpreter (this test process already has mcp
+    # loaded from the fast tier) that imports the whole CLI surface.
+    proc = subprocess.run(
+        [sys.executable, "-c", "import gda.cli, gda.__main__, sys; "
+         "assert 'mcp' not in sys.modules, sorted(m for m in sys.modules if 'mcp' in m)"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr

--- a/tests/test_mcp_registration.py
+++ b/tests/test_mcp_registration.py
@@ -70,6 +70,15 @@ def test_known_tool_has_a_nonempty_output_schema():
     assert info.outputSchema and info.outputSchema.get("type") == "object"
 
 
+def test_non_dispatchable_meta_commands_are_not_registered():
+    # Plan A, proven at the MCP layer (PR #203 review): `gda schema` is
+    # non-dispatchable (no --params-json), so gda-mcp must NOT advertise it as a
+    # tool it cannot fulfil. The dump excludes it at the source, so it never
+    # reaches registration — no per-command exclusion logic in gda-mcp.
+    names = {t.name for t in list_tools(_server()).tools}
+    assert "schema" not in names
+
+
 def test_startup_introspects_the_dump_through_the_seam_once():
     # The surface comes from one `gda schema` run through the shared seam
     # (ADR-0012's single startup subprocess), not a per-command fan-out.

--- a/tests/test_mcp_registration.py
+++ b/tests/test_mcp_registration.py
@@ -1,0 +1,78 @@
+"""S2 (fast): gda-mcp tool-registration coverage (issue #193, ADR-0012).
+
+On startup gda-mcp introspects the aggregate schema dump and registers one MCP
+tool per command — a *faithful mirror* of the installed gda. These tests drive
+the real surface through a fake seam (no gda subprocess, no Godot) over an
+in-memory MCP client, asserting full coverage, the ``<group>_<command>`` name
+map, and that each tool's description / input / output come straight from the
+dump.
+"""
+
+import json
+import re
+
+from gda.mcp.server import build_server, tool_name
+from tests.mcp_support import (
+    FakeGdaRunner,
+    list_tools,
+    real_manifest_json,
+    schema_then,
+)
+
+# The fake seam never dispatches in these tests (registration only); a dispatch
+# attempt is a loud failure so a stray call cannot pass silently.
+def _no_dispatch(args, stdin):
+    raise AssertionError(f"unexpected dispatch in a registration test: {args}")
+
+
+def _server():
+    return build_server(FakeGdaRunner(schema_then(_no_dispatch)))
+
+
+def _manifest_entries():
+    return json.loads(real_manifest_json())["commands"]
+
+
+def test_registers_one_tool_per_command_full_coverage():
+    # Faithful mirror (ADR-0012): the tool set is exactly the dump's commands,
+    # one-to-one, nothing dropped/filtered/deduped.
+    tools = list_tools(_server()).tools
+    expected = {tool_name(e["name"]) for e in _manifest_entries()}
+    got = {t.name for t in tools}
+    assert got == expected
+    assert len(tools) == len(_manifest_entries())  # no collisions collapsed a pair
+
+
+def test_tool_names_are_group_command_with_separators_underscored():
+    # ADR-0005 name map: `<group> <command>` → `<group>_<command>`, with both the
+    # space and any in-command hyphen turned to `_`. Spot-check the tricky ones…
+    names = {t.name for t in list_tools(_server()).tools}
+    assert {"info", "scene_create", "scene_get_exports", "node_connect_signal"} <= names
+    # …and the global invariant: no tool name carries a space or hyphen.
+    assert all(re.fullmatch(r"[a-z0-9_]+", n) for n in names), names
+
+
+def test_each_tool_mirrors_its_commands_description_and_schemas():
+    # description ← command help; inputSchema ← input; outputSchema ← output —
+    # passed through verbatim from the dump (ADR-0012's per-field fidelity).
+    by_name = {tool_name(e["name"]): e for e in _manifest_entries()}
+    for tool in list_tools(_server()).tools:
+        entry = by_name[tool.name]
+        assert tool.description == entry["description"]
+        assert tool.inputSchema == entry["input"]
+        assert tool.outputSchema == entry["output"]
+
+
+def test_known_tool_has_a_nonempty_output_schema():
+    # info's outputSchema is the EngineVersion contract — present so the SDK can
+    # validate a successful call's structuredContent against it (Design dec. 5).
+    info = next(t for t in list_tools(_server()).tools if t.name == "info")
+    assert info.outputSchema and info.outputSchema.get("type") == "object"
+
+
+def test_startup_introspects_the_dump_through_the_seam_once():
+    # The surface comes from one `gda schema` run through the shared seam
+    # (ADR-0012's single startup subprocess), not a per-command fan-out.
+    runner = FakeGdaRunner(schema_then(_no_dispatch))
+    build_server(runner)
+    assert runner.calls == [(["schema"], None)]

--- a/tests/test_mcp_runner.py
+++ b/tests/test_mcp_runner.py
@@ -1,0 +1,42 @@
+"""gda-mcp subprocess seam: launch failures are raw results, never exceptions (#193).
+
+Reviewer-requested regression (PR #203): a gda command that cannot be launched —
+e.g. a bad ``$GDA_BIN`` override pointing nowhere — must surface as a structured
+non-zero :class:`~gda.mcp.runner.GdaResult` that :func:`~gda.mcp.server.dispatch`
+turns into an ``isError`` ``CallToolResult``, NOT an ``OSError`` escaping across
+the MCP boundary (ADR-0011's "can't-run" edge, synthesized by gda-mcp). These are
+fast: the bad binary fails to exec immediately, no Godot involved.
+"""
+
+import json
+
+from gda.mcp.runner import SubprocessGdaRunner
+from gda.mcp.server import dispatch
+
+# A command that cannot be exec'd at all — the unlaunchable-binary case a bad
+# GDA_BIN override produces.
+_UNLAUNCHABLE = SubprocessGdaRunner(command=["/does/not/exist/gda"])
+
+
+def test_unlaunchable_command_returns_a_failure_result_not_an_exception():
+    # The seam catches the OSError and reports it as a non-zero raw result,
+    # naming the offending command in diagnostics — it never raises.
+    result = _UNLAUNCHABLE.run(["info"])
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "/does/not/exist/gda" in result.stderr
+
+
+def test_dispatch_synthesizes_is_error_for_a_launch_failure():
+    # End to end through the real seam: an unlaunchable gda becomes gda-mcp's own
+    # structured isError (the can't-run edge), with the launch diagnostics
+    # preserved — not a traceback.
+    outcome = dispatch(_UNLAUNCHABLE, ["info"], {})
+
+    # A CallToolResult (failure channel), not a raised exception or a result dict.
+    assert outcome.isError is True
+    assert outcome.structuredContent is None
+    body = json.loads(outcome.content[0].text)
+    assert body["error"]["category"] == "adapter"  # gda-mcp's own synthesized error
+    assert "/does/not/exist/gda" in body["error"]["diagnostics"]

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -1,12 +1,14 @@
 """`gda schema` aggregate-surface manifest (issue #192, ADR-0012, ADR-0004).
 
 `gda schema` is a meta command (ADR-0005): top-level and ungrouped, a sibling of
-`gda info`. In a single process — no Godot spawned — it emits the whole command
-surface as one JSON document, one entry per command carrying
+`gda info`. In a single process — no Godot spawned — it emits the **dispatchable**
+command surface as one JSON document, one entry per dispatchable command carrying
 `{name, description, input, output, error}`. It is the whole-surface
 generalisation of per-command `--schema` (ADR-0004): the machine-readable
 manifest gda-mcp introspects once at startup to generate its tool surface
-(ADR-0012).
+(ADR-0012). A non-dispatchable meta command — one with no backing operation, so
+no `--params-json` (e.g. `gda schema` itself) — is excluded from the surface it
+describes (Plan A); `gda schema --schema` still self-describes as any command.
 
 These are fast tests — `gda schema` spawns no Godot, so none of them need the
 engine. Most drive the command in-process via `CliRunner`; the last drives the
@@ -32,11 +34,16 @@ def _manifest() -> dict:
     return json.loads(result.stdout)
 
 
-def _live_command_names() -> set[str]:
+def _live_dispatchable_command_names() -> set[str]:
     """Independently walk the live Typer tree into ``<group> <command>`` names.
 
     Mirrors the manifest's enumeration via a separate traversal so the coverage
-    assertion is a real cross-check, not a tautology against the production walker.
+    assertion is a real cross-check, not a tautology against the production
+    walker. Restricted to *dispatchable* commands — the manifest excludes
+    non-dispatchable meta commands (Plan A) — but keyed on a signal INDEPENDENT
+    of production's ``gda_command``: whether the command exposes a
+    ``--params-json`` option. The two signals are 1:1, so requiring them to agree
+    keeps this an honest cross-check rather than a mirror of the production rule.
     """
     names: set[str] = set()
 
@@ -46,7 +53,11 @@ def _live_command_names() -> set[str]:
             for name, subcommand in subcommands.items():
                 walk(subcommand, [*path, name])
             return
-        names.add(" ".join(path))
+        dispatchable = any(
+            getattr(p, "name", None) == "params_json" for p in command.params
+        )
+        if dispatchable:
+            names.add(" ".join(path))
 
     walk(typer.main.get_command(app), [])
     return names
@@ -73,11 +84,23 @@ def test_name_is_the_group_command_mcp_mapping_basis():
     assert "info" in names
 
 
-def test_manifest_covers_every_command_reachable_from_the_cli():
-    # The manifest is a faithful mirror of the live command tree (ADR-0012):
-    # nothing dropped, filtered, or deduped away.
+def test_manifest_covers_every_dispatchable_command_reachable_from_the_cli():
+    # The manifest is a faithful mirror of the live command tree's dispatchable
+    # commands (ADR-0012, Plan A): every dispatchable command present, nothing
+    # else dropped or deduped, and only non-dispatchable meta commands excluded.
     names = {entry["name"] for entry in _manifest()["commands"]}
-    assert names == _live_command_names()
+    assert names == _live_dispatchable_command_names()
+
+
+def test_non_dispatchable_meta_commands_are_excluded():
+    # Plan A (ADR-0012): the manifest is the dispatchable-operation surface. `gda
+    # schema` is a live, reachable command but a pure self-describer with no
+    # backing operation (no --params-json), so it is NOT a manifest entry —
+    # re-listing the describer inside the surface it describes would be circular.
+    names = {entry["name"] for entry in _manifest()["commands"]}
+    assert "schema" not in names
+    # …yet it remains a real command that self-describes under its own --schema.
+    assert CliRunner().invoke(app, ["schema", "--schema"]).exit_code == 0
 
 
 def test_each_entry_matches_the_commands_own_schema():
@@ -155,5 +178,7 @@ def test_real_console_script_manifest_covers_the_live_command_tree():
 
     assert proc.returncode == 0, proc.stderr
     names = {entry["name"] for entry in json.loads(proc.stdout)["commands"]}
-    assert names == _live_command_names()
-    assert {"info", "schema", "scene create"} <= names
+    assert names == _live_dispatchable_command_names()
+    assert {"info", "scene create"} <= names
+    # The non-dispatchable `schema` meta command is excluded (Plan A).
+    assert "schema" not in names

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,12 @@
 version = 1
 revision = 3
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "annotated-doc"
@@ -21,12 +27,90 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
@@ -39,6 +123,56 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+]
+
+[[package]]
 name = "gda"
 version = "0.1.21"
 source = { editable = "." }
@@ -47,22 +181,86 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+mcp = [
+    { name = "mcp" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "jsonschema" },
+    { name = "mcp" },
     { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.12,<2" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "typer", specifier = ">=0.26.7" },
 ]
+provides-extras = ["mcp"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "jsonschema", specifier = ">=4.26.0" },
+    { name = "mcp", specifier = ">=1.12,<2" },
     { name = "pytest", specifier = ">=9.0.3" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -114,6 +312,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/ee/94c6c50ffc5b5cf4737052275d11b57367f32d1a8516e31dcd60591b3916/mcp-1.28.0.tar.gz", hash = "sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2", size = 636040, upload-time = "2026-06-16T21:37:17.996Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/e1/4c1dc1fbb688641a712d34650c3d58bbbdcb314ddb75bc5817bbf33515a4/mcp-1.28.0-py3-none-any.whl", hash = "sha256:9c1e7cf3a9125557e418ecd4fed8e9adddce81b0dfdae4d6601d700f5beb71a4", size = 221959, upload-time = "2026-06-16T21:37:16.579Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -138,6 +361,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -212,12 +444,40 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -234,6 +494,40 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -367,6 +661,31 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
@@ -400,4 +719,17 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]


### PR DESCRIPTION
## What

The **gda-mcp tracer bullet** (#193): an `mcp` low-level **stdio** server that, at startup, introspects gda's aggregate schema dump (`gda schema`, #192) and registers **one MCP tool per command** — name `<group>_<command>` (`-`→`_`), `description` ← command help, `inputSchema`/`outputSchema` ← the command's schemas. A faithful mirror of the installed gda (ADR-0012), no codegen.

Each tool call shells out to the **same-distribution** gda via `[sys.executable, "-m", "gda"]` (Design decision 3 — never a PATH lookup), forwarding the tool input **verbatim** through `gda <group> <command> --params-json -` (object on stdin; ADR-0015), and maps the outcome mechanically off gda's exit code (ADR-0011):

- **exit 0** → the `--json` result dict; the SDK validates it against the tool's `outputSchema` and wraps it as `structuredContent`. gda-mcp does **not** re-validate — gda's result and its `outputSchema` share one Pydantic model, so conformance is by construction (Design decision 5).
- **non-zero** → `CallToolResult(isError=True)` carrying the full `{category, code, message, diagnostics}` `GdaError` envelope **verbatim and losslessly** as JSON content — never flattened to prose, kept out of `structuredContent`/`outputSchema`. The **can't-run / non-envelope edge** (e.g. `-m gda` import failure, a Click usage error) is synthesized by gda-mcp itself.

### Why low-level `Server`, not FastMCP
Schemas come **from gda** (not Python signatures), tools are discovered at runtime and served by **one generic dispatcher**, and the result/error channels need direct control — the inverse of FastMCP's "one tool = one decorated function" assumption.

### Packaging (ADR-0013)
Behind an optional `gda[mcp]` extra exposing a `gda-mcp` console script (also `uvx --from "gda[mcp]" gda-mcp`). `mcp` is **also** a dev dependency so `uv run pytest` has the SDK. gda **core never imports `mcp`**, and the entry point guards the import with an actionable "install `gda[mcp]`" message. Adds `gda/__main__.py` for the `-m gda` invocation.

## Architecture
- `src/gda/mcp/runner.py` — the single subprocess seam (`GdaRunner`), shared by startup introspection **and** per-tool dispatch; fast tests inject a fake (mirroring gda's own `FakeRunner`, one layer up).
- `src/gda/mcp/server.py` — introspect → register `types.Tool`s → one generic `call_tool` (`validate_input=False`, so gda owns input validation per ADR-0015).
- `src/gda/mcp/__init__.py` — lean guarded `main()`.
- `src/gda/__main__.py` — `python -m gda`.

## Slices (TDD)
| Slice | Form | Status |
|---|---|---|
| S1 info tracer real chain | e2e (in-memory client → in-process server → real gda → real Godot) | ✅ |
| S2 registration coverage | fast (fake seam + real dump) | ✅ |
| S3 error channel + edge | fast | ✅ |
| S4 packaging guard | fast | ✅ |
| S5 parametrized dispatch | fast | ✅ |
| S6 **e2e stdio gate** (non-negotiable) | e2e (real `gda-mcp` console script over stdio → real gda → real Godot: `info` + `scene_create`) | ✅ |

## Tests
- **598 fast** (21 new mcp fast tests) ✅
- **238 e2e** (1 pre-existing skip), incl. the new S1/S6 gates ✅ — run serially (~7 min)
- `uv build` produces a wheel containing `gda/mcp/*`, `gda/__main__.py`, and both `gda` + `gda-mcp` console scripts ✅

Per RULES.md DoD, the fake-`gda` seam does **not** count toward the e2e gate.

## Scope notes
Project-context resolution (#194) and per-agent registration recipes (#195) are **separate open issues** — out of scope here. The `info` half of S6 is #199-independent; `scene_create` exercises `--params-json` (#199, merged in 0.1.21).

Closes #193.
