### PR TITLE
refactor(tests): resolve gda via `python -m gda` in e2e, not `shutil.which`

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -20,8 +20,8 @@ from gda.runner import RunResult
 # MODULE in *this* interpreter's environment — `[sys.executable, "-m", "gda"]` —
 # never a PATH-resolved global. This is the same same-environment resolution
 # ADR-0011 (Design decision 3) mandates for gda-mcp ("never a wrong global `gda` a
-# PATH lookup might resolve"); a `shutil.which("gda")` would instead run whatever is
-# first on PATH (e.g. a uv-tool global, or another worktree's editable install).
+# PATH lookup might resolve"); a `which`-style PATH lookup would instead run whatever
+# is first on PATH (e.g. a uv-tool global, or another worktree's editable install).
 # Under `uv run pytest`, sys.executable is this checkout's venv, so `-m gda` runs
 # this checkout's editable gda deterministically. Spread it: `[*GDA_CMD, *args]`.
 GDA_CMD = [sys.executable, "-m", "gda"]

--- a/tests/support.py
+++ b/tests/support.py
@@ -12,8 +12,19 @@ between modules or imported test-module-to-test-module (issue #39).
 """
 
 import json
+import sys
 
 from gda.runner import RunResult
+
+# The gda CLI invocation prefix for e2e subprocess tests. Resolved as the gda
+# MODULE in *this* interpreter's environment — `[sys.executable, "-m", "gda"]` —
+# never a PATH-resolved global. This is the same same-environment resolution
+# ADR-0011 (Design decision 3) mandates for gda-mcp ("never a wrong global `gda` a
+# PATH lookup might resolve"); a `shutil.which("gda")` would instead run whatever is
+# first on PATH (e.g. a uv-tool global, or another worktree's editable install).
+# Under `uv run pytest`, sys.executable is this checkout's venv, so `-m gda` runs
+# this checkout's editable gda deterministically. Spread it: `[*GDA_CMD, *args]`.
+GDA_CMD = [sys.executable, "-m", "gda"]
 
 
 class FakeRunner:

--- a/tests/test_e2e_asset_file.py
+++ b/tests/test_e2e_asset_file.py
@@ -8,21 +8,20 @@ produced a real resource, not hand-written text.
 """
 
 import json
-import shutil
 import subprocess
 
 import pytest
 
 from gda.binary import resolve_godot_binary
 
+from tests.support import GDA_CMD
+
 GODOT = resolve_godot_binary()
 
 
 def _gda(*args: str) -> subprocess.CompletedProcess:
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     return subprocess.run(
-        [gda_bin, *args, "--godot", str(GODOT)], capture_output=True, text=True
+        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
     )
 
 

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -242,7 +242,7 @@ def test_daemon_uninstall_is_refused_while_running(tmp_path, daemon_runtime_dir)
 @pytest.mark.e2e
 def test_daemon_status_surfaces_the_windowed_display_mode(tmp_path, daemon_runtime_dir):
     # #251: `daemon status` reports the running daemon's launch-time display mode,
-    # read over STATUS_OP through the console script, so an agent can tell whether a
+    # read over STATUS_OP through the `gda` CLI, so an agent can tell whether a
     # live session can serve a `screen` capture before issuing one. No daemon ->
     # `windowed` null (clean, hang-free fallback); a default start -> false; a
     # `--windowed` start -> true. The daemon records the mode at start; no engine

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -1,4 +1,4 @@
-"""S1 (e2e): the full gda-daemon live loop through the console script (#7, #225).
+"""S1 (e2e): the full gda-daemon live loop through the gda CLI (#7, #225).
 
 The Step-6 proof: a real ``gda daemon start`` (real detached daemon, real harness
 install, live-version gate) → a real engine session it launches on demand →
@@ -14,7 +14,6 @@ bump (the installed copy declares an older version), and the paired
 
 import json
 import os
-import shutil
 import subprocess
 
 import pytest
@@ -26,6 +25,8 @@ from gda.harness.install import (
     HARNESS_VERSION,
     installed_harness_version,
 )
+
+from tests.support import GDA_CMD
 
 from .conftest import project_godot
 
@@ -46,8 +47,6 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 
 @pytest.mark.e2e
 def test_daemon_serves_a_real_runtime_tree(tmp_path, daemon_runtime_dir):
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
 
@@ -57,7 +56,7 @@ def test_daemon_serves_a_real_runtime_tree(tmp_path, daemon_runtime_dir):
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,
@@ -89,8 +88,6 @@ def test_daemon_serves_game_get_set_round_trip(tmp_path, daemon_runtime_dir):
     # The #220 DoD: a real daemon → engine session → `game set` mutates a runtime
     # property, applied at a frame boundary, and `game get` observes the change —
     # State consistency (ADR-0020) end-to-end through the real harness over UDS.
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
 
@@ -98,7 +95,7 @@ def test_daemon_serves_game_get_set_round_trip(tmp_path, daemon_runtime_dir):
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,
@@ -136,12 +133,10 @@ def test_daemon_serves_game_get_set_round_trip(tmp_path, daemon_runtime_dir):
 
 def _gda(tmp_path, env):
     """A `gda <args> --project <tmp> --godot <GODOT> --json` subprocess helper."""
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,

--- a/tests/test_e2e_diag.py
+++ b/tests/test_e2e_diag.py
@@ -20,13 +20,13 @@ serially in review.
 
 import json
 import os
-import shutil
 import subprocess
 import time
 
 import pytest
 
 from gda.binary import resolve_godot_binary
+from tests.support import GDA_CMD
 
 from .conftest import project_godot
 
@@ -75,8 +75,6 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 
 @pytest.mark.e2e
 def test_diag_reads_back_a_known_runtime_error_and_log_line(tmp_path, daemon_runtime_dir):
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
     (tmp_path / "main.gd").write_text(MAIN_GD, encoding="utf-8")
@@ -85,7 +83,7 @@ def test_diag_reads_back_a_known_runtime_error_and_log_line(tmp_path, daemon_run
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,
@@ -144,8 +142,6 @@ def test_diag_reads_back_a_multi_frame_callstack(tmp_path, daemon_runtime_dir):
     # — not just the top `file:line`. Same lifecycle as the sibling test: a
     # NON-diag live op (`game tree`) launches + warms the session, THEN diag
     # observes the daemon-owned Session log.
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
     (tmp_path / "main.gd").write_text(CALLSTACK_MAIN_GD, encoding="utf-8")
@@ -154,7 +150,7 @@ def test_diag_reads_back_a_multi_frame_callstack(tmp_path, daemon_runtime_dir):
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,

--- a/tests/test_e2e_export.py
+++ b/tests/test_e2e_export.py
@@ -14,12 +14,12 @@ not a fixed value.
 
 import json
 import re
-import shutil
 import subprocess
 
 import pytest
 
 from gda.binary import resolve_godot_binary
+from tests.support import GDA_CMD
 
 GODOT = resolve_godot_binary()
 
@@ -62,12 +62,10 @@ VERSION_DIR = re.compile(r"^\d+\.\d+\.\d+\.[a-z0-9]+$")
 
 def _gda_project(project) -> "callable":
     """A ``gda`` bound to ``--project`` for res:// resolution of the cfg."""
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
 
     def gda(*args: str) -> subprocess.CompletedProcess:
         return subprocess.run(
-            [gda_bin, *args, "--godot", str(GODOT), "--project", str(project)],
+            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
             capture_output=True,
             text=True,
         )
@@ -138,11 +136,8 @@ def test_export_list_without_project_yields_project_not_found(tmp_path):
     # export list reads export_presets.cfg in a project, so it cannot run
     # projectless: run from a non-project directory with no --project, it refuses
     # with project_not_found rather than returning a misleading empty listing.
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
-
     listed = subprocess.run(
-        [gda_bin, "export", "list", "--json", "--godot", str(GODOT)],
+        [*GDA_CMD, "export", "list", "--json", "--godot", str(GODOT)],
         capture_output=True,
         text=True,
         cwd=str(tmp_path),

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -27,7 +27,6 @@ path) run unconditionally.
 """
 
 import json
-import shutil
 import subprocess
 import warnings
 import zipfile
@@ -41,6 +40,7 @@ from gda.harness.install import (
     HARNESS_RES_DIR,
     install_harness,
 )
+from tests.support import GDA_CMD
 
 GODOT = resolve_godot_binary()
 
@@ -82,12 +82,9 @@ binary_format/embed_pck=false
 
 def _gda_project(project) -> "callable":
     """A ``gda`` bound to ``--godot`` + ``--project`` for the real engine."""
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
-
     def gda(*args: str) -> subprocess.CompletedProcess:
         return subprocess.run(
-            [gda_bin, *args, "--godot", str(GODOT), "--project", str(project)],
+            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
             capture_output=True,
             text=True,
         )

--- a/tests/test_e2e_game.py
+++ b/tests/test_e2e_game.py
@@ -10,24 +10,23 @@ RULES.md DoD the fake-runner command tests do not count toward this gate.
 
 import json
 import os
-import shutil
 import subprocess
 
 import pytest
 
 from gda.exit_codes import EXIT_LIVE
 
+from tests.support import GDA_CMD
+
 
 @pytest.mark.e2e
 def test_game_tree_without_a_daemon_reports_daemon_not_running(tmp_path):
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
 
     # An empty runtime dir so discovery finds no daemon for this fresh project.
     env = {**os.environ, "XDG_RUNTIME_DIR": str(tmp_path / "run")}
     proc = subprocess.run(
-        [gda_bin, "game", "tree", "--project", str(tmp_path), "--json"],
+        [*GDA_CMD, "game", "tree", "--project", str(tmp_path), "--json"],
         capture_output=True,
         text=True,
         env=env,

--- a/tests/test_e2e_game.py
+++ b/tests/test_e2e_game.py
@@ -1,8 +1,8 @@
-"""S1 (e2e): `gda game` live commands through the real console script (#7).
+"""S1 (e2e): `gda game` live commands through the real `gda` CLI (`python -m gda`, #7).
 
 This slice's real path is the attach-or-fail: a real ``gda game tree`` with no
 running daemon must emit the typed ``daemon_not_running`` envelope and exit
-``EXIT_LIVE`` — exercised through the installed console script and the real
+``EXIT_LIVE`` — exercised through the out-of-process `gda` CLI and the real
 ``DaemonRunner`` + discovery (no fake at the seam). The connected path (a live
 tree from a real engine session) lands with the daemon, a later slice. Per
 RULES.md DoD the fake-runner command tests do not count toward this gate.

--- a/tests/test_e2e_info.py
+++ b/tests/test_e2e_info.py
@@ -7,23 +7,20 @@ supported version (>= 4.4) per ADR-0003.
 """
 
 import json
-import shutil
 import subprocess
 
 import pytest
 
 from gda.binary import resolve_godot_binary
+from tests.support import GDA_CMD
 
 GODOT = resolve_godot_binary()
 
 
 @pytest.mark.e2e
 def test_gda_info_json_against_real_godot():
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
-
     proc = subprocess.run(
-        [gda_bin, "info", "--json", "--godot", str(GODOT)],
+        [*GDA_CMD, "info", "--json", "--godot", str(GODOT)],
         capture_output=True,
         text=True,
     )
@@ -44,11 +41,8 @@ def test_gda_info_missing_binary_yields_structured_error_end_to_end():
     # against a binary that cannot launch. No installed engine required — the
     # point is that the path does NOT exist. The runner synthesizes exit 127,
     # the CLI emits a structured JSON error on stdout.
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
-
     proc = subprocess.run(
-        [gda_bin, "info", "--godot", "/nonexistent/Godot"],
+        [*GDA_CMD, "info", "--godot", "/nonexistent/Godot"],
         capture_output=True,
         text=True,
     )

--- a/tests/test_e2e_info.py
+++ b/tests/test_e2e_info.py
@@ -1,6 +1,6 @@
 """S1 (e2e): gda info --json against the real Godot engine.
 
-Spawns the installed `gda` console script as a subprocess against the real
+Spawns the `gda` CLI (`python -m gda`) as a subprocess against the real
 Godot binary (path per RULES.md), asserts stdout is a single valid JSON object
 carrying the engine version, and that the version satisfies the minimum
 supported version (>= 4.4) per ADR-0003.

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -14,12 +14,12 @@ project_godot (#180).
 
 import json
 import os
-import shutil
 import subprocess
 
 import pytest
 
 from gda.binary import resolve_godot_binary
+from tests.support import GDA_CMD
 
 from .conftest import project_godot
 
@@ -103,8 +103,6 @@ def test_daemon_serves_input_key_observed_via_game_get(tmp_path, daemon_runtime_
     # The #221 DoD: a real daemon -> engine session -> `input key Right` pushes a key
     # event into the running game, whose `_input` moves the Player, observed via
     # `game get` — end-to-end through the real harness over UDS (ADR-0020).
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(KEY_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(KEY_PLAYER_GD, encoding="utf-8")
@@ -113,7 +111,7 @@ def test_daemon_serves_input_key_observed_via_game_get(tmp_path, daemon_runtime_
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,
@@ -156,8 +154,6 @@ def test_daemon_serves_input_mouse_click_observed_via_game_get(tmp_path, daemon_
     # InputEventMouseButton through the real `push_input` viewport path into the
     # running game's `_input`, which snaps the Player to the click position —
     # observed via `game get` (ADR-0020).
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MOUSE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(MOUSE_PLAYER_GD, encoding="utf-8")
@@ -166,7 +162,7 @@ def test_daemon_serves_input_mouse_click_observed_via_game_get(tmp_path, daemon_
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,
@@ -208,8 +204,6 @@ def test_daemon_serves_input_action_observed_via_game_get(tmp_path, daemon_runti
     # `input action move_right` presses an action the running InputMap declares; the
     # Player polls it each frame and advances. The press is held across frames until
     # released, so position.x increases — observed via game get.
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(ACTION_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(ACTION_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(ACTION_PLAYER_GD, encoding="utf-8")
@@ -218,7 +212,7 @@ def test_daemon_serves_input_action_observed_via_game_get(tmp_path, daemon_runti
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,
@@ -263,8 +257,6 @@ def test_daemon_serves_input_sequence_across_frames(tmp_path, daemon_runtime_dir
     # multi-frame base (#223), returned as ONE blocking result. Three Right presses at
     # frames 0/1/2 each move the Player by 10, so position.x advances by 30 over the
     # window — observed via game get.
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(KEY_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(KEY_PLAYER_GD, encoding="utf-8")
@@ -273,7 +265,7 @@ def test_daemon_serves_input_sequence_across_frames(tmp_path, daemon_runtime_dir
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,
@@ -320,8 +312,6 @@ def test_daemon_serves_input_sequence_across_frames(tmp_path, daemon_runtime_dir
 def test_input_action_unknown_action_reports_live_unknown_action(tmp_path, daemon_runtime_dir):
     # An action absent from the running InputMap is the typed harness op-error,
     # relayed through the daemon (exit-0 sentinel) and mapped by classify_live.
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(KEY_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(KEY_PLAYER_GD, encoding="utf-8")
@@ -330,7 +320,7 @@ def test_input_action_unknown_action_reports_live_unknown_action(tmp_path, daemo
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,
@@ -352,15 +342,13 @@ def test_input_action_unknown_action_reports_live_unknown_action(tmp_path, daemo
 @pytest.mark.e2e
 def test_input_key_without_a_daemon_reports_daemon_not_running(tmp_path):
     # The attach-or-fail path through the real DaemonRunner + discovery, no daemon.
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
 
     from gda.exit_codes import EXIT_LIVE
 
     env = {**os.environ, "XDG_RUNTIME_DIR": str(tmp_path / "run")}
     proc = subprocess.run(
-        [gda, "input", "key", "Right", "--project", str(tmp_path), "--json"],
+        [*GDA_CMD, "input", "key", "Right", "--project", str(tmp_path), "--json"],
         capture_output=True,
         text=True,
         env=env,

--- a/tests/test_e2e_logger.py
+++ b/tests/test_e2e_logger.py
@@ -25,13 +25,13 @@ serially in review.
 
 import json
 import os
-import shutil
 import subprocess
 import time
 
 import pytest
 
 from gda.binary import resolve_godot_binary
+from tests.support import GDA_CMD
 
 from .conftest import project_godot
 
@@ -65,8 +65,6 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 
 @pytest.mark.e2e
 def test_logger_tail_reads_back_structured_records_and_raw_lines(tmp_path, daemon_runtime_dir):
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
     (tmp_path / "main.gd").write_text(MAIN_GD, encoding="utf-8")
@@ -75,7 +73,7 @@ def test_logger_tail_reads_back_structured_records_and_raw_lines(tmp_path, daemo
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -8,21 +8,19 @@ verification of ``node add``'s effect.
 
 import json
 import os
-import shutil
 import subprocess
 
 import pytest
 
 from gda.binary import resolve_godot_binary
+from tests.support import GDA_CMD
 
 GODOT = resolve_godot_binary()
 
 
 def _gda(*args: str) -> subprocess.CompletedProcess:
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     return subprocess.run(
-        [gda_bin, *args, "--godot", str(GODOT)], capture_output=True, text=True
+        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
     )
 
 
@@ -33,10 +31,8 @@ def _gda_env(extra_env: dict, *args: str) -> subprocess.CompletedProcess:
     this environment — the channel the production-inert
     ``GDA_TEST_PERTURB_BEFORE_SAVE`` test seam rides on (issue #226).
     """
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     return subprocess.run(
-        [gda_bin, *args, "--godot", str(GODOT)],
+        [*GDA_CMD, *args, "--godot", str(GODOT)],
         capture_output=True,
         text=True,
         env={**os.environ, **extra_env},

--- a/tests/test_e2e_params_json.py
+++ b/tests/test_e2e_params_json.py
@@ -1,7 +1,7 @@
 """S1 (e2e): gda --params-json against the real Godot engine (issue #199, ADR-0015).
 
-Drives the structured params-input ABI through the real installed console script
-and a real Godot process: a JSON params object (on the command line, and via
+Drives the structured params-input ABI through the real out-of-process `gda` CLI
+(`python -m gda`) and a real Godot process: a JSON params object (on the command line, and via
 stdin) produces the same on-disk effect as the argv form — the ``.tscn`` is
 created and reads back. Per RULES.md DoD the fake-runner fast tests do not count
 toward this gate.

--- a/tests/test_e2e_params_json.py
+++ b/tests/test_e2e_params_json.py
@@ -8,26 +8,25 @@ toward this gate.
 """
 
 import json
-import shutil
 import subprocess
 
 import pytest
 
 from gda.binary import resolve_godot_binary
 
+from tests.support import GDA_CMD
+
 GODOT = resolve_godot_binary()
 
 
 @pytest.mark.e2e
 def test_scene_create_via_params_json_creates_the_scene(godot_project):
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     scene_path = godot_project / "main.tscn"
     params = json.dumps({"path": str(scene_path), "root_type": "Node2D"})
 
     created = subprocess.run(
         [
-            gda_bin,
+            *GDA_CMD,
             "scene",
             "create",
             "--params-json",
@@ -50,7 +49,7 @@ def test_scene_create_via_params_json_creates_the_scene(godot_project):
 
     # And reads back through the engine — the file is loadable, not just present.
     got = subprocess.run(
-        [gda_bin, "scene", "get", str(scene_path), "--json", "--godot", str(GODOT)],
+        [*GDA_CMD, "scene", "get", str(scene_path), "--json", "--godot", str(GODOT)],
         capture_output=True,
         text=True,
     )
@@ -61,13 +60,11 @@ def test_scene_create_via_params_json_creates_the_scene(godot_project):
 @pytest.mark.e2e
 def test_scene_create_via_params_json_stdin_creates_the_scene(godot_project):
     # `--params-json -` reads the object from stdin through the real chain.
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     scene_path = godot_project / "fromstdin.tscn"
     params = json.dumps({"path": str(scene_path), "root_type": "Node2D"})
 
     created = subprocess.run(
-        [gda_bin, "scene", "create", "--params-json", "-", "--json", "--godot", str(GODOT)],
+        [*GDA_CMD, "scene", "create", "--params-json", "-", "--json", "--godot", str(GODOT)],
         input=params,
         capture_output=True,
         text=True,

--- a/tests/test_e2e_perf.py
+++ b/tests/test_e2e_perf.py
@@ -11,12 +11,13 @@ Run e2e SERIALLY; not a fresh empty HOME (Godot first-run). The
 
 import json
 import os
-import shutil
 import subprocess
 
 import pytest
 
 from gda.binary import resolve_godot_binary
+
+from tests.support import GDA_CMD
 
 from .conftest import project_godot
 
@@ -59,8 +60,6 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 def test_daemon_serves_a_live_perf_snapshot(tmp_path, daemon_runtime_dir):
     # `perf monitors`: a real daemon -> engine session -> the running game's live
     # Performance counters, snapshotted in one frame (frame-coherent, ADR-0020).
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
 
@@ -68,7 +67,7 @@ def test_daemon_serves_a_live_perf_snapshot(tmp_path, daemon_runtime_dir):
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,
@@ -98,8 +97,6 @@ def test_daemon_serves_a_property_timeline_over_a_window(tmp_path, daemon_runtim
     # `perf monitor --property --frames N`: the time-windowed multi-frame base
     # (#223) collects one sample per frame across the engine session and returns
     # the whole N-sample timeline in a single blocking call (ADR-0017 one-shot RPC).
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
 
@@ -107,7 +104,7 @@ def test_daemon_serves_a_property_timeline_over_a_window(tmp_path, daemon_runtim
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,
@@ -144,8 +141,6 @@ def test_daemon_serves_a_signal_timeline_over_a_window(tmp_path, daemon_runtime_
     # disconnects on finalize. The Player emits `ticked(n)` once per _process frame,
     # so a window of N frames records emissions carrying the int tick arg — the real
     # get_signal_list / connect / record / disconnect path (#239).
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SIGNAL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(SIGNAL_PLAYER_GD, encoding="utf-8")
@@ -154,7 +149,7 @@ def test_daemon_serves_a_signal_timeline_over_a_window(tmp_path, daemon_runtime_
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,
@@ -199,8 +194,6 @@ def test_daemon_serves_a_signal_timeline_over_a_window(tmp_path, daemon_runtime_
 def test_perf_monitor_missing_node_reports_live_perf_node_not_found(tmp_path, daemon_runtime_dir):
     # A path that resolves to no running node is the typed harness op-error,
     # relayed through the daemon (exit-0 sentinel) and mapped by classify_live.
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
 
@@ -208,7 +201,7 @@ def test_perf_monitor_missing_node_reports_live_perf_node_not_found(tmp_path, da
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,
@@ -232,15 +225,13 @@ def test_perf_monitor_missing_node_reports_live_perf_node_not_found(tmp_path, da
 @pytest.mark.e2e
 def test_perf_monitors_without_a_daemon_reports_daemon_not_running(tmp_path):
     # The attach-or-fail path through the real DaemonRunner + discovery, no daemon.
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
 
     from gda.exit_codes import EXIT_LIVE
 
     env = {**os.environ, "XDG_RUNTIME_DIR": str(tmp_path / "run")}
     proc = subprocess.run(
-        [gda, "perf", "monitors", "--project", str(tmp_path), "--json"],
+        [*GDA_CMD, "perf", "monitors", "--project", str(tmp_path), "--json"],
         capture_output=True,
         text=True,
         env=env,

--- a/tests/test_e2e_project.py
+++ b/tests/test_e2e_project.py
@@ -12,21 +12,19 @@ the e2e fixture has none, so that surface is exercised as a no-op here.
 """
 
 import json
-import shutil
 import subprocess
 
 import pytest
 
 from gda.binary import resolve_godot_binary
+from tests.support import GDA_CMD
 
 GODOT = resolve_godot_binary()
 
 
 def _gda(project, *args: str) -> subprocess.CompletedProcess:
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     return subprocess.run(
-        [gda_bin, *args, "--project", str(project), "--godot", str(GODOT)],
+        [*GDA_CMD, *args, "--project", str(project), "--godot", str(GODOT)],
         capture_output=True,
         text=True,
     )
@@ -262,10 +260,8 @@ def test_project_remove_autoload_unknown_name_is_a_clean_error(godot_project):
 def test_project_info_without_project_is_a_clean_error():
     # Projectless: ProjectSettings would report only the engine's bare defaults,
     # not the agent's project, so it is refused with project_not_found.
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     proc = subprocess.run(
-        [gda_bin, "project", "info", "--json", "--godot", str(GODOT)],
+        [*GDA_CMD, "project", "info", "--json", "--godot", str(GODOT)],
         capture_output=True,
         text=True,
         cwd="/tmp",

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -11,7 +11,6 @@ acceptance criterion: the same reference graph backs both).
 """
 
 import json
-import shutil
 import subprocess
 
 import pytest
@@ -19,6 +18,7 @@ import pytest
 from gda.binary import resolve_godot_binary
 
 from .conftest import project_godot
+from tests.support import GDA_CMD
 
 GODOT = resolve_godot_binary()
 
@@ -122,10 +122,8 @@ def refgraph_project(tmp_path):
 
 
 def _gda(project, *args: str) -> subprocess.CompletedProcess:
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     return subprocess.run(
-        [gda_bin, *args, "--godot", str(GODOT), "--project", str(project)],
+        [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
         capture_output=True,
         text=True,
     )
@@ -432,10 +430,8 @@ def test_statistics_counts_binary_assets_as_files_but_not_lines(tmp_path):
 def test_dependencies_without_project_is_project_not_found(tmp_path):
     # Run projectless (no --project, cwd is not a project): the res:// scan has no
     # tree to walk, so it refuses with the registered project_not_found code.
-    gda_bin = shutil.which("gda")
-    assert gda_bin
     proc = subprocess.run(
-        [gda_bin, "project", "dependencies", "--godot", str(GODOT), "--json"],
+        [*GDA_CMD, "project", "dependencies", "--godot", str(GODOT), "--json"],
         capture_output=True,
         text=True,
         cwd=str(tmp_path),

--- a/tests/test_e2e_resource.py
+++ b/tests/test_e2e_resource.py
@@ -24,12 +24,13 @@ modes, are exercised end to end.
 
 import json
 import os
-import shutil
 import subprocess
 
 import pytest
 
 from gda.binary import resolve_godot_binary
+
+from tests.support import GDA_CMD
 
 GODOT = resolve_godot_binary()
 
@@ -44,10 +45,8 @@ DATA_TRES = """\
 
 
 def _gda(*args: str) -> subprocess.CompletedProcess:
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     return subprocess.run(
-        [gda_bin, *args, "--godot", str(GODOT)], capture_output=True, text=True
+        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
     )
 
 
@@ -63,12 +62,10 @@ def _import_project(project) -> None:
 
 def _gda_project(project) -> "callable":
     """A ``gda`` bound to ``--godot`` and ``--project`` for res:// / UID resolution."""
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
 
     def gda(*args: str) -> subprocess.CompletedProcess:
         return subprocess.run(
-            [gda_bin, *args, "--godot", str(GODOT), "--project", str(project)],
+            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
             capture_output=True,
             text=True,
         )
@@ -78,10 +75,8 @@ def _gda_project(project) -> "callable":
 
 def _gda_env(extra_env: dict, *args: str) -> subprocess.CompletedProcess:
     """``_gda`` with extra env vars in the child's environment (issue #226 seam)."""
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     return subprocess.run(
-        [gda_bin, *args, "--godot", str(GODOT)],
+        [*GDA_CMD, *args, "--godot", str(GODOT)],
         capture_output=True,
         text=True,
         env={**os.environ, **extra_env},
@@ -518,11 +513,8 @@ def test_resource_uid_path_without_uid_is_no_uid_assigned(imported_project):
 def test_resource_uid_projectless_run_is_project_not_found():
     # Resolution queries the project's UID cache, so a projectless run is refused
     # with project_not_found rather than a misleading "no UID" answer.
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
-
     proc = subprocess.run(
-        [gda_bin, "resource", "uid", "uid://b00000000000b", "--godot", str(GODOT), "--json"],
+        [*GDA_CMD, "resource", "uid", "uid://b00000000000b", "--godot", str(GODOT), "--json"],
         capture_output=True,
         text=True,
     )

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -8,21 +8,19 @@ structured-level verification of ``scene create``'s effect.
 
 import json
 import os
-import shutil
 import subprocess
 
 import pytest
 
 from gda.binary import resolve_godot_binary
+from tests.support import GDA_CMD
 
 GODOT = resolve_godot_binary()
 
 
 def _gda(*args: str) -> subprocess.CompletedProcess:
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     return subprocess.run(
-        [gda_bin, *args, "--godot", str(GODOT)], capture_output=True, text=True
+        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
     )
 
 
@@ -32,12 +30,9 @@ def test_res_path_round_trip_against_the_project_fixture(godot_project):
     # project fixture, a res:// path resolves against it — proving the fixture
     # is actually handed to the engine (it previously never reached it). The
     # created scene lands inside the project and reads back through res://.
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
-
     def gda(*args: str) -> subprocess.CompletedProcess:
         return subprocess.run(
-            [gda_bin, *args, "--godot", str(GODOT), "--project", str(godot_project)],
+            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(godot_project)],
             capture_output=True,
             text=True,
         )
@@ -135,12 +130,9 @@ def test_scene_create_creates_missing_parent_directories(godot_project):
 def test_scene_create_creates_relative_parent_directories_against_project(
     godot_project,
 ):
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
-
     created = subprocess.run(
         [
-            gda_bin,
+            *GDA_CMD,
             "scene",
             "create",
             "demo/main.tscn",
@@ -352,12 +344,10 @@ def test_scene_create_unknown_root_type_yields_structured_error_end_to_end(
 
 def _gda_project(project) -> "callable":
     """A ``_gda`` bound to ``--project`` for res:// enumeration/resolution."""
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
 
     def gda(*args: str) -> subprocess.CompletedProcess:
         return subprocess.run(
-            [gda_bin, *args, "--godot", str(GODOT), "--project", str(project)],
+            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
             capture_output=True,
             text=True,
         )
@@ -465,11 +455,8 @@ def test_scene_list_without_project_yields_project_not_found(tmp_path):
     # scene list cannot enumerate res:// projectless: run from a non-project
     # directory with no --project, it must refuse with the structured
     # project_not_found code rather than return a misleading empty listing.
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
-
     listed = subprocess.run(
-        [gda_bin, "scene", "list", "--json", "--godot", str(GODOT)],
+        [*GDA_CMD, "scene", "list", "--json", "--godot", str(GODOT)],
         capture_output=True,
         text=True,
         cwd=str(tmp_path),

--- a/tests/test_e2e_scene_exports.py
+++ b/tests/test_e2e_scene_exports.py
@@ -12,21 +12,20 @@ The scene is built end-to-end with the real CLI: ``scene create`` →
 """
 
 import json
-import shutil
 import subprocess
 
 import pytest
 
 from gda.binary import resolve_godot_binary
 
+from tests.support import GDA_CMD
+
 GODOT = resolve_godot_binary()
 
 
 def _gda(*args: str) -> subprocess.CompletedProcess:
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     return subprocess.run(
-        [gda_bin, *args, "--godot", str(GODOT)], capture_output=True, text=True
+        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
     )
 
 

--- a/tests/test_e2e_scene_security.py
+++ b/tests/test_e2e_scene_security.py
@@ -32,12 +32,12 @@ The contract pinned (verified on Godot 4.6.3):
 """
 
 import json
-import shutil
 import subprocess
 
 import pytest
 
 from gda.binary import resolve_godot_binary
+from tests.support import GDA_CMD
 
 from .conftest import project_godot
 
@@ -45,10 +45,8 @@ GODOT = resolve_godot_binary()
 
 
 def _gda(*args: str, cwd=None) -> subprocess.CompletedProcess:
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     return subprocess.run(
-        [gda_bin, *args, "--godot", str(GODOT)],
+        [*GDA_CMD, *args, "--godot", str(GODOT)],
         capture_output=True,
         text=True,
         cwd=str(cwd) if cwd is not None else None,
@@ -86,12 +84,10 @@ def test_scene_get_does_not_execute_scene_code(godot_project):
     (godot_project / "evil.gd").write_text(EVIL_GD, encoding="utf-8")
     (godot_project / "evil.tscn").write_text(EVIL_TSCN, encoding="utf-8")
 
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     # Run from inside the project so res://evil.gd resolves — the condition
     # under which the script would load and (on the buggy path) execute.
     proc = subprocess.run(
-        [gda_bin, "scene", "get", "evil.tscn", "--json", "--godot", str(GODOT)],
+        [*GDA_CMD, "scene", "get", "evil.tscn", "--json", "--godot", str(GODOT)],
         capture_output=True,
         text=True,
         cwd=str(godot_project),

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -21,13 +21,13 @@ within the `sun_path` limit.
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 
 import pytest
 
 from gda.binary import resolve_godot_binary
+from tests.support import GDA_CMD
 
 from .conftest import project_godot
 
@@ -77,7 +77,7 @@ def _runner(gda, tmp_path):
 
     def run(*args):
         return subprocess.run(
-            [gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [*gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
             capture_output=True,
             text=True,
             env=env,
@@ -92,10 +92,8 @@ def _runner(gda, tmp_path):
 def test_windowed_daemon_captures_a_single_viewport_frame(tmp_path, daemon_runtime_dir):
     # `daemon start --windowed` -> a WINDOWED engine session -> `screen capture`
     # writes a real PNG of the running viewport (magic + dims > 0).
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     _scaffold(tmp_path)
-    run = _runner(gda, tmp_path)
+    run = _runner(GDA_CMD, tmp_path)
     out = tmp_path / "shot.png"
 
     try:
@@ -124,10 +122,8 @@ def test_windowed_daemon_captures_a_single_viewport_frame(tmp_path, daemon_runti
 @_needs_display
 def test_windowed_daemon_inline_embeds_the_base64(tmp_path, daemon_runtime_dir):
     # `screen capture --inline` additionally embeds the base64 PNG in the reply.
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     _scaffold(tmp_path)
-    run = _runner(gda, tmp_path)
+    run = _runner(GDA_CMD, tmp_path)
     out = tmp_path / "shot.png"
 
     try:
@@ -148,10 +144,8 @@ def test_windowed_daemon_captures_a_frame_window(tmp_path, daemon_runtime_dir):
     # `screen frames --frames 3`: the time-windowed multi-frame base (#223) collects
     # 3 viewport frames over the engine session and returns them in one blocking
     # call; the CLI writes one PNG per frame (path-only).
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     _scaffold(tmp_path)
-    run = _runner(gda, tmp_path)
+    run = _runner(GDA_CMD, tmp_path)
     out_dir = tmp_path / "frames"
 
     try:
@@ -181,10 +175,8 @@ def test_headless_session_reports_live_display_unavailable(tmp_path, daemon_runt
     # A default (HEADLESS) daemon session has the dummy DisplayServer; a `screen
     # capture` there is refused with the typed live_display_unavailable (the
     # self-revealing remediation: start --windowed). No file is written.
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     _scaffold(tmp_path)
-    run = _runner(gda, tmp_path)
+    run = _runner(GDA_CMD, tmp_path)
     out = tmp_path / "shot.png"
 
     try:
@@ -206,10 +198,8 @@ def test_screen_capture_with_no_daemon_reports_daemon_not_running(
 ):
     # No daemon started: `screen capture` is the attach-or-fail daemon_not_running
     # (ADR-0017), the same typed error every live op reports with no daemon.
-    gda = shutil.which("gda")
-    assert gda, "the `gda` console script is not on PATH"
     _scaffold(tmp_path)
-    run = _runner(gda, tmp_path)
+    run = _runner(GDA_CMD, tmp_path)
 
     cap = run("screen", "capture", "--output", str(tmp_path / "shot.png"))
 

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -17,25 +17,23 @@ import pytest
 from gda.binary import resolve_godot_binary
 from gda.runner import OPERATIONS_GD
 
+from tests.support import GDA_CMD
+
 GODOT = resolve_godot_binary()
 
 
 def _gda(*args: str) -> subprocess.CompletedProcess:
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     return subprocess.run(
-        [gda_bin, *args, "--godot", str(GODOT)], capture_output=True, text=True
+        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
     )
 
 
 def _gda_project(project) -> "callable":
     """A ``_gda`` bound to ``--project`` for res:// enumeration/resolution."""
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
 
     def gda(*args: str) -> subprocess.CompletedProcess:
         return subprocess.run(
-            [gda_bin, *args, "--godot", str(GODOT), "--project", str(project)],
+            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
             capture_output=True,
             text=True,
         )
@@ -45,10 +43,8 @@ def _gda_project(project) -> "callable":
 
 def _gda_env(extra_env: dict, *args: str) -> subprocess.CompletedProcess:
     """``_gda`` with extra env vars in the child's environment (issue #226 seam)."""
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
     return subprocess.run(
-        [gda_bin, *args, "--godot", str(GODOT)],
+        [*GDA_CMD, *args, "--godot", str(GODOT)],
         capture_output=True,
         text=True,
         env={**os.environ, **extra_env},
@@ -414,11 +410,8 @@ def test_script_list_without_project_yields_project_not_found(tmp_path):
     # script list cannot enumerate res:// projectless: run from a non-project
     # directory with no --project, it must refuse with the structured
     # project_not_found code rather than return a misleading empty listing.
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
-
     listed = subprocess.run(
-        [gda_bin, "script", "list", "--json", "--godot", str(GODOT)],
+        [*GDA_CMD, "script", "list", "--json", "--godot", str(GODOT)],
         capture_output=True,
         text=True,
         cwd=str(tmp_path),

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -12,8 +12,9 @@ describes (Plan A); `gda schema --schema` still self-describes as any command.
 
 These are fast tests — `gda schema` spawns no Godot, so none of them need the
 engine. Most drive the command in-process via `CliRunner`; the last drives the
-real installed `gda` console script as a subprocess to protect the public entry
-point. That one is deliberately NOT marked `e2e`: this repo's `e2e` marker means
+real out-of-process `gda` CLI (`python -m gda`, the same `app` the console script
+wraps) as a subprocess, so the manifest is exercised through a real process, not
+only in-process. That one is deliberately NOT marked `e2e`: this repo's `e2e` marker means
 "spawns a real Godot process" and gates a schedule/manual-only CI job, whereas
 this check is cheap and deterministic and belongs in the default PR gate.
 """
@@ -304,7 +305,7 @@ def test_self_described_manifest_describes_the_nullable_constraints_field():
     ]
 
 
-def test_real_console_script_manifest_covers_the_live_command_tree():
+def test_real_out_of_process_cli_manifest_covers_the_live_command_tree():
     # The real out-of-process `gda` CLI (invoked as `python -m gda`) — not the
     # in-process CliRunner — emits the manifest and covers the whole live command
     # tree (issue #192). Under `uv run` (how CI runs the fast suite) `sys.executable`

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -19,13 +19,13 @@ this check is cheap and deterministic and belongs in the default PR gate.
 """
 
 import json
-import shutil
 import subprocess
 
 import typer
 from typer.testing import CliRunner
 
 from gda.cli import app
+from tests.support import GDA_CMD
 
 
 def _manifest() -> dict:
@@ -305,14 +305,11 @@ def test_self_described_manifest_describes_the_nullable_constraints_field():
 
 
 def test_real_console_script_manifest_covers_the_live_command_tree():
-    # The real installed `gda` entry point — not the in-process CliRunner —
-    # emits the manifest and covers the whole live command tree (issue #192).
-    # Under `uv run` (how CI runs the fast suite) this resolves to the project
-    # venv's console script, so it tracks the current checkout.
-    gda_bin = shutil.which("gda")
-    assert gda_bin, "the `gda` console script is not on PATH"
-
-    proc = subprocess.run([gda_bin, "schema"], capture_output=True, text=True)
+    # The real out-of-process `gda` CLI (invoked as `python -m gda`) — not the
+    # in-process CliRunner — emits the manifest and covers the whole live command
+    # tree (issue #192). Under `uv run` (how CI runs the fast suite) `sys.executable`
+    # is the project venv, so `-m gda` runs the current checkout's gda.
+    proc = subprocess.run([*GDA_CMD, "schema"], capture_output=True, text=True)
 
     assert proc.returncode == 0, proc.stderr
     names = {entry["name"] for entry in json.loads(proc.stdout)["commands"]}


### PR DESCRIPTION
## Problem

The e2e suite resolved the gda CLI with `shutil.which("gda")` (55 sites, 22 files) — a **PATH lookup** that can run a *different* gda than the checkout under test. In this multi-worktree setup `which gda` resolves to a uv-tool global (`~/.local/share/uv/tools/gda`) that only *coincidentally* tracks one worktree; on another branch or a fresh clone it would silently exercise the wrong gda.

This is the exact anti-pattern **ADR-0011 (Design decision 3)** already rejects for production: `gda-mcp` invokes `[sys.executable, "-m", "gda", …]` precisely so it runs "the *exact* gda … never a wrong global `gda` a PATH lookup might resolve" (`src/gda/__main__.py` exists for this).

## Change

- Add a shared `GDA_CMD = [sys.executable, "-m", "gda"]` to `tests/support.py` and spread it (`[*GDA_CMD, *args]`) at every e2e call site.
- Drop the now-obsolete `"the gda console script is not on PATH"` asserts and the unused `import shutil`.
- Under `uv run pytest`, `sys.executable` is this checkout's venv, so `-m gda` runs **this checkout's** editable gda deterministically — no PATH dependency.

Behavior-preserving — no test semantics change. Full suite green: **967 unit + 286 e2e** (1 e2e skipped — export templates absent).

## Merge order note

This branch (off `main`) converts the single `shutil.which` site in `tests/test_e2e_harness_install.py`, which **PR #297 also rewrites** (that test moves to a raw `godot --export-pack`). Land **#297 first**, then this rebases with a trivial resolution on that one file (the converted line is simply absent in #297's version).

Closes #299
