### PR TITLE
feat(logger): structured runtime log channel via gda logger tail

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ result it can act on — never engine logs it has to scrape. It runs in **two mo
 | Parse results instead of scraping engine logs | `--json` (one clean object) and `--schema` (a JSON-Schema contract) |
 | Hand an agent Godot tools | the bundled **Skill** (`gda skill`) or the **`gda-mcp`** server |
 | Automate CI, exports, and project analysis | headless commands — no editor, no plugin, just a Godot binary |
-| Debug a *running* game's runtime behavior | `gda daemon start`, then `game` / `diag` / `perf` / `input` / `screen` |
+| Debug a *running* game's runtime behavior | `gda daemon start`, then `game` / `diag` / `logger` / `perf` / `input` / `screen` |
 
 ---
 
@@ -449,7 +449,12 @@ flags — `gda --help` is the authoritative list of what is installed.
 | Command | What it does |
 | ------- | ------------ |
 | `diag errors` | Tail the running game's runtime errors (categorized). |
-| `diag log` | Tail the running game's raw output log (`print` + stderr). |
+
+**`logger`** — structured runtime log
+
+| Command | What it does |
+| ------- | ------------ |
+| `logger tail` | Tail the running game's whole runtime log as structured records (`--level`, `--limit`, `--raw`). |
 
 **`perf`** — performance monitoring
 

--- a/docs/adr/0022-runtime-diagnostics-via-daemon-owned-session-log.md
+++ b/docs/adr/0022-runtime-diagnostics-via-daemon-owned-session-log.md
@@ -4,6 +4,16 @@ status: accepted
 
 # Runtime diagnostics via a daemon-owned session log
 
