### PR TITLE
docs(adr): align Phase 2 gda-daemon live-operation requirements

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,10 +21,18 @@ never itself a phase. Its order relative to other components follows ADR-0000.
 _Avoid_: the server, mcp wrapper
 
 **gda-daemon**:
-A long-lived process that holds a persistent connection to a running Godot
-engine, serving operations that require a live engine rather than a fresh
-headless process per call.
+A long-lived, per-project process that supervises transient `Engine session`s and
+brokers IPC to them, serving operations that require a live engine rather than a
+fresh headless process per call. The daemon is persistent; the engine it connects to
+is not — the connection lasts only as long as an `Engine session` (ADR-0017).
 _Avoid_: the service, background server
+
+**gda harness**:
+The game-side autoload `gda` installs into a `Trusted project` so that `gda-daemon`
+can run live operations inside an `Engine session` over IPC. It is inert — opening no
+connection — unless the daemon launched the session, so it stays dormant in a human
+editor run, a plain run, and a shipped build (ADR-0018).
+_Avoid_: plugin, addon, agent
 
 ### Operations
 
@@ -35,10 +43,27 @@ run a test). The basis of Phase 1.
 _Avoid_: batch op, offline op
 
 **Live operation**:
-An operation that requires an already-running engine/editor to observe or mutate
-in-place state (e.g. inspect the live scene tree, runtime inspection, UndoRedo,
-input simulation). Served through `gda-daemon`, not by a one-shot headless call.
+An operation that requires an already-running engine to observe or control its
+in-place runtime state (e.g. the runtime scene tree, runtime property get/set, input
+simulation, viewport capture, performance/signal monitoring). Served through
+`gda-daemon` against a running game, not by a one-shot headless call; the editor
+context (UndoRedo, the editor's open-scene tree) is out of scope (ADR-0017).
 _Avoid_: realtime op, online op
+
+**Engine session**:
+A single transient run of a gda-owned Godot game, launched and held by `gda-daemon`
+with the `gda harness` injected, against which `Live operation`s are served. The
+daemon outlives individual sessions; a session is (re)launched per feedback-loop
+iteration to observe the project's current on-disk state (ADR-0017).
+_Avoid_: game run, live session, play session
+
+**State consistency**:
+The guarantee `gda-daemon` provides over an `Engine session`'s runtime state: live
+operations are serialized through a single writer, so a read observes the preceding
+write; each operation is frame-coherent (applied/observed at a frame boundary); and
+the state is bound to the session, not surviving its relaunch. A Phase-2 live-layer
+property only — Phase-1 headless calls are stateless (ADR-0020).
+_Avoid_: consistency, coherence, sync
 
 **Headless launch**:
 The one-shot `godot --headless` spawn primitive that both Phase-1 channels — the
@@ -95,6 +120,13 @@ code to run: autoload constructors at engine startup (every `--project` op), and
 the `_init` of scripts on nodes that an instantiating operation constructs.
 _Avoid_: attack surface, code-execution risk
 
+**Concurrent external editor**:
+A human-opened Godot editor on the same project while `gda` is driving it (e.g. to
+view, run, or verify agent output). Phase 2 assumes `gda` is the project's sole
+driver and does not defend against a concurrent external editor's writes (ADR-0018,
+extending ADR-0009).
+_Avoid_: second instance, shared editor
+
 ### Delivery phases
 
 The order in which **capabilities** are delivered. This is distinct from ADR-0000's
@@ -107,16 +139,18 @@ service dependency.
 _Avoid_: MVP (broader), v1
 
 **Phase 2**:
-The later delivery — `gda` also serves live operations through `gda-daemon`'s
-persistent engine connection.
+The later delivery — `gda` also serves live operations through `gda-daemon` and a
+live `Engine session`.
 _Avoid_: v2
 
 ### Command surface
 
 **Command group**:
 A top-level grouping of `gda` commands named after a Godot domain object
-(`scene`, `node`, `script`, `project`, `resource`, `export`, …). Invoked as
-`gda <group> <command>`.
+(`scene`, `node`, `script`, `project`, `resource`, `export`, the running-game
+`game`, …). Invoked as `gda <group> <command>`. Live operations are placed under
+their real domain-object group too — marked live by their `kind`, not by a separate
+group (ADR-0019).
 _Avoid_: namespace, category, module
 
 **Domain command**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -146,9 +146,10 @@ _Avoid_: v2
 ### Command surface
 
 **Command group**:
