### PR TITLE
docs(gda-mcp): per-agent registration recipes (#195)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,54 @@ so any MCP-speaking agent can drive Godot through it. Try it with no install:
 uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
 ```
 
-To register it with **Claude Code, Codex, Cursor, or Claude Desktop** (user and project scope), see
-the [registration recipes](docs/gda-mcp-registration.md). (Once `gda` is on PyPI —
-[#207](https://github.com/aigengame/godot-agent/issues/207) — this simplifies to
-`uvx --from "gda[mcp]" gda-mcp`.)
+Register it by dropping the matching config in place. `gda-mcp` picks your Godot project from the
+client's workspace `roots` where available, otherwise from `GDA_PROJECT` (ADR-0014).
+
+**Claude Code** — `.mcp.json` in the project root (auto-detects the workspace project):
+
+```json
+{
+  "mcpServers": {
+    "gda-mcp": {
+      "command": "uvx",
+      "args": ["--from", "gda[mcp] @ git+https://github.com/aigengame/godot-agent", "gda-mcp"]
+    }
+  }
+}
+```
+
+**Codex** — `~/.codex/config.toml` (global) or `.codex/config.toml` (project; pin the project path):
+
+```toml
+[mcp_servers.gda-mcp]
+command = "uvx"
+args = ["--from", "gda[mcp] @ git+https://github.com/aigengame/godot-agent", "gda-mcp"]
+
+[mcp_servers.gda-mcp.env]
+GDA_PROJECT = "/absolute/path/to/your/godot/project"
+```
+
+**Cursor** — `.cursor/mcp.json` in the project root:
+
+```json
+{
+  "mcpServers": {
+    "gda-mcp": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["--from", "gda[mcp] @ git+https://github.com/aigengame/godot-agent", "gda-mcp"],
+      "env": { "GDA_PROJECT": "${workspaceFolder}" }
+    }
+  }
+}
+```
+
+> Cursor and Claude Desktop are GUI-launched with a minimal `PATH`, so a bare `uvx` may not resolve —
+> use an absolute path (`which uvx`) for `command`. Full recipes — user vs project scope, Claude
+> Desktop, the `PATH` fix, and per-agent project pinning — are in the
+> [registration recipes](docs/gda-mcp-registration.md). Once `gda` is on PyPI
+> ([#207](https://github.com/aigengame/godot-agent/issues/207)), the `@ git+…` part drops to just
+> `"gda[mcp]"`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,10 @@ so any MCP-speaking agent can drive Godot through it. Try it with no install:
 uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
 ```
 
-Register it by dropping the matching config in place. `gda-mcp` picks your Godot project from the
-client's workspace `roots` where available, otherwise from `GDA_PROJECT` (ADR-0014).
+Register it by dropping the matching config in place. `gda-mcp` picks your Godot project from
+`GDA_PROJECT` if set, otherwise the client's workspace `roots`, otherwise the working directory
+(ADR-0014). An explicitly set `GDA_PROJECT` that is not a valid project is reported as an error, not
+silently replaced.
 
 **Claude Code** — project scope, `.mcp.json` at the repo root (auto-detects the project via `roots`):
 
@@ -212,19 +214,23 @@ project):
       "type": "stdio",
       "command": "uvx",
       "args": ["--from", "gda[mcp] @ git+https://github.com/aigengame/godot-agent", "gda-mcp"],
