### PR TITLE
docs: add "Use it as a Skill" to the README + docs/gda-skill.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ gda skill --install --dir ~/.claude/skills/gda  # write it into a skills directo
 ```
 
 `--dir` is caller-supplied — there's no built-in default; the [skill recipes](docs/gda-skill.md)
-cover the install locations and which agents load Skills. Or fetch the same file straight from the
-repo, if you'd rather not go through `gda skill` — you still install `gda`, since the Skill drives it:
+list each agent's skills directory (Claude Code's `~/.claude/skills/`, Codex's `~/.agents/skills/`,
+…). Or fetch the same file straight from the repo, if you'd rather not go through `gda skill` — you
+still install `gda`, since the Skill drives it:
 
 ```bash
 curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \

--- a/README.md
+++ b/README.md
@@ -88,6 +88,25 @@ uv run gda --help
 ```
 </details>
 
+### Use it as a Skill
+
+`gda` ships an agent **Skill** — a `SKILL.md` that teaches an AI agent *how and when* to drive
+Godot from the CLI. It's the lightest way in (no server to register), bundled in the package and
+version-locked to your install. Print it, or install it into your agent's skills directory:
+
+```bash
+gda skill                                       # print SKILL.md (redirect it anywhere)
+gda skill --install --dir ~/.claude/skills/gda  # write it into a skills directory
+```
+
+`--dir` is caller-supplied — there's no built-in default; the [skill recipes](docs/gda-skill.md)
+list the per-agent paths. Prefer not to install `gda`? Take the canonical file from the repo:
+
+```bash
+curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \
+  https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md
+```
+
 ### Use it as an MCP server
 
 `gda` ships a stdio [MCP](https://modelcontextprotocol.io) server behind a `[mcp]` extra,

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ gda skill --install --dir ~/.claude/skills/gda  # write it into a skills directo
 ```
 
 `--dir` is caller-supplied — there's no built-in default; the [skill recipes](docs/gda-skill.md)
-list the per-agent paths. Or fetch the same file straight from the repo, if you'd rather not go
-through `gda skill` — you still install `gda`, since the Skill drives it:
+cover the install locations and which agents load Skills. Or fetch the same file straight from the
+repo, if you'd rather not go through `gda skill` — you still install `gda`, since the Skill drives it:
 
 ```bash
 curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ gda skill --install --dir ~/.claude/skills/gda  # write it into a skills directo
 ```
 
 `--dir` is caller-supplied — there's no built-in default; the [skill recipes](docs/gda-skill.md)
