### PR TITLE
docs(adr): ADR-0021 daemon transport/discovery + ADR-0003 live floor (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ for the full picture.
 - 🔜 `gda-daemon` for *live operations* against a **running game** (Phase 2): runtime scene
   tree, runtime properties, input simulation, viewport capture, performance/signal monitoring —
   via `gda daemon` lifecycle commands. Live commands are placed by domain object (a narrow `game`
-  group for the runtime scene graph); the editor context is out of scope. See ADR-0017–0020.
+  group for the runtime scene graph); the editor context is out of scope. Phase-2 live needs
+  **Godot 4.6+** and is **macOS/Linux only** (it uses Unix domain sockets); Phase-1 headless is
+  unaffected — still 4.4+ and cross-platform. See ADR-0017–0021.
 
 **Out of scope for now**
 
@@ -588,7 +590,7 @@ drives a real engine. Everything between the CLI and the runner runs as real cod
 | ----------------- | ------------------------------------------------------------------------- | ------ |
 | **Phase 1** | `gda` serving *headless operations* standalone: `info`, structured errors, `--schema`, and the domain command groups `scene`, `node`, `script`, `project` (incl. static-analysis), `resource`, `export`, `shader`, `theme`. | ✅ Surface complete |
 | **`gda-mcp`** | A thin MCP adapter generated mechanically from `--schema` — first on top of Phase 1, following `gda` forward automatically. | ✅ Shipped |
