### PR TITLE
feat: perf — runtime performance monitoring + the time-windowed live base (#223)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -143,7 +143,6 @@ operation, and parse codes the CLI assigns).
 | `live_perf_node_not_found` | `live` | `classifier` | `6` | A live perf monitor's node path does not resolve to a node in the running scene tree (Phase 2, #223). |
 | `live_perf_property_not_found` | `live` | `classifier` | `6` | A live perf monitor targeted a property the running node does not expose for reading (Phase 2, #223). |
 | `live_perf_signal_not_found` | `live` | `classifier` | `6` | A live perf monitor targeted a signal the running node does not declare (Phase 2, #223). |
-| `live_perf_timeout` | `live` | `classifier` | `6` | A live perf time-windowed collection did not complete within the harness's frame budget (Phase 2, #223). |
 | `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
 
 ## Considered options

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -140,6 +140,10 @@ operation, and parse codes the CLI assigns).
 | `live_node_not_found` | `live` | `classifier` | `6` | A live game operation's node path does not resolve to a node in the running scene tree (Phase 2, #220). |
 | `live_unknown_property` | `live` | `classifier` | `6` | A live game get or set targeted a property the running node does not expose for the requested operation (no such readable storage property for get, or no such settable property for set) (Phase 2, #220). |
 | `live_uncoercible_value` | `live` | `classifier` | `6` | A live game set value cannot be coerced to the running property's declared Godot type (Phase 2, #220). |
+| `live_perf_node_not_found` | `live` | `classifier` | `6` | A live perf monitor's node path does not resolve to a node in the running scene tree (Phase 2, #223). |
+| `live_perf_property_not_found` | `live` | `classifier` | `6` | A live perf monitor targeted a property the running node does not expose for reading (Phase 2, #223). |
+| `live_perf_signal_not_found` | `live` | `classifier` | `6` | A live perf monitor targeted a signal the running node does not declare (Phase 2, #223). |
+| `live_perf_timeout` | `live` | `classifier` | `6` | A live perf time-windowed collection did not complete within the harness's frame budget (Phase 2, #223). |
 | `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
 
 ## Considered options

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -57,10 +57,12 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > per frame (frame-coherent, ADR-0020), and replies **once** with the whole timeline
 > when the budget is met. This keeps the **one-shot RPC** this ADR prescribes — the
 > client still issues one request and blocks for one reply — while the collection
-> itself is multi-frame. A bounded frame ceiling fails a stalled/crashed window with
-> `live_perf_timeout` (the time-windowed analogue of the boot guard), so a hung
-> engine cannot hang the RPC forever. The base is general: #222's viewport capture
-> reuses it by supplying its own sampler/finalizer, with no `_process` change.
+> itself is multi-frame. The window finalizes on its sample count and the requested
+> frame count is bounded model-side (`PerfMonitorParams`, ADR-0015), so the window
+> has no timeout of its own; a genuinely stalled engine — which never advances the
+> window at all — is caught by the daemon-level `live_timeout`, the real
+> stalled-engine guard. The base is general: #222's viewport capture reuses it by
+> supplying its own sampler/finalizer, with no `_process` change.
 
 ## Decision
 

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -47,6 +47,21 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > operations.gd OP_ERROR mirror; a separate test mirrors them against the harness
 > consts.
 
+> **Outcome (2026-06-22, #223) — the time-windowed multi-frame mechanism is now
+> IMPLEMENTED in the gda harness, realizing this ADR's one-shot RPC contract for a
+> multi-frame op.** Until now every live op replied on a single frame. `perf monitor`
+> (over N frames) needed a handler that spans frames, so the harness `_process` loop
+> gained a multi-frame base: a handler that cannot finish in one frame opens a
+> *window* (a frame budget + a per-frame sampler + a finalizer) instead of returning
+> a payload; the loop advances the window one frame per tick, accumulates one sample
+> per frame (frame-coherent, ADR-0020), and replies **once** with the whole timeline
+> when the budget is met. This keeps the **one-shot RPC** this ADR prescribes — the
+> client still issues one request and blocks for one reply — while the collection
+> itself is multi-frame. A bounded frame ceiling fails a stalled/crashed window with
+> `live_perf_timeout` (the time-windowed analogue of the boot guard), so a hung
+> engine cannot hang the RPC forever. The base is general: #222's viewport capture
+> reuses it by supplying its own sampler/finalizer, with no `_process` change.
+
 ## Decision
 
 **1. An execution-channel selector, chosen per command by a static `kind`.**

--- a/docs/adr/0020-live-state-consistency.md
+++ b/docs/adr/0020-live-state-consistency.md
@@ -17,6 +17,17 @@ not reloaded by a running session, and the agent (re)launches the session to pic
 on-disk edits (ADR-0017). #5's question is only "within a session, what do live reads
 and writes guarantee".
 
+> **Outcome (2026-06-22, #223) — the multi-frame timeline of decision 3 is now
+> IMPLEMENTED.** Decision 3 (Frame-coherent) anticipated that "time-windowed ops
+> (monitor / capture over N frames) are explicitly multi-frame and return a per-frame
+> timeline." `perf monitor` realizes that: the gda harness collects one sample at each
+> frame boundary on the engine's main thread over the requested N frames, so every
+> sample is itself a coherent single-frame snapshot, and the whole per-frame timeline
+> is returned as one blocking result (per ADR-0017's one-shot RPC, whose Outcome note
+> records the harness multi-frame base). Frame-coherence thus holds per-sample within
+> a window exactly as it holds for a single-frame op; the window only sequences N such
+> coherent snapshots.
+
 ## Decision
 
 `state consistency` is the property [gda-daemon](../../CONTEXT.md) provides over one

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -474,8 +474,15 @@ headless is unaffected (4.4+, cross-platform).
 - **`input` (input simulation):** key / mouse / action / sequence injection into the
   running game; record / replay.
 - **`screen` / capture:** running-game viewport screenshot, multi-frame capture.
-- **`perf` / monitor:** performance monitors, property monitoring over N frames,
-  signal watching.
+- **`perf` (runtime performance monitoring):** `perf monitors` snapshots the running
+  game's instantaneous Performance counters in one frame (shipped, #223); `perf
+  monitor --property … --frames N` / `--signal … --frames N` collects a per-frame
+  property/signal timeline over N frames and returns it as one blocking payload
+  (shipped, #223). The time-windowed collection runs on the gda harness's multi-frame
+  base — per-frame accumulation, replied once (ADR-0017 one-shot RPC, ADR-0020
+  multi-frame). A missing node is `live_perf_node_not_found`, an absent property
+  `live_perf_property_not_found`, an absent signal `live_perf_signal_not_found`, and a
+  collection that overruns its frame budget `live_perf_timeout`.
 - **diagnostics:** runtime errors and output log of the running game.
 - **lifecycle (the `daemon` command group):** `gda daemon start` / `stop` / `status`, and `gda daemon
   install` / `uninstall` for the `gda harness` (ADR-0018).

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -480,9 +480,12 @@ headless is unaffected (4.4+, cross-platform).
   property/signal timeline over N frames and returns it as one blocking payload
   (shipped, #223). The time-windowed collection runs on the gda harness's multi-frame
   base — per-frame accumulation, replied once (ADR-0017 one-shot RPC, ADR-0020
-  multi-frame). A missing node is `live_perf_node_not_found`, an absent property
-  `live_perf_property_not_found`, an absent signal `live_perf_signal_not_found`, and a
-  collection that overruns its frame budget `live_perf_timeout`.
+  multi-frame). The `--frames` count is bounded model-side (1..600, ADR-0015) and
+  exactly one of `--property`/`--signal` is required, so an over-range or ambiguous
+  request is a structured `invalid_params` before it reaches the harness. A missing
+  node is `live_perf_node_not_found`, an absent property `live_perf_property_not_found`,
+  an absent signal `live_perf_signal_not_found`; a genuinely stalled engine is caught
+  by the daemon-level `live_timeout`.
 - **diagnostics:** runtime errors and output log of the running game.
 - **lifecycle (the `daemon` command group):** `gda daemon start` / `stop` / `status`, and `gda daemon
   install` / `uninstall` for the `gda harness` (ADR-0018).

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -25,6 +25,8 @@ from gda.errors import (
     classify_game_set,
     classify_game_tree,
     classify_info,
+    classify_perf_monitor,
+    classify_perf_monitors,
     classify_script_validate,
 )
 from gda.execution import ExecutionKind
@@ -68,6 +70,10 @@ from gda.models import (
     GameTreeParams,
     GameTreeResult,
     InfoParams,
+    PerfMonitorParams,
+    PerfMonitorResult,
+    PerfMonitorsParams,
+    PerfMonitorsResult,
     ProjectDependenciesParams,
     ProjectDependenciesResult,
     ProjectFindReferencesParams,
@@ -242,6 +248,18 @@ game_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(game_app, name="game")
+
+# The perf command group (Phase 2, ADR-0019, #223): runtime performance monitoring
+# of the RUNNING game, served LIVE through gda-daemon (`kind = LIVE`). `perf
+# monitors` snapshots the engine's Performance counters in one frame; `perf monitor`
+# collects a per-frame property/signal timeline over N frames (the time-windowed
+# multi-frame harness base). Like `game`, a domain-object group marked live by
+# `kind`, not by the tree (ADR-0019).
+perf_app = typer.Typer(
+    help="Monitor the running game's runtime performance (live; macOS/Linux only).",
+    no_args_is_help=True,
+)
+app.add_typer(perf_app, name="perf")
 
 # The daemon command group (Phase 2, ADR-0017): gda's own per-project daemon
 # lifecycle — a deliberate extension of ADR-0005's domain-object grouping to an
@@ -577,6 +595,97 @@ def game_set(
     _dispatch(
         GAME_SET_COMMAND,
         GameSetParams(node=node, property=property, value=value),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+    )
+
+
+PERF_MONITORS_COMMAND: HeadlessCommand[PerfMonitorsResult] = HeadlessCommand(
+    operation="perf-monitors",
+    input_model=PerfMonitorsParams,
+    output_model=PerfMonitorsResult,
+    classify=classify_perf_monitors,
+    kind=ExecutionKind.LIVE,
+)
+
+
+@perf_app.command(name="monitors", cls=PERF_MONITORS_COMMAND.command_class())
+def perf_monitors(
+    json_output: bool = json_option(),
+    schema: bool = PERF_MONITORS_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Snapshot the running game's performance monitors (live).
+
+    Routes through gda-daemon to the engine session (kind = LIVE, ADR-0017): the
+    instantaneous Performance counters — fps, frame timing, memory, object/node
+    counts, render stats, active physics/navigation objects — read in one frame, so
+    the values are mutually coherent (ADR-0020). Live ops are macOS/Linux only and
+    need a running daemon: with none, it reports `daemon_not_running`.
+    """
+    _dispatch(
+        PERF_MONITORS_COMMAND,
+        PerfMonitorsParams(),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+    )
+
+
+PERF_MONITOR_COMMAND: HeadlessCommand[PerfMonitorResult] = HeadlessCommand(
+    operation="perf-monitor",
+    input_model=PerfMonitorParams,
+    output_model=PerfMonitorResult,
+    classify=classify_perf_monitor,
+    kind=ExecutionKind.LIVE,
+)
+
+
+@perf_app.command(name="monitor", cls=PERF_MONITOR_COMMAND.command_class())
+def perf_monitor(
+    node: str = typer.Argument(
+        ...,
+        help="Runtime node path as `game tree` reports it (absolute, e.g. /root/Main/Player).",
+    ),
+    property: Optional[str] = typer.Option(
+        None,
+        "--property",
+        help="The property to sample each frame (mutually exclusive with --signal).",
+    ),
+    signal: Optional[str] = typer.Option(
+        None,
+        "--signal",
+        help="The signal whose emissions to record over the window (mutually exclusive with --property).",
+    ),
+    frames: int = typer.Option(
+        60,
+        "--frames",
+        min=1,
+        help="The number of frames to collect over (the harness clamps an excessive value).",
+    ),
+    json_output: bool = json_option(),
+    schema: bool = PERF_MONITOR_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Watch one running node over a frame window (live, time-windowed).
+
+    Routes through gda-daemon to the engine session (kind = LIVE, ADR-0017) and
+    collects a per-frame timeline over `--frames` frames, returned as one blocking
+    payload (ADR-0017 one-shot RPC, ADR-0020 multi-frame). Pass exactly one of
+    `--property` (records the property's value each frame) or `--signal` (records
+    the signal's emissions over the window). With no daemon it reports
+    `daemon_not_running`; an absent node is `live_perf_node_not_found`, an absent
+    property `live_perf_property_not_found`, an absent signal
+    `live_perf_signal_not_found`.
+    """
+    _dispatch(
+        PERF_MONITOR_COMMAND,
+        PerfMonitorParams(node=node, property=property, signal=signal, frames=frames),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -70,6 +70,7 @@ from gda.models import (
     GameTreeParams,
     GameTreeResult,
     InfoParams,
+    MAX_WINDOW_FRAMES,
     PerfMonitorParams,
     PerfMonitorResult,
     PerfMonitorsParams,
@@ -664,7 +665,11 @@ def perf_monitor(
         60,
         "--frames",
         min=1,
-        help="The number of frames to collect over (the harness clamps an excessive value).",
+        max=MAX_WINDOW_FRAMES,
+        help=(
+            f"The number of frames to collect over, 1..{MAX_WINDOW_FRAMES} (the "
+            "gda harness's per-window ceiling)."
+        ),
     ),
     json_output: bool = json_option(),
     schema: bool = PERF_MONITOR_COMMAND.schema_option(),
@@ -683,6 +688,14 @@ def perf_monitor(
     property `live_perf_property_not_found`, an absent signal
     `live_perf_signal_not_found`.
     """
+    # Exactly one of --property/--signal is required (the same rule the model
+    # enforces for --params-json). On the argv path it is a usage error (exit 2),
+    # keeping the argv ergonomics, mirroring `script create`'s --content/--extends
+    # check; --params-json surfaces the same rule as a structured invalid_params.
+    if property is not None and signal is not None:
+        raise typer.BadParameter("--property and --signal are mutually exclusive.")
+    if property is None and signal is None:
+        raise typer.BadParameter("perf monitor needs --property or --signal.")
     _dispatch(
         PERF_MONITOR_COMMAND,
         PerfMonitorParams(node=node, property=property, signal=signal, frames=frames),

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -468,6 +468,39 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCodeSource.CLASSIFIER,
         "A live game set value cannot be coerced to the running property's declared Godot type.",
     ),
+    # Per live-operation failures the gda harness reports for `perf` (#223). Same
+    # shape as the #220 game op-errors above: LIVE-category, classifier-source,
+    # exit_code EXIT_LIVE, harness-mirrored (a test mirrors them against the harness
+    # LIVE_ERROR_* consts). live_perf_timeout is reported by the harness's
+    # time-windowed base when a collection cannot complete within its frame budget.
+    ErrorCodeSpec(
+        "live_perf_node_not_found",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A live perf monitor's node path does not resolve to a node in the running scene tree.",
+    ),
+    ErrorCodeSpec(
+        "live_perf_property_not_found",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A live perf monitor targeted a property the running node does not expose for reading.",
+    ),
+    ErrorCodeSpec(
+        "live_perf_signal_not_found",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A live perf monitor targeted a signal the running node does not declare.",
+    ),
+    ErrorCodeSpec(
+        "live_perf_timeout",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A live perf time-windowed collection did not complete within the harness's frame budget.",
+    ),
     # A pre-launch platform precondition, not a live-runtime failure: live needs
     # Unix domain sockets, which are UNIX-only, so it is an ENVIRONMENT-category
     # code in the binary_not_found bucket (ADR-0021), decided before any engine

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -471,8 +471,10 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
     # Per live-operation failures the gda harness reports for `perf` (#223). Same
     # shape as the #220 game op-errors above: LIVE-category, classifier-source,
     # exit_code EXIT_LIVE, harness-mirrored (a test mirrors them against the harness
-    # LIVE_ERROR_* consts). live_perf_timeout is reported by the harness's
-    # time-windowed base when a collection cannot complete within its frame budget.
+    # LIVE_ERROR_* consts). A stalled/crashed engine is caught by the daemon-level
+    # `live_timeout`, not a perf-specific code: the time-windowed base finalizes on
+    # sample count (reached before any frame ceiling), so it never emits its own
+    # timeout — there is no `live_perf_timeout`.
     ErrorCodeSpec(
         "live_perf_node_not_found",
         ErrorCategory.LIVE,
@@ -493,13 +495,6 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         EXIT_LIVE,
         ErrorCodeSource.CLASSIFIER,
         "A live perf monitor targeted a signal the running node does not declare.",
-    ),
-    ErrorCodeSpec(
-        "live_perf_timeout",
-        ErrorCategory.LIVE,
-        EXIT_LIVE,
-        ErrorCodeSource.CLASSIFIER,
-        "A live perf time-windowed collection did not complete within the harness's frame budget.",
     ),
     # A pre-launch platform precondition, not a live-runtime failure: live needs
     # Unix domain sockets, which are UNIX-only, so it is an ENVIRONMENT-category

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -57,6 +57,8 @@ from gda.models import (
     GameTreeResult,
     GdaError,
     OperationErrorEnvelope,
+    PerfMonitorResult,
+    PerfMonitorsResult,
     ScriptDiagnostic,
     ScriptValidateResult,
 )
@@ -442,6 +444,16 @@ def classify_game_get(result: RunResult, binary: Path) -> GameGetResult | Failur
 def classify_game_set(result: RunResult, binary: Path) -> GameSetResult | Failure:
     """The per-command live classifier for ``gda game set`` (mirrors ``classify_game_tree``)."""
     return classify_live(result, binary, GameSetResult)
+
+
+def classify_perf_monitors(result: RunResult, binary: Path) -> PerfMonitorsResult | Failure:
+    """The per-command live classifier for ``gda perf monitors`` (#223, mirrors ``classify_game_tree``)."""
+    return classify_live(result, binary, PerfMonitorsResult)
+
+
+def classify_perf_monitor(result: RunResult, binary: Path) -> PerfMonitorResult | Failure:
+    """The per-command live classifier for ``gda perf monitor`` (#223, mirrors ``classify_game_tree``)."""
+    return classify_live(result, binary, PerfMonitorResult)
 
 
 # A non-fatal export warning the engine prints to stderr. WARNING is Godot's

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -37,19 +37,14 @@ const LIVE_ERROR_UNCOERCIBLE_VALUE := "live_uncoercible_value"
 const LIVE_ERROR_PERF_NODE_NOT_FOUND := "live_perf_node_not_found"
 const LIVE_ERROR_PERF_PROPERTY_NOT_FOUND := "live_perf_property_not_found"
 const LIVE_ERROR_PERF_SIGNAL_NOT_FOUND := "live_perf_signal_not_found"
-const LIVE_ERROR_PERF_TIMEOUT := "live_perf_timeout"
 
-# The frame count a time-windowed op may request before the harness clamps it
-# (#223). A window collects one sample per frame, so an unbounded N would block the
-# RPC for an unbounded time; this bounds the collection to a generous ceiling.
+# The frame count a time-windowed op may request (#223). A window collects one
+# sample per frame, so an unbounded N would block the one-shot RPC for an unbounded
+# time; this bounds the collection to a generous ceiling. The bound is ENFORCED
+# model-side (PerfMonitorParams.frames, ADR-0015), so an over-range request is
+# rejected before it reaches the harness — the harness no longer clamps. Mirrored
+# in src/gda/models.py (MAX_WINDOW_FRAMES); a test keeps the two in sync.
 const MAX_WINDOW_FRAMES := 600
-
-# A window's hard frame budget guard (#223). A window finalizes when it has
-# collected its requested frame count, but if the engine stalls (a crash mid-window,
-# a frame that never advances) the window must still fail rather than hang the RPC
-# forever — the time-windowed analogue of the _pending_frames > 300 boot guard. The
-# ceiling is the max requestable frames plus headroom for the few-frame settle.
-const WINDOW_FRAME_LIMIT := MAX_WINDOW_FRAMES + 60
 
 var _peer: StreamPeerUDS = null
 var _authed := false
@@ -146,18 +141,18 @@ func _send_frame(payload: PackedByteArray) -> void:
 # calls `sample` once (frame-coherent, ADR-0020) and accumulates its return into a
 # samples Array; once `frames` samples are collected (or an error sample is
 # returned) it calls `finalize(samples)` for the final payload and replies once.
-# A hard frame budget (WINDOW_FRAME_LIMIT) fails with live_perf_timeout so a
-# stalled/crashed engine cannot hang the RPC forever. #221's capture op reuses
-# this same base by adding its own sample/finalize Callables — no _process change.
+# A truly stalled engine never runs _advance_window at all, so the window has no
+# timeout of its own — the daemon-level `live_timeout` is the stalled-engine guard.
+# #221's capture op reuses this same base by adding its own sample/finalize
+# Callables — no _process change.
 
 # Open a window: store its frame budget, sampler, and finalizer, then let
-# _process drive it. `frames` is the number of per-frame samples to collect,
-# clamped to MAX_WINDOW_FRAMES. Returns null so _run's caller does not reply now.
+# _process drive it. `frames` is the number of per-frame samples to collect; it is
+# already bounded to 1..MAX_WINDOW_FRAMES model-side (PerfMonitorParams, ADR-0015),
+# so the harness does not clamp. Returns null so _run's caller does not reply now.
 func _begin_window(frames: int, sample: Callable, finalize: Callable) -> Variant:
-	var budget := clampi(frames, 1, MAX_WINDOW_FRAMES)
 	_window_state = {
-		"budget": budget,
-		"elapsed": 0,
+		"budget": frames,
 		"samples": [],
 		"sample": sample,
 		"finalize": finalize,
@@ -168,15 +163,9 @@ func _begin_window(frames: int, sample: Callable, finalize: Callable) -> Variant
 # Advance the active window one frame. Collects one sample; finalizes once the
 # frame budget is met. A sample handler may abort the window early by returning a
 # Dictionary carrying an "error" key (e.g. a node that vanished mid-window) — that
-# envelope is sent verbatim. The frame ceiling is the time-windowed boot-guard.
+# envelope is sent verbatim.
 func _advance_window() -> void:
 	var state: Dictionary = _window_state
-	state["elapsed"] = int(state["elapsed"]) + 1
-	if int(state["elapsed"]) > WINDOW_FRAME_LIMIT:
-		_finish_window(_error(LIVE_ERROR_PERF_TIMEOUT,
-				"time-windowed collection did not complete within "
-				+ str(WINDOW_FRAME_LIMIT) + " frames"))
-		return
 	var sampler: Callable = state["sample"]
 	var sampled: Variant = sampler.call()
 	# A sampler may abort the window by returning a Dictionary with an "error" key
@@ -434,15 +423,18 @@ func _begin_signal_monitor(node: Node, path: String, signal_name: String, frames
 	var sample := func() -> Variant:
 		frame_box["n"] = int(frame_box["n"]) + 1
 		return null
-	var finalize := func(_samples: Array) -> String:
+	var finalize := func(samples: Array) -> String:
 		var live: Node = node_ref.get_ref()
 		if live != null and live.is_connected(signal_name, recorder):
 			live.disconnect(signal_name, recorder)
+		# Report the ACTUAL window length (one per-frame sample was accumulated each
+		# tick), consistent with the property finalizer's samples.size() — not the
+		# originally-requested `frames`.
 		return _ok({
 			"node": path,
 			"kind": "signal",
 			"signal": signal_name,
-			"frames": frames,
+			"frames": samples.size(),
 			"emissions": emissions,
 		})
 	return _begin_window(frames, sample, finalize)

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -20,26 +20,67 @@ const LAUNCH_MARKER := "gda-daemon"
 const RESULT_BEGIN := "<<<GDA:RESULT>>>"
 const RESULT_END := "<<<GDA:END>>>"
 
-# The live operations this harness serves, keyed by their wire op name (#220).
+# The live operations this harness serves, keyed by their wire op name (#220, #223).
 const OP_GAME_TREE := "game-tree"
 const OP_GAME_GET := "game-get"
 const OP_GAME_SET := "game-set"
+const OP_PERF_MONITORS := "perf-monitors"
+const OP_PERF_MONITOR := "perf-monitor"
 
-# The per-op LIVE failure codes the harness reports in-band (#220). Each MUST be a
-# registered LIVE-category code (src/gda/error_codes.py) so the daemon's exit-0
+# The per-op LIVE failure codes the harness reports in-band (#220, #223). Each MUST
+# be a registered LIVE-category code (src/gda/error_codes.py) so the daemon's exit-0
 # relay is mapped by classify_live, not misrouted to contract_violation; a Python
 # mirror test (tests/test_error_registry.py) keeps these in sync with the registry.
 const LIVE_ERROR_NODE_NOT_FOUND := "live_node_not_found"
 const LIVE_ERROR_UNKNOWN_PROPERTY := "live_unknown_property"
 const LIVE_ERROR_UNCOERCIBLE_VALUE := "live_uncoercible_value"
+const LIVE_ERROR_PERF_NODE_NOT_FOUND := "live_perf_node_not_found"
+const LIVE_ERROR_PERF_PROPERTY_NOT_FOUND := "live_perf_property_not_found"
+const LIVE_ERROR_PERF_SIGNAL_NOT_FOUND := "live_perf_signal_not_found"
+const LIVE_ERROR_PERF_TIMEOUT := "live_perf_timeout"
+
+# The frame count a time-windowed op may request before the harness clamps it
+# (#223). A window collects one sample per frame, so an unbounded N would block the
+# RPC for an unbounded time; this bounds the collection to a generous ceiling.
+const MAX_WINDOW_FRAMES := 600
+
+# A window's hard frame budget guard (#223). A window finalizes when it has
+# collected its requested frame count, but if the engine stalls (a crash mid-window,
+# a frame that never advances) the window must still fail rather than hang the RPC
+# forever — the time-windowed analogue of the _pending_frames > 300 boot guard. The
+# ceiling is the max requestable frames plus headroom for the few-frame settle.
+const WINDOW_FRAME_LIMIT := MAX_WINDOW_FRAMES + 60
 
 var _peer: StreamPeerUDS = null
 var _authed := false
 var _pending = null
 var _pending_frames := 0
+# The active time-windowed collection, or null when none is running (#223). A
+# multi-frame handler sets this from _run instead of returning a payload; the
+# _process loop then advances it one frame per tick until it finalizes. See
+# _begin_window / _advance_window.
+var _window_state = null
 
 
 func _ready() -> void:
+	_perf_monitors = {
+		"fps": Performance.TIME_FPS,
+		"process_time": Performance.TIME_PROCESS,
+		"physics_process_time": Performance.TIME_PHYSICS_PROCESS,
+		"static_memory": Performance.MEMORY_STATIC,
+		"static_memory_max": Performance.MEMORY_STATIC_MAX,
+		"object_count": Performance.OBJECT_COUNT,
+		"node_count": Performance.OBJECT_NODE_COUNT,
+		"orphan_node_count": Performance.OBJECT_ORPHAN_NODE_COUNT,
+		"resource_count": Performance.OBJECT_RESOURCE_COUNT,
+		"draw_calls": Performance.RENDER_TOTAL_DRAW_CALLS_IN_FRAME,
+		"objects_in_frame": Performance.RENDER_TOTAL_OBJECTS_IN_FRAME,
+		"primitives_in_frame": Performance.RENDER_TOTAL_PRIMITIVES_IN_FRAME,
+		"video_memory": Performance.RENDER_VIDEO_MEM_USED,
+		"physics_2d_active_objects": Performance.PHYSICS_2D_ACTIVE_OBJECTS,
+		"physics_3d_active_objects": Performance.PHYSICS_3D_ACTIVE_OBJECTS,
+		"navigation_active_maps": Performance.NAVIGATION_ACTIVE_MAPS,
+	}
 	var user_args := OS.get_cmdline_user_args()
 	var idx := user_args.find(LAUNCH_MARKER)
 	if idx == -1 or idx + 2 >= user_args.size():
@@ -62,6 +103,13 @@ func _process(_delta: float) -> void:
 	if _peer == null or not _authed:
 		return
 	_peer.poll()
+	# A time-windowed op owns the connection until it finalizes (#223): advance it
+	# one frame and serve nothing else this tick, so per-frame samples stay
+	# frame-coherent (ADR-0020) and the single-writer order is preserved (one op at
+	# a time). _advance_window replies once and clears _window_state when done.
+	if _window_state != null:
+		_advance_window()
+		return
 	# Read one pending request when a full length prefix is available; the body
 	# follows in the same daemon write, so get_data does not block in practice.
 	if _pending == null and _peer.get_available_bytes() >= 4:
@@ -77,8 +125,13 @@ func _process(_delta: float) -> void:
 	if _pending != null:
 		_pending_frames += 1
 		if get_tree().current_scene != null or _pending_frames > 300:
-			_send_frame(_run(_pending).to_utf8_buffer())
+			# _run returns a finished sentinel payload for a single-frame op (reply
+			# now), or null when the handler instead opened a multi-frame window
+			# (_window_state is set) — then the loop above drives it to completion.
+			var reply: Variant = _run(_pending)
 			_pending = null
+			if reply != null:
+				_send_frame((reply as String).to_utf8_buffer())
 
 
 func _send_frame(payload: PackedByteArray) -> void:
@@ -86,11 +139,72 @@ func _send_frame(payload: PackedByteArray) -> void:
 	_peer.put_data(payload)
 
 
-# Dispatch one live request to its handler by op name (#220). A request is the
-# ADR-0002 {"op", "params"} envelope the daemon relays verbatim; each handler
-# returns a full sentinel-framed payload (a success via _ok or a failure via
-# _error), so adding an op is one match arm + one handler.
-func _run(request) -> String:
+# --- Time-windowed multi-frame base (#223) ------------------------------------
+# A multi-frame handler does not return a finished payload from _run; instead it
+# calls _begin_window with a per-frame `sample` Callable and a `finalize` Callable,
+# returning null so _process keeps ticking. Each subsequent frame, _advance_window
+# calls `sample` once (frame-coherent, ADR-0020) and accumulates its return into a
+# samples Array; once `frames` samples are collected (or an error sample is
+# returned) it calls `finalize(samples)` for the final payload and replies once.
+# A hard frame budget (WINDOW_FRAME_LIMIT) fails with live_perf_timeout so a
+# stalled/crashed engine cannot hang the RPC forever. #221's capture op reuses
+# this same base by adding its own sample/finalize Callables — no _process change.
+
+# Open a window: store its frame budget, sampler, and finalizer, then let
+# _process drive it. `frames` is the number of per-frame samples to collect,
+# clamped to MAX_WINDOW_FRAMES. Returns null so _run's caller does not reply now.
+func _begin_window(frames: int, sample: Callable, finalize: Callable) -> Variant:
+	var budget := clampi(frames, 1, MAX_WINDOW_FRAMES)
+	_window_state = {
+		"budget": budget,
+		"elapsed": 0,
+		"samples": [],
+		"sample": sample,
+		"finalize": finalize,
+	}
+	return null
+
+
+# Advance the active window one frame. Collects one sample; finalizes once the
+# frame budget is met. A sample handler may abort the window early by returning a
+# Dictionary carrying an "error" key (e.g. a node that vanished mid-window) — that
+# envelope is sent verbatim. The frame ceiling is the time-windowed boot-guard.
+func _advance_window() -> void:
+	var state: Dictionary = _window_state
+	state["elapsed"] = int(state["elapsed"]) + 1
+	if int(state["elapsed"]) > WINDOW_FRAME_LIMIT:
+		_finish_window(_error(LIVE_ERROR_PERF_TIMEOUT,
+				"time-windowed collection did not complete within "
+				+ str(WINDOW_FRAME_LIMIT) + " frames"))
+		return
+	var sampler: Callable = state["sample"]
+	var sampled: Variant = sampler.call()
+	# A sampler may abort the window by returning a Dictionary with an "error" key
+	# (e.g. the monitored node was freed mid-window): send that envelope verbatim.
+	if typeof(sampled) == TYPE_DICTIONARY and (sampled as Dictionary).has("error"):
+		_finish_window(RESULT_BEGIN + JSON.stringify(sampled) + RESULT_END)
+		return
+	var samples: Array = state["samples"]
+	samples.append(sampled)
+	if samples.size() >= int(state["budget"]):
+		var finalizer: Callable = state["finalize"]
+		_finish_window(finalizer.call(samples))
+
+
+# Reply once with a window's final payload and clear the window so the loop
+# resumes serving the next request.
+func _finish_window(payload: String) -> void:
+	_window_state = null
+	_send_frame(payload.to_utf8_buffer())
+
+
+# Dispatch one live request to its handler by op name (#220, #223). A request is
+# the ADR-0002 {"op", "params"} envelope the daemon relays verbatim. A single-frame
+# handler returns a full sentinel-framed payload (success via _ok, failure via
+# _error). A multi-frame handler instead opens a window via _begin_window and
+# returns null, so _process keeps ticking. Adding an op is one match arm + one
+# handler.
+func _run(request) -> Variant:
 	if typeof(request) != TYPE_DICTIONARY:
 		return _error("operation_failed", "unsupported live operation")
 	var op: Variant = request.get("op")
@@ -104,6 +218,10 @@ func _run(request) -> String:
 			return _handle_game_get(params)
 		OP_GAME_SET:
 			return _handle_game_set(params)
+		OP_PERF_MONITORS:
+			return _handle_perf_monitors()
+		OP_PERF_MONITOR:
+			return _handle_perf_monitor(params)
 		_:
 			return _error("operation_failed", "unsupported live operation")
 
@@ -186,6 +304,171 @@ func _handle_game_set(params: Dictionary) -> String:
 		"type": _type_name(declared_type),
 		"value": _jsonify(node.get(prop_name)),
 	})
+
+
+# --- perf (runtime performance monitoring, #223) ------------------------------
+
+# The performance monitors snapshotted by `perf monitors`, keyed by their public
+# name. Each entry pairs the human/wire name with the Godot Performance.Monitor
+# enum to sample (#223). Built once at _ready (a plain var, not a const, so the
+# initializer is an ordinary runtime expression and never a const-expression
+# concern). One source of truth so the snapshot and any docs stay in step; the
+# breadth covers timing, memory, object counts, render stats, and the active
+# physics/navigation object counts.
+var _perf_monitors := {}
+
+
+# perf monitors: snapshot the running game's performance monitors in one frame —
+# the instantaneous counters Godot's Performance singleton exposes (fps, frame
+# timing, memory, object/node counts, render stats, active physics/navigation
+# objects). Single-frame and frame-coherent (ADR-0020): every value reads on the
+# same _process tick. The value's type is the Godot type Performance.get_monitor
+# returns (a float), reported so a consumer need not guess.
+func _handle_perf_monitors() -> String:
+	var monitors := {}
+	for name in _perf_monitors:
+		var value: float = Performance.get_monitor(_perf_monitors[name])
+		monitors[name] = {
+			"name": name,
+			"type": _type_name(typeof(value)),
+			"value": _jsonify(value),
+		}
+	return _ok({
+		"timestamp": Time.get_ticks_msec(),
+		"monitors": monitors,
+	})
+
+
+# perf monitor: collect a per-frame timeline over a window (#223) — either a
+# property's value each frame (--property) or a signal's emissions over the window
+# (--signal). The first time-windowed live op, built on the multi-frame base: it
+# resolves and validates up front (a missing node / property / signal fails
+# immediately), then opens a window whose sampler runs once per frame. The reply
+# is one blocking payload carrying the whole timeline (ADR-0017 one-shot RPC).
+func _handle_perf_monitor(params: Dictionary) -> Variant:
+	var path := _string_param(params, "node")
+	var node := _resolve_runtime_node(path)
+	if node == null:
+		return _error(LIVE_ERROR_PERF_NODE_NOT_FOUND,
+				"no node at runtime path: " + path)
+
+	var frames := _int_param(params, "frames", 1)
+	var prop_name := _string_param(params, "property")
+	var signal_name := _string_param(params, "signal")
+
+	if params.has("signal") and not signal_name.is_empty():
+		return _begin_signal_monitor(node, path, signal_name, frames)
+	if params.has("property") and not prop_name.is_empty():
+		return _begin_property_monitor(node, path, prop_name, frames)
+	# Neither selector given: a property monitor with an empty property is an
+	# unknown property, the clearest of the two for a malformed request.
+	return _error(LIVE_ERROR_PERF_PROPERTY_NOT_FOUND,
+			"node " + path + " perf monitor needs a --property or --signal")
+
+
+# Open a property timeline window: validate the property is readable, then sample
+# its jsonified value each frame. The sampler re-resolves nothing — the node is
+# captured — but a node freed mid-window yields a typed error sample that aborts
+# the window cleanly.
+func _begin_property_monitor(node: Node, path: String, prop_name: String, frames: int) -> Variant:
+	if _property_type(node, prop_name) == TYPE_NIL:
+		return _error(LIVE_ERROR_PERF_PROPERTY_NOT_FOUND,
+				"node " + path + " has no readable property: " + prop_name)
+	var node_ref: WeakRef = weakref(node)
+	var frame_box := {"n": 0}
+	var sample := func() -> Variant:
+		var live: Node = node_ref.get_ref()
+		if live == null:
+			return {"error": {
+				"code": LIVE_ERROR_PERF_NODE_NOT_FOUND,
+				"message": "node " + path + " was freed during monitoring",
+			}}
+		var entry := {
+			"frame": int(frame_box["n"]),
+			"timestamp": Time.get_ticks_msec(),
+			"value": _jsonify(live.get(prop_name)),
+		}
+		frame_box["n"] = int(frame_box["n"]) + 1
+		return entry
+	var finalize := func(samples: Array) -> String:
+		return _ok({
+			"node": path,
+			"kind": "property",
+			"property": prop_name,
+			"frames": samples.size(),
+			"samples": samples,
+		})
+	return _begin_window(frames, sample, finalize)
+
+
+# Open a signal timeline window: validate the signal exists, connect a recorder
+# that appends each emission ({frame, args, timestamp}), and sample the current
+# frame index each frame. On finalize, disconnect and return the recorded
+# emissions. The per-frame sample drives the window's clock; the recorder runs on
+# the signal's own emission, so an emission is tagged with the frame it landed in.
+func _begin_signal_monitor(node: Node, path: String, signal_name: String, frames: int) -> Variant:
+	var arg_count := _signal_arg_count(node, signal_name)
+	if arg_count < 0:
+		return _error(LIVE_ERROR_PERF_SIGNAL_NOT_FOUND,
+				"node " + path + " has no signal: " + signal_name)
+	var emissions: Array = []
+	var frame_box := {"n": 0}
+	# A signal carries a fixed declared arg count; a recorder Callable connected to
+	# a signal must accept at least that many positional args. A max-arity recorder
+	# (4 defaulted params) accepts any signal up to 4 args, and the declared count
+	# (captured above) tells it exactly how many of its params are real emission
+	# args — so a legitimate null arg within the declared arity is preserved and a
+	# trailing default is never mistaken for one.
+	var recorder := func(arg0 = null, arg1 = null, arg2 = null, arg3 = null) -> void:
+		var all_args := [arg0, arg1, arg2, arg3]
+		var args: Array = []
+		for i in mini(arg_count, all_args.size()):
+			args.append(_jsonify(all_args[i]))
+		emissions.append({
+			"frame": int(frame_box["n"]),
+			"timestamp": Time.get_ticks_msec(),
+			"args": args,
+		})
+	node.connect(signal_name, recorder)
+	var node_ref: WeakRef = weakref(node)
+	var sample := func() -> Variant:
+		frame_box["n"] = int(frame_box["n"]) + 1
+		return null
+	var finalize := func(_samples: Array) -> String:
+		var live: Node = node_ref.get_ref()
+		if live != null and live.is_connected(signal_name, recorder):
+			live.disconnect(signal_name, recorder)
+		return _ok({
+			"node": path,
+			"kind": "signal",
+			"signal": signal_name,
+			"frames": frames,
+			"emissions": emissions,
+		})
+	return _begin_window(frames, sample, finalize)
+
+
+# The declared positional argument count of `node`'s signal by this name, or -1
+# when the node declares no such signal — read from get_signal_list (the runtime
+# signal surface, including script-declared signals). Validating off the signal
+# list, not a try/connect (which only fails at emit time), and the arg count
+# bounds how many emission args the recorder records.
+func _signal_arg_count(node: Node, signal_name: String) -> int:
+	for sig in node.get_signal_list():
+		if String(sig.get("name", "")) == signal_name:
+			var args: Variant = sig.get("args", [])
+			return (args as Array).size() if typeof(args) == TYPE_ARRAY else 0
+	return -1
+
+
+# Read an int param defensively (the params arrive as arbitrary JSON): a missing or
+# non-numeric value falls back to `fallback` rather than crashing a typed
+# assignment, so a malformed param degrades gracefully.
+func _int_param(params: Dictionary, key: String, fallback: int) -> int:
+	var value: Variant = params.get(key, fallback)
+	if typeof(value) == TYPE_FLOAT or typeof(value) == TYPE_INT:
+		return int(value)
+	return fallback
 
 
 # Resolve a node by its ABSOLUTE runtime path (e.g. /root/Main/Player), the form

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -2492,6 +2492,120 @@ class GameSetResult(BaseModel):
     value: Any = Field(description="The coerced value as JSON, as the running node now holds it.")
 
 
+class PerfMonitor(BaseModel):
+    """One performance monitor as ``gda perf monitors`` snapshots it (Phase 2, #223).
+
+    A single counter from the running game's ``Performance`` singleton: its public
+    ``name`` (e.g. ``fps``, ``static_memory``), the Godot ``type`` of the sampled
+    value (``float``, as ``Performance.get_monitor`` returns), and its ``value`` as
+    JSON. Carried uniformly so an agent reads every monitor through one shape.
+    """
+
+    name: str
+    type: str = Field(description="The sampled value's Godot type (e.g. float).")
+    value: Any = Field(description="The monitor's value as JSON.")
+
+
+class PerfMonitorsParams(BaseModel):
+    """The params of ``gda perf monitors``: none — snapshot all monitors at once.
+
+    Empty: ``perf monitors`` reads the whole instantaneous monitor set of the
+    engine session held by ``gda-daemon`` in a single frame (frame-coherent,
+    ADR-0020); there is nothing to select.
+    """
+
+
+class PerfMonitorsResult(BaseModel):
+    """The result of ``gda perf monitors``: a one-frame performance snapshot (#223).
+
+    The running game's instantaneous ``Performance`` counters — timing, memory,
+    object/node counts, render stats, active physics/navigation objects — keyed by
+    monitor name, plus the engine ``timestamp`` (ms since session start) the
+    snapshot was taken at. Read in one frame, so the values are mutually coherent.
+    """
+
+    timestamp: int = Field(
+        description="Engine time the snapshot was taken (ms, Time.get_ticks_msec)."
+    )
+    monitors: dict[str, PerfMonitor] = Field(
+        description="The performance monitors, keyed by name."
+    )
+
+
+class PerfMonitorParams(BaseModel):
+    """The params of ``gda perf monitor``: watch one node over a frame window (#223).
+
+    Time-windowed: the gda harness collects a per-frame timeline over ``frames``
+    frames and returns it as one blocking payload (ADR-0017 one-shot RPC, ADR-0020
+    multi-frame). Exactly one of ``property`` / ``signal`` selects what to watch:
+    ``property`` records the property's value each frame; ``signal`` records the
+    signal's emissions over the window. The node is addressed by its runtime
+    (absolute) path, as ``game tree`` reports it.
+    """
+
+    node: str = Field(description=_RUNTIME_NODE_DESC)
+    property: str | None = Field(
+        default=None,
+        description="The property to sample each frame (mutually exclusive with --signal).",
+    )
+    signal: str | None = Field(
+        default=None,
+        description="The signal whose emissions to record over the window (mutually exclusive with --property).",
+    )
+    frames: int = Field(
+        default=60,
+        ge=1,
+        description="The number of frames to collect over (the harness clamps an excessive value).",
+    )
+
+
+class PerfPropertySample(BaseModel):
+    """One per-frame sample of a watched property (``gda perf monitor --property``, #223)."""
+
+    frame: int = Field(description="The 0-based frame index within the window.")
+    timestamp: int = Field(description="Engine time the sample was taken (ms).")
+    value: Any = Field(description="The property's value as JSON at that frame.")
+
+
+class PerfSignalEmission(BaseModel):
+    """One recorded emission of a watched signal (``gda perf monitor --signal``, #223)."""
+
+    frame: int = Field(description="The frame index the emission landed in.")
+    timestamp: int = Field(description="Engine time the emission was recorded (ms).")
+    args: list[Any] = Field(
+        default_factory=list, description="The emission's arguments as JSON."
+    )
+
+
+class PerfMonitorResult(BaseModel):
+    """The result of ``gda perf monitor``: a collected per-frame timeline (#223).
+
+    Carries the watched ``node`` (runtime path), the ``kind`` of timeline
+    (``property`` or ``signal``), and the number of ``frames`` collected. For a
+    property watch, ``samples`` is the per-frame value timeline and ``emissions``
+    is empty; for a signal watch, ``emissions`` is the recorded emissions over the
+    window and ``samples`` is empty. The harness reports exactly one of the two.
+    """
+
+    node: str = Field(description="The watched node's runtime (absolute) path.")
+    kind: str = Field(description="The timeline kind: 'property' or 'signal'.")
+    frames: int = Field(description="The number of frames the window collected over.")
+    property: str | None = Field(
+        default=None, description="The watched property (a property watch only)."
+    )
+    signal: str | None = Field(
+        default=None, description="The watched signal (a signal watch only)."
+    )
+    samples: list[PerfPropertySample] = Field(
+        default_factory=list,
+        description="The per-frame property timeline (a property watch only).",
+    )
+    emissions: list[PerfSignalEmission] = Field(
+        default_factory=list,
+        description="The recorded signal emissions over the window (a signal watch only).",
+    )
+
+
 class DaemonStartParams(BaseModel):
     """The params of ``gda daemon start``: none (the project is the --project context)."""
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -2492,6 +2492,18 @@ class GameSetResult(BaseModel):
     value: Any = Field(description="The coerced value as JSON, as the running node now holds it.")
 
 
+# The per-window frame ceiling a time-windowed live op may request (#223). A
+# window collects exactly one sample per frame, so an unbounded N would block the
+# one-shot RPC for an unbounded time; this is the same generous ceiling the gda
+# harness enforces (``MAX_WINDOW_FRAMES`` in ``harness/gda_harness.gd``). Mirrored
+# here so ``PerfMonitorParams.frames`` rejects an over-range value model-side
+# (ADR-0015) — the model is the input source of truth for BOTH argv and
+# ``--params-json``, so the bound is checked before a request ever reaches the
+# harness, which therefore no longer clamps. The mirror is asserted by a harness-
+# const test (``tests/test_error_registry.py``).
+MAX_WINDOW_FRAMES = 600
+
+
 class PerfMonitor(BaseModel):
     """One performance monitor as ``gda perf monitors`` snapshots it (Phase 2, #223).
 
@@ -2541,6 +2553,11 @@ class PerfMonitorParams(BaseModel):
     ``property`` records the property's value each frame; ``signal`` records the
     signal's emissions over the window. The node is addressed by its runtime
     (absolute) path, as ``game tree`` reports it.
+
+    The selector rule and the ``frames`` bound are enforced model-side
+    (ADR-0015) so BOTH the argv path and ``--params-json`` reject a malformed
+    request with the structured ``invalid_params`` error rather than the harness
+    silently preferring one selector or clamping an over-range ``frames``.
     """
 
     node: str = Field(description=_RUNTIME_NODE_DESC)
@@ -2555,8 +2572,30 @@ class PerfMonitorParams(BaseModel):
     frames: int = Field(
         default=60,
         ge=1,
-        description="The number of frames to collect over (the harness clamps an excessive value).",
+        le=MAX_WINDOW_FRAMES,
+        description=(
+            "The number of frames to collect over, 1.."
+            f"{MAX_WINDOW_FRAMES} (the gda harness's per-window ceiling). An "
+            "over-range value is rejected, not clamped."
+        ),
     )
+
+    @model_validator(mode="after")
+    def _exactly_one_selector(self) -> "PerfMonitorParams":
+        # Exactly one of property/signal selects what to watch. Enforced model-side
+        # (ADR-0015) so the argv and --params-json paths agree and the harness is
+        # never handed an ambiguous request (it would otherwise silently prefer the
+        # signal). Neither set or both set is a usage/invalid-params error.
+        if self.property is None and self.signal is None:
+            raise ValueError(
+                "perf monitor needs exactly one of --property or --signal "
+                "(neither was given)."
+            )
+        if self.property is not None and self.signal is not None:
+            raise ValueError(
+                "--property and --signal are mutually exclusive; pass exactly one."
+            )
+        return self
 
 
 class PerfPropertySample(BaseModel):

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -41,6 +41,8 @@ from gda.models import (
     NodeMoveResult,
     NodeRemoveResult,
     NodeSetResult,
+    PerfMonitorResult,
+    PerfMonitorsResult,
     ProjectAddAutoloadResult,
     ProjectGetResult,
     ProjectInfoResult,
@@ -172,6 +174,39 @@ def render_game_set(was_set: "GameSetResult") -> str:
         f"set {was_set.path}.{was_set.property} ({was_set.type}) = "
         f"{format_value(was_set.value)}"
     )
+
+
+def render_perf_monitors(snapshot: "PerfMonitorsResult") -> str:
+    """Render a performance-monitor snapshot as one ``name = value`` line each (#223).
+
+    A flat list of the running game's monitors, sorted by name for a stable
+    human-facing order, headed by the snapshot timestamp.
+    """
+    header = f"perf @ {snapshot.timestamp}ms"
+    lines = [
+        f"  {name} = {format_value(monitor.value)}"
+        for name, monitor in sorted(snapshot.monitors.items())
+    ]
+    return "\n".join([header, *lines])
+
+
+def render_perf_monitor(timeline: "PerfMonitorResult") -> str:
+    """Render a per-frame timeline (#223): a value line per frame, or an emission per row.
+
+    A property watch lists ``frame: value`` per sample; a signal watch lists
+    ``frame: args`` per recorded emission. Headed by the watched node and target.
+    """
+    if timeline.kind == "signal":
+        header = f"{timeline.node} signal {timeline.signal} ({timeline.frames} frames)"
+        rows = [
+            f"  frame {e.frame}: {format_value(e.args)}" for e in timeline.emissions
+        ]
+        return "\n".join([header, *rows])
+    header = f"{timeline.node} property {timeline.property} ({timeline.frames} frames)"
+    rows = [
+        f"  frame {s.frame}: {format_value(s.value)}" for s in timeline.samples
+    ]
+    return "\n".join([header, *rows])
 
 
 def render_daemon_start(started: "DaemonStartResult") -> str:
@@ -578,6 +613,8 @@ _RENDERERS = {
     GameTreeResult: render_game_tree,
     GameGetResult: render_game_get,
     GameSetResult: render_game_set,
+    PerfMonitorsResult: render_perf_monitors,
+    PerfMonitorResult: render_perf_monitor,
     DaemonStartResult: render_daemon_start,
     DaemonStopResult: render_daemon_stop,
     DaemonStatusResult: render_daemon_status,

--- a/tests/support.py
+++ b/tests/support.py
@@ -409,3 +409,41 @@ GAME_SET_RESULT = {
     "type": "Vector2",
     "value": [10.0, 20.0],
 }
+
+# Sample ``gda perf monitors`` / ``gda perf monitor`` results — the running game's
+# runtime performance, served LIVE through gda-daemon (#223). Shared by the
+# perf-command success/schema tests. ``monitors`` is keyed by monitor name; the
+# timeline carries one of ``samples`` (property watch) or ``emissions`` (signal).
+PERF_MONITORS_RESULT = {
+    "timestamp": 12345,
+    "monitors": {
+        "fps": {"name": "fps", "type": "float", "value": 60.0},
+        "static_memory": {"name": "static_memory", "type": "float", "value": 1048576.0},
+        "node_count": {"name": "node_count", "type": "float", "value": 3.0},
+    },
+}
+
+PERF_MONITOR_PROPERTY_RESULT = {
+    "node": "/root/Main/Player",
+    "kind": "property",
+    "property": "position",
+    "frames": 3,
+    "samples": [
+        {"frame": 0, "timestamp": 100, "value": [0.0, 0.0]},
+        {"frame": 1, "timestamp": 116, "value": [1.0, 0.0]},
+        {"frame": 2, "timestamp": 132, "value": [2.0, 0.0]},
+    ],
+    "emissions": [],
+}
+
+PERF_MONITOR_SIGNAL_RESULT = {
+    "node": "/root/Main/Player",
+    "kind": "signal",
+    "signal": "hit",
+    "frames": 3,
+    "samples": [],
+    "emissions": [
+        {"frame": 1, "timestamp": 116, "args": [42]},
+        {"frame": 2, "timestamp": 132, "args": []},
+    ],
+}

--- a/tests/test_e2e_perf.py
+++ b/tests/test_e2e_perf.py
@@ -1,0 +1,174 @@
+"""S (e2e): `gda perf` live commands through the real gda-daemon loop (#223).
+
+The Step-6 proof for perf: a real `gda daemon start` (real detached daemon, real
+harness install, live-version gate) -> a real engine session it launches on
+demand -> `gda perf monitors` returns the RUNNING game's live performance
+snapshot, and `gda perf monitor --property ... --frames N` returns an N-sample
+per-frame timeline collected by the harness's time-windowed multi-frame base.
+Run e2e SERIALLY; not a fresh empty HOME (Godot first-run). The
+`daemon_runtime_dir` fixture keeps the daemon's UDS path within `sun_path`.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+from .conftest import project_godot
+
+GODOT = resolve_godot_binary()
+
+# A main scene with a Player Node2D so the launched session has a runtime
+# SceneTree to monitor; Player.position is a Vector2 storage property the property
+# timeline samples each frame. File logging stays disabled via project_godot (#180).
+MAIN_TSCN = (
+    "[gd_scene format=3]\n\n"
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="Player" type="Node2D" parent="."]\n'
+)
+PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+
+@pytest.mark.e2e
+def test_daemon_serves_a_live_perf_snapshot(tmp_path, daemon_runtime_dir):
+    # `perf monitors`: a real daemon -> engine session -> the running game's live
+    # Performance counters, snapshotted in one frame (frame-coherent, ADR-0020).
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        snap = run("perf", "monitors")
+        assert snap.returncode == 0, snap.stdout + snap.stderr
+        doc = json.loads(snap.stdout)
+        # A real snapshot: a timestamp and the named monitors, with live values.
+        assert isinstance(doc["timestamp"], int)
+        monitors = doc["monitors"]
+        assert "fps" in monitors and "static_memory" in monitors
+        assert "node_count" in monitors and "draw_calls" in monitors
+        # node_count is the running tree's live node total (at least Main + Player).
+        assert monitors["node_count"]["value"] >= 2
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_serves_a_property_timeline_over_a_window(tmp_path, daemon_runtime_dir):
+    # `perf monitor --property --frames N`: the time-windowed multi-frame base
+    # (#223) collects one sample per frame across the engine session and returns
+    # the whole N-sample timeline in a single blocking call (ADR-0017 one-shot RPC).
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        timeline = run(
+            "perf", "monitor", "/root/Main/Player",
+            "--property", "position", "--frames", "5",
+        )
+        assert timeline.returncode == 0, timeline.stdout + timeline.stderr
+        doc = json.loads(timeline.stdout)
+        assert doc["node"] == "/root/Main/Player"
+        assert doc["kind"] == "property"
+        assert doc["property"] == "position"
+        # An N-sample timeline, one per frame, frame-indexed 0..N-1 (ADR-0020).
+        assert doc["frames"] == 5
+        assert len(doc["samples"]) == 5
+        assert [s["frame"] for s in doc["samples"]] == [0, 1, 2, 3, 4]
+        # Each sample carries the Vector2 position projection [x, y].
+        assert all(len(s["value"]) == 2 for s in doc["samples"])
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_perf_monitor_missing_node_reports_live_perf_node_not_found(tmp_path, daemon_runtime_dir):
+    # A path that resolves to no running node is the typed harness op-error,
+    # relayed through the daemon (exit-0 sentinel) and mapped by classify_live.
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    try:
+        assert run("daemon", "start").returncode == 0
+
+        from gda.exit_codes import EXIT_LIVE
+
+        missing = run(
+            "perf", "monitor", "/root/Main/Ghost", "--property", "position", "--frames", "2"
+        )
+        assert missing.returncode == EXIT_LIVE, missing.stdout + missing.stderr
+        assert json.loads(missing.stdout)["error"]["code"] == "live_perf_node_not_found"
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_perf_monitors_without_a_daemon_reports_daemon_not_running(tmp_path):
+    # The attach-or-fail path through the real DaemonRunner + discovery, no daemon.
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+
+    from gda.exit_codes import EXIT_LIVE
+
+    env = {**os.environ, "XDG_RUNTIME_DIR": str(tmp_path / "run")}
+    proc = subprocess.run(
+        [gda, "perf", "monitors", "--project", str(tmp_path), "--json"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert proc.returncode == EXIT_LIVE, proc.stdout + proc.stderr
+    error = json.loads(proc.stdout)["error"]
+    assert error["code"] == "daemon_not_running"
+    assert "gda daemon start" in error["message"]

--- a/tests/test_e2e_perf.py
+++ b/tests/test_e2e_perf.py
@@ -32,6 +32,26 @@ MAIN_TSCN = (
 )
 PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
+# A Player that DECLARES a custom signal and emits it once per _process frame with
+# a single int argument (a monotonically increasing tick). The signal e2e watches
+# this signal over a window and asserts the recorded emissions — exercising the
+# real get_signal_list / connect / record / disconnect path in the harness (#239).
+SIGNAL_PLAYER_GD = (
+    "extends Node2D\n"
+    "signal ticked(n)\n"
+    "var _n := 0\n"
+    "func _process(_delta: float) -> void:\n"
+    "\t_n += 1\n"
+    "\tticked.emit(_n)\n"
+)
+SIGNAL_MAIN_TSCN = (
+    '[gd_scene load_steps=2 format=3]\n\n'
+    '[ext_resource type="Script" path="res://player.gd" id="1"]\n\n'
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="Player" type="Node2D" parent="."]\n'
+    'script = ExtResource("1")\n'
+)
+
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
 
@@ -113,6 +133,64 @@ def test_daemon_serves_a_property_timeline_over_a_window(tmp_path, daemon_runtim
         assert [s["frame"] for s in doc["samples"]] == [0, 1, 2, 3, 4]
         # Each sample carries the Vector2 position projection [x, y].
         assert all(len(s["value"]) == 2 for s in doc["samples"])
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_serves_a_signal_timeline_over_a_window(tmp_path, daemon_runtime_dir):
+    # `perf monitor --signal --frames N`: the time-windowed base connects a recorder
+    # to a REAL script-declared signal, records each emission over the window, then
+    # disconnects on finalize. The Player emits `ticked(n)` once per _process frame,
+    # so a window of N frames records emissions carrying the int tick arg — the real
+    # get_signal_list / connect / record / disconnect path (#239).
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(SIGNAL_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "player.gd").write_text(SIGNAL_PLAYER_GD, encoding="utf-8")
+
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        timeline = run(
+            "perf", "monitor", "/root/Main/Player",
+            "--signal", "ticked", "--frames", "5",
+        )
+        assert timeline.returncode == 0, timeline.stdout + timeline.stderr
+        doc = json.loads(timeline.stdout)
+        assert doc["node"] == "/root/Main/Player"
+        assert doc["kind"] == "signal"
+        assert doc["signal"] == "ticked"
+        # The window collected its requested frame count (frames reports the ACTUAL
+        # window length, consistent with the property monitor).
+        assert doc["frames"] == 5
+        # A property timeline is empty for a signal watch (the harness reports one).
+        assert doc["samples"] == []
+        # The Player emits once per _process frame, so the window records emissions —
+        # at least one, each carrying the single int tick arg the signal declares.
+        emissions = doc["emissions"]
+        assert len(emissions) >= 1, doc
+        for emission in emissions:
+            assert len(emission["args"]) == 1
+            assert isinstance(emission["args"][0], int)
+            assert "frame" in emission and "timestamp" in emission
+        # The recorded tick args are strictly increasing (the Player increments _n
+        # each frame before emitting), proving real emission args were captured.
+        ticks = [e["args"][0] for e in emissions]
+        assert ticks == sorted(ticks) and len(set(ticks)) == len(ticks), ticks
     finally:
         run("daemon", "stop")
 

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -37,13 +37,17 @@ GDSCRIPT_HARNESS_LIVE_CODE = re.compile(
 )
 BARE_FAIL_CODE = re.compile(r'_fail\(\s*"[a-z_]+"')
 
-# The per-operation LIVE failures the gda harness reports in-band (#220). The
+# The per-operation LIVE failures the gda harness reports in-band (#220, #223). The
 # generic daemon-channel LIVE codes (daemon_not_running, …) are surfaced by the
 # Python daemon client, NOT the harness, so they are not mirrored in GDScript.
 HARNESS_LIVE_ERROR_CODES = (
     "live_node_not_found",
     "live_unknown_property",
     "live_uncoercible_value",
+    "live_perf_node_not_found",
+    "live_perf_property_not_found",
+    "live_perf_signal_not_found",
+    "live_perf_timeout",
 )
 
 

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -47,7 +47,6 @@ HARNESS_LIVE_ERROR_CODES = (
     "live_perf_node_not_found",
     "live_perf_property_not_found",
     "live_perf_signal_not_found",
-    "live_perf_timeout",
 )
 
 
@@ -150,3 +149,21 @@ def test_gdscript_harness_live_error_codes_mirror_python_harness_subset():
     for code in mirrored_codes:
         spec = ERROR_CODE_BY_CODE[code]
         assert spec.category is ErrorCategory.LIVE
+
+
+HARNESS_MAX_WINDOW_FRAMES = re.compile(
+    r'^const MAX_WINDOW_FRAMES := (\d+)$', re.MULTILINE
+)
+
+
+def test_max_window_frames_mirrors_the_harness_const():
+    # The time-windowed frame ceiling is bounded model-side (PerfMonitorParams,
+    # ADR-0015) by gda.models.MAX_WINDOW_FRAMES, mirroring the harness's
+    # MAX_WINDOW_FRAMES const so the model rejects exactly what the harness would
+    # otherwise have to defend against. Keep the two in sync.
+    from gda.models import MAX_WINDOW_FRAMES
+
+    harness = GDA_HARNESS_GD.read_text(encoding="utf-8")
+    match = HARNESS_MAX_WINDOW_FRAMES.search(harness)
+    assert match is not None, "MAX_WINDOW_FRAMES const missing from gda_harness.gd"
+    assert int(match.group(1)) == MAX_WINDOW_FRAMES

--- a/tests/test_params_json.py
+++ b/tests/test_params_json.py
@@ -296,6 +296,66 @@ def test_script_set_params_json_rejects_inconsistent_edit_fields(monkeypatch):
     assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
 
 
+def test_perf_monitor_params_json_rejects_both_selectors(monkeypatch):
+    # Exactly one of property/signal is enforced model-side (PerfMonitorParams,
+    # ADR-0015), so --params-json cannot pass both (the harness would otherwise
+    # silently prefer signal) — it is structured invalid_params, not a silent pick.
+    result = CliRunner().invoke(
+        app,
+        [
+            "perf", "monitor",
+            "--params-json",
+            '{"node": "/root/Main/Player", "property": "position", "signal": "hit"}',
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+
+
+def test_perf_monitor_params_json_rejects_neither_selector(monkeypatch):
+    # Neither property nor signal is also invalid_params via --params-json: the
+    # request is ambiguous, not a default-to-something dispatch.
+    result = CliRunner().invoke(
+        app,
+        ["perf", "monitor", "--params-json", '{"node": "/root/Main/Player"}'],
+    )
+
+    assert result.exit_code != 0
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+
+
+def test_perf_monitor_params_json_rejects_frames_over_range(monkeypatch):
+    # frames is bounded 1..MAX_WINDOW_FRAMES model-side, so an over-range value is
+    # rejected (NOT silently clamped) as structured invalid_params via --params-json.
+    result = CliRunner().invoke(
+        app,
+        [
+            "perf", "monitor",
+            "--params-json",
+            '{"node": "/root/Main/Player", "property": "position", "frames": 601}',
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+
+
+def test_perf_monitor_params_json_rejects_frames_below_range(monkeypatch):
+    # The lower bound (>= 1) is enforced model-side too: frames 0 is invalid_params.
+    result = CliRunner().invoke(
+        app,
+        [
+            "perf", "monitor",
+            "--params-json",
+            '{"node": "/root/Main/Player", "property": "position", "frames": 0}',
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+
+
 def test_script_set_params_json_derives_mode_like_argv(monkeypatch):
     # Parity: the edit mode is derived from the supplied fields model-side, so a
     # --params-json caller need not (and should not) supply it.

--- a/tests/test_perf_commands.py
+++ b/tests/test_perf_commands.py
@@ -260,32 +260,6 @@ def test_perf_monitor_unknown_signal_reports_live_perf_signal_not_found(monkeypa
     assert json.loads(result.stdout)["error"]["code"] == "live_perf_signal_not_found"
 
 
-def test_perf_monitor_timeout_reports_live_perf_timeout(monkeypatch, tmp_path):
-    # The harness time-windowed base reports live_perf_timeout when a collection
-    # cannot complete within its frame budget; it is a LIVE-category code, so
-    # classify_live maps it (exit EXIT_LIVE), not the contract_violation fallthrough.
-    inject_live_runner(
-        monkeypatch,
-        RunResult(
-            stdout=error_sentinel("live_perf_timeout", "did not complete in budget"),
-            stderr="",
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app,
-        [
-            "perf", "monitor", "/root/Main/Player",
-            "--property", "position",
-            "--project", str(_project(tmp_path)), "--json",
-        ],
-    )
-
-    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
-    assert json.loads(result.stdout)["error"]["code"] == "live_perf_timeout"
-
-
 def test_perf_monitor_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
 
@@ -300,6 +274,70 @@ def test_perf_monitor_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
     assert json.loads(result.stdout)["error"]["code"] == "daemon_not_running"
+
+
+# --- argv selector / frames validation (#239) ---------------------------------
+# Exactly one of --property/--signal is required and --frames is bounded. On the
+# argv path these are usage errors (exit 2), the engine is never reached; the
+# --params-json path surfaces them as the structured invalid_params error (see
+# tests/test_params_json.py). Both forms derive from the one PerfMonitorParams
+# model (ADR-0015), so neither can bypass the rule.
+
+
+def test_perf_monitor_argv_both_selectors_is_a_usage_error(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "perf", "monitor", "/root/Main/Player",
+            "--property", "position", "--signal", "hit",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == 2, result.stdout + result.stderr
+    assert fake.calls == []
+
+
+def test_perf_monitor_argv_no_selector_is_a_usage_error(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "perf", "monitor", "/root/Main/Player",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == 2, result.stdout + result.stderr
+    assert fake.calls == []
+
+
+def test_perf_monitor_argv_frames_over_range_is_a_usage_error(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "perf", "monitor", "/root/Main/Player",
+            "--property", "position", "--frames", "601",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == 2, result.stdout + result.stderr
+    assert fake.calls == []
 
 
 def test_perf_monitor_schema_reports_kind_live_and_is_self_describing():

--- a/tests/test_perf_commands.py
+++ b/tests/test_perf_commands.py
@@ -1,0 +1,311 @@
+"""`gda perf` — runtime performance monitoring of the running game, LIVE (#223).
+
+Engine-free: a fake daemon runner at the LIVE seam exercises the full
+Typer→classify_live→JSON pipeline (mirroring ``test_game_commands``), and the
+no-daemon attach-or-fail path runs the real ``DaemonRunner`` against an empty
+runtime dir. The real-engine round trip (the time-windowed harness base + the
+Performance snapshot) is the e2e in ``test_e2e_perf``.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.exit_codes import EXIT_LIVE
+from gda.runner import RunResult
+from tests.support import (
+    PERF_MONITOR_PROPERTY_RESULT,
+    PERF_MONITOR_SIGNAL_RESULT,
+    PERF_MONITORS_RESULT,
+    error_sentinel,
+    inject_live_runner,
+    sentinel,
+)
+
+
+def _project(tmp_path):
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return tmp_path
+
+
+# --- perf monitors (single-frame snapshot) ------------------------------------
+
+
+def test_perf_monitors_emits_a_snapshot_through_the_live_channel(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(PERF_MONITORS_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app, ["perf", "monitors", "--project", str(_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["timestamp"] == 12345
+    assert data["monitors"]["fps"]["value"] == 60.0
+    assert data["monitors"]["node_count"]["type"] == "float"
+    # Routed through the LIVE seam, dispatching the perf-monitors operation (no args).
+    assert fake.calls == [("perf-monitors", {})]
+
+
+def test_perf_monitors_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):
+    # No fake: the real DaemonRunner + discovery run against an empty runtime dir,
+    # so no daemon is found — the attach-or-fail typed error (ADR-0017).
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
+
+    result = CliRunner().invoke(
+        app, ["perf", "monitors", "--project", str(_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "daemon_not_running"
+    assert error["category"] == "live"
+    assert "gda daemon start" in error["message"]
+
+
+def test_perf_monitors_schema_is_self_describing():
+    result = CliRunner().invoke(app, ["perf", "monitors", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    schema = json.loads(result.stdout)
+    assert "input" in schema and "output" in schema
+    assert schema["kind"] == "live"
+
+
+def test_perf_monitors_without_a_project_reports_project_not_found(monkeypatch, tmp_path):
+    # No --project and a projectless cwd -> the project resolves to None, which is a
+    # project-resolution error, NOT a daemon error (ADR-0021).
+    monkeypatch.chdir(tmp_path)  # tmp_path holds no project.godot
+
+    result = CliRunner().invoke(app, ["perf", "monitors", "--json"])
+
+    assert result.exit_code != 0, result.stdout
+    assert json.loads(result.stdout)["error"]["code"] == "project_not_found"
+
+
+def test_perf_monitors_on_non_unix_reports_live_unsupported_platform(monkeypatch, tmp_path):
+    monkeypatch.setattr("gda.live_runner._is_unix", lambda: False)
+
+    result = CliRunner().invoke(
+        app, ["perf", "monitors", "--project", str(_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code != 0, result.stdout
+    assert json.loads(result.stdout)["error"]["code"] == "live_unsupported_platform"
+
+
+# --- perf monitor (time-windowed property/signal timeline) --------------------
+
+
+def test_perf_monitor_property_emits_a_timeline_through_the_live_channel(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "perf", "monitor", "/root/Main/Player",
+            "--property", "position", "--frames", "3",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["kind"] == "property"
+    assert data["property"] == "position"
+    assert [s["frame"] for s in data["samples"]] == [0, 1, 2]
+    assert data["emissions"] == []
+    # The node, property, signal (absent) and frame count are threaded to the op.
+    assert fake.calls == [
+        (
+            "perf-monitor",
+            {
+                "node": "/root/Main/Player",
+                "property": "position",
+                "signal": None,
+                "frames": 3,
+            },
+        )
+    ]
+
+
+def test_perf_monitor_signal_records_emissions_through_the_live_channel(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(PERF_MONITOR_SIGNAL_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "perf", "monitor", "/root/Main/Player",
+            "--signal", "hit", "--frames", "3",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["kind"] == "signal"
+    assert data["signal"] == "hit"
+    assert data["emissions"][0]["args"] == [42]
+    assert data["samples"] == []
+    assert fake.calls == [
+        (
+            "perf-monitor",
+            {
+                "node": "/root/Main/Player",
+                "property": None,
+                "signal": "hit",
+                "frames": 3,
+            },
+        )
+    ]
+
+
+def test_perf_monitor_default_frame_count_is_threaded(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0),
+    )
+
+    CliRunner().invoke(
+        app,
+        [
+            "perf", "monitor", "/root/Main/Player",
+            "--property", "position",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    # The default frames (60) is passed through when --frames is omitted.
+    assert fake.calls[0][1]["frames"] == 60
+
+
+def test_perf_monitor_missing_node_reports_live_perf_node_not_found(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("live_perf_node_not_found", "no node at runtime path"),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "perf", "monitor", "/root/Main/Ghost",
+            "--property", "position",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "live_perf_node_not_found"
+    assert error["category"] == "live"
+
+
+def test_perf_monitor_unknown_property_reports_live_perf_property_not_found(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("live_perf_property_not_found", "no readable property"),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "perf", "monitor", "/root/Main/Player",
+            "--property", "nope",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    assert json.loads(result.stdout)["error"]["code"] == "live_perf_property_not_found"
+
+
+def test_perf_monitor_unknown_signal_reports_live_perf_signal_not_found(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("live_perf_signal_not_found", "no signal"),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "perf", "monitor", "/root/Main/Player",
+            "--signal", "nope",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    assert json.loads(result.stdout)["error"]["code"] == "live_perf_signal_not_found"
+
+
+def test_perf_monitor_timeout_reports_live_perf_timeout(monkeypatch, tmp_path):
+    # The harness time-windowed base reports live_perf_timeout when a collection
+    # cannot complete within its frame budget; it is a LIVE-category code, so
+    # classify_live maps it (exit EXIT_LIVE), not the contract_violation fallthrough.
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("live_perf_timeout", "did not complete in budget"),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "perf", "monitor", "/root/Main/Player",
+            "--property", "position",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    assert json.loads(result.stdout)["error"]["code"] == "live_perf_timeout"
+
+
+def test_perf_monitor_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "perf", "monitor", "/root/Main/Player",
+            "--property", "position",
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    assert json.loads(result.stdout)["error"]["code"] == "daemon_not_running"
+
+
+def test_perf_monitor_schema_reports_kind_live_and_is_self_describing():
+    result = CliRunner().invoke(app, ["perf", "monitor", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    schema = json.loads(result.stdout)
+    assert "input" in schema and "output" in schema
+    assert schema["kind"] == "live"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -19,6 +19,11 @@ from gda.models import (
     NodeGetResult,
     NodeProperty,
     NodeSetResult,
+    PerfMonitor,
+    PerfMonitorResult,
+    PerfMonitorsResult,
+    PerfPropertySample,
+    PerfSignalEmission,
     SceneNode,
     ScriptCreateResult,
     ScriptDeleteResult,
@@ -155,6 +160,49 @@ def test_render_game_set_renders_the_set_runtime_property():
         value=[10.0, 20.0],
     )
     assert render(result) == "set /root/Main/Player.position (Vector2) = [10.0, 20.0]"
+
+
+def test_render_perf_monitors_renders_a_sorted_snapshot():
+    result = PerfMonitorsResult(
+        timestamp=500,
+        monitors={
+            "fps": PerfMonitor(name="fps", type="float", value=60.0),
+            "node_count": PerfMonitor(name="node_count", type="float", value=3.0),
+        },
+    )
+    # Monitors are listed in a stable (name-sorted) order under the timestamp header.
+    assert render(result) == "perf @ 500ms\n  fps = 60.0\n  node_count = 3.0"
+
+
+def test_render_perf_monitor_property_renders_a_per_frame_timeline():
+    result = PerfMonitorResult(
+        node="/root/Main/Player",
+        kind="property",
+        property="position",
+        frames=2,
+        samples=[
+            PerfPropertySample(frame=0, timestamp=100, value=[0.0, 0.0]),
+            PerfPropertySample(frame=1, timestamp=116, value=[1.0, 0.0]),
+        ],
+    )
+    assert render(result) == (
+        "/root/Main/Player property position (2 frames)\n"
+        "  frame 0: [0.0, 0.0]\n"
+        "  frame 1: [1.0, 0.0]"
+    )
+
+
+def test_render_perf_monitor_signal_renders_recorded_emissions():
+    result = PerfMonitorResult(
+        node="/root/Main/Player",
+        kind="signal",
+        signal="hit",
+        frames=2,
+        emissions=[PerfSignalEmission(frame=1, timestamp=116, args=[42])],
+    )
+    assert render(result) == (
+        "/root/Main/Player signal hit (2 frames)\n  frame 1: [42]"
+    )
 
 
 def test_render_is_keyed_by_result_type():

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1152,6 +1152,34 @@ def test_sample_game_results_validate_against_emitted_output_schemas():
     jsonschema.validate(instance=GAME_SET_RESULT, schema=set_doc["output"])
 
 
+def test_perf_commands_schema_report_kind_live_and_are_model_derived():
+    # The LIVE perf commands (#223) self-describe like any command — input/output
+    # contracts derived from their models, plus the LIVE execution kind (ADR-0017).
+    monitors_doc = json.loads(CliRunner().invoke(app, ["perf", "monitors", "--schema"]).stdout)
+    monitor_doc = json.loads(CliRunner().invoke(app, ["perf", "monitor", "--schema"]).stdout)
+
+    for doc in (monitors_doc, monitor_doc):
+        assert "input" in doc and "output" in doc
+        assert doc["kind"] == "live"
+
+
+def test_sample_perf_results_validate_against_emitted_output_schemas():
+    # A sample --json payload of each perf command satisfies the contract its
+    # --schema emits (the ADR-0004 hard gate for the LIVE perf group, #223).
+    from tests.support import (
+        PERF_MONITOR_PROPERTY_RESULT,
+        PERF_MONITOR_SIGNAL_RESULT,
+        PERF_MONITORS_RESULT,
+    )
+
+    monitors_doc = json.loads(CliRunner().invoke(app, ["perf", "monitors", "--schema"]).stdout)
+    monitor_doc = json.loads(CliRunner().invoke(app, ["perf", "monitor", "--schema"]).stdout)
+
+    jsonschema.validate(instance=PERF_MONITORS_RESULT, schema=monitors_doc["output"])
+    jsonschema.validate(instance=PERF_MONITOR_PROPERTY_RESULT, schema=monitor_doc["output"])
+    jsonschema.validate(instance=PERF_MONITOR_SIGNAL_RESULT, schema=monitor_doc["output"])
+
+
 def test_schema_kind_is_identical_via_argv_and_params_json_forms():
     # `--schema` is intercepted at the same single emission point for both the
     # argv form and the `--params-json` form (the --schema check runs first), so


### PR DESCRIPTION
## What

`gda perf` (LIVE): `perf monitors` (instantaneous `Performance` snapshot) and `perf monitor --node <abs> --property <p> | --signal <s> --frames N` (a per-frame timeline over N frames, returned as one blocking result). This PR also lands the **shared time-windowed multi-frame base** in the harness that #221's input-sequence reuses.

Closes #223.

## Why

After `game tree/get/set` (#220) could read/poke runtime state, there was no way to read the running game's performance, nor any harness mechanism for time-windowed ops — both prescribed by ADR-0017/0020 but unimplemented.

## How

**The shared base (`gda_harness.gd`).** `_run` now returns `Variant`: a `String` (single-frame op → reply this frame, behaviour-preserving for game tree/get/set + `perf monitors`) or `null` (a multi-frame handler opened a *window* via `_begin_window(frames, sample, finalize)`). While `_window_state` is set, `_process` advances one sample per frame (single-writer order preserved), finalizing once and replying — with a hard `WINDOW_FRAME_LIMIT` guard → `live_perf_timeout` so a hung game can't stall the RPC. **A new live op adds one `match` arm + a handler that calls `_begin_window` — no `_process` change** (this is exactly how #221's sequence plugs in).

**perf.** `perf monitors` snapshots 16 `Performance` monitors (fps, process/physics time, static memory, object/node/orphan counts, draw calls/objects/primitives, video mem, physics-2D/3D + nav active counts). `perf monitor` reuses #220's `_resolve_runtime_node`/`_jsonify`/`_property_type` for property timelines, and `get_signal_list` + `connect` for signal-emission capture. Group `perf`; follows the #220 live-op pattern (models/cli/errors/`classify_live`/render).

**Error codes (LIVE/classifier/6):** `live_perf_node_not_found`, `live_perf_property_not_found`, `live_perf_signal_not_found`, `live_perf_timeout` — registered + ADR-0002 rows + a harness-const mirror test.

## Docs

`> Outcome (#223)` notes on ADR-0017 + ADR-0020 (the time-windowed multi-frame mechanism is now implemented); `command-catalog.md` marks `perf` shipped.

## Tests (independently re-run by the reviewer)

- `uv run pytest -m "not e2e"` → **698 passed**
- Full real-Godot e2e (`GDA_GODOT=…`, serial) → **257 passed, 1 skipped** — includes the new `perf` snapshot + property-timeline e2e AND the full game/headless suite confirming the `_run`→`Variant` base refactor broke nothing.

> CI's Godot e2e job is gated/skips on a normal PR, so the local e2e above is this PR's e2e verification.

## Notes for the reviewer

- `_RENDERERS` + `cli.py` `add_typer` + `error_codes.py` + ADR-0002 + `models.py` appends overlap with the parallel #224 — resolved by serial merge (this lands first; #224 rebases).
- Signal recorder is bounded to ≤4 args (`_signal_arg_count`); signals with >4 args lose the tail (acceptable for a monitor).
