### PR TITLE
refactor: consolidate the error-building seam (one sentinel writer + daemon reply builders)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -4,6 +4,14 @@ status: accepted
 
 # Headless structured output: sentinel-delimited JSON on stdout
 
+> **Outcome (2026-06-23, #260):** the sentinel result format now has a single home
+> for both directions — `gda.parser.build_result` (write) is the inverse of
+> `gda.parser.parse_result` (read) — and a daemon- or live-client-synthesized reply
+> is built once through `gda.daemon.protocol.result_reply` / `error_reply` (the
+> latter over the shared `gda.parser.error_envelope`), replacing four hand-rolled
+> copies of the `<<<GDA:RESULT>>>…<<<GDA:END>>>` wrapping. No contract change — the
+> emitted bytes, exit codes, and envelope shape are identical.
+
 Structured output is `gda`'s core differentiator (ADR-0000), but a headless Godot
 process mixes its version banner, warnings, errors, and `print()` output into
 stdout/stderr. `godot-mcp` does not solve this — it returns the raw stdout blob as

--- a/src/gda/daemon/protocol.py
+++ b/src/gda/daemon/protocol.py
@@ -5,12 +5,20 @@ so messages sent back-to-back on one connection stay distinct. The CLI↔daemon 
 and the daemon→harness *request* carry JSON (``write_message`` / ``read_message``);
 the harness→daemon *response* carries the raw ADR-0002 sentinel string as bytes
 (``write_frame`` / ``read_frame``), so the existing parser is reused unchanged.
+
+It also provides the standard daemon→CLI reply-content builders (``result_reply`` /
+``error_reply``) — the one place the daemon and the live client shape a reply dict
+around a sentinel payload, so a relayed, daemon-served, or synthesized reply is
+classified exactly like a headless engine run's.
 """
 
 import json
 import socket
 import struct
 from typing import Any
+
+from gda.exit_codes import EXIT_LIVE
+from gda.parser import build_result, error_envelope
 
 _LENGTH = struct.Struct(">I")  # 4-byte big-endian frame length
 
@@ -53,3 +61,24 @@ def _recv_exactly(sock: socket.socket, count: int) -> bytes | None:
         chunks.append(chunk)
         remaining -= len(chunk)
     return b"".join(chunks)
+
+
+def result_reply(payload: Any, *, exit_code: int = 0) -> dict:
+    """A daemon→CLI reply carrying ``payload`` as the ADR-0002 sentinel result.
+
+    The reply dict the CLI socket leg sends back: the sentinel-wrapped payload in
+    ``stdout`` (built once by :func:`gda.parser.build_result`), empty ``stderr``, and
+    ``exit_code`` — so ``classify_run`` / ``parse_result`` handle a daemon-served or
+    relayed result exactly like a headless engine run's.
+    """
+    return {"stdout": build_result(payload), "stderr": "", "exit_code": exit_code}
+
+
+def error_reply(code: str, message: str) -> dict:
+    """A daemon→CLI reply carrying a LIVE error envelope (exit ``EXIT_LIVE``).
+
+    The single builder for a daemon- or client-synthesized live failure (no session,
+    dropped connection, timeout, op error): the same ADR-0002 envelope a real op
+    error uses, so ``classify_live`` maps the ``code`` through the normal pipeline.
+    """
+    return result_reply(error_envelope(code, message), exit_code=EXIT_LIVE)

--- a/src/gda/daemon/protocol.py
+++ b/src/gda/daemon/protocol.py
@@ -63,15 +63,15 @@ def _recv_exactly(sock: socket.socket, count: int) -> bytes | None:
     return b"".join(chunks)
 
 
-def result_reply(payload: Any, *, exit_code: int = 0) -> dict:
-    """A daemon→CLI reply carrying ``payload`` as the ADR-0002 sentinel result.
+def result_reply(payload: Any) -> dict:
+    """A daemon→CLI reply carrying a SUCCESS ``payload`` as the ADR-0002 sentinel (exit 0).
 
-    The reply dict the CLI socket leg sends back: the sentinel-wrapped payload in
-    ``stdout`` (built once by :func:`gda.parser.build_result`), empty ``stderr``, and
-    ``exit_code`` — so ``classify_run`` / ``parse_result`` handle a daemon-served or
-    relayed result exactly like a headless engine run's.
+    The reply dict the CLI socket leg sends back for a daemon-served or relayed
+    success: the sentinel-wrapped payload in ``stdout`` (built once by
+    :func:`gda.parser.build_result`), empty ``stderr``, and exit ``0`` — so
+    ``classify_run`` / ``parse_result`` handle it exactly like a headless engine run's.
     """
-    return {"stdout": build_result(payload), "stderr": "", "exit_code": exit_code}
+    return _reply(payload, 0)
 
 
 def error_reply(code: str, message: str) -> dict:
@@ -81,4 +81,14 @@ def error_reply(code: str, message: str) -> dict:
     dropped connection, timeout, op error): the same ADR-0002 envelope a real op
     error uses, so ``classify_live`` maps the ``code`` through the normal pipeline.
     """
-    return result_reply(error_envelope(code, message), exit_code=EXIT_LIVE)
+    return _reply(error_envelope(code, message), EXIT_LIVE)
+
+
+def _reply(payload: Any, exit_code: int) -> dict:
+    """The shared reply-dict shape: a sentinel-wrapped ``payload`` + ``exit_code``.
+
+    Private so the two public builders own the ADR-0002 exit invariant —
+    :func:`result_reply` is exit ``0`` (success), :func:`error_reply` is ``EXIT_LIVE``
+    (live error) — and no caller can pair a success payload with a non-zero exit.
+    """
+    return {"stdout": build_result(payload), "stderr": "", "exit_code": exit_code}

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -8,7 +8,6 @@ liveness, ``__stop__`` graceful shutdown); any other op is a project live op,
 served by the engine session, which is (re)launched lazily on demand.
 """
 
