### PR TITLE
test: verify gda-mcp auto-exposes live commands as tools (#227)

### DIFF
--- a/tests/test_e2e_mcp_live.py
+++ b/tests/test_e2e_mcp_live.py
@@ -134,11 +134,19 @@ def test_mcp_live_game_tree_relays_daemon_not_running_verbatim(
         # The full GdaError envelope crossed verbatim as text content.
         assert result.content, "expected the GdaError envelope as text content"
         payload = json.loads(result.content[0].text)
+        # Assert the COMPLETE envelope shape, not a subset: lossless routing is the
+        # property #227 exists to prove, so a relay that silently dropped a field
+        # (most plausibly `diagnostics`) or wrapped it differently must fail here.
+        assert set(payload) == {"error"}, payload
         error = payload["error"]
+        assert set(error) == {"category", "code", "message", "diagnostics"}, error
         assert error["code"] == "daemon_not_running"
         assert error["category"] == "live"
         # The remediation message is preserved, not flattened to bare prose.
         assert "gda daemon start" in error["message"]
+        # `diagnostics` — the field a lossy relay would most plausibly drop — is
+        # present and its value crosses intact (empty for this synthesized error).
+        assert error["diagnostics"] == ""
     finally:
         anyio.run(_stop_daemon, server)
 

--- a/tests/test_e2e_mcp_live.py
+++ b/tests/test_e2e_mcp_live.py
@@ -1,0 +1,154 @@
+"""S1 (e2e): a LIVE command served end-to-end through gda-mcp (issue #227).
+
+The #227 verification, top to bottom: an in-memory MCP client → the in-process
+gda-mcp ``Server`` → the real ``gda`` subprocess seam → ``gda-daemon`` → an
+``Engine session`` it launches with the harness → the running game's runtime
+``SceneTree``. It proves a live command auto-exposes and *routes* as a tool with
+NO live-specific code in gda-mcp (ADR-0011): the same generic ``--params-json``
+dispatch + exit-code map that serves a headless tool carries the live one, so on
+success the SDK validates and wraps gda's result as ``structuredContent`` and on
+failure gda's full ``GdaError`` envelope crosses verbatim as ``isError`` content.
+
+Two routings:
+
+- **success** — ``daemon_start`` then ``game_tree`` over one MCP session: the
+  daemon launches the session on demand, the live op returns the runtime tree,
+  and ``structuredContent.root.name == "Main"`` (the same proof as
+  ``test_e2e_daemon``, now driven through gda-mcp instead of the console script).
+- **failure** — ``game_tree`` with no daemon: gda's typed
+  ``daemon_not_running`` / category ``live`` envelope reaches the client
+  losslessly as ``isError`` content, with ``structuredContent is None`` (the
+  envelope is kept out of the success channel — ADR-0011).
+
+Godot is resolved by gda's OWN precedence (gda-mcp never hardcodes it); the
+project reaches gda via the ``GDA_PROJECT`` env channel gda-mcp injects. Both are
+pinned via ``monkeypatch.setenv`` for determinism. Run e2e serially; not a fresh
+empty HOME (Godot first-run). ``daemon_runtime_dir`` keeps the daemon's UDS path
+within the OS ``sun_path`` limit (NOT ``tmp_path``).
+"""
+
+import json
+import os
+
+import anyio
+import pytest
+from mcp.shared.memory import create_connected_server_and_client_session as connect
+
+from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
+from gda.mcp.project_context import GDA_PROJECT_ENV
+from gda.mcp.runner import SubprocessGdaRunner
+from gda.mcp.server import build_server
+
+from .conftest import project_godot
+
+GODOT = resolve_godot_binary()
+
+# Reuse test_e2e_daemon's scaffold: a main scene so the launched session has a
+# runtime SceneTree to read; a Player child mirrors the daemon e2e fixture. File
+# logging stays disabled via project_godot (issue #180).
+MAIN_TSCN = (
+    "[gd_scene format=3]\n\n"
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="Player" type="Node2D" parent="."]\n'
+)
+PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+
+def _scaffold_project(tmp_path):
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+
+
+def _pin_env(monkeypatch, project):
+    # Pin Godot for the nested `gda` via gda's own env precedence (never hardcoded
+    # in gda-mcp), and hand gda the project through the GDA_PROJECT channel the
+    # in-process server reads at resolve time and forwards on every dispatch
+    # (ADR-0014). The daemon the start tool spawns inherits XDG_RUNTIME_DIR (set
+    # short by daemon_runtime_dir) through the subprocess environment.
+    monkeypatch.setenv(GODOT_BIN_ENV, str(GODOT))
+    monkeypatch.setenv(GDA_PROJECT_ENV, str(project))
+
+
+@pytest.mark.e2e
+def test_mcp_live_game_tree_routes_through_daemon_to_a_real_tree(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # Success routing: the live `game tree` tool, dispatched by the SAME generic
+    # gda-mcp path as a headless tool, returns the RUNNING game's runtime tree as
+    # validated structuredContent.
+    _scaffold_project(tmp_path)
+    _pin_env(monkeypatch, tmp_path)
+    server = build_server(SubprocessGdaRunner.default())
+
+    async def _drive():
+        async with connect(server) as session:
+            # Start the daemon over MCP; it installs the harness and stands ready
+            # to launch an engine session on demand.
+            started = await session.call_tool("daemon_start", {})
+            tree = await session.call_tool("game_tree", {})
+            return started, tree
+
+    try:
+        started, tree = anyio.run(_drive)
+
+        # daemon_start succeeded through the generic dispatcher (exit 0 → result
+        # dict wrapped as structuredContent by the SDK).
+        assert started.isError is False, started.content
+        assert started.structuredContent["installed_harness"] is True
+
+        # The live op routed CLI → daemon → engine session and returned the live
+        # runtime tree — exactly what a headless tool's success looks like.
+        assert tree.isError is False, tree.content
+        root = tree.structuredContent["root"]
+        assert root["name"] == "Main"
+        assert root["type"] == "Node2D"
+    finally:
+        anyio.run(_stop_daemon, server)
+
+
+@pytest.mark.e2e
+def test_mcp_live_game_tree_relays_daemon_not_running_verbatim(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # Failure routing: with no daemon, gda's typed `daemon_not_running` / category
+    # `live` GdaError reaches the MCP client losslessly as isError content, and is
+    # kept OUT of structuredContent (ADR-0011) — the same error channel a headless
+    # tool failure uses, carrying a live-category code.
+    _scaffold_project(tmp_path)
+    _pin_env(monkeypatch, tmp_path)
+    server = build_server(SubprocessGdaRunner.default())
+
+    async def _drive():
+        async with connect(server) as session:
+            return await session.call_tool("game_tree", {})
+
+    try:
+        result = anyio.run(_drive)
+
+        assert result.isError is True, result.content
+        # The success channel is empty: gda-mcp never puts a failure envelope into
+        # structuredContent / outputSchema.
+        assert result.structuredContent is None
+        # The full GdaError envelope crossed verbatim as text content.
+        assert result.content, "expected the GdaError envelope as text content"
+        payload = json.loads(result.content[0].text)
+        error = payload["error"]
+        assert error["code"] == "daemon_not_running"
+        assert error["category"] == "live"
+        # The remediation message is preserved, not flattened to bare prose.
+        assert "gda daemon start" in error["message"]
+    finally:
+        anyio.run(_stop_daemon, server)
+
+
+async def _stop_daemon(server):
+    # Best-effort teardown over a fresh MCP session: stop any daemon this test
+    # left running so e2e runs stay isolated. Tolerant of "no daemon" (the failure
+    # test never starts one).
+    try:
+        async with connect(server) as session:
+            await session.call_tool("daemon_stop", {})
+    except Exception:
+        pass

--- a/tests/test_mcp_live_generic.py
+++ b/tests/test_mcp_live_generic.py
@@ -8,16 +8,19 @@ awareness of whether a command is headless or live. So its two core modules
 command's execution kind, no daemon channel, no live-ness in any form
 (``live`` / ``daemon`` / ``kind`` / ``ExecutionKind``).
 
-The guard scans the modules' executable **code tokens only** — comments and
-string literals (docstrings) are stripped first. The two modules legitimately
-say "a live session" in prose to mean an *active MCP session* (unrelated to the
-Phase-2 live channel); a literal text scan would false-fire on that and tempt an
-edit to clean generic code. Scanning code keeps the invariant honest: it trips
-on a real reference like ``cmd.kind`` or an ``import`` of the daemon channel —
-which is exactly the ADR-0011 violation to surface, not patch — while letting
-the prose stand.
+The guard scans the modules with only **comments and docstrings** stripped —
+every *executable* string literal is kept. The two modules legitimately say "a
+live session" in a *docstring* to mean an *active MCP session* (unrelated to the
+Phase-2 live channel), so docstrings are dropped to avoid a false fire; but a real
+per-phase reference — ``entry["kind"] == "live"``, an argv ``["daemon", …]``, an
+``import`` of the daemon channel — lives in *executable* tokens (a dict key, a
+call argument, a name), which the scan keeps visible. So it trips on exactly the
+ADR-0011 violation to surface, not patch, while letting the prose stand. Stripping
+*all* string literals, as a first cut did, would blind the guard to string-keyed
+branching — the gap PR #246 review caught.
 """
 
+import ast
 import io
 import re
 import tokenize
@@ -30,35 +33,55 @@ import gda.mcp.server
 # command's execution kind, the daemon channel, or live-ness in any form.
 _FORBIDDEN = ("live", "daemon", "kind", "ExecutionKind")
 
-# Token kinds that are documentation/structure, not executable code — stripped so
-# the scan sees only what the module *does*, never what it *says* about itself.
-_NON_CODE_TOKENS = frozenset(
-    {
-        tokenize.COMMENT,
-        tokenize.STRING,  # drops docstrings and every string literal
-        tokenize.NL,
-        tokenize.NEWLINE,
-        tokenize.INDENT,
-        tokenize.DEDENT,
-        tokenize.ENCODING,
-        tokenize.ENDMARKER,
-    }
-)
+
+def _docstring_starts(source: str) -> set[tuple[int, int]]:
+    """Start positions of every module/class/function docstring literal.
+
+    A docstring is the first string-expression statement of a module, class, or
+    function — the only string literal that is *documentation*. Every other string
+    literal is executable code (a dict key like ``entry["kind"]``, an argv element
+    like ``["daemon", …]``) and MUST stay visible to the scan, or the guard would
+    miss the very per-phase branching it forbids (PR #246 review). Identifying
+    docstrings by AST position lets us drop exactly those and keep the rest.
+    """
+    starts: set[tuple[int, int]] = set()
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            continue
+        body = getattr(node, "body", [])
+        if (
+            body
+            and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        ):
+            const = body[0].value
+            starts.add((const.lineno, const.col_offset))
+    return starts
 
 
 def _code_text(module) -> str:
-    """The module's source with comments and string literals removed.
+    """The module's source with comments and docstrings removed — every
+    *executable* string literal kept.
 
-    Leaves only identifiers/keywords/operators, so a substring match cannot
-    false-fire on prose like the docstrings' "a live session".
+    So a real per-phase reference (``entry["kind"] == "live"``, an argv
+    ``["daemon", …]``, an import naming the daemon channel) stays visible to the
+    forbidden-vocabulary scan, while the modules' legitimate prose — a docstring
+    saying "a live session" to mean an active MCP session — is dropped and cannot
+    false-fire.
     """
     source = Path(module.__file__).read_text(encoding="utf-8")
-    readline = io.StringIO(source).readline
-    return " ".join(
-        tok.string
-        for tok in tokenize.generate_tokens(readline)
-        if tok.type not in _NON_CODE_TOKENS
-    )
+    docstrings = _docstring_starts(source)
+    kept: list[str] = []
+    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+        if tok.type == tokenize.COMMENT:
+            continue
+        if tok.type == tokenize.STRING and tok.start in docstrings:
+            continue  # a docstring — not executable code
+        kept.append(tok.string)
+    return " ".join(kept)
 
 
 def _phase_vocabulary_in(module) -> list[str]:

--- a/tests/test_mcp_live_generic.py
+++ b/tests/test_mcp_live_generic.py
@@ -1,0 +1,84 @@
+"""S2 (fast): gda-mcp carries zero live/phase-specific code (issue #227, ADR-0011).
+
+The verification slice's structural invariant turned into an enforced regression
+guard: gda-mcp is a *generic* CLI-subprocess client — it maps the aggregate
+schema dump (ADR-0012) to tools and dispatches by exit code (ADR-0011), with no
+awareness of whether a command is headless or live. So its two core modules
+(``server.py``, ``runner.py``) must carry no live-phase *logic*: no branch on a
+command's execution kind, no daemon channel, no live-ness in any form
+(``live`` / ``daemon`` / ``kind`` / ``ExecutionKind``).
+
+The guard scans the modules' executable **code tokens only** — comments and
+string literals (docstrings) are stripped first. The two modules legitimately
+say "a live session" in prose to mean an *active MCP session* (unrelated to the
+Phase-2 live channel); a literal text scan would false-fire on that and tempt an
+edit to clean generic code. Scanning code keeps the invariant honest: it trips
+on a real reference like ``cmd.kind`` or an ``import`` of the daemon channel —
+which is exactly the ADR-0011 violation to surface, not patch — while letting
+the prose stand.
+"""
+
+import io
+import re
+import tokenize
+from pathlib import Path
+
+import gda.mcp.runner
+import gda.mcp.server
+
+# The live-phase vocabulary gda-mcp's code must never reference: a branch on a
+# command's execution kind, the daemon channel, or live-ness in any form.
+_FORBIDDEN = ("live", "daemon", "kind", "ExecutionKind")
+
+# Token kinds that are documentation/structure, not executable code — stripped so
+# the scan sees only what the module *does*, never what it *says* about itself.
+_NON_CODE_TOKENS = frozenset(
+    {
+        tokenize.COMMENT,
+        tokenize.STRING,  # drops docstrings and every string literal
+        tokenize.NL,
+        tokenize.NEWLINE,
+        tokenize.INDENT,
+        tokenize.DEDENT,
+        tokenize.ENCODING,
+        tokenize.ENDMARKER,
+    }
+)
+
+
+def _code_text(module) -> str:
+    """The module's source with comments and string literals removed.
+
+    Leaves only identifiers/keywords/operators, so a substring match cannot
+    false-fire on prose like the docstrings' "a live session".
+    """
+    source = Path(module.__file__).read_text(encoding="utf-8")
+    readline = io.StringIO(source).readline
+    return " ".join(
+        tok.string
+        for tok in tokenize.generate_tokens(readline)
+        if tok.type not in _NON_CODE_TOKENS
+    )
+
+
+def _phase_vocabulary_in(module) -> list[str]:
+    code = _code_text(module)
+    return [w for w in _FORBIDDEN if re.search(rf"\b{w}\b", code)]
+
+
+def test_server_code_has_no_live_or_phase_specific_vocabulary():
+    hits = _phase_vocabulary_in(gda.mcp.server)
+    assert not hits, (
+        f"src/gda/mcp/server.py's code references phase-specific vocabulary {hits}; "
+        "gda-mcp must stay generic (ADR-0011) — surface this as a violation, "
+        "do not patch the guard."
+    )
+
+
+def test_runner_code_has_no_live_or_phase_specific_vocabulary():
+    hits = _phase_vocabulary_in(gda.mcp.runner)
+    assert not hits, (
+        f"src/gda/mcp/runner.py's code references phase-specific vocabulary {hits}; "
+        "gda-mcp must stay generic (ADR-0011) — surface this as a violation, "
+        "do not patch the guard."
+    )

--- a/tests/test_mcp_registration.py
+++ b/tests/test_mcp_registration.py
@@ -79,6 +79,23 @@ def test_non_dispatchable_meta_commands_are_not_registered():
     assert "schema" not in names
 
 
+def test_live_command_game_tree_appears_as_a_tool_mirroring_the_dump():
+    # ADR-0011 verification (#227): a LIVE command reaches the tool surface with
+    # NO per-phase code — it goes through the exact same generic schema→tool
+    # transform as a headless command. `game tree` (the #7 tracer) must register
+    # as the `game_tree` tool, and its description/input/output must mirror the
+    # dump entry field-for-field, indistinguishably from any headless tool.
+    by_name = {tool_name(e["name"]): e for e in _manifest_entries()}
+    assert "game_tree" in by_name  # the aggregate dump (ADR-0012) carries the live cmd
+    tools = {t.name: t for t in list_tools(_server()).tools}
+    assert "game_tree" in tools, "the live `game tree` command was not registered"
+    tool = tools["game_tree"]
+    entry = by_name["game_tree"]
+    assert tool.description == entry["description"]
+    assert tool.inputSchema == entry["input"]
+    assert tool.outputSchema == entry["output"]
+
+
 def test_startup_introspects_the_dump_through_the_seam_once():
     # The surface comes from one `gda schema` run through the shared seam
     # (ADR-0012's single startup subprocess), not a per-command fan-out.


### PR DESCRIPTION
## Summary

Verification slice proving that **gda-mcp auto-exposes live commands as MCP tools with no per-phase work** (ADR-0011): a live command appears in the generated tool surface from the aggregate `gda schema` dump (ADR-0012), and a tool call routes CLI → daemon and returns the same `structuredContent` on success / `isError` + full `GdaError` on failure that a headless tool does.

Closes #227.

## Zero production code

`git diff main...HEAD` touches **only `tests/`**. `src/gda/mcp/server.py` and `runner.py` are already fully generic — no `kind`/`live`/`daemon` branching — so no production change was needed (and none was made). A structural guard test now enforces this invariant.

## Tests

- **Fast — surface appearance** (`tests/test_mcp_registration.py`): the live `game tree` registers as the `game_tree` tool from the real `gda schema` dump; its `inputSchema`/`outputSchema`/`description` mirror the dump entry field-for-field.
- **Fast — genericity guard** (`tests/test_mcp_live_generic.py`): asserts `server.py`/`runner.py` **executable code** (comments + string literals stripped via `tokenize`) contains no `live`/`daemon`/`kind`/`ExecutionKind`. Token-based rather than raw-text because `server.py` legitimately uses the word "live" in docstrings to mean an active MCP session — a raw-text scan would false-positive on clean code and tempt a production-comment edit (itself an ADR-0011 violation). The guard enforces the real invariant: no `kind`/daemon branching in logic.
- **e2e** (`tests/test_e2e_mcp_live.py`, 2 tests): against a real `daemon start`-stood-up daemon + engine session, the MCP `game_tree` call returns `isError=False` with `structuredContent.root.name=="Main"` (same success shape as a headless tool); with no daemon it returns `isError=True` + the verbatim `daemon_not_running` / `category:"live"` `GdaError` in `content` (same failure channel as a headless tool).

`uv run pytest -m "not e2e"` (mcp suites) → 9 passed. `pytest -m e2e tests/test_e2e_mcp_live.py` → **2 passed** against real Godot 4.6.3 (run serially by the reviewer).
