### PR TITLE
feat(packaging): render README on PyPI and add project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,16 +2,33 @@
 name = "gda"
 version = "0.1.23"
 description = "An agent-facing Godot CLI with structured output"
+readme = "README.md"
 authors = [
     { name = "haihong.qin", email = "haihongqin@gmail.com" }
 ]
 license = "MIT"
 license-files = ["LICENSE"]
+keywords = ["godot", "cli", "agent", "mcp", "game-development"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Games/Entertainment",
+    "Topic :: Software Development :: Build Tools",
+]
 requires-python = ">=3.13"
 dependencies = [
     "pydantic>=2.13.4",
     "typer>=0.26.7",
 ]
+
+[project.urls]
+Homepage = "https://github.com/aigengame/godot-agent"
+Repository = "https://github.com/aigengame/godot-agent"
+Issues = "https://github.com/aigengame/godot-agent/issues"
+Changelog = "https://github.com/aigengame/godot-agent/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 # The MCP adapter (gda-mcp) ships inside this one distribution, gated behind an

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,8 +20,6 @@
     { "type": "ci", "section": "Continuous Integration", "hidden": true }
   ],
   "packages": {
-    ".": {
-      "release-as": "0.1.24"
-    }
+    ".": {}
   }
 }


### PR DESCRIPTION
## Why

Two goals in one change:

1. **Trigger the 0.1.24 release** that performs the first PyPI publish. #211's `release-as` did **not** work: release-please reads it ("Setting version from release-as configuration") but then **skips** because there were **no user-facing (`feat`/`fix`) commits** since 0.1.23 — only `ci`/`docs`/`chore`. A `feat` is required to cut a release.
2. **Enrich the distribution for its first PyPI listing** — a real, user-facing improvement to the published package.

## What

- `pyproject.toml`:
  - `readme = "README.md"` → the PyPI project page renders the README instead of being blank.
  - `[project.urls]` — Homepage / Repository / Issues / Changelog.
  - `classifiers` + `keywords` for discoverability.
- `release-please-config.json`: **remove `release-as`** — it's both insufficient here and a foot-gun (would pin every future release to 0.1.24). With this `feat`, release-please bumps `0.1.23 → 0.1.24` naturally; no override needed.

## Verification

- `uv build` ✅ (metadata accepted by the uv_build backend; `uv.lock` unchanged, so CI `--frozen` passes)
- `twine check dist/*` ✅ **PASSED** — the same metadata + long-description validation PyPI runs on upload (so the classifiers are valid and the README renders).
- Confirmed in the wheel METADATA: 7 classifiers, 4 Project-URLs, `Description-Content-Type: text/markdown`, long-description body present.

No canonical install commands added here — those would 404 until the publish lands, so the docs reconciliation stays a post-publish follow-up (ADR-0016).

## Sequence

1. Merge this PR → release-please opens the **0.1.24 Release PR**.
2. Merge the 0.1.24 Release PR → release run executes `build-release → publish-pypi` (**first publish**) `→ publish-github-release`.
3. Post-publish follow-up PR: reconcile docs (git-source → canonical commands) → closes #207. (`release-as` is already gone, so no cleanup needed.)

Refs: #207
