### PR TITLE
docs: record the gda Skill channel — ADR-0024 + CONTEXT.md vocabulary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,15 @@ orthogonal to the delivery phases: first delivered on top of Phase 1, it follows
 never itself a phase. Its order relative to other components follows ADR-0000.
 _Avoid_: the server, mcp wrapper
 
+**gda skill**:
+The Agent Skill (a `SKILL.md`) that teaches an AI agent how and when to drive `gda`
+through the CLI — a third agent-facing channel alongside `gda-mcp`. Where `gda-mcp`
+exposes the surface as generated tools, the skill points the agent at the CLI itself plus
+the guidance to use it; an agent uses whichever channel its runtime supports. It ships
+in-package and is emitted by the `gda skill` command, so its guidance stays version-locked
+to the installed CLI (ADR-0024).
+_Avoid_: plugin, addon, the SKILL.md file
+
 **gda-daemon**:
 A long-lived, per-project process that supervises transient `Engine session`s and
 brokers IPC to them, serving operations that require a live engine rather than a

--- a/docs/adr/0024-gda-skill-channel-and-distribution.md
+++ b/docs/adr/0024-gda-skill-channel-and-distribution.md
@@ -1,0 +1,64 @@
+---
+status: accepted
+---
+
+# gda skill: an Agent Skill as a third agent-facing channel, shipped in-package
+
+An agent can reach [gda](../../CONTEXT.md) two ways today: the CLI directly, and
+[gda-mcp](../../CONTEXT.md) (ADR-0011), which exposes the same surface as MCP tools
+generated from `--schema` (ADR-0012). This ADR adds a third — an **Agent Skill**: a
+`SKILL.md` that teaches an agent *how and when* to drive the `gda` CLI — and fixes how it
+is distributed. It mirrors the single-distribution packaging stance ADR-0013 took for
+gda-mcp.
+
+## Decision
+
+**A Skill is the third agent-facing channel.** The three channels ride the one `gda`
+command surface and are equivalent in capability: the **CLI** is raw invocation;
+**gda-mcp** is that surface as generated tools (ADR-0012); a **Skill** points the agent at
+the CLI itself plus the guidance for how and when to use it. An agent uses whichever its
+runtime supports — a Skill is the lightest path (no server to register), native to agents
+that load `SKILL.md`.
+
+**Shipped in-package, emitted by `gda skill`.** The canonical `SKILL.md` lives inside the
+`gda` distribution under the package dir — the same way the GDScript payload ships
+(resolved by a package-relative path, not `importlib.resources`) — so a `gda skill`
+meta-command can emit it and the guidance stays **version-locked to the installed CLI**.
+This is the single-version argument ADR-0013 makes for the MCP adapter, applied to the
+Skill: the manifest and the commands it describes cannot skew because they are one
+distribution. `gda skill` is a **pure emitter** meta-command (no Godot spawn), a sibling
+of `info`/`schema`, carrying `--json`/`--schema` like them; an optional `--install` writes
+the manifest into the agent's skills directory.
+
+**Hybrid distribution, one source.** Because the canonical file lives in the repo *under*
+the package, it is both shipped in the wheel and browsable / curl-able from the source
+tree — one source, two access paths (the `gda skill` command for installed users; the
+repo file for a manual drop-in). There is no second copy to drift.
+
+**Vendor specifics stay out of the core.** The `SKILL.md` content and the CONTEXT.md term
+stay agent-neutral; agent-specific install directories live in the registration recipes
+doc, not in the manifest or this ADR — the same separation ADR-0014 draws for project
+resolution.
+
+## Considered options
+
+- **Repo-hosted `SKILL.md`, manual copy only (rejected as the sole mechanism).** Zero
+  code, but the guidance is not version-locked to the installed CLI and can drift, and
+  there is no self-install. Kept as *one* of the two hybrid access paths, not the only one.
+- **A separate skill package or marketplace plugin (rejected).** A second distribution and
+  version line, at odds with the single-distribution authority (ADR-0008 / ADR-0013).
+- **In-package `SKILL.md` + `gda skill` command, hybrid access (chosen).**
+
+## Consequences
+
+- `gda skill` reaches the MCP surface like any meta command (it carries `--schema`), so an
+  MCP agent can fetch the same guidance — the channels reinforce rather than fork.
+- The Skill covers the **full** surface (headless + live); live's prerequisites (a running
+  daemon, Godot 4.6+, macOS/Linux, `--windowed` for `screen` capture) are stated in the
+  body, not gated by it.
+- The `description` is the only thing an agent sees when deciding to load the Skill; it is
+  tuned to trigger on building/modifying a Godot game and kept free of time-sensitive
+  detail (no versions/dates that drift).
+- The one canonical `SKILL.md` under the package dir is the single source; the README's
+  "Use it as a Skill" section and `docs/gda-skill.md` link to it and to the `gda skill`
+  install path.

--- a/docs/adr/0024-gda-skill-channel-and-distribution.md
+++ b/docs/adr/0024-gda-skill-channel-and-distribution.md
@@ -13,12 +13,12 @@ gda-mcp.
 
 ## Decision
 
