### PR TITLE
fix(readme): render the title image on PyPI via an absolute URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # godot-agent (`gda`)
 
-![godot-agent title image](assets/godot-agent-title.png)
+![godot-agent title image](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)
 
 > An agent-first **CLI and MCP server** that lets AI agents drive the [Godot Engine](https://godotengine.org) to build games — with **structured output** built for programmatic consumption.
 


### PR DESCRIPTION
## Problem

`gda`'s README is reused verbatim as the PyPI long description. The title image used a repo-relative path:

```markdown
![godot-agent title image](assets/godot-agent-title.png)
```

PyPI has no repo context, so the relative path doesn't resolve and the title image renders **broken** on https://pypi.org/project/gda/.

## Fix

Point the image at the absolute raw GitHub URL — it renders on **both** GitHub and PyPI:

```markdown
![godot-agent title image](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)
```

Verified the URL resolves: `HTTP 200`, `content-type: image/png`.

## Notes

- **Effective on the next release.** PyPI long descriptions are immutable per release, so 0.1.24's page stays broken. This is typed `fix` so it cuts the next patch release (0.1.25), whose publish re-renders the project page from the corrected README.
- **Merge order:** merging #214 (the docs reconciliation, `docs`/no bump) **before** this `fix` means the 0.1.25 release carries both the canonical commands and the fixed image — the PyPI page lands fully correct in one release.
- **Relative doc links left as-is** (LICENSE, `docs/adr/*`, `CONTEXT.md`, …): the README is GitHub-first, where they navigate correctly; PyPI users reach docs via the project's GitHub links. Converting ~30 links to absolute would be noisy for marginal benefit. Happy to do it separately if wanted.

Refs: #207