-| **Phase 2** | `gda` also serving *live operations* through `gda-daemon` and a live *engine session*. | 🗓 Planned |
+| **Phase 2** | `gda` also serving *live operations* through `gda-daemon` and a live *engine session* (requires Godot 4.6+, macOS/Linux only; headless stays 4.4+ and cross-platform — ADR-0021). | 🗓 Planned |
 
 Track progress and proposals on the [issue tracker](https://github.com/aigengame/godot-agent/issues).
 

--- a/docs/adr/0003-target-godot-version.md
+++ b/docs/adr/0003-target-godot-version.md
@@ -4,6 +4,13 @@ status: accepted
 
 # Target Godot version: 4.x, minimum 4.4, tested against 4.6
 
+> **Amended by [ADR-0021](0021-gda-daemon-transport-discovery-and-live-version-floor.md)
+> (2026-06-21, #7) for the live layer:** Phase-2 [live operations](../../CONTEXT.md)
+> require **Godot ≥ 4.6**, because the daemon↔harness transport is a Unix domain socket
+> and `StreamPeerUDS` landed in 4.6-stable. The minimum stated below **stands unchanged
+> for the Phase-1 headless layer (4.4)** — headless uses neither the daemon nor UDS. UDS
+> is also UNIX-only, so live is macOS/Linux only; headless stays cross-platform.
+
 GDScript APIs, `--headless` behaviour, and `Engine.get_version_info()` fields all
 vary across Godot versions, and the 3.x and 4.x lines are effectively two different
 engines. `gda` must declare which versions it supports so that e2e tests can assert

--- a/docs/adr/0003-target-godot-version.md
+++ b/docs/adr/0003-target-godot-version.md
@@ -41,6 +41,8 @@ making "version too old" a programmatically detectable failure.
 
 ## Consequences
 
-- e2e tests assume 4.6 locally; CI/other machines must provide a 4.4+ engine.
+- e2e tests assume 4.6 locally. **Headless** e2e need a **4.4+** engine; **Phase-2 live**
+  e2e need a **4.6+** engine (ADR-0021), so CI/other machines running the live suites must
+  provide 4.6+ — the headless suites still run on 4.4+.
 - 3.x is explicitly unsupported.
 - The minimum-version check depends on the `gda info` operation (issue #2) existing.

--- a/docs/adr/0011-gda-mcp-integration-mechanism.md
+++ b/docs/adr/0011-gda-mcp-integration-mechanism.md
@@ -65,9 +65,10 @@ Phase 2 automatically" literally true:
   per-phase work to cover live operations — it is a client of the daemon only
   transitively, through the CLI.
 
-> Refined by ADR-0017 / ADR-0020: the gda-daemon design referenced below as
-> "still-parked (#5, #7)" is now decided — ADR-0017 fixes its live-execution mechanism
-> and ADR-0020 defines the "state consistency" (#5) this ADR anticipates.
+> Refined by ADR-0017 / ADR-0020 / ADR-0021: the gda-daemon design referenced below as
+> "still-parked (#5, #7)" is now decided — ADR-0017 fixes its live-execution mechanism,
+> ADR-0020 defines the "state consistency" (#5) this ADR anticipates, and ADR-0021
+> fixes the daemon transport / discovery (the remaining #7 item). #7 is no longer parked.
 
 ## Considered options
 

--- a/docs/adr/0021-gda-daemon-transport-discovery-and-live-version-floor.md
+++ b/docs/adr/0021-gda-daemon-transport-discovery-and-live-version-floor.md
@@ -27,13 +27,36 @@ it is *told* a path.
 
 **2. Discovery is per-project and deterministic.** The CLI and the lifecycle commands
 locate the daemon by deriving the socket and **pidfile** paths from the **resolved
-project root** (gda's existing `GDA_PROJECT → … → cwd` precedence, ADR-0006), under a
-short per-user runtime directory. Liveness is the pidfile (a held advisory lock = alive;
-a grabbable lock + present socket = stale, to be reclaimed). `gda daemon status` and a
-live command's **attach-or-fail** check (ADR-0017) both key on *socket present +
-pidfile alive*. The paths must stay **short**: a UDS path is bounded by the OS
-`sun_path` limit (104 bytes on macOS, 108 on Linux), so the runtime directory is a
-short `~/.gda`-style location, never the long macOS `$TMPDIR`.
+project root** (gda's existing `GDA_PROJECT → … → cwd` precedence, ADR-0006). To make
+`daemon start`, `daemon status`, and a live command's attach all agree on the **same
+daemon identity** regardless of how the project was referenced, the derivation is fixed
+as a contract (the exact hash function is an implementation choice, the contract is not):
+
+- **Canonicalize first.** The resolved project root is reduced to its canonical absolute
+  path (symlinks resolved) before derivation, so two references to one project derive one
+  identity and two different projects never collide.
+- **Names are a stable hash of that canonical path.** Same canonical path → same socket
+  and pidfile names; different paths → different names. The **pidfile records the
+  canonical project path**, so a hash collision or a reused runtime slot is detectable:
+  `status` / attach treat a pidfile whose recorded path ≠ the caller's resolved path as
+  **foreign** (not this project's daemon), never as a hit.
+- **Private, short runtime directory.** The socket and pidfile live in a per-user,
+  owner-only (`0700`) runtime directory — `$XDG_RUNTIME_DIR` when set (Linux), else a
+  `~/.gda/run`-style location — created with `0700` and the socket owner-only. This is
+  what makes "no localhost surface" *also* "no other-user surface": the socket is never
+  in a world-reachable directory. The directory must be **short**: a UDS path is bounded
+  by the OS `sun_path` limit (104 bytes on macOS, 108 on Linux), never the long macOS
+  `$TMPDIR`.
+- **No resolved project is an error, not a global daemon.** The daemon is per-project by
+  definition; when ADR-0006 resolves no project, `daemon start` / `status` and any live
+  command return the structured project-resolution error (a project is required) rather
+  than falling back to a default/global daemon.
+
+Liveness is the pidfile (a held advisory lock = alive; a grabbable lock + present socket
+= **stale**). `daemon start` reclaims a stale slot (unlink the socket, relaunch);
+`daemon status` reports *not running* for a stale or foreign pidfile; a live command's
+attach treats either as `daemon_not_running`. `gda daemon status` and the attach-or-fail
+check (ADR-0017) both key on *socket present + pidfile alive + recorded path matches*.
 
 **3. The wire format reuses the ADR-0002 sentinel result shape.** A live op's payload
 crosses both legs as the **same** `<<<GDA:RESULT>>>…<<<GDA:END>>>` sentinel a headless
@@ -88,10 +111,12 @@ capability with no installed 4.4/4.5 live users to preserve.
     is UNIX-only today, rather than surfacing a raw socket error. `--help` / `--schema`
     for the `daemon` group and live commands state the UNIX-only constraint.
     The platform check precedes the version check (it needs no engine launch).
-  - **Future Windows support is the rejected TCP option, not a redesign.** When
-    warranted, Windows live runs the localhost-TCP daemon↔harness variant above (and a
-    named-pipe or TCP CLI↔daemon leg); it is a future ADR + slice, would **not** raise
-    the headless floor, and does not block this slice.
+  - **Future Windows support is out of scope here, left to its own ADR.** A *candidate*
+    path — should it be pursued — is the localhost-TCP daemon↔harness variant above (with
+    a named-pipe or TCP CLI↔daemon leg); that future ADR + slice evaluates the transport
+    on its own facts. It is named here only to show the cutoff is not a dead end; it is
+    **not** decided now, would **not** raise the headless floor, and does not block this
+    slice.
 - **Amends ADR-0003**: the live floor is 4.6; a pointer is added on ADR-0003. The
   headless floor is untouched.
 - **Implementation constraint**: socket/pidfile paths must respect the `sun_path`

--- a/docs/adr/0021-gda-daemon-transport-discovery-and-live-version-floor.md
+++ b/docs/adr/0021-gda-daemon-transport-discovery-and-live-version-floor.md
@@ -1,0 +1,109 @@
+---
+status: accepted
+---
+
+# gda-daemon transport and discovery: Unix domain sockets end-to-end, per-project socket + pidfile discovery, and a Phase-2 live floor of Godot 4.6
+
+ADR-0017 fixed [gda-daemon](../../CONTEXT.md)'s shape — a per-project supervisor + IPC
+broker holding a transient [engine session](../../CONTEXT.md) with the
+[gda harness](../../CONTEXT.md), routed by a static `kind` channel selector — but
+**explicitly left three choices to the first implementation slice (#7)**: the
+daemon's *transport*, its *discovery*, and the daemon↔harness *wire format*. PRD #6
+records the same: "daemon transport / discovery — owned by the first slice #7." This
+ADR fixes those three, and the one consequence they force: a **Phase-2 live version
+floor**.
+
+## Decision
+
+**1. Transport is a Unix domain socket on both legs.** Both
+`CLI → daemon` and `daemon → harness` are **UDS**, not TCP. The daemon (Python) listens
+on `AF_UNIX` stream sockets; the harness (GDScript) connects back with
+`StreamPeerUDS`. There is **no localhost TCP listener, no port, and no port scan** —
+rejecting godot-mcp-pro's fixed `6505–6514` range probe. The daemon binds **two**
+sockets per project: one the CLI clients connect to, and one the session's harness
+connects back on; the harness socket path is handed to the engine session through the
+launch marker (the args after `--`, ADR-0018), so the harness never discovers a port,
+it is *told* a path.
+
+**2. Discovery is per-project and deterministic.** The CLI and the lifecycle commands
+locate the daemon by deriving the socket and **pidfile** paths from the **resolved
+project root** (gda's existing `GDA_PROJECT → … → cwd` precedence, ADR-0006), under a
+short per-user runtime directory. Liveness is the pidfile (a held advisory lock = alive;
+a grabbable lock + present socket = stale, to be reclaimed). `gda daemon status` and a
+live command's **attach-or-fail** check (ADR-0017) both key on *socket present +
+pidfile alive*. The paths must stay **short**: a UDS path is bounded by the OS
+`sun_path` limit (104 bytes on macOS, 108 on Linux), so the runtime directory is a
+short `~/.gda`-style location, never the long macOS `$TMPDIR`.
+
+**3. The wire format reuses the ADR-0002 sentinel result shape.** A live op's payload
+crosses both legs as the **same** `<<<GDA:RESULT>>>…<<<GDA:END>>>` sentinel a headless
+subprocess emits on stdout. The daemon relays the harness's sentinel string verbatim
+into the `RunResult` the daemon IPC client returns, so `classify_run` / sentinel
+parsing / output-model validation / `--json` / `GdaError` emission are **reused
+unchanged** (ADR-0017). Request framing on each leg is a length-prefixed JSON
+`{op, params}`; only the daemon-side framing is new code, the parser is not.
+
+**4. Phase-2 live requires Godot ≥ 4.6 (amending ADR-0003).** `StreamPeerUDS` /
+`UDSServer` landed in **Godot 4.6-stable** ("Core: Add UNIX domain socket support");
+they do not exist in 4.4 / 4.5. Because the harness leg (decision 1) is UDS, the
+engine session — hence **live operations** — needs **4.6+**. `gda daemon start`
+**version-gates**: an engine below 4.6 returns the structured `version`-category error
+ADR-0003 already defines for "too old," naming the floor. This amends ADR-0003 **for the
+live layer only**: the **Phase-1 headless floor stays 4.4** (headless uses neither UDS
+nor the daemon). 4.6 is already gda's development/test baseline, and live is a new
+capability with no installed 4.4/4.5 live users to preserve.
+
+## Considered options
+
+- **Localhost TCP for the daemon↔harness leg (keep a 4.4 live floor).** The harness
+  would use `StreamPeerTCP` to a 127.0.0.1 ephemeral port the daemon picks and injects
+  via the launch marker (token-authenticated, still no scan). Rejected **for UNIX**:
+  it adds a second transport and a loopback listener for a brand-new capability with no
+  4.4/4.5 live users, where UDS-everywhere is uniform and surface-free. **This rejected
+  option is exactly the forward path for Windows** (see Consequences), where UDS is
+  unavailable.
+- **godot-mcp-pro's fixed TCP port-range scan (`6505–6514`).** Rejected: brittle under
+  port collisions and multiple projects; UDS keys cleanly on a per-project path.
+- **A discovery registry / daemon-of-daemons.** Rejected: a deterministic per-project
+  path + pidfile is the simplest thing that supports the per-project model; a registry
+  is unwarranted machinery.
+- **A bespoke daemon↔harness wire format.** Rejected: reusing the ADR-0002 sentinel is
+  what lets the entire classify/parse/emit pipeline be reused unchanged.
+
+## Consequences
+
+- The live stack is **uniform UDS**: one transport, one discovery story, no localhost
+  surface, no token handshake required for the harness port (there is no port).
+- **Non-UNIX (Windows) platforms.** Both legs are UDS — `AF_UNIX` (Python, the
+  CLI↔daemon leg) and `StreamPeerUDS` (GDScript, the daemon↔harness leg) — and both are
+  UNIX-only, so the **entire** Phase-2 live stack (not merely the harness leg) is
+  **macOS/Linux only**; there is no partial degradation. The boundary is deliberate and
+  contained:
+  - **Phase-1 headless is unaffected and stays cross-platform** — it spawns one-shot
+    `godot --headless` subprocesses and never touches the daemon or a socket, so a
+    Windows user keeps the full headless surface.
+  - **Fail fast, not cryptically.** On a non-UNIX platform `gda daemon start` (and any
+    live command's attach-or-fail) returns a **typed structured error** — candidate
+    code `live_unsupported_platform` — whose message names the limitation and that live
+    is UNIX-only today, rather than surfacing a raw socket error. `--help` / `--schema`
+    for the `daemon` group and live commands state the UNIX-only constraint.
+    The platform check precedes the version check (it needs no engine launch).
+  - **Future Windows support is the rejected TCP option, not a redesign.** When
+    warranted, Windows live runs the localhost-TCP daemon↔harness variant above (and a
+    named-pipe or TCP CLI↔daemon leg); it is a future ADR + slice, would **not** raise
+    the headless floor, and does not block this slice.
+- **Amends ADR-0003**: the live floor is 4.6; a pointer is added on ADR-0003. The
+  headless floor is untouched.
+- **Implementation constraint**: socket/pidfile paths must respect the `sun_path`
+  length limit (short runtime dir).
+- **Candidate error codes** (registered in `src/gda/error_codes.py` + the ADR-0002
+  table by the implementing slice, per ADR-0002 — *not* accepted ABI here, and
+  classifier-source so none are GDScript-mirrored): `daemon_not_running`,
+  `engine_session_not_running` (daemon up, no live session), `engine_disconnected`
+  (session lost mid-op), `live_timeout`, `live_unsupported_platform`, and the
+  live-version-floor reuse of the ADR-0003 `version` gate. The first four are
+  live-runtime failures (candidates for a new `ErrorCategory.LIVE`, ADR-0017);
+  `live_unsupported_platform` is instead an **`environment`**-category code — a
+  pre-launch platform precondition (no `AF_UNIX`), the same bucket as
+  `binary_not_found` / `launch_timeout`, decided before any engine launch.
+- **Closes the open transport/discovery item** carried by ADR-0017, PRD #6, and #7.

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -24,7 +24,7 @@ when they only touch a scene/resource *file*. `gda` classifies by CONTEXT.md ins
   capture, performance/signal monitoring). Served by `gda-daemon` against a **running
   game**, not an attached editor; the editor context is out of scope (ADR-0017). Live
   commands are placed by their real domain object, not in a single "live" group
-  (ADR-0019). **Mechanism decided (ADR-0017–0020); catalogue delivered incrementally.**
+  (ADR-0019). **Mechanism decided (ADR-0017–0021); catalogue delivered incrementally.**
 
 This catalog does **not** carry a per-command status column — that would duplicate, and
 drift from, the issue tracker. For the **headless** backlog open the **Phase 1 —

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -449,8 +449,11 @@ These create or edit resource files (`.gdshader`, `.tres`) and so are headless.
 Listed coarsely; enumerated as slices when Phase 2 (PRD #6) is worked. All require a
 running `Engine session` and so cannot be a one-shot headless call. Mechanism is fixed
 by ADR-0017 (execution), ADR-0018 (harness), ADR-0019 (placement), ADR-0020
-(consistency); scope is the **running game**, not an attached editor. Live ops are
-distributed by their real domain object (ADR-0019), not lumped into one "live" group.
+(consistency), and ADR-0021 (transport / discovery); scope is the **running game**, not
+an attached editor. Live ops are distributed by their real domain object (ADR-0019), not
+lumped into one "live" group. Because the daemon↔harness transport is a Unix domain
+socket (ADR-0021), **Phase-2 live requires Godot 4.6+ and is macOS/Linux only**; Phase-1
+headless is unaffected (4.4+, cross-platform).
 
 - **`game` (the running game's scene graph):** live `get` of the runtime scene tree;
   runtime node property `get`/`set`. The on-disk counterparts stay under `scene` /


### PR DESCRIPTION
## What

Lands the architectural decisions from planning the **gda-daemon bootstrap (#7)** —
the transport / discovery / wire-format choices that ADR-0017 and PRD #6 explicitly
parked for the first Phase-2 implementation slice.

- **New `ADR-0021`** — gda-daemon transport and discovery:
  - **Transport**: Unix domain socket on **both** legs (CLI↔daemon via Python `AF_UNIX`;
    daemon↔harness via GDScript `StreamPeerUDS`). No TCP, no port scan.
  - **Discovery**: per-project **socket + pidfile** derived deterministically from the
    resolved project root (ADR-0006 precedence), `sun_path`-length-aware.
  - **Wire format**: reuse the ADR-0002 sentinel so classify / parse / emit are unchanged.
  - **Phase-2 live floor = Godot ≥ 4.6** (`StreamPeerUDS` landed in 4.6-stable, verified
    against the real 4.6.3 binary). Amends ADR-0003; the **Phase-1 headless floor stays 4.4**.
  - **Windows / non-UNIX**: live is macOS/Linux only (both legs are `AF_UNIX`/UDS);
    headless is unaffected and cross-platform; live/`daemon` commands fail fast with a
    typed `live_unsupported_platform` error; the future Windows path is the localhost-TCP
    variant (a later ADR/slice), not a redesign.
- **`ADR-0003` amendment note** pointing to ADR-0021 (live layer ≥ 4.6; headless 4.4 unchanged).

Issue **#7** has been reformatted to the `/to-issues` slice template (Parent / What to
build / Acceptance criteria / Blocked by), folding in the resolved decisions, the version
gate, and the Windows guidance/error acceptance criterion. (Issue edits are separate from
this PR's file changes.)

## Why

ADR-0017 fixed the daemon's *mechanism* but left transport/discovery to #7; the UDS-vs-TCP
choice turned out to hinge on a verified fact — the target Godot 4.6.3 binary supports
`StreamPeerUDS` in GDScript — which makes UDS-everywhere viable at the cost of a 4.6 live
floor. The maintainer chose UDS-everywhere + the 4.6 live floor.

## Review

Pre-publish adversarial review (independent subagent) found no blocking issues; its
SHOULD-FIX items (re-include `engine_session_not_running`; make the CLI↔daemon Windows
break explicit; classify `live_unsupported_platform` as `environment`; date/grammar on the
ADR-0003 note) are applied in this branch.

Scope is **docs only** — no code. Implementation follows the approved 7-step tracer-bullet
plan under #7.

Refs #7. Amends ADR-0003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)