### PR TITLE
feat: gda harness lifecycle — version self-sync and paired uninstall (#225)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -137,6 +137,7 @@ operation, and parse codes the CLI assigns).
 | `engine_session_not_running` | `live` | `classifier` | `6` | The daemon is running but holds no live engine session to serve the live operation (Phase 2). |
 | `engine_disconnected` | `live` | `classifier` | `6` | The engine session disconnected before the live operation returned — the game crashed or the harness connection dropped (Phase 2). |
 | `live_timeout` | `live` | `classifier` | `6` | A live operation did not return from the engine session before the daemon's timeout (Phase 2). |
+| `daemon_running` | `live` | `classifier` | `6` | A daemon-lifecycle command was refused because a gda-daemon is running for the project; stop it first with `gda daemon stop` (Phase 2, #225). |
 | `live_node_not_found` | `live` | `classifier` | `6` | A live game operation's node path does not resolve to a node in the running scene tree (Phase 2, #220). |
 | `live_unknown_property` | `live` | `classifier` | `6` | A live game get or set targeted a property the running node does not expose for the requested operation (no such readable storage property for get, or no such settable property for set) (Phase 2, #220). |
 | `live_uncoercible_value` | `live` | `classifier` | `6` | A live game set value cannot be coerced to the running property's declared Godot type (Phase 2, #220). |

--- a/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
+++ b/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
@@ -39,6 +39,22 @@ so two instances can touch the project at once.
 > grows, the treatment to revisit is per-module fragments + an automatic summary
 > (the same direction RULES.md flags for central registries), under its own ADR.
 
+> **Outcome (2026-06-22, #225 / PR #247) — the harness lifecycle is complete:
+> version self-sync and paired uninstall.** Point 1's "self-syncs the harness to the
+> running `gda` version" is realized: `_materialize` prepends a `# gda-harness-version:
+> <N>` header (from a `HARNESS_VERSION` const — NOT the package version, since the
+> harness changes far less often than `gda` ships), so the version check rides the
+> existing idempotent content-compare: a mismatch re-materializes, a match is a no-op
+> (never an unconditional overwrite, which would bump mtime and trip the concurrent-
+> editor prompt of point 4). `gda daemon start` runs this self-sync **whether or not a
+> daemon is already up** (PR #247 review), so upgrading `gda` never strands a stale
+> harness; `harness_synced` is true only on a real stale→current rewrite, distinct from
+> a first install (`installed_harness`). The paired `gda daemon uninstall` strips the
+> `[autoload]` entry **first**, then deletes the files — crash-safe ordering, so a
+> mid-failure leaves a harmless stray inert `.gd`, never a dangling autoload (point 3);
+> the autoload edit is scoped to the `[autoload]` section so a same-named key elsewhere
+> is never touched. Verified resident-inert in a plain run and an exported PCK.
+
 ## Decision
 
 **1. The harness is an installed autoload, not a runtime injection.** `gda` bundles

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -19,6 +19,7 @@ from gda.daemon_ops import (
     run_daemon_start_operation,
     run_daemon_status_operation,
     run_daemon_stop_operation,
+    run_daemon_uninstall_operation,
 )
 from gda.errors import (
     Failure,
@@ -65,6 +66,8 @@ from gda.models import (
     DaemonStatusResult,
     DaemonStopParams,
     DaemonStopResult,
+    DaemonUninstallParams,
+    DaemonUninstallResult,
     DiagErrorsParams,
     DiagErrorsResult,
     DiagLogParams,
@@ -1096,12 +1099,23 @@ DAEMON_STATUS_COMMAND: HeadlessCommand[DaemonStatusResult] = HeadlessCommand(
     output_model=DaemonStatusResult,
 )
 
+DAEMON_UNINSTALL_COMMAND: HeadlessCommand[DaemonUninstallResult] = HeadlessCommand(
+    operation="daemon-uninstall",
+    input_model=DaemonUninstallParams,
+    output_model=DaemonUninstallResult,
+)
+
 # The daemon lifecycle commands run a process-management recipe (gda.daemon_ops),
 # not the sentinel pipeline — the same shape as `export run`. They carry no Godot
 # execution channel, so they are routed by command identity, shared by the argv
 # bodies and the --params-json path so both forms drive the SAME recipe.
 _DAEMON_COMMANDS = frozenset(
-    {DAEMON_START_COMMAND, DAEMON_STOP_COMMAND, DAEMON_STATUS_COMMAND}
+    {
+        DAEMON_START_COMMAND,
+        DAEMON_STOP_COMMAND,
+        DAEMON_STATUS_COMMAND,
+        DAEMON_UNINSTALL_COMMAND,
+    }
 )
 
 
@@ -1118,6 +1132,8 @@ def _daemon_dispatch(
         outcome = run_daemon_start_operation(resolved, godot)
     elif cmd is DAEMON_STOP_COMMAND:
         outcome = run_daemon_stop_operation(resolved)
+    elif cmd is DAEMON_UNINSTALL_COMMAND:
+        outcome = run_daemon_uninstall_operation(resolved)
     else:
         outcome = run_daemon_status_operation(resolved)
     if isinstance(outcome, Failure):
@@ -1179,6 +1195,29 @@ def daemon_status(
     _daemon_dispatch(
         DAEMON_STATUS_COMMAND, json_output=json_output, godot=godot, project=project
     )
+
+
+@daemon_app.command(name="uninstall", cls=DAEMON_UNINSTALL_COMMAND.command_class())
+def daemon_uninstall(
+    json_output: bool = json_option(),
+    schema: bool = DAEMON_UNINSTALL_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Remove the gda harness autoload and files from the project (ADR-0018).
+
+    A release-hygiene step: removal is paired and crash-safe — the [autoload] entry
+    is stripped first, then the files — so a mid-failure never leaves a dangling
+    autoload that would crash an exported game. Idempotent (a no-op if not
+    installed). Refused while a daemon is running (`daemon_running`); stop it first
+    with `gda daemon stop`. Live is macOS/Linux only; elsewhere reports
+    `live_unsupported_platform`.
+    """
+    _daemon_dispatch(
+        DAEMON_UNINSTALL_COMMAND, json_output=json_output, godot=godot, project=project
+    )
+
 
 SCENE_CREATE_COMMAND: HeadlessCommand[SceneCreateResult] = HeadlessCommand(
     operation="scene-create",

--- a/src/gda/daemon_ops.py
+++ b/src/gda/daemon_ops.py
@@ -31,8 +31,18 @@ from gda.daemon.discovery import (
 from gda.daemon.protocol import read_message, write_message
 from gda.daemon.server import STATUS_OP, STOP_OP
 from gda.errors import Failure, _failure, unresolvable_binary_failure
-from gda.harness.install import install_harness
-from gda.models import DaemonStartResult, DaemonStatusResult, DaemonStopResult
+from gda.harness.install import (
+    HARNESS_VERSION,
+    install_harness,
+    installed_harness_version,
+    uninstall_harness,
+)
+from gda.models import (
+    DaemonStartResult,
+    DaemonStatusResult,
+    DaemonStopResult,
+    DaemonUninstallResult,
+)
 
 _READY_TIMEOUT = 8.0
 _STOP_TIMEOUT = 8.0
@@ -157,11 +167,14 @@ def run_daemon_start_operation(
         )
     existing = daemon_pid(paths)
     if existing is not None:
-        # Idempotent: a daemon is already up for this project.
+        # Idempotent: a daemon is already up for this project. It syncs nothing —
+        # report the version already installed on disk (None when somehow absent).
         return DaemonStartResult(
             pid=existing,
             socket_path=str(paths.cli_socket),
             installed_harness=False,
+            harness_synced=False,
+            harness_version=installed_harness_version(project) or HARNESS_VERSION,
             already_running=True,
         )
 
@@ -194,7 +207,9 @@ def run_daemon_start_operation(
     return DaemonStartResult(
         pid=pid,
         socket_path=str(paths.cli_socket),
-        installed_harness=installed,
+        installed_harness=installed.changed,
+        harness_synced=installed.synced,
+        harness_version=installed.version,
         already_running=False,
     )
 
@@ -241,3 +256,39 @@ def run_daemon_status_operation(project: Optional[Path]) -> "DaemonStatusResult 
     return DaemonStatusResult(
         running=pid is not None, pid=pid, socket_path=str(paths.cli_socket)
     )
+
+
+def run_daemon_uninstall_operation(
+    project: Optional[Path],
+) -> "DaemonUninstallResult | Failure":
+    """Remove the harness autoload + files from the project (ADR-0018, #225).
+
+    A release-hygiene step (ADR-0018 point 3): removal is paired and crash-safe
+    (autoload entry first, then files — :func:`uninstall_harness`). It is **refused
+    while a daemon is running** (``daemon_running``): the daemon holds a live engine
+    session whose autoload this would yank out from under it. Idempotent: a no-op
+    success when nothing is installed (mirrors ``daemon stop``).
+    """
+    if not _is_unix():
+        return _failure(
+            "live_unsupported_platform",
+            "the gda-daemon requires a UNIX platform (macOS/Linux); it uses Unix "
+            "domain sockets, which are unavailable here",
+            "",
+        )
+    if project is None:
+        return _failure(
+            "project_not_found",
+            "gda daemon needs a Godot project; pass --project or run inside one",
+            "",
+        )
+    paths = daemon_paths(project)
+    if daemon_pid(paths) is not None:
+        return _failure(
+            "daemon_running",
+            "a gda-daemon is running for this project; stop it first with "
+            "`gda daemon stop` before uninstalling the harness",
+            "",
+        )
+    result = uninstall_harness(project)
+    return DaemonUninstallResult(removed=result.removed)

--- a/src/gda/daemon_ops.py
+++ b/src/gda/daemon_ops.py
@@ -32,9 +32,7 @@ from gda.daemon.protocol import read_message, write_message
 from gda.daemon.server import STATUS_OP, STOP_OP
 from gda.errors import Failure, _failure, unresolvable_binary_failure
 from gda.harness.install import (
-    HARNESS_VERSION,
     install_harness,
-    installed_harness_version,
     uninstall_harness,
 )
 from gda.models import (
@@ -167,14 +165,21 @@ def run_daemon_start_operation(
         )
     existing = daemon_pid(paths)
     if existing is not None:
-        # Idempotent: a daemon is already up for this project. It syncs nothing —
-        # report the version already installed on disk (None when somehow absent).
+        # Idempotent: a daemon is already up for this project — but still self-sync
+        # the installed harness (#225), so upgrading `gda` while an old daemon stays
+        # up never leaves a stale harness on disk. The next engine session the
+        # daemon launches reads the synced copy (sessions launch lazily and relaunch
+        # once the prior one dies, ADR-0017), so a `daemon start` before any live op
+        # — the common flow — is fully resynced. `harness_synced` is true only on a
+        # real stale→current rewrite, so a steady-state repeat start still reports
+        # false and writes nothing (no mtime bump, no concurrent-editor prompt).
+        installed = install_harness(project)
         return DaemonStartResult(
             pid=existing,
             socket_path=str(paths.cli_socket),
-            installed_harness=False,
-            harness_synced=False,
-            harness_version=installed_harness_version(project) or HARNESS_VERSION,
+            installed_harness=installed.changed,
+            harness_synced=installed.synced,
+            harness_version=installed.version,
             already_running=True,
         )
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -440,6 +440,20 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A live operation did not return from the engine session before the"
         " daemon's timeout.",
     ),
+    # The harness-lifecycle refusal (#225, ADR-0018): `gda daemon uninstall`
+    # removes the harness autoload + files, which would yank the autoload out from
+    # under a live engine session the daemon is holding — so it refuses while a
+    # daemon is running. Same shape as the other daemon-channel LIVE codes:
+    # LIVE-category, classifier-source (the uninstall recipe emits it, not a
+    # headless operation), exit EXIT_LIVE; NOT GDScript-mirrored.
+    ErrorCodeSpec(
+        "daemon_running",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A daemon-lifecycle command was refused because a gda-daemon is running"
+        " for the project; stop it first with `gda daemon stop`.",
+    ),
     # Per live-operation failures the gda harness reports in-band (#220). Harness
     # op-errors arrive with exit_code 0 (the daemon relays the sentinel verbatim),
     # so each MUST be a LIVE-category code for ``classify_live`` to map it before

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -127,11 +127,14 @@ def _materialize(project: Path) -> bool:
 
 
 def _ensure_autoload(text: str) -> tuple[str, bool]:
-    """Ensure the harness autoload line is present; return (text, changed)."""
-    line = _autoload_line()
-    if line in text:
-        return text, False
+    """Ensure the harness autoload line is present in ``[autoload]``; (text, changed).
 
+    The "already present" decision is scoped to the ``[autoload]`` section: only an
+    EXACT GdaHarness line *inside* ``[autoload]`` is a no-op. There is no global
+    early return on the line appearing anywhere in the file, so a same-named key in
+    another section is never consulted, re-pointed, or removed (PR #247 review).
+    """
+    line = _autoload_line()
     lines = text.splitlines()
     trailing = "\n" if text.endswith("\n") else ""
 
@@ -149,6 +152,10 @@ def _ensure_autoload(text: str) -> tuple[str, bool]:
             if autoload_header_index is None:
                 autoload_header_index = i
         elif stripped.startswith(f"{HARNESS_AUTOLOAD_NAME}="):
+            # A GdaHarness entry inside [autoload]: a no-op when already exact,
+            # otherwise re-point it in place.
+            if stripped == line:
+                return text, False
             lines[i] = line
             return "\n".join(lines) + trailing, True
 

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -1,4 +1,4 @@
-"""Install the gda harness autoload into a project (ADR-0018).
+"""Install / uninstall the gda harness autoload in a project (ADR-0018).
 
 ``gda daemon start`` performs this **one-time, install-time write** (never a
 per-launch mutation, which would race a concurrent editor and corrupt config):
@@ -9,10 +9,25 @@ and reports whether it changed anything (``installed_harness``).
 The write is Python-side because it happens *before* any engine session exists.
 It mirrors the autoload semantics ``operations.gd`` uses for ``project
 add-autoload`` (issue #119): the value is the ``res://`` path prefixed with ``*``
-(the enabled-singleton form). Version self-sync and paired uninstall are #225.
+(the enabled-singleton form).
+
+**Version self-sync (#225, D1).** ``_materialize`` prepends a leading GDScript
+comment header ``# gda-harness-version: <N>`` (sourced from ``HARNESS_VERSION``,
+NOT the package version — the harness changes far less often than ``gda`` ships).
+Because that header is part of the materialized content, the version check **falls
+out of the existing content-compare**: a mismatch re-materializes, a match is a
+no-op (never an unconditional overwrite, which would bump mtime and trip the
+concurrent-editor prompt). ``installed_harness_version`` reads the header back.
+
+**Paired uninstall (#225, D2).** ``uninstall_harness`` removes the ``[autoload]``
+entry **first**, then deletes the files — so a mid-failure leaves only a harmless
+stray inert ``.gd``, never a dangling autoload pointing at a missing script (which
+crashes an exported game, ADR-0018). It is idempotent: a no-op success when the
+harness is not installed (mirrors ``daemon stop``).
 """
 
 from pathlib import Path
+from typing import Optional
 
 # The autoload name and the res:// location the bundled harness is installed to.
 HARNESS_AUTOLOAD_NAME = "GdaHarness"
@@ -21,10 +36,12 @@ HARNESS_FILE = "gda_harness.gd"
 HARNESS_RES_PATH = f"res://{HARNESS_RES_DIR}/{HARNESS_FILE}"
 
 # Bumped when the bundled harness changes; the daemon self-syncs the installed
-# copy to it (#225). Unused by the install logic now — only re-materialize on a
-# content difference — but the anchor lives here for #225.
+# copy to it (#225). The installed copy declares its version in a leading header
+# (`# gda-harness-version: <N>`); a mismatch re-materializes via the content
+# compare. NOT the package version — the harness changes far less often.
 HARNESS_VERSION = "0"
 
+_VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"
 _BUNDLED_HARNESS = Path(__file__).parent / HARNESS_FILE
 
@@ -34,14 +51,48 @@ def _autoload_line() -> str:
     return f'{HARNESS_AUTOLOAD_NAME}="*{HARNESS_RES_PATH}"'
 
 
+def _version_header() -> str:
+    return f"{_VERSION_HEADER_PREFIX} {HARNESS_VERSION}"
+
+
+def _materialized_content() -> str:
+    """The exact bytes the installed harness should hold: version header + body."""
+    return f"{_version_header()}\n{_BUNDLED_HARNESS.read_text(encoding='utf-8')}"
+
+
+def _harness_dest(project: Path) -> Path:
+    return project / HARNESS_RES_DIR / HARNESS_FILE
+
+
+def installed_harness_version(project: Path) -> Optional[str]:
+    """The version declared in the installed harness's header, or None if absent.
+
+    Reads the leading ``# gda-harness-version: <N>`` comment ``_materialize``
+    prepends. Returns None when no harness file is installed or its header is
+    missing/unrecognized (treated as a mismatch -> re-materialize).
+    """
+    dest = _harness_dest(project)
+    if not dest.exists():
+        return None
+    first = dest.read_text(encoding="utf-8").splitlines()[:1]
+    if first and first[0].startswith(_VERSION_HEADER_PREFIX):
+        return first[0][len(_VERSION_HEADER_PREFIX) :].strip()
+    return None
+
+
 def _materialize(project: Path) -> bool:
-    """Write the bundled harness under res://addons; True iff it changed on disk."""
-    dest = project / HARNESS_RES_DIR / HARNESS_FILE
-    bundled = _BUNDLED_HARNESS.read_text(encoding="utf-8")
-    if dest.exists() and dest.read_text(encoding="utf-8") == bundled:
+    """Write the bundled harness under res://addons; True iff it changed on disk.
+
+    The destination content is the version header + the bundled body, so a version
+    bump (or a body change) is a content difference — re-materialize only then,
+    never unconditionally (an mtime bump would trip the concurrent-editor prompt).
+    """
+    dest = _harness_dest(project)
+    content = _materialized_content()
+    if dest.exists() and dest.read_text(encoding="utf-8") == content:
         return False
     dest.parent.mkdir(parents=True, exist_ok=True)
-    dest.write_text(bundled, encoding="utf-8")
+    dest.write_text(content, encoding="utf-8")
     return True
 
 
@@ -86,3 +137,51 @@ def install_harness(project: Path) -> bool:
     if autoload_added:
         project_godot.write_text(new_text, encoding="utf-8")
     return materialized or autoload_added
+
+
+def _remove_autoload(text: str) -> tuple[str, bool]:
+    """Drop the harness autoload line from ``project.godot`` text; (text, changed).
+
+    Removes only the ``GdaHarness=...`` line, leaving the ``[autoload]`` section
+    header and any sibling autoloads intact (the inverse of ``_ensure_autoload``).
+    """
+    lines = text.splitlines()
+    kept = [
+        raw for raw in lines if not raw.strip().startswith(f"{HARNESS_AUTOLOAD_NAME}=")
+    ]
+    if len(kept) == len(lines):
+        return text, False
+    trailing = "\n" if text.endswith("\n") else ""
+    return "\n".join(kept) + trailing, True
+
+
+def _remove_files(project: Path) -> bool:
+    """Delete the materialized harness file (and its now-empty addon dir); changed?"""
+    dest = _harness_dest(project)
+    removed = dest.exists()
+    dest.unlink(missing_ok=True)
+    addon_dir = project / HARNESS_RES_DIR
+    if addon_dir.is_dir() and not any(addon_dir.iterdir()):
+        addon_dir.rmdir()
+    return removed
+
+
+def uninstall_harness(project: Path) -> bool:
+    """Idempotently remove the harness autoload and files from ``project`` (#225).
+
+    Crash-safe ordering (ADR-0018, D2): strip the ``[autoload]`` entry **first**
+    (a single atomic ``write_text``), then delete the files — so a mid-failure
+    leaves only a harmless stray inert ``.gd``, never a dangling autoload pointing
+    at a missing script (which crashes an exported game). Returns whether anything
+    was removed; a no-op success (``False``) when nothing is installed (mirrors
+    ``daemon stop``).
+    """
+    project_godot = project / "project.godot"
+    autoload_removed = False
+    if project_godot.exists():
+        text = project_godot.read_text(encoding="utf-8")
+        new_text, autoload_removed = _remove_autoload(text)
+        if autoload_removed:
+            project_godot.write_text(new_text, encoding="utf-8")
+    files_removed = _remove_files(project)
+    return autoload_removed or files_removed

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -53,9 +53,11 @@ class HarnessInstall:
 
     ``changed`` is the existing ``installed_harness`` signal the daemon reports —
     True iff the file was (re)materialized OR the autoload entry was added/repointed.
-    ``synced`` is True only on a real version/body re-materialize (the
-    ``harness_synced`` the daemon reports — distinct from merely adding the autoload
-    entry). ``version`` is the version now installed on disk.
+    ``synced`` is True ONLY when an **already-installed** harness was rewritten to a
+    new version/body (a stale→current resync — the ``harness_synced`` the daemon
+    reports). A first install is NOT a sync: it is already visible via ``changed`` /
+    ``installed_harness``, so ``synced`` stays False there. ``version`` is the
+    version now installed on disk.
     """
 
     changed: bool
@@ -133,18 +135,28 @@ def _ensure_autoload(text: str) -> tuple[str, bool]:
     lines = text.splitlines()
     trailing = "\n" if text.endswith("\n") else ""
 
-    # A GdaHarness entry pointing somewhere else — re-point it in place.
+    # Re-point an existing GdaHarness entry, or insert a fresh one — both scoped to
+    # the [autoload] section, so a same-named key in another section is never
+    # touched (PR #247 review; symmetric with _remove_autoload).
+    section: Optional[str] = None
+    autoload_header_index: Optional[int] = None
     for i, raw in enumerate(lines):
-        if raw.strip().startswith(f"{HARNESS_AUTOLOAD_NAME}="):
+        stripped = raw.strip()
+        section = _section_of(stripped, section)
+        if section != _AUTOLOAD_HEADER:
+            continue
+        if stripped == _AUTOLOAD_HEADER:
+            if autoload_header_index is None:
+                autoload_header_index = i
+        elif stripped.startswith(f"{HARNESS_AUTOLOAD_NAME}="):
             lines[i] = line
             return "\n".join(lines) + trailing, True
 
-    # An existing [autoload] section — insert right after its header, preserving
-    # any sibling autoloads.
-    for i, raw in enumerate(lines):
-        if raw.strip() == _AUTOLOAD_HEADER:
-            lines.insert(i + 1, line)
-            return "\n".join(lines) + trailing, True
+    # An existing [autoload] section with no GdaHarness entry — insert right after
+    # its header, preserving any sibling autoloads.
+    if autoload_header_index is not None:
+        lines.insert(autoload_header_index + 1, line)
+        return "\n".join(lines) + trailing, True
 
     # No [autoload] section — append one at EOF (sections may appear in any order).
     base = text if text.endswith("\n") else text + "\n"
@@ -156,9 +168,11 @@ def install_harness(project: Path) -> HarnessInstall:
 
     Returns a :class:`HarnessInstall`: ``changed`` (the ``installed_harness`` the
     daemon reports — ``True`` on a first install or a re-materialize/re-point),
-    ``synced`` (``True`` only on a real version/body re-materialize, the
-    ``harness_synced`` the daemon reports), and the ``version`` now on disk.
+    ``synced`` (``True`` only when an **already-installed** harness was rewritten to
+    a new version/body — the ``harness_synced`` the daemon reports), and the
+    ``version`` now on disk.
     """
+    existed = _harness_dest(project).exists()
     materialized = _materialize(project)
     project_godot = project / "project.godot"
     text = project_godot.read_text(encoding="utf-8")
@@ -167,21 +181,44 @@ def install_harness(project: Path) -> HarnessInstall:
         project_godot.write_text(new_text, encoding="utf-8")
     return HarnessInstall(
         changed=materialized or autoload_added,
-        synced=materialized,
+        # A *resync*, not a first install: the file must have already existed AND
+        # been rewritten (stale version/body → current). A first install rewrites
+        # too, but is reported by ``changed`` / ``installed_harness`` (PR #247 review).
+        synced=existed and materialized,
         version=HARNESS_VERSION,
     )
+
+
+def _section_of(stripped: str, current: Optional[str]) -> Optional[str]:
+    """The active INI section after a stripped line, or ``current`` if unchanged.
+
+    A section header is ``[name]``; any other line leaves the section as-is. Used to
+    scope harness-key edits to ``[autoload]`` so a same-named key in another section
+    of ``project.godot`` is never touched (PR #247 review).
+    """
+    if stripped.startswith("[") and stripped.endswith("]"):
+        return stripped
+    return current
 
 
 def _remove_autoload(text: str) -> tuple[str, bool]:
     """Drop the harness autoload line from ``project.godot`` text; (text, changed).
 
-    Removes only the ``GdaHarness=...`` line, leaving the ``[autoload]`` section
-    header and any sibling autoloads intact (the inverse of ``_ensure_autoload``).
+    Removes only the ``GdaHarness=...`` line **inside the ``[autoload]`` section**,
+    leaving the section header and any sibling autoloads intact (the inverse of
+    ``_ensure_autoload``). A same-named key in another section is left untouched.
     """
     lines = text.splitlines()
-    kept = [
-        raw for raw in lines if not raw.strip().startswith(f"{HARNESS_AUTOLOAD_NAME}=")
-    ]
+    section: Optional[str] = None
+    kept: list[str] = []
+    for raw in lines:
+        stripped = raw.strip()
+        section = _section_of(stripped, section)
+        if section == _AUTOLOAD_HEADER and stripped.startswith(
+            f"{HARNESS_AUTOLOAD_NAME}="
+        ):
+            continue  # drop the autoload entry only
+        kept.append(raw)
     if len(kept) == len(lines):
         return text, False
     trailing = "\n" if text.endswith("\n") else ""

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -26,6 +26,7 @@ crashes an exported game, ADR-0018). It is idempotent: a no-op success when the
 harness is not installed (mirrors ``daemon stop``).
 """
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -44,6 +45,33 @@ HARNESS_VERSION = "0"
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"
 _BUNDLED_HARNESS = Path(__file__).parent / HARNESS_FILE
+
+
+@dataclass(frozen=True)
+class HarnessInstall:
+    """The outcome of an ``install_harness`` call (#225).
+
+    ``changed`` is the existing ``installed_harness`` signal the daemon reports —
+    True iff the file was (re)materialized OR the autoload entry was added/repointed.
+    ``synced`` is True only on a real version/body re-materialize (the
+    ``harness_synced`` the daemon reports — distinct from merely adding the autoload
+    entry). ``version`` is the version now installed on disk.
+    """
+
+    changed: bool
+    synced: bool
+    version: str
+
+
+@dataclass(frozen=True)
+class HarnessUninstall:
+    """The outcome of an ``uninstall_harness`` call (#225).
+
+    ``removed`` is True iff anything was removed (the autoload entry and/or the
+    files); False is the idempotent no-op when the harness was not installed.
+    """
+
+    removed: bool
 
 
 def _autoload_line() -> str:
@@ -123,12 +151,13 @@ def _ensure_autoload(text: str) -> tuple[str, bool]:
     return f"{base}\n{_AUTOLOAD_HEADER}\n\n{line}\n", True
 
 
-def install_harness(project: Path) -> bool:
-    """Idempotently install the harness autoload into ``project``.
+def install_harness(project: Path) -> HarnessInstall:
+    """Idempotently install the harness autoload into ``project`` (#225).
 
-    Returns whether anything changed (the ``installed_harness`` the daemon
-    reports): ``True`` on a first install or a re-materialize/re-point, ``False``
-    when the harness file and the autoload entry are already in place.
+    Returns a :class:`HarnessInstall`: ``changed`` (the ``installed_harness`` the
+    daemon reports — ``True`` on a first install or a re-materialize/re-point),
+    ``synced`` (``True`` only on a real version/body re-materialize, the
+    ``harness_synced`` the daemon reports), and the ``version`` now on disk.
     """
     materialized = _materialize(project)
     project_godot = project / "project.godot"
@@ -136,7 +165,11 @@ def install_harness(project: Path) -> bool:
     new_text, autoload_added = _ensure_autoload(text)
     if autoload_added:
         project_godot.write_text(new_text, encoding="utf-8")
-    return materialized or autoload_added
+    return HarnessInstall(
+        changed=materialized or autoload_added,
+        synced=materialized,
+        version=HARNESS_VERSION,
+    )
 
 
 def _remove_autoload(text: str) -> tuple[str, bool]:
@@ -166,15 +199,15 @@ def _remove_files(project: Path) -> bool:
     return removed
 
 
-def uninstall_harness(project: Path) -> bool:
+def uninstall_harness(project: Path) -> HarnessUninstall:
     """Idempotently remove the harness autoload and files from ``project`` (#225).
 
     Crash-safe ordering (ADR-0018, D2): strip the ``[autoload]`` entry **first**
     (a single atomic ``write_text``), then delete the files — so a mid-failure
     leaves only a harmless stray inert ``.gd``, never a dangling autoload pointing
-    at a missing script (which crashes an exported game). Returns whether anything
-    was removed; a no-op success (``False``) when nothing is installed (mirrors
-    ``daemon stop``).
+    at a missing script (which crashes an exported game). Returns a
+    :class:`HarnessUninstall`; ``removed`` is ``False`` (a no-op success) when
+    nothing is installed (mirrors ``daemon stop``).
     """
     project_godot = project / "project.godot"
     autoload_removed = False
@@ -184,4 +217,4 @@ def uninstall_harness(project: Path) -> bool:
         if autoload_removed:
             project_godot.write_text(new_text, encoding="utf-8")
     files_removed = _remove_files(project)
-    return autoload_removed or files_removed
+    return HarnessUninstall(removed=autoload_removed or files_removed)

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -3070,6 +3070,19 @@ class DaemonStartResult(BaseModel):
     installed_harness: bool = Field(
         description="Whether this start installed or updated the harness autoload (ADR-0018)."
     )
+    harness_synced: bool = Field(
+        default=False,
+        description=(
+            "Whether this start re-materialized the harness to the running gda's "
+            "version because the installed copy declared an older one — true only "
+            "on a real version-mismatch rewrite, not merely adding the autoload "
+            "entry (#225, ADR-0018)."
+        ),
+    )
+    harness_version: str = Field(
+        default="",
+        description="The gda harness version now installed in the project (#225).",
+    )
     already_running: bool = Field(
         description="Whether a daemon was already running, so start was a no-op."
     )
@@ -3104,3 +3117,18 @@ class DaemonStatusResult(BaseModel):
         default=None, description="The running daemon's pid, if any."
     )
     socket_path: str = Field(description="The per-project CLI socket path.")
+
+
+class DaemonUninstallParams(BaseModel):
+    """The params of ``gda daemon uninstall``: none (the project is the --project context)."""
+
+
+class DaemonUninstallResult(BaseModel):
+    """The result of ``gda daemon uninstall``: the paired harness removal (ADR-0018, #225)."""
+
+    removed: bool = Field(
+        description=(
+            "Whether the harness autoload and files were removed; False is the "
+            "idempotent no-op when no harness was installed (mirrors daemon stop)."
+        )
+    )

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -25,6 +25,7 @@ from gda.models import (
     DaemonStartResult,
     DaemonStatusResult,
     DaemonStopResult,
+    DaemonUninstallResult,
     DiagErrorsResult,
     DiagLogResult,
     EngineVersion,
@@ -273,7 +274,12 @@ def render_input_sequence(injected: "InputSequenceResult") -> str:
 def render_daemon_start(started: "DaemonStartResult") -> str:
     """Render a `gda daemon start` outcome for humans."""
     state = "already running" if started.already_running else "started"
-    harness = " (installed harness)" if started.installed_harness else ""
+    if started.harness_synced:
+        harness = f" (synced harness to v{started.harness_version})"
+    elif started.installed_harness:
+        harness = " (installed harness)"
+    else:
+        harness = ""
     return f"daemon {state}: pid {started.pid} on {started.socket_path}{harness}"
 
 
@@ -289,6 +295,13 @@ def render_daemon_status(status: "DaemonStatusResult") -> str:
     if status.running:
         return f"daemon running: pid {status.pid} on {status.socket_path}"
     return "daemon not running"
+
+
+def render_daemon_uninstall(uninstalled: "DaemonUninstallResult") -> str:
+    """Render a `gda daemon uninstall` outcome for humans."""
+    if uninstalled.removed:
+        return "harness uninstalled"
+    return "no harness was installed"
 
 
 def render_scene_exports(scene: "SceneGetExportsResult") -> str:
@@ -685,6 +698,7 @@ _RENDERERS = {
     DaemonStartResult: render_daemon_start,
     DaemonStopResult: render_daemon_stop,
     DaemonStatusResult: render_daemon_status,
+    DaemonUninstallResult: render_daemon_uninstall,
     SceneGetExportsResult: render_scene_exports,
     SceneListResult: render_scene_list,
     SceneDeleteResult: render_scene_delete,

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -64,7 +64,7 @@ def _start(project, **kw):
 # --- start reports harness_synced / harness_version (#225, D1) ----------------
 
 
-def test_start_reports_harness_version_and_first_install_is_a_sync(
+def test_start_reports_harness_version_and_first_install_is_not_a_sync(
     tmp_path, short_runtime, fake_ready, monkeypatch
 ):
     project = _project(tmp_path)
@@ -73,10 +73,10 @@ def test_start_reports_harness_version_and_first_install_is_a_sync(
     started = _start(project)
 
     assert isinstance(started, DaemonStartResult), started
-    # The existing field still reports a change (a first install).
+    # A first install is reported by installed_harness, NOT as a sync (#247 review):
+    # harness_synced is reserved for correcting an already-installed stale harness.
     assert started.installed_harness is True
-    # The two additive fields THIS issue owns.
-    assert started.harness_synced is True  # a real version-mismatch (re)write
+    assert started.harness_synced is False
     assert started.harness_version == HARNESS_VERSION
     assert installed_harness_version(project) == HARNESS_VERSION
 
@@ -88,7 +88,8 @@ def test_start_reports_not_synced_when_version_already_matches(
     monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
 
     first = _start(project)
-    assert first.harness_synced is True
+    assert first.installed_harness is True
+    assert first.harness_synced is False  # first install is not a resync (#247)
 
     # A second start at the same HARNESS_VERSION must NOT re-sync (no rewrite), but
     # still reports the installed version.
@@ -98,11 +99,11 @@ def test_start_reports_not_synced_when_version_already_matches(
     assert again.harness_version == HARNESS_VERSION
 
 
-def test_already_running_start_reports_installed_version_without_syncing(
+def test_already_running_start_is_a_noop_when_harness_is_current(
     tmp_path, short_runtime, monkeypatch
 ):
     project = _project(tmp_path)
-    # Install once so a version is on disk, then simulate a live daemon.
+    # A current harness on disk, then a live daemon already up.
     install_harness(project)
     monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: 999)
 
@@ -112,8 +113,39 @@ def test_already_running_start_reports_installed_version_without_syncing(
 
     assert isinstance(started, DaemonStartResult)
     assert started.already_running is True
-    assert started.harness_synced is False  # an idempotent start syncs nothing
+    # An already-running start re-checks the harness; a CURRENT one is a no-op (no
+    # rewrite, no mtime bump), so it neither installs nor syncs.
+    assert started.installed_harness is False
+    assert started.harness_synced is False
     assert started.harness_version == HARNESS_VERSION
+
+
+def test_already_running_start_resyncs_a_stale_harness(
+    tmp_path, short_runtime, monkeypatch
+):
+    # PR #247 review: a daemon already up must NOT skip the harness self-sync. If
+    # `gda` is upgraded while the old daemon stays running, an already-running start
+    # still re-materializes a stale installed harness — so the next engine session
+    # the daemon launches picks up the current copy, never a stale mismatch.
+    project = _project(tmp_path)
+    install_harness(project)
+    # Simulate an older gda's harness left on disk: rewrite the version header stale.
+    harness = project / HARNESS_RES_DIR / HARNESS_FILE
+    lines = harness.read_text(encoding="utf-8").splitlines()
+    lines[0] = "# gda-harness-version: stale-old"
+    harness.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    assert installed_harness_version(project) == "stale-old"
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: 999)
+
+    started = daemon_ops.run_daemon_start_operation(
+        project, None, version_check=_OK_VERSION
+    )
+
+    assert isinstance(started, DaemonStartResult)
+    assert started.already_running is True
+    assert started.harness_synced is True  # stale -> re-materialized despite running
+    assert started.harness_version == HARNESS_VERSION
+    assert installed_harness_version(project) == HARNESS_VERSION  # rewritten on disk
 
 
 # --- uninstall recipe (#225, D2) ----------------------------------------------

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -1,0 +1,201 @@
+"""gda daemon lifecycle payload mapping (#225, ADR-0018): start sync report + uninstall.
+
+Fast unit tests for the *payload* the daemon-lifecycle recipes return — distinct
+from ``test_daemon_ops`` (which spawns a REAL daemon and so is e2e). The process
+lifecycle and a real install are exercised by the e2e suite; here the spawn /
+readiness / liveness seams are stubbed so the focus is the additive
+``DaemonStartResult`` fields this issue owns (``harness_synced`` /
+``harness_version``) and the new ``run_daemon_uninstall_operation`` recipe
+(refused while a daemon is running; idempotent paired removal otherwise).
+"""
+
+import json
+import os
+
+import pytest
+from typer.testing import CliRunner
+
+import gda.daemon_ops as daemon_ops
+from gda.cli import app
+from gda.errors import Failure
+from gda.harness.install import (
+    HARNESS_FILE,
+    HARNESS_RES_DIR,
+    HARNESS_VERSION,
+    install_harness,
+    installed_harness_version,
+)
+from gda.models import DaemonStartResult, DaemonUninstallResult
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+_OK_VERSION = lambda binary: (4, 6)  # noqa: E731
+
+
+def _project(tmp_path):
+    (tmp_path / "project.godot").write_text(
+        'config_version=5\n\n[application]\n\nconfig/name="t"\n', encoding="utf-8"
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def short_runtime(monkeypatch, tmp_path):
+    # Keep derived socket paths short enough to pass the UDS sun_path gate without
+    # binding a real socket (no daemon is spawned here).
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/tmp")
+    return tmp_path
+
+
+@pytest.fixture
+def fake_ready(monkeypatch):
+    # No real daemon is spawned, so stub the spawn (no-op) and the readiness wait
+    # (return a fixed pid) — the start recipe then returns its mapped payload.
+    monkeypatch.setattr(daemon_ops, "_await_ready", lambda paths, *a, **k: 4242)
+    return 4242
+
+
+def _start(project, **kw):
+    return daemon_ops.run_daemon_start_operation(
+        project, None, spawn=lambda p, b: None, version_check=_OK_VERSION, **kw
+    )
+
+
+# --- start reports harness_synced / harness_version (#225, D1) ----------------
+
+
+def test_start_reports_harness_version_and_first_install_is_a_sync(
+    tmp_path, short_runtime, fake_ready, monkeypatch
+):
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
+
+    started = _start(project)
+
+    assert isinstance(started, DaemonStartResult), started
+    # The existing field still reports a change (a first install).
+    assert started.installed_harness is True
+    # The two additive fields THIS issue owns.
+    assert started.harness_synced is True  # a real version-mismatch (re)write
+    assert started.harness_version == HARNESS_VERSION
+    assert installed_harness_version(project) == HARNESS_VERSION
+
+
+def test_start_reports_not_synced_when_version_already_matches(
+    tmp_path, short_runtime, fake_ready, monkeypatch
+):
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
+
+    first = _start(project)
+    assert first.harness_synced is True
+
+    # A second start at the same HARNESS_VERSION must NOT re-sync (no rewrite), but
+    # still reports the installed version.
+    again = _start(project)
+    assert again.harness_synced is False
+    assert again.installed_harness is False
+    assert again.harness_version == HARNESS_VERSION
+
+
+def test_already_running_start_reports_installed_version_without_syncing(
+    tmp_path, short_runtime, monkeypatch
+):
+    project = _project(tmp_path)
+    # Install once so a version is on disk, then simulate a live daemon.
+    install_harness(project)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: 999)
+
+    started = daemon_ops.run_daemon_start_operation(
+        project, None, version_check=_OK_VERSION
+    )
+
+    assert isinstance(started, DaemonStartResult)
+    assert started.already_running is True
+    assert started.harness_synced is False  # an idempotent start syncs nothing
+    assert started.harness_version == HARNESS_VERSION
+
+
+# --- uninstall recipe (#225, D2) ----------------------------------------------
+
+
+def test_uninstall_refused_while_a_daemon_is_running(tmp_path, short_runtime, monkeypatch):
+    project = _project(tmp_path)
+    install_harness(project)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: 999)  # a live daemon
+
+    outcome = daemon_ops.run_daemon_uninstall_operation(project)
+
+    assert isinstance(outcome, Failure), outcome
+    assert outcome.error.code == "daemon_running"
+    # Refusal must not touch the install: the harness file is still on disk.
+    assert (project / HARNESS_RES_DIR / HARNESS_FILE).exists()
+
+
+def test_uninstall_removes_harness_when_no_daemon(tmp_path, short_runtime, monkeypatch):
+    project = _project(tmp_path)
+    install_harness(project)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
+
+    outcome = daemon_ops.run_daemon_uninstall_operation(project)
+
+    assert isinstance(outcome, DaemonUninstallResult), outcome
+    assert outcome.removed is True
+    assert not (project / HARNESS_RES_DIR / HARNESS_FILE).exists()
+
+
+def test_uninstall_is_idempotent_no_op_when_not_installed(
+    tmp_path, short_runtime, monkeypatch
+):
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
+
+    outcome = daemon_ops.run_daemon_uninstall_operation(project)
+
+    assert isinstance(outcome, DaemonUninstallResult)
+    assert outcome.removed is False  # nothing to remove -> no-op success
+
+
+# --- CLI surface (#225) -------------------------------------------------------
+
+
+def test_cli_daemon_uninstall_emits_removal_json(tmp_path, short_runtime, monkeypatch):
+    # `gda daemon uninstall --json` routes through the recipe and emits the typed
+    # DaemonUninstallResult. No daemon is running for the fresh tmp project, so the
+    # paired removal proceeds.
+    project = _project(tmp_path)
+    install_harness(project)
+
+    result = CliRunner().invoke(
+        app, ["daemon", "uninstall", "--project", str(project), "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["removed"] is True
+    assert not (project / HARNESS_RES_DIR / HARNESS_FILE).exists()
+
+
+def test_cli_daemon_uninstall_refused_while_running_exits_live(
+    tmp_path, short_runtime, monkeypatch
+):
+    # Refused while a daemon is running: the CLI surfaces the daemon_running error
+    # envelope at the LIVE exit code (6).
+    project = _project(tmp_path)
+    install_harness(project)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: 999)
+
+    result = CliRunner().invoke(
+        app, ["daemon", "uninstall", "--project", str(project), "--json"]
+    )
+
+    assert result.exit_code == 6, result.output
+    assert json.loads(result.stdout)["error"]["code"] == "daemon_running"
+
+
+def test_cli_daemon_uninstall_schema_describes_the_result(tmp_path):
+    # The command is --schema self-describing (ADR-0004), so gda-mcp follows it.
+    result = CliRunner().invoke(app, ["daemon", "uninstall", "--schema"])
+
+    assert result.exit_code == 0, result.output
+    schema = json.loads(result.stdout)
+    assert "removed" in json.dumps(schema)

--- a/tests/test_daemon_ops.py
+++ b/tests/test_daemon_ops.py
@@ -17,6 +17,7 @@ from gda.daemon_ops import (
     run_daemon_status_operation,
     run_daemon_stop_operation,
 )
+from gda.harness.install import HARNESS_VERSION
 from gda.models import DaemonStartResult, DaemonStatusResult, DaemonStopResult
 
 pytestmark = [
@@ -44,6 +45,9 @@ def test_daemon_start_status_stop_lifecycle(tmp_path, daemon_runtime_dir):
         assert isinstance(started, DaemonStartResult), started
         assert started.already_running is False
         assert started.installed_harness is True  # harness installed + reported
+        # #225: a first install is a real version-sync, reporting the version.
+        assert started.harness_synced is True
+        assert started.harness_version == HARNESS_VERSION
         assert daemon_pid(paths) == started.pid
 
         # Idempotent: a second start finds the running daemon.
@@ -52,6 +56,8 @@ def test_daemon_start_status_stop_lifecycle(tmp_path, daemon_runtime_dir):
         assert again.already_running is True
         assert again.pid == started.pid
         assert again.installed_harness is False
+        assert again.harness_synced is False  # syncs nothing
+        assert again.harness_version == HARNESS_VERSION
 
         status = run_daemon_status_operation(project)
         assert isinstance(status, DaemonStatusResult)

--- a/tests/test_daemon_ops.py
+++ b/tests/test_daemon_ops.py
@@ -45,8 +45,8 @@ def test_daemon_start_status_stop_lifecycle(tmp_path, daemon_runtime_dir):
         assert isinstance(started, DaemonStartResult), started
         assert started.already_running is False
         assert started.installed_harness is True  # harness installed + reported
-        # #225: a first install is a real version-sync, reporting the version.
-        assert started.harness_synced is True
+        # #225/#247: a first install is reported by installed_harness, not as a sync.
+        assert started.harness_synced is False
         assert started.harness_version == HARNESS_VERSION
         assert daemon_pid(paths) == started.pid
 

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -168,7 +168,7 @@ def test_daemon_start_re_syncs_harness_after_a_version_bump(tmp_path, daemon_run
         first = run("daemon", "start")
         assert first.returncode == 0, first.stdout + first.stderr
         first_doc = json.loads(first.stdout)
-        assert first_doc["harness_synced"] is True  # a first install IS a sync
+        assert first_doc["harness_synced"] is False  # a first install is NOT a sync (#247)
         assert first_doc["harness_version"] == HARNESS_VERSION
         assert installed_harness_version(tmp_path) == HARNESS_VERSION
 

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -1,4 +1,4 @@
-"""S1 (e2e): the full gda-daemon live loop through the console script (#7).
+"""S1 (e2e): the full gda-daemon live loop through the console script (#7, #225).
 
 The Step-6 proof: a real ``gda daemon start`` (real detached daemon, real harness
 install, live-version gate) → a real engine session it launches on demand →
@@ -6,6 +6,10 @@ install, live-version gate) → a real engine session it launches on demand →
 the harness over Unix domain sockets → ``gda daemon stop`` tears it down. Run e2e
 serially; not a fresh empty HOME (Godot first-run). The ``daemon_runtime_dir``
 fixture keeps the daemon's UDS path within the OS ``sun_path`` limit.
+
+#225 adds the harness-lifecycle e2e: start re-syncs the harness after a version
+bump (the installed copy declares an older version), and the paired
+``gda daemon uninstall`` (install→uninstall idempotent; refused while running).
 """
 
 import json
@@ -16,6 +20,12 @@ import subprocess
 import pytest
 
 from gda.binary import resolve_godot_binary
+from gda.harness.install import (
+    HARNESS_FILE,
+    HARNESS_RES_DIR,
+    HARNESS_VERSION,
+    installed_harness_version,
+)
 
 from .conftest import project_godot
 
@@ -120,5 +130,115 @@ def test_daemon_serves_game_get_set_round_trip(tmp_path, daemon_runtime_dir):
         position = next(p for p in get_doc["properties"] if p["name"] == "position")
         assert position["type"] == "Vector2"
         assert position["value"] == [10.0, 20.0]
+    finally:
+        run("daemon", "stop")
+
+
+def _gda(tmp_path, env):
+    """A `gda <args> --project <tmp> --godot <GODOT> --json` subprocess helper."""
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+
+    def run(*args):
+        return subprocess.run(
+            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    return run
+
+
+@pytest.mark.e2e
+def test_daemon_start_re_syncs_harness_after_a_version_bump(tmp_path, daemon_runtime_dir):
+    # #225 D1: the daemon self-syncs the installed harness to the running gda's
+    # version. A real start installs at HARNESS_VERSION; we then SIMULATE a
+    # previously-installed OLDER copy by rewriting its leading version header to a
+    # stale value, stop the daemon, and start again. The second start must detect
+    # the mismatch and re-materialize (harness_synced True), syncing the on-disk
+    # version back to HARNESS_VERSION.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+    harness = tmp_path / HARNESS_RES_DIR / HARNESS_FILE
+
+    try:
+        first = run("daemon", "start")
+        assert first.returncode == 0, first.stdout + first.stderr
+        first_doc = json.loads(first.stdout)
+        assert first_doc["harness_synced"] is True  # a first install IS a sync
+        assert first_doc["harness_version"] == HARNESS_VERSION
+        assert installed_harness_version(tmp_path) == HARNESS_VERSION
+
+        # Stop, then corrupt the installed header to a stale older version so the
+        # next start sees a version mismatch.
+        assert run("daemon", "stop").returncode == 0
+        lines = harness.read_text(encoding="utf-8").splitlines()
+        lines[0] = "# gda-harness-version: stale-old"
+        harness.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        assert installed_harness_version(tmp_path) == "stale-old"
+
+        resynced = run("daemon", "start")
+        assert resynced.returncode == 0, resynced.stdout + resynced.stderr
+        resynced_doc = json.loads(resynced.stdout)
+        assert resynced_doc["harness_synced"] is True  # version mismatch -> resync
+        assert resynced_doc["harness_version"] == HARNESS_VERSION
+        assert installed_harness_version(tmp_path) == HARNESS_VERSION  # synced back
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_install_then_uninstall_is_paired_and_idempotent(
+    tmp_path, daemon_runtime_dir
+):
+    # #225 D2: a real start installs the harness; with the daemon stopped,
+    # `daemon uninstall` removes BOTH the [autoload] entry and the files (paired),
+    # and a second uninstall is an idempotent no-op success.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+    harness = tmp_path / HARNESS_RES_DIR / HARNESS_FILE
+
+    try:
+        assert run("daemon", "start").returncode == 0
+        assert harness.exists()
+        assert run("daemon", "stop").returncode == 0
+
+        first = run("daemon", "uninstall")
+        assert first.returncode == 0, first.stdout + first.stderr
+        assert json.loads(first.stdout)["removed"] is True
+        assert not harness.exists()  # files gone
+        text = (tmp_path / "project.godot").read_text(encoding="utf-8")
+        assert "GdaHarness" not in text  # autoload entry stripped
+
+        # Idempotent: a second uninstall removes nothing (no-op success).
+        again = run("daemon", "uninstall")
+        assert again.returncode == 0, again.stdout + again.stderr
+        assert json.loads(again.stdout)["removed"] is False
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_uninstall_is_refused_while_running(tmp_path, daemon_runtime_dir):
+    # #225 D2: uninstall is refused while a daemon is running — it would yank the
+    # harness autoload out from under the live engine session. The CLI surfaces the
+    # daemon_running error at the LIVE exit (6), and the install is untouched.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+    harness = tmp_path / HARNESS_RES_DIR / HARNESS_FILE
+
+    try:
+        assert run("daemon", "start").returncode == 0
+        assert harness.exists()
+
+        refused = run("daemon", "uninstall")
+        assert refused.returncode == 6, refused.stdout + refused.stderr
+        assert json.loads(refused.stdout)["error"]["code"] == "daemon_running"
+        assert harness.exists()  # refusal left the install intact
     finally:
         run("daemon", "stop")

--- a/tests/test_e2e_harness_install.py
+++ b/tests/test_e2e_harness_install.py
@@ -1,11 +1,19 @@
-"""S1 (e2e): the installed gda harness loads inert in a real engine (#7, ADR-0018).
+"""S1 (e2e): the installed gda harness loads inert in a real engine (#7, #225, ADR-0018).
 
-Per RULES.md DoD the fast install tests do not count toward this gate: this boots
-a REAL Godot on a project with the harness installed and asserts the autoload is
-valid GDScript and stays inert — no daemon launch marker, so it opens nothing and
-the engine boots clean. The daemon<->harness connection itself is a later slice.
+Per RULES.md DoD the fast install tests do not count toward this gate: these boot
+a REAL Godot on a project with the harness installed and assert the autoload is
+valid GDScript and stays inert — no daemon launch marker, so it opens no
+connection and the engine boots clean. The exact failure ADR-0018 guards (a
+dangling autoload crashing the boot, or the harness opening a connection in a
+plain run / shipped build) must NOT occur.
+
+Two boots: a plain ``--path`` run (#7, strengthened by #225), and an EXPORTED PCK
+run (#225) — the harness packed into a templateless ``.pck`` and run with no
+``gda-daemon`` marker, the shipped-build path ADR-0018 point 2 calls out.
 """
 
+import json
+import shutil
 import subprocess
 
 import pytest
@@ -26,15 +34,30 @@ GODOT = resolve_godot_binary()
 MAIN_TSCN = '[gd_scene format=3]\n\n[node name="Main" type="Node"]\n'
 PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
+# The harness only connects when a `gda-daemon` marker is present in the user args
+# (StreamPeerUDS.connect_to_host). An inert boot opens nothing, so none of these
+# connection/socket diagnostics may appear in the engine output.
+_CONNECTION_NOISE = ("StreamPeerUDS", "connect_to_host", "harness_socket", ".sock")
+
+
+def _assert_inert_boot(out: str, returncode: int) -> None:
+    assert "SCRIPT ERROR" not in out, out
+    assert "Parse Error" not in out, out
+    # Strengthened (#225): the autoload must not have opened a connection — no
+    # daemon marker, so it returns early and touches no socket.
+    for needle in _CONNECTION_NOISE:
+        assert needle not in out, f"unexpected harness connection activity: {needle}\n{out}"
+    assert returncode == 0, out
+
 
 @pytest.mark.e2e
 def test_installed_harness_boots_inert_in_a_real_engine(tmp_path):
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
 
-    changed = install_harness(tmp_path)
+    result = install_harness(tmp_path)
 
-    assert changed is True
+    assert result.changed is True
     assert (tmp_path / "addons" / "gda_harness" / "gda_harness.gd").exists()
     text = (tmp_path / "project.godot").read_text(encoding="utf-8")
     assert f'{HARNESS_AUTOLOAD_NAME}="*{HARNESS_RES_PATH}"' in text
@@ -48,7 +71,63 @@ def test_installed_harness_boots_inert_in_a_real_engine(tmp_path):
         text=True,
         timeout=60,
     )
-    out = proc.stdout + proc.stderr
-    assert "SCRIPT ERROR" not in out, out
-    assert "Parse Error" not in out, out
-    assert proc.returncode == 0, out
+    _assert_inert_boot(proc.stdout + proc.stderr, proc.returncode)
+
+
+@pytest.mark.e2e
+def test_exported_pck_with_harness_runs_inert(tmp_path):
+    # #225 / ADR-0018 point 2: the harness installed into a project must stay inert
+    # in a SHIPPED build. Pack the project (harness autoload included) into a
+    # templateless .pck via `export run --mode pack` (needs no platform templates),
+    # then RUN that .pck with no `gda-daemon` marker — the engine loads the packed
+    # autoload, which must boot clean and open nothing (the exact crash ADR-0018
+    # guards: a dangling/active autoload in an exported game).
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    install_harness(tmp_path)
+
+    # A minimal Linux preset so `export run --mode pack` has a preset to pack from
+    # (pack produces project data only; platform is immaterial, no templates used).
+    (tmp_path / "export_presets.cfg").write_text(
+        "[preset.0]\n\n"
+        'name="Pack"\n'
+        'platform="Linux/X11"\n'
+        "runnable=true\n"
+        'export_filter="all_resources"\n'
+        'include_filter=""\n'
+        'exclude_filter=""\n'
+        'export_path="build/game.x86_64"\n\n'
+        "[preset.0.options]\n\n"
+        "binary_format/embed_pck=false\n",
+        encoding="utf-8",
+    )
+    pck_rel = "dist/game.pck"
+    pck = tmp_path / pck_rel
+    pck.parent.mkdir(parents=True, exist_ok=True)
+
+    packed = subprocess.run(
+        [
+            gda, "export", "run", "--preset", "Pack",
+            "--mode", "pack", "--output", pck_rel,
+            "--project", str(tmp_path), "--godot", str(GODOT), "--json",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert packed.returncode == 0, packed.stdout + packed.stderr
+    assert json.loads(packed.stdout)["mode"] == "pack"
+    assert pck.exists(), f"expected packed .pck at {pck}"
+
+    # Run the engine against the packed .pck (the shipped-build path): the packed
+    # GdaHarness autoload must boot inert — no marker, so it opens nothing.
+    proc = subprocess.run(
+        [str(GODOT), "--headless", "--main-pack", str(pck), "--quit"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    _assert_inert_boot(proc.stdout + proc.stderr, proc.returncode)

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -23,6 +23,11 @@ LIVE_ERROR_CODES = (
     "engine_session_not_running",
     "engine_disconnected",
     "live_timeout",
+    # The harness-lifecycle refusal (#225): `daemon uninstall` is refused while a
+    # daemon is running. Same shape as the other daemon-channel LIVE codes —
+    # LIVE-category, classifier-source (the uninstall recipe emits it), exit 6,
+    # NOT GDScript-mirrored.
+    "daemon_running",
 )
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_harness_install.py
+++ b/tests/test_harness_install.py
@@ -131,6 +131,25 @@ def test_matched_version_does_not_rewrite_the_file(tmp_path):
     assert gd.stat().st_mtime_ns == before  # not rewritten
 
 
+def test_install_is_not_fooled_by_the_exact_line_outside_autoload(tmp_path):
+    # PR #247 review (round 2): the "already present" check is scoped to [autoload].
+    # The EXACT GdaHarness line sitting in another section must NOT make install
+    # think the entry exists (the old global early return did) — it still adds a
+    # real entry under [autoload].
+    project_godot = tmp_path / "project.godot"
+    project_godot.write_text(
+        f"config_version=5\n\n[decoy]\n\n{_autoload_line()}\n", encoding="utf-8"
+    )
+
+    result = install_harness(tmp_path)
+
+    assert result.changed is True
+    text = project_godot.read_text(encoding="utf-8")
+    assert "[autoload]" in text  # a real [autoload] section was added
+    # The line now appears twice: the untouched decoy + the real [autoload] entry.
+    assert text.count(_autoload_line()) == 2
+
+
 # --- Paired uninstall (#225, D2) ----------------------------------------------
 
 

--- a/tests/test_harness_install.py
+++ b/tests/test_harness_install.py
@@ -34,9 +34,11 @@ def _harness_file(project):
 def test_install_materializes_harness_and_writes_autoload_entry(tmp_path):
     (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
 
-    changed = install_harness(tmp_path)
+    result = install_harness(tmp_path)
 
-    assert changed is True
+    assert result.changed is True
+    assert result.synced is True  # the harness file was materialized
+    assert result.version == HARNESS_VERSION
     gd = tmp_path / "addons" / "gda_harness" / "gda_harness.gd"
     assert gd.exists()
     assert "extends Node" in gd.read_text(encoding="utf-8")
@@ -50,8 +52,8 @@ def test_install_materializes_harness_and_writes_autoload_entry(tmp_path):
 def test_install_is_idempotent(tmp_path):
     (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
 
-    assert install_harness(tmp_path) is True  # first install changes the project
-    assert install_harness(tmp_path) is False  # second is a no-op
+    assert install_harness(tmp_path).changed is True  # first install changes it
+    assert install_harness(tmp_path).changed is False  # second is a no-op
 
     text = (tmp_path / "project.godot").read_text(encoding="utf-8")
     assert text.count(_autoload_line()) == 1  # not duplicated
@@ -61,7 +63,7 @@ def test_install_preserves_existing_autoloads(tmp_path):
     existing = _NO_AUTOLOAD + '\n[autoload]\n\nOther="*res://other.gd"\n'
     (tmp_path / "project.godot").write_text(existing, encoding="utf-8")
 
-    assert install_harness(tmp_path) is True
+    assert install_harness(tmp_path).changed is True
 
     text = (tmp_path / "project.godot").read_text(encoding="utf-8")
     assert 'Other="*res://other.gd"' in text  # sibling autoload preserved
@@ -96,8 +98,8 @@ def test_version_mismatch_re_materializes(tmp_path, monkeypatch):
     # the change. The mismatch falls out of the existing content-compare, not a
     # separate branch.
     (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
-    assert install_harness(tmp_path) is True  # first install at current version
-    assert install_harness(tmp_path) is False  # idempotent at the same version
+    assert install_harness(tmp_path).changed is True  # first install
+    assert install_harness(tmp_path).changed is False  # idempotent same version
 
     # Simulate a previously-installed copy at an older version by rewriting only
     # the header to a stale value (the on-disk version no longer matches).
@@ -107,9 +109,11 @@ def test_version_mismatch_re_materializes(tmp_path, monkeypatch):
     gd.write_text("\n".join(lines) + "\n", encoding="utf-8")
     assert installed_harness_version(tmp_path) == "stale-old"
 
-    assert install_harness(tmp_path) is True  # version mismatch -> re-materialize
+    resynced = install_harness(tmp_path)  # version mismatch -> re-materialize
+    assert resynced.changed is True
+    assert resynced.synced is True  # the re-materialize is a real sync
     assert installed_harness_version(tmp_path) == HARNESS_VERSION  # synced
-    assert install_harness(tmp_path) is False  # idempotent again
+    assert install_harness(tmp_path).changed is False  # idempotent again
 
 
 def test_matched_version_does_not_rewrite_the_file(tmp_path):
@@ -121,7 +125,9 @@ def test_matched_version_does_not_rewrite_the_file(tmp_path):
     gd = _harness_file(tmp_path)
     before = gd.stat().st_mtime_ns
 
-    assert install_harness(tmp_path) is False
+    result = install_harness(tmp_path)
+    assert result.changed is False
+    assert result.synced is False  # nothing re-materialized
     assert gd.stat().st_mtime_ns == before  # not rewritten
 
 
@@ -133,9 +139,9 @@ def test_uninstall_removes_both_autoload_and_files(tmp_path):
     install_harness(tmp_path)
     assert _harness_file(tmp_path).exists()
 
-    removed = uninstall_harness(tmp_path)
+    result = uninstall_harness(tmp_path)
 
-    assert removed is True
+    assert result.removed is True
     text = (tmp_path / "project.godot").read_text(encoding="utf-8")
     assert _autoload_line() not in text  # autoload entry stripped
     assert HARNESS_AUTOLOAD_NAME not in text  # no dangling GdaHarness= line
@@ -184,9 +190,9 @@ def test_uninstall_is_idempotent_when_not_installed(tmp_path):
     # Uninstall when nothing is installed is a no-op success (mirrors daemon stop).
     (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
 
-    assert uninstall_harness(tmp_path) is False  # nothing to remove
+    assert uninstall_harness(tmp_path).removed is False  # nothing to remove
 
     # And a second uninstall after a real one is also a no-op.
     install_harness(tmp_path)
-    assert uninstall_harness(tmp_path) is True
-    assert uninstall_harness(tmp_path) is False
+    assert uninstall_harness(tmp_path).removed is True
+    assert uninstall_harness(tmp_path).removed is False

--- a/tests/test_harness_install.py
+++ b/tests/test_harness_install.py
@@ -37,7 +37,7 @@ def test_install_materializes_harness_and_writes_autoload_entry(tmp_path):
     result = install_harness(tmp_path)
 
     assert result.changed is True
-    assert result.synced is True  # the harness file was materialized
+    assert result.synced is False  # a first install is NOT a resync (#247 review)
     assert result.version == HARNESS_VERSION
     gd = tmp_path / "addons" / "gda_harness" / "gda_harness.gd"
     assert gd.exists()
@@ -147,6 +147,26 @@ def test_uninstall_removes_both_autoload_and_files(tmp_path):
     assert HARNESS_AUTOLOAD_NAME not in text  # no dangling GdaHarness= line
     assert not _harness_file(tmp_path).exists()  # files deleted
     assert not (tmp_path / HARNESS_RES_DIR).exists()  # the addon dir too
+
+
+def test_uninstall_scopes_removal_to_the_autoload_section(tmp_path):
+    # PR #247 review: uninstall must strip the GdaHarness row from [autoload] ONLY,
+    # never a same-named key in another section of project.godot.
+    project_godot = tmp_path / "project.godot"
+    project_godot.write_text(_NO_AUTOLOAD, encoding="utf-8")
+    install_harness(tmp_path)  # writes the real autoload entry into [autoload]
+    # Inject a same-named decoy key in an unrelated section.
+    project_godot.write_text(
+        '[some_plugin]\n\nGdaHarness="keep-me"\n\n'
+        + project_godot.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    uninstall_harness(tmp_path)
+
+    text = project_godot.read_text(encoding="utf-8")
+    assert 'GdaHarness="keep-me"' in text  # the unrelated section key is untouched
+    assert _autoload_line() not in text  # the [autoload] entry is gone
 
 
 def test_uninstall_removes_autoload_before_files(tmp_path, monkeypatch):

--- a/tests/test_harness_install.py
+++ b/tests/test_harness_install.py
@@ -1,14 +1,23 @@
-"""gda harness install (#7, ADR-0018): idempotent project.godot autoload write.
+"""gda harness install (#7, #225, ADR-0018): idempotent project.godot autoload write.
 
 Pure filesystem: materialize the bundled harness under ``res://addons/`` and add
 its ``[autoload]`` entry to ``project.godot`` — a one-time, install-time write
-(never a per-launch mutation), idempotent and order-preserving.
+(never a per-launch mutation), idempotent and order-preserving. #225 adds the
+version self-sync (a leading ``# gda-harness-version: <N>`` header on the
+materialized file, riding the existing content-compare so re-materialize happens
+only on a version mismatch) and the paired uninstall (autoload entry removed
+first, then the files — crash-safe ordering, ADR-0018).
 """
 
 from gda.harness.install import (
     HARNESS_AUTOLOAD_NAME,
+    HARNESS_FILE,
+    HARNESS_RES_DIR,
     HARNESS_RES_PATH,
+    HARNESS_VERSION,
     install_harness,
+    installed_harness_version,
+    uninstall_harness,
 )
 
 _NO_AUTOLOAD = 'config_version=5\n\n[application]\n\nconfig/name="t"\n'
@@ -16,6 +25,10 @@ _NO_AUTOLOAD = 'config_version=5\n\n[application]\n\nconfig/name="t"\n'
 
 def _autoload_line() -> str:
     return f'{HARNESS_AUTOLOAD_NAME}="*{HARNESS_RES_PATH}"'
+
+
+def _harness_file(project):
+    return project / HARNESS_RES_DIR / HARNESS_FILE
 
 
 def test_install_materializes_harness_and_writes_autoload_entry(tmp_path):
@@ -54,3 +67,126 @@ def test_install_preserves_existing_autoloads(tmp_path):
     assert 'Other="*res://other.gd"' in text  # sibling autoload preserved
     assert _autoload_line() in text  # harness added
     assert text.count("[autoload]") == 1  # no duplicate section
+
+
+# --- Version self-sync (#225, D1) ---------------------------------------------
+
+
+def test_materialized_harness_carries_the_version_header(tmp_path):
+    # _materialize prepends a `# gda-harness-version: <N>` comment header so the
+    # installed copy declares its version on disk; installed_harness_version reads
+    # it back. The header is sourced from HARNESS_VERSION, NOT the package version.
+    (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
+
+    install_harness(tmp_path)
+
+    head = _harness_file(tmp_path).read_text(encoding="utf-8").splitlines()[0]
+    assert head == f"# gda-harness-version: {HARNESS_VERSION}"
+    assert installed_harness_version(tmp_path) == HARNESS_VERSION
+
+
+def test_installed_harness_version_is_none_when_absent(tmp_path):
+    # No installed harness file -> no installed version (a clean project).
+    assert installed_harness_version(tmp_path) is None
+
+
+def test_version_mismatch_re_materializes(tmp_path, monkeypatch):
+    # The installed copy declares an OLD version: install must re-materialize so the
+    # version header (and body) self-sync to the running HARNESS_VERSION, and report
+    # the change. The mismatch falls out of the existing content-compare, not a
+    # separate branch.
+    (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
+    assert install_harness(tmp_path) is True  # first install at current version
+    assert install_harness(tmp_path) is False  # idempotent at the same version
+
+    # Simulate a previously-installed copy at an older version by rewriting only
+    # the header to a stale value (the on-disk version no longer matches).
+    gd = _harness_file(tmp_path)
+    lines = gd.read_text(encoding="utf-8").splitlines()
+    lines[0] = "# gda-harness-version: stale-old"
+    gd.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    assert installed_harness_version(tmp_path) == "stale-old"
+
+    assert install_harness(tmp_path) is True  # version mismatch -> re-materialize
+    assert installed_harness_version(tmp_path) == HARNESS_VERSION  # synced
+    assert install_harness(tmp_path) is False  # idempotent again
+
+
+def test_matched_version_does_not_rewrite_the_file(tmp_path):
+    # When the installed version matches, _materialize must NOT touch the file —
+    # an unconditional overwrite would bump its mtime and trip the concurrent-editor
+    # prompt (ADR-0018). Assert the file's mtime is unchanged across a no-op install.
+    (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
+    install_harness(tmp_path)
+    gd = _harness_file(tmp_path)
+    before = gd.stat().st_mtime_ns
+
+    assert install_harness(tmp_path) is False
+    assert gd.stat().st_mtime_ns == before  # not rewritten
+
+
+# --- Paired uninstall (#225, D2) ----------------------------------------------
+
+
+def test_uninstall_removes_both_autoload_and_files(tmp_path):
+    (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
+    install_harness(tmp_path)
+    assert _harness_file(tmp_path).exists()
+
+    removed = uninstall_harness(tmp_path)
+
+    assert removed is True
+    text = (tmp_path / "project.godot").read_text(encoding="utf-8")
+    assert _autoload_line() not in text  # autoload entry stripped
+    assert HARNESS_AUTOLOAD_NAME not in text  # no dangling GdaHarness= line
+    assert not _harness_file(tmp_path).exists()  # files deleted
+    assert not (tmp_path / HARNESS_RES_DIR).exists()  # the addon dir too
+
+
+def test_uninstall_removes_autoload_before_files(tmp_path, monkeypatch):
+    # Crash-safe ordering (ADR-0018, D2): the [autoload] entry must be stripped
+    # FIRST, then the files — so a mid-failure leaves only a harmless stray inert
+    # .gd, never a dangling autoload pointing at a missing script (which crashes an
+    # exported game). Force the file-delete step to blow up and assert the autoload
+    # was already gone.
+    (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
+    install_harness(tmp_path)
+
+    import gda.harness.install as install_mod
+
+    def boom(_project):
+        raise RuntimeError("file deletion failed mid-uninstall")
+
+    monkeypatch.setattr(install_mod, "_remove_files", boom)
+
+    try:
+        uninstall_harness(tmp_path)
+    except RuntimeError:
+        pass  # the file-delete step failed, as injected
+
+    text = (tmp_path / "project.godot").read_text(encoding="utf-8")
+    assert _autoload_line() not in text  # autoload removed BEFORE the files
+
+
+def test_uninstall_preserves_sibling_autoloads(tmp_path):
+    existing = _NO_AUTOLOAD + '\n[autoload]\n\nOther="*res://other.gd"\n'
+    (tmp_path / "project.godot").write_text(existing, encoding="utf-8")
+    install_harness(tmp_path)
+
+    uninstall_harness(tmp_path)
+
+    text = (tmp_path / "project.godot").read_text(encoding="utf-8")
+    assert _autoload_line() not in text  # harness entry gone
+    assert 'Other="*res://other.gd"' in text  # sibling preserved
+
+
+def test_uninstall_is_idempotent_when_not_installed(tmp_path):
+    # Uninstall when nothing is installed is a no-op success (mirrors daemon stop).
+    (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
+
+    assert uninstall_harness(tmp_path) is False  # nothing to remove
+
+    # And a second uninstall after a real one is also a no-op.
+    install_harness(tmp_path)
+    assert uninstall_harness(tmp_path) is True
+    assert uninstall_harness(tmp_path) is False

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -11,6 +11,8 @@ import pytest
 
 from gda import render as render_mod
 from gda.models import (
+    DaemonStartResult,
+    DaemonUninstallResult,
     EngineVersion,
     GameGetResult,
     GameSetResult,
@@ -203,6 +205,30 @@ def test_render_perf_monitor_signal_renders_recorded_emissions():
     assert render(result) == (
         "/root/Main/Player signal hit (2 frames)\n  frame 1: [42]"
     )
+
+
+def test_render_daemon_start_surfaces_a_version_sync(tmp_path):
+    # #225: a real version-mismatch re-materialize is surfaced as a sync to the
+    # installed version (distinct from merely adding the autoload entry).
+    synced = DaemonStartResult(
+        pid=42,
+        socket_path="/tmp/x.sock",
+        installed_harness=True,
+        harness_synced=True,
+        harness_version="3",
+        already_running=False,
+    )
+    assert render(synced) == "daemon started: pid 42 on /tmp/x.sock (synced harness to v3)"
+
+    # A first install (changed but not a version-mismatch resync) reads as install.
+    installed = synced.model_copy(update={"harness_synced": False})
+    assert render(installed) == "daemon started: pid 42 on /tmp/x.sock (installed harness)"
+
+
+def test_render_daemon_uninstall_reports_removal(tmp_path):
+    # #225: uninstall renders the paired removal, with the idempotent no-op form.
+    assert render(DaemonUninstallResult(removed=True)) == "harness uninstalled"
+    assert render(DaemonUninstallResult(removed=False)) == "no harness was installed"
 
 
 def test_render_is_keyed_by_result_type():


### PR DESCRIPTION
## Summary

Completes the gda harness lifecycle beyond #7's minimal install (ADR-0018):
- **Version self-sync** — `gda daemon start` re-materializes the installed harness when its version differs from the running `gda`, and reports it, so an agent never hits a stale-harness mismatch.
- **Paired uninstall** — `gda daemon uninstall` removes the `[autoload]` entry and the harness files together (a dangling autoload crashes an exported game).
- **Inertness** — verified the runtime gate keeps the harness resident-inert in a plain run and an exported build.

Closes #225.

## Design

**Version source = `HARNESS_VERSION` const, not the package version** (the harness changes far less often than `gda` ships). `_materialize()` prepends a `# gda-harness-version: <N>` header; because the header rides the existing idempotent content-compare, version self-sync **falls out of the existing compare** — re-materialize happens only on a version/body mismatch (no unconditional overwrite → no mtime bump that would trip the concurrent-editor prompt). Reported via two **additive** `DaemonStartResult` fields: `harness_synced` (true only on a real re-materialize) and `harness_version`.

**Uninstall is crash-safe** — strip the `[autoload]` entry first (atomic `write_text`), then delete files, so a mid-failure leaves only a harmless stray inert `.gd`, never a dangling autoload. Refused while a daemon is running (new `daemon_running` code, exit 6); idempotent no-op when not installed.

## ABI

- `daemon start` payload gains `harness_synced: bool` + `harness_version: str` (existing `installed_harness` / `already_running` unchanged).
- `daemon uninstall` → `DaemonUninstallResult{removed: bool}`; refused-while-running → `daemon_running` `GdaError` (category `live`, exit 6).
- **API note for #222's rebase:** `install_harness()` now returns `HarnessInstall` (was `bool`); direct callers updated to use `.changed`/`.synced`.

## Tests

`uv run pytest -m "not e2e"` → **800 passed** (+20; independently re-run by the reviewer). e2e → **7 passed** against real Godot 4.6.3 (run serially): start re-sync after a version bump, install→uninstall (paired/atomic/idempotent), uninstall-refused-while-running, strengthened plain-run inert boot (asserts no socket activity), and a new exported-PCK inert boot (`export run --mode pack` → run with no `gda-daemon` marker → clean inert boot — the exact failure ADR-0018 guards).

## Follow-up at merge

ADR-0018 outcome note recording the realized lifecycle (version self-sync + paired uninstall + inertness verification) to be appended when this lands. The `daemon_running` error-table row is already in ADR-0002 (kept in sync with `error_codes.py`).
