### PR TITLE
fix: restructure README & package metadata around the user's fastest path

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -189,3 +189,23 @@ input/params and result models, execution `kind`, failure `classify`r, human
 dispatch path, or built by walking the live Typer tree (ADR-0012) for a
 whole-surface view — never parallel registries to keep in sync (ADR-0023).
 _Avoid_: command spec, command config, command registry entry
+
+### Public-facing copy
+
+**Positioning descriptor**:
+The single authoritative one-line phrase naming what `gda` *is* — currently "Godot AI
+agent CLI, Skill, and MCP server" — front-loading the primary search terms (Godot · AI
+agent · CLI/Skill/MCP). One positioning source, mirrored across three surfaces that change
+together and must not drift: the README **H1** (Title Case), the `pyproject` `description`,
+and the GitHub repository `description` (the metadata pair in sentence case, optionally
+extended with "… with structured JSON/schema output, headless automation, and live runtime
+control"). Its head noun stays "CLI, Skill, and MCP server", so it names a *tool* — not a
+claim that `gda` is itself an agent.
+_Avoid_: tagline, slogan, hero, the value sentence
+
+**Hero**:
+The README's opening *value* statement — what `gda` does for you ("`gda` gives your AI
+coding agent … structured, machine-readable control of the Godot Engine", headless then
+live). README-only and free to evolve there; it does **not** mirror the `Positioning
+descriptor` and is never replicated into `pyproject` or the repo metadata.
+_Avoid_: tagline, subtitle, positioning descriptor

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 ![godot-agent title image](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)
 
