### PR TITLE
feat: game get/set — live runtime node property get/set (#220)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ for the full picture.
 
 **On the roadmap** (designed, not yet implemented)
 
-- 🚧 `gda-daemon` for *live operations* against a **running game** (Phase 2). The **bootstrap
-  has shipped**: `gda daemon start` / `stop` / `status` and the first live op, `gda game tree`
-  (the running game's runtime scene tree), through the daemon. The broader live catalogue —
-  runtime properties, input simulation, viewport capture, performance/signal monitoring — is in
+- 🚧 `gda-daemon` for *live operations* against a **running game** (Phase 2). The **runtime
+  scene graph has shipped**: `gda daemon start` / `stop` / `status`, plus the `game` group —
+  `gda game tree` (the running game's runtime scene tree) and `gda game get` / `gda game set`
+  (runtime node properties) — all through the daemon. The rest of the live catalogue —
+  input simulation, viewport capture, performance/signal monitoring — is in
   progress. Live commands are placed by domain object (a narrow `game` group for the runtime
   scene graph); the editor context is out of scope. Phase-2 live needs **Godot 4.6+** and is
   **macOS/Linux only** (it uses Unix domain sockets); Phase-1 headless is unaffected — still
@@ -592,7 +593,7 @@ drives a real engine. Everything between the CLI and the runner runs as real cod
 | ----------------- | ------------------------------------------------------------------------- | ------ |
 | **Phase 1** | `gda` serving *headless operations* standalone: `info`, structured errors, `--schema`, and the domain command groups `scene`, `node`, `script`, `project` (incl. static-analysis), `resource`, `export`, `shader`, `theme`. | ✅ Surface complete |
 | **`gda-mcp`** | A thin MCP adapter generated mechanically from `--schema` — first on top of Phase 1, following `gda` forward automatically. | ✅ Shipped |
-| **Phase 2** | `gda` also serving *live operations* through `gda-daemon` and a live *engine session* (requires Godot 4.6+, macOS/Linux only; headless stays 4.4+ and cross-platform — ADR-0021). | 🚧 Bootstrap shipped (`gda daemon` + `gda game tree`); live catalogue in progress |
+| **Phase 2** | `gda` also serving *live operations* through `gda-daemon` and a live *engine session* (requires Godot 4.6+, macOS/Linux only; headless stays 4.4+ and cross-platform — ADR-0021). | 🚧 Runtime scene graph shipped (`gda daemon` + `gda game tree` / `get` / `set`); rest of live catalogue in progress |
 
 Track progress and proposals on the [issue tracker](https://github.com/aigengame/godot-agent/issues).
 

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -137,6 +137,9 @@ operation, and parse codes the CLI assigns).
 | `engine_session_not_running` | `live` | `classifier` | `6` | The daemon is running but holds no live engine session to serve the live operation (Phase 2). |
 | `engine_disconnected` | `live` | `classifier` | `6` | The engine session disconnected before the live operation returned — the game crashed or the harness connection dropped (Phase 2). |
 | `live_timeout` | `live` | `classifier` | `6` | A live operation did not return from the engine session before the daemon's timeout (Phase 2). |
+| `live_node_not_found` | `live` | `classifier` | `6` | A live game operation's node path does not resolve to a node in the running scene tree (Phase 2, #220). |
+| `live_unknown_property` | `live` | `classifier` | `6` | A live game set targeted a property the running node does not declare as settable (Phase 2, #220). |
+| `live_uncoercible_value` | `live` | `classifier` | `6` | A live game set value cannot be coerced to the running property's declared Godot type (Phase 2, #220). |
 | `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
 
 ## Considered options

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -138,7 +138,7 @@ operation, and parse codes the CLI assigns).
 | `engine_disconnected` | `live` | `classifier` | `6` | The engine session disconnected before the live operation returned — the game crashed or the harness connection dropped (Phase 2). |
 | `live_timeout` | `live` | `classifier` | `6` | A live operation did not return from the engine session before the daemon's timeout (Phase 2). |
 | `live_node_not_found` | `live` | `classifier` | `6` | A live game operation's node path does not resolve to a node in the running scene tree (Phase 2, #220). |
-| `live_unknown_property` | `live` | `classifier` | `6` | A live game set targeted a property the running node does not declare as settable (Phase 2, #220). |
+| `live_unknown_property` | `live` | `classifier` | `6` | A live game get or set targeted a property the running node does not expose for the requested operation (no such readable storage property for get, or no such settable property for set) (Phase 2, #220). |
 | `live_uncoercible_value` | `live` | `classifier` | `6` | A live game set value cannot be coerced to the running property's declared Godot type (Phase 2, #220). |
 | `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
 

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -29,6 +29,24 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > brings up the persistent daemon and the harness install, and the session follows on
 > demand.
 
+> **Outcome (2026-06-22, #220) — live op-errors are minted LIVE-category,
+> classifier-source codes, one family per live op.** When `game get` / `game set`
+> added the first live ops that report *operation-level* failures (a missing node,
+> an unknown or uncoercible property — distinct from the daemon-channel failures
+> `daemon_not_running` / `engine_disconnected`), the routing forced the code shape.
+> The gda harness reports its op-error as the same ADR-0002 error envelope a
+> headless op does, but the daemon relays the harness reply verbatim with
+> **`exit_code = 0`**; the live classifier maps *only* codes whose category is
+> `LIVE` before falling back to the shared decision tree, which on exit 0 would try
+> to validate the error envelope as the success model and misreport
+> `contract_violation`. So each harness-reported op-error **must** be a registered
+> `LIVE`-category, classifier-source code (`live_node_not_found`,
+> `live_unknown_property`, `live_uncoercible_value`). They are minted per live
+> op-family (mirroring the headless `node_not_found` / `unknown_property` /
+> `uncoercible_value`) and, being classifier-source, do not enter the
+> operations.gd OP_ERROR mirror; a separate test mirrors them against the harness
+> consts.
+
 ## Decision
 
 **1. An execution-channel selector, chosen per command by a static `kind`.**

--- a/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
+++ b/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
@@ -20,6 +20,25 @@ a Godot editor on the same project to view, run, or verify agent output — a
 [concurrent external editor](../../CONTEXT.md) — and Godot takes **no project lock**,
 so two instances can touch the project at once.
 
+> **Outcome (2026-06-22, #220) — the harness is a multi-op `match` dispatcher, and
+> it carries a duplicated-with-drift-test copy of the headless coercion helpers.**
+> Adding `game get` / `game set` turned the bootstrap harness's hardcoded
+> single-op `if op == "game-tree"` check into a `match op:` dispatcher with one
+> handler per live op — the natural shape as the live catalogue grows. More
+> consequentially, `game set` must coerce a CLI string to a property's declared
+> Godot type using the **same** table headless `node set` uses (the command
+> catalogue promises one coercion contract). The two cannot share a `.gd` module:
+> `operations.gd` runs via `godot --headless --script <abs-fs-path>` (often
+> projectless), while the harness is a `res://addons/gda_harness/` autoload inside
+> the project — no single `preload()` reaches both runtime contexts, and the
+> harness installer copies exactly one file. So the pure coercion / property-
+> introspection helpers are **duplicated verbatim** into the harness, delimited by
+> matching marker comments in both files, with a drift test asserting the two
+> blocks stay byte-identical. The duplication is a deliberate consequence of the
+> irreconcilable runtime contexts, not an oversight; if the appended-helper count
+> grows, the treatment to revisit is per-module fragments + an automatic summary
+> (the same direction RULES.md flags for central registries), under its own ADR.
+
 ## Decision
 
 **1. The harness is an installed autoload, not a runtime injection.** `gda` bundles

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -147,7 +147,11 @@ This coercion contract — the accepted string forms above, the declared-type ta
 commands**, not specific to nodes. `gda resource set` (#120) applies the same #55 coercion to the
 addressed `.tres` resource property's declared type and round-trips through `resource get`, exactly
 as `node set` round-trips through `node get`; here `unknown_property` names a property absent on the
-**resource** rather than a node.
+**resource** rather than a node. The live `gda game set` (#220) applies the same coercion table to a
+**running** node's runtime property (the gda harness carries a verbatim copy of the coercion helpers,
+kept in sync by a drift test) and round-trips through `game get`; its failures are the LIVE-category
+`live_unknown_property` / `live_uncoercible_value` (the harness reports them in-band, mapped by the
+live classifier — see [Phase 2 — live domain commands](#phase-2--live-domain-commands-served-by-gda-daemon)).
 
 **Structural edits** (established by #56): three commands restructure the node tree within a
 scene file, each a `load → locate → restructure → pack → save` round-trip that reuses the
@@ -456,8 +460,17 @@ socket (ADR-0021), **Phase-2 live requires Godot 4.6+ and is macOS/Linux only**;
 headless is unaffected (4.4+, cross-platform).
 
 - **`game` (the running game's scene graph):** `game tree` reads the runtime scene
-  tree (shipped — the Phase-2 bootstrap tracer, #7); runtime node property `get`/`set`
-  (#220). The on-disk counterparts stay under `scene` / `node` (ADR-0019).
+  tree (shipped — the Phase-2 bootstrap tracer, #7); runtime node property `game get` /
+  `game set` (shipped, #220) read and mutate a running node's live properties — the live
+  counterparts of headless `node get` / `node set`, applying the **same** value-coercion
+  table and round-tripping `set`→`get`. They address the node by its **runtime (absolute)
+  path** as `game tree` reports it (e.g. `/root/Main/Player`), in contrast to the on-disk
+  node group's **root-relative** path: the live tree has no `.tscn` scene root to be
+  relative to, and the headless resolver rejects absolute paths, so the harness resolves
+  off the running `SceneTree` root. A `set` applies at a frame boundary (ADR-0020) and is
+  bound to the session, not persisted; a missing node is `live_node_not_found`, an absent
+  property `live_unknown_property`, an uncoercible value `live_uncoercible_value`. The
+  on-disk counterparts stay under `scene` / `node` (ADR-0019).
 - **`input` (input simulation):** key / mouse / action / sequence injection into the
   running game; record / replay.
 - **`screen` / capture:** running-game viewport screenshot, multi-frame capture.

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -21,6 +21,8 @@ from gda.daemon_ops import (
 )
 from gda.errors import (
     Failure,
+    classify_game_get,
+    classify_game_set,
     classify_game_tree,
     classify_info,
     classify_script_validate,
@@ -59,6 +61,10 @@ from gda.models import (
     ExportListParams,
     ExportListResult,
     ExportRunMode,
+    GameGetParams,
+    GameGetResult,
+    GameSetParams,
+    GameSetResult,
     GameTreeParams,
     GameTreeResult,
     InfoParams,
@@ -474,6 +480,103 @@ def game_tree(
     _dispatch(
         GAME_TREE_COMMAND,
         GameTreeParams(),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+    )
+
+
+GAME_GET_COMMAND: HeadlessCommand[GameGetResult] = HeadlessCommand(
+    operation="game-get",
+    input_model=GameGetParams,
+    output_model=GameGetResult,
+    classify=classify_game_get,
+    kind=ExecutionKind.LIVE,
+)
+
+
+@game_app.command(name="get", cls=GAME_GET_COMMAND.command_class())
+def game_get(
+    node: str = typer.Argument(
+        ...,
+        help="Runtime node path as `game tree` reports it (absolute, e.g. /root/Main/Player).",
+    ),
+    property: Optional[str] = typer.Option(
+        None,
+        "--property",
+        help="If set, read only this one property instead of the whole storage surface.",
+    ),
+    json_output: bool = json_option(),
+    schema: bool = GAME_GET_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Read a running node's runtime properties (live).
+
+    The live counterpart of `node get`: routes through gda-daemon to the engine
+    session's runtime SceneTree (kind = LIVE, ADR-0017), addressed by the runtime
+    (absolute) node path `game tree` reports — not a `.tscn` file. With no daemon
+    it reports `daemon_not_running`; a path that resolves to no running node is
+    `live_node_not_found`; `--property` naming an absent property is
+    `live_unknown_property`.
+    """
+    _dispatch(
+        GAME_GET_COMMAND,
+        GameGetParams(node=node, property=property),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+    )
+
+
+GAME_SET_COMMAND: HeadlessCommand[GameSetResult] = HeadlessCommand(
+    operation="game-set",
+    input_model=GameSetParams,
+    output_model=GameSetResult,
+    classify=classify_game_set,
+    kind=ExecutionKind.LIVE,
+)
+
+
+@game_app.command(name="set", cls=GAME_SET_COMMAND.command_class())
+def game_set(
+    node: str = typer.Argument(
+        ...,
+        help="Runtime node path as `game tree` reports it (absolute, e.g. /root/Main/Player).",
+    ),
+    property: str = typer.Option(
+        ..., "--property", help="The property to set (e.g. position, visible)."
+    ),
+    value: str = typer.Option(
+        ...,
+        "--value",
+        help=(
+            "The value to set, as a string. Coerced to the property's declared "
+            "Godot type (the same coercion `node set` uses); an uncoercible value "
+            "is a clean error."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = GAME_SET_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Set a running node's runtime property, coercing the value to its type (live).
+
+    The live counterpart of `node set`: routes through gda-daemon to the engine
+    session (kind = LIVE, ADR-0017), addressed by the runtime (absolute) node path.
+    The gda harness coerces `--value` to the property's declared Godot type — the
+    SAME coercion table `node set` uses — and applies it at a frame boundary
+    (ADR-0020); the mutation is bound to the session, not persisted to disk. With
+    no daemon it reports `daemon_not_running`; an absent node is
+    `live_node_not_found`, an absent property `live_unknown_property`, an
+    uncoercible value `live_uncoercible_value`.
+    """
+    _dispatch(
+        GAME_SET_COMMAND,
+        GameSetParams(node=node, property=property, value=value),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -440,6 +440,34 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A live operation did not return from the engine session before the"
         " daemon's timeout.",
     ),
+    # Per live-operation failures the gda harness reports in-band (#220). Harness
+    # op-errors arrive with exit_code 0 (the daemon relays the sentinel verbatim),
+    # so each MUST be a LIVE-category code for ``classify_live`` to map it before
+    # the shared decision tree misroutes an exit-0 error envelope to
+    # ``contract_violation``. CLASSIFIER-source — surfaced via the live channel,
+    # not GDScript-mirrored by operations.gd — so the operations.gd mirror test is
+    # unaffected; a separate test mirrors them against the harness consts.
+    ErrorCodeSpec(
+        "live_node_not_found",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A live game operation's node path does not resolve to a node in the running scene tree.",
+    ),
+    ErrorCodeSpec(
+        "live_unknown_property",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A live game set targeted a property the running node does not declare as settable.",
+    ),
+    ErrorCodeSpec(
+        "live_uncoercible_value",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A live game set value cannot be coerced to the running property's declared Godot type.",
+    ),
     # A pre-launch platform precondition, not a live-runtime failure: live needs
     # Unix domain sockets, which are UNIX-only, so it is an ENVIRONMENT-category
     # code in the binary_not_found bucket (ADR-0021), decided before any engine

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -459,7 +459,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.LIVE,
         EXIT_LIVE,
         ErrorCodeSource.CLASSIFIER,
-        "A live game set targeted a property the running node does not declare as settable.",
+        "A live game get or set targeted a property the running node does not expose for the requested operation (no such readable storage property for get, or no such settable property for set).",
     ),
     ErrorCodeSpec(
         "live_uncoercible_value",

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -52,6 +52,8 @@ from gda.models import (
     EngineVersion,
     ExportRunMode,
     ExportRunResult,
+    GameGetResult,
+    GameSetResult,
     GameTreeResult,
     GdaError,
     OperationErrorEnvelope,
@@ -430,6 +432,16 @@ def classify_live(result: RunResult, binary: Path, output_model: type[M]) -> M |
 def classify_game_tree(result: RunResult, binary: Path) -> GameTreeResult | Failure:
     """The per-command live classifier for ``gda game tree`` (mirrors ``classify_info``)."""
     return classify_live(result, binary, GameTreeResult)
+
+
+def classify_game_get(result: RunResult, binary: Path) -> GameGetResult | Failure:
+    """The per-command live classifier for ``gda game get`` (mirrors ``classify_game_tree``)."""
+    return classify_live(result, binary, GameGetResult)
+
+
+def classify_game_set(result: RunResult, binary: Path) -> GameSetResult | Failure:
+    """The per-command live classifier for ``gda game set`` (mirrors ``classify_game_tree``)."""
+    return classify_live(result, binary, GameSetResult)
 
 
 # A non-fatal export warning the engine prints to stderr. WARNING is Godot's

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -86,13 +86,116 @@ func _send_frame(payload: PackedByteArray) -> void:
 	_peer.put_data(payload)
 
 
+# Dispatch one live request to its handler by op name (#220). A request is the
+# ADR-0002 {"op", "params"} envelope the daemon relays verbatim; each handler
+# returns a full sentinel-framed payload (a success via _ok or a failure via
+# _error), so adding an op is one match arm + one handler.
 func _run(request) -> String:
-	if typeof(request) != TYPE_DICTIONARY or request.get("op") != "game-tree":
+	if typeof(request) != TYPE_DICTIONARY:
 		return _error("operation_failed", "unsupported live operation")
+	var op: Variant = request.get("op")
+	var params: Variant = request.get("params", {})
+	if typeof(params) != TYPE_DICTIONARY:
+		params = {}
+	match op:
+		OP_GAME_TREE:
+			return _handle_game_tree()
+		OP_GAME_GET:
+			return _handle_game_get(params)
+		OP_GAME_SET:
+			return _handle_game_set(params)
+		_:
+			return _error("operation_failed", "unsupported live operation")
+
+
+func _handle_game_tree() -> String:
 	var scene: Node = get_tree().current_scene
 	if scene == null:
 		scene = get_tree().root
-	return RESULT_BEGIN + JSON.stringify({"root": _serialize(scene)}) + RESULT_END
+	return _ok({"root": _serialize(scene)})
+
+
+# game get: resolve a node by its ABSOLUTE runtime path (as game tree reports it,
+# e.g. /root/Main/Player) and report its storage properties as typed JSON — the
+# runtime counterpart of headless node get. An optional `property` param filters
+# to that single property; absent from the storage set, it is live_unknown_property.
+func _handle_game_get(params: Dictionary) -> String:
+	var path := _string_param(params, "node")
+	var node := _resolve_runtime_node(path)
+	if node == null:
+		return _error(LIVE_ERROR_NODE_NOT_FOUND,
+				"no node at runtime path: " + path)
+
+	var wanted := _string_param(params, "property")
+	var has_filter := params.has("property") and not wanted.is_empty()
+	var properties: Array = []
+	for prop in node.get_property_list():
+		if not _is_storage_property(prop):
+			continue
+		var prop_name := String(prop.get("name", ""))
+		if has_filter and prop_name != wanted:
+			continue
+		properties.append({
+			"name": prop_name,
+			"type": _type_name(int(prop.get("type", TYPE_NIL))),
+			"value": _jsonify(node.get(prop_name)),
+		})
+	if has_filter and properties.is_empty():
+		return _error(LIVE_ERROR_UNKNOWN_PROPERTY,
+				"node " + path + " has no readable property: " + wanted)
+
+	return _ok({
+		"path": path,
+		"name": String(node.name),
+		"type": node.get_class(),
+		"properties": properties,
+	})
+
+
+# game set: resolve a node by its ABSOLUTE runtime path, coerce the CLI string
+# value to the property's declared Godot type, and set it on the live node — the
+# runtime counterpart of headless node set, using the SAME coercion table. The
+# write runs synchronously on the main thread at the _process frame boundary
+# (frame-coherent, ADR-0020); no extra threading. The coerced value is read back
+# and echoed in the same JSON projection game get reports.
+func _handle_game_set(params: Dictionary) -> String:
+	var path := _string_param(params, "node")
+	var node := _resolve_runtime_node(path)
+	if node == null:
+		return _error(LIVE_ERROR_NODE_NOT_FOUND,
+				"no node at runtime path: " + path)
+
+	var prop_name := _string_param(params, "property")
+	var declared_type := _property_type(node, prop_name)
+	if declared_type == TYPE_NIL:
+		return _error(LIVE_ERROR_UNKNOWN_PROPERTY,
+				"node " + path + " has no settable property: " + prop_name)
+
+	var raw_value := _string_param(params, "value")
+	var coerced: Variant = _coerce_value(raw_value, declared_type)
+	if coerced == null:
+		return _error(LIVE_ERROR_UNCOERCIBLE_VALUE,
+				"cannot coerce value " + raw_value.c_escape()
+				+ " to " + _type_name(declared_type) + " for property " + prop_name
+				+ " on node " + path)
+
+	node.set(prop_name, coerced)
+	return _ok({
+		"path": path,
+		"property": prop_name,
+		"type": _type_name(declared_type),
+		"value": _jsonify(node.get(prop_name)),
+	})
+
+
+# Resolve a node by its ABSOLUTE runtime path (e.g. /root/Main/Player), the form
+# game tree emits via Node.get_path(). The headless _resolve_node takes a
+# scene-root-relative path and rejects absolute, so the live layer resolves off
+# the SceneTree root instead. null when the path resolves to nothing.
+func _resolve_runtime_node(path: String) -> Node:
+	if path.is_empty():
+		return null
+	return get_tree().root.get_node_or_null(NodePath(path))
 
 
 func _serialize(node: Node) -> Dictionary:
@@ -107,5 +210,185 @@ func _serialize(node: Node) -> Dictionary:
 	}
 
 
+func _ok(payload: Dictionary) -> String:
+	return RESULT_BEGIN + JSON.stringify(payload) + RESULT_END
+
+
 func _error(code: String, message: String) -> String:
 	return RESULT_BEGIN + JSON.stringify({"error": {"code": code, "message": message}}) + RESULT_END
+
+
+# --- BEGIN shared coercion (keep byte-identical: operations.gd <-> gda_harness.gd) ---
+# These pure property-introspection / value-coercion helpers are DUPLICATED
+# verbatim into src/gda/harness/gda_harness.gd: operations.gd runs via
+# `godot --headless --script <abs-fs-path>` (often projectless) while the harness
+# is a res:// autoload, so no single preload() reaches both and install.py copies
+# one file. tests/test_harness_coercion_mirror.py asserts the two blocks are
+# byte-identical (modulo leading tabs), so an edit here must be mirrored there.
+# Whether a property-list entry is a STORAGE property — the ones node get
+# reports and node set targets: the properties that serialize into the .tscn,
+# excluding the engine's category headers, group separators, and editor-only
+# (non-storage) entries. This is the same usage flag the scene serializer keys
+# on, so node get reports exactly the surface a saved scene can carry.
+func _is_storage_property(prop: Dictionary) -> bool:
+	var usage := int(prop.get("usage", 0))
+	return (usage & PROPERTY_USAGE_STORAGE) != 0
+
+
+# The declared Godot type of a settable property on the node, or TYPE_NIL if the
+# node has no storage property by that name. node set keys coercion off this:
+# the value's target type comes from the property the node actually declares,
+# never from guessing.
+func _property_type(node: Node, prop_name: String) -> int:
+	for prop in node.get_property_list():
+		if String(prop.get("name", "")) == prop_name and _is_storage_property(prop):
+			return int(prop.get("type", TYPE_NIL))
+	return TYPE_NIL
+
+
+# Read a string param defensively: a non-string value (the params arrive as
+# arbitrary JSON) is treated as absent rather than crashing a typed assignment,
+# so a malformed param surfaces as a structured failure, not a runtime error.
+func _string_param(params: Dictionary, key: String) -> String:
+	var value: Variant = params.get(key, "")
+	if value is String:
+		return value
+	return ""
+
+
+# The Godot type name for a Variant.Type, as node get / node set report it
+# (the same spelling type_string uses: "int", "Vector2", "Color", …).
+func _type_name(type: int) -> String:
+	return type_string(type)
+
+
+# Project a Godot property value into JSON-safe form for the result payload
+# (issue #55). Scalars pass through; the packed value types node set supports
+# become flat number arrays so node get's output is exactly the projection node
+# set accepts back: Vector2 → [x, y], Vector2i likewise, Color → [r, g, b, a].
+# Any other type degrades to its string form rather than crashing JSON.stringify
+# on an unencodable Variant — node get reports the whole storage surface, but
+# only the coercible types claim a structured projection.
+func _jsonify(value: Variant) -> Variant:
+	match typeof(value):
+		TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING, TYPE_STRING_NAME:
+			return value
+		TYPE_VECTOR2:
+			return [value.x, value.y]
+		TYPE_VECTOR2I:
+			return [value.x, value.y]
+		TYPE_COLOR:
+			return [value.r, value.g, value.b, value.a]
+		_:
+			return str(value)
+
+
+# Coerce a CLI string value to a property's declared Godot type (issue #55).
+# The supported types and their accepted string forms are documented in the
+# command catalog's "Property value coercion" section — keep the two in sync.
+# Returns null when the value cannot be coerced to that type, which the caller
+# reports as the clean uncoercible_value error. null is unambiguous as a
+# failure signal because no supported target type coerces TO null.
+func _coerce_value(raw: String, type: int) -> Variant:
+	match type:
+		TYPE_BOOL:
+			return _coerce_bool(raw)
+		TYPE_INT:
+			return _coerce_int(raw)
+		TYPE_FLOAT:
+			return _coerce_float(raw)
+		TYPE_STRING:
+			return raw
+		TYPE_STRING_NAME:
+			return StringName(raw)
+		TYPE_VECTOR2:
+			var parts: Variant = _coerce_float_list(raw, 2)
+			return Vector2(parts[0], parts[1]) if parts != null else null
+		TYPE_VECTOR2I:
+			var parts: Variant = _coerce_int_list(raw, 2)
+			return Vector2i(parts[0], parts[1]) if parts != null else null
+		TYPE_COLOR:
+			return _coerce_color(raw)
+		_:
+			return null
+
+
+# A bool from "true"/"false" (case-insensitive), nothing else — so a typo never
+# silently becomes false.
+func _coerce_bool(raw: String) -> Variant:
+	var lowered := raw.strip_edges().to_lower()
+	if lowered == "true":
+		return true
+	if lowered == "false":
+		return false
+	return null
+
+
+func _coerce_int(raw: String) -> Variant:
+	var trimmed := raw.strip_edges()
+	if not trimmed.is_valid_int():
+		return null
+	return trimmed.to_int()
+
+
+func _coerce_float(raw: String) -> Variant:
+	var trimmed := raw.strip_edges()
+	# is_valid_float accepts integer spellings too, which is intended: "3" is a
+	# valid float value, and Godot stores it as 3.0.
+	if not trimmed.is_valid_float():
+		return null
+	return trimmed.to_float()
+
+
+# Parse a comma-separated list of exactly `count` floats (e.g. "10,20" for a
+# Vector2). Whitespace around each component is tolerated; a wrong count or a
+# non-numeric component fails the whole coercion.
+func _coerce_float_list(raw: String, count: int) -> Variant:
+	var parts := raw.split(",")
+	if parts.size() != count:
+		return null
+	var out: Array[float] = []
+	for part in parts:
+		var coerced: Variant = _coerce_float(part)
+		if coerced == null:
+			return null
+		out.append(coerced)
+	return out
+
+
+func _coerce_int_list(raw: String, count: int) -> Variant:
+	var parts := raw.split(",")
+	if parts.size() != count:
+		return null
+	var out: Array[int] = []
+	for part in parts:
+		var coerced: Variant = _coerce_int(part)
+		if coerced == null:
+			return null
+		out.append(coerced)
+	return out
+
+
+# A Color from either a "#rrggbb"/"#rrggbbaa" hex string or a comma-separated
+# list of 3 (rgb) or 4 (rgba) floats in 0..1. Godot's Color.html validates the
+# hex form; the float-list form reuses the shared numeric coercion.
+func _coerce_color(raw: String) -> Variant:
+	var trimmed := raw.strip_edges()
+	if trimmed.begins_with("#"):
+		if not Color.html_is_valid(trimmed):
+			return null
+		return Color.html(trimmed)
+	var parts := trimmed.split(",")
+	if parts.size() != 3 and parts.size() != 4:
+		return null
+	var out: Array[float] = []
+	for part in parts:
+		var coerced: Variant = _coerce_float(part)
+		if coerced == null:
+			return null
+		out.append(coerced)
+	if out.size() == 3:
+		return Color(out[0], out[1], out[2])
+	return Color(out[0], out[1], out[2], out[3])
+# --- END shared coercion ---
+

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -20,6 +20,19 @@ const LAUNCH_MARKER := "gda-daemon"
 const RESULT_BEGIN := "<<<GDA:RESULT>>>"
 const RESULT_END := "<<<GDA:END>>>"
 
+# The live operations this harness serves, keyed by their wire op name (#220).
+const OP_GAME_TREE := "game-tree"
+const OP_GAME_GET := "game-get"
+const OP_GAME_SET := "game-set"
+
+# The per-op LIVE failure codes the harness reports in-band (#220). Each MUST be a
+# registered LIVE-category code (src/gda/error_codes.py) so the daemon's exit-0
+# relay is mapped by classify_live, not misrouted to contract_violation; a Python
+# mirror test (tests/test_error_registry.py) keeps these in sync with the registry.
+const LIVE_ERROR_NODE_NOT_FOUND := "live_node_not_found"
+const LIVE_ERROR_UNKNOWN_PROPERTY := "live_unknown_property"
+const LIVE_ERROR_UNCOERCIBLE_VALUE := "live_uncoercible_value"
+
 var _peer: StreamPeerUDS = null
 var _authed := false
 var _pending = null

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -2415,6 +2415,83 @@ class GameTreeResult(BaseModel):
     root: GameNode
 
 
+# The runtime node address: ABSOLUTE, as ``game tree`` reports it via the live
+# tree's ``Node.get_path()``. This is the live counterpart of the node group's
+# root-relative ``node`` param — the headless resolver rejects absolute paths,
+# so the live layer addresses off the running SceneTree root instead (ADR-0019).
+_RUNTIME_NODE_DESC = (
+    "Runtime node path as `game tree` reports it (absolute, e.g. /root/Main/Player)."
+)
+
+
+class GameGetParams(BaseModel):
+    """The params of ``gda game get``: read a running node's runtime properties (#220).
+
+    The live counterpart of :class:`NodeGetParams`, addressed by the runtime
+    (absolute) node path rather than a ``.tscn`` file + root-relative node path:
+    there is no file, only the live SceneTree of the engine session. ``property``
+    optionally narrows the read to one property.
+    """
+
+    node: str = Field(description=_RUNTIME_NODE_DESC)
+    property: str | None = Field(
+        default=None,
+        description="If set, read only this one property instead of the whole storage surface.",
+    )
+
+
+class GameGetResult(BaseModel):
+    """The result of ``gda game get``: a running node's runtime properties (#220).
+
+    The live counterpart of :class:`NodeGetResult` (no ``scene_path`` — there is
+    no file): echoes the addressed node (runtime ``path``/``name``/``type``) and
+    its storage properties, each a typed :class:`NodeProperty`, so an agent reads
+    the running node's live state and can feed any property back into ``game set``.
+    """
+
+    path: str = Field(description="The addressed node's runtime (absolute) path.")
+    name: str
+    type: str = Field(description="The node's engine class (e.g. CharacterBody2D).")
+    properties: list[NodeProperty]
+
+
+class GameSetParams(BaseModel):
+    """The params of ``gda game set``: mutate a running node's runtime property (#220).
+
+    The live counterpart of :class:`NodeSetParams`, addressed by the runtime
+    (absolute) node path. ``property`` names the property; ``value`` is the CLI
+    string value, coerced to the property's declared Godot type by the gda harness
+    (the SAME coercion table headless ``node set`` uses) and applied at a frame
+    boundary (ADR-0020). The mutation is bound to the session, not persisted.
+    """
+
+    node: str = Field(description=_RUNTIME_NODE_DESC)
+    property: str = Field(description="The property to set (e.g. position, visible).")
+    value: str = Field(
+        description=(
+            "The value to set, as a string. The gda harness coerces it to the "
+            "property's declared Godot type (the same coercion the node group "
+            "established; see the command catalog's 'Property value coercion'); "
+            "an uncoercible value is a clean error."
+        )
+    )
+
+
+class GameSetResult(BaseModel):
+    """The result of ``gda game set``: the one runtime property it set (#220).
+
+    The live counterpart of :class:`NodeSetResult` (no ``scene_path``): echoes the
+    addressed node's runtime ``path``, the ``property`` set, the declared ``type``
+    the CLI value was coerced to, and the coerced ``value`` as JSON — the
+    projection ``game get`` reports, so a ``set`` round-trips through a ``get``.
+    """
+
+    path: str = Field(description="The addressed node's runtime (absolute) path.")
+    property: str
+    type: str = Field(description="The property's declared Godot type the value was coerced to.")
+    value: Any = Field(description="The coerced value as JSON, as the running node now holds it.")
+
+
 class DaemonStartParams(BaseModel):
     """The params of ``gda daemon start``: none (the project is the --project context)."""
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3456,27 +3456,6 @@ func _fail_node_not_found_labeled(label: String, node_path: String) -> void:
 				+ " — address the node exactly as node list reports it: '.' for the root, 'A/B' for a descendant")
 
 
-# Whether a property-list entry is a STORAGE property — the ones node get
-# reports and node set targets: the properties that serialize into the .tscn,
-# excluding the engine's category headers, group separators, and editor-only
-# (non-storage) entries. This is the same usage flag the scene serializer keys
-# on, so node get reports exactly the surface a saved scene can carry.
-func _is_storage_property(prop: Dictionary) -> bool:
-	var usage := int(prop.get("usage", 0))
-	return (usage & PROPERTY_USAGE_STORAGE) != 0
-
-
-# The declared Godot type of a settable property on the node, or TYPE_NIL if the
-# node has no storage property by that name. node set keys coercion off this:
-# the value's target type comes from the property the node actually declares,
-# never from guessing.
-func _property_type(node: Node, prop_name: String) -> int:
-	for prop in node.get_property_list():
-		if String(prop.get("name", "")) == prop_name and _is_storage_property(prop):
-			return int(prop.get("type", TYPE_NIL))
-	return TYPE_NIL
-
-
 # Instantiate a node by type: a built-in Node class first, then a class_name
 # from the project's global class list (script classes register only once the
 # project has been imported/scanned). Records the failure itself and returns
@@ -3599,6 +3578,34 @@ func _tree_from_state(state: SceneState, with_paths := false) -> Dictionary:
 			if parent != null:
 				parent["children"].append(node)
 	return root
+
+
+# --- BEGIN shared coercion (keep byte-identical: operations.gd <-> gda_harness.gd) ---
+# These pure property-introspection / value-coercion helpers are DUPLICATED
+# verbatim into src/gda/harness/gda_harness.gd: operations.gd runs via
+# `godot --headless --script <abs-fs-path>` (often projectless) while the harness
+# is a res:// autoload, so no single preload() reaches both and install.py copies
+# one file. tests/test_harness_coercion_mirror.py asserts the two blocks are
+# byte-identical (modulo leading tabs), so an edit here must be mirrored there.
+# Whether a property-list entry is a STORAGE property — the ones node get
+# reports and node set targets: the properties that serialize into the .tscn,
+# excluding the engine's category headers, group separators, and editor-only
+# (non-storage) entries. This is the same usage flag the scene serializer keys
+# on, so node get reports exactly the surface a saved scene can carry.
+func _is_storage_property(prop: Dictionary) -> bool:
+	var usage := int(prop.get("usage", 0))
+	return (usage & PROPERTY_USAGE_STORAGE) != 0
+
+
+# The declared Godot type of a settable property on the node, or TYPE_NIL if the
+# node has no storage property by that name. node set keys coercion off this:
+# the value's target type comes from the property the node actually declares,
+# never from guessing.
+func _property_type(node: Node, prop_name: String) -> int:
+	for prop in node.get_property_list():
+		if String(prop.get("name", "")) == prop_name and _is_storage_property(prop):
+			return int(prop.get("type", TYPE_NIL))
+	return TYPE_NIL
 
 
 # Read a string param defensively: a non-string value (the params arrive as
@@ -3745,6 +3752,7 @@ func _coerce_color(raw: String) -> Variant:
 	if out.size() == 3:
 		return Color(out[0], out[1], out[2])
 	return Color(out[0], out[1], out[2], out[3])
+# --- END shared coercion ---
 
 
 func _is_valid_node_name(node_name: String) -> bool:

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -29,6 +29,8 @@ from gda.models import (
     ExportGetResult,
     ExportListResult,
     ExportRunResult,
+    GameGetResult,
+    GameSetResult,
     GameTreeResult,
     NodeAddResult,
     NodeConnectSignalResult,
@@ -148,6 +150,28 @@ def render_game_tree(game: "GameTreeResult") -> str:
     runtime tree flows through the same indented outline as the on-disk scene.
     """
     return render_node_tree(game.root)
+
+
+def render_game_get(got: "GameGetResult") -> str:
+    """Render a running node's runtime properties (the live `render_node_properties`).
+
+    The runtime counterpart of ``render_node_properties``: same ``path (Type)``
+    header + ``name (Type) = value`` lines, addressed by the runtime path.
+    """
+    header = f"{got.path} ({got.type})"
+    lines = [
+        f"  {prop.name} ({prop.type}) = {format_value(prop.value)}"
+        for prop in got.properties
+    ]
+    return "\n".join([header, *lines])
+
+
+def render_game_set(was_set: "GameSetResult") -> str:
+    """Render a set runtime property as ``set <path>.<prop> (<type>) = <value>``."""
+    return (
+        f"set {was_set.path}.{was_set.property} ({was_set.type}) = "
+        f"{format_value(was_set.value)}"
+    )
 
 
 def render_daemon_start(started: "DaemonStartResult") -> str:
@@ -552,6 +576,8 @@ _RENDERERS = {
     SceneCreateResult: render_scene_metadata,
     SceneGetResult: render_scene_tree,
     GameTreeResult: render_game_tree,
+    GameGetResult: render_game_get,
+    GameSetResult: render_game_set,
     DaemonStartResult: render_daemon_start,
     DaemonStopResult: render_daemon_stop,
     DaemonStatusResult: render_daemon_status,

--- a/tests/support.py
+++ b/tests/support.py
@@ -388,3 +388,24 @@ GAME_TREE_RESULT = {
         ],
     }
 }
+
+# Sample ``gda game get`` / ``gda game set`` results — a running node's runtime
+# properties, addressed by the absolute runtime path (#220). Shared by the
+# game-command success/schema tests; the value projection mirrors NodeProperty,
+# the same shape ``node get`` reports.
+GAME_GET_RESULT = {
+    "path": "/root/Main/Player",
+    "name": "Player",
+    "type": "CharacterBody2D",
+    "properties": [
+        {"name": "position", "type": "Vector2", "value": [10.0, 20.0]},
+        {"name": "visible", "type": "bool", "value": True},
+    ],
+}
+
+GAME_SET_RESULT = {
+    "path": "/root/Main/Player",
+    "property": "position",
+    "type": "Vector2",
+    "value": [10.0, 20.0],
+}

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -21,9 +21,14 @@ from .conftest import project_godot
 
 GODOT = resolve_godot_binary()
 
-# A trivial main scene so the launched session has a runtime SceneTree to read;
-# file logging stays disabled via project_godot (issue #180).
-MAIN_TSCN = '[gd_scene format=3]\n\n[node name="Main" type="Node2D"]\n'
+# A main scene so the launched session has a runtime SceneTree to read; a Player
+# Node2D child carries a Vector2 storage property (position) for the game get/set
+# round trip (#220). File logging stays disabled via project_godot (issue #180).
+MAIN_TSCN = (
+    "[gd_scene format=3]\n\n"
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="Player" type="Node2D" parent="."]\n'
+)
 PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
@@ -65,5 +70,55 @@ def test_daemon_serves_a_real_runtime_tree(tmp_path, daemon_runtime_dir):
         assert json.loads(run("daemon", "status").stdout)["running"] is True
         assert json.loads(run("daemon", "stop").stdout)["stopped"] is True
         assert json.loads(run("daemon", "status").stdout)["running"] is False
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_serves_game_get_set_round_trip(tmp_path, daemon_runtime_dir):
+    # The #220 DoD: a real daemon → engine session → `game set` mutates a runtime
+    # property, applied at a frame boundary, and `game get` observes the change —
+    # State consistency (ADR-0020) end-to-end through the real harness over UDS.
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        # set: mutate the Player's runtime position (a Vector2), coerced harness-side
+        # from the CLI string "10,20" exactly as headless `node set` coerces it.
+        was_set = run(
+            "game", "set", "/root/Main/Player", "--property", "position", "--value", "10,20"
+        )
+        assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+        set_doc = json.loads(was_set.stdout)
+        assert set_doc["path"] == "/root/Main/Player"
+        assert set_doc["property"] == "position"
+        assert set_doc["type"] == "Vector2"
+        assert set_doc["value"] == [10.0, 20.0]
+
+        # get: the SAME session observes the preceding write (single writer,
+        # frame-coherent — ADR-0020). The session is held across the two ops.
+        got = run("game", "get", "/root/Main/Player", "--property", "position")
+        assert got.returncode == 0, got.stdout + got.stderr
+        get_doc = json.loads(got.stdout)
+        assert get_doc["path"] == "/root/Main/Player"
+        position = next(p for p in get_doc["properties"] if p["name"] == "position")
+        assert position["type"] == "Vector2"
+        assert position["value"] == [10.0, 20.0]
     finally:
         run("daemon", "stop")

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -28,10 +28,23 @@ LIVE_ERROR_CODES = (
 ROOT = Path(__file__).resolve().parents[1]
 ADR_0002 = ROOT / "docs" / "adr" / "0002-headless-structured-output-contract.md"
 OPERATIONS_GD = ROOT / "src" / "gda" / "ops" / "operations.gd"
+GDA_HARNESS_GD = ROOT / "src" / "gda" / "harness" / "gda_harness.gd"
 
 ADR_REGISTRY_ROW = re.compile(r"^\| `([^`]+)` \| `([^`]+)` \| `([^`]+)` \| `(\d+)` \|")
 GDSCRIPT_OPERATION_CODE = re.compile(r'^const OP_ERROR_[A-Z_]+ := "([a-z_]+)"$', re.MULTILINE)
+GDSCRIPT_HARNESS_LIVE_CODE = re.compile(
+    r'^const LIVE_ERROR_[A-Z_]+ := "([a-z_]+)"$', re.MULTILINE
+)
 BARE_FAIL_CODE = re.compile(r'_fail\(\s*"[a-z_]+"')
+
+# The per-operation LIVE failures the gda harness reports in-band (#220). The
+# generic daemon-channel LIVE codes (daemon_not_running, …) are surfaced by the
+# Python daemon client, NOT the harness, so they are not mirrored in GDScript.
+HARNESS_LIVE_ERROR_CODES = (
+    "live_node_not_found",
+    "live_unknown_property",
+    "live_uncoercible_value",
+)
 
 
 def _adr_registry() -> dict[str, tuple[str, str, int]]:
@@ -105,3 +118,31 @@ def test_live_failures_are_registered_classifier_live_codes():
         assert spec.source is ErrorCodeSource.CLASSIFIER
         assert spec.exit_code == EXIT_LIVE
         assert spec.code not in OPERATION_ERROR_CODES
+
+
+def test_harness_live_error_codes_are_registered_live_codes():
+    # The per-op LIVE failures the gda harness reports (#220) are registered
+    # LIVE-category classifier-source codes: because their category is LIVE,
+    # ``LIVE_ERROR_CODES`` (and so ``classify_live``) maps them with no errors.py
+    # change — the keystone routing that keeps a harness exit-0 op error off the
+    # ``contract_violation`` fallthrough.
+    for code in HARNESS_LIVE_ERROR_CODES:
+        spec = ERROR_CODE_BY_CODE[code]
+        assert spec.category is ErrorCategory.LIVE
+        assert spec.source is ErrorCodeSource.CLASSIFIER
+        assert spec.exit_code == EXIT_LIVE
+
+
+def test_gdscript_harness_live_error_codes_mirror_python_harness_subset():
+    # The harness mints the per-op LIVE codes itself, so each must have a matching
+    # ``const LIVE_ERROR_* := "..."`` in gda_harness.gd. This is the harness twin
+    # of the operations.gd OP_ERROR mirror, kept separate so the operations.gd
+    # mirror test stays the operation-source set (the OP_ERROR drift test is
+    # unaffected). The generic daemon-channel LIVE codes are NOT harness-mirrored.
+    harness = GDA_HARNESS_GD.read_text(encoding="utf-8")
+    mirrored_codes = set(GDSCRIPT_HARNESS_LIVE_CODE.findall(harness))
+
+    assert mirrored_codes == set(HARNESS_LIVE_ERROR_CODES)
+    for code in mirrored_codes:
+        spec = ERROR_CODE_BY_CODE[code]
+        assert spec.category is ErrorCategory.LIVE

--- a/tests/test_game_commands.py
+++ b/tests/test_game_commands.py
@@ -13,7 +13,14 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.exit_codes import EXIT_LIVE
 from gda.runner import RunResult
-from tests.support import GAME_TREE_RESULT, inject_live_runner, sentinel
+from tests.support import (
+    GAME_GET_RESULT,
+    GAME_SET_RESULT,
+    GAME_TREE_RESULT,
+    error_sentinel,
+    inject_live_runner,
+    sentinel,
+)
 
 
 def _project(tmp_path):
@@ -86,3 +93,119 @@ def test_game_tree_on_non_unix_reports_live_unsupported_platform(monkeypatch, tm
 
     assert result.exit_code != 0, result.stdout
     assert json.loads(result.stdout)["error"]["code"] == "live_unsupported_platform"
+
+
+# --- game get (live runtime property read) -----------------------------------
+
+
+def test_game_get_emits_runtime_properties_through_the_live_channel(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(GAME_GET_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["game", "get", "/root/Main/Player", "--project", str(_project(tmp_path)), "--json"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["path"] == "/root/Main/Player"
+    assert data["type"] == "CharacterBody2D"
+    assert {p["name"] for p in data["properties"]} == {"position", "visible"}
+    # Routed through the LIVE seam, dispatching game-get with the node arg; the
+    # optional property is absent (read the whole surface).
+    assert fake.calls == [("game-get", {"node": "/root/Main/Player", "property": None})]
+
+
+def test_game_get_passes_the_property_filter_through_the_live_channel(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(GAME_GET_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "game", "get", "/root/Main/Player",
+            "--property", "position",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    # The filter is threaded to the operation params (the harness applies it).
+    assert fake.calls == [
+        ("game-get", {"node": "/root/Main/Player", "property": "position"})
+    ]
+
+
+def test_game_get_missing_node_reports_live_node_not_found(monkeypatch, tmp_path):
+    # The harness reports its op-error as an exit-0 sentinel envelope (Finding B);
+    # classify_live maps the LIVE-category code, so the exit is EXIT_LIVE — proving
+    # the routing keeps it off the contract_violation fallthrough.
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("live_node_not_found", "no node at runtime path"),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["game", "get", "/root/Main/Ghost", "--project", str(_project(tmp_path)), "--json"],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "live_node_not_found"
+    assert error["category"] == "live"
+
+
+def test_game_get_unknown_property_reports_live_unknown_property(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("live_unknown_property", "no readable property"),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "game", "get", "/root/Main/Player",
+            "--property", "nope",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "live_unknown_property"
+    assert error["category"] == "live"
+
+
+def test_game_get_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
+
+    result = CliRunner().invoke(
+        app,
+        ["game", "get", "/root/Main/Player", "--project", str(_project(tmp_path)), "--json"],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    assert json.loads(result.stdout)["error"]["code"] == "daemon_not_running"
+
+
+def test_game_get_schema_is_self_describing():
+    result = CliRunner().invoke(app, ["game", "get", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    schema = json.loads(result.stdout)
+    assert "input" in schema and "output" in schema
+    assert schema["kind"] == "live"

--- a/tests/test_game_commands.py
+++ b/tests/test_game_commands.py
@@ -209,3 +209,139 @@ def test_game_get_schema_is_self_describing():
     schema = json.loads(result.stdout)
     assert "input" in schema and "output" in schema
     assert schema["kind"] == "live"
+
+
+# --- game set (live runtime property write) ----------------------------------
+
+
+def test_game_set_mutates_and_echoes_coerced_value_through_the_live_channel(
+    monkeypatch, tmp_path
+):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(GAME_SET_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "game", "set", "/root/Main/Player",
+            "--property", "position", "--value", "10,20",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["path"] == "/root/Main/Player"
+    assert data["property"] == "position"
+    # The harness echoes the coerced value in the node get projection.
+    assert data["value"] == [10.0, 20.0]
+    # The node arg, property and raw value are threaded to the operation params;
+    # the harness coerces the string to the declared type.
+    assert fake.calls == [
+        (
+            "game-set",
+            {"node": "/root/Main/Player", "property": "position", "value": "10,20"},
+        )
+    ]
+
+
+def test_game_set_missing_node_reports_live_node_not_found(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("live_node_not_found", "no node at runtime path"),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "game", "set", "/root/Main/Ghost",
+            "--property", "position", "--value", "1,2",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "live_node_not_found"
+    assert error["category"] == "live"
+
+
+def test_game_set_unknown_property_reports_live_unknown_property(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("live_unknown_property", "no settable property"),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "game", "set", "/root/Main/Player",
+            "--property", "nope", "--value", "1",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "live_unknown_property"
+    assert error["category"] == "live"
+
+
+def test_game_set_uncoercible_value_reports_live_uncoercible_value(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("live_uncoercible_value", "cannot coerce value"),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "game", "set", "/root/Main/Player",
+            "--property", "position", "--value", "not-a-vector",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "live_uncoercible_value"
+    assert error["category"] == "live"
+
+
+def test_game_set_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "game", "set", "/root/Main/Player",
+            "--property", "position", "--value", "1,2",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    assert json.loads(result.stdout)["error"]["code"] == "daemon_not_running"
+
+
+def test_game_set_schema_is_self_describing():
+    result = CliRunner().invoke(app, ["game", "set", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    schema = json.loads(result.stdout)
+    assert "input" in schema and "output" in schema
+    assert schema["kind"] == "live"

--- a/tests/test_harness_coercion_mirror.py
+++ b/tests/test_harness_coercion_mirror.py
@@ -1,0 +1,51 @@
+"""Drift check: the shared coercion block is byte-identical in both .gd files.
+
+``operations.gd`` (the headless op dispatcher, run via ``godot --headless
+--script <abs-fs-path>``) and ``gda_harness.gd`` (the live res:// autoload) need
+the SAME property-introspection / value-coercion helpers so ``game set`` coerces
+exactly as headless ``node set`` does. No single ``preload()`` reaches both
+runtime contexts and ``install.py`` copies one file, so the block is DUPLICATED
+verbatim rather than extracted into a shared module (keystone decision, #220).
+
+This test is the drift guard: it extracts the marker-delimited block from both
+files and asserts they are byte-identical (modulo leading tabs, which differ only
+if a copy is re-indented). Modeled on the registry drift checks in
+``tests/test_error_registry.py``. An edit to one block that is not mirrored in
+the other fails here.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OPERATIONS_GD = ROOT / "src" / "gda" / "ops" / "operations.gd"
+GDA_HARNESS_GD = ROOT / "src" / "gda" / "harness" / "gda_harness.gd"
+
+# The block both files delimit with these matching marker comments.
+BLOCK = re.compile(
+    r"^# --- BEGIN shared coercion .*?$\n(?P<body>.*?)^# --- END shared coercion ---$",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _shared_block(path: Path) -> str:
+    """The marker-delimited shared block, with each line's leading tabs stripped.
+
+    Leading tabs are normalized so an accidental re-indent of one copy is not
+    flagged as content drift — only the helper LOGIC must match.
+    """
+    text = path.read_text(encoding="utf-8")
+    matches = BLOCK.findall(text)
+    assert len(matches) == 1, (
+        f"expected exactly one shared-coercion block in {path.name}, found {len(matches)}"
+    )
+    body = matches[0]
+    return "\n".join(line.lstrip("\t") for line in body.splitlines())
+
+
+def test_shared_coercion_block_is_byte_identical_across_the_two_gd_files():
+    operations_block = _shared_block(OPERATIONS_GD)
+    harness_block = _shared_block(GDA_HARNESS_GD)
+
+    assert operations_block, "the operations.gd shared block must be non-empty"
+    assert operations_block == harness_block

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -12,6 +12,8 @@ import pytest
 from gda import render as render_mod
 from gda.models import (
     EngineVersion,
+    GameGetResult,
+    GameSetResult,
     ListedNode,
     ListedScript,
     NodeGetResult,
@@ -132,6 +134,27 @@ def test_render_node_set_routes_value_through_the_helper():
         value=False,
     )
     assert render(result) == "set ..visible (bool) = false"
+
+
+def test_render_game_get_renders_runtime_properties_by_absolute_path():
+    result = GameGetResult(
+        path="/root/Main/Player",
+        name="Player",
+        type="Node2D",
+        properties=[NodeProperty(name="position", type="Vector2", value=[10.0, 20.0])],
+    )
+    rendered = render(result)
+    assert rendered == "/root/Main/Player (Node2D)\n  position (Vector2) = [10.0, 20.0]"
+
+
+def test_render_game_set_renders_the_set_runtime_property():
+    result = GameSetResult(
+        path="/root/Main/Player",
+        property="position",
+        type="Vector2",
+        value=[10.0, 20.0],
+    )
+    assert render(result) == "set /root/Main/Player.position (Vector2) = [10.0, 20.0]"
 
 
 def test_render_is_keyed_by_result_type():

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1106,6 +1106,52 @@ def test_live_command_schema_reports_kind_live_without_a_daemon():
     assert doc["kind"] == "live"
 
 
+def test_game_get_set_schemas_report_kind_live_and_are_model_derived():
+    # The LIVE runtime property commands (#220) self-describe like any command —
+    # input/output from their typed models, the uniform error envelope, kind=live.
+    from gda.models import (
+        GameGetParams,
+        GameGetResult,
+        GameSetParams,
+        GameSetResult,
+    )
+
+    get_doc = json.loads(CliRunner().invoke(app, ["game", "get", "--schema"]).stdout)
+    set_doc = json.loads(CliRunner().invoke(app, ["game", "set", "--schema"]).stdout)
+
+    assert get_doc["kind"] == set_doc["kind"] == "live"
+    assert get_doc["input"] == GameGetParams.model_json_schema()
+    assert get_doc["output"] == GameGetResult.model_json_schema()
+    assert set_doc["input"] == GameSetParams.model_json_schema()
+    assert set_doc["output"] == GameSetResult.model_json_schema()
+    assert get_doc["error"] == set_doc["error"] == GdaErrorEnvelope.model_json_schema()
+    # The runtime-node param documents the absolute-path addressing agents must use.
+    assert "absolute" in get_doc["input"]["properties"]["node"]["description"]
+    assert "coerce" in set_doc["input"]["properties"]["value"]["description"].lower()
+    jsonschema.Draft202012Validator.check_schema(get_doc["input"])
+    jsonschema.Draft202012Validator.check_schema(get_doc["output"])
+    jsonschema.Draft202012Validator.check_schema(set_doc["input"])
+    jsonschema.Draft202012Validator.check_schema(set_doc["output"])
+
+
+def test_sample_game_results_validate_against_emitted_output_schemas():
+    # A sample --json payload of each game command satisfies the contract its
+    # --schema emits (the ADR-0004 hard gate for the LIVE game group, #220).
+    from tests.support import (
+        GAME_GET_RESULT,
+        GAME_SET_RESULT,
+        GAME_TREE_RESULT,
+    )
+
+    tree_doc = json.loads(CliRunner().invoke(app, ["game", "tree", "--schema"]).stdout)
+    get_doc = json.loads(CliRunner().invoke(app, ["game", "get", "--schema"]).stdout)
+    set_doc = json.loads(CliRunner().invoke(app, ["game", "set", "--schema"]).stdout)
+
+    jsonschema.validate(instance=GAME_TREE_RESULT, schema=tree_doc["output"])
+    jsonschema.validate(instance=GAME_GET_RESULT, schema=get_doc["output"])
+    jsonschema.validate(instance=GAME_SET_RESULT, schema=set_doc["output"])
+
+
 def test_schema_kind_is_identical_via_argv_and_params_json_forms():
     # `--schema` is intercepted at the same single emission point for both the
     # argv form and the `--params-json` form (the --schema check runs first), so


### PR DESCRIPTION
## What

The keystone Wave-1 live command pair: `gda game get <NODE>` / `gda game set <NODE> --property P --value V` read and mutate a node's **runtime** properties on the running game, served LIVE through `gda-daemon` → the `gda harness` against the live `SceneTree`. The on-disk counterparts stay under `node` (ADR-0019).

Closes #220.

## Why

After `game tree` (#7) could *see* the runtime tree, an agent still couldn't *inspect or poke* runtime node state. This closes that gap and sets the live-op pattern reused by #221/#223/#224.

## How

Two recon findings drove the design:
- **Absolute-path addressing** — `game tree` emits absolute runtime paths (`/root/Main/Player`); resolved harness-side via `get_tree().root.get_node_or_null(NodePath(path))` (headless `_resolve_node` is root-relative and not reused).
- **Harness op-errors arrive `exit_code=0`** (the daemon relays the sentinel verbatim), and `classify_live` maps only LIVE-category codes before the shared tree would misroute an exit-0 error envelope to `contract_violation` — so harness op-errors **must** be LIVE-category codes.

Keystone decisions:
1. **Coercion duplicated into `gda_harness.gd`, guarded by a byte-identical drift test** (`tests/test_harness_coercion_mirror.py`) rather than a shared `.gd` module: `operations.gd` runs `--script <abs-fs>` (often projectless) while the harness is a `res://addons/` autoload — no single `preload()` reaches both, and the installer copies one file. The catalog's "same coercion table as `node set`" guarantee is held by the drift test.
2. **Three new LIVE codes** — `live_node_not_found`, `live_unknown_property`, `live_uncoercible_value` (category `live`, source `classifier`, exit 6), forced by Finding B + ADR-0002's one-code-one-spec rule. A separate mirror test ties them to the harness consts; the `operations.gd`↔OPERATION mirror is untouched.

Mechanics: the bootstrap harness's hardcoded single-op `if` becomes a `match op:` **multi-op dispatcher** (`_handle_game_tree/get/set`) — each future live op adds one arm, dissolving the single-`if` merge hotspot. `game set` calls `node.set()` synchronously in the `_process`-served handler (main thread, frame boundary) ⇒ frame-coherent per ADR-0020. `game get` returns all storage properties by default, `--property` filters to one; non-coercible-type values degrade to string via `_jsonify` (symmetric with `node get`).

Touches the 4-file live-op pattern (`models.py`, `cli.py`, `errors.py` reusing `classify_live`, `gda_harness.gd`) plus `render.py` (two renderers; the `_RENDERERS` registry is a Wave-1 append point) and `operations.gd` (a **pure relocation** of two helpers into the shared-coercion marker block — verified no logic change). Daemon/`live_runner` untouched.

## Docs (co-located)

`error_codes.py` + ADR-0002 table (3 LIVE rows); `command-catalog.md` (game get/set shipped, absolute-path addressing, shared coercion); `> Outcome (#220)` note-style amendments to ADR-0017 (live-error taxonomy / Finding B) and ADR-0018 (multi-op dispatcher + coercion duplication rationale).

## Tests (independently re-run by the reviewer)

- `uv run pytest -m "not e2e"` → **677 passed**
- Full real-Godot e2e (`GDA_GODOT=…`, serial) → **253 passed, 1 skipped** — includes the new DoD round-trip (`game set position 10,20` → result `[10,20]` → `game get` → `[10,20]` on the held session), the preserved `game tree` e2e, and the full headless suite confirming the `operations.gd` relocation broke nothing.

> CI's "Godot e2e tests" job is gated (manual/schedule) and **skips** on a normal PR, so the real-Godot e2e above — run locally — is this PR's e2e verification. The unit job (`-m "not e2e"`) runs in CI.

## Notes for the reviewer

- **CLI arg style** hybridizes the issue's all-positional sketch (`game set <node> <property> <value>`) to `<NODE>` positional + `--property`/`--value` flags, matching headless `node set` for consistency. Flag if issue-verbatim is preferred.
- `render.py` `_RENDERERS` + the harness `match` are the central append-points the next live slices (#221/#223/#224) will extend.
