### PR TITLE
feat(skill): install into a known agent's skills dir via --provider/--scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,14 +165,17 @@ Godot from the CLI. It's the lightest way in (no server to register), bundled in
 version-locked to your install. Print it, or install it into your agent's skills directory:
 
 ```bash
-gda skill                                       # print SKILL.md (redirect it anywhere)
-gda skill --install --dir ~/.claude/skills/gda  # write it into a skills directory
+gda skill                                              # print SKILL.md (redirect it anywhere)
+gda skill --install --provider claude --scope user     # resolve a known agent's skills dir
+gda skill --install --dir ~/.claude/skills/gda         # …or give the directory yourself
 ```
 
-`--dir` is caller-supplied — there's no built-in default; the [skill recipes](docs/gda-skill.md)
-list each agent's skills directory (Claude Code's `~/.claude/skills/`, Codex's `~/.agents/skills/`,
-…). Or fetch the same file straight from the repo, if you'd rather not go through `gda skill` — you
-still install `gda`, since the Skill drives it:
+`--install --provider <claude|codex> --scope <project|user>` resolves a known agent's skills
+directory (`--scope` defaults to `user`); `--dir` is the neutral fallback for any other agent —
+there's no built-in default. The [skill recipes](docs/gda-skill.md) list each agent's directory
+(Claude Code's `~/.claude/skills/`, Codex's `~/.agents/skills/`, …). Or fetch the same file straight
+from the repo, if you'd rather not go through `gda skill` — you still install `gda`, since the Skill
+drives it:
 
 ```bash
 curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \

--- a/docs/adr/0024-gda-skill-channel-and-distribution.md
+++ b/docs/adr/0024-gda-skill-channel-and-distribution.md
@@ -4,6 +4,14 @@ status: accepted
 
 # gda skill: an Agent Skill as a third agent-facing channel, shipped in-package
 
+> **Extension (2026-06-25) — opt-in known-agent install ([ADR-0027](0027-gda-skill-provider-install.md)).**
+> The "core carries no agent-specific default install location" decision below stands for the
+> *default* path: a plain `gda skill` and a bare `--install` still require an explicit `--dir`.
+> ADR-0027 adds an **opt-in** convenience on top — `--install --provider <agent> --scope <scope>`
+> resolves a known agent's skills directory (Claude Code's `.claude/skills/`, the cross-agent
+> `.agents/skills/`) only when the caller names a provider, with `--dir` remaining the neutral
+> fallback and the `SKILL.md` content still agent-neutral.
+
 An agent can reach [gda](../../CONTEXT.md) two ways today: the CLI directly, and
 [gda-mcp](../../CONTEXT.md) (ADR-0011), which exposes the same surface as MCP tools
 generated from `--schema` (ADR-0012). This ADR adds a third — an **Agent Skill**: a

--- a/docs/adr/0027-gda-skill-provider-install.md
+++ b/docs/adr/0027-gda-skill-provider-install.md
@@ -1,0 +1,67 @@
+---
+status: accepted
+---
+
+# `gda skill --install --provider <agent> --scope <scope>`: a known-agent install convenience
+
+[ADR-0024](0024-gda-skill-channel-and-distribution.md) shipped `gda skill` and decided that
+**core carries no agent-specific default install location**: a plain `gda skill` prints the
+manifest, and `--install` requires an explicit `--dir`. The per-agent target directory (Claude
+Code's `.claude/skills/`, the cross-agent `.agents/skills/`, …) was documented in
+`docs/gda-skill.md`, *not* defaulted in core. That keeps the default neutral, but it pushes a
+rote lookup onto every user: to install, you must first go read which directory your agent scans
+and type it out. This ADR adds a convenience that removes the lookup **without** giving up the
+neutral default.
+
+## Decision
+
+**Name a known agent instead of a directory.** `gda skill --install` gains two optional params:
+`--provider <agent>` (a closed set — currently `claude`, `codex`) and `--scope <project|user>`
+(default `user`). When `--provider` is given, `gda` resolves that agent's skills directory at the
+chosen scope and installs there, reusing the exact `--dir` write path. `--provider` implies
+`--install` (as `--dir` already does), and `--dir` and `--provider` are **mutually exclusive** —
+they name the same target two ways.
+
+| provider | `--scope project` (CWD-relative) | `--scope user` (under `$HOME`) |
+| --- | --- | --- |
+| `claude` | `.claude/skills/gda` | `~/.claude/skills/gda` |
+| `codex`  | `.agents/skills/gda` | `~/.agents/skills/gda` |
+
+Codex follows the cross-agent **Agent Skills** namespace `.agents/skills` (per OpenAI's Codex
+docs), **not** `.codex/skills`; the `gda/` leaf is the skill's own directory
+(`<base>/gda/SKILL.md`), the layout `docs/gda-skill.md` already documents.
+
+**This extends ADR-0024, it does not reverse it.** The default behaviour is unchanged: plain
+`gda skill` and a bare `--install` still carry no built-in path, the `SKILL.md` content stays
+agent-neutral, and `--dir` remains the general, vendor-neutral escape hatch for any agent — listed
+here or not. The agent→directory table is the *one* piece of vendor knowledge admitted into core,
+quarantined to a single module (`gda/skill_targets.py`) and reachable **only** when the caller
+explicitly opts in by naming a provider. It is best-effort and may lag an agent's upstream change;
+`--dir` is always the fallback.
+
+**One normalization point.** `--provider`/`--scope` resolve to `install_dir` inside `SkillParams`
+(the model), so the argv flags and a `--params-json` object produce identical params and the same
+install — the same single-source-of-truth seam ADR-0015 draws for every command. `provider` and
+`scope` therefore appear as enum-constrained fields in `gda skill --schema`, so **gda-mcp generates
+a closed-choice tool** (`skill(provider=…, scope=…)`) with no skill-specific code (ADR-0011/0012).
+
+## Considered options
+
+- **Keep core neutral, docs only (rejected).** Honours ADR-0024 to the letter but leaves the rote
+  per-agent lookup in place — the usability gap this ADR exists to close.
+- **A general default install location in core (rejected).** Reintroduces exactly the agent-specific
+  default ADR-0024 refused, and for the *default* path, not an opt-in one.
+- **`--provider` as the value of `--install` (rejected).** `gda skill --install claude` reads well
+  but turns `--install` from a boolean into a value option, breaking the existing
+  `gda skill --install --dir <path>` form. A separate `--provider` is additive and backward-compatible.
+- **A known-agent table behind an explicit `--provider`, `--dir` as the neutral fallback (chosen).**
+
+## Consequences
+
+- The vendor table lives only in `gda/skill_targets.py`; adding an agent is a one-line table entry,
+  and `--dir` covers any agent absent from it, so the closed `--provider` set never blocks a user.
+- `--scope` is agent-neutral (it only toggles project-local vs. user-level); a project-scope install
+  resolves against the CWD, so the reported `installed_path` is relative — consistent with a relative
+  `--dir`.
+- `docs/gda-skill.md` and the README "Use it as a Skill" section document the convenience alongside
+  the still-supported `--dir` and raw-`curl` paths; ADR-0024 carries a dated note pointing here.

--- a/docs/gda-skill.md
+++ b/docs/gda-skill.md
@@ -20,18 +20,34 @@ One canonical file, two ways to obtain it:
 
 ## Install it where your agent loads skills
 
-A `SKILL.md` is loaded by most coding agents — only the **discovery directory** differs.
-`gda skill --install --dir <dir>` writes `<dir>/SKILL.md` (creating parent dirs); there is **no
-built-in default location**, so point `--dir` at the directory your agent scans:
+A `SKILL.md` is loaded by most coding agents — only the **discovery directory** differs:
 
 | Agent | Personal (all projects) | Project scope (committed) |
 | --- | --- | --- |
 | **Claude Code** | `~/.claude/skills/gda/` | `.claude/skills/gda/` |
 | **Codex and other agents** | `~/.agents/skills/gda/` | `.agents/skills/gda/` |
 
+### Name your agent (recommended)
+
+For the agents above, let `gda` resolve the directory — `--install --provider <agent> --scope
+<project|user>` (ADR-0027). `--scope` defaults to `user`; `--provider` implies `--install`:
+
 ```bash