-> **The agent-first CLI, Skill, and MCP server for the [Godot Engine](https://godotengine.org).**
-> Give your AI coding agent structured, machine-readable control of Godot — create
-> scenes, edit nodes & scripts, and export builds headlessly, then drive a *running*
-> game live: runtime tree, input, screenshots, performance.
+> **Godot for AI agents.** Give your AI coding agent — or your shell scripts and CI —
+> structured, machine-readable control of the [Godot Engine](https://godotengine.org):
+> create scenes, edit nodes & scripts, and export builds headlessly, then drive a
+> *running* game live (runtime tree, input, screenshots, performance). One command
+> surface, three ways in: a **CLI**, an agent **Skill**, and an **MCP server**.
 
 [![pre-1.0](https://img.shields.io/badge/status-pre--1.0-orange)](https://pypi.org/project/gda/)
 [![CI](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
@@ -25,10 +26,6 @@ result it can act on — never engine logs it has to scrape. It runs in **two mo
 - **Live** — drive a *running* game through a background daemon for everything only a
   live engine can do: read the runtime scene tree, get/set runtime properties, simulate
   input, capture screenshots, and sample performance.
-
-Drive it **three ways**, all the same command surface: the raw **`gda`** CLI, an agent
-**Skill** (a `SKILL.md` that teaches your agent how and when to use it), or the **`gda-mcp`**
-MCP server (tools generated from `gda`'s own schemas). See [How it works](#how-it-works).
 
 > `gda` is **pre-1.0**: every command works end-to-end today, but the CLI surface may
 > still change before 1.0.
@@ -59,7 +56,22 @@ MCP server (tools generated from `gda`'s own schemas). See [How it works](#how-i
 
 ---
 
+## Capabilities at a glance
+
+| What you need | Reach for |
+| --- | --- |
+| Build project files from an agent or script | `scene` / `node` / `script` / `resource` / `shader` / `theme` — create & edit headlessly |
+| Parse results instead of scraping engine logs | `--json` (one clean object) and `--schema` (a JSON-Schema contract) |
+| Hand an agent Godot tools | the bundled **Skill** (`gda skill`) or the **`gda-mcp`** server |
+| Automate CI, exports, and project analysis | headless commands — no editor, no plugin, just a Godot binary |
+| Debug a *running* game's runtime behavior | `gda daemon start`, then `game` / `diag` / `perf` / `input` / `screen` |
+
+---
+
 ## Installation
+
+**Requirements:** Python 3.13+, and a [Godot](https://godotengine.org) binary — 4.4+ for
+headless commands, 4.6+ on macOS/Linux for live (daemon) commands.
 
 Install the CLI from PyPI onto your `PATH`:
 
@@ -86,6 +98,64 @@ uv sync                  # create the environment + install dependencies
 uv run gda --help
 ```
 </details>
+
+---
+
+## Quick start
+
+**Point `gda` at your Godot binary**, then ask the engine its version — no project needed:
+
+```bash
+export GDA_GODOT="/path/to/Godot"   # or pass --godot to any command
+gda info --json
+# {"major":4,"minor":6,"patch":3,"status":"stable","string":"4.6.3-stable (official)",…}
+```
+
+stdout is always clean JSON you can pipe; all engine and script diagnostics go to stderr:
+
+```bash
+gda info --json | jq .major   # → 4
+```
+
+**Build a scene headlessly.** Point `gda` at a Godot project (a directory with `project.godot`)
+once; relative paths then resolve *inside* it, and nodes are addressed by their path relative to
+the scene root:
+
+```bash
+export GDA_PROJECT="/path/to/your/godot-project"   # or pass --project to any command
+gda scene create scenes/main.tscn --root-type Node2D --json
+gda node add  scenes/main.tscn --type Sprite2D --name Hero --json
+gda node set  scenes/main.tscn --node Hero --property position --value 10,20 --json
+gda scene get scenes/main.tscn --json
+# {"path":"scenes/main.tscn","root":{"name":"main","type":"Node2D","children":[{"name":"Hero",…}]}}
+```
+
+> No project? `gda` still runs **projectless** on plain filesystem paths (relative to your current
+> directory) — only `res://` resolution needs a project. See [Configuration](#configuration).
+
+**Drive a *running* game live** — the same project, now observed at runtime (macOS/Linux, Godot 4.6+):
+
+```bash
+gda daemon start             # start the daemon for $GDA_PROJECT (installs the harness)
+gda game tree --json         # the runtime scene tree, after _ready
+gda perf monitors --json     # live engine counters: fps, memory, node count
+gda daemon stop
+```
+
+(`gda screen capture` works live too, but needs a windowed session — start the daemon
+with `gda daemon start --windowed`.)
+
+---
+
+## Choose your integration
+
+`gda` exposes the **same command surface** three ways — pick whichever your agent (or you) supports:
+
+| Entry point | Best for | How |
+| --- | --- | --- |
+| **CLI** (`gda`) | humans, shell scripts, CI, and agents that can run commands | `gda <group> <command> --json` |
+| **Skill** (`gda skill`) | coding agents that support Agent Skills and prefer a token-light CLI workflow | print/install `SKILL.md` (below) |
+| **MCP** (`gda-mcp`) | agents that call tools over the Model Context Protocol | run the stdio server (below) |
 
 ### Use it as a Skill
 
@@ -118,17 +188,12 @@ uvx --from "gda[mcp]" gda-mcp
 ```
 
 The server resolves two pieces of context — which Godot **project** to drive and which Godot
-**binary** to run (MCP can't pass per-call flags; see
-[Configuration](#configuration) for what `GDA_PROJECT` and `GDA_GODOT` do):
+**binary** to run (MCP can't pass per-call flags):
 
-- **Project** — `gda-mcp` uses `GDA_PROJECT` if set; otherwise the **workspace roots** the
-  client advertises (the folder you have open, for clients that support MCP roots); otherwise
-  the server's **working directory** (where the `gda-mcp` process was launched). A roots or cwd
-  candidate is used only if it is a real Godot project (has `project.godot`), else resolution
-  moves on; a *set-but-invalid* `GDA_PROJECT`, by contrast, is a reported error, not a silent
-  fallback. *(The CLI resolves a project differently — `--project` → `GDA_PROJECT` → cwd; the
-  MCP server has no flags, so `GDA_PROJECT` is the explicit override and the protocol's
-  workspace `roots` are the auto-detected fallback.)*
+- **Project** — set `GDA_PROJECT` when your client can't advertise workspace **roots**; otherwise
+  `gda-mcp` auto-detects the project from the roots the client sends (the folder you have open). A
+  *set-but-invalid* `GDA_PROJECT` is a reported error, not a silent fallback. See
+  [Configuration](#configuration) for the full CLI-vs-MCP resolution order.
 - **Engine** — set `GDA_GODOT` to your Godot binary, e.g. `"GDA_GODOT": "/path/to/Godot"`.
 
 
@@ -217,48 +282,6 @@ command — register via the JSON above or the Settings → MCP UI.
 
 ---
 
-## Quick start
-
-Point `gda` at your Godot binary, then ask the engine its version:
-
-```bash
-export GDA_GODOT="/path/to/Godot"   # or pass --godot to any command
-gda info --json
-# {"major":4,"minor":6,"patch":3,"status":"stable","string":"4.6.3-stable (official)",…}
-```
-
-stdout is always clean JSON you can pipe; all engine and script diagnostics go to stderr:
-
-```bash
-gda info --json | jq .major   # → 4
-```
-
-Build a scene headlessly and read it back as a structured tree (nodes are addressed by
-their path relative to the scene root):
-
-```bash
-gda scene create game/main.tscn --root-type Node2D --json
-gda node add  game/main.tscn --type Sprite2D --name Hero --json
-gda node set  game/main.tscn --node Hero --property position --value 10,20 --json
-gda scene get game/main.tscn --json
-# {"path":"game/main.tscn","root":{"name":"main","type":"Node2D","children":[{"name":"Hero",…}]}}
-```
-
-Now drive a **running game live** — `game/` must be a Godot project (a directory with
-`project.godot`); macOS/Linux, Godot 4.6+:
-
-```bash
-gda daemon start --project game            # start the daemon (installs the harness)
-gda game tree --project game --json        # the runtime scene tree, after _ready
-gda perf monitors --project game --json    # live engine counters: fps, memory, node count
-gda daemon stop --project game
-```
-
-(`gda screen capture` works live too, but needs a windowed session — start the daemon
-with `gda daemon start --windowed`.)
-
----
-
 ## How it works
 
 `gda` is three components serving operations in two modes:
@@ -305,6 +328,9 @@ Every command supports `--json` and `--schema` — except `gda schema` itself, w
 the aggregate manifest as JSON directly. Commands that read or mutate a `res://` path
 resolve a [project context](#configuration). Run `gda <group> <command> --help` for full
 flags — `gda --help` is the authoritative list of what is installed.
+
+**New here?** A good first path: `gda info` → `gda scene create` → `gda node add` →
+`gda script validate` → `gda export run`; then go live with `gda daemon start` → `gda game tree`.
 
 **Meta** — about `gda` / the engine itself
 
@@ -474,7 +500,12 @@ references resolve deterministically) in this order:
 
 A named directory must be a project, or `gda` reports it as an error. When none resolves,
 `gda` runs **projectless** — only filesystem paths (absolute or cwd-relative) resolve, not
-`res://`.
+`res://`. The **MCP server** has no flags, so it resolves a project a little differently:
+
+| Context | Project resolution order |
+| --- | --- |
+| **CLI** | `--project` → `GDA_PROJECT` → cwd (if it holds `project.godot`), else projectless |
+| **MCP** (`gda-mcp`) | `GDA_PROJECT` → client workspace `roots` → server cwd — each used only if it holds `project.godot` |
 
 <details>
 <summary>Project code execution — what runs when you point at a project</summary>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# godot-agent (`gda`)
+# godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
 ![godot-agent title image](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ![godot-agent title image](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)
 
-> **The Godot AI Agent CLI, Skill, and MCP Server.** Give your AI coding agent — or your
-> shell scripts and CI — structured, machine-readable control of the [Godot Engine](https://godotengine.org):
-> create scenes, edit nodes & scripts, and export builds headlessly, then drive a *running*
-> game live (runtime tree, input, screenshots, performance) — one command surface, three ways in.
+> **`gda` gives your AI coding agent — or your shell scripts and CI — structured, machine-readable
+> control of the [Godot Engine](https://godotengine.org).** Create scenes, edit nodes & scripts,
+> and export builds headlessly, then drive a *running* game live: runtime tree, input,
+> screenshots, performance — one command surface, three ways in.
 
 [![pre-1.0](https://img.shields.io/badge/status-pre--1.0-orange)](https://pypi.org/project/gda/)
 [![CI](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 ![godot-agent title image](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)
 
-> **Godot for AI agents.** Give your AI coding agent — or your shell scripts and CI —
-> structured, machine-readable control of the [Godot Engine](https://godotengine.org):
-> create scenes, edit nodes & scripts, and export builds headlessly, then drive a
-> *running* game live (runtime tree, input, screenshots, performance). One command
-> surface, three ways in: a **CLI**, an agent **Skill**, and an **MCP server**.
+> **The Godot AI Agent CLI, Skill, and MCP Server.** Give your AI coding agent — or your
+> shell scripts and CI — structured, machine-readable control of the [Godot Engine](https://godotengine.org):
+> create scenes, edit nodes & scripts, and export builds headlessly, then drive a *running*
+> game live (runtime tree, input, screenshots, performance) — one command surface, three ways in.
 
 [![pre-1.0](https://img.shields.io/badge/status-pre--1.0-orange)](https://pypi.org/project/gda/)
 [![CI](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)

--- a/README.md
+++ b/README.md
@@ -132,9 +132,11 @@ gda scene get scenes/main.tscn --json
 > No project? `gda` still runs **projectless** on plain filesystem paths (relative to your current
 > directory) — only `res://` resolution needs a project. See [Configuration](#configuration).
 
-**Drive a *running* game live** — the same project, now observed at runtime (macOS/Linux, Godot 4.6+):
+**Drive a *running* game live.** Live ops run the project's **main scene**, so point it at the
+one you just built, then start the daemon (macOS/Linux, Godot 4.6+):
 
 ```bash
+gda project set application/run/main_scene --value res://scenes/main.tscn --json
 gda daemon start             # start the daemon for $GDA_PROJECT (installs the harness)
 gda game tree --json         # the runtime scene tree, after _ready
 gda perf monitors --json     # live engine counters: fps, memory, node count
@@ -503,8 +505,8 @@ A named directory must be a project, or `gda` reports it as an error. When none 
 
 | Context | Project resolution order |
 | --- | --- |
-| **CLI** | `--project` → `GDA_PROJECT` → cwd (if it holds `project.godot`), else projectless |
-| **MCP** (`gda-mcp`) | `GDA_PROJECT` → client workspace `roots` → server cwd — each used only if it holds `project.godot` |
+| **CLI** | `--project` → `GDA_PROJECT` (both strict — invalid is reported) → cwd if it holds `project.godot`, else projectless |
+| **MCP** (`gda-mcp`) | `GDA_PROJECT` (strict — set-but-invalid is reported, not skipped) → a *valid* client workspace `root` → a *valid* server cwd, else projectless |
 
 <details>
 <summary>Project code execution — what runs when you point at a project</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gda"
 version = "0.1.38"
-description = "Godot for AI agents: a CLI, Skill, and MCP server with structured JSON/schema output — headless scene/script/export automation plus live runtime control."
+description = "Godot AI agent CLI, Skill, and MCP server with structured JSON/schema output — headless scene/script/export automation plus live runtime control."
 readme = "README.md"
 authors = [
     { name = "haihong.qin", email = "haihongqin@gmail.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "gda"
 version = "0.1.38"
-description = "Agent-first CLI, Skill, and MCP server for the Godot engine, with structured output for AI agents"
+description = "Godot for AI agents: a CLI, Skill, and MCP server with structured JSON/schema output — headless scene/script/export automation plus live runtime control."
 readme = "README.md"
 authors = [
     { name = "haihong.qin", email = "haihongqin@gmail.com" }
 ]
 license = "MIT"
 license-files = ["LICENSE"]
-keywords = ["godot", "godot-engine", "cli", "mcp", "model-context-protocol", "ai-agent", "agent", "agent-skill", "skill", "structured-output", "game-development", "automation", "llm"]
+keywords = ["godot", "godot-engine", "godot-ai", "godot-mcp", "cli", "mcp", "model-context-protocol", "ai-agent", "coding-agent", "agent", "agent-skill", "skill", "gdscript", "structured-output", "game-development", "automation", "llm"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",


### PR DESCRIPTION
## Why

Acts on an external optimization report for the README + project description, audited against three weighted principles — **User-facing (40%) · Highlight features (30%) · SEO (30%)**. The report's central thesis was sound (lead with the user's outcome and the fastest success path; treat CLI/Skill/MCP as entry points), so this PR adopts it — while **rejecting** its "agent control plane" tagline (architecturally inapt — implies central orchestration of distributed state) and **deferring** its bloatier suggestions (persona blocks, GIF) to keep the README lean.

## What changed

**`README.md`** (net **+30 lines / +5%**, vs the report's raw +12–22%):
- **Reorder** — a minimal Install + Quick start now come *before* the ~130 lines of CLI/Skill/MCP setup, so a new user can prove the tool works before reading client-specific registration.
- **Hero** — `The Godot AI Agent CLI, Skill, and MCP Server`: front-loads the SEO terms while keeping the head noun ("CLI, Skill, and MCP Server") accurate, so "Godot AI Agent" reads as the domain modifier, not a claim that gda is an agent. No "control plane".
- **New tables** — "Capabilities at a glance" (task → tool) and "Choose your integration" (CLI/Skill/MCP); one consolidated CLI-vs-MCP project-resolution table in Configuration (duplicated prose trimmed from the MCP section).
- **Quick start ambiguity fixed** — the old example used `game/` first as a bare projectless path and then as a `--project` Godot project. Now it sets `GDA_PROJECT` once and uses project-relative paths consistently, so `scenes/main.tscn` means one file both headless and live.
- A "most-used commands" first-path line; the full command catalog stays visible (SEO + agent retrieval).

**`pyproject.toml`** — package summary leads with the positioning and surfaces live runtime control (the old summary omitted it); added high-intent keywords `godot-ai`, `godot-mcp`, `coding-agent`, `gdscript`.

## Verification
- Ran the **new** Quick start headless sequence (`scene create` → `node add` → `node set` → `scene get`) against a real Godot project with `GDA_PROJECT` set — all succeed and the JSON output matches the documented shapes.
- Confirmed every daemon/live command resolves the project via the shared precedence (`--project` → `GDA_PROJECT` → cwd), so the live block is correct relying on the exported `GDA_PROJECT`.
- Internal anchors (`#configuration`, `#how-it-works`) and section seams checked; no test references the changed metadata (docs/metadata only — no code change).

## Guardrails honored
Live mode stays "macOS/Linux only"; pre-1.0 note and trusted-project execution note retained; SEO via natural keyword repetition + topics, not heading stuffing.

## Follow-up (not in this PR)
GitHub repo **description + topics** are applied via `gh repo edit` (outward-facing, not a PR change) — held until this hero wording is confirmed, so the public description mirrors the merged README:

```
gh repo edit aigengame/godot-agent \
  --description "Godot AI agent CLI, Skill, and MCP server — structured JSON/schema output, headless scene/script/export automation, and live runtime control." \
  --add-topic godot-ai --add-topic godot-mcp --add-topic coding-agent
```
