### PR TITLE
feat(daemon): report running daemon's windowed mode via `daemon status` (#251)

### DIFF
--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -106,7 +106,10 @@ class DaemonServer:
     def _handle(self, request: dict) -> dict | None:
         op = request.get("op")
         if op == STATUS_OP:
-            return {"ok": True, "pid": os.getpid()}
+            # `windowed` lets `gda daemon status` report the daemon's launch-time
+            # display mode (#251): the running daemon is the only authority for the
+            # mode it was started with, so it travels back on the control reply.
+            return {"ok": True, "pid": os.getpid(), "windowed": self.windowed}
         if op == STOP_OP:
             self._stopping = True
             return {"ok": True, "pid": os.getpid()}

--- a/src/gda/daemon_ops.py
+++ b/src/gda/daemon_ops.py
@@ -274,8 +274,21 @@ def run_daemon_status_operation(project: Optional[Path]) -> "DaemonStatusResult 
         )
     paths = daemon_paths(project)
     pid = daemon_pid(paths)
+    # Liveness stays the pidfile's call (ADR-0021). When a daemon is up, round-trip
+    # its STATUS_OP to read the launch-time display mode — the running daemon is the
+    # only authority for the mode it was started with, which a pidfile cannot record
+    # (#251). No daemon -> no round trip; a transient round-trip miss on a dying
+    # daemon -> `windowed` stays None. `_control`'s bounded timeout means no hang.
+    windowed = None
+    if pid is not None:
+        reply = _control(paths.cli_socket, STATUS_OP)
+        if reply and reply.get("ok"):
+            windowed = reply.get("windowed")
     return DaemonStatusResult(
-        running=pid is not None, pid=pid, socket_path=str(paths.cli_socket)
+        running=pid is not None,
+        pid=pid,
+        socket_path=str(paths.cli_socket),
+        windowed=windowed,
     )
 
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -3312,6 +3312,16 @@ class DaemonStatusResult(BaseModel):
         default=None, description="The running daemon's pid, if any."
     )
     socket_path: str = Field(description="The per-project CLI socket path.")
+    windowed: bool | None = Field(
+        default=None,
+        description=(
+            "Whether the running daemon was launched windowed (no --headless), the "
+            "mode a `screen` capture op requires — read over the daemon's STATUS_OP, "
+            "the running daemon being the authority for its launch-time mode (#251). "
+            "**null** when no daemon is running (alongside `running: false`), since "
+            "there is no mode to report."
+        ),
+    )
 
 
 class DaemonUninstallParams(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -3318,8 +3318,9 @@ class DaemonStatusResult(BaseModel):
             "Whether the running daemon was launched windowed (no --headless), the "
             "mode a `screen` capture op requires — read over the daemon's STATUS_OP, "
             "the running daemon being the authority for its launch-time mode (#251). "
-            "**null** when no daemon is running (alongside `running: false`), since "
-            "there is no mode to report."
+            "**null** when the mode is undetermined: either no daemon is running "
+            "(alongside `running: false`), or a daemon is running (`running: true`) "
+            "but its bounded STATUS_OP round trip missed transiently."
         ),
     )
 

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -316,7 +316,10 @@ def render_daemon_stop(stopped: "DaemonStopResult") -> str:
 def render_daemon_status(status: "DaemonStatusResult") -> str:
     """Render a `gda daemon status` outcome for humans."""
     if status.running:
-        return f"daemon running: pid {status.pid} on {status.socket_path}"
+        # Mirror `daemon start`: note the display mode only when windowed (#251),
+        # since headless is the default and an unknown mode (null) has nothing to say.
+        mode = " [windowed]" if status.windowed else ""
+        return f"daemon running: pid {status.pid} on {status.socket_path}{mode}"
     return "daemon not running"
 
 

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -25,7 +25,11 @@ from gda.harness.install import (
     install_harness,
     installed_harness_version,
 )