-      "env": { "GDA_PROJECT": "${workspaceFolder}" }
+      "env": {
+        "GDA_PROJECT": "${workspaceFolder}",
+        "PATH": "/opt/homebrew/bin:/usr/local/bin:${userHome}/.local/bin:${env:PATH}"
+      }
     }
   }
 }
 ```
 
-User scope (every project) — the same config in `~/.cursor/mcp.json`; `${workspaceFolder}` still
-resolves per open project. (Cursor has no `mcp add` shell command — register via the JSON above or
-the Settings → MCP UI.)
+User scope (every project) — the same config in `~/.cursor/mcp.json`, but set `GDA_PROJECT` to an
+absolute path (`${workspaceFolder}` is only reliable in the project-level file). Cursor has no
+`mcp add` shell command — register via the JSON above or the Settings → MCP UI.
 
 > Cursor and Claude Desktop are GUI-launched with a minimal `PATH`, so a bare `uvx` may not resolve —
+> the Cursor snippet above repairs it in `env`; if `uvx` is still not found (or for Claude Desktop),
 > use an absolute path (`which uvx`) for `command`. Full recipes — user vs project scope, Claude
-> Desktop, the `PATH` fix, and per-agent project pinning — are in the
+> Desktop, and per-agent project pinning — are in the
 > [registration recipes](docs/gda-mcp-registration.md). Once `gda` is on PyPI
 > ([#207](https://github.com/aigengame/godot-agent/issues/207)), the `@ git+…` part drops to just
 > `"gda[mcp]"`.

--- a/README.md
+++ b/README.md
@@ -194,8 +194,13 @@ args = ["--from", "gda[mcp] @ git+https://github.com/aigengame/godot-agent", "gd
 GDA_PROJECT = "/absolute/path/to/your/godot/project"
 ```
 
-User scope (every project) — the same `[mcp_servers.gda-mcp]` table in `~/.codex/config.toml` (Codex
-has no workspace variable, so `GDA_PROJECT` stays an absolute path).
+User scope (every project) — the same table in `~/.codex/config.toml`, or add it with the CLI
+(Codex has no workspace variable, so `GDA_PROJECT` stays an absolute path):
+
+```bash
+codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- \
+  uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
+```
 
 **Cursor** — project scope, `.cursor/mcp.json` at the repo root (`${workspaceFolder}` tracks the open
 project):
@@ -214,7 +219,8 @@ project):
 ```
 
 User scope (every project) — the same config in `~/.cursor/mcp.json`; `${workspaceFolder}` still
-resolves per open project.
+resolves per open project. (Cursor has no `mcp add` shell command — register via the JSON above or
+the Settings → MCP UI.)
 
 > Cursor and Claude Desktop are GUI-launched with a minimal `PATH`, so a bare `uvx` may not resolve —
 > use an absolute path (`which uvx`) for `command`. Full recipes — user vs project scope, Claude

--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
 Register it by dropping the matching config in place. `gda-mcp` picks your Godot project from the
 client's workspace `roots` where available, otherwise from `GDA_PROJECT` (ADR-0014).
 
-**Claude Code** — `.mcp.json` in the project root (auto-detects the workspace project):
+**Claude Code** — project scope: `.mcp.json` in the project root (committed; auto-detects the
+workspace project):
 
 ```json
 {
@@ -174,6 +175,13 @@ client's workspace `roots` where available, otherwise from `GDA_PROJECT` (ADR-00
     }
   }
 }
+```
+
+…or user scope (available in every project), via the CLI — writes `~/.claude.json`:
+
+```bash
+claude mcp add --scope user gda-mcp -- \
+  uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
 ```
 
 **Codex** — `~/.codex/config.toml` (global) or `.codex/config.toml` (project; pin the project path):

--- a/README.md
+++ b/README.md
@@ -163,8 +163,7 @@ uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
 Register it by dropping the matching config in place. `gda-mcp` picks your Godot project from the
 client's workspace `roots` where available, otherwise from `GDA_PROJECT` (ADR-0014).
 
-**Claude Code** — project scope: `.mcp.json` in the project root (committed; auto-detects the
-workspace project):
+**Claude Code** — project scope, `.mcp.json` at the repo root (auto-detects the project via `roots`):
 
 ```json
 {
@@ -177,14 +176,14 @@ workspace project):
 }
 ```
 
-…or user scope (available in every project), via the CLI — writes `~/.claude.json`:
+User scope (every project) — the CLI, which writes `~/.claude.json`:
 
 ```bash
 claude mcp add --scope user gda-mcp -- \
   uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
 ```
 
-**Codex** — `~/.codex/config.toml` (global) or `.codex/config.toml` (project; pin the project path):
+**Codex** — project scope, `.codex/config.toml` at the repo root (the project must be trusted):
 
 ```toml
 [mcp_servers.gda-mcp]