-list the per-agent paths. Prefer not to install `gda`? Take the canonical file from the repo:
+list the per-agent paths. Or fetch the same file straight from the repo, if you'd rather not go
+through `gda skill` — you still install `gda`, since the Skill drives it:
 
 ```bash
 curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \

--- a/docs/gda-skill.md
+++ b/docs/gda-skill.md
@@ -20,23 +20,25 @@ One canonical file, two ways to obtain it:
 
 ## Install it where your agent loads skills
 
-Agent Skills (a `SKILL.md`) are loaded natively by **Claude Code** (and other agents in the Claude
-ecosystem). `gda skill --install --dir <dir>` writes `<dir>/SKILL.md` (creating parent dirs); there
-is **no built-in default location**, so point `--dir` at the agent's skills directory:
+A `SKILL.md` is loaded by most coding agents — only the **discovery directory** differs.
+`gda skill --install --dir <dir>` writes `<dir>/SKILL.md` (creating parent dirs); there is **no
+built-in default location**, so point `--dir` at the directory your agent scans:
 
-- **Claude Code** — personal (every project): `~/.claude/skills/gda/`; project scope (committed,
-  shared with your team): your project's skills directory, e.g. `.claude/skills/gda/`.
+| Agent | Personal (all projects) | Project scope (committed) |
+| --- | --- | --- |
+| **Claude Code** | `~/.claude/skills/gda/` | `.claude/skills/gda/` |
+| **Codex and other agents** | `~/.agents/skills/gda/` | `.agents/skills/gda/` |
 
-  ```bash
-  gda skill --install --dir ~/.claude/skills/gda
-  # …or fetch the same file directly, instead of going through `gda skill`:
-  curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \
-    https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md
-  ```
+```bash
+gda skill --install --dir ~/.claude/skills/gda    # Claude Code (personal scope)
+gda skill --install --dir ~/.agents/skills/gda    # Codex & others (personal scope)
+# …or fetch the same file directly, instead of going through `gda skill`:
+curl --create-dirs -o ~/.agents/skills/gda/SKILL.md \
+  https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md
+```
 
-- **Agents that don't load `SKILL.md` (e.g. Codex, Cursor)** — drive `gda` through the
-  [MCP server](gda-mcp-registration.md) or the raw CLI instead; the Skill's content can also be
-  pasted in as context.
+Check your agent's docs if its skills directory differs; whichever directory it scans, the
+manifest is the same file.
 
 ## What the Skill assumes
 

--- a/docs/gda-skill.md
+++ b/docs/gda-skill.md
@@ -8,17 +8,21 @@ the installed CLI (ADR-0024).
 
 ## Get the Skill
 
-One canonical file, two equivalent sources:
+One canonical file, two ways to obtain it:
 
-- **From an installed `gda`** — `gda skill` prints the manifest; `gda skill --json` wraps it as
-  `{name, version, content}` (the `version` is the installed `gda` version) for programmatic use.
+- **From an installed `gda`** (recommended) — `gda skill` prints the manifest; `gda skill --json`
+  wraps it as `{name, version, content}`. This is **version-locked** to your installed `gda`, so
+  the guidance always matches the CLI it describes (ADR-0024).
 - **From the repo** — [`src/gda/skill/SKILL.md`](../src/gda/skill/SKILL.md), raw at
-  `https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md`.
+  `https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md`. This
+  tracks `main`, so it may differ from an older installed `gda` — prefer `gda skill` if you
+  already have `gda`.
 
 ## Install it where your agent loads skills
 
-`gda skill --install --dir <dir>` writes `<dir>/SKILL.md` (creating parent dirs). There is **no
-built-in default location** — point `--dir` at your agent's skills directory:
+Agent Skills (a `SKILL.md`) are loaded natively by **Claude Code** (and other agents in the Claude
+ecosystem). `gda skill --install --dir <dir>` writes `<dir>/SKILL.md` (creating parent dirs); there
+is **no built-in default location**, so point `--dir` at the agent's skills directory:
 
 - **Claude Code** — personal (every project): `~/.claude/skills/gda/`; project scope (committed,
   shared with your team): your project's skills directory, e.g. `.claude/skills/gda/`.
@@ -30,9 +34,9 @@ built-in default location** — point `--dir` at your agent's skills directory:
     https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md
   ```
 
-- **Other agents (Codex, Cursor, …)** — if your agent loads `SKILL.md` files, install into its
-  skills directory the same way. If it does not, the Skill is still useful as pasted context, or
-  drive `gda` through the [MCP server](gda-mcp-registration.md) or the raw CLI instead.
+- **Agents that don't load `SKILL.md` (e.g. Codex, Cursor)** — drive `gda` through the
+  [MCP server](gda-mcp-registration.md) or the raw CLI instead; the Skill's content can also be
+  pasted in as context.
 
 ## What the Skill assumes
 

--- a/docs/gda-skill.md
+++ b/docs/gda-skill.md
@@ -25,7 +25,7 @@ built-in default location** — point `--dir` at your agent's skills directory:
 
   ```bash
   gda skill --install --dir ~/.claude/skills/gda
-  # …or without installing gda, take the file straight from the repo:
+  # …or fetch the same file directly, instead of going through `gda skill`:
   curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \
     https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md
   ```

