### PR TITLE
feat: surface execution kind in --schema (#230)

### DIFF
--- a/docs/adr/0004-schema-flag-self-description.md
+++ b/docs/adr/0004-schema-flag-self-description.md
@@ -4,6 +4,16 @@ status: accepted
 
 # `--schema` is self-description, not a caller-supplied contract
 
+> **Outcome (2026-06-22, #230 / PR #232):** the per-command `--schema` object
+> gained a fourth, additive key — `kind`, the command's static `ExecutionKind`
+> (`headless` / `export` / `live`, ADR-0017) — alongside `input` / `output` /
+> `error`. Like the `{input, output}` → `{input, output, error}` move described
+> below, this is a strict superset: `gda-mcp` still maps only `input` / `output`,
+> so it stays backward compatible (ADR-0012). `kind` is `null` only for a
+> self-description emitted without a backing command (e.g. `gda schema --schema`);
+> in the aggregate manifest (ADR-0012) every dispatchable entry's `kind` is
+> required and enum-constrained.
+
 ADR-0000 lists `--schema` as a core capability without defining it. We fix its
 semantics here, and deliberately scope out an overloaded interpretation.
 

--- a/docs/adr/0012-gda-mcp-tool-surface-generation.md
+++ b/docs/adr/0012-gda-mcp-tool-surface-generation.md
@@ -4,6 +4,15 @@ status: accepted
 
 # gda-mcp tool-surface generation: runtime introspection of a whole-surface schema dump, no hand-curated profiles
 
+> **Outcome (2026-06-22, #230 / PR #232):** each manifest entry gained an
+> additive `kind` field (the command's static `ExecutionKind` — `headless` /
+> `export` / `live`, ADR-0017), so `{name, description, input, output, error}`
+> below is now `{name, description, input, output, error, kind}`. gda-mcp's
+> mechanical mapping is unchanged — it still derives `inputSchema` ← `input` and
+> `outputSchema` ← `output` and simply ignores `kind` — so the addition is
+> backward compatible. On the aggregate entry `kind` is required and
+> enum-constrained, so a consumer of `gda schema --schema` can rely on it.
+
 ADR-0011 fixes [gda-mcp](../../CONTEXT.md) as a subprocess adapter that consumes
 `gda`'s public ABI. ADR-0004 / ADR-0005 make each command self-describing
 (`--schema` → `{input, output, error}`) and give a deterministic CLI→MCP name map

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -175,8 +175,17 @@ def schema_command_class(
         def parse_args(self, ctx: typer.Context, args: list[str]) -> list[str]:
             if "--schema" in args:
                 self._parse_relaxed(ctx, args)
+                # Carry the command's static execution channel (ADR-0017) from
+                # the one source of truth — the backing ``HeadlessCommand.kind``
+                # — into the self-description (issue #230). ``ExecutionKind``
+                # subclasses ``str``, so it serializes as the lowercase value
+                # ("headless"/"export"/"live"). ``None`` for the bare ``gda
+                # schema`` meta command, which has no backing command to run.
+                kind = command.kind if command is not None else None
                 typer.echo(
-                    CommandSchema.of(input_model, output_model).model_dump_json()
+                    CommandSchema.of(
+                        input_model, output_model, kind=kind
+                    ).model_dump_json()
                 )
                 raise typer.Exit()
             if command is not None and "--params-json" in args:

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -18,6 +18,8 @@ from pydantic import (
     model_validator,
 )
 
+from gda.execution import ExecutionKind
+
 
 class ErrorCategory(str, Enum):
     """The coarse buckets a ``gda`` operation can fail into (issue #3).
@@ -127,35 +129,38 @@ class CommandSchema(BaseModel):
     separate ``isError`` channel, so the future adapter must not fold ``error``
     into ``outputSchema``.
 
-    ``kind`` carries the command's static execution channel — the lowercase
-    :class:`~gda.execution.ExecutionKind` value (``"headless"`` / ``"export"`` /
-    ``"live"``) — taken from the command descriptor's single source of truth
-    (``HeadlessCommand.kind``), so an agent can branch on a command's channel
-    without inferring it (issue #230, stories 14/15/24). It is additive and
-    optional: gda-mcp maps only ``input`` / ``output`` / ``description`` and
-    ignores it, so adding it is backward-compatible (ADR-0012). ``None`` only when
-    a self-description is emitted without a backing command (e.g. ``gda schema``).
+    ``kind`` carries the command's static execution channel as the typed
+    :class:`~gda.execution.ExecutionKind` (serialized as the lowercase value
+    ``"headless"`` / ``"export"`` / ``"live"``), taken from the command
+    descriptor's single source of truth (``HeadlessCommand.kind``), so an agent
+    can branch on a command's channel without inferring it (issue #230, stories
+    14/15/24). Typing it as the enum makes the value enum-constrained in any
+    derived schema. It is additive: gda-mcp maps only ``input`` / ``output`` /
+    ``description`` and ignores it, so adding it is backward-compatible
+    (ADR-0012). It is ``None`` only when a self-description is emitted without a
+    backing command (e.g. ``gda schema``); a real per-command ``--schema`` always
+    carries a kind.
     """
 
     input: dict[str, Any]
     output: dict[str, Any]
     error: dict[str, Any]
-    kind: str | None = None
+    kind: ExecutionKind | None = None
 
     @classmethod
     def of(
         cls,
         input_model: type[BaseModel],
         output_model: type[BaseModel],
-        kind: str | None = None,
+        kind: ExecutionKind | None = None,
     ) -> "CommandSchema":
         """Derive the contract from a command's params and result models.
 
         ``error`` is the shared failure-envelope schema, the same for every
         command, so it takes no per-command model argument. ``kind`` is the
-        command's static :class:`~gda.execution.ExecutionKind` value (issue
-        #230); an ``ExecutionKind`` passed in serializes to its lowercase string
-        because it subclasses ``str``.
+        command's static :class:`~gda.execution.ExecutionKind` (issue #230); it
+        serializes to its lowercase string because ``ExecutionKind`` subclasses
+        ``str``.
         """
         return cls(
             input=input_model.model_json_schema(),
@@ -176,10 +181,14 @@ class CommandManifestEntry(BaseModel):
     (its help text, which flows into the MCP tool description).
 
     ``kind`` mirrors :class:`CommandSchema`'s: the entry's static execution
-    channel (``"headless"`` / ``"export"`` / ``"live"``), taken from the same
-    descriptor source of truth so the aggregate and per-command forms agree
-    (issue #230). Additive and ignored by gda-mcp (ADR-0012). Every dispatchable
-    manifest entry has a backing command, so it is always populated here.
+    channel as the typed :class:`~gda.execution.ExecutionKind` (serialized
+    ``"headless"`` / ``"export"`` / ``"live"``), taken from the same descriptor
+    source of truth so the aggregate and per-command forms agree (issue #230).
+    Additive and ignored by gda-mcp (ADR-0012). Unlike :class:`CommandSchema`'s
+    optional ``kind``, here it is **required**: every aggregate entry is a
+    dispatchable command with a backing descriptor, so the self-described surface
+    schema (``gda schema --schema``) guarantees the field and constrains it to
+    the execution-kind enum — a consumer can rely on it always being present.
     """
 
     name: str
@@ -187,7 +196,7 @@ class CommandManifestEntry(BaseModel):
     input: dict[str, Any]
     output: dict[str, Any]
     error: dict[str, Any]
-    kind: str | None = None
+    kind: ExecutionKind
 
 
 class SurfaceManifest(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -126,25 +126,42 @@ class CommandSchema(BaseModel):
     half is kept OUT of ``output``: a non-zero-exit failure maps to MCP's
     separate ``isError`` channel, so the future adapter must not fold ``error``
     into ``outputSchema``.
+
+    ``kind`` carries the command's static execution channel — the lowercase
+    :class:`~gda.execution.ExecutionKind` value (``"headless"`` / ``"export"`` /
+    ``"live"``) — taken from the command descriptor's single source of truth
+    (``HeadlessCommand.kind``), so an agent can branch on a command's channel
+    without inferring it (issue #230, stories 14/15/24). It is additive and
+    optional: gda-mcp maps only ``input`` / ``output`` / ``description`` and
+    ignores it, so adding it is backward-compatible (ADR-0012). ``None`` only when
+    a self-description is emitted without a backing command (e.g. ``gda schema``).
     """
 
     input: dict[str, Any]
     output: dict[str, Any]
     error: dict[str, Any]
+    kind: str | None = None
 
     @classmethod
     def of(
-        cls, input_model: type[BaseModel], output_model: type[BaseModel]
+        cls,
+        input_model: type[BaseModel],
+        output_model: type[BaseModel],
+        kind: str | None = None,
     ) -> "CommandSchema":
         """Derive the contract from a command's params and result models.
 
         ``error`` is the shared failure-envelope schema, the same for every
-        command, so it takes no per-command model argument.
+        command, so it takes no per-command model argument. ``kind`` is the
+        command's static :class:`~gda.execution.ExecutionKind` value (issue
+        #230); an ``ExecutionKind`` passed in serializes to its lowercase string
+        because it subclasses ``str``.
         """
         return cls(
             input=input_model.model_json_schema(),
             output=output_model.model_json_schema(),
             error=GdaErrorEnvelope.model_json_schema(),
+            kind=kind,
         )
 
 
@@ -157,6 +174,12 @@ class CommandManifestEntry(BaseModel):
     ``<group> <command>`` MCP mapping basis, ADR-0005, e.g. ``scene create``;
     bare for a meta command such as ``info``) and the command's ``description``
     (its help text, which flows into the MCP tool description).
+
+    ``kind`` mirrors :class:`CommandSchema`'s: the entry's static execution
+    channel (``"headless"`` / ``"export"`` / ``"live"``), taken from the same
+    descriptor source of truth so the aggregate and per-command forms agree
+    (issue #230). Additive and ignored by gda-mcp (ADR-0012). Every dispatchable
+    manifest entry has a backing command, so it is always populated here.
     """
 
     name: str
@@ -164,6 +187,7 @@ class CommandManifestEntry(BaseModel):
     input: dict[str, Any]
     output: dict[str, Any]
     error: dict[str, Any]
+    kind: str | None = None
 
 
 class SurfaceManifest(BaseModel):

--- a/src/gda/surface.py
+++ b/src/gda/surface.py
@@ -79,9 +79,15 @@ def _collect(
     # the command cannot be driven via ``--params-json`` (ADR-0015) and therefore
     # is not part of the dispatchable-operation surface gda-mcp serves. Reading it
     # off the command object reuses that one authority rather than re-deriving it.
-    if getattr(command, "gda_command", None) is None:
+    gda_command = getattr(command, "gda_command", None)
+    if gda_command is None:
         return
-    schema = CommandSchema.of(input_model, output_model)
+    # Carry the command's static execution channel (ADR-0017) from the same
+    # single source of truth the per-command ``--schema`` uses — the backing
+    # ``HeadlessCommand.kind`` — so the aggregate and per-command forms agree
+    # (issue #230). A dispatchable entry always has a backing command here, so
+    # ``kind`` is always populated.
+    schema = CommandSchema.of(input_model, output_model, kind=gda_command.kind)
     description = (command.help or command.short_help or "").strip()
     entries.append(
         CommandManifestEntry(
@@ -90,5 +96,6 @@ def _collect(
             input=schema.input,
             output=schema.output,
             error=schema.error,
+            kind=schema.kind,
         )
     )

--- a/src/gda/surface.py
+++ b/src/gda/surface.py
@@ -96,6 +96,9 @@ def _collect(
             input=schema.input,
             output=schema.output,
             error=schema.error,
-            kind=schema.kind,
+            # The descriptor's ``kind`` directly (non-optional here), satisfying
+            # the entry's required ``kind`` field — a dispatchable command always
+            # has one (issue #230).
+            kind=gda_command.kind,
         )
     )

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -440,9 +440,9 @@ def test_export_run_unknown_preset_reuses_export_get_error(monkeypatch, tmp_path
 
 
 def test_export_run_schema_emits_contract_without_engine(monkeypatch):
-    # ADR-0004 hard gate: --schema emits the {input, output, error} contract,
-    # spawns no Godot (both seams would raise if touched), and never requires the
-    # operational --preset.
+    # ADR-0004 hard gate: --schema emits the {input, output, error} contract
+    # (plus the additive #230 `kind`), spawns no Godot (both seams would raise if
+    # touched), and never requires the operational --preset.
     def _boom(*args, **kwargs):
         raise AssertionError("--schema must not spawn any engine")
 
@@ -453,7 +453,10 @@ def test_export_run_schema_emits_contract_without_engine(monkeypatch):
 
     assert result.exit_code == 0, result.stdout + result.stderr
     schema = json.loads(result.stdout)
-    assert set(schema) == {"input", "output", "error"}
+    assert set(schema) == {"input", "output", "error", "kind"}
+    # export run is the one EXPORT-channel command (issue #230); its sibling
+    # read-only export commands stay HEADLESS.
+    assert schema["kind"] == "export"
     # The input schema carries the command's params, now including the #170
     # --mode and --output overrides; the output schema carries the result.
     assert "preset" in schema["input"]["properties"]

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -200,6 +200,28 @@ def test_schema_command_is_itself_self_describing():
     assert doc["error"] == GdaErrorEnvelope.model_json_schema()
 
 
+def test_self_described_manifest_guarantees_a_constrained_entry_kind():
+    # issue #230 / PR #232 review: the aggregate entry's `kind` must be a HARD
+    # part of the self-described surface schema, not optional — a consumer
+    # validating `gda schema --schema`'s manifest schema can rely on every
+    # dispatchable entry carrying an execution-kind from a fixed set. Assert it
+    # against the actual `gda schema --schema` self-description, not just the model.
+    result = CliRunner().invoke(app, ["schema", "--schema"])
+    assert result.exit_code == 0, result.stdout
+    manifest_schema = json.loads(result.stdout)["output"]
+
+    entry = manifest_schema["$defs"]["CommandManifestEntry"]
+    # Required, not nullable/defaulted.
+    assert "kind" in entry["required"], entry["required"]
+    # Constrained to the execution-kind enum (via a $ref to ExecutionKind).
+    assert entry["properties"]["kind"] == {"$ref": "#/$defs/ExecutionKind"}
+    assert manifest_schema["$defs"]["ExecutionKind"]["enum"] == [
+        "headless",
+        "export",
+        "live",
+    ]
+
+
 def test_real_console_script_manifest_covers_the_live_command_tree():
     # The real installed `gda` entry point — not the in-process CliRunner —
     # emits the manifest and covers the whole live command tree (issue #192).

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -151,6 +151,40 @@ def test_every_input_field_has_a_non_empty_description():
     assert not missing, "input fields missing a description:\n" + "\n".join(missing)
 
 
+def test_every_entry_carries_an_execution_kind():
+    # issue #230: each manifest entry advertises its static execution `kind`
+    # (HEADLESS / EXPORT / LIVE) so gda-mcp / an agent can branch on a command's
+    # channel without inferring it. The enum subclasses `str`, so the value is the
+    # lowercase string, never the Python enum repr.
+    entries = _manifest()["commands"]
+    assert entries
+    for entry in entries:
+        assert entry["kind"] in {"headless", "export", "live"}, entry["name"]
+
+
+def test_entry_kind_matches_the_commands_own_schema_kind():
+    # Each entry's `kind` is the same single source of truth the command emits
+    # under its own `--schema` (ADR-0004 / ADR-0012): one descriptor field, not a
+    # parallel projection — so the aggregate and per-command forms must agree.
+    for entry in _manifest()["commands"]:
+        result = CliRunner().invoke(app, [*entry["name"].split(" "), "--schema"])
+        assert result.exit_code == 0, result.stdout
+        own = json.loads(result.stdout)
+        assert entry["kind"] == own["kind"], entry["name"]
+
+
+def test_all_three_execution_kinds_appear_in_the_aggregate():
+    # The surface spans all three channels: the default HEADLESS commands, the
+    # one EXPORT command (`export run`), and the LIVE commands (`game tree`).
+    by_name = {entry["name"]: entry for entry in _manifest()["commands"]}
+    assert by_name["scene get"]["kind"] == "headless"
+    assert by_name["export run"]["kind"] == "export"
+    assert by_name["game tree"]["kind"] == "live"
+    # All three kinds are represented in the aggregate as a whole.
+    kinds = {entry["kind"] for entry in by_name.values()}
+    assert {"headless", "export", "live"} <= kinds
+
+
 def test_schema_command_is_itself_self_describing():
     # The meta command is under the same ADR-0004 gate as every other command:
     # `gda schema --schema` emits its own {input, output, error} contract, with

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1056,6 +1056,75 @@ def test_help_takes_precedence_over_schema_regardless_of_argv_order():
         assert not result.stdout.lstrip().startswith("{")
 
 
+# --- execution kind in --schema (issue #230, ADR-0004/ADR-0012) --------------
+#
+# Each command's `--schema` carries its static execution `kind` (HEADLESS /
+# EXPORT / LIVE), taken from the one source of truth — the command descriptor's
+# `HeadlessCommand.kind` — so an agent (and gda-mcp) can branch on a command's
+# channel without inferring it. The enum subclasses `str`, so the emitted JSON
+# value is the lowercase string ("headless" / "export" / "live"), never the
+# Python repr "ExecutionKind.HEADLESS".
+
+
+def test_headless_command_schema_reports_kind_headless():
+    # A default HEADLESS command (scene get routes through operations.gd) reports
+    # its channel as the lowercase enum value, not the Python enum repr.
+    result = CliRunner().invoke(app, ["scene", "get", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["kind"] == "headless"
+
+
+def test_export_run_command_schema_reports_kind_export():
+    # `export run` is the EXPORT channel (native --export-<mode>, not the
+    # operations.gd sentinel) — its schema must say so. Sibling export commands
+    # (get/list) stay HEADLESS.
+    result = CliRunner().invoke(app, ["export", "run", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["kind"] == "export"
+
+
+def test_export_get_and_list_commands_schema_report_kind_headless():
+    # Only `export run` is EXPORT; the read-only export commands are HEADLESS.
+    for command in (["export", "get"], ["export", "list"]):
+        result = CliRunner().invoke(app, [*command, "--schema"])
+        assert result.exit_code == 0
+        assert json.loads(result.stdout)["kind"] == "headless"
+
+
+def test_live_command_schema_reports_kind_live_without_a_daemon():
+    # `game tree` is a LIVE command served through gda-daemon — but `--schema` is
+    # intercepted in parse_args before any execution, so it self-describes with
+    # NO daemon running, reporting its channel as "live".
+    result = CliRunner().invoke(app, ["game", "tree", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["kind"] == "live"
+
+
+def test_schema_kind_is_identical_via_argv_and_params_json_forms():
+    # `--schema` is intercepted at the same single emission point for both the
+    # argv form and the `--params-json` form (the --schema check runs first), so
+    # the emitted `kind` must be byte-identical between the two — proving the one
+    # source of truth is threaded through, not duplicated per path.
+    argv_doc = json.loads(
+        CliRunner().invoke(app, ["scene", "get", "--schema"]).stdout
+    )
+    params_json_doc = json.loads(
+        CliRunner()
+        .invoke(app, ["scene", "get", "--params-json", "{}", "--schema"])
+        .stdout
+    )
+
+    assert argv_doc["kind"] == params_json_doc["kind"] == "headless"
+    # The whole contract is identical across the two forms, not just `kind`.
+    assert argv_doc == params_json_doc
+
+
 def test_extra_positional_args_are_a_usage_error_even_with_schema():
     # issue #36 (2): --schema must not swallow a malformed command line. Extra
     # positional args still fail with a usage error (exit 2), not exit 0 + schema.


### PR DESCRIPTION
## What

Add each command's execution **`kind`** (`headless` / `export` / `live`) to its `--schema` self-description, derived from the command descriptor's single source of truth (`HeadlessCommand.kind`, an `ExecutionKind`). Additive and backward-compatible.

Closes #230.

## Why

`--schema` already reports a command's input/output/error JSON Schemas but not its execution channel, so an agent — and gda-mcp, which consumes `--schema` mechanically (ADR-0012) — could not tell a live command from a headless one from the schema alone.

This is the **one** central implementation of the "`--schema` describes the live kind" acceptance line (stories 14/15/24, ADR-0004) that was otherwise scattered across the live slices (#220 / #221 / #222) and #7 — implemented once here so those slices reference it rather than each re-touching the schema-emission path (a known append-conflict hotspot).

## How

- `src/gda/models.py` — add additive `kind: str | None = None` to `CommandSchema` and `CommandManifestEntry`; `CommandSchema.of(...)` accepts and threads `kind`.
- `src/gda/headless.py` — the single `--schema` emission point (`_SchemaCommand.parse_args`, serving both the argv and `--params-json` forms) passes the backing `command.kind` (`None` for the bare `gda schema` meta command).
- `src/gda/surface.py` — the aggregate manifest builder passes `gda_command.kind`, so the aggregate and per-command forms agree.
- `src/gda/mcp/server.py` is **untouched** — gda-mcp maps only `name`/`description`/`input`/`output`, so the new field is ignored (ADR-0012); adding it is backward-compatible.

`ExecutionKind` subclasses `str`, so it serializes as the lowercase value (`"headless"`/`"export"`/`"live"`), never `"ExecutionKind.HEADLESS"`.

## Tests

- `tests/test_schema_command.py` — per-command `kind` for HEADLESS (`scene get`), EXPORT (`export run`), LIVE (`game tree`, asserted without a daemon since `--schema` is intercepted before execution), and argv ↔ `--params-json` parity.
- `tests/test_schema_aggregate.py` — every manifest entry carries a `kind` that matches that command's own `--schema`; all three kinds present.
- `tests/test_export_run_commands.py` — updated one pre-existing exact-key-set assertion to include the additive `kind`.

Verified: `uv run pytest tests/test_schema_command.py tests/test_schema_aggregate.py tests/test_export_run_commands.py` → **97 passed**; `uv run pytest -m "not e2e"` → **655 passed** (independently re-run by the reviewer).