@@ -195,7 +194,11 @@ args = ["--from", "gda[mcp] @ git+https://github.com/aigengame/godot-agent", "gd
 GDA_PROJECT = "/absolute/path/to/your/godot/project"
 ```
 
-**Cursor** — `.cursor/mcp.json` in the project root:
+User scope (every project) — the same `[mcp_servers.gda-mcp]` table in `~/.codex/config.toml` (Codex
+has no workspace variable, so `GDA_PROJECT` stays an absolute path).
+
+**Cursor** — project scope, `.cursor/mcp.json` at the repo root (`${workspaceFolder}` tracks the open
+project):
 
 ```json
 {
@@ -209,6 +212,9 @@ GDA_PROJECT = "/absolute/path/to/your/godot/project"
   }
 }
 ```
+
+User scope (every project) — the same config in `~/.cursor/mcp.json`; `${workspaceFolder}` still
+resolves per open project.
 
 > Cursor and Claude Desktop are GUI-launched with a minimal `PATH`, so a bare `uvx` may not resolve —
 > use an absolute path (`which uvx`) for `command`. Full recipes — user vs project scope, Claude

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ for the full picture.
 > are settled (see [`CONTEXT.md`](CONTEXT.md) and [`docs/adr/`](docs/adr/)), and every headless
 > domain command group designed in
 > [PRD #17](https://github.com/aigengame/godot-agent/issues/17) now ships end-to-end against a real
-> engine. `gda` is still pre-1.0 and not yet published to a package index; the next milestones are
-> the `gda-mcp` adapter and Phase 2 live operations.
+> engine. `gda` is still pre-1.0 and not yet published to a package index
+> ([#207](https://github.com/aigengame/godot-agent/issues/207)); **`gda-mcp` now ships** alongside
+> the CLI, and the next milestone is Phase 2 live operations.
 
 **Working today — the full headless command surface**
 
@@ -74,10 +75,14 @@ for the full picture.
   classification, and project-context / `res://` path resolution
   ([ADR-0006](docs/adr/0006-project-context-and-path-resolution.md)).
 
