### PR TITLE
feat: surface live-stack constraints in --schema (#233)

### DIFF
--- a/docs/adr/0004-schema-flag-self-description.md
+++ b/docs/adr/0004-schema-flag-self-description.md
@@ -14,6 +14,16 @@ status: accepted
 > in the aggregate manifest (ADR-0012) every dispatchable entry's `kind` is
 > required and enum-constrained.
 
+> **Outcome (2026-06-22, #233 / PR #245):** the per-command `--schema` object
+> gained a fifth, additive key — `constraints`, the command's
+> `LiveStackConstraints` (platform set + minimum Godot version) for
+> live-stack-dependent commands, `null` otherwise. The platform/version values
+> are decided in ADR-0021 and now surfaced **structurally** rather than in
+> `--help` / manifest prose, sourced from the single
+> `gda.execution.live_stack_constraints` predicate so the structured field and
+> the surrounding prose cannot drift. Like `kind`, gda-mcp ignores it (ADR-0012),
+> so it stays a strict superset — backward compatible.
+
 ADR-0000 lists `--schema` as a core capability without defining it. We fix its
 semantics here, and deliberately scope out an overloaded interpretation.
 

--- a/docs/adr/0012-gda-mcp-tool-surface-generation.md
+++ b/docs/adr/0012-gda-mcp-tool-surface-generation.md
@@ -13,6 +13,14 @@ status: accepted
 > backward compatible. On the aggregate entry `kind` is required and
 > enum-constrained, so a consumer of `gda schema --schema` can rely on it.
 
+> **Outcome (2026-06-22, #233 / PR #245):** each manifest entry gained an
+> additive `constraints` field (the command's `LiveStackConstraints` — platform
+> set + minimum Godot version, ADR-0021; `null` for non-live-stack commands), so
+> the entry above is now `{name, description, input, output, error, kind,
+> constraints}`. gda-mcp's mapping is unchanged — it ignores `kind` /
+> `constraints` — so the addition is backward compatible. On the aggregate entry
+> the `constraints` key is always present, its value nullable.
+
 ADR-0011 fixes [gda-mcp](../../CONTEXT.md) as a subprocess adapter that consumes
 `gda`'s public ABI. ADR-0004 / ADR-0005 make each command self-describing
 (`--schema` → `{input, output, error}`) and give a deterministic CLI→MCP name map

--- a/docs/adr/0021-gda-daemon-transport-discovery-and-live-version-floor.md
+++ b/docs/adr/0021-gda-daemon-transport-discovery-and-live-version-floor.md
@@ -4,6 +4,13 @@ status: accepted
 
 # gda-daemon transport and discovery: Unix domain sockets end-to-end, per-project socket + pidfile discovery, and a Phase-2 live floor of Godot 4.6
 
+> **Outcome (2026-06-22, #233 / PR #245):** the Phase-2 live floor decided here
+> (macOS/Linux via Unix domain sockets, Godot 4.6+) is now surfaced as a
+> structured `constraints` field in per-command `--schema` and the aggregate
+> manifest (ADR-0004, ADR-0012) — machine-discoverable, no longer `--help` prose.
+> `gda.execution.MIN_LIVE_VERSION` is the single source the daemon-start version
+> gate and the schema predicate share.
+
 ADR-0017 fixed [gda-daemon](../../CONTEXT.md)'s shape — a per-project supervisor + IPC
 broker holding a transient [engine session](../../CONTEXT.md) with the
 [gda harness](../../CONTEXT.md), routed by a static `kind` channel selector — but

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -266,7 +266,7 @@ app.add_typer(theme_app, name="theme")
 # `node`. It is a domain-object group named after the running game, not a phase
 # group — the headless/live split is carried by `kind`, never by the tree.
 game_app = typer.Typer(
-    help="Act on the running game (live; macOS/Linux only, needs `gda daemon start`).",
+    help="Act on the running game (live; needs `gda daemon start`).",
     no_args_is_help=True,
 )
 app.add_typer(game_app, name="game")
@@ -279,7 +279,7 @@ app.add_typer(game_app, name="game")
 # diagnosable. From the CLI's side it routes like any live command (kind = LIVE
 # -> the daemon socket); the daemon recognizes the diag op names.
 diag_app = typer.Typer(
-    help="Read the running game's runtime diagnostics (live; macOS/Linux only, needs `gda daemon start`).",
+    help="Read the running game's runtime diagnostics (live; needs `gda daemon start`).",
     no_args_is_help=True,
 )
 app.add_typer(diag_app, name="diag")
@@ -291,7 +291,7 @@ app.add_typer(diag_app, name="diag")
 # multi-frame harness base). Like `game`, a domain-object group marked live by
 # `kind`, not by the tree (ADR-0019).
 perf_app = typer.Typer(
-    help="Monitor the running game's runtime performance (live; macOS/Linux only).",
+    help="Monitor the running game's runtime performance (live).",
     no_args_is_help=True,
 )
 app.add_typer(perf_app, name="perf")
@@ -307,7 +307,7 @@ app.add_typer(perf_app, name="perf")
 # `gda <group> <command>` → `<group>_<command>` dispatch + gda-mcp tool-name mapping
 # (ADR-0005/0011/0012).
 input_app = typer.Typer(
-    help="Inject input into the running game (live; macOS/Linux only).",
+    help="Inject input into the running game (live).",
     no_args_is_help=True,
 )
 app.add_typer(input_app, name="input")
@@ -318,7 +318,7 @@ app.add_typer(input_app, name="input")
 # stop / status manage the daemon PROCESS, so — like `export run` — they run a
 # recipe (gda.daemon_ops) rather than the sentinel pipeline.
 daemon_app = typer.Typer(
-    help="Manage the per-project gda-daemon (live ops; macOS/Linux only, Godot 4.6+).",
+    help="Manage the per-project gda-daemon (live ops).",
     no_args_is_help=True,
 )
 app.add_typer(daemon_app, name="daemon")
@@ -541,10 +541,11 @@ def game_tree(
 
     Routes through gda-daemon to the engine session it holds (kind = LIVE,
     ADR-0017): the runtime SceneTree after _ready and dynamic instantiation,
-    distinct from the on-disk .tscn read by `scene get` (ADR-0019). Live ops are
-    macOS/Linux only (Unix domain sockets) and need a running daemon: with none,
-    it reports the typed `daemon_not_running` error naming the remediation
-    (`gda daemon start`); on a non-UNIX platform, `live_unsupported_platform`.
+    distinct from the on-disk .tscn read by `scene get` (ADR-0019). Live ops need
+    a running daemon: with none, it reports the typed `daemon_not_running` error
+    naming the remediation (`gda daemon start`); on an unsupported platform,
+    `live_unsupported_platform`. The platform/Godot-version precondition is the
+    structured `constraints` field of `--schema` (ADR-0021), not restated here.
     """
     _dispatch(
         GAME_TREE_COMMAND,
@@ -763,8 +764,8 @@ def perf_monitors(
     Routes through gda-daemon to the engine session (kind = LIVE, ADR-0017): the
     instantaneous Performance counters — fps, frame timing, memory, object/node
     counts, render stats, active physics/navigation objects — read in one frame, so
-    the values are mutually coherent (ADR-0020). Live ops are macOS/Linux only and
-    need a running daemon: with none, it reports `daemon_not_running`.
+    the values are mutually coherent (ADR-0020). Live ops need a running daemon:
+    with none, it reports `daemon_not_running`.
     """
     _dispatch(
         PERF_MONITORS_COMMAND,
@@ -1137,8 +1138,9 @@ def daemon_start(
 
     Brings up the live context: a long-lived, per-project daemon, after a reported
     idempotent harness install (ADR-0018). Never auto-spawned by a live call —
-    launching the engine is a deliberate, declared effect (ADR-0017). Live is
-    UNIX-only and needs Godot 4.6+ (ADR-0021).
+    launching the engine is a deliberate, declared effect (ADR-0017). The
+    platform/Godot-version precondition is the structured `constraints` field of
+    `--schema` (ADR-0021), not restated here.
     """
     _daemon_dispatch(
         DAEMON_START_COMMAND, json_output=json_output, godot=godot, project=project
@@ -1155,8 +1157,8 @@ def daemon_stop(
 ) -> None:
     """Stop the per-project gda-daemon (a no-op if none is running).
 
-    Live operations are macOS/Linux only (Unix domain sockets); on a non-UNIX
-    platform this reports `live_unsupported_platform`.
+    On an unsupported platform this reports `live_unsupported_platform`; the
+    platform precondition is the structured `constraints` field of `--schema`.
     """
     _daemon_dispatch(
         DAEMON_STOP_COMMAND, json_output=json_output, godot=godot, project=project
@@ -1173,8 +1175,8 @@ def daemon_status(
 ) -> None:
     """Report whether a per-project gda-daemon is running.
 
-    Live operations are macOS/Linux only (Unix domain sockets); on a non-UNIX
-    platform this reports `live_unsupported_platform`.
+    On an unsupported platform this reports `live_unsupported_platform`; the
+    platform precondition is the structured `constraints` field of `--schema`.
     """
     _daemon_dispatch(
         DAEMON_STATUS_COMMAND, json_output=json_output, godot=godot, project=project

--- a/src/gda/daemon_ops.py
+++ b/src/gda/daemon_ops.py
@@ -31,6 +31,7 @@ from gda.daemon.discovery import (
 from gda.daemon.protocol import read_message, write_message
 from gda.daemon.server import STATUS_OP, STOP_OP
 from gda.errors import Failure, _failure, unresolvable_binary_failure
+from gda.execution import MIN_LIVE_VERSION
 from gda.harness.install import install_harness
 from gda.models import DaemonStartResult, DaemonStatusResult, DaemonStopResult
 
@@ -39,7 +40,9 @@ _STOP_TIMEOUT = 8.0
 _POLL = 0.05
 
 # Phase-2 live requires Godot 4.6+ (the UDS transport landed in 4.6; ADR-0021).
-MIN_LIVE_VERSION = (4, 6)
+# The floor itself lives in ``gda.execution`` as the single source of truth — the
+# ``live_stack_constraints`` predicate that surfaces it in ``--schema`` (issue
+# #233) shares it — and is imported back here for the version gate.
 _VERSION_RE = re.compile(r"(\d+)\.(\d+)")
 
 # Seams tests override to avoid launching a real process / running the engine.

--- a/src/gda/execution.py
+++ b/src/gda/execution.py
@@ -13,6 +13,7 @@ import cycle.
 """
 
 import enum
+from typing import Optional
 
 
 class ExecutionKind(str, enum.Enum):
@@ -29,3 +30,47 @@ class ExecutionKind(str, enum.Enum):
     HEADLESS = "headless"
     EXPORT = "export"
     LIVE = "live"
+
+
+# Phase-2 live requires Godot 4.6+ (the UDS transport landed in 4.6; ADR-0021).
+# The single source of truth for the live-stack Godot floor, named here in the
+# leaf taxonomy module so both ``gda.daemon_ops`` (the version gate) and the
+# ``live_stack_constraints`` predicate below read the same tuple. Surfaced in
+# ``--schema`` as the dotted ``"4.6"`` string (issue #233).
+MIN_LIVE_VERSION = (4, 6)
+
+
+def live_stack_constraints(
+    kind: ExecutionKind, operation: str
+) -> Optional[tuple[list[str], Optional[str]]]:
+    """The live-stack constraint for a command, or ``None`` if it has none.
+
+    The single authority that marks a command as depending on gda's daemon/live
+    stack (issue #233), keyed on the two static descriptor facts both ``--schema``
+    emission paths already share — the command's :class:`ExecutionKind` and its
+    operation name — so the per-command ``--schema`` and the aggregate manifest
+    can never drift, and ``gda.cli`` needs no edit.
+
+    A command depends on the live stack when it is a LIVE-channel op **or** part
+    of the ``daemon`` lifecycle group (``operation`` ``daemon-*``). The two facets:
+
+    - ``platforms`` is uniform ``["linux", "macos"]`` across the whole set — the
+      live stack rides Unix domain sockets (ADR-0021), unsupported on Windows.
+    - ``min_godot_version`` is the :data:`MIN_LIVE_VERSION` floor **only where a
+      command launches/uses the engine** — every LIVE op and ``daemon-start`` —
+      and ``None`` for ``daemon-stop`` / ``daemon-status``, which only talk to an
+      already-running daemon over UDS and never touch the engine.
+
+    Returned as plain primitives (a ``(platforms, version)`` pair, version a
+    dotted string or ``None``); this is a leaf module that must not import
+    ``gda.models``, so wrapping into the :class:`~gda.models.LiveStackConstraints`
+    model is left to the emission points.
+    """
+    is_daemon = operation.startswith("daemon-")
+    if kind is not ExecutionKind.LIVE and not is_daemon:
+        return None
+    launches_engine = kind is ExecutionKind.LIVE or operation == "daemon-start"
+    version = (
+        ".".join(str(part) for part in MIN_LIVE_VERSION) if launches_engine else None
+    )
+    return ["linux", "macos"], version

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -25,8 +25,8 @@ from gda.errors import (
     invalid_params_json_failure,
     unresolvable_binary_failure,
 )
-from gda.execution import ExecutionKind
-from gda.models import CommandSchema, GdaErrorEnvelope
+from gda.execution import ExecutionKind, live_stack_constraints
+from gda.models import CommandSchema, GdaErrorEnvelope, LiveStackConstraints
 from gda.render import render
 from gda.runner import GodotRunner, RunResult, SubprocessGodotRunner
 
@@ -39,6 +39,30 @@ RunnerFactory = Callable[[Path, Optional[Path]], GodotRunner]
 def make_subprocess_runner(binary: Path, project: Optional[Path] = None) -> GodotRunner:
     """Build the default real Godot runner for ``binary`` and ``project``."""
     return SubprocessGodotRunner(binary, project=project)
+
+
+def command_constraints(
+    command: "Optional[HeadlessCommand]",
+) -> Optional[LiveStackConstraints]:
+    """Wrap a command's live-stack constraint into the model, or ``None``.
+
+    The one place the leaf :func:`gda.execution.live_stack_constraints`
+    predicate's primitives are lifted into the :class:`LiveStackConstraints`
+    model, shared by the per-command ``--schema`` path here and the aggregate
+    manifest builder (``gda.surface``) so the two forms cannot drift (issue
+    #233). ``None`` for a command with no backing descriptor (the bare ``gda
+    schema`` meta command) and for any command the predicate reports no live-stack
+    dependence for.
+    """
+    if command is None:
+        return None
+    constraint = live_stack_constraints(command.kind, command.operation)
+    if constraint is None:
+        return None
+    platforms, min_godot_version = constraint
+    return LiveStackConstraints(
+        platforms=platforms, min_godot_version=min_godot_version
+    )
 
 
 def json_option() -> bool:
@@ -182,9 +206,17 @@ def schema_command_class(
                 # ("headless"/"export"/"live"). ``None`` for the bare ``gda
                 # schema`` meta command, which has no backing command to run.
                 kind = command.kind if command is not None else None
+                # The live-stack constraint (issue #233) comes from the same one
+                # source of truth — the predicate keyed on the backing command's
+                # ``kind`` + ``operation`` — wrapped into the model here so the
+                # per-command ``--schema`` and the aggregate manifest agree.
+                constraints = command_constraints(command)
                 typer.echo(
                     CommandSchema.of(
-                        input_model, output_model, kind=kind
+                        input_model,
+                        output_model,
+                        kind=kind,
+                        constraints=constraints,
                     ).model_dump_json()
                 )
                 raise typer.Exit()

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -229,6 +229,16 @@ class CommandManifestEntry(BaseModel):
     dispatchable command with a backing descriptor, so the self-described surface
     schema (``gda schema --schema``) guarantees the field and constrains it to
     the execution-kind enum — a consumer can rely on it always being present.
+
+    ``constraints`` mirrors :class:`CommandSchema`'s: the entry's
+    :class:`LiveStackConstraints`, or ``None`` for a command with no live-stack
+    dependence (issue #233), from the same single
+    :func:`gda.execution.live_stack_constraints` authority so the aggregate and
+    per-command forms agree. Unlike :class:`CommandSchema`'s defaulted field, the
+    **key is required** here (every dispatchable entry is computed from a backing
+    descriptor, so the self-described surface schema guarantees the key is
+    present) while its **value is nullable** (``null`` for non-live-stack
+    commands) — a consumer can rely on the key always being there to read.
     """
 
     name: str
@@ -237,6 +247,7 @@ class CommandManifestEntry(BaseModel):
     output: dict[str, Any]
     error: dict[str, Any]
     kind: ExecutionKind
+    constraints: LiveStackConstraints | None
 
 
 class SurfaceManifest(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -139,7 +139,11 @@ class LiveStackConstraints(BaseModel):
     """
 
     platforms: list[str]
-    min_godot_version: str | None = None
+    # Required key, nullable value: the wrapper always supplies it (``None`` for
+    # daemon stop/status), and the emitted objects always carry the key — so the
+    # self-described schema marks it required, matching the actual ABI (issue #233,
+    # PR #245 review). Not defaulted, or the schema would allow the key's omission.
+    min_godot_version: str | None
 
 
 class CommandSchema(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -113,6 +113,35 @@ class SchemaAllParams(BaseModel):
     """
 
 
+class LiveStackConstraints(BaseModel):
+    """The platform / Godot-version precondition a live-stack command needs (issue #233).
+
+    A structured, machine-discoverable form of the constraint that ``gda``'s
+    daemon/live stack carries — macOS/Linux only (Unix domain sockets) and, where
+    a command launches/uses the engine, Godot 4.6+ (ADR-0021) — replacing the
+    prose that used to live only in ``--help`` text and the manifest description.
+    Present (non-``null``) only on commands that depend on the live stack: the
+    LIVE-channel domain commands (``game …``) and the ``daemon`` lifecycle group;
+    every other command's ``constraints`` is ``null``.
+
+    Both facets come from the single :func:`gda.execution.live_stack_constraints`
+    authority, so the structured field and the help/manifest prose cannot drift:
+
+    - ``platforms`` is the uniform ``["linux", "macos"]`` (UDS) across the whole
+      live-stack set.
+    - ``min_godot_version`` is the dotted floor (``"4.6"``) only where a command
+      launches/uses the engine (``game …``, ``daemon start``); ``None`` for
+      ``daemon stop`` / ``daemon status``, which only talk to a running daemon
+      over UDS and never touch the engine.
+
+    Additive and ignored by gda-mcp, which maps only ``input`` / ``output`` /
+    ``description`` (ADR-0012), so adding it is backward-compatible (ADR-0004).
+    """
+
+    platforms: list[str]
+    min_godot_version: str | None = None
+
+
 class CommandSchema(BaseModel):
     """A command's self-description: its ``input``, ``output`` and ``error`` JSON Schemas (ADR-0004).
 
@@ -140,12 +169,19 @@ class CommandSchema(BaseModel):
     (ADR-0012). It is ``None`` only when a self-description is emitted without a
     backing command (e.g. ``gda schema``); a real per-command ``--schema`` always
     carries a kind.
+
+    ``constraints`` carries the command's :class:`LiveStackConstraints` — the
+    platform / Godot-version precondition for gda's daemon/live stack — or
+    ``None`` for a command with no live-stack dependence (issue #233). Both forms
+    are sourced from the single :func:`gda.execution.live_stack_constraints`
+    authority. Additive and ignored by gda-mcp (ADR-0012, ADR-0004).
     """
 
     input: dict[str, Any]
     output: dict[str, Any]
     error: dict[str, Any]
     kind: ExecutionKind | None = None
+    constraints: LiveStackConstraints | None = None
 
     @classmethod
     def of(
@@ -153,6 +189,7 @@ class CommandSchema(BaseModel):
         input_model: type[BaseModel],
         output_model: type[BaseModel],
         kind: ExecutionKind | None = None,
+        constraints: LiveStackConstraints | None = None,
     ) -> "CommandSchema":
         """Derive the contract from a command's params and result models.
 
@@ -160,13 +197,16 @@ class CommandSchema(BaseModel):
         command, so it takes no per-command model argument. ``kind`` is the
         command's static :class:`~gda.execution.ExecutionKind` (issue #230); it
         serializes to its lowercase string because ``ExecutionKind`` subclasses
-        ``str``.
+        ``str``. ``constraints`` is the command's live-stack precondition or
+        ``None`` (issue #233), computed by the caller from the single
+        :func:`gda.execution.live_stack_constraints` authority.
         """
         return cls(
             input=input_model.model_json_schema(),
             output=output_model.model_json_schema(),
             error=GdaErrorEnvelope.model_json_schema(),
             kind=kind,
+            constraints=constraints,
         )
 
 

--- a/src/gda/surface.py
+++ b/src/gda/surface.py
@@ -23,6 +23,7 @@ dispatch (ADR-0011/0012).
 
 import typer
 
+from gda.headless import command_constraints
 from gda.models import CommandManifestEntry, CommandSchema, SurfaceManifest
 
 
@@ -87,7 +88,14 @@ def _collect(
     # ``HeadlessCommand.kind`` — so the aggregate and per-command forms agree
     # (issue #230). A dispatchable entry always has a backing command here, so
     # ``kind`` is always populated.
-    schema = CommandSchema.of(input_model, output_model, kind=gda_command.kind)
+    # The live-stack constraint (issue #233) comes from the same one predicate
+    # the per-command ``--schema`` uses, wrapped by the shared helper — so the
+    # aggregate and per-command forms cannot drift. ``None`` for a command with no
+    # live-stack dependence.
+    constraints = command_constraints(gda_command)
+    schema = CommandSchema.of(
+        input_model, output_model, kind=gda_command.kind, constraints=constraints
+    )
     description = (command.help or command.short_help or "").strip()
     entries.append(
         CommandManifestEntry(
@@ -100,5 +108,8 @@ def _collect(
             # the entry's required ``kind`` field — a dispatchable command always
             # has one (issue #230).
             kind=gda_command.kind,
+            # The entry's required ``constraints`` key (issue #233); its value is
+            # the command's live-stack precondition or ``None`` (nullable).
+            constraints=schema.constraints,
         )
     )

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -441,8 +441,9 @@ def test_export_run_unknown_preset_reuses_export_get_error(monkeypatch, tmp_path
 
 def test_export_run_schema_emits_contract_without_engine(monkeypatch):
     # ADR-0004 hard gate: --schema emits the {input, output, error} contract
-    # (plus the additive #230 `kind`), spawns no Godot (both seams would raise if
-    # touched), and never requires the operational --preset.
+    # (plus the additive #230 `kind` and #233 `constraints`), spawns no Godot
+    # (both seams would raise if touched), and never requires the operational
+    # --preset.
     def _boom(*args, **kwargs):
         raise AssertionError("--schema must not spawn any engine")
 
@@ -453,10 +454,12 @@ def test_export_run_schema_emits_contract_without_engine(monkeypatch):
 
     assert result.exit_code == 0, result.stdout + result.stderr
     schema = json.loads(result.stdout)
-    assert set(schema) == {"input", "output", "error", "kind"}
+    assert set(schema) == {"input", "output", "error", "kind", "constraints"}
     # export run is the one EXPORT-channel command (issue #230); its sibling
     # read-only export commands stay HEADLESS.
     assert schema["kind"] == "export"
+    # export run is not a live-stack command, so it carries no constraint (#233).
+    assert schema["constraints"] is None
     # The input schema carries the command's params, now including the #170
     # --mode and --output overrides; the output schema carries the result.
     assert "preset" in schema["input"]["properties"]

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -185,6 +185,35 @@ def test_all_three_execution_kinds_appear_in_the_aggregate():
     assert {"headless", "export", "live"} <= kinds
 
 
+def test_entry_constraints_match_the_commands_own_schema_constraints():
+    # issue #233: each entry's `constraints` is the same single source of truth
+    # the command emits under its own `--schema` — one predicate, not a parallel
+    # projection — so the aggregate and per-command forms must agree exactly,
+    # including the null case.
+    for entry in _manifest()["commands"]:
+        result = CliRunner().invoke(app, [*entry["name"].split(" "), "--schema"])
+        assert result.exit_code == 0, result.stdout
+        own = json.loads(result.stdout)
+        assert entry["constraints"] == own["constraints"], entry["name"]
+
+
+def test_live_stack_entries_carry_constraints_and_others_are_null():
+    # The live-stack set carries structured `constraints`; everything else is
+    # null (#233). `game tree` (LIVE) and `daemon start` launch the engine → the
+    # 4.6 floor; `daemon stop`/`status` are UDS-only → null version; `scene get`
+    # and `export run` have no live-stack dependence → null entirely.
+    by_name = {entry["name"]: entry for entry in _manifest()["commands"]}
+
+    full = {"platforms": ["linux", "macos"], "min_godot_version": "4.6"}
+    version_null = {"platforms": ["linux", "macos"], "min_godot_version": None}
+    assert by_name["game tree"]["constraints"] == full
+    assert by_name["daemon start"]["constraints"] == full
+    assert by_name["daemon stop"]["constraints"] == version_null
+    assert by_name["daemon status"]["constraints"] == version_null
+    assert by_name["scene get"]["constraints"] is None
+    assert by_name["export run"]["constraints"] is None
+
+
 def test_schema_command_is_itself_self_describing():
     # The meta command is under the same ADR-0004 gate as every other command:
     # `gda schema --schema` emits its own {input, output, error} contract, with
@@ -219,6 +248,37 @@ def test_self_described_manifest_guarantees_a_constrained_entry_kind():
         "headless",
         "export",
         "live",
+    ]
+
+
+def test_self_described_manifest_describes_the_nullable_constraints_field():
+    # issue #233: the aggregate entry's `constraints` is a HARD part of the
+    # self-described surface schema — the KEY is required (every dispatchable
+    # entry carries it) while the VALUE is nullable (a $ref to LiveStackConstraints
+    # or null for non-live-stack commands). Assert against the actual `gda schema
+    # --schema` self-description, not just the model, so a consumer validating the
+    # manifest schema can rely on the field's type/shape.
+    result = CliRunner().invoke(app, ["schema", "--schema"])
+    assert result.exit_code == 0, result.stdout
+    manifest_schema = json.loads(result.stdout)["output"]
+
+    entry = manifest_schema["$defs"]["CommandManifestEntry"]
+    # The key is required, not optional/defaulted.
+    assert "constraints" in entry["required"], entry["required"]
+    # The value is nullable: a $ref to LiveStackConstraints OR null.
+    assert entry["properties"]["constraints"] == {
+        "anyOf": [
+            {"$ref": "#/$defs/LiveStackConstraints"},
+            {"type": "null"},
+        ]
+    }
+    # The referenced model carries the two facets, with min_godot_version itself
+    # nullable (the daemon stop/status case).
+    lsc = manifest_schema["$defs"]["LiveStackConstraints"]
+    assert "platforms" in lsc["required"]
+    assert lsc["properties"]["min_godot_version"]["anyOf"] == [
+        {"type": "string"},
+        {"type": "null"},
     ]
 
 

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -214,6 +214,24 @@ def test_live_stack_entries_carry_constraints_and_others_are_null():
     assert by_name["export run"]["constraints"] is None
 
 
+def test_live_command_descriptions_do_not_restate_the_structured_constraint():
+    # issue #233 / PR #245 review: the live-stack precondition is the structured
+    # `constraints` field's job — the single source. The help/manifest description
+    # prose must NOT independently restate the platform set or the Godot floor, or
+    # it becomes the very drift source #233 set out to remove (a LIVE command's
+    # prose once said "macOS/Linux only" yet omitted the 4.6 floor its structured
+    # field carried). Guard a representative slice of the live-stack surface: the
+    # constraint is discoverable structurally, never duplicated in prose.
+    by_name = {entry["name"]: entry for entry in _manifest()["commands"]}
+    for name in ("game tree", "perf monitors", "daemon start", "daemon stop"):
+        description = by_name[name]["description"]
+        assert "macOS" not in description, (name, description)
+        assert "Linux" not in description, (name, description)
+        assert "4.6" not in description, (name, description)
+        # …yet the precondition is still discoverable, structurally.
+        assert by_name[name]["constraints"] is not None, name
+
+
 def test_schema_command_is_itself_self_describing():
     # The meta command is under the same ADR-0004 gate as every other command:
     # `gda schema --schema` emits its own {input, output, error} contract, with
@@ -276,6 +294,10 @@ def test_self_described_manifest_describes_the_nullable_constraints_field():
     # nullable (the daemon stop/status case).
     lsc = manifest_schema["$defs"]["LiveStackConstraints"]
     assert "platforms" in lsc["required"]
+    # Both facets are required KEYS (the emitted object always carries them);
+    # min_godot_version's VALUE is nullable for the daemon stop/status case
+    # (issue #233, PR #245 review — key always present, value nullable).
+    assert "min_godot_version" in lsc["required"]
     assert lsc["properties"]["min_godot_version"]["anyOf"] == [
         {"type": "string"},
         {"type": "null"},

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1268,6 +1268,68 @@ def test_live_command_schema_reports_live_stack_constraints():
     }
 
 
+def test_daemon_start_schema_carries_constraints_despite_kind_headless():
+    # `daemon start` is kind=headless (it runs the process-management recipe, not
+    # the engine sentinel) but it launches the engine session, so it is
+    # live-stack-dependent and carries the FULL constraint — keying purely on
+    # kind==LIVE would have left it prose-only. (#233, PR #232 recheck.)
+    result = CliRunner().invoke(app, ["daemon", "start", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["kind"] == "headless"
+    assert doc["constraints"] == {
+        "platforms": ["linux", "macos"],
+        "min_godot_version": "4.6",
+    }
+
+
+def test_daemon_stop_and_status_schema_carry_platforms_but_null_version():
+    # `daemon stop` / `daemon status` only talk to an already-running daemon over
+    # UDS — they never launch the engine — so they carry the uniform platform set
+    # but a NULL min_godot_version: the version floor applies only where a command
+    # uses the engine (#233).
+    for command in (["daemon", "stop"], ["daemon", "status"]):
+        result = CliRunner().invoke(app, [*command, "--schema"])
+        assert result.exit_code == 0, result.stdout
+        doc = json.loads(result.stdout)
+        assert doc["constraints"] == {
+            "platforms": ["linux", "macos"],
+            "min_godot_version": None,
+        }
+
+
+def test_plain_headless_and_export_commands_carry_null_constraints():
+    # A plain headless domain op (`scene get`) and the EXPORT command (`export
+    # run`) have no live-stack dependence, so `constraints` is null — mirroring
+    # how `kind` is null for a backing-less self-description (#233).
+    for command in (["scene", "get"], ["export", "run"]):
+        result = CliRunner().invoke(app, [*command, "--schema"])
+        assert result.exit_code == 0, result.stdout
+        doc = json.loads(result.stdout)
+        assert doc["constraints"] is None, command
+
+
+def test_schema_constraints_are_identical_via_argv_and_params_json_forms():
+    # `--schema` is intercepted at the same single emission point for both the
+    # argv and the `--params-json` forms, so the emitted `constraints` must be
+    # byte-identical across the two — proving the one predicate is threaded
+    # through, not duplicated per path (#233). Use a LIVE command so the field is
+    # populated, not null.
+    argv_doc = json.loads(
+        CliRunner().invoke(app, ["game", "tree", "--schema"]).stdout
+    )
+    params_json_doc = json.loads(
+        CliRunner()
+        .invoke(app, ["game", "tree", "--params-json", "{}", "--schema"])
+        .stdout
+    )
+
+    assert argv_doc["constraints"] == params_json_doc["constraints"]
+    # The whole contract is identical across the two forms, not just constraints.
+    assert argv_doc == params_json_doc
+
+
 def test_extra_positional_args_are_a_usage_error_even_with_schema():
     # issue #36 (2): --schema must not swallow a malformed command line. Extra
     # positional args still fail with a usage error (exit 2), not exit 0 + schema.

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1244,6 +1244,30 @@ def test_schema_kind_is_identical_via_argv_and_params_json_forms():
     assert argv_doc == params_json_doc
 
 
+# --- live-stack constraints in --schema (issue #233, ADR-0004/ADR-0021) ------
+#
+# Every command that depends on gda's daemon/live stack carries a structured
+# `constraints` field — the platform set (macOS/Linux, UDS) and, where the
+# command launches/uses the engine, the Godot-4.6+ floor (ADR-0021) — sourced
+# from the single `live_stack_constraints` predicate both emission paths share,
+# so help/manifest prose and the structured field never drift. Commands with no
+# live-stack dependence carry `null`.
+
+
+def test_live_command_schema_reports_live_stack_constraints():
+    # `game tree` is a LIVE command (kind=live): it both runs on UDS-only
+    # platforms and uses the engine, so it carries the full constraint —
+    # platforms + the Godot-4.6+ floor.
+    result = CliRunner().invoke(app, ["game", "tree", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["constraints"] == {
+        "platforms": ["linux", "macos"],
+        "min_godot_version": "4.6",
+    }
+
+
 def test_extra_positional_args_are_a_usage_error_even_with_schema():
     # issue #36 (2): --schema must not swallow a malformed command line. Extra
     # positional args still fail with a usage error (exit 2), not exit 0 + schema.


### PR DESCRIPTION
## Summary

Surfaces the **live-stack constraint** (platform set + minimum Godot version) as a structured `constraints` field in both per-command `--schema` and the aggregate `gda schema` manifest, replacing the prose that previously lived only in `--help` / manifest descriptions. Makes the precondition machine-discoverable: an agent (or gda-mcp) can tell from the schema alone that a command needs a UNIX platform — and, where relevant, Godot 4.6+ — before attempting it.

Closes #233.

## Design — single-authority predicate (no per-command marker)

A pure leaf function `live_stack_constraints(kind, operation)` in `src/gda/execution.py` is the single source both emission paths call, so the per-command schema and the aggregate manifest cannot drift:

- `platforms = ["linux","macos"]` when `kind is LIVE` **or** `operation.startswith("daemon-")`
- `min_godot_version = "4.6"` only where the engine is launched/used (`kind is LIVE` **or** `operation == "daemon-start"`) — `null` for `daemon stop`/`daemon status` (UDS-only)
- `null` otherwise

This keys on facts the command descriptors already carry, so it **touches zero `cli.py`** and auto-covers future LIVE commands (e.g. #222's `screen`) and daemon commands (#225's `daemon uninstall`) with no per-command work. `MIN_LIVE_VERSION = (4,6)` moved down into `execution.py` as the single source (`daemon_ops.py` re-exports it, backward-compatible).

## ABI

```json
"constraints": { "platforms": ["linux","macos"], "min_godot_version": "4.6" }   // LIVE + daemon start
"constraints": { "platforms": ["linux","macos"], "min_godot_version": null }     // daemon stop/status
"constraints": null                                                              // plain headless / export
```

Additive / backward-compatible (ADR-0004); gda-mcp maps input→inputSchema / output→outputSchema unchanged (ADR-0012) — no mcp files touched.

## Tests

`uv run pytest -m "not e2e"` → **788 passed** (independently re-run by the reviewer). New tests at the CLI ABI seam in `tests/test_schema_command.py` (5) and `tests/test_schema_aggregate.py` (3): `game tree` (4.6), `daemon start` (4.6 despite `kind=headless`), `daemon stop`/`status` (version null), `scene get` / `export run` (null), argv↔`--params-json` byte-parity, aggregate↔per-command agreement, and `gda schema --schema` self-describing the nullable `$ref`. No e2e in this slice.

## Follow-up at merge

ADR-0004 / ADR-0012 outcome notes (the `constraints` additive superset) + ADR-0021 cross-reference to be appended when this lands.