-import json
 import os
 import secrets
 import signal
@@ -16,10 +15,8 @@ import socket
 
 from gda.daemon.diag import parse_errors, parse_log
 from gda.daemon.discovery import DaemonPaths, acquire_pidfile, ensure_runtime_dir
-from gda.daemon.protocol import read_message, write_message
+from gda.daemon.protocol import error_reply, read_message, result_reply, write_message
 from gda.daemon.session import EngineSession, launch_session
-from gda.exit_codes import EXIT_LIVE
-from gda.parser import RESULT_BEGIN, RESULT_END
 
 # Control ops on the CLI socket — daemon lifetime, not project domain ops.
 STATUS_OP = "__status__"
@@ -120,7 +117,7 @@ class DaemonServer:
         # A project live op. Serialized against the one session (single writer).
         session = self._ensure_session()
         if session is None:
-            return _op_error_reply(
+            return error_reply(
                 "engine_session_not_running",
                 "the gda-daemon could not launch an engine session (no Godot binary, "
                 "or the harness did not connect)",
@@ -147,7 +144,7 @@ class DaemonServer:
         # would give it a hidden project-code-execution side effect (ADR-0009).
         session = self._session
         if session is None or session.log_file is None:
-            return _op_error_reply(
+            return error_reply(
                 "engine_session_not_running",
                 "the gda-daemon holds no engine session to read runtime "
                 "diagnostics from; diag observes an already-launched session and "
@@ -157,15 +154,15 @@ class DaemonServer:
         try:
             raw = session.log_file.read_bytes()
         except OSError:
-            return _op_error_reply(
+            return error_reply(
                 "live_log_unavailable",
                 f"the engine session's diagnostics log at {session.log_file} is "
                 "missing or unreadable",
             )
         limit = params.get("limit")
         if op == DIAG_ERRORS_OP:
-            return _ok_reply({"errors": parse_errors(raw, limit=limit)})
-        return _ok_reply({"lines": parse_log(raw, limit=limit)})
+            return result_reply({"errors": parse_errors(raw, limit=limit)})
+        return result_reply({"lines": parse_log(raw, limit=limit)})
 
     def _ensure_session(self) -> EngineSession | None:
         if self._session is not None and self._session.alive():
@@ -222,28 +219,3 @@ class DaemonServer:
                 os.unlink(path)
             except FileNotFoundError:
                 pass
-
-
-def _op_error_reply(code: str, message: str) -> dict:
-    """A CLI reply carrying a LIVE error envelope as the ADR-0002 sentinel payload."""
-    body = json.dumps({"error": {"code": code, "message": message}})
-    return {
-        "stdout": f"{RESULT_BEGIN}{body}{RESULT_END}\n",
-        "stderr": "",
-        "exit_code": EXIT_LIVE,
-    }
-
-
-def _ok_reply(payload: dict) -> dict:
-    """A CLI reply carrying a daemon-served success payload as the ADR-0002 sentinel.
-
-    The daemon-served ``gda diag`` ops build their result here rather than relaying
-    a harness reply; classification (``classify_live`` / ``parse_result``) treats
-    it exactly like an engine op's sentinel, so the CLI/model/render path is shared.
-    """
-    body = json.dumps(payload)
-    return {
-        "stdout": f"{RESULT_BEGIN}{body}{RESULT_END}\n",
-        "stderr": "",
-        "exit_code": 0,
-    }

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -12,7 +12,6 @@ viewport-capturing op (ADR-0017). The session is (re)launched per feedback-loop
 iteration so it observes the project's current on-disk state.
 """
 
-import json
 import os
 import signal
 import socket
@@ -20,9 +19,7 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
-from gda.daemon.protocol import read_frame, write_message
-from gda.exit_codes import EXIT_LIVE
-from gda.parser import RESULT_BEGIN, RESULT_END
+from gda.daemon.protocol import error_reply, read_frame, write_message
 
 LAUNCH_MARKER = "gda-daemon"
 # Engine boot + autoload + harness connect; a windowed/cold start can be slow.
@@ -62,14 +59,14 @@ class EngineSession:
             write_message(self._conn, {"op": operation, "params": params})
             reply = read_frame(self._conn)  # the raw ADR-0002 sentinel string
         except TimeoutError:
-            return _live_reply(
+            return error_reply(
                 "live_timeout",
                 f"the engine session did not return within {int(OP_TIMEOUT)}s",
             )
         except OSError:
-            return _live_reply("engine_disconnected", "the engine session dropped the connection")
+            return error_reply("engine_disconnected", "the engine session dropped the connection")
         if reply is None:
-            return _live_reply("engine_disconnected", "the engine session closed before replying")
+            return error_reply("engine_disconnected", "the engine session closed before replying")
         return {"stdout": reply.decode("utf-8", "replace"), "stderr": "", "exit_code": 0}
 
     def close(self) -> None:
@@ -169,10 +166,3 @@ def _terminate(proc: subprocess.Popen) -> None:
             pass
 
 
-def _live_reply(code: str, message: str) -> dict:
-    body = json.dumps({"error": {"code": code, "message": message}})
-    return {
-        "stdout": f"{RESULT_BEGIN}{body}{RESULT_END}\n",
-        "stderr": "",
-        "exit_code": EXIT_LIVE,
-    }

--- a/src/gda/live_runner.py
+++ b/src/gda/live_runner.py
@@ -14,7 +14,6 @@ becomes ``engine_disconnected``. Both ride the normal classify pipeline via
 ``classify_live``.
 """
 
-import json
 import os
 import socket
 from dataclasses import dataclass
@@ -22,9 +21,7 @@ from pathlib import Path
 from typing import Optional
 
 from gda.daemon.discovery import daemon_paths, daemon_pid
-from gda.daemon.protocol import read_message, write_message
-from gda.exit_codes import EXIT_LIVE
-from gda.parser import RESULT_BEGIN, RESULT_END
+from gda.daemon.protocol import error_reply, read_message, write_message
 from gda.runner import GodotRunner, RunResult
 
 # Bounds a live call so it never hangs the CLI forever; generous because the
@@ -109,8 +106,9 @@ def _live_error_result(code: str, message: str) -> RunResult:
     """A synthesized RunResult carrying a LIVE error envelope in the sentinel.
 
     The client surfaces its own failures (no daemon, dropped connection) through
-    the SAME ADR-0002 envelope a real op error uses, so ``classify_live`` maps
-    them to the registered code through the normal pipeline — no special path.
+    the SAME ADR-0002 envelope a real op error uses — built once by
+    :func:`gda.daemon.protocol.error_reply` (the daemon synthesizes the identical
+    reply dict) — so ``classify_live`` maps them to the registered code through the
+    normal pipeline, no special path.
     """
-    body = json.dumps({"error": {"code": code, "message": message}})
-    return RunResult(stdout=f"{RESULT_BEGIN}{body}{RESULT_END}\n", stderr="", exit_code=EXIT_LIVE)
+    return RunResult(**error_reply(code, message))

--- a/src/gda/parser.py
+++ b/src/gda/parser.py
@@ -36,3 +36,25 @@ def parse_result(stdout: str) -> Any:
     if not payload:
         raise ValueError("empty GDA result payload between sentinels")
     return json.loads(payload)
+
+
+def build_result(payload: Any) -> str:
+    """Wrap ``payload`` as the ADR-0002 sentinel result string — the inverse of
+    :func:`parse_result`.
+
+    The single place the sentinel string is constructed. The engine op, the daemon,
+    and the live client all emit ``<<<GDA:RESULT>>>{json}<<<GDA:END>>>`` followed by
+    a trailing newline (matching what every emitter wrote before this was shared), so
+    a relayed or synthesized result is byte-identical to a real engine run's.
+    """
+    return f"{RESULT_BEGIN}{json.dumps(payload)}{RESULT_END}\n"
+
+
+def error_envelope(code: str, message: str) -> dict:
+    """The ADR-0002 operation-error payload — ``{"error": {"code", "message"}}``.
+
+    The one place that envelope dict is built (it mirrors
+    :class:`~gda.models.OperationErrorEnvelope`); wrap it with :func:`build_result`
+    to synthesize a sentinel error result.
+    """
+    return {"error": {"code": code, "message": message}}

--- a/tests/test_sentinel_result.py
+++ b/tests/test_sentinel_result.py
@@ -49,8 +49,12 @@ def test_result_reply_carries_the_sentinel_payload_at_exit_zero():
     }
 
 
-def test_result_reply_honors_an_explicit_exit_code():
-    assert result_reply({"ok": True}, exit_code=EXIT_LIVE)["exit_code"] == EXIT_LIVE
+def test_the_exit_invariant_is_owned_by_the_builders_not_the_caller():
+    # result_reply is success-only (exit 0) and error_reply is the only live-error
+    # path (EXIT_LIVE): the public seam has no exit_code knob, so a caller cannot
+    # pair a success payload with a non-zero exit (#261 review hardening).
+    assert result_reply({"ok": True})["exit_code"] == 0
+    assert error_reply("engine_disconnected", "dropped")["exit_code"] == EXIT_LIVE
 
 
 def test_error_reply_is_a_live_error_envelope_at_exit_live():

--- a/tests/test_sentinel_result.py
+++ b/tests/test_sentinel_result.py
@@ -1,0 +1,89 @@
+"""The ADR-0002 sentinel result builders and the daemon reply builders (#260).
+
+These pin the behavior-preserving consolidation: ``gda.parser.build_result`` is the
+write-twin of ``parse_result`` (round-trips), ``error_envelope`` is the one error
+payload shape, and ``gda.daemon.protocol.result_reply`` / ``error_reply`` produce the
+exact reply dicts the four hand-rolled copies used to build. The asserted strings are
+literal so a drift in the emitted bytes is caught here, not only end-to-end.
+"""
+
+import json
+
+import pytest
+
+from gda.daemon.protocol import error_reply, result_reply
+from gda.exit_codes import EXIT_LIVE
+from gda.parser import (
+    RESULT_BEGIN,
+    RESULT_END,
+    build_result,
+    error_envelope,
+    parse_result,
+)
+
+
+def test_build_result_wraps_payload_in_the_sentinel_with_trailing_newline():
+    payload = {"value": 42, "name": "Player"}
+    # Byte-identical to the f-string every emitter used before this was shared.
+    assert build_result(payload) == f"{RESULT_BEGIN}{json.dumps(payload)}{RESULT_END}\n"
+
+
+def test_build_result_round_trips_through_parse_result():
+    # The write side is the exact inverse of the read side.
+    for payload in ({}, {"a": 1}, {"error": {"code": "x", "message": "m"}}, {"l": [1, 2]}):
+        assert parse_result(build_result(payload)) == payload
+
+
+def test_error_envelope_is_the_operation_error_payload_shape():
+    assert error_envelope("node_not_found", "no such node") == {
+        "error": {"code": "node_not_found", "message": "no such node"}
+    }
+
+
+def test_result_reply_carries_the_sentinel_payload_at_exit_zero():
+    payload = {"lines": ["a", "b"]}
+    assert result_reply(payload) == {
+        "stdout": build_result(payload),
+        "stderr": "",
+        "exit_code": 0,
+    }
+
+
+def test_result_reply_honors_an_explicit_exit_code():
+    assert result_reply({"ok": True}, exit_code=EXIT_LIVE)["exit_code"] == EXIT_LIVE
+
+
+def test_error_reply_is_a_live_error_envelope_at_exit_live():
+    # The single builder the daemon and the live client both synthesize from; the
+    # envelope is sentinel-wrapped and carries the live exit code.
+    reply = error_reply("engine_disconnected", "the engine session dropped the connection")
+    assert reply == {
+        "stdout": build_result(
+            {"error": {"code": "engine_disconnected", "message": "the engine session dropped the connection"}}
+        ),
+        "stderr": "",
+        "exit_code": EXIT_LIVE,
+    }
+    # And it parses back to the error envelope a classifier reads.
+    assert parse_result(reply["stdout"]) == error_envelope(
+        "engine_disconnected", "the engine session dropped the connection"
+    )
+
+
+def test_live_client_error_result_matches_the_daemon_error_reply():
+    # The live client's synthesized RunResult is the object form of the SAME dict the
+    # daemon sends, so a client-side failure classifies identically to a relayed one.
+    from gda.live_runner import _live_error_result
+
+    result = _live_error_result("daemon_not_running", "no daemon")
+    reply = error_reply("daemon_not_running", "no daemon")
+    assert result.stdout == reply["stdout"]
+    assert result.stderr == reply["stderr"]
+    assert result.exit_code == reply["exit_code"]
+
+
+@pytest.mark.parametrize("missing", ["no sentinel here", ""])
+def test_parse_result_still_rejects_non_sentinel_output(missing):
+    # The read side is unchanged by the consolidation.
+    with pytest.raises(ValueError):
+        parse_result(missing)


### PR DESCRIPTION
Candidate #2 from the 2026-06-23 architecture deepening review. Behavior-preserving consolidation of the ADR-0002 result-building seam.

Closes #260.

## Why

The sentinel-wrapping ceremony `f"{RESULT_BEGIN}{json.dumps(payload)}{RESULT_END}\n"` was copied across **4 sites** while `parser.py` owned only the *parse* side of that exact format; `session._live_reply` and `server._op_error_reply` were **byte-identical**; and the `{"error": {code, message}}` envelope was hand-built in several places.

## What changed

A layered single-home consolidation — the registries/contract are untouched:

- **`parser.py`** gains the write-twin of `parse_result`: `build_result(payload) -> str` (the one place the sentinel string — incl. the trailing `\n` — is built) and `error_envelope(code, message) -> dict` (the one ADR-0002 error payload shape, mirroring `OperationErrorEnvelope`). Stays json-only/leaf.
- **`daemon/protocol.py`** gains the daemon→CLI reply builders `result_reply(payload, *, exit_code=0)` and `error_reply(code, message)` (the reply dict is what protocol.py frames; imports the parser shapes + `EXIT_LIVE`, both leaf — no cycle).
- **Consumers** stop hand-rolling it: `session._live_reply` + `server._op_error_reply` (byte-identical) collapse to one `error_reply`; `server._ok_reply` → `result_reply`; `live_runner._live_error_result` → `RunResult(**error_reply(...))`. Each site drops its now-unused `RESULT_BEGIN`/`RESULT_END`/`json`/`EXIT_LIVE` imports. The verbatim harness-relay in `session.py` (passes an already-wrapped sentinel through) and the plain control replies (`__status__`/`__stop__`) are left untouched.

Out of scope (as agreed): `error_codes.py`'s registry — `_failure` is already the deep CLI error-builder. The GDScript engine-side wrapping (the cross-language mirror) is a separate future concern.

## Behavior preservation

Identical sentinel bytes, exit codes (`EXIT_LIVE` for live errors, `0` for ok), envelope shape, and `--json` / `GdaError` output. **No existing test was modified.** After this change, no `RESULT_BEGIN`/`RESULT_END` wrapping remains in Python outside `parser.build_result`.

## Verification (independently re-run)

- Fast suite: **855 passed** (846 baseline + 9 new sentinel/reply unit tests), 279 deselected.
- e2e (serial, real engine): daemon + diag + game = **8 passed** — covers `error_reply` (`engine_session_not_running`, live failures), `result_reply` (daemon-served `diag`), and the live relay end-to-end.
- New `tests/test_sentinel_result.py`: `build_result` literal-bytes + round-trip through `parse_result`; `error_envelope` shape; `result_reply`/`error_reply` produce the exact dicts the old helpers did; `_live_error_result` matches `error_reply`.

## Docs

A dated **Outcome** note on `docs/adr/0002-headless-structured-output-contract.md` records the single-home consolidation (body unchanged; no contract change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)