### PR TITLE
docs(adr-0018): record that daemon install is folded into daemon start (#6)

### DIFF
--- a/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
+++ b/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
@@ -55,6 +55,17 @@ so two instances can touch the project at once.
 > the autoload edit is scoped to the `[autoload]` section so a same-named key elsewhere
 > is never touched. Verified resident-inert in a plain run and an exported PCK.
 
+> **Outcome (2026-06-23, Phase-2 completion) — there is no standalone `gda daemon
+> install`; install is folded into `gda daemon start`.** Decision 1 below names an
+> agent-runnable `gda daemon install`; the delivered command surface has none. The
+> harness is only useful with a running daemon, so there is no install-without-start
+> use case: `gda daemon start` performs the idempotent install (reporting
+> `installed_harness`, and self-syncing a stale copy per the #225 note above), while
+> teardown is the explicit `gda daemon uninstall` (a release build must be able to
+> remove the dev tooling deliberately). The lifecycle is thus deliberately
+> **asymmetric** — implicit install on `start`, explicit `uninstall` — not a symmetric
+> install/uninstall pair. Decision 1's wording is preserved as the point-in-time record.
+
 ## Decision
 
 **1. The harness is an installed autoload, not a runtime injection.** `gda` bundles


### PR DESCRIPTION
Phase-2 completion recheck found a doc↔code drift in **ADR-0018**: decision 1 names an agent-runnable `gda daemon install`, but the delivered command surface has none — install is folded into `gda daemon start` (idempotent, reports `installed_harness`, self-syncs a stale copy). 

Adds a dated **Outcome note** recording the deliberately **asymmetric** harness lifecycle — implicit install on `start`, explicit `daemon uninstall` (a release build must deliberately remove dev tooling) — and preserves decision 1's prose as the point-in-time record (per the project's ADR-preserve-decision-record convention). Docs-only; no code change.

Closes the last consistency item from the Phase-2 (PRD #6) completion review.
