### PR TITLE
docs(gda-mcp): reconcile install/registration docs to canonical PyPI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ for the full picture.
 > are settled (see [`CONTEXT.md`](CONTEXT.md) and [`docs/adr/`](docs/adr/)), and every headless
 > domain command group designed in
 > [PRD #17](https://github.com/aigengame/godot-agent/issues/17) now ships end-to-end against a real
-> engine. `gda` is still pre-1.0 and not yet published to a package index
-> ([#207](https://github.com/aigengame/godot-agent/issues/207)); **`gda-mcp` now ships** alongside
-> the CLI, and the next milestone is Phase 2 live operations.
+> engine. `gda` is pre-1.0 and published on
+> [PyPI](https://pypi.org/project/gda/); **`gda-mcp` now ships** alongside the
+> CLI, and the next milestone is Phase 2 live operations.
 
 **Working today — the full headless command surface**
 
@@ -135,7 +135,20 @@ in [`docs/adr/`](docs/adr/).
 
 ## Installation
 
-`gda` is not yet published to a package index; install it from source with `uv`.
+Install `gda` from PyPI as a standalone CLI on your `PATH`:
+
+```bash
+uv tool install gda      # or: pipx install gda
+gda --help
+```
+
+Or add it to a project / environment:
+
+```bash
+uv add gda               # or: pip install gda
+```
+
+**From source** (for development or unreleased changes):
 
 ```bash
 git clone https://github.com/aigengame/godot-agent.git
@@ -144,20 +157,13 @@ uv sync          # create the environment and install dependencies
 uv run gda --help
 ```
 
-To install `gda` as a standalone CLI on your `PATH`:
-
-```bash
-uv tool install .
-gda --help
-```
-
 ### MCP server (`gda-mcp`)
 
 `gda` ships a stdio [MCP](https://modelcontextprotocol.io) server behind an optional `[mcp]` extra,
 so any MCP-speaking agent can drive Godot through it. Try it with no install:
 
 ```bash
-uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
+uvx --from "gda[mcp]" gda-mcp
 ```
 
 Register it by dropping the matching config in place. `gda-mcp` picks your Godot project from
@@ -172,7 +178,7 @@ silently replaced.
   "mcpServers": {
     "gda-mcp": {
       "command": "uvx",
-      "args": ["--from", "gda[mcp] @ git+https://github.com/aigengame/godot-agent", "gda-mcp"]
+      "args": ["--from", "gda[mcp]", "gda-mcp"]
     }
   }
 }
@@ -182,7 +188,7 @@ User scope (every project) — the CLI, which writes `~/.claude.json`:
 
 ```bash
 claude mcp add --scope user gda-mcp -- \
-  uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
+  uvx --from "gda[mcp]" gda-mcp
 ```
 
 **Codex** — project scope, `.codex/config.toml` at the repo root (the project must be trusted):
@@ -190,7 +196,7 @@ claude mcp add --scope user gda-mcp -- \
 ```toml
 [mcp_servers.gda-mcp]
 command = "uvx"
-args = ["--from", "gda[mcp] @ git+https://github.com/aigengame/godot-agent", "gda-mcp"]
+args = ["--from", "gda[mcp]", "gda-mcp"]
 
 [mcp_servers.gda-mcp.env]
 GDA_PROJECT = "/absolute/path/to/your/godot/project"
@@ -201,7 +207,7 @@ User scope (every project) — the same table in `~/.codex/config.toml`, or add 
 
 ```bash
 codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- \
-  uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
+  uvx --from "gda[mcp]" gda-mcp
 ```
 
 **Cursor** — project scope, `.cursor/mcp.json` at the repo root (`${workspaceFolder}` tracks the open
@@ -213,7 +219,7 @@ project):
     "gda-mcp": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["--from", "gda[mcp] @ git+https://github.com/aigengame/godot-agent", "gda-mcp"],
+      "args": ["--from", "gda[mcp]", "gda-mcp"],
       "env": {
         "GDA_PROJECT": "${workspaceFolder}",
         "PATH": "/opt/homebrew/bin:/usr/local/bin:${userHome}/.local/bin:${env:PATH}"
@@ -231,9 +237,7 @@ absolute path (`${workspaceFolder}` is only reliable in the project-level file).
 > the Cursor snippet above repairs it in `env`; if `uvx` is still not found (or for Claude Desktop),
 > use an absolute path (`which uvx`) for `command`. Full recipes — user vs project scope, Claude
 > Desktop, and per-agent project pinning — are in the
-> [registration recipes](docs/gda-mcp-registration.md). Once `gda` is on PyPI
-> ([#207](https://github.com/aigengame/godot-agent/issues/207)), the `@ git+…` part drops to just
-> `"gda[mcp]"`.
+> [registration recipes](docs/gda-mcp-registration.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -142,10 +142,10 @@ uv tool install gda      # or: pipx install gda
 gda --help
 ```
 
-Or add it to a project / environment:
+Or into an existing environment:
 
 ```bash
-uv add gda               # or: pip install gda
+pip install gda
 ```
 
 **From source** (for development or unreleased changes):

--- a/docs/adr/0013-gda-mcp-packaging-and-launch.md
+++ b/docs/adr/0013-gda-mcp-packaging-and-launch.md
@@ -25,11 +25,9 @@ the extra is absent (running it without the extra fails with a clear "install
 **low-level** stdio server. The portable registration vector across every surveyed
 agent (Claude Code, Codex, Claude Desktop, Cursor) is a stdio server described by
 `command` + `args` (+ optional `env`); gda-mcp targets exactly that shape. Two
-invocations are supported: the installed console script `gda-mcp`, and a zero-install
-`uvx`. Until `gda` is published to PyPI (tracked by #207), the zero-install form
-resolves the package from the public git repo —
-`uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp`; once on
-PyPI it simplifies to the canonical `uvx --from "gda[mcp]" gda-mcp`.
+invocations are supported: the installed console script `gda-mcp`, and a
+zero-install `uvx --from "gda[mcp]" gda-mcp`, resolving the package from PyPI
+(where `gda` is published via Trusted Publishing — ADR-0016).
 
 **Per-agent registration recipes are a shipped deliverable** (user- and
 project-scope) — not left to the user to derive — because the agents diverge in

--- a/docs/adr/0016-publish-to-pypi-via-trusted-publishing.md
+++ b/docs/adr/0016-publish-to-pypi-via-trusted-publishing.md
@@ -134,12 +134,15 @@ enables a dry run before the first real publish.
 
 - After the one-time setup and the next cut release, `pip install "gda[mcp]"`
   and `uvx --from "gda[mcp]" gda-mcp` work from a clean environment — the
-  ADR-0013 promise is fulfilled.
-- **Follow-up, gated on the first successful publish:** reconcile the git-source
-  form back to the canonical form in the #195 registration recipes
-  (`docs/gda-mcp-registration.md`), `README.md`, and ADR-0013's prose. Done only
-  *after* a real PyPI release exists, so the docs never advertise a command that
-  404s.
+  ADR-0013 promise is fulfilled. **Realized in 0.1.24**, the first release
+  published through this pipeline: `gda` is now on PyPI, and a clean Python 3.13
+  `uv pip install "gda[mcp]"` resolves 0.1.24 with both the `gda` and `gda-mcp`
+  console scripts working.
+- **Follow-up, gated on the first successful publish — done:** the git-source
+  form is reconciled back to the canonical commands in the #195 registration
+  recipes (`docs/gda-mcp-registration.md`), `README.md`, and ADR-0013's prose.
+  This happened only *after* 0.1.24 published, so the docs never advertised a
+  command that 404s.
 - The `pypi` GitHub Environment carries no protection rules, keeping the release
   fully automated; the human gate stays at the Release PR merge (ADR-0007).
   Adding required reviewers to the environment is an available hardening — it

--- a/docs/adr/0016-publish-to-pypi-via-trusted-publishing.md
+++ b/docs/adr/0016-publish-to-pypi-via-trusted-publishing.md
@@ -4,6 +4,15 @@ status: accepted
 
 # Distribution: publish `gda` to PyPI via Trusted Publishing
 
+> **Outcome (realized in 0.1.24, 2026-06-20):** `gda` is now published on
+> [PyPI](https://pypi.org/project/gda/) and the install/registration docs are
+> reconciled to the canonical commands (#214). The Context, Decision, and
+> Consequences below are the **point-in-time decision record** from before the
+> first publish; their pre-publish framing (e.g. "not on PyPI today", "the name is
+> claimed only on the first publish") is kept as written rather than rewritten to
+> the current state — an ADR records the decision in its original context.
+> Acceptance-criteria verification lives on #207.
+
 [ADR-0013](0013-gda-mcp-packaging-and-launch.md) makes the canonical install and
 registration commands `pip install "gda[mcp]"` and `uvx --from "gda[mcp]" gda-mcp`.
 Neither works today: `gda` is not on PyPI (`pypi.org/pypi/gda` → 404). The
@@ -134,15 +143,12 @@ enables a dry run before the first real publish.
 
 - After the one-time setup and the next cut release, `pip install "gda[mcp]"`
   and `uvx --from "gda[mcp]" gda-mcp` work from a clean environment — the
-  ADR-0013 promise is fulfilled. **Realized in 0.1.24**, the first release
-  published through this pipeline: `gda` is now on PyPI, and a clean Python 3.13
-  `uv pip install "gda[mcp]"` resolves 0.1.24 with both the `gda` and `gda-mcp`
-  console scripts working.
-- **Follow-up, gated on the first successful publish — done:** the git-source
-  form is reconciled back to the canonical commands in the #195 registration
-  recipes (`docs/gda-mcp-registration.md`), `README.md`, and ADR-0013's prose.
-  This happened only *after* 0.1.24 published, so the docs never advertised a
-  command that 404s.
+  ADR-0013 promise is fulfilled.
+- **Follow-up, gated on the first successful publish:** reconcile the git-source
+  form back to the canonical form in the #195 registration recipes
+  (`docs/gda-mcp-registration.md`), `README.md`, and ADR-0013's prose. Done only
+  *after* a real PyPI release exists, so the docs never advertise a command that
+  404s.
 - The `pypi` GitHub Environment carries no protection rules, keeping the release
   fully automated; the human gate stays at the Release PR merge (ADR-0007).
   Adding required reviewers to the environment is an available hardening — it

--- a/docs/gda-mcp-registration.md
+++ b/docs/gda-mcp-registration.md
@@ -19,20 +19,14 @@ a single per-user config (no project scope).
   [`uv`](https://docs.astral.sh/uv/):
 
   ```
-  uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
+  uvx --from "gda[mcp]" gda-mcp
   ```
 
 - **Installed** — put the `gda-mcp` console script on your PATH:
 
   ```
-  uv tool install "gda[mcp] @ git+https://github.com/aigengame/godot-agent"
+  uv tool install "gda[mcp]"
   ```
-
-> **Note** — `gda` is not on PyPI yet (tracked by
-> [#207](https://github.com/aigengame/godot-agent/issues/207)). Until it is, the
-> zero-install form resolves the package from git as shown above. Once published, it
-> simplifies to the canonical `uvx --from "gda[mcp]" gda-mcp` /
-> `pip install "gda[mcp]"`.
 
 ### The server needs a Godot engine
 
@@ -103,7 +97,7 @@ than the launch workspace.
       "command": "uvx",
       "args": [
         "--from",
-        "gda[mcp] @ git+https://github.com/aigengame/godot-agent",
+        "gda[mcp]",
         "gda-mcp"
       ],
       "env": {}
@@ -120,7 +114,7 @@ Code provides `CLAUDE_PROJECT_DIR` in the server environment).
 
 ```bash
 claude mcp add --scope user gda-mcp -- \
-  uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
+  uvx --from "gda[mcp]" gda-mcp
 ```
 
 Everything after `--` is the launch command. `--scope user` makes the server available
@@ -153,7 +147,7 @@ explicitly** (an absolute path — Codex has no `${workspaceFolder}` substitutio
 ```toml
 [mcp_servers.gda-mcp]
 command = "uvx"
-args = ["--from", "gda[mcp] @ git+https://github.com/aigengame/godot-agent", "gda-mcp"]
+args = ["--from", "gda[mcp]", "gda-mcp"]
 
 [mcp_servers.gda-mcp.env]
 GDA_PROJECT = "/absolute/path/to/your/godot/project"
@@ -164,7 +158,7 @@ GDA_PROJECT = "/absolute/path/to/your/godot/project"
 ```toml
 [mcp_servers.gda-mcp]
 command = "uvx"
-args = ["--from", "gda[mcp] @ git+https://github.com/aigengame/godot-agent", "gda-mcp"]
+args = ["--from", "gda[mcp]", "gda-mcp"]
 # Pin the project; you can also set cwd = "..." for the server process.
 
 [mcp_servers.gda-mcp.env]
@@ -175,7 +169,7 @@ GDA_PROJECT = "/absolute/path/to/your/godot/project"
 
 ```bash
 codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/project -- \
-  uvx --from "gda[mcp] @ git+https://github.com/aigengame/godot-agent" gda-mcp
+  uvx --from "gda[mcp]" gda-mcp
 ```
 
 `--env KEY=VALUE` (repeatable) precedes `--`; everything after `--` is the launch
@@ -204,7 +198,7 @@ constraint above.
       "command": "/Users/you/.local/bin/uvx",
       "args": [
         "--from",
-        "gda[mcp] @ git+https://github.com/aigengame/godot-agent",
+        "gda[mcp]",
         "gda-mcp"
       ],
       "env": {
@@ -246,7 +240,7 @@ no `type` field. Claude Desktop is **GUI-launched** — use an **absolute path**
       "command": "/Users/you/.local/bin/uvx",
       "args": [
         "--from",
-        "gda[mcp] @ git+https://github.com/aigengame/godot-agent",
+        "gda[mcp]",
         "gda-mcp"
       ],
       "env": {
@@ -287,9 +281,8 @@ active workspace changes is tracked in
 
 ## Notes
 
-- **After PyPI ([#207](https://github.com/aigengame/godot-agent/issues/207))** every
-  `"gda[mcp] @ git+https://github.com/aigengame/godot-agent"` above simplifies to
-  `"gda[mcp]"`, and `uv tool install "gda[mcp]"` / `pip install "gda[mcp]"` work directly.
+- **`gda` is on [PyPI](https://pypi.org/project/gda/)**, so the `"gda[mcp]"` spec above
+  resolves directly — `uv tool install "gda[mcp]"` / `pip install "gda[mcp]"` work as shown.
 - **`GDA_BIN`** overrides which `gda` the adapter shells out to (default: the `gda` in
   the same install). An escape hatch for unusual layouts; see ADR-0013.
 - **Trust** — a `--project` op runs the target project's own code at engine startup

--- a/docs/gda-mcp-registration.md
+++ b/docs/gda-mcp-registration.md
@@ -15,7 +15,7 @@ a single per-user config (no project scope).
 
 `gda-mcp` is launched as a `command` + `args` stdio server. Two forms:
 
-- **Zero-install (recommended to try)** — run straight from the public repo with
+- **Zero-install (recommended to try)** — run it straight from PyPI with
   [`uv`](https://docs.astral.sh/uv/):
 
   ```


### PR DESCRIPTION
## Why

`gda` is now published on PyPI ([0.1.24](https://pypi.org/project/gda/), verified end-to-end). The install/registration docs still used the temporary **git-source** form (`gda[mcp] @ git+https://github.com/aigengame/godot-agent`) that ADR-0016 said to keep "only until the first publish, so the docs never advertise a 404 command". That gate has passed — this is the reconciliation.

## What

- **`README.md`** — Installation section is now PyPI-first (`uv tool install gda` / `pip install gda`; from-source kept as the dev path); all `gda-mcp` registration recipes use `"gda[mcp]"`; the Project-status line now states gda is on PyPI.
- **`docs/gda-mcp-registration.md`** — all four agent recipes (Claude Code / Codex / Cursor / Claude Desktop) + the launch commands use `"gda[mcp]"`; the git-source `Note` and the post-PyPI caveats are dropped/rewritten.
- **ADR-0013** — the zero-install invocation is the canonical `uvx --from "gda[mcp]" gda-mcp`, resolving from PyPI.
- **ADR-0016** — Consequences mark the first publish **realized in 0.1.24** and the docs reconciliation **done**.

`grep -rn "git+https" README.md docs/` is clean except ADR-0016's problem-statement (intentionally preserved — it's the point-in-time Context that motivated the ADR, not a user-facing install command).

## Completes #207

This was the last open acceptance criterion. The other four were already met and verified:

- [x] distribution ADR (ADR-0016)
- [x] `gda` name claimed on PyPI (0.1.24)
- [x] release workflow publishes to PyPI, idempotent (verified by the 0.1.24 run)
- [x] clean-env `pip install "gda[mcp]"` / `uvx --from "gda[mcp]" gda-mcp` work (verified on a fresh Python 3.13 env → 0.1.24, both console scripts present)
- [x] docs reconciled to canonical commands ← **this PR**

Closes #207
