### PR TITLE
chore(release): force 0.1.24 to verify the PyPI publish path

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,6 +20,8 @@
     { "type": "ci", "section": "Continuous Integration", "hidden": true }
   ],
   "packages": {
-    ".": {}
+    ".": {
+      "release-as": "0.1.24"
+    }
   }
 }


### PR DESCRIPTION
## Why

Actively verify the new PyPI publish chain from #210 end-to-end, and claim the `gda` name on PyPI via the configured pending publisher. The first publish only fires on a versioned release, and there is no pending `feat`/`fix` to bump the version naturally (only `ci`/`docs` landed since 0.1.23).

## What

Set `release-as: "0.1.24"` in `release-please-config.json` — ADR-0007/0008's sanctioned force-version path. (`Release-As:` commit footers don't survive this repo's squash policy, which blanks the squash body, so the config field is the reliable trigger.)

## Sequence

1. **Merge this PR** → release-please opens a Release PR for **0.1.24**.
2. **Merge the 0.1.24 Release PR** → the release run executes `build-release → publish-pypi → publish-github-release`; `publish-pypi` performs the **first PyPI publish** (creates the `gda` project, claims the name).
3. Post-publish follow-up PR: **remove `release-as`** (otherwise it pins every future release to 0.1.24) **+ reconcile docs** from the git-source form to the canonical `pip install "gda[mcp]"` / `uvx --from "gda[mcp]"` commands — closing out #207.

## Watch points on the release run

- `publish-pypi` goes green and `https://pypi.org/project/gda/` appears.
- If `publish-pypi` fails, `publish-github-release` fails at its guard (no tag minted) → recover with **Re-run failed jobs** once the cause is fixed (per ADR-0016).

Refs: #207
