### PR TITLE
feat: gda-daemon bootstrap — Phase-2 live operations end-to-end (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,14 @@ for the full picture.
 
 **On the roadmap** (designed, not yet implemented)
 
-- 🔜 `gda-daemon` for *live operations* against a **running game** (Phase 2): runtime scene
-  tree, runtime properties, input simulation, viewport capture, performance/signal monitoring —
-  via `gda daemon` lifecycle commands. Live commands are placed by domain object (a narrow `game`
-  group for the runtime scene graph); the editor context is out of scope. Phase-2 live needs
-  **Godot 4.6+** and is **macOS/Linux only** (it uses Unix domain sockets); Phase-1 headless is
-  unaffected — still 4.4+ and cross-platform. See ADR-0017–0021.
+- 🚧 `gda-daemon` for *live operations* against a **running game** (Phase 2). The **bootstrap
+  has shipped**: `gda daemon start` / `stop` / `status` and the first live op, `gda game tree`
+  (the running game's runtime scene tree), through the daemon. The broader live catalogue —
+  runtime properties, input simulation, viewport capture, performance/signal monitoring — is in
+  progress. Live commands are placed by domain object (a narrow `game` group for the runtime
+  scene graph); the editor context is out of scope. Phase-2 live needs **Godot 4.6+** and is
+  **macOS/Linux only** (it uses Unix domain sockets); Phase-1 headless is unaffected — still
+  4.4+ and cross-platform. See ADR-0017–0021.
 
 **Out of scope for now**
 
@@ -590,7 +592,7 @@ drives a real engine. Everything between the CLI and the runner runs as real cod
 | ----------------- | ------------------------------------------------------------------------- | ------ |
 | **Phase 1** | `gda` serving *headless operations* standalone: `info`, structured errors, `--schema`, and the domain command groups `scene`, `node`, `script`, `project` (incl. static-analysis), `resource`, `export`, `shader`, `theme`. | ✅ Surface complete |
 | **`gda-mcp`** | A thin MCP adapter generated mechanically from `--schema` — first on top of Phase 1, following `gda` forward automatically. | ✅ Shipped |
-| **Phase 2** | `gda` also serving *live operations* through `gda-daemon` and a live *engine session* (requires Godot 4.6+, macOS/Linux only; headless stays 4.4+ and cross-platform — ADR-0021). | 🗓 Planned |
+| **Phase 2** | `gda` also serving *live operations* through `gda-daemon` and a live *engine session* (requires Godot 4.6+, macOS/Linux only; headless stays 4.4+ and cross-platform — ADR-0021). | 🚧 Bootstrap shipped (`gda daemon` + `gda game tree`); live catalogue in progress |
 
 Track progress and proposals on the [issue tracker](https://github.com/aigengame/godot-agent/issues).
 

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -132,6 +132,10 @@ operation, and parse codes the CLI assigns).
 | `invalid_target` | `operation` | `operation` | `4` | A project find-references target is empty or not a valid `res://` path or `class_name`. |
 | `contract_violation` | `parse` | `parser` | `5` | The process claimed success but violated the structured-output contract. |
 | `tree_too_deep` | `parse` | `classifier` | `5` | The engine emitted a valid result tree that nests past gda's recursion limit; the payload is contract-conformant, the limit is wrapper-side (shares the `parse` exit code; the `code` distinguishes it from `contract_violation`). |
+| `daemon_not_running` | `live` | `classifier` | `6` | A live command found no running gda-daemon for the project; start one with `gda daemon start` (Phase 2, ADR-0017 / ADR-0021). |
+| `engine_session_not_running` | `live` | `classifier` | `6` | The daemon is running but holds no live engine session to serve the live operation (Phase 2). |
+| `engine_disconnected` | `live` | `classifier` | `6` | The engine session disconnected before the live operation returned — the game crashed or the harness connection dropped (Phase 2). |
+| `live_timeout` | `live` | `classifier` | `6` | A live operation did not return from the engine session before the daemon's timeout (Phase 2). |
 
 ## Considered options
 

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -136,6 +136,7 @@ operation, and parse codes the CLI assigns).
 | `engine_session_not_running` | `live` | `classifier` | `6` | The daemon is running but holds no live engine session to serve the live operation (Phase 2). |
 | `engine_disconnected` | `live` | `classifier` | `6` | The engine session disconnected before the live operation returned — the game crashed or the harness connection dropped (Phase 2). |
 | `live_timeout` | `live` | `classifier` | `6` | A live operation did not return from the engine session before the daemon's timeout (Phase 2). |
+| `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
 
 ## Considered options
 

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -18,6 +18,17 @@ This ADR fixes that **mechanism and its running-game scope**. It does not enumer
 the live command catalogue, which is delivered incrementally per ADR-0005 and
 tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 
+> **Outcome (2026-06-21, #7 / PR #229) — two scoped narrowings in the bootstrap:**
+> (1) **Session mode.** The bootstrap's only live op is `game tree`, which reads the
+> runtime `SceneTree` and needs no viewport, so its engine session is launched
+> **`--headless`**, not windowed. The "windowed by default" of decision 2 below is for
+> viewport capture; the daemon switches to a **windowed** session when the first
+> capturing op lands (#222), which carries that change. (2) **Launch timing.** The
+> session is **launched lazily on the first live op**, not eagerly at `daemon start` —
+> consistent with this ADR's "(re)launched per feedback-loop iteration"; `daemon start`
+> brings up the persistent daemon and the harness install, and the session follows on
+> demand.
+
 ## Decision
 
 **1. An execution-channel selector, chosen per command by a static `kind`.**

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -455,9 +455,9 @@ lumped into one "live" group. Because the daemon↔harness transport is a Unix d
 socket (ADR-0021), **Phase-2 live requires Godot 4.6+ and is macOS/Linux only**; Phase-1
 headless is unaffected (4.4+, cross-platform).
 
-- **`game` (the running game's scene graph):** live `get` of the runtime scene tree;
-  runtime node property `get`/`set`. The on-disk counterparts stay under `scene` /
-  `node` (ADR-0019).
+- **`game` (the running game's scene graph):** `game tree` reads the runtime scene
+  tree (shipped — the Phase-2 bootstrap tracer, #7); runtime node property `get`/`set`
+  (#220). The on-disk counterparts stay under `scene` / `node` (ADR-0019).
 - **`input` (input simulation):** key / mouse / action / sequence injection into the
   running game; record / replay.
 - **`screen` / capture:** running-game viewport screenshot, multi-frame capture.

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 
 from gda.errors import (
     Failure,
+    classify_game_tree,
     classify_info,
     classify_script_validate,
 )
@@ -40,12 +41,15 @@ from gda.headless import (
     schema_command_class,
     schema_option,
 )
+from gda.live_runner import make_daemon_runner
 from gda.models import (
     EngineVersion,
     ExportGetParams,
     ExportListParams,
     ExportListResult,
     ExportRunMode,
+    GameTreeParams,
+    GameTreeResult,
     InfoParams,
     ProjectDependenciesParams,
     ProjectDependenciesResult,
@@ -211,6 +215,14 @@ theme_app = typer.Typer(
 )
 app.add_typer(theme_app, name="theme")
 
+# The game command group (Phase 2, ADR-0019): the RUNNING game's runtime scene
+# graph, served LIVE through gda-daemon (`kind = LIVE`). `game tree` reads the
+# runtime SceneTree after _ready; the on-disk counterparts stay under `scene` /
+# `node`. It is a domain-object group named after the running game, not a phase
+# group — the headless/live split is carried by `kind`, never by the tree.
+game_app = typer.Typer(help="Act on the running game (live).", no_args_is_help=True)
+app.add_typer(game_app, name="game")
+
 
 def _version_callback(value: Optional[bool]) -> None:
     if value:
@@ -252,6 +264,17 @@ def _make_export_runner(binary: Path, project: Optional[Path]) -> ExportRunner:
     return make_subprocess_export_runner(binary, project)
 
 
+def _make_live_runner(binary: Optional[Path], project: Optional[Path]) -> GodotRunner:
+    """Build the LIVE runner — the per-project gda-daemon IPC client (ADR-0017).
+
+    The ``kind = LIVE`` twin of :func:`_make_runner`, a seam tests override to
+    inject a fake daemon runner. ``binary`` is unused: a live op reaches the
+    running daemon, not a fresh engine, so the daemon (not the CLI) owns the
+    engine session.
+    """
+    return make_daemon_runner(project)
+
+
 def _emit(
     cmd: HeadlessCommand[M],
     params: BaseModel,
@@ -262,18 +285,23 @@ def _emit(
 ) -> None:
     """Drive ``cmd.emit`` with the shared CLI execution tail.
 
-    The sole reference to the runner seam ``_make_runner`` — held here, at call
-    time, so the test monkeypatch on ``gda.cli._make_runner`` still binds rather
-    than being frozen as a def-time default. Both the domain dispatch
+    Selects the runner seam by the command's execution channel ``kind`` (ADR-0017):
+    a ``LIVE`` command goes through :func:`_make_live_runner` (the daemon IPC
+    client), every other through :func:`_make_runner`. Both seams are referenced
+    here at call time, so a test monkeypatch on ``gda.cli._make_runner`` /
+    ``gda.cli._make_live_runner`` still binds. Both the domain dispatch
     (:func:`_dispatch`) and the meta dispatch (:func:`_dispatch_meta`) funnel
     through here; they differ only in how ``project`` is obtained.
     """
+    make_runner = (
+        _make_live_runner if cmd.kind is ExecutionKind.LIVE else _make_runner
+    )
     cmd.emit(
         params,
         godot=godot,
         project=project,
         json_output=json_output,
-        make_runner=_make_runner,
+        make_runner=make_runner,
     )
 
 
@@ -383,6 +411,39 @@ INFO_COMMAND: HeadlessCommand[EngineVersion] = HeadlessCommand(
     output_model=EngineVersion,
     classify=classify_info,
 )
+
+GAME_TREE_COMMAND: HeadlessCommand[GameTreeResult] = HeadlessCommand(
+    operation="game-tree",
+    input_model=GameTreeParams,
+    output_model=GameTreeResult,
+    classify=classify_game_tree,
+    kind=ExecutionKind.LIVE,
+)
+
+
+@game_app.command(name="tree", cls=GAME_TREE_COMMAND.command_class())
+def game_tree(
+    json_output: bool = json_option(),
+    schema: bool = GAME_TREE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Read the running game's runtime scene tree (live).
+
+    Routes through gda-daemon to the engine session it holds (kind = LIVE,
+    ADR-0017): the runtime SceneTree after _ready and dynamic instantiation,
+    distinct from the on-disk .tscn read by `scene get` (ADR-0019). With no
+    running daemon it reports the typed `daemon_not_running` error naming the
+    remediation (`gda daemon start`).
+    """
+    _dispatch(
+        GAME_TREE_COMMAND,
+        GameTreeParams(),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+    )
 
 SCENE_CREATE_COMMAND: HeadlessCommand[SceneCreateResult] = HeadlessCommand(
     operation="scene-create",

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -14,6 +14,11 @@ from typing import Optional
 import typer
 from pydantic import BaseModel
 
+from gda.daemon_ops import (
+    run_daemon_start_operation,
+    run_daemon_status_operation,
+    run_daemon_stop_operation,
+)
 from gda.errors import (
     Failure,
     classify_game_tree,
@@ -43,6 +48,12 @@ from gda.headless import (
 )
 from gda.live_runner import make_daemon_runner
 from gda.models import (
+    DaemonStartParams,
+    DaemonStartResult,
+    DaemonStatusParams,
+    DaemonStatusResult,
+    DaemonStopParams,
+    DaemonStopResult,
     EngineVersion,
     ExportGetParams,
     ExportListParams,
@@ -223,6 +234,14 @@ app.add_typer(theme_app, name="theme")
 game_app = typer.Typer(help="Act on the running game (live).", no_args_is_help=True)
 app.add_typer(game_app, name="game")
 
+# The daemon command group (Phase 2, ADR-0017): gda's own per-project daemon
+# lifecycle — a deliberate extension of ADR-0005's domain-object grouping to an
+# infrastructure object (gda-daemon), not a top-level meta singleton. start /
+# stop / status manage the daemon PROCESS, so — like `export run` — they run a
+# recipe (gda.daemon_ops) rather than the sentinel pipeline.
+daemon_app = typer.Typer(help="Manage the per-project gda-daemon.", no_args_is_help=True)
+app.add_typer(daemon_app, name="daemon")
+
 
 def _version_callback(value: Optional[bool]) -> None:
     if value:
@@ -390,6 +409,14 @@ def _run_params_json(
             emit_failure(outcome)
         emit_result(outcome, json_output)
         return
+    if cmd in _DAEMON_COMMANDS:
+        # daemon lifecycle commands run their process recipe (gda.daemon_ops),
+        # not the sentinel pipeline; route --params-json to the SAME recipe the
+        # argv body uses (their params are empty, so nothing else is needed).
+        _daemon_dispatch(
+            cmd, json_output=json_output, godot=godot, project=options.get("project")
+        )
+        return
     if "project" in options:
         _dispatch(
             cmd,
@@ -443,6 +470,101 @@ def game_tree(
         json_output=json_output,
         godot=godot,
         project=project,
+    )
+
+
+DAEMON_START_COMMAND: HeadlessCommand[DaemonStartResult] = HeadlessCommand(
+    operation="daemon-start",
+    input_model=DaemonStartParams,
+    output_model=DaemonStartResult,
+)
+
+DAEMON_STOP_COMMAND: HeadlessCommand[DaemonStopResult] = HeadlessCommand(
+    operation="daemon-stop",
+    input_model=DaemonStopParams,
+    output_model=DaemonStopResult,
+)
+
+DAEMON_STATUS_COMMAND: HeadlessCommand[DaemonStatusResult] = HeadlessCommand(
+    operation="daemon-status",
+    input_model=DaemonStatusParams,
+    output_model=DaemonStatusResult,
+)
+
+# The daemon lifecycle commands run a process-management recipe (gda.daemon_ops),
+# not the sentinel pipeline — the same shape as `export run`. They carry no Godot
+# execution channel, so they are routed by command identity, shared by the argv
+# bodies and the --params-json path so both forms drive the SAME recipe.
+_DAEMON_COMMANDS = frozenset(
+    {DAEMON_START_COMMAND, DAEMON_STOP_COMMAND, DAEMON_STATUS_COMMAND}
+)
+
+
+def _daemon_dispatch(
+    cmd: HeadlessCommand[M],
+    *,
+    json_output: bool,
+    godot: Optional[str],
+    project: Optional[str],
+) -> None:
+    """Run a ``daemon`` lifecycle command through its process-management recipe."""
+    resolved = resolve_project_dir(project)
+    if cmd is DAEMON_START_COMMAND:
+        outcome = run_daemon_start_operation(resolved, godot)
+    elif cmd is DAEMON_STOP_COMMAND:
+        outcome = run_daemon_stop_operation(resolved)
+    else:
+        outcome = run_daemon_status_operation(resolved)
+    if isinstance(outcome, Failure):
+        emit_failure(outcome)
+    emit_result(outcome, json_output)
+
+
+@daemon_app.command(name="start", cls=DAEMON_START_COMMAND.command_class())
+def daemon_start(
+    json_output: bool = json_option(),
+    schema: bool = DAEMON_START_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Start the per-project gda-daemon (idempotent), installing the harness.
+
+    Brings up the live context: a long-lived, per-project daemon, after a reported
+    idempotent harness install (ADR-0018). Never auto-spawned by a live call —
+    launching the engine is a deliberate, declared effect (ADR-0017). Live is
+    UNIX-only and needs Godot 4.6+ (ADR-0021).
+    """
+    _daemon_dispatch(
+        DAEMON_START_COMMAND, json_output=json_output, godot=godot, project=project
+    )
+
+
+@daemon_app.command(name="stop", cls=DAEMON_STOP_COMMAND.command_class())
+def daemon_stop(
+    json_output: bool = json_option(),
+    schema: bool = DAEMON_STOP_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Stop the per-project gda-daemon (a no-op if none is running)."""
+    _daemon_dispatch(
+        DAEMON_STOP_COMMAND, json_output=json_output, godot=godot, project=project
+    )
+
+
+@daemon_app.command(name="status", cls=DAEMON_STATUS_COMMAND.command_class())
+def daemon_status(
+    json_output: bool = json_option(),
+    schema: bool = DAEMON_STATUS_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Report whether a per-project gda-daemon is running."""
+    _daemon_dispatch(
+        DAEMON_STATUS_COMMAND, json_output=json_output, godot=godot, project=project
     )
 
 SCENE_CREATE_COMMAND: HeadlessCommand[SceneCreateResult] = HeadlessCommand(

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -19,6 +19,7 @@ from gda.errors import (
     classify_info,
     classify_script_validate,
 )
+from gda.execution import ExecutionKind
 from gda.export_run import (
     EXPORT_GET_COMMAND,
     EXPORT_RUN_COMMAND,
@@ -341,9 +342,10 @@ def _run_params_json(
     options = ctx.params
     json_output = bool(options.get("json_output", False))
     godot = options.get("godot")
-    if cmd is EXPORT_RUN_COMMAND:
+    if cmd.kind is ExecutionKind.EXPORT:
         # export run is the native-export recipe (#187), not the sentinel
-        # pipeline, so it cannot go through cmd.emit. Mirror its body so
+        # pipeline, so it cannot go through cmd.emit. Selected by its static
+        # execution channel (ADR-0017), not command identity. Mirror its body so
         # --params-json drives the SAME run_export_operation path as the argv
         # form. params.output is already normalized (ExportRunParams.output is a
         # NormalizedPath), so no extra normalization is needed here.

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -231,7 +231,10 @@ app.add_typer(theme_app, name="theme")
 # runtime SceneTree after _ready; the on-disk counterparts stay under `scene` /
 # `node`. It is a domain-object group named after the running game, not a phase
 # group — the headless/live split is carried by `kind`, never by the tree.
-game_app = typer.Typer(help="Act on the running game (live).", no_args_is_help=True)
+game_app = typer.Typer(
+    help="Act on the running game (live; macOS/Linux only, needs `gda daemon start`).",
+    no_args_is_help=True,
+)
 app.add_typer(game_app, name="game")
 
 # The daemon command group (Phase 2, ADR-0017): gda's own per-project daemon
@@ -239,7 +242,10 @@ app.add_typer(game_app, name="game")
 # infrastructure object (gda-daemon), not a top-level meta singleton. start /
 # stop / status manage the daemon PROCESS, so — like `export run` — they run a
 # recipe (gda.daemon_ops) rather than the sentinel pipeline.
-daemon_app = typer.Typer(help="Manage the per-project gda-daemon.", no_args_is_help=True)
+daemon_app = typer.Typer(
+    help="Manage the per-project gda-daemon (live ops; macOS/Linux only, Godot 4.6+).",
+    no_args_is_help=True,
+)
 app.add_typer(daemon_app, name="daemon")
 
 
@@ -460,9 +466,10 @@ def game_tree(
 
     Routes through gda-daemon to the engine session it holds (kind = LIVE,
     ADR-0017): the runtime SceneTree after _ready and dynamic instantiation,
-    distinct from the on-disk .tscn read by `scene get` (ADR-0019). With no
-    running daemon it reports the typed `daemon_not_running` error naming the
-    remediation (`gda daemon start`).
+    distinct from the on-disk .tscn read by `scene get` (ADR-0019). Live ops are
+    macOS/Linux only (Unix domain sockets) and need a running daemon: with none,
+    it reports the typed `daemon_not_running` error naming the remediation
+    (`gda daemon start`); on a non-UNIX platform, `live_unsupported_platform`.
     """
     _dispatch(
         GAME_TREE_COMMAND,

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -555,7 +555,11 @@ def daemon_stop(
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Stop the per-project gda-daemon (a no-op if none is running)."""
+    """Stop the per-project gda-daemon (a no-op if none is running).
+
+    Live operations are macOS/Linux only (Unix domain sockets); on a non-UNIX
+    platform this reports `live_unsupported_platform`.
+    """
     _daemon_dispatch(
         DAEMON_STOP_COMMAND, json_output=json_output, godot=godot, project=project
     )
@@ -569,7 +573,11 @@ def daemon_status(
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Report whether a per-project gda-daemon is running."""
+    """Report whether a per-project gda-daemon is running.
+
+    Live operations are macOS/Linux only (Unix domain sockets); on a non-UNIX
+    platform this reports `live_unsupported_platform`.
+    """
     _daemon_dispatch(
         DAEMON_STATUS_COMMAND, json_output=json_output, godot=godot, project=project
     )

--- a/src/gda/daemon/__init__.py
+++ b/src/gda/daemon/__init__.py
@@ -1,0 +1,6 @@
+"""gda-daemon: the per-project supervisor + IPC broker for live operations.
+
+A long-lived, per-project process that holds a transient engine session and
+serves live operations over a Unix domain socket (ADR-0017, ADR-0021). This
+package is the daemon's own runtime, distinct from the one-shot CLI.
+"""

--- a/src/gda/daemon/__main__.py
+++ b/src/gda/daemon/__main__.py
@@ -16,13 +16,13 @@ from gda.daemon.server import DaemonServer
 def main() -> None:
     parser = argparse.ArgumentParser(prog="gda.daemon")
     parser.add_argument("--project", required=True, help="The project root to serve.")
-    # Accepted for forward-compatibility with the engine-session slice; unused here.
-    parser.add_argument("--godot", default="")
-    parser.add_argument("--token", default="")
+    parser.add_argument(
+        "--godot", default="", help="The resolved Godot binary for engine sessions."
+    )
     args = parser.parse_args()
 
     paths = daemon_paths(Path(args.project))
-    DaemonServer(paths).serve()
+    DaemonServer(paths, godot=args.godot).serve()
 
 
 if __name__ == "__main__":

--- a/src/gda/daemon/__main__.py
+++ b/src/gda/daemon/__main__.py
@@ -1,0 +1,29 @@
+"""``python -m gda.daemon``: the detached per-project daemon entry (ADR-0017).
+
+``gda daemon start`` spawns this in its own session (detached from the one-shot
+CLI). It derives the per-project paths the same way the CLI does — same
+``GDA_PROJECT``/env, so it binds the very socket the CLI will connect to — and
+runs the server loop until stopped.
+"""
+
+import argparse
+from pathlib import Path
+
+from gda.daemon.discovery import daemon_paths
+from gda.daemon.server import DaemonServer
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="gda.daemon")
+    parser.add_argument("--project", required=True, help="The project root to serve.")
+    # Accepted for forward-compatibility with the engine-session slice; unused here.
+    parser.add_argument("--godot", default="")
+    parser.add_argument("--token", default="")
+    args = parser.parse_args()
+
+    paths = daemon_paths(Path(args.project))
+    DaemonServer(paths).serve()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gda/daemon/discovery.py
+++ b/src/gda/daemon/discovery.py
@@ -99,10 +99,28 @@ def ensure_runtime_dir(paths: DaemonPaths) -> Path:
     return paths.runtime_dir
 
 
-def write_pidfile(paths: DaemonPaths, pid: int) -> None:
-    """Record ``pid`` and the canonical project path for liveness/foreign checks."""
+def acquire_pidfile(paths: DaemonPaths, pid: int):
+    """Open + advisory-lock the pidfile, record ``pid`` + canonical path; return the held handle.
+
+    The daemon keeps the returned file open for its whole lifetime so the ``flock``
+    is *held* — that held lock IS the liveness signal (ADR-0021): a held lock means
+    a live daemon, a grabbable lock means a crashed/stale one, with no reliance on
+    ``os.kill`` PID-liveness (which a reused PID could spoof). The OS releases the
+    lock when the daemon exits or crashes, so liveness self-heals with no cleanup.
+    Raises ``OSError`` if another live daemon already holds it (a start race).
+    """
+    import fcntl
+
     ensure_runtime_dir(paths)
-    paths.pidfile.write_text(f"{pid}\n{paths.project}\n", encoding="utf-8")
+    handle = open(paths.pidfile, "w", encoding="utf-8")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        handle.close()
+        raise
+    handle.write(f"{pid}\n{paths.project}\n")
+    handle.flush()
+    return handle
 
 
 def read_pidfile(paths: DaemonPaths) -> tuple[int, Path] | None:
@@ -117,28 +135,34 @@ def read_pidfile(paths: DaemonPaths) -> tuple[int, Path] | None:
     return int(lines[0].strip()), Path(lines[1].strip())
 
 
-def _pid_alive(pid: int) -> bool:
-    if pid <= 0:
+def _pidfile_lock_held(pidfile: Path) -> bool:
+    """Whether the pidfile's advisory lock is currently held by a live daemon."""
+    import fcntl
+
+    try:
+        probe = open(pidfile, "r", encoding="utf-8")
+    except FileNotFoundError:
         return False
     try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False  # no such process — stale
-    except PermissionError:
-        return True  # alive, owned by another user
+        fcntl.flock(probe.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError:
+        return True  # could not grab it -> held by a live daemon
+    else:
+        fcntl.flock(probe.fileno(), fcntl.LOCK_UN)  # we grabbed it -> stale; release
         return False
-    return True
+    finally:
+        probe.close()
 
 
 def daemon_pid(paths: DaemonPaths) -> int | None:
-    """The pid of a LIVE daemon for THIS project, or ``None``.
+    """The pid of a LIVE daemon for THIS project, or ``None`` (ADR-0021).
 
-    ``None`` when there is no pidfile, it is malformed, the recorded process is
-    dead (**stale**), or the recorded project path differs from this project
-    (**foreign** — a hash collision or a reused runtime slot). ``daemon start``
-    reclaims a stale slot; ``daemon status`` and a live command's attach read this
-    as not-running (``daemon_not_running``).
+    Live requires all three: the pidfile's recorded project **matches** this
+    project (else *foreign* — a hash collision / reused slot), the CLI socket is
+    **bound** (present), and the pidfile's advisory lock is **held** (a grabbable
+    lock means a crashed/stale daemon). So a reused PID or a stale socket is never
+    mistaken for a live daemon. ``daemon start`` reclaims a stale slot; ``status``
+    and a live command's attach read this as not-running.
     """
     info = read_pidfile(paths)
     if info is None:
@@ -146,6 +170,8 @@ def daemon_pid(paths: DaemonPaths) -> int | None:
     pid, recorded = info
     if recorded != paths.project:
         return None  # foreign
-    if not _pid_alive(pid):
-        return None  # stale
+    if not paths.cli_socket.exists():
+        return None  # not bound -> stale
+    if not _pidfile_lock_held(paths.pidfile):
+        return None  # grabbable -> crashed/stale
     return pid

--- a/src/gda/daemon/discovery.py
+++ b/src/gda/daemon/discovery.py
@@ -1,0 +1,151 @@
+"""Per-project gda-daemon discovery (ADR-0021).
+
+The CLI and the ``daemon`` lifecycle commands locate a project's daemon by
+deriving deterministic socket and pidfile paths from the **canonical** project
+root, under a short, private (``0700``) per-user runtime directory. The
+derivation is a fixed contract so ``daemon start``, ``daemon status``, and a live
+command's attach all agree on one daemon identity (ADR-0021):
+
+- the project root is canonicalized (symlinks resolved) before derivation, so two
+  references to one project derive one identity and two projects never collide;
+- the socket/pidfile basenames are a stable hash of that canonical path;
+- the runtime directory is ``$XDG_RUNTIME_DIR/gda`` when set (Linux), else
+  ``~/.gda/run`` — both short, to respect the UDS ``sun_path`` length limit;
+- the pidfile records the canonical project path, so a hash collision or a reused
+  runtime slot is detectable (a recorded path that differs is *foreign*, not a
+  hit) and liveness can be probed without a false match.
+
+This module is pure (paths + filesystem reads); the daemon process that binds the
+sockets and reclaims stale slots lives in :mod:`gda.daemon.server` (a later slice).
+"""
+
+import hashlib
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+# The private runtime directory the sockets/pidfile live in. Kept short so the
+# absolute socket path stays under the OS ``sun_path`` limit (104 bytes on macOS,
+# 108 on Linux); the long macOS ``$TMPDIR`` is deliberately never used.
+XDG_RUNTIME_ENV = "XDG_RUNTIME_DIR"
+RUNTIME_SUBDIR = "gda"
+HOME_RUNTIME_DIR = "~/.gda/run"
+
+# Conservative UDS path bound (macOS ``sun_path`` is 104 bytes); a derived socket
+# longer than this would fail to bind, so we surface it as a clear error here.
+UDS_PATH_MAX = 104
+
+
+@dataclass(frozen=True)
+class DaemonPaths:
+    """The per-project daemon's on-disk identity (ADR-0021)."""
+
+    project: Path  # the canonical (symlink-resolved) project root
+    runtime_dir: Path  # the private 0700 directory the files live in
+    cli_socket: Path  # CLI <-> daemon UDS
+    harness_socket: Path  # daemon <-> harness UDS (path injected into the session)
+    pidfile: Path  # liveness + the recorded canonical project path
+
+
+def _runtime_dir(env: Mapping[str, str]) -> Path:
+    xdg = env.get(XDG_RUNTIME_ENV)
+    if xdg:
+        return Path(xdg) / RUNTIME_SUBDIR
+    return Path(HOME_RUNTIME_DIR).expanduser()
+
+
+def _project_slug(canonical_project: Path) -> str:
+    # A stable, short hash of the canonical absolute path: same project -> same
+    # slug, different projects -> different slugs. The full path is recorded in
+    # the pidfile, so the (astronomically unlikely) collision is still detectable.
+    return hashlib.sha256(str(canonical_project).encode("utf-8")).hexdigest()[:16]
+
+
+def within_uds_limit(socket_path: Path) -> bool:
+    """Whether ``socket_path`` fits the OS ``sun_path`` limit so it can bind.
+
+    Pure derivation never raises on length (so it is testable under any tmp dir);
+    the daemon checks this before binding and surfaces a clear error instead of an
+    opaque bind failure (ADR-0021). The default runtime dirs are short enough that
+    this only ever trips on an unusually long ``$XDG_RUNTIME_DIR``.
+    """
+    return len(str(socket_path)) <= UDS_PATH_MAX
+
+
+def daemon_paths(project: Path, env: Mapping[str, str] | None = None) -> DaemonPaths:
+    """Derive the per-project daemon paths from ``project`` (ADR-0021)."""
+    env = os.environ if env is None else env
+    canonical = Path(project).expanduser().resolve()
+    runtime = _runtime_dir(env)
+    slug = _project_slug(canonical)
+    return DaemonPaths(
+        project=canonical,
+        runtime_dir=runtime,
+        cli_socket=runtime / f"{slug}.cli.sock",
+        harness_socket=runtime / f"{slug}.harness.sock",
+        pidfile=runtime / f"{slug}.pid",
+    )
+
+
+def ensure_runtime_dir(paths: DaemonPaths) -> Path:
+    """Create the private (``0700``) runtime directory, returning it.
+
+    Owner-only so the socket is never in a world-reachable directory — the "no
+    other-user surface" half of ADR-0021's "no localhost surface".
+    """
+    paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(paths.runtime_dir, 0o700)
+    return paths.runtime_dir
+
+
+def write_pidfile(paths: DaemonPaths, pid: int) -> None:
+    """Record ``pid`` and the canonical project path for liveness/foreign checks."""
+    ensure_runtime_dir(paths)
+    paths.pidfile.write_text(f"{pid}\n{paths.project}\n", encoding="utf-8")
+
+
+def read_pidfile(paths: DaemonPaths) -> tuple[int, Path] | None:
+    """Parse the pidfile into ``(pid, recorded_project)``, or ``None`` if absent/malformed."""
+    try:
+        text = paths.pidfile.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    lines = text.splitlines()
+    if len(lines) < 2 or not lines[0].strip().isdigit():
+        return None
+    return int(lines[0].strip()), Path(lines[1].strip())
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False  # no such process — stale
+    except PermissionError:
+        return True  # alive, owned by another user
+    except OSError:
+        return False
+    return True
+
+
+def daemon_pid(paths: DaemonPaths) -> int | None:
+    """The pid of a LIVE daemon for THIS project, or ``None``.
+
+    ``None`` when there is no pidfile, it is malformed, the recorded process is
+    dead (**stale**), or the recorded project path differs from this project
+    (**foreign** — a hash collision or a reused runtime slot). ``daemon start``
+    reclaims a stale slot; ``daemon status`` and a live command's attach read this
+    as not-running (``daemon_not_running``).
+    """
+    info = read_pidfile(paths)
+    if info is None:
+        return None
+    pid, recorded = info
+    if recorded != paths.project:
+        return None  # foreign
+    if not _pid_alive(pid):
+        return None  # stale
+    return pid

--- a/src/gda/daemon/protocol.py
+++ b/src/gda/daemon/protocol.py
@@ -1,0 +1,46 @@
+"""Length-prefixed JSON framing for the daemon's IPC legs (ADR-0021).
+
+Both the CLI↔daemon and (in a later slice) daemon↔harness legs exchange JSON
+objects over a stream socket. A message is a 4-byte big-endian length prefix
+followed by that many UTF-8 JSON bytes, so two messages sent back-to-back on one
+connection stay distinct. The daemon↔harness *response* body carries the raw
+ADR-0002 sentinel string, so the existing parser is reused unchanged.
+"""
+
+import json
+import socket
+import struct
+from typing import Any
+
+_LENGTH = struct.Struct(">I")  # 4-byte big-endian frame length
+
+
+def write_message(sock: socket.socket, obj: Any) -> None:
+    """Send ``obj`` as one length-prefixed JSON frame."""
+    body = json.dumps(obj).encode("utf-8")
+    sock.sendall(_LENGTH.pack(len(body)) + body)
+
+
+def read_message(sock: socket.socket) -> Any | None:
+    """Read one length-prefixed JSON frame, or ``None`` if the peer closed."""
+    header = _recv_exactly(sock, _LENGTH.size)
+    if header is None:
+        return None
+    (length,) = _LENGTH.unpack(header)
+    body = _recv_exactly(sock, length)
+    if body is None:
+        return None
+    return json.loads(body.decode("utf-8"))
+
+
+def _recv_exactly(sock: socket.socket, count: int) -> bytes | None:
+    """Read exactly ``count`` bytes, or ``None`` if the peer closed mid-frame."""
+    chunks: list[bytes] = []
+    remaining = count
+    while remaining > 0:
+        chunk = sock.recv(remaining)
+        if not chunk:
+            return None
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)

--- a/src/gda/daemon/protocol.py
+++ b/src/gda/daemon/protocol.py
@@ -1,10 +1,10 @@
-"""Length-prefixed JSON framing for the daemon's IPC legs (ADR-0021).
+"""Length-prefixed framing for the daemon's IPC legs (ADR-0021).
 
-Both the CLI↔daemon and (in a later slice) daemon↔harness legs exchange JSON
-objects over a stream socket. A message is a 4-byte big-endian length prefix
-followed by that many UTF-8 JSON bytes, so two messages sent back-to-back on one
-connection stay distinct. The daemon↔harness *response* body carries the raw
-ADR-0002 sentinel string, so the existing parser is reused unchanged.
+A frame is a 4-byte big-endian length prefix followed by that many payload bytes,
+so messages sent back-to-back on one connection stay distinct. The CLI↔daemon leg
+and the daemon→harness *request* carry JSON (``write_message`` / ``read_message``);
+the harness→daemon *response* carries the raw ADR-0002 sentinel string as bytes
+(``write_frame`` / ``read_frame``), so the existing parser is reused unchanged.
 """
 
 import json
@@ -15,19 +15,28 @@ from typing import Any
 _LENGTH = struct.Struct(">I")  # 4-byte big-endian frame length
 
 
-def write_message(sock: socket.socket, obj: Any) -> None:
-    """Send ``obj`` as one length-prefixed JSON frame."""
-    body = json.dumps(obj).encode("utf-8")
-    sock.sendall(_LENGTH.pack(len(body)) + body)
+def write_frame(sock: socket.socket, payload: bytes) -> None:
+    """Send ``payload`` as one length-prefixed frame."""
+    sock.sendall(_LENGTH.pack(len(payload)) + payload)
 
 
-def read_message(sock: socket.socket) -> Any | None:
-    """Read one length-prefixed JSON frame, or ``None`` if the peer closed."""
+def read_frame(sock: socket.socket) -> bytes | None:
+    """Read one length-prefixed frame's payload, or ``None`` if the peer closed."""
     header = _recv_exactly(sock, _LENGTH.size)
     if header is None:
         return None
     (length,) = _LENGTH.unpack(header)
-    body = _recv_exactly(sock, length)
+    return _recv_exactly(sock, length)
+
+
+def write_message(sock: socket.socket, obj: Any) -> None:
+    """Send ``obj`` as one length-prefixed JSON frame."""
+    write_frame(sock, json.dumps(obj).encode("utf-8"))
+
+
+def read_message(sock: socket.socket) -> Any | None:
+    """Read one length-prefixed JSON frame, or ``None`` if the peer closed."""
+    body = read_frame(sock)
     if body is None:
         return None
     return json.loads(body.decode("utf-8"))

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -1,0 +1,118 @@
+"""The gda-daemon server: the per-project Unix-domain-socket broker (ADR-0017).
+
+A long-lived process that binds the project's CLI socket, records its pidfile,
+and serves one request at a time off the socket — single-writer serialization of
+live operations against the session it holds (ADR-0020). Two control ops manage
+its lifetime (``__status__`` liveness, ``__stop__`` graceful shutdown); any other
+op is a project live op.
+
+This slice (the daemon bootstrap, 6a) holds **no** engine session yet, so a live
+op returns ``engine_session_not_running`` through the normal ADR-0002 sentinel
+reply; launching and brokering the session is the next slice.
+"""
+
+import json
+import os
+import signal
+import socket
+
+from gda.daemon.discovery import DaemonPaths, ensure_runtime_dir, write_pidfile
+from gda.daemon.protocol import read_message, write_message
+from gda.exit_codes import EXIT_LIVE
+from gda.parser import RESULT_BEGIN, RESULT_END
+
+# Control ops on the CLI socket — daemon lifetime, not project domain ops.
+STATUS_OP = "__status__"
+STOP_OP = "__stop__"
+
+
+class DaemonServer:
+    """Binds the per-project CLI socket and serves requests until stopped."""
+
+    def __init__(self, paths: DaemonPaths) -> None:
+        self.paths = paths
+        self._stopping = False
+        self._listener: socket.socket | None = None
+
+    def serve(self) -> None:
+        ensure_runtime_dir(self.paths)
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        # Reclaim a stale socket a crashed predecessor may have left bound.
+        try:
+            os.unlink(self.paths.cli_socket)
+        except FileNotFoundError:
+            pass
+        listener.bind(str(self.paths.cli_socket))
+        listener.listen()
+        self._listener = listener
+        write_pidfile(self.paths, os.getpid())
+
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            signal.signal(sig, self._on_signal)
+
+        try:
+            self._accept_loop()
+        finally:
+            self._cleanup()
+
+    def _on_signal(self, signum: int, frame: object) -> None:
+        # Closing the listener unblocks a pending accept(); the loop then exits.
+        self._stopping = True
+        if self._listener is not None:
+            self._listener.close()
+
+    def _accept_loop(self) -> None:
+        assert self._listener is not None
+        while not self._stopping:
+            try:
+                conn, _ = self._listener.accept()
+            except OSError:
+                break  # listener closed by a signal
+            with conn:
+                request = read_message(conn)
+                if request is not None:
+                    reply = self._handle(request)
+                    if reply is not None:
+                        write_message(conn, reply)
+            if self._stopping:
+                break
+
+    def _handle(self, request: dict) -> dict | None:
+        op = request.get("op")
+        if op == STATUS_OP:
+            return {"ok": True, "pid": os.getpid()}
+        if op == STOP_OP:
+            self._stopping = True
+            return {"ok": True, "pid": os.getpid()}
+        # A project live op. No engine session is held in this slice, so report it
+        # through the normal sentinel pipeline (classify_live maps the code).
+        return _op_error_reply(
+            "engine_session_not_running",
+            "the gda-daemon holds no live engine session yet",
+        )
+
+    def _cleanup(self) -> None:
+        if self._listener is not None:
+            try:
+                self._listener.close()
+            except OSError:
+                pass
+        for path in (
+            self.paths.cli_socket,
+            self.paths.harness_socket,
+            self.paths.pidfile,
+        ):
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+
+
+def _op_error_reply(code: str, message: str) -> dict:
+    """A CLI reply carrying a LIVE error envelope as the ADR-0002 sentinel payload."""
+    body = json.dumps({"error": {"code": code, "message": message}})
+    return {
+        "stdout": f"{RESULT_BEGIN}{body}{RESULT_END}\n",
+        "stderr": "",
+        "exit_code": EXIT_LIVE,
+    }

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -14,7 +14,7 @@ import secrets
 import signal
 import socket
 
-from gda.daemon.discovery import DaemonPaths, ensure_runtime_dir, write_pidfile
+from gda.daemon.discovery import DaemonPaths, acquire_pidfile, ensure_runtime_dir
 from gda.daemon.protocol import read_message, write_message
 from gda.daemon.session import EngineSession, launch_session
 from gda.exit_codes import EXIT_LIVE
@@ -36,12 +36,16 @@ class DaemonServer:
         self._listener: socket.socket | None = None
         self._harness_listener: socket.socket | None = None
         self._session: EngineSession | None = None
+        self._pidfile_handle = None
 
     def serve(self) -> None:
         ensure_runtime_dir(self.paths)
         self._listener = self._bind(self.paths.cli_socket)
         self._harness_listener = self._bind(self.paths.harness_socket)
-        write_pidfile(self.paths, os.getpid())
+        # Hold the pidfile's advisory lock for our lifetime — that held lock is the
+        # liveness signal the CLI keys on (ADR-0021); bind first so the socket is
+        # present before we are reported live.
+        self._pidfile_handle = acquire_pidfile(self.paths, os.getpid())
 
         for sig in (signal.SIGTERM, signal.SIGINT):
             signal.signal(sig, self._on_signal)
@@ -123,6 +127,11 @@ class DaemonServer:
     def _cleanup(self) -> None:
         if self._session is not None:
             self._session.close()
+        if self._pidfile_handle is not None:
+            try:
+                self._pidfile_handle.close()  # releases the advisory lock
+            except OSError:
+                pass
         for sock in (self._listener, self._harness_listener):
             if sock is not None:
                 try:

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -1,23 +1,22 @@
 """The gda-daemon server: the per-project Unix-domain-socket broker (ADR-0017).
 
-A long-lived process that binds the project's CLI socket, records its pidfile,
-and serves one request at a time off the socket — single-writer serialization of
-live operations against the session it holds (ADR-0020). Two control ops manage
-its lifetime (``__status__`` liveness, ``__stop__`` graceful shutdown); any other
-op is a project live op.
-
-This slice (the daemon bootstrap, 6a) holds **no** engine session yet, so a live
-op returns ``engine_session_not_running`` through the normal ADR-0002 sentinel
-reply; launching and brokering the session is the next slice.
+A long-lived process that binds the project's CLI socket (for the CLI) and harness
+socket (for the engine session's harness), records its pidfile, and serves one
+request at a time — single-writer serialization of live operations against the one
+session it holds (ADR-0020). Two control ops manage its lifetime (``__status__``
+liveness, ``__stop__`` graceful shutdown); any other op is a project live op,
+served by the engine session, which is (re)launched lazily on demand.
 """
 
 import json
 import os
+import secrets
 import signal
 import socket
 
 from gda.daemon.discovery import DaemonPaths, ensure_runtime_dir, write_pidfile
 from gda.daemon.protocol import read_message, write_message
+from gda.daemon.session import EngineSession, launch_session
 from gda.exit_codes import EXIT_LIVE
 from gda.parser import RESULT_BEGIN, RESULT_END
 
@@ -27,24 +26,21 @@ STOP_OP = "__stop__"
 
 
 class DaemonServer:
-    """Binds the per-project CLI socket and serves requests until stopped."""
+    """Binds the per-project sockets and serves requests until stopped."""
 
-    def __init__(self, paths: DaemonPaths) -> None:
+    def __init__(self, paths: DaemonPaths, godot: str = "") -> None:
         self.paths = paths
+        self.godot = godot
+        self._token = secrets.token_hex(16)
         self._stopping = False
         self._listener: socket.socket | None = None
+        self._harness_listener: socket.socket | None = None
+        self._session: EngineSession | None = None
 
     def serve(self) -> None:
         ensure_runtime_dir(self.paths)
-        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        # Reclaim a stale socket a crashed predecessor may have left bound.
-        try:
-            os.unlink(self.paths.cli_socket)
-        except FileNotFoundError:
-            pass
-        listener.bind(str(self.paths.cli_socket))
-        listener.listen()
-        self._listener = listener
+        self._listener = self._bind(self.paths.cli_socket)
+        self._harness_listener = self._bind(self.paths.harness_socket)
         write_pidfile(self.paths, os.getpid())
 
         for sig in (signal.SIGTERM, signal.SIGINT):
@@ -54,6 +50,18 @@ class DaemonServer:
             self._accept_loop()
         finally:
             self._cleanup()
+
+    @staticmethod
+    def _bind(path) -> socket.socket:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        # Reclaim a stale socket a crashed predecessor may have left bound.
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        sock.bind(str(path))
+        sock.listen()
+        return sock
 
     def _on_signal(self, signum: int, frame: object) -> None:
         # Closing the listener unblocks a pending accept(); the loop then exits.
@@ -84,19 +92,43 @@ class DaemonServer:
         if op == STOP_OP:
             self._stopping = True
             return {"ok": True, "pid": os.getpid()}
-        # A project live op. No engine session is held in this slice, so report it
-        # through the normal sentinel pipeline (classify_live maps the code).
-        return _op_error_reply(
-            "engine_session_not_running",
-            "the gda-daemon holds no live engine session yet",
+        # A project live op. Serialized against the one session (single writer).
+        session = self._ensure_session()
+        if session is None:
+            return _op_error_reply(
+                "engine_session_not_running",
+                "the gda-daemon could not launch an engine session (no Godot binary, "
+                "or the harness did not connect)",
+            )
+        return session.request(op, request.get("params", {}))
+
+    def _ensure_session(self) -> EngineSession | None:
+        if self._session is not None and self._session.alive():
+            return self._session
+        if self._session is not None:
+            self._session.close()
+            self._session = None
+        if not self.godot:
+            return None
+        assert self._harness_listener is not None
+        self._session = launch_session(
+            self.paths.project,
+            self.godot,
+            self._harness_listener,
+            self.paths.harness_socket,
+            self._token,
         )
+        return self._session
 
     def _cleanup(self) -> None:
-        if self._listener is not None:
-            try:
-                self._listener.close()
-            except OSError:
-                pass
+        if self._session is not None:
+            self._session.close()
+        for sock in (self._listener, self._harness_listener):
+            if sock is not None:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
         for path in (
             self.paths.cli_socket,
             self.paths.harness_socket,

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -1,0 +1,133 @@
+"""The engine session gda-daemon holds for live operations (ADR-0017).
+
+A transient gda-owned Godot run with the gda harness injected. The daemon listens
+on the harness socket, launches the engine with the launch marker + the harness
+socket path + an auth token (the args after ``--``), waits for the harness to
+connect back over ``StreamPeerUDS`` and present the token, then relays one live op
+at a time to it and returns the sentinel payload it replies with.
+
+The session runs ``--headless`` for the tracer op (``game tree`` reads the runtime
+``SceneTree`` and needs no viewport); a windowed session arrives with the first
+viewport-capturing op (ADR-0017). The session is (re)launched per feedback-loop
+iteration so it observes the project's current on-disk state.
+"""
+
+import json
+import os
+import signal
+import socket
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from gda.daemon.protocol import read_frame, write_message
+from gda.exit_codes import EXIT_LIVE
+from gda.parser import RESULT_BEGIN, RESULT_END
+
+LAUNCH_MARKER = "gda-daemon"
+# Engine boot + autoload + harness connect; a windowed/cold start can be slow.
+CONNECT_TIMEOUT = 25.0
+
+
+class EngineSession:
+    """A launched engine run plus the daemon's connection to its harness."""
+
+    def __init__(self, proc: subprocess.Popen, conn: socket.socket) -> None:
+        self._proc = proc
+        self._conn = conn
+
+    def alive(self) -> bool:
+        return self._proc.poll() is None
+
+    def request(self, operation: str, params: dict) -> dict:
+        """Relay one live op to the harness; return the CLI reply dict."""
+        try:
+            write_message(self._conn, {"op": operation, "params": params})
+            reply = read_frame(self._conn)  # the raw ADR-0002 sentinel string
+        except OSError:
+            return _live_reply("engine_disconnected", "the engine session dropped the connection")
+        if reply is None:
+            return _live_reply("engine_disconnected", "the engine session closed before replying")
+        return {"stdout": reply.decode("utf-8", "replace"), "stderr": "", "exit_code": 0}
+
+    def close(self) -> None:
+        try:
+            self._conn.close()
+        except OSError:
+            pass
+        _terminate(self._proc)
+
+
+def launch_session(
+    project: Path,
+    binary: str,
+    harness_listener: socket.socket,
+    harness_socket: Path,
+    token: str,
+    timeout: float = CONNECT_TIMEOUT,
+) -> Optional[EngineSession]:
+    """Launch a headless engine session and wait for the harness to connect."""
+    proc = subprocess.Popen(
+        [
+            str(binary),
+            "--headless",
+            "--path",
+            str(project),
+            "--",
+            LAUNCH_MARKER,
+            str(harness_socket),
+            token,
+        ],
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    harness_listener.settimeout(timeout)
+    try:
+        conn, _ = harness_listener.accept()
+    except OSError:  # includes socket.timeout
+        _terminate(proc)
+        return None
+
+    # The harness's first frame is the auth token.
+    try:
+        presented = read_frame(conn)
+    except OSError:
+        presented = None
+    if presented is None or presented.decode("utf-8", "replace") != token:
+        try:
+            conn.close()
+        except OSError:
+            pass
+        _terminate(proc)
+        return None
+    return EngineSession(proc, conn)
+
+
+def _terminate(proc: subprocess.Popen) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    except OSError:
+        try:
+            proc.terminate()
+        except OSError:
+            pass
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        try:
+            proc.kill()
+        except OSError:
+            pass
+
+
+def _live_reply(code: str, message: str) -> dict:
+    body = json.dumps({"error": {"code": code, "message": message}})
+    return {
+        "stdout": f"{RESULT_BEGIN}{body}{RESULT_END}\n",
+        "stderr": "",
+        "exit_code": EXIT_LIVE,
+    }

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -27,6 +27,9 @@ from gda.parser import RESULT_BEGIN, RESULT_END
 LAUNCH_MARKER = "gda-daemon"
 # Engine boot + autoload + harness connect; a windowed/cold start can be slow.
 CONNECT_TIMEOUT = 25.0
+# Bounds one live op against the harness so a stuck op cannot hang the daemon
+# forever; surfaced as the registered ``live_timeout`` (ADR-0021).
+OP_TIMEOUT = 30.0
 
 
 class EngineSession:
@@ -42,8 +45,14 @@ class EngineSession:
     def request(self, operation: str, params: dict) -> dict:
         """Relay one live op to the harness; return the CLI reply dict."""
         try:
+            self._conn.settimeout(OP_TIMEOUT)
             write_message(self._conn, {"op": operation, "params": params})
             reply = read_frame(self._conn)  # the raw ADR-0002 sentinel string
+        except TimeoutError:
+            return _live_reply(
+                "live_timeout",
+                f"the engine session did not return within {int(OP_TIMEOUT)}s",
+            )
         except OSError:
             return _live_reply("engine_disconnected", "the engine session dropped the connection")
         if reply is None:

--- a/src/gda/daemon_ops.py
+++ b/src/gda/daemon_ops.py
@@ -22,7 +22,12 @@ from pathlib import Path
 from typing import Callable, Optional
 
 from gda.binary import resolve_godot_binary
-from gda.daemon.discovery import DaemonPaths, daemon_paths, daemon_pid
+from gda.daemon.discovery import (
+    DaemonPaths,
+    daemon_paths,
+    daemon_pid,
+    within_uds_limit,
+)
 from gda.daemon.protocol import read_message, write_message
 from gda.daemon.server import STATUS_OP, STOP_OP
 from gda.errors import Failure, _failure, unresolvable_binary_failure
@@ -139,6 +144,17 @@ def run_daemon_start_operation(
             "",
         )
     paths = daemon_paths(project)
+    if not (
+        within_uds_limit(paths.cli_socket) and within_uds_limit(paths.harness_socket)
+    ):
+        # Fail clearly here rather than letting the daemon's bind() overflow the
+        # OS sun_path limit and the start time out into a vague error (ADR-0021).
+        return _failure(
+            "daemon_not_running",
+            "the runtime directory yields a socket path longer than the OS limit "
+            "for a Unix domain socket; set a shorter $XDG_RUNTIME_DIR",
+            "",
+        )
     existing = daemon_pid(paths)
     if existing is not None:
         # Idempotent: a daemon is already up for this project.
@@ -184,6 +200,13 @@ def run_daemon_start_operation(
 
 
 def run_daemon_stop_operation(project: Optional[Path]) -> "DaemonStopResult | Failure":
+    if not _is_unix():
+        return _failure(
+            "live_unsupported_platform",
+            "the gda-daemon requires a UNIX platform (macOS/Linux); it uses Unix "
+            "domain sockets, which are unavailable here",
+            "",
+        )
     if project is None:
         return _failure(
             "project_not_found",
@@ -200,6 +223,13 @@ def run_daemon_stop_operation(project: Optional[Path]) -> "DaemonStopResult | Fa
 
 
 def run_daemon_status_operation(project: Optional[Path]) -> "DaemonStatusResult | Failure":
+    if not _is_unix():
+        return _failure(
+            "live_unsupported_platform",
+            "the gda-daemon requires a UNIX platform (macOS/Linux); it uses Unix "
+            "domain sockets, which are unavailable here",
+            "",
+        )
     if project is None:
         return _failure(
             "project_not_found",

--- a/src/gda/daemon_ops.py
+++ b/src/gda/daemon_ops.py
@@ -1,0 +1,172 @@
+"""The ``gda daemon`` lifecycle recipe (ADR-0017), parallel to ``export_run``.
+
+The ``daemon start`` / ``stop`` / ``status`` commands are not ``operations.gd``
+ops and not a live execution channel — they manage the daemon *process*. So, like
+``export run``, each is a recipe that RETURNS its typed outcome (never emits/exits)
+and the CLI owns emission. ``start`` gates the platform (live is UNIX-only,
+ADR-0021), performs the reported idempotent harness install (ADR-0018), spawns the
+detached daemon, and waits until it is accepting; ``stop`` asks it to shut down;
+``status`` reports liveness from the pidfile.
+
+The engine session the daemon holds — and the live-version gate that needs it —
+land in the next slice; this recipe stands up the process lifecycle.
+"""
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Callable, Optional
+
+from gda.daemon.discovery import DaemonPaths, daemon_paths, daemon_pid
+from gda.daemon.protocol import read_message, write_message
+from gda.daemon.server import STATUS_OP, STOP_OP
+from gda.errors import Failure, _failure
+from gda.harness.install import install_harness
+from gda.models import DaemonStartResult, DaemonStatusResult, DaemonStopResult
+
+_READY_TIMEOUT = 8.0
+_STOP_TIMEOUT = 8.0
+_POLL = 0.05
+
+# A spawn seam tests override to avoid launching a real detached process.
+SpawnDaemon = Callable[[Path, Optional[str]], None]
+
+
+def _is_unix() -> bool:
+    return os.name == "posix"
+
+
+def _spawn_daemon(project: Path, godot: Optional[str]) -> None:
+    """Spawn the detached, per-project daemon (its own session, no std streams)."""
+    subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "gda.daemon",
+            "--project",
+            str(project),
+            "--godot",
+            str(godot or ""),
+        ],
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _control(cli_socket: Path, op: str, timeout: float = 2.0) -> Optional[dict]:
+    """Send a control op (``__status__`` / ``__stop__``) and return the reply."""
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(timeout)
+            sock.connect(str(cli_socket))
+            write_message(sock, {"op": op})
+            return read_message(sock)
+    except OSError:
+        return None
+
+
+def _await_ready(paths: DaemonPaths, timeout: float = _READY_TIMEOUT) -> Optional[int]:
+    """Wait until the daemon is alive AND accepting; return its pid or None."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        pid = daemon_pid(paths)
+        if pid is not None:
+            reply = _control(paths.cli_socket, STATUS_OP)
+            if reply and reply.get("ok"):
+                return pid
+        time.sleep(_POLL)
+    return None
+
+
+def _await_gone(paths: DaemonPaths, pid: int, timeout: float = _STOP_TIMEOUT) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if daemon_pid(paths) is None:
+            return
+        time.sleep(_POLL)
+    # Graceful stop did not take — fall back to a signal.
+    try:
+        os.kill(pid, 15)
+    except OSError:
+        pass
+
+
+def run_daemon_start_operation(
+    project: Optional[Path],
+    godot: Optional[str],
+    *,
+    spawn: Optional[SpawnDaemon] = None,
+) -> "DaemonStartResult | Failure":
+    if not _is_unix():
+        return _failure(
+            "live_unsupported_platform",
+            "live operations require a UNIX platform (macOS/Linux); the daemon uses "
+            "Unix domain sockets, which are unavailable here",
+            "",
+        )
+    if project is None:
+        return _failure(
+            "project_not_found",
+            "gda daemon needs a Godot project; pass --project or run inside one",
+            "",
+        )
+    paths = daemon_paths(project)
+    existing = daemon_pid(paths)
+    if existing is not None:
+        # Idempotent: a daemon is already up for this project.
+        return DaemonStartResult(
+            pid=existing,
+            socket_path=str(paths.cli_socket),
+            installed_harness=False,
+            already_running=True,
+        )
+    installed = install_harness(project)
+    (spawn or _spawn_daemon)(project, godot)
+    pid = _await_ready(paths)
+    if pid is None:
+        return _failure(
+            "daemon_not_running",
+            "the gda-daemon did not start (it never began accepting on its socket)",
+            "",
+        )
+    return DaemonStartResult(
+        pid=pid,
+        socket_path=str(paths.cli_socket),
+        installed_harness=installed,
+        already_running=False,
+    )
+
+
+def run_daemon_stop_operation(project: Optional[Path]) -> "DaemonStopResult | Failure":
+    if project is None:
+        return _failure(
+            "project_not_found",
+            "gda daemon needs a Godot project; pass --project or run inside one",
+            "",
+        )
+    paths = daemon_paths(project)
+    pid = daemon_pid(paths)
+    if pid is None:
+        return DaemonStopResult(stopped=False, pid=None)
+    _control(paths.cli_socket, STOP_OP)
+    _await_gone(paths, pid)
+    return DaemonStopResult(stopped=True, pid=pid)
+
+
+def run_daemon_status_operation(project: Optional[Path]) -> "DaemonStatusResult | Failure":
+    if project is None:
+        return _failure(
+            "project_not_found",
+            "gda daemon needs a Godot project; pass --project or run inside one",
+            "",
+        )
+    paths = daemon_paths(project)
+    pid = daemon_pid(paths)
+    return DaemonStatusResult(
+        running=pid is not None, pid=pid, socket_path=str(paths.cli_socket)
+    )

--- a/src/gda/daemon_ops.py
+++ b/src/gda/daemon_ops.py
@@ -13,6 +13,7 @@ land in the next slice; this recipe stands up the process lifecycle.
 """
 
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -20,10 +21,11 @@ import time
 from pathlib import Path
 from typing import Callable, Optional
 
+from gda.binary import resolve_godot_binary
 from gda.daemon.discovery import DaemonPaths, daemon_paths, daemon_pid
 from gda.daemon.protocol import read_message, write_message
 from gda.daemon.server import STATUS_OP, STOP_OP
-from gda.errors import Failure, _failure
+from gda.errors import Failure, _failure, unresolvable_binary_failure
 from gda.harness.install import install_harness
 from gda.models import DaemonStartResult, DaemonStatusResult, DaemonStopResult
 
@@ -31,15 +33,35 @@ _READY_TIMEOUT = 8.0
 _STOP_TIMEOUT = 8.0
 _POLL = 0.05
 
-# A spawn seam tests override to avoid launching a real detached process.
-SpawnDaemon = Callable[[Path, Optional[str]], None]
+# Phase-2 live requires Godot 4.6+ (the UDS transport landed in 4.6; ADR-0021).
+MIN_LIVE_VERSION = (4, 6)
+_VERSION_RE = re.compile(r"(\d+)\.(\d+)")
+
+# Seams tests override to avoid launching a real process / running the engine.
+SpawnDaemon = Callable[[Path, str], None]
+VersionCheck = Callable[[str], Optional[tuple]]
 
 
 def _is_unix() -> bool:
     return os.name == "posix"
 
 
-def _spawn_daemon(project: Path, godot: Optional[str]) -> None:
+def _engine_version(binary: str) -> Optional[tuple]:
+    """The running engine's (major, minor) via ``--version``, or None if unknown."""
+    try:
+        result = subprocess.run(
+            [str(binary), "--headless", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except OSError:
+        return None
+    match = _VERSION_RE.search(result.stdout + result.stderr)
+    return (int(match.group(1)), int(match.group(2))) if match else None
+
+
+def _spawn_daemon(project: Path, binary: str) -> None:
     """Spawn the detached, per-project daemon (its own session, no std streams)."""
     subprocess.Popen(
         [
@@ -49,7 +71,7 @@ def _spawn_daemon(project: Path, godot: Optional[str]) -> None:
             "--project",
             str(project),
             "--godot",
-            str(godot or ""),
+            str(binary),
         ],
         start_new_session=True,
         stdin=subprocess.DEVNULL,
@@ -101,6 +123,7 @@ def run_daemon_start_operation(
     godot: Optional[str],
     *,
     spawn: Optional[SpawnDaemon] = None,
+    version_check: Optional[VersionCheck] = None,
 ) -> "DaemonStartResult | Failure":
     if not _is_unix():
         return _failure(
@@ -125,8 +148,26 @@ def run_daemon_start_operation(
             installed_harness=False,
             already_running=True,
         )
+
+    # The daemon needs the engine binary for its sessions; resolve it and gate the
+    # live version here (ADR-0021), so the floor is reported at start, not midway.
+    try:
+        binary = resolve_godot_binary(godot)
+    except ValueError as exc:
+        return unresolvable_binary_failure(str(exc))
+    version = (version_check or _engine_version)(str(binary))
+    if version is None or tuple(version) < MIN_LIVE_VERSION:
+        minimum = ".".join(str(part) for part in MIN_LIVE_VERSION)
+        found = ".".join(str(part) for part in version) if version else "unknown"
+        return _failure(
+            "unsupported_version",
+            f"live operations require Godot {minimum}+ (the daemon transport uses Unix "
+            f"domain sockets, added in {minimum}); the engine reports {found}",
+            "",
+        )
+
     installed = install_harness(project)
-    (spawn or _spawn_daemon)(project, godot)
+    (spawn or _spawn_daemon)(project, str(binary))
     pid = _await_ready(paths)
     if pid is None:
         return _failure(

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from enum import Enum
 
 from gda.exit_codes import (
+    EXIT_LIVE,
     EXIT_NOT_FOUND,
     EXIT_OPERATION,
     EXIT_PARSE,
@@ -395,6 +396,42 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCodeSource.CLASSIFIER,
         "The engine emitted a valid result tree that nests past gda's recursion"
         " limit; the payload is contract-conformant, the limit is wrapper-side.",
+    ),
+    # Phase-2 live execution channel (ADR-0017, ADR-0021). Classifier-source —
+    # surfaced by the daemon IPC client / the daemon, never by a headless
+    # operation — so they are NOT GDScript-mirrored. They share the EXIT_LIVE
+    # exit; the code tells the failure modes apart.
+    ErrorCodeSpec(
+        "daemon_not_running",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A live command found no running gda-daemon for the project; start one"
+        " with `gda daemon start`.",
+    ),
+    ErrorCodeSpec(
+        "engine_session_not_running",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "The daemon is running but holds no live engine session to serve the"
+        " live operation.",
+    ),
+    ErrorCodeSpec(
+        "engine_disconnected",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "The engine session disconnected before the live operation returned"
+        " (the game crashed or the harness connection dropped).",
+    ),
+    ErrorCodeSpec(
+        "live_timeout",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A live operation did not return from the engine session before the"
+        " daemon's timeout.",
     ),
 )
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -440,3 +440,10 @@ ERROR_CODE_BY_CODE: dict[str, ErrorCodeSpec] = {spec.code: spec for spec in ERRO
 OPERATION_ERROR_CODES: frozenset[str] = frozenset(
     spec.code for spec in ERROR_CODES if spec.source is ErrorCodeSource.OPERATION
 )
+
+# The Phase-2 live failure codes (ADR-0017, ADR-0021). Surfaced from a sentinel
+# error envelope by the daemon IPC client / the daemon and mapped to the
+# registered code by ``classify_live`` — the live analogue of OPERATION_ERROR_CODES.
+LIVE_ERROR_CODES: frozenset[str] = frozenset(
+    spec.code for spec in ERROR_CODES if spec.category is ErrorCategory.LIVE
+)

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -433,6 +433,18 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A live operation did not return from the engine session before the"
         " daemon's timeout.",
     ),
+    # A pre-launch platform precondition, not a live-runtime failure: live needs
+    # Unix domain sockets, which are UNIX-only, so it is an ENVIRONMENT-category
+    # code in the binary_not_found bucket (ADR-0021), decided before any engine
+    # launch and classifier-source (no operation reports it).
+    ErrorCodeSpec(
+        "live_unsupported_platform",
+        ErrorCategory.ENVIRONMENT,
+        EXIT_NOT_FOUND,
+        ErrorCodeSource.CLASSIFIER,
+        "Live operations require a UNIX platform (macOS/Linux); they use Unix"
+        " domain sockets, which are unavailable here.",
+    ),
 )
 
 ERROR_CODE_BY_CODE: dict[str, ErrorCodeSpec] = {spec.code: spec for spec in ERROR_CODES}

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -43,11 +43,16 @@ from typing import TypeVar
 
 from pydantic import BaseModel, ValidationError
 
-from gda.error_codes import ERROR_CODE_BY_CODE, OPERATION_ERROR_CODES
+from gda.error_codes import (
+    ERROR_CODE_BY_CODE,
+    LIVE_ERROR_CODES,
+    OPERATION_ERROR_CODES,
+)
 from gda.models import (
     EngineVersion,
     ExportRunMode,
     ExportRunResult,
+    GameTreeResult,
     GdaError,
     OperationErrorEnvelope,
     ScriptDiagnostic,
@@ -377,6 +382,45 @@ def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
         )
 
     return version
+
+
+def _live_error_from_payload(result: RunResult) -> Failure | None:
+    """A LIVE-code error envelope on stdout becomes its registered ``Failure``.
+
+    The daemon IPC client / the daemon report a live failure as the *same*
+    ADR-0002 error envelope a headless op uses, but carrying a classifier-source
+    LIVE code (``daemon_not_running``, …). ``classify_run`` would fall back to
+    ``operation_failed`` for a non-operation code, so this maps the LIVE code to
+    its registered ``Failure`` directly. A non-LIVE envelope returns ``None`` so
+    the shared decision tree still handles it.
+    """
+    pair = _operation_error_from_payload(result)
+    if pair is None:
+        return None
+    code, message = pair
+    if code in LIVE_ERROR_CODES:
+        return _failure(code, message, result.stderr)
+    return None
+
+
+def classify_live(result: RunResult, binary: Path, output_model: type[M]) -> M | Failure:
+    """Classify a live operation's raw result (ADR-0017).
+
+    A live op returns the same ``RunResult`` + ADR-0002 sentinel a headless op
+    does, so the success path is ``classify_run`` verbatim and the public contract
+    is identical. The one addition is the LIVE error envelope
+    (``daemon_not_running``, ``engine_disconnected``, …), surfaced here as its
+    registered classifier-source code before the shared decision tree runs.
+    """
+    failure = _live_error_from_payload(result)
+    if failure is not None:
+        return failure
+    return classify_run(result, binary, output_model)
+
+
+def classify_game_tree(result: RunResult, binary: Path) -> GameTreeResult | Failure:
+    """The per-command live classifier for ``gda game tree`` (mirrors ``classify_info``)."""
+    return classify_live(result, binary, GameTreeResult)
 
 
 # A non-fatal export warning the engine prints to stderr. WARNING is Godot's

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -384,21 +384,30 @@ def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
     return version
 
 
-def _live_error_from_payload(result: RunResult) -> Failure | None:
-    """A LIVE-code error envelope on stdout becomes its registered ``Failure``.
+# Codes the daemon IPC client / the daemon surface through the live sentinel that
+# classify_run would otherwise misroute. The LIVE codes are live-runtime failures;
+# ``live_unsupported_platform`` is an ENVIRONMENT-category pre-launch precondition
+# (ADR-0021) but still arrives via the live path, so classify_live must surface it
+# too (else classify_run falls back to operation_failed for a non-operation code).
+# ``project_not_found`` is deliberately NOT here — it is an operation-source code
+# classify_run already maps, so it falls through to the shared decision tree.
+_LIVE_CLIENT_CODES = LIVE_ERROR_CODES | {"live_unsupported_platform"}
 
-    The daemon IPC client / the daemon report a live failure as the *same*
-    ADR-0002 error envelope a headless op uses, but carrying a classifier-source
-    LIVE code (``daemon_not_running``, …). ``classify_run`` would fall back to
-    ``operation_failed`` for a non-operation code, so this maps the LIVE code to
-    its registered ``Failure`` directly. A non-LIVE envelope returns ``None`` so
-    the shared decision tree still handles it.
+
+def _live_error_from_payload(result: RunResult) -> Failure | None:
+    """A live-channel error envelope on stdout becomes its registered ``Failure``.
+
+    The daemon IPC client / the daemon report a live failure as the *same* ADR-0002
+    error envelope a headless op uses, carrying a classifier-source code. This maps
+    the daemon-channel codes to their registered ``Failure`` directly; any other
+    envelope returns ``None`` so the shared ``classify_run`` decision tree handles
+    it (e.g. ``project_not_found``).
     """
     pair = _operation_error_from_payload(result)
     if pair is None:
         return None
     code, message = pair
-    if code in LIVE_ERROR_CODES:
+    if code in _LIVE_CLIENT_CODES:
         return _failure(code, message, result.stderr)
     return None
 

--- a/src/gda/execution.py
+++ b/src/gda/execution.py
@@ -1,0 +1,31 @@
+"""The execution-channel taxonomy.
+
+Every ``gda`` command is fulfilled through one of a small, fixed set of
+execution channels, chosen at command-definition time and carried as a static
+``kind`` on the command descriptor (ADR-0017). The runner factory selects the
+channel by this ``kind``; classification, sentinel parsing, and ``--json`` /
+``GdaError`` emission are shared across channels.
+
+This is a leaf module with no ``gda`` imports (the same discipline as
+``gda.exit_codes``), so the descriptor (``gda.headless``), the dispatcher
+(``gda.cli``), and the export/live recipes can all name the taxonomy without an
+import cycle.
+"""
+
+import enum
+
+
+class ExecutionKind(str, enum.Enum):
+    """Which execution channel fulfils a command (ADR-0017).
+
+    - ``HEADLESS`` — the default: a one-shot ``godot --headless --script
+      operations.gd`` sentinel op (ADR-0002, ADR-0010).
+    - ``EXPORT`` — the native ``--export-<mode>`` recipe, the editor-only export
+      capability that cannot run through ``operations.gd`` (ADR-0010).
+    - ``LIVE`` — a live operation served by ``gda-daemon`` against a running
+      engine session, reached through a daemon IPC client (ADR-0017).
+    """
+
+    HEADLESS = "headless"
+    EXPORT = "export"
+    LIVE = "live"

--- a/src/gda/exit_codes.py
+++ b/src/gda/exit_codes.py
@@ -18,6 +18,11 @@ glance and new codes cannot silently collide.
   envelope ``code`` distinguishes them, exactly as the many ``operation`` codes
   share exit ``4``. Exit codes stay at category granularity; finer detail is the
   ``code`` field's job (ADR-0002, ADR-0004).
+- ``EXIT_LIVE`` (exit ``6``) is the Phase-2 ``live`` category: a live operation
+  failed against ``gda-daemon`` / the engine session — no running daemon, a lost
+  session, or a live timeout (ADR-0017, ADR-0021). Like ``operation`` and
+  ``parse`` it spans several ``GdaError.code``s that the ``code`` field tells
+  apart.
 """
 
 EXIT_NOT_FOUND = 127
@@ -25,3 +30,4 @@ EXIT_TIMEOUT = 124
 EXIT_VERSION = 3
 EXIT_OPERATION = 4
 EXIT_PARSE = 5
+EXIT_LIVE = 6

--- a/src/gda/export_run.py
+++ b/src/gda/export_run.py
@@ -42,6 +42,7 @@ from gda.errors import (
     export_path_unset_failure,
     export_templates_missing_failure,
 )
+from gda.execution import ExecutionKind
 from gda.export_runner import ExportRunner, make_subprocess_export_runner
 from gda.headless import HeadlessCommand, RunnerFactory, make_subprocess_runner
 from gda.models import (
@@ -75,6 +76,7 @@ EXPORT_RUN_COMMAND: HeadlessCommand[ExportRunResult] = HeadlessCommand(
     operation="export-run",
     input_model=ExportRunParams,
     output_model=ExportRunResult,
+    kind=ExecutionKind.EXPORT,
 )
 
 

--- a/src/gda/harness/__init__.py
+++ b/src/gda/harness/__init__.py
@@ -1,0 +1,6 @@
+"""The gda harness: the game-side autoload gda-daemon installs into a project.
+
+Bundles the harness GDScript and the Python installer that registers it as a
+project autoload (ADR-0018). The harness is inert unless gda-daemon launched the
+run, so it does nothing in a human editor run, a plain run, or a shipped build.
+"""

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -9,18 +9,90 @@ extends Node
 # it does nothing in a human editor run, a plain `godot --path` run, and a
 # shipped/exported build.
 #
-# This is the inert gate only (#7 Step 3). The daemon<->harness connection
-# (StreamPeerUDS, available since Godot 4.6) and the live-operation dispatch land
-# in a later slice (#7 Step 6).
+# When the daemon DID launch this run, the marker is followed by the daemon's
+# harness socket path and an auth token. The harness connects back over a Unix
+# domain socket (StreamPeerUDS, Godot 4.6+), presents the token, then serves one
+# live op at a time: it reads a length-prefixed JSON request, runs it on the main
+# thread at a frame boundary (frame-coherent, ADR-0020), and writes back the
+# ADR-0002 sentinel payload as one length-prefixed frame.
 
 const LAUNCH_MARKER := "gda-daemon"
+const RESULT_BEGIN := "<<<GDA:RESULT>>>"
+const RESULT_END := "<<<GDA:END>>>"
+
+var _peer: StreamPeerUDS = null
+var _authed := false
+var _pending = null
+var _pending_frames := 0
 
 
 func _ready() -> void:
 	var user_args := OS.get_cmdline_user_args()
-	if not user_args.has(LAUNCH_MARKER):
-		# Not launched by gda-daemon — stay resident and do nothing.
+	var idx := user_args.find(LAUNCH_MARKER)
+	if idx == -1 or idx + 2 >= user_args.size():
+		# Inert: not launched by gda-daemon. Stay resident and do nothing.
 		return
-	# Launched by gda-daemon: the live connection is wired in a later slice. Until
-	# then this is intentionally a no-op so the installed autoload is safe to ship.
-	pass
+	var socket_path: String = user_args[idx + 1]
+	var token: String = user_args[idx + 2]
+
+	var peer := StreamPeerUDS.new()
+	peer.big_endian = true
+	if peer.connect_to_host(socket_path) != OK:
+		return
+	_peer = peer
+	# The first frame the daemon expects is the auth token.
+	_send_frame(token.to_utf8_buffer())
+	_authed = true
+
+
+func _process(_delta: float) -> void:
+	if _peer == null or not _authed:
+		return
+	_peer.poll()
+	# Read one pending request when a full length prefix is available; the body
+	# follows in the same daemon write, so get_data does not block in practice.
+	if _pending == null and _peer.get_available_bytes() >= 4:
+		var length := _peer.get_u32()
+		var chunk := _peer.get_data(length)
+		if chunk[0] == OK:
+			_pending = JSON.parse_string((chunk[1] as PackedByteArray).get_string_from_utf8())
+			_pending_frames = 0
+	# Serve only once the runtime scene graph is up — the harness autoload's
+	# _ready runs BEFORE the main scene is instantiated, so a request that arrives
+	# during boot waits for current_scene (frame-coherent, ADR-0020); a bounded
+	# fallback to the SceneTree root means a sceneless project never hangs.
+	if _pending != null:
+		_pending_frames += 1
+		if get_tree().current_scene != null or _pending_frames > 300:
+			_send_frame(_run(_pending).to_utf8_buffer())
+			_pending = null
+
+
+func _send_frame(payload: PackedByteArray) -> void:
+	_peer.put_u32(payload.size())
+	_peer.put_data(payload)
+
+
+func _run(request) -> String:
+	if typeof(request) != TYPE_DICTIONARY or request.get("op") != "game-tree":
+		return _error("operation_failed", "unsupported live operation")
+	var scene: Node = get_tree().current_scene
+	if scene == null:
+		scene = get_tree().root
+	return RESULT_BEGIN + JSON.stringify({"root": _serialize(scene)}) + RESULT_END
+
+
+func _serialize(node: Node) -> Dictionary:
+	var children: Array = []
+	for child in node.get_children():
+		children.append(_serialize(child))
+	return {
+		"name": String(node.name),
+		"type": node.get_class(),
+		"path": String(node.get_path()),
+		"children": children,
+	}
+
+
+func _error(code: String, message: String) -> String:
+	return RESULT_BEGIN + JSON.stringify({"error": {"code": code, "message": message}}) + RESULT_END

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -1,0 +1,26 @@
+extends Node
+
+# The gda harness (ADR-0017, ADR-0018). Installed as a project [autoload] by
+# `gda daemon`. It is INERT unless gda-daemon launched this run: at startup it
+# looks for the daemon's launch marker in the user args (after `--`); absent it,
+# it returns early — opening no connection, starting no server — and stays
+# resident. It must NOT free()/queue_free() itself: Godot crashes if an autoload
+# is freed at runtime, so a resident do-nothing node is the safe inert form. Thus
+# it does nothing in a human editor run, a plain `godot --path` run, and a
+# shipped/exported build.
+#
+# This is the inert gate only (#7 Step 3). The daemon<->harness connection
+# (StreamPeerUDS, available since Godot 4.6) and the live-operation dispatch land
+# in a later slice (#7 Step 6).
+
+const LAUNCH_MARKER := "gda-daemon"
+
+
+func _ready() -> void:
+	var user_args := OS.get_cmdline_user_args()
+	if not user_args.has(LAUNCH_MARKER):
+		# Not launched by gda-daemon — stay resident and do nothing.
+		return
+	# Launched by gda-daemon: the live connection is wired in a later slice. Until
+	# then this is intentionally a no-op so the installed autoload is safe to ship.
+	pass

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -1,0 +1,88 @@
+"""Install the gda harness autoload into a project (ADR-0018).
+
+``gda daemon start`` performs this **one-time, install-time write** (never a
+per-launch mutation, which would race a concurrent editor and corrupt config):
+it materializes the bundled harness under ``res://addons/`` and ensures its
+``[autoload]`` entry in ``project.godot``. It is idempotent and order-preserving,
+and reports whether it changed anything (``installed_harness``).
+
+The write is Python-side because it happens *before* any engine session exists.
+It mirrors the autoload semantics ``operations.gd`` uses for ``project
+add-autoload`` (issue #119): the value is the ``res://`` path prefixed with ``*``
+(the enabled-singleton form). Version self-sync and paired uninstall are #225.
+"""
+
+from pathlib import Path
+
+# The autoload name and the res:// location the bundled harness is installed to.
+HARNESS_AUTOLOAD_NAME = "GdaHarness"
+HARNESS_RES_DIR = "addons/gda_harness"
+HARNESS_FILE = "gda_harness.gd"
+HARNESS_RES_PATH = f"res://{HARNESS_RES_DIR}/{HARNESS_FILE}"
+
+# Bumped when the bundled harness changes; the daemon self-syncs the installed
+# copy to it (#225). Unused by the install logic now — only re-materialize on a
+# content difference — but the anchor lives here for #225.
+HARNESS_VERSION = "0"
+
+_AUTOLOAD_HEADER = "[autoload]"
+_BUNDLED_HARNESS = Path(__file__).parent / HARNESS_FILE
+
+
+def _autoload_line() -> str:
+    # Enabled-singleton form: the res:// path prefixed with "*" (issue #119).
+    return f'{HARNESS_AUTOLOAD_NAME}="*{HARNESS_RES_PATH}"'
+
+
+def _materialize(project: Path) -> bool:
+    """Write the bundled harness under res://addons; True iff it changed on disk."""
+    dest = project / HARNESS_RES_DIR / HARNESS_FILE
+    bundled = _BUNDLED_HARNESS.read_text(encoding="utf-8")
+    if dest.exists() and dest.read_text(encoding="utf-8") == bundled:
+        return False
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(bundled, encoding="utf-8")
+    return True
+
+
+def _ensure_autoload(text: str) -> tuple[str, bool]:
+    """Ensure the harness autoload line is present; return (text, changed)."""
+    line = _autoload_line()
+    if line in text:
+        return text, False
+
+    lines = text.splitlines()
+    trailing = "\n" if text.endswith("\n") else ""
+
+    # A GdaHarness entry pointing somewhere else — re-point it in place.
+    for i, raw in enumerate(lines):
+        if raw.strip().startswith(f"{HARNESS_AUTOLOAD_NAME}="):
+            lines[i] = line
+            return "\n".join(lines) + trailing, True
+
+    # An existing [autoload] section — insert right after its header, preserving
+    # any sibling autoloads.
+    for i, raw in enumerate(lines):
+        if raw.strip() == _AUTOLOAD_HEADER:
+            lines.insert(i + 1, line)
+            return "\n".join(lines) + trailing, True
+
+    # No [autoload] section — append one at EOF (sections may appear in any order).
+    base = text if text.endswith("\n") else text + "\n"
+    return f"{base}\n{_AUTOLOAD_HEADER}\n\n{line}\n", True
+
+
+def install_harness(project: Path) -> bool:
+    """Idempotently install the harness autoload into ``project``.
+
+    Returns whether anything changed (the ``installed_harness`` the daemon
+    reports): ``True`` on a first install or a re-materialize/re-point, ``False``
+    when the harness file and the autoload entry are already in place.
+    """
+    materialized = _materialize(project)
+    project_godot = project / "project.godot"
+    text = project_godot.read_text(encoding="utf-8")
+    new_text, autoload_added = _ensure_autoload(text)
+    if autoload_added:
+        project_godot.write_text(new_text, encoding="utf-8")
+    return materialized or autoload_added

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -294,15 +294,22 @@ class HeadlessCommand(Generic[M]):
         (``export run``) can branch on it. :meth:`run` adds the
         emit-and-exit-on-failure behavior on top.
         """
-        try:
-            binary = resolve_godot_binary(godot)
-        except ValueError as exc:
-            # An empty ``--godot ""`` (a natural $GDA_GODOT mistake) makes
-            # resolution raise *before* a runner exists — there is no binary to
-            # launch, the same environment failure as a missing one. Map it to
-            # the structured ``binary_not_found`` envelope so it never escapes as
-            # a raw traceback (issue #33), mirroring the runner's NOT_FOUND path.
-            return unresolvable_binary_failure(str(exc))
+        if self.kind is ExecutionKind.LIVE:
+            # A live op reaches the running daemon, not a fresh engine, so it
+            # needs no Godot binary — the daemon owns the engine session
+            # (ADR-0017). Skip resolution so `gda game tree` with no daemon
+            # reports daemon_not_running, not a spurious binary_not_found.
+            binary: Optional[Path] = None
+        else:
+            try:
+                binary = resolve_godot_binary(godot)
+            except ValueError as exc:
+                # An empty ``--godot ""`` (a natural $GDA_GODOT mistake) makes
+                # resolution raise *before* a runner exists — there is no binary to
+                # launch, the same environment failure as a missing one. Map it to
+                # the structured ``binary_not_found`` envelope so it never escapes as
+                # a raw traceback (issue #33), mirroring the runner's NOT_FOUND path.
+                return unresolvable_binary_failure(str(exc))
         runner = make_runner(binary, project)
         result = runner.run(self.operation, params.model_dump())
 

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -25,6 +25,7 @@ from gda.errors import (
     invalid_params_json_failure,
     unresolvable_binary_failure,
 )
+from gda.execution import ExecutionKind
 from gda.models import CommandSchema, GdaErrorEnvelope
 from gda.render import render
 from gda.runner import GodotRunner, RunResult, SubprocessGodotRunner
@@ -260,6 +261,11 @@ class HeadlessCommand(Generic[M]):
     input_model: type[BaseModel]
     output_model: type[M]
     classify: Classifier[M] | None = None
+    # The static execution channel this command is fulfilled through (ADR-0017).
+    # Defaults to HEADLESS — the sentinel ``operations.gd`` pipeline — so every
+    # existing command keeps its channel without restating it; EXPORT and LIVE
+    # commands declare their channel explicitly.
+    kind: ExecutionKind = ExecutionKind.HEADLESS
 
     def schema_option(self) -> bool:
         """Return the Typer ``--schema`` flag for this command."""

--- a/src/gda/live_runner.py
+++ b/src/gda/live_runner.py
@@ -1,0 +1,92 @@
+"""The LIVE execution channel: a daemon IPC client (ADR-0017, ADR-0021).
+
+A ``LIVE`` command's runner is a client of the per-project ``gda-daemon`` rather
+than a one-shot ``godot`` subprocess. It returns the SAME ``RunResult`` shape a
+headless subprocess returns — ``stdout`` carrying the ADR-0002 sentinel payload —
+so classification, sentinel parsing, output-model validation, and ``--json`` /
+``GdaError`` emission are reused unchanged (the dispatcher's one new decision is
+which runner factory to use, keyed on the command's ``kind``).
+
+With no running daemon (or no resolved project) the client synthesizes a
+``daemon_not_running`` sentinel envelope — the attach-or-fail typed error that
+makes the daemon's start timing self-revealing (ADR-0017). A dropped connection
+becomes ``engine_disconnected``. Both ride the normal classify pipeline via
+``classify_live``.
+"""
+
+import json
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from gda.daemon.discovery import daemon_paths, daemon_pid
+from gda.daemon.protocol import read_message, write_message
+from gda.exit_codes import EXIT_LIVE
+from gda.parser import RESULT_BEGIN, RESULT_END
+from gda.runner import GodotRunner, RunResult
+
+
+def make_daemon_runner(project: Optional[Path]) -> GodotRunner:
+    """Build the LIVE runner for ``project`` — the daemon-channel runner factory."""
+    return DaemonRunner(project)
+
+
+@dataclass
+class DaemonRunner:
+    """A :class:`~gda.runner.GodotRunner` that serves a live op via gda-daemon."""
+
+    project: Optional[Path]
+
+    def run(self, operation: str, params: dict) -> RunResult:
+        if self.project is None:
+            # A live op is per-project; with no resolved project there is no
+            # daemon to find (ADR-0021). Attach-or-fail, naming the remediation.
+            return _live_error_result(
+                "daemon_not_running",
+                "no Godot project resolved; a live operation needs a project with a "
+                "running gda-daemon (start one with `gda daemon start`)",
+            )
+        paths = daemon_paths(self.project)
+        if daemon_pid(paths) is None:
+            return _live_error_result(
+                "daemon_not_running",
+                f"no gda-daemon is running for {self.project}; "
+                "start one with `gda daemon start`",
+            )
+        return self._request(paths.cli_socket, operation, params)
+
+    def _request(self, cli_socket: Path, operation: str, params: dict) -> RunResult:
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                sock.connect(str(cli_socket))
+                write_message(sock, {"op": operation, "params": params})
+                reply = read_message(sock)
+        except OSError:
+            return _live_error_result(
+                "engine_disconnected",
+                "the gda-daemon connection dropped before the live operation returned",
+            )
+        if reply is None:
+            return _live_error_result(
+                "engine_disconnected",
+                "the gda-daemon closed the connection before replying",
+            )
+        # The daemon relays the engine session's sentinel payload verbatim as the
+        # RunResult fields; classify_live / parse_result handle it like any op.
+        return RunResult(
+            stdout=str(reply.get("stdout", "")),
+            stderr=str(reply.get("stderr", "")),
+            exit_code=int(reply.get("exit_code", 0)),
+        )
+
+
+def _live_error_result(code: str, message: str) -> RunResult:
+    """A synthesized RunResult carrying a LIVE error envelope in the sentinel.
+
+    The client surfaces its own failures (no daemon, dropped connection) through
+    the SAME ADR-0002 envelope a real op error uses, so ``classify_live`` maps
+    them to the registered code through the normal pipeline — no special path.
+    """
+    body = json.dumps({"error": {"code": code, "message": message}})
+    return RunResult(stdout=f"{RESULT_BEGIN}{body}{RESULT_END}\n", stderr="", exit_code=EXIT_LIVE)

--- a/src/gda/live_runner.py
+++ b/src/gda/live_runner.py
@@ -15,6 +15,7 @@ becomes ``engine_disconnected``. Both ride the normal classify pipeline via
 """
 
 import json
+import os
 import socket
 from dataclasses import dataclass
 from pathlib import Path
@@ -25,6 +26,15 @@ from gda.daemon.protocol import read_message, write_message
 from gda.exit_codes import EXIT_LIVE
 from gda.parser import RESULT_BEGIN, RESULT_END
 from gda.runner import GodotRunner, RunResult
+
+# Bounds a live call so it never hangs the CLI forever; generous because the
+# daemon may launch the engine session on the first op (ADR-0017). A timeout is
+# surfaced as the registered ``live_timeout`` (ADR-0021).
+LIVE_REQUEST_TIMEOUT = 60.0
+
+
+def _is_unix() -> bool:
+    return os.name == "posix"
 
 
 def make_daemon_runner(project: Optional[Path]) -> GodotRunner:
@@ -39,13 +49,21 @@ class DaemonRunner:
     project: Optional[Path]
 
     def run(self, operation: str, params: dict) -> RunResult:
-        if self.project is None:
-            # A live op is per-project; with no resolved project there is no
-            # daemon to find (ADR-0021). Attach-or-fail, naming the remediation.
+        # Platform gate first (ADR-0021): live is UNIX-only (UDS), checked before
+        # any project / daemon resolution and before any version concern.
+        if not _is_unix():
             return _live_error_result(
-                "daemon_not_running",
-                "no Godot project resolved; a live operation needs a project with a "
-                "running gda-daemon (start one with `gda daemon start`)",
+                "live_unsupported_platform",
+                "live operations require a UNIX platform (macOS/Linux); they use "
+                "Unix domain sockets, which are unavailable here",
+            )
+        if self.project is None:
+            # No resolved project is a project-resolution error, not a daemon one
+            # (ADR-0021): a live op is per-project, so there is no daemon to find.
+            return _live_error_result(
+                "project_not_found",
+                "no Godot project resolved; a live operation needs a project "
+                "(pass --project or run inside one)",
             )
         paths = daemon_paths(self.project)
         if daemon_pid(paths) is None:
@@ -59,9 +77,15 @@ class DaemonRunner:
     def _request(self, cli_socket: Path, operation: str, params: dict) -> RunResult:
         try:
             with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                sock.settimeout(LIVE_REQUEST_TIMEOUT)
                 sock.connect(str(cli_socket))
                 write_message(sock, {"op": operation, "params": params})
                 reply = read_message(sock)
+        except TimeoutError:
+            return _live_error_result(
+                "live_timeout",
+                f"the live operation did not return within {int(LIVE_REQUEST_TIMEOUT)}s",
+            )
         except OSError:
             return _live_error_result(
                 "engine_disconnected",

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -2351,3 +2351,32 @@ class ProjectRemoveAutoloadResult(BaseModel):
     """
 
     name: str = Field(description="The unregistered autoload's global name.")
+
+
+class GameNode(BaseModel):
+    """One node of the RUNNING game's runtime scene tree (Phase 2, ADR-0019).
+
+    The runtime counterpart of :class:`SceneNode`: ``gda game tree`` reports the
+    live ``SceneTree`` after ``_ready`` and dynamic instantiation, so it carries
+    the runtime node ``path`` alongside ``name``/``type``/``children``. Distinct
+    from the on-disk ``.tscn`` read by ``scene get`` (a different object, ADR-0019).
+    """
+
+    name: str
+    type: str
+    path: str
+    children: list["GameNode"] = []
+
+
+class GameTreeParams(BaseModel):
+    """The params of ``gda game tree``: read the running game's runtime scene tree.
+
+    Empty — it reads the whole runtime tree of the engine session held by
+    ``gda-daemon`` (a subtree root may be added by a later slice).
+    """
+
+
+class GameTreeResult(BaseModel):
+    """The result of ``gda game tree``: the running game's runtime scene tree."""
+
+    root: GameNode

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -2380,3 +2380,53 @@ class GameTreeResult(BaseModel):
     """The result of ``gda game tree``: the running game's runtime scene tree."""
 
     root: GameNode
+
+
+class DaemonStartParams(BaseModel):
+    """The params of ``gda daemon start``: none (the project is the --project context)."""
+
+
+class DaemonStartResult(BaseModel):
+    """The result of ``gda daemon start``: the live context it brought up (ADR-0017)."""
+
+    pid: int = Field(description="The gda-daemon process id.")
+    socket_path: str = Field(
+        description="The per-project CLI socket the daemon listens on."
+    )
+    installed_harness: bool = Field(
+        description="Whether this start installed or updated the harness autoload (ADR-0018)."
+    )
+    already_running: bool = Field(
+        description="Whether a daemon was already running, so start was a no-op."
+    )
+
+
+class DaemonStopParams(BaseModel):
+    """The params of ``gda daemon stop``: none."""
+
+
+class DaemonStopResult(BaseModel):
+    """The result of ``gda daemon stop``: whether a running daemon was torn down."""
+
+    stopped: bool = Field(
+        description="Whether a running daemon was stopped (False if none was running)."
+    )
+    pid: int | None = Field(
+        default=None, description="The stopped daemon's pid, if one was running."
+    )
+
+
+class DaemonStatusParams(BaseModel):
+    """The params of ``gda daemon status``: none."""
+
+
+class DaemonStatusResult(BaseModel):
+    """The result of ``gda daemon status``: whether a per-project daemon is up."""
+
+    running: bool = Field(
+        description="Whether a gda-daemon is running for the project."
+    )
+    pid: int | None = Field(
+        default=None, description="The running daemon's pid, if any."
+    )
+    socket_path: str = Field(description="The per-project CLI socket path.")

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -20,7 +20,7 @@ from pydantic import (
 
 
 class ErrorCategory(str, Enum):
-    """The four coarse buckets a ``gda`` operation can fail into (issue #3).
+    """The coarse buckets a ``gda`` operation can fail into (issue #3).
 
     This is the coarse axis; each category fans out to one or more finer,
     stable ``GdaError.code`` values (e.g. ENVIRONMENT → ``binary_not_found`` /
@@ -33,12 +33,16 @@ class ErrorCategory(str, Enum):
     launched engine that failed to deliver a result (the operation reported an
     error, or the engine crashed). PARSE is a violation of the structured-output
     contract (ADR-0002): a missing/malformed sentinel or a wrong-shape payload.
+    LIVE is a Phase-2 live operation failing against ``gda-daemon`` / the engine
+    session — no running daemon, a lost session, or a live timeout (ADR-0017,
+    ADR-0021).
     """
 
     ENVIRONMENT = "environment"
     VERSION = "version"
     OPERATION = "operation"
     PARSE = "parse"
+    LIVE = "live"
 
 
 class GdaError(BaseModel):

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -26,6 +26,7 @@ from gda.models import (
     ExportGetResult,
     ExportListResult,
     ExportRunResult,
+    GameTreeResult,
     NodeAddResult,
     NodeConnectSignalResult,
     NodeDisconnectSignalResult,
@@ -134,6 +135,16 @@ def render_scene_metadata(scene: "SceneCreateResult") -> str:
 def render_scene_tree(scene: "SceneGetResult") -> str:
     """Render a read scene's node tree."""
     return render_node_tree(scene.root)
+
+
+def render_game_tree(game: "GameTreeResult") -> str:
+    """Render the running game's runtime scene tree (ADR-0019).
+
+    The runtime counterpart of ``render_scene_tree``: ``render_node_tree`` reads
+    only ``name``/``type``/``children``, which a ``GameNode`` carries, so the
+    runtime tree flows through the same indented outline as the on-disk scene.
+    """
+    return render_node_tree(game.root)
 
 
 def render_scene_exports(scene: "SceneGetExportsResult") -> str:
@@ -516,6 +527,7 @@ def render_engine_version(version: "EngineVersion") -> str:
 _RENDERERS = {
     SceneCreateResult: render_scene_metadata,
     SceneGetResult: render_scene_tree,
+    GameTreeResult: render_game_tree,
     SceneGetExportsResult: render_scene_exports,
     SceneListResult: render_scene_list,
     SceneDeleteResult: render_scene_delete,

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -22,6 +22,9 @@ import json
 from typing import Any, Protocol, runtime_checkable
 
 from gda.models import (
+    DaemonStartResult,
+    DaemonStatusResult,
+    DaemonStopResult,
     EngineVersion,
     ExportGetResult,
     ExportListResult,
@@ -145,6 +148,27 @@ def render_game_tree(game: "GameTreeResult") -> str:
     runtime tree flows through the same indented outline as the on-disk scene.
     """
     return render_node_tree(game.root)
+
+
+def render_daemon_start(started: "DaemonStartResult") -> str:
+    """Render a `gda daemon start` outcome for humans."""
+    state = "already running" if started.already_running else "started"
+    harness = " (installed harness)" if started.installed_harness else ""
+    return f"daemon {state}: pid {started.pid} on {started.socket_path}{harness}"
+
+
+def render_daemon_stop(stopped: "DaemonStopResult") -> str:
+    """Render a `gda daemon stop` outcome for humans."""
+    if stopped.stopped:
+        return f"daemon stopped (pid {stopped.pid})"
+    return "no daemon was running"
+
+
+def render_daemon_status(status: "DaemonStatusResult") -> str:
+    """Render a `gda daemon status` outcome for humans."""
+    if status.running:
+        return f"daemon running: pid {status.pid} on {status.socket_path}"
+    return "daemon not running"
 
 
 def render_scene_exports(scene: "SceneGetExportsResult") -> str:
@@ -528,6 +552,9 @@ _RENDERERS = {
     SceneCreateResult: render_scene_metadata,
     SceneGetResult: render_scene_tree,
     GameTreeResult: render_game_tree,
+    DaemonStartResult: render_daemon_start,
+    DaemonStopResult: render_daemon_stop,
+    DaemonStatusResult: render_daemon_status,
     SceneGetExportsResult: render_scene_exports,
     SceneListResult: render_scene_list,
     SceneDeleteResult: render_scene_delete,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,11 @@ needs its own ``project.godot`` must build it through this helper (passing its
 extra sections via ``extra``) so the logging stays disabled.
 """
 
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
 import pytest
 
 from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
@@ -89,3 +94,28 @@ def godot_project(tmp_path):
     """A temp Godot project dir: ``project.godot`` scaffolded, cleanup owned by pytest."""
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     return tmp_path
+
+
+@pytest.fixture
+def daemon_runtime_dir(monkeypatch):
+    """A SHORT ``XDG_RUNTIME_DIR`` for tests that bind a real gda-daemon socket (#7).
+
+    A Unix-domain-socket path is bounded by the OS ``sun_path`` limit — **104
+    bytes on macOS**, 108 on Linux. pytest's macOS ``tmp_path`` lives under a long
+    ``/private/var/folders/...`` prefix, so the daemon's
+    ``<runtime>/gda/<hash>.cli.sock`` overflows the limit and ``bind()`` fails (the
+    daemon then never becomes ready and ``start`` times out). Any test that starts
+    a **real** daemon must therefore point ``XDG_RUNTIME_DIR`` at a SHORT directory
+    — ``/tmp`` is short and POSIX-present — NOT ``tmp_path``. This fixture yields
+    that dir (and cleans it up); the daemon's discovery (``gda.daemon.discovery``)
+    reads ``XDG_RUNTIME_DIR`` and the spawned daemon inherits it.
+
+    Tests that only *derive* socket paths, or that expect NO daemon (so never
+    ``bind()``), can keep using ``tmp_path``; only a real bind needs this. UNIX
+    only (the whole live stack is — ADR-0021), so use it under an ``os.name ==
+    'posix'`` guard.
+    """
+    runtime = tempfile.mkdtemp(prefix="gda-", dir="/tmp")
+    monkeypatch.setenv("XDG_RUNTIME_DIR", runtime)
+    yield Path(runtime)
+    shutil.rmtree(runtime, ignore_errors=True)

--- a/tests/support.py
+++ b/tests/support.py
@@ -73,6 +73,18 @@ def inject_runner(monkeypatch, result: RunResult) -> FakeRunner:
     return fake
 
 
+def inject_live_runner(monkeypatch, result: RunResult) -> FakeRunner:
+    """Swap the CLI's LIVE (daemon) runner seam for a ``FakeRunner`` (#7).
+
+    The ``kind = LIVE`` twin of :func:`inject_runner`: live commands route through
+    ``gda.cli._make_live_runner`` (the daemon IPC client), so a fake injected here
+    exercises the full Typer→classify_live→JSON pipeline without a real daemon.
+    """
+    fake = FakeRunner(result)
+    monkeypatch.setattr("gda.cli._make_live_runner", lambda binary, project=None: fake)
+    return fake
+
+
 # A sample ``gda info`` result, shaped as ``Engine.get_version_info()`` reports
 # it. Shared by the info success/schema tests so the canned engine version has a
 # single source of truth (issue #39).
@@ -357,4 +369,22 @@ THEME_CREATE_RESULT = {
     "path": "/tmp/proj/ui.tres",
     "type": "Theme",
     "created_dirs": [],
+}
+
+# A sample ``gda game tree`` result — the running game's runtime scene tree
+# (ADR-0019). Shared by the game-command success/schema tests.
+GAME_TREE_RESULT = {
+    "root": {
+        "name": "Main",
+        "type": "Node2D",
+        "path": "/root/Main",
+        "children": [
+            {
+                "name": "Player",
+                "type": "CharacterBody2D",
+                "path": "/root/Main/Player",
+                "children": [],
+            }
+        ],
+    }
 }

--- a/tests/test_daemon_discovery.py
+++ b/tests/test_daemon_discovery.py
@@ -8,15 +8,15 @@ project root, under a short private runtime directory.
 import os
 from pathlib import Path
 
+import pytest
+
 from gda.daemon.discovery import (
+    acquire_pidfile,
     daemon_paths,
     daemon_pid,
+    ensure_runtime_dir,
     within_uds_limit,
-    write_pidfile,
 )
-
-# A pid far above any real process table (macOS pid_max ~99998) — reliably dead.
-DEAD_PID = 4_000_000
 
 
 def test_daemon_paths_are_deterministic_and_canonical_per_project(tmp_path):
@@ -46,28 +46,49 @@ def test_daemon_paths_are_deterministic_and_canonical_per_project(tmp_path):
     assert paths.pidfile.parent == tmp_path / "run" / "gda"
 
 
-def test_daemon_pid_distinguishes_running_stale_and_foreign(tmp_path):
+@pytest.mark.skipif(os.name != "posix", reason="pidfile liveness uses flock (UNIX)")
+def test_daemon_pid_requires_recorded_path_socket_and_held_lock(tmp_path):
     proj = tmp_path / "game"
     proj.mkdir()
     env = {"XDG_RUNTIME_DIR": str(tmp_path / "run")}
     paths = daemon_paths(proj, env=env)
 
-    # No pidfile -> not running.
+    # Nothing yet -> not running.
     assert daemon_pid(paths) is None
 
-    # A live pid recorded for THIS project -> running (our own pid is alive), and
-    # the runtime dir is created private (0700) for the "no other-user surface"
-    # property (ADR-0021).
-    write_pidfile(paths, os.getpid())
-    assert daemon_pid(paths) == os.getpid()
-    assert (paths.runtime_dir.stat().st_mode & 0o777) == 0o700
+    handle = acquire_pidfile(paths, os.getpid())  # holds the advisory lock
+    try:
+        # Lock held but the CLI socket is not bound yet -> not running.
+        assert daemon_pid(paths) is None
+        # Bind the socket -> all three hold (recorded path + socket + held lock),
+        # and the runtime dir is private (0700) for the no-other-user-surface
+        # property (ADR-0021).
+        paths.cli_socket.touch()
+        assert daemon_pid(paths) == os.getpid()
+        assert (paths.runtime_dir.stat().st_mode & 0o777) == 0o700
+    finally:
+        handle.close()  # releases the advisory lock
 
-    # A dead pid -> stale -> not running (start reclaims it; status reports down).
-    write_pidfile(paths, DEAD_PID)
+    # Socket still present, but the lock is now grabbable -> stale -> not running.
+    # This is what makes a crashed daemon / reused PID self-heal (ADR-0021): the OS
+    # drops the lock on exit, so no os.kill PID-liveness guess is needed.
     assert daemon_pid(paths) is None
 
-    # A live pid but a DIFFERENT recorded project -> foreign -> not running.
-    paths.pidfile.write_text(f"{os.getpid()}\n{tmp_path / 'elsewhere'}\n", encoding="utf-8")
+
+@pytest.mark.skipif(os.name != "posix", reason="pidfile liveness uses flock (UNIX)")
+def test_daemon_pid_foreign_recorded_path_is_not_a_hit(tmp_path):
+    proj = tmp_path / "game"
+    proj.mkdir()
+    env = {"XDG_RUNTIME_DIR": str(tmp_path / "run")}
+    paths = daemon_paths(proj, env=env)
+    ensure_runtime_dir(paths)
+    paths.cli_socket.touch()
+
+    # A pidfile recording a DIFFERENT project is foreign (a hash collision / reused
+    # slot), regardless of socket/lock — never this project's daemon.
+    paths.pidfile.write_text(
+        f"{os.getpid()}\n{tmp_path / 'elsewhere'}\n", encoding="utf-8"
+    )
     assert daemon_pid(paths) is None
 
 

--- a/tests/test_daemon_discovery.py
+++ b/tests/test_daemon_discovery.py
@@ -1,0 +1,76 @@
+"""gda-daemon per-project discovery (#7, ADR-0021).
+
+Pure path derivation + pidfile liveness: no daemon process, no engine. A daemon
+is located by deriving deterministic socket/pidfile paths from the canonical
+project root, under a short private runtime directory.
+"""
+
+import os
+from pathlib import Path
+
+from gda.daemon.discovery import (
+    daemon_paths,
+    daemon_pid,
+    within_uds_limit,
+    write_pidfile,
+)
+
+# A pid far above any real process table (macOS pid_max ~99998) — reliably dead.
+DEAD_PID = 4_000_000
+
+
+def test_daemon_paths_are_deterministic_and_canonical_per_project(tmp_path):
+    proj = tmp_path / "game"
+    proj.mkdir()
+    env = {"XDG_RUNTIME_DIR": str(tmp_path / "run")}
+
+    paths = daemon_paths(proj, env=env)
+
+    # Same project referenced differently derives ONE identity (so start / status
+    # / attach agree): a trailing slash, and a symlink, both canonicalize to it.
+    assert daemon_paths(Path(str(proj) + "/"), env=env) == paths
+    link = tmp_path / "alias"
+    link.symlink_to(proj)
+    assert daemon_paths(link, env=env) == paths
+
+    # A different project derives a different socket.
+    other = tmp_path / "other"
+    other.mkdir()
+    assert daemon_paths(other, env=env).cli_socket != paths.cli_socket
+
+    # The canonical project root is recorded, and the two legs are distinct
+    # sockets under the private runtime dir.
+    assert paths.project == proj.resolve()
+    assert paths.cli_socket != paths.harness_socket
+    assert paths.cli_socket.parent == tmp_path / "run" / "gda"
+    assert paths.pidfile.parent == tmp_path / "run" / "gda"
+
+
+def test_daemon_pid_distinguishes_running_stale_and_foreign(tmp_path):
+    proj = tmp_path / "game"
+    proj.mkdir()
+    env = {"XDG_RUNTIME_DIR": str(tmp_path / "run")}
+    paths = daemon_paths(proj, env=env)
+
+    # No pidfile -> not running.
+    assert daemon_pid(paths) is None
+
+    # A live pid recorded for THIS project -> running (our own pid is alive), and
+    # the runtime dir is created private (0700) for the "no other-user surface"
+    # property (ADR-0021).
+    write_pidfile(paths, os.getpid())
+    assert daemon_pid(paths) == os.getpid()
+    assert (paths.runtime_dir.stat().st_mode & 0o777) == 0o700
+
+    # A dead pid -> stale -> not running (start reclaims it; status reports down).
+    write_pidfile(paths, DEAD_PID)
+    assert daemon_pid(paths) is None
+
+    # A live pid but a DIFFERENT recorded project -> foreign -> not running.
+    paths.pidfile.write_text(f"{os.getpid()}\n{tmp_path / 'elsewhere'}\n", encoding="utf-8")
+    assert daemon_pid(paths) is None
+
+
+def test_within_uds_limit_flags_overlong_socket_paths():
+    assert within_uds_limit(Path("/run/user/1000/gda/0123456789abcdef.cli.sock"))
+    assert not within_uds_limit(Path("/" + "x" * 200 + ".sock"))

--- a/tests/test_daemon_ops.py
+++ b/tests/test_daemon_ops.py
@@ -8,9 +8,6 @@ focus is the socket/pidfile lifecycle and idempotent start. The full session loo
 """
 
 import os
-import shutil
-import tempfile
-from pathlib import Path
 
 import pytest
 
@@ -27,18 +24,10 @@ pytestmark = [
     pytest.mark.e2e,  # start resolves a real Godot binary
 ]
 
-# A 4.6 engine so the live-version gate passes without running the engine.
+# A 4.6 engine so the live-version gate passes without running the engine. The
+# short-runtime-dir requirement (UDS sun_path limit) is the shared
+# ``daemon_runtime_dir`` fixture in conftest.
 _OK_VERSION = lambda binary: (4, 6)  # noqa: E731
-
-
-@pytest.fixture
-def short_runtime(monkeypatch):
-    # A real UDS path must fit the OS ``sun_path`` limit (~104B); pytest's macOS
-    # tmp_path is already too long, so point XDG_RUNTIME_DIR at a short /tmp dir.
-    runtime = tempfile.mkdtemp(prefix="gda-", dir="/tmp")
-    monkeypatch.setenv("XDG_RUNTIME_DIR", runtime)
-    yield Path(runtime)
-    shutil.rmtree(runtime, ignore_errors=True)
 
 
 def _project(tmp_path):
@@ -46,7 +35,7 @@ def _project(tmp_path):
     return tmp_path
 
 
-def test_daemon_start_status_stop_lifecycle(tmp_path, short_runtime):
+def test_daemon_start_status_stop_lifecycle(tmp_path, daemon_runtime_dir):
     project = _project(tmp_path)
     paths = daemon_paths(project)
 
@@ -76,7 +65,7 @@ def test_daemon_start_status_stop_lifecycle(tmp_path, short_runtime):
     assert not paths.cli_socket.exists()
 
 
-def test_live_version_gate_rejects_below_4_6(tmp_path, short_runtime):
+def test_live_version_gate_rejects_below_4_6(tmp_path, daemon_runtime_dir):
     from gda.errors import Failure
 
     project = _project(tmp_path)
@@ -88,7 +77,7 @@ def test_live_version_gate_rejects_below_4_6(tmp_path, short_runtime):
     assert daemon_pid(daemon_paths(project)) is None  # nothing spawned
 
 
-def test_daemon_status_and_stop_when_not_running(tmp_path, short_runtime):
+def test_daemon_status_and_stop_when_not_running(tmp_path, daemon_runtime_dir):
     project = _project(tmp_path)
 
     status = run_daemon_status_operation(project)

--- a/tests/test_daemon_ops.py
+++ b/tests/test_daemon_ops.py
@@ -1,0 +1,90 @@
+"""gda-daemon process lifecycle (#7, ADR-0017): start / status / stop.
+
+Spawns the REAL detached daemon process (Python only — no engine) against a short
+runtime dir, so the socket/pidfile lifecycle, idempotent start, and the
+no-session live-op reply are exercised end-to-end without Godot.
+"""
+
+import os
+import shutil
+import socket
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from gda.daemon.discovery import daemon_paths, daemon_pid
+from gda.daemon.protocol import read_message, write_message
+from gda.daemon_ops import (
+    run_daemon_start_operation,
+    run_daemon_status_operation,
+    run_daemon_stop_operation,
+)
+from gda.models import DaemonStartResult, DaemonStatusResult, DaemonStopResult
+from gda.parser import parse_result
+
+# The daemon binds AF_UNIX sockets — UNIX-only (ADR-0021).
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+
+@pytest.fixture
+def short_runtime(monkeypatch):
+    # A real UDS path must fit the OS ``sun_path`` limit (~104B); pytest's macOS
+    # tmp_path is already too long, so point XDG_RUNTIME_DIR at a short /tmp dir.
+    runtime = tempfile.mkdtemp(prefix="gda-", dir="/tmp")
+    monkeypatch.setenv("XDG_RUNTIME_DIR", runtime)
+    yield Path(runtime)
+    shutil.rmtree(runtime, ignore_errors=True)
+
+
+def _project(tmp_path):
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_daemon_start_status_stop_lifecycle(tmp_path, short_runtime):
+    project = _project(tmp_path)
+    paths = daemon_paths(project)
+
+    try:
+        started = run_daemon_start_operation(project, None)
+        assert isinstance(started, DaemonStartResult), started
+        assert started.already_running is False
+        assert started.installed_harness is True  # harness installed + reported
+        assert daemon_pid(paths) == started.pid
+
+        # Idempotent: a second start finds the running daemon.
+        again = run_daemon_start_operation(project, None)
+        assert isinstance(again, DaemonStartResult)
+        assert again.already_running is True
+        assert again.pid == started.pid
+        assert again.installed_harness is False
+
+        status = run_daemon_status_operation(project)
+        assert isinstance(status, DaemonStatusResult)
+        assert status.running is True and status.pid == started.pid
+
+        # A live op against the running daemon: no session held yet, so it returns
+        # the engine_session_not_running sentinel through the normal reply.
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.connect(str(paths.cli_socket))
+            write_message(sock, {"op": "game-tree", "params": {}})
+            reply = read_message(sock)
+        assert parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    finally:
+        stopped = run_daemon_stop_operation(project)
+        assert isinstance(stopped, DaemonStopResult)
+
+    # Torn down: pidfile dead, socket gone.
+    assert daemon_pid(paths) is None
+    assert not paths.cli_socket.exists()
+
+
+def test_daemon_status_and_stop_when_not_running(tmp_path, short_runtime):
+    project = _project(tmp_path)
+
+    status = run_daemon_status_operation(project)
+    assert isinstance(status, DaemonStatusResult) and status.running is False
+
+    stopped = run_daemon_stop_operation(project)
+    assert isinstance(stopped, DaemonStopResult) and stopped.stopped is False

--- a/tests/test_daemon_ops.py
+++ b/tests/test_daemon_ops.py
@@ -1,30 +1,34 @@
 """gda-daemon process lifecycle (#7, ADR-0017): start / status / stop.
 
-Spawns the REAL detached daemon process (Python only — no engine) against a short
-runtime dir, so the socket/pidfile lifecycle, idempotent start, and the
-no-session live-op reply are exercised end-to-end without Godot.
+Spawns the REAL detached daemon process against a short runtime dir. ``start`` now
+resolves the engine binary and gates the live version, so this needs a Godot
+install (e2e), but the version check is injected so no engine actually runs — the
+focus is the socket/pidfile lifecycle and idempotent start. The full session loop
+(a real runtime tree) is the CLI e2e in ``test_e2e_daemon``.
 """
 
 import os
 import shutil
-import socket
 import tempfile
 from pathlib import Path
 
 import pytest
 
 from gda.daemon.discovery import daemon_paths, daemon_pid
-from gda.daemon.protocol import read_message, write_message
 from gda.daemon_ops import (
     run_daemon_start_operation,
     run_daemon_status_operation,
     run_daemon_stop_operation,
 )
 from gda.models import DaemonStartResult, DaemonStatusResult, DaemonStopResult
-from gda.parser import parse_result
 
-# The daemon binds AF_UNIX sockets — UNIX-only (ADR-0021).
-pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+pytestmark = [
+    pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"),
+    pytest.mark.e2e,  # start resolves a real Godot binary
+]
+
+# A 4.6 engine so the live-version gate passes without running the engine.
+_OK_VERSION = lambda binary: (4, 6)  # noqa: E731
 
 
 @pytest.fixture
@@ -47,14 +51,14 @@ def test_daemon_start_status_stop_lifecycle(tmp_path, short_runtime):
     paths = daemon_paths(project)
 
     try:
-        started = run_daemon_start_operation(project, None)
+        started = run_daemon_start_operation(project, None, version_check=_OK_VERSION)
         assert isinstance(started, DaemonStartResult), started
         assert started.already_running is False
         assert started.installed_harness is True  # harness installed + reported
         assert daemon_pid(paths) == started.pid
 
         # Idempotent: a second start finds the running daemon.
-        again = run_daemon_start_operation(project, None)
+        again = run_daemon_start_operation(project, None, version_check=_OK_VERSION)
         assert isinstance(again, DaemonStartResult)
         assert again.already_running is True
         assert again.pid == started.pid
@@ -63,14 +67,6 @@ def test_daemon_start_status_stop_lifecycle(tmp_path, short_runtime):
         status = run_daemon_status_operation(project)
         assert isinstance(status, DaemonStatusResult)
         assert status.running is True and status.pid == started.pid
-
-        # A live op against the running daemon: no session held yet, so it returns
-        # the engine_session_not_running sentinel through the normal reply.
-        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
-            sock.connect(str(paths.cli_socket))
-            write_message(sock, {"op": "game-tree", "params": {}})
-            reply = read_message(sock)
-        assert parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
     finally:
         stopped = run_daemon_stop_operation(project)
         assert isinstance(stopped, DaemonStopResult)
@@ -78,6 +74,18 @@ def test_daemon_start_status_stop_lifecycle(tmp_path, short_runtime):
     # Torn down: pidfile dead, socket gone.
     assert daemon_pid(paths) is None
     assert not paths.cli_socket.exists()
+
+
+def test_live_version_gate_rejects_below_4_6(tmp_path, short_runtime):
+    from gda.errors import Failure
+
+    project = _project(tmp_path)
+    outcome = run_daemon_start_operation(
+        project, None, version_check=lambda binary: (4, 5)
+    )
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "unsupported_version"
+    assert daemon_pid(daemon_paths(project)) is None  # nothing spawned
 
 
 def test_daemon_status_and_stop_when_not_running(tmp_path, short_runtime):

--- a/tests/test_daemon_protocol.py
+++ b/tests/test_daemon_protocol.py
@@ -1,0 +1,24 @@
+"""Length-prefixed JSON framing for the daemon's IPC legs (#7, ADR-0021)."""
+
+import socket
+
+from gda.daemon.protocol import read_message, write_message
+
+
+def test_protocol_roundtrips_and_frames_back_to_back_messages():
+    a, b = socket.socketpair()
+    try:
+        write_message(a, {"op": "game-tree", "params": {}})
+        assert read_message(b) == {"op": "game-tree", "params": {}}
+
+        # Framing keeps two messages sent back-to-back distinct (no run-together).
+        write_message(a, {"n": 1})
+        write_message(a, {"n": 2})
+        assert read_message(b) == {"n": 1}
+        assert read_message(b) == {"n": 2}
+
+        # A closed peer reads as None rather than hanging or erroring.
+        a.close()
+        assert read_message(b) is None
+    finally:
+        b.close()

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -5,14 +5,26 @@ engine), so the no-session and control-op paths stay covered in the fast suite.
 """
 
 import os
+import socket
 
 import pytest
 
 from gda.daemon.discovery import daemon_paths
 from gda.daemon.server import DaemonServer
+from gda.daemon.session import EngineSession
+from gda.daemon_ops import (
+    run_daemon_status_operation,
+    run_daemon_stop_operation,
+)
+from gda.errors import Failure
 from gda.parser import parse_result
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+
+class _FakeProc:
+    def poll(self):
+        return None
 
 
 def test_live_op_without_a_launchable_session_is_engine_session_not_running(tmp_path):
@@ -33,3 +45,31 @@ def test_control_ops_report_liveness_and_request_stop(tmp_path):
     stop = server._handle({"op": "__stop__"})
     assert stop["ok"] is True
     assert server._stopping is True
+
+
+def test_engine_session_request_times_out_as_live_timeout(monkeypatch):
+    # A harness that never replies must surface the registered live_timeout, not
+    # hang the daemon forever (ADR-0021).
+    monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
+    daemon_end, silent_harness = socket.socketpair()
+    session = EngineSession(_FakeProc(), daemon_end)
+    try:
+        reply = session.request("game-tree", {})
+        assert parse_result(reply["stdout"])["error"]["code"] == "live_timeout"
+    finally:
+        daemon_end.close()
+        silent_harness.close()
+
+
+def test_daemon_status_on_non_unix_is_live_unsupported_platform(monkeypatch, tmp_path):
+    monkeypatch.setattr("gda.daemon_ops._is_unix", lambda: False)
+    outcome = run_daemon_status_operation(tmp_path)
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "live_unsupported_platform"
+
+
+def test_daemon_stop_on_non_unix_is_live_unsupported_platform(monkeypatch, tmp_path):
+    monkeypatch.setattr("gda.daemon_ops._is_unix", lambda: False)
+    outcome = run_daemon_stop_operation(tmp_path)
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "live_unsupported_platform"

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -1,0 +1,35 @@
+"""DaemonServer request handling, in-process (#7).
+
+Exercises the server's request branching directly (no spawned process, no real
+engine), so the no-session and control-op paths stay covered in the fast suite.
+"""
+
+import os
+
+import pytest
+
+from gda.daemon.discovery import daemon_paths
+from gda.daemon.server import DaemonServer
+from gda.parser import parse_result
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+
+def test_live_op_without_a_launchable_session_is_engine_session_not_running(tmp_path):
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    # No Godot binary -> ensure_session cannot launch -> engine_session_not_running.
+    server = DaemonServer(daemon_paths(tmp_path), godot="")
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+
+    assert parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+
+
+def test_control_ops_report_liveness_and_request_stop(tmp_path):
+    server = DaemonServer(daemon_paths(tmp_path), godot="")
+
+    assert server._handle({"op": "__status__"})["ok"] is True
+
+    stop = server._handle({"op": "__stop__"})
+    assert stop["ok"] is True
+    assert server._stopping is True

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -1,0 +1,68 @@
+"""S1 (e2e): `gda daemon` lifecycle through the real console script (#7).
+
+Drives the installed ``gda`` console script against a REAL detached daemon
+process: start (idempotent, reports the harness install) → status → a live op
+that finds the daemon but no engine session yet (``engine_session_not_running``)
+→ stop → torn down. The engine session itself is the next slice; this proves the
+CLI → daemon-process → IPC path end-to-end. Python-only (no engine).
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+from gda.exit_codes import EXIT_LIVE
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+
+@pytest.mark.e2e
+def test_daemon_lifecycle_through_the_cli(tmp_path):
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+
+    # A SHORT runtime dir so the daemon's UDS path fits sun_path (~104B).
+    runtime = tempfile.mkdtemp(prefix="gda-e2e-", dir="/tmp")
+    env = {**os.environ, "XDG_RUNTIME_DIR": runtime}
+
+    def run(*args):
+        return subprocess.run(
+            [gda, *args, "--project", str(tmp_path), "--json"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+        start_data = json.loads(started.stdout)
+        assert start_data["already_running"] is False
+        assert start_data["installed_harness"] is True
+        assert start_data["pid"] > 0
+
+        # Idempotent: a second start reports the already-running daemon.
+        again = json.loads(run("daemon", "start").stdout)
+        assert again["already_running"] is True and again["pid"] == start_data["pid"]
+
+        assert json.loads(run("daemon", "status").stdout)["running"] is True
+
+        # A live op reaches the running daemon but it holds no engine session yet.
+        tree = run("game", "tree")
+        assert tree.returncode == EXIT_LIVE, tree.stdout + tree.stderr
+        assert json.loads(tree.stdout)["error"]["code"] == "engine_session_not_running"
+
+        stop = run("daemon", "stop")
+        assert stop.returncode == 0, stop.stdout + stop.stderr
+        assert json.loads(stop.stdout)["stopped"] is True
+
+        assert json.loads(run("daemon", "status").stdout)["running"] is False
+    finally:
+        run("daemon", "stop")
+        shutil.rmtree(runtime, ignore_errors=True)

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -4,14 +4,14 @@ The Step-6 proof: a real ``gda daemon start`` (real detached daemon, real harnes
 install, live-version gate) → a real engine session it launches on demand →
 ``gda game tree`` returns the RUNNING game's runtime scene tree, observed live via
 the harness over Unix domain sockets → ``gda daemon stop`` tears it down. Run e2e
-serially; not a fresh empty HOME (Godot first-run).
+serially; not a fresh empty HOME (Godot first-run). The ``daemon_runtime_dir``
+fixture keeps the daemon's UDS path within the OS ``sun_path`` limit.
 """
 
 import json
 import os
 import shutil
 import subprocess
-import tempfile
 
 import pytest
 
@@ -30,15 +30,15 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 
 
 @pytest.mark.e2e
-def test_daemon_serves_a_real_runtime_tree(tmp_path):
+def test_daemon_serves_a_real_runtime_tree(tmp_path, daemon_runtime_dir):
     gda = shutil.which("gda")
     assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
 
-    # A SHORT runtime dir so the daemon's UDS paths fit sun_path (~104B).
-    runtime = tempfile.mkdtemp(prefix="gda-e2e-", dir="/tmp")
-    env = {**os.environ, "XDG_RUNTIME_DIR": runtime}
+    # XDG_RUNTIME_DIR is set short by the daemon_runtime_dir fixture; the spawned
+    # daemon inherits it through the subprocess environment.
+    env = {**os.environ}
 
     def run(*args):
         return subprocess.run(
@@ -67,4 +67,3 @@ def test_daemon_serves_a_real_runtime_tree(tmp_path):
         assert json.loads(run("daemon", "status").stdout)["running"] is False
     finally:
         run("daemon", "stop")
-        shutil.rmtree(runtime, ignore_errors=True)

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -1,10 +1,10 @@
-"""S1 (e2e): `gda daemon` lifecycle through the real console script (#7).
+"""S1 (e2e): the full gda-daemon live loop through the console script (#7).
 
-Drives the installed ``gda`` console script against a REAL detached daemon
-process: start (idempotent, reports the harness install) → status → a live op
-that finds the daemon but no engine session yet (``engine_session_not_running``)
-→ stop → torn down. The engine session itself is the next slice; this proves the
-CLI → daemon-process → IPC path end-to-end. Python-only (no engine).
+The Step-6 proof: a real ``gda daemon start`` (real detached daemon, real harness
+install, live-version gate) → a real engine session it launches on demand →
+``gda game tree`` returns the RUNNING game's runtime scene tree, observed live via
+the harness over Unix domain sockets → ``gda daemon stop`` tears it down. Run e2e
+serially; not a fresh empty HOME (Godot first-run).
 """
 
 import json
@@ -15,53 +15,55 @@ import tempfile
 
 import pytest
 
-from gda.exit_codes import EXIT_LIVE
+from gda.binary import resolve_godot_binary
+
+from .conftest import project_godot
+
+GODOT = resolve_godot_binary()
+
+# A trivial main scene so the launched session has a runtime SceneTree to read;
+# file logging stays disabled via project_godot (issue #180).
+MAIN_TSCN = '[gd_scene format=3]\n\n[node name="Main" type="Node2D"]\n'
+PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
 
 @pytest.mark.e2e
-def test_daemon_lifecycle_through_the_cli(tmp_path):
+def test_daemon_serves_a_real_runtime_tree(tmp_path):
     gda = shutil.which("gda")
     assert gda, "the `gda` console script is not on PATH"
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
 
-    # A SHORT runtime dir so the daemon's UDS path fits sun_path (~104B).
+    # A SHORT runtime dir so the daemon's UDS paths fit sun_path (~104B).
     runtime = tempfile.mkdtemp(prefix="gda-e2e-", dir="/tmp")
     env = {**os.environ, "XDG_RUNTIME_DIR": runtime}
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--json"],
+            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,
-            timeout=30,
+            timeout=90,
         )
 
     try:
         started = run("daemon", "start")
         assert started.returncode == 0, started.stdout + started.stderr
-        start_data = json.loads(started.stdout)
-        assert start_data["already_running"] is False
-        assert start_data["installed_harness"] is True
-        assert start_data["pid"] > 0
+        assert json.loads(started.stdout)["installed_harness"] is True
 
-        # Idempotent: a second start reports the already-running daemon.
-        again = json.loads(run("daemon", "start").stdout)
-        assert again["already_running"] is True and again["pid"] == start_data["pid"]
+        # The daemon launches the engine session on demand and relays the live op;
+        # the result is the running game's runtime scene tree.
+        tree = run("game", "tree")
+        assert tree.returncode == 0, tree.stdout + tree.stderr
+        root = json.loads(tree.stdout)["root"]
+        assert root["name"] == "Main"
+        assert root["type"] == "Node2D"
 
         assert json.loads(run("daemon", "status").stdout)["running"] is True
-
-        # A live op reaches the running daemon but it holds no engine session yet.
-        tree = run("game", "tree")
-        assert tree.returncode == EXIT_LIVE, tree.stdout + tree.stderr
-        assert json.loads(tree.stdout)["error"]["code"] == "engine_session_not_running"
-
-        stop = run("daemon", "stop")
-        assert stop.returncode == 0, stop.stdout + stop.stderr
-        assert json.loads(stop.stdout)["stopped"] is True
-
+        assert json.loads(run("daemon", "stop").stdout)["stopped"] is True
         assert json.loads(run("daemon", "status").stdout)["running"] is False
     finally:
         run("daemon", "stop")

--- a/tests/test_e2e_game.py
+++ b/tests/test_e2e_game.py
@@ -1,0 +1,40 @@
+"""S1 (e2e): `gda game` live commands through the real console script (#7).
+
+This slice's real path is the attach-or-fail: a real ``gda game tree`` with no
+running daemon must emit the typed ``daemon_not_running`` envelope and exit
+``EXIT_LIVE`` — exercised through the installed console script and the real
+``DaemonRunner`` + discovery (no fake at the seam). The connected path (a live
+tree from a real engine session) lands with the daemon, a later slice. Per
+RULES.md DoD the fake-runner command tests do not count toward this gate.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from gda.exit_codes import EXIT_LIVE
+
+
+@pytest.mark.e2e
+def test_game_tree_without_a_daemon_reports_daemon_not_running(tmp_path):
+    gda_bin = shutil.which("gda")
+    assert gda_bin, "the `gda` console script is not on PATH"
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+
+    # An empty runtime dir so discovery finds no daemon for this fresh project.
+    env = {**os.environ, "XDG_RUNTIME_DIR": str(tmp_path / "run")}
+    proc = subprocess.run(
+        [gda_bin, "game", "tree", "--project", str(tmp_path), "--json"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert proc.returncode == EXIT_LIVE, proc.stdout + proc.stderr
+    error = json.loads(proc.stdout)["error"]
+    assert error["code"] == "daemon_not_running"
+    assert error["category"] == "live"
+    assert "gda daemon start" in error["message"]

--- a/tests/test_e2e_harness_install.py
+++ b/tests/test_e2e_harness_install.py
@@ -1,0 +1,54 @@
+"""S1 (e2e): the installed gda harness loads inert in a real engine (#7, ADR-0018).
+
+Per RULES.md DoD the fast install tests do not count toward this gate: this boots
+a REAL Godot on a project with the harness installed and asserts the autoload is
+valid GDScript and stays inert — no daemon launch marker, so it opens nothing and
+the engine boots clean. The daemon<->harness connection itself is a later slice.
+"""
+
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+from gda.harness.install import (
+    HARNESS_AUTOLOAD_NAME,
+    HARNESS_RES_PATH,
+    install_harness,
+)
+
+from .conftest import project_godot
+
+GODOT = resolve_godot_binary()
+
+# A trivial main scene so a normal (non-`--script`) boot runs the autoload's
+# `_ready`; file logging stays disabled via project_godot (issue #180).
+MAIN_TSCN = '[gd_scene format=3]\n\n[node name="Main" type="Node"]\n'
+PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
+
+
+@pytest.mark.e2e
+def test_installed_harness_boots_inert_in_a_real_engine(tmp_path):
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+
+    changed = install_harness(tmp_path)
+
+    assert changed is True
+    assert (tmp_path / "addons" / "gda_harness" / "gda_harness.gd").exists()
+    text = (tmp_path / "project.godot").read_text(encoding="utf-8")
+    assert f'{HARNESS_AUTOLOAD_NAME}="*{HARNESS_RES_PATH}"' in text
+
+    # Boot the real engine. The installed autoload must load (valid GDScript) and
+    # stay inert — no `gda-daemon` marker in the args, so it returns early and
+    # opens nothing, and the engine boots without a script/parse error.
+    proc = subprocess.run(
+        [str(GODOT), "--headless", "--path", str(tmp_path), "--quit"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    out = proc.stdout + proc.stderr
+    assert "SCRIPT ERROR" not in out, out
+    assert "Parse Error" not in out, out
+    assert proc.returncode == 0, out

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -12,6 +12,18 @@ from gda.error_codes import (
     ErrorCodeSource,
 )
 from gda.errors import _failure
+from gda.exit_codes import EXIT_LIVE
+from gda.models import ErrorCategory
+
+# The live execution channel's failure codes (ADR-0017 / ADR-0021). Registered
+# here as the first Phase-2 slice's error contract; emitted by the daemon IPC
+# client and the daemon as the live capability lands.
+LIVE_ERROR_CODES = (
+    "daemon_not_running",
+    "engine_session_not_running",
+    "engine_disconnected",
+    "live_timeout",
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 ADR_0002 = ROOT / "docs" / "adr" / "0002-headless-structured-output-contract.md"
@@ -80,3 +92,16 @@ def test_gdscript_fail_calls_do_not_use_literal_error_codes():
     gdscript = OPERATIONS_GD.read_text(encoding="utf-8")
 
     assert not BARE_FAIL_CODE.search(gdscript)
+
+
+def test_live_failures_are_registered_classifier_live_codes():
+    # A live operation's failure is a classifier-source LIVE code (ADR-0017 /
+    # ADR-0021): the new LIVE category, the shared EXIT_LIVE exit, and — because
+    # no headless operation reports it — NOT GDScript-mirrored (the mirror subset
+    # below stays the operation-source set, so the drift test is unaffected).
+    for code in LIVE_ERROR_CODES:
+        spec = ERROR_CODE_BY_CODE[code]
+        assert spec.category is ErrorCategory.LIVE
+        assert spec.source is ErrorCodeSource.CLASSIFIER
+        assert spec.exit_code == EXIT_LIVE
+        assert spec.code not in OPERATION_ERROR_CODES

--- a/tests/test_export_run_operation.py
+++ b/tests/test_export_run_operation.py
@@ -18,10 +18,25 @@ surface, complementary to the command tests in
 from pathlib import Path
 
 from gda.errors import Failure
-from gda.export_run import run_export_operation
+from gda.execution import ExecutionKind
+from gda.export_run import (
+    EXPORT_GET_COMMAND,
+    EXPORT_RUN_COMMAND,
+    run_export_operation,
+)
 from gda.models import ExportRunMode, ExportRunResult
 from gda.runner import RunResult
 from tests.support import FakeExportRunner, FakeRunner, error_sentinel, sentinel
+
+
+def test_export_run_command_is_the_native_export_channel():
+    # ``export run`` is the one editor-only-export capability that does not run
+    # through operations.gd, so it carries the EXPORT execution channel (ADR-0017
+    # / ADR-0010); ``export get`` resolves via the sentinel pipeline and stays
+    # HEADLESS. The dispatcher selects the native recipe by this kind.
+    assert EXPORT_RUN_COMMAND.kind is ExecutionKind.EXPORT
+    assert EXPORT_GET_COMMAND.kind is ExecutionKind.HEADLESS
+
 
 GET_RESULT = {
     "index": 0,

--- a/tests/test_game_commands.py
+++ b/tests/test_game_commands.py
@@ -62,3 +62,27 @@ def test_game_tree_schema_is_self_describing():
     schema = json.loads(result.stdout)
     # Self-describes its input and output contracts like any headless command.
     assert "input" in schema and "output" in schema
+
+
+def test_game_tree_without_a_project_reports_project_not_found(monkeypatch, tmp_path):
+    # No --project and a projectless cwd -> the project resolves to None, which is
+    # a project-resolution error, NOT a daemon error (ADR-0021).
+    monkeypatch.chdir(tmp_path)  # tmp_path holds no project.godot
+
+    result = CliRunner().invoke(app, ["game", "tree", "--json"])
+
+    assert result.exit_code != 0, result.stdout
+    assert json.loads(result.stdout)["error"]["code"] == "project_not_found"
+
+
+def test_game_tree_on_non_unix_reports_live_unsupported_platform(monkeypatch, tmp_path):
+    # The live stack is UNIX-only (UDS); a non-UNIX platform fails fast with the
+    # typed error, before touching the daemon (ADR-0021).
+    monkeypatch.setattr("gda.live_runner._is_unix", lambda: False)
+
+    result = CliRunner().invoke(
+        app, ["game", "tree", "--project", str(_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code != 0, result.stdout
+    assert json.loads(result.stdout)["error"]["code"] == "live_unsupported_platform"

--- a/tests/test_game_commands.py
+++ b/tests/test_game_commands.py
@@ -1,0 +1,64 @@
+"""`gda game` — the running game's runtime scene graph, served LIVE (#7, ADR-0019).
+
+Engine-free: a fake daemon runner at the LIVE seam exercises the full
+Typer→classify_live→JSON pipeline, and the no-daemon attach-or-fail path runs the
+real ``DaemonRunner`` against an empty runtime dir. The real-engine round trip is
+the e2e.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.exit_codes import EXIT_LIVE
+from gda.runner import RunResult
+from tests.support import GAME_TREE_RESULT, inject_live_runner, sentinel
+
+
+def _project(tmp_path):
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_game_tree_emits_runtime_tree_json_through_the_live_channel(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(GAME_TREE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app, ["game", "tree", "--project", str(_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["root"]["name"] == "Main"
+    assert data["root"]["children"][0]["type"] == "CharacterBody2D"
+    # Routed through the LIVE seam, dispatching the game-tree operation (no args).
+    assert fake.calls == [("game-tree", {})]
+
+
+def test_game_tree_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):
+    # No fake: the real DaemonRunner + discovery run, against an empty runtime dir
+    # so no daemon is found — the attach-or-fail typed error (ADR-0017).
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
+
+    result = CliRunner().invoke(
+        app, ["game", "tree", "--project", str(_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "daemon_not_running"
+    assert error["category"] == "live"
+    assert "gda daemon start" in error["message"]
+
+
+def test_game_tree_schema_is_self_describing():
+    result = CliRunner().invoke(app, ["game", "tree", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    schema = json.loads(result.stdout)
+    # Self-describes its input and output contracts like any headless command.
+    assert "input" in schema and "output" in schema

--- a/tests/test_harness_install.py
+++ b/tests/test_harness_install.py
@@ -1,0 +1,56 @@
+"""gda harness install (#7, ADR-0018): idempotent project.godot autoload write.
+
+Pure filesystem: materialize the bundled harness under ``res://addons/`` and add
+its ``[autoload]`` entry to ``project.godot`` — a one-time, install-time write
+(never a per-launch mutation), idempotent and order-preserving.
+"""
+
+from gda.harness.install import (
+    HARNESS_AUTOLOAD_NAME,
+    HARNESS_RES_PATH,
+    install_harness,
+)
+
+_NO_AUTOLOAD = 'config_version=5\n\n[application]\n\nconfig/name="t"\n'
+
+
+def _autoload_line() -> str:
+    return f'{HARNESS_AUTOLOAD_NAME}="*{HARNESS_RES_PATH}"'
+
+
+def test_install_materializes_harness_and_writes_autoload_entry(tmp_path):
+    (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
+
+    changed = install_harness(tmp_path)
+
+    assert changed is True
+    gd = tmp_path / "addons" / "gda_harness" / "gda_harness.gd"
+    assert gd.exists()
+    assert "extends Node" in gd.read_text(encoding="utf-8")
+
+    text = (tmp_path / "project.godot").read_text(encoding="utf-8")
+    assert "[autoload]" in text
+    # enabled-singleton form: the res:// path prefixed with "*".
+    assert _autoload_line() in text
+
+
+def test_install_is_idempotent(tmp_path):
+    (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
+
+    assert install_harness(tmp_path) is True  # first install changes the project
+    assert install_harness(tmp_path) is False  # second is a no-op
+
+    text = (tmp_path / "project.godot").read_text(encoding="utf-8")
+    assert text.count(_autoload_line()) == 1  # not duplicated
+
+
+def test_install_preserves_existing_autoloads(tmp_path):
+    existing = _NO_AUTOLOAD + '\n[autoload]\n\nOther="*res://other.gd"\n'
+    (tmp_path / "project.godot").write_text(existing, encoding="utf-8")
+
+    assert install_harness(tmp_path) is True
+
+    text = (tmp_path / "project.godot").read_text(encoding="utf-8")
+    assert 'Other="*res://other.gd"' in text  # sibling autoload preserved
+    assert _autoload_line() in text  # harness added
+    assert text.count("[autoload]") == 1  # no duplicate section

--- a/tests/test_headless_command.py
+++ b/tests/test_headless_command.py
@@ -6,10 +6,23 @@ from pathlib import Path
 import pytest
 import typer
 
+from gda.execution import ExecutionKind
 from gda.headless import HeadlessCommand
 from gda.models import EngineVersion, InfoParams
 from gda.runner import LaunchFailure, RunResult
 from tests.support import VERSION_INFO, FakeRunner, sentinel
+
+
+def test_headless_command_classifies_its_execution_channel_as_headless_by_default():
+    # A command carries a static execution-channel `kind` (ADR-0017); a plain
+    # sentinel-pipeline command is HEADLESS without having to say so.
+    command: HeadlessCommand[EngineVersion] = HeadlessCommand(
+        operation="info",
+        input_model=InfoParams,
+        output_model=EngineVersion,
+    )
+
+    assert command.kind is ExecutionKind.HEADLESS
 
 
 def test_headless_command_emit_owns_runner_classification_and_json_output(capsys):


### PR DESCRIPTION
## What

Implements the **bootstrap** of **#7** (gda-daemon, the first Phase-2 slice) — the daemon process, the LIVE execution channel, and the `game tree` tracer — per the approved plan and ADR-0017/0018/0019/0020/0021. This is the bootstrap mechanism, **not** every #7 acceptance line (see the scope clarification at the bottom). `gda game tree` now returns the **running game's runtime scene tree**, observed live through a real engine session over Unix domain sockets, with the same `--json` / `GdaError` contract a headless command returns.

Six tracer-bullet commits, each green and e2e-gated:

1. **refactor(cli)**: `ExecutionKind` channel selector — folds the `export run` identity special-case into a `kind` switch.
2. **feat(errors)**: `ErrorCategory.LIVE` + `EXIT_LIVE` + the LIVE error codes, synced into the ADR-0002 table.
3. **feat(daemon)**: per-project discovery (canonicalize → hash → private `0700` dir → liveness) + idempotent harness install + the inert harness gate.
4. **feat(game)**: the LIVE channel (`DaemonRunner`, runner-factory by `kind`, `classify_live`) + the `game tree` tracer.
5. **feat(daemon)**: the daemon lifecycle process (UDS broker + pidfile + start/stop/status + platform gate).
6. **feat(daemon)**: the engine session + harness `StreamPeerUDS` relay + the live-version gate — the full loop.

\+ **test(daemon)**: a shared `daemon_runtime_dir` conftest fixture documenting the UDS `sun_path` gotcha.

## The live loop (proven by e2e)

`gda daemon start` → idempotent harness install (reported) → on-demand **headless** engine session (launch marker + harness UDS path + auth token) → harness connects via `StreamPeerUDS`, authenticates → `gda game tree` reads the runtime `SceneTree` at a frame boundary → real tree → `gda daemon stop` tears it down. No daemon → typed `daemon_not_running`; engine < 4.6 → typed `version` error; non-UNIX → `live_unsupported_platform`.

## Decisions / honest notes

- **Session runs `--headless` for the tracer** (`game tree` reads the SceneTree, needs no viewport). A **windowed** session lands with viewport capture (**#222**) — a scoped deviation from ADR-0017's "windowed by default", which exists for capture.
- **`--schema` operation `kind`** (story 24) is **deferred** — a cross-cutting schema-ABI change touching every command + gda-mcp, better as its own slice.
- **`live_unsupported_platform`** (Windows/non-UNIX fail-fast) is fast-tested; its real e2e cannot run on the macOS/Linux dev+CI boxes.

## DoD

- Fast suite: **641 passed**.
- Full e2e suite (serial, real Godot 4.6): **247 passed, 1 skipped** (benign `export_templates_missing` — no local export templates).
- `uv build` clean; the bundled `gda_harness.gd` + all new modules are packaged.

## Refs

Refs #7. Builds on **ADR-0021** (PR #228, merged). This ships the bootstrap mechanism + tracer + a hardened control plane; it does **not** satisfy every #7 acceptance line verbatim — `--schema` `kind` → #230, windowed session → #222. Close #7 once you agree those are out-of-scope-for-bootstrap, or keep it open until #230.


---

## Update — review response (`ab1473b`)

Hardened the daemon control plane and reconciled the contract per review:
- **Timeouts** on the live IPC client + session relay → `live_timeout` (no more indefinite blocking).
- **flock-based liveness** (ADR-0021): held advisory lock + bound socket + recorded-path match; reused-PID / stale-socket false-positives gone, crashed daemon self-heals.
- **Full non-UNIX gate** on `daemon stop`/`status` + the LIVE runner (`live_unsupported_platform`, platform first).
- **Projectless** live op → `project_not_found`; `within_uds_limit` checked before bind.
- **Docs**: ADR-0017 scoped-narrowing note (headless tracer session → windowed with #222; lazy launch), README/catalog mark bootstrap shipped, `--help` states the UNIX-only / 4.6+ constraint.

**Scope clarification:** this PR ships the **bootstrap mechanism + the `game tree` tracer + a hardened control plane**. Two items are deferred to their own slices: **`--schema` `kind`** → #230 (cross-cutting, touches gda-mcp), **windowed session** → #222 (viewport capture). So it does **not** claim to satisfy every #7 acceptance line verbatim — close #7 once you agree those two are bootstrap-out-of-scope, or keep it open until #230 lands.