+> Outcome (2026-06-24, #281): the raw **`diag log`** described below is
+> **superseded by `gda logger tail`** — the structured runtime-log channel
+> (ADR-0026). `gda logger tail` parses the *same* daemon-owned Session log into
+> typed `LogRecord`s by default (and preserves the verbatim lines under `--raw`),
+> while **`diag` retains `errors` only**. The daemon-side read path this ADR
+> established is unchanged — `logger tail` is a second daemon-served log op
+> reading `session.log_file`, exactly like `diag errors`; only the surface and the
+> default output shape changed. References below to `diag log` / the `diag-log` op
+> name describe the original `diag`-only state and are kept point-in-time.
+
 `gda diag` reads the running game's runtime diagnostics — its errors and its
 output log — over the live channel (story group, #224). This needs the running
 game's error stream and its `print()` output, but Godot exposes neither to

--- a/docs/adr/0026-structured-runtime-log-protocol.md
+++ b/docs/adr/0026-structured-runtime-log-protocol.md
@@ -13,6 +13,21 @@ is unstructured. This ADR adds `gda logger`: a structured runtime-log channel an
 that backs it. It is in scope under ADR-0025 (read-only observability is in; interactive debugging
 is out) and deliberately does **not** tap Godot's remote-debug protocol.
 
+> **Amendment (2026-06-25, #281) — the read result is `LoggerTailResult { records: LogRecord[] }`,
+> the passive parse is whole-log lossless, and `--raw` returns info records.** Decision 3 wrote the
+> read contract as "→ `LogRecord[]`"; it is delivered as a single-field result object
+> `LoggerTailResult` whose `records` **is** that `LogRecord[]` — mirroring how `diag errors` delivers
+> `DiagError[]` as `DiagErrorsResult.errors` (the established wrapper convention; one output model
+> keeps the `--schema` projection well-defined). There is **no** second `lines` field. `--raw` returns
+> the **same** shape with every captured line as an unclassified `info` record carrying its verbatim
+> text (not a separate `{lines: str[]}` shape), so the channel is uniformly typed `LogRecord[]`.
+> Honouring decision 2's "the daemon parses the **whole** Session log … every other line as a plain
+> `info` record", the passive parse is **lossless**: an engine error/warning becomes a typed record
+> (its `at:` folded into `source`), and **every other line — including the `GDScript backtrace`
+> continuation lines after an error — becomes a plain `info` record** (a first implementation that
+> dropped those continuation lines was corrected). Errors thus still appear in both surfaces by
+> design: `logger tail` is the full stream; `diag errors` is the focused, callstack-enriched view.
+
 ## Decision
 
 **1. `LogRecord` — the structured unit.** One typed model (backing `--json` / `--schema`):

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -516,10 +516,12 @@ headless is unaffected (4.4+, cross-platform).
 - **`logger` (structured runtime log):** the running game's whole runtime log as structured
   records (shipped, #281, ADR-0026). `gda logger tail [--level <min>] [--limit <N>] [--raw]` parses
   the same daemon-owned `Session log` into typed `LogRecord`s — engine errors/warnings via the diag
-  parser (carrying `source` + an `origin` sub-kind), every other line a plain `info` record — so an
-  un-instrumented project gets structured logs for free. `level` is the closed, ordered enum
-  `debug < info < warning < error` (`--level` filters by minimum severity); `--limit N` tails the
-  most-recent-N; `--raw` returns the verbatim lines the superseded `diag log` returned. Daemon-served
+  parser (carrying `source` + an `origin` sub-kind), **every other line a plain `info` record (the
+  whole log, nothing dropped)** — so an un-instrumented project gets structured logs for free. The
+  result is `LoggerTailResult { records: LogRecord[] }` (mirroring `diag errors`' `{errors: […]}`).
+  `level` is the closed, ordered enum `debug < info < warning < error` (`--level` filters by minimum
+  severity); `--limit N` tails the most-recent-N; `--raw` skips classification, returning every line
+  as a verbatim `info` record (the superseded `diag log` view, still `LogRecord[]`). Daemon-served
   and crash-survivable like `diag` (ADR-0022). The opt-in rich `gda_log()` protocol layers on in a
   follow-up slice (#282).
 - **lifecycle (the `daemon` command group):** `gda daemon start` / `stop` / `status`, and `gda daemon

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -506,13 +506,22 @@ headless is unaffected (4.4+, cross-platform).
   node is `live_perf_node_not_found`, an absent property `live_perf_property_not_found`,
   an absent signal `live_perf_signal_not_found`; a genuinely stalled engine is caught
   by the daemon-level `live_timeout`.
-- **`diag` (diagnostics):** runtime errors and output log of the running game (shipped, #224).
-  `gda diag errors` reads the running game's runtime errors as structured `{level, message,
-  function?, file?, line?}` (warnings included, distinguished by `level`); `gda diag log` reads
-  its raw output lines; both take `--limit N`. Daemon-served, not harness-relayed: the daemon
-  reads the `Session log` it launched the engine with (`--log-file`), so it works even after the
-  game has crashed — a remembered session with a missing log is `live_log_unavailable`, an empty
-  log is an empty result (ADR-0022).
+- **`diag` (diagnostics):** runtime errors of the running game (shipped, #224). `gda diag errors`
+  reads the running game's runtime errors as structured `{level, message, function?, file?, line?}`
+  (warnings included, distinguished by `level`), with `--limit N`. Daemon-served, not
+  harness-relayed: the daemon reads the `Session log` it launched the engine with (`--log-file`),
+  so it works even after the game has crashed — a remembered session with a missing log is
+  `live_log_unavailable`, an empty log is an empty result (ADR-0022). (The raw `diag log` is
+  **superseded by `gda logger tail`** below.)
+- **`logger` (structured runtime log):** the running game's whole runtime log as structured
+  records (shipped, #281, ADR-0026). `gda logger tail [--level <min>] [--limit <N>] [--raw]` parses
+  the same daemon-owned `Session log` into typed `LogRecord`s — engine errors/warnings via the diag
+  parser (carrying `source` + an `origin` sub-kind), every other line a plain `info` record — so an
+  un-instrumented project gets structured logs for free. `level` is the closed, ordered enum
+  `debug < info < warning < error` (`--level` filters by minimum severity); `--limit N` tails the
+  most-recent-N; `--raw` returns the verbatim lines the superseded `diag log` returned. Daemon-served
+  and crash-survivable like `diag` (ADR-0022). The opt-in rich `gda_log()` protocol layers on in a
+  follow-up slice (#282).
 - **lifecycle (the `daemon` command group):** `gda daemon start` / `stop` / `status`, and `gda daemon
   install` / `uninstall` for the `gda harness` (ADR-0018).
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -24,7 +24,6 @@ from gda.daemon_ops import (
 from gda.errors import (
     Failure,
     classify_diag_errors,
-    classify_diag_log,
     classify_game_get,
     classify_game_set,
     classify_game_tree,
@@ -33,6 +32,7 @@ from gda.errors import (
     classify_input_key,
     classify_input_mouse,
     classify_input_sequence,
+    classify_logger_tail,
     classify_perf_monitor,
     classify_perf_monitors,
     classify_script_validate,
@@ -69,8 +69,6 @@ from gda.models import (
     DaemonUninstallResult,
     DiagErrorsParams,
     DiagErrorsResult,
-    DiagLogParams,
-    DiagLogResult,
     EngineVersion,
     ExportGetParams,
     ExportListParams,
@@ -94,6 +92,9 @@ from gda.models import (
     InputMouseResult,
     InputSequenceParams,
     InputSequenceResult,
+    LogLevel,
+    LoggerTailParams,
+    LoggerTailResult,
     MAX_WINDOW_FRAMES,
     MouseButton,
     PerfMonitorParams,
@@ -196,7 +197,6 @@ from gda.render import (
     render_daemon_stop,
     render_daemon_uninstall,
     render_diag_errors,
-    render_diag_log,
     render_engine_version,
     render_export_list,
     render_export_run,
@@ -207,6 +207,7 @@ from gda.render import (
     render_input_key,
     render_input_mouse,
     render_input_sequence,
+    render_logger_tail,
     render_node_add,
     render_node_connect_signal,
     render_node_disconnect_signal,
@@ -359,6 +360,18 @@ diag_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(diag_app, name="diag")
+
+# The logger command group (Phase 2, ADR-0019, ADR-0026, #281): the running game's
+# STRUCTURED runtime-log stream as a domain object, marked LIVE by `kind`. Like
+# `diag`, it is daemon-served — the daemon parses the Session log it owns
+# (`--log-file`) into typed `LogRecord`s rather than relaying to the harness, so a
+# crash stays diagnosable. `logger tail` is the passive, non-invasive floor of the
+# structured-log protocol; the raw `diag log` is superseded by `logger tail --raw`.
+logger_app = typer.Typer(
+    help="Read the running game's structured runtime log (live; needs `gda daemon start`).",
+    no_args_is_help=True,
+)
+app.add_typer(logger_app, name="logger")
 
 # The perf command group (Phase 2, ADR-0019, #223): runtime performance monitoring
 # of the RUNNING game, served LIVE through gda-daemon (`kind = LIVE`). `perf
@@ -907,36 +920,76 @@ def diag_errors(
     )
 
 
-DIAG_LOG_COMMAND: HeadlessCommand[DiagLogResult] = HeadlessCommand(
-    operation="diag-log",
-    input_model=DiagLogParams,
-    output_model=DiagLogResult,
-    render=render_diag_log,
-    classify=classify_diag_log,
+def _logger_level_option() -> Optional[LogLevel]:
+    """The `--level <min>` option for `gda logger tail`: a minimum-severity filter.
+
+    Bound to the closed :class:`~gda.models.LogLevel` enum (Click choices), so an
+    out-of-set value is a usage error on the argv path, mirroring the enum-typed
+    field on ``LoggerTailParams`` that the ``--params-json`` / ``--schema`` path
+    enforces. Omitting it returns all severities.
+    """
+    return typer.Option(
+        None,
+        "--level",
+        help=(
+            "If set, return only records at or above this minimum severity over the "
+            "closed ordering debug < info < warning < error. Omit for all."
+        ),
+    )
+
+
+def _logger_raw_option() -> bool:
+    """The `--raw` flag for `gda logger tail`: verbatim lines instead of records.
+
+    The superseded `diag log` view: with it, the result carries the verbatim
+    captured lines (`lines`) and no structured records.
+    """
+    return typer.Option(
+        False,
+        "--raw",
+        help="Return the verbatim captured log lines instead of structured records.",
+    )
+
+
+LOGGER_TAIL_COMMAND: HeadlessCommand[LoggerTailResult] = HeadlessCommand(
+    operation="logger-tail",
+    input_model=LoggerTailParams,
+    output_model=LoggerTailResult,
+    render=render_logger_tail,
+    classify=classify_logger_tail,
     kind=ExecutionKind.LIVE,
 )
 
 
-@diag_app.command(name="log", cls=DIAG_LOG_COMMAND.command_class())
-def diag_log(
+@logger_app.command(name="tail", cls=LOGGER_TAIL_COMMAND.command_class())
+def logger_tail(
+    level: Optional[LogLevel] = _logger_level_option(),
     limit: Optional[int] = _diag_limit_option(),
+    raw: bool = _logger_raw_option(),
     json_output: bool = json_option(),
-    schema: bool = DIAG_LOG_COMMAND.schema_option(),
+    schema: bool = LOGGER_TAIL_COMMAND.schema_option(),
     params_json: Optional[str] = params_json_option(),
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Read the running game's raw output log (live).
+    """Read the running game's structured runtime log (live).
 
-    The daemon-served counterpart of `diag errors`: the full captured output
-    stream (print output AND error lines) verbatim, one entry per line, read from
-    the same daemon-owned Session log (#224). `--limit N` tails the most recent N
-    lines. The same no-daemon / no-session / missing-log typed errors apply; an
-    empty log is an empty result.
+    The passive, non-invasive structured runtime-log channel (#281, ADR-0026): the
+    daemon parses the whole daemon-owned Session log into typed `LogRecord`s —
+    engine errors/warnings via the diag parser (carrying `source` + an `origin`
+    sub-kind), every other line a plain `info` record. So an un-instrumented
+    project gets structured logs for free. `--level <min>` filters by minimum
+    severity over the closed ordering debug < info < warning < error; `--limit N`
+    tails the most recent N (after the filter); `--raw` returns the verbatim lines
+    instead (the superseded `diag log` view). Daemon-served like `diag`: read from
+    the `--log-file` the daemon owns, so it works even after the game has crashed.
+    With no daemon it reports `daemon_not_running`; with a daemon but no session
+    ever launched, `engine_session_not_running`; with a session whose log file is
+    gone, `live_log_unavailable`. An empty log is an empty result, not an error.
     """
     _dispatch(
-        DIAG_LOG_COMMAND,
-        DiagLogParams(limit=limit),
+        LOGGER_TAIL_COMMAND,
+        LoggerTailParams(level=level, limit=limit, raw=raw),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -866,11 +866,12 @@ def game_set(
 
 
 def _diag_limit_option() -> Optional[int]:
-    """The shared `--limit N` option for the `diag` group: tail the most recent N.
+    """The shared `--limit N` option for the log-reading live commands: tail N.
 
-    Bound to ``>= 1`` (Click ``min``) so a zero/negative limit is a usage error on
-    the argv path, mirroring the ``ge=1`` constraint on ``DiagErrorsParams`` /
-    ``DiagLogParams`` that the ``--params-json`` / ``--schema`` path enforces.
+    Used by both ``gda diag errors`` and ``gda logger tail``. Bound to ``>= 1``
+    (Click ``min``) so a zero/negative limit is a usage error on the argv path,
+    mirroring the ``ge=1`` constraint on ``DiagErrorsParams`` / ``LoggerTailParams``
+    that the ``--params-json`` / ``--schema`` path enforces.
     """
     return typer.Option(
         None,

--- a/src/gda/daemon/diag.py
+++ b/src/gda/daemon/diag.py
@@ -224,13 +224,14 @@ def _info_record(seq: int, message: str) -> dict:
 def _error_record(seq: int, entry: dict) -> dict:
     """A ``parse_errors`` entry as a typed error/warning ``LogRecord`` (#281)."""
     rec_level, origin = _DIAG_LEVEL_TO_RECORD.get(entry["level"], ("error", "engine"))
-    source = None
-    if entry.get("file") is not None or entry.get("function") is not None or entry.get("line") is not None:
-        source = {
-            "function": entry.get("function"),
-            "file": entry.get("file"),
-            "line": entry.get("line"),
-        }
+    # A `source` frame only when the engine logged an `at:` location; a bare error
+    # (no follow-on) leaves `source` null rather than an all-null frame.
+    has_location = any(entry.get(k) is not None for k in ("function", "file", "line"))
+    source = (
+        {"function": entry.get("function"), "file": entry.get("file"), "line": entry.get("line")}
+        if has_location
+        else None
+    )
     return {
         "seq": seq,
         "level": rec_level,

--- a/src/gda/daemon/diag.py
+++ b/src/gda/daemon/diag.py
@@ -137,20 +137,30 @@ _DIAG_LEVEL_TO_RECORD = {
 
 
 def parse_log_records(
-    data: str | bytes, level: str | None = None, limit: int | None = None
+    data: str | bytes,
+    level: str | None = None,
+    limit: int | None = None,
+    raw: bool = False,
 ) -> list[dict]:
     """The whole Session log as structured ``LogRecord`` dicts (#281, ADR-0026).
 
-    The passive structured runtime-log channel: every captured line becomes a
-    typed record. An engine error/warning (recognized by the same two-line format
-    :func:`parse_errors` reads) yields a typed record carrying its normalized
-    ``level`` (mapped onto the closed enum), an ``origin`` sub-kind
+    The passive structured runtime-log channel: EVERY captured line becomes a
+    typed record, so the structured stream represents the whole Session log
+    losslessly (ADR-0026 decision 2). An engine error/warning (recognized by the
+    same two-line format :func:`parse_errors` reads) yields a typed record carrying
+    its normalized ``level`` (mapped onto the closed enum), an ``origin`` sub-kind
     (``engine`` / ``script`` / ``shader``), and a ``source`` ``{function, file,
-    line}`` frame when the log recorded an ``at:`` line; its ``at:`` follow-on (and
-    any continuation backtrace) is folded in, never re-emitted as its own record.
-    Every OTHER line becomes a plain ``info`` record. Each record carries a
-    monotonic ``seq`` in capture order and a present-but-empty ``fields`` object
-    (populated only by the opt-in #282 protocol).
+    line}`` frame when the log recorded an ``at:`` line; the ``at:`` follow-on is
+    folded into ``source`` rather than re-emitted. Every OTHER line — game output,
+    the engine banner, AND the indented ``GDScript backtrace`` continuation lines
+    that follow an error — becomes a plain ``info`` record (nothing is dropped).
+    Each record carries a monotonic ``seq`` in capture order and a present-but-
+    empty ``fields`` object (populated only by the opt-in #282 protocol).
+
+    With ``raw`` set, classification is skipped entirely: every captured line
+    becomes a plain ``info`` record carrying its verbatim text (the view the
+    superseded ``diag log`` returned, now uniformly typed as ``LogRecord[]``) —
+    even an error header stays a verbatim ``info`` line.
 
     ``level`` filters by minimum severity over the closed ordering
     ``debug < info < warning < error`` (e.g. ``"warning"`` drops ``info`` and
@@ -159,46 +169,38 @@ def parse_log_records(
     -> ``[]``; it never raises on a malformed/continuation line or bad UTF-8.
     """
     lines = _lines(data)
-
-    # First pass: identify which line indices belong to an engine error block (the
-    # `<TYPE>:` header, its optional `at:` follow-on, and any continuation
-    # backtrace lines up to the next header / blank boundary). Those are rendered
-    # as ONE typed record from `parse_errors`; everything else is an info line.
     records: list[dict] = []
     seq = 0
-    i = 0
-    n = len(lines)
-    while i < n:
-        header = _ERROR_HEADER.match(lines[i])
-        if header is None:
-            # A plain captured line -> an `info` record (game output, banner, …).
-            records.append(_info_record(seq, lines[i]))
+
+    if raw:
+        # `--raw`: no classification — each captured line is a verbatim `info`
+        # record (the superseded `diag log` view, uniformly typed as LogRecord[]).
+        for line in lines:
+            records.append(_info_record(seq, line))
             seq += 1
-            i += 1
-            continue
-        # An engine error block. Reuse `parse_errors` on just this header (+ its
-        # optional at-line) so the level/source extraction stays single-sourced.
-        block = lines[i]
-        consumed = 1
-        if i + 1 < n and _AT_LINE.match(lines[i + 1]) is not None:
-            block += "\n" + lines[i + 1]
-            consumed += 1
-        parsed = parse_errors(block)
-        # `parse_errors` yields exactly one entry for a single header.
-        records.append(_error_record(seq, parsed[0]))
-        seq += 1
-        # Skip the indented continuation backtrace the engine appends after the
-        # error (e.g. `   <Stack trace> …`): it is engine noise tied to this error,
-        # not game output, so the structured channel drops it. A non-indented line
-        # is fresh output and ends the block.
-        j = i + consumed
-        while (
-            j < n
-            and _ERROR_HEADER.match(lines[j]) is None
-            and _is_backtrace_continuation(lines[j])
-        ):
-            j += 1
-        i = j
+    else:
+        # An engine error/warning header (+ its optional `at:` follow-on) becomes
+        # ONE typed record via `parse_errors` (single-sourced level/source); the
+        # `at:` line is folded into `source`. EVERY other line — including the
+        # `GDScript backtrace` continuation lines after an error — becomes a plain
+        # `info` record, so the whole log is represented (ADR-0026 decision 2).
+        i = 0
+        n = len(lines)
+        while i < n:
+            if _ERROR_HEADER.match(lines[i]) is None:
+                records.append(_info_record(seq, lines[i]))
+                seq += 1
+                i += 1
+                continue
+            block = lines[i]
+            consumed = 1
+            if i + 1 < n and _AT_LINE.match(lines[i + 1]) is not None:
+                block += "\n" + lines[i + 1]
+                consumed += 1
+            # `parse_errors` yields exactly one entry for a single header.
+            records.append(_error_record(seq, parse_errors(block)[0]))
+            seq += 1
+            i += consumed
 
     if level is not None and level in _LEVEL_RANK:
         floor = _LEVEL_RANK[level]
@@ -240,15 +242,3 @@ def _error_record(seq: int, entry: dict) -> dict:
         "origin": origin,
         "fields": {},
     }
-
-
-def _is_backtrace_continuation(line: str) -> bool:
-    """True for an engine backtrace/continuation line that belongs to an error.
-
-    A continuation line is the indented backtrace the engine appends after an
-    error's ``at:`` line (e.g. ``   <Stack trace> …``). It is engine noise tied to
-    the preceding error, not game output, so the structured channel drops it. A
-    non-indented line is treated as fresh output (an ``info`` record), so a
-    ``print`` that happens to follow an error is never swallowed.
-    """
-    return line[:1].isspace() and line.strip() != ""

--- a/src/gda/daemon/diag.py
+++ b/src/gda/daemon/diag.py
@@ -108,3 +108,146 @@ def parse_log(data: str | bytes, limit: int | None = None) -> list[str]:
     if limit is not None and limit >= 0:
         return lines[-limit:] if limit else []
     return lines
+
+
+# --- The structured `LogRecord` channel (#281, ADR-0026) -----------------------
+#
+# The PASSIVE, non-invasive floor: parse the WHOLE Session log into typed
+# `LogRecord`s. Engine errors/warnings come from `parse_errors` above (reused
+# verbatim — this code is purely additive); every OTHER captured line becomes a
+# plain `info` record. An un-instrumented project gets structured logs for free.
+# The opt-in rich `gda_log()` protocol (the `<<<GDA:LOG>>>` marker) is a SEPARATE
+# follow-up slice (#282) and is NOT parsed here.
+
+# The closed, ordered severity enum (ADR-0026): `debug < info < warning < error`.
+# A record's rank is its index, so `--level <min>` is a well-defined `>=` filter.
+_LEVEL_ORDER = ("debug", "info", "warning", "error")
+_LEVEL_RANK = {name: i for i, name in enumerate(_LEVEL_ORDER)}
+
+# Map a `parse_errors` diag `level` onto the closed `LogRecord` (level, origin)
+# pair: the engine's finer kinds collapse onto the enum, with the sub-kind kept
+# in `origin` (ADR-0026). `SCRIPT ERROR` / `SHADER ERROR` are still `error` level;
+# only `origin` tells them apart.
+_DIAG_LEVEL_TO_RECORD = {
+    "error": ("error", "engine"),
+    "warning": ("warning", "engine"),
+    "script_error": ("error", "script"),
+    "shader_error": ("error", "shader"),
+}
+
+
+def parse_log_records(
+    data: str | bytes, level: str | None = None, limit: int | None = None
+) -> list[dict]:
+    """The whole Session log as structured ``LogRecord`` dicts (#281, ADR-0026).
+
+    The passive structured runtime-log channel: every captured line becomes a
+    typed record. An engine error/warning (recognized by the same two-line format
+    :func:`parse_errors` reads) yields a typed record carrying its normalized
+    ``level`` (mapped onto the closed enum), an ``origin`` sub-kind
+    (``engine`` / ``script`` / ``shader``), and a ``source`` ``{function, file,
+    line}`` frame when the log recorded an ``at:`` line; its ``at:`` follow-on (and
+    any continuation backtrace) is folded in, never re-emitted as its own record.
+    Every OTHER line becomes a plain ``info`` record. Each record carries a
+    monotonic ``seq`` in capture order and a present-but-empty ``fields`` object
+    (populated only by the opt-in #282 protocol).
+
+    ``level`` filters by minimum severity over the closed ordering
+    ``debug < info < warning < error`` (e.g. ``"warning"`` drops ``info`` and
+    ``debug``); an unknown value disables the filter. ``limit`` tails the most
+    recent ``N`` records AFTER the level filter. Best-effort and pure: empty input
+    -> ``[]``; it never raises on a malformed/continuation line or bad UTF-8.
+    """
+    lines = _lines(data)
+
+    # First pass: identify which line indices belong to an engine error block (the
+    # `<TYPE>:` header, its optional `at:` follow-on, and any continuation
+    # backtrace lines up to the next header / blank boundary). Those are rendered
+    # as ONE typed record from `parse_errors`; everything else is an info line.
+    records: list[dict] = []
+    seq = 0
+    i = 0
+    n = len(lines)
+    while i < n:
+        header = _ERROR_HEADER.match(lines[i])
+        if header is None:
+            # A plain captured line -> an `info` record (game output, banner, …).
+            records.append(_info_record(seq, lines[i]))
+            seq += 1
+            i += 1
+            continue
+        # An engine error block. Reuse `parse_errors` on just this header (+ its
+        # optional at-line) so the level/source extraction stays single-sourced.
+        block = lines[i]
+        consumed = 1
+        if i + 1 < n and _AT_LINE.match(lines[i + 1]) is not None:
+            block += "\n" + lines[i + 1]
+            consumed += 1
+        parsed = parse_errors(block)
+        # `parse_errors` yields exactly one entry for a single header.
+        records.append(_error_record(seq, parsed[0]))
+        seq += 1
+        # Skip the indented continuation backtrace the engine appends after the
+        # error (e.g. `   <Stack trace> …`): it is engine noise tied to this error,
+        # not game output, so the structured channel drops it. A non-indented line
+        # is fresh output and ends the block.
+        j = i + consumed
+        while (
+            j < n
+            and _ERROR_HEADER.match(lines[j]) is None
+            and _is_backtrace_continuation(lines[j])
+        ):
+            j += 1
+        i = j
+
+    if level is not None and level in _LEVEL_RANK:
+        floor = _LEVEL_RANK[level]
+        records = [r for r in records if _LEVEL_RANK[r["level"]] >= floor]
+
+    if limit is not None and limit >= 0:
+        return records[-limit:] if limit else []
+    return records
+
+
+def _info_record(seq: int, message: str) -> dict:
+    """A plain captured line as an ``info`` ``LogRecord`` (#281)."""
+    return {
+        "seq": seq,
+        "level": "info",
+        "message": message,
+        "source": None,
+        "origin": None,
+        "fields": {},
+    }
+
+
+def _error_record(seq: int, entry: dict) -> dict:
+    """A ``parse_errors`` entry as a typed error/warning ``LogRecord`` (#281)."""
+    rec_level, origin = _DIAG_LEVEL_TO_RECORD.get(entry["level"], ("error", "engine"))
+    source = None
+    if entry.get("file") is not None or entry.get("function") is not None or entry.get("line") is not None:
+        source = {
+            "function": entry.get("function"),
+            "file": entry.get("file"),
+            "line": entry.get("line"),
+        }
+    return {
+        "seq": seq,
+        "level": rec_level,
+        "message": entry["message"],
+        "source": source,
+        "origin": origin,
+        "fields": {},
+    }
+
+
+def _is_backtrace_continuation(line: str) -> bool:
+    """True for an engine backtrace/continuation line that belongs to an error.
+
+    A continuation line is the indented backtrace the engine appends after an
+    error's ``at:`` line (e.g. ``   <Stack trace> …``). It is engine noise tied to
+    the preceding error, not game output, so the structured channel drops it. A
+    non-indented line is treated as fresh output (an ``info`` record), so a
+    ``print`` that happens to follow an error is never swallowed.
+    """
+    return line[:1].isspace() and line.strip() != ""

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -13,7 +13,7 @@ import secrets
 import signal
 import socket
 
-from gda.daemon.diag import parse_errors, parse_log
+from gda.daemon.diag import parse_errors, parse_log, parse_log_records
 from gda.daemon.discovery import DaemonPaths, acquire_pidfile, ensure_runtime_dir
 from gda.daemon.protocol import error_reply, read_message, result_reply, write_message
 from gda.daemon.session import EngineSession, launch_session
@@ -22,13 +22,14 @@ from gda.daemon.session import EngineSession, launch_session
 STATUS_OP = "__status__"
 STOP_OP = "__stop__"
 
-# `gda diag` ops (#224): daemon-served live ops. Unlike the other live ops, they
-# are NOT relayed to the harness — the daemon serves them directly from the
-# Session log it launched the engine with (`--log-file`). Served even after the
-# session process has died, so a crash stays diagnosable.
+# Daemon-served log ops (#224, #281): the `gda diag errors` and `gda logger tail`
+# ops. Unlike the other live ops, they are NOT relayed to the harness — the daemon
+# serves them directly from the Session log it launched the engine with
+# (`--log-file`). Served even after the session process has died, so a crash stays
+# diagnosable. (`diag log` is SUPERSEDED by `logger tail --raw`, ADR-0026.)
 DIAG_ERRORS_OP = "diag-errors"
-DIAG_LOG_OP = "diag-log"
-DIAG_OPS = (DIAG_ERRORS_OP, DIAG_LOG_OP)
+LOGGER_TAIL_OP = "logger-tail"
+LOG_OPS = (DIAG_ERRORS_OP, LOGGER_TAIL_OP)
 
 
 class DaemonServer:
@@ -110,10 +111,11 @@ class DaemonServer:
         if op == STOP_OP:
             self._stopping = True
             return {"ok": True, "pid": os.getpid()}
-        if op in DIAG_OPS:
-            # `gda diag` is daemon-served: the daemon reads the Session log it owns
-            # rather than relaying to the harness (#224).
-            return self._handle_diag(op, request.get("params", {}))
+        if op in LOG_OPS:
+            # `gda diag errors` / `gda logger tail` are daemon-served: the daemon
+            # reads the Session log it owns rather than relaying to the harness
+            # (#224, #281).
+            return self._handle_log(op, request.get("params", {}))
         # A project live op. Serialized against the one session (single writer).
         session = self._ensure_session()
         if session is None:
@@ -124,22 +126,24 @@ class DaemonServer:
             )
         return session.request(op, request.get("params", {}))
 
-    def _handle_diag(self, op: str, params: dict) -> dict:
-        """Serve a `gda diag` op from the Session log this daemon owns (#224).
+    def _handle_log(self, op: str, params: dict) -> dict:
+        """Serve a daemon-side log op from the Session log this daemon owns (#224, #281).
 
         Reads the running game's captured errors/output from the ``--log-file``
-        the daemon launched the engine with. Crucially served even when the
-        session process has DIED — diag does NOT launch or relaunch a session (a
-        read-only diagnostic must not run the project's code, ADR-0009; a relaunch
-        would also truncate the log and lose the crash). It requires only that a
-        session was launched this daemon lifetime (ADR-0022): it reads the one the
-        daemon already holds, alive OR dead. With NO session launched this lifetime
-        it is ``engine_session_not_running`` — diag does not create one; the user
-        launches a session by running a live op (e.g. ``gda game tree``), not by
-        diag. With a remembered session whose log file is missing/unreadable it is
-        ``live_log_unavailable`` (an empty log is an empty result, not an error).
+        the daemon launched the engine with, for ``diag errors`` (structured engine
+        errors) and ``logger tail`` (the whole log as structured ``LogRecord``s, or
+        verbatim lines with ``--raw``). Crucially served even when the session
+        process has DIED — it does NOT launch or relaunch a session (a read-only
+        diagnostic must not run the project's code, ADR-0009; a relaunch would also
+        truncate the log and lose the crash). It requires only that a session was
+        launched this daemon lifetime (ADR-0022): it reads the one the daemon
+        already holds, alive OR dead. With NO session launched this lifetime it is
+        ``engine_session_not_running`` — the user launches a session by running a
+        live op (e.g. ``gda game tree``). With a remembered session whose log file
+        is missing/unreadable it is ``live_log_unavailable`` (an empty log is an
+        empty result, not an error).
         """
-        # Use the session the daemon already holds — never launch one here. diag is
+        # Use the session the daemon already holds — never launch one here. This is
         # a read-only observer of an already-launched session (ADR-0022); launching
         # would give it a hidden project-code-execution side effect (ADR-0009).
         session = self._session
@@ -147,9 +151,9 @@ class DaemonServer:
             return error_reply(
                 "engine_session_not_running",
                 "the gda-daemon holds no engine session to read runtime "
-                "diagnostics from; diag observes an already-launched session and "
+                "diagnostics from; it observes an already-launched session and "
                 "does not start one — launch a session first by running a live op "
-                "(e.g. `gda game tree`), then re-run diag",
+                "(e.g. `gda game tree`), then re-run the read",
             )
         try:
             raw = session.log_file.read_bytes()
@@ -162,7 +166,11 @@ class DaemonServer:
         limit = params.get("limit")
         if op == DIAG_ERRORS_OP:
             return result_reply({"errors": parse_errors(raw, limit=limit)})
-        return result_reply({"lines": parse_log(raw, limit=limit)})
+        # logger-tail: structured LogRecords by default; verbatim lines with --raw.
+        if params.get("raw"):
+            return result_reply({"records": [], "lines": parse_log(raw, limit=limit)})
+        records = parse_log_records(raw, level=params.get("level"), limit=limit)
+        return result_reply({"records": records, "lines": []})
 
     def _ensure_session(self) -> EngineSession | None:
         if self._session is not None and self._session.alive():

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -13,7 +13,7 @@ import secrets
 import signal
 import socket
 
-from gda.daemon.diag import parse_errors, parse_log, parse_log_records
+from gda.daemon.diag import parse_errors, parse_log_records
 from gda.daemon.discovery import DaemonPaths, acquire_pidfile, ensure_runtime_dir
 from gda.daemon.protocol import error_reply, read_message, result_reply, write_message
 from gda.daemon.session import EngineSession, launch_session
@@ -166,11 +166,12 @@ class DaemonServer:
         limit = params.get("limit")
         if op == DIAG_ERRORS_OP:
             return result_reply({"errors": parse_errors(raw, limit=limit)})
-        # logger-tail: structured LogRecords by default; verbatim lines with --raw.
-        if params.get("raw"):
-            return result_reply({"records": [], "lines": parse_log(raw, limit=limit)})
-        records = parse_log_records(raw, level=params.get("level"), limit=limit)
-        return result_reply({"records": records, "lines": []})
+        # logger-tail: the whole Session log as structured LogRecord[] (records-only
+        # result); `--raw` returns every line as a verbatim `info` record.
+        records = parse_log_records(
+            raw, level=params.get("level"), limit=limit, raw=bool(params.get("raw"))
+        )
+        return result_reply({"records": records})
 
     def _ensure_session(self) -> EngineSession | None:
         if self._session is not None and self._session.alive():

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -50,7 +50,6 @@ from gda.error_codes import (
 )
 from gda.models import (
     DiagErrorsResult,
-    DiagLogResult,
     EngineVersion,
     ExportRunMode,
     ExportRunResult,
@@ -62,6 +61,7 @@ from gda.models import (
     InputKeyResult,
     InputMouseResult,
     InputSequenceResult,
+    LoggerTailResult,
     OperationErrorEnvelope,
     PerfMonitorResult,
     PerfMonitorsResult,
@@ -463,9 +463,16 @@ def classify_diag_errors(result: RunResult, binary: Path) -> DiagErrorsResult | 
     return classify_live(result, binary, DiagErrorsResult)
 
 
-def classify_diag_log(result: RunResult, binary: Path) -> DiagLogResult | Failure:
-    """The per-command live classifier for ``gda diag log`` (mirrors ``classify_diag_errors``)."""
-    return classify_live(result, binary, DiagLogResult)
+def classify_logger_tail(result: RunResult, binary: Path) -> LoggerTailResult | Failure:
+    """The per-command live classifier for ``gda logger tail`` (#281; mirrors ``classify_diag_errors``).
+
+    ``logger tail`` is daemon-served (the daemon reads its own Session log,
+    ADR-0022/ADR-0026), but its reply rides the same ADR-0002 sentinel envelope as
+    any live op, so the live error codes (``daemon_not_running``,
+    ``engine_session_not_running``, ``live_log_unavailable``) flow through the
+    shared ``classify_live``.
+    """
+    return classify_live(result, binary, LoggerTailResult)
 
 
 def classify_perf_monitors(result: RunResult, binary: Path) -> PerfMonitorsResult | Failure:

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -2653,25 +2653,147 @@ class DiagErrorsResult(BaseModel):
     errors: list[DiagError]
 
 
-class DiagLogParams(BaseModel):
-    """The params of ``gda diag log``: read the running game's raw output log (#224).
+# The `logger` command group (Phase 2, ADR-0019, ADR-0026, #281): the running
+# game's STRUCTURED runtime-log stream, daemon-served from the Session log like
+# `diag` (`--log-file`, ADR-0022) and so crash-survivable. The passive,
+# non-invasive floor of the structured-log protocol — `diag log` (raw) is
+# SUPERSEDED by `gda logger tail`, whose default output is structured records.
 
-    ``limit`` tails the most recent N lines (constrained ``>= 1``); v1 returns the
-    current session's log with no incremental offset. Omitting ``limit`` returns
-    all lines.
+
+class SourceFrame(BaseModel):
+    """A source location ``{function, file, line}`` (ADR-0026).
+
+    A small, generic frame model: a function name, the source path it lives in,
+    and the line, each ``null`` when the source did not carry it. Used for a
+    :class:`LogRecord`'s ``source`` (the ``at:`` follow-on the engine logs after an
+    error); named generically because the error-callstack slice (#283) reuses it
+    for an error's call frames.
     """
 
+    function: str | None = Field(
+        default=None, description="The reporting function, or null when unknown."
+    )
+    file: str | None = Field(
+        default=None, description="The source path (e.g. res://main.gd), or null when unknown."
+    )
+    line: int | None = Field(default=None, description="The 1-based source line, or null when unknown.")
+
+
+class LogLevel(str, Enum):
+    """The closed, ordered severity of a :class:`LogRecord` (ADR-0026).
+
+    ``debug < info < warning < error`` — a TOTAL order, so ``--level <min>``
+    filtering is a well-defined ``>=`` contract (ADR-0004). The engine's finer
+    kinds collapse onto it (``WARNING`` -> ``warning``; ``ERROR`` / ``SCRIPT
+    ERROR`` / ``SHADER ERROR`` -> ``error``), with the sub-kind kept in
+    :class:`LogRecord.origin`.
+    """
+
+    DEBUG = "debug"
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+class LogOrigin(str, Enum):
+    """Where a typed :class:`LogRecord` came from — the sub-kind (ADR-0026).
+
+    Preserves the distinction the closed :class:`LogLevel` collapses: an engine
+    error vs a script error vs a shader error (all ``error`` level) vs an opt-in
+    ``gda_log()`` record (#282). ``null`` on a plain ``info`` line that carries no
+    engine/app origin.
+    """
+
+    ENGINE = "engine"
+    SCRIPT = "script"
+    SHADER = "shader"
+    GDA_LOG = "gda_log"
+
+
+class LogRecord(BaseModel):
+    """One structured record of the running game's runtime log (ADR-0026, #281).
+
+    The typed unit of the structured runtime-log channel, parsed from the
+    daemon-owned Session log. ``seq`` is a monotonic ordinal in capture order.
+    ``level`` is the closed, ordered :class:`LogLevel`. ``message`` is the logged
+    text. ``source`` is the ``{function, file, line}`` frame when the engine
+    recorded an ``at:`` location (engine errors/warnings), else ``null``.
+    ``origin`` names the sub-kind the closed level collapses (``engine`` /
+    ``script`` / ``shader`` / ``gda_log``), else ``null`` for a plain ``info``
+    line. ``fields`` is an app-supplied structured object — empty here (the passive
+    floor); populated only by the opt-in ``gda_log()`` protocol (#282).
+    """
+
+    seq: int = Field(description="Monotonic ordinal in capture order (0-based).")
+    level: LogLevel = Field(description="Closed, ordered severity: debug < info < warning < error.")
+    message: str = Field(description="The logged message text.")
+    source: SourceFrame | None = Field(
+        default=None,
+        description="The {function, file, line} location when known (engine errors), else null.",
+    )
+    origin: LogOrigin | None = Field(
+        default=None,
+        description=(
+            "The sub-kind the closed level collapses (engine / script / shader / "
+            "gda_log), or null for a plain info line."
+        ),
+    )
+    fields: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "App-supplied structured fields; empty for a passively-parsed record, "
+            "populated only by the opt-in gda_log() protocol (#282)."
+        ),
+    )
+
+
+class LoggerTailParams(BaseModel):
+    """The params of ``gda logger tail``: read the running game's structured log (#281).
+
+    Reads the current Engine session's captured log as structured records.
+    ``level`` filters by minimum severity over the closed ordering
+    ``debug < info < warning < error`` (e.g. ``warning`` excludes ``info`` /
+    ``debug``); omit for all severities. ``limit`` tails the most recent N records
+    (constrained ``>= 1``) AFTER the level filter; omit for all. ``raw`` returns
+    the verbatim log lines instead (the behaviour the superseded ``diag log``
+    returned), bypassing structuring.
+    """
+
+    level: LogLevel | None = Field(
+        default=None,
+        description=(
+            "If set, return only records at or above this minimum severity over the "
+            "closed ordering debug < info < warning < error. Omit for all."
+        ),
+    )
     limit: int | None = Field(default=None, ge=1, description=_DIAG_LIMIT_DESC)
+    raw: bool = Field(
+        default=False,
+        description=(
+            "If set, return the verbatim captured log lines instead of structured "
+            "records (the superseded `diag log` behaviour). `records` is then empty "
+            "and `lines` carries the raw lines."
+        ),
+    )
 
 
-class DiagLogResult(BaseModel):
-    """The result of ``gda diag log``: the running game's raw output lines (#224).
+class LoggerTailResult(BaseModel):
+    """The result of ``gda logger tail``: the running game's structured log (#281).
 
-    The full captured stream (print output AND error lines) verbatim, one entry
-    per line; an empty ``lines`` list is a successful empty read.
+    By default ``records`` carries the structured :class:`LogRecord`s (and
+    ``lines`` is empty). With ``--raw`` the channels swap: ``lines`` carries the
+    verbatim captured lines and ``records`` is empty. Either way an empty read is a
+    successful empty result, not an error.
     """
 
-    lines: list[str]
+    records: list[LogRecord] = Field(
+        default_factory=list,
+        description="The structured log records; empty when `--raw` was requested.",
+    )
+    lines: list[str] = Field(
+        default_factory=list,
+        description="The verbatim captured lines; populated only when `--raw` was requested.",
+    )
 
 
 # The per-window frame ceiling a time-windowed live op may request (#223). A

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -2754,9 +2754,9 @@ class LoggerTailParams(BaseModel):
     ``level`` filters by minimum severity over the closed ordering
     ``debug < info < warning < error`` (e.g. ``warning`` excludes ``info`` /
     ``debug``); omit for all severities. ``limit`` tails the most recent N records
-    (constrained ``>= 1``) AFTER the level filter; omit for all. ``raw`` returns
-    the verbatim log lines instead (the behaviour the superseded ``diag log``
-    returned), bypassing structuring.
+    (constrained ``>= 1``) AFTER the level filter; omit for all. ``raw`` skips
+    classification, returning every captured line as a verbatim ``info`` record
+    (the view the superseded ``diag log`` returned), still as ``LogRecord[]``.
     """
 
     level: LogLevel | None = Field(
@@ -2770,9 +2770,9 @@ class LoggerTailParams(BaseModel):
     raw: bool = Field(
         default=False,
         description=(
-            "If set, return the verbatim captured log lines instead of structured "
-            "records (the superseded `diag log` behaviour). `records` is then empty "
-            "and `lines` carries the raw lines."
+            "If set, skip classification: return every captured line as a verbatim "
+            "`info` record (the superseded `diag log` view), still as LogRecord[]. "
+            "Otherwise lines are classified into typed records."
         ),
     )
 
@@ -2780,19 +2780,19 @@ class LoggerTailParams(BaseModel):
 class LoggerTailResult(BaseModel):
     """The result of ``gda logger tail``: the running game's structured log (#281).
 
-    By default ``records`` carries the structured :class:`LogRecord`s (and
-    ``lines`` is empty). With ``--raw`` the channels swap: ``lines`` carries the
-    verbatim captured lines and ``records`` is empty. Either way an empty read is a
-    successful empty result, not an error.
+    ``records`` is the whole captured Session log as ``LogRecord[]`` — one record
+    per line: engine errors/warnings typed (their ``at:`` folded into ``source``),
+    every other line a plain ``info`` record (ADR-0026 decision 2, amended #281).
+    With ``--raw`` the same shape carries every line as an unclassified ``info``
+    record holding its verbatim text (the view the superseded ``diag log``
+    returned). It mirrors how ``diag errors`` delivers ``DiagError[]`` as
+    ``DiagErrorsResult.errors``. An empty read is a successful empty result, not an
+    error.
     """
 
     records: list[LogRecord] = Field(
         default_factory=list,
-        description="The structured log records; empty when `--raw` was requested.",
-    )
-    lines: list[str] = Field(
-        default_factory=list,
-        description="The verbatim captured lines; populated only when `--raw` was requested.",
+        description="The whole Session log as structured records (LogRecord[]).",
     )
 
 

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -215,14 +215,12 @@ def render_diag_errors(diag: "DiagErrorsResult") -> str:
 def render_logger_tail(tail: "LoggerTailResult") -> str:
     """Render the running game's structured runtime log (#281, ADR-0026).
 
-    Default: one ``LEVEL: message (at: loc)`` line per record, the location
-    appended when known (a plain info line omits it). With ``--raw`` the result
-    carries verbatim ``lines`` instead, rendered one per line (the superseded
-    ``diag log`` view). An empty read renders a short note rather than a blank
-    string, so the human output is never ambiguous.
+    One ``LEVEL: message (at: loc)`` line per record, the location appended when
+    known (a plain info line omits it). Under ``--raw`` records are unclassified
+    ``info`` lines carrying verbatim text, so they render as the message alone (the
+    superseded ``diag log`` view). An empty read renders a short note rather than a
+    blank string, so the human output is never ambiguous.
     """
-    if tail.lines:
-        return "\n".join(tail.lines)
     if not tail.records:
         return "no log records"
     lines = []

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
         DaemonStopResult,
         DaemonUninstallResult,
         DiagErrorsResult,
-        DiagLogResult,
         EngineVersion,
         ExportGetResult,
         ExportListResult,
@@ -45,6 +44,7 @@ if TYPE_CHECKING:
         InputKeyResult,
         InputMouseResult,
         InputSequenceResult,
+        LoggerTailResult,
         NodeAddResult,
         NodeConnectSignalResult,
         NodeDisconnectSignalResult,
@@ -212,11 +212,36 @@ def render_diag_errors(diag: "DiagErrorsResult") -> str:
     return "\n".join(lines)
 
 
-def render_diag_log(diag: "DiagLogResult") -> str:
-    """Render the running game's raw output log — its lines verbatim, one per line (#224)."""
-    if not diag.lines:
-        return "no output"
-    return "\n".join(diag.lines)
+def render_logger_tail(tail: "LoggerTailResult") -> str:
+    """Render the running game's structured runtime log (#281, ADR-0026).
+
+    Default: one ``LEVEL: message (at: loc)`` line per record, the location
+    appended when known (a plain info line omits it). With ``--raw`` the result
+    carries verbatim ``lines`` instead, rendered one per line (the superseded
+    ``diag log`` view). An empty read renders a short note rather than a blank
+    string, so the human output is never ambiguous.
+    """
+    if tail.lines:
+        return "\n".join(tail.lines)
+    if not tail.records:
+        return "no log records"
+    lines = []
+    for rec in tail.records:
+        line = f"{rec.level.value.upper()}: {rec.message}"
+        if rec.source is not None and rec.source.file is not None:
+            loc = (
+                f"{rec.source.file}:{rec.source.line}"
+                if rec.source.line is not None
+                else rec.source.file
+            )
+            at = (
+                f" (at: {rec.source.function} {loc})"
+                if rec.source.function
+                else f" (at: {loc})"
+            )
+            line += at
+        lines.append(line)
+    return "\n".join(lines)
 
 
 def render_perf_monitors(snapshot: "PerfMonitorsResult") -> str:

--- a/tests/support.py
+++ b/tests/support.py
@@ -489,7 +489,8 @@ DIAG_ERRORS_RESULT = {
 # daemon-served from the Session log (#281, ADR-0026). Shared by the
 # logger-command success/schema/render tests. The default carries typed
 # ``records`` (the closed level enum, sub-kind in ``origin``, ``source`` when
-# known, ``fields`` present-but-empty); ``--raw`` swaps to verbatim ``lines``.
+# known, ``fields`` present-but-empty); ``--raw`` is the SAME ``records`` shape
+# with every line an unclassified ``info`` record (verbatim message).
 LOGGER_TAIL_RESULT = {
     "records": [
         {
@@ -517,16 +518,20 @@ LOGGER_TAIL_RESULT = {
             "fields": {},
         },
     ],
-    "lines": [],
 }
 
+# ``--raw``: the same ``records`` shape, every line an unclassified ``info`` record
+# carrying its verbatim text (even an ``ERROR:`` header stays a plain info line).
 LOGGER_TAIL_RAW_RESULT = {
-    "records": [],
-    "lines": [
-        "known line",
-        "ERROR: boom",
-        "   at: _ready (res://main.gd:9)",
-        "another line",
+    "records": [
+        {"seq": 0, "level": "info", "message": "known line",
+         "source": None, "origin": None, "fields": {}},
+        {"seq": 1, "level": "info", "message": "ERROR: boom",
+         "source": None, "origin": None, "fields": {}},
+        {"seq": 2, "level": "info", "message": "   at: _ready (res://main.gd:9)",
+         "source": None, "origin": None, "fields": {}},
+        {"seq": 3, "level": "info", "message": "another line",
+         "source": None, "origin": None, "fields": {}},
     ],
 }
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -454,10 +454,11 @@ GAME_SET_RESULT = {
     "value": [10.0, 20.0],
 }
 
-# Sample ``gda diag errors`` / ``gda diag log`` results — the running game's
-# runtime diagnostics, daemon-served from the Session log (#224). Shared by the
-# diag-command success/schema/render tests. ``errors`` carries warnings too,
-# distinguished by ``level``; a bare error may omit the location fields.
+# Sample ``gda diag errors`` result — the running game's runtime errors,
+# daemon-served from the Session log (#224). Shared by the diag-command
+# success/schema/render tests. ``errors`` carries warnings too, distinguished by
+# ``level``; a bare error may omit the location fields. (The raw ``diag log`` is
+# superseded by ``gda logger tail`` — see ``LOGGER_TAIL_RAW_RESULT``, #281.)
 DIAG_ERRORS_RESULT = {
     "errors": [
         {
@@ -484,13 +485,49 @@ DIAG_ERRORS_RESULT = {
     ]
 }
 
-DIAG_LOG_RESULT = {
+# Sample ``gda logger tail`` results — the running game's STRUCTURED runtime log,
+# daemon-served from the Session log (#281, ADR-0026). Shared by the
+# logger-command success/schema/render tests. The default carries typed
+# ``records`` (the closed level enum, sub-kind in ``origin``, ``source`` when
+# known, ``fields`` present-but-empty); ``--raw`` swaps to verbatim ``lines``.
+LOGGER_TAIL_RESULT = {
+    "records": [
+        {
+            "seq": 0,
+            "level": "info",
+            "message": "known line",
+            "source": None,
+            "origin": None,
+            "fields": {},
+        },
+        {
+            "seq": 1,
+            "level": "error",
+            "message": "boom",
+            "source": {"function": "_ready", "file": "res://main.gd", "line": 9},
+            "origin": "engine",
+            "fields": {},
+        },
+        {
+            "seq": 2,
+            "level": "warning",
+            "message": "careful",
+            "source": {"function": "_process", "file": "res://main.gd", "line": 20},
+            "origin": "engine",
+            "fields": {},
+        },
+    ],
+    "lines": [],
+}
+
+LOGGER_TAIL_RAW_RESULT = {
+    "records": [],
     "lines": [
         "known line",
         "ERROR: boom",
         "   at: _ready (res://main.gd:9)",
         "another line",
-    ]
+    ],
 }
 
 # Sample ``gda perf monitors`` / ``gda perf monitor`` results — the running game's

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -3,10 +3,11 @@
 In-process, engine-free. ``diag`` is a daemon-served live op (ADR: runtime-
 diagnostics-via-daemon-owned-session-log): the daemon launches the Engine session
 with ``--log-file <session path>``, remembers that path, and serves ``diag-errors``
-/ ``diag-log`` by reading the file directly — NOT by relaying to the harness, and
-even after the session process has died (so a crash stays diagnosable). These
-tests exercise the launch argv, the remembered path, and the daemon's ``_handle``
-read path against a temp log file.
+by reading the file directly — NOT by relaying to the harness, and even after the
+session process has died (so a crash stays diagnosable). These tests exercise the
+launch argv, the remembered path, and the daemon's ``_handle`` read path against a
+temp log file. (The raw ``diag-log`` op is superseded by ``logger-tail`` — see
+``test_daemon_logger.py``, #281.)
 """
 
 import os

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -115,17 +115,6 @@ def test_diag_errors_reads_structured_errors_from_the_log(tmp_path):
     assert payload["errors"][0]["line"] == 9
 
 
-def test_diag_log_reads_raw_lines_from_the_log(tmp_path):
-    log_file = tmp_path / "session.log"
-    log_file.write_text("known line\nERROR: boom\n", encoding="utf-8")
-    server = _server_with_session(tmp_path, log_file)
-
-    reply = server._handle({"op": "diag-log", "params": {}})
-    payload = parse_result(reply["stdout"])
-
-    assert "known line" in payload["lines"]
-
-
 def test_diag_errors_limit_tails_the_most_recent_n(tmp_path):
     log_file = tmp_path / "session.log"
     log_file.write_text(
@@ -160,19 +149,17 @@ def test_diag_empty_log_is_an_empty_result_not_an_error(tmp_path):
     server = _server_with_session(tmp_path, log_file)
 
     errors_reply = server._handle({"op": "diag-errors", "params": {}})
-    log_reply = server._handle({"op": "diag-log", "params": {}})
 
     assert parse_result(errors_reply["stdout"])["errors"] == []
-    assert parse_result(log_reply["stdout"])["lines"] == []
 
 
-@pytest.mark.parametrize("op", ["diag-errors", "diag-log"])
-def test_diag_with_no_session_launched_is_engine_session_not_running(monkeypatch, tmp_path, op):
+def test_diag_with_no_session_launched_is_engine_session_not_running(monkeypatch, tmp_path):
     # ADR-0022: diag observes an already-launched session; it does NOT launch one.
-    # With NO session launched this daemon lifetime, BOTH diag ops return a
-    # structured `engine_session_not_running` (exit 6) — and crucially diag must
-    # NOT spawn an engine session as a side effect, even with a Godot binary set
-    # (that hidden project-code-execution side effect is the bug under ADR-0009).
+    # With NO session launched this daemon lifetime, diag-errors returns a
+    # structured `engine_session_not_running` (exit 6) — and crucially it must NOT
+    # spawn an engine session as a side effect, even with a Godot binary set (that
+    # hidden project-code-execution side effect is the bug under ADR-0009).
+    op = "diag-errors"
     server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
 
     # Trip-wire: if diag tries to launch a session, fail loudly.

--- a/tests/test_daemon_logger.py
+++ b/tests/test_daemon_logger.py
@@ -56,11 +56,11 @@ def test_logger_tail_reads_structured_records_from_the_log(tmp_path):
     assert err["message"] == "boom"
     assert err["origin"] == "engine"
     assert err["source"] == {"function": "_ready", "file": "res://main.gd", "line": 9}
-    # Default is structured: the raw `lines` channel is empty.
-    assert payload["lines"] == []
 
 
-def test_logger_tail_raw_returns_verbatim_lines(tmp_path):
+def test_logger_tail_raw_returns_verbatim_info_records(tmp_path):
+    # --raw skips classification: every line is a verbatim `info` record (still
+    # LogRecord[]), so even an `ERROR:` header stays an unclassified info line.
     log_file = tmp_path / "session.log"
     log_file.write_text("known line\nERROR: boom\n", encoding="utf-8")
     server = _server_with_session(tmp_path, log_file)
@@ -68,8 +68,9 @@ def test_logger_tail_raw_returns_verbatim_lines(tmp_path):
     reply = server._handle({"op": "logger-tail", "params": {"raw": True}})
     payload = parse_result(reply["stdout"])
 
-    assert "known line" in payload["lines"]
-    assert payload["records"] == []
+    messages = [r["message"] for r in payload["records"]]
+    assert messages == ["known line", "ERROR: boom"]
+    assert all(r["level"] == "info" and r["source"] is None for r in payload["records"])
 
 
 def test_logger_tail_level_filters_by_minimum_severity(tmp_path):
@@ -124,7 +125,6 @@ def test_logger_tail_empty_log_is_an_empty_result_not_an_error(tmp_path):
     payload = parse_result(reply["stdout"])
 
     assert payload["records"] == []
-    assert payload["lines"] == []
 
 
 def test_logger_tail_with_no_session_is_engine_session_not_running(tmp_path):

--- a/tests/test_daemon_logger.py
+++ b/tests/test_daemon_logger.py
@@ -1,0 +1,147 @@
+"""Daemon-side `logger-tail` serving from the daemon-owned Session log (#281).
+
+In-process, engine-free. Like ``diag``, ``logger-tail`` is a daemon-served live op
+(ADR-0022, ADR-0026): the daemon serves it by reading the ``--log-file`` it
+launched the engine with — NOT by relaying to the harness, and even after the
+session process has died (so a crash stays diagnosable). These tests exercise the
+daemon's ``_handle`` read path for the structured + raw channels against a temp
+log file, plus the same no-session / missing-file typed errors ``diag`` returns.
+"""
+
+import os
+
+import pytest
+
+from gda.daemon.discovery import daemon_paths
+from gda.daemon.server import DaemonServer
+from gda.daemon.session import EngineSession
+from gda.parser import parse_result
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+
+class _FakeProc:
+    def __init__(self, returncode=None):
+        self.returncode = returncode
+
+    def poll(self):
+        return self.returncode
+
+
+def _project(tmp_path):
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return tmp_path
+
+
+def _server_with_session(tmp_path, log_file, alive=True):
+    server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
+    server._session = EngineSession(_FakeProc(None if alive else 0), conn=None, log_file=log_file)
+    return server
+
+
+def test_logger_tail_reads_structured_records_from_the_log(tmp_path):
+    log_file = tmp_path / "session.log"
+    log_file.write_text(
+        "print output\nERROR: boom\n   at: _ready (res://main.gd:9)\n", encoding="utf-8"
+    )
+    server = _server_with_session(tmp_path, log_file)
+
+    reply = server._handle({"op": "logger-tail", "params": {}})
+    payload = parse_result(reply["stdout"])
+
+    records = payload["records"]
+    assert records[0]["level"] == "info"
+    assert records[0]["message"] == "print output"
+    err = next(r for r in records if r["level"] == "error")
+    assert err["message"] == "boom"
+    assert err["origin"] == "engine"
+    assert err["source"] == {"function": "_ready", "file": "res://main.gd", "line": 9}
+    # Default is structured: the raw `lines` channel is empty.
+    assert payload["lines"] == []
+
+
+def test_logger_tail_raw_returns_verbatim_lines(tmp_path):
+    log_file = tmp_path / "session.log"
+    log_file.write_text("known line\nERROR: boom\n", encoding="utf-8")
+    server = _server_with_session(tmp_path, log_file)
+
+    reply = server._handle({"op": "logger-tail", "params": {"raw": True}})
+    payload = parse_result(reply["stdout"])
+
+    assert "known line" in payload["lines"]
+    assert payload["records"] == []
+
+
+def test_logger_tail_level_filters_by_minimum_severity(tmp_path):
+    log_file = tmp_path / "session.log"
+    log_file.write_text(
+        "plain output\nWARNING: heads up\n   at: f (res://a.gd:1)\n"
+        "ERROR: boom\n   at: g (res://b.gd:2)\n",
+        encoding="utf-8",
+    )
+    server = _server_with_session(tmp_path, log_file)
+
+    reply = server._handle({"op": "logger-tail", "params": {"level": "warning"}})
+    payload = parse_result(reply["stdout"])
+
+    levels = {r["level"] for r in payload["records"]}
+    assert "info" not in levels  # the plain output line is filtered out
+    assert levels == {"warning", "error"}
+
+
+def test_logger_tail_limit_tails_the_most_recent_n(tmp_path):
+    log_file = tmp_path / "session.log"
+    log_file.write_text("one\ntwo\nthree\n", encoding="utf-8")
+    server = _server_with_session(tmp_path, log_file)
+
+    reply = server._handle({"op": "logger-tail", "params": {"limit": 1}})
+    payload = parse_result(reply["stdout"])
+
+    assert len(payload["records"]) == 1
+    assert payload["records"][0]["message"] == "three"
+
+
+def test_logger_tail_serves_even_when_the_session_process_has_died(tmp_path):
+    # A crash is diagnosable: the daemon serves logger-tail from the remembered log
+    # file even after the session process has exited (ADR-0022 rationale).
+    log_file = tmp_path / "session.log"
+    log_file.write_text("ERROR: crashed\n   at: _ready (res://main.gd:3)\n", encoding="utf-8")
+    server = _server_with_session(tmp_path, log_file, alive=False)
+
+    reply = server._handle({"op": "logger-tail", "params": {}})
+    payload = parse_result(reply["stdout"])
+
+    crashed = next(r for r in payload["records"] if "crashed" in r["message"])
+    assert crashed["level"] == "error"
+
+
+def test_logger_tail_empty_log_is_an_empty_result_not_an_error(tmp_path):
+    log_file = tmp_path / "session.log"
+    log_file.write_text("", encoding="utf-8")
+    server = _server_with_session(tmp_path, log_file)
+
+    reply = server._handle({"op": "logger-tail", "params": {}})
+    payload = parse_result(reply["stdout"])
+
+    assert payload["records"] == []
+    assert payload["lines"] == []
+
+
+def test_logger_tail_with_no_session_is_engine_session_not_running(tmp_path):
+    # ADR-0022: a daemon-served log op observes an already-launched session; it does
+    # NOT launch one. With none launched this lifetime it is a structured error.
+    server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
+
+    reply = server._handle({"op": "logger-tail", "params": {}})
+
+    assert parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    assert server._session is None
+
+
+def test_logger_tail_with_a_remembered_session_but_missing_file_is_live_log_unavailable(tmp_path):
+    log_file = tmp_path / "missing.log"  # never created
+    server = _server_with_session(tmp_path, log_file, alive=False)
+
+    reply = server._handle({"op": "logger-tail", "params": {}})
+
+    assert parse_result(reply["stdout"])["error"]["code"] == "live_log_unavailable"

--- a/tests/test_diag_commands.py
+++ b/tests/test_diag_commands.py
@@ -17,7 +17,6 @@ from gda.exit_codes import EXIT_LIVE
 from gda.runner import RunResult
 from tests.support import (
     DIAG_ERRORS_RESULT,
-    DIAG_LOG_RESULT,
     error_sentinel,
     inject_live_runner,
     sentinel,
@@ -73,30 +72,6 @@ def test_diag_errors_rejects_a_non_positive_limit_on_the_argv_path(tmp_path):
         assert result.exit_code == 2, (bad, result.stdout + result.stderr)
 
 
-def test_diag_log_rejects_a_non_positive_limit_on_the_argv_path(tmp_path):
-    for bad in ("0", "-1"):
-        result = CliRunner().invoke(
-            app, ["diag", "log", "--limit", bad, "--project", str(_project(tmp_path)), "--json"]
-        )
-        assert result.exit_code == 2, (bad, result.stdout + result.stderr)
-
-
-def test_diag_log_emits_raw_lines_json_through_the_live_channel(monkeypatch, tmp_path):
-    fake = inject_live_runner(
-        monkeypatch,
-        RunResult(stdout=sentinel(DIAG_LOG_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["diag", "log", "--project", str(_project(tmp_path)), "--json"]
-    )
-
-    assert result.exit_code == 0, result.stdout + result.stderr
-    data = json.loads(result.stdout)
-    assert "known line" in data["lines"]
-    assert fake.calls == [("diag-log", {"limit": None})]
-
-
 def test_diag_errors_human_output_renders_levels(monkeypatch, tmp_path):
     inject_live_runner(
         monkeypatch,
@@ -109,18 +84,6 @@ def test_diag_errors_human_output_renders_levels(monkeypatch, tmp_path):
     # Human output names the level and message; the location is shown when present.
     assert "boom" in result.stdout
     assert "res://main.gd:9" in result.stdout
-
-
-def test_diag_log_human_output_renders_lines(monkeypatch, tmp_path):
-    inject_live_runner(
-        monkeypatch,
-        RunResult(stdout=sentinel(DIAG_LOG_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(app, ["diag", "log", "--project", str(_project(tmp_path))])
-
-    assert result.exit_code == 0, result.stdout + result.stderr
-    assert "known line" in result.stdout
 
 
 def test_diag_errors_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):
@@ -160,20 +123,19 @@ def test_diag_errors_log_unavailable_is_a_typed_live_error(monkeypatch, tmp_path
 
 
 def test_diag_params_json_rejects_a_non_positive_limit_as_invalid_params(monkeypatch, tmp_path):
-    # The `ge=1` bound on DiagErrorsParams / DiagLogParams: a zero/negative limit
-    # via --params-json is a structured `invalid_params` (reflected in --schema),
-    # not a silent "no limit". No dispatch happens — the model validation fails
-    # first, so no live runner is needed.
-    for op, key in (("errors", "errors"), ("log", "log")):  # both diag ops
-        for bad in (0, -1):
-            result = CliRunner().invoke(
-                app,
-                ["diag", op, "--params-json", json.dumps({"limit": bad}),
-                 "--project", str(_project(tmp_path)), "--json"],
-            )
-            assert result.exit_code != 0, (op, bad, result.stdout + result.stderr)
-            err = json.loads(result.stdout)["error"]
-            assert err["code"] == "invalid_params", (op, bad, err)
+    # The `ge=1` bound on DiagErrorsParams: a zero/negative limit via --params-json
+    # is a structured `invalid_params` (reflected in --schema), not a silent "no
+    # limit". No dispatch happens — model validation fails first, so no live runner
+    # is needed.
+    for bad in (0, -1):
+        result = CliRunner().invoke(
+            app,
+            ["diag", "errors", "--params-json", json.dumps({"limit": bad}),
+             "--project", str(_project(tmp_path)), "--json"],
+        )
+        assert result.exit_code != 0, (bad, result.stdout + result.stderr)
+        err = json.loads(result.stdout)["error"]
+        assert err["code"] == "invalid_params", (bad, err)
 
 
 def test_diag_errors_schema_reflects_the_limit_lower_bound():
@@ -193,14 +155,5 @@ def test_diag_errors_schema_is_self_describing_and_live():
     assert result.exit_code == 0, result.stdout + result.stderr
     schema = json.loads(result.stdout)
     # Self-describes its input/output contract and its LIVE execution kind.
-    assert "input" in schema and "output" in schema
-    assert schema["kind"] == "live"
-
-
-def test_diag_log_schema_is_self_describing_and_live():
-    result = CliRunner().invoke(app, ["diag", "log", "--schema"])
-
-    assert result.exit_code == 0, result.stdout + result.stderr
-    schema = json.loads(result.stdout)
     assert "input" in schema and "output" in schema
     assert schema["kind"] == "live"

--- a/tests/test_e2e_diag.py
+++ b/tests/test_e2e_diag.py
@@ -3,12 +3,13 @@
 The #224 DoD: a real `gda daemon start` -> a NON-diag live op (`gda game tree`)
 LAUNCHES the engine session (the daemon spawns it with `--log-file`, its own
 Session log) and blocks until the main scene is current, so the scene's `_ready`
-(which `push_error`s and `print`s a KNOWN marker) has run and flushed -> THEN
-`gda diag errors` reads the error back STRUCTURED (with a normalized `level`) and
-`gda diag log` reads the printed line back. diag OBSERVES the already-launched
-session; it does NOT create one (ADR-0022). Daemon-served: the diag read works
-against the daemon-owned log even though `project_godot` disables the project's
-own file logging — the daemon's `--log-file` forces logging on regardless.
+(which `push_error`s a KNOWN marker) has run and flushed -> THEN `gda diag errors`
+reads the error back STRUCTURED (with a normalized `level`). diag OBSERVES the
+already-launched session; it does NOT create one (ADR-0022). Daemon-served: the
+diag read works against the daemon-owned log even though `project_godot` disables
+the project's own file logging — the daemon's `--log-file` forces logging on
+regardless. (The raw output-log read-back moved to `gda logger tail` — see
+`test_e2e_logger.py`, #281.)
 
 Run e2e serially; not a fresh empty HOME (Godot first-run). The
 `daemon_runtime_dir` fixture keeps the daemon's UDS path within the OS `sun_path`
@@ -113,9 +114,5 @@ def test_diag_reads_back_a_known_runtime_error_and_log_line(tmp_path, daemon_run
         assert known, error_docs
         # push_error surfaces as an error-class diagnostic (ERROR / SCRIPT ERROR).
         assert known[0]["level"] in ("error", "script_error"), known[0]
-
-        # diag log: the SAME session's captured output stream carries the print line.
-        lines = poll_diag("log", "lines", "known line")
-        assert any("known line" in line for line in lines), lines
     finally:
         run("daemon", "stop")

--- a/tests/test_e2e_logger.py
+++ b/tests/test_e2e_logger.py
@@ -88,8 +88,8 @@ def test_logger_tail_reads_back_structured_records_and_raw_lines(tmp_path, daemo
             proc = run("logger", "tail", *extra_args)
             assert proc.returncode == 0, proc.stdout + proc.stderr
             doc = json.loads(proc.stdout)
-            last = doc["records"] or doc["lines"]
-            texts = [r["message"] if isinstance(r, dict) else r for r in last]
+            last = doc["records"]
+            texts = [r["message"] for r in last]
             if any(needle in t for t in texts):
                 return last
             time.sleep(1.0)
@@ -133,11 +133,14 @@ def test_logger_tail_reads_back_structured_records_and_raw_lines(tmp_path, daemo
         assert errors_only, "expected the error to survive --level error"
         assert all(r["level"] == "error" for r in errors_only)
 
-        # `--raw` returns the same content as verbatim lines (the superseded
-        # `diag log` view): the print line and the ERROR header are present.
-        raw_lines = poll_records(["--raw"], "known line")
-        assert any("known line" in line for line in raw_lines), raw_lines
-        assert any("known error" in line for line in raw_lines), raw_lines
+        # `--raw` returns the same content as verbatim, unclassified `info` records
+        # (the superseded `diag log` view, now LogRecord[]): the print line and the
+        # ERROR header are both present, both as plain info records.
+        raw_records = poll_records(["--raw"], "known line")
+        raw_messages = [r["message"] for r in raw_records]
+        assert any("known line" in m for m in raw_messages), raw_records
+        assert any("known error" in m for m in raw_messages), raw_records
+        assert all(r["level"] == "info" for r in raw_records)
 
         # The structured read survives after the session ends: stop the daemon's
         # session implicitly is not exposed, but the persisted log is still served

--- a/tests/test_e2e_logger.py
+++ b/tests/test_e2e_logger.py
@@ -1,0 +1,151 @@
+"""S1 (e2e): `gda logger tail` reads a running game's real structured log (#281).
+
+The #281 DoD: a real `gda daemon start` -> a NON-diag live op (`gda game tree`)
+LAUNCHES the engine session (the daemon spawns it with `--log-file`, its own
+Session log) and blocks until the main scene is current, so the scene's `_ready`
+(which `print`s a KNOWN line, `push_warning`s a KNOWN warning, and `push_error`s a
+KNOWN error) has run and flushed -> THEN `gda logger tail --json` reads them back
+as STRUCTURED `LogRecord`s (the print as an `info` record, the push_warning as a
+`warning`, the push_error as an `error` carrying an engine `source`), and
+`gda logger tail --raw` reads the same content back as verbatim lines. `logger
+tail` OBSERVES the already-launched session; it does NOT create one (ADR-0022).
+Daemon-served: the read works against the daemon-owned log even though
+`project_godot` disables the project's own file logging — the daemon's
+`--log-file` forces logging on regardless. The structured read survives after the
+session ends (the persisted log, ADR-0022).
+
+Run e2e serially; not a fresh empty HOME (Godot first-run). The
+`daemon_runtime_dir` fixture keeps the daemon's UDS path within the OS `sun_path`
+limit. NOTE: this module is the DoD and is NOT run by the implementing slice — a
+sibling worktree runs a real Godot concurrently, so the main agent runs all e2e
+serially in review.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import time
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+from .conftest import project_godot
+
+GODOT = resolve_godot_binary()
+
+# A main scene whose root script emits a KNOWN print line, a KNOWN warning, and a
+# KNOWN error at `_ready`, so the daemon's Session log captures all three for
+# `logger tail` to read back structured. print -> a plain `info` record;
+# push_warning -> a `warning` record (engine WARNING + `at:` line); push_error ->
+# an `error` record (engine ERROR + `at:` line, carrying a source frame).
+MAIN_GD = """\
+extends Node2D
+
+func _ready() -> void:
+	print("known line")
+	push_warning("known warning")
+	push_error("known error")
+"""
+
+MAIN_TSCN = (
+    "[gd_scene load_steps=2 format=3]\n\n"
+    '[ext_resource type="Script" path="res://main.gd" id="1"]\n\n'
+    '[node name="Main" type="Node2D"]\n'
+    'script = ExtResource("1")\n'
+)
+PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+
+@pytest.mark.e2e
+def test_logger_tail_reads_back_structured_records_and_raw_lines(tmp_path, daemon_runtime_dir):
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "main.gd").write_text(MAIN_GD, encoding="utf-8")
+
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    def poll_records(extra_args, needle, timeout=15.0):
+        # The session is already launched + warmed by `game tree`; this short poll
+        # is a belt-and-suspenders for the log flush, NOT for launching the session.
+        deadline = time.monotonic() + timeout
+        last = []
+        while time.monotonic() < deadline:
+            proc = run("logger", "tail", *extra_args)
+            assert proc.returncode == 0, proc.stdout + proc.stderr
+            doc = json.loads(proc.stdout)
+            last = doc["records"] or doc["lines"]
+            texts = [r["message"] if isinstance(r, dict) else r for r in last]
+            if any(needle in t for t in texts):
+                return last
+            time.sleep(1.0)
+        return last
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        # Launch + warm the session with a NON-logger live op. `game tree` blocks
+        # until the main scene is current, so the game's `_ready` has printed /
+        # push_warned / push_errored the known markers into the daemon's --log-file
+        # by the time this returns.
+        tree = run("game", "tree")
+        assert tree.returncode == 0, tree.stdout + tree.stderr
+
+        # Default: structured records. The known print is a plain `info` record.
+        records = poll_records([], "known line")
+        info = [r for r in records if "known line" in r["message"]]
+        assert info, records
+        assert info[0]["level"] == "info"
+        assert info[0]["origin"] is None
+
+        # The push_error is an `error` record carrying an engine source frame.
+        records = poll_records([], "known error")
+        errors = [r for r in records if "known error" in r["message"]]
+        assert errors, records
+        assert errors[0]["level"] == "error"
+        assert errors[0]["origin"] in ("engine", "script")
+        assert errors[0]["source"] is not None
+        assert errors[0]["source"]["file"]  # res://main.gd, when the engine logged it
+
+        # The push_warning is a `warning` record (told apart from the error by level).
+        records = poll_records([], "known warning")
+        warnings = [r for r in records if "known warning" in r["message"]]
+        assert warnings, records
+        assert warnings[0]["level"] == "warning"
+
+        # `--level error` filters out the info + warning records, keeping the error.
+        errors_only = poll_records(["--level", "error"], "known error")
+        assert errors_only, "expected the error to survive --level error"
+        assert all(r["level"] == "error" for r in errors_only)
+
+        # `--raw` returns the same content as verbatim lines (the superseded
+        # `diag log` view): the print line and the ERROR header are present.
+        raw_lines = poll_records(["--raw"], "known line")
+        assert any("known line" in line for line in raw_lines), raw_lines
+        assert any("known error" in line for line in raw_lines), raw_lines
+
+        # The structured read survives after the session ends: stop the daemon's
+        # session implicitly is not exposed, but the persisted log is still served
+        # while the daemon lives — re-read once more to assert idempotent crash-
+        # survivable behaviour (ADR-0022): the records are still there.
+        again = run("logger", "tail")
+        assert again.returncode == 0, again.stdout + again.stderr
+        again_records = json.loads(again.stdout)["records"]
+        assert any("known error" in r["message"] for r in again_records), again_records
+    finally:
+        run("daemon", "stop")

--- a/tests/test_logger_commands.py
+++ b/tests/test_logger_commands.py
@@ -1,0 +1,193 @@
+"""`gda logger tail` — the running game's STRUCTURED runtime log, served LIVE (#281).
+
+Engine-free: a fake daemon runner at the LIVE seam exercises the full
+Typer -> classify_live -> JSON pipeline, and the no-daemon attach-or-fail path
+runs the real ``DaemonRunner`` against an empty runtime dir. The real-engine
+read-back is the e2e. Like ``diag``, ``logger tail`` is a daemon-served live op
+(the daemon reads its own Session log), but from the CLI's side it is an ordinary
+``kind = LIVE`` command — same routing as ``game``.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.exit_codes import EXIT_LIVE
+from gda.runner import RunResult
+from tests.support import (
+    LOGGER_TAIL_RAW_RESULT,
+    LOGGER_TAIL_RESULT,
+    error_sentinel,
+    inject_live_runner,
+    sentinel,
+)
+
+
+def _project(tmp_path):
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_logger_tail_emits_structured_records_json_through_the_live_channel(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(LOGGER_TAIL_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app, ["logger", "tail", "--project", str(_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["records"][0]["level"] == "info"
+    assert data["records"][1]["level"] == "error"
+    assert data["records"][1]["origin"] == "engine"
+    assert data["records"][1]["source"]["file"] == "res://main.gd"
+    # Routed through the LIVE seam, dispatching the logger-tail op (no filters).
+    assert fake.calls == [("logger-tail", {"level": None, "limit": None, "raw": False})]
+
+
+def test_logger_tail_passes_level_and_limit_through(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(LOGGER_TAIL_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["logger", "tail", "--level", "warning", "--limit", "5",
+         "--project", str(_project(tmp_path)), "--json"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert fake.calls == [("logger-tail", {"level": "warning", "limit": 5, "raw": False})]
+
+
+def test_logger_tail_raw_passes_raw_flag_and_returns_verbatim_lines(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(LOGGER_TAIL_RAW_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app, ["logger", "tail", "--raw", "--project", str(_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert "known line" in data["lines"]
+    assert data["records"] == []
+    assert fake.calls == [("logger-tail", {"level": None, "limit": None, "raw": True})]
+
+
+def test_logger_tail_rejects_a_non_positive_limit_on_the_argv_path(tmp_path):
+    # `--limit` is bound to >= 1 (Click min): a zero/negative limit is a usage
+    # error, not a silently-accepted "no limit". No live runner needed.
+    for bad in ("0", "-1"):
+        result = CliRunner().invoke(
+            app, ["logger", "tail", "--limit", bad, "--project", str(_project(tmp_path)), "--json"]
+        )
+        assert result.exit_code == 2, (bad, result.stdout + result.stderr)
+
+
+def test_logger_tail_rejects_an_unknown_level_on_the_argv_path(tmp_path):
+    # `--level` is the closed enum; an out-of-set value is a usage error.
+    result = CliRunner().invoke(
+        app, ["logger", "tail", "--level", "trace", "--project", str(_project(tmp_path)), "--json"]
+    )
+    assert result.exit_code == 2, result.stdout + result.stderr
+
+
+def test_logger_tail_human_output_renders_records(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(LOGGER_TAIL_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(app, ["logger", "tail", "--project", str(_project(tmp_path))])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    # Human output names the level and message; the location is shown when present.
+    assert "known line" in result.stdout
+    assert "boom" in result.stdout
+    assert "res://main.gd:9" in result.stdout
+
+
+def test_logger_tail_raw_human_output_renders_lines(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(LOGGER_TAIL_RAW_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(app, ["logger", "tail", "--raw", "--project", str(_project(tmp_path))])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "known line" in result.stdout
+
+
+def test_logger_tail_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):
+    # No fake: the real DaemonRunner + discovery run against an empty runtime dir.
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
+
+    result = CliRunner().invoke(
+        app, ["logger", "tail", "--project", str(_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "daemon_not_running"
+    assert error["category"] == "live"
+
+
+def test_logger_tail_log_unavailable_is_a_typed_live_error(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("live_log_unavailable", "log missing"),
+            stderr="",
+            exit_code=EXIT_LIVE,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app, ["logger", "tail", "--project", str(_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "live_log_unavailable"
+    assert error["category"] == "live"
+
+
+def test_logger_tail_params_json_rejects_a_non_positive_limit_as_invalid_params(monkeypatch, tmp_path):
+    for bad in (0, -1):
+        result = CliRunner().invoke(
+            app,
+            ["logger", "tail", "--params-json", json.dumps({"limit": bad}),
+             "--project", str(_project(tmp_path)), "--json"],
+        )
+        assert result.exit_code != 0, (bad, result.stdout + result.stderr)
+        err = json.loads(result.stdout)["error"]
+        assert err["code"] == "invalid_params", (bad, err)
+
+
+def test_logger_tail_schema_reflects_the_limit_lower_bound_and_is_live():
+    result = CliRunner().invoke(app, ["logger", "tail", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    schema = json.loads(result.stdout)
+    assert schema["kind"] == "live"
+    assert "input" in schema and "output" in schema
+    limit_schema = schema["input"]["properties"]["limit"]
+    minimums = [sub.get("minimum") for sub in limit_schema.get("anyOf", [limit_schema])]
+    assert 1 in minimums, limit_schema
+
+
+def test_diag_log_is_gone_superseded_by_logger_tail():
+    # The raw `diag log` is SUPERSEDED by `gda logger tail --raw` (ADR-0026): it is
+    # no longer a command. `diag errors` remains.
+    result = CliRunner().invoke(app, ["diag", "log", "--schema"])
+    assert result.exit_code != 0, result.stdout
+    assert CliRunner().invoke(app, ["diag", "errors", "--schema"]).exit_code == 0

--- a/tests/test_logger_commands.py
+++ b/tests/test_logger_commands.py
@@ -65,7 +65,7 @@ def test_logger_tail_passes_level_and_limit_through(monkeypatch, tmp_path):
     assert fake.calls == [("logger-tail", {"level": "warning", "limit": 5, "raw": False})]
 
 
-def test_logger_tail_raw_passes_raw_flag_and_returns_verbatim_lines(monkeypatch, tmp_path):
+def test_logger_tail_raw_passes_raw_flag_and_returns_verbatim_info_records(monkeypatch, tmp_path):
     fake = inject_live_runner(
         monkeypatch,
         RunResult(stdout=sentinel(LOGGER_TAIL_RAW_RESULT), stderr="", exit_code=0),
@@ -77,8 +77,12 @@ def test_logger_tail_raw_passes_raw_flag_and_returns_verbatim_lines(monkeypatch,
 
     assert result.exit_code == 0, result.stdout + result.stderr
     data = json.loads(result.stdout)
-    assert "known line" in data["lines"]
-    assert data["records"] == []
+    # --raw returns LogRecord[] too: every line a verbatim, unclassified info record.
+    assert "lines" not in data
+    messages = [r["message"] for r in data["records"]]
+    assert "known line" in messages
+    assert "ERROR: boom" in messages  # the header is verbatim, not classified
+    assert all(r["level"] == "info" for r in data["records"])
     assert fake.calls == [("logger-tail", {"level": None, "limit": None, "raw": True})]
 
 

--- a/tests/test_logger_parser.py
+++ b/tests/test_logger_parser.py
@@ -1,0 +1,167 @@
+"""The Session-log -> structured `LogRecord` parser (#281, ADR-0026).
+
+`parse_log_records` is the PASSIVE, non-invasive floor of the structured
+runtime-log channel: a pure function over a Godot engine log file's text — no
+daemon, no engine — so the logic is fast-unit-testable. It reuses the existing
+`parse_errors` for the engine's two-line error/warning pairs (carrying the
+`source` frame) and turns every other captured line into a plain `info` record.
+
+Each yielded record is the ADR-0026 `LogRecord` dict shape: `{seq, level,
+message, source?, origin?, fields}` where `level` is the closed, ordered enum
+`debug < info < warning < error`. The engine's finer kinds map onto it — WARNING
+-> (warning, origin=engine); ERROR -> (error, engine); SCRIPT ERROR -> (error,
+script); SHADER ERROR -> (error, shader) — with the sub-kind preserved in
+`origin`. `--level <min>` filters by minimum severity; `--limit N` tails the
+most-recent-N.
+"""
+
+from gda.daemon.diag import parse_log_records
+
+# A realistic Godot --log-file capture: print output interleaved with the engine's
+# two-line error pairs across all four ErrorType strings, a multi-line backtrace,
+# and a trailing bare ERROR line with no at-line.
+SAMPLE_LOG = """\
+Godot Engine v4.6.stable.official - https://godotengine.org
+known line
+ERROR: known error
+   at: _ready (res://main.gd:12)
+WARNING: a warning happened
+   at: _process (res://main.gd:20)
+SCRIPT ERROR: a script error
+   at: do_thing (res://player.gd:7)
+   <Stack trace> player.gd:7 @ do_thing()
+SHADER ERROR: a shader error
+   at: compile (res://wave.gdshader:3)
+another output line
+ERROR: trailing error with no at line
+"""
+
+
+def _by_message(records, needle):
+    return next(r for r in records if needle in r["message"])
+
+
+def test_plain_lines_become_info_records():
+    records = parse_log_records(SAMPLE_LOG)
+    known = _by_message(records, "known line")
+    assert known["level"] == "info"
+    # An info line has no engine source/origin; fields is present-but-empty (#282).
+    assert known["origin"] is None
+    assert known["source"] is None
+    assert known["fields"] == {}
+
+
+def test_engine_error_is_an_error_record_with_engine_origin_and_source():
+    records = parse_log_records(SAMPLE_LOG)
+    err = _by_message(records, "known error")
+    assert err["level"] == "error"
+    assert err["origin"] == "engine"
+    assert err["source"] == {"function": "_ready", "file": "res://main.gd", "line": 12}
+
+
+def test_engine_warning_maps_to_warning_level_engine_origin():
+    records = parse_log_records(SAMPLE_LOG)
+    warn = _by_message(records, "a warning happened")
+    assert warn["level"] == "warning"
+    assert warn["origin"] == "engine"
+    assert warn["source"]["function"] == "_process"
+
+
+def test_script_error_maps_to_error_level_script_origin():
+    # ADR-0026: SCRIPT ERROR -> (level=error, origin=script) — the closed enum has
+    # no `script_error`; the sub-kind lives in `origin`.
+    records = parse_log_records(SAMPLE_LOG)
+    rec = _by_message(records, "a script error")
+    assert rec["level"] == "error"
+    assert rec["origin"] == "script"
+    assert rec["source"]["file"] == "res://player.gd"
+
+
+def test_shader_error_maps_to_error_level_shader_origin():
+    records = parse_log_records(SAMPLE_LOG)
+    rec = _by_message(records, "a shader error")
+    assert rec["level"] == "error"
+    assert rec["origin"] == "shader"
+
+
+def test_trailing_error_without_an_at_line_has_no_source():
+    records = parse_log_records(SAMPLE_LOG)
+    rec = _by_message(records, "trailing error with no at line")
+    assert rec["level"] == "error"
+    assert rec["origin"] == "engine"
+    assert rec["source"] is None
+
+
+def test_records_carry_a_monotonic_seq_in_capture_order():
+    records = parse_log_records(SAMPLE_LOG)
+    seqs = [r["seq"] for r in records]
+    assert seqs == sorted(seqs)
+    assert len(set(seqs)) == len(seqs)  # unique
+    # The first captured line is the engine banner (an info record).
+    assert records[0]["message"].startswith("Godot Engine")
+
+
+def test_the_two_line_error_pair_yields_one_record_not_two():
+    # The `   at:` follow-on is folded into the error's `source`, NOT emitted as a
+    # second info record — so the location line never appears as its own message.
+    records = parse_log_records(SAMPLE_LOG)
+    assert not any(r["message"].lstrip().startswith("at:") for r in records)
+
+
+def test_continuation_backtrace_line_is_dropped_not_an_info_record():
+    # The `<Stack trace>` line follows a parsed error; it is engine backtrace noise,
+    # not game output, so it is skipped (it is consumed as part of the error block).
+    records = parse_log_records(SAMPLE_LOG)
+    assert not any("Stack trace" in r["message"] for r in records)
+
+
+def test_level_filter_excludes_lower_severities():
+    # The closed ordering debug < info < warning < error makes `--level warning`
+    # drop info (and debug) while keeping warning + error.
+    records = parse_log_records(SAMPLE_LOG, level="warning")
+    levels = {r["level"] for r in records}
+    assert "info" not in levels
+    assert "warning" in levels
+    assert "error" in levels
+
+
+def test_level_filter_error_keeps_only_errors():
+    records = parse_log_records(SAMPLE_LOG, level="error")
+    assert {r["level"] for r in records} == {"error"}
+
+
+def test_level_filter_info_keeps_everything_at_or_above_info():
+    records = parse_log_records(SAMPLE_LOG, level="info")
+    # No debug lines in the sample, so info is the floor: nothing is dropped.
+    assert len(records) == len(parse_log_records(SAMPLE_LOG))
+
+
+def test_limit_tails_the_most_recent_n():
+    records = parse_log_records(SAMPLE_LOG, limit=2)
+    assert len(records) == 2
+    assert records[-1]["message"] == "trailing error with no at line"
+
+
+def test_limit_applies_after_the_level_filter():
+    # `--limit` tails the FILTERED stream, not the raw one: the most-recent-N of
+    # the records that passed `--level`.
+    records = parse_log_records(SAMPLE_LOG, level="error", limit=1)
+    assert len(records) == 1
+    assert records[0]["message"] == "trailing error with no at line"
+
+
+def test_accepts_bytes_and_decodes_best_effort():
+    records = parse_log_records(b"hello\nERROR: boom\n   at: f (res://a.gd:1)\n")
+    assert _by_message(records, "hello")["level"] == "info"
+    assert _by_message(records, "boom")["level"] == "error"
+
+
+def test_empty_input_is_an_empty_list():
+    assert parse_log_records("") == []
+    assert parse_log_records(b"") == []
+
+
+def test_never_fails_on_garbage():
+    # Pure noise still parses (every line is an info record); bad UTF-8 is replaced.
+    assert parse_log_records("just text\nmore text\n")  # non-empty, no raise
+    assert isinstance(parse_log_records(b"\xff\xfe not utf8 \x00"), list)

--- a/tests/test_logger_parser.py
+++ b/tests/test_logger_parser.py
@@ -108,11 +108,28 @@ def test_the_two_line_error_pair_yields_one_record_not_two():
     assert not any(r["message"].lstrip().startswith("at:") for r in records)
 
 
-def test_continuation_backtrace_line_is_dropped_not_an_info_record():
-    # The `<Stack trace>` line follows a parsed error; it is engine backtrace noise,
-    # not game output, so it is skipped (it is consumed as part of the error block).
+def test_continuation_backtrace_line_becomes_an_info_record():
+    # ADR-0026 decision 2 (amended #281): the WHOLE Session log is represented. The
+    # `<Stack trace>` continuation line after an error is NOT dropped — it becomes a
+    # plain `info` record. The error's `at:` is still folded into its `source`, but
+    # the backtrace lines stay in the stream so `logger tail` is the full log.
     records = parse_log_records(SAMPLE_LOG)
-    assert not any("Stack trace" in r["message"] for r in records)
+    trace = _by_message(records, "Stack trace")
+    assert trace["level"] == "info"
+    assert trace["source"] is None
+    assert trace["origin"] is None
+
+
+def test_raw_returns_every_line_as_a_verbatim_info_record():
+    # `raw=True` skips classification entirely: every captured line — even an
+    # `ERROR:`/`WARNING:` header — is a verbatim `info` record (still LogRecord[]),
+    # the uniformly-typed form of the superseded `diag log` view.
+    records = parse_log_records(SAMPLE_LOG, raw=True)
+    assert all(r["level"] == "info" and r["source"] is None for r in records)
+    messages = [r["message"] for r in records]
+    assert "ERROR: known error" in messages  # the header is verbatim, not classified
+    assert "known line" in messages
+    assert len(records) == len(SAMPLE_LOG.splitlines())
 
 
 def test_level_filter_excludes_lower_severities():


### PR DESCRIPTION
## What & why

Adds **`gda logger tail`** — a new `logger` LIVE command group that parses the whole daemon-owned `Session log` into structured `LogRecord`s (the **passive, non-invasive floor**: an un-instrumented project gets structured logs for free). Engine errors/warnings become typed records (level + `source` + `origin`); every other line becomes a plain `info` record. `--raw` returns the verbatim lines the old `diag log` did.

The raw **`diag log` is superseded by `gda logger tail`** and removed; `diag` keeps `errors`. Realizes **ADR-0026** (structured runtime log protocol) under **ADR-0025**. The opt-in rich `gda_log()` protocol layers on top in the follow-up (#282).

## Acceptance criteria

- [x] `gda logger tail --json` → `LogRecord[]` (`{seq, level, message, source?, origin?, fields?}`, `level` closed ordered enum `debug<info<warning<error`).
- [x] Engine errors/warnings typed via the shared diag parser (level + `source`, sub-kind in `origin`); other lines → `info`.
- [x] `--level <min>` filters by min severity; `--limit <N>` caps to most-recent-N.
- [x] `--raw` yields verbatim lines; the raw `diag log` command is superseded/removed.
- [x] Works after a session crash (reads the persisted session log).
- [x] `--schema` gate passes; manifest now lists `logger tail`, not `diag log`.
- [x] Doc reconciliation: dated `> Outcome` note on **ADR-0022**; `docs/command-catalog.md` + `README.md` updated.

## Tests

- Fast tier: **906 passed**. Schema gate: **96 passed**.
- Real-Godot e2e (`tests/test_e2e_logger.py` + `tests/test_e2e_diag.py`, run by reviewer): **2 passed** — `logger tail` structured records + `--raw`; diag errors still works.

## Reviewer / merge notes

- **`diag.py` is purely additive**: new `parse_log_records()` + helpers; `parse_errors()`'s signature/body are untouched, so the sibling slice #283 (which edits `parse_errors` for callstacks) merges in a separate code block.
- Introduces the shared **`SourceFrame`** model (`{function, file, line}`) for `LogRecord.source`; **#283 reuses the same model name/shape** for error callstacks — dedup to one definition at merge.
- **Recommended merge order: this PR first** — it anchors `SourceFrame` + the logger parser and unblocks Wave 2 (#282 `gda_log()`).

Closes #281