-from gda.models import DaemonStartResult, DaemonUninstallResult
+from gda.models import (
+    DaemonStartResult,
+    DaemonStatusResult,
+    DaemonUninstallResult,
+)
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
@@ -272,6 +276,81 @@ def test_cli_daemon_start_defaults_to_headless(tmp_path, short_runtime, monkeypa
     assert result.exit_code == 0, result.output
     assert captured["windowed"] is False
     assert json.loads(result.stdout)["windowed"] is False
+
+
+# --- status surfaces the running daemon's display mode (#251) -----------------
+# `daemon status` is no longer pidfile-only: when a daemon is up it round-trips the
+# STATUS_OP control op to read the daemon's launch-time `windowed` mode, so an agent
+# can tell whether a live session can serve a `screen` capture before issuing one.
+# No daemon -> `running: False` and `windowed: None`, with no round trip and no hang.
+
+
+def test_status_reports_windowed_read_over_the_control_op(
+    tmp_path, short_runtime, monkeypatch
+):
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: 4242)
+    # Stub the IPC round trip: a windowed daemon answers STATUS_OP with windowed=True.
+    monkeypatch.setattr(
+        daemon_ops, "_control", lambda sock, op, **kw: {"ok": True, "windowed": True}
+    )
+
+    status = daemon_ops.run_daemon_status_operation(project)
+
+    assert isinstance(status, DaemonStatusResult), status
+    assert status.running is True and status.pid == 4242
+    assert status.windowed is True
+
+
+def test_status_reports_headless_when_the_daemon_is_headless(
+    tmp_path, short_runtime, monkeypatch
+):
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: 4242)
+    monkeypatch.setattr(
+        daemon_ops, "_control", lambda sock, op, **kw: {"ok": True, "windowed": False}
+    )
+
+    status = daemon_ops.run_daemon_status_operation(project)
+
+    assert isinstance(status, DaemonStatusResult)
+    assert status.running is True and status.windowed is False
+
+
+def test_status_windowed_is_null_when_no_daemon_is_running(
+    tmp_path, short_runtime, monkeypatch
+):
+    # No daemon: `running` is False and `windowed` is None, and crucially the status
+    # path must NOT round-trip (nothing to connect to) — a clean, hang-free fallback.
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
+
+    def _must_not_connect(*a, **k):
+        raise AssertionError("status must not round-trip when no daemon is running")
+
+    monkeypatch.setattr(daemon_ops, "_control", _must_not_connect)
+
+    status = daemon_ops.run_daemon_status_operation(project)
+
+    assert isinstance(status, DaemonStatusResult)
+    assert status.running is False
+    assert status.windowed is None
+
+
+def test_status_windowed_is_null_when_the_control_round_trip_fails(
+    tmp_path, short_runtime, monkeypatch
+):
+    # Pidfile says alive but the control round trip yields nothing (a transient race
+    # on a dying daemon): `windowed` falls back to None rather than erroring.
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: 4242)
+    monkeypatch.setattr(daemon_ops, "_control", lambda sock, op, **kw: None)
+
+    status = daemon_ops.run_daemon_status_operation(project)
+
+    assert isinstance(status, DaemonStatusResult)
+    assert status.running is True
+    assert status.windowed is None
 
 
 # --- uninstall recipe (#225, D2) ----------------------------------------------

--- a/tests/test_daemon_ops.py
+++ b/tests/test_daemon_ops.py
@@ -62,6 +62,9 @@ def test_daemon_start_status_stop_lifecycle(tmp_path, daemon_runtime_dir):
         status = run_daemon_status_operation(project)
         assert isinstance(status, DaemonStatusResult)
         assert status.running is True and status.pid == started.pid
+        # #251: status round-trips STATUS_OP to read the daemon's launch-time mode.
+        # This daemon was started headless (the default), so it reports windowed.
+        assert status.windowed is False
     finally:
         stopped = run_daemon_stop_operation(project)
         assert isinstance(stopped, DaemonStopResult)
@@ -69,6 +72,28 @@ def test_daemon_start_status_stop_lifecycle(tmp_path, daemon_runtime_dir):
     # Torn down: pidfile dead, socket gone.
     assert daemon_pid(paths) is None
     assert not paths.cli_socket.exists()
