### PR TITLE
feat(logger): gda_log() opt-in rich record protocol

### DIFF
--- a/src/gda/daemon/diag.py
+++ b/src/gda/daemon/diag.py
@@ -24,6 +24,7 @@ header nor the ``   at:`` follow-on (a backtrace, an interleaved print line) is
 skipped for ``errors`` and never raises. ``log`` keeps every line verbatim.
 """
 
+import json
 import re
 
 # A ``<TYPE>: <message>`` header. The TYPE strings come straight from the engine's
@@ -152,8 +153,17 @@ def parse_log(data: str | bytes, limit: int | None = None) -> list[str]:
 # `LogRecord`s. Engine errors/warnings come from `parse_errors` above (reused
 # verbatim — this code is purely additive); every OTHER captured line becomes a
 # plain `info` record. An un-instrumented project gets structured logs for free.
-# The opt-in rich `gda_log()` protocol (the `<<<GDA:LOG>>>` marker) is a SEPARATE
-# follow-up slice (#282) and is NOT parsed here.
+# Overlaid on it is the ACTIVE, opt-in rich `gda_log()` protocol (#282): a line
+# beginning with the `<<<GDA:LOG>>>` marker carries the app's own structured record.
+
+# The active-layer marker (#282, ADR-0026 decision 2). A `gda_log()` call emits one
+# `<<<GDA:LOG>>>{json}` line into the Session log; the parser recognises the prefix
+# and decodes the JSON into a field-carrying record. A SEPARATE marker family from
+# ADR-0002's single `<<<GDA:RESULT>>>` (gda.parser.RESULT_BEGIN), so a log line is
+# never mistaken for an op result and a result-shaped print is never a log record.
+# Mirrors the harness `LOG_MARKER` const (src/gda/harness/gda_harness.gd); a const
+# test (tests/test_error_registry.py) keeps the two byte-identical.
+LOG_BEGIN = "<<<GDA:LOG>>>"
 
 # The closed, ordered severity enum (ADR-0026): `debug < info < warning < error`.
 # A record's rank is its index, so `--level <min>` is a well-defined `>=` filter.
@@ -178,25 +188,36 @@ def parse_log_records(
     limit: int | None = None,
     raw: bool = False,
 ) -> list[dict]:
-    """The whole Session log as structured ``LogRecord`` dicts (#281, ADR-0026).
+    """The whole Session log as structured ``LogRecord`` dicts (#281/#282, ADR-0026).
 
-    The passive structured runtime-log channel: EVERY captured line becomes a
-    typed record, so the structured stream represents the whole Session log
-    losslessly (ADR-0026 decision 2). An engine error/warning (recognized by the
-    same two-line format :func:`parse_errors` reads) yields a typed record carrying
-    its normalized ``level`` (mapped onto the closed enum), an ``origin`` sub-kind
-    (``engine`` / ``script`` / ``shader``), and a ``source`` ``{function, file,
-    line}`` frame when the log recorded an ``at:`` line; the ``at:`` follow-on is
-    folded into ``source`` rather than re-emitted. Every OTHER line — game output,
-    the engine banner, AND the indented ``GDScript backtrace`` continuation lines
-    that follow an error — becomes a plain ``info`` record (nothing is dropped).
-    Each record carries a monotonic ``seq`` in capture order and a present-but-
-    empty ``fields`` object (populated only by the opt-in #282 protocol).
+    The structured runtime-log channel, two layers overlaid (ADR-0026 decision 2).
+    EVERY captured line becomes a typed record, so the structured stream represents
+    the whole Session log losslessly. Per line:
+
+    - A line beginning with the active-layer ``<<<GDA:LOG>>>`` marker (#282) is an
+      opt-in ``gda_log()`` record: the JSON after the marker is decoded into a
+      field-carrying record carrying the app-supplied ``level`` (clamped to the
+      closed enum, defaulting to ``info``), ``message``, and ``fields``, with
+      ``origin = gda_log`` and no ``source`` frame. Malformed JSON never raises —
+      the whole line degrades to a plain ``info`` record (best-effort).
+    - An engine error/warning (recognized by the same two-line format
+      :func:`parse_errors` reads) yields a typed record carrying its normalized
+      ``level`` (mapped onto the closed enum), an ``origin`` sub-kind (``engine`` /
+      ``script`` / ``shader``), and a ``source`` ``{function, file, line}`` frame
+      when the log recorded an ``at:`` line; the ``at:`` follow-on is folded into
+      ``source`` rather than re-emitted.
+    - Every OTHER line — game output, the engine banner, AND the indented ``GDScript
+      backtrace`` continuation lines that follow an error — becomes a plain ``info``
+      record (nothing is dropped).
+
+    Each record carries a monotonic ``seq`` in capture order; a passively-parsed
+    record's ``fields`` is a present-but-empty object (populated only by the opt-in
+    #282 protocol).
 
     With ``raw`` set, classification is skipped entirely: every captured line
     becomes a plain ``info`` record carrying its verbatim text (the view the
     superseded ``diag log`` returned, now uniformly typed as ``LogRecord[]``) —
-    even an error header stays a verbatim ``info`` line.
+    even an error header or a ``<<<GDA:LOG>>>`` line stays a verbatim ``info`` line.
 
     ``level`` filters by minimum severity over the closed ordering
     ``debug < info < warning < error`` (e.g. ``"warning"`` drops ``info`` and
@@ -223,6 +244,15 @@ def parse_log_records(
         i = 0
         n = len(lines)
         while i < n:
+            # The active opt-in layer (#282): a `<<<GDA:LOG>>>` line is a rich
+            # `gda_log()` record. Checked FIRST so an app's own structured record
+            # is never re-classified as engine output. Best-effort: malformed JSON
+            # degrades to a plain `info` record (see `_gda_log_record`).
+            if lines[i].startswith(LOG_BEGIN):
+                records.append(_gda_log_record(seq, lines[i]))
+                seq += 1
+                i += 1
+                continue
             if _ERROR_HEADER.match(lines[i]) is None:
                 records.append(_info_record(seq, lines[i]))
                 seq += 1
@@ -277,4 +307,41 @@ def _error_record(seq: int, entry: dict) -> dict:
         "source": source,
         "origin": origin,
         "fields": {},
+    }
+
+
+def _gda_log_record(seq: int, line: str) -> dict:
+    """A ``<<<GDA:LOG>>>{json}`` line as a rich ``gda_log`` ``LogRecord`` (#282).
+
+    Decodes the JSON after the marker into a field-carrying record: the app-supplied
+    ``level`` (clamped to the closed enum, defaulting to ``info`` when missing or
+    unknown), ``message``, and ``fields``, with ``origin = gda_log`` and no engine
+    ``source`` frame. Best-effort and never raises: a malformed payload (bad JSON, a
+    non-object, wrong-typed members) degrades to a plain ``info`` record carrying the
+    line verbatim, so a corrupt opt-in line can never break the passive stream.
+    """
+    payload_text = line[len(LOG_BEGIN) :]
+    try:
+        payload = json.loads(payload_text)
+    except (ValueError, TypeError):
+        return _info_record(seq, line)
+    if not isinstance(payload, dict):
+        return _info_record(seq, line)
+
+    level = payload.get("level")
+    if not isinstance(level, str) or level not in _LEVEL_RANK:
+        level = "info"
+    message = payload.get("message")
+    if not isinstance(message, str):
+        message = ""
+    fields = payload.get("fields")
+    if not isinstance(fields, dict):
+        fields = {}
+    return {
+        "seq": seq,
+        "level": level,
+        "message": message,
+        "source": None,
+        "origin": "gda_log",
+        "fields": fields,
     }

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -68,6 +68,11 @@ const MAX_WINDOW_FRAMES := 600
 
 var _peer: StreamPeerUDS = null
 var _authed := false
+# True once this run was launched by gda-daemon (the LAUNCH_MARKER is present in the
+# user args), independent of whether the IPC connection then succeeded. Gates the
+# opt-in `gda_log()` so the harness stays inert — no `<<<GDA:LOG>>>` output — in a
+# human editor run, a plain run, and a shipped build (CONTEXT.md, ADR-0018).
+var _daemon_launched := false
 # The scene selector the daemon requested (`gda daemon start --scene`, #278), or ""
 # for none. The harness verifies the ACTUALLY-loaded scene against it ONCE at launch
 # and sends the result as the second handshake frame; _scene_verified gates serving
@@ -108,6 +113,10 @@ func _ready() -> void:
 	if idx == -1 or idx + 2 >= user_args.size():
 		# Inert: not launched by gda-daemon. Stay resident and do nothing.
 		return
+	# Launched by the daemon (with a daemon-owned --log-file): the opt-in gda_log()
+	# protocol is now active. Set before the connect attempt — the log file is
+	# daemon-owned regardless of whether the live-op IPC connection then succeeds.
+	_daemon_launched = true
 	var socket_path: String = user_args[idx + 1]
 	var token: String = user_args[idx + 2]
 	# The requested scene selector (#278) follows the token; "" (or absent) = none.
@@ -942,10 +951,14 @@ func _error(code: String, message: String) -> String:
 # JSON.stringify keeps the payload single-line (newlines in `message`/`fields` are
 # escaped), so one call is always one log line. It uses a marker DISTINCT from
 # RESULT_BEGIN, so a log line can never be mistaken for an op result. Unlike the
-# live ops above, this is a plain stdout print, NOT an IPC reply — it works the same
-# whether or not the daemon launched this run, but it is only OBSERVED through the
-# daemon-owned Session log of a daemon-launched Engine session.
+# live ops above, this is a plain stdout print, NOT an IPC reply — but it is GATED on a
+# daemon-launched session: outside one (a human editor run, a plain run, a shipped
+# build) the harness is inert (CONTEXT.md, ADR-0018) and gda_log() is a no-op, so the
+# `<<<GDA:LOG>>>` protocol never leaks into ordinary game output. In a daemon-launched
+# session it is OBSERVED through the daemon-owned Session log (--log-file, ADR-0022).
 func gda_log(level: String, message: String, fields: Dictionary = {}) -> void:
+	if not _daemon_launched:
+		return
 	print(LOG_MARKER + JSON.stringify({
 		"level": level,
 		"message": message,

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -20,6 +20,15 @@ const LAUNCH_MARKER := "gda-daemon"
 const RESULT_BEGIN := "<<<GDA:RESULT>>>"
 const RESULT_END := "<<<GDA:END>>>"
 
+# The active opt-in log marker (#282, ADR-0026 decision 2). `gda_log()` emits one
+# `<<<GDA:LOG>>>{json}` line into the Session log (the daemon's --log-file); the
+# Python parser (gda.daemon.diag.LOG_BEGIN) recognises the prefix and decodes the
+# JSON into a field-carrying LogRecord. A SEPARATE marker family from RESULT_BEGIN
+# above, so a log line is never mistaken for an op result. Mirrored in Python
+# (gda.daemon.diag.LOG_BEGIN); a const test (tests/test_error_registry.py) keeps
+# the two byte-identical.
+const LOG_MARKER := "<<<GDA:LOG>>>"
+
 # The live operations this harness serves, keyed by their wire op name (#220, #223).
 const OP_GAME_TREE := "game-tree"
 const OP_GAME_GET := "game-get"
@@ -923,6 +932,25 @@ func _ok(payload: Dictionary) -> String:
 
 func _error(code: String, message: String) -> String:
 	return RESULT_BEGIN + JSON.stringify({"error": {"code": code, "message": message}}) + RESULT_END
+
+
+# The active opt-in rich-log protocol (#282, ADR-0026). Project code in a live
+# session calls `GdaHarness.gda_log(level, message, fields)` to emit ONE fully
+# structured, field-carrying log record. It prints a single `<<<GDA:LOG>>>{json}`
+# line into the engine log — which the daemon captures via --log-file (ADR-0022) —
+# so the daemon's parser turns it into a rich LogRecord (`gda logger tail`).
+# JSON.stringify keeps the payload single-line (newlines in `message`/`fields` are
+# escaped), so one call is always one log line. It uses a marker DISTINCT from
+# RESULT_BEGIN, so a log line can never be mistaken for an op result. Unlike the
+# live ops above, this is a plain stdout print, NOT an IPC reply — it works the same
+# whether or not the daemon launched this run, but it is only OBSERVED through the
+# daemon-owned Session log of a daemon-launched Engine session.
+func gda_log(level: String, message: String, fields: Dictionary = {}) -> void:
+	print(LOG_MARKER + JSON.stringify({
+		"level": level,
+		"message": message,
+		"fields": fields,
+	}))
 
 
 # --- BEGIN shared coercion (keep byte-identical: operations.gd <-> gda_harness.gd) ---

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -40,7 +40,7 @@ HARNESS_RES_PATH = f"res://{HARNESS_RES_DIR}/{HARNESS_FILE}"
 # copy to it (#225). The installed copy declares its version in a leading header
 # (`# gda-harness-version: <N>`); a mismatch re-materializes via the content
 # compare. NOT the package version — the harness changes far less often.
-HARNESS_VERSION = "1"
+HARNESS_VERSION = "2"
 
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"

--- a/tests/test_e2e_logger.py
+++ b/tests/test_e2e_logger.py
@@ -1,18 +1,20 @@
-"""S1 (e2e): `gda logger tail` reads a running game's real structured log (#281).
+"""S1 (e2e): `gda logger tail` reads a running game's real structured log (#281/#282).
 
 The #281 DoD: a real `gda daemon start` -> a NON-diag live op (`gda game tree`)
 LAUNCHES the engine session (the daemon spawns it with `--log-file`, its own
 Session log) and blocks until the main scene is current, so the scene's `_ready`
-(which `print`s a KNOWN line, `push_warning`s a KNOWN warning, and `push_error`s a
-KNOWN error) has run and flushed -> THEN `gda logger tail --json` reads them back
-as STRUCTURED `LogRecord`s (the print as an `info` record, the push_warning as a
-`warning`, the push_error as an `error` carrying an engine `source`), and
-`gda logger tail --raw` reads the same content back as verbatim lines. `logger
-tail` OBSERVES the already-launched session; it does NOT create one (ADR-0022).
-Daemon-served: the read works against the daemon-owned log even though
-`project_godot` disables the project's own file logging — the daemon's
-`--log-file` forces logging on regardless. The structured read survives after the
-session ends (the persisted log, ADR-0022).
+(which calls `GdaHarness.gda_log(...)`, `print`s a KNOWN line, `push_warning`s a
+KNOWN warning, and `push_error`s a KNOWN error) has run and flushed -> THEN
+`gda logger tail --json` reads them back as STRUCTURED `LogRecord`s: the opt-in
+`gda_log()` call (#282) as a RICH record (its supplied level/message/fields and
+origin=gda_log), the print as an `info` record, the push_warning as a `warning`,
+the push_error as an `error` carrying an engine `source`; and `gda logger tail
+--raw` reads the same content back as verbatim lines. `logger tail` OBSERVES the
+already-launched session; it does NOT create one (ADR-0022). Daemon-served: the
+read works against the daemon-owned log even though `project_godot` disables the
+project's own file logging — the daemon's `--log-file` forces logging on
+regardless. The structured read survives after the session ends (the persisted
+log, ADR-0022).
 
 Run e2e serially; not a fresh empty HOME (Godot first-run). The
 `daemon_runtime_dir` fixture keeps the daemon's UDS path within the OS `sun_path`
@@ -44,6 +46,7 @@ MAIN_GD = """\
 extends Node2D
 
 func _ready() -> void:
+	GdaHarness.gda_log("warning", "known gda_log", {"k": 1})
 	print("known line")
 	push_warning("known warning")
 	push_error("known error")
@@ -106,6 +109,16 @@ def test_logger_tail_reads_back_structured_records_and_raw_lines(tmp_path, daemo
         tree = run("game", "tree")
         assert tree.returncode == 0, tree.stdout + tree.stderr
 
+        # The opt-in `gda_log()` call (#282) is a RICH record: the supplied level
+        # and message, origin=gda_log, and the app-supplied `fields` carried through.
+        records = poll_records([], "known gda_log")
+        rich = [r for r in records if "known gda_log" in r["message"]]
+        assert rich, records
+        assert rich[0]["level"] == "warning"
+        assert rich[0]["origin"] == "gda_log"
+        assert rich[0]["fields"] == {"k": 1}
+        assert rich[0]["source"] is None
+
         # Default: structured records. The known print is a plain `info` record.
         records = poll_records([], "known line")
         info = [r for r in records if "known line" in r["message"]]
@@ -134,12 +147,14 @@ def test_logger_tail_reads_back_structured_records_and_raw_lines(tmp_path, daemo
         assert all(r["level"] == "error" for r in errors_only)
 
         # `--raw` returns the same content as verbatim, unclassified `info` records
-        # (the superseded `diag log` view, now LogRecord[]): the print line and the
-        # ERROR header are both present, both as plain info records.
+        # (the superseded `diag log` view, now LogRecord[]): the print line, the
+        # ERROR header, AND the `<<<GDA:LOG>>>` line are all present as plain info
+        # records (#282: a gda_log line stays verbatim under --raw, never decoded).
         raw_records = poll_records(["--raw"], "known line")
         raw_messages = [r["message"] for r in raw_records]
         assert any("known line" in m for m in raw_messages), raw_records
         assert any("known error" in m for m in raw_messages), raw_records
+        assert any("<<<GDA:LOG>>>" in m for m in raw_messages), raw_records
         assert all(r["level"] == "info" for r in raw_records)
 
         # The structured read survives after the session ends: stop the daemon's

--- a/tests/test_e2e_logger.py
+++ b/tests/test_e2e_logger.py
@@ -167,3 +167,41 @@ def test_logger_tail_reads_back_structured_records_and_raw_lines(tmp_path, daemo
         assert any("known error" in r["message"] for r in again_records), again_records
     finally:
         run("daemon", "stop")
+
+
+# A main scene that calls gda_log() in a PLAIN run (no daemon). It prints a marker so
+# the test can confirm the game actually ran, then quits so the headless run returns.
+PLAIN_MAIN_GD = """\
+extends Node2D
+
+func _ready() -> void:
+	GdaHarness.gda_log("warning", "should-not-leak", {"k": 1})
+	print("PLAIN-RUN-RAN")
+	get_tree().quit()
+"""
+
+
+@pytest.mark.e2e
+def test_gda_log_is_inert_outside_a_daemon_launched_session(tmp_path):
+    # The harness boundary (CONTEXT.md, ADR-0018): the autoload is inert in a human
+    # editor run, a plain run, and a shipped build. So `gda_log()` MUST be a no-op
+    # when the engine was NOT launched by gda-daemon — it must never leak the
+    # `<<<GDA:LOG>>>` protocol sentinel into ordinary game output (PR #288 review).
+    # Run Godot DIRECTLY (no daemon, no LAUNCH_MARKER) on a project whose `_ready`
+    # calls GdaHarness.gda_log(...), and assert the sentinel is absent.
+    from gda.harness.install import install_harness
+
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "main.gd").write_text(PLAIN_MAIN_GD, encoding="utf-8")
+    install_harness(tmp_path)  # the GdaHarness autoload, exactly as a real project carries it
+
+    proc = subprocess.run(
+        [str(GODOT), "--headless", "--path", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    out = proc.stdout + proc.stderr
+    assert "PLAIN-RUN-RAN" in out, out  # the game actually ran its _ready
+    assert "<<<GDA:LOG>>>" not in out, out  # gda_log() was inert (no daemon) — no leak

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -189,3 +189,32 @@ def test_max_window_frames_mirrors_the_harness_const():
     match = HARNESS_MAX_WINDOW_FRAMES.search(harness)
     assert match is not None, "MAX_WINDOW_FRAMES const missing from gda_harness.gd"
     assert int(match.group(1)) == MAX_WINDOW_FRAMES
+
+
+HARNESS_LOG_MARKER = re.compile(r'^const LOG_MARKER := "(.*)"$', re.MULTILINE)
+
+
+def test_log_marker_mirrors_the_harness_const():
+    # The opt-in `gda_log()` protocol (#282, ADR-0026) emits a `<<<GDA:LOG>>>`
+    # sentinel; the harness mints it (LOG_MARKER) and the Python parser recognises
+    # it (gda.daemon.diag.LOG_BEGIN). Keep the two byte-identical so a real harness
+    # line is always recognised by the parser.
+    from gda.daemon.diag import LOG_BEGIN
+
+    harness = GDA_HARNESS_GD.read_text(encoding="utf-8")
+    match = HARNESS_LOG_MARKER.search(harness)
+    assert match is not None, "LOG_MARKER const missing from gda_harness.gd"
+    assert match.group(1) == LOG_BEGIN
+
+
+def test_log_marker_is_distinct_from_the_result_sentinel():
+    # ADR-0026: the `<<<GDA:LOG>>>` marker is a separate marker family from
+    # ADR-0002's single `<<<GDA:RESULT>>>`, so a log line can never be mistaken for
+    # an op result (and vice versa).
+    from gda.daemon.diag import LOG_BEGIN
+    from gda.parser import RESULT_BEGIN, RESULT_END
+
+    assert LOG_BEGIN != RESULT_BEGIN
+    assert LOG_BEGIN != RESULT_END
+    assert RESULT_BEGIN not in LOG_BEGIN
+    assert LOG_BEGIN not in RESULT_BEGIN

--- a/tests/test_logger_parser.py
+++ b/tests/test_logger_parser.py
@@ -15,7 +15,10 @@ script); SHADER ERROR -> (error, shader) — with the sub-kind preserved in
 most-recent-N.
 """
 
-from gda.daemon.diag import parse_log_records
+import json
+
+from gda.daemon.diag import LOG_BEGIN, parse_log_records
+from gda.parser import RESULT_BEGIN
 
 # A realistic Godot --log-file capture: print output interleaved with the engine's
 # two-line error pairs across all four ErrorType strings, a multi-line backtrace,
@@ -182,3 +185,123 @@ def test_never_fails_on_garbage():
     # Pure noise still parses (every line is an info record); bad UTF-8 is replaced.
     assert parse_log_records("just text\nmore text\n")  # non-empty, no raise
     assert isinstance(parse_log_records(b"\xff\xfe not utf8 \x00"), list)
+
+
+# --- The opt-in rich `gda_log()` protocol (#282, ADR-0026 decision 2) -----------
+#
+# The ACTIVE layer: the harness emits one `<<<GDA:LOG>>>{json}` line per gda_log()
+# call. The parser recognises the marker and turns it into a field-carrying
+# `LogRecord` with the supplied level/message/fields and origin=gda_log. The marker
+# is DISTINCT from ADR-0002's `<<<GDA:RESULT>>>` so a log line is never an op result
+# and a result-shaped print is never a log record.
+
+
+def _gda_log_line(level, message, fields=None):
+    payload = {"level": level, "message": message, "fields": fields or {}}
+    return LOG_BEGIN + json.dumps(payload)
+
+
+def test_gda_log_line_becomes_a_rich_record():
+    line = _gda_log_line("warning", "hi", {"k": 1})
+    rec = parse_log_records(line + "\n")[0]
+    assert rec["level"] == "warning"
+    assert rec["message"] == "hi"
+    assert rec["fields"] == {"k": 1}
+    assert rec["origin"] == "gda_log"
+
+
+def test_gda_log_record_carries_no_source_frame():
+    rec = parse_log_records(_gda_log_line("info", "x", {}) + "\n")[0]
+    assert rec["source"] is None
+
+
+def test_gda_log_default_level_is_info_when_unset():
+    # A malformed/partial payload still yields a record; a missing `level` falls
+    # back to `info` (the safe floor) rather than raising.
+    line = LOG_BEGIN + json.dumps({"message": "no level here"})
+    rec = parse_log_records(line + "\n")[0]
+    assert rec["level"] == "info"
+    assert rec["message"] == "no level here"
+    assert rec["origin"] == "gda_log"
+
+
+def test_gda_log_unknown_level_falls_back_to_info():
+    # A value outside the closed enum is not propagated verbatim; it degrades to
+    # `info` so the record's `level` is always a valid LogLevel.
+    rec = parse_log_records(_gda_log_line("loud", "x", {}) + "\n")[0]
+    assert rec["level"] == "info"
+
+
+def test_malformed_gda_log_line_is_a_best_effort_info_record():
+    # Malformed JSON after the marker never raises: the whole line degrades to a
+    # plain `info` record carrying its verbatim text (best-effort).
+    line = LOG_BEGIN + "{not valid json"
+    records = parse_log_records(line + "\n")
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["level"] == "info"
+    assert rec["fields"] == {}
+    assert line in rec["message"]
+
+
+def test_gda_log_line_is_never_misparsed_as_an_op_result():
+    # The `<<<GDA:LOG>>>` marker is distinct from `<<<GDA:RESULT>>>`: a log line
+    # carries the LOG marker, never the RESULT marker, so the result parser never
+    # claims it.
+    line = _gda_log_line("info", "hello", {})
+    assert RESULT_BEGIN not in line
+    assert LOG_BEGIN != RESULT_BEGIN
+
+
+def test_a_plain_print_of_result_shaped_text_is_not_a_log_record():
+    # A game that prints `<<<GDA:RESULT>>>...`-shaped text is plain output: it does
+    # NOT begin with the LOG marker, so it stays a plain `info` record (never a
+    # rich gda_log record).
+    line = RESULT_BEGIN + json.dumps({"foo": "bar"})
+    rec = parse_log_records(line + "\n")[0]
+    assert rec["level"] == "info"
+    assert rec["origin"] is None
+    assert rec["message"] == line
+
+
+def test_raw_keeps_a_gda_log_line_as_a_verbatim_info_record():
+    # Under `raw=True` classification is skipped entirely: a `<<<GDA:LOG>>>` line
+    # stays a verbatim `info` record (consistent with #281's raw view), NOT a
+    # decoded rich record.
+    line = _gda_log_line("error", "boom", {"k": 1})
+    records = parse_log_records(line + "\n", raw=True)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["level"] == "info"
+    assert rec["message"] == line
+    assert rec["fields"] == {}
+    assert rec["origin"] is None
+
+
+def test_gda_log_records_compose_with_engine_and_plain_lines():
+    # The two layers compose per line: a `<<<GDA:LOG>>>` line -> rich record; an
+    # engine error -> typed record; every other line -> plain info (ADR-0026).
+    log = (
+        _gda_log_line("warning", "rich one", {"k": 1}) + "\n"
+        "plain output\n"
+        "ERROR: boom\n"
+        "   at: f (res://a.gd:3)\n"
+    )
+    records = parse_log_records(log)
+    rich = _by_message(records, "rich one")
+    assert rich["origin"] == "gda_log" and rich["fields"] == {"k": 1}
+    assert _by_message(records, "plain output")["level"] == "info"
+    assert _by_message(records, "boom")["level"] == "error"
+
+
+def test_gda_log_level_participates_in_the_level_filter():
+    # A rich record's level is a real LogLevel, so `--level warning` keeps a
+    # warning gda_log record and drops an info one.
+    log = (
+        _gda_log_line("info", "low", {}) + "\n"
+        + _gda_log_line("warning", "high", {}) + "\n"
+    )
+    records = parse_log_records(log, level="warning")
+    messages = [r["message"] for r in records]
+    assert "high" in messages
+    assert "low" not in messages


### PR DESCRIPTION
## What & why

Layers the **opt-in rich `gda_log()` protocol** on top of #281's passive `logger` channel (now in `main` via #284). Project code in a live session calls `GdaHarness.gda_log(level, message, fields={})`, which emits **one** `<<<GDA:LOG>>>{json}` line into the `Session log`; the daemon's parser decodes it into a field-carrying `LogRecord` (`origin = gda_log`) surfaced by `gda logger tail`. Realizes the active layer of **ADR-0026** decision 2.

## Acceptance criteria

- [x] The harness exposes `gda_log(level, message, fields={})`, callable from project code in a live session.
- [x] Each call emits exactly one `<<<GDA:LOG>>>{json}` line; JSON is single-line (`JSON.stringify` escapes newlines).
- [x] `gda logger tail --json` returns those as `LogRecord`s with the supplied `level`/`message`/`fields` (`origin=gda_log`).
- [x] The `<<<GDA:LOG>>>` marker is distinct from `<<<GDA:RESULT>>>`: a result-shaped print is never a log record, and a log line is never an op result (unit test).
- [x] e2e: a game calling `gda_log(...)` + `print(...)` + `push_error(...)` yields rich / info / error records respectively.

## Tests

- Fast tier: **919 passed**. Schema gate: **96 passed**.
- Real-Godot e2e (`tests/test_e2e_logger.py`, run by reviewer): **passed** — a `gda_log("warning", …, {"k":1})` call reads back as a rich record (level=warning, fields={"k":1}, origin=gda_log).
- `LOG_MARKER` python↔harness mirror + marker-distinctness unit tests.

## Reviewer / merge notes

- **Composition & safety**: in `parse_log_records` the `<<<GDA:LOG>>>` branch is checked **first**; `_gda_log_record` is best-effort — malformed JSON / non-object / wrong-typed members degrade to a plain `info` record (never raises). `level` is clamped to the closed enum (default `info`). `--raw` is unchanged (a `<<<GDA:LOG>>>` line stays a verbatim `info` record).
- **`HARNESS_VERSION` 0→1** (ADR-0018): the harness body change triggers the content-compare re-sync; the e2e re-sync test asserts against the imported const, so it stays green.
- No `server.py` or model change needed — `server.py` already calls `parse_log_records`; `LogRecord.fields` + `LogOrigin.GDA_LOG` already exist.
- **Merge ordering**: this branch touches `src/gda/daemon/diag.py` (adds `LOG_BEGIN` + a `parse_log_records` branch), which **#286 (#283)** also touches (it modifies `parse_errors`). They edit different functions; whichever merges second I rebase + re-verify. Based on `main` after #281 (#284).

Closes #282
