### PR TITLE
feat: a shipped build never carries the gda harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ one you just built, then start the daemon (macOS/Linux, Godot 4.6+):
 
 ```bash
 gda project set application/run/main_scene --value res://scenes/main.tscn --json
-gda daemon start             # start the daemon for $GDA_PROJECT (installs the harness)
+gda daemon start             # start the daemon for $GDA_PROJECT (installs the in-game harness)
 gda game tree --json         # the runtime scene tree, after _ready
 gda perf monitors --json     # live engine counters: fps, memory, node count
 gda daemon stop
@@ -438,7 +438,7 @@ flags — `gda --help` is the authoritative list of what is installed.
 
 | Command | What it does |
 | ------- | ------------ |
-| `daemon start` | Start the per-project daemon and install the harness; the engine session launches on the first live op (`--windowed` for `screen` capture). |
+| `daemon start` | Start the per-project daemon and install the in-game harness; the engine session launches on the first live op (`--windowed` for `screen` capture). |
 | `daemon stop` | Stop the project's daemon and any running engine session. |
 | `daemon status` | Report the daemon's state (running, windowed mode, session). |
 | `daemon uninstall` | Remove the in-game `gda` harness (autoload entry + files) from the project — an explicit dev-tooling teardown; `gda export run` already strips it from exported artifacts automatically. |

--- a/README.md
+++ b/README.md
@@ -302,6 +302,10 @@ command — register via the JSON above or the Settings → MCP UI.
   in-game harness, and brokers requests over a Unix domain socket (runtime tree, input,
   screenshots, performance, diagnostics).
 
+The harness is **dev-only**: `gda export run` strips it from the exported artifact, and it
+self-disables in any exported build — so a shipped game carries and runs nothing
+daemon-related.
+
 **Platform & version support:**
 
 | Mode | Godot | Platforms |
@@ -437,7 +441,7 @@ flags — `gda --help` is the authoritative list of what is installed.
 | `daemon start` | Start the per-project daemon and install the harness; the engine session launches on the first live op (`--windowed` for `screen` capture). |
 | `daemon stop` | Stop the project's daemon and any running engine session. |
 | `daemon status` | Report the daemon's state (running, windowed mode, session). |
-| `daemon uninstall` | Remove the in-game `gda` harness autoload from the project. |
+| `daemon uninstall` | Remove the in-game `gda` harness (autoload entry + files) from the project — an explicit dev-tooling teardown; `gda export run` already strips it from exported artifacts automatically. |
 
 **`game`** — the running game's runtime scene graph
 

--- a/README.md
+++ b/README.md
@@ -302,9 +302,9 @@ command — register via the JSON above or the Settings → MCP UI.
   in-game harness, and brokers requests over a Unix domain socket (runtime tree, input,
   screenshots, performance, diagnostics).
 
-The harness is **dev-only**: `gda export run` strips it from the exported artifact, and it
-self-disables in any exported build — so a shipped game carries and runs nothing
-daemon-related.
+The in-game harness `gda-daemon` injects is **dev-only**: `gda export run` strips it from the
+exported artifact, and it self-disables in any exported build — so a shipped game carries and
+runs nothing daemon-related.
 
 **Platform & version support:**
 

--- a/README.md
+++ b/README.md
@@ -303,8 +303,9 @@ command — register via the JSON above or the Settings → MCP UI.
   screenshots, performance, diagnostics).
 
 The in-game harness `gda-daemon` injects is **dev-only**: `gda export run` strips it from the
-exported artifact, and it self-disables in any exported build — so a shipped game carries and
-runs nothing daemon-related.
+artifact entirely, and built any other way (editor GUI, raw `godot --export`) it still
+self-disables in the exported game — so a shipped game never *runs* anything daemon-related
+(and via `gda export run`, doesn't even carry it).
 
 **Platform & version support:**
 

--- a/README.md
+++ b/README.md
@@ -296,8 +296,8 @@ command — register via the JSON above or the Settings → MCP UI.
 | **`gda-mcp`**    | An MCP server exposing the same operations as tools, from `--schema`. |
 | **`gda-daemon`** | A per-project process supervising a running game for live operations. |
 
-- **Headless operations** need no running engine — `gda` runs them one-shot with nothing
-  to install (create a scene, edit a script, export, analyze).
+- **Headless operations** run one-shot — no daemon, nothing to install (create a scene, edit
+  a script, export, analyze).
 - **Live operations** require a running game — `gda-daemon` launches it, injects an inert
   in-game harness, and brokers requests over a Unix domain socket (runtime tree, input,
   screenshots, performance, diagnostics).
@@ -572,7 +572,7 @@ or agent can branch on the failure **category without parsing the JSON error**:
 | `3`       | `version`     | The detected Godot version is below the supported minimum.            |
 | `4`       | `operation`   | The engine ran but the operation failed — a registered operation error, an engine crash, or an unstructured non-zero exit. |
 | `5`       | `parse`       | The process claimed success but violated the structured-output contract. |
-| `6`       | `live`        | A live operation failed — e.g. no running daemon/session, or a live timeout (Phase-2 live). |
+| `6`       | `live`        | A live operation failed — e.g. no running daemon/session, or a live timeout. |
 
 These values are the public ABI; their authoritative source is
 [`src/gda/exit_codes.py`](src/gda/exit_codes.py). The `{"error": {category, code, …}}`

--- a/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
+++ b/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
@@ -66,26 +66,17 @@ so two instances can touch the project at once.
 > **asymmetric** — implicit install on `start`, explicit `uninstall` — not a symmetric
 > install/uninstall pair. Decision 1's wording is preserved as the point-in-time record.
 
-> **Outcome (2026-06-25) — a shipped build never carries the harness: `gda export run`
-> strips it, and the harness self-disables in any exported build.** The bottom line is
-> that a shipped build must carry zero daemon-related files/config and must not depend on
-> the developer remembering `gda daemon uninstall`. Engine research settled the mechanism:
-> an export **cannot** remove a `project.godot` autoload after the fact — `project.binary`
-> is serialized whole from `ProjectSettings` *after* every `EditorExportPlugin` hook, with
-> no hook to alter it (`editor/export/editor_export_platform.cpp` `save_custom`), and the
-> entry re-leaks through `override.cfg` (loaded via `set()` into the same `props` map that
-> `save_custom` writes), so the only reliable guarantee is that the autoload is gone
-> **before** the export reads the project. So **`gda export run` paired-strips the harness
-> transactionally** (uninstall → native export → reinstall in a `finally`): the gda export
-> path is harness-free and forget-proof, the dev project is left untouched, and a mid-export
-> crash leaves it harness-*absent* (safe). As **defense in depth** for export routes that
-> bypass gda (editor GUI, raw `godot --export`), the harness `_ready()` returns immediately
-> under `OS.has_feature("template")` — true only in an exported build, false on the editor
-> binary every session runs on — so a harness that *did* reach a shipped build is provably
-> inert. Coverage chosen: **gda export = physically clean; every other route = provably
-> inert** (files may physically remain there but never activate). Extending *physical*
-> cleanliness to non-gda routes would need an ephemeral install that reopens Decision 1's
-> "no per-launch mutation" and is deferred.
+> **Outcome (2026-06-25) — the export/teardown half of this lifecycle is decided in
+> ADR-0028.** A shipped build must carry zero daemon-related files/config without depending
+> on the developer remembering `gda daemon uninstall`. Because an export **cannot** strip a
+> `project.godot` autoload after the fact (it is serialized whole into `project.binary`), the
+> guarantee is achieved before the export, not during it: **`gda export run` paired-strips the
+> harness transactionally** (forget-proof, dev project untouched), and the harness
+> **self-disables in any exported build** via `OS.has_feature("template")` (defence in depth
+> for non-gda export routes). Coverage: gda export = physically clean; every other route =
+> provably inert. See **ADR-0028** for the full decision and the rejected alternatives
+> (`override.cfg` re-leak, file-only `exclude_filter`, feature-tagged autoload, ephemeral
+> install).
 >
 > **Correction to point 3's wording.** Point 3 says a dangling autoload (file excluded, entry
 > kept) "crashes the exported game at startup." On the current engine it is **not** a hard

--- a/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
+++ b/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
@@ -66,6 +66,35 @@ so two instances can touch the project at once.
 > **asymmetric** — implicit install on `start`, explicit `uninstall` — not a symmetric
 > install/uninstall pair. Decision 1's wording is preserved as the point-in-time record.
 
+> **Outcome (2026-06-25) — a shipped build never carries the harness: `gda export run`
+> strips it, and the harness self-disables in any exported build.** The bottom line is
+> that a shipped build must carry zero daemon-related files/config and must not depend on
+> the developer remembering `gda daemon uninstall`. Engine research settled the mechanism:
+> an export **cannot** remove a `project.godot` autoload after the fact — `project.binary`
+> is serialized whole from `ProjectSettings` *after* every `EditorExportPlugin` hook, with
+> no hook to alter it (`editor/export/editor_export_platform.cpp` `save_custom`), and the
+> entry re-leaks through `override.cfg` (loaded via `set()` into the same `props` map that
+> `save_custom` writes), so the only reliable guarantee is that the autoload is gone
+> **before** the export reads the project. So **`gda export run` paired-strips the harness
+> transactionally** (uninstall → native export → reinstall in a `finally`): the gda export
+> path is harness-free and forget-proof, the dev project is left untouched, and a mid-export
+> crash leaves it harness-*absent* (safe). As **defense in depth** for export routes that
+> bypass gda (editor GUI, raw `godot --export`), the harness `_ready()` returns immediately
+> under `OS.has_feature("template")` — true only in an exported build, false on the editor
+> binary every session runs on — so a harness that *did* reach a shipped build is provably
+> inert. Coverage chosen: **gda export = physically clean; every other route = provably
+> inert** (files may physically remain there but never activate). Extending *physical*
+> cleanliness to non-gda routes would need an ephemeral install that reopens Decision 1's
+> "no per-launch mutation" and is deferred.
+>
+> **Correction to point 3's wording.** Point 3 says a dangling autoload (file excluded, entry
+> kept) "crashes the exported game at startup." On the current engine it is **not** a hard
+> crash: autoload instantiation logs `ERR_CONTINUE` and *skips* the missing autoload
+> (`main/main.cpp`, the `ERR_CONTINUE_MSG` arms of the autoload loop). It is still
+> unacceptable — startup error spam in a shipped game — so the paired strip (never a
+> file-only `exclude_filter`) stands; the rationale is "no error spam / no orphaned config,"
+> not "avoid a crash." Point 3's text is preserved as the point-in-time record.
+
 ## Decision
 
 **1. The harness is an installed autoload, not a runtime injection.** `gda` bundles

--- a/docs/adr/0028-harness-export-cleanliness.md
+++ b/docs/adr/0028-harness-export-cleanliness.md
@@ -1,0 +1,107 @@
+---
+status: accepted
+---
+
+# Harness export-cleanliness: `gda export run` strips it, the harness self-disables in exported builds
+
+ADR-0017/0018 install the [gda harness](../../CONTEXT.md) as a `project.godot` `[autoload]`
+entry plus a `res://addons/gda_harness/` script, so `gda-daemon` can run [live
+operations](../../CONTEXT.md) inside an [Engine session](../../CONTEXT.md). ADR-0018 makes
+the harness **inert** in a non-daemon run and offers an explicit `gda daemon uninstall`
+teardown. But a **shipped build must carry zero daemon-related files or config — as if the
+mechanism never existed — and this must not depend on the developer remembering to
+uninstall.** Inert-but-present is not enough (build hygiene, store/AV review, and "no
+orphaned dev tooling" are real requirements); and `gda export run` had no harness awareness,
+so a forgotten harness shipped verbatim.
+
+The engine forecloses the obvious fixes (verified against the Godot source):
+
+- **An export cannot remove a `project.godot` autoload after the fact.** `project.binary` is
+  serialized **whole** from `ProjectSettings` *after* every `EditorExportPlugin` hook, and no
+  hook can alter the packed settings (`editor/export/editor_export_platform.cpp`
+  `save_custom`; `editor/export/editor_export_plugin.h` exposes only file/resource/scene
+  hooks). So once the autoload is in `project.godot`, it is in every export.
+- **`override.cfg` re-leaks it.** Settings loaded from `override.cfg` go through `set()` into
+  the very `props` map `save_custom` serializes (`core/config/project_settings.cpp`), so any
+  export run by a binary that loads `override.cfg` — including the editor binary `gda export
+  run` uses — writes the autoload straight back into `project.binary`.
+- **`exclude_filter` removes only files**, never the autoload entry. A file-excluded but
+  still-referenced autoload then logs `ERR_CONTINUE` and is skipped at startup
+  (`main/main.cpp` autoload loop) — startup error spam in the shipped game (this corrects
+  ADR-0018 point 3's "crashes the exported game" wording: it is skip-with-error, not a hard
+  crash, on the current engine — but still unacceptable).
+- **Feature-tagged autoloads are not supported** — `autoload/GdaHarness.editor=…` registers an
+  autoload literally *named* `GdaHarness.editor`; the feature override is never consulted at
+  autoload load.
+
+So the only reliable guarantee is that the autoload is **gone before the export reads the
+project** — it must never be present at export time, not stripped during it.
+
+## Decision
+
+**1. `gda export run` strips the harness transactionally.** Before the native
+`--export-<mode>` run (the [Headless launch](../../CONTEXT.md) native-export channel), the
+operation paired-uninstalls the harness — autoload entry first, then files, the crash-safe
+ordering ADR-0018 already uses — and reinstalls it in a `finally` after the export returns.
+The artifact is therefore harness-free **by construction and forget-proof** (no `gda daemon
+uninstall` step required), the dev project is left byte-identical, and a mid-export crash
+leaves the project harness-**absent** (the safe direction — no orphaned autoload), which the
+next `gda daemon start` repairs. It is a no-op when no harness is installed.
+
+**2. The harness self-disables in any exported build.** As defence in depth for export routes
+that bypass `gda export run` (the Godot editor GUI, a raw `godot --export-*`), the harness
+`_ready()` returns immediately under `OS.has_feature("template")`. `template` is true **only**
+in an exported template build and false on the editor (tools) binary every daemon session runs
+on (`core/os/os.cpp`), so this never disables a legitimate session and a harness that *did*
+reach a shipped build does literally nothing, regardless of launch args.
+
+**3. Coverage: gda export = physically clean; every other route = provably inert.** The
+supported, agent-driven release path (`gda export run`) gives full physical absence; any other
+export route gives guaranteed inertness (the harness may physically remain there but never
+activates). Extending *physical* cleanliness to non-gda routes is deliberately **not** taken
+on here (see Considered options).
+
+## Considered options
+
+- **Strip the autoload at export via an `EditorExportPlugin` (rejected — impossible).** No hook
+  can modify the packed `ProjectSettings`/autoload list; `project.binary` is written wholesale
+  after all plugin hooks. This is the pivotal constraint that rules out an "export-time filter".
+- **`exclude_filter` the harness file only (rejected).** Removes the file but leaves the
+  autoload entry dangling → startup `ERR_CONTINUE` error spam in the shipped game. Removal must
+  be **paired** (entry + file), which is what `gda daemon uninstall` / the decision-1 strip do.
+- **Install the autoload via `override.cfg` instead of `project.godot` (rejected).** Aimed to
+  keep `project.godot` clean, but `override.cfg` settings are loaded into the same `props` map
+  `save_custom` serializes, so the export (run by an `override.cfg`-loading binary) re-leaks the
+  autoload into `project.binary`. It also packs/loads in the exported context. Buys nothing.
+- **Feature-tagged autoload `autoload/GdaHarness.editor` (rejected).** Unsupported by the engine
+  (registers a literally-named autoload; feature override not consulted at autoload load).
+- **Rely on the existing manual `gda daemon uninstall` before export (rejected).** Forget-prone
+  — the exact failure this ADR exists to remove. Kept as an explicit teardown, not the guarantee.
+- **Ephemeral install — auto-uninstall on daemon/session stop, self-heal on next start
+  (deferred).** Would make the project clean between sessions and thus give *physical*
+  cleanliness on **all** export routes (incl. the editor GUI). Deferred: it reopens ADR-0018
+  Decision 1's "no per-launch `project.godot` mutation" (concurrent-editor races, dirty-on-crash),
+  adds per-session churn, and still leaves a crash-residual window (covered as inert by
+  decision 2). Revisit only if non-gda routes later need physical, not just inert, cleanliness.
+
+## Consequences
+
+- `gda export run` (`run_export_operation`) now brackets the native export with the
+  harness strip/restore, reusing the ADR-0018 `install`/`uninstall` paired helpers; a no-op when
+  no harness is present. Verified by unit tests (strip-during-export, restore-after,
+  restore-on-exception, no-op-when-absent) and an e2e (`export run --mode pack` archive omits
+  `gda_harness.gd`, project restored).
+- The harness `_ready()` template gate is verified resident-inert in a real engine and in an
+  exported pack; the "exported pck runs inert" e2e packs via a **raw** `godot --export-pack`
+  (which does not strip) and asserts the harness is genuinely present, so "inert" stays
+  meaningful.
+- **ADR-0018 is the harness *install/lifecycle* record; this ADR owns the *export/teardown*
+  half.** ADR-0018 carries a dated pointer to this ADR and retains the corrected note on its
+  point 3 (the dangling-autoload behaviour is `ERR_CONTINUE`, not a crash). The trust model is
+  unchanged (ADR-0009): this is build hygiene + defence in depth, not a new security boundary —
+  a shipped harness was already inert by the launch-marker gate (ADR-0018 point 2).
+- CONTEXT.md needs no new term: the [gda harness](../../CONTEXT.md) glossary entry ("stays
+  dormant in … a shipped build") remains accurate; the strip is a `gda export run` behaviour, not
+  a property of the term.
+- README states the harness is dev-only (stripped from `gda export run` artifacts, self-disables
+  in shipped builds) and that `gda daemon uninstall` is the explicit manual teardown.

--- a/docs/adr/0028-harness-export-cleanliness.md
+++ b/docs/adr/0028-harness-export-cleanliness.md
@@ -42,11 +42,14 @@ project** — it must never be present at export time, not stripped during it.
 **1. `gda export run` strips the harness transactionally.** Before the native
 `--export-<mode>` run (the [Headless launch](../../CONTEXT.md) native-export channel), the
 operation paired-uninstalls the harness — autoload entry first, then files, the crash-safe
-ordering ADR-0018 already uses — and reinstalls it in a `finally` after the export returns.
-The artifact is therefore harness-free **by construction and forget-proof** (no `gda daemon
-uninstall` step required), the dev project is left byte-identical, and a mid-export crash
-leaves the project harness-**absent** (the safe direction — no orphaned autoload), which the
-next `gda daemon start` repairs. It is a no-op when no harness is installed.
+ordering ADR-0018 already uses — then, in a `finally`, **restores the exact pre-export state**
+(a byte-exact snapshot of `project.godot` + the harness file, NOT a fresh install — which
+would canonicalize a noncanonical autoload, synthesize one for a stray harness file that had
+none, or rewrite a stale body to the current version). The artifact is therefore harness-free
+**by construction and forget-proof** (no `gda daemon uninstall` step required), the dev
+project is left **byte-identical**, and a mid-export crash leaves the project harness-**absent**
+(the safe direction — no orphaned autoload), which the next `gda daemon start` repairs. It is
+a no-op when no harness is installed.
 
 **2. The harness self-disables in any exported build.** As defence in depth for export routes
 that bypass `gda export run` (the Godot editor GUI, a raw `godot --export-*`), the harness
@@ -86,15 +89,22 @@ on here (see Considered options).
 
 ## Consequences
 
-- `gda export run` (`run_export_operation`) now brackets the native export with the
-  harness strip/restore, reusing the ADR-0018 `install`/`uninstall` paired helpers; a no-op when
-  no harness is present. Verified by unit tests (strip-during-export, restore-after,
-  restore-on-exception, no-op-when-absent) and an e2e (`export run --mode pack` archive omits
-  `gda_harness.gd`, project restored).
-- The harness `_ready()` template gate is verified resident-inert in a real engine and in an
-  exported pack; the "exported pck runs inert" e2e packs via a **raw** `godot --export-pack`
-  (which does not strip) and asserts the harness is genuinely present, so "inert" stays
-  meaningful.
+- `gda export run` (`run_export_operation`) now brackets the native export with the harness
+  strip/restore: the strip reuses the ADR-0018 paired `uninstall`, but the restore **replays a
+  byte-exact snapshot** (not `install`), so the dev project is byte-identical even for a
+  stale / stray-file / noncanonical prior state; a no-op when no harness is present. Verified
+  by unit tests (byte-identical restore, stray-file → no autoload synthesized, stale-body →
+  not re-materialized, restore-on-exception) and an e2e (`export run --mode pack` archive omits
+  `gda_harness.gd` **and** the packed `project.binary` declares no `GdaHarness` autoload, the
+  project restored after).
+- The `template` gate is proven **statically** (a CI-runnable test asserts `if
+  OS.has_feature("template"): return` is the first statement of `_ready()`). Its
+  **behavioural** proof needs a real exported template binary (export templates + the e2e job)
+  and is deferred to **issue #301**, guarded by a tripwire e2e that warns once templates exist.
+  The separate "exported pck runs inert" e2e proves the **no-marker** resident-inert path
+  (ADR-0018 point 2) — it runs on the editor binary, where `template` is false — packing via a
+  **raw** `godot --export-pack` (which does not strip) and asserting the harness is genuinely
+  present, so "inert" stays meaningful.
 - **ADR-0018 is the harness *install/lifecycle* record; this ADR owns the *export/teardown*
   half.** ADR-0018 carries a dated pointer to this ADR and retains the corrected note on its
   point 3 (the dangling-autoload behaviour is `ERR_CONTINUE`, not a crash). The trust model is

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -1483,7 +1483,8 @@ def daemon_uninstall(
 
     A release-hygiene step: removal is paired and crash-safe — the [autoload] entry
     is stripped first, then the files — so a mid-failure never leaves a dangling
-    autoload that would crash an exported game. Idempotent (a no-op if not
+    autoload (which an exported game logs `ERR_CONTINUE` and skips at startup —
+    error spam, not a hard crash; ADR-0028). Idempotent (a no-op if not
     installed). Refused while a daemon is running (`daemon_running`); stop it first
     with `gda daemon stop`. Live is macOS/Linux only; elsewhere reports
     `live_unsupported_platform`.

--- a/src/gda/export_run.py
+++ b/src/gda/export_run.py
@@ -45,6 +45,7 @@ from gda.errors import (
     export_templates_missing_failure,
 )
 from gda.export_runner import ExportRunner, make_subprocess_export_runner
+from gda.harness.install import install_harness, uninstall_harness
 from gda.headless import HeadlessCommand, RunnerFactory, make_subprocess_runner
 from gda.models import (
     ExportGetParams,
@@ -143,7 +144,22 @@ def run_export_operation(
     # invocation, not the raw --preset string, is keyed on it.
     binary = resolve_godot_binary(godot)
     export_runner = make_export_runner(binary, project)
-    export_output = export_runner.run(got.name, mode.value, output_path)
+    # The dev-only harness must never reach the artifact (ADR-0018): an export
+    # cannot strip a project.godot autoload after the fact (it is serialized whole
+    # into project.binary), so the only reliable guarantee is that the harness is
+    # already gone before the native export reads the project. Paired-uninstall it
+    # first (autoload entry + files, crash-safe ordering) and restore it after, so
+    # the gda export path is harness-free yet the dev project is left untouched.
+    # This is forget-proof: it needs no `gda daemon uninstall` step. A no-op when no
+    # harness is installed; if gda dies mid-export the project is left harness-ABSENT
+    # (the safe direction — no dangling autoload), and the next `daemon start`
+    # reinstalls it.
+    strip = uninstall_harness(project) if project is not None else None
+    try:
+        export_output = export_runner.run(got.name, mode.value, output_path)
+    finally:
+        if strip is not None and strip.removed:
+            install_harness(project)
     return classify_export_run(
         export_output,
         binary,

--- a/src/gda/export_run.py
+++ b/src/gda/export_run.py
@@ -144,7 +144,7 @@ def run_export_operation(
     # invocation, not the raw --preset string, is keyed on it.
     binary = resolve_godot_binary(godot)
     export_runner = make_export_runner(binary, project)
-    # The dev-only harness must never reach the artifact (ADR-0018): an export
+    # The dev-only harness must never reach the artifact (ADR-0028): an export
     # cannot strip a project.godot autoload after the fact (it is serialized whole
     # into project.binary), so the only reliable guarantee is that the harness is
     # already gone before the native export reads the project. Paired-uninstall it

--- a/src/gda/export_run.py
+++ b/src/gda/export_run.py
@@ -34,6 +34,7 @@ root) beside that recipe, where it is the command's single fully-bound descripto
 """
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -45,7 +46,7 @@ from gda.errors import (
     export_templates_missing_failure,
 )
 from gda.export_runner import ExportRunner, make_subprocess_export_runner
-from gda.harness.install import install_harness, uninstall_harness
+from gda.harness.install import HARNESS_FILE, HARNESS_RES_DIR, uninstall_harness
 from gda.headless import HeadlessCommand, RunnerFactory, make_subprocess_runner
 from gda.models import (
     ExportGetParams,
@@ -59,6 +60,54 @@ from gda.render import render_export_get
 # the sentinel channel's ``RunnerFactory``. Spelled here (not in ``headless``)
 # because only the export recipe spawns a native ``--export-<mode>`` process.
 ExportRunnerFactory = Callable[[Path, Optional[Path]], ExportRunner]
+
+
+@dataclass(frozen=True)
+class _HarnessSnapshot:
+    """The EXACT pre-export state of the two files the export strip touches.
+
+    Restoring from this snapshot leaves the dev project byte-identical (ADR-0028's
+    "untouched" guarantee) — unlike a fresh ``install_harness``, which would
+    canonicalize a noncanonical autoload, rewrite a stale harness body to the
+    current version, or ADD a ``GdaHarness`` autoload for a stray harness file that
+    had none. Captured before the strip; replayed in the ``finally`` after the
+    native export.
+    """
+
+    project_godot: Path
+    project_godot_bytes: Optional[bytes]
+    harness_file: Path
+    harness_file_bytes: Optional[bytes]
+
+    @classmethod
+    def capture(cls, project: Path) -> "_HarnessSnapshot":
+        project_godot = project / "project.godot"
+        harness_file = project / HARNESS_RES_DIR / HARNESS_FILE
+        return cls(
+            project_godot,
+            project_godot.read_bytes() if project_godot.exists() else None,
+            harness_file,
+            harness_file.read_bytes() if harness_file.exists() else None,
+        )
+
+    def restore(self) -> None:
+        """Put both files back to their captured bytes, writing only when changed.
+
+        A file absent at capture is left absent (the strip removed it); otherwise its
+        exact bytes are rewritten, but only if the current on-disk state differs — so
+        the common no-harness export touches nothing (no spurious ``project.godot``
+        mtime bump against a concurrent editor, ADR-0018).
+        """
+        for path, before in (
+            (self.project_godot, self.project_godot_bytes),
+            (self.harness_file, self.harness_file_bytes),
+        ):
+            if before is None:
+                path.unlink(missing_ok=True)
+            elif not path.exists() or path.read_bytes() != before:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(before)
+
 
 EXPORT_GET_COMMAND: HeadlessCommand[ExportGetResult] = HeadlessCommand(
     operation="export-get",
@@ -147,19 +196,23 @@ def run_export_operation(
     # The dev-only harness must never reach the artifact (ADR-0028): an export
     # cannot strip a project.godot autoload after the fact (it is serialized whole
     # into project.binary), so the only reliable guarantee is that the harness is
-    # already gone before the native export reads the project. Paired-uninstall it
-    # first (autoload entry + files, crash-safe ordering) and restore it after, so
-    # the gda export path is harness-free yet the dev project is left untouched.
-    # This is forget-proof: it needs no `gda daemon uninstall` step. A no-op when no
-    # harness is installed; if gda dies mid-export the project is left harness-ABSENT
-    # (the safe direction — no dangling autoload), and the next `daemon start`
-    # reinstalls it.
-    strip = uninstall_harness(project) if project is not None else None
+    # already gone before the native export reads the project. SNAPSHOT the exact
+    # pre-export state, paired-uninstall the harness (autoload entry + files,
+    # crash-safe ordering) so the export sees a clean project, then restore the
+    # snapshot — byte-for-byte, NOT a fresh install (which would add/canonicalize an
+    # autoload or rewrite stale bytes, mutating a project that was not cleanly
+    # installed). The dev project is thus left byte-identical and the step is
+    # forget-proof (no `gda daemon uninstall` needed). A no-op when no harness is
+    # present; if gda dies mid-export the project is left harness-ABSENT (the safe
+    # direction — no dangling autoload), and the next `daemon start` reinstalls it.
+    snapshot = _HarnessSnapshot.capture(project) if project is not None else None
+    if snapshot is not None:
+        uninstall_harness(project)
     try:
         export_output = export_runner.run(got.name, mode.value, output_path)
     finally:
-        if strip is not None and strip.removed:
-            install_harness(project)
+        if snapshot is not None:
+            snapshot.restore()
     return classify_export_run(
         export_output,
         binary,

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -90,7 +90,7 @@ var _window_state = null
 
 
 func _ready() -> void:
-	# Defence in depth (ADR-0018): stay fully inert in any EXPORTED build, even if a
+	# Defence in depth (ADR-0028): stay fully inert in any EXPORTED build, even if a
 	# build somehow shipped with the harness installed (e.g. exported outside `gda
 	# export run`, which strips it). `template` is true ONLY in an exported template
 	# build and false on the editor (tools) binary every gda-daemon session runs on —

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -90,6 +90,14 @@ var _window_state = null
 
 
 func _ready() -> void:
+	# Defence in depth (ADR-0018): stay fully inert in any EXPORTED build, even if a
+	# build somehow shipped with the harness installed (e.g. exported outside `gda
+	# export run`, which strips it). `template` is true ONLY in an exported template
+	# build and false on the editor (tools) binary every gda-daemon session runs on —
+	# so this never disables a legitimate session, and a shipped build does literally
+	# nothing here regardless of the launch args below.
+	if OS.has_feature("template"):
+		return
 	_perf_monitors = {
 		"fps": Performance.TIME_FPS,
 		"process_time": Performance.TIME_PROCESS,

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -21,9 +21,10 @@ concurrent-editor prompt). ``installed_harness_version`` reads the header back.
 
 **Paired uninstall (#225, D2).** ``uninstall_harness`` removes the ``[autoload]``
 entry **first**, then deletes the files — so a mid-failure leaves only a harmless
-stray inert ``.gd``, never a dangling autoload pointing at a missing script (which
-crashes an exported game, ADR-0018). It is idempotent: a no-op success when the
-harness is not installed (mirrors ``daemon stop``).
+stray inert ``.gd``, never a dangling autoload pointing at a missing script (which an
+exported game logs ``ERR_CONTINUE`` and skips at startup — error spam, not a hard
+crash; ADR-0028). It is idempotent: a no-op success when the harness is not installed
+(mirrors ``daemon stop``).
 """
 
 from dataclasses import dataclass
@@ -249,7 +250,8 @@ def uninstall_harness(project: Path) -> HarnessUninstall:
     Crash-safe ordering (ADR-0018, D2): strip the ``[autoload]`` entry **first**
     (a single atomic ``write_text``), then delete the files — so a mid-failure
     leaves only a harmless stray inert ``.gd``, never a dangling autoload pointing
-    at a missing script (which crashes an exported game). Returns a
+    at a missing script (which an exported game logs ``ERR_CONTINUE`` and skips at
+    startup — error spam, not a hard crash; ADR-0028). Returns a
     :class:`HarnessUninstall`; ``removed`` is ``False`` (a no-op success) when
     nothing is installed (mirrors ``daemon stop``).
     """

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -40,7 +40,7 @@ HARNESS_RES_PATH = f"res://{HARNESS_RES_DIR}/{HARNESS_FILE}"
 # copy to it (#225). The installed copy declares its version in a leading header
 # (`# gda-harness-version: <N>`); a mismatch re-materializes via the content
 # compare. NOT the package version — the harness changes far less often.
-HARNESS_VERSION = "2"
+HARNESS_VERSION = "3"
 
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -29,6 +29,7 @@ path) run unconditionally.
 import json
 import shutil
 import subprocess
+import warnings
 import zipfile
 
 import pytest
@@ -277,3 +278,35 @@ def test_export_run_pack_omits_installed_harness_and_restores_it(godot_project):
     # The dev project is left UNTOUCHED: harness restored on disk and in config.
     assert harness_file.exists(), "the harness file must be restored after export"
     assert HARNESS_AUTOLOAD_NAME in project_godot.read_text(encoding="utf-8")
+
+
+@pytest.mark.e2e
+def test_template_gate_behavioural_proof_is_due_once_templates_exist(godot_project):
+    # TRIPWIRE for ADR-0028's harness `template` gate. The gate
+    # (`if OS.has_feature("template"): return`, the first statement of `_ready()`) is
+    # proven STATICALLY by
+    # tests/test_harness_install.py::test_ready_gates_on_template_feature_as_its_first_statement.
+    # Its BEHAVIOURAL proof needs a real exported TEMPLATE binary, which needs
+    # installed export templates (issue #301). The default PR CI both skips the e2e
+    # job AND lacks templates, so that gap could be silently forgotten. This guard
+    # stays a LOUD skip while templates are absent and emits a WARNING the moment a
+    # runner has them — so #301 gets implemented rather than left undone.
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    gda = _gda_project(godot_project)
+    if not _templates_installed(gda):
+        pytest.skip(
+            "export templates absent: the template-gate BEHAVIOURAL proof cannot run "
+            "here (covered statically by "
+            "test_ready_gates_on_template_feature_as_its_first_statement). Implement "
+            "it where templates exist — issue #301."
+        )
+    warnings.warn(
+        "Godot export templates are now installed: implement the behavioural "
+        "template-gate e2e (issue #301) — export a template binary, run it with a "
+        "`gda-daemon` marker + a live socket, and assert the harness never connects — "
+        "then remove this tripwire. Until then the `template` gate is proven only "
+        "statically.",
+        stacklevel=2,
+    )

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -29,6 +29,7 @@ path) run unconditionally.
 import json
 import shutil
 import subprocess
+import zipfile
 
 import pytest
 
@@ -260,14 +261,19 @@ def test_export_run_pack_omits_installed_harness_and_restores_it(godot_project):
 
     assert run.returncode == 0, run.stdout + run.stderr
     assert artifact.exists(), f"expected .zip at the override path {artifact}"
-    # The artifact must NOT contain the harness script.
-    listing = subprocess.run(
-        ["unzip", "-l", str(artifact)], capture_output=True, text=True
-    )
-    assert listing.returncode == 0, listing.stdout + listing.stderr
-    assert HARNESS_FILE not in listing.stdout, (
-        "the exported archive still carries the harness:\n" + listing.stdout
-    )
+    with zipfile.ZipFile(artifact) as zf:
+        names = zf.namelist()
+        # (a) The harness SCRIPT is absent from the archive.
+        assert not any(HARNESS_FILE in n for n in names), (
+            "the exported archive still carries the harness script:\n" + "\n".join(names)
+        )
+        # (b) The packed project settings declare NO GdaHarness autoload — the
+        # specific Godot risk (project.binary serializes ProjectSettings wholesale,
+        # ADR-0028), so checking the file's absence alone is not enough.
+        binary_entry = next(n for n in names if n.endswith("project.binary"))
+        assert HARNESS_AUTOLOAD_NAME.encode() not in zf.read(binary_entry), (
+            "packed project.binary still declares the GdaHarness autoload"
+        )
     # The dev project is left UNTOUCHED: harness restored on disk and in config.
     assert harness_file.exists(), "the harness file must be restored after export"
     assert HARNESS_AUTOLOAD_NAME in project_godot.read_text(encoding="utf-8")

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -33,6 +33,12 @@ import subprocess
 import pytest
 
 from gda.binary import resolve_godot_binary
+from gda.harness.install import (
+    HARNESS_AUTOLOAD_NAME,
+    HARNESS_FILE,
+    HARNESS_RES_DIR,
+    install_harness,
+)
 
 GODOT = resolve_godot_binary()
 
@@ -218,3 +224,50 @@ def test_export_run_pack_writes_pck_without_templates(godot_project):
     assert data["output_path"] == override_rel
     assert artifact.exists(), f"expected .pck at the override path {artifact}"
     assert not configured.exists(), "the override must not write the configured path"
+
+
+@pytest.mark.e2e
+def test_export_run_pack_omits_installed_harness_and_restores_it(godot_project):
+    # ADR-0018: `gda export run` must NEVER carry the dev-only harness into the
+    # artifact — and without the developer having to `gda daemon uninstall` first.
+    # With the harness INSTALLED, a pack export to a .zip (so we can list it) must
+    # contain NO gda_harness.gd, and the dev project must be left UNTOUCHED (the
+    # harness file + autoload entry restored). Pack needs no templates, so this runs
+    # on a template-less machine and gives real on-disk verification.
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    # Pack content unrelated to the harness, so the archive is non-empty even after
+    # the harness is stripped (a bare project alone yields Godot's "select one file").
+    (godot_project / "main.gd").write_text(
+        "extends Node\n\nfunc _ready() -> void:\n\tpass\n", encoding="utf-8"
+    )
+    install_harness(godot_project)
+    harness_file = godot_project / HARNESS_RES_DIR / HARNESS_FILE
+    project_godot = godot_project / "project.godot"
+    assert harness_file.exists(), "precondition: harness installed on disk"
+    assert HARNESS_AUTOLOAD_NAME in project_godot.read_text(encoding="utf-8")
+
+    override_rel = "dist/packed.zip"
+    artifact = godot_project / override_rel
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    gda = _gda_project(godot_project)
+
+    run = gda(
+        "export", "run", "--preset", "Linux/X11",
+        "--mode", "pack", "--output", override_rel, "--json",
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert artifact.exists(), f"expected .zip at the override path {artifact}"
+    # The artifact must NOT contain the harness script.
+    listing = subprocess.run(
+        ["unzip", "-l", str(artifact)], capture_output=True, text=True
+    )
+    assert listing.returncode == 0, listing.stdout + listing.stderr
+    assert HARNESS_FILE not in listing.stdout, (
+        "the exported archive still carries the harness:\n" + listing.stdout
+    )
+    # The dev project is left UNTOUCHED: harness restored on disk and in config.
+    assert harness_file.exists(), "the harness file must be restored after export"
+    assert HARNESS_AUTOLOAD_NAME in project_godot.read_text(encoding="utf-8")

--- a/tests/test_e2e_harness_install.py
+++ b/tests/test_e2e_harness_install.py
@@ -3,8 +3,8 @@
 Per RULES.md DoD the fast install tests do not count toward this gate: these boot
 a REAL Godot on a project with the harness installed and assert the autoload is
 valid GDScript and stays inert — no daemon launch marker, so it opens no
-connection and the engine boots clean. The exact failure ADR-0018 guards (a
-dangling autoload crashing the boot, or the harness opening a connection in a
+connection and the engine boots clean. The exact failures ADR-0018 guards (a
+dangling autoload spamming startup errors, or the harness opening a connection in a
 plain run / shipped build) must NOT occur.
 
 Two boots: a plain ``--path`` run (#7, strengthened by #225), and an EXPORTED PCK
@@ -17,6 +17,13 @@ ADR-0018's export-strip, ``gda export run`` removes the harness from its artifac
 property here — that a harness which *did* reach a shipped build stays inert — the
 pack must come from a route that does not strip it, and the harness's presence in
 the pack is asserted so "inert" is never trivially true.
+
+NOTE on what the PCK boot proves: it runs the pack with the EDITOR (tools) binary via
+``--main-pack``, where ``OS.has_feature("template")`` is FALSE — so it exercises the
+**no-marker** inert path (ADR-0018 point 2), not ADR-0028's ``template`` gate. The
+gate's behavioural proof needs a real exported template binary (templates + the e2e
+job); its CI-runnable static proof — that the gate is the first statement of
+``_ready()`` — lives in ``tests/test_harness_install.py``.
 """
 
 import subprocess

--- a/tests/test_e2e_harness_install.py
+++ b/tests/test_e2e_harness_install.py
@@ -10,10 +10,15 @@ plain run / shipped build) must NOT occur.
 Two boots: a plain ``--path`` run (#7, strengthened by #225), and an EXPORTED PCK
 run (#225) — the harness packed into a templateless ``.pck`` and run with no
 ``gda-daemon`` marker, the shipped-build path ADR-0018 point 2 calls out.
+
+The PCK boot packs via a RAW ``godot --export-pack`` (NOT ``gda export run``): since
+ADR-0018's export-strip, ``gda export run`` removes the harness from its artifacts
+(verified in ``tests/test_e2e_export_run.py``), so to exercise the DEFENSE-IN-DEPTH
+property here — that a harness which *did* reach a shipped build stays inert — the
+pack must come from a route that does not strip it, and the harness's presence in
+the pack is asserted so "inert" is never trivially true.
 """
 
-import json
-import shutil
 import subprocess
 
 import pytest
@@ -76,21 +81,19 @@ def test_installed_harness_boots_inert_in_a_real_engine(tmp_path):
 
 @pytest.mark.e2e
 def test_exported_pck_with_harness_runs_inert(tmp_path):
-    # #225 / ADR-0018 point 2: the harness installed into a project must stay inert
-    # in a SHIPPED build. Pack the project (harness autoload included) into a
-    # templateless .pck via `export run --mode pack` (needs no platform templates),
-    # then RUN that .pck with no `gda-daemon` marker — the engine loads the packed
-    # autoload, which must boot clean and open nothing (the exact crash ADR-0018
-    # guards: a dangling/active autoload in an exported game).
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
-
+    # #225 / ADR-0018 point 2 (defense in depth): a harness that DID reach a SHIPPED
+    # build must stay inert. `gda export run` now strips the harness from its
+    # artifacts (see tests/test_e2e_export_run.py), so to exercise the residual case
+    # we pack via a RAW `godot --export-pack` (which does NOT strip), assert the
+    # harness is genuinely IN the pack, then RUN that .pck with no `gda-daemon`
+    # marker — the packed GdaHarness autoload must boot clean and open nothing (the
+    # exact failure ADR-0018 guards: a dangling/active autoload in an exported game).
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
     install_harness(tmp_path)
 
-    # A minimal Linux preset so `export run --mode pack` has a preset to pack from
-    # (pack produces project data only; platform is immaterial, no templates used).
+    # A minimal Linux preset so `--export-pack` has a preset to pack from (pack
+    # produces project data only; platform is immaterial, no templates used).
     (tmp_path / "export_presets.cfg").write_text(
         "[preset.0]\n\n"
         'name="Pack"\n'
@@ -104,23 +107,23 @@ def test_exported_pck_with_harness_runs_inert(tmp_path):
         "binary_format/embed_pck=false\n",
         encoding="utf-8",
     )
-    pck_rel = "dist/game.pck"
-    pck = tmp_path / pck_rel
+    pck = tmp_path / "dist" / "game.pck"
     pck.parent.mkdir(parents=True, exist_ok=True)
 
+    # RAW engine export (bypasses gda's strip on purpose) so the harness is packed.
     packed = subprocess.run(
         [
-            gda, "export", "run", "--preset", "Pack",
-            "--mode", "pack", "--output", pck_rel,
-            "--project", str(tmp_path), "--godot", str(GODOT), "--json",
+            str(GODOT), "--headless", "--path", str(tmp_path),
+            "--export-pack", "Pack", str(pck),
         ],
         capture_output=True,
         text=True,
         timeout=120,
     )
-    assert packed.returncode == 0, packed.stdout + packed.stderr
-    assert json.loads(packed.stdout)["mode"] == "pack"
-    assert pck.exists(), f"expected packed .pck at {pck}"
+    assert pck.exists(), f"expected packed .pck at {pck}\n{packed.stdout}{packed.stderr}"
+    # Non-trivial precondition: the harness path really is inside the pack (the pck
+    # file table stores res:// paths as plaintext), so "inert" below is meaningful.
+    assert b"gda_harness.gd" in pck.read_bytes(), "the harness was not packed"
 
     # Run the engine against the packed .pck (the shipped-build path): the packed
     # GdaHarness autoload must boot inert — no marker, so it opens nothing.

--- a/tests/test_export_run_operation.py
+++ b/tests/test_export_run_operation.py
@@ -24,6 +24,7 @@ from gda.export_run import (
     EXPORT_GET_COMMAND,
     run_export_operation,
 )
+from gda.harness.install import install_harness, uninstall_harness
 from gda.models import ExportRunMode, ExportRunResult
 from gda.runner import RunResult
 from tests.support import FakeExportRunner, FakeRunner, error_sentinel, sentinel
@@ -206,6 +207,98 @@ def test_pack_is_exempt_from_templates_preflight():
     assert isinstance(outcome, ExportRunResult)
     assert outcome.mode is ExportRunMode.PACK
     assert export_runner.calls == [("Linux/X11", "pack", "build/game.x86_64")]
+
+
+# --- Transactional harness strip (ADR-0018: a shipped build must never carry the
+# dev-only harness). run_export_operation paired-uninstalls the harness before the
+# native export and restores it after, so the gda export path is harness-free yet
+# the dev project is left unchanged. These drive a real temp project so the on-disk
+# strip/restore is observed, with the export runner pinned to a fake. ----------------
+
+
+def _project_with_harness(tmp_path: Path) -> Path:
+    """A minimal real project with the harness installed; returns the harness path."""
+    (tmp_path / "project.godot").write_text(
+        'config_version=5\n\n[application]\n\nconfig/name="t"\n', encoding="utf-8"
+    )
+    install_harness(tmp_path)
+    harness = tmp_path / "addons" / "gda_harness" / "gda_harness.gd"
+    assert harness.exists()  # precondition: installed
+    return harness
+
+
+def _run_export_in(project: Path, export_runner) -> object:
+    """Invoke run_export_operation against a real ``project`` with seams pinned."""
+    return run_export_operation(
+        preset="Linux/X11",
+        mode=ExportRunMode.PACK,  # pack: no template preflight, runs the native seam
+        output_override="build/game.zip",
+        godot="/tmp/Godot",
+        project=project,
+        make_runner=lambda binary, project=None: _get_runner(),
+        make_export_runner=lambda binary, project=None: export_runner,
+    )
+
+
+def test_export_strips_harness_during_run_then_restores(tmp_path):
+    # The harness is ABSENT on disk while the native export builds the artifact, and
+    # RESTORED afterward — so it never reaches the build, but the dev project is left
+    # exactly as it was.
+    harness = _project_with_harness(tmp_path)
+    seen = {}
+
+    class _AssertingRunner:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str, str]] = []
+
+        def run(self, preset, mode, output_path):
+            seen["harness_present_during_export"] = harness.exists()
+            self.calls.append((preset, mode, output_path))
+            return RunResult(stdout="", stderr="", exit_code=0)
+
+    runner = _AssertingRunner()
+    outcome = _run_export_in(tmp_path, runner)
+
+    assert isinstance(outcome, ExportRunResult)
+    assert seen["harness_present_during_export"] is False  # stripped for the export
+    assert harness.exists()  # restored after
+    # The restore is the FULL paired install: the autoload entry is back too.
+    assert "GdaHarness" in (tmp_path / "project.godot").read_text(encoding="utf-8")
+
+
+def test_export_restores_harness_even_when_native_run_raises(tmp_path):
+    # A crash-safe finally: if the native export raises, the harness is still
+    # restored (never left stripped by a mid-export failure on the gda path).
+    harness = _project_with_harness(tmp_path)
+
+    class _BoomRunner:
+        def run(self, preset, mode, output_path):
+            raise RuntimeError("export blew up")
+
+    try:
+        _run_export_in(tmp_path, _BoomRunner())
+    except RuntimeError:
+        pass
+    assert harness.exists()  # restored despite the exception
+    assert "GdaHarness" in (tmp_path / "project.godot").read_text(encoding="utf-8")
+
+
+def test_export_is_a_noop_when_no_harness_installed(tmp_path):
+    # With no harness installed, the strip is a harmless no-op: nothing is created,
+    # and the export still runs to completion.
+    (tmp_path / "project.godot").write_text(
+        'config_version=5\n\n[application]\n', encoding="utf-8"
+    )
+    # Ensure a clean slate (idempotent): no harness present.
+    uninstall_harness(tmp_path)
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+    outcome = _run_export_in(tmp_path, export_runner)
+
+    assert isinstance(outcome, ExportRunResult)
+    assert not (tmp_path / "addons" / "gda_harness").exists()
+    assert "GdaHarness" not in (tmp_path / "project.godot").read_text(encoding="utf-8")
+    assert export_runner.calls == [("Linux/X11", "pack", "build/game.zip")]
 
 
 def test_native_nonzero_exit_returns_export_failed():

--- a/tests/test_export_run_operation.py
+++ b/tests/test_export_run_operation.py
@@ -240,11 +240,15 @@ def _run_export_in(project: Path, export_runner) -> object:
     )
 
 
-def test_export_strips_harness_during_run_then_restores(tmp_path):
+def test_export_strips_harness_during_run_then_restores_byte_identical(tmp_path):
     # The harness is ABSENT on disk while the native export builds the artifact, and
-    # RESTORED afterward — so it never reaches the build, but the dev project is left
-    # exactly as it was.
+    # the dev project is restored BYTE-IDENTICAL afterward (ADR-0028) — not merely
+    # "an autoload named GdaHarness exists", but the exact prior project.godot and
+    # harness bytes.
     harness = _project_with_harness(tmp_path)
+    project_godot = tmp_path / "project.godot"
+    godot_before = project_godot.read_bytes()
+    harness_before = harness.read_bytes()
     seen = {}
 
     class _AssertingRunner:
@@ -261,9 +265,9 @@ def test_export_strips_harness_during_run_then_restores(tmp_path):
 
     assert isinstance(outcome, ExportRunResult)
     assert seen["harness_present_during_export"] is False  # stripped for the export
-    assert harness.exists()  # restored after
-    # The restore is the FULL paired install: the autoload entry is back too.
-    assert "GdaHarness" in (tmp_path / "project.godot").read_text(encoding="utf-8")
+    # Byte-identical restore of BOTH files — the dev project is untouched.
+    assert project_godot.read_bytes() == godot_before
+    assert harness.read_bytes() == harness_before
 
 
 def test_export_restores_harness_even_when_native_run_raises(tmp_path):
@@ -299,6 +303,50 @@ def test_export_is_a_noop_when_no_harness_installed(tmp_path):
     assert not (tmp_path / "addons" / "gda_harness").exists()
     assert "GdaHarness" not in (tmp_path / "project.godot").read_text(encoding="utf-8")
     assert export_runner.calls == [("Linux/X11", "pack", "build/game.zip")]
+
+
+def test_export_restores_a_stale_harness_body_unchanged_not_a_fresh_install(tmp_path):
+    # ADR-0028 "byte-identical": a STALE installed harness (older version/body) must
+    # be restored exactly as it was — NOT re-materialized to the current
+    # HARNESS_VERSION. A fresh install_harness would rewrite it; the snapshot restore
+    # preserves the prior bytes.
+    harness = _project_with_harness(tmp_path)
+    stale = b"# gda-harness-version: stale-old\nextends Node\n# old body\n"
+    harness.write_bytes(stale)
+    godot_before = (tmp_path / "project.godot").read_bytes()
+
+    outcome = _run_export_in(
+        tmp_path, FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+    )
+
+    assert isinstance(outcome, ExportRunResult)
+    assert harness.read_bytes() == stale  # not bumped to the current version
+    assert (tmp_path / "project.godot").read_bytes() == godot_before
+
+
+def test_export_does_not_add_autoload_for_a_stray_harness_file(tmp_path):
+    # The reviewer's repro: a project with ONLY a stray harness file and NO
+    # [autoload] entry must come out of export with NO autoload added. The strip
+    # removes the stray file (so it cannot ship); the byte-exact restore puts the
+    # stray file back WITHOUT synthesizing an autoload the project never had.
+    (tmp_path / "project.godot").write_text(
+        'config_version=5\n\n[application]\n', encoding="utf-8"
+    )
+    stray = tmp_path / "addons" / "gda_harness" / "gda_harness.gd"
+    stray.parent.mkdir(parents=True, exist_ok=True)
+    stray.write_bytes(b"extends Node\n# stray, no autoload entry\n")
+    godot_before = (tmp_path / "project.godot").read_bytes()
+
+    outcome = _run_export_in(
+        tmp_path, FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+    )
+
+    assert isinstance(outcome, ExportRunResult)
+    # No autoload synthesized — project.godot is byte-identical to before.
+    assert (tmp_path / "project.godot").read_bytes() == godot_before
+    assert "GdaHarness" not in (tmp_path / "project.godot").read_text(encoding="utf-8")
+    # The stray file is restored (the project is left exactly as found).
+    assert stray.read_bytes() == b"extends Node\n# stray, no autoload entry\n"
 
 
 def test_native_nonzero_exit_returns_export_failed():

--- a/tests/test_harness_install.py
+++ b/tests/test_harness_install.py
@@ -191,8 +191,9 @@ def test_uninstall_scopes_removal_to_the_autoload_section(tmp_path):
 def test_uninstall_removes_autoload_before_files(tmp_path, monkeypatch):
     # Crash-safe ordering (ADR-0018, D2): the [autoload] entry must be stripped
     # FIRST, then the files — so a mid-failure leaves only a harmless stray inert
-    # .gd, never a dangling autoload pointing at a missing script (which crashes an
-    # exported game). Force the file-delete step to blow up and assert the autoload
+    # .gd, never a dangling autoload pointing at a missing script (which makes an
+    # exported game log ERR_CONTINUE and skip it at startup — error spam, not a hard
+    # crash; ADR-0028). Force the file-delete step to blow up and assert the autoload
     # was already gone.
     (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
     install_harness(tmp_path)
@@ -235,3 +236,36 @@ def test_uninstall_is_idempotent_when_not_installed(tmp_path):
     install_harness(tmp_path)
     assert uninstall_harness(tmp_path).removed is True
     assert uninstall_harness(tmp_path).removed is False
+
+
+def test_ready_gates_on_template_feature_as_its_first_statement():
+    # ADR-0028 defence in depth: an EXPORTED build must self-disable the harness,
+    # "regardless of launch args". That holds iff `if OS.has_feature("template"):
+    # return` is the FIRST executable statement of `_ready()` — it must run BEFORE
+    # any launch-marker / socket handling, so an exported template build (where the
+    # `template` feature is true) returns immediately.
+    #
+    # The behavioural proof needs a real exported template binary (the editor binary
+    # has `template` == false), which requires installed export templates and the
+    # Godot e2e job — skipped on PRs. This STATIC guard runs in the default PR gate
+    # instead, so the property is checked on every PR rather than assumed.
+    from pathlib import Path
+
+    import gda.harness.install as install_mod
+
+    bundled = Path(install_mod.__file__).parent / HARNESS_FILE
+    lines = bundled.read_text(encoding="utf-8").splitlines()
+    ready_at = next(
+        i for i, line in enumerate(lines) if line.strip().startswith("func _ready(")
+    )
+    # The first two non-blank, non-comment body lines of _ready().
+    body: list[str] = []
+    for line in lines[ready_at + 1 :]:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        body.append(stripped)
+        if len(body) == 2:
+            break
+    assert body[0] == 'if OS.has_feature("template"):', body
+    assert body[1] == "return", body


### PR DESCRIPTION
## Problem

A shipped build must carry **zero** daemon-related files/config — as if the live mechanism never existed — and this **cannot depend on the developer remembering `gda daemon uninstall`**. Today `gda export run` has no harness awareness, so a forgotten harness (installed by `gda daemon start` into `project.godot`'s `[autoload]` + `res://addons/gda_harness/`) ships verbatim.

## Why the obvious fixes don't work (engine research against `../godot`)

- **An export cannot strip an autoload.** `project.binary` is serialized whole from `ProjectSettings` *after* every `EditorExportPlugin` hook, with no hook to alter it (`editor/export/editor_export_platform.cpp` `save_custom`).
- **`exclude_filter` removes only files**, not the autoload entry; a file-excluded dangling autoload then logs `ERR_CONTINUE` spam at startup (`main/main.cpp` autoload loop) — note: logged + skipped, **not** the hard crash ADR-0018 originally claimed.
- **`override.cfg` re-leaks**: it's loaded via `set()` into the same `props` map that `save_custom` serializes, so any export by a binary that loads it (the editor binary `gda export run` uses) writes the autoload right back into `project.binary`.
- **feature-tagged autoloads are unsupported** (`autoload/X.editor` registers an autoload literally named `X.editor`).

⇒ The only reliable guarantee is that the autoload is **gone before the export reads the project**.

## Approach (two complementary mechanisms)

1. **Transactional strip in `gda export run`** (`src/gda/export_run.py`): paired-uninstall the harness (autoload entry + files, crash-safe ordering) before the native export and restore it in a `finally`. The gda export path is **physically clean and forget-proof**; the dev project is left untouched; a mid-export crash leaves it harness-*absent* (the safe direction). Reuses the existing `uninstall_harness`/`install_harness`.
2. **Runtime build-type gate** (`src/gda/harness/gda_harness.gd`): `_ready()` returns immediately under `OS.has_feature("template")` — true only in an exported build, false on the editor binary every session runs on. Defense-in-depth so a harness reaching a build via a **non-gda** route (editor GUI, raw `godot --export`) is **provably inert**. `HARNESS_VERSION` 2→3 so installed copies re-materialize.

**Coverage:** gda export = physically clean · every other route = provably inert. (Physical cleanliness on non-gda routes would need an ephemeral install reopening ADR-0018's "no per-launch mutation"; deferred.)

## Tests

- **Unit** (`tests/test_export_run_operation.py`): strip-during-export, restore-after, restore-on-exception, no-op-when-absent.
- **e2e** (`tests/test_e2e_export_run.py`): install harness → `export run --mode pack --output …zip` → archive omits `gda_harness.gd` and the project is restored.
- **Reconciled** (`tests/test_e2e_harness_install.py`): the "exported pck runs inert" boot now packs via a **raw `godot --export-pack`** (since `gda export run` strips), asserting the harness is genuinely in the pack so "inert" stays meaningful.
- Full suite green: **970 unit + 287 e2e** (1 e2e skipped — export templates absent).

## Docs

New **ADR-0028** records the export-cleanliness decision and the rejected alternatives (override.cfg re-leak, file-only exclude_filter, feature-tagged autoload, ephemeral install); ADR-0018 shrinks to a pointer and keeps the corrected point-3 (`ERR_CONTINUE`, not a crash) note. README: the harness is dev-only (export strips it / it self-disables in shipped builds); `daemon uninstall` clarified.


---
Tracking/review issue: Closes #298