-gda skill --install --dir ~/.claude/skills/gda    # Claude Code (personal scope)
-gda skill --install --dir ~/.agents/skills/gda    # Codex & others (personal scope)
+gda skill --install --provider claude --scope user      # ~/.claude/skills/gda/
+gda skill --install --provider claude --scope project   # ./.claude/skills/gda/
+gda skill --install --provider codex  --scope project   # ./.agents/skills/gda/
+```
+
+Codex uses the cross-agent `.agents/skills` namespace (per OpenAI's Codex docs), not `.codex/skills`.
+
+### Or give the directory yourself
+
+`gda skill --install --dir <dir>` writes `<dir>/SKILL.md` (creating parent dirs) — the neutral path
+for any agent, listed above or not (there is **no** built-in default; `--dir` and `--provider` are
+mutually exclusive):
+
+```bash
+gda skill --install --dir ~/.claude/skills/gda    # an explicit directory
 # …or fetch the same file directly, instead of going through `gda skill`:
 curl --create-dirs -o ~/.agents/skills/gda/SKILL.md \
   https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -259,6 +259,7 @@ from gda.screen_ops import (
     run_screen_frames_operation,
 )
 from gda.skill_ops import build_skill_result
+from gda.skill_targets import SkillProvider, SkillScope
 from gda.surface import build_surface_manifest
 
 app = typer.Typer(
@@ -3173,8 +3174,21 @@ def skill(
     dir: Optional[str] = typer.Option(
         None,
         "--dir",
-        help="The skills directory to install into (caller-supplied; no default). "
-        "Implies --install.",
+        help="The skills directory to install into (caller-supplied; the neutral path, "
+        "no default). Implies --install. Mutually exclusive with --provider.",
+    ),
+    provider: Optional[SkillProvider] = typer.Option(
+        None,
+        "--provider",
+        "-p",
+        help="Install into a known agent's skills directory (claude/codex) instead of "
+        "--dir, resolved with --scope (ADR-0027). Implies --install.",
+    ),
+    scope: SkillScope = typer.Option(
+        SkillScope.USER,
+        "--scope",
+        help="With --provider: the agent's per-project (committed) or per-user (all "
+        "projects) skills dir; default user.",
     ),
     json_output: bool = json_option(),
     schema: bool = SKILL_COMMAND.schema_option(),
@@ -3185,21 +3199,30 @@ def skill(
     The canonical `SKILL.md` ships inside the `gda` package and is version-locked to
     the install (ADR-0024): a plain run prints it verbatim (so
     `gda skill > .../SKILL.md` drops it to disk), `--json` emits
-    `{name, version, content}`, and `--install --dir <path>` writes it to a
-    caller-supplied directory, creating parents and overwriting, then reports the path.
-    Core carries no agent-specific default location — the caller supplies the per-agent
-    skills dir (ADR-0024). A sibling of `info`/`schema`, carrying `--schema` like them.
+    `{name, version, content}`, and an install writes it to a directory, creating
+    parents and overwriting, then reports the path. The install target is named one
+    of two ways: `--dir <path>` (the neutral path; core carries no agent-specific
+    default, ADR-0024), or `--provider <agent> --scope <scope>` which resolves a known
+    agent's skills directory (the opt-in convenience, ADR-0027). A sibling of
+    `info`/`schema`, carrying `--schema` like them.
     """
-    # An install needs an explicit target dir (ADR-0024). `--dir` implying an install is
-    # normalized inside SkillParams so argv and --params-json produce identical params
-    # (ADR-0015) — the CLI just forwards the raw flags.
-    if install and dir is None:
+    # The target is named by --dir OR --provider; they name the SAME thing two ways, so
+    # both at once is ambiguous, and an install with neither has nowhere to write. Both
+    # rules are mirrored in SkillParams (so the --params-json path enforces them too,
+    # ADR-0015); resolving provider→dir also happens there. The CLI raises the friendly
+    # usage errors and otherwise just forwards the raw flags.
+    if dir is not None and provider is not None:
         raise typer.BadParameter(
-            "`--install` requires `--dir` (the skills directory to write into)"
+            "`--dir` and `--provider` are mutually exclusive: name a directory OR an "
+            "agent, not both"
+        )
+    if install and dir is None and provider is None:
+        raise typer.BadParameter(
+            "`--install` requires `--dir` or `--provider` (where to write the SKILL.md)"
         )
     _dispatch_recipe(
         SKILL_COMMAND,
-        SkillParams(install=install, install_dir=dir),
+        SkillParams(install=install, install_dir=dir, provider=provider, scope=scope),
         json_output=json_output,
         godot=None,
         project=None,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -19,6 +19,7 @@ from pydantic import (
 )
 
 from gda.execution import ExecutionKind
+from gda.skill_targets import SkillProvider, SkillScope, resolve_skill_dir
 
 
 class ErrorCategory(str, Enum):
@@ -2257,34 +2258,56 @@ class EngineVersion(BaseModel):
 
 
 class SkillParams(BaseModel):
-    """The operation params of ``gda skill`` (ADR-0024).
+    """The operation params of ``gda skill`` (ADR-0024, extended ADR-0027).
 
     ``gda skill`` is a pure emitter meta command: it reads the bundled
     ``SKILL.md`` from the package and emits or installs it — no Godot is spawned.
-    Its only param is ``install``: when set, the manifest is written to the
-    caller-supplied ``install_dir`` instead of being printed. There is no
-    agent-specific default location in core (ADR-0024); ``install_dir`` is required
-    for an install. It is carried as a string so the ``--params-json`` and ``--schema``
-    paths describe it the same way the argv ``--dir`` option supplies it.
+    ``install`` writes the manifest to a target instead of printing it. The target
+    is named one of two ways: a caller-supplied ``install_dir`` (the neutral path,
+    ADR-0024 — core carries no default location), or a known ``provider`` whose
+    skills directory is resolved at ``scope`` (the opt-in convenience, ADR-0027).
+    The two are mutually exclusive; ``provider`` normalizes to ``install_dir`` here so
+    the argv and ``--params-json`` paths resolve identically (ADR-0015).
     """
 
     install: bool = Field(
         default=False,
-        description="If true, WRITE the bundled SKILL.md to install_dir "
+        description="If true, WRITE the bundled SKILL.md to the target "
         "instead of returning it; the result then reports the written path.",
     )
     install_dir: str | None = Field(
         default=None,
-        description="The skills directory to install into (caller-supplied; required "
-        "for an install, no default). Parent dirs are created and an existing file is "
-        "overwritten. Providing it implies an install (ADR-0015 parity with argv --dir).",
+        description="The skills directory to install into (caller-supplied; the neutral "
+        "path, no default). Parent dirs are created and an existing file is overwritten. "
+        "Providing it implies an install (ADR-0015 parity with argv --dir). Mutually "
+        "exclusive with provider.",
+    )
+    provider: SkillProvider | None = Field(
+        default=None,
+        description="Install into a KNOWN agent's skills directory instead of a "
+        "caller-supplied install_dir: resolves that agent's directory at scope "
+        "(ADR-0027). Mutually exclusive with install_dir; providing it implies an install.",
+    )
+    scope: SkillScope = Field(
+        default=SkillScope.USER,
+        description="With provider, whether to install into the agent's per-project "
+        "(committed) or per-user (all projects) skills directory; default user.",
     )
 
     @model_validator(mode="after")
-    def _dir_implies_install(self) -> "SkillParams":
-        # Single source of truth (ADR-0015): naming a target directory means "install
-        # there", whether the params arrive from argv (``--dir``) or a ``--params-json``
-        # object — normalized here in the model, not in the CLI body, so both agree.
+    def _resolve_install_target(self) -> "SkillParams":
+        # Single source of truth (ADR-0015): normalize the target HERE, in the model, so
+        # argv and a --params-json object agree. A named provider resolves to its known
+        # skills dir (ADR-0027) — but provider and an explicit install_dir name the SAME
+        # thing two ways, so giving both is ambiguous and rejected. Then, whichever way a
+        # target was named, naming one means "install there".
+        if self.provider is not None:
+            if self.install_dir is not None:
+                raise ValueError(
+                    "provider and install_dir are mutually exclusive: name an agent "
+                    "(--provider) OR a directory (--dir), not both"
+                )
+            self.install_dir = resolve_skill_dir(self.provider, self.scope)
         if self.install_dir is not None:
             self.install = True
         return self

--- a/src/gda/skill_targets.py
+++ b/src/gda/skill_targets.py
@@ -1,0 +1,72 @@
+"""Known per-agent skills directories for ``gda skill --install --provider`` (ADR-0027).
+
+ADR-0024 kept agent-specific install paths *out of core*: a plain ``gda skill`` and a
+bare ``--install`` carry no default location, and ``--dir`` is the neutral escape hatch.
+ADR-0027 **extends** that with an explicit opt-in — when the caller NAMES a ``--provider``,
+``gda`` resolves a known skills directory for it. The default (no provider) still has no
+built-in path, the ``SKILL.md`` content stays agent-neutral, and ``--dir`` remains the
+general override, so ADR-0024's "the default is neutral" principle is preserved while the
+named-provider path is merely a convenience.
+
+This module is the single home of that vendor knowledge: which agents are known and where
+each loads skills, by scope. The directories follow each agent's documented convention —
+Claude Code's ``.claude/skills/``, and the cross-agent Agent Skills namespace
+``.agents/skills/`` that Codex (per OpenAI's Codex docs) and other agents scan. The leaf
+``gda/`` is the skill's own directory (``<base>/gda/SKILL.md``), the layout
+``docs/gda-skill.md`` documents. The table is best-effort and may lag an agent's upstream
+change; ``--dir`` is always the fallback when a path is wrong or an agent is not listed here.
+"""
+
+from enum import Enum
+
+
+class SkillProvider(str, Enum):
+    """A known agent whose skills directory ``gda skill --install`` can target (ADR-0027).
+
+    A closed set, so an unknown ``--provider`` is a usage error rather than a guess; an
+    agent not listed here is still served by the neutral ``--dir`` path (ADR-0024).
+    """
+
+    CLAUDE = "claude"
+    CODEX = "codex"
+
+
+class SkillScope(str, Enum):
+    """Where a skill is installed: per-project (committed) or per-user (all projects).
+
+    Agent-neutral — it only chooses between an agent's project-local skills directory
+    (resolved against the current directory) and its user-level one (under ``$HOME``).
+    """
+
+    PROJECT = "project"
+    USER = "user"
+
+
+# The known per-agent skills directories, by scope. Each value is the install BASE dir
+# with the skill's own ``gda/`` leaf already appended, so the written file is
+# ``<value>/SKILL.md`` (the layout docs/gda-skill.md documents). Project paths are
+# relative (resolved against the CWD); user paths use ``~`` (expanded by the install).
+# Vendor-specific by design and kept to this one module (ADR-0027) so core logic and the
+# SKILL.md content stay agent-neutral. Codex follows the cross-agent ``.agents/skills``
+# namespace per OpenAI's Codex docs, NOT ``.codex/skills``.
+PROVIDER_SKILL_DIRS: dict[SkillProvider, dict[SkillScope, str]] = {
+    SkillProvider.CLAUDE: {
+        SkillScope.PROJECT: ".claude/skills/gda",
+        SkillScope.USER: "~/.claude/skills/gda",
+    },
+    SkillProvider.CODEX: {
+        SkillScope.PROJECT: ".agents/skills/gda",
+        SkillScope.USER: "~/.agents/skills/gda",
+    },
+}
+
+
+def resolve_skill_dir(provider: SkillProvider, scope: SkillScope) -> str:
+    """Return the known install directory for ``provider`` at ``scope`` (ADR-0027).
+
+    The returned path is the install BASE (with the ``gda/`` leaf), suitable as
+    ``SkillParams.install_dir``; the existing install path expands ``~`` and writes
+    ``<dir>/SKILL.md``. Every ``SkillProvider`` × ``SkillScope`` pair is present, so this
+    never raises for a valid enum pair.
+    """
+    return PROVIDER_SKILL_DIRS[provider][scope]

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -252,3 +252,130 @@ def test_bundled_skill_is_included_in_the_built_wheel(tmp_path):
     assert any(
         name.endswith("gda/skill/SKILL.md") for name in names
     ), f"gda/skill/SKILL.md missing from {wheels[-1].name}: {names}"
+
+
+# --- `--provider`/`--scope` convenience install (ADR-0027) -------------------------
+#
+# `gda skill --install --provider <agent> --scope <scope>` resolves a known agent's
+# skills directory and reuses the same `--dir` install path. Project scope is exercised
+# in a tmp CWD; user scope is asserted via the resolution table and a HOME-pinned run, so
+# CI never writes into the real home directory.
+
+from gda.skill_targets import (  # noqa: E402  (grouped with the feature it tests)
+    PROVIDER_SKILL_DIRS,
+    SkillProvider,
+    SkillScope,
+    resolve_skill_dir,
+)
+
+
+@pytest.mark.parametrize(
+    "provider, scope, expected",
+    [
+        (SkillProvider.CLAUDE, SkillScope.PROJECT, ".claude/skills/gda"),
+        (SkillProvider.CLAUDE, SkillScope.USER, "~/.claude/skills/gda"),
+        (SkillProvider.CODEX, SkillScope.PROJECT, ".agents/skills/gda"),
+        (SkillProvider.CODEX, SkillScope.USER, "~/.agents/skills/gda"),
+    ],
+)
+def test_resolve_skill_dir_maps_every_provider_scope(provider, scope, expected):
+    # The known-agent table covers all four combos and matches docs/gda-skill.md; user
+    # scope is asserted here WITHOUT touching the real HOME. Codex uses the cross-agent
+    # `.agents/skills` namespace (OpenAI Codex docs), not `.codex/skills`.
+    assert resolve_skill_dir(provider, scope) == expected
+    assert PROVIDER_SKILL_DIRS[provider][scope] == expected
+
+
+def test_skill_install_provider_claude_project_writes_into_dot_claude(tmp_path, monkeypatch):
+    # `--provider claude --scope project` resolves to `.claude/skills/gda`, relative to
+    # the CWD — install it into a tmp project dir.
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        app, ["skill", "--install", "--provider", "claude", "--scope", "project"]
+    )
+
+    assert result.exit_code == 0
+    written = tmp_path / ".claude" / "skills" / "gda" / "SKILL.md"
+    assert written.read_text(encoding="utf-8") == BUNDLED
+
+
+def test_skill_install_provider_codex_project_uses_agents_namespace(tmp_path, monkeypatch):
+    # Codex follows the cross-agent `.agents/skills` namespace, NOT `.codex/skills`.
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        app, ["skill", "--install", "--provider", "codex", "--scope", "project"]
+    )
+
+    assert result.exit_code == 0
+    written = tmp_path / ".agents" / "skills" / "gda" / "SKILL.md"
+    assert written.read_text(encoding="utf-8") == BUNDLED
+
+
+def test_skill_provider_implies_install_and_defaults_to_user_scope(tmp_path, monkeypatch):
+    # Naming a provider implies an install (like --dir does), and --scope defaults to
+    # user — under HOME. Pin HOME at a tmp dir so we never touch the real one.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    result = CliRunner().invoke(app, ["skill", "--provider", "claude", "--json"])
+
+    assert result.exit_code == 0
+    written = tmp_path / ".claude" / "skills" / "gda" / "SKILL.md"
+    assert written.read_text(encoding="utf-8") == BUNDLED
+    assert json.loads(result.stdout)["installed_path"] == str(written)
+
+
+def test_skill_dir_and_provider_are_mutually_exclusive(tmp_path):
+    # --dir and --provider name the SAME target two ways; giving both is ambiguous.
+    result = CliRunner().invoke(
+        app, ["skill", "--dir", str(tmp_path), "--provider", "claude"]
+    )
+
+    assert result.exit_code != 0
+    assert not (tmp_path / "SKILL.md").exists()
+
+
+def test_skill_unknown_provider_is_a_usage_error():
+    # A closed enum: an unlisted agent is rejected, not guessed (it falls back to --dir).
+    result = CliRunner().invoke(app, ["skill", "--provider", "gemini"])
+
+    assert result.exit_code != 0
+
+
+def test_skill_provider_params_json_drives_the_same_resolution(tmp_path, monkeypatch):
+    # ADR-0015: --params-json resolves provider/scope identically to the argv flags.
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        app,
+        [
+            "skill",
+            "--params-json",
+            json.dumps({"provider": "claude", "scope": "project"}),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    written = tmp_path / ".claude" / "skills" / "gda" / "SKILL.md"
+    assert written.read_text(encoding="utf-8") == BUNDLED
+    # Project scope resolves to a CWD-relative dir, so the reported path is relative —
+    # consistent with how a relative `--dir` already behaves.
+    assert json.loads(result.stdout)["installed_path"] == ".claude/skills/gda/SKILL.md"
+
+
+def test_skill_params_provider_and_dir_conflict_raises():
+    # The core backstop behind the CLI guard: provider and install_dir are exclusive.
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        SkillParams(provider=SkillProvider.CLAUDE, install_dir="/tmp/x")
+
+
+def test_skill_schema_input_constrains_provider_and_scope():
+    # provider/scope become first-class params, so the input schema gains enum-constrained
+    # fields and gda-mcp generates a closed-choice tool (ADR-0012). The enum may render via
+    # $defs/$ref, so assert the constrained values appear in the input schema blob.
+    doc = json.loads(CliRunner().invoke(app, ["skill", "--schema"]).stdout)
+    props = doc["input"]["properties"]
+    assert "provider" in props and "scope" in props
+    blob = json.dumps(doc["input"])
+    assert "claude" in blob and "codex" in blob
+    assert "project" in blob and "user" in blob


### PR DESCRIPTION
## What & why

`gda skill --install` previously required an explicit `--dir`, forcing users to look up each
agent's skills directory by hand. This adds an opt-in convenience:

```
gda skill --install --provider <claude|codex> --scope <project|user>
```

It resolves the known directory and reuses the existing `--dir` write path. `--provider`
implies `--install` and is mutually exclusive with `--dir`; `--scope` defaults to `user`.

| provider | `--scope project` (CWD-relative) | `--scope user` (under `$HOME`) |
| --- | --- | --- |
| `claude` | `.claude/skills/gda` | `~/.claude/skills/gda` |
| `codex`  | `.agents/skills/gda` | `~/.agents/skills/gda` |

Codex uses the cross-agent `.agents/skills` namespace (per OpenAI's Codex docs), **not**
`.codex/skills`.

## Design

- The agent→directory table is the one piece of vendor knowledge admitted to core,
  quarantined to `src/gda/skill_targets.py` and reachable only when a provider is named.
- `--provider`/`--scope` normalize to `install_dir` inside `SkillParams`, so the argv flags
  and a `--params-json` object resolve identically (ADR-0015), and the fields appear as
  enum-constrained inputs in `gda skill --schema` — so **gda-mcp generates a closed-choice
  tool** with no skill-specific code.
- This **extends** ADR-0024 (the default stays neutral: `--dir`, no built-in path) rather than
  reversing it. Recorded as **ADR-0027**, with a dated extension note on ADR-0024 (body preserved).

## Test plan

- `pytest -m "not e2e"` green (964 passed); +12 tests in `tests/test_skill_command.py` covering
  the provider/scope→dir mappings, `--provider` implies install, `--dir`+`--provider` and unknown
  provider as usage errors, `--params-json` parity, and the schema enums.
- Manual e2e in a tmp project: `--provider claude --scope project` → `.claude/skills/gda/SKILL.md`;
  `--provider codex` → `.agents/skills/gda/SKILL.md`; schema input carries `provider`/`scope`.
- User-scope real-`$HOME` install verified manually by the maintainer.

Closes #291
