### PR TITLE
feat(daemon): run a chosen scene via daemon start --scene

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -150,6 +150,7 @@ operation, and parse codes the CLI assigns).
 | `live_unknown_property` | `live` | `classifier` | `6` | A live game get or set targeted a property the running node does not expose for the requested operation (no such readable storage property for get, or no such settable property for set) (Phase 2, #220). |
 | `live_uncoercible_value` | `live` | `classifier` | `6` | A live game set value cannot be coerced to the running property's declared Godot type (Phase 2, #220). |
 | `live_log_unavailable` | `live` | `classifier` | `6` | A live engine session was launched but its diagnostics log file is missing or unreadable, so `gda diag` cannot read the running game's errors/output (Phase 2, #224). |
+| `live_scene_not_found` | `live` | `classifier` | `6` | A `gda daemon start --scene` selector names a scene that does not exist in the project, so no engine session can be launched on it (it is never silently replaced by the project's main_scene) (Phase 2, #278). |
 | `live_perf_node_not_found` | `live` | `classifier` | `6` | A live perf monitor's node path does not resolve to a node in the running scene tree (Phase 2, #223). |
 | `live_perf_property_not_found` | `live` | `classifier` | `6` | A live perf monitor targeted a property the running node does not expose for reading (Phase 2, #223). |
 | `live_perf_signal_not_found` | `live` | `classifier` | `6` | A live perf monitor targeted a signal the running node does not declare (Phase 2, #223). |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -146,11 +146,12 @@ operation, and parse codes the CLI assigns).
 | `engine_disconnected` | `live` | `classifier` | `6` | The engine session disconnected before the live operation returned — the game crashed or the harness connection dropped (Phase 2). |
 | `live_timeout` | `live` | `classifier` | `6` | A live operation did not return from the engine session before the daemon's timeout (Phase 2). |
 | `daemon_running` | `live` | `classifier` | `6` | A daemon-lifecycle command was refused because a gda-daemon is running for the project; stop it first with `gda daemon stop` (Phase 2, #225). |
+| `daemon_already_running` | `live` | `classifier` | `6` | A `gda daemon start --scene` was refused because a gda-daemon is already running for the project; `--scene` only takes effect at start, so stop it with `gda daemon stop` then start again with `--scene` (Phase 2, #278). |
 | `live_node_not_found` | `live` | `classifier` | `6` | A live game operation's node path does not resolve to a node in the running scene tree (Phase 2, #220). |
 | `live_unknown_property` | `live` | `classifier` | `6` | A live game get or set targeted a property the running node does not expose for the requested operation (no such readable storage property for get, or no such settable property for set) (Phase 2, #220). |
 | `live_uncoercible_value` | `live` | `classifier` | `6` | A live game set value cannot be coerced to the running property's declared Godot type (Phase 2, #220). |
 | `live_log_unavailable` | `live` | `classifier` | `6` | A live engine session was launched but its diagnostics log file is missing or unreadable, so `gda diag` cannot read the running game's errors/output (Phase 2, #224). |
-| `live_scene_not_found` | `live` | `classifier` | `6` | A `gda daemon start --scene` selector names a scene that does not exist in the project, so no engine session can be launched on it (it is never silently replaced by the project's main_scene) (Phase 2, #278). |
+| `live_scene_not_found` | `live` | `classifier` | `6` | A `gda daemon start --scene` selector did not load: the launched session ran a different scene (Godot silently falls back to main_scene for a missing/invalid path or UID), verified by the harness at launch — gda never falls back (Phase 2, #278). |
 | `live_perf_node_not_found` | `live` | `classifier` | `6` | A live perf monitor's node path does not resolve to a node in the running scene tree (Phase 2, #223). |
 | `live_perf_property_not_found` | `live` | `classifier` | `6` | A live perf monitor targeted a property the running node does not expose for reading (Phase 2, #223). |
 | `live_perf_signal_not_found` | `live` | `classifier` | `6` | A live perf monitor targeted a signal the running node does not declare (Phase 2, #223). |

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -489,7 +489,10 @@ def _make_live_runner(binary: Optional[Path], project: Optional[Path]) -> GodotR
 
 def _daemon_start_recipe(params, *, project, godot):
     return run_daemon_start_operation(
-        resolve_project_dir(project), godot, windowed=params.windowed
+        resolve_project_dir(project),
+        godot,
+        windowed=params.windowed,
+        scene=params.scene,
     )
 
 
@@ -1385,6 +1388,16 @@ def daemon_start(
             "headless host (#222)."
         ),
     ),
+    scene: Optional[str] = typer.Option(
+        None,
+        "--scene",
+        help=(
+            "Boot the engine session on this scene (a res:// path or uid:// value) "
+            "instead of the project's main_scene; default runs main_scene. A "
+            "non-existent scene is a typed `live_scene_not_found` error, never a "
+            "silent fall back (#278)."
+        ),
+    ),
     json_output: bool = json_option(),
     schema: bool = DAEMON_START_COMMAND.schema_option(),
     params_json: Optional[str] = params_json_option(),
@@ -1398,14 +1411,15 @@ def daemon_start(
     launching the engine is a deliberate, declared effect (ADR-0017). The
     platform/Godot-version precondition is the structured `constraints` field of
     `--schema` (ADR-0021), not restated here. `--windowed` is a start-time declared
-    mode for the engine session a `screen` capture op needs (#222).
+    mode for the engine session a `screen` capture op needs (#222); `--scene` boots
+    the session on a chosen scene instead of the project's main_scene (#278).
     """
-    # Build the params model from the argv option (the single source of truth,
-    # ADR-0015) so the recipe reads `windowed` off it on BOTH the argv and
+    # Build the params model from the argv options (the single source of truth,
+    # ADR-0015) so the recipe reads `windowed`/`scene` off it on BOTH the argv and
     # --params-json paths — no special-casing.
     _dispatch_recipe(
         DAEMON_START_COMMAND,
-        DaemonStartParams(windowed=windowed),
+        DaemonStartParams(windowed=windowed, scene=scene),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/daemon/__main__.py
+++ b/src/gda/daemon/__main__.py
@@ -24,10 +24,20 @@ def main() -> None:
         action="store_true",
         help="Launch engine sessions windowed (no --headless), for `screen` capture (#222).",
     )
+    parser.add_argument(
+        "--scene",
+        default=None,
+        help=(
+            "Boot the engine session on this scene (a res:// path or uid:// value) "
+            "instead of the project's main_scene (#278)."
+        ),
+    )
     args = parser.parse_args()
 
     paths = daemon_paths(Path(args.project))
-    DaemonServer(paths, godot=args.godot, windowed=args.windowed).serve()
+    DaemonServer(
+        paths, godot=args.godot, windowed=args.windowed, scene=args.scene
+    ).serve()
 
 
 if __name__ == "__main__":

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -16,7 +16,7 @@ import socket
 from gda.daemon.diag import parse_errors, parse_log_records
 from gda.daemon.discovery import DaemonPaths, acquire_pidfile, ensure_runtime_dir
 from gda.daemon.protocol import error_reply, read_message, result_reply, write_message
-from gda.daemon.session import EngineSession, launch_session
+from gda.daemon.session import EngineSession, SceneMismatch, launch_session
 
 # Control ops on the CLI socket — daemon lifetime, not project domain ops.
 STATUS_OP = "__status__"
@@ -128,12 +128,20 @@ class DaemonServer:
             # (#224, #281).
             return self._handle_log(op, request.get("params", {}))
         # A project live op. Serialized against the one session (single writer).
-        # A non-existent `--scene` selector is a TYPED failure caught BEFORE launch —
-        # never a silent fall back to main_scene (#278, ADR-0017 amendment).
-        scene_error = self._scene_not_found_reply()
-        if scene_error is not None:
-            return scene_error
-        session = self._ensure_session()
+        # The scene selector is verified ONCE at launch (in the harness): a mismatch
+        # is a typed live_scene_not_found, never a silent fall back to main_scene and
+        # never a per-request re-check (#278, ADR-0017 amendment, ADR-0020).
+        try:
+            session = self._ensure_session()
+        except SceneMismatch as mismatch:
+            return error_reply(
+                "live_scene_not_found",
+                f"the --scene selector {mismatch.requested!r} did not load: the "
+                f"session ran {mismatch.current!r} instead (Godot silently falls "
+                "back to main_scene for a missing/invalid scene). gda never falls "
+                "back — fix the path/UID or omit --scene to run the project's "
+                "main_scene",
+            )
         if session is None:
             return error_reply(
                 "engine_session_not_running",
@@ -188,34 +196,6 @@ class DaemonServer:
             raw, level=params.get("level"), limit=limit, raw=bool(params.get("raw"))
         )
         return result_reply({"records": records})
-
-    def _scene_not_found_reply(self) -> dict | None:
-        """Reject a non-existent ``--scene`` selector with a typed error (#278).
-
-        Validates a ``res://``/filesystem scene selector against the project on disk
-        BEFORE a launch, so a missing scene is a precise ``live_scene_not_found``
-        rather than a vague launch failure — and is NEVER silently replaced by the
-        project's ``main_scene`` (ADR-0017 amendment). A ``uid://…`` selector cannot
-        be resolved daemon-side without the engine's UID cache, so it is passed
-        through to the engine (the engine validates it). ``None`` (no selector) is
-        the unchanged default. Returns an error reply when the path is missing, else
-        ``None``.
-        """
-        scene = self.scene
-        if scene is None or scene.startswith("uid://"):
-            return None
-        # Map a `res://…` selector to its on-disk path under the project root; a bare
-        # filesystem path is taken relative to the project (or absolute as given).
-        rel = scene[len("res://") :] if scene.startswith("res://") else scene
-        candidate = (self.paths.project / rel).expanduser()
-        if candidate.is_file():
-            return None
-        return error_reply(
-            "live_scene_not_found",
-            f"the --scene selector {scene!r} does not name a scene that exists in the "
-            f"project at {self.paths.project}; gda never falls back to main_scene — "
-            "fix the path/UID or omit --scene to run the project's main_scene",
-        )
 
     def _ensure_session(self) -> EngineSession | None:
         if self._session is not None and self._session.alive():

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -35,7 +35,13 @@ LOG_OPS = (DIAG_ERRORS_OP, LOGGER_TAIL_OP)
 class DaemonServer:
     """Binds the per-project sockets and serves requests until stopped."""
 
-    def __init__(self, paths: DaemonPaths, godot: str = "", windowed: bool = False) -> None:
+    def __init__(
+        self,
+        paths: DaemonPaths,
+        godot: str = "",
+        windowed: bool = False,
+        scene: str | None = None,
+    ) -> None:
         self.paths = paths
         self.godot = godot
         # The start-time declared display mode (ADR-0017 refined, #222): when true the
@@ -43,6 +49,11 @@ class DaemonServer:
         # has a real DisplayServer; fixed for the daemon's life (ADR-0020 single
         # session), never switched mid-session.
         self.windowed = windowed
+        # The start-time scene selector (ADR-0017 amendment, #278): when set the engine
+        # session boots this chosen scene (a `res://…` path or `uid://…` value) via
+        # Godot's `--scene` engine option instead of the project's main_scene; None
+        # runs main_scene unchanged. Fixed for the daemon's life (ADR-0020).
+        self.scene = scene
         self._token = secrets.token_hex(16)
         self._stopping = False
         self._listener: socket.socket | None = None
@@ -117,6 +128,11 @@ class DaemonServer:
             # (#224, #281).
             return self._handle_log(op, request.get("params", {}))
         # A project live op. Serialized against the one session (single writer).
+        # A non-existent `--scene` selector is a TYPED failure caught BEFORE launch —
+        # never a silent fall back to main_scene (#278, ADR-0017 amendment).
+        scene_error = self._scene_not_found_reply()
+        if scene_error is not None:
+            return scene_error
         session = self._ensure_session()
         if session is None:
             return error_reply(
@@ -173,6 +189,34 @@ class DaemonServer:
         )
         return result_reply({"records": records})
 
+    def _scene_not_found_reply(self) -> dict | None:
+        """Reject a non-existent ``--scene`` selector with a typed error (#278).
+
+        Validates a ``res://``/filesystem scene selector against the project on disk
+        BEFORE a launch, so a missing scene is a precise ``live_scene_not_found``
+        rather than a vague launch failure — and is NEVER silently replaced by the
+        project's ``main_scene`` (ADR-0017 amendment). A ``uid://…`` selector cannot
+        be resolved daemon-side without the engine's UID cache, so it is passed
+        through to the engine (the engine validates it). ``None`` (no selector) is
+        the unchanged default. Returns an error reply when the path is missing, else
+        ``None``.
+        """
+        scene = self.scene
+        if scene is None or scene.startswith("uid://"):
+            return None
+        # Map a `res://…` selector to its on-disk path under the project root; a bare
+        # filesystem path is taken relative to the project (or absolute as given).
+        rel = scene[len("res://") :] if scene.startswith("res://") else scene
+        candidate = (self.paths.project / rel).expanduser()
+        if candidate.is_file():
+            return None
+        return error_reply(
+            "live_scene_not_found",
+            f"the --scene selector {scene!r} does not name a scene that exists in the "
+            f"project at {self.paths.project}; gda never falls back to main_scene — "
+            "fix the path/UID or omit --scene to run the project's main_scene",
+        )
+
     def _ensure_session(self) -> EngineSession | None:
         if self._session is not None and self._session.alive():
             return self._session
@@ -190,6 +234,7 @@ class DaemonServer:
             self._token,
             log_file=self._session_log_path(),
             windowed=self.windowed,
+            scene=self.scene,
         )
         return self._session
 

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -134,13 +134,17 @@ class DaemonServer:
         try:
             session = self._ensure_session()
         except SceneMismatch as mismatch:
+            detail = (
+                f"no scene named {mismatch.requested!r} exists in the project"
+                if mismatch.current is None
+                else f"the session ran {mismatch.current!r} instead (Godot silently "
+                "falls back to main_scene for an invalid scene)"
+            )
             return error_reply(
                 "live_scene_not_found",
-                f"the --scene selector {mismatch.requested!r} did not load: the "
-                f"session ran {mismatch.current!r} instead (Godot silently falls "
-                "back to main_scene for a missing/invalid scene). gda never falls "
-                "back — fix the path/UID or omit --scene to run the project's "
-                "main_scene",
+                f"the --scene selector {mismatch.requested!r} did not load: {detail}. "
+                "gda never falls back — fix the path/UID or omit --scene to run the "
+                "project's main_scene",
             )
         if session is None:
             return error_reply(
@@ -205,6 +209,18 @@ class DaemonServer:
             self._session = None
         if not self.godot:
             return None
+        # A res:// / filesystem scene selector that names no file is rejected HERE,
+        # at the launch boundary (NOT per-request — finding 1), as a typed
+        # SceneMismatch. Godot does not fall-back-and-run for a missing res:// path:
+        # it fails to launch and the harness never connects, so the launch-time
+        # harness verification can't see it. A bad uid:// (which Godot DOES silently
+        # run as main_scene) is caught by that verification inside launch_session
+        # instead. Both surface live_scene_not_found (#278, ADR-0017 amendment).
+        scene = self.scene
+        if scene is not None and not scene.startswith("uid://"):
+            rel = scene[len("res://") :] if scene.startswith("res://") else scene
+            if not (self.paths.project / rel).expanduser().is_file():
+                raise SceneMismatch(scene)
         assert self._harness_listener is not None
         self._session = launch_session(
             self.paths.project,

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -12,6 +12,7 @@ viewport-capturing op (ADR-0017). The session is (re)launched per feedback-loop
 iteration so it observes the project's current on-disk state.
 """
 
+import json
 import os
 import signal
 import socket
@@ -27,6 +28,25 @@ CONNECT_TIMEOUT = 25.0
 # Bounds one live op against the harness so a stuck op cannot hang the daemon
 # forever; surfaced as the registered ``live_timeout`` (ADR-0021).
 OP_TIMEOUT = 30.0
+
+
+class SceneMismatch(Exception):
+    """The launched session loaded a scene other than the requested ``--scene``.
+
+    Raised by :func:`launch_session` when the harness's launch-time verification
+    reports the ACTUALLY-loaded scene differs from the requested selector — Godot
+    silently falls back to ``main_scene`` for a bad ``uid://`` (and a stale/missing
+    selector), so this is the no-silent-fallback guarantee's signal (#278). The
+    daemon maps it to the typed ``live_scene_not_found`` (ADR-0017 amendment). It is
+    distinct from a generic launch failure (``launch_session`` returns ``None``).
+    """
+
+    def __init__(self, requested: str, current: str) -> None:
+        super().__init__(
+            f"requested scene {requested!r} but the session loaded {current!r}"
+        )
+        self.requested = requested
+        self.current = current
 
 
 class EngineSession:
@@ -106,6 +126,17 @@ def launch_session(
     runs ``main_scene`` unchanged). The selector accepts a scene path or UID and is
     start-time declared, fixed for the session's life (ADR-0017 amendment, ADR-0020).
 
+    The selector is ALSO threaded into the harness arg tail (after the launch
+    marker, socket, and token; the empty string when ``None``) so the harness can
+    verify the ACTUALLY-loaded scene against it at launch — the only way to honor
+    "no silent fallback" for a ``uid://`` selector (the harness resolves uids; Godot
+    silently falls back to ``main_scene`` for a bad one). After the token, the
+    harness sends a SECOND frame, the verification result
+    ``{"scene_ok": bool, "current": "res://…"}``. This function returns the verified
+    :class:`EngineSession` when ``scene_ok``, raises :class:`SceneMismatch` when the
+    loaded scene differs from the requested selector, and returns ``None`` on a
+    generic launch failure (no connect / bad token / timeout).
+
     When ``log_file`` is given, the engine is launched with Godot's
     ``--log-file <abs path>`` so the session writes BOTH its output and its errors
     to that one daemon-owned file (it forces file logging on even when the project
@@ -120,6 +151,9 @@ def launch_session(
     # `--scene <path|UID>` is an ENGINE option, so it sits before `--path` (and so
     # before the `--` payload separator) alongside the other engine args (#278).
     scene_args = ["--scene", scene] if scene is not None else []
+    # The harness tail also carries the selector (empty string when none) so the
+    # harness can verify the loaded scene against it at launch (#278).
+    requested_scene = scene if scene is not None else ""
     proc = subprocess.Popen(
         [
             str(binary),
@@ -132,6 +166,7 @@ def launch_session(
             LAUNCH_MARKER,
             str(harness_socket),
             token,
+            requested_scene,
         ],
         start_new_session=True,
         stdin=subprocess.DEVNULL,
@@ -157,7 +192,37 @@ def launch_session(
             pass
         _terminate(proc)
         return None
+
+    # The harness's second frame is the launch-time scene verification: it reports
+    # whether the scene the session ACTUALLY loaded matches the requested selector
+    # (#278). A mismatch — including Godot's silent main_scene fallback for a bad
+    # uid — tears the session down and raises SceneMismatch so the daemon surfaces a
+    # typed live_scene_not_found rather than serving the wrong scene.
+    try:
+        verify_frame = read_frame(conn)
+    except OSError:
+        verify_frame = None
+    if verify_frame is None:
+        _close(conn)
+        _terminate(proc)
+        return None
+    try:
+        verify = json.loads(verify_frame.decode("utf-8", "replace"))
+    except (ValueError, TypeError):
+        verify = {}
+    if not isinstance(verify, dict) or not verify.get("scene_ok", False):
+        current = verify.get("current", "") if isinstance(verify, dict) else ""
+        _close(conn)
+        _terminate(proc)
+        raise SceneMismatch(scene if scene is not None else "", str(current))
     return EngineSession(proc, conn, log_file=log_file)
+
+
+def _close(conn: socket.socket) -> None:
+    try:
+        conn.close()
+    except OSError:
+        pass
 
 
 def _terminate(proc: subprocess.Popen) -> None:

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -33,17 +33,21 @@ OP_TIMEOUT = 30.0
 class SceneMismatch(Exception):
     """The launched session loaded a scene other than the requested ``--scene``.
 
-    Raised by :func:`launch_session` when the harness's launch-time verification
-    reports the ACTUALLY-loaded scene differs from the requested selector — Godot
-    silently falls back to ``main_scene`` for a bad ``uid://`` (and a stale/missing
-    selector), so this is the no-silent-fallback guarantee's signal (#278). The
-    daemon maps it to the typed ``live_scene_not_found`` (ADR-0017 amendment). It is
+    Raised at the launch boundary when the requested ``--scene`` cannot be honoured:
+    either the daemon's pre-launch check finds a ``res://`` selector that names no
+    file (``current`` is ``None`` — Godot would fail to launch rather than run it),
+    or the harness's launch-time verification reports the ACTUALLY-loaded scene
+    differs from the selector (Godot silently ran ``main_scene`` for a bad
+    ``uid://``). Either way it is the no-silent-fallback guarantee's signal (#278);
+    the daemon maps it to the typed ``live_scene_not_found`` (ADR-0017 amendment),
     distinct from a generic launch failure (``launch_session`` returns ``None``).
     """
 
-    def __init__(self, requested: str, current: str) -> None:
+    def __init__(self, requested: str, current: str | None = None) -> None:
         super().__init__(
             f"requested scene {requested!r} but the session loaded {current!r}"
+            if current is not None
+            else f"requested scene {requested!r} does not exist in the project"
         )
         self.requested = requested
         self.current = current

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -87,6 +87,7 @@ def launch_session(
     log_file: Optional[Path] = None,
     timeout: float = CONNECT_TIMEOUT,
     windowed: bool = False,
+    scene: Optional[str] = None,
 ) -> Optional[EngineSession]:
     """Launch an engine session and wait for the harness to connect.
 
@@ -96,6 +97,14 @@ def launch_session(
     runs with a real ``DisplayServer`` whose viewport a ``screen`` capture op can
     read pixels from; ``--headless``'s dummy ``DisplayServer`` cannot (ADR-0017).
     The mode is start-time declared and fixed for the session's life (ADR-0020).
+
+    When ``scene`` is set (``gda daemon start --scene <path|UID>``, #278) the engine
+    is launched with Godot's ``--scene <path|UID>`` engine option — placed BEFORE
+    ``--path`` alongside ``--headless``/``--log-file`` — so the session boots that
+    chosen scene instead of the project's ``main_scene`` (verified to run the scene
+    without mutating ``main_scene``). Omitted when ``scene`` is ``None`` (the default,
+    runs ``main_scene`` unchanged). The selector accepts a scene path or UID and is
+    start-time declared, fixed for the session's life (ADR-0017 amendment, ADR-0020).
 
     When ``log_file`` is given, the engine is launched with Godot's
     ``--log-file <abs path>`` so the session writes BOTH its output and its errors
@@ -108,11 +117,15 @@ def launch_session(
     """
     log_args = ["--log-file", str(log_file)] if log_file is not None else []
     headless_args = [] if windowed else ["--headless"]
+    # `--scene <path|UID>` is an ENGINE option, so it sits before `--path` (and so
+    # before the `--` payload separator) alongside the other engine args (#278).
+    scene_args = ["--scene", scene] if scene is not None else []
     proc = subprocess.Popen(
         [
             str(binary),
             *headless_args,
             *log_args,
+            *scene_args,
             "--path",
             str(project),
             "--",

--- a/src/gda/daemon_ops.py
+++ b/src/gda/daemon_ops.py
@@ -182,6 +182,18 @@ def run_daemon_start_operation(
         )
     existing = daemon_pid(paths)
     if existing is not None:
+        if scene is not None:
+            # `--scene` only takes effect at daemon START (the daemon holds it for the
+            # session it launches). A daemon is already up, so the chosen scene would
+            # be silently ignored — surface a typed refusal instead of a quiet no-op
+            # (#278 review finding 3). The remediation: stop, then start --scene.
+            return _failure(
+                "daemon_already_running",
+                "a gda-daemon is already running for this project, so `--scene` would "
+                "be ignored — it only takes effect when the daemon starts. Run "
+                "`gda daemon stop`, then `gda daemon start --scene <path|UID>`",
+                "",
+            )
         # Idempotent: a daemon is already up for this project — but still self-sync
         # the installed harness (#225), so upgrading `gda` while an old daemon stays
         # up never leaves a stale harness on disk. The next engine session the

--- a/src/gda/daemon_ops.py
+++ b/src/gda/daemon_ops.py
@@ -54,7 +54,7 @@ _POLL = 0.05
 _VERSION_RE = re.compile(r"(\d+)\.(\d+)")
 
 # Seams tests override to avoid launching a real process / running the engine.
-SpawnDaemon = Callable[[Path, str, bool], None]
+SpawnDaemon = Callable[[Path, str, bool, Optional[str]], None]
 VersionCheck = Callable[[str], Optional[tuple]]
 
 
@@ -77,12 +77,17 @@ def _engine_version(binary: str) -> Optional[tuple]:
     return (int(match.group(1)), int(match.group(2))) if match else None
 
 
-def _spawn_daemon(project: Path, binary: str, windowed: bool) -> None:
+def _spawn_daemon(
+    project: Path, binary: str, windowed: bool, scene: Optional[str]
+) -> None:
     """Spawn the detached, per-project daemon (its own session, no std streams).
 
     ``windowed`` is forwarded as ``--windowed`` so the daemon launches its engine
     session with a real ``DisplayServer`` (no ``--headless``) — the start-time
     declared display mode a ``screen`` capture op needs (ADR-0017 refined, #222).
+    ``scene`` is forwarded as ``--scene <path|UID>`` so the daemon boots the session
+    on that chosen scene instead of the project's main_scene (ADR-0017 amendment,
+    #278); omitted when ``None``.
     """
     subprocess.Popen(
         [
@@ -94,6 +99,7 @@ def _spawn_daemon(project: Path, binary: str, windowed: bool) -> None:
             "--godot",
             str(binary),
             *(["--windowed"] if windowed else []),
+            *(["--scene", scene] if scene is not None else []),
         ],
         start_new_session=True,
         stdin=subprocess.DEVNULL,
@@ -145,6 +151,7 @@ def run_daemon_start_operation(
     godot: Optional[str],
     *,
     windowed: bool = False,
+    scene: Optional[str] = None,
     spawn: Optional[SpawnDaemon] = None,
     version_check: Optional[VersionCheck] = None,
 ) -> "DaemonStartResult | Failure":
@@ -216,7 +223,7 @@ def run_daemon_start_operation(
         )
 
     installed = install_harness(project)
-    (spawn or _spawn_daemon)(project, str(binary), windowed)
+    (spawn or _spawn_daemon)(project, str(binary), windowed, scene)
     pid = _await_ready(paths)
     if pid is None:
         return _failure(

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -496,6 +496,21 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A live engine session was launched but its diagnostics log file is missing"
         " or unreadable, so `gda diag` cannot read the running game's errors/output.",
     ),
+    # `gda daemon start --scene <path|UID>` boots the session on a CHOSEN scene
+    # (#278, ADR-0017 amendment). A missing/non-existent selector must surface this
+    # TYPED failure rather than silently falling back to the project's main_scene:
+    # the daemon validates a res:// selector against the project before launching.
+    # CLASSIFIER-source (the daemon mints it, not the harness), so it is NOT
+    # GDScript-mirrored.
+    ErrorCodeSpec(
+        "live_scene_not_found",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A `gda daemon start --scene` selector names a scene that does not exist in"
+        " the project, so no engine session can be launched on it (it is never"
+        " silently replaced by the project's main_scene).",
+    ),
     # Per live-operation failures the gda harness reports for `perf` (#223). Same
     # shape as the #220 game op-errors above: LIVE-category, classifier-source,
     # exit_code EXIT_LIVE, harness-mirrored (a test mirrors them against the harness

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -454,6 +454,20 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A daemon-lifecycle command was refused because a gda-daemon is running"
         " for the project; stop it first with `gda daemon stop`.",
     ),
+    # The `daemon start --scene` refusal (#278 review): `--scene` only takes effect
+    # at daemon start, so requesting it against a daemon that is already running is a
+    # typed refusal rather than a silent no-op that ignores the chosen scene. Same
+    # daemon-channel shape: LIVE-category, classifier-source (the start recipe emits
+    # it), exit EXIT_LIVE; NOT GDScript-mirrored.
+    ErrorCodeSpec(
+        "daemon_already_running",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A `gda daemon start --scene` was refused because a gda-daemon is already"
+        " running for the project; `--scene` only takes effect at start, so stop it"
+        " with `gda daemon stop` then start again with `--scene`.",
+    ),
     # Per live-operation failures the gda harness reports in-band (#220). Harness
     # op-errors arrive with exit_code 0 (the daemon relays the sentinel verbatim),
     # so each MUST be a LIVE-category code for ``classify_live`` to map it before
@@ -498,18 +512,21 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
     ),
     # `gda daemon start --scene <path|UID>` boots the session on a CHOSEN scene
     # (#278, ADR-0017 amendment). A missing/non-existent selector must surface this
-    # TYPED failure rather than silently falling back to the project's main_scene:
-    # the daemon validates a res:// selector against the project before launching.
-    # CLASSIFIER-source (the daemon mints it, not the harness), so it is NOT
+    # TYPED failure rather than silently falling back to the project's main_scene.
+    # The harness verifies the ACTUALLY-loaded scene against the requested selector
+    # at launch (the only way to catch a bad uid, which Godot silently replaces with
+    # main_scene); a mismatch is surfaced by the daemon as this code. CLASSIFIER-
+    # source (the daemon mints it from the harness verification frame), so it is NOT
     # GDScript-mirrored.
     ErrorCodeSpec(
         "live_scene_not_found",
         ErrorCategory.LIVE,
         EXIT_LIVE,
         ErrorCodeSource.CLASSIFIER,
-        "A `gda daemon start --scene` selector names a scene that does not exist in"
-        " the project, so no engine session can be launched on it (it is never"
-        " silently replaced by the project's main_scene).",
+        "A `gda daemon start --scene` selector did not load: the launched session ran"
+        " a different scene (Godot silently falls back to main_scene for a"
+        " missing/invalid path or UID), verified by the harness at launch — gda never"
+        " falls back.",
     ),
     # Per live-operation failures the gda harness reports for `perf` (#223). Same
     # shape as the #220 game op-errors above: LIVE-category, classifier-source,

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -59,6 +59,13 @@ const MAX_WINDOW_FRAMES := 600
 
 var _peer: StreamPeerUDS = null
 var _authed := false
+# The scene selector the daemon requested (`gda daemon start --scene`, #278), or ""
+# for none. The harness verifies the ACTUALLY-loaded scene against it ONCE at launch
+# and sends the result as the second handshake frame; _scene_verified gates serving
+# ops until that frame is sent (so a mismatch is caught before any op runs).
+var _requested_scene := ""
+var _scene_verified := false
+var _verify_frames := 0
 var _pending = null
 var _pending_frames := 0
 # The active time-windowed collection, or null when none is running (#223). A
@@ -94,6 +101,9 @@ func _ready() -> void:
 		return
 	var socket_path: String = user_args[idx + 1]
 	var token: String = user_args[idx + 2]
+	# The requested scene selector (#278) follows the token; "" (or absent) = none.
+	if idx + 3 < user_args.size():
+		_requested_scene = user_args[idx + 3]
 
 	var peer := StreamPeerUDS.new()
 	peer.big_endian = true
@@ -109,6 +119,18 @@ func _process(_delta: float) -> void:
 	if _peer == null or not _authed:
 		return
 	_peer.poll()
+	# Launch-time scene verification (#278): before serving ANY op, send the second
+	# handshake frame reporting whether the scene the session ACTUALLY loaded matches
+	# the requested `--scene` selector. current_scene is null at autoload _ready (the
+	# main scene loads after autoloads), so wait for it on a frame boundary — the same
+	# wait the op loop uses — with a bounded fallback so a sceneless project never
+	# hangs the handshake. Verified ONCE, never re-checked per op.
+	if not _scene_verified:
+		_verify_frames += 1
+		if get_tree().current_scene != null or _verify_frames > 300:
+			_send_scene_verification()
+			_scene_verified = true
+		return
 	# A time-windowed op owns the connection until it finalizes (#223): advance it
 	# one frame and serve nothing else this tick, so per-frame samples stay
 	# frame-coherent (ADR-0020) and the single-writer order is preserved (one op at
@@ -143,6 +165,38 @@ func _process(_delta: float) -> void:
 func _send_frame(payload: PackedByteArray) -> void:
 	_peer.put_u32(payload.size())
 	_peer.put_data(payload)
+
+
+# Send the launch-time scene-verification frame (#278): the JSON
+# {"scene_ok": bool, "current": "res://…"} the daemon reads after the token. With no
+# selector requested (_requested_scene == ""), scene_ok is trivially true (the
+# main_scene default is unchanged). Otherwise scene_ok is whether the ACTUALLY-loaded
+# scene matches the requested selector — the no-silent-fallback guarantee, including
+# a bad uid:// that Godot replaced with main_scene.
+func _send_scene_verification() -> void:
+	var current: Node = get_tree().current_scene
+	var current_path := String(current.scene_file_path) if current != null else ""
+	var ok := true
+	if not _requested_scene.is_empty():
+		ok = _scene_matches(_requested_scene, current_path)
+	var frame := {"scene_ok": ok, "current": current_path}
+	_send_frame(JSON.stringify(frame).to_utf8_buffer())
+
+
+# Whether the loaded scene path matches the requested selector (#278). A `res://…`
+# (or filesystem) selector compares directly to the loaded scene_file_path. A
+# `uid://…` selector is resolved to its res:// path via ResourceUID and compared; a
+# uid the project does not know resolves to nothing, so it never matches — which is
+# exactly how a bad uid (that Godot silently replaced with main_scene) is caught.
+func _scene_matches(requested: String, current_path: String) -> bool:
+	if current_path.is_empty():
+		return false
+	if requested.begins_with("uid://"):
+		var id := ResourceUID.text_to_id(requested)
+		if id == -1 or not ResourceUID.has_id(id):
+			return false
+		return ResourceUID.get_id_path(id) == current_path
+	return requested == current_path
 
 
 # --- Time-windowed multi-frame base (#223) ------------------------------------

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -40,7 +40,7 @@ HARNESS_RES_PATH = f"res://{HARNESS_RES_DIR}/{HARNESS_FILE}"
 # copy to it (#225). The installed copy declares its version in a leading header
 # (`# gda-harness-version: <N>`); a mismatch re-materializes via the content
 # compare. NOT the package version — the harness changes far less often.
-HARNESS_VERSION = "0"
+HARNESS_VERSION = "1"
 
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -3396,14 +3396,17 @@ class ScreenFramesResult(BaseModel):
 
 
 class DaemonStartParams(BaseModel):
-    """The params of ``gda daemon start``: the display mode of its engine session (#222).
+    """The params of ``gda daemon start``: its engine session's display mode and scene.
 
-    Empty but for ``windowed``: the project is the ``--project`` context. ``windowed``
-    is a START-TIME declared mode (ADR-0017 refined by #222) — the daemon launches its
-    engine session windowed (no ``--headless``) so a ``screen`` capture op has a real
-    ``DisplayServer`` to read pixels from; default false keeps the cheap non-visual
-    sessions (``game tree``, ``perf``, ``diag``) headless. The mode is fixed for the
-    session's life (ADR-0020 single session) — it is NOT switched mid-session.
+    The project is the ``--project`` context. ``windowed`` is a START-TIME declared
+    mode (ADR-0017 refined by #222) — the daemon launches its engine session windowed
+    (no ``--headless``) so a ``screen`` capture op has a real ``DisplayServer`` to read
+    pixels from; default false keeps the cheap non-visual sessions (``game tree``,
+    ``perf``, ``diag``) headless. ``scene`` is a START-TIME selector (ADR-0017 amended
+    by #278): when set the daemon boots the session on that chosen scene via Godot's
+    ``--scene`` engine option (before ``--path``) instead of the project's
+    ``main_scene``; default null runs ``main_scene`` unchanged. Both modes are fixed
+    for the session's life (ADR-0020 single session) — NOT switched mid-session.
     """
 
     windowed: bool = Field(
@@ -3412,6 +3415,15 @@ class DaemonStartParams(BaseModel):
             "Launch the engine session windowed (no --headless) so `screen` capture "
             "ops have a display; default headless. Requires a display/Xvfb on a "
             "headless host."
+        ),
+    )
+    scene: str | None = Field(
+        default=None,
+        description=(
+            "Boot the engine session on this scene (a `res://…` path or a `uid://…` "
+            "value, per Godot's `--scene`) instead of the project's main_scene; "
+            "default null runs main_scene unchanged. A non-existent scene is a typed "
+            "`live_scene_not_found` error, never a silent fall back to main_scene."
         ),
     )
 

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -91,6 +91,74 @@ def test_engine_session_exposes_its_log_file_path(tmp_path):
     assert session.log_file == log_file
 
 
+# --- #278: launch carries `--scene <path|UID>` BEFORE `--path`, omitted by default ---
+
+
+def _capture_launch_argv(monkeypatch, project, **launch_kw):
+    """Drive ``launch_session`` engine-free and return the argv it built."""
+    captured = {}
+
+    class _ImmediatePopen:
+        def __init__(self, argv, **kwargs):
+            captured["argv"] = argv
+            self.pid = 4242
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(subprocess, "Popen", _ImmediatePopen)
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+
+    class _NoAcceptListener:
+        def settimeout(self, _):
+            pass
+
+        def accept(self):
+            raise TimeoutError
+
+    launch_session(
+        project,
+        "godot",
+        _NoAcceptListener(),
+        project / "h.sock",
+        "tok",
+        timeout=0.1,
+        **launch_kw,
+    )
+    return captured["argv"]
+
+
+def test_launch_session_inserts_scene_before_path_when_set(monkeypatch, tmp_path):
+    project = _project(tmp_path)
+    argv = _capture_launch_argv(monkeypatch, project, scene="res://B.tscn")
+
+    # `--scene <path>` is an ENGINE option: present, paired, and BEFORE `--path`
+    # (and so before the `--` payload separator too).
+    assert "--scene" in argv
+    assert argv[argv.index("--scene") + 1] == "res://B.tscn"
+    assert argv.index("--scene") < argv.index("--path")
+    assert argv.index("--scene") < argv.index("--")
+
+
+def test_launch_session_accepts_a_uid_scene_selector(monkeypatch, tmp_path):
+    # Godot's `--scene` accepts a `uid://…` value too; the launch passes it through
+    # verbatim in the same engine-option slot.
+    project = _project(tmp_path)
+    argv = _capture_launch_argv(monkeypatch, project, scene="uid://abc123")
+
+    assert argv[argv.index("--scene") + 1] == "uid://abc123"
+    assert argv.index("--scene") < argv.index("--path")
+
+
+def test_launch_session_omits_scene_by_default(monkeypatch, tmp_path):
+    # No selector: behaviour unchanged — the engine runs the project's main_scene,
+    # so no `--scene` engine option appears in the argv.
+    project = _project(tmp_path)
+    argv = _capture_launch_argv(monkeypatch, project)
+
+    assert "--scene" not in argv
+
+
 # --- Slice 2: the daemon serves diag from the remembered log file ---
 
 

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -141,10 +141,11 @@ def test_launch_session_inserts_scene_before_path_when_set(monkeypatch, tmp_path
     assert argv[argv.index("--scene") + 1] == "res://B.tscn"
     assert argv.index("--scene") < argv.index("--path")
     assert argv.index("--scene") < argv.index("--")
-    # The selector ALSO threads into the harness arg tail (after the launch marker,
-    # socket, token) so the harness can verify the ACTUALLY-loaded scene at launch.
+    # The selector ALSO threads into the harness arg tail (the LAST arg, after the
+    # launch marker, socket, token) so the harness can verify the loaded scene.
     assert argv[-1] == "res://B.tscn"
-    assert argv.index("--scene") < argv.index("--") < argv.index(argv[-1])
+    # The trailing selector slot sits after the `--` payload separator.
+    assert len(argv) - 1 > argv.index("--")
 
 
 def test_launch_session_accepts_a_uid_scene_selector(monkeypatch, tmp_path):

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -10,14 +10,17 @@ temp log file. (The raw ``diag-log`` op is superseded by ``logger-tail`` — see
 ``test_daemon_logger.py``, #281.)
 """
 
+import json
 import os
+import socket
 import subprocess
 
 import pytest
 
 from gda.daemon.discovery import daemon_paths
+from gda.daemon.protocol import read_frame, write_frame
 from gda.daemon.server import DaemonServer
-from gda.daemon.session import EngineSession, launch_session
+from gda.daemon.session import EngineSession, SceneMismatch, launch_session
 from gda.parser import parse_result
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
@@ -138,25 +141,144 @@ def test_launch_session_inserts_scene_before_path_when_set(monkeypatch, tmp_path
     assert argv[argv.index("--scene") + 1] == "res://B.tscn"
     assert argv.index("--scene") < argv.index("--path")
     assert argv.index("--scene") < argv.index("--")
+    # The selector ALSO threads into the harness arg tail (after the launch marker,
+    # socket, token) so the harness can verify the ACTUALLY-loaded scene at launch.
+    assert argv[-1] == "res://B.tscn"
+    assert argv.index("--scene") < argv.index("--") < argv.index(argv[-1])
 
 
 def test_launch_session_accepts_a_uid_scene_selector(monkeypatch, tmp_path):
     # Godot's `--scene` accepts a `uid://…` value too; the launch passes it through
-    # verbatim in the same engine-option slot.
+    # verbatim in the same engine-option slot AND in the harness tail.
     project = _project(tmp_path)
     argv = _capture_launch_argv(monkeypatch, project, scene="uid://abc123")
 
     assert argv[argv.index("--scene") + 1] == "uid://abc123"
     assert argv.index("--scene") < argv.index("--path")
+    assert argv[-1] == "uid://abc123"
 
 
 def test_launch_session_omits_scene_by_default(monkeypatch, tmp_path):
     # No selector: behaviour unchanged — the engine runs the project's main_scene,
-    # so no `--scene` engine option appears in the argv.
+    # so no `--scene` engine option appears in the argv. The harness tail still
+    # carries a slot for the selector — an EMPTY string (no selector requested).
     project = _project(tmp_path)
     argv = _capture_launch_argv(monkeypatch, project)
 
     assert "--scene" not in argv
+    # The trailing harness-tail selector slot is the empty string (no selector).
+    assert argv[-1] == ""
+
+
+# --- #278 (review): launch-time scene verification handshake ------------------
+# After the auth token, the harness sends a SECOND frame: the scene-verification
+# result {"scene_ok": bool, "current": "res://…"}. launch_session reads it and
+# returns a verified session, raises SceneMismatch, or returns None (generic fail).
+
+
+class _OneShotListener:
+    """A harness listener whose accept() hands back a pre-connected socket once."""
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    def settimeout(self, _):
+        pass
+
+    def accept(self):
+        if self._conn is None:
+            raise TimeoutError
+        conn, self._conn = self._conn, None
+        return conn, None
+
+
+def _launch_with_fake_harness(monkeypatch, tmp_path, *, token, verify, scene):
+    """Drive launch_session against a socketpair playing the harness side.
+
+    The "harness" end presents ``token`` then sends the ``verify`` dict as the
+    second frame. Returns the launch_session outcome (or the raised exception class
+    via pytest.raises in the caller).
+    """
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc())
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    daemon_end, harness_end = socket.socketpair()
+    # The harness presents its token, then the scene-verification frame.
+    write_frame(harness_end, token.to_utf8_buffer() if hasattr(token, "to_utf8_buffer") else token.encode("utf-8"))
+    if verify is not None:
+        write_frame(harness_end, json.dumps(verify).encode("utf-8"))
+    try:
+        return launch_session(
+            tmp_path,
+            "godot",
+            _OneShotListener(daemon_end),
+            tmp_path / "h.sock",
+            token,
+            timeout=1.0,
+            scene=scene,
+        )
+    finally:
+        harness_end.close()
+
+
+def test_launch_returns_verified_session_when_scene_ok(monkeypatch, tmp_path):
+    _project(tmp_path)
+    session = _launch_with_fake_harness(
+        monkeypatch,
+        tmp_path,
+        token="tok",
+        verify={"scene_ok": True, "current": "res://B.tscn"},
+        scene="res://B.tscn",
+    )
+    assert isinstance(session, EngineSession)
+
+
+def test_launch_raises_scene_mismatch_when_loaded_scene_differs(monkeypatch, tmp_path):
+    _project(tmp_path)
+    with pytest.raises(SceneMismatch):
+        _launch_with_fake_harness(
+            monkeypatch,
+            tmp_path,
+            token="tok",
+            verify={"scene_ok": False, "current": "res://main.tscn"},
+            scene="res://B.tscn",
+        )
+
+
+def test_launch_with_no_selector_does_not_require_a_verification_frame(monkeypatch, tmp_path):
+    # No selector: scene_ok is trivially true (the harness sends it as ok), and the
+    # session is verified — the main_scene default is unchanged.
+    _project(tmp_path)
+    session = _launch_with_fake_harness(
+        monkeypatch,
+        tmp_path,
+        token="tok",
+        verify={"scene_ok": True, "current": "res://main.tscn"},
+        scene=None,
+    )
+    assert isinstance(session, EngineSession)
+
+
+def test_launch_returns_none_on_bad_token(monkeypatch, tmp_path):
+    _project(tmp_path)
+    # A wrong token aborts the handshake BEFORE the verification frame: a generic
+    # launch failure (None), distinct from a scene mismatch.
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc())
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    daemon_end, harness_end = socket.socketpair()
+    write_frame(harness_end, b"WRONG")
+    try:
+        outcome = launch_session(
+            tmp_path,
+            "godot",
+            _OneShotListener(daemon_end),
+            tmp_path / "h.sock",
+            "tok",
+            timeout=1.0,
+            scene="res://B.tscn",
+        )
+    finally:
+        harness_end.close()
+    assert outcome is None
 
 
 # --- Slice 2: the daemon serves diag from the remembered log file ---

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -11,6 +11,7 @@ readiness / liveness seams are stubbed so the focus is the additive
 
 import json
 import os
+from pathlib import Path as _Path
 
 import pytest
 from typer.testing import CliRunner
@@ -61,7 +62,11 @@ def fake_ready(monkeypatch):
 
 def _start(project, **kw):
     return daemon_ops.run_daemon_start_operation(
-        project, None, spawn=lambda p, b, w: None, version_check=_OK_VERSION, **kw
+        project,
+        None,
+        spawn=lambda p, b, w, s: None,
+        version_check=_OK_VERSION,
+        **kw,
     )
 
 
@@ -170,7 +175,7 @@ def test_start_defaults_to_headless_and_reports_windowed_false(
     started = daemon_ops.run_daemon_start_operation(
         project,
         None,
-        spawn=lambda p, b, windowed: spawned.append((p, b, windowed)),
+        spawn=lambda p, b, windowed, scene: spawned.append((p, b, windowed)),
         version_check=_OK_VERSION,
     )
 
@@ -191,7 +196,7 @@ def test_start_windowed_threads_mode_into_spawn_and_result(
         project,
         None,
         windowed=True,
-        spawn=lambda p, b, windowed: spawned.append((p, b, windowed)),
+        spawn=lambda p, b, windowed, scene: spawned.append((p, b, windowed)),
         version_check=_OK_VERSION,
     )
 
@@ -199,6 +204,133 @@ def test_start_windowed_threads_mode_into_spawn_and_result(
     assert started.windowed is True
     # The windowed mode is threaded into the spawn (the daemon argv carries it).
     assert spawned[0][2] is True
+
+
+# `daemon start --scene <path|UID>` is a START-TIME selector: the daemon holds it
+# and passes it to the engine session as `--scene` (before `--path`). The recipe
+# threads the value into the spawn (the daemon argv) — like `windowed`. With no
+# `--scene`, the spawn carries `None` and the session runs the project's main_scene
+# unchanged (#278, ADR-0017 amendment).
+
+
+def test_start_threads_scene_into_spawn_when_set(
+    tmp_path, short_runtime, fake_ready, monkeypatch
+):
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
+    spawned: list[tuple] = []
+
+    started = daemon_ops.run_daemon_start_operation(
+        project,
+        None,
+        scene="res://B.tscn",
+        spawn=lambda p, b, windowed, scene: spawned.append((p, b, windowed, scene)),
+        version_check=_OK_VERSION,
+    )
+
+    assert isinstance(started, DaemonStartResult), started
+    # The selector is threaded into the spawn (the daemon argv carries it).
+    assert spawned[0][3] == "res://B.tscn"
+
+
+def test_start_defaults_to_no_scene_selector(
+    tmp_path, short_runtime, fake_ready, monkeypatch
+):
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
+    spawned: list[tuple] = []
+
+    started = daemon_ops.run_daemon_start_operation(
+        project,
+        None,
+        spawn=lambda p, b, windowed, scene: spawned.append((p, b, windowed, scene)),
+        version_check=_OK_VERSION,
+    )
+
+    assert isinstance(started, DaemonStartResult), started
+    # No selector: the spawn carries None — the session runs main_scene unchanged.
+    assert spawned[0][3] is None
+
+
+def test_spawn_daemon_forwards_scene_into_the_daemon_argv(monkeypatch):
+    # `_spawn_daemon` builds the detached `python -m gda.daemon` argv; the selector
+    # is forwarded as `--scene <value>` so the daemon process holds it (#278).
+    import subprocess as _subprocess
+
+    captured: dict = {}
+
+    class _FakePopen:
+        def __init__(self, argv, **kwargs):
+            captured["argv"] = argv
+
+    monkeypatch.setattr(_subprocess, "Popen", _FakePopen)
+
+    daemon_ops._spawn_daemon(_Path("/proj"), "godot", False, "res://B.tscn")
+
+    argv = captured["argv"]
+    assert "--scene" in argv
+    assert argv[argv.index("--scene") + 1] == "res://B.tscn"
+
+
+def test_spawn_daemon_omits_scene_when_none(monkeypatch):
+    import subprocess as _subprocess
+
+    captured: dict = {}
+
+    class _FakePopen:
+        def __init__(self, argv, **kwargs):
+            captured["argv"] = argv
+
+    monkeypatch.setattr(_subprocess, "Popen", _FakePopen)
+
+    daemon_ops._spawn_daemon(_Path("/proj"), "godot", False, None)
+
+    assert "--scene" not in captured["argv"]
+
+
+def test_daemon_main_parses_scene_into_the_server(monkeypatch):
+    # `python -m gda.daemon --scene res://B.tscn` parses the selector and constructs
+    # the DaemonServer with it, so a launched session boots that scene (#278).
+    import gda.daemon.__main__ as daemon_main
+
+    captured: dict = {}
+
+    class _FakeServer:
+        def __init__(self, paths, godot="", windowed=False, scene=None):
+            captured["scene"] = scene
+
+        def serve(self):
+            pass
+
+    monkeypatch.setattr(daemon_main, "DaemonServer", _FakeServer)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["gda.daemon", "--project", "/proj", "--scene", "res://B.tscn"],
+    )
+
+    daemon_main.main()
+
+    assert captured["scene"] == "res://B.tscn"
+
+
+def test_daemon_main_scene_defaults_to_none(monkeypatch):
+    import gda.daemon.__main__ as daemon_main
+
+    captured: dict = {}
+
+    class _FakeServer:
+        def __init__(self, paths, godot="", windowed=False, scene=None):
+            captured["scene"] = scene
+
+        def serve(self):
+            pass
+
+    monkeypatch.setattr(daemon_main, "DaemonServer", _FakeServer)
+    monkeypatch.setattr("sys.argv", ["gda.daemon", "--project", "/proj"])
+
+    daemon_main.main()
+
+    assert captured["scene"] is None
 
 
 def test_already_running_start_reports_windowed_unknown(
@@ -276,6 +408,69 @@ def test_cli_daemon_start_defaults_to_headless(tmp_path, short_runtime, monkeypa
     assert result.exit_code == 0, result.output
     assert captured["windowed"] is False
     assert json.loads(result.stdout)["windowed"] is False
+
+
+def test_cli_daemon_start_scene_threads_the_selector_to_the_recipe(
+    tmp_path, short_runtime, monkeypatch
+):
+    # `gda daemon start --scene res://B.tscn` reaches the recipe with the selector;
+    # the argv option is the start-time scene the session boots (#278).
+    project = _project(tmp_path)
+    captured: dict = {}
+
+    def fake_start(proj, godot, *, windowed=False, scene=None, **kw):
+        captured["scene"] = scene
+        return DaemonStartResult(
+            pid=1,
+            socket_path="/tmp/x.sock",
+            installed_harness=False,
+            harness_version=HARNESS_VERSION,
+            windowed=windowed,
+            already_running=False,
+        )
+
+    monkeypatch.setattr("gda.cli.run_daemon_start_operation", fake_start)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "daemon",
+            "start",
+            "--scene",
+            "res://B.tscn",
+            "--project",
+            str(project),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["scene"] == "res://B.tscn"
+
+
+def test_cli_daemon_start_defaults_to_no_scene(tmp_path, short_runtime, monkeypatch):
+    project = _project(tmp_path)
+    captured: dict = {}
+
+    def fake_start(proj, godot, *, windowed=False, scene=None, **kw):
+        captured["scene"] = scene
+        return DaemonStartResult(
+            pid=1,
+            socket_path="/tmp/x.sock",
+            installed_harness=False,
+            harness_version=HARNESS_VERSION,
+            windowed=windowed,
+            already_running=False,
+        )
+
+    monkeypatch.setattr("gda.cli.run_daemon_start_operation", fake_start)
+
+    result = CliRunner().invoke(
+        app, ["daemon", "start", "--project", str(project), "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["scene"] is None
 
 
 # --- status surfaces the running daemon's display mode (#251) -----------------

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -354,6 +354,41 @@ def test_already_running_start_reports_windowed_unknown(
     assert started.windowed is None
 
 
+def test_already_running_start_with_scene_is_a_typed_refusal(
+    tmp_path, short_runtime, monkeypatch
+):
+    # Finding 3: `--scene` only takes effect at daemon START. Requesting it against a
+    # daemon that is already running would otherwise be a SILENT no-op (the chosen
+    # scene never reaches the daemon). It is instead a typed `daemon_already_running`
+    # refusal naming the remediation (stop, then start --scene).
+    project = _project(tmp_path)
+    install_harness(project)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: 999)
+
+    failure = daemon_ops.run_daemon_start_operation(
+        project, None, scene="res://B.tscn", version_check=_OK_VERSION
+    )
+
+    assert isinstance(failure, Failure), failure
+    assert failure.error.code == "daemon_already_running"
+
+
+def test_already_running_start_without_scene_stays_idempotent_success(
+    tmp_path, short_runtime, monkeypatch
+):
+    # The already-running + NO `--scene` path is unchanged: idempotent success.
+    project = _project(tmp_path)
+    install_harness(project)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: 999)
+
+    started = daemon_ops.run_daemon_start_operation(
+        project, None, version_check=_OK_VERSION
+    )
+
+    assert isinstance(started, DaemonStartResult)
+    assert started.already_running is True
+
+
 def test_cli_daemon_start_windowed_threads_the_flag_to_the_recipe(
     tmp_path, short_runtime, monkeypatch
 ):

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -82,6 +82,9 @@ def test_a_verified_session_is_reused_without_re_checking_the_scene(tmp_path, mo
         calls["n"] += 1
         return served
 
+    # The selector names a scene that EXISTS, so the launch-boundary res:// pre-check
+    # passes and the (patched) launch proceeds; the point is it launches only ONCE.
+    (tmp_path / "B.tscn").write_text("[gd_scene format=3]\n", encoding="utf-8")
     monkeypatch.setattr("gda.daemon.server.launch_session", _launch_once)
     server = DaemonServer(_project_with_marker(tmp_path), godot="godot", scene="res://B.tscn")
     server._harness_listener = object()  # launch_session is patched; value unused
@@ -95,7 +98,9 @@ def test_a_verified_session_is_reused_without_re_checking_the_scene(tmp_path, mo
 
 def test_a_generic_launch_failure_is_engine_session_not_running(tmp_path, monkeypatch):
     # A None launch outcome (no connect / bad token / timeout) stays the generic
-    # engine_session_not_running — distinct from a scene mismatch.
+    # engine_session_not_running — distinct from a scene mismatch. The selector
+    # exists, so the res:// pre-check passes and the (patched) launch is reached.
+    (tmp_path / "B.tscn").write_text("[gd_scene format=3]\n", encoding="utf-8")
     monkeypatch.setattr("gda.daemon.server.launch_session", lambda *a, **k: None)
     server = DaemonServer(_project_with_marker(tmp_path), godot="godot", scene="res://B.tscn")
     server._harness_listener = object()  # launch_session is patched; value unused
@@ -105,6 +110,24 @@ def test_a_generic_launch_failure_is_engine_session_not_running(tmp_path, monkey
     assert (
         parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
     )
+
+
+def test_missing_res_scene_is_live_scene_not_found_before_launch(tmp_path, monkeypatch):
+    # A res:// selector that names NO file is rejected at the launch boundary, BEFORE
+    # launching — Godot would fail to launch (not fall-back-and-run) for a missing
+    # res:// path, so the harness verification can't see it; the daemon's pre-check
+    # surfaces the typed live_scene_not_found and never spawns the engine (#278).
+    def _must_not_launch(*a, **k):
+        raise AssertionError("launch_session must not be called for a missing res:// scene")
+
+    monkeypatch.setattr("gda.daemon.server.launch_session", _must_not_launch)
+    server = DaemonServer(_project_with_marker(tmp_path), godot="godot", scene="res://nope.tscn")
+    server._harness_listener = object()
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+
+    assert parse_result(reply["stdout"])["error"]["code"] == "live_scene_not_found"
+    assert server._session is None
 
 
 def test_no_scene_selector_runs_main_scene_unchanged(tmp_path):

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -46,7 +46,7 @@ def test_live_op_without_a_launchable_session_is_engine_session_not_running(tmp_
 
 def _project_with_marker(tmp_path):
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
+    return daemon_paths(tmp_path)
 
 
 def test_scene_mismatch_at_launch_is_a_typed_live_scene_not_found(tmp_path, monkeypatch):
@@ -60,6 +60,7 @@ def test_scene_mismatch_at_launch_is_a_typed_live_scene_not_found(tmp_path, monk
 
     monkeypatch.setattr("gda.daemon.server.launch_session", _mismatch)
     server = DaemonServer(_project_with_marker(tmp_path), godot="godot", scene="res://B.tscn")
+    server._harness_listener = object()  # launch_session is patched; value unused
 
     reply = server._handle({"op": "game-tree", "params": {}})
 
@@ -83,6 +84,7 @@ def test_a_verified_session_is_reused_without_re_checking_the_scene(tmp_path, mo
 
     monkeypatch.setattr("gda.daemon.server.launch_session", _launch_once)
     server = DaemonServer(_project_with_marker(tmp_path), godot="godot", scene="res://B.tscn")
+    server._harness_listener = object()  # launch_session is patched; value unused
 
     server._handle({"op": "game-tree", "params": {}})
     server._handle({"op": "game-tree", "params": {}})
@@ -96,6 +98,7 @@ def test_a_generic_launch_failure_is_engine_session_not_running(tmp_path, monkey
     # engine_session_not_running — distinct from a scene mismatch.
     monkeypatch.setattr("gda.daemon.server.launch_session", lambda *a, **k: None)
     server = DaemonServer(_project_with_marker(tmp_path), godot="godot", scene="res://B.tscn")
+    server._harness_listener = object()  # launch_session is patched; value unused
 
     reply = server._handle({"op": "game-tree", "params": {}})
 

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -37,55 +37,76 @@ def test_live_op_without_a_launchable_session_is_engine_session_not_running(tmp_
     assert parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
 
 
-def test_a_nonexistent_scene_selector_is_a_typed_live_scene_not_found(tmp_path):
-    # #278 / ADR-0017 amendment: a missing/non-existent `--scene` selector MUST
-    # surface a typed `live_scene_not_found` — NEVER a silent fall back to
-    # main_scene. The daemon validates the res:// selector against the project
-    # before launching, so the failure is precise (not a vague launch error).
+# --- #278 (review): scene verification happens at LAUNCH (in the harness), never
+# per-request. The daemon maps the launch outcome: a verified session is cached and
+# reused without re-checking (so deleting the scene file mid-session does NOT break
+# live ops); a scene MISMATCH (loaded scene != requested selector, incl. a bad uid
+# that Godot fell back from) tears the session down and is a typed live_scene_not_found.
+
+
+def _project_with_marker(tmp_path):
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    server = DaemonServer(
-        daemon_paths(tmp_path), godot="godot", scene="res://nope.tscn"
-    )
+    return tmp_path
+
+
+def test_scene_mismatch_at_launch_is_a_typed_live_scene_not_found(tmp_path, monkeypatch):
+    # The harness reported the loaded scene != the requested selector (the no-silent-
+    # fallback guarantee, incl. a bad uid Godot replaced with main_scene): the daemon
+    # surfaces a typed live_scene_not_found, not a vague launch error.
+    from gda.daemon.session import SceneMismatch
+
+    def _mismatch(*a, **k):
+        raise SceneMismatch("res://B.tscn", "res://main.tscn")
+
+    monkeypatch.setattr("gda.daemon.server.launch_session", _mismatch)
+    server = DaemonServer(_project_with_marker(tmp_path), godot="godot", scene="res://B.tscn")
 
     reply = server._handle({"op": "game-tree", "params": {}})
 
     assert parse_result(reply["stdout"])["error"]["code"] == "live_scene_not_found"
+    # The half-alive (wrong-scene) session was NOT cached for reuse.
+    assert server._session is None
 
 
-def test_an_existing_scene_selector_passes_the_validation_gate(tmp_path):
-    # An existing res:// scene passes scene validation; with no real Godot binary
-    # the launch then fails as engine_session_not_running (not scene_not_found) —
-    # proving the gate let a real scene through.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    (tmp_path / "B.tscn").write_text("[gd_scene format=3]\n", encoding="utf-8")
-    server = DaemonServer(daemon_paths(tmp_path), godot="", scene="res://B.tscn")
+def test_a_verified_session_is_reused_without_re_checking_the_scene(tmp_path, monkeypatch):
+    # Finding 1 fix: scene is verified ONCE at launch. A verified session is cached
+    # and reused on later ops — launch_session is called exactly once even across
+    # multiple live ops (no per-request disk/scene re-validation), so deleting the
+    # scene file after launch cannot break a live op.
+    calls = {"n": 0}
+    served = EngineSession(_FakeProc(), conn=None)
+    served.request = lambda op, params: {"stdout": "ok", "stderr": "", "exit_code": 0}
+
+    def _launch_once(*a, **k):
+        calls["n"] += 1
+        return served
+
+    monkeypatch.setattr("gda.daemon.server.launch_session", _launch_once)
+    server = DaemonServer(_project_with_marker(tmp_path), godot="godot", scene="res://B.tscn")
+
+    server._handle({"op": "game-tree", "params": {}})
+    server._handle({"op": "game-tree", "params": {}})
+    server._handle({"op": "game-tree", "params": {}})
+
+    assert calls["n"] == 1  # launched (and verified) once, reused thereafter
+
+
+def test_a_generic_launch_failure_is_engine_session_not_running(tmp_path, monkeypatch):
+    # A None launch outcome (no connect / bad token / timeout) stays the generic
+    # engine_session_not_running — distinct from a scene mismatch.
+    monkeypatch.setattr("gda.daemon.server.launch_session", lambda *a, **k: None)
+    server = DaemonServer(_project_with_marker(tmp_path), godot="godot", scene="res://B.tscn")
 
     reply = server._handle({"op": "game-tree", "params": {}})
 
     assert (
-        parse_result(reply["stdout"])["error"]["code"]
-        == "engine_session_not_running"
-    )
-
-
-def test_a_uid_scene_selector_passes_the_validation_gate(tmp_path):
-    # A `uid://…` selector cannot be checked by file existence daemon-side; it is
-    # passed through to the engine, so it clears the gate (and then fails to launch
-    # here with no real binary) rather than being wrongly rejected as not-found.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    server = DaemonServer(daemon_paths(tmp_path), godot="", scene="uid://abc123")
-
-    reply = server._handle({"op": "game-tree", "params": {}})
-
-    assert (
-        parse_result(reply["stdout"])["error"]["code"]
-        == "engine_session_not_running"
+        parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
     )
 
 
 def test_no_scene_selector_runs_main_scene_unchanged(tmp_path):
-    # The selector-less default is unchanged: no scene validation, straight to the
-    # launch path (which here is engine_session_not_running with no real binary).
+    # The selector-less default is unchanged: straight to the launch path (which here
+    # is engine_session_not_running with no real binary), no scene verification.
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
     server = DaemonServer(daemon_paths(tmp_path), godot="")
 

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -37,6 +37,66 @@ def test_live_op_without_a_launchable_session_is_engine_session_not_running(tmp_
     assert parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
 
 
+def test_a_nonexistent_scene_selector_is_a_typed_live_scene_not_found(tmp_path):
+    # #278 / ADR-0017 amendment: a missing/non-existent `--scene` selector MUST
+    # surface a typed `live_scene_not_found` — NEVER a silent fall back to
+    # main_scene. The daemon validates the res:// selector against the project
+    # before launching, so the failure is precise (not a vague launch error).
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    server = DaemonServer(
+        daemon_paths(tmp_path), godot="godot", scene="res://nope.tscn"
+    )
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+
+    assert parse_result(reply["stdout"])["error"]["code"] == "live_scene_not_found"
+
+
+def test_an_existing_scene_selector_passes_the_validation_gate(tmp_path):
+    # An existing res:// scene passes scene validation; with no real Godot binary
+    # the launch then fails as engine_session_not_running (not scene_not_found) —
+    # proving the gate let a real scene through.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    (tmp_path / "B.tscn").write_text("[gd_scene format=3]\n", encoding="utf-8")
+    server = DaemonServer(daemon_paths(tmp_path), godot="", scene="res://B.tscn")
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+
+    assert (
+        parse_result(reply["stdout"])["error"]["code"]
+        == "engine_session_not_running"
+    )
+
+
+def test_a_uid_scene_selector_passes_the_validation_gate(tmp_path):
+    # A `uid://…` selector cannot be checked by file existence daemon-side; it is
+    # passed through to the engine, so it clears the gate (and then fails to launch
+    # here with no real binary) rather than being wrongly rejected as not-found.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    server = DaemonServer(daemon_paths(tmp_path), godot="", scene="uid://abc123")
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+
+    assert (
+        parse_result(reply["stdout"])["error"]["code"]
+        == "engine_session_not_running"
+    )
+
+
+def test_no_scene_selector_runs_main_scene_unchanged(tmp_path):
+    # The selector-less default is unchanged: no scene validation, straight to the
+    # launch path (which here is engine_session_not_running with no real binary).
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    server = DaemonServer(daemon_paths(tmp_path), godot="")
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+
+    assert (
+        parse_result(reply["stdout"])["error"]["code"]
+        == "engine_session_not_running"
+    )
+
+
 def test_control_ops_report_liveness_and_request_stop(tmp_path):
     server = DaemonServer(daemon_paths(tmp_path), godot="")
 

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -276,3 +276,65 @@ def test_daemon_status_surfaces_the_windowed_display_mode(tmp_path, daemon_runti
         assert windowed["windowed"] is True
     finally:
         run("daemon", "stop")
+
+
+# A SECOND scene the session can boot via `--scene`, distinct from main.tscn so the
+# runtime tree's root name proves WHICH scene ran. Its root is "B" (not "Main").
+B_TSCN = (
+    "[gd_scene format=3]\n\n"
+    '[node name="B" type="Node2D"]\n\n'
+    '[node name="Marker" type="Node2D" parent="."]\n'
+)
+
+
+@pytest.mark.e2e
+def test_daemon_start_scene_runs_the_chosen_scene_not_main(tmp_path, daemon_runtime_dir):
+    # #278 (ADR-0017 amendment): `daemon start --scene res://B.tscn` boots the chosen
+    # scene B — `game tree` reports B's root (not Main's), proving the engine received
+    # `--scene` (before `--path`) — and `project.godot`'s `main_scene` is UNCHANGED
+    # (no mutation, F6-equivalent). With scenes A (main) + B present.
+    project_text = PROJECT_GODOT
+    (tmp_path / "project.godot").write_text(project_text, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "B.tscn").write_text(B_TSCN, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+
+    try:
+        started = run("daemon", "start", "--scene", "res://B.tscn")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        tree = run("game", "tree")
+        assert tree.returncode == 0, tree.stdout + tree.stderr
+        root = json.loads(tree.stdout)["root"]
+        # The chosen scene B ran — NOT the project's main_scene (Main).
+        assert root["name"] == "B"
+        assert any(c["name"] == "Marker" for c in root.get("children", []))
+
+        # main_scene is untouched on disk (running a scene is not setting it).
+        assert (
+            'run/main_scene="res://main.tscn"'
+            in (tmp_path / "project.godot").read_text(encoding="utf-8")
+        )
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_start_nonexistent_scene_is_typed_live_scene_not_found(
+    tmp_path, daemon_runtime_dir
+):
+    # #278: a non-existent `--scene` selector surfaces a TYPED `live_scene_not_found`
+    # (LIVE exit 6) on the first live op — NEVER a silent fall back to main_scene.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+
+    try:
+        started = run("daemon", "start", "--scene", "res://does_not_exist.tscn")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        tree = run("game", "tree")
+        assert tree.returncode == 6, tree.stdout + tree.stderr
+        assert json.loads(tree.stdout)["error"]["code"] == "live_scene_not_found"
+    finally:
+        run("daemon", "stop")

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -325,6 +325,8 @@ def test_daemon_start_nonexistent_scene_is_typed_live_scene_not_found(
 ):
     # #278: a non-existent `--scene` selector surfaces a TYPED `live_scene_not_found`
     # (LIVE exit 6) on the first live op — NEVER a silent fall back to main_scene.
+    # Detected at launch by the harness (the loaded scene != the requested selector),
+    # surfaced when the lazy launch is triggered by `game tree`.
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
     run = _gda(tmp_path, {**os.environ})
@@ -336,5 +338,83 @@ def test_daemon_start_nonexistent_scene_is_typed_live_scene_not_found(
         tree = run("game", "tree")
         assert tree.returncode == 6, tree.stdout + tree.stderr
         assert json.loads(tree.stdout)["error"]["code"] == "live_scene_not_found"
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_start_nonexistent_uid_is_typed_not_silent_main_scene(
+    tmp_path, daemon_runtime_dir
+):
+    # #278 review finding 2: Godot given a BAD `uid://` selector silently falls back
+    # to main_scene. Launch-time harness verification catches this — the loaded scene
+    # (main) != the requested uid — and surfaces a typed `live_scene_not_found`, NOT a
+    # silent success on main_scene.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+
+    try:
+        started = run("daemon", "start", "--scene", "uid://doesnotexist000")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        tree = run("game", "tree")
+        assert tree.returncode == 6, tree.stdout + tree.stderr
+        assert json.loads(tree.stdout)["error"]["code"] == "live_scene_not_found"
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_start_scene_against_a_running_daemon_is_a_typed_refusal(
+    tmp_path, daemon_runtime_dir
+):
+    # #278 review finding 3: `--scene` only takes effect at daemon START. Against a
+    # daemon that is already running it is a typed `daemon_already_running` refusal,
+    # NOT a silent no-op that quietly ignores the chosen scene.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "B.tscn").write_text(B_TSCN, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+
+    try:
+        assert run("daemon", "start").returncode == 0
+
+        refused = run("daemon", "start", "--scene", "res://B.tscn")
+        assert refused.returncode == 6, refused.stdout + refused.stderr
+        assert json.loads(refused.stdout)["error"]["code"] == "daemon_already_running"
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_scene_verified_once_at_launch_survives_deleting_the_file(
+    tmp_path, daemon_runtime_dir
+):
+    # #278 review finding 1: scene is verified ONCE at launch, never per-request. A
+    # live session bound to scene B keeps serving B after B.tscn is deleted on disk —
+    # the running game does not reload disk edits (ADR-0017/0020 session-bound state),
+    # so a later `game tree` STILL reports B, not `live_scene_not_found`.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    b_scene = tmp_path / "B.tscn"
+    b_scene.write_text(B_TSCN, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+
+    try:
+        assert run("daemon", "start", "--scene", "res://B.tscn").returncode == 0
+
+        first = run("game", "tree")
+        assert first.returncode == 0, first.stdout + first.stderr
+        assert json.loads(first.stdout)["root"]["name"] == "B"
+
+        # Delete the scene file out from under the LIVE session.
+        b_scene.unlink()
+
+        # The session is bound to B and verified once at launch — it STILL serves B
+        # (no per-request disk re-validation).
+        again = run("game", "tree")
+        assert again.returncode == 0, again.stdout + again.stderr
+        assert json.loads(again.stdout)["root"]["name"] == "B"
     finally:
         run("daemon", "stop")

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -29,10 +29,16 @@ LIVE_ERROR_CODES = (
     # NOT GDScript-mirrored.
     "daemon_running",
     # The session-scene-selection failure (#278): `daemon start --scene <bad>`
-    # surfaces a typed not-found rather than silently running main_scene. The daemon
-    # mints it (validating the res:// selector before launch), so it is a
-    # daemon-channel classifier-source LIVE code, NOT GDScript-mirrored.
+    # surfaces a typed not-found rather than silently running main_scene. The
+    # harness verifies the ACTUALLY-LOADED scene against the requested selector at
+    # launch; a mismatch is surfaced by the daemon as this daemon-channel
+    # classifier-source LIVE code, NOT GDScript-mirrored.
     "live_scene_not_found",
+    # The already-running + `--scene` refusal (#278 review): `--scene` only takes
+    # effect at daemon start, so requesting it against a daemon that is already
+    # running is a typed refusal rather than a silent no-op. Classifier-source (the
+    # start recipe emits it), NOT GDScript-mirrored.
+    "daemon_already_running",
 )
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -28,6 +28,11 @@ LIVE_ERROR_CODES = (
     # LIVE-category, classifier-source (the uninstall recipe emits it), exit 6,
     # NOT GDScript-mirrored.
     "daemon_running",
+    # The session-scene-selection failure (#278): `daemon start --scene <bad>`
+    # surfaces a typed not-found rather than silently running main_scene. The daemon
+    # mints it (validating the res:// selector before launch), so it is a
+    # daemon-channel classifier-source LIVE code, NOT GDScript-mirrored.
+    "live_scene_not_found",
 )
 
 ROOT = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## What & why

Threads an optional **`gda daemon start --scene <path|UID>`** selector through the daemon into the live `Engine session` launch, so the session boots a chosen scene via Godot's native `--scene` engine option (inserted **before** `--path`). With no `--scene`, behaviour is unchanged (runs `main_scene`). A missing/non-existent scene — `res://` path **or** `uid://` — surfaces a typed `live_scene_not_found`, **never** a silent fallback to `main_scene`.

Realizes the **ADR-0017 amendment (2026-06-24, #278)** (session scene selection as an extension of Decision 2) under **ADR-0025** (surface-inclusion). Trust boundary unchanged (running a scene runs its `_ready` — the same trusted-project surface mutating ops already cross, ADR-0009).

## Acceptance criteria

- [x] `gda daemon start --scene <path|UID>` launches the session on the given scene; engine receives `--scene` before `--path`.
- [x] No `--scene` → still runs `main_scene` (no behaviour change for existing callers).
- [x] Accepts a path **or** a UID; a non-existent scene (either form) → typed `live_scene_not_found` (`LIVE`/classifier code, exit 6), not a silent fallback.
- [x] Unit coverage of launch-argv construction (`--scene` inserted in the right position when set, omitted when not).
- [x] `--schema` gate passes; `--json` / error-envelope shapes unchanged.
- [x] e2e (real Godot 4.6): `daemon start --scene res://B.tscn` → `game tree` reports **B**, `main_scene` unchanged; non-existent `res://` and bad `uid://` → typed error.

## Scene validation — at the launch boundary (post-review rework)

The selector is validated **once, at session launch** (not per-request), by what *actually loaded* — so an alive session is never re-validated against later disk changes (ADR-0020 session-bound). Two engine behaviours, one typed outcome:

- **`res://` / filesystem path** — checked for existence at the launch boundary **before** spawning (Godot fails to launch on a missing `res://` rather than fall-back-and-run, so it must be caught pre-launch) → `live_scene_not_found`.
- **`uid://`** — can't be resolved daemon-side, so the **harness verifies at launch**: it compares the actually-loaded `current_scene.scene_file_path` against the selector (resolving the uid via `ResourceUID`). Godot silently runs `main_scene` for a bad uid; the harness detects the mismatch → the daemon tears the session down → `live_scene_not_found`. **No silent fallback.**
- **Already-running daemon + `--scene`** — `--scene` is a start-time selector; a repeat start with `--scene` on a live daemon returns a typed **`daemon_already_running`** (guides `gda daemon stop` then start), instead of silently ignoring it. Already-running with no `--scene` stays idempotent success.

## Tests

- Fast tier: **929 passed** (`pytest -m "not e2e"`). Schema gate: **96 passed**.
- Real-Godot e2e (`tests/test_e2e_daemon.py`): **11 passed**, incl. chosen-scene runs / `main_scene` unchanged, missing `res://` → typed, bad `uid://` → typed (not silent `main_scene`), already-running `--scene` → typed refusal, and a verified session surviving deletion of the scene file mid-session (no per-request re-validation).

## Notes

- New `LIVE` classifier-source codes: `live_scene_not_found`, `daemon_already_running` (registered in `error_codes.py` + the ADR-0002 table).
- **Merge note:** bumps `HARNESS_VERSION` `0`→`1` (harness gains launch-time scene verification). PR #288 (#282) also bumps it to `1`; the two will be reconciled to one coherent value when the second of them merges.
- Disjoint from the diag/logger CLI surface; touches the daemon-launch stack + harness handshake.

Closes #278
