### PR TITLE
ci(release): publish gda to PyPI via Trusted Publishing (#207)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,12 +138,22 @@ jobs:
   publish-pypi:
     name: Publish to PyPI (Trusted Publishing)
     runs-on: ubuntu-latest
-    needs: build-release
+    needs:
+      - cut-release
+      - build-release
+    # Run on any non-cancelled post-cut outcome — the guard step below decides
+    # pass/fail — instead of letting a failed build-release SKIP this job.
+    # "Re-run failed jobs" reliably re-runs FAILED jobs and their dependents, but
+    # whether it re-runs a job that was SKIPPED because an upstream failed is
+    # undocumented; relying on it would strand ADR-0007's recovery path. Turning
+    # an upstream failure into an explicit failure of THIS job keeps the whole
+    # post-cut tail re-runnable. Gated on release_created so ordinary pushes that
+    # cut nothing still skip it.
+    if: ${{ !cancelled() && needs.cut-release.outputs.release_created == 'true' }}
+    #
     # Runs BEFORE publish-github-release. Un-drafting the GitHub Release (the next
-    # job) is what creates the git tag, and ADR-0007's recovery model treats the
-    # tag as the atomic "release succeeded" signal: every load-bearing step runs
-    # before it, so a PyPI failure leaves a tag-less draft that the release-PR gate
-    # flags and "Re-run failed jobs" converges (ADR-0016).
+    # job) is what creates the git tag — ADR-0007's atomic "release succeeded"
+    # signal — so a PyPI failure here means no tag is minted (ADR-0016).
     #
     # This job holds id-token: write and NOTHING else, and runs no project, test,
     # or build code — it only downloads the prebuilt artifact and publishes it.
@@ -159,6 +169,16 @@ jobs:
       name: pypi
       url: https://pypi.org/p/gda
     steps:
+      # Fail (don't silently skip) when the build did not succeed, so this is a
+      # FAILED job that "Re-run failed jobs" re-runs — not a skipped one whose
+      # re-run is undocumented.
+      - name: Require the build to have succeeded
+        if: ${{ needs.build-release.result != 'success' }}
+        run: |
+          echo "build-release did not succeed (result: ${{ needs.build-release.result }})." >&2
+          echo "Failing so 'Re-run failed jobs' re-runs this job once the build is repaired." >&2
+          exit 1
+
       - name: Download distributions
         uses: actions/download-artifact@v8.0.1
         with:
@@ -182,13 +202,30 @@ jobs:
     needs:
       - cut-release
       - publish-pypi
-    # Only contents: write here, no id-token. Runs after PyPI publish succeeds;
-    # the un-draft below creates the tag — ADR-0007's commit point.
+    # Same run-on-failure rationale as publish-pypi: run on any non-cancelled
+    # post-cut outcome so a failed publish-pypi makes THIS job fail (via the guard
+    # below) rather than skip — keeping it in the set "Re-run failed jobs" re-runs,
+    # so recovery drives through to tag creation once PyPI is repaired (ADR-0007 /
+    # ADR-0016). Gated on release_created so ordinary pushes skip it.
+    if: ${{ !cancelled() && needs.cut-release.outputs.release_created == 'true' }}
+    # Only contents: write here, no id-token. The un-draft below creates the tag
+    # — ADR-0007's commit point — and the guard ensures it runs only after PyPI
+    # has actually published.
     permissions:
       contents: write
     env:
       RELEASE_TAG: ${{ needs.cut-release.outputs.tag_name }}
     steps:
+      # Fail before the un-draft when PyPI did not publish: this both prevents a
+      # tag from being minted without a PyPI release AND makes this a FAILED (not
+      # skipped) job that "Re-run failed jobs" reliably re-runs.
+      - name: Require the PyPI publish to have succeeded
+        if: ${{ needs.publish-pypi.result != 'success' }}
+        run: |
+          echo "publish-pypi did not succeed (result: ${{ needs.publish-pypi.result }})." >&2
+          echo "Failing before the un-draft so no tag is created; 'Re-run failed jobs' re-runs this once PyPI is repaired." >&2
+          exit 1
+
       - name: Download distributions
         uses: actions/download-artifact@v8.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,18 @@ jobs:
       needs.cut-release.outputs.release_created == 'true'
     permissions:
       contents: write
+      # Trusted Publishing mints a short-lived, scoped PyPI upload token from an
+      # OIDC token instead of a stored API secret (ADR-0016). The publish step
+      # below needs to request it.
+      id-token: write
+    # Scope the OIDC trust to a named GitHub Environment so only this job — not an
+    # arbitrary workflow in the repo — can publish to PyPI; the PyPI trusted
+    # publisher is configured with this exact environment name. No protection
+    # rules: the release stays fully automated and the human gate remains the
+    # Release PR merge (ADR-0007 / ADR-0016).
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gda
 
     env:
       RELEASE_TAG: ${{ needs.cut-release.outputs.tag_name }}
@@ -117,6 +129,23 @@ jobs:
 
       - name: Build distributions
         run: uv build
+
+      # Publish to PyPI BEFORE the GitHub Release is un-drafted. Un-drafting is
+      # what creates the git tag, and ADR-0007's recovery model treats the tag as
+      # the atomic "release succeeded" signal: everything load-bearing runs before
+      # it, so a failure here leaves a tag-less draft that the release-PR gate
+      # flags and "Re-run failed jobs" converges (ADR-0016). The publish is
+      # idempotent via skip-existing — PyPI files are immutable, so a re-run from
+      # the same tagged commit skips whatever already landed and uploads the rest,
+      # mirroring the --clobber idempotency of the gh release upload below.
+      # Trusted Publishing (OIDC) is used; configuring the PyPI pending publisher
+      # is the one-time human step tracked on #207. Until that is done this step
+      # fails the release — intended: it is the gate that proves the publisher is
+      # configured before any tag is minted.
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
       - name: Publish GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       # The commit release-please tagged the release at — not necessarily the
-      # push HEAD, so github-release builds the right tree under concurrency (#83).
+      # push HEAD, so build-release builds the right tree under concurrency (#83).
       sha: ${{ steps.release.outputs.sha }}
     steps:
       - name: Run release-please (release cutting only)
@@ -57,28 +57,20 @@ jobs:
           manifest-file: .release-please-manifest.json
           skip-github-pull-request: true
 
-  github-release:
-    name: Build, verify, and publish release artifacts
+  build-release:
+    name: Build and verify release artifacts
     runs-on: ubuntu-latest
     needs: cut-release
     # Run when release-please just cut a release (draft).
     if: >-
       !failure() && !cancelled() &&
       needs.cut-release.outputs.release_created == 'true'
+    # Deliberately NO id-token here: the job that runs project, test, and
+    # build-backend code must never hold PyPI publishing authority. OIDC lives
+    # only in the isolated publish-pypi job below, so an injected build/test path
+    # cannot mint a PyPI credential (ADR-0016).
     permissions:
-      contents: write
-      # Trusted Publishing mints a short-lived, scoped PyPI upload token from an
-      # OIDC token instead of a stored API secret (ADR-0016). The publish step
-      # below needs to request it.
-      id-token: write
-    # Scope the OIDC trust to a named GitHub Environment so only this job — not an
-    # arbitrary workflow in the repo — can publish to PyPI; the PyPI trusted
-    # publisher is configured with this exact environment name. No protection
-    # rules: the release stays fully automated and the human gate remains the
-    # Release PR merge (ADR-0007 / ADR-0016).
-    environment:
-      name: pypi
-      url: https://pypi.org/p/gda
+      contents: read
 
     env:
       RELEASE_TAG: ${{ needs.cut-release.outputs.tag_name }}
@@ -130,22 +122,78 @@ jobs:
       - name: Build distributions
         run: uv build
 
-      # Publish to PyPI BEFORE the GitHub Release is un-drafted. Un-drafting is
-      # what creates the git tag, and ADR-0007's recovery model treats the tag as
-      # the atomic "release succeeded" signal: everything load-bearing runs before
-      # it, so a failure here leaves a tag-less draft that the release-PR gate
-      # flags and "Re-run failed jobs" converges (ADR-0016). The publish is
-      # idempotent via skip-existing — PyPI files are immutable, so a re-run from
+      # Build once here (in the no-OIDC job) and hand the sdist+wheel to both
+      # publish jobs as a run-scoped artifact. This keeps the build-backend
+      # invocation out of any job that holds publishing authority, and keeps PyPI
+      # and the GitHub Release byte-identical. overwrite:true so a "Re-run failed
+      # jobs" that re-runs this job re-uploads cleanly (ADR-0016).
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: gda-release-distributions
+          path: dist/
+          if-no-files-found: error
+          overwrite: true
+
+  publish-pypi:
+    name: Publish to PyPI (Trusted Publishing)
+    runs-on: ubuntu-latest
+    needs: build-release
+    # Runs BEFORE publish-github-release. Un-drafting the GitHub Release (the next
+    # job) is what creates the git tag, and ADR-0007's recovery model treats the
+    # tag as the atomic "release succeeded" signal: every load-bearing step runs
+    # before it, so a PyPI failure leaves a tag-less draft that the release-PR gate
+    # flags and "Re-run failed jobs" converges (ADR-0016).
+    #
+    # This job holds id-token: write and NOTHING else, and runs no project, test,
+    # or build code — it only downloads the prebuilt artifact and publishes it.
+    # That isolation is the supply-chain boundary the PyPA action calls for: PyPI
+    # publishing authority never overlaps the build/test environment.
+    permissions:
+      id-token: write
+    # Scope the OIDC trust to a named GitHub Environment so only this job can mint
+    # a PyPI-publishable token; the PyPI trusted publisher is configured with this
+    # exact environment name. No protection rules: the release stays fully
+    # automated and the human gate remains the Release PR merge (ADR-0007/0016).
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gda
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: gda-release-distributions
+          path: dist/
+
+      # Idempotent via skip-existing: PyPI files are immutable, so a re-run from
       # the same tagged commit skips whatever already landed and uploads the rest,
-      # mirroring the --clobber idempotency of the gh release upload below.
-      # Trusted Publishing (OIDC) is used; configuring the PyPI pending publisher
-      # is the one-time human step tracked on #207. Until that is done this step
-      # fails the release — intended: it is the gate that proves the publisher is
-      # configured before any tag is minted.
-      - name: Publish to PyPI (Trusted Publishing)
+      # mirroring the --clobber idempotency of the gh release upload downstream.
+      # Configuring the PyPI pending publisher is the one-time human step on #207;
+      # until then this step fails the release — intended, it gates tag creation on
+      # a working publisher.
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
+
+  publish-github-release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    needs:
+      - cut-release
+      - publish-pypi
+    # Only contents: write here, no id-token. Runs after PyPI publish succeeds;
+    # the un-draft below creates the tag — ADR-0007's commit point.
+    permissions:
+      contents: write
+    env:
+      RELEASE_TAG: ${{ needs.cut-release.outputs.tag_name }}
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: gda-release-distributions
+          path: dist/
 
       - name: Publish GitHub Release
         env:
@@ -167,14 +215,16 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - cut-release
-      - github-release
+      - build-release
+      - publish-pypi
+      - publish-github-release
     # Runs after any cut release is published. The same-run `needs` only sees
     # this run's job statuses, but the hazard is repo-global and survives the
     # run: a failed verify-and-build chain leaves a tag-less draft whose merged
     # Release PR is already labeled "autorelease: tagged", so a later ordinary
     # push reaches here with everything merely skipped. The tag_gate step below
     # is the actual guard — it refuses maintenance unless the manifest version's
-    # tag exists (#82). On pushes that cut no release the github-release job is
+    # tag exists (#82). On pushes that cut no release the build/publish chain is
     # skipped and this still runs.
     if: >-
       !failure() && !cancelled()

--- a/docs/adr/0016-publish-to-pypi-via-trusted-publishing.md
+++ b/docs/adr/0016-publish-to-pypi-via-trusted-publishing.md
@@ -1,0 +1,118 @@
+---
+status: accepted
+---
+
+# Distribution: publish `gda` to PyPI via Trusted Publishing
+
+[ADR-0013](0013-gda-mcp-packaging-and-launch.md) makes the canonical install and
+registration commands `pip install "gda[mcp]"` and `uvx --from "gda[mcp]" gda-mcp`.
+Neither works today: `gda` is not on PyPI (`pypi.org/pypi/gda` → 404). The
+release pipeline ([ADR-0007](0007-release-automation-with-release-please.md))
+builds distributions with `uv build` and attaches them to a **GitHub Release
+only** — there is no publish step to a package index. As a stopgap the
+[#195](https://github.com/aigengame/godot-agent/issues/195) registration recipes
+ship the git-source form
+`uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp`,
+which the ADR-0013 prose promises to simplify "once on PyPI". This ADR records
+the decision that makes the canonical form real.
+
+## Decision
+
+**Publish the built `gda` distributions (sdist + wheel) to PyPI on every cut
+release, via PyPI Trusted Publishing (OIDC) — no long-lived API token.**
+
+- **Where it runs.** The publish is a step inside the existing `github-release`
+  job of `release.yml`, not a new workflow. That job already checks out the
+  exact tagged commit, runs the full test suite, and `uv build`s the
+  distributions; PyPI publish consumes the same `dist/` those steps produce. One
+  release pipeline, one version source (ADR-0007 / ADR-0008) — unchanged.
+
+- **Auth: Trusted Publishing, not a stored token.** The job requests an OIDC
+  token (`permissions: id-token: write`) and `pypa/gh-action-pypi-publish`
+  exchanges it for a short-lived, scoped PyPI upload credential. This honours
+  ADR-0007's stance that "a long-lived credential is a cost we do not need to
+  pay": no `PYPI_API_TOKEN` secret to store, rotate, or leak. The OIDC trust is
+  scoped to a named GitHub Environment (`pypi`) so only this job — not an
+  arbitrary workflow in the repo — can mint a publishable token.
+
+- **Ordering: publish to PyPI *before* the GitHub Release is un-drafted.**
+  Un-drafting the GitHub Release is what creates the git tag, and ADR-0007's
+  recovery model treats **the tag as the atomic "release succeeded" signal** —
+  everything that must succeed runs before it, so a failure leaves a *tag-less
+  draft* that the release-PR-maintenance gate flags ("needs recovery") and
+  "Re-run failed jobs" converges. Slotting PyPI publish between `uv build` and
+  the un-draft brings PyPI under that same guarantee: a PyPI failure wedges the
+  draft exactly like a build failure does, and recovery is the existing,
+  documented re-run — no new failure mode, no new runbook.
+
+- **Idempotent, like the GitHub-Release upload.** PyPI files are **immutable**
+  (a filename can never be re-uploaded), so the publish uses `skip-existing:
+  true`: a re-run from the same tagged commit skips whatever already landed and
+  uploads the rest. This mirrors the `--clobber` idempotency of the
+  `gh release upload` step — together they make the whole publish phase
+  re-runnable, which is what ADR-0007's recovery depends on. Re-runs are safe
+  because they build from the **same** tagged commit (ADR-0008's single version
+  authority), so "skip what exists" never hides a content change.
+
+- **Project name `gda`, claimed via a pending publisher.** `gda` is free on
+  PyPI today. Trusted Publishing's *pending publisher* mechanism both registers
+  the trust and reserves the name: the project is created automatically on the
+  first successful publish. If the name turns out to be taken or squatted before
+  setup, the fallback is to pick an alternative distribution name and update
+  ADR-0013's canonical commands accordingly — the workflow change is unaffected.
+
+### One-time human setup (outside this repo)
+
+The workflow is inert until a maintainer configures the PyPI side once (tracked
+on #207, labelled `ready-for-human`):
+
+1. On PyPI (account with 2FA), register a **pending publisher** for project
+   `gda`: owner `aigengame`, repository `godot-agent`, workflow `release.yml`,
+   environment `pypi`.
+2. Create the GitHub Environment `pypi` in the repo settings (auto-created on
+   first use if omitted; created explicitly if protection rules are wanted).
+
+Optionally a TestPyPI pending publisher (same fields, `environment: testpypi`)
+enables a dry run before the first real publish.
+
+## Considered options
+
+- **Trusted Publishing / OIDC (chosen).** No stored credential; the upload
+  token is short-lived and scoped to one environment. Aligns with ADR-0007's
+  no-long-lived-credential stance and is the PyPA-recommended path for CI.
+- **PyPI API token in GitHub Secrets (rejected).** A long-lived credential that
+  must be stored, scoped, and rotated, and is exfiltratable from a compromised
+  workflow — precisely the cost ADR-0007 declined to pay for the GitHub token.
+- **A separate publish workflow / job with artifact hand-off (rejected).** A
+  standalone job (download the `dist/` artifact, publish) is the PyPA tutorial's
+  shape, but it would run *after* `github-release` — i.e. after the tag already
+  exists — breaking the "everything load-bearing happens before the tag"
+  invariant the recovery model rests on. Inlining the step keeps PyPI under the
+  existing tag-as-commit-point guarantee at the cost of running the whole job in
+  the `pypi` environment.
+- **No GitHub Environment scoping (rejected).** Trusted Publishing works without
+  naming an environment, but then any workflow in the repo that can request an
+  OIDC token could publish. Scoping to a `pypi` environment is cheap defence in
+  depth and the recommended configuration.
+
+## Consequences
+
+- After the one-time setup and the next cut release, `pip install "gda[mcp]"`
+  and `uvx --from "gda[mcp]" gda-mcp` work from a clean environment — the
+  ADR-0013 promise is fulfilled.
+- **Follow-up, gated on the first successful publish:** reconcile the git-source
+  form back to the canonical form in the #195 registration recipes
+  (`docs/gda-mcp-registration.md`), `README.md`, and ADR-0013's prose. Done only
+  *after* a real PyPI release exists, so the docs never advertise a command that
+  404s.
+- The `pypi` GitHub Environment carries no protection rules, keeping the release
+  fully automated; the human gate stays at the Release PR merge (ADR-0007).
+  Adding required reviewers to the environment is an available hardening — it
+  would introduce a second, pre-publish human gate — but is deliberately not
+  taken now.
+- Trusted Publishing emits PEP 740 attestations by default, so released
+  artifacts carry verifiable provenance at no extra cost.
+- **Supply-chain note.** `pypa/gh-action-pypi-publish@release/v1` is pinned to
+  the action's recommended floating major tag, consistent with the repo's other
+  tag-pinned actions; pinning to a full commit SHA is an available future
+  hardening.

--- a/docs/adr/0016-publish-to-pypi-via-trusted-publishing.md
+++ b/docs/adr/0016-publish-to-pypi-via-trusted-publishing.md
@@ -21,29 +21,38 @@ the decision that makes the canonical form real.
 **Publish the built `gda` distributions (sdist + wheel) to PyPI on every cut
 release, via PyPI Trusted Publishing (OIDC) — no long-lived API token.**
 
-- **Where it runs.** The publish is a step inside the existing `github-release`
-  job of `release.yml`, not a new workflow. That job already checks out the
-  exact tagged commit, runs the full test suite, and `uv build`s the
-  distributions; PyPI publish consumes the same `dist/` those steps produce. One
-  release pipeline, one version source (ADR-0007 / ADR-0008) — unchanged.
+- **Where it runs: a minimal publish job, isolated from build/test.** The former
+  single `github-release` job is split into three jobs in `release.yml`:
+  `build-release` (checkout the tagged commit, run the full suite, `uv build`,
+  upload the `dist/` as a run-scoped artifact), `publish-pypi` (download the
+  artifact, publish to PyPI), and `publish-github-release` (download the
+  artifact, upload it to the GitHub Release and un-draft). One release pipeline,
+  one version source (ADR-0007 / ADR-0008) — unchanged; what changes is only the
+  job graph.
 
-- **Auth: Trusted Publishing, not a stored token.** The job requests an OIDC
-  token (`permissions: id-token: write`) and `pypa/gh-action-pypi-publish`
-  exchanges it for a short-lived, scoped PyPI upload credential. This honours
-  ADR-0007's stance that "a long-lived credential is a cost we do not need to
-  pay": no `PYPI_API_TOKEN` secret to store, rotate, or leak. The OIDC trust is
-  scoped to a named GitHub Environment (`pypi`) so only this job — not an
-  arbitrary workflow in the repo — can mint a publishable token.
+- **Auth: Trusted Publishing, not a stored token — scoped to the publish job
+  alone.** `publish-pypi` requests an OIDC token (`permissions: id-token: write`)
+  and `pypa/gh-action-pypi-publish` exchanges it for a short-lived, scoped PyPI
+  upload credential. This honours ADR-0007's stance that "a long-lived
+  credential is a cost we do not need to pay": no `PYPI_API_TOKEN` secret to
+  store, rotate, or leak. Crucially, `id-token: write` is granted to
+  **`publish-pypi` only** — a job that runs no project, test, or build-backend
+  code, just an artifact download and the publish — so the build/test
+  environment never holds publishing authority and an injected build/test path
+  cannot mint a PyPI credential. The trust is further scoped to a named GitHub
+  Environment (`pypi`) so only this job can request a publishable token.
 
-- **Ordering: publish to PyPI *before* the GitHub Release is un-drafted.**
-  Un-drafting the GitHub Release is what creates the git tag, and ADR-0007's
-  recovery model treats **the tag as the atomic "release succeeded" signal** —
-  everything that must succeed runs before it, so a failure leaves a *tag-less
-  draft* that the release-PR-maintenance gate flags ("needs recovery") and
-  "Re-run failed jobs" converges. Slotting PyPI publish between `uv build` and
-  the un-draft brings PyPI under that same guarantee: a PyPI failure wedges the
-  draft exactly like a build failure does, and recovery is the existing,
-  documented re-run — no new failure mode, no new runbook.
+- **Ordering: `publish-pypi` before `publish-github-release`.** Un-drafting the
+  GitHub Release (in `publish-github-release`) is what creates the git tag, and
+  ADR-0007's recovery model treats **the tag as the atomic "release succeeded"
+  signal** — everything that must succeed runs before it, so a failure leaves a
+  *tag-less draft* that the release-PR-maintenance gate flags ("needs recovery")
+  and "Re-run failed jobs" converges. Ordering PyPI publish as the job *before*
+  the un-draft keeps PyPI under that same guarantee: a PyPI failure skips
+  `publish-github-release`, so no tag is minted, and recovery is the existing,
+  documented re-run — no new failure mode, no new runbook. The tag-as-commit-point
+  ordering is a property of the job *sequence*, not of co-locating publish with
+  build — so isolating the publish costs nothing here.
 
 - **Idempotent, like the GitHub-Release upload.** PyPI files are **immutable**
   (a filename can never be re-uploaded), so the publish uses `skip-existing:
@@ -54,12 +63,16 @@ release, via PyPI Trusted Publishing (OIDC) — no long-lived API token.**
   because they build from the **same** tagged commit (ADR-0008's single version
   authority), so "skip what exists" never hides a content change.
 
-- **Project name `gda`, claimed via a pending publisher.** `gda` is free on
-  PyPI today. Trusted Publishing's *pending publisher* mechanism both registers
-  the trust and reserves the name: the project is created automatically on the
-  first successful publish. If the name turns out to be taken or squatted before
-  setup, the fallback is to pick an alternative distribution name and update
-  ADR-0013's canonical commands accordingly — the workflow change is unaffected.
+- **Project name `gda`, claimed only by the first publish — not by setup.**
+  `gda` is unregistered on PyPI today. Registering a *pending publisher* does
+  **not** reserve the name: PyPI creates the project (and thereby claims the
+  name) only on the first successful publish, and if another account registers
+  `gda` before then, the pending publisher is invalidated. So the name is
+  effectively claimed by *landing the first release*, not by configuring the
+  publisher — until that release publishes, `gda` stays available to anyone. If
+  it is taken or squatted before then, the fallback is to pick an alternative
+  distribution name and update ADR-0013's canonical commands accordingly; the
+  workflow change is unaffected.
 
 ### One-time human setup (outside this repo)
 
@@ -83,13 +96,22 @@ enables a dry run before the first real publish.
 - **PyPI API token in GitHub Secrets (rejected).** A long-lived credential that
   must be stored, scoped, and rotated, and is exfiltratable from a compromised
   workflow — precisely the cost ADR-0007 declined to pay for the GitHub token.
-- **A separate publish workflow / job with artifact hand-off (rejected).** A
-  standalone job (download the `dist/` artifact, publish) is the PyPA tutorial's
-  shape, but it would run *after* `github-release` — i.e. after the tag already
-  exists — breaking the "everything load-bearing happens before the tag"
-  invariant the recovery model rests on. Inlining the step keeps PyPI under the
-  existing tag-as-commit-point guarantee at the cost of running the whole job in
-  the `pypi` environment.
+- **A separate, isolated publish job with artifact hand-off (chosen).** A
+  minimal `publish-pypi` job — download the `dist/` artifact, publish, nothing
+  else — is the PyPA-recommended shape, and it keeps `id-token: write` out of
+  the build/test environment. It does *not* break the tag-as-commit-point
+  invariant: the tag is created by the *downstream* `publish-github-release`
+  job's un-draft, so ordering `publish-pypi` ahead of it preserves "everything
+  load-bearing happens before the tag" while isolating the OIDC privilege. (An
+  earlier draft of this ADR rejected this option on the false premise that a
+  separate job must run *after* the GitHub Release; the recovery model depends on
+  job *ordering*, not on co-locating publish with build.)
+- **One job holding OIDC across build, test, and publish (rejected).** Inlining
+  the publish step in the build/test job is simpler, but `id-token: write` is
+  job-scoped, so the whole test/build environment — project autoloads, the test
+  suite, the build backend — could request an OIDC token and exchange it for a
+  PyPI credential. That is the supply-chain privilege bleed the PyPA action
+  explicitly warns against; the split above removes it.
 - **No GitHub Environment scoping (rejected).** Trusted Publishing works without
   naming an environment, but then any workflow in the repo that can request an
   OIDC token could publish. Scoping to a `pypi` environment is cheap defence in

--- a/docs/adr/0016-publish-to-pypi-via-trusted-publishing.md
+++ b/docs/adr/0016-publish-to-pypi-via-trusted-publishing.md
@@ -42,17 +42,30 @@ release, via PyPI Trusted Publishing (OIDC) — no long-lived API token.**
   cannot mint a PyPI credential. The trust is further scoped to a named GitHub
   Environment (`pypi`) so only this job can request a publishable token.
 
-- **Ordering: `publish-pypi` before `publish-github-release`.** Un-drafting the
+- **Ordering, and a re-runnable recovery across the split.** Un-drafting the
   GitHub Release (in `publish-github-release`) is what creates the git tag, and
   ADR-0007's recovery model treats **the tag as the atomic "release succeeded"
   signal** — everything that must succeed runs before it, so a failure leaves a
   *tag-less draft* that the release-PR-maintenance gate flags ("needs recovery")
-  and "Re-run failed jobs" converges. Ordering PyPI publish as the job *before*
-  the un-draft keeps PyPI under that same guarantee: a PyPI failure skips
-  `publish-github-release`, so no tag is minted, and recovery is the existing,
-  documented re-run — no new failure mode, no new runbook. The tag-as-commit-point
-  ordering is a property of the job *sequence*, not of co-locating publish with
-  build — so isolating the publish costs nothing here.
+  and **"Re-run failed jobs"** converges. Ordering `publish-pypi` before the
+  un-draft keeps PyPI under that guarantee; the tag-as-commit-point property is a
+  function of the job *sequence*, not of co-locating publish with build.
+
+  Splitting one job into three does introduce a hazard the single job lacked:
+  GitHub's **"Re-run failed jobs"** reliably re-runs *failed* jobs and their
+  dependents, but whether it re-runs a job that was *skipped* because an upstream
+  failed is **undocumented** — and a naive split makes each downstream job skip
+  on upstream failure, so recovery could leave the un-draft stuck skipped and
+  never converge. To keep ADR-0007's contract independent of that grey area, each
+  downstream job (`publish-pypi`, `publish-github-release`) **runs on any
+  non-cancelled post-cut outcome** (`if: !cancelled() && release_created`) and a
+  first **guard step fails it explicitly** when its upstream did not succeed,
+  instead of skipping. Every post-cut job is therefore either *successful* or
+  *failed* (never skipped-because-upstream-failed), so "Re-run failed jobs"
+  re-runs the entire failed tail and drives through to tag creation once the
+  failure is repaired — exactly as the single job did. The guard on
+  `publish-github-release` doubles as a correctness check: it blocks the un-draft
+  (hence the tag) unless PyPI actually published.
 
 - **Idempotent, like the GitHub-Release upload.** PyPI files are **immutable**
   (a filename can never be re-uploaded), so the publish uses `skip-existing:


### PR DESCRIPTION
## What

Add a PyPI publish step to the release pipeline and record the decision in **ADR-0016**, so the canonical install/registration commands promised by ADR-0013 (`pip install "gda[mcp]"`, `uvx --from "gda[mcp]" gda-mcp`) can work. Today `gda` is not on PyPI and the #195 recipes ship a git-source stopgap.

Split out of #207 (the workflow + ADR slice). **Does not close #207** — the PyPI-side human setup, first publish, and doc reconciliation remain.

## Changes

- **`.github/workflows/release.yml`** — in the existing `github-release` job:
  - `pypa/gh-action-pypi-publish@release/v1` step with `skip-existing: true`, inserted **after `uv build` and before the GitHub Release is un-drafted**.
  - `id-token: write` permission + `environment: pypi` to scope the OIDC trust.
- **`docs/adr/0016-publish-to-pypi-via-trusted-publishing.md`** — the distribution decision.

## Key design points

- **Trusted Publishing (OIDC), no stored token** — honours ADR-0007's "no long-lived credential" stance.
- **Ordering** — publish runs before the un-draft that creates the git tag, so PyPI falls under ADR-0007's *tag-as-commit-point* recovery model: a failure leaves a tag-less draft that the release-PR gate flags and **"Re-run failed jobs"** converges.
- **Idempotent** — `skip-existing: true` (PyPI files are immutable; a re-run from the same tagged commit skips what already landed), mirroring the `--clobber` GitHub upload.

## ⚠️ Merge ordering

This step is **inert until the PyPI pending publisher is configured** (one-time human setup, `ready-for-human` on #207). Complete the PyPI/GitHub-Environment setup **before** merging — otherwise the next cut release fails at this step and leaves a recoverable but noisy tag-less draft.

One-time human setup (also in ADR-0016):
1. PyPI → **Add a pending publisher** for project `gda`: owner `aigengame`, repo `godot-agent`, workflow `release.yml`, environment `pypi`.
2. Create GitHub Environment `pypi` (no protection rules → stays fully automated).

## Follow-up (after first successful publish)

Reconcile the git-source form back to the canonical commands in `docs/gda-mcp-registration.md`, `README.md`, and ADR-0013's prose — done only after a real PyPI release exists so docs never advertise a 404 command.

Refs: #207