--- a/docs/gda-skill.md
+++ b/docs/gda-skill.md
@@ -1,0 +1,51 @@
+# Installing the `gda` Skill with your agent
+
+`gda` ships an agent **Skill** — a `SKILL.md` that teaches an AI agent *how and when* to drive
+Godot through the `gda` CLI. It is the lightest of `gda`'s three agent-facing surfaces
+(**CLI · Skill · MCP**): no server to register, just a file your agent loads. The Skill is
+bundled in the `gda` package and emitted by `gda skill`, so its guidance is version-locked to
+the installed CLI (ADR-0024).
+
+## Get the Skill
+
+One canonical file, two equivalent sources:
+
+- **From an installed `gda`** — `gda skill` prints the manifest; `gda skill --json` wraps it as
+  `{name, version, content}` (the `version` is the installed `gda` version) for programmatic use.
+- **From the repo** — [`src/gda/skill/SKILL.md`](../src/gda/skill/SKILL.md), raw at
+  `https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md`.
+
+## Install it where your agent loads skills
+
+`gda skill --install --dir <dir>` writes `<dir>/SKILL.md` (creating parent dirs). There is **no
+built-in default location** — point `--dir` at your agent's skills directory:
+
+- **Claude Code** — personal (every project): `~/.claude/skills/gda/`; project scope (committed,
+  shared with your team): your project's skills directory, e.g. `.claude/skills/gda/`.
+
+  ```bash
+  gda skill --install --dir ~/.claude/skills/gda
+  # …or without installing gda, take the file straight from the repo:
+  curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \
+    https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md
+  ```
+
+- **Other agents (Codex, Cursor, …)** — if your agent loads `SKILL.md` files, install into its
+  skills directory the same way. If it does not, the Skill is still useful as pasted context, or
+  drive `gda` through the [MCP server](gda-mcp-registration.md) or the raw CLI instead.
+
+## What the Skill assumes
+
+The Skill teaches the CLI — the agent still needs `gda` on its `PATH` and a Godot engine to run.
+Point `gda` at the engine with `GDA_GODOT`, and resolve a project with `GDA_PROJECT` (or run
+inside a Godot project directory), exactly as for any `gda` use. See the README's
+[Configuration](../README.md#configuration).
+
+## Notes
+
+- The Skill, the [MCP server](gda-mcp-registration.md), and the raw CLI are three ways into the
+  **same** `gda` command surface — pick whichever your agent supports (ADR-0024).
+- `gda skill` is itself on the `gda schema` surface, so an MCP agent can fetch the same guidance
+  through its generated tool.
+- The bundled `SKILL.md` is the single source; this repo's copy and the `gda skill` output are
+  the same file, so the guidance never drifts from the installed CLI.


### PR DESCRIPTION
Slice 3/4 of the `gda-skill` milestone (after #266/#270, now on `main`).

## What
- **README** gains `### Use it as a Skill`, placed **before** "Use it as an MCP server", with the hybrid install paths: `gda skill --install --dir <dir>` (or `gda skill > …`) and curling the in-repo `src/gda/skill/SKILL.md`. Notes that `--dir` is caller-supplied (no default), pointing to the recipes doc for per-agent paths.
- **`docs/gda-skill.md`** — a recipes companion mirroring `gda-mcp-registration.md`: get the Skill (installed `gda skill` vs repo file), where to install it (Claude Code personal/project dirs; honest note that agents not loading `SKILL.md` can use it as context or the CLI/MCP), what it assumes (`gda` on PATH, `GDA_GODOT`/project), and the three-surfaces relationship.

## Verified
- `### Use it as a Skill` sits before the MCP section; all referenced paths/anchors resolve.
- The documented commands behave as written: `gda skill --install --dir <dir>` writes `<dir>/SKILL.md`; `gda skill` prints and exits 0.

`docs:` only — no release. The three-surfaces positioning reframe + the README exit-6 fix follow in #268.

Closes #267