+**Also working today — the MCP adapter**
+
+- ✅ `gda-mcp`, a thin [Model Context Protocol](https://modelcontextprotocol.io) stdio server that
+  exposes the whole `gda` surface as MCP tools, generated mechanically from `--schema`. Register it
+  with your agent using the [registration recipes](docs/gda-mcp-registration.md).
+
 **On the roadmap** (designed, not yet implemented)
 
-- 🔜 `gda-mcp`, a thin [Model Context Protocol](https://modelcontextprotocol.io) adapter generated
-  mechanically from `--schema` — the `--schema` hard gate is precisely what makes it cheap.
 - 🔜 `gda-daemon` for *live operations* against a running engine (Phase 2): live scene tree,
   runtime inspection, input simulation, `scene play`/`stop`, screenshots.
 
@@ -145,6 +150,20 @@ To install `gda` as a standalone CLI on your `PATH`:
 uv tool install .
 gda --help
 ```
+
+### MCP server (`gda-mcp`)
+
+`gda` ships a stdio [MCP](https://modelcontextprotocol.io) server behind an optional `[mcp]` extra,
+so any MCP-speaking agent can drive Godot through it. Try it with no install:
+
+```bash
+uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
+```
+
+To register it with **Claude Code, Codex, Cursor, or Claude Desktop** (user and project scope), see
+the [registration recipes](docs/gda-mcp-registration.md). (Once `gda` is on PyPI —
+[#207](https://github.com/aigengame/godot-agent/issues/207) — this simplifies to
+`uvx --from "gda[mcp]" gda-mcp`.)
 
 ---
 
@@ -490,7 +509,7 @@ drives a real engine. Everything between the CLI and the runner runs as real cod
 | Phase / component | Delivers                                                                  | Status |
 | ----------------- | ------------------------------------------------------------------------- | ------ |
 | **Phase 1** | `gda` serving *headless operations* standalone: `info`, structured errors, `--schema`, and the domain command groups `scene`, `node`, `script`, `project` (incl. static-analysis), `resource`, `export`, `shader`, `theme`. | ✅ Surface complete |
-| **`gda-mcp`** | A thin MCP adapter generated mechanically from `--schema` — first on top of Phase 1, following `gda` forward automatically. | 🔜 Next |
+| **`gda-mcp`** | A thin MCP adapter generated mechanically from `--schema` — first on top of Phase 1, following `gda` forward automatically. | ✅ Shipped |
 | **Phase 2** | `gda` also serving *live operations* through `gda-daemon`'s persistent engine connection. | 🗓 Planned |
 
 Track progress and proposals on the [issue tracker](https://github.com/aigengame/godot-agent/issues).

--- a/docs/adr/0013-gda-mcp-packaging-and-launch.md
+++ b/docs/adr/0013-gda-mcp-packaging-and-launch.md
@@ -26,7 +26,10 @@ the extra is absent (running it without the extra fails with a clear "install
 agent (Claude Code, Codex, Claude Desktop, Cursor) is a stdio server described by
 `command` + `args` (+ optional `env`); gda-mcp targets exactly that shape. Two
 invocations are supported: the installed console script `gda-mcp`, and a zero-install
-`uvx --from "gda[mcp]" gda-mcp`.
+`uvx`. Until `gda` is published to PyPI (tracked by #207), the zero-install form
+resolves the package from the public git repo —
+`uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp`; once on
+PyPI it simplifies to the canonical `uvx --from "gda[mcp]" gda-mcp`.
 
 **Per-agent registration recipes are a shipped deliverable** (user- and
 project-scope) — not left to the user to derive — because the agents diverge in

--- a/docs/gda-mcp-registration.md
+++ b/docs/gda-mcp-registration.md
@@ -257,6 +257,27 @@ install`). After editing, fully quit and reopen Claude Desktop.
 
 ---
 
+## Working across multiple projects
+
+`gda-mcp` targets **one** Godot project per server: it resolves the project once (on the first tool
+call) and reuses it for the server's lifetime. A fresh agent session spawns a fresh server, which
+resolves again.
+
+- **One project at a time** — the common case; nothing special needed. A project-scoped registration
+  (or a pinned `GDA_PROJECT`) gives one server : one project.
+- **Several projects** — the reliable pattern is **one registration per project**: register at
+  project scope (the per-repo `.mcp.json` / `.codex/config.toml` / `.cursor/mcp.json` above) so each
+  project gets its own server pinned to it.
+- A **user/global** registration follows the client's signal where there is one: Claude Code resolves
+  the workspace from `roots`, and Cursor's `${workspaceFolder}` tracks the open project, so each tends
+  to target the project you are working in. Codex has no per-workspace signal, so a global Codex
+  registration stays pinned to the single `GDA_PROJECT` you set.
+
+Switching the active project **within a single live session** (without starting a new one) is not yet
+supported — the server keeps the project it first resolved. Dynamic re-resolution when the client's
+active workspace changes is tracked in
+[#209](https://github.com/aigengame/godot-agent/issues/209).
+
 ## Notes
 
 - **After PyPI ([#207](https://github.com/aigengame/godot-agent/issues/207))** every

--- a/docs/gda-mcp-registration.md
+++ b/docs/gda-mcp-registration.md
@@ -6,7 +6,8 @@ ships inside the one `gda` distribution behind an optional `[mcp]` extra (ADR-00
 any MCP-speaking agent can drive Godot through it.
 
 This guide gives copy-pasteable registration recipes for **Claude Code**, **Codex**,
-**Cursor**, and **Claude Desktop**, at both user and project scope.
+**Cursor**, and **Claude Desktop**, at user and project scope — except **Claude Desktop**, which has
+a single per-user config (no project scope).
 
 ## Before you start
 
@@ -42,16 +43,18 @@ recipe's `env` block, e.g. `"GDA_GODOT": "/Applications/Godot.app/Contents/MacOS
 ### How the server finds your Godot project
 
 `gda-mcp` resolves one target Godot project for the server by an agent-neutral
-precedence (ADR-0014), first valid hit wins:
+precedence (ADR-0014), first hit wins:
 
 1. **`GDA_PROJECT`** in the server's `env` — explicit and portable; works in every agent.
 2. the **`roots/list`** the client advertises — used automatically by clients that
    support it (e.g. Claude Code), no config needed.
 3. the process **cwd** — last-resort fallback (unreliable across agents).
 
-A candidate is only used when it is a real Godot project (contains `project.godot`).
-**Recommended: register at project scope, or pin `GDA_PROJECT`.** Each recipe below
-shows the right way to pin the project for that agent.
+A `roots` or cwd candidate is used only when it is a real Godot project (contains
+`project.godot`); otherwise resolution moves on. An explicitly set **`GDA_PROJECT`** is stricter: if
+it is not a valid project, `gda` reports a typed error rather than silently falling back to `roots`
+or cwd. **Recommended: register at project scope, or pin `GDA_PROJECT`.** Each recipe below shows the
+right way to pin the project for that agent.
 
 ## Two cross-cutting constraints
 
@@ -75,7 +78,8 @@ unaffected.
 ### Project pinning is agent-specific
 
 The mechanism is always one of the three neutral signals above, but how you supply the
-project path differs per agent: `GDA_PROJECT` everywhere, `${workspaceFolder}` on Cursor,
+project path differs per agent: `GDA_PROJECT` everywhere, `${workspaceFolder}` on Cursor (project
+scope),
 `${CLAUDE_PROJECT_DIR}` or `roots` on Claude Code, an absolute path on Codex / Claude
 Desktop.
 
@@ -185,8 +189,8 @@ Config: `.cursor/mcp.json` at the project root (project scope) or `~/.cursor/mcp
 (global scope); project takes precedence. The stdio `type` field is required in current
 Cursor.
 
-Cursor resolves `${workspaceFolder}` (and `${userHome}`, `${env:NAME}`) inside
-`command`/`args`/`env`, so pin the open project cleanly with
+Cursor resolves `${workspaceFolder}`, `${userHome}`, and `${env:NAME}` inside
+`command`/`args`/`env`, so the **project-scoped** config pins the open project cleanly with
 `"GDA_PROJECT": "${workspaceFolder}"`. Cursor is **GUI-launched** — mind the minimal-PATH
 constraint above.
 
@@ -217,8 +221,9 @@ Replace the absolute `command` path with the output of `which uvx`. To keep a ba
 
 ### Global scope — `~/.cursor/mcp.json`
 
-Identical structure; use a literal absolute project path for `GDA_PROJECT` (a global
-config is not tied to one workspace), or omit it and rely on the workspace per project.
+Same structure, but set `GDA_PROJECT` to a literal **absolute** project path: `${workspaceFolder}` is
+only reliable in the project-level `.cursor/mcp.json` — Cursor does not document it for the global
+config, and it has been reported passed through unexpanded there.
 
 ---
 
@@ -268,10 +273,12 @@ resolves again.
 - **Several projects** — the reliable pattern is **one registration per project**: register at
   project scope (the per-repo `.mcp.json` / `.codex/config.toml` / `.cursor/mcp.json` above) so each
   project gets its own server pinned to it.
-- A **user/global** registration follows the client's signal where there is one: Claude Code resolves
-  the workspace from `roots`, and Cursor's `${workspaceFolder}` tracks the open project, so each tends
-  to target the project you are working in. Codex has no per-workspace signal, so a global Codex
-  registration stays pinned to the single `GDA_PROJECT` you set.
+- A **user/global** registration follows the open project only where the client advertises a
+  per-session signal: **Claude Code** advertises `roots`, so it targets the workspace you open it in.
+  **Cursor** and **Codex** have no reliable per-window signal for a global config (Cursor's
+  `${workspaceFolder}` is reliable only in the project-level file), so a global registration there is
+  pinned to the single `GDA_PROJECT` you set — register at project scope for those if you work across
+  several projects.
 
 Switching the active project **within a single live session** (without starting a new one) is not yet
 supported — the server keeps the project it first resolved. Dynamic re-resolution when the client's

--- a/docs/gda-mcp-registration.md
+++ b/docs/gda-mcp-registration.md
@@ -1,0 +1,269 @@
+# Registering `gda-mcp` with your agent
+
+`gda-mcp` is a stdio [MCP](https://modelcontextprotocol.io) server that exposes the
+whole `gda` command surface as MCP tools, generated from `gda`'s own `--schema`. It
+ships inside the one `gda` distribution behind an optional `[mcp]` extra (ADR-0013), so
+any MCP-speaking agent can drive Godot through it.
+
+This guide gives copy-pasteable registration recipes for **Claude Code**, **Codex**,
+**Cursor**, and **Claude Desktop**, at both user and project scope.
+
+## Before you start
+
+### Launch command
+
+`gda-mcp` is launched as a `command` + `args` stdio server. Two forms:
+
+- **Zero-install (recommended to try)** — run straight from the public repo with
+  [`uv`](https://docs.astral.sh/uv/):
+
+  ```
+  uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
+  ```
+
+- **Installed** — put the `gda-mcp` console script on your PATH:
+
+  ```
+  uv tool install "gda[mcp] @ git+https://github.com/aigengame/godot-agent"
+  ```
+
+> **Note** — `gda` is not on PyPI yet (tracked by
+> [#207](https://github.com/aigengame/godot-agent/issues/207)). Until it is, the
+> zero-install form resolves the package from git as shown above. Once published, it
+> simplifies to the canonical `uvx --from "gda[mcp]" gda-mcp` /
+> `pip install "gda[mcp]"`.
+
+### The server needs a Godot engine
+
+`gda-mcp` shells out to `gda`, which spawns the Godot engine. If `godot` is not at
+`gda`'s default location (or you want to pin a specific build), add `GDA_GODOT` to the
+recipe's `env` block, e.g. `"GDA_GODOT": "/Applications/Godot.app/Contents/MacOS/Godot"`.
+
+### How the server finds your Godot project
+
+`gda-mcp` resolves one target Godot project for the server by an agent-neutral
+precedence (ADR-0014), first valid hit wins:
+
+1. **`GDA_PROJECT`** in the server's `env` — explicit and portable; works in every agent.
+2. the **`roots/list`** the client advertises — used automatically by clients that
+   support it (e.g. Claude Code), no config needed.
+3. the process **cwd** — last-resort fallback (unreliable across agents).
+
+A candidate is only used when it is a real Godot project (contains `project.godot`).
+**Recommended: register at project scope, or pin `GDA_PROJECT`.** Each recipe below
+shows the right way to pin the project for that agent.
+
+## Two cross-cutting constraints
+
+### Minimal PATH on GUI-launched agents
+
+**Claude Desktop and Cursor** are launched from the Dock/Finder with a **minimal PATH**
+that usually omits `~/.local/bin`, `/opt/homebrew/bin`, and `/usr/local/bin`, so a bare
+`command: "uvx"` or `"gda-mcp"` can fail with "command not found". For those two agents,
+use an **absolute path** to the executable, or inject a `PATH` into `env`:
+
+```jsonc
+// find the absolute path first:  which uvx   /   which gda-mcp
+"command": "/Users/you/.local/bin/uvx"
+// …or keep the bare command and repair PATH:
+"env": { "PATH": "/opt/homebrew/bin:/usr/local/bin:/Users/you/.local/bin:/usr/bin:/bin" }
+```
+
+The CLI agents (**Claude Code**, **Codex**) inherit a normal shell PATH and are
+unaffected.
+
+### Project pinning is agent-specific
+
+The mechanism is always one of the three neutral signals above, but how you supply the
+project path differs per agent: `GDA_PROJECT` everywhere, `${workspaceFolder}` on Cursor,
+`${CLAUDE_PROJECT_DIR}` or `roots` on Claude Code, an absolute path on Codex / Claude
+Desktop.
+
+---
+
+## Claude Code
+
+Config: `.mcp.json` at the project root (project scope, shareable via version control) or
+`~/.claude.json` (user/local scope). No `type` field — stdio is implicit.
+
+Claude Code **advertises `roots`**, so `gda-mcp` auto-detects the workspace project with
+no `GDA_PROJECT` needed. Pin `GDA_PROJECT` explicitly only if you want a project other
+than the launch workspace.
+
+### Project scope — `.mcp.json` (committed to the repo)
+
+```json
+{
+  "mcpServers": {
+    "gda-mcp": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "gda[mcp] @ git+https://github.com/aigengame/godot-agent",
+        "gda-mcp"
+      ],
+      "env": {}
+    }
+  }
+}
+```
+
+The empty `env` is enough: Claude Code's advertised `roots` resolve the project. To pin
+it explicitly instead, set `"env": { "GDA_PROJECT": "${CLAUDE_PROJECT_DIR}" }` (Claude
+Code provides `CLAUDE_PROJECT_DIR` in the server environment).
+
+### User scope — the CLI
+
+```bash
+claude mcp add --scope user gda-mcp -- \
+  uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
+```
+
+Everything after `--` is the launch command. `--scope user` makes the server available
+across all your projects (stored in `~/.claude.json`); use `--scope project` to write a
+`.mcp.json` instead, or `--scope local` for this project only. Add `--env KEY=VALUE`
+(repeatable) before the `--` to set environment variables.
+
+### Verify
+
+```bash
+claude mcp list          # gda-mcp should be listed
+claude mcp get gda-mcp   # shows the command/args/env
+```
+
+In a session, `/mcp` shows server status and the `scene_*`, `node_*`, `info`, … tools.
+
+---
+
+## Codex
+
+Config: `~/.codex/config.toml` (global) or `.codex/config.toml` at the project root
+(project-local, **trusted projects only**; the closest file to your cwd wins). TOML, with
+a `[mcp_servers.<name>]` table. No `type` key — Codex infers stdio from `command`.
+
+Codex does not reliably advertise `roots` or set the project cwd, so **pin `GDA_PROJECT`
+explicitly** (an absolute path — Codex has no `${workspaceFolder}` substitution).
+
+### Global scope — `~/.codex/config.toml`
+
+```toml
+[mcp_servers.gda-mcp]
+command = "uvx"
+args = ["--from", "gda[mcp] @ git+https://github.com/aigengame/godot-agent", "gda-mcp"]
+
+[mcp_servers.gda-mcp.env]
+GDA_PROJECT = "/absolute/path/to/your/godot/project"
+```
+
+### Project scope — `.codex/config.toml` (committed; project must be trusted)
+
+```toml
+[mcp_servers.gda-mcp]
+command = "uvx"
+args = ["--from", "gda[mcp] @ git+https://github.com/aigengame/godot-agent", "gda-mcp"]
+# Pin the project; you can also set cwd = "..." for the server process.
+
+[mcp_servers.gda-mcp.env]
+GDA_PROJECT = "/absolute/path/to/your/godot/project"
+```
+
+### The CLI
+
+```bash
+codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/project -- \
+  uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
+```
+
+`--env KEY=VALUE` (repeatable) precedes `--`; everything after `--` is the launch
+command. This writes into `~/.codex/config.toml`.
+
+---
+
+## Cursor
+
+Config: `.cursor/mcp.json` at the project root (project scope) or `~/.cursor/mcp.json`
+(global scope); project takes precedence. The stdio `type` field is required in current
+Cursor.
+
+Cursor resolves `${workspaceFolder}` (and `${userHome}`, `${env:NAME}`) inside
+`command`/`args`/`env`, so pin the open project cleanly with
+`"GDA_PROJECT": "${workspaceFolder}"`. Cursor is **GUI-launched** — mind the minimal-PATH
+constraint above.
+
+### Project scope — `.cursor/mcp.json`
+
+```json
+{
+  "mcpServers": {
+    "gda-mcp": {
+      "type": "stdio",
+      "command": "/Users/you/.local/bin/uvx",
+      "args": [
+        "--from",
+        "gda[mcp] @ git+https://github.com/aigengame/godot-agent",
+        "gda-mcp"
+      ],
+      "env": {
+        "GDA_PROJECT": "${workspaceFolder}"
+      }
+    }
+  }
+}
+```
+
+Replace the absolute `command` path with the output of `which uvx`. To keep a bare
+`"command": "uvx"`, add a repaired `PATH` to `env`:
+`"PATH": "/opt/homebrew/bin:/usr/local/bin:${userHome}/.local/bin:${env:PATH}"`.
+
+### Global scope — `~/.cursor/mcp.json`
+
+Identical structure; use a literal absolute project path for `GDA_PROJECT` (a global
+config is not tied to one workspace), or omit it and rely on the workspace per project.
+
+---
+
+## Claude Desktop
+
+Config: a single per-user file (no project scope — Claude Desktop is a desktop app with
+one global config):
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+(Settings → Developer → "Edit Config" opens it.) Same `mcpServers` schema as Claude Code;
+no `type` field. Claude Desktop is **GUI-launched** — use an **absolute path** and pin
+`GDA_PROJECT` to an absolute path.
+
+```json
+{
+  "mcpServers": {
+    "gda-mcp": {
+      "command": "/Users/you/.local/bin/uvx",
+      "args": [
+        "--from",
+        "gda[mcp] @ git+https://github.com/aigengame/godot-agent",
+        "gda-mcp"
+      ],
+      "env": {
+        "GDA_PROJECT": "/absolute/path/to/your/godot/project"
+      }
+    }
+  }
+}
+```
+
+Find the `command` path with `which uvx` (or `which gda-mcp` if you used `uv tool
+install`). After editing, fully quit and reopen Claude Desktop.
+
+---
+
+## Notes
+
+- **After PyPI ([#207](https://github.com/aigengame/godot-agent/issues/207))** every
+  `"gda[mcp] @ git+https://github.com/aigengame/godot-agent"` above simplifies to
+  `"gda[mcp]"`, and `uv tool install "gda[mcp]"` / `pip install "gda[mcp]"` work directly.
+- **`GDA_BIN`** overrides which `gda` the adapter shells out to (default: the `gda` in
+  the same install). An escape hatch for unusual layouts; see ADR-0013.
+- **Trust** — a `--project` op runs the target project's own code at engine startup
+  (autoloads); `gda` assumes a trusted project (ADR-0009). Only point `gda-mcp` at
+  projects you trust.


### PR DESCRIPTION
## Summary

Ships the per-agent MCP registration recipes for `gda-mcp` — the documentation deliverable of PRD #8 / ADR-0013.

Closes #195.

## What's in it

- **`docs/gda-mcp-registration.md`** — copy-pasteable stdio registration recipes for **Claude Code, Codex, Cursor, and Claude Desktop**, at user and project scope. Each recipe gives:
  - the launch command (`command` + `args`),
  - the **minimal-PATH** mitigation for GUI-launched agents (Claude Desktop, Cursor) — absolute path / `PATH`-via-`env`,
  - agent-neutral **project pinning** consistent with ADR-0014: `GDA_PROJECT` everywhere, `${workspaceFolder}` on Cursor, `roots`/`CLAUDE_PROJECT_DIR` on Claude Code, an absolute path on Codex / Claude Desktop.
- **README** — a new `MCP server (gda-mcp)` install subsection linking the recipes, and the status/roadmap reconciled from "gda-mcp 🔜 Next" to **shipped**.
- **ADR-0013** — the zero-install line reconciled to the git-source form that works today.

## Install mechanism (option A)

`gda` is **not on PyPI** (the release pipeline only attaches wheels to GitHub Releases). So the recipes install from the **public git repo** today:

```
uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
```

Publishing to PyPI — after which every recipe simplifies to the canonical `uvx --from "gda[mcp]"` — is split out as a follow-up: **#207**. The recipes and ADR-0013 note this.

## Verification

The git-source launch and a real registration were both checked locally:

- `uvx --from "gda[mcp] @ git+…" gda-mcp` resolves, builds, and starts (clean EOF exit).
- Registering the **exact** git-uvx recipe in this project (Claude Code, local scope) and running `claude mcp get gda-mcp` reports **`Status: ✔ Connected`** — real agent → spawned server → introspected tool surface. The temporary registration was removed afterward.

Acceptance criteria (#195):

- [x] User- and project-scope recipes for Claude Code, Codex, Claude Desktop, and Cursor, each with config + launch command
- [x] Minimal-PATH constraint documented with the absolute-path / `PATH`-via-env mitigation
- [x] Each recipe shows how the project is pinned, consistent with #194

Docs-only change; no code touched (CI fast tests unaffected).