+
+
+def test_daemon_status_reports_a_windowed_daemons_mode(tmp_path, daemon_runtime_dir):
+    # #251: a daemon started `--windowed` reports `windowed: True` over STATUS_OP,
+    # read back by `daemon status`. No engine session is launched here (lazy launch,
+    # ADR-0017) — the daemon process merely records the declared mode — so this needs
+    # no display and is headless-CI safe.
+    project = _project(tmp_path)
+
+    try:
+        started = run_daemon_start_operation(
+            project, None, windowed=True, version_check=_OK_VERSION
+        )
+        assert isinstance(started, DaemonStartResult), started
+        assert started.windowed is True
+
+        status = run_daemon_status_operation(project)
+        assert isinstance(status, DaemonStatusResult)
+        assert status.running is True
+        assert status.windowed is True
+    finally:
+        run_daemon_stop_operation(project)
 
 
 def test_live_version_gate_rejects_below_4_6(tmp_path, daemon_runtime_dir):
@@ -88,6 +113,8 @@ def test_daemon_status_and_stop_when_not_running(tmp_path, daemon_runtime_dir):
 
     status = run_daemon_status_operation(project)
     assert isinstance(status, DaemonStatusResult) and status.running is False
+    # No daemon -> no mode to read; `windowed` is None (no round trip, no hang, #251).
+    assert status.windowed is None
 
     stopped = run_daemon_stop_operation(project)
     assert isinstance(stopped, DaemonStopResult) and stopped.stopped is False

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -47,6 +47,17 @@ def test_control_ops_report_liveness_and_request_stop(tmp_path):
     assert server._stopping is True
 
 
+def test_status_op_reports_the_declared_display_mode(tmp_path):
+    # `daemon status` reads the running daemon's launch-time display mode over
+    # STATUS_OP (#251) — the daemon is the only authority for the mode it was
+    # started with — so the control reply must carry `windowed`.
+    headless = DaemonServer(daemon_paths(tmp_path), godot="")
+    assert headless._handle({"op": "__status__"})["windowed"] is False
+
+    windowed = DaemonServer(daemon_paths(tmp_path), godot="", windowed=True)
+    assert windowed._handle({"op": "__status__"})["windowed"] is True
+
+
 def test_engine_session_request_times_out_as_live_timeout(monkeypatch):
     # A harness that never replies must surface the registered live_timeout, not
     # hang the daemon forever (ADR-0021).

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -242,3 +242,37 @@ def test_daemon_uninstall_is_refused_while_running(tmp_path, daemon_runtime_dir)
         assert harness.exists()  # refusal left the install intact
     finally:
         run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_status_surfaces_the_windowed_display_mode(tmp_path, daemon_runtime_dir):
