### PR TITLE
refactor: command descriptor as the single per-command registration (ADR-0023)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -170,3 +170,13 @@ _Avoid_: tool, action
 A top-level command about `gda` or the engine itself rather than a domain object
 (`gda info`, `gda version`, `gda help`); exempt from grouping.
 _Avoid_: global command, system command
+
+**Command descriptor**:
+The single per-command registration object (`HeadlessCommand`) naming everything
+`gda` needs to run, render, and self-describe one command: its `operation` name,
+input/params and result models, execution `kind`, failure `classify`r, human
+`render`er, and optional `recipe` channel. The render map, dispatch routing, and
+`--schema` are **projections derived from it** — read off the descriptor on the
+dispatch path, or built by walking the live Typer tree (ADR-0012) for a
+whole-surface view — never parallel registries to keep in sync (ADR-0023).
+_Avoid_: command spec, command config, command registry entry

--- a/docs/adr/0023-command-descriptor-single-registration.md
+++ b/docs/adr/0023-command-descriptor-single-registration.md
@@ -1,0 +1,112 @@
+---
+status: accepted
+---
+
+# The command descriptor is the single per-command registration; render, dispatch channel, and schema are projections of it
+
+ADR-0017 put a static `kind` (`HEADLESS` / `EXPORT` / `LIVE`) on the command
+descriptor so the runner factory selects an execution channel by a single field,
+not an identity special-case. ADR-0004 / ADR-0012 made `--schema` and the
+aggregate manifest *derive* from the descriptor's models, walking the **live Typer
+command tree** rather than a hand-maintained list (zero central registry to keep in
+sync). Both ADRs point the same way: **one fact per command, everything else
+derived.** This ADR finishes that arc for the two facts still left out.
+
+Today the [command descriptor](../../CONTEXT.md) (`HeadlessCommand`: `operation`,
+`input_model`, `output_model`, `classify`, `kind`) holds five of a command's facts,
+but two more live elsewhere:
+
+- **The human renderer** lives in `render.py`'s 61-entry, type-keyed `_RENDERERS`
+  dict. Adding a command means defining the renderer *and* appending a dict entry —
+  a central append hot-spot ~hundreds of lines from the descriptor, and a
+  parallel-merge conflict point.
+- **The execution channel for recipe commands** (the `daemon` lifecycle group and
+  `screen` capture) is selected by **two identity frozensets**
+  (`_DAEMON_COMMANDS`, `_SCREEN_COMMANDS` in `cli.py`) — a *third* selection
+  mechanism alongside `kind` (export) and the default sentinel/live path. The
+  dispatch in `_run_params_json` (and its argv twin) branches three different ways;
+  a command added to the wrong-or-no frozenset routes **silently to the wrong
+  runner**, with no test asserting the sets are complete.
+
+So adding or renaming one command touches ~5 sites across `cli.py`, `render.py`, and
+`models.py`, held together only by the `operation`-name string convention. An
+architecture review (the 2026-06-23 deepening sweep) had two independent passes —
+command dispatch, and models/schema/render — converge on the same root cause: **the
+descriptor is the natural single registration, but it is only half-built.**
+
+## Decision
+
+**1. The `HeadlessCommand` descriptor is the single per-command registration. It
+absorbs the two missing facts.**
+
+- **`render`** — the per-result renderer, typed `Callable[[M], str]` against the
+  command's `output_model` `M`. `emit_result` renders through the descriptor's
+  `render`; the type-keyed `_RENDERERS` dict in `render.py` is **removed**. (The
+  renderer *functions* stay in `render.py`; only the dispatch dict goes.)
+- **`recipe`** — an optional execution-channel seam. A command **with** a `recipe`
+  is fulfilled by that recipe (the `export` / `daemon` / `screen` paths that bypass
+  the sentinel `cmd.emit`); a command **without** one goes through `cmd.emit` with
+  the `kind`-selected runner (sentinel `operations.gd` for `HEADLESS`, daemon IPC
+  for `LIVE`). This collapses the tri-modal selection — export-by-`kind`,
+  daemon-by-identity, screen-by-identity — into **one** descriptor-driven branch and
+  **dissolves both identity frozensets**.
+
+**2. The render map and dispatch routing are projections of the descriptor, not
+parallel registries.** On the `cmd.emit` path the descriptor is already in hand, so
+rendering and channel selection read off `cmd` directly. Where a whole-surface view
+is needed, it is built by walking the **live Typer tree** — the same authority
+ADR-0012 established for the schema manifest (`surface.py`), each leaf already
+carrying its backing descriptor as `gda_command` — never a hand-maintained list.
+
+**3. Scope is the Python side only; behavior is preserved.** The cross-language
+`operation`-name contract (the Python ↔ GDScript `OP_ERROR` mirror) and the GDScript
+dispatch in `operations.gd` are **out of scope** (left to their own future
+decision). The public contract is unchanged: same `--json` / `GdaError` / `--schema`
+output, same dispatch outcomes. This is an internal deepening.
+
+**4. A registration invariant test replaces the runtime `KeyError`.** A test walks
+the live Typer tree and asserts every dispatchable command's descriptor carries a
+renderer and resolves to exactly one channel (`recipe` xor `kind`-runner), and that
+no renderer is orphaned. The "command wired without a renderer" failure
+(`render()`'s `KeyError`) moves from first-invocation to test time.
+
+## Considered options
+
+- **Per-command-group modules** (`gda/commands/scene/` holding that group's models +
+  descriptor + renderer + CLI wiring). Rejected **for now**: a much larger move on
+  the central files, higher parallel-merge risk, and — as the review's models/render
+  pass cautioned — it can merely *spread* the `models.py` god-file across many files
+  without deepening anything unless the import surface and registration are also
+  consolidated. Revisit in its own ADR if the descriptor consolidation proves
+  insufficient.
+- **Keep the type-keyed `_RENDERERS` dict; only dissolve the frozensets.** Rejected:
+  it leaves the render append hot-spot and a second registry standing — half the
+  friction the review identified.
+- **A decorator / explicit registry of all descriptors.** Rejected: the live Typer
+  tree already *is* the registry (ADR-0012); a parallel registry duplicates that
+  authority and reintroduces the very drift this ADR removes.
+- **Fold only `daemon`/`screen` into the descriptor, leave `export` on its
+  `kind`-path.** Rejected: it would leave the dispatch bimodal (recipe-by-field +
+  export-by-kind) for no real gain; one uniform `recipe` seam is simpler and
+  complete.
+
+## Consequences
+
+- **One place per command.** The render map and dispatch are derived, so the two
+  append hot-spots dissolve and the silent-misroute frozenset risk is gone.
+- **`recipe` signature unification is the one-time cost.** The three recipes
+  (`run_export_operation`, the `daemon` lifecycle dispatch, `run_screen_*`) must
+  present a single shape — `recipe(params, *, project, godot, json_output)` owning
+  its own emission — so the dispatcher can call them uniformly. Contained, and paid
+  once.
+- **`emit_result` gains a renderer argument**; `render(result)`'s type dispatch is
+  removed (or retained only as a thin internal fallback). `render.py` keeps the
+  renderer functions and loses the 61-entry table.
+- **gda-mcp is unaffected** — it still derives its tool surface from the aggregate
+  manifest (ADR-0011/0012); the descriptor's new fields are not part of the wire
+  schema.
+- **Two follow-ons stay open, each its own ADR if pursued**: the cross-language
+  `operation`-name contract / GDScript dispatch (the review's deferred candidate),
+  and the per-group module split above.
+- Generalises the `kind` selector of ADR-0017 and reuses the tree-walk of ADR-0012;
+  amends neither — it completes the direction both set.

--- a/docs/adr/0023-command-descriptor-single-registration.md
+++ b/docs/adr/0023-command-descriptor-single-registration.md
@@ -44,12 +44,18 @@ absorbs the two missing facts.**
   `render`; the type-keyed `_RENDERERS` dict in `render.py` is **removed**. (The
   renderer *functions* stay in `render.py`; only the dispatch dict goes.)
 - **`recipe`** — an optional execution-channel seam. A command **with** a `recipe`
-  is fulfilled by that recipe (the `export` / `daemon` / `screen` paths that bypass
-  the sentinel `cmd.emit`); a command **without** one goes through `cmd.emit` with
-  the `kind`-selected runner (sentinel `operations.gd` for `HEADLESS`, daemon IPC
-  for `LIVE`). This collapses the tri-modal selection — export-by-`kind`,
-  daemon-by-identity, screen-by-identity — into **one** descriptor-driven branch and
-  **dissolves both identity frozensets**.
+  is fulfilled by it (the `export` / `daemon` / `screen` paths that bypass the
+  sentinel `cmd.emit`): the recipe **produces the outcome** (resolve the project +
+  run the CLI-side operation, returning the result model or a `Failure`), and a
+  shared dispatch tail emits it through the descriptor's **own `render`** — so a
+  recipe command renders identically to a sentinel one and emission stays
+  single-sourced, never duplicated per recipe. A command **without** a recipe goes
+  through `cmd.emit` with the `kind`-selected runner (sentinel `operations.gd` for
+  `HEADLESS`, daemon IPC for `LIVE`). This collapses the tri-modal selection —
+  export-by-`kind`, daemon-by-identity, screen-by-identity — into **one**
+  descriptor-driven branch (`recipe is None`?) and **dissolves both identity
+  frozensets** and the per-command identity-branching inside the old daemon
+  dispatch (each daemon command now carries its own recipe).
 
 **2. The render map and dispatch routing are projections of the descriptor, not
 parallel registries.** On the `cmd.emit` path the descriptor is already in hand, so
@@ -95,10 +101,12 @@ no renderer is orphaned. The "command wired without a renderer" failure
 - **One place per command.** The render map and dispatch are derived, so the two
   append hot-spots dissolve and the silent-misroute frozenset risk is gone.
 - **`recipe` signature unification is the one-time cost.** The three recipes
-  (`run_export_operation`, the `daemon` lifecycle dispatch, `run_screen_*`) must
-  present a single shape — `recipe(params, *, project, godot, json_output)` owning
-  its own emission — so the dispatcher can call them uniformly. Contained, and paid
-  once.
+  (`run_export_operation`, the per-command `run_daemon_*_operation`, `run_screen_*`)
+  are wrapped as thin per-command closures of one shape — `recipe(params, *,
+  project, godot)` returning the result model or a `Failure` — so the dispatcher
+  calls them uniformly and a shared tail emits the outcome via `cmd.render`.
+  Emission is **not** duplicated in each recipe; it stays the one shared path both
+  channels use. Contained, and paid once.
 - **`emit_result` gains a renderer argument**; `render(result)`'s type dispatch is
   removed (or retained only as a thin internal fallback). `render.py` keeps the
   renderer functions and loses the 61-entry table.

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -8,6 +8,7 @@ binary resolution → runner → sentinel parse → typed model → JSON.
 """
 
 import json
+from dataclasses import replace
 from importlib.metadata import version as package_version
 from pathlib import Path
 from typing import Optional
@@ -77,6 +78,7 @@ from gda.models import (
     ExportListParams,
     ExportListResult,
     ExportRunMode,
+    ExportRunParams,
     GameGetParams,
     GameGetResult,
     GameSetParams,
@@ -184,7 +186,6 @@ from gda.models import (
     SurfaceManifest,
     ThemeCreateParams,
     ThemeCreateResult,
-    normalize_path,
     resolve_set_mode,
 )
 from gda.project import resolve_project_dir
@@ -457,6 +458,74 @@ def _make_live_runner(binary: Optional[Path], project: Optional[Path]) -> GodotR
     return make_daemon_runner(project)
 
 
+# --- Recipe channels (ADR-0023) -----------------------------------------------
+# Each recipe command (export run / the daemon lifecycle / screen) carries one of
+# these on its descriptor (``recipe=``). A recipe PRODUCES the outcome — resolve the
+# project (kept CLI-side, ADR-0006) + run the CLI-side operation — and RETURNS the
+# typed result or a Failure; emission stays the shared tail (:func:`_dispatch_recipe`
+# → ``cmd.render``), so a recipe command renders exactly like a sentinel one. The
+# runner seams (``_make_*``) are referenced at call time so test monkeypatches on
+# ``gda.cli._make_runner`` / ``_make_live_runner`` still bind. ``params`` is the
+# built model — the single source of truth (ADR-0015), identical on the argv and
+# ``--params-json`` paths — so windowed/output/etc. are read off it, never special-cased.
+
+
+def _daemon_start_recipe(params, *, project, godot):
+    return run_daemon_start_operation(
+        resolve_project_dir(project), godot, windowed=params.windowed
+    )
+
+
+def _daemon_stop_recipe(params, *, project, godot):
+    return run_daemon_stop_operation(resolve_project_dir(project))
+
+
+def _daemon_status_recipe(params, *, project, godot):
+    return run_daemon_status_operation(resolve_project_dir(project))
+
+
+def _daemon_uninstall_recipe(params, *, project, godot):
+    return run_daemon_uninstall_operation(resolve_project_dir(project))
+
+
+def _screen_capture_recipe(params, *, project, godot):
+    return run_screen_capture_operation(
+        resolve_project_dir(project),
+        Path(params.output),
+        inline=params.inline,
+        make_runner=_make_live_runner,
+    )
+
+
+def _screen_frames_recipe(params, *, project, godot):
+    return run_screen_frames_operation(
+        resolve_project_dir(project),
+        params.frames,
+        Path(params.output_dir),
+        make_runner=_make_live_runner,
+    )
+
+
+def _export_run_recipe(params, *, project, godot):
+    return run_export_operation(
+        preset=params.preset,
+        mode=params.mode,
+        output_override=params.output,
+        godot=godot,
+        project=resolve_project_dir(project),
+        make_runner=_make_runner,
+        make_export_runner=_make_export_runner,
+    )
+
+
+# ``EXPORT_RUN_COMMAND`` is defined in ``gda.export_run`` (its descriptor sits beside
+# ``run_export_operation`` to avoid an export_run↔cli import cycle), but its recipe
+# needs cli's runner seams, which live here. cli.py is the composition root for
+# dispatch, so it completes the registration: rebind the imported descriptor with its
+# recipe. (export GET stays a plain sentinel command — no recipe.)
+EXPORT_RUN_COMMAND = replace(EXPORT_RUN_COMMAND, recipe=_export_run_recipe)
+
+
 def _emit(
     cmd: HeadlessCommand[M],
     params: BaseModel,
@@ -536,6 +605,31 @@ def _dispatch_meta(
     )
 
 
+def _dispatch_recipe(
+    cmd: HeadlessCommand[M],
+    params: BaseModel,
+    *,
+    json_output: bool,
+    godot: Optional[str],
+    project: Optional[str],
+) -> None:
+    """Run a recipe command through its descriptor's ``recipe``, then emit (ADR-0023).
+
+    A recipe command (``export run`` / the ``daemon`` lifecycle / ``screen``) is
+    fulfilled by a CLI-side recipe that PRODUCES the outcome, not the sentinel
+    ``cmd.emit``. Emission is the SAME shared tail every command uses —
+    :func:`emit_result` with the command's own ``cmd.render`` — so a recipe command
+    renders identically to a sentinel one; only outcome production differs. Shared by
+    the argv bodies and the ``--params-json`` path, so the two forms are
+    indistinguishable downstream (ADR-0015). Project resolution stays CLI-side
+    (ADR-0006), owned by each recipe.
+    """
+    outcome = cmd.recipe(params, project=project, godot=godot)
+    if isinstance(outcome, Failure):
+        emit_failure(outcome)
+    emit_result(outcome, json_output, cmd.render)
+
+
 def _run_params_json(
     cmd: HeadlessCommand[M], params: BaseModel, ctx: typer.Context
 ) -> None:
@@ -552,63 +646,19 @@ def _run_params_json(
     options = ctx.params
     json_output = bool(options.get("json_output", False))
     godot = options.get("godot")
-    if cmd.kind is ExecutionKind.EXPORT:
-        # export run is the native-export recipe (#187), not the sentinel
-        # pipeline, so it cannot go through cmd.emit. Selected by its static
-        # execution channel (ADR-0017), not command identity. Mirror its body so
-        # --params-json drives the SAME run_export_operation path as the argv
-        # form. params.output is already normalized (ExportRunParams.output is a
-        # NormalizedPath), so no extra normalization is needed here.
-        outcome = run_export_operation(
-            preset=params.preset,
-            mode=params.mode,
-            output_override=params.output,
-            godot=godot,
-            project=resolve_project_dir(options.get("project")),
-            make_runner=_make_runner,
-            make_export_runner=_make_export_runner,
-        )
-        if isinstance(outcome, Failure):
-            emit_failure(outcome)
-        emit_result(outcome, json_output, cmd.render)
-        return
-    if cmd in _DAEMON_COMMANDS:
-        # daemon lifecycle commands run their process recipe (gda.daemon_ops),
-        # not the sentinel pipeline; route --params-json to the SAME recipe the
-        # argv body uses. `daemon start` carries the `windowed` mode in its params
-        # model (#222); the other lifecycle commands have empty params.
-        _daemon_dispatch(
+    if cmd.recipe is not None:
+        # A recipe command (export run / daemon lifecycle / screen) is fulfilled by
+        # its descriptor's recipe, not the sentinel cmd.emit — ONE descriptor-driven
+        # branch, no kind/identity selection (ADR-0023). The recipe reads everything
+        # from the built params model (windowed/output/…), so --params-json drives the
+        # SAME path as the argv body.
+        _dispatch_recipe(
             cmd,
+            params,
             json_output=json_output,
             godot=godot,
             project=options.get("project"),
-            windowed=bool(getattr(params, "windowed", False)),
         )
-        return
-    if cmd in _SCREEN_COMMANDS:
-        # screen commands run the gda.screen_ops recipe, not the sentinel pipeline;
-        # route --params-json to the SAME recipe the argv body uses. The output
-        # path(s) are now part of the params model (#222, PR #248 review), so they
-        # come from `params` — the single source of truth (ADR-0015), supplied
-        # entirely by the JSON object, never recovered from ctx.params.
-        resolved = resolve_project_dir(options.get("project"))
-        if cmd is SCREEN_CAPTURE_COMMAND:
-            outcome = run_screen_capture_operation(
-                resolved,
-                Path(params.output),
-                inline=params.inline,
-                make_runner=_make_live_runner,
-            )
-        else:
-            outcome = run_screen_frames_operation(
-                resolved,
-                params.frames,
-                Path(params.output_dir),
-                make_runner=_make_live_runner,
-            )
-        if isinstance(outcome, Failure):
-            emit_failure(outcome)
-        emit_result(outcome, json_output, cmd.render)
         return
     if "project" in options:
         _dispatch(
@@ -1209,6 +1259,7 @@ DAEMON_START_COMMAND: HeadlessCommand[DaemonStartResult] = HeadlessCommand(
     input_model=DaemonStartParams,
     output_model=DaemonStartResult,
     render=render_daemon_start,
+    recipe=_daemon_start_recipe,
 )
 
 DAEMON_STOP_COMMAND: HeadlessCommand[DaemonStopResult] = HeadlessCommand(
@@ -1216,6 +1267,7 @@ DAEMON_STOP_COMMAND: HeadlessCommand[DaemonStopResult] = HeadlessCommand(
     input_model=DaemonStopParams,
     output_model=DaemonStopResult,
     render=render_daemon_stop,
+    recipe=_daemon_stop_recipe,
 )
 
 DAEMON_STATUS_COMMAND: HeadlessCommand[DaemonStatusResult] = HeadlessCommand(
@@ -1223,6 +1275,7 @@ DAEMON_STATUS_COMMAND: HeadlessCommand[DaemonStatusResult] = HeadlessCommand(
     input_model=DaemonStatusParams,
     output_model=DaemonStatusResult,
     render=render_daemon_status,
+    recipe=_daemon_status_recipe,
 )
 
 DAEMON_UNINSTALL_COMMAND: HeadlessCommand[DaemonUninstallResult] = HeadlessCommand(
@@ -1230,45 +1283,8 @@ DAEMON_UNINSTALL_COMMAND: HeadlessCommand[DaemonUninstallResult] = HeadlessComma
     input_model=DaemonUninstallParams,
     output_model=DaemonUninstallResult,
     render=render_daemon_uninstall,
+    recipe=_daemon_uninstall_recipe,
 )
-
-# The daemon lifecycle commands run a process-management recipe (gda.daemon_ops),
-# not the sentinel pipeline — the same shape as `export run`. They carry no Godot
-# execution channel, so they are routed by command identity, shared by the argv
-# bodies and the --params-json path so both forms drive the SAME recipe.
-_DAEMON_COMMANDS = frozenset(
-    {
-        DAEMON_START_COMMAND,
-        DAEMON_STOP_COMMAND,
-        DAEMON_STATUS_COMMAND,
-        DAEMON_UNINSTALL_COMMAND,
-    }
-)
-
-
-def _daemon_dispatch(
-    cmd: HeadlessCommand[M],
-    *,
-    json_output: bool,
-    godot: Optional[str],
-    project: Optional[str],
-    windowed: bool = False,
-) -> None:
-    """Run a ``daemon`` lifecycle command through its process-management recipe."""
-    resolved = resolve_project_dir(project)
-    if cmd is DAEMON_START_COMMAND:
-        # `daemon start --windowed` declares the engine session's display mode at
-        # launch (#222); other lifecycle commands ignore it.
-        outcome = run_daemon_start_operation(resolved, godot, windowed=windowed)
-    elif cmd is DAEMON_STOP_COMMAND:
-        outcome = run_daemon_stop_operation(resolved)
-    elif cmd is DAEMON_UNINSTALL_COMMAND:
-        outcome = run_daemon_uninstall_operation(resolved)
-    else:
-        outcome = run_daemon_status_operation(resolved)
-    if isinstance(outcome, Failure):
-        emit_failure(outcome)
-    emit_result(outcome, json_output, cmd.render)
 
 
 @daemon_app.command(name="start", cls=DAEMON_START_COMMAND.command_class())
@@ -1297,12 +1313,15 @@ def daemon_start(
     `--schema` (ADR-0021), not restated here. `--windowed` is a start-time declared
     mode for the engine session a `screen` capture op needs (#222).
     """
-    _daemon_dispatch(
+    # Build the params model from the argv option (the single source of truth,
+    # ADR-0015) so the recipe reads `windowed` off it on BOTH the argv and
+    # --params-json paths — no special-casing.
+    _dispatch_recipe(
         DAEMON_START_COMMAND,
+        DaemonStartParams(windowed=windowed),
         json_output=json_output,
         godot=godot,
         project=project,
-        windowed=windowed,
     )
 
 
@@ -1319,8 +1338,12 @@ def daemon_stop(
     On an unsupported platform this reports `live_unsupported_platform`; the
     platform precondition is the structured `constraints` field of `--schema`.
     """
-    _daemon_dispatch(
-        DAEMON_STOP_COMMAND, json_output=json_output, godot=godot, project=project
+    _dispatch_recipe(
+        DAEMON_STOP_COMMAND,
+        DaemonStopParams(),
+        json_output=json_output,
+        godot=godot,
+        project=project,
     )
 
 
@@ -1337,8 +1360,12 @@ def daemon_status(
     On an unsupported platform this reports `live_unsupported_platform`; the
     platform precondition is the structured `constraints` field of `--schema`.
     """
-    _daemon_dispatch(
-        DAEMON_STATUS_COMMAND, json_output=json_output, godot=godot, project=project
+    _dispatch_recipe(
+        DAEMON_STATUS_COMMAND,
+        DaemonStatusParams(),
+        json_output=json_output,
+        godot=godot,
+        project=project,
     )
 
 
@@ -1359,24 +1386,29 @@ def daemon_uninstall(
     with `gda daemon stop`. Live is macOS/Linux only; elsewhere reports
     `live_unsupported_platform`.
     """
-    _daemon_dispatch(
-        DAEMON_UNINSTALL_COMMAND, json_output=json_output, godot=godot, project=project
+    _dispatch_recipe(
+        DAEMON_UNINSTALL_COMMAND,
+        DaemonUninstallParams(),
+        json_output=json_output,
+        godot=godot,
+        project=project,
     )
 
 
 # The `screen` commands are LIVE but run a CLI-side recipe (gda.screen_ops), not
 # the sentinel pipeline: the harness returns the PNG as base64 in the sentinel and
 # the CLI must DECODE + WRITE a file before it has the path-based public result. So
-# — like `export run` and the daemon lifecycle commands — each carries a descriptor
-# for its --schema/--params-json wiring (kind = LIVE makes "kind":"live" appear,
-# #230) but dispatches through its recipe. They are selected by command identity in
-# the --params-json path, the same as the daemon commands.
+# — like `export run` and the daemon lifecycle commands — each carries a `recipe` on
+# its descriptor (ADR-0023): dispatch runs it instead of cmd.emit, selected by the
+# single `recipe is not None` test, not command identity. `kind = LIVE` is kept as a
+# descriptor fact so "kind":"live" still appears in --schema (#230).
 SCREEN_CAPTURE_COMMAND: HeadlessCommand[ScreenCaptureResult] = HeadlessCommand(
     operation="screen-capture",
     input_model=ScreenCaptureParams,
     output_model=ScreenCaptureResult,
     render=render_screen_capture,
     kind=ExecutionKind.LIVE,
+    recipe=_screen_capture_recipe,
 )
 
 SCREEN_FRAMES_COMMAND: HeadlessCommand[ScreenFramesResult] = HeadlessCommand(
@@ -1385,9 +1417,8 @@ SCREEN_FRAMES_COMMAND: HeadlessCommand[ScreenFramesResult] = HeadlessCommand(
     output_model=ScreenFramesResult,
     render=render_screen_frames,
     kind=ExecutionKind.LIVE,
+    recipe=_screen_frames_recipe,
 )
-
-_SCREEN_COMMANDS = frozenset({SCREEN_CAPTURE_COMMAND, SCREEN_FRAMES_COMMAND})
 
 
 @screen_app.command(name="capture", cls=SCREEN_CAPTURE_COMMAND.command_class())
@@ -1420,17 +1451,15 @@ def screen_capture(
     """
     # Build the params model from the argv options so `output` is validated and
     # ~-normalized through the SAME single source of truth the --params-json path
-    # uses (ADR-0015/ADR-0006) — not a raw, un-normalized Path.
-    params = ScreenCaptureParams(output=str(output), inline=inline)
-    outcome = run_screen_capture_operation(
-        resolve_project_dir(project),
-        Path(params.output),
-        inline=params.inline,
-        make_runner=_make_live_runner,
+    # uses (ADR-0015/ADR-0006) — not a raw, un-normalized Path. Dispatch through the
+    # descriptor's recipe, exactly as the --params-json path does (ADR-0023).
+    _dispatch_recipe(
+        SCREEN_CAPTURE_COMMAND,
+        ScreenCaptureParams(output=str(output), inline=inline),
+        json_output=json_output,
+        godot=godot,
+        project=project,
     )
-    if isinstance(outcome, Failure):
-        emit_failure(outcome)
-    emit_result(outcome, json_output, SCREEN_CAPTURE_COMMAND.render)
 
 
 @screen_app.command(name="frames", cls=SCREEN_FRAMES_COMMAND.command_class())
@@ -1467,17 +1496,15 @@ def screen_frames(
     `live_display_unavailable`. With no daemon it reports `daemon_not_running`.
     """
     # Same params model the --params-json path builds (ADR-0015): `output_dir` is
-    # validated and ~-normalized through it, not passed as a raw Path.
-    params = ScreenFramesParams(frames=frames, output_dir=str(output_dir))
-    outcome = run_screen_frames_operation(
-        resolve_project_dir(project),
-        params.frames,
-        Path(params.output_dir),
-        make_runner=_make_live_runner,
+    # validated and ~-normalized through it, not passed as a raw Path. Dispatch
+    # through the descriptor's recipe, exactly as the --params-json path (ADR-0023).
+    _dispatch_recipe(
+        SCREEN_FRAMES_COMMAND,
+        ScreenFramesParams(frames=frames, output_dir=str(output_dir)),
+        json_output=json_output,
+        godot=godot,
+        project=project,
     )
-    if isinstance(outcome, Failure):
-        emit_failure(outcome)
-    emit_result(outcome, json_output, SCREEN_FRAMES_COMMAND.render)
 
 
 SCENE_CREATE_COMMAND: HeadlessCommand[SceneCreateResult] = HeadlessCommand(
@@ -1777,15 +1804,11 @@ PROJECT_STATISTICS_COMMAND: HeadlessCommand[ProjectStatisticsResult] = HeadlessC
 )
 
 
-# Path normalization now lives in the models (ADR-0015) via the NormalizedPath
-# field type, the single home shared by the argv and ``--params-json`` paths —
-# every domain command's body passes its raw path straight to the params model.
-# The one exception is ``export run`` (issue #187): its argv body does NOT build
-# an ``ExportRunParams`` (it passes preset/mode/output straight to
-# ``run_export_operation``), so the model's NormalizedPath on ``output`` only
-# fires on the ``--params-json`` path. The argv ``--output`` is therefore still
-# normalized here, via this alias, to keep both export-run paths consistent.
-_normalize_path = normalize_path
+# Path normalization lives in the models (ADR-0015) via the NormalizedPath field
+# type, the single home shared by the argv and ``--params-json`` paths — every
+# command's body (``export run`` included, since ADR-0023 routed it through a built
+# ``ExportRunParams``) passes its raw path straight to the params model, which
+# ~-expands it. There is no CLI-layer normalization step left to share.
 
 
 @scene_app.command(cls=SCENE_CREATE_COMMAND.command_class())
@@ -2802,22 +2825,17 @@ def run_export(
     ``--output`` overrides the preset's configured ``export_path``; both are
     reflected in the native invocation and the reported result (#170).
     """
-    # --output is a filesystem path: normalize it ONCE here (ADR-0006, ~-expanded)
-    # at the CLI layer before it reaches the operation, like every other
-    # path-taking command. The operation receives the already-normalized override.
-    override_output = _normalize_path(output) if output is not None else None
-    outcome = run_export_operation(
-        preset=preset,
-        mode=mode,
-        output_override=override_output,
+    # Build the params model from the argv options (the single source of truth,
+    # ADR-0015): ExportRunParams.output is a NormalizedPath, so the model ~-expands
+    # it (ADR-0006) — argv and --params-json normalize identically. Dispatch through
+    # the descriptor's recipe (ADR-0023), exactly like every other recipe command.
+    _dispatch_recipe(
+        EXPORT_RUN_COMMAND,
+        ExportRunParams(preset=preset, mode=mode, output=output),
+        json_output=json_output,
         godot=godot,
-        project=resolve_project_dir(project),
-        make_runner=_make_runner,
-        make_export_runner=_make_export_runner,
+        project=project,
     )
-    if isinstance(outcome, Failure):
-        emit_failure(outcome)
-    emit_result(outcome, json_output, EXPORT_RUN_COMMAND.render)
 
 
 @resource_app.command(name="uid", cls=RESOURCE_UID_COMMAND.command_class())

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -188,6 +188,66 @@ from gda.models import (
     resolve_set_mode,
 )
 from gda.project import resolve_project_dir
+from gda.render import (
+    render_daemon_start,
+    render_daemon_status,
+    render_daemon_stop,
+    render_daemon_uninstall,
+    render_diag_errors,
+    render_diag_log,
+    render_engine_version,
+    render_export_list,
+    render_game_get,
+    render_game_set,
+    render_game_tree,
+    render_input_action,
+    render_input_key,
+    render_input_mouse,
+    render_input_sequence,
+    render_node_add,
+    render_node_connect_signal,
+    render_node_disconnect_signal,
+    render_node_duplicate,
+    render_node_list,
+    render_node_move,
+    render_node_properties,
+    render_node_remove,
+    render_node_set,
+    render_perf_monitor,
+    render_perf_monitors,
+    render_project_add_autoload,
+    render_project_dependencies,
+    render_project_find_references,
+    render_project_find_unused_resources,
+    render_project_get,
+    render_project_info,
+    render_project_remove_autoload,
+    render_project_set,
+    render_project_statistics,
+    render_resource_create,
+    render_resource_delete,
+    render_resource_properties,
+    render_resource_set,
+    render_resource_uid,
+    render_scene_delete,
+    render_scene_exports,
+    render_scene_list,
+    render_scene_metadata,
+    render_scene_tree,
+    render_screen_capture,
+    render_screen_frames,
+    render_script_attach,
+    render_script_create,
+    render_script_delete,
+    render_script_get,
+    render_script_list,
+    render_script_set,
+    render_script_validate,
+    render_shader_create,
+    render_shader_get,
+    render_shader_set,
+    render_theme_create,
+)
 from gda.runner import GodotRunner
 from gda.screen_ops import (
     run_screen_capture_operation,
@@ -442,8 +502,8 @@ def _dispatch(
     seam, the ``json_output`` pass-through, and the JSON-vs-text branch. Each
     command keeps its own Typer signature, params construction, and
     pre-dispatch validation; only this execution tail is shared. Human
-    rendering is type-dispatched by :func:`gda.render.render` inside
-    ``cmd.emit`` (issue #186), so no renderer is threaded here.
+    rendering is done by the command's own renderer (``cmd.render``, ADR-0023)
+    inside ``cmd.emit``, so no renderer is threaded here.
     """
     _emit(
         cmd,
@@ -510,7 +570,7 @@ def _run_params_json(
         )
         if isinstance(outcome, Failure):
             emit_failure(outcome)
-        emit_result(outcome, json_output)
+        emit_result(outcome, json_output, cmd.render)
         return
     if cmd in _DAEMON_COMMANDS:
         # daemon lifecycle commands run their process recipe (gda.daemon_ops),
@@ -548,7 +608,7 @@ def _run_params_json(
             )
         if isinstance(outcome, Failure):
             emit_failure(outcome)
-        emit_result(outcome, json_output)
+        emit_result(outcome, json_output, cmd.render)
         return
     if "project" in options:
         _dispatch(
@@ -569,6 +629,7 @@ INFO_COMMAND: HeadlessCommand[EngineVersion] = HeadlessCommand(
     operation="info",
     input_model=InfoParams,
     output_model=EngineVersion,
+    render=render_engine_version,
     classify=classify_info,
 )
 
@@ -576,6 +637,7 @@ GAME_TREE_COMMAND: HeadlessCommand[GameTreeResult] = HeadlessCommand(
     operation="game-tree",
     input_model=GameTreeParams,
     output_model=GameTreeResult,
+    render=render_game_tree,
     classify=classify_game_tree,
     kind=ExecutionKind.LIVE,
 )
@@ -612,6 +674,7 @@ GAME_GET_COMMAND: HeadlessCommand[GameGetResult] = HeadlessCommand(
     operation="game-get",
     input_model=GameGetParams,
     output_model=GameGetResult,
+    render=render_game_get,
     classify=classify_game_get,
     kind=ExecutionKind.LIVE,
 )
@@ -656,6 +719,7 @@ GAME_SET_COMMAND: HeadlessCommand[GameSetResult] = HeadlessCommand(
     operation="game-set",
     input_model=GameSetParams,
     output_model=GameSetResult,
+    render=render_game_set,
     classify=classify_game_set,
     kind=ExecutionKind.LIVE,
 )
@@ -724,6 +788,7 @@ DIAG_ERRORS_COMMAND: HeadlessCommand[DiagErrorsResult] = HeadlessCommand(
     operation="diag-errors",
     input_model=DiagErrorsParams,
     output_model=DiagErrorsResult,
+    render=render_diag_errors,
     classify=classify_diag_errors,
     kind=ExecutionKind.LIVE,
 )
@@ -763,6 +828,7 @@ DIAG_LOG_COMMAND: HeadlessCommand[DiagLogResult] = HeadlessCommand(
     operation="diag-log",
     input_model=DiagLogParams,
     output_model=DiagLogResult,
+    render=render_diag_log,
     classify=classify_diag_log,
     kind=ExecutionKind.LIVE,
 )
@@ -798,6 +864,7 @@ PERF_MONITORS_COMMAND: HeadlessCommand[PerfMonitorsResult] = HeadlessCommand(
     operation="perf-monitors",
     input_model=PerfMonitorsParams,
     output_model=PerfMonitorsResult,
+    render=render_perf_monitors,
     classify=classify_perf_monitors,
     kind=ExecutionKind.LIVE,
 )
@@ -832,6 +899,7 @@ PERF_MONITOR_COMMAND: HeadlessCommand[PerfMonitorResult] = HeadlessCommand(
     operation="perf-monitor",
     input_model=PerfMonitorParams,
     output_model=PerfMonitorResult,
+    render=render_perf_monitor,
     classify=classify_perf_monitor,
     kind=ExecutionKind.LIVE,
 )
@@ -901,6 +969,7 @@ INPUT_KEY_COMMAND: HeadlessCommand[InputKeyResult] = HeadlessCommand(
     operation="input-key",
     input_model=InputKeyParams,
     output_model=InputKeyResult,
+    render=render_input_key,
     classify=classify_input_key,
     kind=ExecutionKind.LIVE,
 )
@@ -950,6 +1019,7 @@ INPUT_MOUSE_CLICK_COMMAND: HeadlessCommand[InputMouseResult] = HeadlessCommand(
     operation="input-mouse-click",
     input_model=InputMouseClickParams,
     output_model=InputMouseResult,
+    render=render_input_mouse,
     classify=classify_input_mouse,
     kind=ExecutionKind.LIVE,
 )
@@ -992,6 +1062,7 @@ INPUT_MOUSE_MOVE_COMMAND: HeadlessCommand[InputMouseResult] = HeadlessCommand(
     operation="input-mouse-move",
     input_model=InputMouseMoveParams,
     output_model=InputMouseResult,
+    render=render_input_mouse,
     classify=classify_input_mouse,
     kind=ExecutionKind.LIVE,
 )
@@ -1026,6 +1097,7 @@ INPUT_ACTION_COMMAND: HeadlessCommand[InputActionResult] = HeadlessCommand(
     operation="input-action",
     input_model=InputActionParams,
     output_model=InputActionResult,
+    render=render_input_action,
     classify=classify_input_action,
     kind=ExecutionKind.LIVE,
 )
@@ -1077,6 +1149,7 @@ INPUT_SEQUENCE_COMMAND: HeadlessCommand[InputSequenceResult] = HeadlessCommand(
     operation="input-sequence",
     input_model=InputSequenceParams,
     output_model=InputSequenceResult,
+    render=render_input_sequence,
     classify=classify_input_sequence,
     kind=ExecutionKind.LIVE,
 )
@@ -1135,24 +1208,28 @@ DAEMON_START_COMMAND: HeadlessCommand[DaemonStartResult] = HeadlessCommand(
     operation="daemon-start",
     input_model=DaemonStartParams,
     output_model=DaemonStartResult,
+    render=render_daemon_start,
 )
 
 DAEMON_STOP_COMMAND: HeadlessCommand[DaemonStopResult] = HeadlessCommand(
     operation="daemon-stop",
     input_model=DaemonStopParams,
     output_model=DaemonStopResult,
+    render=render_daemon_stop,
 )
 
 DAEMON_STATUS_COMMAND: HeadlessCommand[DaemonStatusResult] = HeadlessCommand(
     operation="daemon-status",
     input_model=DaemonStatusParams,
     output_model=DaemonStatusResult,
+    render=render_daemon_status,
 )
 
 DAEMON_UNINSTALL_COMMAND: HeadlessCommand[DaemonUninstallResult] = HeadlessCommand(
     operation="daemon-uninstall",
     input_model=DaemonUninstallParams,
     output_model=DaemonUninstallResult,
+    render=render_daemon_uninstall,
 )
 
 # The daemon lifecycle commands run a process-management recipe (gda.daemon_ops),
@@ -1191,7 +1268,7 @@ def _daemon_dispatch(
         outcome = run_daemon_status_operation(resolved)
     if isinstance(outcome, Failure):
         emit_failure(outcome)
-    emit_result(outcome, json_output)
+    emit_result(outcome, json_output, cmd.render)
 
 
 @daemon_app.command(name="start", cls=DAEMON_START_COMMAND.command_class())
@@ -1298,6 +1375,7 @@ SCREEN_CAPTURE_COMMAND: HeadlessCommand[ScreenCaptureResult] = HeadlessCommand(
     operation="screen-capture",
     input_model=ScreenCaptureParams,
     output_model=ScreenCaptureResult,
+    render=render_screen_capture,
     kind=ExecutionKind.LIVE,
 )
 
@@ -1305,6 +1383,7 @@ SCREEN_FRAMES_COMMAND: HeadlessCommand[ScreenFramesResult] = HeadlessCommand(
     operation="screen-frames",
     input_model=ScreenFramesParams,
     output_model=ScreenFramesResult,
+    render=render_screen_frames,
     kind=ExecutionKind.LIVE,
 )
 
@@ -1351,7 +1430,7 @@ def screen_capture(
     )
     if isinstance(outcome, Failure):
         emit_failure(outcome)
-    emit_result(outcome, json_output)
+    emit_result(outcome, json_output, SCREEN_CAPTURE_COMMAND.render)
 
 
 @screen_app.command(name="frames", cls=SCREEN_FRAMES_COMMAND.command_class())
@@ -1398,85 +1477,98 @@ def screen_frames(
     )
     if isinstance(outcome, Failure):
         emit_failure(outcome)
-    emit_result(outcome, json_output)
+    emit_result(outcome, json_output, SCREEN_FRAMES_COMMAND.render)
 
 
 SCENE_CREATE_COMMAND: HeadlessCommand[SceneCreateResult] = HeadlessCommand(
     operation="scene-create",
     input_model=SceneCreateParams,
     output_model=SceneCreateResult,
+    render=render_scene_metadata,
 )
 
 SCENE_GET_COMMAND: HeadlessCommand[SceneGetResult] = HeadlessCommand(
     operation="scene-get",
     input_model=SceneGetParams,
     output_model=SceneGetResult,
+    render=render_scene_tree,
 )
 
 SCENE_GET_EXPORTS_COMMAND: HeadlessCommand[SceneGetExportsResult] = HeadlessCommand(
     operation="scene-get-exports",
     input_model=SceneGetExportsParams,
     output_model=SceneGetExportsResult,
+    render=render_scene_exports,
 )
 
 SCENE_LIST_COMMAND: HeadlessCommand[SceneListResult] = HeadlessCommand(
     operation="scene-list",
     input_model=SceneListParams,
     output_model=SceneListResult,
+    render=render_scene_list,
 )
 
 SCENE_DELETE_COMMAND: HeadlessCommand[SceneDeleteResult] = HeadlessCommand(
     operation="scene-delete",
     input_model=SceneDeleteParams,
     output_model=SceneDeleteResult,
+    render=render_scene_delete,
 )
 
 NODE_ADD_COMMAND: HeadlessCommand[NodeAddResult] = HeadlessCommand(
     operation="node-add",
     input_model=NodeAddParams,
     output_model=NodeAddResult,
+    render=render_node_add,
 )
 
 NODE_LIST_COMMAND: HeadlessCommand[NodeListResult] = HeadlessCommand(
     operation="node-list",
     input_model=NodeListParams,
     output_model=NodeListResult,
+    render=render_node_list,
 )
 
 NODE_GET_COMMAND: HeadlessCommand[NodeGetResult] = HeadlessCommand(
     operation="node-get",
     input_model=NodeGetParams,
     output_model=NodeGetResult,
+    render=render_node_properties,
 )
 
 NODE_SET_COMMAND: HeadlessCommand[NodeSetResult] = HeadlessCommand(
     operation="node-set",
     input_model=NodeSetParams,
     output_model=NodeSetResult,
+    render=render_node_set,
 )
 
 NODE_REMOVE_COMMAND: HeadlessCommand[NodeRemoveResult] = HeadlessCommand(
     operation="node-remove",
     input_model=NodeRemoveParams,
     output_model=NodeRemoveResult,
+    render=render_node_remove,
 )
 
 NODE_DUPLICATE_COMMAND: HeadlessCommand[NodeDuplicateResult] = HeadlessCommand(
     operation="node-duplicate",
     input_model=NodeDuplicateParams,
     output_model=NodeDuplicateResult,
+    render=render_node_duplicate,
 )
 
 NODE_MOVE_COMMAND: HeadlessCommand[NodeMoveResult] = HeadlessCommand(
     operation="node-move",
     input_model=NodeMoveParams,
     output_model=NodeMoveResult,
+    render=render_node_move,
 )
 
 NODE_CONNECT_SIGNAL_COMMAND: HeadlessCommand[NodeConnectSignalResult] = HeadlessCommand(
     operation="node-connect-signal",
     input_model=NodeConnectSignalParams,
     output_model=NodeConnectSignalResult,
+    render=render_node_connect_signal,
 )
 
 NODE_DISCONNECT_SIGNAL_COMMAND: HeadlessCommand[NodeDisconnectSignalResult] = (
@@ -1484,6 +1576,7 @@ NODE_DISCONNECT_SIGNAL_COMMAND: HeadlessCommand[NodeDisconnectSignalResult] = (
         operation="node-disconnect-signal",
         input_model=NodeDisconnectSignalParams,
         output_model=NodeDisconnectSignalResult,
+        render=render_node_disconnect_signal,
     )
 )
 
@@ -1491,42 +1584,49 @@ SCRIPT_CREATE_COMMAND: HeadlessCommand[ScriptCreateResult] = HeadlessCommand(
     operation="script-create",
     input_model=ScriptCreateParams,
     output_model=ScriptCreateResult,
+    render=render_script_create,
 )
 
 SCRIPT_GET_COMMAND: HeadlessCommand[ScriptGetResult] = HeadlessCommand(
     operation="script-get",
     input_model=ScriptGetParams,
     output_model=ScriptGetResult,
+    render=render_script_get,
 )
 
 SCRIPT_LIST_COMMAND: HeadlessCommand[ScriptListResult] = HeadlessCommand(
     operation="script-list",
     input_model=ScriptListParams,
     output_model=ScriptListResult,
+    render=render_script_list,
 )
 
 SCRIPT_DELETE_COMMAND: HeadlessCommand[ScriptDeleteResult] = HeadlessCommand(
     operation="script-delete",
     input_model=ScriptDeleteParams,
     output_model=ScriptDeleteResult,
+    render=render_script_delete,
 )
 
 SCRIPT_SET_COMMAND: HeadlessCommand[ScriptSetResult] = HeadlessCommand(
     operation="script-set",
     input_model=ScriptSetParams,
     output_model=ScriptSetResult,
+    render=render_script_set,
 )
 
 SCRIPT_ATTACH_COMMAND: HeadlessCommand[ScriptAttachResult] = HeadlessCommand(
     operation="script-attach",
     input_model=ScriptAttachParams,
     output_model=ScriptAttachResult,
+    render=render_script_attach,
 )
 
 SCRIPT_VALIDATE_COMMAND: HeadlessCommand[ScriptValidateResult] = HeadlessCommand(
     operation="script-validate",
     input_model=ScriptValidateParams,
     output_model=ScriptValidateResult,
+    render=render_script_validate,
     classify=classify_script_validate,
 )
 
@@ -1534,30 +1634,35 @@ RESOURCE_CREATE_COMMAND: HeadlessCommand[ResourceCreateResult] = HeadlessCommand
     operation="resource-create",
     input_model=ResourceCreateParams,
     output_model=ResourceCreateResult,
+    render=render_resource_create,
 )
 
 RESOURCE_GET_COMMAND: HeadlessCommand[ResourceGetResult] = HeadlessCommand(
     operation="resource-get",
     input_model=ResourceGetParams,
     output_model=ResourceGetResult,
+    render=render_resource_properties,
 )
 
 RESOURCE_SET_COMMAND: HeadlessCommand[ResourceSetResult] = HeadlessCommand(
     operation="resource-set",
     input_model=ResourceSetParams,
     output_model=ResourceSetResult,
+    render=render_resource_set,
 )
 
 RESOURCE_DELETE_COMMAND: HeadlessCommand[ResourceDeleteResult] = HeadlessCommand(
     operation="resource-delete",
     input_model=ResourceDeleteParams,
     output_model=ResourceDeleteResult,
+    render=render_resource_delete,
 )
 
 EXPORT_LIST_COMMAND: HeadlessCommand[ExportListResult] = HeadlessCommand(
     operation="export-list",
     input_model=ExportListParams,
     output_model=ExportListResult,
+    render=render_export_list,
 )
 
 # EXPORT_GET_COMMAND / EXPORT_RUN_COMMAND live in gda.export_run (imported above):
@@ -1569,30 +1674,35 @@ RESOURCE_UID_COMMAND: HeadlessCommand[ResourceUidResult] = HeadlessCommand(
     operation="resource-uid",
     input_model=ResourceUidParams,
     output_model=ResourceUidResult,
+    render=render_resource_uid,
 )
 
 PROJECT_INFO_COMMAND: HeadlessCommand[ProjectInfoResult] = HeadlessCommand(
     operation="project-info",
     input_model=ProjectInfoParams,
     output_model=ProjectInfoResult,
+    render=render_project_info,
 )
 
 PROJECT_GET_COMMAND: HeadlessCommand[ProjectGetResult] = HeadlessCommand(
     operation="project-get",
     input_model=ProjectGetParams,
     output_model=ProjectGetResult,
+    render=render_project_get,
 )
 
 PROJECT_SET_COMMAND: HeadlessCommand[ProjectSetResult] = HeadlessCommand(
     operation="project-set",
     input_model=ProjectSetParams,
     output_model=ProjectSetResult,
+    render=render_project_set,
 )
 
 PROJECT_ADD_AUTOLOAD_COMMAND: HeadlessCommand[ProjectAddAutoloadResult] = HeadlessCommand(
     operation="project-add-autoload",
     input_model=ProjectAddAutoloadParams,
     output_model=ProjectAddAutoloadResult,
+    render=render_project_add_autoload,
 )
 
 PROJECT_REMOVE_AUTOLOAD_COMMAND: HeadlessCommand[ProjectRemoveAutoloadResult] = (
@@ -1600,6 +1710,7 @@ PROJECT_REMOVE_AUTOLOAD_COMMAND: HeadlessCommand[ProjectRemoveAutoloadResult] = 
         operation="project-remove-autoload",
         input_model=ProjectRemoveAutoloadParams,
         output_model=ProjectRemoveAutoloadResult,
+        render=render_project_remove_autoload,
     )
 )
 
@@ -1607,24 +1718,28 @@ SHADER_CREATE_COMMAND: HeadlessCommand[ShaderCreateResult] = HeadlessCommand(
     operation="shader-create",
     input_model=ShaderCreateParams,
     output_model=ShaderCreateResult,
+    render=render_shader_create,
 )
 
 SHADER_GET_COMMAND: HeadlessCommand[ShaderGetResult] = HeadlessCommand(
     operation="shader-get",
     input_model=ShaderGetParams,
     output_model=ShaderGetResult,
+    render=render_shader_get,
 )
 
 SHADER_SET_COMMAND: HeadlessCommand[ShaderSetResult] = HeadlessCommand(
     operation="shader-set",
     input_model=ShaderSetParams,
     output_model=ShaderSetResult,
+    render=render_shader_set,
 )
 
 THEME_CREATE_COMMAND: HeadlessCommand[ThemeCreateResult] = HeadlessCommand(
     operation="theme-create",
     input_model=ThemeCreateParams,
     output_model=ThemeCreateResult,
+    render=render_theme_create,
 )
 
 PROJECT_FIND_REFERENCES_COMMAND: HeadlessCommand[ProjectFindReferencesResult] = (
@@ -1632,6 +1747,7 @@ PROJECT_FIND_REFERENCES_COMMAND: HeadlessCommand[ProjectFindReferencesResult] = 
         operation="project-find-references",
         input_model=ProjectFindReferencesParams,
         output_model=ProjectFindReferencesResult,
+        render=render_project_find_references,
     )
 )
 
@@ -1640,6 +1756,7 @@ PROJECT_DEPENDENCIES_COMMAND: HeadlessCommand[ProjectDependenciesResult] = (
         operation="project-dependencies",
         input_model=ProjectDependenciesParams,
         output_model=ProjectDependenciesResult,
+        render=render_project_dependencies,
     )
 )
 
@@ -1649,12 +1766,14 @@ PROJECT_FIND_UNUSED_RESOURCES_COMMAND: HeadlessCommand[
     operation="project-find-unused-resources",
     input_model=ProjectFindUnusedResourcesParams,
     output_model=ProjectFindUnusedResourcesResult,
+    render=render_project_find_unused_resources,
 )
 
 PROJECT_STATISTICS_COMMAND: HeadlessCommand[ProjectStatisticsResult] = HeadlessCommand(
     operation="project-statistics",
     input_model=ProjectStatisticsParams,
     output_model=ProjectStatisticsResult,
+    render=render_project_statistics,
 )
 
 
@@ -2698,7 +2817,7 @@ def run_export(
     )
     if isinstance(outcome, Failure):
         emit_failure(outcome)
-    emit_result(outcome, json_output)
+    emit_result(outcome, json_output, EXPORT_RUN_COMMAND.render)
 
 
 @resource_app.command(name="uid", cls=RESOURCE_UID_COMMAND.command_class())

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -8,7 +8,6 @@ binary resolution → runner → sentinel parse → typed model → JSON.
 """
 
 import json
-from dataclasses import replace
 from importlib.metadata import version as package_version
 from pathlib import Path
 from typing import Optional
@@ -41,7 +40,6 @@ from gda.errors import (
 from gda.execution import ExecutionKind
 from gda.export_run import (
     EXPORT_GET_COMMAND,
-    EXPORT_RUN_COMMAND,
     run_export_operation,
 )
 from gda.export_runner import ExportRunner, make_subprocess_export_runner
@@ -79,6 +77,7 @@ from gda.models import (
     ExportListResult,
     ExportRunMode,
     ExportRunParams,
+    ExportRunResult,
     GameGetParams,
     GameGetResult,
     GameSetParams,
@@ -198,6 +197,7 @@ from gda.render import (
     render_diag_log,
     render_engine_version,
     render_export_list,
+    render_export_run,
     render_game_get,
     render_game_set,
     render_game_tree,
@@ -518,12 +518,21 @@ def _export_run_recipe(params, *, project, godot):
     )
 
 
-# ``EXPORT_RUN_COMMAND`` is defined in ``gda.export_run`` (its descriptor sits beside
-# ``run_export_operation`` to avoid an export_run↔cli import cycle), but its recipe
-# needs cli's runner seams, which live here. cli.py is the composition root for
-# dispatch, so it completes the registration: rebind the imported descriptor with its
-# recipe. (export GET stays a plain sentinel command — no recipe.)
-EXPORT_RUN_COMMAND = replace(EXPORT_RUN_COMMAND, recipe=_export_run_recipe)
+# ``export-run`` does NOT route through operations.gd: the Godot export subsystem is
+# editor-only C++, so the export is a native --export-<mode> invocation driven by
+# ``run_export_operation`` (gda.export_run). Its descriptor is the single fully-bound
+# registration (ADR-0023) and is defined HERE — not beside the operation — because its
+# recipe needs cli's runner seams, and cli.py is the dispatch composition root. (Its
+# sibling ``EXPORT_GET_COMMAND`` is a plain sentinel command and stays in gda.export_run,
+# which consumes it directly.)
+EXPORT_RUN_COMMAND: HeadlessCommand[ExportRunResult] = HeadlessCommand(
+    operation="export-run",
+    input_model=ExportRunParams,
+    output_model=ExportRunResult,
+    kind=ExecutionKind.EXPORT,
+    render=render_export_run,
+    recipe=_export_run_recipe,
+)
 
 
 def _emit(
@@ -1692,10 +1701,10 @@ EXPORT_LIST_COMMAND: HeadlessCommand[ExportListResult] = HeadlessCommand(
     render=render_export_list,
 )
 
-# EXPORT_GET_COMMAND / EXPORT_RUN_COMMAND live in gda.export_run (imported above):
-# they are co-located with run_export_operation, which drives export-get to
-# resolve the preset, so the recipe can reuse them without an export_run ↔ cli
-# import cycle (issue #187).
+# EXPORT_GET_COMMAND lives in gda.export_run (imported above), co-located with
+# run_export_operation, which drives export-get to resolve the preset without an
+# export_run ↔ cli import cycle (issue #187). EXPORT_RUN_COMMAND is defined above in
+# this module instead (its recipe needs cli's runner seams, ADR-0023).
 
 RESOURCE_UID_COMMAND: HeadlessCommand[ResourceUidResult] = HeadlessCommand(
     operation="resource-uid",

--- a/src/gda/export_run.py
+++ b/src/gda/export_run.py
@@ -25,10 +25,12 @@ surface (driven with the two injected seams; see
 this process's stderr as advisory diagnostics; only the public result/error
 envelope and the process exit are deferred to the CLI caller.
 
-The two ``EXPORT_GET_COMMAND`` / ``EXPORT_RUN_COMMAND`` :class:`HeadlessCommand`
-definitions live here, not in ``cli.py``, so the operation can drive ``export
-get`` without an ``export_run ↔ cli`` import cycle; ``cli.py`` imports both from
-here.
+``EXPORT_GET_COMMAND`` lives here — a plain sentinel command this operation drives
+directly (``export get`` resolves the preset), so co-locating it avoids an
+``export_run ↔ cli`` import cycle. ``EXPORT_RUN_COMMAND`` does NOT: its recipe needs
+the CLI runner seams, so it is registered in ``gda.cli`` (the dispatch composition
+root) beside that recipe, where it is the command's single fully-bound descriptor
+(ADR-0023).
 """
 
 from collections.abc import Callable
@@ -42,17 +44,15 @@ from gda.errors import (
     export_path_unset_failure,
     export_templates_missing_failure,
 )
-from gda.execution import ExecutionKind
 from gda.export_runner import ExportRunner, make_subprocess_export_runner
 from gda.headless import HeadlessCommand, RunnerFactory, make_subprocess_runner
 from gda.models import (
     ExportGetParams,
     ExportGetResult,
     ExportRunMode,
-    ExportRunParams,
     ExportRunResult,
 )
-from gda.render import render_export_get, render_export_run
+from gda.render import render_export_get
 
 # The factory seam for the native export runner — the ``export run``-only twin of
 # the sentinel channel's ``RunnerFactory``. Spelled here (not in ``headless``)
@@ -64,22 +64,6 @@ EXPORT_GET_COMMAND: HeadlessCommand[ExportGetResult] = HeadlessCommand(
     input_model=ExportGetParams,
     output_model=ExportGetResult,
     render=render_export_get,
-)
-
-# export run is the one command that does NOT route through operations.gd: the
-# Godot export subsystem is editor-only C++, unreachable from a --script
-# SceneTree run, so the export itself is a native --export-<mode> invocation
-# (gda.export_runner). This HeadlessCommand is used only for its --schema /
-# --json model plumbing; the recipe is run by run_export_operation below —
-# export-get resolves the preset + path, the native ExportRunner exports,
-# classify_export_run turns the subprocess outcome into the typed result —
-# rather than the shared sentinel pipeline.
-EXPORT_RUN_COMMAND: HeadlessCommand[ExportRunResult] = HeadlessCommand(
-    operation="export-run",
-    input_model=ExportRunParams,
-    output_model=ExportRunResult,
-    render=render_export_run,
-    kind=ExecutionKind.EXPORT,
 )
 
 

--- a/src/gda/export_run.py
+++ b/src/gda/export_run.py
@@ -52,6 +52,7 @@ from gda.models import (
     ExportRunParams,
     ExportRunResult,
 )
+from gda.render import render_export_get, render_export_run
 
 # The factory seam for the native export runner — the ``export run``-only twin of
 # the sentinel channel's ``RunnerFactory``. Spelled here (not in ``headless``)
@@ -62,6 +63,7 @@ EXPORT_GET_COMMAND: HeadlessCommand[ExportGetResult] = HeadlessCommand(
     operation="export-get",
     input_model=ExportGetParams,
     output_model=ExportGetResult,
+    render=render_export_get,
 )
 
 # export run is the one command that does NOT route through operations.gd: the
@@ -76,6 +78,7 @@ EXPORT_RUN_COMMAND: HeadlessCommand[ExportRunResult] = HeadlessCommand(
     operation="export-run",
     input_model=ExportRunParams,
     output_model=ExportRunResult,
+    render=render_export_run,
     kind=ExecutionKind.EXPORT,
 )
 

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -287,7 +287,7 @@ _fail = emit_failure
 
 
 def emit_result(
-    result: BaseModel, json_output: bool, render: "Optional[Callable[[Any], str]]"
+    result: BaseModel, json_output: bool, render: "Callable[[Any], str]"
 ) -> None:
     """Emit a typed success result as JSON or human-readable text.
 
@@ -298,17 +298,11 @@ def emit_result(
     recipe commands (``export run``, the ``daemon`` lifecycle, ``screen``), which
     pass their descriptor's renderer so every command renders success identically.
 
-    ``render`` is ``None`` only for a misregistered command (one whose descriptor
-    set no renderer); the registration invariant test (ADR-0023) keeps that off the
-    dispatchable surface, so it is a programming error rather than a user-facing one.
+    ``render`` is always present: it is a required descriptor field (ADR-0023), and
+    both ``emit`` and the recipe dispatch pass ``cmd.render``.
     """
     if json_output:
         typer.echo(result.model_dump_json())
-    elif render is None:  # pragma: no cover - guarded by the registration test
-        raise RuntimeError(
-            f"no renderer for result type {type(result)!r}; the command's "
-            "HeadlessCommand must set render= (ADR-0023)"
-        )
     else:
         typer.echo(render(result))
 
@@ -325,17 +319,18 @@ class HeadlessCommand(Generic[M]):
     operation: str
     input_model: type[BaseModel]
     output_model: type[M]
+    # The command's human renderer — its result model -> text (ADR-0023). A command
+    # renders through its own descriptor, so there is no central type-keyed table to
+    # keep in sync. REQUIRED (no default): every command renders, so the type system
+    # carries the guarantee; the registration invariant test also enforces it on the
+    # live command tree.
+    render: Renderer[M]
     classify: Classifier[M] | None = None
     # The static execution channel this command is fulfilled through (ADR-0017).
     # Defaults to HEADLESS — the sentinel ``operations.gd`` pipeline — so every
     # existing command keeps its channel without restating it; EXPORT and LIVE
     # commands declare their channel explicitly.
     kind: ExecutionKind = ExecutionKind.HEADLESS
-    # The command's human renderer — its result model -> text (ADR-0023). A command
-    # renders through its own descriptor, so there is no central type-keyed table to
-    # keep in sync. Defaults to ``None`` to keep direct-construction fixtures valid;
-    # every dispatchable command sets it, enforced by the registration invariant test.
-    render: Renderer[M] | None = None
     # The command's CLI-side execution channel (ADR-0023). When set, the command is a
     # recipe (``export run`` / ``daemon`` lifecycle / ``screen``): dispatch runs this
     # to produce the outcome instead of the sentinel ``emit``. ``None`` (the default)

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -36,6 +36,15 @@ Classifier = Callable[[RunResult, Path], M | Failure]
 # (ADR-0023) so a command renders through its own registration, not a central
 # type-keyed table.
 Renderer = Callable[[M], str]
+# A recipe command's CLI-side execution channel (ADR-0023): given the built params
+# model and the CLI context, it PRODUCES the outcome (resolve + run), returning the
+# result model or a Failure. Carried on the descriptor so a command with a recipe
+# is fulfilled by it instead of the sentinel `emit`; emission stays the shared tail
+# (the descriptor's `render`), so a recipe command renders identically to a
+# sentinel one. ``export run`` / the ``daemon`` lifecycle / ``screen`` are recipes.
+# Not parameterized over ``M``: the recipe's keyword-only context means an Ellipsis
+# parameter spec (``Callable[..., …]``), which is not a subscriptable generic alias.
+Recipe = Callable[..., "BaseModel | Failure"]
 RunnerFactory = Callable[[Path, Optional[Path]], GodotRunner]
 
 
@@ -327,6 +336,12 @@ class HeadlessCommand(Generic[M]):
     # keep in sync. Defaults to ``None`` to keep direct-construction fixtures valid;
     # every dispatchable command sets it, enforced by the registration invariant test.
     render: Renderer[M] | None = None
+    # The command's CLI-side execution channel (ADR-0023). When set, the command is a
+    # recipe (``export run`` / ``daemon`` lifecycle / ``screen``): dispatch runs this
+    # to produce the outcome instead of the sentinel ``emit``. ``None`` (the default)
+    # means the command runs through ``emit`` with its ``kind``-selected runner — so a
+    # single ``recipe is None`` test selects the channel, no identity table.
+    recipe: "Recipe | None" = None
 
     def schema_option(self) -> bool:
         """Return the Typer ``--schema`` flag for this command."""

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -11,7 +11,7 @@ import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generic, NoReturn, Optional, TypeVar
+from typing import Any, Generic, NoReturn, Optional, TypeVar
 
 import typer
 from pydantic import BaseModel, ValidationError
@@ -27,12 +27,15 @@ from gda.errors import (
 )
 from gda.execution import ExecutionKind, live_stack_constraints
 from gda.models import CommandSchema, GdaErrorEnvelope, LiveStackConstraints
-from gda.render import render
 from gda.runner import GodotRunner, RunResult, SubprocessGodotRunner
 
 M = TypeVar("M", bound=BaseModel)
 
 Classifier = Callable[[RunResult, Path], M | Failure]
+# A command's human renderer: its result model -> text. Carried on the descriptor
+# (ADR-0023) so a command renders through its own registration, not a central
+# type-keyed table.
+Renderer = Callable[[M], str]
 RunnerFactory = Callable[[Path, Optional[Path]], GodotRunner]
 
 
@@ -274,17 +277,29 @@ def emit_failure(failure: Failure) -> NoReturn:
 _fail = emit_failure
 
 
-def emit_result(result: BaseModel, json_output: bool) -> None:
+def emit_result(
+    result: BaseModel, json_output: bool, render: "Optional[Callable[[Any], str]]"
+) -> None:
     """Emit a typed success result as JSON or human-readable text.
 
     The single home for the public success channel: a result model becomes its
-    ``--json`` serialization when ``json_output``, else the type-dispatched
-    human rendering by :func:`gda.render.render` (issue #186). Shared by the
-    sentinel-pipeline commands (via :meth:`HeadlessCommand.emit`) and the
-    native-export command (``export run``), so both render success identically.
+    ``--json`` serialization when ``json_output``, else the human text produced by
+    the command's own ``render`` (its descriptor's renderer, ADR-0023). Shared by
+    the sentinel-pipeline commands (via :meth:`HeadlessCommand.emit`) and the
+    recipe commands (``export run``, the ``daemon`` lifecycle, ``screen``), which
+    pass their descriptor's renderer so every command renders success identically.
+
+    ``render`` is ``None`` only for a misregistered command (one whose descriptor
+    set no renderer); the registration invariant test (ADR-0023) keeps that off the
+    dispatchable surface, so it is a programming error rather than a user-facing one.
     """
     if json_output:
         typer.echo(result.model_dump_json())
+    elif render is None:  # pragma: no cover - guarded by the registration test
+        raise RuntimeError(
+            f"no renderer for result type {type(result)!r}; the command's "
+            "HeadlessCommand must set render= (ADR-0023)"
+        )
     else:
         typer.echo(render(result))
 
@@ -307,6 +322,11 @@ class HeadlessCommand(Generic[M]):
     # existing command keeps its channel without restating it; EXPORT and LIVE
     # commands declare their channel explicitly.
     kind: ExecutionKind = ExecutionKind.HEADLESS
+    # The command's human renderer — its result model -> text (ADR-0023). A command
+    # renders through its own descriptor, so there is no central type-keyed table to
+    # keep in sync. Defaults to ``None`` to keep direct-construction fixtures valid;
+    # every dispatchable command sets it, enforced by the registration invariant test.
+    render: Renderer[M] | None = None
 
     def schema_option(self) -> bool:
         """Return the Typer ``--schema`` flag for this command."""
@@ -396,12 +416,11 @@ class HeadlessCommand(Generic[M]):
     ) -> None:
         """Run the command and emit either JSON or human-readable output.
 
-        Human output is rendered by the module-level :func:`gda.render.render`,
-        which dispatches on the result type — there is no per-command renderer
-        seam to thread, since every command renders through the same type-keyed
-        table (issue #186).
+        Human output is rendered by the command's own ``render`` (its descriptor's
+        renderer, ADR-0023) — the descriptor is in hand here, so there is no
+        type-keyed table to consult.
         """
         result = self.run(
             params, godot=godot, project=project, make_runner=make_runner
         )
-        emit_result(result, json_output)
+        emit_result(result, json_output, self.render)

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -2,9 +2,11 @@
 
 The result models (``gda.models``) are pure ``--schema`` / ``--json`` data
 contracts (ADR-0004); presentation does not live in them. This module owns the
-human-readable text path: one renderer per result type, selected by result type
-via :func:`render`, plus the typed helpers that keep the presentation layer from
-reaching into a model's value shape or across a union of result types.
+human-readable text path: one renderer per result type, plus the typed helpers
+that keep the presentation layer from reaching into a model's value shape or
+across a union of result types. A command binds its renderer on its own
+``HeadlessCommand`` descriptor (``render=``, ADR-0023) — there is no central
+type-keyed dispatch table here; emission calls the descriptor's renderer.
 
 Two seams are deliberately funnelled through one place here:
 
@@ -19,70 +21,74 @@ Two seams are deliberately funnelled through one place here:
 """
 
 import json
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-from gda.models import (
-    DaemonStartResult,
-    DaemonStatusResult,
-    DaemonStopResult,
-    DaemonUninstallResult,
-    DiagErrorsResult,
-    DiagLogResult,
-    EngineVersion,
-    ExportGetResult,
-    ExportListResult,
-    ExportRunResult,
-    GameGetResult,
-    GameSetResult,
-    GameTreeResult,
-    InputActionResult,
-    InputKeyResult,
-    InputMouseResult,
-    InputSequenceResult,
-    NodeAddResult,
-    NodeConnectSignalResult,
-    NodeDisconnectSignalResult,
-    NodeDuplicateResult,
-    NodeGetResult,
-    NodeListResult,
-    NodeMoveResult,
-    NodeRemoveResult,
-    NodeSetResult,
-    PerfMonitorResult,
-    PerfMonitorsResult,
-    ProjectAddAutoloadResult,
-    ProjectGetResult,
-    ProjectInfoResult,
-    ProjectRemoveAutoloadResult,
-    ProjectSetResult,
-    ResourceCreateResult,
-    ResourceDeleteResult,
-    ResourceGetResult,
-    ResourceSetResult,
-    ResourceUidResult,
-    SceneCreateResult,
-    SceneDeleteResult,
-    SceneGetExportsResult,
-    SceneGetResult,
-    SceneListResult,
-    SceneNode,
-    ScreenCaptureResult,
-    ScreenFramesResult,
-    ScriptAttachResult,
-    ScriptCreateResult,
-    ScriptDeleteResult,
-    ScriptGetResult,
-    ScriptListResult,
-    ScriptSetResult,
-    ScriptValidateResult,
-    ShaderCreateResult,
-    ShaderGetResult,
-    ShaderSetResult,
-    ThemeCreateResult,
-    ProjectDependenciesResult,
-    ProjectFindReferencesResult,
-    ProjectFindUnusedResourcesResult,
-    ProjectStatisticsResult,
+if TYPE_CHECKING:
+    # The result models are referenced only in string annotations on the renderers
+    # below; since ADR-0023 removed the type-keyed dispatch table, nothing here
+    # needs them at runtime. Keep them import-time only for type-checkers.
+    from gda.models import (
+        DaemonStartResult,
+        DaemonStatusResult,
+        DaemonStopResult,
+        DaemonUninstallResult,
+        DiagErrorsResult,
+        DiagLogResult,
+        EngineVersion,
+        ExportGetResult,
+        ExportListResult,
+        ExportRunResult,
+        GameGetResult,
+        GameSetResult,
+        GameTreeResult,
+        InputActionResult,
+        InputKeyResult,
+        InputMouseResult,
+        InputSequenceResult,
+        NodeAddResult,
+        NodeConnectSignalResult,
+        NodeDisconnectSignalResult,
+        NodeDuplicateResult,
+        NodeGetResult,
+        NodeListResult,
+        NodeMoveResult,
+        NodeRemoveResult,
+        NodeSetResult,
+        PerfMonitorResult,
+        PerfMonitorsResult,
+        ProjectAddAutoloadResult,
+        ProjectGetResult,
+        ProjectInfoResult,
+        ProjectRemoveAutoloadResult,
+        ProjectSetResult,
+        ResourceCreateResult,
+        ResourceDeleteResult,
+        ResourceGetResult,
+        ResourceSetResult,
+        ResourceUidResult,
+        SceneCreateResult,
+        SceneDeleteResult,
+        SceneGetExportsResult,
+        SceneGetResult,
+        SceneListResult,
+        SceneNode,
+        ScreenCaptureResult,
+        ScreenFramesResult,
+        ScriptAttachResult,
+        ScriptCreateResult,
+        ScriptDeleteResult,
+        ScriptGetResult,
+        ScriptListResult,
+        ScriptSetResult,
+        ScriptValidateResult,
+        ShaderCreateResult,
+        ShaderGetResult,
+        ShaderSetResult,
+        ThemeCreateResult,
+        ProjectDependenciesResult,
+        ProjectFindReferencesResult,
+        ProjectFindUnusedResourcesResult,
+        ProjectStatisticsResult,
 )
 
 
@@ -700,86 +706,3 @@ def render_project_statistics(stats: "ProjectStatisticsResult") -> str:
 def render_engine_version(version: "EngineVersion") -> str:
     """Render the engine version as its one-line version string."""
     return version.string
-
-
-# Renderer selection keyed by result type: each result model maps to the one
-# renderer that turns it into human-readable text. :func:`render` dispatches on
-# ``type(result)``, so a command sources its renderer from this module by its
-# result type rather than carrying an inline closure (composes with #139's
-# ``render`` dispatch parameter).
-_RENDERERS = {
-    SceneCreateResult: render_scene_metadata,
-    SceneGetResult: render_scene_tree,
-    GameTreeResult: render_game_tree,
-    GameGetResult: render_game_get,
-    GameSetResult: render_game_set,
-    DiagErrorsResult: render_diag_errors,
-    DiagLogResult: render_diag_log,
-    PerfMonitorsResult: render_perf_monitors,
-    PerfMonitorResult: render_perf_monitor,
-    InputKeyResult: render_input_key,
-    InputMouseResult: render_input_mouse,
-    InputActionResult: render_input_action,
-    InputSequenceResult: render_input_sequence,
-    ScreenCaptureResult: render_screen_capture,
-    ScreenFramesResult: render_screen_frames,
-    DaemonStartResult: render_daemon_start,
-    DaemonStopResult: render_daemon_stop,
-    DaemonStatusResult: render_daemon_status,
-    DaemonUninstallResult: render_daemon_uninstall,
-    SceneGetExportsResult: render_scene_exports,
-    SceneListResult: render_scene_list,
-    SceneDeleteResult: render_scene_delete,
-    NodeAddResult: render_node_add,
-    NodeListResult: render_node_list,
-    NodeGetResult: render_node_properties,
-    NodeSetResult: render_node_set,
-    NodeRemoveResult: render_node_remove,
-    NodeDuplicateResult: render_node_duplicate,
-    NodeMoveResult: render_node_move,
-    NodeConnectSignalResult: render_node_connect_signal,
-    NodeDisconnectSignalResult: render_node_disconnect_signal,
-    ScriptCreateResult: render_script_create,
-    ScriptGetResult: render_script_get,
-    ScriptListResult: render_script_list,
-    ScriptDeleteResult: render_script_delete,
-    ScriptSetResult: render_script_set,
-    ScriptAttachResult: render_script_attach,
-    ScriptValidateResult: render_script_validate,
-    ResourceCreateResult: render_resource_create,
-    ResourceGetResult: render_resource_properties,
-    ResourceSetResult: render_resource_set,
-    ResourceDeleteResult: render_resource_delete,
-    ExportListResult: render_export_list,
-    ExportGetResult: render_export_get,
-    ExportRunResult: render_export_run,
-    ResourceUidResult: render_resource_uid,
-    ProjectInfoResult: render_project_info,
-    ProjectGetResult: render_project_get,
-    ProjectSetResult: render_project_set,
-    ProjectAddAutoloadResult: render_project_add_autoload,
-    ProjectRemoveAutoloadResult: render_project_remove_autoload,
-    ShaderCreateResult: render_shader_create,
-    ShaderGetResult: render_shader_get,
-    ShaderSetResult: render_shader_set,
-    ThemeCreateResult: render_theme_create,
-    ProjectFindReferencesResult: render_project_find_references,
-    ProjectDependenciesResult: render_project_dependencies,
-    ProjectFindUnusedResourcesResult: render_project_find_unused_resources,
-    ProjectStatisticsResult: render_project_statistics,
-    EngineVersion: render_engine_version,
-}
-
-
-def render(result: Any) -> str:
-    """Render any ``gda`` result to human-readable text, keyed by its type.
-
-    Looks the result's concrete type up in the type → renderer table and applies
-    the matching renderer. A result type with no registered renderer is a
-    programming error (a new command wired without a renderer), not a runtime
-    user error, so it raises rather than guessing a format.
-    """
-    renderer = _RENDERERS.get(type(result))
-    if renderer is None:
-        raise KeyError(f"no renderer registered for result type {type(result)!r}")
-    return renderer(result)

--- a/tests/test_command_descriptor_registry.py
+++ b/tests/test_command_descriptor_registry.py
@@ -80,3 +80,43 @@ def test_no_renderer_is_orphaned():
     )
     # And nothing claims to be bound that the module does not define (a stale import).
     assert not (bound - defined), f"descriptors bind undefined renderers: {sorted(bound - defined)}"
+
+
+# The recipe-bearing commands — those fulfilled by a CLI-side recipe (export run /
+# the daemon lifecycle / screen) instead of the sentinel `cmd.emit` (ADR-0023). This
+# set is the modern, descriptor-driven replacement for the old `_DAEMON_COMMANDS` /
+# `_SCREEN_COMMANDS` identity frozensets + the export `kind` special-case: now it is
+# an asserted INVARIANT over the descriptors, not a dispatch mechanism.
+_RECIPE_OPERATIONS = {
+    "export-run",
+    "daemon-start",
+    "daemon-stop",
+    "daemon-status",
+    "daemon-uninstall",
+    "screen-capture",
+    "screen-frames",
+}
+
+
+def test_recipe_commands_are_exactly_the_known_recipe_set():
+    # Guards both regressions the frozensets used to risk: a recipe command silently
+    # losing its recipe (→ routed to the sentinel runner) or a sentinel command
+    # gaining one. The dispatch reads `cmd.recipe`; this pins which commands have it.
+    have_recipe = {
+        cmd.operation for _, cmd in _dispatchable() if cmd.recipe is not None
+    }
+    assert have_recipe == _RECIPE_OPERATIONS
+
+
+def test_every_dispatchable_command_resolves_to_exactly_one_channel():
+    # The single-channel invariant (ADR-0023): a command is dispatched EITHER by its
+    # recipe OR by `cmd.emit` with its kind-selected runner — never both, never
+    # neither. The two are mutually exclusive by `recipe is None`; both paths emit
+    # through `cmd.render`, so every command (recipe or not) still needs a renderer.
+    for name, cmd in _dispatchable():
+        if cmd.recipe is not None:
+            assert callable(cmd.recipe), f"{name}: recipe is set but not callable"
+        # render is the shared emission tail for BOTH channels (asserted non-None by
+        # test_every_dispatchable_command_carries_a_renderer); restated here as the
+        # reason a recipe command needs no separate emission path.
+        assert cmd.render is not None, f"{name}: no renderer for its emission tail"

--- a/tests/test_command_descriptor_registry.py
+++ b/tests/test_command_descriptor_registry.py
@@ -1,0 +1,82 @@
+"""Command descriptor registration invariants (ADR-0023).
+
+ADR-0023 makes the ``HeadlessCommand`` descriptor the single per-command
+registration: its ``render`` is the command's human renderer, replacing the old
+type-keyed dispatch table in :mod:`gda.render`. These tests walk the LIVE Typer
+command tree — the same authority :mod:`gda.surface` uses for the schema manifest
+— and assert every dispatchable command carries a renderer, and that no renderer
+in :mod:`gda.render` is orphaned. This turns the former first-invocation
+``KeyError`` ("command wired without a renderer") into a test-time guarantee.
+"""
+
+import typer
+
+import gda.render as render_mod
+from gda.cli import app
+
+
+def _leaf_commands(command, path):
+    """Yield ``(name, command_obj)`` for every leaf of the Typer tree (cf. gda.surface).
+
+    A group is identified by its ``commands`` mapping (the same Click duck-type the
+    surface walker uses); a leaf has none.
+    """
+    subcommands = getattr(command, "commands", None)
+    if subcommands is not None:
+        for name, sub in subcommands.items():
+            yield from _leaf_commands(sub, [*path, name])
+        return
+    yield " ".join(path), command
+
+
+def _dispatchable():
+    """The dispatchable leaf commands — those with a backing ``HeadlessCommand``.
+
+    Mirrors the surface manifest's dispatchable-operation surface: a leaf whose
+    ``gda_command`` is ``None`` (the bare ``gda schema`` meta command) is not a
+    dispatchable operation and carries no renderer.
+    """
+    root = typer.main.get_command(app)
+    for name, command in _leaf_commands(root, []):
+        gda_command = getattr(command, "gda_command", None)
+        if gda_command is not None:
+            yield name, gda_command
+
+
+def test_every_dispatchable_command_carries_a_renderer():
+    # The KeyError replacement: a command wired without a renderer is caught here at
+    # test time, not on its first human-output invocation.
+    dispatchable = list(_dispatchable())
+    assert dispatchable, "the Typer tree walk found no dispatchable commands"
+    missing = [name for name, cmd in dispatchable if cmd.render is None]
+    assert not missing, f"commands missing render= (ADR-0023): {missing}"
+    not_callable = [name for name, cmd in dispatchable if not callable(cmd.render)]
+    assert not not_callable, f"commands with a non-callable render: {not_callable}"
+
+
+# Renderers that are internal helpers — composed by other renderers, never bound to
+# a command result type, so legitimately absent from every descriptor.
+_HELPER_RENDERERS = {
+    "render_node_tree",  # the indented tree walk reused by scene-get / node-list
+    "render_script_metadata",  # the shared path/class_name/extends script surface
+    "render_shader_metadata",  # the shared shader-metadata surface
+}
+
+
+def test_no_renderer_is_orphaned():
+    # Every ``render_*`` in gda.render is either bound to a command (reachable via a
+    # descriptor) or a known internal helper — no dead renderer survives the move off
+    # the type-keyed table.
+    defined = {
+        name
+        for name in dir(render_mod)
+        if name.startswith("render_") and callable(getattr(render_mod, name))
+    }
+    bound = {cmd.render.__name__ for _, cmd in _dispatchable()}
+    orphaned = defined - bound - _HELPER_RENDERERS
+    assert not orphaned, (
+        f"render_* functions defined but bound to no command and not a known helper: "
+        f"{sorted(orphaned)}"
+    )
+    # And nothing claims to be bound that the module does not define (a stale import).
+    assert not (bound - defined), f"descriptors bind undefined renderers: {sorted(bound - defined)}"

--- a/tests/test_export_run_operation.py
+++ b/tests/test_export_run_operation.py
@@ -17,11 +17,11 @@ surface, complementary to the command tests in
 
 from pathlib import Path
 
+from gda.cli import EXPORT_RUN_COMMAND  # the single fully-bound descriptor (ADR-0023)
 from gda.errors import Failure
 from gda.execution import ExecutionKind
 from gda.export_run import (
     EXPORT_GET_COMMAND,
-    EXPORT_RUN_COMMAND,
     run_export_operation,
 )
 from gda.models import ExportRunMode, ExportRunResult

--- a/tests/test_headless_command.py
+++ b/tests/test_headless_command.py
@@ -9,6 +9,7 @@ import typer
 from gda.execution import ExecutionKind
 from gda.headless import HeadlessCommand
 from gda.models import EngineVersion, InfoParams
+from gda.render import render_engine_version
 from gda.runner import LaunchFailure, RunResult
 from tests.support import VERSION_INFO, FakeRunner, sentinel
 
@@ -20,6 +21,7 @@ def test_headless_command_classifies_its_execution_channel_as_headless_by_defaul
         operation="info",
         input_model=InfoParams,
         output_model=EngineVersion,
+        render=render_engine_version,
     )
 
     assert command.kind is ExecutionKind.HEADLESS
@@ -40,6 +42,7 @@ def test_headless_command_emit_owns_runner_classification_and_json_output(capsys
         operation="info",
         input_model=InfoParams,
         output_model=EngineVersion,
+        render=render_engine_version,
     )
 
     command.emit(
@@ -74,6 +77,7 @@ def test_headless_command_emit_owns_structured_failure_output(capsys):
         operation="info",
         input_model=InfoParams,
         output_model=EngineVersion,
+        render=render_engine_version,
     )
 
     with pytest.raises(typer.Exit) as raised:
@@ -102,6 +106,7 @@ def test_empty_godot_path_maps_to_structured_binary_not_found(capsys):
         operation="info",
         input_model=InfoParams,
         output_model=EngineVersion,
+        render=render_engine_version,
     )
 
     with pytest.raises(typer.Exit) as raised:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,15 +1,21 @@
 """The presentation layer (``gda.render``) — issue #140.
 
-Human rendering lives in a dedicated module, selected by result type, and reads
+Human rendering lives in a dedicated module, one renderer per result type, reading
 typed surfaces (a value helper, a shared script-metadata interface) rather than
 reaching into a model's ``.value`` or across a union of result types. These are
-unit tests on the presentation module itself; the end-to-end human-output text
-per command is pinned by the existing command tests, which still pass unchanged.
+unit tests on the renderers themselves; the end-to-end human-output text per
+command is pinned by ``test_human_output.py``, and the descriptor-carried
+renderer invariant (every command has one, none orphaned — ADR-0023) by
+``test_command_descriptor_registry.py``.
+
+Since ADR-0023 each command binds its renderer on its ``HeadlessCommand``
+descriptor and there is no central ``render()`` type-dispatch, so these tests call
+the renderer functions directly — the assertions (a renderer's exact text) are
+unchanged.
 """
 
 import pytest
 
-from gda import render as render_mod
 from gda.models import (
     DaemonStartResult,
     DaemonStatusResult,
@@ -33,7 +39,21 @@ from gda.models import (
     ScriptGetResult,
     ScriptSetResult,
 )
-from gda.render import ScriptMetadata, format_value, render, render_node_tree
+from gda.render import (
+    ScriptMetadata,
+    format_value,
+    render_daemon_start,
+    render_daemon_status,
+    render_daemon_uninstall,
+    render_engine_version,
+    render_game_get,
+    render_game_set,
+    render_node_properties,
+    render_node_set,
+    render_node_tree,
+    render_perf_monitor,
+    render_perf_monitors,
+)
 
 # The five script result types the metadata renderer used to read as a union.
 SCRIPT_METADATA_MODELS = [
@@ -129,7 +149,7 @@ def test_render_node_properties_routes_value_through_the_helper():
         type="Node2D",
         properties=[NodeProperty(name="position", type="Vector2", value=[1.0, 2.0])],
     )
-    rendered = render(result)
+    rendered = render_node_properties(result)
     assert rendered == ". (Node2D)\n  position (Vector2) = [1.0, 2.0]"
 
 
@@ -141,7 +161,7 @@ def test_render_node_set_routes_value_through_the_helper():
         type="bool",
         value=False,
     )
-    assert render(result) == "set ..visible (bool) = false"
+    assert render_node_set(result) == "set ..visible (bool) = false"
 
 
 def test_render_game_get_renders_runtime_properties_by_absolute_path():
@@ -151,7 +171,7 @@ def test_render_game_get_renders_runtime_properties_by_absolute_path():
         type="Node2D",
         properties=[NodeProperty(name="position", type="Vector2", value=[10.0, 20.0])],
     )
-    rendered = render(result)
+    rendered = render_game_get(result)
     assert rendered == "/root/Main/Player (Node2D)\n  position (Vector2) = [10.0, 20.0]"
 
 
@@ -162,7 +182,7 @@ def test_render_game_set_renders_the_set_runtime_property():
         type="Vector2",
         value=[10.0, 20.0],
     )
-    assert render(result) == "set /root/Main/Player.position (Vector2) = [10.0, 20.0]"
+    assert render_game_set(result) == "set /root/Main/Player.position (Vector2) = [10.0, 20.0]"
 
 
 def test_render_perf_monitors_renders_a_sorted_snapshot():
@@ -174,7 +194,7 @@ def test_render_perf_monitors_renders_a_sorted_snapshot():
         },
     )
     # Monitors are listed in a stable (name-sorted) order under the timestamp header.
-    assert render(result) == "perf @ 500ms\n  fps = 60.0\n  node_count = 3.0"
+    assert render_perf_monitors(result) == "perf @ 500ms\n  fps = 60.0\n  node_count = 3.0"
 
 
 def test_render_perf_monitor_property_renders_a_per_frame_timeline():
@@ -188,7 +208,7 @@ def test_render_perf_monitor_property_renders_a_per_frame_timeline():
             PerfPropertySample(frame=1, timestamp=116, value=[1.0, 0.0]),
         ],
     )
-    assert render(result) == (
+    assert render_perf_monitor(result) == (
         "/root/Main/Player property position (2 frames)\n"
         "  frame 0: [0.0, 0.0]\n"
         "  frame 1: [1.0, 0.0]"
@@ -203,7 +223,7 @@ def test_render_perf_monitor_signal_renders_recorded_emissions():
         frames=2,
         emissions=[PerfSignalEmission(frame=1, timestamp=116, args=[42])],
     )
-    assert render(result) == (
+    assert render_perf_monitor(result) == (
         "/root/Main/Player signal hit (2 frames)\n  frame 1: [42]"
     )
 
@@ -219,11 +239,11 @@ def test_render_daemon_start_surfaces_a_version_sync(tmp_path):
         harness_version="3",
         already_running=False,
     )
-    assert render(synced) == "daemon started: pid 42 on /tmp/x.sock (synced harness to v3)"
+    assert render_daemon_start(synced) == "daemon started: pid 42 on /tmp/x.sock (synced harness to v3)"
 
     # A first install (changed but not a version-mismatch resync) reads as install.
     installed = synced.model_copy(update={"harness_synced": False})
-    assert render(installed) == "daemon started: pid 42 on /tmp/x.sock (installed harness)"
+    assert render_daemon_start(installed) == "daemon started: pid 42 on /tmp/x.sock (installed harness)"
 
 
 def test_render_daemon_status_notes_the_windowed_session(tmp_path):
@@ -232,28 +252,26 @@ def test_render_daemon_status_notes_the_windowed_session(tmp_path):
     windowed = DaemonStatusResult(
         running=True, pid=42, socket_path="/tmp/x.sock", windowed=True
     )
-    assert render(windowed) == "daemon running: pid 42 on /tmp/x.sock [windowed]"
+    assert render_daemon_status(windowed) == "daemon running: pid 42 on /tmp/x.sock [windowed]"
 
     headless = windowed.model_copy(update={"windowed": False})
-    assert render(headless) == "daemon running: pid 42 on /tmp/x.sock"
+    assert render_daemon_status(headless) == "daemon running: pid 42 on /tmp/x.sock"
 
     # An unknown mode (e.g. a transient round-trip miss) renders no marker either.
     unknown = windowed.model_copy(update={"windowed": None})
-    assert render(unknown) == "daemon running: pid 42 on /tmp/x.sock"
+    assert render_daemon_status(unknown) == "daemon running: pid 42 on /tmp/x.sock"
 
     stopped = DaemonStatusResult(running=False, socket_path="/tmp/x.sock")
-    assert render(stopped) == "daemon not running"
+    assert render_daemon_status(stopped) == "daemon not running"
 
 
 def test_render_daemon_uninstall_reports_removal(tmp_path):
     # #225: uninstall renders the paired removal, with the idempotent no-op form.
-    assert render(DaemonUninstallResult(removed=True)) == "harness uninstalled"
-    assert render(DaemonUninstallResult(removed=False)) == "no harness was installed"
+    assert render_daemon_uninstall(DaemonUninstallResult(removed=True)) == "harness uninstalled"
+    assert render_daemon_uninstall(DaemonUninstallResult(removed=False)) == "no harness was installed"
 
 
-def test_render_is_keyed_by_result_type():
-    # render() selects the renderer by the result's concrete type, so a command
-    # sources its renderer from the module by result type, not an inline closure.
+def test_render_engine_version_renders_the_one_line_version_string():
     version = EngineVersion(
         major=4,
         minor=6,
@@ -265,26 +283,4 @@ def test_render_is_keyed_by_result_type():
         string="4.6.3-stable (official)",
         timestamp=0,
     )
-    assert render(version) == "4.6.3-stable (official)"
-
-
-def test_render_rejects_an_unregistered_result_type():
-    # An unrecognized result type is a programming error (a command wired with no
-    # renderer), surfaced loudly rather than silently mis-formatted.
-    with pytest.raises(KeyError):
-        render(object())
-
-
-def test_every_command_result_type_has_a_renderer():
-    # The type → renderer table covers every result type a command emits, so the
-    # keyed dispatch never falls through for a real command.
-    from gda import cli
-
-    output_models = {
-        cmd.output_model
-        for name in dir(cli)
-        if name.endswith("_COMMAND")
-        for cmd in [getattr(cli, name)]
-    }
-    registered = set(render_mod._RENDERERS)
-    assert output_models <= registered
+    assert render_engine_version(version) == "4.6.3-stable (official)"


### PR DESCRIPTION
Implements ADR-0023 — the deepening candidate #1 from the 2026-06-23 architecture review. Finishes the arc ADR-0017 (the `kind` selector) and ADR-0012 (tree-walk derivation) started: per-command knowledge converges onto the **command descriptor**, and the scattered registries become projections of it.

Closes #257. Closes #258.

## Why

Per-command knowledge was split across ~5 sites in 3 files, held together only by the `operation`-name string convention:
- the **renderer** lived in `render.py`'s 61-entry type-keyed `_RENDERERS` dict (a central append hot-spot, far from the descriptor);
- the **execution channel** for recipe commands was selected by two identity frozensets (`_DAEMON_COMMANDS` / `_SCREEN_COMMANDS`) — a *third* selection mechanism alongside `kind`, where a missed entry routed silently to the wrong runner.

## What changed

`HeadlessCommand` now carries two more facts, and the registries derive from it:

- **`render`** (#257) — the per-result renderer, type-bound to `output_model`. `emit_result` renders through the descriptor; the 61-entry `_RENDERERS` dict and the `render(result)` type-dispatch are **deleted** (the `render_*` functions stay).
- **`recipe`** (#258) — an optional CLI-side execution channel. A command with a `recipe` *produces* its outcome (resolve + run); a shared `_dispatch_recipe` tail emits it via the command's **own `render`**, so a recipe command renders identically to a sentinel one (emission single-sourced). Dispatch — argv **and** `--params-json` — collapses to one branch: `recipe is None? cmd.emit : run the recipe`. The `_DAEMON_COMMANDS` / `_SCREEN_COMMANDS` frozensets **and** the per-command identity-branching inside the old `_daemon_dispatch` are **deleted** — each daemon/screen/export command now carries its own recipe.

Scope is Python-side only and **behavior-preserving**: same `--json` / `GdaError` / `--schema` (the `kind` still feeds the live-stack `constraints`). The cross-language `operation`-name contract and a per-group module split remain open (each its own future ADR). gda-mcp is unaffected (it derives from the manifest).

> **Note on a deviation from the ADR draft:** the ADR first proposed the recipe "own its own emission"; the implementation refined this to *recipe produces the outcome, shared tail emits via `cmd.render`* — strictly cleaner (one emission path for both channels). ADR-0023's text was updated to match in this PR.

## New invariant (replaces a runtime KeyError)

`tests/test_command_descriptor_registry.py` walks the **live Typer tree** (the same authority `surface.py` uses) and asserts: every dispatchable command has a renderer; no renderer is orphaned; the recipe-bearing set is exactly `{export-run, daemon-{start,stop,status,uninstall}, screen-{capture,frames}}`; every command resolves to exactly one channel (recipe **xor** kind-runner). The old "command wired without a renderer" `KeyError` is now caught at test time.

## Verification (independently re-run)

- **Fast suite: 846 passed** (844 baseline + 2 new registry tests), 279 deselected.
- **e2e (serial, real console script): 35 passed, 1 skipped** across all five dispatch channels — sentinel-headless (`scene`), live (`game`), daemon-recipe (`daemon`), export-recipe (`export run`), screen-recipe (`screen`). The 1 skip is the pre-existing headless windowed-capture skip.
- `--schema` is unchanged (the `test_schema_*` suites pass): `export run` → `kind=export, constraints=null`; `daemon status` → `kind=headless, constraints={linux,macos,null}`; `screen capture` → `kind=live, constraints={linux,macos,4.6}`.
- Export path normalization confirmed equivalent to the removed `_normalize_path` (now model-side via `NormalizedPath`, unifying the argv and `--params-json` paths).

## Commits

1. `docs(adr-0023)` — the decision + the `Command descriptor` term in CONTEXT.md
2. `refactor(headless)` — #257 renderer onto the descriptor
3. `refactor(cli)` — #258 recipe channel + unified dispatch
