### PR TITLE
docs(adr): surface-inclusion principle (ADR-0025) + ADR-0017 scene-selection amendment

### DIFF
--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -82,14 +82,29 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > `main_scene`.** Decision 2 holds the running *game* but never fixed *which* scene it boots; the
 > session has so far run the project's configured `main_scene`. To serve "run a specific scene" —
 > the F6-equivalent the engine exposes natively as `godot --scene <path|UID>` (verified to run that
-> scene without mutating `main_scene`) — the session launch gains an **optional scene selector**,
-> threaded from the CLI to the daemon's session launch and passed to the engine as
-> `--scene <path|UID>` (an engine option, before `--path`). This is a deliberate **extension** of
-> Decision 2's running-game scope, not a reversal: still a gda-owned game, still headless by
-> default, still the same harness and live surface (ADR-0019 / 0020), only with a chosen entry
-> scene. It does **not** reach the out-of-scope editor context (there is no editor "current
-> scene"). The selector-less default is unchanged. Realized by the run-a-scene slice (#278); the
-> surface-inclusion rationale (why `run` is in scope at all) is recorded in ADR-0025.
+> scene without mutating `main_scene`) — the session launch gains an **optional scene selector**.
+>
+> **Public surface — `gda daemon start --scene <path|UID>`.** It is a **start-time daemon option**:
+> the daemon holds the value and passes it to the engine as `--scene <path|UID>` (an engine option,
+> before `--path`) when the session is **lazily launched on the first live op** (the #7 note above).
+> With no `--scene`, behaviour is unchanged (runs `main_scene`). The selector accepts a scene **path
+> or UID** (per Godot's `--scene`). Any `scene play` / `game run` ergonomic wrapper is a **separate
+> follow-up**, not part of this amendment.
+>
+> **Failure semantics — typed error, never a silent fallback.** A missing or non-existent scene
+> selector **must** surface a typed `GdaError` (a `LIVE` classifier-source code minted by the slice,
+> per decision 6 below); it must **not** silently fall back to `main_scene`. A typed failure beats a
+> wrong positive path the agent cannot detect.
+>
+> **Trust boundary unchanged.** Launching a chosen scene runs that scene's `_ready` and game code —
+> the **same trusted-project / project-code execution surface** that running `main_scene` and every
+> mutating op already cross (ADR-0009, ADR-0018), not a new boundary. It does **not** reach the
+> out-of-scope editor context (there is no editor "current scene").
+>
+> This is a deliberate **extension** of Decision 2's running-game scope, not a reversal: still a
+> gda-owned game, headless by default, same harness and live surface (ADR-0019 / 0020), only with a
+> chosen entry scene. The selector-less default is unchanged. Realized by the run-a-scene slice
+> (#278); the surface-inclusion rationale (why `run` is in scope at all) is recorded in ADR-0025.
 
 ## Decision
 

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -78,6 +78,19 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > the #223 time-windowed base — a 1-frame window for a single shot, an N-frame window
 > for a sequence — so the one-shot RPC contract holds.
 
+> **Amendment (2026-06-24, #278) — the session may run a *chosen scene*, not only the project's
+> `main_scene`.** Decision 2 holds the running *game* but never fixed *which* scene it boots; the
+> session has so far run the project's configured `main_scene`. To serve "run a specific scene" —
+> the F6-equivalent the engine exposes natively as `godot --scene <path|UID>` (verified to run that
+> scene without mutating `main_scene`) — the session launch gains an **optional scene selector**,
+> threaded from the CLI to the daemon's session launch and passed to the engine as
+> `--scene <path|UID>` (an engine option, before `--path`). This is a deliberate **extension** of
+> Decision 2's running-game scope, not a reversal: still a gda-owned game, still headless by
+> default, still the same harness and live surface (ADR-0019 / 0020), only with a chosen entry
+> scene. It does **not** reach the out-of-scope editor context (there is no editor "current
+> scene"). The selector-less default is unchanged. Realized by the run-a-scene slice (#278); the
+> surface-inclusion rationale (why `run` is in scope at all) is recorded in ADR-0025.
+
 ## Decision
 
 **1. An execution-channel selector, chosen per command by a static `kind`.**

--- a/docs/adr/0025-surface-inclusion-principle.md
+++ b/docs/adr/0025-surface-inclusion-principle.md
@@ -1,0 +1,63 @@
+---
+status: accepted
+---
+
+# gda surface inclusion: agent value + structured-operation fit, not engine-CLI parity
+
+ADR-0005 fixed *how* `gda` commands are named and grouped; it did not fix *which* engine
+capabilities earn a command. As the surface grows, a recurring question keeps returning —
+"should `gda` wrap Godot feature/flag X?" (most recently: run a project / run a specific scene;
+before that: `.cs` support, asset import). Answering it ad hoc invites two opposite failures:
+importing engine flags with no agent value (surface bloat), or refusing capabilities that clearly
+advance the agent loop (gaps). This ADR records the inclusion criterion.
+
+## Decision
+
+`gda` is **not a CLI wrapper over the engine launcher.** It is an agent-facing layer of
+**structured operations** — most of which the engine CLI does not expose at all (`node add/set`,
+`script set`, signal wiring, …), expressed through gda's own GDScript payload. So the surface is
+**not** driven by parity with `godot --help`.
+
+**Inclusion criterion — wrap an engine capability as a `gda` command iff both hold:**
+
+1. **Agent value** — it advances the agent's write → run → observe → fix loop, or a
+   CI/automation need an agent drives. (Not: human-interactive editor/dev tooling.)
+2. **Structured-operation fit** — it can be expressed as a typed operation behind gda's contract:
+   one `--json` result, a `--schema` self-description (ADR-0004), and a stable `GdaError` envelope
+   (ADR-0002). Streaming, an interactive REPL/stepping loop, and editor-GUI state do not fit.
+
+A capability failing either test stays out, regardless of how prominent the engine flag is.
+
+**Worked classification (Godot 4.6 `--help`):**
+
+- *In, by this criterion:* running a project / a specific scene (the missing piece of the loop —
+  see the ADR-0017 amendment and #278), export (already `gda export run`), and — case by case —
+  `--script` one-shot, `--check-only`, `--import`.
+- *Out:* editor / project-manager GUI, debugger / LSP / DAP servers, rendering / display / audio
+  drivers, GPU / profiling internals, `--doctool` / `--gdscript-docs` / `--dump-extension-api`
+  codegen, `--build-solutions`, `--convert-3to4`, debug visualizers — no agent value and/or no
+  structured-operation fit.
+
+**Corollary — interactive debugging is out; observability is in.** Godot's remote-debug protocol
+(`--remote-debug`) offers rich data, but its variable inspection / breakpoints / step / eval require
+a *paused* game, which fails criterion 2 (and contradicts gda's async one-shot-RPC and
+frame-coherence, ADR-0011 / 0017 / 0020). Read-only structured signals from it (error callstacks,
+profiler frames) may qualify; the interactive surface does not. Any tap of that protocol is its own
+ADR.
+
+## Considered options
+
+- **Mirror the engine CLI for completeness (rejected).** Produces bloat (dev-tooling flags) and is
+  incoherent — gda already exceeds the CLI with structured ops the CLI lacks.
+- **Add capabilities purely on request, with no stated criterion (rejected).** The status quo; it
+  re-opens the same debate per feature and drifts.
+- **A stated inclusion criterion (chosen).** Gives every future "should gda support X?" a durable,
+  one-paragraph answer and keeps the surface coherent with ADR-0001 / 0004 / 0005.
+
+## Consequences
+
+- "Run a project / a specific scene" is in scope; the first slice is #278 (ADR-0017 amendment).
+- Engine dev-tooling flags stay out unless a concrete agent need re-qualifies one, each as a typed op.
+- Interactive debugging stays out; structured observability (errors + callstacks, perf) is the model.
+  Tapping Godot's remote-debug protocol for the read-only parts is deferred to its own ADR.
+- This criterion governs `gda`'s scope only; it does not change command naming/grouping (ADR-0005).

--- a/docs/adr/0025-surface-inclusion-principle.md
+++ b/docs/adr/0025-surface-inclusion-principle.md
@@ -28,15 +28,18 @@ advance the agent loop (gaps). This ADR records the inclusion criterion.
 
 A capability failing either test stays out, regardless of how prominent the engine flag is.
 
-**Worked classification (Godot 4.6 `--help`):**
+**Worked classification (Godot 4.6 `--help`) — illustrative, not a roadmap.** The lists below show
+the criterion *applied*; they are **non-binding examples**, not surface decisions made by this ADR.
+Only "run a project / a specific scene" is **committed** here (via #278); `export` is already shipped.
+Every other entry remains its own future decision under this same criterion.
 
-- *In, by this criterion:* running a project / a specific scene (the missing piece of the loop —
-  see the ADR-0017 amendment and #278), export (already `gda export run`), and — case by case —
+- *In, by this criterion:* running a project / a specific scene (committed — ADR-0017 amendment, #278),
+  export (already `gda export run`), and — case by case, **only if a concrete agent need appears** —
   `--script` one-shot, `--check-only`, `--import`.
-- *Out:* editor / project-manager GUI, debugger / LSP / DAP servers, rendering / display / audio
-  drivers, GPU / profiling internals, `--doctool` / `--gdscript-docs` / `--dump-extension-api`
-  codegen, `--build-solutions`, `--convert-3to4`, debug visualizers — no agent value and/or no
-  structured-operation fit.
+- *Out, by this criterion:* editor / project-manager GUI, debugger / LSP / DAP servers, rendering /
+  display / audio drivers, GPU / profiling internals, `--doctool` / `--gdscript-docs` /
+  `--dump-extension-api` codegen, `--build-solutions`, `--convert-3to4`, debug visualizers — no agent
+  value and/or no structured-operation fit.
 
 **Corollary — interactive debugging is out; observability is in.** Godot's remote-debug protocol
 (`--remote-debug`) offers rich data, but its variable inspection / breakpoints / step / eval require
@@ -60,4 +63,10 @@ ADR.
 - Engine dev-tooling flags stay out unless a concrete agent need re-qualifies one, each as a typed op.
 - Interactive debugging stays out; structured observability (errors + callstacks, perf) is the model.
   Tapping Godot's remote-debug protocol for the read-only parts is deferred to its own ADR.
-- This criterion governs `gda`'s scope only; it does not change command naming/grouping (ADR-0005).
+- This criterion governs `gda`'s scope only; it does not change command naming/grouping (ADR-0005 /
+  ADR-0019). The concrete entry point for the accepted run surface is `gda daemon start --scene`
+  (#278); any `scene play` / `game run` wrapper is a separate follow-up.
+- The concrete command placement and any `docs/command-catalog.md` entry for the run surface land
+  with the implementation slice (#278), **not** this principle ADR — the catalog is a non-binding
+  feature map and committed status is tracked in the issue tracker (the milestone), so the accepted
+  surface is intentionally not pre-catalogued here.


### PR DESCRIPTION
Prerequisite decisions for the run-a-specific-scene slice (#278).

## ADR-0025 — surface inclusion principle (new)
Records *which* engine capabilities earn a `gda` command (ADR-0005 fixed naming, not inclusion). Criterion: **agent value + structured-operation fit, not engine-CLI parity.** Puts running a project/scene in scope; keeps editor/dev-tooling flags and **interactive** debugging (break/step/eval) out, while leaving read-only observability (errors+callstacks, perf) eligible. Gives the recurring "should gda support feature X?" question a durable, one-paragraph answer.

## ADR-0017 — amendment (scene selection)
Records that the live `Engine session` may boot a **chosen scene** via a `--scene <path|UID>` passthrough — an **extension** of Decision 2's running-game scope (not a reversal): same gda-owned game, headless by default, same harness and live surface; only the entry scene changes. Default (no `--scene`) unchanged. Editor "current scene" remains out of scope.

## Notes
- Docs-only (no package change); does not trigger a release.
- Unblocks #278 (run-a-scene slice), which implements the `--scene` passthrough.
