### PR TITLE
docs: restore per-agent user-scope MCP registration recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,13 @@ uvx --from "gda[mcp]" gda-mcp
 workspace `roots`, otherwise the working directory. An explicitly set
 `GDA_PROJECT` that is not a valid project is reported as an error, not silently replaced.
 
-<details>
-<summary>Register with Claude Code / Codex / Cursor</summary>
 
-**Claude Code** — project scope, `.mcp.json` at the repo root (auto-detects the project via `roots`):
+#### Register with Coding Agents
+
+<details>
+<summary>Claude Code</summary>
+
+Project scope, `.mcp.json` at the repo root (auto-detects the project via `roots`):
 
 ```json
 {
@@ -123,7 +126,12 @@ User scope (every project) — the CLI, which writes `~/.claude.json`:
 claude mcp add --scope user gda-mcp -- uvx --from "gda[mcp]" gda-mcp
 ```
 
-**Codex** — project scope, `.codex/config.toml` at the repo root (the project must be trusted):
+</details>
+
+<details>
+<summary>Codex</summary>
+
+Project scope, `.codex/config.toml` at the repo root (the project must be trusted):
 
 ```toml
 [mcp_servers.gda-mcp]
@@ -134,7 +142,20 @@ args = ["--from", "gda[mcp]", "gda-mcp"]
 GDA_PROJECT = "/absolute/path/to/your/godot/project"
 ```
 
-**Cursor** — project scope, `.cursor/mcp.json` at the repo root (`${workspaceFolder}`
+User scope (every project) — the same table in `~/.codex/config.toml`, or add it with the
+CLI (Codex has no workspace variable, so `GDA_PROJECT` stays an absolute path):
+
+```bash
+codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- \
+  uvx --from "gda[mcp]" gda-mcp
+```
+
+</details>
+
+<details>
+<summary>Cursor</summary>
+
+Project scope, `.cursor/mcp.json` at the repo root (`${workspaceFolder}`
 tracks the open project):
 
 ```json
@@ -152,6 +173,10 @@ tracks the open project):
   }
 }
 ```
+
+User scope (every project) — the same config in `~/.cursor/mcp.json`, but set `GDA_PROJECT`
+to an absolute path (`${workspaceFolder}` is only reliable in the project-level file).
+Cursor has no `mcp add` command — register via the JSON above or the Settings → MCP UI.
 
 > GUI-launched clients (Cursor, Claude Desktop) start with a minimal `PATH`, so a bare
 > `uvx` may not resolve — the Cursor snippet repairs it in `env`; if `uvx` is still not

--- a/README.md
+++ b/README.md
@@ -101,9 +101,8 @@ uvx --from "gda[mcp]" gda-mcp
 workspace `roots`, otherwise the working directory. An explicitly set
 `GDA_PROJECT` that is not a valid project is reported as an error, not silently replaced.
 
-It finds the Godot engine the same way the CLI does — add `GDA_GODOT` to a recipe's `env`
-(MCP has no per-call `--godot` flag) unless your engine is at the default location, e.g.
-`"GDA_GODOT": "/path/to/Godot"`.
+Point the server at your Godot binary with `GDA_GODOT` in a recipe's `env` (MCP has no
+per-call `--godot` flag) — e.g. `"GDA_GODOT": "/path/to/Godot"`.
 
 
 #### Register with Coding Agents

--- a/README.md
+++ b/README.md
@@ -166,8 +166,7 @@ tracks the open project):
       "command": "uvx",
       "args": ["--from", "gda[mcp]", "gda-mcp"],
       "env": {
-        "GDA_PROJECT": "${workspaceFolder}",
-        "PATH": "/opt/homebrew/bin:/usr/local/bin:${userHome}/.local/bin:${env:PATH}"
+        "GDA_PROJECT": "${workspaceFolder}"
       }
     }
   }
