### PR TITLE
feat: add the gda skill command and bundled SKILL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ flags — `gda --help` is the authoritative list of what is installed.
 | ------- | ------------ |
 | `gda info`   | Report the Godot engine version info. |
 | `gda schema` | Emit the whole command surface as one machine-readable JSON manifest. |
+| `gda skill`  | Emit or install the bundled Agent Skill (`SKILL.md`) that teaches an agent how to drive `gda`. |
 
 ### Headless commands — Godot 4.4+, all platforms
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -3122,14 +3122,16 @@ def skill(
     Core carries no agent-specific default location — the caller supplies the per-agent
     skills dir (ADR-0024). A sibling of `info`/`schema`, carrying `--schema` like them.
     """
-    # --dir implies --install; an install needs an explicit target dir (ADR-0024).
+    # An install needs an explicit target dir (ADR-0024). `--dir` implying an install is
+    # normalized inside SkillParams so argv and --params-json produce identical params
+    # (ADR-0015) — the CLI just forwards the raw flags.
     if install and dir is None:
         raise typer.BadParameter(
             "`--install` requires `--dir` (the skills directory to write into)"
         )
     _dispatch_recipe(
         SKILL_COMMAND,
-        SkillParams(install=install or dir is not None, install_dir=dir),
+        SkillParams(install=install, install_dir=dir),
         json_output=json_output,
         godot=None,
         project=None,

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -182,6 +182,8 @@ from gda.models import (
     ShaderGetResult,
     ShaderSetParams,
     ShaderSetResult,
+    SkillParams,
+    SkillResult,
     SurfaceManifest,
     ThemeCreateParams,
     ThemeCreateResult,
@@ -247,6 +249,7 @@ from gda.render import (
     render_shader_create,
     render_shader_get,
     render_shader_set,
+    render_skill,
     render_theme_create,
 )
 from gda.runner import GodotRunner
@@ -254,6 +257,7 @@ from gda.screen_ops import (
     run_screen_capture_operation,
     run_screen_frames_operation,
 )
+from gda.skill_ops import build_skill_result
 from gda.surface import build_surface_manifest
 
 app = typer.Typer(
@@ -506,6 +510,13 @@ def _screen_frames_recipe(params, *, project, godot):
     )
 
 
+def _skill_recipe(params, *, project, godot):
+    # A pure local emitter (ADR-0024): no project, no Godot — it reads the bundled
+    # SKILL.md and either returns it (version-locked) or installs it. ``project`` /
+    # ``godot`` are part of the recipe contract but unused here (a meta command).
+    return build_skill_result(install=params.install, install_dir=params.install_dir)
+
+
 def _export_run_recipe(params, *, project, godot):
     return run_export_operation(
         preset=params.preset,
@@ -690,6 +701,19 @@ INFO_COMMAND: HeadlessCommand[EngineVersion] = HeadlessCommand(
     output_model=EngineVersion,
     render=render_engine_version,
     classify=classify_info,
+)
+
+# `gda skill` is a pure emitter meta command (ADR-0024): it reads the in-package
+# SKILL.md and emits or installs it, spawning no Godot — so, like `export run` and
+# the daemon lifecycle, it carries a `recipe` on its descriptor and dispatches
+# through it (`_dispatch_recipe`) rather than the sentinel pipeline. It stays
+# HEADLESS `kind` (the default) and meta (no --project), a sibling of info/schema.
+SKILL_COMMAND: HeadlessCommand[SkillResult] = HeadlessCommand(
+    operation="skill",
+    input_model=SkillParams,
+    output_model=SkillResult,
+    render=render_skill,
+    recipe=_skill_recipe,
 )
 
 GAME_TREE_COMMAND: HeadlessCommand[GameTreeResult] = HeadlessCommand(
@@ -3068,6 +3092,43 @@ def info(
         InfoParams(),
         json_output=json_output,
         godot=godot,
+    )
+
+
+@app.command(cls=SKILL_COMMAND.command_class())
+def skill(
+    install: bool = typer.Option(
+        False,
+        "--install",
+        help="Write the bundled SKILL.md into the skills directory instead of printing it.",
+    ),
+    dir: Optional[str] = typer.Option(
+        None,
+        "--dir",
+        help="The skills directory to install into (default ~/.claude/skills/gda); "
+        "implies --install.",
+    ),
+    json_output: bool = json_option(),
+    schema: bool = SKILL_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+) -> None:
+    """Emit or install the bundled gda Agent Skill (no Godot is spawned).
+
+    The canonical `SKILL.md` ships inside the `gda` package and is version-locked to
+    the install (ADR-0024): a plain run prints it verbatim (so
+    `gda skill > .../SKILL.md` drops it to disk), `--json` emits
+    `{name, version, content}`, and `--install` (or any `--dir`) writes it to the
+    skills directory (default `~/.claude/skills/gda/SKILL.md`), creating parents and
+    overwriting, then reports the path. A sibling of `info`/`schema`, carrying
+    `--schema` like them.
+    """
+    # --dir implies --install: naming a target directory means "install there".
+    _dispatch_recipe(
+        SKILL_COMMAND,
+        SkillParams(install=install or dir is not None, install_dir=dir),
+        json_output=json_output,
+        godot=None,
+        project=None,
     )
 
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -3105,8 +3105,8 @@ def skill(
     dir: Optional[str] = typer.Option(
         None,
         "--dir",
-        help="The skills directory to install into (default ~/.claude/skills/gda); "
-        "implies --install.",
+        help="The skills directory to install into (caller-supplied; no default). "
+        "Implies --install.",
     ),
     json_output: bool = json_option(),
     schema: bool = SKILL_COMMAND.schema_option(),
@@ -3117,12 +3117,16 @@ def skill(
     The canonical `SKILL.md` ships inside the `gda` package and is version-locked to
     the install (ADR-0024): a plain run prints it verbatim (so
     `gda skill > .../SKILL.md` drops it to disk), `--json` emits
-    `{name, version, content}`, and `--install` (or any `--dir`) writes it to the
-    skills directory (default `~/.claude/skills/gda/SKILL.md`), creating parents and
-    overwriting, then reports the path. A sibling of `info`/`schema`, carrying
-    `--schema` like them.
+    `{name, version, content}`, and `--install --dir <path>` writes it to a
+    caller-supplied directory, creating parents and overwriting, then reports the path.
+    Core carries no agent-specific default location — the caller supplies the per-agent
+    skills dir (ADR-0024). A sibling of `info`/`schema`, carrying `--schema` like them.
     """
-    # --dir implies --install: naming a target directory means "install there".
+    # --dir implies --install; an install needs an explicit target dir (ADR-0024).
+    if install and dir is None:
+        raise typer.BadParameter(
+            "`--install` requires `--dir` (the skills directory to write into)"
+        )
     _dispatch_recipe(
         SKILL_COMMAND,
         SkillParams(install=install or dir is not None, install_dir=dir),

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -2277,8 +2277,17 @@ class SkillParams(BaseModel):
         default=None,
         description="The skills directory to install into (caller-supplied; required "
         "for an install, no default). Parent dirs are created and an existing file is "
-        "overwritten. Ignored unless installing.",
+        "overwritten. Providing it implies an install (ADR-0015 parity with argv --dir).",
     )
+
+    @model_validator(mode="after")
+    def _dir_implies_install(self) -> "SkillParams":
+        # Single source of truth (ADR-0015): naming a target directory means "install
+        # there", whether the params arrive from argv (``--dir``) or a ``--params-json``
+        # object — normalized here in the model, not in the CLI body, so both agree.
+        if self.install_dir is not None:
+            self.install = True
+        return self
 
 
 class SkillResult(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -2256,6 +2256,46 @@ class EngineVersion(BaseModel):
     timestamp: int
 
 
+class SkillParams(BaseModel):
+    """The operation params of ``gda skill`` (ADR-0024).
+
+    ``gda skill`` is a pure emitter meta command: it reads the bundled
+    ``SKILL.md`` from the package and emits or installs it — no Godot is spawned.
+    Its only param is ``install``: when set, the manifest is written to
+    ``install_dir`` (default ``~/.claude/skills/gda``) instead of being printed.
+    ``install_dir`` is carried as a string so the ``--params-json`` and ``--schema``
+    paths describe it the same way the argv ``--dir`` option supplies it.
+    """
+
+    install: bool = Field(
+        default=False,
+        description="If true, WRITE the bundled SKILL.md to the skills directory "
+        "instead of returning it; the result then reports the written path.",
+    )
+    install_dir: str | None = Field(
+        default=None,
+        description="The skills directory to install into when installing "
+        "(default ~/.claude/skills/gda); parent dirs are created and an existing "
+        "file is overwritten. Ignored unless installing.",
+    )
+
+
+class SkillResult(BaseModel):
+    """The result of ``gda skill``: the bundled Skill, version-locked (ADR-0024).
+
+    ``name``/``version``/``content`` carry the manifest's identity, the installed
+    ``gda`` version (from ``importlib.metadata``, so the guidance cannot skew from
+    the CLI it describes), and the full ``SKILL.md`` text. ``installed_path`` is the
+    path written on ``--install`` and ``None`` for a plain emit, so one model serves
+    both the emit and install paths.
+    """
+
+    name: str
+    version: str
+    content: str
+    installed_path: Path | None = None
+
+
 class ProjectInfoParams(BaseModel):
     """The operation params of ``gda project info`` — none (ADR-0004).
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -2261,22 +2261,23 @@ class SkillParams(BaseModel):
 
     ``gda skill`` is a pure emitter meta command: it reads the bundled
     ``SKILL.md`` from the package and emits or installs it — no Godot is spawned.
-    Its only param is ``install``: when set, the manifest is written to
-    ``install_dir`` (default ``~/.claude/skills/gda``) instead of being printed.
-    ``install_dir`` is carried as a string so the ``--params-json`` and ``--schema``
+    Its only param is ``install``: when set, the manifest is written to the
+    caller-supplied ``install_dir`` instead of being printed. There is no
+    agent-specific default location in core (ADR-0024); ``install_dir`` is required
+    for an install. It is carried as a string so the ``--params-json`` and ``--schema``
     paths describe it the same way the argv ``--dir`` option supplies it.
     """
 
     install: bool = Field(
         default=False,
-        description="If true, WRITE the bundled SKILL.md to the skills directory "
+        description="If true, WRITE the bundled SKILL.md to install_dir "
         "instead of returning it; the result then reports the written path.",
     )
     install_dir: str | None = Field(
         default=None,
-        description="The skills directory to install into when installing "
-        "(default ~/.claude/skills/gda); parent dirs are created and an existing "
-        "file is overwritten. Ignored unless installing.",
+        description="The skills directory to install into (caller-supplied; required "
+        "for an install, no default). Parent dirs are created and an existing file is "
+        "overwritten. Ignored unless installing.",
     )
 
 

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -84,6 +84,7 @@ if TYPE_CHECKING:
         ShaderCreateResult,
         ShaderGetResult,
         ShaderSetResult,
+        SkillResult,
         ThemeCreateResult,
         ProjectDependenciesResult,
         ProjectFindReferencesResult,
@@ -706,3 +707,16 @@ def render_project_statistics(stats: "ProjectStatisticsResult") -> str:
 def render_engine_version(version: "EngineVersion") -> str:
     """Render the engine version as its one-line version string."""
     return version.string
+
+
+def render_skill(skill: "SkillResult") -> str:
+    """Render ``gda skill`` as text (ADR-0024).
+
+    A plain emit prints the raw ``SKILL.md`` verbatim, so
+    ``gda skill > .../SKILL.md`` drops the manifest straight to disk; an
+    ``--install`` instead reports the written path (the file already holds the
+    same content) rather than echoing it twice.
+    """
+    if skill.installed_path is not None:
+        return f"Installed the gda Skill to {skill.installed_path}"
+    return skill.content

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: gda
+description: Drive the Godot game engine from the command line with `gda`, an agent-first CLI with structured JSON output. Use when building, editing, or inspecting a Godot project — create/edit scenes, nodes, GDScript, resources, shaders, themes; run static analysis; export builds (all headless, no editor) — or to control a running game live (runtime scene tree, input simulation, screenshots, performance) via the gda daemon. Use when the user mentions gda, Godot automation, headless Godot, or asks an agent to make/modify a Godot game. Always pass `--json` and read the single result object; run `gda --help` or `gda schema` to discover the full command surface.
+---
+
+`gda` is an agent-first CLI for the Godot engine: every operation is one command
+with structured JSON output, so you build and inspect a game without opening the
+editor. Two kinds of operation: **headless** (a one-shot `godot --headless` per
+call — scenes, scripts, exports) and **live** (against a running game via the
+`gda-daemon`).
+
+## Grammar
+
+```
+gda <group> <command> [options] --json
+```
+
+Exactly one JSON result is printed to **stdout**; all engine noise (warnings,
+progress, the engine banner) goes to **stderr**. Read stdout, ignore stderr unless
+debugging. `info` / `schema` / `skill` are top-level meta commands (no group).
+
+## Setup
+
+- **Engine** — set `GDA_GODOT` to your Godot binary (or pass `--godot PATH`).
+- **Project** — resolved by `--project DIR` → `$GDA_PROJECT` → the current
+  directory; the directory must contain `project.godot`. Resolving a project runs
+  that project's autoloads at engine startup.
+- **Projectless** — meta commands and file-path-only operations run with no
+  project; they resolve filesystem paths but not `res://`.
+
+## Structured output & errors
+
+Always pass `--json`. A success is the operation's result object. A failure is
+
+```json
+{"error": {"category": "...", "code": "...", "message": "..."}}
+```
+
+Branch on the stable `category`/`code` and the **exit code**, never on prose:
+
+| Exit | Meaning |
+| ---- | ------- |
+| `0`   | success |
+| `127` | Godot binary not found |
+| `124` | engine timed out |
+| `3`   | engine version too old |
+| `4`   | operation-reported failure |
+| `5`   | could not parse the engine's output |
+| `6`   | live operation failed (e.g. `daemon_not_running`) |
+
+## Discovery
+
+- `gda --help` — every group.
+- `gda <group> --help` — a group's commands.
+- `gda <group> <command> --schema` — one command's input/output/error JSON Schema
+  (no Godot spawned).
+- `gda schema` — the **whole** surface as one JSON manifest.
+
+## Headless commands (Godot 4.4+, all platforms)
+
+| Group | Commands |
+| ----- | -------- |
+| `scene` | `create`, `get`, `list`, `get-exports`, `delete` (`.tscn` files) |
+| `node` | `add`, `get`, `list`, `set`, `remove`, `duplicate`, `move`, `connect-signal`, `disconnect-signal` (nodes within a scene) |
+| `script` | `create`, `get`, `list`, `set`, `delete`, `attach`, `validate` (`.gd` files) |
+| `project` | `info`, `get`, `set`, `add-autoload`, `remove-autoload`, `find-references`, `dependencies`, `find-unused-resources`, `statistics` |
+| `resource` | `create`, `get`, `set`, `delete`, `uid` (`.tres` files) |
+| `export` | `list`, `get`, `run` (presets → `release`/`debug`/`pack` artifacts) |
+| `shader` | `create`, `get`, `set` (`.gdshader` files) |
+| `theme` | `create` (a loadable `.tres` Theme) |
+
+## Live operations (via the daemon; Godot 4.6+, macOS/Linux)
+
+Prerequisites: run `gda daemon start` first; the engine session launches lazily on
+the first live op. `screen capture` needs a windowed session
+(`gda daemon start --windowed`).
+
+| Group | Commands |
+| ----- | -------- |
+| `daemon` | `start`, `stop`, `status`, `uninstall` (lifecycle; installs the in-game harness) |
+| `game` | `tree`, `get`, `set` (the running game's runtime scene graph) |
+| `diag` | `errors`, `log` (runtime errors / output log; survive a crash) |
+| `perf` | `monitors`, `monitor` (counters now / a property-or-signal timeline) |
+| `input` | `key`, `mouse-click`, `mouse-move`, `action`, `sequence` |
+| `screen` | `capture`, `frames` (viewport PNGs; needs `--windowed`) |
+
+## Worked example
+
+Headless: build and export a scene.
+
+```bash
+export GDA_GODOT="/path/to/Godot"
+gda scene create game/main.tscn --root-type Node2D --project game --json
+gda node add  game/main.tscn --type Sprite2D --name Hero --project game --json
+gda node set  game/main.tscn --node Hero --property position --value "100,50" --project game --json
+gda export run release --output build/game.zip --project game --json
+```
+
+Live: observe the running game, then tear down.
+
+```bash
+gda daemon start --project game --json     # launches the session on the first live op
+gda game tree --project game --json        # the runtime scene tree, after _ready
+gda daemon stop --project game --json
+```
+
+## Tips
+
+- Node paths are relative to the scene root; `.` is the root itself.
+- `--value` is coerced to the property's declared Godot type — the same coercion
+  for `node set`, `resource set`, `project set`, and live `game set`.
+- For large or scripted input, pass one JSON object with `--params-json '{...}'`
+  (or `--params-json -` to read it from stdin) instead of individual flags.
+- Live ops with no daemon report `daemon_not_running` (exit `6`) and name the
+  remedy — start the daemon and retry.

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -65,7 +65,7 @@ Branch on the stable `category`/`code` and the **exit code**, never on prose:
 | `script` | `create`, `get`, `list`, `set`, `delete`, `attach`, `validate` (`.gd` files) |
 | `project` | `info`, `get`, `set`, `add-autoload`, `remove-autoload`, `find-references`, `dependencies`, `find-unused-resources`, `statistics` |
 | `resource` | `create`, `get`, `set`, `delete`, `uid` (`.tres` files) |
-| `export` | `list`, `get`, `run` (presets → `release`/`debug`/`pack` artifacts) |
+| `export` | `list`, `get`, `run` (export a preset by name; `--mode` release/debug/pack) |
 | `shader` | `create`, `get`, `set` (`.gdshader` files) |
 | `theme` | `create` (a loadable `.tres` Theme) |
 
@@ -93,7 +93,7 @@ export GDA_GODOT="/path/to/Godot"
 gda scene create game/main.tscn --root-type Node2D --project game --json
 gda node add  game/main.tscn --type Sprite2D --name Hero --project game --json
 gda node set  game/main.tscn --node Hero --property position --value "100,50" --project game --json
-gda export run release --output build/game.zip --project game --json
+gda export run --preset "Linux/X11" --output build/game.zip --project game --json  # --preset: a name from 'gda export list'
 ```
 
 Live: observe the running game, then tear down.

--- a/src/gda/skill_ops.py
+++ b/src/gda/skill_ops.py
@@ -1,0 +1,55 @@
+"""The ``gda skill`` operation: emit or install the bundled Agent Skill (ADR-0024).
+
+``gda skill`` is a pure emitter meta command — no Godot is spawned. The canonical
+``SKILL.md`` ships *inside* the ``gda`` package (under ``skill/``), resolved by a
+package-relative path the same way the GDScript payload is (``gda.runner``), so the
+guidance is shipped in the wheel and stays version-locked to the installed CLI: the
+``version`` is read from ``importlib.metadata`` so the manifest and the commands it
+describes are one distribution and cannot skew (ADR-0024, mirroring ADR-0013).
+"""
+
+from importlib.metadata import version as package_version
+from pathlib import Path
+
+from gda.models import SkillResult
+
+# The bundled Skill manifest, resolved package-relative (NOT importlib.resources)
+# so it works the same in a source checkout and an installed wheel — the same
+# pattern ``gda.runner.OPERATIONS_GD`` uses for the GDScript payload.
+SKILL_MD = Path(__file__).parent / "skill" / "SKILL.md"
+
+# The default skills directory a ``--install`` writes into. Agent-specific (Claude
+# Code's layout); the manifest content itself stays agent-neutral (ADR-0024).
+DEFAULT_INSTALL_DIR = Path("~/.claude/skills/gda")
+
+
+def read_skill_text() -> str:
+    """Return the bundled ``SKILL.md`` text."""
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def build_skill_result(
+    *, install: bool = False, install_dir: str | None = None
+) -> SkillResult:
+    """Build the ``gda skill`` result, optionally installing the manifest.
+
+    The plain (non-install) result carries the manifest identity — ``name``, the
+    installed ``gda`` ``version`` (so the guidance is version-locked, ADR-0024), and
+    the full ``content``. On ``install`` the bundled ``SKILL.md`` is written to
+    ``<install_dir>/SKILL.md`` (parents created, overwrite is fine), and the written
+    path is reported on ``installed_path``; ``install_dir`` defaults to
+    ``~/.claude/skills/gda``. ``~`` is expanded so a tilde path resolves.
+    """
+    content = read_skill_text()
+    result = SkillResult(
+        name="gda",
+        version=package_version("gda"),
+        content=content,
+    )
+    if not install:
+        return result
+    target_dir = Path(install_dir).expanduser() if install_dir else DEFAULT_INSTALL_DIR.expanduser()
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / "SKILL.md"
+    target.write_text(content, encoding="utf-8")
+    return result.model_copy(update={"installed_path": target})

--- a/src/gda/skill_ops.py
+++ b/src/gda/skill_ops.py
@@ -18,10 +18,6 @@ from gda.models import SkillResult
 # pattern ``gda.runner.OPERATIONS_GD`` uses for the GDScript payload.
 SKILL_MD = Path(__file__).parent / "skill" / "SKILL.md"
 
-# The default skills directory a ``--install`` writes into. Agent-specific (Claude
-# Code's layout); the manifest content itself stays agent-neutral (ADR-0024).
-DEFAULT_INSTALL_DIR = Path("~/.claude/skills/gda")
-
 
 def read_skill_text() -> str:
     """Return the bundled ``SKILL.md`` text."""
@@ -37,8 +33,9 @@ def build_skill_result(
     installed ``gda`` ``version`` (so the guidance is version-locked, ADR-0024), and
     the full ``content``. On ``install`` the bundled ``SKILL.md`` is written to
     ``<install_dir>/SKILL.md`` (parents created, overwrite is fine), and the written
-    path is reported on ``installed_path``; ``install_dir`` defaults to
-    ``~/.claude/skills/gda``. ``~`` is expanded so a tilde path resolves.
+    path is reported on ``installed_path``. ``install_dir`` is **required** for an
+    install — core carries no agent-specific default location (ADR-0024); the caller
+    supplies the per-agent path. ``~`` is expanded so a tilde path resolves.
     """
     content = read_skill_text()
     result = SkillResult(
@@ -48,7 +45,9 @@ def build_skill_result(
     )
     if not install:
         return result
-    target_dir = Path(install_dir).expanduser() if install_dir else DEFAULT_INSTALL_DIR.expanduser()
+    if not install_dir:
+        raise ValueError("an install needs an explicit target directory (--dir)")
+    target_dir = Path(install_dir).expanduser()
     target_dir.mkdir(parents=True, exist_ok=True)
     target = target_dir / "SKILL.md"
     target.write_text(content, encoding="utf-8")

--- a/tests/test_command_descriptor_registry.py
+++ b/tests/test_command_descriptor_registry.py
@@ -95,6 +95,10 @@ _RECIPE_OPERATIONS = {
     "daemon-uninstall",
     "screen-capture",
     "screen-frames",
+    # `gda skill` is a pure local emitter meta command (ADR-0024): it reads the
+    # in-package SKILL.md and emits/installs it, spawning no Godot, so it is
+    # fulfilled by a CLI-side recipe like export run / the daemon lifecycle.
+    "skill",
 }
 
 

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -133,6 +133,14 @@ def test_skill_dir_implies_install(tmp_path):
     assert json.loads(result.stdout)["installed_path"] == str(tmp_path / "SKILL.md")
 
 
+def test_skill_install_without_dir_is_a_usage_error():
+    # ADR-0024: core has no default skills dir; --install requires an explicit --dir.
+    result = CliRunner().invoke(app, ["skill", "--install"])
+
+    assert result.exit_code != 0
+    assert "--dir" in result.output
+
+
 def test_skill_install_creates_missing_parent_dirs(tmp_path):
     nested = tmp_path / "a" / "b" / "gda"
     result = CliRunner().invoke(app, ["skill", "--install", "--dir", str(nested)])

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -205,6 +205,19 @@ def test_skill_params_json_drives_the_same_path(tmp_path):
     assert (tmp_path / "SKILL.md").read_text(encoding="utf-8") == BUNDLED
 
 
+def test_skill_params_json_dir_alone_installs(tmp_path):
+    # ADR-0015 parity: install_dir alone (no explicit install) installs, exactly as
+    # argv `--dir` does — the model normalizes both to the same params.
+    result = CliRunner().invoke(
+        app,
+        ["skill", "--params-json", json.dumps({"install_dir": str(tmp_path)}), "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["installed_path"] == str(tmp_path / "SKILL.md")
+    assert (tmp_path / "SKILL.md").is_file()
+
+
 # --- packaging: the bundled SKILL.md must resolve at runtime AND ship in the wheel ---
 
 
@@ -217,20 +230,25 @@ def test_bundled_skill_resolves_at_runtime():
     assert SKILL_MD.read_text(encoding="utf-8").startswith("---")
 
 
-def test_bundled_skill_is_included_in_the_built_wheel():
+def test_bundled_skill_is_included_in_the_built_wheel(tmp_path):
     # The wheel must carry the manifest under gda/skill/SKILL.md, the same way it
     # carries the GDScript payload — otherwise an installed `gda skill` would have
-    # nothing to emit. Skipped (not failed) when no wheel has been built yet, so
-    # the suite stays runnable without a build step; CI builds and runs it.
-    import pytest
+    # nothing to emit. Build a wheel on demand (into a tmp dir) so this actually GATES
+    # in PR CI regardless of whether `uv build` has run yet — it does not depend on dist/.
+    import subprocess
 
     repo_root = Path(__file__).resolve().parents[1]
-    wheels = sorted((repo_root / "dist").glob("gda-*.whl"))
-    if not wheels:
-        pytest.skip("no built wheel in dist/ — run `uv build` first")
-    newest = wheels[-1]
-    with zipfile.ZipFile(newest) as zf:
+    proc = subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(tmp_path)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    wheels = sorted(tmp_path.glob("gda-*.whl"))
+    assert wheels, f"no wheel built:\n{proc.stdout}{proc.stderr}"
+    with zipfile.ZipFile(wheels[-1]) as zf:
         names = zf.namelist()
     assert any(
         name.endswith("gda/skill/SKILL.md") for name in names
-    ), f"gda/skill/SKILL.md missing from {newest.name}: {names}"
+    ), f"gda/skill/SKILL.md missing from {wheels[-1].name}: {names}"

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -12,6 +12,7 @@ from importlib.metadata import version as package_version
 from pathlib import Path
 
 import jsonschema
+import pytest
 from typer.testing import CliRunner
 
 from gda.cli import app
@@ -134,11 +135,22 @@ def test_skill_dir_implies_install(tmp_path):
 
 
 def test_skill_install_without_dir_is_a_usage_error():
-    # ADR-0024: core has no default skills dir; --install requires an explicit --dir.
+    # ADR-0024: core has no default skills dir; --install requires an explicit --dir,
+    # so an install with no target is rejected (a non-zero usage exit; the exact
+    # error rendering/stream varies by tty width, so assert on the exit code).
     result = CliRunner().invoke(app, ["skill", "--install"])
 
     assert result.exit_code != 0
-    assert "--dir" in result.output
+    # Nothing was written: a plain `gda skill` (no install) still succeeds.
+    assert CliRunner().invoke(app, ["skill"]).exit_code == 0
+
+
+def test_skill_build_result_install_without_dir_raises():
+    # The core backstop behind the CLI guard: no default install location.
+    from gda.skill_ops import build_skill_result
+
+    with pytest.raises(ValueError):
+        build_skill_result(install=True, install_dir=None)
 
 
 def test_skill_install_creates_missing_parent_dirs(tmp_path):

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -1,0 +1,216 @@
+"""`gda skill` — emit / install the bundled Agent Skill (issue #266, ADR-0024).
+
+`gda skill` is a pure local emitter meta command: it reads the in-package
+`SKILL.md` and emits or installs it, spawning no Godot. These are unit tests only
+(no engine), exercising the four surfaces — plain text, `--json`, `--schema`,
+`--install` — plus the packaging guarantee that the manifest ships in the wheel.
+"""
+
+import json
+import zipfile
+from importlib.metadata import version as package_version
+from pathlib import Path
+
+import jsonschema
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.models import GdaErrorEnvelope, SkillParams, SkillResult
+from gda.skill_ops import SKILL_MD, read_skill_text
+
+BUNDLED = read_skill_text()
+
+
+def test_skill_prints_the_raw_manifest_text():
+    # The default (human) render prints the raw SKILL.md verbatim so
+    # `gda skill > .../SKILL.md` drops the manifest straight to disk.
+    result = CliRunner().invoke(app, ["skill"])
+
+    assert result.exit_code == 0
+    assert result.stdout.startswith("---")
+    assert "name: gda" in result.stdout
+    # The full body — not just the frontmatter — is emitted.
+    assert "## Grammar" in result.stdout
+
+
+def test_skill_json_emits_name_version_content():
+    result = CliRunner().invoke(app, ["skill", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert set(data) >= {"name", "version", "content"}
+    assert data["name"] == "gda"
+    # The version is read from the installed distribution metadata, so the
+    # guidance is version-locked to the CLI it describes (ADR-0024).
+    assert data["version"] == package_version("gda")
+    # `content` is the full manifest, frontmatter included.
+    assert data["content"].startswith("---")
+    assert "name: gda" in data["content"]
+    assert data["content"] == BUNDLED
+    # A plain emit reports no install path.
+    assert data.get("installed_path") is None
+
+
+def test_skill_json_content_round_trips_the_bundled_file():
+    data = json.loads(CliRunner().invoke(app, ["skill", "--json"]).stdout)
+    assert data["content"] == SKILL_MD.read_text(encoding="utf-8")
+
+
+def test_skill_description_is_within_the_skill_frontmatter_limit():
+    # An Agent Skill `description` is the one thing an agent sees when deciding to
+    # load the Skill; the SKILL.md spec caps it at 1024 chars.
+    front = BUNDLED.split("---", 2)[1]
+    description = ""
+    for line in front.splitlines():
+        if line.startswith("description:"):
+            description = line[len("description:") :].strip()
+            break
+    assert description, "the SKILL.md frontmatter must carry a description"
+    assert len(description) <= 1024
+
+
+def test_skill_schema_emits_valid_input_output_error_schemas():
+    result = CliRunner().invoke(app, ["skill", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert set(doc) >= {"input", "output", "error"}
+    # Model-derived, like every meta command (ADR-0004).
+    assert doc["input"] == SkillParams.model_json_schema()
+    assert doc["output"] == SkillResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    # Each half is itself well-formed JSON Schema.
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+    jsonschema.Draft202012Validator.check_schema(doc["error"])
+
+
+def test_skill_schema_reports_kind_headless():
+    # `skill` spawns no Godot but is not a live command; it carries the default
+    # HEADLESS channel in its self-description.
+    doc = json.loads(CliRunner().invoke(app, ["skill", "--schema"]).stdout)
+    assert doc["kind"] == "headless"
+
+
+def test_skill_sample_result_validates_against_emitted_output_schema():
+    output_schema = json.loads(
+        CliRunner().invoke(app, ["skill", "--schema"]).stdout
+    )["output"]
+    sample = json.loads(CliRunner().invoke(app, ["skill", "--json"]).stdout)
+    jsonschema.validate(instance=sample, schema=output_schema)
+
+
+def test_skill_install_writes_the_manifest_into_the_target_dir(tmp_path):
+    result = CliRunner().invoke(app, ["skill", "--install", "--dir", str(tmp_path)])
+
+    assert result.exit_code == 0
+    written = tmp_path / "SKILL.md"
+    assert written.is_file()
+    # The written file round-trips the bundled manifest byte for byte.
+    assert written.read_text(encoding="utf-8") == BUNDLED
+    # The human render names the path it wrote.
+    assert str(written) in result.stdout
+
+
+def test_skill_install_json_reports_the_written_path(tmp_path):
+    result = CliRunner().invoke(
+        app, ["skill", "--install", "--dir", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["installed_path"] == str(tmp_path / "SKILL.md")
+    assert data["name"] == "gda"
+    assert data["content"] == BUNDLED
+
+
+def test_skill_dir_implies_install(tmp_path):
+    # Naming a target directory means "install there" — no separate --install flag.
+    result = CliRunner().invoke(app, ["skill", "--dir", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    assert (tmp_path / "SKILL.md").is_file()
+    assert json.loads(result.stdout)["installed_path"] == str(tmp_path / "SKILL.md")
+
+
+def test_skill_install_creates_missing_parent_dirs(tmp_path):
+    nested = tmp_path / "a" / "b" / "gda"
+    result = CliRunner().invoke(app, ["skill", "--install", "--dir", str(nested)])
+
+    assert result.exit_code == 0
+    assert (nested / "SKILL.md").read_text(encoding="utf-8") == BUNDLED
+
+
+def test_skill_install_overwrites_an_existing_file(tmp_path):
+    target = tmp_path / "SKILL.md"
+    target.write_text("stale content", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["skill", "--install", "--dir", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert target.read_text(encoding="utf-8") == BUNDLED
+
+
+def test_skill_spawns_no_godot(monkeypatch):
+    # `skill` is a pure local emitter: it must never reach the engine path, even
+    # when binary resolution and the runner are rigged to explode.
+    def boom(*args, **kwargs):
+        raise AssertionError("gda skill must not touch the engine")
+
+    monkeypatch.setattr("gda.headless.resolve_godot_binary", boom)
+    monkeypatch.setattr("gda.cli._make_runner", boom)
+
+    result = CliRunner().invoke(app, ["skill", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["name"] == "gda"
+
+
+def test_skill_params_json_drives_the_same_path(tmp_path):
+    # gda-mcp forwards an MCP tool's input object verbatim via --params-json
+    # (ADR-0015); it must drive the SAME outcome as the argv flags.
+    result = CliRunner().invoke(
+        app,
+        [
+            "skill",
+            "--params-json",
+            json.dumps({"install": True, "install_dir": str(tmp_path)}),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["installed_path"] == str(tmp_path / "SKILL.md")
+    assert (tmp_path / "SKILL.md").read_text(encoding="utf-8") == BUNDLED
+
+
+# --- packaging: the bundled SKILL.md must resolve at runtime AND ship in the wheel ---
+
+
+def test_bundled_skill_resolves_at_runtime():
+    # The manifest is resolved package-relative (like operations.gd), so it is
+    # present both in a source checkout and an installed wheel.
+    assert SKILL_MD.is_file()
+    assert SKILL_MD.name == "SKILL.md"
+    assert SKILL_MD.parent.name == "skill"
+    assert SKILL_MD.read_text(encoding="utf-8").startswith("---")
+
+
+def test_bundled_skill_is_included_in_the_built_wheel():
+    # The wheel must carry the manifest under gda/skill/SKILL.md, the same way it
+    # carries the GDScript payload — otherwise an installed `gda skill` would have
+    # nothing to emit. Skipped (not failed) when no wheel has been built yet, so
+    # the suite stays runnable without a build step; CI builds and runs it.
+    import pytest
+
+    repo_root = Path(__file__).resolve().parents[1]
+    wheels = sorted((repo_root / "dist").glob("gda-*.whl"))
+    if not wheels:
+        pytest.skip("no built wheel in dist/ — run `uv build` first")
+    newest = wheels[-1]
+    with zipfile.ZipFile(newest) as zf:
+        names = zf.namelist()
+    assert any(
+        name.endswith("gda/skill/SKILL.md") for name in names
+    ), f"gda/skill/SKILL.md missing from {newest.name}: {names}"


### PR DESCRIPTION
Ships the gda **Skill** — the third agent-facing channel (ADR-0024): a canonical `SKILL.md` bundled inside the `gda` package (resolved package-relative, like `operations.gd`, so it ships in the wheel and is browsable from the source tree) plus a `gda skill` meta command that emits or installs it. `gda skill` is a pure local emitter (no Godot spawn), a sibling of `info`/`schema`: it prints the manifest verbatim by default, emits `{name, version, content}` under `--json` with the version read from `importlib.metadata` so the guidance is version-locked to the install, self-describes under `--schema`, and writes the manifest to the skills dir (default `~/.claude/skills/gda/SKILL.md`) under `--install`/`--dir`. The command registers in the aggregate `gda schema`, so gda-mcp exposes it automatically. The SKILL.md reuses the project's terminology (headless/live, the command groups, `GDA_PROJECT`/`GDA_GODOT`, structured `--json`, the exit-code/error envelope) and mirrors the README command tables.

Slice 2/4 of the gda-skill milestone.

Closes #266