-**A Skill is the third agent-facing channel.** The three channels ride the one `gda`
-command surface and are equivalent in capability: the **CLI** is raw invocation;
-**gda-mcp** is that surface as generated tools (ADR-0012); a **Skill** points the agent at
-the CLI itself plus the guidance for how and when to use it. An agent uses whichever its
-runtime supports — a Skill is the lightest path (no server to register), native to agents
-that load `SKILL.md`.
+**A Skill is the third agent-facing channel.** The three channels expose the **same
+underlying `gda` command surface** but differ as integration mechanisms: the **CLI** is
+raw invocation; **gda-mcp** is that surface as generated tools (ADR-0012); a **Skill** is
+guidance that teaches an agent to drive the CLI itself — it executes nothing of its own. An
+agent uses whichever its runtime supports — a Skill is the lightest path (no server to
+register), native to agents that load `SKILL.md`.
 
 **Shipped in-package, emitted by `gda skill`.** The canonical `SKILL.md` lives inside the
 `gda` distribution under the package dir — the same way the GDScript payload ships
@@ -27,8 +27,9 @@ meta-command can emit it and the guidance stays **version-locked to the installe
 This is the single-version argument ADR-0013 makes for the MCP adapter, applied to the
 Skill: the manifest and the commands it describes cannot skew because they are one
 distribution. `gda skill` is a **pure emitter** meta-command (no Godot spawn), a sibling
-of `info`/`schema`, carrying `--json`/`--schema` like them; an optional `--install` writes
-the manifest into the agent's skills directory.
+of `info`/`schema`, carrying `--json`/`--schema` like them. Installing is neutral: `gda
+skill` emits to stdout, and an optional `--install --dir <path>` writes the manifest to a
+**caller-supplied** directory — core carries no agent-specific default location (see below).
 
 **Hybrid distribution, one source.** Because the canonical file lives in the repo *under*
 the package, it is both shipped in the wheel and browsable / curl-able from the source
@@ -36,9 +37,10 @@ tree — one source, two access paths (the `gda skill` command for installed use
 repo file for a manual drop-in). There is no second copy to drift.
 
 **Vendor specifics stay out of the core.** The `SKILL.md` content and the CONTEXT.md term
-stay agent-neutral; agent-specific install directories live in the registration recipes
-doc, not in the manifest or this ADR — the same separation ADR-0014 draws for project
-resolution.
+stay agent-neutral, and **`gda skill` defaults to no agent-specific install path**: it
+emits to stdout, and `--install` requires an explicit `--dir`. The per-agent target path
+(e.g. a given agent's skills directory) is documented in the registration recipes doc, not
+defaulted in core — the same separation ADR-0014 draws for project resolution.
 
 ## Considered options
 
@@ -51,14 +53,13 @@ resolution.
 
 ## Consequences
 
-- `gda skill` reaches the MCP surface like any meta command (it carries `--schema`), so an
-  MCP agent can fetch the same guidance — the channels reinforce rather than fork.
+- `gda skill` is a descriptor-backed command and appears in the aggregate `gda schema`
+  manifest, so gda-mcp generates a tool for it through the normal dispatchable surface
+  (ADR-0011 / ADR-0012) — not via any skill-specific path. An MCP agent can therefore fetch
+  the same guidance; the channels reinforce rather than fork.
 - The Skill covers the **full** surface (headless + live); live's prerequisites (a running
   daemon, Godot 4.6+, macOS/Linux, `--windowed` for `screen` capture) are stated in the
   body, not gated by it.
-- The `description` is the only thing an agent sees when deciding to load the Skill; it is
-  tuned to trigger on building/modifying a Godot game and kept free of time-sensitive
-  detail (no versions/dates that drift).
-- The one canonical `SKILL.md` under the package dir is the single source; the README's
-  "Use it as a Skill" section and `docs/gda-skill.md` link to it and to the `gda skill`
-  install path.
+- The one canonical `SKILL.md` under the package dir is the single source; the user-facing
+  "Use it as a Skill" README section and `docs/gda-skill.md` (added in #267) will link to
+  it and to the `gda skill` install path.


### PR DESCRIPTION
Slice 1/4 of the `gda-skill` milestone — the decision record (lands first; the implementation in #266 references it).

## What
- **ADR-0024** (`docs/adr/0024-gda-skill-channel-and-distribution.md`): the Skill is a third agent-facing channel alongside the CLI and gda-mcp; ship a canonical `SKILL.md` **in-package** (version-locked, emitted by `gda skill`), distribute **hybrid** (in-package + a browsable repo file, one source), keep vendor specifics out of the core. Mirrors ADR-0013's single-distribution stance; relates the three channels (CLI = raw, MCP = generated tools, Skill = CLI + guidance).
- **CONTEXT.md**: a new agent-neutral `gda skill` vocabulary term, placed next to `gda-mcp`.

## Notes
- `docs:` only — no release. The `gda skill` command, the `SKILL.md`, README and positioning follow in #266 → #267 → #268.

Closes #265
