### PR TITLE
feat(gda-mcp): project-context resolution via portable precedence (#194)

### DIFF
--- a/docs/adr/0014-gda-mcp-project-context-resolution.md
+++ b/docs/adr/0014-gda-mcp-project-context-resolution.md
@@ -16,8 +16,13 @@ breaking either decision.
 **The target project is server context, not a per-call tool parameter.** gda-mcp does
 **not** inject a `project` field into any tool's inputSchema; the tool surface stays a
 faithful mirror of `--schema` (ADR-0012), and `gda` still receives the project exactly
-as ADR-0006 specifies. gda-mcp resolves one target project for the server and passes
-it as `--project` to every `gda` subprocess it spawns.
+as ADR-0006 specifies. gda-mcp resolves one target project for the server and hands it
+to its `gda` subprocesses through gda's own **`GDA_PROJECT`** channel (ADR-0006) — set
+on the subprocess environment, **not** a `--project` flag. The env channel applies
+uniformly: project-taking domain commands consume it, while meta commands (`info`) that
+take no project simply ignore it — so gda-mcp needs no per-command knowledge of which
+commands accept a project, and a `--project` flag (which meta commands reject outright)
+is never forged.
 
 **Resolution is by a portable precedence, with cwd only as a last resort** — because
 the launch working directory is not reliably the project across MCP clients (clients
@@ -32,16 +37,18 @@ gda-mcp resolves, first hit wins:
 2. the MCP **`roots/list`** the client advertises — the protocol-native workspace signal,
 3. the process **cwd**, as a last-resort fallback.
 
-**A candidate is asserted as an explicit project only when it is a valid Godot
-project** (it contains `project.godot`). gda-mcp does **not** promote an unvalidated
-cwd or root into an explicit `--project`, because ADR-0006 gives `--project` /
-`$GDA_PROJECT` strict semantics (must be a real project) while leaving cwd lenient.
-So an explicit `GDA_PROJECT`, and any validated `roots`/cwd candidate, are passed as
-`gda --project <dir>`; if nothing resolves to a valid
-project, gda-mcp passes **no** `--project` and lets `gda` apply its own ADR-0006 cwd
-resolution — including running projectless when the cwd is not a project. gda-mcp
-does not itself reject projectless operation; an op that requires a project surfaces
-`gda`'s own typed error, relayed unchanged.
+**A candidate is asserted as the project only when it is a valid Godot project** (it
+contains `project.godot`). gda-mcp does **not** promote an unvalidated cwd or root,
+because ADR-0006 gives `$GDA_PROJECT` strict semantics (must be a real project) while
+leaving cwd lenient. So a validated `roots` or cwd candidate is exported as
+`GDA_PROJECT=<dir>` on the subprocess; if nothing resolves to a valid project, gda-mcp
+sets **no** `GDA_PROJECT` and lets `gda` apply its own ADR-0006 resolution over the
+inherited environment — including running projectless when neither `$GDA_PROJECT` nor
+the cwd is a project. An explicitly set but **invalid** `GDA_PROJECT` is left untouched
+in the inherited environment (not silently shadowed by a roots/cwd candidate), so `gda`
+surfaces its own strict typed error for project-taking commands. gda-mcp does not itself
+reject projectless operation; an op that requires a project surfaces `gda`'s own typed
+error, relayed unchanged.
 
 ## Considered options
 

--- a/docs/adr/0014-gda-mcp-project-context-resolution.md
+++ b/docs/adr/0014-gda-mcp-project-context-resolution.md
@@ -68,8 +68,12 @@ error, relayed unchanged.
 - A **user-scoped** server with nothing pinned falls back through `roots/list` / cwd;
   it works for the single-active-project workflow but cannot, in this first delivery,
   follow a user juggling several projects in one session.
-- The startup `roots/list` read (precedence 2) is part of the resolution contract,
-  not a staged extra — the first delivery implements the full precedence above.
+- The `roots/list` read (precedence 2) is part of the resolution contract, not a
+  staged extra — the first delivery implements the full precedence above. Because
+  `roots/list` is a server→client request that needs a live session, it cannot run
+  at process startup; resolution is **snapshotted on the first tool call** and then
+  cached for the server's lifetime (one server : one project). Re-resolving when the
+  client's active root changes is the deferred `roots/list_changed` path below.
 - **No vendor coupling in the core.** This ADR names no specific agent; per-agent
   registration — how each agent's config sets the server's `env` / launch command and
   pins the project — is the registration recipes' concern (ADR-0013), which must cover

--- a/docs/adr/0014-gda-mcp-project-context-resolution.md
+++ b/docs/adr/0014-gda-mcp-project-context-resolution.md
@@ -20,25 +20,24 @@ as ADR-0006 specifies. gda-mcp resolves one target project for the server and pa
 it as `--project` to every `gda` subprocess it spawns.
 
 **Resolution is by a portable precedence, with cwd only as a last resort** — because
-the launch working directory is not reliably the project across agents (Claude Code
-ignores a configured `cwd`, claude-code#17565; Cursor / Claude Desktop leave it at the
-launch dir or undefined `/`; only Codex sets it reliably). gda-mcp resolves, first hit
-wins:
+the launch working directory is not reliably the project across MCP clients (clients
+differ in whether the operator can set it, and several leave it at an arbitrary launch
+directory or undefined). The precedence names only agent-neutral primitives — gda's own
+env, the MCP protocol's own workspace signal, and cwd; how any specific agent is
+configured to supply them belongs to the registration recipes (ADR-0013), not here.
+gda-mcp resolves, first hit wins:
 
-1. an explicit **`GDA_PROJECT`** in the server's environment (the user pins it in any
-   agent's `env` / TOML; Cursor can inject `${workspaceFolder}`),
-2. **`CLAUDE_PROJECT_DIR`** (Claude Code sets this in the server env to the project
-   root, for free),
-3. the MCP **`roots/list`** the client advertises (Claude Code populates it with the
-   launch dir),
-4. the process **cwd**, as a last-resort fallback.
+1. an explicit **`GDA_PROJECT`** in the server's environment — the operator pins it in
+   the MCP server's `env` config; the neutral, agent-independent anchor,
+2. the MCP **`roots/list`** the client advertises — the protocol-native workspace signal,
+3. the process **cwd**, as a last-resort fallback.
 
 **A candidate is asserted as an explicit project only when it is a valid Godot
 project** (it contains `project.godot`). gda-mcp does **not** promote an unvalidated
 cwd or root into an explicit `--project`, because ADR-0006 gives `--project` /
 `$GDA_PROJECT` strict semantics (must be a real project) while leaving cwd lenient.
-So an explicit `GDA_PROJECT` / `CLAUDE_PROJECT_DIR`, and any validated `roots`/cwd
-candidate, are passed as `gda --project <dir>`; if nothing resolves to a valid
+So an explicit `GDA_PROJECT`, and any validated `roots`/cwd candidate, are passed as
+`gda --project <dir>`; if nothing resolves to a valid
 project, gda-mcp passes **no** `--project` and lets `gda` apply its own ADR-0006 cwd
 resolution — including running projectless when the cwd is not a project. gda-mcp
 does not itself reject projectless operation; an op that requires a project surfaces
@@ -51,19 +50,24 @@ does not itself reject projectless operation; an op that requires a project surf
   an operation parameter) and (b) breaks ADR-0012's pure transform — gda-mcp would
   synthesize a field absent from `--schema` into every tool. Not worth it for the
   first delivery; project-scoped registration covers the common workflow.
-- **cwd as the primary signal (rejected).** The obvious choice, but unusable: three of
-  four agents can't set it or leave it undefined. Demoted to last-resort fallback.
+- **cwd as the primary signal (rejected).** The obvious choice, but unusable: most MCP
+  clients can't set it reliably or leave it undefined. Demoted to last-resort fallback.
 - **Server context via a portable precedence (chosen).**
 
 ## Consequences
 
 - **Recommended registration is project-scoped** (or with `GDA_PROJECT` pinned),
   giving one server : one project — the clean, ADR-0006-aligned mode.
-- A **user-scoped** server with nothing pinned falls back through `CLAUDE_PROJECT_DIR`
-  / `roots/list` / cwd; it works for the single-active-project workflow but cannot, in
-  this first delivery, follow a user juggling several projects in one session.
-- The startup `roots/list` read (precedence 3) is part of the resolution contract,
+- A **user-scoped** server with nothing pinned falls back through `roots/list` / cwd;
+  it works for the single-active-project workflow but cannot, in this first delivery,
+  follow a user juggling several projects in one session.
+- The startup `roots/list` read (precedence 2) is part of the resolution contract,
   not a staged extra — the first delivery implements the full precedence above.
+- **No vendor coupling in the core.** This ADR names no specific agent; per-agent
+  registration — how each agent's config sets the server's `env` / launch command and
+  pins the project — is the registration recipes' concern (ADR-0013), which must cover
+  several top agents rather than privilege one. Keeping vendor specifics out of the
+  resolution contract is what lets gda-mcp stay an independent, consumer-agnostic service.
 - **Future multi-project without a tool parameter:** honour MCP `roots/list_changed`
   to re-resolve when the client's active root changes — the MCP-native path to
   multi-project support that still keeps the project out of the tool surface. This

--- a/src/gda/mcp/project_context.py
+++ b/src/gda/mcp/project_context.py
@@ -1,0 +1,58 @@
+"""gda-mcp server project-context resolution (issue #194, ADR-0014).
+
+gda-mcp is a long-lived server serving many calls; it resolves ONE target Godot
+project for the server and hands it to its ``gda`` subprocesses. Resolution is by
+an **agent-neutral portable precedence** (cwd is unreliable across MCP clients),
+first hit wins:
+
+1. an explicit ``GDA_PROJECT`` in the server's environment,
+2. the MCP ``roots/list`` the client advertises,
+3. the process cwd, as a last-resort fallback.
+
+The precedence names only agent-neutral primitives — gda's own env, the MCP
+protocol's own workspace signal, and cwd. No agent-specific env var appears here;
+per-agent config is the registration recipes' concern (ADR-0013), not the core.
+
+This module owns only the *pure* resolution (``env``/``roots``/``cwd`` in, a
+project dir or ``None`` out). The resolved dir reaches ``gda`` through gda's own
+``GDA_PROJECT`` channel (ADR-0006) — set on the subprocess env — so meta commands
+(``info``) that take no project ignore it while domain commands consume it, with
+no per-command knowledge in gda-mcp.
+
+Per ADR-0011 gda-mcp imports no gda internal symbol; the ``GDA_PROJECT`` name and
+the ``project.godot`` marker are part of the public ABI, defined locally here.
+"""
+
+from pathlib import Path
+from typing import Mapping, Optional, Sequence
+
+# Public ABI, redefined locally rather than imported from gda (ADR-0011).
+GDA_PROJECT_ENV = "GDA_PROJECT"
+PROJECT_MARKER = "project.godot"
+
+
+def _is_project(path: Path) -> bool:
+    """Whether ``path`` is a Godot project root (holds a ``project.godot``)."""
+    return (path / PROJECT_MARKER).exists()
+
+
+def resolve_project_dir(
+    env: Mapping[str, str], roots: Sequence[str], cwd: Path
+) -> Optional[Path]:
+    """Resolve the server's target project by the ADR-0014 precedence."""
+    gda_project = env.get(GDA_PROJECT_ENV)
+    if gda_project:
+        # An explicitly pinned GDA_PROJECT is strict (ADR-0006): if it is not a
+        # real project we do NOT silently fall through to a roots/cwd candidate.
+        # Resolve None and inject nothing — gda inherits the explicit GDA_PROJECT
+        # and surfaces its own typed error for project-taking commands, while
+        # projectless meta commands (info) ignore it.
+        candidate = Path(gda_project).expanduser()
+        return candidate if _is_project(candidate) else None
+
+    for root in roots:
+        candidate = Path(root)
+        if _is_project(candidate):
+            return candidate
+
+    return cwd if _is_project(cwd) else None

--- a/src/gda/mcp/runner.py
+++ b/src/gda/mcp/runner.py
@@ -20,7 +20,10 @@ import shlex
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional, Protocol
+
+from gda.mcp.project_context import GDA_PROJECT_ENV
 
 # Override the default ``-m gda`` invocation with an explicit command line.
 GDA_BIN_ENV = "GDA_BIN"
@@ -49,7 +52,13 @@ class GdaRunner(Protocol):
     result/error mapping engine-free.
     """
 
-    def run(self, args: list[str], *, stdin: Optional[str] = None) -> GdaResult: ...
+    def run(
+        self,
+        args: list[str],
+        *,
+        stdin: Optional[str] = None,
+        project: Optional[Path] = None,
+    ) -> GdaResult: ...
 
 
 def gda_command() -> list[str]:
@@ -76,7 +85,23 @@ class SubprocessGdaRunner:
         """Build the runner from the resolved :func:`gda_command`."""
         return cls(command=gda_command())
 
-    def run(self, args: list[str], *, stdin: Optional[str] = None) -> GdaResult:
+    def run(
+        self,
+        args: list[str],
+        *,
+        stdin: Optional[str] = None,
+        project: Optional[Path] = None,
+    ) -> GdaResult:
+        # Hand the resolved project to gda through its own ``GDA_PROJECT`` channel
+        # (ADR-0006), not a ``--project`` flag: meta commands (``info``) that
+        # reject ``--project`` simply ignore the env, so gda-mcp injects uniformly
+        # with no per-command knowledge (ADR-0014, mechanism D). ``project=None``
+        # leaves the inherited environment untouched — an explicit-but-invalid
+        # ``GDA_PROJECT`` then reaches gda, which surfaces its own typed error for
+        # project-taking commands.
+        env: Optional[dict[str, str]] = None
+        if project is not None:
+            env = {**os.environ, GDA_PROJECT_ENV: str(project)}
         # Capture raw bytes (no ``text=True``) and decode UTF-8 explicitly, like
         # gda's own runner (issue #33): gda emits its ``--json`` result as UTF-8
         # via pydantic, which can carry non-ASCII (e.g. a CJK node name); a
@@ -86,6 +111,7 @@ class SubprocessGdaRunner:
                 [*self.command, *args],
                 input=stdin.encode("utf-8") if stdin is not None else None,
                 capture_output=True,
+                env=env,
             )
         except OSError as exc:
             # The gda command itself could not be launched — e.g. a ``$GDA_BIN``

--- a/src/gda/mcp/server.py
+++ b/src/gda/mcp/server.py
@@ -31,6 +31,7 @@ import os
 from importlib.metadata import version
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import unquote, urlparse
 
 import mcp.server.stdio
 import mcp.types as types
@@ -172,6 +173,51 @@ def dispatch(
     )
 
 
+async def _session_root_dirs(session) -> list[str]:
+    """The client's advertised roots as local dir paths (ADR-0014 precedence 2).
+
+    A server->client ``roots/list`` request, so it needs a live session and is
+    issued lazily (see :class:`_ProjectResolver`). Best-effort: skip clients that
+    do not declare the roots capability, and degrade any failure to *no roots*
+    (gda's own cwd resolution then applies) rather than breaking dispatch — roots
+    is one optional precedence level, never a hard dependency.
+    """
+    if not session.check_client_capability(
+        types.ClientCapabilities(roots=types.RootsCapability())
+    ):
+        return []
+    try:
+        result = await session.list_roots()
+    except Exception:
+        return []
+    # A Root.uri is a file:// URI; recover the local path (percent-decoded).
+    dirs = [unquote(urlparse(str(root.uri)).path) for root in result.roots]
+    return [d for d in dirs if d]
+
+
+class _ProjectResolver:
+    """Resolves and caches the server's one target project (ADR-0014).
+
+    Resolution is deferred to the first tool call because precedence level 2
+    (``roots/list``) is a server->client request needing a live session. The
+    result is cached: the server targets one project (one ``server : project``),
+    re-resolution on a changing root is the deferred ``roots/list_changed`` path.
+    """
+
+    def __init__(self, env, cwd: Path) -> None:
+        self._env = env
+        self._cwd = cwd
+        self._resolved = False
+        self._project: Optional[Path] = None
+
+    async def resolve(self, session) -> Optional[Path]:
+        if not self._resolved:
+            roots = await _session_root_dirs(session)
+            self._project = resolve_project_dir(self._env, roots, self._cwd)
+            self._resolved = True
+        return self._project
+
+
 def build_server(runner: GdaRunner) -> Server:
     """Introspect the dump → register one tool per command → wire the dispatcher.
 
@@ -179,11 +225,11 @@ def build_server(runner: GdaRunner) -> Server:
     knowledge, so it stays correct as gda's surface grows without edits here.
     """
     commands = _load_commands(runner)
-    # Resolve the server's one target project (ADR-0014). env + cwd only for now;
-    # the MCP roots/list precedence level (a live server->client request) is wired
-    # in a later slice. The resolved dir reaches gda via the GDA_PROJECT env
-    # channel on every dispatch (mechanism D), so meta commands ignore it.
-    project = resolve_project_dir(os.environ, [], Path.cwd())
+    # The server's one target project (ADR-0014), resolved lazily on the first
+    # tool call (precedence 2, roots/list, needs a live session) and cached. The
+    # resolved dir reaches gda via the GDA_PROJECT env channel on every dispatch
+    # (mechanism D), so meta commands ignore it.
+    resolver = _ProjectResolver(os.environ, Path.cwd())
     tools = [
         types.Tool(
             name=tool_name(entry["name"]),
@@ -221,6 +267,7 @@ def build_server(runner: GdaRunner) -> Server:
                 ],
                 isError=True,
             )
+        project = await resolver.resolve(server.request_context.session)
         return dispatch(runner, argv, arguments or {}, project)
 
     return server

--- a/src/gda/mcp/server.py
+++ b/src/gda/mcp/server.py
@@ -27,7 +27,9 @@ envelope); it never imports a gda internal symbol.
 """
 
 import json
+import os
 from importlib.metadata import version
+from pathlib import Path
 from typing import Any, Optional
 
 import mcp.server.stdio
@@ -35,6 +37,7 @@ import mcp.types as types
 from mcp.server.lowlevel import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 
+from gda.mcp.project_context import resolve_project_dir
 from gda.mcp.runner import GdaResult, GdaRunner, SubprocessGdaRunner
 
 SERVER_NAME = "gda-mcp"
@@ -118,7 +121,10 @@ def _synthesized_error(message: str, result: GdaResult) -> types.CallToolResult:
 
 
 def dispatch(
-    runner: GdaRunner, argv: list[str], arguments: dict[str, Any]
+    runner: GdaRunner,
+    argv: list[str],
+    arguments: dict[str, Any],
+    project: Optional[Path] = None,
 ) -> dict[str, Any] | types.CallToolResult:
     """Forward one MCP tool call to gda and map the outcome (ADR-0011/0015).
 
@@ -134,7 +140,9 @@ def dispatch(
     # ``--params-json -``; ``--json`` makes gda emit the machine-readable result.
     # gda-mcp builds no per-command argv beyond the command name — no binding
     # knowledge — so new commands/params reach the surface with no gda-mcp change.
-    result = runner.run([*argv, "--params-json", "-", "--json"], stdin=params_json)
+    result = runner.run(
+        [*argv, "--params-json", "-", "--json"], stdin=params_json, project=project
+    )
 
     if result.returncode == 0:
         try:
@@ -171,6 +179,11 @@ def build_server(runner: GdaRunner) -> Server:
     knowledge, so it stays correct as gda's surface grows without edits here.
     """
     commands = _load_commands(runner)
+    # Resolve the server's one target project (ADR-0014). env + cwd only for now;
+    # the MCP roots/list precedence level (a live server->client request) is wired
+    # in a later slice. The resolved dir reaches gda via the GDA_PROJECT env
+    # channel on every dispatch (mechanism D), so meta commands ignore it.
+    project = resolve_project_dir(os.environ, [], Path.cwd())
     tools = [
         types.Tool(
             name=tool_name(entry["name"]),
@@ -208,7 +221,7 @@ def build_server(runner: GdaRunner) -> Server:
                 ],
                 isError=True,
             )
-        return dispatch(runner, argv, arguments or {})
+        return dispatch(runner, argv, arguments or {}, project)
 
     return server
 

--- a/tests/mcp_support.py
+++ b/tests/mcp_support.py
@@ -14,6 +14,7 @@ The fast tiers drive the surface from the **real** aggregate dump
 true mirror of the live ``gda`` surface, not a hand-stubbed subset.
 """
 
+from pathlib import Path
 from typing import Callable, Optional
 
 import anyio
@@ -27,14 +28,25 @@ Responder = Callable[[list[str], Optional[str]], GdaResult]
 
 
 class FakeGdaRunner:
-    """A fake ``GdaRunner``: routes each invocation through a responder, records calls."""
+    """A fake ``GdaRunner``: routes each invocation through a responder, records calls.
+
+    Each recorded call is ``(args, stdin, project)`` — ``project`` is the resolved
+    Godot project gda-mcp injects via the ``GDA_PROJECT`` env channel (ADR-0014,
+    #194), so tests assert the project that reached the seam without a subprocess.
+    """
 
     def __init__(self, responder: Responder) -> None:
         self.responder = responder
-        self.calls: list[tuple[list[str], Optional[str]]] = []
+        self.calls: list[tuple[list[str], Optional[str], Optional[Path]]] = []
 
-    def run(self, args: list[str], *, stdin: Optional[str] = None) -> GdaResult:
-        self.calls.append((args, stdin))
+    def run(
+        self,
+        args: list[str],
+        *,
+        stdin: Optional[str] = None,
+        project: Optional[Path] = None,
+    ) -> GdaResult:
+        self.calls.append((args, stdin, project))
         return self.responder(args, stdin)
 
 

--- a/tests/mcp_support.py
+++ b/tests/mcp_support.py
@@ -93,12 +93,24 @@ def list_tools(server):
     return anyio.run(_inner)
 
 
-def call_tool(server, name: str, arguments: dict):
-    """Open an in-memory MCP session, call one tool, return its ``CallToolResult``."""
+def call_tool(server, name: str, arguments: dict, *, roots: Optional[list[str]] = None):
+    """Open an in-memory MCP session, call one tool, return its ``CallToolResult``.
+
+    When ``roots`` is given the in-memory client advertises them (as ``file://``
+    URIs) and answers the server's ``roots/list`` request with them, so the
+    server's project-context resolution (ADR-0014 precedence 2) can be exercised.
+    """
     from mcp.shared.memory import create_connected_server_and_client_session as connect
 
+    list_roots_callback = None
+    if roots is not None:
+        from mcp.types import ListRootsResult, Root
+
+        async def list_roots_callback(_context):
+            return ListRootsResult(roots=[Root(uri=Path(r).as_uri()) for r in roots])
+
     async def _inner():
-        async with connect(server) as session:
+        async with connect(server, list_roots_callback=list_roots_callback) as session:
             return await session.call_tool(name, arguments)
 
     return anyio.run(_inner)

--- a/tests/test_e2e_mcp_project_context.py
+++ b/tests/test_e2e_mcp_project_context.py
@@ -1,0 +1,94 @@
+"""S1 (e2e): gda-mcp project-context resolution — real MCP -> gda -> engine (#194).
+
+The DoD gate for project-context resolution (ADR-0014): an in-memory MCP client
+-> in-process low-level Server -> the real ``-m gda`` subprocess -> a real Godot
+engine, with the project resolved by gda-mcp and handed to gda through the
+``GDA_PROJECT`` env channel (mechanism D). Fakes at the seam (the S2/S3 tiers)
+exercise the resolver engine-free; this tier proves the resolution actually
+drives gda against the right project on a real engine.
+
+Godot is pinned via gda's OWN ``$GDA_GODOT`` precedence (gda-mcp never hardcodes
+it); the e2e marker reuses the shared ``_require_godot_engine`` gate.
+"""
+
+from pathlib import Path
+
+import anyio
+import pytest
+from mcp.shared.memory import create_connected_server_and_client_session as connect
+from mcp.types import ListRootsResult, Root
+
+from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
+from gda.mcp.runner import SubprocessGdaRunner
+from gda.mcp.server import build_server
+
+GODOT = resolve_godot_binary()
+
+
+def _call_tool(server, name, arguments, *, roots=None):
+    """Drive one tool call over a real in-memory MCP session (optionally advertising roots)."""
+    list_roots_callback = None
+    if roots is not None:
+
+        async def list_roots_callback(_ctx):
+            return ListRootsResult(roots=[Root(uri=Path(r).as_uri()) for r in roots])
+
+    async def _drive():
+        async with connect(server, list_roots_callback=list_roots_callback) as session:
+            return await session.call_tool(name, arguments)
+
+    return anyio.run(_drive)
+
+
+@pytest.mark.e2e
+def test_roots_resolution_drives_real_tool_against_resolved_project(
+    godot_project, monkeypatch
+):
+    # The strongest proof: gda cannot read MCP roots itself, so a res:// write
+    # landing in the advertised-root project proves gda-mcp resolved the project
+    # from roots/list and injected it via GDA_PROJECT for the real gda subprocess.
+    monkeypatch.setenv(GODOT_BIN_ENV, str(GODOT))
+    monkeypatch.delenv("GDA_PROJECT", raising=False)
+    server = build_server(SubprocessGdaRunner.default())
+
+    result = _call_tool(
+        server,
+        "scene_create",
+        {"path": "res://from_roots.tscn", "root_type": "Node2D"},
+        roots=[str(godot_project)],
+    )
+
+    assert result.isError is False, result.content
+    assert (godot_project / "from_roots.tscn").exists()
+
+
+@pytest.mark.e2e
+def test_gda_project_scoped_resolution_drives_real_tool(godot_project, monkeypatch):
+    # The recommended project-scoped mode: GDA_PROJECT pins the project, res://
+    # resolves against it, and the scene file lands in that project on a real engine.
+    monkeypatch.setenv(GODOT_BIN_ENV, str(GODOT))
+    monkeypatch.setenv("GDA_PROJECT", str(godot_project))
+    server = build_server(SubprocessGdaRunner.default())
+
+    result = _call_tool(
+        server, "scene_create", {"path": "res://pinned.tscn", "root_type": "Node2D"}
+    )
+
+    assert result.isError is False, result.content
+    assert (godot_project / "pinned.tscn").exists()
+
+
+@pytest.mark.e2e
+def test_meta_command_tolerates_a_pinned_project(godot_project, monkeypatch):
+    # Mechanism D's payoff: with a project pinned, the meta tool `info` — which
+    # rejects a `--project` flag outright — still succeeds, because the project
+    # rides the GDA_PROJECT env channel that meta commands simply ignore. A flag
+    # mechanism would have broken every meta tool whenever a project was pinned.
+    monkeypatch.setenv(GODOT_BIN_ENV, str(GODOT))
+    monkeypatch.delenv("GDA_PROJECT", raising=False)
+    server = build_server(SubprocessGdaRunner.default())
+
+    result = _call_tool(server, "info", {}, roots=[str(godot_project)])
+
+    assert result.isError is False, result.content
+    assert result.structuredContent["major"] == 4

--- a/tests/test_mcp_dispatch.py
+++ b/tests/test_mcp_dispatch.py
@@ -30,7 +30,7 @@ def test_scene_create_input_object_builds_params_json_dispatch():
     assert result.isError is False
     assert result.structuredContent == SCENE_CREATE_RESULT
     # The seam was driven with the gda command argv + verbatim object on stdin.
-    dispatch_args, dispatch_stdin = runner.calls[-1]
+    dispatch_args, dispatch_stdin, _ = runner.calls[-1]
     assert dispatch_args == ["scene", "create", "--params-json", "-", "--json"]
     assert json.loads(dispatch_stdin) == arguments
 
@@ -46,7 +46,7 @@ def test_multiword_command_name_maps_back_to_the_right_argv():
 
     call_tool(server, "scene_get_exports", {"path": "res://main.tscn"})
 
-    dispatch_args, _ = runner.calls[-1]
+    dispatch_args, _, _ = runner.calls[-1]
     assert dispatch_args[:2] == ["scene", "get-exports"]
 
 
@@ -62,6 +62,6 @@ def test_no_param_tool_dispatches_an_empty_params_object():
 
     assert result.isError is False
     assert result.structuredContent["string"] == VERSION_INFO["string"]
-    dispatch_args, dispatch_stdin = runner.calls[-1]
+    dispatch_args, dispatch_stdin, _ = runner.calls[-1]
     assert dispatch_args == ["info", "--params-json", "-", "--json"]
     assert json.loads(dispatch_stdin) == {}

--- a/tests/test_mcp_project_context.py
+++ b/tests/test_mcp_project_context.py
@@ -1,0 +1,86 @@
+"""L1 fast tests for gda-mcp project-context resolution (issue #194, ADR-0014).
+
+The pure resolver ``resolve_project_dir(env, roots, cwd)`` implements the
+agent-neutral precedence ``GDA_PROJECT -> roots/list -> cwd`` with
+``project.godot`` validation. No subprocess, no engine, no MCP session — the
+precedence and validation are a pure function, asserted in isolation (the
+ADR-0014 / #194 acceptance criterion).
+"""
+
+from pathlib import Path
+
+from gda.mcp.project_context import resolve_project_dir
+
+
+def _project(dir_path: Path) -> Path:
+    """Mark ``dir_path`` a Godot project (a ``project.godot`` is all that counts)."""
+    dir_path.mkdir(parents=True, exist_ok=True)
+    (dir_path / "project.godot").write_text("", encoding="utf-8")
+    return dir_path
+
+
+def test_gda_project_env_resolves_to_that_project(tmp_path):
+    proj = _project(tmp_path)
+    result = resolve_project_dir(
+        env={"GDA_PROJECT": str(proj)}, roots=[], cwd=Path("/nonexistent")
+    )
+    assert result == proj
+
+
+def test_root_resolves_when_gda_project_unset(tmp_path):
+    proj = _project(tmp_path)
+    result = resolve_project_dir(
+        env={}, roots=[str(proj)], cwd=Path("/nonexistent")
+    )
+    assert result == proj
+
+
+def test_cwd_used_when_it_is_a_project_and_nothing_else_resolves(tmp_path):
+    proj = _project(tmp_path)
+    result = resolve_project_dir(env={}, roots=[], cwd=proj)
+    assert result == proj
+
+
+def test_first_valid_root_wins_invalid_roots_skipped(tmp_path):
+    not_a_project = tmp_path / "plain"
+    not_a_project.mkdir()
+    proj = _project(tmp_path / "game")
+    later = _project(tmp_path / "other")
+    result = resolve_project_dir(
+        env={},
+        roots=[str(not_a_project), str(proj), str(later)],
+        cwd=Path("/nonexistent"),
+    )
+    assert result == proj
+
+
+def test_nothing_resolves_to_none(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    result = resolve_project_dir(env={}, roots=[str(plain)], cwd=plain)
+    assert result is None
+
+
+def test_gda_project_takes_precedence_over_root(tmp_path):
+    pinned = _project(tmp_path / "pinned")
+    root = _project(tmp_path / "root")
+    result = resolve_project_dir(
+        env={"GDA_PROJECT": str(pinned)}, roots=[str(root)], cwd=Path("/nonexistent")
+    )
+    assert result == pinned
+
+
+def test_invalid_gda_project_does_not_fall_through_to_root(tmp_path):
+    # ADR-0006 strict explicit semantics: an explicitly set but invalid
+    # GDA_PROJECT must NOT be silently shadowed by a roots/cwd candidate. The
+    # resolver yields None and injects nothing, so gda inherits the explicit
+    # GDA_PROJECT and surfaces its own typed error for project-taking commands.
+    bad = tmp_path / "not-a-project"
+    bad.mkdir()
+    valid_root = _project(tmp_path / "game")
+    result = resolve_project_dir(
+        env={"GDA_PROJECT": str(bad)},
+        roots=[str(valid_root)],
+        cwd=Path("/nonexistent"),
+    )
+    assert result is None

--- a/tests/test_mcp_project_injection.py
+++ b/tests/test_mcp_project_injection.py
@@ -1,0 +1,81 @@
+"""L2 fast tests: gda-mcp injects the resolved project via GDA_PROJECT (#194).
+
+Mechanism D (ADR-0014, corrected): gda-mcp hands the resolved project to gda
+through gda's own ``GDA_PROJECT`` env channel (ADR-0006) on the subprocess, not a
+``--project`` flag. So project-taking domain commands consume it while meta
+commands (``info``) that reject ``--project`` simply ignore the env — gda-mcp
+needs zero per-command knowledge.
+
+These assert the *seam* behavior (the subprocess env, the dispatch passthrough),
+engine-free. The real MCP -> gda -> engine chain is the L4 e2e gate.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+from gda.mcp.runner import SubprocessGdaRunner
+from gda.mcp.server import build_server, dispatch
+from tests.mcp_support import FakeGdaRunner, call_tool, gda_result, schema_then
+from tests.support import SCENE_CREATE_RESULT
+
+
+def _project(dir_path: Path) -> Path:
+    """Mark ``dir_path`` a Godot project (a ``project.godot`` is all that counts)."""
+    (dir_path / "project.godot").write_text("", encoding="utf-8")
+    return dir_path
+
+# A tiny stand-in "gda": echoes the GDA_PROJECT the child process actually sees,
+# so the test observes the real subprocess environment without spawning gda.
+_ECHO_GDA_PROJECT = [
+    sys.executable,
+    "-c",
+    "import os, sys; sys.stdout.write(os.environ.get('GDA_PROJECT', ''))",
+]
+
+
+def test_subprocess_runner_injects_resolved_project_as_gda_project_env(tmp_path):
+    runner = SubprocessGdaRunner(command=_ECHO_GDA_PROJECT)
+    result = runner.run([], project=tmp_path)
+    assert result.stdout == str(tmp_path)
+
+
+def test_subprocess_runner_leaves_inherited_env_when_no_project(monkeypatch):
+    # project=None must not strip an inherited GDA_PROJECT: gda then applies its
+    # own ADR-0006 resolution (including surfacing a typed error if it is invalid).
+    monkeypatch.setenv("GDA_PROJECT", "/inherited/project")
+    runner = SubprocessGdaRunner(command=_ECHO_GDA_PROJECT)
+    result = runner.run([], project=None)
+    assert result.stdout == "/inherited/project"
+
+
+def test_dispatch_passes_resolved_project_to_runner(tmp_path):
+    runner = FakeGdaRunner(lambda args, stdin: gda_result(stdout="{}"))
+    dispatch(runner, ["scene", "create"], {"path": "main.tscn"}, project=tmp_path)
+    _args, _stdin, project = runner.calls[-1]
+    assert project == tmp_path
+
+
+def test_dispatch_defaults_to_no_project(tmp_path):
+    runner = FakeGdaRunner(lambda args, stdin: gda_result(stdout="{}"))
+    dispatch(runner, ["scene", "create"], {"path": "main.tscn"})
+    _args, _stdin, project = runner.calls[-1]
+    assert project is None
+
+
+def test_server_resolves_gda_project_env_and_injects_it_on_dispatch(
+    tmp_path, monkeypatch
+):
+    # The full env -> resolve -> inject glue: GDA_PROJECT points at a real project,
+    # so every tool call dispatches gda against it (here observed at the seam).
+    proj = _project(tmp_path)
+    monkeypatch.setenv("GDA_PROJECT", str(proj))
+    runner = FakeGdaRunner(
+        schema_then(lambda args, stdin: gda_result(json.dumps(SCENE_CREATE_RESULT)))
+    )
+    server = build_server(runner)
+
+    call_tool(server, "scene_create", {"path": "main.tscn", "root_type": "Node2D"})
+
+    _args, _stdin, project = runner.calls[-1]
+    assert project == proj

--- a/tests/test_mcp_project_injection.py
+++ b/tests/test_mcp_project_injection.py
@@ -22,6 +22,7 @@ from tests.support import SCENE_CREATE_RESULT
 
 def _project(dir_path: Path) -> Path:
     """Mark ``dir_path`` a Godot project (a ``project.godot`` is all that counts)."""
+    dir_path.mkdir(parents=True, exist_ok=True)
     (dir_path / "project.godot").write_text("", encoding="utf-8")
     return dir_path
 
@@ -79,3 +80,79 @@ def test_server_resolves_gda_project_env_and_injects_it_on_dispatch(
 
     _args, _stdin, project = runner.calls[-1]
     assert project == proj
+
+
+def _scene_create_runner():
+    return FakeGdaRunner(
+        schema_then(lambda args, stdin: gda_result(json.dumps(SCENE_CREATE_RESULT)))
+    )
+
+
+def test_client_root_resolves_project_when_gda_project_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv("GDA_PROJECT", raising=False)
+    proj = _project(tmp_path / "game")
+    runner = _scene_create_runner()
+    server = build_server(runner)
+
+    call_tool(
+        server,
+        "scene_create",
+        {"path": "main.tscn", "root_type": "Node2D"},
+        roots=[str(proj)],
+    )
+
+    _args, _stdin, project = runner.calls[-1]
+    assert project == proj
+
+
+def test_gda_project_env_beats_client_roots(tmp_path, monkeypatch):
+    pinned = _project(tmp_path / "pinned")
+    other = _project(tmp_path / "other")
+    monkeypatch.setenv("GDA_PROJECT", str(pinned))
+    runner = _scene_create_runner()
+    server = build_server(runner)
+
+    call_tool(
+        server,
+        "scene_create",
+        {"path": "main.tscn", "root_type": "Node2D"},
+        roots=[str(other)],
+    )
+
+    _args, _stdin, project = runner.calls[-1]
+    assert project == pinned
+
+
+def test_invalid_client_roots_skipped_first_valid_used(tmp_path, monkeypatch):
+    monkeypatch.delenv("GDA_PROJECT", raising=False)
+    not_a_project = tmp_path / "plain"
+    not_a_project.mkdir()
+    proj = _project(tmp_path / "game")
+    runner = _scene_create_runner()
+    server = build_server(runner)
+
+    call_tool(
+        server,
+        "scene_create",
+        {"path": "main.tscn", "root_type": "Node2D"},
+        roots=[str(not_a_project), str(proj)],
+    )
+
+    _args, _stdin, project = runner.calls[-1]
+    assert project == proj
+
+
+def test_no_roots_capability_degrades_to_no_project_without_error(
+    tmp_path, monkeypatch
+):
+    # Client advertises no roots and cwd is not a project: resolution degrades to
+    # no project and dispatch still succeeds (roots is optional, never required).
+    monkeypatch.delenv("GDA_PROJECT", raising=False)
+    runner = _scene_create_runner()
+    server = build_server(runner)
+
+    result = call_tool(server, "scene_create", {"path": "x.tscn", "root_type": "Node2D"})
+
+    assert result.isError is False
+    _args, _stdin, project = runner.calls[-1]
+    assert project is None

--- a/tests/test_mcp_project_injection.py
+++ b/tests/test_mcp_project_injection.py
@@ -16,7 +16,13 @@ from pathlib import Path
 
 from gda.mcp.runner import SubprocessGdaRunner
 from gda.mcp.server import build_server, dispatch
-from tests.mcp_support import FakeGdaRunner, call_tool, gda_result, schema_then
+from tests.mcp_support import (
+    FakeGdaRunner,
+    call_tool,
+    gda_result,
+    list_tools,
+    schema_then,
+)
 from tests.support import SCENE_CREATE_RESULT
 
 
@@ -25,6 +31,17 @@ def _project(dir_path: Path) -> Path:
     dir_path.mkdir(parents=True, exist_ok=True)
     (dir_path / "project.godot").write_text("", encoding="utf-8")
     return dir_path
+
+
+def test_no_tool_inputschema_carries_a_project_field():
+    # ADR-0014/0012: the project is server context, never a tool parameter — the
+    # tool surface stays a faithful mirror of --schema, so gda-mcp synthesizes no
+    # `project` field into any tool's inputSchema.
+    runner = FakeGdaRunner(schema_then(lambda _args, _stdin: gda_result("{}")))
+    server = build_server(runner)
+    for tool in list_tools(server).tools:
+        properties = (tool.inputSchema or {}).get("properties", {})
+        assert "project" not in properties, tool.name
 
 # A tiny stand-in "gda": echoes the GDA_PROJECT the child process actually sees,
 # so the test observes the real subprocess environment without spawning gda.

--- a/tests/test_mcp_project_injection.py
+++ b/tests/test_mcp_project_injection.py
@@ -159,6 +159,36 @@ def test_invalid_client_roots_skipped_first_valid_used(tmp_path, monkeypatch):
     assert project == proj
 
 
+def test_project_is_snapshotted_on_first_call_then_cached(tmp_path, monkeypatch):
+    # Timing contract (ADR-0014): roots/list is a server->client request needing a
+    # live session, so resolution is snapshotted on the FIRST tool call (not at
+    # process startup) and then cached for the server's lifetime — one server :
+    # one project. A later call advertising a different root reuses the first
+    # snapshot; re-resolving on a changed root is the deferred roots/list_changed
+    # path, out of scope for the first delivery.
+    monkeypatch.delenv("GDA_PROJECT", raising=False)
+    first = _project(tmp_path / "first")
+    second = _project(tmp_path / "second")
+    runner = _scene_create_runner()
+    server = build_server(runner)
+
+    call_tool(
+        server,
+        "scene_create",
+        {"path": "res://a.tscn", "root_type": "Node2D"},
+        roots=[str(first)],
+    )
+    call_tool(
+        server,
+        "scene_create",
+        {"path": "res://b.tscn", "root_type": "Node2D"},
+        roots=[str(second)],
+    )
+
+    _args, _stdin, project = runner.calls[-1]
+    assert project == first
+
+
 def test_no_roots_capability_degrades_to_no_project_without_error(
     tmp_path, monkeypatch
 ):

--- a/tests/test_mcp_registration.py
+++ b/tests/test_mcp_registration.py
@@ -84,4 +84,6 @@ def test_startup_introspects_the_dump_through_the_seam_once():
     # (ADR-0012's single startup subprocess), not a per-command fan-out.
     runner = FakeGdaRunner(schema_then(_no_dispatch))
     build_server(runner)
-    assert runner.calls == [(["schema"], None)]
+    # The startup introspection call carries no project (the schema meta command
+    # is projectless); per-tool dispatch is what injects the resolved project.
+    assert runner.calls == [(["schema"], None, None)]


### PR DESCRIPTION
## Summary

Resolves the gda-mcp server's target Godot project (ADR-0014) and hands it to the `gda` subprocesses, so a project-scoped registration drives operations against the right project automatically.

Closes #194.

### Two ADR-0014 corrections (both reconciled across PRD #8 / #194 / #195)

1. **Agent-neutral resolution.** Dropped `CLAUDE_PROJECT_DIR` (a Claude Code-specific env var, redundant with the MCP-native `roots/list`). The precedence is now the agent-neutral **`GDA_PROJECT` → `roots/list` → cwd**, and the ADR's normative text names no specific agent. Per-agent specifics belong to the registration recipes (ADR-0013), which stays multi-agent. gda-mcp is a consumer-agnostic service; vendor coupling in the core was the wrong shape.
2. **Mechanism corrected to the `GDA_PROJECT` env channel.** The prior "pass `--project` to every subprocess" wording was impossible — meta commands like `info` reject `--project` outright. The resolved project now rides gda's own `GDA_PROJECT` env channel (ADR-0006): project-taking domain commands consume it, meta commands ignore it, and gda-mcp needs **zero per-command knowledge**.

## How it works

- A pure resolver `resolve_project_dir(env, roots, cwd)` owns the full precedence + `project.godot` validation. An explicitly pinned but invalid `GDA_PROJECT` resolves to `None` without falling through (ADR-0006 strict), so gda surfaces its own typed error.
- `roots/list` is a server→client request, so resolution is deferred to the first tool call (needs a live session) and cached — one server targets one project. It is capability-gated and fail-safe to "no roots", never a hard dependency.
- The resolved dir is set on the subprocess env via the `GdaRunner` seam; `project=None` leaves the inherited env untouched.
- No `project` field is synthesized into any tool's inputSchema — the surface stays a faithful mirror of `--schema` (ADR-0012/0014).

## Built TDD in four serial layers (red→green→refactor, commit per layer)

| Layer | What | Tests |
|---|---|---|
| L1 | pure resolver (precedence + validation + no-forge) | 7 fast |
| L2 | inject via `GDA_PROJECT` env through the runner seam | 5 fast |
| L3 | `roots/list` live wiring (lazy, cached, capability-gated) | 4 fast |
| L4 | e2e gate: real MCP → gda → engine | 3 e2e |

## Acceptance criteria (#194)

- [x] Full precedence `GDA_PROJECT → roots/list → cwd`, first hit wins (incl. the live roots/list read)
- [x] Candidate passed only when it holds `project.godot`; otherwise gda's own ADR-0006 resolution applies
- [x] No `project` field injected into any tool's inputSchema (explicit guard test)
- [x] Fast pure-function tests for precedence + validation / no-forge
- [x] e2e: project-scoped resolution drives a real tool against the resolved project (real engine)

## Testing

- **619 fast tests** pass (`pytest -m "not e2e"`).
- **6 mcp e2e tests** pass against a real Godot engine (3 new + 3 existing, no regression). The strongest is roots → real engine: gda cannot read MCP roots itself, so a `res://` write landing in the advertised-root project proves gda-mcp resolved + injected. A meta command (`info`) tolerating a pinned project validates mechanism D where a `--project` flag would have errored.
