### PR TITLE
feat(gda-mcp): follow active project on roots/list_changed (#209)

### DIFF
--- a/docs/adr/0014-gda-mcp-project-context-resolution.md
+++ b/docs/adr/0014-gda-mcp-project-context-resolution.md
@@ -84,3 +84,10 @@ error, relayed unchanged.
   multi-project support that still keeps the project out of the tool surface. This
   *dynamic* re-resolution (not the static `roots/list` read) is the piece deferred
   until a concrete need appears, and is out of scope for the first delivery per PRD #8.
+
+> **Outcome (2026-06-20, #209):** the deferred dynamic re-resolution is now
+> implemented. gda-mcp registers a `roots/list_changed` notification handler that
+> invalidates its cached project, so the next tool call re-runs the precedence
+> above against the now-active roots; a pinned `GDA_PROJECT` still wins (env is read
+> first). The project stays out of the tool surface — no per-call parameter — so
+> ADR-0012 and ADR-0006 are untouched.

--- a/src/gda/mcp/server.py
+++ b/src/gda/mcp/server.py
@@ -199,9 +199,11 @@ class _ProjectResolver:
     """Resolves and caches the server's one target project (ADR-0014).
 
     Resolution is deferred to the first tool call because precedence level 2
-    (``roots/list``) is a server->client request needing a live session. The
-    result is cached: the server targets one project (one ``server : project``),
-    re-resolution on a changing root is the deferred ``roots/list_changed`` path.
+    (``roots/list``) is a server->client request needing a live session, then
+    cached (one ``server : project``). On a client ``roots/list_changed``
+    notification the cache is invalidated, so the next tool call re-runs the full
+    precedence against the now-active roots (#209) — a pinned ``GDA_PROJECT`` still
+    wins because :func:`resolve_project_dir` reads env first.
     """
 
     def __init__(self, env, cwd: Path) -> None:
@@ -209,6 +211,11 @@ class _ProjectResolver:
         self._cwd = cwd
         self._resolved = False
         self._project: Optional[Path] = None
+
+    def invalidate(self) -> None:
+        """Drop the cached project so the next ``resolve`` re-runs the precedence."""
+        self._resolved = False
+        self._project = None
 
     async def resolve(self, session) -> Optional[Path]:
         if not self._resolved:
@@ -228,7 +235,8 @@ def build_server(runner: GdaRunner) -> Server:
     # The server's one target project (ADR-0014), resolved lazily on the first
     # tool call (precedence 2, roots/list, needs a live session) and cached. The
     # resolved dir reaches gda via the GDA_PROJECT env channel on every dispatch
-    # (mechanism D), so meta commands ignore it.
+    # (mechanism D), so meta commands ignore it. A client roots/list_changed
+    # invalidates the cache so the next call re-resolves (#209).
     resolver = _ProjectResolver(os.environ, Path.cwd())
     tools = [
         types.Tool(
@@ -248,6 +256,20 @@ def build_server(runner: GdaRunner) -> Server:
     }
 
     server: Server = Server(SERVER_NAME)
+
+    # A client roots/list_changed means the active project may have moved (#209):
+    # invalidate the cache so the next tool call re-runs the ADR-0014 precedence
+    # against the now-current roots. We only invalidate here, never resolve — a
+    # notification handler runs outside any request context, so there is no live
+    # request_context/session for the roots/list back-request; lazy re-resolution
+    # in call_tool keeps resolve_project_dir the single source of precedence
+    # (so a pinned GDA_PROJECT, read first there, still wins).
+    async def _on_roots_list_changed(_n: types.RootsListChangedNotification) -> None:
+        resolver.invalidate()
+
+    server.notification_handlers[types.RootsListChangedNotification] = (
+        _on_roots_list_changed
+    )
 
     @server.list_tools()
     async def list_tools() -> list[types.Tool]:

--- a/tests/mcp_support.py
+++ b/tests/mcp_support.py
@@ -114,3 +114,41 @@ def call_tool(server, name: str, arguments: dict, *, roots: Optional[list[str]] 
             return await session.call_tool(name, arguments)
 
     return anyio.run(_inner)
+
+
+def roots_changed_call(
+    server,
+    name: str,
+    arguments: dict,
+    *,
+    roots_before: list[str],
+    roots_after: list[str],
+):
+    """Drive #209 within ONE live session: call ``name``, switch the advertised
+    roots and fire ``roots/list_changed``, then call ``name`` again.
+
+    Returns ``(result1, result2)``. The client's ``list_roots_callback`` reads a
+    mutable holder, so the server's first resolve sees ``roots_before`` and the
+    post-notification re-resolve sees ``roots_after`` — exercising dynamic
+    re-resolution that the single-shot :func:`call_tool` (roots fixed at connect,
+    one call) structurally cannot.
+    """
+    from mcp.shared.memory import create_connected_server_and_client_session as connect
+    from mcp.types import ListRootsResult, Root
+
+    holder = {"roots": roots_before}
+
+    async def list_roots_callback(_context):
+        return ListRootsResult(
+            roots=[Root(uri=Path(r).as_uri()) for r in holder["roots"]]
+        )
+
+    async def _inner():
+        async with connect(server, list_roots_callback=list_roots_callback) as session:
+            r1 = await session.call_tool(name, arguments)
+            holder["roots"] = roots_after
+            await session.send_roots_list_changed()
+            r2 = await session.call_tool(name, arguments)
+            return r1, r2
+
+    return anyio.run(_inner)

--- a/tests/test_mcp_project_injection.py
+++ b/tests/test_mcp_project_injection.py
@@ -21,6 +21,7 @@ from tests.mcp_support import (
     call_tool,
     gda_result,
     list_tools,
+    roots_changed_call,
     schema_then,
 )
 from tests.support import SCENE_CREATE_RESULT
@@ -164,8 +165,8 @@ def test_project_is_snapshotted_on_first_call_then_cached(tmp_path, monkeypatch)
     # live session, so resolution is snapshotted on the FIRST tool call (not at
     # process startup) and then cached for the server's lifetime — one server :
     # one project. A later call advertising a different root reuses the first
-    # snapshot; re-resolving on a changed root is the deferred roots/list_changed
-    # path, out of scope for the first delivery.
+    # snapshot. (Re-resolution on a roots/list_changed notification — a different
+    # trigger — is exercised by the two tests below.)
     monkeypatch.delenv("GDA_PROJECT", raising=False)
     first = _project(tmp_path / "first")
     second = _project(tmp_path / "second")
@@ -187,6 +188,49 @@ def test_project_is_snapshotted_on_first_call_then_cached(tmp_path, monkeypatch)
 
     _args, _stdin, project = runner.calls[-1]
     assert project == first
+
+
+def test_roots_list_changed_reresolves_to_the_new_active_project(tmp_path, monkeypatch):
+    # #209: a client roots/list_changed means the active project may have moved.
+    # gda-mcp invalidates its cached project so the NEXT tool call re-runs the
+    # ADR-0014 precedence against the now-current roots.
+    monkeypatch.delenv("GDA_PROJECT", raising=False)
+    first = _project(tmp_path / "first")
+    second = _project(tmp_path / "second")
+    runner = _scene_create_runner()
+    server = build_server(runner)
+
+    roots_changed_call(
+        server,
+        "scene_create",
+        {"path": "res://a.tscn", "root_type": "Node2D"},
+        roots_before=[str(first)],
+        roots_after=[str(second)],
+    )
+
+    _args, _stdin, project = runner.calls[-1]
+    assert project == second
+
+
+def test_roots_list_changed_does_not_override_pinned_gda_project(tmp_path, monkeypatch):
+    # #209: an explicitly pinned GDA_PROJECT wins regardless of a roots change —
+    # resolve_project_dir reads env first, so re-resolution returns the pin.
+    pinned = _project(tmp_path / "pinned")
+    other = _project(tmp_path / "other")
+    monkeypatch.setenv("GDA_PROJECT", str(pinned))
+    runner = _scene_create_runner()
+    server = build_server(runner)
+
+    roots_changed_call(
+        server,
+        "scene_create",
+        {"path": "res://a.tscn", "root_type": "Node2D"},
+        roots_before=[str(pinned)],
+        roots_after=[str(other)],
+    )
+
+    _args, _stdin, project = runner.calls[-1]
+    assert project == pinned
 
 
 def test_no_roots_capability_degrades_to_no_project_without_error(


### PR DESCRIPTION
## What & why

gda-mcp resolves **one** target Godot project (ADR-0014 precedence `GDA_PROJECT → roots/list → cwd`), snapshotted on the first tool call and cached (one server : one project). A user who switches the active project mid-session could therefore not be followed.

This implements the MCP-native fix ADR-0014 names: handle the client's **`roots/list_changed`** notification. On it, the cached project is invalidated so the **next** tool call re-runs the existing precedence against the now-active roots. An explicitly pinned `GDA_PROJECT` still wins. The project stays **out of the tool surface** (no per-call `project` parameter), so ADR-0012 (pure schema→tool transform) and ADR-0006 (project = process context) are untouched.

Builds on #194 (static `roots/list` read + first-call snapshot/cache).

## Design notes

- The handler **only invalidates, never resolves**: a notification handler runs outside any request context, so there is no live `request_context`/session for the `roots/list` back-request. Re-resolution stays in `call_tool`'s lazy path, keeping `resolve_project_dir` the single source of precedence.
- **Pin preservation is free**: `resolve_project_dir` reads `GDA_PROJECT` env first, so re-resolution after invalidation returns the pin unchanged — no pin-check duplicated in the handler.
- No `get_capabilities`/`NotificationOptions` change: that governs server→client notifications, not receiving client notifications; `_handle_notification` dispatches purely on the `notification_handlers` dict (registered the same way the SDK's own `progress_notification()` does).

## Acceptance criteria (all met)

- [x] Server handles the client's `roots/list_changed` notification.
- [x] On the notification, the cached project is re-resolved via the existing precedence; subsequent tool calls target the newly-active project.
- [x] An explicitly pinned `GDA_PROJECT` is not overridden by a roots change.
- [x] Fast tests: a mid-session roots change re-resolves the project; an explicit `GDA_PROJECT` is unaffected.
- [x] ADR-0014's "deferred" note updated to implemented (dated `> Outcome` note, preserving the point-in-time record).

## Decisions

- **Global config `~/.gda/config.yaml`: deliberately NOT introduced here.** Dynamic re-resolution only re-runs the existing precedence; a config file is a new precedence tier crossing the gda/gda-mcp boundary (ADR-0006/0011) and contradicting ADR-0014's deliberately-minimal agent-neutral precedence — it warrants its own ADR + grill if a concrete roots-less-multi-project need appears.
- **Shipped as one vertical slice** (one coherent behavior; sub-splitting would yield slices with no independent value).

## Testing

- New L2 fast tests (`roots_changed_call` helper drives one live session across a `roots/list_changed`): re-resolution to the new project; pinned-env invariance. Re-resolution test verified **10/10 non-flaky**.
- Full fast suite: **622 passed**.
- e2e project-context (real engine): **3 passed**.

Closes #209.
