### PR TITLE
feat(diag): error callstacks in diag errors

### DIFF
--- a/docs/adr/0022-runtime-diagnostics-via-daemon-owned-session-log.md
+++ b/docs/adr/0022-runtime-diagnostics-via-daemon-owned-session-log.md
@@ -61,6 +61,16 @@ apart by `level`). It is best-effort: an unrecognized or continuation line (a
 multi-line backtrace, interleaved print output) is skipped and never fails the
 parse.
 
+> **Outcome (2026-06-25, #283) — `diag errors` now captures the backtrace as a `callstack`.**
+> The "a multi-line backtrace … is skipped" above held while a `DiagError` was a single
+> `{level, message, function?, file?, line?}` frame. The error-callstack slice (#283) extends
+> `parse_errors`: the `GDScript backtrace (most recent call first):` block following the `at:`
+> line is consumed into an ordered `callstack` of `{function, file, line}` frames on each
+> `DiagError` (empty when the engine logged none), surfaced on `gda diag errors` `--json` /
+> `--schema`. Other interleaved lines (non-backtrace print output) are still skipped for
+> `errors`; the *whole* log — backtrace lines included — is available structurally via
+> `gda logger tail` (ADR-0026).
+
 ## Considered options
 
 - **Daemon launches with `--log-file` and reads the file daemon-side** (chosen) —

--- a/docs/adr/0026-structured-runtime-log-protocol.md
+++ b/docs/adr/0026-structured-runtime-log-protocol.md
@@ -13,6 +13,12 @@ is unstructured. This ADR adds `gda logger`: a structured runtime-log channel an
 that backs it. It is in scope under ADR-0025 (read-only observability is in; interactive debugging
 is out) and deliberately does **not** tap Godot's remote-debug protocol.
 
+> **Outcome (2026-06-25, #283) — `diag errors` gained the `callstack`.** The baseline shape above
+> (`{level, message, function, file, line}`) is the pre-#283 state; `diag errors` now additionally
+> carries an ordered `callstack: SourceFrame[]` of `{function, file, line}` frames (decision 4's
+> "callstack-enriched view"), parsed from the Session-log `GDScript backtrace`. Realized by the
+> error-callstack slice #283; see ADR-0022's #283 outcome note.
+
 > **Amendment (2026-06-25, #281) — the read result is `LoggerTailResult { records: LogRecord[] }`,
 > the passive parse is whole-log lossless, and `--raw` returns info records.** Decision 3 wrote the
 > read contract as "→ `LogRecord[]`"; it is delivered as a single-field result object

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -506,9 +506,11 @@ headless is unaffected (4.4+, cross-platform).
   node is `live_perf_node_not_found`, an absent property `live_perf_property_not_found`,
   an absent signal `live_perf_signal_not_found`; a genuinely stalled engine is caught
   by the daemon-level `live_timeout`.
-- **`diag` (diagnostics):** runtime errors of the running game (shipped, #224). `gda diag errors`
-  reads the running game's runtime errors as structured `{level, message, function?, file?, line?}`
-  (warnings included, distinguished by `level`), with `--limit N`. Daemon-served, not
+- **`diag` (diagnostics):** runtime errors of the running game (shipped, #224; callstacks #283). `gda diag errors`
+  reads the running game's runtime errors as structured `{level, message, function?, file?, line?, callstack}`
+  (warnings included, distinguished by `level`), with `--limit N`. `callstack` is an ordered
+  `SourceFrame[]` of `{function, file, line}` frames parsed from the engine's `GDScript backtrace`
+  block in the Session log — empty when the error logged none (#283). Daemon-served, not
   harness-relayed: the daemon reads the `Session log` it launched the engine with (`--log-file`),
   so it works even after the game has crashed — a remembered session with a missing log is
   `live_log_unavailable`, an empty log is an empty result (ADR-0022). (The raw `diag log` is

--- a/src/gda/daemon/diag.py
+++ b/src/gda/daemon/diag.py
@@ -13,8 +13,11 @@ Godot writes an error as a two-line pair (verified against the engine's
        at: <function> (<file>:<line>)
 
 where ``<TYPE>`` is one of ``ERROR`` / ``WARNING`` / ``SCRIPT ERROR`` /
-``SHADER ERROR``. Print output is plain lines. Some errors carry a multi-line
-script backtrace after the ``at:`` line.
+``SHADER ERROR``. Print output is plain lines. A runtime GDScript error carries
+a multi-line call stack after the ``at:`` line — a ``GDScript backtrace (most
+recent call first):`` marker then one ``[N] <function> (<file>:<line>)`` frame
+line per stack frame (#283); ``parse_errors`` folds those frames into the
+error's ordered ``callstack`` (frame ``[0]`` equals the ``at:`` location).
 
 The parsing is **best-effort**: a line that is neither a recognized ``<TYPE>:``
 header nor the ``   at:`` follow-on (a backtrace, an interleaved print line) is
@@ -31,6 +34,16 @@ _ERROR_HEADER = re.compile(r"^(ERROR|WARNING|SCRIPT ERROR|SHADER ERROR): (.*)$")
 # The engine's follow-on location line: ``   at: <function> (<file>:<line>)``.
 # Leading whitespace varies by ErrorType indent, so it is matched loosely.
 _AT_LINE = re.compile(r"^\s*at:\s*(?P<function>.*?)\s*\((?P<file>.*):(?P<line>\d+)\)\s*$")
+
+# After the ``at:`` line, a runtime GDScript error MAY carry a full call stack:
+# a marker line ``GDScript backtrace (most recent call first):`` then one frame
+# line per stack frame, ``       [N] <function> (<file>:<line>)`` (verified
+# against Godot 4.6.3). Frames are ordered most-recent-first; frame ``[0]``
+# equals the ``at:`` location. push_error / warnings carry no backtrace.
+_BACKTRACE_MARKER = re.compile(r"^\s*GDScript backtrace\b.*:\s*$")
+_FRAME_LINE = re.compile(
+    r"^\s*\[\d+\]\s*(?P<function>.*?)\s*\((?P<file>.*):(?P<line>\d+)\)\s*$"
+)
 
 # The engine ``<TYPE>`` string -> the normalized, machine-stable ``level``.
 _LEVEL_BY_TYPE = {
@@ -58,12 +71,15 @@ def _lines(data: str | bytes) -> list[str]:
 def parse_errors(data: str | bytes, limit: int | None = None) -> list[dict]:
     """Structured errors from a Session log's text — best-effort (#224).
 
-    Returns ``{level, message, function, file, line}`` per recognized error
-    header (warnings included, distinguished by ``level``). The optional ``at:``
-    follow-on fills ``function``/``file``/``line``; absent, they are ``None`` (a
-    bare error without a location is not a failure). Unrecognized/continuation
-    lines (backtraces, interleaved print output) are skipped. ``limit`` tails the
-    most recent ``N`` errors. Empty input -> ``[]``.
+    Returns ``{level, message, function, file, line, callstack}`` per recognized
+    error header (warnings included, distinguished by ``level``). The optional
+    ``at:`` follow-on fills ``function``/``file``/``line``; absent, they are
+    ``None`` (a bare error without a location is not a failure). ``callstack`` is
+    the ordered ``{function, file, line}`` frames from the optional ``GDScript
+    backtrace`` block (most-recent-first; frame ``[0]`` equals the ``at:``
+    location); a push_error / warning carries no backtrace, so ``callstack`` is
+    ``[]``. Unrecognized/continuation lines (interleaved print output) are
+    skipped. ``limit`` tails the most recent ``N`` errors. Empty input -> ``[]``.
     """
     lines = _lines(data)
     errors: list[dict] = []
@@ -80,16 +96,36 @@ def parse_errors(data: str | bytes, limit: int | None = None) -> list[dict]:
             "function": None,
             "file": None,
             "line": None,
+            "callstack": [],
         }
         # The next line MAY be the engine's ``at:`` location follow-on; if so,
-        # consume it. Anything else (a backtrace, the next header, an output
-        # line) is left for the next iteration.
+        # consume it. Anything else (the next header, an output line) is left for
+        # the next iteration.
         if i + 1 < len(lines):
             at = _AT_LINE.match(lines[i + 1])
             if at is not None:
                 entry["function"] = at.group("function") or None
                 entry["file"] = at.group("file") or None
                 entry["line"] = int(at.group("line"))
+                i += 1
+        # After the ``at:`` line, the engine MAY emit a ``GDScript backtrace``
+        # marker followed by ``[N] func (file:line)`` frame lines. Consume the
+        # marker and every contiguous frame line into ``callstack``; a non-frame
+        # line (the next header, a print line) ends the block, left for the next
+        # iteration.
+        if i + 1 < len(lines) and _BACKTRACE_MARKER.match(lines[i + 1]):
+            i += 1
+            while i + 1 < len(lines):
+                frame = _FRAME_LINE.match(lines[i + 1])
+                if frame is None:
+                    break
+                entry["callstack"].append(
+                    {
+                        "function": frame.group("function") or None,
+                        "file": frame.group("file") or None,
+                        "line": int(frame.group("line")),
+                    }
+                )
                 i += 1
         errors.append(entry)
         i += 1

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -2608,6 +2608,22 @@ _DIAG_LIMIT_DESC = (
 )
 
 
+class SourceFrame(BaseModel):
+    """One frame of a GDScript call stack: a ``{function, file, line}`` location.
+
+    The ordered unit of a runtime error's ``callstack`` (#283) — the function the
+    engine was in, the source file it lives in, and the line within it. Each
+    facet is nullable so a frame the engine reported only partially still parses
+    (best-effort, never a parse failure).
+    """
+
+    function: str | None = Field(default=None, description="The frame's function name, if known.")
+    file: str | None = Field(
+        default=None, description="The frame's source path (e.g. res://main.gd), if known."
+    )
+    line: int | None = Field(default=None, description="The frame's source line, if known.")
+
+
 class DiagError(BaseModel):
     """One structured runtime error/warning of the running game (#224).
 
@@ -2616,7 +2632,9 @@ class DiagError(BaseModel):
     an agent branches on the severity without parsing prose — warnings are
     included, told apart by ``level``. The location (``function``/``file``/
     ``line``) is filled from the ``   at:`` follow-on when present; a bare error
-    leaves them ``null`` (best-effort, never a parse failure).
+    leaves them ``null`` (best-effort, never a parse failure). A runtime GDScript
+    error additionally carries its ordered ``callstack`` of frames (#283); a bare
+    push_error / warning has no backtrace, so ``callstack`` is empty.
     """
 
     level: str = Field(
@@ -2630,6 +2648,14 @@ class DiagError(BaseModel):
         default=None, description="The source path (e.g. res://main.gd), if known."
     )
     line: int | None = Field(default=None, description="The source line, if known.")
+    callstack: list[SourceFrame] = Field(
+        default_factory=list,
+        description=(
+            "The ordered call stack (most-recent-first) when the engine emitted a "
+            "GDScript backtrace; frame [0] equals the top {function,file,line}. "
+            "Empty for a bare push_error / warning."
+        ),
+    )
 
 
 class DiagErrorsParams(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -2609,12 +2609,13 @@ _DIAG_LIMIT_DESC = (
 
 
 class SourceFrame(BaseModel):
-    """One frame of a GDScript call stack: a ``{function, file, line}`` location.
+    """A source location ``{function, file, line}`` (ADR-0026, #283).
 
-    The ordered unit of a runtime error's ``callstack`` (#283) — the function the
-    engine was in, the source file it lives in, and the line within it. Each
-    facet is nullable so a frame the engine reported only partially still parses
-    (best-effort, never a parse failure).
+    A small, generic frame model: a function name, the source path it lives in,
+    and the line, each ``null`` when the source did not carry it. Shared by a
+    :class:`LogRecord`'s ``source`` (the engine's ``at:`` follow-on) and the
+    ordered ``callstack`` frames of a :class:`DiagError` (best-effort, never a
+    parse failure).
     """
 
     function: str | None = Field(default=None, description="The frame's function name, if known.")
@@ -2684,25 +2685,6 @@ class DiagErrorsResult(BaseModel):
 # `diag` (`--log-file`, ADR-0022) and so crash-survivable. The passive,
 # non-invasive floor of the structured-log protocol — `diag log` (raw) is
 # SUPERSEDED by `gda logger tail`, whose default output is structured records.
-
-
-class SourceFrame(BaseModel):
-    """A source location ``{function, file, line}`` (ADR-0026).
-
-    A small, generic frame model: a function name, the source path it lives in,
-    and the line, each ``null`` when the source did not carry it. Used for a
-    :class:`LogRecord`'s ``source`` (the ``at:`` follow-on the engine logs after an
-    error); named generically because the error-callstack slice (#283) reuses it
-    for an error's call frames.
-    """
-
-    function: str | None = Field(
-        default=None, description="The reporting function, or null when unknown."
-    )
-    file: str | None = Field(
-        default=None, description="The source path (e.g. res://main.gd), or null when unknown."
-    )
-    line: int | None = Field(default=None, description="The 1-based source line, or null when unknown.")
 
 
 class LogLevel(str, Enum):

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -196,8 +196,11 @@ def render_diag_errors(diag: "DiagErrorsResult") -> str:
     """Render the running game's runtime errors as `LEVEL: message (at: loc)` lines (#224).
 
     One line per error/warning; the location is appended when known (a bare error
-    omits it). An empty read renders a short `no runtime errors` note rather than
-    a blank string, so the human output is never ambiguous.
+    omits it). A runtime GDScript error's ordered ``callstack`` (#283) renders as
+    indented ``function (file:line)`` frame lines below the headline (most-recent-
+    first); a bare error with no backtrace shows just its one line. An empty read
+    renders a short `no runtime errors` note rather than a blank string, so the
+    human output is never ambiguous.
     """
     if not diag.errors:
         return "no runtime errors"
@@ -209,6 +212,10 @@ def render_diag_errors(diag: "DiagErrorsResult") -> str:
             at = f" (at: {err.function} {loc})" if err.function else f" (at: {loc})"
             line += at
         lines.append(line)
+        for frame in err.callstack:
+            loc = f"{frame.file}:{frame.line}" if frame.line is not None else frame.file
+            where = f"({loc})" if loc is not None else ""
+            lines.append(f"  {frame.function or '<unknown>'} {where}".rstrip())
     return "\n".join(lines)
 
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -467,6 +467,12 @@ DIAG_ERRORS_RESULT = {
             "function": "_ready",
             "file": "res://main.gd",
             "line": 9,
+            # A runtime GDScript error carries its ordered call stack (#283),
+            # most-recent-first; frame [0] equals the top {function,file,line}.
+            "callstack": [
+                {"function": "_ready", "file": "res://main.gd", "line": 9},
+                {"function": "a", "file": "res://main.gd", "line": 6},
+            ],
         },
         {
             "level": "warning",
@@ -474,6 +480,7 @@ DIAG_ERRORS_RESULT = {
             "function": "_process",
             "file": "res://main.gd",
             "line": 20,
+            "callstack": [],  # a warning has no backtrace
         },
         {
             "level": "error",
@@ -481,6 +488,7 @@ DIAG_ERRORS_RESULT = {
             "function": None,
             "file": None,
             "line": None,
+            "callstack": [],
         },
     ]
 }

--- a/tests/test_diag_commands.py
+++ b/tests/test_diag_commands.py
@@ -42,7 +42,13 @@ def test_diag_errors_emits_structured_errors_json_through_the_live_channel(monke
     data = json.loads(result.stdout)
     assert data["errors"][0]["level"] == "error"
     assert data["errors"][0]["message"] == "boom"
+    # The error carries its ordered call stack (#283); a warning's is empty.
+    assert data["errors"][0]["callstack"] == [
+        {"function": "_ready", "file": "res://main.gd", "line": 9},
+        {"function": "a", "file": "res://main.gd", "line": 6},
+    ]
     assert data["errors"][1]["level"] == "warning"  # warnings included
+    assert data["errors"][1]["callstack"] == []
     # Routed through the LIVE seam, dispatching the diag-errors op (no limit).
     assert fake.calls == [("diag-errors", {"limit": None})]
 
@@ -84,6 +90,9 @@ def test_diag_errors_human_output_renders_levels(monkeypatch, tmp_path):
     # Human output names the level and message; the location is shown when present.
     assert "boom" in result.stdout
     assert "res://main.gd:9" in result.stdout
+    # The call-stack frames render under the error (#283), naming the originating
+    # frame, not just the top location.
+    assert "a (res://main.gd:6)" in result.stdout
 
 
 def test_diag_errors_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):

--- a/tests/test_diag_log_parser.py
+++ b/tests/test_diag_log_parser.py
@@ -119,3 +119,85 @@ def test_parse_log_accepts_bytes_and_is_empty_on_empty():
     assert parse_log(b"a\nb\n") == ["a", "b"]
     assert parse_log("") == []
     assert parse_log(b"") == []
+
+
+# A real Godot 4.6 runtime GDScript error: the `at:` follow-on is succeeded by a
+# `GDScript backtrace (most recent call first):` marker, then one `[N] func
+# (file:line)` frame line per stack frame (verified against Godot 4.6.3). The
+# `at:` frame equals frame `[0]`; frames are ordered most-recent-first.
+BACKTRACE_LOG = """\
+SCRIPT ERROR: Invalid call. Nonexistent function 'do_thing' in base 'Nil'.
+   at: b (res://main.gd:9)
+   GDScript backtrace (most recent call first):
+       [0] b (res://main.gd:9)
+       [1] a (res://main.gd:6)
+       [2] _ready (res://main.gd:3)
+"""
+
+
+def test_parse_errors_extracts_the_ordered_callstack_frames():
+    errors = parse_errors(BACKTRACE_LOG)
+    assert len(errors) == 1
+    callstack = errors[0]["callstack"]
+    assert callstack == [
+        {"function": "b", "file": "res://main.gd", "line": 9},
+        {"function": "a", "file": "res://main.gd", "line": 6},
+        {"function": "_ready", "file": "res://main.gd", "line": 3},
+    ]
+
+
+def test_parse_errors_top_frame_fields_match_the_at_line_unchanged():
+    # The existing single-frame {function,file,line} fields stay the top frame —
+    # equal to frame [0] — and are unchanged by the callstack enrichment.
+    error = parse_errors(BACKTRACE_LOG)[0]
+    assert error["function"] == "b"
+    assert error["file"] == "res://main.gd"
+    assert error["line"] == 9
+    assert error["callstack"][0] == {
+        "function": error["function"],
+        "file": error["file"],
+        "line": error["line"],
+    }
+
+
+def test_parse_errors_callstack_is_empty_for_a_bare_push_error():
+    # A plain push_error / warning carries NO GDScript backtrace; its callstack is
+    # an empty list (not an error, not a one-frame synthesis).
+    errors = parse_errors("ERROR: bare error\n   at: f (res://a.gd:1)\n")
+    assert errors[0]["callstack"] == []
+
+
+def test_parse_errors_callstack_empty_when_no_at_line_either():
+    errors = parse_errors("ERROR: trailing error with no at line\n")
+    assert errors[0]["callstack"] == []
+
+
+def test_parse_errors_backtrace_consumption_stops_before_the_next_error():
+    # An error WITH a backtrace immediately followed by ANOTHER error header: the
+    # frame-consuming loop must stop at the next header and not swallow it, so the
+    # second error is parsed independently with its own (empty) callstack.
+    log = BACKTRACE_LOG + "ERROR: second error\n   at: g (res://b.gd:2)\n"
+    errors = parse_errors(log)
+    assert len(errors) == 2
+    assert errors[0]["message"] == "Invalid call. Nonexistent function 'do_thing' in base 'Nil'."
+    assert len(errors[0]["callstack"]) == 3
+    assert errors[1]["message"] == "second error"
+    assert errors[1]["function"] == "g"
+    assert errors[1]["callstack"] == []
+
+
+def test_parse_errors_backtrace_consumption_stops_before_a_print_line():
+    # An interleaved print line after the frames ends the backtrace; it is neither
+    # a frame nor an error and must not be folded into the callstack.
+    log = BACKTRACE_LOG + "an ordinary print line\n"
+    errors = parse_errors(log)
+    assert len(errors) == 1
+    assert len(errors[0]["callstack"]) == 3
+    assert all("print" not in (f["function"] or "") for f in errors[0]["callstack"])
+
+
+def test_parse_errors_existing_entries_gain_an_empty_callstack_key():
+    # Every entry from the original (backtrace-free) SAMPLE_LOG now carries a
+    # callstack key — empty, since none of those errors has a GDScript backtrace.
+    for error in parse_errors(SAMPLE_LOG):
+        assert error["callstack"] == []

--- a/tests/test_e2e_diag.py
+++ b/tests/test_e2e_diag.py
@@ -52,6 +52,24 @@ MAIN_TSCN = (
 )
 PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
+# A main scene whose `_ready` calls a chain a() -> b() that triggers a runtime
+# GDScript error (calling a method on a null), so the engine emits a `GDScript
+# backtrace` with three frames (b, a, _ready) — most-recent-first — that `gda
+# diag errors` reads back as a multi-frame `callstack` (#283).
+CALLSTACK_MAIN_GD = """\
+extends Node2D
+
+func _ready() -> void:
+	a()
+
+func a() -> void:
+	b()
+
+func b() -> void:
+	var n = null
+	n.do_thing()
+"""
+
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
 
@@ -114,5 +132,70 @@ def test_diag_reads_back_a_known_runtime_error_and_log_line(tmp_path, daemon_run
         assert known, error_docs
         # push_error surfaces as an error-class diagnostic (ERROR / SCRIPT ERROR).
         assert known[0]["level"] in ("error", "script_error"), known[0]
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_diag_reads_back_a_multi_frame_callstack(tmp_path, daemon_runtime_dir):
+    # #283: a deliberately-thrown runtime error whose `_ready` calls a chain
+    # a() -> b() that errors (a null method call). The engine emits a GDScript
+    # backtrace, so `gda diag errors` reports an ordered, multi-frame `callstack`
+    # — not just the top `file:line`. Same lifecycle as the sibling test: a
+    # NON-diag live op (`game tree`) launches + warms the session, THEN diag
+    # observes the daemon-owned Session log.
+    gda = shutil.which("gda")
+    assert gda, "the `gda` console script is not on PATH"
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "main.gd").write_text(CALLSTACK_MAIN_GD, encoding="utf-8")
+
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    def poll_errors(needle, timeout=15.0):
+        deadline = time.monotonic() + timeout
+        last = []
+        while time.monotonic() < deadline:
+            proc = run("diag", "errors")
+            assert proc.returncode == 0, proc.stdout + proc.stderr
+            last = json.loads(proc.stdout)["errors"]
+            if any(needle in e["message"] for e in last):
+                return last
+            time.sleep(1.0)
+        return last
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        # Launch + warm the session; by the time `game tree` returns, the chained
+        # error has been logged with its GDScript backtrace.
+        tree = run("game", "tree")
+        assert tree.returncode == 0, tree.stdout + tree.stderr
+
+        # The null method call surfaces as a script error naming `do_thing`.
+        errors = poll_errors("do_thing")
+        offending = [e for e in errors if "do_thing" in e["message"]]
+        assert offending, errors
+        error = offending[0]
+
+        # The callstack is the ORDERED chain, most-recent-first: b -> a -> _ready.
+        functions = [frame["function"] for frame in error["callstack"]]
+        assert functions == ["b", "a", "_ready"], error
+        # Frame [0] equals the top single-frame location (unchanged behaviour).
+        assert error["callstack"][0]["function"] == error["function"]
+        assert error["callstack"][0]["file"] == error["file"]
+        assert error["callstack"][0]["line"] == error["line"]
+        # Every frame points back into the one script.
+        assert all(frame["file"] == "res://main.gd" for frame in error["callstack"]), error
     finally:
         run("daemon", "stop")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1048,3 +1048,48 @@ def test_theme_create_result_round_trips_path_type_and_dirs():
     assert created.type == "Theme"
     assert created.created_dirs == []
     assert json.loads(created.model_dump_json()) == payload
+
+
+def test_diag_errors_result_round_trips_a_multi_frame_callstack():
+    # A runtime GDScript error carries its ordered call stack (#283): each frame
+    # is {function, file, line}, most-recent-first, with frame [0] equal to the
+    # top {function,file,line}. The whole result round-trips byte-identical.
+    from gda.models import DiagErrorsResult
+
+    payload = {
+        "errors": [
+            {
+                "level": "script_error",
+                "message": "Invalid call. Nonexistent function 'do_thing' in base 'Nil'.",
+                "function": "b",
+                "file": "res://main.gd",
+                "line": 9,
+                "callstack": [
+                    {"function": "b", "file": "res://main.gd", "line": 9},
+                    {"function": "a", "file": "res://main.gd", "line": 6},
+                    {"function": "_ready", "file": "res://main.gd", "line": 3},
+                ],
+            }
+        ]
+    }
+
+    result = DiagErrorsResult.model_validate(payload)
+
+    error = result.errors[0]
+    assert [f.function for f in error.callstack] == ["b", "a", "_ready"]
+    assert error.callstack[0].file == "res://main.gd"
+    assert error.callstack[0].line == 9
+    assert json.loads(result.model_dump_json()) == payload
+
+
+def test_diag_error_callstack_defaults_to_empty_for_a_bare_error():
+    # A bare push_error carries no backtrace: callstack defaults to [] and the
+    # existing single-frame fields stay None — no callstack key required on input.
+    from gda.models import DiagError
+
+    error = DiagError.model_validate(
+        {"level": "error", "message": "boom", "function": None, "file": None, "line": None}
+    )
+
+    assert error.callstack == []
+    assert error.function is None

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -284,3 +284,52 @@ def test_render_engine_version_renders_the_one_line_version_string():
         timestamp=0,
     )
     assert render_engine_version(version) == "4.6.3-stable (official)"
+
+
+def test_render_diag_errors_shows_the_callstack_frames_under_the_error():
+    # A runtime error with a multi-frame call stack (#283): the human view lists
+    # the ordered frames (most-recent-first) under the error's headline line, so
+    # an agent reading the text sees where it originated, not just the top frame.
+    from gda.models import DiagError, DiagErrorsResult, SourceFrame
+    from gda.render import render_diag_errors
+
+    result = DiagErrorsResult(
+        errors=[
+            DiagError(
+                level="script_error",
+                message="Nonexistent function 'do_thing' in base 'Nil'.",
+                function="b",
+                file="res://main.gd",
+                line=9,
+                callstack=[
+                    SourceFrame(function="b", file="res://main.gd", line=9),
+                    SourceFrame(function="a", file="res://main.gd", line=6),
+                    SourceFrame(function="_ready", file="res://main.gd", line=3),
+                ],
+            )
+        ]
+    )
+
+    rendered = render_diag_errors(result)
+
+    # The headline still carries the top location.
+    assert "res://main.gd:9" in rendered
+    # Every frame appears, ordered, naming function and location.
+    assert "a (res://main.gd:6)" in rendered
+    assert "_ready (res://main.gd:3)" in rendered
+    # Frames render below the headline, in order.
+    assert rendered.index("b (res://main.gd:9)") < rendered.index("a (res://main.gd:6)")
+    assert rendered.index("a (res://main.gd:6)") < rendered.index("_ready (res://main.gd:3)")
+
+
+def test_render_diag_errors_omits_a_callstack_block_for_a_bare_error():
+    # A bare error has an empty callstack: the renderer shows just its one line,
+    # with no empty backtrace block.
+    from gda.models import DiagError, DiagErrorsResult
+    from gda.render import render_diag_errors
+
+    rendered = render_diag_errors(
+        DiagErrorsResult(errors=[DiagError(level="error", message="boom")])
+    )
+
+    assert rendered == "ERROR: boom"


### PR DESCRIPTION
## What & why

Enriches **`gda diag errors`** so each error record carries the full **`callstack`** (ordered `{function, file, line}` frames), not just the top `file:line` — an agent sees *where* an error originated. Read-only observability, in scope under **ADR-0025**; does **not** tap Godot's remote-debug protocol and does **not** touch the harness.

Sourced purely from the daemon-owned `Session log`: verified against real Godot 4.6 that a runtime `SCRIPT ERROR` emits a `GDScript backtrace (most recent call first):` block of `[N] func (file:line)` frames. `parse_errors` now consumes those into `callstack`. A `push_error`/warning has no backtrace → `callstack` is empty (not an error).

## Acceptance criteria

- [x] `diag errors --json` records carry an ordered `callstack` of `{function, file, line}` frames when available.
- [x] No backtrace → `callstack` empty (not an error); existing single-frame `{function, file, line}` fields unchanged.
- [x] `--schema` gate passes; the `DiagError` model change is reflected (`SourceFrame` `$def` + `callstack` array).
- [x] e2e (real Godot 4.6): a chained runtime error reports a multi-frame callstack.

## Tests

- Fast tier: **886 passed**. Schema gate: **96 passed**.
- Real-Godot e2e (`tests/test_e2e_diag.py`, run by reviewer): **2 passed**, incl. `test_diag_reads_back_a_multi_frame_callstack` (frames `["b","a","_ready"]`).

## Reviewer / merge notes

- **`diag.py` change is confined to `parse_errors`** + two new module-level regexes (`_BACKTRACE_MARKER`, `_FRAME_LINE`); the sibling slice #281 only *appends* `parse_log_records` to this file, so the merge is region-disjoint.
- Defines a `SourceFrame` model identical in name/shape to #281's. **Merge after #281**: drop this PR's duplicate `SourceFrame` and import the shared one; then re-run the diag + logger parser suites together to confirm `parse_log_records` still skips backtrace lines now that `parse_errors` emits `callstack`.

Closes #283