-A top-level grouping of `gda` commands named after a Godot domain object
-(`scene`, `node`, `script`, `project`, `resource`, `export`, the running-game
-`game`, …). Invoked as `gda <group> <command>`. Live operations are placed under
+A top-level grouping of `gda` commands named after an object the user acts on —
+usually a Godot domain object (`scene`, `node`, `script`, `project`, `resource`,
+`export`, the running-game `game`, …), plus gda's own `daemon` lifecycle group
+(ADR-0017). Invoked as `gda <group> <command>`. Live operations are placed under
 their real domain-object group too — marked live by their `kind`, not by a separate
 group (ADR-0019).
 _Avoid_: namespace, category, module

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It is designed as three layers: **`gda`**, the agent-facing CLI that exposes God
 with structured `--json` output and self-describing schemas; **`gda-mcp`**, a thin
 [Model Context Protocol](https://modelcontextprotocol.io) server that turns those same
 capabilities into MCP tools, derived mechanically from `gda`'s schemas; and **`gda-daemon`**, a
-long-lived process holding a persistent connection to a running engine to serve *live operations*
+long-lived per-project process supervising transient *engine sessions* (a running game) to serve *live operations*
 that a one-shot headless process cannot. `gda` lands first as a standalone headless CLI (Phase 1);
 live operations follow through `gda-daemon` (Phase 2). See [Architecture](#architecture-at-a-glance)
 for the full picture.
@@ -113,7 +113,7 @@ The [command catalog](docs/command-catalog.md) maps the whole command surface (a
 | ------------- | -------------------------------------------------------------------------------------- | ----- |
 | **`gda`**     | The agent-facing Godot CLI — the bottom layer that exposes Godot with structured output | 1     |
 | **`gda-mcp`** | A thin MCP adapter that exposes `gda`'s capabilities as MCP tools, derived from `--schema` | 1+    |
-| **`gda-daemon`** | A long-lived process holding a persistent connection to a running engine for *live operations* | 2     |
+| **`gda-daemon`** | A long-lived per-project process supervising transient engine sessions (a running game) for *live operations* | 2     |
 
 - **Headless operations** need no pre-existing engine state and are fulfilled by a one-shot
   `godot --headless` process (e.g. report version, create a scene, export). This is the basis of
@@ -588,7 +588,7 @@ drives a real engine. Everything between the CLI and the runner runs as real cod
 | ----------------- | ------------------------------------------------------------------------- | ------ |
 | **Phase 1** | `gda` serving *headless operations* standalone: `info`, structured errors, `--schema`, and the domain command groups `scene`, `node`, `script`, `project` (incl. static-analysis), `resource`, `export`, `shader`, `theme`. | ✅ Surface complete |
 | **`gda-mcp`** | A thin MCP adapter generated mechanically from `--schema` — first on top of Phase 1, following `gda` forward automatically. | ✅ Shipped |
-| **Phase 2** | `gda` also serving *live operations* through `gda-daemon`'s persistent engine connection. | 🗓 Planned |
+| **Phase 2** | `gda` also serving *live operations* through `gda-daemon` and a live *engine session*. | 🗓 Planned |
 
 Track progress and proposals on the [issue tracker](https://github.com/aigengame/godot-agent/issues).
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ for the full picture.
 
 **On the roadmap** (designed, not yet implemented)
 
-- 🔜 `gda-daemon` for *live operations* against a running engine (Phase 2): live scene tree,
-  runtime inspection, input simulation, `scene play`/`stop`, screenshots.
+- 🔜 `gda-daemon` for *live operations* against a **running game** (Phase 2): runtime scene
+  tree, runtime properties, input simulation, viewport capture, performance/signal monitoring —
+  via `gda daemon` lifecycle commands. Live commands are placed by domain object (a narrow `game`
+  group for the runtime scene graph); the editor context is out of scope. See ADR-0017–0020.
 
 **Out of scope for now**
 
@@ -116,8 +118,10 @@ The [command catalog](docs/command-catalog.md) maps the whole command surface (a
 - **Headless operations** need no pre-existing engine state and are fulfilled by a one-shot
   `godot --headless` process (e.g. report version, create a scene, export). This is the basis of
   **Phase 1**.
-- **Live operations** require an already-running engine (live scene tree, runtime inspection,
-  UndoRedo, input simulation) and are served by `gda-daemon` in **Phase 2**.
+- **Live operations** require an already-running game (runtime scene tree, runtime properties,
+  input simulation, viewport capture, performance/signal monitoring) and are served by
+  `gda-daemon` in **Phase 2**. The editor context (UndoRedo, the editor's open-scene tree) is
+  out of scope (ADR-0017).
 
 The vocabulary above is defined precisely in [`CONTEXT.md`](CONTEXT.md); the decisions behind it live
 in [`docs/adr/`](docs/adr/).

--- a/docs/adr/0000-architecture-design.md
+++ b/docs/adr/0000-architecture-design.md
@@ -33,6 +33,10 @@ simpler to more complex**, in this component order:
 > performance layer into the necessary carrier of all live-engine capabilities, and
 > delivery is split into Phase 1 (headless) and Phase 2 (live).
 
+> Reconciled by ADR-0020: the "state-consistent" advantage is defined and scoped
+> there — it is a Phase-2 live-layer guarantee (single-writer serialization,
+> frame-coherent, session-bound), not a property of the stateless Phase-1 headless CLI.
+
 ## Development conventions
 
 - Incremental development driven by **vertical slices** and **TDD**:

--- a/docs/adr/0001-godot-integration-mechanism.md
+++ b/docs/adr/0001-godot-integration-mechanism.md
@@ -24,6 +24,11 @@ We adopt a **hybrid, delivered in two phases**:
 This reframes `gda-daemon`: it is not merely an optional performance layer (as
 ADR-0000 implies), but the **necessary carrier of all live-engine capabilities**.
 
+> Refined by ADR-0017: Phase 2's live channel is specified there — the daemon holds a
+> gda-owned running game (not an attached editor) via an in-engine `gda harness`,
+> selected per command by an invisible execution-channel `kind`. Its harness install
+> and concurrent-editor boundary are in ADR-0018.
+
 ## Considered options
 
 - **Pure headless** (like `godot-mcp`) — simplest, but permanently incapable of

--- a/docs/adr/0005-cli-command-taxonomy.md
+++ b/docs/adr/0005-cli-command-taxonomy.md
@@ -41,6 +41,11 @@ command on the same object (e.g. `gda scene create` vs a future live scene-inspe
 are siblings under the same `scene` group; the phase/operation kind is expressed in
 each command's `--schema` metadata, not by splitting the tree.
 
+> Refined by ADR-0019: live commands are placed by their real domain object too —
+> input simulation, capture, and monitoring become their own object groups, and the
+> running game's runtime scene graph gets a narrow `game` object — so there is no
+> single "live" group and the phase still never appears in the tree.
+
 ## The command surface is delivered incrementally, not enumerated up front
 
 The surface grows **one vertical slice at a time** (ADR-0000), not as a pre-declared

--- a/docs/adr/0005-cli-command-taxonomy.md
+++ b/docs/adr/0005-cli-command-taxonomy.md
@@ -21,6 +21,11 @@ rather than a Godot domain object — are exempt from grouping and sit at the to
 `gda info`, `gda version`, `gda help`. This is the usual CLI pattern (`git --version`,
 `docker info`). Everything that acts on a Godot domain object is grouped.
 
+> Extended by ADR-0017: gda's own **`daemon`** lifecycle (`gda daemon start` / `stop` /
+> `status` / `install` / `uninstall`) is a command group named after a gda-infrastructure
+> object — neither a Godot domain object nor a top-level meta singleton — a deliberate
+> extension of this taxonomy for the daemon's surface.
+
 This enables:
 
 - **Zero learning cost** for anyone who knows Godot — a group name *is* an engine

--- a/docs/adr/0009-trust-boundary-trusted-project.md
+++ b/docs/adr/0009-trust-boundary-trusted-project.md
@@ -31,6 +31,10 @@ does not defend against a malicious or untrusted project. Executing that project
 own autoload and scene-script constructors is therefore expected behaviour, not a
 vulnerability, and we **accept and document** it rather than harden in Phase 1.
 
+> Extended by ADR-0018: Phase 2 adds a second axis to this boundary — `gda` is also
+> assumed to be the project's *sole driver*; a concurrent external editor's writes are
+> out of scope, for the same accept-and-document reasons.
+
 The documented [project-code execution surface](../../CONTEXT.md) is classified by
 **mechanism**, on two orthogonal axes — not by a read/mutate split, because
 `node get` is a read that instantiates:

--- a/docs/adr/0011-gda-mcp-integration-mechanism.md
+++ b/docs/adr/0011-gda-mcp-integration-mechanism.md
@@ -65,6 +65,10 @@ Phase 2 automatically" literally true:
   per-phase work to cover live operations — it is a client of the daemon only
   transitively, through the CLI.
 
+> Refined by ADR-0017 / ADR-0020: the gda-daemon design referenced below as
+> "still-parked (#5, #7)" is now decided — ADR-0017 fixes its live-execution mechanism
+> and ADR-0020 defines the "state consistency" (#5) this ADR anticipates.
+
 ## Considered options
 
 - **In-process import (rejected).** gda-mcp imports `gda` and calls its

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -53,7 +53,9 @@ reached by a **direct** daemon↔harness connection, not an editor→game relay.
 **4. A two-level lifecycle: a persistent daemon over transient engine sessions.**
 A persistent, per-project `gda-daemon` (supervisor + IPC broker) holds transient
 [engine sessions](../../CONTEXT.md). Lifecycle is **explicit**:
-`gda daemon start` / `stop` / `status` are [meta commands](../../CONTEXT.md), and a
+`gda daemon start` / `stop` / `status` form a **`daemon` command group** — named
+after gda's own daemon (an infrastructure object), a deliberate extension of
+ADR-0005's domain-object grouping, not a top-level meta singleton like `gda info` — and a
 live [domain command](../../CONTEXT.md) **attaches-or-fails** — with no running
 daemon it returns a typed `daemon_not_running` error whose message names the
 remediation, making the start *timing* self-revealing without upfront ceremony.
@@ -69,14 +71,16 @@ Inherently time-windowed live ops (frame capture, property/signal monitoring ove
 frames) are collected daemon/harness-side and returned as **one** result — no
 streaming enters the public contract.
 
-**6. Live failures are classifier-source codes.** New codes
-(`daemon_not_running`, `engine_disconnected`, `live_timeout`,
-`engine_session_not_running`, …) live in the `src/gda/error_codes.py` registry as
-classifier-source `GdaError`s (possibly under a new `ErrorCategory.LIVE`); the
-daemon IPC client surfaces typed launch/transport failures the way ADR-0010's
-native runner keys on a typed reason rather than overloaded exit codes. The
-agent-facing contract (typed models, `--json`, `--schema` gate, registered
-`GdaError.code`s) is identical to headless.
+**6. Live failures are classifier-source codes.** They are classifier-source
+`GdaError`s (possibly under a new `ErrorCategory.LIVE`); the daemon IPC client
+surfaces typed launch/transport failures the way ADR-0010's native runner keys on a
+typed reason rather than overloaded exit codes. The names used illustratively in this
+ADR (`daemon_not_running`, `engine_disconnected`, `live_timeout`,
+`engine_session_not_running`, …) are **candidate codes, not accepted ABI**: each is
+added to the `src/gda/error_codes.py` registry and the ADR-0002 table by the slice
+that implements it (ADR-0002), not by this ADR. The agent-facing contract (typed
+models, `--json`, `--schema` gate, registered `GdaError.code`s) is identical to
+headless.
 
 ## Considered options
 
@@ -99,7 +103,7 @@ agent-facing contract (typed models, `--json`, `--schema` gate, registered
 
 - New code is **contained**: a `kind` field on the command descriptor, one branch in
   the runner factory, a `DaemonRunner` IPC client, the daemon itself, the
-  `gda daemon` meta commands, the harness (ADR-0018), and a few error codes.
+  `gda daemon` lifecycle commands, the harness (ADR-0018), and a few error codes.
   Everything downstream of `runner.run()` is reused.
 - Per-call `gda` process-start latency is no longer amortised by a Godot spawn for
   live ops — accepted in ADR-0011 as a CLI/daemon-layer concern.
@@ -109,4 +113,4 @@ agent-facing contract (typed models, `--json`, `--schema` gate, registered
   virtual framebuffer on headless CI). Recorded as an environment constraint.
 - "State consistency" (#5) is now concretely scoped: the property of a per-project
   daemon holding one engine session across one-shot CLI calls and across multiple
-  clients — to be defined there.
+  clients — **defined in ADR-0020** (which closes #5).

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -1,0 +1,112 @@
+---
+status: accepted
+---
+
+# Live operation execution: a gda-owned running game with an in-engine harness, routed by an invisible channel selector
+
+ADR-0001 split delivery into Phase 1 (headless) and Phase 2 (live) and named
+[gda-daemon](../../CONTEXT.md) the carrier of all live-engine capabilities.
+ADR-0011 then fixed the Phase-2 *topology*: the daemon sits **below** the CLI, each
+`gda` call is a one-shot stateless RPC to it, and every call — headless or live —
+emits the **same** public `--json` / `GdaError` contract, so the live/headless
+distinction stays invisible (as ADR-0005 keeps it invisible in the command tree)
+and gda-mcp follows into Phase 2 with no per-phase work. What neither ADR settled
+is *how* the daemon serves a [live operation](../../CONTEXT.md): which engine it
+holds, how a `gda` invocation reaches it, and how the daemon is brought up.
+
+This ADR fixes that **mechanism and its running-game scope**. It does not enumerate
+the live command catalogue, which is delivered incrementally per ADR-0005 and
+tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
+
+## Decision
+
+**1. An execution-channel selector, chosen per command by a static `kind`.**
+Today `gda` already has two execution channels behind one dispatch — the
+`operations.gd` sentinel runner and the native-export runner (ADR-0010), the latter
+identified by an identity special-case (`cmd is EXPORT_RUN_COMMAND`). Phase 2
+generalises this: each command carries a static `kind` (`HEADLESS` / `EXPORT` /
+`LIVE`) in its descriptor, decided at command-definition time, and the runner
+factory selects the channel by `kind`. A `LIVE` command's runner is a **daemon IPC
+client** that returns the same `RunResult` and — critically — the **same
+sentinel-delimited result payload** (ADR-0002) a headless subprocess returns. So
+classification (`classify_run`), sentinel parsing, output-model validation, and
+`--json` / `GdaError` emission are **reused unchanged**; the dispatcher gains
+exactly one new decision and the `export run` special-case folds into the uniform
+`kind` switch.
+
+**2. The held engine is a gda-owned running *game*, not an attached editor.**
+The daemon launches and holds a Godot **game** process running the trusted project,
+and serves the **running-game context**: the runtime scene tree, runtime property
+get/set, input simulation, viewport capture, and performance/signal monitoring —
+the capabilities a one-shot headless process fundamentally cannot provide. The
+**editor context** (UndoRedo-aware mutation, the editor's open-scene tree) is
+**out of scope**: `gda` already authors scenes, scripts, and resources headless by
+editing files, so an editor-attached mutation path would largely duplicate Phase-1
+capability. The game runs **windowed** by default because `--headless` uses the
+dummy `DisplayServer` and cannot capture a viewport.
+
+**3. Code runs inside the engine via a gda harness, over a direct IPC connection.**
+Live operations execute inside the game through the [gda harness](../../CONTEXT.md)
+— a game-side autoload whose install and safety lifecycle is decided in ADR-0018 —
+reached by a **direct** daemon↔harness connection, not an editor→game relay.
+
+**4. A two-level lifecycle: a persistent daemon over transient engine sessions.**
+A persistent, per-project `gda-daemon` (supervisor + IPC broker) holds transient
+[engine sessions](../../CONTEXT.md). Lifecycle is **explicit**:
+`gda daemon start` / `stop` / `status` are [meta commands](../../CONTEXT.md), and a
+live [domain command](../../CONTEXT.md) **attaches-or-fails** — with no running
+daemon it returns a typed `daemon_not_running` error whose message names the
+remediation, making the start *timing* self-revealing without upfront ceremony.
+The daemon is **never auto-spawned** by a live call: launching an engine runs the
+project's autoloads (the [project-code execution surface](../../CONTEXT.md),
+ADR-0009), a deliberate effect that must not hide behind a command. A session is
+**(re)launched per feedback-loop iteration**, because an externally edited
+`.tscn` / `.gd` is not reloaded by an already-running game.
+
+**5. One-shot RPC preserved; time-windowed ops collected daemon-side.**
+Each live `gda` call stays a single stateless RPC returning one payload (ADR-0011).
+Inherently time-windowed live ops (frame capture, property/signal monitoring over N
+frames) are collected daemon/harness-side and returned as **one** result — no
+streaming enters the public contract.
+
+**6. Live failures are classifier-source codes.** New codes
+(`daemon_not_running`, `engine_disconnected`, `live_timeout`,
+`engine_session_not_running`, …) live in the `src/gda/error_codes.py` registry as
+classifier-source `GdaError`s (possibly under a new `ErrorCategory.LIVE`); the
+daemon IPC client surfaces typed launch/transport failures the way ADR-0010's
+native runner keys on a typed reason rather than overloaded exit codes. The
+agent-facing contract (typed models, `--json`, `--schema` gate, registered
+`GdaError.code`s) is identical to headless.
+
+## Considered options
+
+- **Attach to a human-opened editor via an EditorPlugin (godot-mcp-pro's model)** —
+  rejected: it assumes a human has the editor open, but `gda` is agent-facing and
+  often has no editor at all; it needs a GUI/display; and its main yield
+  (editor-context UndoRedo mutation) duplicates `gda`'s headless authoring.
+- **One-level lifecycle (daemon lifetime == game lifetime)** — rejected: a game
+  crash would take the whole live context with it. The two-level split gives crash
+  resilience and matches the per-iteration session relaunch of the feedback loop.
+- **Auto-spawn the daemon/engine on the first live call** — rejected: it hides a
+  heavy, autoload-executing side effect behind a command. The attach-or-fail typed
+  error makes the start timing self-revealing without that hidden effect.
+- **Per-call one-shot headless for live ops** — impossible by definition: there is
+  no persistent engine to observe or drive.
+- **A separate live channel in gda-mcp** — already rejected by ADR-0011; gda-mcp
+  reaches the daemon only transitively through the CLI.
+
+## Consequences
+
+- New code is **contained**: a `kind` field on the command descriptor, one branch in
+  the runner factory, a `DaemonRunner` IPC client, the daemon itself, the
+  `gda daemon` meta commands, the harness (ADR-0018), and a few error codes.
+  Everything downstream of `runner.run()` is reused.
+- Per-call `gda` process-start latency is no longer amortised by a Godot spawn for
+  live ops — accepted in ADR-0011 as a CLI/daemon-layer concern.
+- Live requires code inside the engine, so Phase 2 carries a **one-time harness
+  install** (ADR-0018), unlike Phase-1's zero-install headless ops.
+- Viewport capture requires a **windowed** game, hence a display dependency (a
+  virtual framebuffer on headless CI). Recorded as an environment constraint.
+- "State consistency" (#5) is now concretely scoped: the property of a per-project
+  daemon holding one engine session across one-shot CLI calls and across multiple
+  clients — to be defined there.

--- a/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
+++ b/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
@@ -32,9 +32,12 @@ true`), and **self-syncs** the harness to the running `gda` version. This is a
 
 **2. A runtime gate keeps the harness inert unless the daemon launched the session.**
 At startup the harness checks for the daemon's launch marker (in the args after
-`--`); absent it, it frees itself and opens **no** connection. So it is dormant in a
-human editor run, a plain `godot --path` run, and — crucially — a **shipped/exported
-build**. No uninstall is required for safety.
+`--`); absent it, it **returns early — starting no server and opening no connection —
+and stays resident**. It must *not* free itself: Godot autoloads must not be removed
+with `free()` / `queue_free()` at runtime (it crashes the engine), so a resident
+do-nothing autoload is the safe inert form. Thus it is dormant in a human editor run,
+a plain `godot --path` run, and — crucially — a **shipped/exported build**. No
+uninstall is required for safety (only for build hygiene, point 3).
 
 **3. `gda daemon uninstall` removes the autoload entry and the harness files
 together.** A release-hygiene step for teams that require dev tooling to be
@@ -78,6 +81,8 @@ external editor's writes out of scope, with two cheap safeguards:
 - ADR-0009's trust boundary gains a second axis: from "trusted project" to also
   "**single driver**". New glossary terms: `gda harness`, `engine session`
   (ADR-0017), `concurrent external editor`.
-- New classifier-source error code `file_changed_externally`.
+- `file_changed_externally` is a **candidate** classifier-source code — registered in
+  the `src/gda/error_codes.py` registry and the ADR-0002 table by the slice that
+  implements it, not by this ADR.
 - `.godot/` import-cache races between a concurrent editor and an engine session
   remain possible but are recoverable (md5-keyed reimport); not defended, documented.

--- a/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
+++ b/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
@@ -1,0 +1,83 @@
+---
+status: accepted
+---
+
+# gda harness lifecycle, and the concurrent-editor trust boundary
+
+ADR-0017 serves [live operations](../../CONTEXT.md) by running `gda` code inside a
+gda-owned game — the [engine session](../../CONTEXT.md) — via the
+[gda harness](../../CONTEXT.md). Getting that code into a *running game* is
+constrained by the engine: Godot has **no `--autoload` CLI flag** (autoloads come
+from `project.godot`'s `[autoload]` section), `--script` **replaces** the main loop
+(so it cannot run *alongside* the real game the way `operations.gd` runs a headless
+op), `EditorPlugin.add_autoload_singleton()` is **editor-only** and **edits
+`project.godot`**, and `override.cfg` is for **exported** projects. So in-engine
+code cannot be as zero-install as Phase-1's bundled `--script operations.gd`.
+
+Separately, ADR-0009's trust boundary assumes `gda` operates on a *trusted* project
+but says nothing about *who else* operates on it. In Phase 2 a human plausibly opens
+a Godot editor on the same project to view, run, or verify agent output — a
+[concurrent external editor](../../CONTEXT.md) — and Godot takes **no project lock**,
+so two instances can touch the project at once.
+
+## Decision
+
+**1. The harness is an installed autoload, not a runtime injection.** `gda` bundles
+the harness and installs it into the trusted project's `project.godot [autoload]`
+via an idempotent, agent-runnable `gda daemon install`. `gda daemon start`
+auto-installs when missing and **reports** the effect (e.g. `installed_harness:
+true`), and **self-syncs** the harness to the running `gda` version. This is a
+**one-time, version-controllable, install-time write** — not a per-launch mutation
+(which would corrupt config against a concurrent editor, see point 4).
+
+**2. A runtime gate keeps the harness inert unless the daemon launched the session.**
+At startup the harness checks for the daemon's launch marker (in the args after
+`--`); absent it, it frees itself and opens **no** connection. So it is dormant in a
+human editor run, a plain `godot --path` run, and — crucially — a **shipped/exported
+build**. No uninstall is required for safety.
+
+**3. `gda daemon uninstall` removes the autoload entry and the harness files
+together.** A release-hygiene step for teams that require dev tooling to be
+physically absent from the build. Removal is **paired**: stripping the files via an
+export `exclude_filter` while leaving the `[autoload]` entry pointing at a missing
+script **crashes the exported game at startup**, so removal goes through `gda`, not a
+hand-edited export filter.
+
+**4. Concurrent external editor is out of scope; single-driver is assumed
+(extending ADR-0009).** `gda`, running outside the editor, cannot see the editor's
+open buffers, so it **cannot** replicate godot-mcp-pro's open-file write guards
+(pro can, because it *is* the editor). Phase 2 therefore declares a concurrent
+external editor's writes out of scope, with two cheap safeguards:
+
+- **Live injection performs zero runtime `project.godot` mutation** (point 1),
+  eliminating the worst tier — config corruption.
+- **Headless writes are atomic with an optimistic mtime check**, failing with
+  `file_changed_externally` when the target changed since `gda` last read it. The
+  human's editor provides the reciprocal "file changed on disk, reload?" prompt on
+  its side.
+
+## Considered options
+
+- **Runtime-injected autoload, reverted on stop** — rejected: per-launch
+  `project.godot` mutation races a concurrent editor and leaves the project dirty if
+  the daemon crashes mid-session.
+- **Auto-generated wrapper main scene** that hosts the harness and loads the real
+  main scene as a child — rejected: it intercepts the boot flow and changes
+  SceneTree-root semantics, breaking games that assume they are the root main scene.
+- **Human-enabled editor plugin (godot-mcp-pro's model)** — rejected: it inserts a
+  human gate into an agent-driven flow.
+- **Defend against a concurrent external editor** (lock files, process scans,
+  open-buffer detection) — rejected for Phase 2: Godot takes no project lock and
+  leaves no reliable signal, so detection is unreliable; the single-driver
+  assumption is documented instead.
+
+## Consequences
+
+- Phase-2 live carries a **one-time install step**; Phase-1 headless stays
+  zero-install. The boundary is explicit and intentional (ADR-0017).
+- ADR-0009's trust boundary gains a second axis: from "trusted project" to also
+  "**single driver**". New glossary terms: `gda harness`, `engine session`
+  (ADR-0017), `concurrent external editor`.
+- New classifier-source error code `file_changed_externally`.
+- `.godot/` import-cache races between a concurrent editor and an engine session
+  remain possible but are recoverable (md5-keyed reimport); not defended, documented.

--- a/docs/adr/0019-live-command-placement-by-domain-object.md
+++ b/docs/adr/0019-live-command-placement-by-domain-object.md
@@ -1,0 +1,59 @@
+---
+status: accepted
+---
+
+# Live command placement: distributed by domain object, with a narrow `game` object for the running game's scene graph
+
+ADR-0005 groups commands by Godot **domain object** and explicitly **rejected**
+grouping by capability phase (a `headless` group / `live` group), because that leaks
+the delivery dimension into the user surface and separates commands users think of as
+siblings. Phase 2 (ADR-0017) now adds [live operations](../../CONTEXT.md), and the
+naive move — a single `live` / `runtime` / `game` group holding *all* of them — would
+resurrect exactly that rejected phase group wearing a domain-object costume.
+
+## Decision
+
+**1. Live operations are placed by their real Godot domain object, like headless
+operations.** The headless/live distinction is carried by the per-command `kind`
+(ADR-0017), never by a group. So the live-only capabilities become their **own
+domain-object groups** populated by their actual object — input simulation under an
+`input` group, viewport capture under a `screen` / `viewport` group, runtime
+monitoring under a `perf` / `monitor` group, etc. — not lumped together as "live".
+There is **no single live group**, so the phase still never appears in the tree
+(ADR-0005 holds).
+
+**2. The one genuine collision gets a narrow `game` object.** The only place a
+headless reading and a runtime reading of the same thing both exist is the **running
+game's scene graph**: the runtime scene tree and runtime node properties, versus the
+on-disk `.tscn` read by `scene get` / `node get`. The *running game* is itself a Godot
+domain object (the runtime `SceneTree` / `MainLoop`, distinct from on-disk assets), so
+it gets a **narrow `game` group** holding only its live scene graph (`tree`, runtime
+`get` / `set`). `game` is **not** a catch-all for all live ops.
+
+**Why `game` is a domain-object group, not the rejected phase group.** ADR-0005
+rejected grouping by *delivery phase*. `game` is named after an *object* (the running
+game) that merely happens to exist only at runtime; input / capture / perf are
+separate object groups, so nothing collapses into one "live" bucket. The phase is
+still invisible; only objects appear in the tree.
+
+## Considered options
+
+- **A single `live` / `runtime` / `game` mega-group for all live ops** — rejected: it
+  *is* ADR-0005's phase group renamed, and it buckets unrelated capabilities (input,
+  capture, perf) by their phase rather than their object.
+- **Keep runtime tree/props under `scene` / `node`, disambiguated by a name qualifier
+  or a `--running` flag** — the flag is rejected (one command = one schema = one
+  context; a flag that swaps the output schema breaks that). A name qualifier under
+  `scene` / `node` is viable but conflates "the authored on-disk scene" with "the
+  running game's tree", which are different enough to be different objects.
+
+## Consequences
+
+- The "scene tree" concept now spans two objects: on-disk under `scene`, runtime under
+  `game`. Mitigated by help / `--schema` cross-references; accepted because the two are
+  genuinely different objects (authored asset vs running runtime tree).
+- `docs/command-catalog.md`'s Phase-2 section is narrowed accordingly: running-game
+  scope, live ops distributed by object, the narrow `game` group for the runtime scene
+  graph.
+- Error-code allocation is orthogonal to placement (by failure-mode / source —
+  ADR-0017, ADR-0002), so this grouping decision does not affect codes.

--- a/docs/adr/0020-live-state-consistency.md
+++ b/docs/adr/0020-live-state-consistency.md
@@ -1,0 +1,59 @@
+---
+status: accepted
+---
+
+# Live state consistency: single-writer serialization, frame-coherent, session-bound
+
+ADR-0000 claimed "state consistency" as a headline advantage of `gda`; ADR-0001
+scoped it to the Phase-2 live layer (Phase-1 headless calls are stateless); and #5
+parked the precise definition until the daemon model was decided. With that model now
+fixed — a per-project daemon holding a transient [engine session](../../CONTEXT.md)
+(ADR-0017) under a single-driver trust boundary (ADR-0018) — this ADR defines the
+guarantee and reconciles ADR-0000's blanket claim.
+
+**Scope.** This is about the consistency of an *engine session's runtime state* only.
+Disk↔runtime coherence is **out of scope**: an externally edited `.tscn` / `.gd` is
+not reloaded by a running session, and the agent (re)launches the session to pick up
+on-disk edits (ADR-0017). #5's question is only "within a session, what do live reads
+and writes guarantee".
+
+## Decision
+
+`state consistency` is the property [gda-daemon](../../CONTEXT.md) provides over one
+engine session's runtime state:
+
+1. **Single-writer serialization.** The daemon serializes all live operations against
+   the one engine session. Phase 2 supports a **single writer** (the driving agent),
+   consistent with ADR-0018's single-driver boundary; any additional clients are
+   **readers only**.
+2. **Read-after-write within the driver's sequence.** Because calls are serialized and
+   each returns only after it completes, a read issued after a write observes that
+   write.
+3. **Frame-coherent.** Each live op is applied/observed at a **frame boundary on the
+   engine's main thread** (Godot requires scene-tree access on the main thread), so a
+   single op is a coherent single-frame snapshot and a write applies atomically
+   between frames. Time-windowed ops (monitor / capture over N frames) are explicitly
+   multi-frame and return a per-frame timeline.
+4. **Session-bound.** Runtime state lives in the engine session and does **not**
+   survive its (re)launch (ADR-0017); consistency is scoped within one session.
+
+**Reconciling ADR-0000.** Its blanket "state-consistent" advantage holds **only** for
+this Phase-2 live layer under these scoped guarantees — not for the stateless Phase-1
+headless CLI (ADR-0001). Recorded here and via a pointer on ADR-0000.
+
+## Considered options
+
+- **Multi-writer concurrent clients** — rejected for Phase 2: it contradicts the
+  single-driver boundary (ADR-0018) and would need a full concurrency protocol
+  (locking, ordering, cross-client visibility) disproportionate to an agent-facing
+  tool. If multiple agents co-writing one live engine is ever required, it warrants
+  its own ADR **superseding** this one.
+
+## Consequences
+
+- The guarantee is simple and testable: serialize live calls against one session and
+  assert read-after-write and frame-coherent snapshots; no concurrency protocol to
+  verify.
+- `state consistency` becomes a defined CONTEXT.md glossary term, closing #5.
+- **Multi-writer is the explicit no.** A future need supersedes this ADR rather than
+  stretching it.

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -27,8 +27,9 @@ when they only touch a scene/resource *file*. `gda` classifies by CONTEXT.md ins
   (ADR-0019). **Mechanism decided (ADR-0017–0020); catalogue delivered incrementally.**
 
 This catalog does **not** carry a per-command status column — that would duplicate, and
-drift from, the issue tracker. For the live backlog (what is committed, in flight, and
-done) open the **Phase 1 — headless operations** milestone. Inline references to issues
+drift from, the issue tracker. For the **headless** backlog open the **Phase 1 —
+headless operations** milestone; for the **live** backlog open the **Phase 2 — live
+operations** milestone. Inline references to issues
 in the prose below (e.g. "established by #53") cite the slice that defined a behavior;
 they are provenance, not status markers.
 

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -19,9 +19,12 @@ when they only touch a scene/resource *file*. `gda` classifies by CONTEXT.md ins
 - **Phase 1 (headless)** — fulfillable by a one-shot `godot --headless` process that
   loads a file from disk, mutates it, and saves it (or just reads it). No pre-existing
   engine state required. **This is the near-term increment.**
-- **Phase 2 (live)** — requires an already-running engine/editor to observe or mutate
-  in-place state (runtime scene tree, runtime properties, input simulation, play/stop,
-  screenshots of a running game, editor diagnostics). Served by `gda-daemon`. **Parked.**
+- **Phase 2 (live)** — requires an already-running engine to observe or control its
+  runtime state (runtime scene tree, runtime properties, input simulation, viewport
+  capture, performance/signal monitoring). Served by `gda-daemon` against a **running
+  game**, not an attached editor; the editor context is out of scope (ADR-0017). Live
+  commands are placed by their real domain object, not in a single "live" group
+  (ADR-0019). **Mechanism decided (ADR-0017–0020); catalogue delivered incrementally.**
 
 This catalog does **not** carry a per-command status column — that would duplicate, and
 drift from, the issue tracker. For the live backlog (what is committed, in flight, and
@@ -440,19 +443,30 @@ These create or edit resource files (`.gdshader`, `.tres`) and so are headless.
 
 ---
 
-## Phase 2 — live domain commands (parked, served by `gda-daemon`)
+## Phase 2 — live domain commands (served by `gda-daemon`)
 
-Listed coarsely; enumerated when Phase 2 (PRD #6) is unparked. All require a running
-engine/editor and so cannot be a one-shot headless call.
+Listed coarsely; enumerated as slices when Phase 2 (PRD #6) is worked. All require a
+running `Engine session` and so cannot be a one-shot headless call. Mechanism is fixed
+by ADR-0017 (execution), ADR-0018 (harness), ADR-0019 (placement), ADR-0020
+(consistency); scope is the **running game**, not an attached editor. Live ops are
+distributed by their real domain object (ADR-0019), not lumped into one "live" group.
 
-- **`scene` (live):** `play`, `stop`, live `get` of the running/edited scene tree, `save` the open scene, instance a packed scene into the open scene.
-- **`node` (live):** runtime property `get`/`set`, anchor presets, group membership on the live tree.
-- **runtime introspection:** running-game scene tree, performance monitors, autoload state, frame capture, property monitoring.
-- **input simulation:** key / mouse / action / sequence injection into a running game.
-- **diagnostics & capture:** editor errors, output log, editor & game screenshots, screenshot diff.
-- **editor utilities:** run editor script, reload plugin/project, list signals.
-- **testing harness:** run scenario, assert node/screen state, stress test, recording/replay.
-- **`input-map` (live):** `get`/`set` InputMap actions on a running engine.
+- **`game` (the running game's scene graph):** live `get` of the runtime scene tree;
+  runtime node property `get`/`set`. The on-disk counterparts stay under `scene` /
+  `node` (ADR-0019).
+- **`input` (input simulation):** key / mouse / action / sequence injection into the
+  running game; record / replay.
+- **`screen` / capture:** running-game viewport screenshot, multi-frame capture.
+- **`perf` / monitor:** performance monitors, property monitoring over N frames,
+  signal watching.
+- **diagnostics:** runtime errors and output log of the running game.
+- **lifecycle (meta):** `gda daemon start` / `stop` / `status`, and `gda daemon
+  install` / `uninstall` for the `gda harness` (ADR-0018).
+
+Out of scope (editor context, ADR-0017): UndoRedo-aware mutation, the editor's
+open-scene tree, saving the open scene, editor errors/screenshots, run-editor-script,
+reload-plugin/project. Authoring that `godot-mcp-pro` does through a live editor, `gda`
+does headless by editing files.
 
 ---
 

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -461,7 +461,7 @@ distributed by their real domain object (ADR-0019), not lumped into one "live" g
 - **`perf` / monitor:** performance monitors, property monitoring over N frames,
   signal watching.
 - **diagnostics:** runtime errors and output log of the running game.
-- **lifecycle (meta):** `gda daemon start` / `stop` / `status`, and `gda daemon
+- **lifecycle (the `daemon` command group):** `gda daemon start` / `stop` / `status`, and `gda daemon
   install` / `uninstall` for the `gda harness` (ADR-0018).
 
 Out of scope (editor context, ADR-0017): UndoRedo-aware mutation, the editor's


### PR DESCRIPTION
## What

Aligns the **Phase 2 — live operations via gda-daemon** requirements ahead of
implementation, capturing this session's decisions as ADRs + glossary updates, and
reconciling the issue tracker. Docs only.

## Decisions captured

| ADR | Decision |
|---|---|
| **0017** | Live execution: a gda-owned running **game** (not an attached editor) with an in-engine **gda harness**, routed by an invisible per-command channel `kind`; two-level lifecycle (persistent daemon over transient engine sessions); explicit `gda daemon start`, attach-or-fail. |
| **0018** | gda harness lifecycle (agent-installable autoload, runtime-gated inert, paired uninstall) and the **concurrent-editor / single-driver** trust boundary (extends ADR-0009). |
| **0019** | Live command placement by **real domain object** (no "live" mega-group), with a narrow **`game`** object for the running game's scene graph (refines ADR-0005). |
| **0020** | Live **state consistency**: single-writer serialization, frame-coherent, session-bound; reconciles ADR-0000's blanket claim. |

## Glossary (CONTEXT.md)

New terms: `gda harness`, `engine session`, `state consistency`, `concurrent external
editor`. Refined: `gda-daemon`, `live operation`, `Phase 2`, `Command group`.

## Other

- `docs/command-catalog.md`: Phase 2 section narrowed to the running-game scope.
- Forward pointers added to ADR-0000/0001/0005/0009 (point-in-time records preserved,
  not rewritten).
- Issue tracker reconciled: **#6** rewritten as the authoritative Phase-2 PRD; **#7**
  repurposed as the daemon-bootstrap first slice; **#5** resolved here (ADR-0020).

#6 (parent PRD) and #7 (first slice) remain open for delivery.

Closes #5