+    # #251: `daemon status` reports the running daemon's launch-time display mode,
+    # read over STATUS_OP through the console script, so an agent can tell whether a
+    # live session can serve a `screen` capture before issuing one. No daemon ->
+    # `windowed` null (clean, hang-free fallback); a default start -> false; a
+    # `--windowed` start -> true. The daemon records the mode at start; no engine
+    # session is launched here (lazy launch, ADR-0017), so this needs no display.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+
+    # No daemon running yet: running False, windowed null.
+    before = json.loads(run("daemon", "status").stdout)
+    assert before["running"] is False
+    assert before["windowed"] is None
+
+    try:
+        # The default start is headless -> status reports windowed False.
+        assert run("daemon", "start").returncode == 0
+        headless = json.loads(run("daemon", "status").stdout)
+        assert headless["running"] is True
+        assert headless["windowed"] is False
+        assert run("daemon", "stop").returncode == 0
+
+        # A `--windowed` start -> status reports windowed True.
+        assert run("daemon", "start", "--windowed").returncode == 0
+        windowed = json.loads(run("daemon", "status").stdout)
+        assert windowed["running"] is True
+        assert windowed["windowed"] is True
+    finally:
+        run("daemon", "stop")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -12,6 +12,7 @@ import pytest
 from gda import render as render_mod
 from gda.models import (
     DaemonStartResult,
+    DaemonStatusResult,
     DaemonUninstallResult,
     EngineVersion,
     GameGetResult,
@@ -223,6 +224,25 @@ def test_render_daemon_start_surfaces_a_version_sync(tmp_path):
     # A first install (changed but not a version-mismatch resync) reads as install.
     installed = synced.model_copy(update={"harness_synced": False})
     assert render(installed) == "daemon started: pid 42 on /tmp/x.sock (installed harness)"
+
+
+def test_render_daemon_status_notes_the_windowed_session(tmp_path):
+    # #251: `daemon status` surfaces the running daemon's display mode. Like
+    # `daemon start`, the marker shows only when windowed (headless is the default).
+    windowed = DaemonStatusResult(
+        running=True, pid=42, socket_path="/tmp/x.sock", windowed=True
+    )
+    assert render(windowed) == "daemon running: pid 42 on /tmp/x.sock [windowed]"
+
+    headless = windowed.model_copy(update={"windowed": False})
+    assert render(headless) == "daemon running: pid 42 on /tmp/x.sock"
+
+    # An unknown mode (e.g. a transient round-trip miss) renders no marker either.
+    unknown = windowed.model_copy(update={"windowed": None})
+    assert render(unknown) == "daemon running: pid 42 on /tmp/x.sock"
+
+    stopped = DaemonStatusResult(running=False, socket_path="/tmp/x.sock")
+    assert render(stopped) == "daemon not running"
 
 
 def test_render_daemon_uninstall_reports_removal(tmp_path):


### PR DESCRIPTION
## What

`gda daemon status` now reports the **running daemon's actual launch-time display mode** (`windowed`), so an agent can tell whether a live session can serve a `screen` capture op before issuing one.

Closes #251.

## Why

Today `run_daemon_status_operation` is **pidfile-only** — it never round-trips to the daemon. After PR #248, an already-running `gda daemon start` reports `windowed: null` ("not determined here"). So there was previously **no** way for an agent to read a running daemon's display mode.

## How

- `DaemonStatusResult` gains a `windowed: bool | null` field; `gda daemon status --schema` self-describes it, and gda-mcp picks it up mechanically (the tool surface is generated from the model schema).
- `run_daemon_status_operation` round-trips the daemon's `STATUS_OP` (via the existing bounded-timeout `_control` helper) when a daemon is up, and surfaces the reply's `windowed`. **Liveness stays the pidfile's call** (ADR-0021); when no daemon is running there is no round trip, so `windowed` is `null` alongside `running: false` — a clean, hang-free fallback.
- The live-stack `constraints` field and the `--json` / `GdaError` contract are unchanged.
- `render_daemon_status` notes ` [windowed]` only when windowed (mirrors `daemon start`).

### ⚠️ Correction to the issue's premise

The issue stated *"The daemon server already replies `windowed` over its `STATUS_OP`"* — this was **not** the case. `server.py` held `self.windowed` but the `STATUS_OP` handler returned only `{"ok": True, "pid": ...}`. This PR adds `windowed` to that reply (one line); the rest of the design is exactly as the issue describes.

## Acceptance criteria

- [x] `DaemonStatusResult` gains `windowed: bool | null`; `--schema` self-describes it
- [x] `daemon status` against a running daemon reports its actual launch-time `windowed` mode (read over `STATUS_OP`), not a pidfile guess
- [x] No daemon running → `running: false` and `windowed: null`, no error, no hang (bounded connect timeout)
- [x] Same `--json` / `GdaError` contract; live-stack `constraints` unchanged
- [x] Real-engine e2e: `daemon start --windowed` → `windowed: true`; default start → `windowed: false`; no daemon → `windowed: null`

## Tests

- **Fast:** server `STATUS_OP` carries `windowed`; recipe round-trip mapping (windowed True/False, null when no daemon, null on a transient round-trip miss); `render_daemon_status` marker; full fast suite green (844 passed).
- **e2e (serial, real daemon):** `test_daemon_ops.py` lifecycle reports `windowed: false` (default) + a windowed-start reports `true` + not-running reports `null`; `test_e2e_daemon.py` covers the full CLI acceptance scenario. No engine session is launched for these (lazy launch, ADR-0017), so they need no display and are headless-CI safe.