@@ -179,9 +178,9 @@ to an absolute path (`${workspaceFolder}` is only reliable in the project-level 
 Cursor has no `mcp add` command — register via the JSON above or the Settings → MCP UI.
 
 > GUI-launched clients (Cursor, Claude Desktop) start with a minimal `PATH`, so a bare
-> `uvx` may not resolve — the Cursor snippet repairs it in `env`; if `uvx` is still not
-> found (or for Claude Desktop), use an absolute path (`which uvx`) for `command`. Full
-> recipes — user vs project scope, Claude Desktop, per-agent project pinning — are in the
+> `uvx` may not resolve. The simplest fix is an absolute `command` — run `which uvx` and
+> use its output. Full recipes — absolute paths, PATH injection, user vs project scope,
+> Claude Desktop, per-agent project pinning — are in the
 > [registration recipes](docs/gda-mcp-registration.md).
 </details>
 

--- a/README.md
+++ b/README.md
@@ -97,12 +97,17 @@ so any MCP agent (Claude Code, Codex, Cursor, …) can drive Godot. Try it with 
 uvx --from "gda[mcp]" gda-mcp
 ```
 
-`gda-mcp` picks your Godot project from `GDA_PROJECT` if set, otherwise the client's
-workspace `roots`, otherwise the working directory. An explicitly set
-`GDA_PROJECT` that is not a valid project is reported as an error, not silently replaced.
+The server takes two things from the recipe's `env` — which Godot **project** to drive and
+which Godot **binary** to run (MCP can't pass per-call flags; see
+[Configuration](#configuration) for what `GDA_PROJECT` and `GDA_GODOT` do):
 
-Point the server at your Godot binary with `GDA_GODOT` in a recipe's `env` (MCP has no
-per-call `--godot` flag) — e.g. `"GDA_GODOT": "/path/to/Godot"`.
+- **Project** — `gda-mcp` uses `GDA_PROJECT` if set; otherwise the **workspace roots** the
+  client advertises (the folder you have open in your editor/agent — Claude Code sends this
+  automatically); otherwise the server's **working directory** (where the `gda-mcp` process
+  was launched). A set-but-invalid `GDA_PROJECT` is a reported error, not a silent fallback.
+  *(Same idea as the CLI's `--project` → `GDA_PROJECT` → cwd order — MCP just has no
+  `--project` flag, so the client's roots are the auto-detected stand-in for it.)*
+- **Engine** — set `GDA_GODOT` to your Godot binary, e.g. `"GDA_GODOT": "/path/to/Godot"`.
 
 
 #### Register with Coding Agents

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ uvx --from "gda[mcp]" gda-mcp
 workspace `roots`, otherwise the working directory. An explicitly set
 `GDA_PROJECT` that is not a valid project is reported as an error, not silently replaced.
 
+It finds the Godot engine the same way the CLI does — add `GDA_GODOT` to a recipe's `env`
+(MCP has no per-call `--godot` flag) unless your engine is at the default location, e.g.
+`"GDA_GODOT": "/path/to/Godot"`.
+
 
 #### Register with Coding Agents
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ which Godot **binary** to run (MCP can't pass per-call flags; see
 [Configuration](#configuration) for what `GDA_PROJECT` and `GDA_GODOT` do):
 
 - **Project** — `gda-mcp` uses `GDA_PROJECT` if set; otherwise the **workspace roots** the
-  client advertises (the folder you have open in your editor/agent — Claude Code sends this
-  automatically); otherwise the server's **working directory** (where the `gda-mcp` process
+  client advertises (the folder you have open in your editor/agent, for clients that
+  support MCP roots); otherwise the server's **working directory** (where the `gda-mcp` process
   was launched). A set-but-invalid `GDA_PROJECT` is a reported error, not a silent fallback.
   *(Same idea as the CLI's `--project` → `GDA_PROJECT` → cwd order — MCP just has no
   `--project` flag, so the client's roots are the auto-detected stand-in for it.)*

--- a/README.md
+++ b/README.md
@@ -97,16 +97,18 @@ so any MCP agent (Claude Code, Codex, Cursor, …) can drive Godot. Try it with 
 uvx --from "gda[mcp]" gda-mcp
 ```
 
-The server takes two things from the recipe's `env` — which Godot **project** to drive and
-which Godot **binary** to run (MCP can't pass per-call flags; see
+The server resolves two pieces of context — which Godot **project** to drive and which Godot
+**binary** to run (MCP can't pass per-call flags; see
 [Configuration](#configuration) for what `GDA_PROJECT` and `GDA_GODOT` do):
 
 - **Project** — `gda-mcp` uses `GDA_PROJECT` if set; otherwise the **workspace roots** the
-  client advertises (the folder you have open in your editor/agent, for clients that
-  support MCP roots); otherwise the server's **working directory** (where the `gda-mcp` process
-  was launched). A set-but-invalid `GDA_PROJECT` is a reported error, not a silent fallback.
-  *(Same idea as the CLI's `--project` → `GDA_PROJECT` → cwd order — MCP just has no
-  `--project` flag, so the client's roots are the auto-detected stand-in for it.)*
+  client advertises (the folder you have open, for clients that support MCP roots); otherwise
+  the server's **working directory** (where the `gda-mcp` process was launched). A roots or cwd
+  candidate is used only if it is a real Godot project (has `project.godot`), else resolution
+  moves on; a *set-but-invalid* `GDA_PROJECT`, by contrast, is a reported error, not a silent
+  fallback. *(The CLI resolves a project differently — `--project` → `GDA_PROJECT` → cwd; the
+  MCP server has no flags, so `GDA_PROJECT` is the explicit override and the protocol's
+  workspace `roots` are the auto-detected fallback.)*
 - **Engine** — set `GDA_GODOT` to your Godot binary, e.g. `"GDA_GODOT": "/path/to/Godot"`.
 
 
@@ -150,8 +152,9 @@ args = ["--from", "gda[mcp]", "gda-mcp"]
 GDA_PROJECT = "/absolute/path/to/your/godot/project"
 ```
 
-User scope (every project) — the same table in `~/.codex/config.toml`, or add it with the
-CLI (Codex has no workspace variable, so `GDA_PROJECT` stays an absolute path):
+User scope (available everywhere, but pinned to one project) — the same table in
+`~/.codex/config.toml`, or add it with the CLI. Codex has no workspace variable, so
+`GDA_PROJECT` is an absolute path; use project scope if you work across several projects:
 
 ```bash
 codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- \
@@ -171,7 +174,7 @@ tracks the open project):
   "mcpServers": {
     "gda-mcp": {
       "type": "stdio",
-      "command": "uvx",
+      "command": "/path/to/uvx",
       "args": ["--from", "gda[mcp]", "gda-mcp"],
       "env": {
         "GDA_PROJECT": "${workspaceFolder}"
@@ -181,14 +184,14 @@ tracks the open project):
 }
 ```
 
-User scope (every project) — the same config in `~/.cursor/mcp.json`, but set `GDA_PROJECT`
-to an absolute path (`${workspaceFolder}` is only reliable in the project-level file).
-Cursor has no `mcp add` command — register via the JSON above or the Settings → MCP UI.
+User scope (available everywhere, but pinned to one project) — the same config in
+`~/.cursor/mcp.json` with `GDA_PROJECT` set to an absolute path (`${workspaceFolder}` only
+works in project scope; use project scope for several projects). Cursor has no `mcp add`
+command — register via the JSON above or the Settings → MCP UI.
 
-> GUI-launched clients (Cursor, Claude Desktop) start with a minimal `PATH`, so a bare
-> `uvx` may not resolve. The simplest fix is an absolute `command` — run `which uvx` and
-> use its output. Full recipes — absolute paths, PATH injection, user vs project scope,
-> Claude Desktop, per-agent project pinning — are in the
+> Cursor is GUI-launched with a minimal `PATH`, so a bare `uvx` may not resolve — hence the
+> absolute `command` above; fill it with the output of `which uvx`. Full recipes — PATH
+> injection, Claude Desktop, user vs project scope, per-agent project pinning — are in the
 > [registration recipes](docs/gda-mcp-registration.md).
 </details>
 


### PR DESCRIPTION
## What & why

The README rewrite (#262) reorganized the MCP registration recipes into per-agent `<details>` blocks but **dropped the user-scope variants for Codex and Cursor** (Claude Code's was retained). That left the three agents inconsistent and diverged from the canonical `docs/gda-mcp-registration.md` and the v0.1.35 README.

## Changes
- **Codex** — restore user scope: `codex mcp add gda-mcp --env GDA_PROJECT=... -- uvx --from "gda[mcp]" gda-mcp`.
- **Cursor** — restore user scope: `~/.cursor/mcp.json` with an absolute `GDA_PROJECT`, plus the Settings → MCP UI note.
- Tidy: drop a stray trailing space after `<summary>Cursor</summary>`; even out the blank line before the Codex block's `</details>`.

All three agents now show **both project and user scope**, matching `docs/gda-mcp-registration.md`. Verified: user-scope commands match the canonical recipes doc; `<details>` blocks balanced; renders correctly on GitHub.

Type is `docs:` → no release. If you want this reflected on the PyPI README (currently 0.1.36 lacks it), say so and I'll retitle to `fix:` for a 0.1.37 patch.
