### PR TITLE
feat: screen — runtime viewport capture of the running game (#222)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -148,6 +148,7 @@ operation, and parse codes the CLI assigns).
 | `live_invalid_key` | `live` | `classifier` | `6` | A live input key event named a key the engine could not resolve to a keycode (Phase 2, #221). |
 | `live_unknown_action` | `live` | `classifier` | `6` | A live input action targeted an action the running game's InputMap does not declare (Phase 2, #221). |
 | `live_invalid_event_spec` | `live` | `classifier` | `6` | A live input sequence event has a type the harness does not recognize (Phase 2, #221). |
+| `live_display_unavailable` | `live` | `classifier` | `6` | A live `screen` capture ran on a headless engine session (the dummy DisplayServer cannot read pixels); start the daemon windowed with `gda daemon start --windowed` (Phase 2, #222). |
 | `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
 
 ## Considered options

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -64,6 +64,20 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > stalled-engine guard. The base is general: #222's viewport capture reuses it by
 > supplying its own sampler/finalizer, with no `_process` change.
 
+> **Outcome (2026-06-22, #222 / PR #248) — the windowed session is a start-time
+> declared mode, refining the #7 note above.** #222 adds `screen capture` / `screen
+> frames` (viewport capture), the first ops needing a real `DisplayServer`. The #7 note
+> anticipated the daemon "switches to a windowed session when the first capturing op
+> lands"; #222 does **not** switch mid-session. A relaunch would discard the session's
+> accumulated runtime state and silently re-run autoloads, breaking ADR-0020's
+> session-bound consistency and this ADR's "deliberate, declared effect". Instead the
+> display mode is declared once at `gda daemon start --windowed`; the `--headless`
+> session stays the cheap default (decision 2's "windowed by default" becomes an
+> explicit per-session opt-in), and a capture op on a headless session fails with the
+> typed `live_display_unavailable` naming the remediation. The capture handlers reuse
+> the #223 time-windowed base — a 1-frame window for a single shot, an N-frame window
+> for a sequence — so the one-shot RPC contract holds.
+
 ## Decision
 
 **1. An execution-channel selector, chosen per command by a static `kind`.**

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -146,6 +146,10 @@ from gda.models import (
     ResourceUidParams,
     ResourceUidResult,
     SchemaAllParams,
+    ScreenCaptureParams,
+    ScreenCaptureResult,
+    ScreenFramesParams,
+    ScreenFramesResult,
     SceneCreateParams,
     SceneCreateResult,
     SceneDeleteParams,
@@ -185,6 +189,10 @@ from gda.models import (
 )
 from gda.project import resolve_project_dir
 from gda.runner import GodotRunner
+from gda.screen_ops import (
+    run_screen_capture_operation,
+    run_screen_frames_operation,
+)
 from gda.surface import build_surface_manifest
 
 app = typer.Typer(
@@ -314,6 +322,17 @@ input_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(input_app, name="input")
+
+# The screen command group (Phase 2, ADR-0019): the running game's VIEWPORT is the
+# domain object (not under `game`, whose object is the runtime scene graph). Both
+# commands are LIVE (kind = LIVE), routed through gda-daemon to a WINDOWED engine
+# session (`gda daemon start --windowed`); on a headless session a capture is the
+# typed `live_display_unavailable` (#222).
+screen_app = typer.Typer(
+    help="Capture the running game's viewport (live; macOS/Linux only, windowed session).",
+    no_args_is_help=True,
+)
+app.add_typer(screen_app, name="screen")
 
 # The daemon command group (Phase 2, ADR-0017): gda's own per-project daemon
 # lifecycle — a deliberate extension of ADR-0005's domain-object grouping to an
@@ -496,10 +515,40 @@ def _run_params_json(
     if cmd in _DAEMON_COMMANDS:
         # daemon lifecycle commands run their process recipe (gda.daemon_ops),
         # not the sentinel pipeline; route --params-json to the SAME recipe the
-        # argv body uses (their params are empty, so nothing else is needed).
+        # argv body uses. `daemon start` carries the `windowed` mode in its params
+        # model (#222); the other lifecycle commands have empty params.
         _daemon_dispatch(
-            cmd, json_output=json_output, godot=godot, project=options.get("project")
+            cmd,
+            json_output=json_output,
+            godot=godot,
+            project=options.get("project"),
+            windowed=bool(getattr(params, "windowed", False)),
         )
+        return
+    if cmd in _SCREEN_COMMANDS:
+        # screen commands run the gda.screen_ops recipe, not the sentinel pipeline;
+        # route --params-json to the SAME recipe the argv body uses. The output
+        # path(s) are now part of the params model (#222, PR #248 review), so they
+        # come from `params` — the single source of truth (ADR-0015), supplied
+        # entirely by the JSON object, never recovered from ctx.params.
+        resolved = resolve_project_dir(options.get("project"))
+        if cmd is SCREEN_CAPTURE_COMMAND:
+            outcome = run_screen_capture_operation(
+                resolved,
+                Path(params.output),
+                inline=params.inline,
+                make_runner=_make_live_runner,
+            )
+        else:
+            outcome = run_screen_frames_operation(
+                resolved,
+                params.frames,
+                Path(params.output_dir),
+                make_runner=_make_live_runner,
+            )
+        if isinstance(outcome, Failure):
+            emit_failure(outcome)
+        emit_result(outcome, json_output)
         return
     if "project" in options:
         _dispatch(
@@ -1126,11 +1175,14 @@ def _daemon_dispatch(
     json_output: bool,
     godot: Optional[str],
     project: Optional[str],
+    windowed: bool = False,
 ) -> None:
     """Run a ``daemon`` lifecycle command through its process-management recipe."""
     resolved = resolve_project_dir(project)
     if cmd is DAEMON_START_COMMAND:
-        outcome = run_daemon_start_operation(resolved, godot)
+        # `daemon start --windowed` declares the engine session's display mode at
+        # launch (#222); other lifecycle commands ignore it.
+        outcome = run_daemon_start_operation(resolved, godot, windowed=windowed)
     elif cmd is DAEMON_STOP_COMMAND:
         outcome = run_daemon_stop_operation(resolved)
     elif cmd is DAEMON_UNINSTALL_COMMAND:
@@ -1144,6 +1196,15 @@ def _daemon_dispatch(
 
 @daemon_app.command(name="start", cls=DAEMON_START_COMMAND.command_class())
 def daemon_start(
+    windowed: bool = typer.Option(
+        False,
+        "--windowed",
+        help=(
+            "Launch the engine session windowed (no --headless) so `screen` capture "
+            "ops have a display; default headless. Needs a display/Xvfb on a "
+            "headless host (#222)."
+        ),
+    ),
     json_output: bool = json_option(),
     schema: bool = DAEMON_START_COMMAND.schema_option(),
     params_json: Optional[str] = params_json_option(),
@@ -1156,10 +1217,15 @@ def daemon_start(
     idempotent harness install (ADR-0018). Never auto-spawned by a live call —
     launching the engine is a deliberate, declared effect (ADR-0017). The
     platform/Godot-version precondition is the structured `constraints` field of
-    `--schema` (ADR-0021), not restated here.
+    `--schema` (ADR-0021), not restated here. `--windowed` is a start-time declared
+    mode for the engine session a `screen` capture op needs (#222).
     """
     _daemon_dispatch(
-        DAEMON_START_COMMAND, json_output=json_output, godot=godot, project=project
+        DAEMON_START_COMMAND,
+        json_output=json_output,
+        godot=godot,
+        project=project,
+        windowed=windowed,
     )
 
 
@@ -1219,6 +1285,120 @@ def daemon_uninstall(
     _daemon_dispatch(
         DAEMON_UNINSTALL_COMMAND, json_output=json_output, godot=godot, project=project
     )
+
+
+# The `screen` commands are LIVE but run a CLI-side recipe (gda.screen_ops), not
+# the sentinel pipeline: the harness returns the PNG as base64 in the sentinel and
+# the CLI must DECODE + WRITE a file before it has the path-based public result. So
+# — like `export run` and the daemon lifecycle commands — each carries a descriptor
+# for its --schema/--params-json wiring (kind = LIVE makes "kind":"live" appear,
+# #230) but dispatches through its recipe. They are selected by command identity in
+# the --params-json path, the same as the daemon commands.
+SCREEN_CAPTURE_COMMAND: HeadlessCommand[ScreenCaptureResult] = HeadlessCommand(
+    operation="screen-capture",
+    input_model=ScreenCaptureParams,
+    output_model=ScreenCaptureResult,
+    kind=ExecutionKind.LIVE,
+)
+
+SCREEN_FRAMES_COMMAND: HeadlessCommand[ScreenFramesResult] = HeadlessCommand(
+    operation="screen-frames",
+    input_model=ScreenFramesParams,
+    output_model=ScreenFramesResult,
+    kind=ExecutionKind.LIVE,
+)
+
+_SCREEN_COMMANDS = frozenset({SCREEN_CAPTURE_COMMAND, SCREEN_FRAMES_COMMAND})
+
+
+@screen_app.command(name="capture", cls=SCREEN_CAPTURE_COMMAND.command_class())
+def screen_capture(
+    output: Path = typer.Option(
+        ...,
+        "--output",
+        "-o",
+        help="The file path to write the captured PNG frame to.",
+    ),
+    inline: bool = typer.Option(
+        False,
+        "--inline",
+        help="Also embed the base64-encoded PNG in the result (default: path only).",
+    ),
+    json_output: bool = json_option(),
+    schema: bool = SCREEN_CAPTURE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Capture a single frame of the running game's viewport (live).
+
+    Routes through gda-daemon to the engine session (kind = LIVE, ADR-0017): the
+    harness reads the viewport texture, PNG-encodes it, and returns it base64 in the
+    sentinel; the CLI decodes it and WRITES the PNG to `--output`, returning the path
+    + dims + bytes + format. `--inline` also embeds the base64. Needs a WINDOWED
+    session (`gda daemon start --windowed`); a headless one is
+    `live_display_unavailable`. With no daemon it reports `daemon_not_running`.
+    """
+    # Build the params model from the argv options so `output` is validated and
+    # ~-normalized through the SAME single source of truth the --params-json path
+    # uses (ADR-0015/ADR-0006) — not a raw, un-normalized Path.
+    params = ScreenCaptureParams(output=str(output), inline=inline)
+    outcome = run_screen_capture_operation(
+        resolve_project_dir(project),
+        Path(params.output),
+        inline=params.inline,
+        make_runner=_make_live_runner,
+    )
+    if isinstance(outcome, Failure):
+        emit_failure(outcome)
+    emit_result(outcome, json_output)
+
+
+@screen_app.command(name="frames", cls=SCREEN_FRAMES_COMMAND.command_class())
+def screen_frames(
+    frames: int = typer.Option(
+        2,
+        "--frames",
+        min=1,
+        max=MAX_WINDOW_FRAMES,
+        help=(
+            f"The number of viewport frames to capture, 1..{MAX_WINDOW_FRAMES} (the "
+            "gda harness's per-window ceiling)."
+        ),
+    ),
+    output_dir: Path = typer.Option(
+        ...,
+        "--output-dir",
+        "-d",
+        help="The directory to write the captured PNG frames into (frame_NNNN.png).",
+    ),
+    json_output: bool = json_option(),
+    schema: bool = SCREEN_FRAMES_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Capture a window of viewport frames in one blocking call (live, time-windowed).
+
+    Routes through gda-daemon to the engine session (kind = LIVE, ADR-0017) and
+    collects one frame per frame boundary over `--frames` frames, returned as one
+    blocking payload (ADR-0017 one-shot RPC, ADR-0020 multi-frame). Each frame's PNG
+    is written into `--output-dir` (path-only — an N-frame base64 sequence would blow
+    the agent's context). Needs a WINDOWED session; a headless one is
+    `live_display_unavailable`. With no daemon it reports `daemon_not_running`.
+    """
+    # Same params model the --params-json path builds (ADR-0015): `output_dir` is
+    # validated and ~-normalized through it, not passed as a raw Path.
+    params = ScreenFramesParams(frames=frames, output_dir=str(output_dir))
+    outcome = run_screen_frames_operation(
+        resolve_project_dir(project),
+        params.frames,
+        Path(params.output_dir),
+        make_runner=_make_live_runner,
+    )
+    if isinstance(outcome, Failure):
+        emit_failure(outcome)
+    emit_result(outcome, json_output)
 
 
 SCENE_CREATE_COMMAND: HeadlessCommand[SceneCreateResult] = HeadlessCommand(

--- a/src/gda/daemon/__main__.py
+++ b/src/gda/daemon/__main__.py
@@ -19,10 +19,15 @@ def main() -> None:
     parser.add_argument(
         "--godot", default="", help="The resolved Godot binary for engine sessions."
     )
+    parser.add_argument(
+        "--windowed",
+        action="store_true",
+        help="Launch engine sessions windowed (no --headless), for `screen` capture (#222).",
+    )
     args = parser.parse_args()
 
     paths = daemon_paths(Path(args.project))
-    DaemonServer(paths, godot=args.godot).serve()
+    DaemonServer(paths, godot=args.godot, windowed=args.windowed).serve()
 
 
 if __name__ == "__main__":

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -37,9 +37,14 @@ DIAG_OPS = (DIAG_ERRORS_OP, DIAG_LOG_OP)
 class DaemonServer:
     """Binds the per-project sockets and serves requests until stopped."""
 
-    def __init__(self, paths: DaemonPaths, godot: str = "") -> None:
+    def __init__(self, paths: DaemonPaths, godot: str = "", windowed: bool = False) -> None:
         self.paths = paths
         self.godot = godot
+        # The start-time declared display mode (ADR-0017 refined, #222): when true the
+        # engine session is launched windowed (no --headless) so a `screen` capture op
+        # has a real DisplayServer; fixed for the daemon's life (ADR-0020 single
+        # session), never switched mid-session.
+        self.windowed = windowed
         self._token = secrets.token_hex(16)
         self._stopping = False
         self._listener: socket.socket | None = None
@@ -175,6 +180,7 @@ class DaemonServer:
             self.paths.harness_socket,
             self._token,
             log_file=self._session_log_path(),
+            windowed=self.windowed,
         )
         return self._session
 

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -89,8 +89,16 @@ def launch_session(
     token: str,
     log_file: Optional[Path] = None,
     timeout: float = CONNECT_TIMEOUT,
+    windowed: bool = False,
 ) -> Optional[EngineSession]:
-    """Launch a headless engine session and wait for the harness to connect.
+    """Launch an engine session and wait for the harness to connect.
+
+    The session is ``--headless`` by default — the cheap non-visual sessions
+    (``game tree``, ``perf``, ``diag``) need no viewport. When ``windowed`` is set
+    (``gda daemon start --windowed``, #222) ``--headless`` is OMITTED so the session
+    runs with a real ``DisplayServer`` whose viewport a ``screen`` capture op can
+    read pixels from; ``--headless``'s dummy ``DisplayServer`` cannot (ADR-0017).
+    The mode is start-time declared and fixed for the session's life (ADR-0020).
 
     When ``log_file`` is given, the engine is launched with Godot's
     ``--log-file <abs path>`` so the session writes BOTH its output and its errors
@@ -102,10 +110,11 @@ def launch_session(
     via-daemon-owned-session-log). The session still relays live ops to the harness.
     """
     log_args = ["--log-file", str(log_file)] if log_file is not None else []
+    headless_args = [] if windowed else ["--headless"]
     proc = subprocess.Popen(
         [
             str(binary),
-            "--headless",
+            *headless_args,
             *log_args,
             "--path",
             str(project),

--- a/src/gda/daemon_ops.py
+++ b/src/gda/daemon_ops.py
@@ -54,7 +54,7 @@ _POLL = 0.05
 _VERSION_RE = re.compile(r"(\d+)\.(\d+)")
 
 # Seams tests override to avoid launching a real process / running the engine.
-SpawnDaemon = Callable[[Path, str], None]
+SpawnDaemon = Callable[[Path, str, bool], None]
 VersionCheck = Callable[[str], Optional[tuple]]
 
 
@@ -77,8 +77,13 @@ def _engine_version(binary: str) -> Optional[tuple]:
     return (int(match.group(1)), int(match.group(2))) if match else None
 
 
-def _spawn_daemon(project: Path, binary: str) -> None:
-    """Spawn the detached, per-project daemon (its own session, no std streams)."""
+def _spawn_daemon(project: Path, binary: str, windowed: bool) -> None:
+    """Spawn the detached, per-project daemon (its own session, no std streams).
+
+    ``windowed`` is forwarded as ``--windowed`` so the daemon launches its engine
+    session with a real ``DisplayServer`` (no ``--headless``) — the start-time
+    declared display mode a ``screen`` capture op needs (ADR-0017 refined, #222).
+    """
     subprocess.Popen(
         [
             sys.executable,
@@ -88,6 +93,7 @@ def _spawn_daemon(project: Path, binary: str) -> None:
             str(project),
             "--godot",
             str(binary),
+            *(["--windowed"] if windowed else []),
         ],
         start_new_session=True,
         stdin=subprocess.DEVNULL,
@@ -138,6 +144,7 @@ def run_daemon_start_operation(
     project: Optional[Path],
     godot: Optional[str],
     *,
+    windowed: bool = False,
     spawn: Optional[SpawnDaemon] = None,
     version_check: Optional[VersionCheck] = None,
 ) -> "DaemonStartResult | Failure":
@@ -183,6 +190,11 @@ def run_daemon_start_operation(
             installed_harness=installed.changed,
             harness_synced=installed.synced,
             harness_version=installed.version,
+            # An idempotent start does not relaunch the session and cannot re-derive
+            # the running daemon's display mode from the pidfile, so report `None`
+            # ("not determined here") rather than a misleading `False` — a daemon
+            # launched windowed would otherwise read as headless (#222, PR #248 review).
+            windowed=None,
             already_running=True,
         )
 
@@ -204,7 +216,7 @@ def run_daemon_start_operation(
         )
 
     installed = install_harness(project)
-    (spawn or _spawn_daemon)(project, str(binary))
+    (spawn or _spawn_daemon)(project, str(binary), windowed)
     pid = _await_ready(paths)
     if pid is None:
         return _failure(
@@ -218,6 +230,7 @@ def run_daemon_start_operation(
         installed_harness=installed.changed,
         harness_synced=installed.synced,
         harness_version=installed.version,
+        windowed=windowed,
         already_running=False,
     )
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -555,6 +555,22 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCodeSource.CLASSIFIER,
         "A live input sequence event has a type the harness does not recognize.",
     ),
+    # The `screen` capture failure the gda harness reports for #222. Same shape as
+    # the other per-op LIVE codes (LIVE-category, classifier-source, exit_code
+    # EXIT_LIVE, harness-mirrored): a viewport capture needs a real DisplayServer,
+    # which the dummy headless one is not — so a screen op on a session NOT started
+    # `gda daemon start --windowed` reports this, the self-revealing remediation
+    # (start the daemon windowed). The harness guards on
+    # `DisplayServer.get_name() == "headless"` before touching the viewport.
+    ErrorCodeSpec(
+        "live_display_unavailable",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A live screen capture ran on a headless engine session (the dummy "
+        "DisplayServer cannot read pixels); start the daemon with `gda daemon start "
+        "--windowed`.",
+    ),
     # A pre-launch platform precondition, not a live-runtime failure: live needs
     # Unix domain sockets, which are UNIX-only, so it is an ENVIRONMENT-category
     # code in the binary_not_found bucket (ADR-0021), decided before any engine

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -31,6 +31,8 @@ const OP_INPUT_MOUSE_CLICK := "input-mouse-click"
 const OP_INPUT_MOUSE_MOVE := "input-mouse-move"
 const OP_INPUT_ACTION := "input-action"
 const OP_INPUT_SEQUENCE := "input-sequence"
+const OP_SCREEN_CAPTURE := "screen-capture"
+const OP_SCREEN_FRAMES := "screen-frames"
 
 # The per-op LIVE failure codes the harness reports in-band (#220, #223). Each MUST
 # be a registered LIVE-category code (src/gda/error_codes.py) so the daemon's exit-0
@@ -45,6 +47,7 @@ const LIVE_ERROR_PERF_SIGNAL_NOT_FOUND := "live_perf_signal_not_found"
 const LIVE_ERROR_INVALID_KEY := "live_invalid_key"
 const LIVE_ERROR_UNKNOWN_ACTION := "live_unknown_action"
 const LIVE_ERROR_INVALID_EVENT_SPEC := "live_invalid_event_spec"
+const LIVE_ERROR_DISPLAY_UNAVAILABLE := "live_display_unavailable"
 
 # The frame count a time-windowed op may request (#223). A window collects one
 # sample per frame, so an unbounded N would block the one-shot RPC for an unbounded
@@ -229,6 +232,10 @@ func _run(request) -> Variant:
 			return _handle_input_action(params)
 		OP_INPUT_SEQUENCE:
 			return _handle_input_sequence(params)
+		OP_SCREEN_CAPTURE:
+			return _handle_screen_capture(params)
+		OP_SCREEN_FRAMES:
+			return _handle_screen_frames(params)
 		_:
 			return _error("operation_failed", "unsupported live operation")
 
@@ -714,6 +721,104 @@ func _apply_sequence_event(event: Dictionary) -> Variant:
 		_:
 			return {"code": LIVE_ERROR_INVALID_EVENT_SPEC,
 					"message": "unsupported input sequence event type: " + type}
+
+
+# --- screen (runtime viewport capture, #222) ----------------------------------
+#
+# Capture the running game's VIEWPORT over the LIVE channel: read the viewport's
+# rendered texture as an Image, PNG-encode it, and base64 the PNG into the ADR-0002
+# sentinel reply (a UTF-8-safe wire). The CLI decodes it and writes the file.
+#
+# Display guard: a viewport capture needs a real DisplayServer to have rendered
+# pixels. Under `--headless` Godot uses the dummy "headless" DisplayServer whose
+# texture is empty, so a capture there is the typed `live_display_unavailable`
+# (start the daemon `--windowed`). Checked up front, before opening any window.
+#
+# GPU-framebuffer timing: `get_viewport().get_texture().get_image()` reads the
+# texture for the LAST rendered frame, which can be empty if read before the first
+# real frame has rendered (the harness's _ready runs before the main scene is even
+# instantiated). Both ops therefore capture INSIDE a window tick — reusing the #223
+# time-windowed base — so the sample runs on a _process frame boundary AFTER the
+# scene is up (the _process loop only dispatches once current_scene != null), by
+# which point a frame has rendered. `screen capture` is a 1-frame window; `screen
+# frames` an N-frame one. No _process change — same sampler/finalizer base as perf.
+
+
+# True when the running session has no real display — the dummy "headless"
+# DisplayServer (`--headless`, i.e. the daemon was NOT started --windowed), whose
+# viewport renders no pixels. The one runtime fact the model cannot pre-check.
+func _display_is_headless() -> bool:
+	return DisplayServer.get_name() == "headless"
+
+
+# Capture the current viewport frame as a base64 PNG + its dims. Returns a frame
+# Dictionary on success, or an {"error": {...}} envelope (window-aborting form) if
+# the image could not be read/encoded. Shared by both screen ops' samplers so the
+# single-frame and multi-frame captures encode identically.
+func _capture_frame() -> Dictionary:
+	var texture := get_viewport().get_texture()
+	if texture == null:
+		return {"error": {
+			"code": LIVE_ERROR_DISPLAY_UNAVAILABLE,
+			"message": "the running viewport has no texture to capture",
+		}}
+	var image: Image = texture.get_image()
+	if image == null or image.is_empty():
+		return {"error": {
+			"code": LIVE_ERROR_DISPLAY_UNAVAILABLE,
+			"message": "the running viewport rendered no image to capture",
+		}}
+	var png := image.save_png_to_buffer()
+	return {
+		"width": image.get_width(),
+		"height": image.get_height(),
+		"format": "png",
+		"bytes": png.size(),
+		"png_base64": Marshalls.raw_to_base64(png),
+	}
+
+
+# screen capture: capture ONE viewport frame, returned as a base64 PNG + dims (the
+# CLI writes the file). A 1-frame window so the capture lands on a _process tick
+# after the scene is up and a frame has rendered (the GPU-timing fix). A headless
+# session is the typed live_display_unavailable, refused up front.
+func _handle_screen_capture(_params: Dictionary) -> Variant:
+	if _display_is_headless():
+		return _error(LIVE_ERROR_DISPLAY_UNAVAILABLE,
+				"the engine session is headless (no DisplayServer to render pixels); "
+				+ "start the daemon with `gda daemon start --windowed`")
+	var sample := func() -> Variant:
+		var frame := _capture_frame()
+		if frame.has("error"):
+			return frame  # abort the window with the typed error envelope
+		return frame
+	var finalize := func(samples: Array) -> String:
+		# A 1-frame window: the single sample is the captured frame, returned flat.
+		return _ok(samples[0])
+	return _begin_window(1, sample, finalize)
+
+
+# screen frames: capture a WINDOW of N viewport frames, one per frame boundary,
+# returned as the per-frame base64 PNG list (the CLI writes one file per frame).
+# Reuses the #223 time-windowed base with its own capture sampler/finalizer — no
+# _process change. A headless session is the typed live_display_unavailable.
+func _handle_screen_frames(params: Dictionary) -> Variant:
+	if _display_is_headless():
+		return _error(LIVE_ERROR_DISPLAY_UNAVAILABLE,
+				"the engine session is headless (no DisplayServer to render pixels); "
+				+ "start the daemon with `gda daemon start --windowed`")
+	var frames := _int_param(params, "frames", 1)
+	var sample := func() -> Variant:
+		var frame := _capture_frame()
+		if frame.has("error"):
+			return frame  # abort the window with the typed error envelope
+		return frame
+	var finalize := func(samples: Array) -> String:
+		return _ok({
+			"count": samples.size(),
+			"frames": samples,
+		})
+	return _begin_window(frames, sample, finalize)
 
 
 # Read a float param defensively (the params arrive as arbitrary JSON): a missing

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -3111,8 +3111,137 @@ class InputSequenceResult(BaseModel):
     frames: int = Field(description="The number of frames the window spanned.")
 
 
+# --- screen (runtime viewport capture, #222) ----------------------------------
+# Capture the running game's viewport over the LIVE channel. The harness reads
+# `get_viewport().get_texture().get_image()`, PNG-encodes it, and base64s the PNG
+# into the ADR-0002 UTF-8 sentinel reply; the CLI decodes it and WRITES the PNG
+# under the agent's control. The default return is a written file PATH + dims +
+# bytes + format — a 1080p base64 inline is ~MBs of JSON and an N-frame sequence
+# would blow the agent's context — so `screen capture` adds `--inline` for the
+# base64 and `screen frames` is path-only. The capture needs a windowed session
+# (`gda daemon start --windowed`); a headless one is `live_display_unavailable`.
+
+
+class ScreenCaptureParams(BaseModel):
+    """The params of ``gda screen capture``: where to write one viewport frame (#222).
+
+    Captures the running game's current viewport in one frame (frame-coherent,
+    ADR-0020). ``output`` is part of the public input contract (ADR-0004) and the
+    single source of truth for both the emitted ``input`` schema and ``--params-json``
+    parsing (ADR-0015): the CLI decodes the harness's encoded pixels and writes them
+    there. It is ``~``-normalized once at the boundary (ADR-0006). The harness op
+    itself carries none of these fields — the recipe writes the file CLI-side.
+    """
+
+    output: NormalizedPath = Field(
+        description="The filesystem path to write the captured PNG frame to."
+    )
+    inline: bool = Field(
+        default=False,
+        description="Also embed the base64-encoded PNG in the result (default: path only).",
+    )
+
+
+class ScreenCaptureResult(BaseModel):
+    """The result of ``gda screen capture``: a written PNG frame (#222).
+
+    The default return: the ``path`` the decoded PNG was written to, its ``width`` /
+    ``height`` in pixels, the on-disk ``bytes``, and the ``format`` (``png``).
+    ``inline`` carries the base64 PNG only when ``--inline`` was passed (otherwise
+    null) — a single capture may be embedded for an in-context preview, but it is
+    opt-in so the default reply stays small.
+    """
+
+    path: str = Field(description="The filesystem path the PNG frame was written to.")
+    width: int = Field(description="The captured frame's width in pixels.")
+    height: int = Field(description="The captured frame's height in pixels.")
+    bytes: int = Field(description="The written PNG's size in bytes.")
+    format: str = Field(default="png", description="The image format (png).")
+    inline: str | None = Field(
+        default=None,
+        description="The base64-encoded PNG, present only when --inline was passed.",
+    )
+
+
+class ScreenFramesParams(BaseModel):
+    """The params of ``gda screen frames``: capture a window of viewport frames (#222).
+
+    Time-windowed (the gda harness's multi-frame base, #223): one viewport frame is
+    captured at each of ``frames`` frame boundaries and the whole sequence returns
+    as one blocking payload (ADR-0017 one-shot RPC, ADR-0020 multi-frame).
+    ``frames`` is bounded to ``MAX_WINDOW_FRAMES`` model-side (ADR-0015) — the same
+    per-window ceiling ``perf monitor`` enforces — so an over-range request is a
+    structured ``invalid_params`` on both the argv and ``--params-json`` paths, never
+    a request the harness must clamp.
+    """
+
+    frames: int = Field(
+        default=2,
+        ge=1,
+        le=MAX_WINDOW_FRAMES,
+        description=(
+            "The number of viewport frames to capture, 1.."
+            f"{MAX_WINDOW_FRAMES} (the gda harness's per-window ceiling). An "
+            "over-range value is rejected, not clamped."
+        ),
+    )
+    output_dir: NormalizedPath = Field(
+        description=(
+            "The directory to write the captured PNG frames into (frame_NNNN.png). "
+            "Part of the input contract (ADR-0004/ADR-0015), ~-normalized (ADR-0006)."
+        )
+    )
+
+
+class ScreenFrame(BaseModel):
+    """One captured frame in a ``gda screen frames`` sequence (#222).
+
+    The path-only per-frame projection: the ``path`` the decoded PNG was written
+    to, its ``width`` / ``height``, on-disk ``bytes``, and ``format``. No base64 —
+    an N-frame sequence is path-only so it never blows the agent's context.
+    """
+
+    path: str = Field(description="The filesystem path this frame's PNG was written to.")
+    width: int = Field(description="The frame's width in pixels.")
+    height: int = Field(description="The frame's height in pixels.")
+    bytes: int = Field(description="The written PNG's size in bytes.")
+    format: str = Field(default="png", description="The image format (png).")
+
+
+class ScreenFramesResult(BaseModel):
+    """The result of ``gda screen frames``: the written PNG sequence (#222).
+
+    Carries the ``count`` of frames captured and the per-frame ``frames`` list, each
+    a written PNG path (path-only, ADR-0019 distinct output schema from the single
+    ``screen capture``). The window collects one frame per frame boundary over the
+    requested count (ADR-0020 multi-frame).
+    """
+
+    count: int = Field(description="The number of frames captured over the window.")
+    frames: list[ScreenFrame] = Field(
+        description="The captured frames, in window order, each a written PNG path."
+    )
+
+
 class DaemonStartParams(BaseModel):
-    """The params of ``gda daemon start``: none (the project is the --project context)."""
+    """The params of ``gda daemon start``: the display mode of its engine session (#222).
+
+    Empty but for ``windowed``: the project is the ``--project`` context. ``windowed``
+    is a START-TIME declared mode (ADR-0017 refined by #222) — the daemon launches its
+    engine session windowed (no ``--headless``) so a ``screen`` capture op has a real
+    ``DisplayServer`` to read pixels from; default false keeps the cheap non-visual
+    sessions (``game tree``, ``perf``, ``diag``) headless. The mode is fixed for the
+    session's life (ADR-0020 single session) — it is NOT switched mid-session.
+    """
+
+    windowed: bool = Field(
+        default=False,
+        description=(
+            "Launch the engine session windowed (no --headless) so `screen` capture "
+            "ops have a display; default headless. Requires a display/Xvfb on a "
+            "headless host."
+        ),
+    )
 
 
 class DaemonStartResult(BaseModel):
@@ -3137,6 +3266,17 @@ class DaemonStartResult(BaseModel):
     harness_version: str = Field(
         default="",
         description="The gda harness version now installed in the project (#225).",
+    )
+    windowed: bool | None = Field(
+        default=None,
+        description=(
+            "Whether the engine session was launched windowed (no --headless), the "
+            "mode a `screen` capture op requires. The launched mode on a fresh start; "
+            "**null** on an idempotent already-running start, which does not relaunch "
+            "the session and cannot re-derive the running daemon's launch-time mode "
+            "from the pidfile — null means 'not determined here', not 'headless' "
+            "(#222, PR #248 review)."
+        ),
     )
     already_running: bool = Field(
         description="Whether a daemon was already running, so start was a no-op."

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -66,6 +66,8 @@ from gda.models import (
     SceneGetResult,
     SceneListResult,
     SceneNode,
+    ScreenCaptureResult,
+    ScreenFramesResult,
     ScriptAttachResult,
     ScriptCreateResult,
     ScriptDeleteResult,
@@ -280,7 +282,28 @@ def render_daemon_start(started: "DaemonStartResult") -> str:
         harness = " (installed harness)"
     else:
         harness = ""
-    return f"daemon {state}: pid {started.pid} on {started.socket_path}{harness}"
+    # The session's display mode is part of the live context the start brought up
+    # (#222) — note it only when windowed, since headless is the default.
+    mode = " [windowed]" if started.windowed else ""
+    return f"daemon {state}: pid {started.pid} on {started.socket_path}{mode}{harness}"
+
+
+def render_screen_capture(captured: "ScreenCaptureResult") -> str:
+    """Render a captured viewport frame as ``captured WxH -> path`` (#222)."""
+    inline = " (+inline)" if captured.inline else ""
+    return (
+        f"captured {captured.width}x{captured.height} "
+        f"({captured.bytes} bytes) -> {captured.path}{inline}"
+    )
+
+
+def render_screen_frames(captured: "ScreenFramesResult") -> str:
+    """Render a captured frame sequence: a header + one ``WxH -> path`` per frame (#222)."""
+    header = f"captured {captured.count} frames"
+    rows = [
+        f"  {frame.width}x{frame.height} -> {frame.path}" for frame in captured.frames
+    ]
+    return "\n".join([header, *rows])
 
 
 def render_daemon_stop(stopped: "DaemonStopResult") -> str:
@@ -695,6 +718,8 @@ _RENDERERS = {
     InputMouseResult: render_input_mouse,
     InputActionResult: render_input_action,
     InputSequenceResult: render_input_sequence,
+    ScreenCaptureResult: render_screen_capture,
+    ScreenFramesResult: render_screen_frames,
     DaemonStartResult: render_daemon_start,
     DaemonStopResult: render_daemon_stop,
     DaemonStatusResult: render_daemon_status,

--- a/src/gda/screen_ops.py
+++ b/src/gda/screen_ops.py
@@ -1,0 +1,150 @@
+"""The ``gda screen`` capture recipe (#222), parallel to ``daemon_ops`` / ``export_run``.
+
+``screen capture`` / ``screen frames`` are LIVE ops, but unlike the other live
+commands they cannot go straight through ``HeadlessCommand.emit``: the gda harness
+returns the PNG as base64 in the ADR-0002 sentinel, and the CLI must DECODE it and
+WRITE a file before it has the path-based public result. So each is a recipe that
+RETURNS its typed outcome (never emits/exits) and the CLI owns emission — the same
+shape ``export run`` and the ``daemon`` lifecycle commands use.
+
+The recipe runs the shared LIVE runner (the daemon IPC client), classifies the raw
+result against an INTERMEDIATE harness-reply model via ``classify_live`` so every
+LIVE failure (``daemon_not_running``, ``engine_disconnected``,
+``live_display_unavailable``, …) flows through the one registered-code pipeline,
+then decodes the base64 PNG(s) and writes them under the agent's chosen path. A
+failed capture writes nothing.
+"""
+
+import base64
+from pathlib import Path
+from typing import Callable, Optional
+
+from pydantic import BaseModel, Field
+
+from gda.errors import Failure, classify_live
+from gda.live_runner import make_daemon_runner
+from gda.models import (
+    ScreenCaptureResult,
+    ScreenFrame,
+    ScreenFramesResult,
+)
+from gda.runner import GodotRunner
+
+# The LIVE runner factory seam, the SAME shape gda.cli._make_live_runner has —
+# ``(binary, project) -> GodotRunner`` — so the CLI threads its own seam in and a
+# test's ``inject_live_runner`` (which patches ``gda.cli._make_live_runner``) binds
+# without a second injection point. ``binary`` is unused (a live op reaches the
+# daemon, not a fresh engine), matching the live channel.
+LiveRunnerFactory = Callable[[Optional[Path], Optional[Path]], GodotRunner]
+
+
+# --- intermediate harness-reply models (the wire shape, decoded CLI-side) -----
+# These match exactly what the harness emits in the sentinel: the PNG base64 plus
+# the frame's dims/format. They are NOT the public result (the public result is the
+# WRITTEN-file projection below); they exist only so the success payload validates
+# through classify_live just like any live op, surfacing LIVE errors uniformly.
+
+
+class _CaptureReply(BaseModel):
+    width: int
+    height: int
+    format: str = Field(default="png")
+    bytes: int
+    png_base64: str
+
+
+class _FrameReply(BaseModel):
+    width: int
+    height: int
+    format: str = Field(default="png")
+    bytes: int
+    png_base64: str
+
+
+class _FramesReply(BaseModel):
+    count: int
+    frames: list[_FrameReply]
+
+
+def _default_runner(binary: Optional[Path], project: Optional[Path]) -> GodotRunner:
+    """Build the LIVE runner for ``project`` — the daemon-channel runner factory.
+
+    Matches the ``(binary, project)`` factory shape so the CLI's
+    ``_make_live_runner`` is a drop-in; ``binary`` is unused (the daemon owns the
+    engine session).
+    """
+    return make_daemon_runner(project)
+
+
+def _write_png(png_base64: str, destination: Path) -> int:
+    """Decode a base64 PNG and write it to ``destination``; return the byte length."""
+    raw = base64.b64decode(png_base64)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(raw)
+    return len(raw)
+
+
+def run_screen_capture_operation(
+    project: Optional[Path],
+    output: Path,
+    *,
+    inline: bool = False,
+    make_runner: Optional[LiveRunnerFactory] = None,
+) -> "ScreenCaptureResult | Failure":
+    """Capture one viewport frame, write it to ``output``, return the typed result.
+
+    The single-frame recipe: run the ``screen-capture`` live op, surface any LIVE
+    failure via ``classify_live`` (so ``daemon_not_running`` /
+    ``live_display_unavailable`` ride the registered-code pipeline), then decode the
+    base64 PNG and write it to ``output``. ``--inline`` additionally embeds the
+    base64 in the result; the default reply is path + dims + bytes + format.
+    """
+    runner = (make_runner or _default_runner)(None, project)
+    result = runner.run("screen-capture", {})
+    reply = classify_live(result, None, _CaptureReply)
+    if isinstance(reply, Failure):
+        return reply
+    written = _write_png(reply.png_base64, output)
+    return ScreenCaptureResult(
+        path=str(output),
+        width=reply.width,
+        height=reply.height,
+        bytes=written,
+        format=reply.format,
+        inline=reply.png_base64 if inline else None,
+    )
+
+
+def run_screen_frames_operation(
+    project: Optional[Path],
+    frames: int,
+    output_dir: Path,
+    *,
+    make_runner: Optional[LiveRunnerFactory] = None,
+) -> "ScreenFramesResult | Failure":
+    """Capture a window of ``frames`` viewport frames, write each PNG, return paths.
+
+    The multi-frame recipe (the harness's time-windowed base, #223): run the
+    ``screen-frames`` live op, surface any LIVE failure via ``classify_live``, then
+    write one PNG per captured frame into ``output_dir`` (``frame_0000.png`` …) and
+    return the path-only sequence — no base64, which would blow the agent's context.
+    """
+    runner = (make_runner or _default_runner)(None, project)
+    result = runner.run("screen-frames", {"frames": frames})
+    reply = classify_live(result, None, _FramesReply)
+    if isinstance(reply, Failure):
+        return reply
+    written: list[ScreenFrame] = []
+    for index, frame in enumerate(reply.frames):
+        path = output_dir / f"frame_{index:04d}.png"
+        size = _write_png(frame.png_base64, path)
+        written.append(
+            ScreenFrame(
+                path=str(path),
+                width=frame.width,
+                height=frame.height,
+                bytes=size,
+                format=frame.format,
+            )
+        )
+    return ScreenFramesResult(count=reply.count, frames=written)

--- a/tests/support.py
+++ b/tests/support.py
@@ -85,6 +85,50 @@ def inject_live_runner(monkeypatch, result: RunResult) -> FakeRunner:
     return fake
 
 
+def screen_capture_reply(png_base64: str, *, width: int, height: int) -> dict:
+    """A canned ``screen capture`` HARNESS reply payload (#222).
+
+    The wire shape the gda harness emits in the ADR-0002 sentinel for a single
+    frame: the PNG bytes base64-encoded plus the frame's dims and format. The CLI
+    recipe decodes ``png_base64`` and WRITES a file, so a command test drives the
+    real decode/write path with a tiny real PNG.
+    """
+    import base64
+
+    raw = base64.b64decode(png_base64)
+    return {
+        "width": width,
+        "height": height,
+        "format": "png",
+        "bytes": len(raw),
+        "png_base64": png_base64,
+    }
+
+
+def screen_frames_reply(
+    png_base64s: list[str], *, width: int = 16, height: int = 16
+) -> dict:
+    """A canned ``screen frames`` HARNESS reply payload (#222).
+
+    The wire shape the gda harness emits for a multi-frame window: a list of
+    per-frame entries, each carrying its PNG base64 + dims + format, plus the
+    window's frame ``count``. The CLI recipe writes one PNG file per frame.
+    """
+    import base64
+
+    frames = [
+        {
+            "width": width,
+            "height": height,
+            "format": "png",
+            "bytes": len(base64.b64decode(b64)),
+            "png_base64": b64,
+        }
+        for b64 in png_base64s
+    ]
+    return {"count": len(frames), "frames": frames}
+
+
 # A sample ``gda info`` result, shaped as ``Engine.get_version_info()`` reports
 # it. Shared by the info success/schema tests so the canned engine version has a
 # single source of truth (issue #39).

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -57,7 +57,7 @@ def fake_ready(monkeypatch):
 
 def _start(project, **kw):
     return daemon_ops.run_daemon_start_operation(
-        project, None, spawn=lambda p, b: None, version_check=_OK_VERSION, **kw
+        project, None, spawn=lambda p, b, w: None, version_check=_OK_VERSION, **kw
     )
 
 
@@ -146,6 +146,132 @@ def test_already_running_start_resyncs_a_stale_harness(
     assert started.harness_synced is True  # stale -> re-materialized despite running
     assert started.harness_version == HARNESS_VERSION
     assert installed_harness_version(project) == HARNESS_VERSION  # rewritten on disk
+
+
+# --- start declares the display mode (#222, D1) -------------------------------
+# `daemon start --windowed` is a START-TIME declared mode: the daemon launches a
+# windowed engine session (no `--headless`) so a `screen` op can capture pixels
+# (ADR-0017 refined; ADR-0020 single session). The recipe threads `windowed` into
+# the spawn (the daemon argv) and surfaces it on the result so an agent sees the
+# mode. Default is headless (the cheap non-visual sessions).
+
+
+def test_start_defaults_to_headless_and_reports_windowed_false(
+    tmp_path, short_runtime, fake_ready, monkeypatch
+):
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
+    spawned: list[tuple] = []
+
+    started = daemon_ops.run_daemon_start_operation(
+        project,
+        None,
+        spawn=lambda p, b, windowed: spawned.append((p, b, windowed)),
+        version_check=_OK_VERSION,
+    )
+
+    assert isinstance(started, DaemonStartResult), started
+    assert started.windowed is False
+    # The default (headless) mode is threaded into the spawn.
+    assert spawned == [(project, str(daemon_ops.resolve_godot_binary(None)), False)]
+
+
+def test_start_windowed_threads_mode_into_spawn_and_result(
+    tmp_path, short_runtime, fake_ready, monkeypatch
+):
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
+    spawned: list[tuple] = []
+
+    started = daemon_ops.run_daemon_start_operation(
+        project,
+        None,
+        windowed=True,
+        spawn=lambda p, b, windowed: spawned.append((p, b, windowed)),
+        version_check=_OK_VERSION,
+    )
+
+    assert isinstance(started, DaemonStartResult), started
+    assert started.windowed is True
+    # The windowed mode is threaded into the spawn (the daemon argv carries it).
+    assert spawned[0][2] is True
+
+
+def test_already_running_start_reports_windowed_unknown(
+    tmp_path, short_runtime, monkeypatch
+):
+    # PR #248 review: an idempotent start does not relaunch the session and cannot
+    # re-derive the running daemon's launch-time display mode from the pidfile, so it
+    # reports `None` ("not determined here"), NOT a misleading `False` — even though
+    # `--windowed=True` was requested, a running daemon's mode is whatever it was
+    # launched with, which this start neither knows nor changes.
+    project = _project(tmp_path)
+    install_harness(project)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: 999)
+
+    started = daemon_ops.run_daemon_start_operation(
+        project, None, windowed=True, version_check=_OK_VERSION
+    )
+
+    assert isinstance(started, DaemonStartResult)
+    assert started.already_running is True
+    assert started.windowed is None
+
+
+def test_cli_daemon_start_windowed_threads_the_flag_to_the_recipe(
+    tmp_path, short_runtime, monkeypatch
+):
+    # `gda daemon start --windowed` reaches the recipe with windowed=True; the argv
+    # flag is the start-time declared display mode (#222).
+    project = _project(tmp_path)
+    captured: dict = {}
+
+    def fake_start(proj, godot, *, windowed=False, **kw):
+        captured["windowed"] = windowed
+        return DaemonStartResult(
+            pid=1,
+            socket_path="/tmp/x.sock",
+            installed_harness=False,
+            harness_version=HARNESS_VERSION,
+            windowed=windowed,
+            already_running=False,
+        )
+
+    monkeypatch.setattr("gda.cli.run_daemon_start_operation", fake_start)
+
+    result = CliRunner().invoke(
+        app, ["daemon", "start", "--windowed", "--project", str(project), "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["windowed"] is True
+    assert json.loads(result.stdout)["windowed"] is True
+
+
+def test_cli_daemon_start_defaults_to_headless(tmp_path, short_runtime, monkeypatch):
+    project = _project(tmp_path)
+    captured: dict = {}
+
+    def fake_start(proj, godot, *, windowed=False, **kw):
+        captured["windowed"] = windowed
+        return DaemonStartResult(
+            pid=1,
+            socket_path="/tmp/x.sock",
+            installed_harness=False,
+            harness_version=HARNESS_VERSION,
+            windowed=windowed,
+            already_running=False,
+        )
+
+    monkeypatch.setattr("gda.cli.run_daemon_start_operation", fake_start)
+
+    result = CliRunner().invoke(
+        app, ["daemon", "start", "--project", str(project), "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["windowed"] is False
+    assert json.loads(result.stdout)["windowed"] is False
 
 
 # --- uninstall recipe (#225, D2) ----------------------------------------------

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -1,0 +1,201 @@
+"""S (e2e): `gda screen` live viewport capture through the real gda-daemon loop (#222).
+
+The Step-6 proof for screen: a real `gda daemon start --windowed` (real detached
+daemon, real harness install, a WINDOWED engine session — no `--headless`) ->
+`gda screen capture` writes a real PNG of the RUNNING game's viewport, and
+`gda screen frames --frames 3` writes a 3-frame sequence collected by the harness's
+time-windowed multi-frame base. The headless-session guard is proven by starting
+the daemon WITHOUT `--windowed` and asserting the typed `live_display_unavailable`;
+the no-daemon path asserts `daemon_not_running`.
+
+CI / headless hosts: a windowed session needs a real DisplayServer. On Linux CI
+(no physical display) run this module under a virtual framebuffer, e.g.::
+
+    xvfb-run -a uv run pytest tests/test_e2e_screen.py -m e2e
+
+macOS has a real display, so it runs directly. Run the e2e tier SERIALLY (a shared
+windowed session is heavier than a headless one) and NOT under a fresh empty HOME
+(Godot first-run). The `daemon_runtime_dir` fixture keeps the daemon's UDS path
+within the `sun_path` limit.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+from .conftest import project_godot
+
+GODOT = resolve_godot_binary()
+
+# The PNG magic the written capture must start with — the proof it is a real,
+# decodable image (not an empty/placeholder buffer).
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+# A main scene with a visible ColorRect so the windowed viewport renders non-empty
+# content; the capture asserts dims > 0, the frames test asserts each file decodes.
+# File logging stays disabled via project_godot (#180).
+MAIN_TSCN = (
+    "[gd_scene format=3]\n\n"
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="Rect" type="ColorRect" parent="."]\n'
+    "offset_right = 200.0\n"
+    "offset_bottom = 150.0\n"
+    "color = Color(0.2, 0.6, 0.9, 1)\n"
+)
+PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+
+def _scaffold(tmp_path):
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+
+
+def _runner(gda, tmp_path):
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+        )
+
+    return run
+
+
+@pytest.mark.e2e
+def test_windowed_daemon_captures_a_single_viewport_frame(tmp_path, daemon_runtime_dir):
+    # `daemon start --windowed` -> a WINDOWED engine session -> `screen capture`
+    # writes a real PNG of the running viewport (magic + dims > 0).
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+    _scaffold(tmp_path)
+    run = _runner(gda, tmp_path)
+    out = tmp_path / "shot.png"
+
+    try:
+        started = run("daemon", "start", "--windowed")
+        assert started.returncode == 0, started.stdout + started.stderr
+        assert json.loads(started.stdout)["windowed"] is True
+
+        cap = run("screen", "capture", "--output", str(out))
+        assert cap.returncode == 0, cap.stdout + cap.stderr
+        doc = json.loads(cap.stdout)
+        assert doc["path"] == str(out)
+        assert doc["width"] > 0 and doc["height"] > 0
+        assert doc["format"] == "png"
+        # The written file is a real PNG (the magic the spec requires) with bytes.
+        assert out.exists()
+        data = out.read_bytes()
+        assert data.startswith(PNG_MAGIC)
+        assert doc["bytes"] == len(data) > 0
+        # No --inline -> no base64 embedded (the default small reply).
+        assert doc.get("inline") is None
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_windowed_daemon_inline_embeds_the_base64(tmp_path, daemon_runtime_dir):
+    # `screen capture --inline` additionally embeds the base64 PNG in the reply.
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+    _scaffold(tmp_path)
+    run = _runner(gda, tmp_path)
+    out = tmp_path / "shot.png"
+
+    try:
+        assert run("daemon", "start", "--windowed").returncode == 0
+        cap = run("screen", "capture", "--inline", "--output", str(out))
+        assert cap.returncode == 0, cap.stdout + cap.stderr
+        doc = json.loads(cap.stdout)
+        import base64
+
+        assert base64.b64decode(doc["inline"]).startswith(PNG_MAGIC)
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_windowed_daemon_captures_a_frame_window(tmp_path, daemon_runtime_dir):
+    # `screen frames --frames 3`: the time-windowed multi-frame base (#223) collects
+    # 3 viewport frames over the engine session and returns them in one blocking
+    # call; the CLI writes one PNG per frame (path-only).
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+    _scaffold(tmp_path)
+    run = _runner(gda, tmp_path)
+    out_dir = tmp_path / "frames"
+
+    try:
+        assert run("daemon", "start", "--windowed").returncode == 0
+        frames = run("screen", "frames", "--frames", "3", "--output-dir", str(out_dir))
+        assert frames.returncode == 0, frames.stdout + frames.stderr
+        doc = json.loads(frames.stdout)
+        assert doc["count"] == 3
+        assert len(doc["frames"]) == 3
+        for frame in doc["frames"]:
+            assert frame["width"] > 0 and frame["height"] > 0
+            assert frame["format"] == "png"
+            path = frame["path"]
+            assert path.startswith(str(out_dir))
+            data = open(path, "rb").read()
+            assert data.startswith(PNG_MAGIC)
+            assert frame["bytes"] == len(data) > 0
+            assert "inline" not in frame  # path-only sequence
+        # Distinct files, one per frame.
+        assert len({f["path"] for f in doc["frames"]}) == 3
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_headless_session_reports_live_display_unavailable(tmp_path, daemon_runtime_dir):
+    # A default (HEADLESS) daemon session has the dummy DisplayServer; a `screen
+    # capture` there is refused with the typed live_display_unavailable (the
+    # self-revealing remediation: start --windowed). No file is written.
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+    _scaffold(tmp_path)
+    run = _runner(gda, tmp_path)
+    out = tmp_path / "shot.png"
+
+    try:
+        # NOTE: no --windowed -> the session is launched --headless (the default).
+        assert run("daemon", "start").returncode == 0
+        cap = run("screen", "capture", "--output", str(out))
+        assert cap.returncode == 6, cap.stdout + cap.stderr  # EXIT_LIVE
+        error = json.loads(cap.stdout)["error"]
+        assert error["code"] == "live_display_unavailable"
+        assert error["category"] == "live"
+        assert not out.exists()  # a refused capture writes nothing
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_screen_capture_with_no_daemon_reports_daemon_not_running(
+    tmp_path, daemon_runtime_dir
+):
+    # No daemon started: `screen capture` is the attach-or-fail daemon_not_running
+    # (ADR-0017), the same typed error every live op reports with no daemon.
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+    _scaffold(tmp_path)
+    run = _runner(gda, tmp_path)
+
+    cap = run("screen", "capture", "--output", str(tmp_path / "shot.png"))
+
+    assert cap.returncode == 6, cap.stdout + cap.stderr  # EXIT_LIVE
+    error = json.loads(cap.stdout)["error"]
+    assert error["code"] == "daemon_not_running"
+    assert "gda daemon start" in error["message"]

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -55,6 +55,9 @@ HARNESS_LIVE_ERROR_CODES = (
     "live_invalid_key",
     "live_unknown_action",
     "live_invalid_event_spec",
+    # #222: a `screen` capture op on a headless engine session — the dummy
+    # DisplayServer cannot read pixels (the session was not started --windowed).
+    "live_display_unavailable",
 )
 
 

--- a/tests/test_screen_commands.py
+++ b/tests/test_screen_commands.py
@@ -1,0 +1,388 @@
+"""`gda screen` — runtime viewport capture of the running game, LIVE (#222).
+
+Engine-free: a fake daemon runner at the LIVE seam exercises the full
+Typer -> screen recipe -> classify_live -> JSON pipeline (mirroring
+``test_perf_commands``). The harness reply carries the PNG as base64 in the
+ADR-0002 sentinel JSON; the CLI decodes it and WRITES a PNG file, so the default
+return is a path + dims + bytes + format (a 1080p base64 inline is ~MBs of JSON;
+an N-frame sequence would blow the agent's context). ``screen capture --inline``
+additionally embeds the base64; ``screen frames`` is path-only.
+
+The no-daemon attach-or-fail path runs the real ``DaemonRunner`` against an empty
+runtime dir. The real-engine windowed round trip (the GPU framebuffer + the
+headless guard) is the e2e in ``test_e2e_screen``.
+"""
+
+import base64
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.exit_codes import EXIT_LIVE
+from gda.models import ScreenCaptureParams, ScreenFramesParams
+from gda.runner import RunResult
+from tests.support import (
+    error_sentinel,
+    inject_live_runner,
+    sentinel,
+    screen_capture_reply,
+    screen_frames_reply,
+)
+
+# A 1x1 transparent PNG (valid, decodes to real bytes) so a written file starts
+# with the PNG magic and has a real byte length.
+_PNG_1X1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+    "+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+_PNG_B64 = base64.b64encode(_PNG_1X1).decode("ascii")
+
+
+def _project(tmp_path):
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return tmp_path
+
+
+# --- input contract: output paths are params, not CLI-only (#222, PR #248) ----
+
+
+def test_screen_capture_params_json_supplies_the_output_path(monkeypatch, tmp_path):
+    # The output path is part of the params model now (ADR-0004/ADR-0015 single
+    # source), so a JSON-only invocation can express it and the PNG is written.
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel(screen_capture_reply(_PNG_B64, width=8, height=8)),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    out = tmp_path / "shot.png"
+    payload = json.dumps({"output": str(out)})
+
+    result = CliRunner().invoke(
+        app,
+        ["screen", "capture", "--params-json", payload,
+         "--project", str(_project(tmp_path)), "--json"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout)["path"] == str(out)
+    assert out.read_bytes().startswith(b"\x89PNG")  # the PNG was actually written
+
+
+def test_screen_capture_params_json_without_output_is_invalid_params(tmp_path):
+    # The worst finding: a JSON-only invocation that omits the now-required output is
+    # a STRUCTURED invalid_params, never an AttributeError on a None path.
+    result = CliRunner().invoke(
+        app,
+        ["screen", "capture", "--params-json", "{}",
+         "--project", str(_project(tmp_path)), "--json"],
+    )
+
+    assert result.exit_code != 0
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+
+
+def test_screen_frames_params_json_supplies_the_output_dir(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel(screen_frames_reply([_PNG_B64, _PNG_B64])),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    out_dir = tmp_path / "frames"
+    payload = json.dumps({"frames": 2, "output_dir": str(out_dir)})
+
+    result = CliRunner().invoke(
+        app,
+        ["screen", "frames", "--params-json", payload,
+         "--project", str(_project(tmp_path)), "--json"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout)["count"] == 2
+    assert (out_dir / "frame_0000.png").exists()
+
+
+def test_screen_schema_input_carries_the_output_contract():
+    # ADR-0004: the public input schema must carry the output path so an agent /
+    # gda-mcp can supply it (the params were empty/frames-only before — PR #248).
+    cap = json.loads(CliRunner().invoke(app, ["screen", "capture", "--schema"]).stdout)
+    assert {"output", "inline"} <= set(cap["input"]["properties"])
+    frm = json.loads(CliRunner().invoke(app, ["screen", "frames", "--schema"]).stdout)
+    assert "output_dir" in frm["input"]["properties"]
+
+
+def test_screen_output_paths_are_tilde_normalized():
+    # ADR-0006: filesystem paths are ~-expanded once at the model boundary (the same
+    # NormalizedPath rule export run --output follows), not kept as a literal "~".
+    assert not ScreenCaptureParams(output="~/shot.png").output.startswith("~")
+    assert ScreenCaptureParams(output="~/shot.png").output.endswith("shot.png")
+    frames = ScreenFramesParams(frames=2, output_dir="~/frames")
+    assert not frames.output_dir.startswith("~")
+    assert frames.output_dir.endswith("frames")
+
+
+# --- screen capture (single frame) --------------------------------------------
+
+
+def test_screen_capture_writes_a_png_and_returns_its_path(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel(screen_capture_reply(_PNG_B64, width=64, height=48)),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    out = tmp_path / "shot.png"
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "screen", "capture",
+            "--output", str(out),
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    # The default return: a written PNG file path + dims + bytes + format.
+    assert data["path"] == str(out)
+    assert data["width"] == 64 and data["height"] == 48
+    assert data["format"] == "png"
+    assert data["bytes"] == len(_PNG_1X1)
+    # No --inline -> no base64 in the JSON (keeps the agent's context small).
+    assert data.get("inline") is None
+    # The file is the decoded PNG on disk (the magic the e2e asserts).
+    assert out.read_bytes() == _PNG_1X1
+    # Routed through the LIVE seam, dispatching the screen-capture op (no params).
+    assert fake.calls == [("screen-capture", {})]
+
+
+def test_screen_capture_inline_embeds_the_base64(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel(screen_capture_reply(_PNG_B64, width=10, height=10)),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    out = tmp_path / "shot.png"
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "screen", "capture", "--inline",
+            "--output", str(out),
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    # --inline embeds the base64 PNG ALONGSIDE the written file (both).
+    assert data["inline"] == _PNG_B64
+    assert data["path"] == str(out)
+    assert out.read_bytes() == _PNG_1X1
+
+
+def test_screen_capture_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):
+    # No fake: the real DaemonRunner + discovery run against an empty runtime dir,
+    # so no daemon is found — the attach-or-fail typed error (ADR-0017).
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "screen", "capture",
+            "--output", str(tmp_path / "shot.png"),
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "daemon_not_running"
+    assert error["category"] == "live"
+    assert "gda daemon start" in error["message"]
+
+
+def test_screen_capture_on_headless_session_reports_live_display_unavailable(
+    monkeypatch, tmp_path
+):
+    # The harness guards a headless DisplayServer and reports the typed error; the
+    # CLI surfaces it (and writes NO file).
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel(
+                "live_display_unavailable", "the engine session is headless"
+            ),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    out = tmp_path / "shot.png"
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "screen", "capture",
+            "--output", str(out),
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    assert json.loads(result.stdout)["error"]["code"] == "live_display_unavailable"
+    assert not out.exists()  # a failed capture writes nothing
+
+
+def test_screen_capture_schema_reports_kind_live_and_is_self_describing():
+    result = CliRunner().invoke(app, ["screen", "capture", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    schema = json.loads(result.stdout)
+    assert "input" in schema and "output" in schema
+    assert schema["kind"] == "live"
+
+
+def test_screen_capture_without_a_project_reports_project_not_found(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)  # holds no project.godot
+
+    result = CliRunner().invoke(
+        app, ["screen", "capture", "--output", str(tmp_path / "s.png"), "--json"]
+    )
+
+    assert result.exit_code != 0, result.stdout
+    assert json.loads(result.stdout)["error"]["code"] == "project_not_found"
+
+
+# --- screen frames (multi-frame, time-windowed) -------------------------------
+
+
+def test_screen_frames_writes_each_png_and_returns_paths(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel(
+                screen_frames_reply([_PNG_B64, _PNG_B64, _PNG_B64], width=32, height=24)
+            ),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    out_dir = tmp_path / "frames"
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "screen", "frames", "--frames", "3",
+            "--output-dir", str(out_dir),
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["count"] == 3
+    assert len(data["frames"]) == 3
+    for frame in data["frames"]:
+        assert frame["width"] == 32 and frame["height"] == 24
+        assert frame["format"] == "png"
+        assert frame["bytes"] == len(_PNG_1X1)
+        # Path-only: no base64 in a frame sequence (would blow the context).
+        assert "inline" not in frame
+        assert Path(frame["path"]).read_bytes() == _PNG_1X1
+    # Distinct paths, one per frame.
+    assert len({f["path"] for f in data["frames"]}) == 3
+    # The requested frame count is threaded to the op.
+    assert fake.calls == [("screen-frames", {"frames": 3})]
+
+
+def test_screen_frames_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "screen", "frames", "--frames", "3",
+            "--output-dir", str(tmp_path / "frames"),
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    assert json.loads(result.stdout)["error"]["code"] == "daemon_not_running"
+
+
+def test_screen_frames_argv_frames_over_range_is_a_usage_error(monkeypatch, tmp_path):
+    # --frames is bounded by the harness's per-window ceiling (MAX_WINDOW_FRAMES);
+    # an over-range value is a usage error on argv (exit 2), engine never reached.
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(screen_frames_reply([_PNG_B64])), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "screen", "frames", "--frames", "601",
+            "--output-dir", str(tmp_path / "frames"),
+            "--project", str(_project(tmp_path)), "--json",
+        ],
+    )
+
+    assert result.exit_code == 2, result.stdout + result.stderr
+    assert fake.calls == []
+
+
+def test_screen_frames_schema_reports_kind_live_and_is_self_describing():
+    result = CliRunner().invoke(app, ["screen", "frames", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    schema = json.loads(result.stdout)
+    assert "input" in schema and "output" in schema
+    assert schema["kind"] == "live"
+
+
+# --- model validation via --params-json (ADR-0015) ----------------------------
+# The frame bound is the ScreenFramesParams model's, so BOTH the argv path (usage
+# error, exit 2) and --params-json (structured invalid_params, exit 0 sentinel)
+# reject the same over-range request — the harness never has to clamp.
+
+
+def test_screen_frames_params_json_over_range_frames_is_invalid_params(
+    monkeypatch, tmp_path
+):
+    # The model validates the --params-json object before dispatch (ADR-0015), so an
+    # over-range `frames` is the structured invalid_params, not a clamp. A valid
+    # output_dir is included in the JSON so the over-range `frames` is the SOLE failing
+    # constraint — output_dir is now a required params field carried IN --params-json,
+    # not a CLI-only option mutually exclusive with it (PR #248 review).
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(screen_frames_reply([_PNG_B64])), stderr="", exit_code=0),
+    )
+    payload = json.dumps({"frames": 601, "output_dir": str(tmp_path / "frames")})
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "screen", "frames",
+            "--project", str(_project(tmp_path)), "--json",
+            "--params-json", payload,
+        ],
+    )
+
+    assert result.exit_code != 0, result.stdout
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert fake.calls == []


### PR DESCRIPTION
## Summary

Adds **`screen` runtime viewport capture** of the running game over the LIVE channel: a single screenshot and a multi-frame capture, returned as PNG image data. Closes the build→run→**observe**→verify loop with on-screen pixels.

Closes #222.

> **Stacked on #225** (base = `feat/225-harness-lifecycle`). Built on #225's evolved `daemon start` surface (added `windowed` *alongside* `harness_synced`/`harness_version`, no conflict). **Merge after #225 (PR #247).** GitHub will retarget this PR to `main` once #225 merges.

## Design

**Windowed session = a start-time declared mode** — `gda daemon start --windowed`. `--headless` uses the dummy `DisplayServer` and cannot capture pixels, so the daemon launches a windowed session only when explicitly asked. A screen op on a headless session fails with the typed `live_display_unavailable` (self-revealing remediation). This **refines ADR-0017's** anticipated "switch to windowed on the first viewport op" (a lazy per-op relaunch) — rejected because a mid-session relaunch throws away runtime state and violates ADR-0020 session-bound consistency — while keeping #7's cheap `--headless` default for non-visual live ops. (ADR-0017 outcome note to be appended at merge.)

**Two sibling commands** under a new `screen` group (the viewport is the domain object, ADR-0019), mirroring `perf monitors`/`perf monitor`:
- `gda screen capture --output PATH [--inline]` → `{path, width, height, bytes, format, inline}`. Writes the PNG and returns the path; `--inline` additionally embeds base64.
- `gda screen frames --frames N --output-dir DIR` → `{count, frames:[{path,width,height,bytes,format}]}`, path-only (an N-frame base64 would blow the agent's context). `--frames` bounded 1..600.

Both are `kind = LIVE`; the wire stays the existing UTF-8 sentinel JSON (harness base64-encodes the PNG; the CLI-side recipe in `screen_ops.py` decodes and writes the file). **GPU-capture timing:** both ops sample **inside a window tick** (reusing #223's `_begin/_advance/_finish_window`, no `_process` change) so `get_viewport().get_texture().get_image()` reads a rendered, non-empty frame; a `_capture_frame()` guard defends against an empty image. The headless guard fires before any window opens.

Schema-emission path (`headless.py`/`surface.py`/`CommandSchema`) untouched — declaring `kind=ExecutionKind.LIVE` makes `"kind":"live"` appear automatically, and #233's predicate auto-covers the `screen` constraints.

## Tests

`uv run pytest -m "not e2e"` → **818 passed** (independently re-run by the reviewer). Real-engine **windowed** e2e (`tests/test_e2e_screen.py`, run serially with a real display) → **5 passed**: single-frame capture (asserts PNG magic + dims>0), inline base64, 3-frame window, headless-session → `live_display_unavailable` (exit 6), no-daemon → `daemon_not_running`. Linux-CI Xvfb path documented in the module docstring.
