### PR TITLE
test(e2e): behaviourally prove the harness template gate (#301)

### DIFF
--- a/.github/actions/install-godot/action.yml
+++ b/.github/actions/install-godot/action.yml
@@ -46,23 +46,23 @@ runs:
         chmod +x "${GDA_GODOT}"
         "${GDA_GODOT}" --headless --version
 
-    # Export templates for the SAME pinned version. Required only by the #301
+    # Export templates for the SAME pinned engine, required only by the #301
     # template-gate behavioural e2e (it exports a real template binary); every other
-    # e2e needs only the editor binary above. Templates MUST match the engine version
-    # exactly — Godot keys them on its full version string with a `.` separator
-    # (4.6-stable -> 4.6.stable) — so both derive from the one `godot-version` input.
-    # A local dev on a different patch (e.g. 4.6.3.stable) needs that patch's .tpz.
+    # e2e needs only the editor binary above. Godot keys templates on a per-version
+    # directory under its user-data dir — lowercase "godot" on Linux — whose name is
+    # the engine's FULL_CONFIG (e.g. "4.6.0.stable", patch ALWAYS included). That name
+    # is authoritative in the .tpz's templates/version.txt, so the version dir is named
+    # from THAT, not guessed from the release tag (which omits the patch).
     - name: Resolve export-template paths
       shell: bash
       run: |
-        version="$(echo '${{ inputs.godot-version }}' | sed 's/-/./')"
-        echo "GODOT_TEMPLATE_DIR=${HOME}/.local/share/godot/export_templates/${version}" >> "$GITHUB_ENV"
+        echo "GODOT_TEMPLATES_ROOT=${HOME}/.local/share/godot/export_templates" >> "$GITHUB_ENV"
 
     - name: Restore cached export templates
       id: templates-cache
       uses: actions/cache@v4
       with:
-        path: ${{ env.GODOT_TEMPLATE_DIR }}
+        path: ${{ env.GODOT_TEMPLATES_ROOT }}
         key: godot-templates-${{ inputs.godot-version }}-linux
 
     - name: Download export templates
@@ -72,14 +72,16 @@ runs:
         curl --fail --location --show-error \
           --output "${RUNNER_TEMP}/templates.tpz" \
           "https://github.com/godotengine/godot/releases/download/${{ inputs.godot-version }}/Godot_v${{ inputs.godot-version }}_export_templates.tpz"
-        # A .tpz is a zip whose top-level templates/ holds the per-platform files;
-        # Godot expects them flattened into the version dir.
+        # A .tpz is a zip whose top-level templates/ holds the per-platform files plus
+        # version.txt (the engine's FULL_CONFIG); flatten them into <root>/<version>/.
         unzip -q "${RUNNER_TEMP}/templates.tpz" -d "${RUNNER_TEMP}/tpz"
-        mkdir -p "${GODOT_TEMPLATE_DIR}"
-        mv "${RUNNER_TEMP}/tpz/templates/"* "${GODOT_TEMPLATE_DIR}/"
+        version="$(cat "${RUNNER_TEMP}/tpz/templates/version.txt")"
+        dest="${GODOT_TEMPLATES_ROOT}/${version}"
+        mkdir -p "${dest}"
+        mv "${RUNNER_TEMP}/tpz/templates/"* "${dest}/"
 
     - name: Verify export templates
       shell: bash
       run: |
-        # The template `--export-debug` uses for Linux/X11 (#301).
-        test -f "${GODOT_TEMPLATE_DIR}/linux_debug.x86_64"
+        # The Linux/X11 debug template the #301 proof's --export-debug uses.
+        find "${GODOT_TEMPLATES_ROOT}" -name linux_debug.x86_64 | grep -q .

--- a/.github/actions/install-godot/action.yml
+++ b/.github/actions/install-godot/action.yml
@@ -50,13 +50,15 @@ runs:
     # template-gate behavioural e2e (it exports a real template binary); every other
     # e2e needs only the editor binary above. Godot keys templates on a per-version
     # directory under its user-data dir — lowercase "godot" on Linux — whose name is
-    # the engine's FULL_CONFIG (e.g. "4.6.0.stable", patch ALWAYS included). That name
-    # is authoritative in the .tpz's templates/version.txt, so the version dir is named
-    # from THAT, not guessed from the release tag (which omits the patch).
+    # the engine's version-config string (e.g. "4.6.stable" for 4.6.0, "4.6.3.stable"
+    # for 4.6.3 — the patch is OMITTED when 0). That name is authoritative in the
+    # .tpz's templates/version.txt, so the version dir is named from THAT, not guessed
+    # from the release tag. The root honors XDG_DATA_HOME so it matches where the
+    # engine (and gda's export-get) actually look.
     - name: Resolve export-template paths
       shell: bash
       run: |
-        echo "GODOT_TEMPLATES_ROOT=${HOME}/.local/share/godot/export_templates" >> "$GITHUB_ENV"
+        echo "GODOT_TEMPLATES_ROOT=${XDG_DATA_HOME:-$HOME/.local/share}/godot/export_templates" >> "$GITHUB_ENV"
 
     - name: Restore cached export templates
       id: templates-cache

--- a/.github/actions/install-godot/action.yml
+++ b/.github/actions/install-godot/action.yml
@@ -1,7 +1,9 @@
 name: Install Godot
 description: >-
-  Download (and cache) a headless Godot binary and export GDA_GODOT for later
-  steps. Single source of truth for the Godot version shared by CI and Release.
+  Download (and cache) a headless Godot binary AND its matching export templates,
+  and export GDA_GODOT for later steps. Single source of truth for the Godot version
+  shared by CI and Release; the export templates let the e2e job run the #301
+  template-gate behavioural proof, which exports a real template binary.
 
 inputs:
   godot-version:
@@ -43,3 +45,41 @@ runs:
       run: |
         chmod +x "${GDA_GODOT}"
         "${GDA_GODOT}" --headless --version
+
+    # Export templates for the SAME pinned version. Required only by the #301
+    # template-gate behavioural e2e (it exports a real template binary); every other
+    # e2e needs only the editor binary above. Templates MUST match the engine version
+    # exactly — Godot keys them on its full version string with a `.` separator
+    # (4.6-stable -> 4.6.stable) — so both derive from the one `godot-version` input.
+    # A local dev on a different patch (e.g. 4.6.3.stable) needs that patch's .tpz.
+    - name: Resolve export-template paths
+      shell: bash
+      run: |
+        version="$(echo '${{ inputs.godot-version }}' | sed 's/-/./')"
+        echo "GODOT_TEMPLATE_DIR=${HOME}/.local/share/godot/export_templates/${version}" >> "$GITHUB_ENV"
+
+    - name: Restore cached export templates
+      id: templates-cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.GODOT_TEMPLATE_DIR }}
+        key: godot-templates-${{ inputs.godot-version }}-linux
+
+    - name: Download export templates
+      if: steps.templates-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        curl --fail --location --show-error \
+          --output "${RUNNER_TEMP}/templates.tpz" \
+          "https://github.com/godotengine/godot/releases/download/${{ inputs.godot-version }}/Godot_v${{ inputs.godot-version }}_export_templates.tpz"
+        # A .tpz is a zip whose top-level templates/ holds the per-platform files;
+        # Godot expects them flattened into the version dir.
+        unzip -q "${RUNNER_TEMP}/templates.tpz" -d "${RUNNER_TEMP}/tpz"
+        mkdir -p "${GODOT_TEMPLATE_DIR}"
+        mv "${RUNNER_TEMP}/tpz/templates/"* "${GODOT_TEMPLATE_DIR}/"
+
+    - name: Verify export templates
+      shell: bash
+      run: |
+        # The template `--export-debug` uses for Linux/X11 (#301).
+        test -f "${GODOT_TEMPLATE_DIR}/linux_debug.x86_64"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,10 @@ on:
         default: false
         type: boolean
   schedule:
-    - cron: "24 3 * * 1"
+    # Nightly (03:24 UTC) — the automatic, dependable trigger for the godot-e2e job
+    # (workflow_dispatch with run-e2e is the on-demand extra). Daily so a regression in
+    # the real-engine tier is caught within a day rather than up to a week.
+    - cron: "24 3 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,18 @@ jobs:
       - name: Install Godot
         uses: ./.github/actions/install-godot
 
+      - name: DIAGNOSTIC (temporary)
+        run: |
+          echo "=== export_templates tree ==="
+          ls -la ~/.local/share/godot/export_templates/ || true
+          for f in ~/.local/share/godot/export_templates/*/version.txt; do echo "$f -> $(cat "$f")"; done || true
+          echo "=== engine version ==="
+          "${GDA_GODOT}" --headless --version || true
+          echo "=== gda export get (Linux/X11) ==="
+          mkdir -p /tmp/diagproj
+          printf 'config_version=5\n\n[application]\n\nconfig/name="diag"\n' > /tmp/diagproj/project.godot
+          printf '[preset.0]\n\nname="Linux/X11"\nplatform="Linux/X11"\nrunnable=true\nexport_path="build/g.x86_64"\n\n[preset.0.options]\n\nbinary_format/embed_pck=false\n' > /tmp/diagproj/export_presets.cfg
+          uv run --frozen python -m gda export get --preset Linux/X11 --project /tmp/diagproj --godot "${GDA_GODOT}" --json || true
+
       - name: Run Godot e2e tests
-        run: uv run --frozen pytest -m e2e
+        run: uv run --frozen pytest -m e2e -rs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,18 +67,8 @@ jobs:
       - name: Install Godot
         uses: ./.github/actions/install-godot
 
-      - name: DIAGNOSTIC (temporary)
-        run: |
-          echo "=== export_templates tree ==="
-          ls -la ~/.local/share/godot/export_templates/ || true
-          for f in ~/.local/share/godot/export_templates/*/version.txt; do echo "$f -> $(cat "$f")"; done || true
-          echo "=== engine version ==="
-          "${GDA_GODOT}" --headless --version || true
-          echo "=== gda export get (Linux/X11) ==="
-          mkdir -p /tmp/diagproj
-          printf 'config_version=5\n\n[application]\n\nconfig/name="diag"\n' > /tmp/diagproj/project.godot
-          printf '[preset.0]\n\nname="Linux/X11"\nplatform="Linux/X11"\nrunnable=true\nexport_path="build/g.x86_64"\n\n[preset.0.options]\n\nbinary_format/embed_pck=false\n' > /tmp/diagproj/export_presets.cfg
-          uv run --frozen python -m gda export get --preset Linux/X11 --project /tmp/diagproj --godot "${GDA_GODOT}" --json || true
-
       - name: Run Godot e2e tests
+        # -rs surfaces skip reasons in the log (e.g. absent export templates, or no
+        # DisplayServer for windowed capture), so a silently-skipped e2e is visible
+        # rather than mistaken for a pass.
         run: uv run --frozen pytest -m e2e -rs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           save-cache: false
 
+      # install-godot also installs the matching export templates, so this job can
+      # run the #301 template-gate behavioural proof (it exports a real template
+      # binary). Every other e2e needs only the editor binary.
       - name: Install Godot
         uses: ./.github/actions/install-godot
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,9 @@ jobs:
         uses: ./.github/actions/install-godot
 
       - name: Run Godot e2e tests
-        run: uv run --frozen pytest -m e2e
+        # -rs surfaces skip reasons (absent export templates, no DisplayServer) so a
+        # silently-skipped e2e is visible in the release log, not mistaken for a pass.
+        run: uv run --frozen pytest -m e2e -rs
 
       - name: Validate release tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Run unit tests
         run: uv run --frozen pytest -m "not e2e"
 
+      # install-godot also installs the matching export templates, so this job can
+      # run the #301 template-gate behavioural proof (it exports a real template
+      # binary). Every other e2e needs only the editor binary.
       - name: Install Godot
         uses: ./.github/actions/install-godot
 

--- a/docs/adr/0003-target-godot-version.md
+++ b/docs/adr/0003-target-godot-version.md
@@ -46,3 +46,11 @@ making "version too old" a programmatically detectable failure.
   provide 4.6+ — the headless suites still run on 4.4+.
 - 3.x is explicitly unsupported.
 - The minimum-version check depends on the `gda info` operation (issue #2) existing.
+- **Export-template detection is standard-official-builds only** (#304, 2026-06-26):
+  `gda`'s export-template readiness (`export get`'s `templates_installed`, used by the
+  `export run` preflight) reconstructs the per-version templates directory from
+  `Engine.get_version_info()`, which exposes no module/precision field. A **non-standard
+  build** — `.mono` (C#) or `.double` (double precision) — names its real templates dir
+  with a `.mono`/`.double` suffix gda cannot reconstruct, so it may under-report
+  templates on those variants. This narrowing is intentional within the 4.x/4.4+ target,
+  not an accidental false-negative.

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -1956,11 +1956,18 @@ func _export_preset_summary(config: ConfigFile, section: String, index: int) -> 
 
 
 # The export-templates version directory name for the running engine, e.g.
-# "4.6.3.stable" — major.minor.patch.status, matching how the editor names the
-# per-version templates folder under <data_dir>/<godot-dir>/export_templates/.
+# "4.6.stable" (4.6.0) or "4.6.3.stable" (4.6.3) — major.minor[.patch].status,
+# matching how the editor names the per-version templates folder under
+# <data_dir>/<godot-dir>/export_templates/. The patch component is OMITTED when it
+# is 0 — exactly as Engine.get_version_info()'s version string does (engine.cpp) and
+# as the official export-template archives are named — so a .0 release resolves to
+# "<major>.<minor>.<status>", not "<major>.<minor>.0.<status>".
 func _export_templates_version_dir() -> String:
 	var v := Engine.get_version_info()
-	return "%d.%d.%d.%s" % [v.major, v.minor, v.patch, v.status]
+	var dir := "%d.%d" % [v.major, v.minor]
+	if int(v.patch) != 0:
+		dir += ".%d" % v.patch
+	return "%s.%s" % [dir, v.status]
 
 
 # Whether the export templates for the running engine version are installed:

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -1962,6 +1962,10 @@ func _export_preset_summary(config: ConfigFile, section: String, index: int) -> 
 # is 0 — exactly as Engine.get_version_info()'s version string does (engine.cpp) and
 # as the official export-template archives are named — so a .0 release resolves to
 # "<major>.<minor>.<status>", not "<major>.<minor>.0.<status>".
+# Known limitation (#304): a NON-standard build appends a module/precision suffix to
+# the real dir name (FULL_CONFIG — e.g. "4.6.stable.mono" for a C# build, "...double"
+# for double precision), which Engine.get_version_info() exposes no field to
+# reconstruct. gda targets STANDARD official builds, where that suffix is empty.
 func _export_templates_version_dir() -> String:
 	var v := Engine.get_version_info()
 	var dir := "%d.%d" % [v.major, v.minor]

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -1957,7 +1957,7 @@ func _export_preset_summary(config: ConfigFile, section: String, index: int) -> 
 
 # The export-templates version directory name for the running engine, e.g.
 # "4.6.3.stable" — major.minor.patch.status, matching how the editor names the
-# per-version templates folder under <data_dir>/Godot/export_templates/.
+# per-version templates folder under <data_dir>/<godot-dir>/export_templates/.
 func _export_templates_version_dir() -> String:
 	var v := Engine.get_version_info()
 	return "%d.%d.%d.%s" % [v.major, v.minor, v.patch, v.status]
@@ -1965,15 +1965,27 @@ func _export_templates_version_dir() -> String:
 
 # Whether the export templates for the running engine version are installed:
 # their per-version directory exists under the user data dir's
-# Godot/export_templates/. Headless --script runs have no EditorPaths singleton,
-# so the path is derived from OS.get_data_dir() (the same root the editor uses)
-# plus the fixed "Godot/export_templates/<version>" layout. This is the readiness
-# signal an agent checks before a future export run (issue #121); it does not
-# verify per-platform template files, only that the version's templates are
+# <godot-dir>/export_templates/. Headless --script runs have no EditorPaths
+# singleton, so the path is derived from OS.get_data_dir() (the same root the editor
+# uses) plus the "<godot-dir>/export_templates/<version>" layout, where <godot-dir>
+# is the engine's per-platform user-dir name (see _godot_user_dir_name — lowercase
+# "godot" on case-sensitive Linux, NOT the macOS/Windows "Godot"). This is the
+# readiness signal an agent checks before a future export run (issue #121); it does
+# not verify per-platform template files, only that the version's templates are
 # present at all.
 func _export_templates_installed(version_dir: String) -> bool:
-	var templates_root := OS.get_data_dir().path_join("Godot").path_join("export_templates")
+	var templates_root := OS.get_data_dir().path_join(_godot_user_dir_name()).path_join("export_templates")
 	return DirAccess.dir_exists_absolute(templates_root.path_join(version_dir))
+
+
+# The engine's per-platform user-data directory name. macOS and Windows capitalize it
+# ("Godot"); every other platform — Linux and the BSDs — uses lowercase "godot", and
+# their filesystems are case-sensitive, so the case is load-bearing. Mirrors the C++
+# OS::get_godot_dir_name() (its default is lowercase; only macOS/Windows override it),
+# which a headless --script run cannot call.
+func _godot_user_dir_name() -> String:
+	var os_name := OS.get_name()
+	return "Godot" if os_name == "macOS" or os_name == "Windows" else "godot"
 
 
 # resource-uid: resolve a Godot resource UID to/from its resource path in BOTH

--- a/tests/support.py
+++ b/tests/support.py
@@ -32,10 +32,13 @@ def templates_installed(gda, preset: str = "Linux/X11") -> bool:
 
     ``gda`` is a bound ``gda <args> --json`` callable (e.g. the e2e tests'
     ``_gda_project``). The single source of truth for the e2e template-presence
-    policy, shared by the export-run happy-path skip and the harness
-    template-gate behavioural proof (#301). ``preset`` selects the platform whose
-    templates are queried — the behavioural proof exports the HOST platform, so it
-    must not hard-code ``Linux/X11``.
+    policy, shared by the export-run happy-path skip and the harness template-gate
+    behavioural proof (#301). ``preset`` only needs to NAME a preset that exists in
+    the project so ``export get`` succeeds; the verdict itself is preset-independent
+    — ``export get`` checks only that the engine's per-version templates DIRECTORY
+    exists, not the platform-specific template files — so a caller on a host with the
+    version dir present but the host platform's file missing still sees ``True`` and
+    must tolerate the export failing later.
     """
     got = gda("export", "get", "--preset", preset, "--json")
     assert got.returncode == 0, got.stdout + got.stderr

--- a/tests/support.py
+++ b/tests/support.py
@@ -27,6 +27,21 @@ from gda.runner import RunResult
 GDA_CMD = [sys.executable, "-m", "gda"]
 
 
+def templates_installed(gda, preset: str = "Linux/X11") -> bool:
+    """Whether the running engine has export templates, via ``gda export get``.
+
+    ``gda`` is a bound ``gda <args> --json`` callable (e.g. the e2e tests'
+    ``_gda_project``). The single source of truth for the e2e template-presence
+    policy, shared by the export-run happy-path skip and the harness
+    template-gate behavioural proof (#301). ``preset`` selects the platform whose
+    templates are queried — the behavioural proof exports the HOST platform, so it
+    must not hard-code ``Linux/X11``.
+    """
+    got = gda("export", "get", "--preset", preset, "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    return json.loads(got.stdout)["templates_installed"]
+
+
 class FakeRunner:
     """A fakeable GodotRunner that records its calls and returns a canned result."""
 

--- a/tests/test_e2e_export.py
+++ b/tests/test_e2e_export.py
@@ -13,7 +13,6 @@ not a fixed value.
 """
 
 import json
-import re
 import subprocess
 
 import pytest
@@ -55,10 +54,26 @@ export_path=""
 html/export_icon=true
 """
 
-# The export-templates version-directory pattern: major.minor[.patch].status,
-# e.g. "4.6.3.stable" or "4.6.stable" — the patch is omitted for a .0 release, as
-# Godot names the dir. What export get reports as templates_version.
-VERSION_DIR = re.compile(r"^\d+\.\d+(?:\.\d+)?\.[a-z0-9]+$")
+def _expected_templates_version() -> str:
+    """The export-templates version-dir name the running engine uses, derived from its
+    OWN version info — major.minor[.patch].status with the patch OMITTED when 0 (e.g.
+    "4.6.stable" for 4.6.0, "4.6.3.stable" for 4.6.3), exactly as engine.cpp formats
+    its version string. Asserting ``templates_version`` against THIS (not a loose
+    regex) makes a regression in operations.gd::_export_templates_version_dir — e.g.
+    re-adding the ``.0`` patch — fail RED here, instead of silently making the
+    template-gate e2e skip (templates_installed would go False on a .0 engine).
+    """
+    info = subprocess.run(
+        [*GDA_CMD, "info", "--json", "--godot", str(GODOT)],
+        capture_output=True,
+        text=True,
+    )
+    assert info.returncode == 0, info.stdout + info.stderr
+    v = json.loads(info.stdout)
+    base = f"{v['major']}.{v['minor']}"
+    if v["patch"]:
+        base += f".{v['patch']}"
+    return f"{base}.{v['status']}"
 
 
 def _gda_project(project) -> "callable":
@@ -168,10 +183,13 @@ def test_export_get_reports_preset_details_and_template_status(godot_project):
     assert data["platform"] == "Web"
     assert data["runnable"] is False
     assert data["export_path"] == ""
-    # Template readiness: a bool verdict plus the version dir it checked, matching
-    # the running engine's major.minor[.patch].status (patch omitted for a .0 release).
+    # Template readiness: a bool verdict plus the EXACT version dir it checked —
+    # derived from the engine's own version (patch omitted for a .0 release), so a
+    # format regression is caught RED here rather than slipping past a loose regex.
     assert isinstance(data["templates_installed"], bool)
-    assert VERSION_DIR.match(data["templates_version"]), data["templates_version"]
+    assert data["templates_version"] == _expected_templates_version(), (
+        data["templates_version"]
+    )
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_export.py
+++ b/tests/test_e2e_export.py
@@ -55,9 +55,10 @@ export_path=""
 html/export_icon=true
 """
 
-# The export-templates version-directory pattern: major.minor.patch.status,
-# e.g. 4.6.3.stable — what export get reports as templates_version.
-VERSION_DIR = re.compile(r"^\d+\.\d+\.\d+\.[a-z0-9]+$")
+# The export-templates version-directory pattern: major.minor[.patch].status,
+# e.g. "4.6.3.stable" or "4.6.stable" — the patch is omitted for a .0 release, as
+# Godot names the dir. What export get reports as templates_version.
+VERSION_DIR = re.compile(r"^\d+\.\d+(?:\.\d+)?\.[a-z0-9]+$")
 
 
 def _gda_project(project) -> "callable":
@@ -168,7 +169,7 @@ def test_export_get_reports_preset_details_and_template_status(godot_project):
     assert data["runnable"] is False
     assert data["export_path"] == ""
     # Template readiness: a bool verdict plus the version dir it checked, matching
-    # the running engine's major.minor.patch.status.
+    # the running engine's major.minor[.patch].status (patch omitted for a .0 release).
     assert isinstance(data["templates_installed"], bool)
     assert VERSION_DIR.match(data["templates_version"]), data["templates_version"]
 

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -31,6 +31,7 @@ import os
 import subprocess
 import sys
 import zipfile
+from pathlib import Path
 
 import pytest
 
@@ -322,3 +323,51 @@ def test_export_run_without_templates_yields_export_templates_missing(
     assert err["category"] == "operation"
     # Fail-fast preflight: no native export ran, so nothing was written.
     assert not (godot_project / "build").exists(), "no artifact when preflight fails"
+
+
+def _host_templates_on_disk() -> bool:
+    """Whether the running platform's export templates are PHYSICALLY present in the
+    engine's real user data dir — computed INDEPENDENTLY of gda's own path logic (the
+    code #304 fixed), by globbing for a platform template file under ANY version dir.
+    A detection regression (Linux ``godot`` vs ``Godot`` case, or a ``.0`` version-dir
+    name) shows up as disagreement between this and ``gda export get``.
+    """
+    home = Path(os.path.expanduser("~"))
+    if sys.platform == "darwin":
+        root = home / "Library" / "Application Support" / "Godot" / "export_templates"
+        return any(root.glob("*/macos.zip"))
+    if sys.platform.startswith("linux"):
+        data = Path(os.environ.get("XDG_DATA_HOME") or home / ".local" / "share")
+        root = data / "godot" / "export_templates"
+        return any(root.glob("*/linux_release.x86_64")) or any(
+            root.glob("*/linux_debug.x86_64")
+        )
+    return False
+
+
+@pytest.mark.e2e
+def test_templates_installed_is_true_when_host_templates_are_on_disk(godot_project):
+    # #304 acceptance, as a HARD assertion: wherever the host's export templates are
+    # physically installed (the CI install-godot step, or a dev who installed them),
+    # `gda export get` MUST report templates_installed=true. This converts a
+    # template-path detection regression — the Linux user-dir case or the .0
+    # version-dir name — from a SILENT skip of the #301 proof into a RED failure (the
+    # very gap that hid the original #304 bug). It skips only where templates are
+    # genuinely absent (a dev box without them); CI always has them.
+    if not _host_templates_on_disk():
+        pytest.skip(
+            "no host export templates on disk (a dev box without them); the CI "
+            "install-godot step provides them, where this assertion guards the "
+            "template-installed path"
+        )
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    gda = _gda_project(godot_project)
+
+    # templates_installed is preset-independent (it only checks the version dir
+    # exists), so any real preset works; the on-disk check above is the source of truth.
+    assert templates_installed(gda) is True, (
+        "host export templates are present on disk but `gda export get` reports "
+        "templates_installed=false — the template-path detection regressed (#304)"
+    )

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -27,7 +27,9 @@ path) run unconditionally.
 """
 
 import json
+import os
 import subprocess
+import sys
 import zipfile
 
 import pytest
@@ -274,3 +276,49 @@ def test_export_run_pack_omits_installed_harness_and_restores_it(godot_project):
     # The dev project is left UNTOUCHED: harness restored on disk and in config.
     assert harness_file.exists(), "the harness file must be restored after export"
     assert HARNESS_AUTOLOAD_NAME in project_godot.read_text(encoding="utf-8")
+
+
+@pytest.mark.e2e
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="forces missing templates by pointing XDG_DATA_HOME at an empty dir, which "
+    "only the Linux/BSD engine honors as its data dir (macOS uses ~/Library/"
+    "Application Support); this restores the Linux CI coverage lost once CI installs "
+    "templates",
+)
+def test_export_run_without_templates_yields_export_templates_missing(
+    godot_project, tmp_path
+):
+    # Restores the LIVE (real-engine) coverage of the export_templates_missing
+    # structured preflight that installing export templates into CI removed: once CI
+    # has templates, test_export_run_writes_to_configured_export_path takes its success
+    # branch and its missing branch goes dead, leaving that error path on faked unit
+    # tests only (which RULES.md DoD says can pass while the artifact is broken). Here
+    # we point the engine's data dir (XDG_DATA_HOME) at an EMPTY dir so it finds NO
+    # export templates, then assert `gda export run` fails fast with the structured
+    # export_templates_missing code BEFORE any native export (#304).
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    (godot_project / "main.gd").write_text(
+        "extends Node\n\nfunc _ready() -> void:\n\tpass\n", encoding="utf-8"
+    )
+    empty_data = tmp_path / "empty-xdg"
+    empty_data.mkdir()
+
+    run = subprocess.run(
+        [
+            *GDA_CMD, "export", "run", "--preset", "Linux/X11", "--json",
+            "--godot", str(GODOT), "--project", str(godot_project),
+        ],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "XDG_DATA_HOME": str(empty_data)},
+    )
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "export_templates_missing", run.stdout + run.stderr
+    assert err["category"] == "operation"
+    # Fail-fast preflight: no native export ran, so nothing was written.
+    assert not (godot_project / "build").exists(), "no artifact when preflight fails"

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -28,7 +28,6 @@ path) run unconditionally.
 
 import json
 import subprocess
-import warnings
 import zipfile
 
 import pytest
@@ -40,7 +39,7 @@ from gda.harness.install import (
     HARNESS_RES_DIR,
     install_harness,
 )
-from tests.support import GDA_CMD
+from tests.support import GDA_CMD, templates_installed
 
 GODOT = resolve_godot_binary()
 
@@ -90,13 +89,6 @@ def _gda_project(project) -> "callable":
         )
 
     return gda
-
-
-def _templates_installed(gda) -> bool:
-    """Ask the real engine (via export get) whether templates are installed."""
-    got = gda("export", "get", "--preset", "Linux/X11", "--json")
-    assert got.returncode == 0, got.stdout + got.stderr
-    return json.loads(got.stdout)["templates_installed"]
 
 
 @pytest.mark.e2e
@@ -151,6 +143,13 @@ def test_export_run_writes_to_configured_export_path(godot_project):
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
+    # all_resources needs at least one exportable file, or the native export fails with
+    # "Must select at least one file to export." This success branch only runs where
+    # templates exist (CI now installs them, #301), so — like the pack tests below — it
+    # must carry pack content; a bare project.godot alone would fail the real export.
+    (godot_project / "main.gd").write_text(
+        "extends Node\n\nfunc _ready() -> void:\n\tpass\n", encoding="utf-8"
+    )
     configured_rel = "build/game.x86_64"
     artifact = godot_project / configured_rel
     artifact.parent.mkdir(parents=True, exist_ok=True)  # the preset's configured dir
@@ -158,7 +157,7 @@ def test_export_run_writes_to_configured_export_path(godot_project):
 
     run = gda("export", "run", "--preset", "Linux/X11", "--json")
 
-    if not _templates_installed(gda):
+    if not templates_installed(gda):
         # Templates absent: gda's structured preflight fails fast with
         # export_templates_missing, before any native export — so no artifact is
         # written. Verify that path live, then skip the success assertion cleanly.
@@ -275,35 +274,3 @@ def test_export_run_pack_omits_installed_harness_and_restores_it(godot_project):
     # The dev project is left UNTOUCHED: harness restored on disk and in config.
     assert harness_file.exists(), "the harness file must be restored after export"
     assert HARNESS_AUTOLOAD_NAME in project_godot.read_text(encoding="utf-8")
-
-
-@pytest.mark.e2e
-def test_template_gate_behavioural_proof_is_due_once_templates_exist(godot_project):
-    # TRIPWIRE for ADR-0028's harness `template` gate. The gate
-    # (`if OS.has_feature("template"): return`, the first statement of `_ready()`) is
-    # proven STATICALLY by
-    # tests/test_harness_install.py::test_ready_gates_on_template_feature_as_its_first_statement.
-    # Its BEHAVIOURAL proof needs a real exported TEMPLATE binary, which needs
-    # installed export templates (issue #301). The default PR CI both skips the e2e
-    # job AND lacks templates, so that gap could be silently forgotten. This guard
-    # stays a LOUD skip while templates are absent and emits a WARNING the moment a
-    # runner has them — so #301 gets implemented rather than left undone.
-    (godot_project / "export_presets.cfg").write_text(
-        EXPORT_PRESETS_CFG, encoding="utf-8"
-    )
-    gda = _gda_project(godot_project)
-    if not _templates_installed(gda):
-        pytest.skip(
-            "export templates absent: the template-gate BEHAVIOURAL proof cannot run "
-            "here (covered statically by "
-            "test_ready_gates_on_template_feature_as_its_first_statement). Implement "
-            "it where templates exist — issue #301."
-        )
-    warnings.warn(
-        "Godot export templates are now installed: implement the behavioural "
-        "template-gate e2e (issue #301) — export a template binary, run it with a "
-        "`gda-daemon` marker + a live socket, and assert the harness never connects — "
-        "then remove this tripwire. Until then the `template` gate is proven only "
-        "statically.",
-        stacklevel=2,
-    )

--- a/tests/test_e2e_harness_install.py
+++ b/tests/test_e2e_harness_install.py
@@ -1,4 +1,4 @@
-"""S1 (e2e): the installed gda harness loads inert in a real engine (#7, #225, ADR-0018).
+"""S1 (e2e): the installed gda harness loads inert in a real engine (#7, #225, #301, ADR-0018, ADR-0028).
 
 Per RULES.md DoD the fast install tests do not count toward this gate: these boot
 a REAL Godot on a project with the harness installed and assert the autoload is
@@ -20,22 +20,33 @@ the pack is asserted so "inert" is never trivially true.
 
 NOTE on what the PCK boot proves: it runs the pack with the EDITOR (tools) binary via
 ``--main-pack``, where ``OS.has_feature("template")`` is FALSE — so it exercises the
-**no-marker** inert path (ADR-0018 point 2), not ADR-0028's ``template`` gate. The
-gate's behavioural proof needs a real exported template binary (templates + the e2e
-job); its CI-runnable static proof — that the gate is the first statement of
-``_ready()`` — lives in ``tests/test_harness_install.py``.
+**no-marker** inert path (ADR-0018 point 2), not ADR-0028's ``template`` gate. That
+gate's BEHAVIOURAL proof — exporting a real TEMPLATE binary (where the feature is
+true) and asserting the harness never connects despite a marker + live socket — is
+``test_template_feature_gates_the_harness_only_in_exported_builds`` below (#301; it
+needs installed export templates, so it skips loudly where they are absent). Its
+CI-runnable static counterpart — that the gate is the first statement of ``_ready()``
+— lives in ``tests/test_harness_install.py``.
 """
 
+import socket
 import subprocess
+import sys
+import threading
+from contextlib import contextmanager
+from typing import NamedTuple
 
 import pytest
 
 from gda.binary import resolve_godot_binary
+from gda.daemon.protocol import read_frame
 from gda.harness.install import (
     HARNESS_AUTOLOAD_NAME,
     HARNESS_RES_PATH,
     install_harness,
 )
+
+from tests.support import GDA_CMD, templates_installed
 
 from .conftest import project_godot
 
@@ -141,3 +152,273 @@ def test_exported_pck_with_harness_runs_inert(tmp_path):
         timeout=60,
     )
     _assert_inert_boot(proc.stdout + proc.stderr, proc.returncode)
+
+
+# --- ADR-0028 template-gate behavioural proof (#301) ------------------------------
+#
+# The two boots above run on the EDITOR binary, where `OS.has_feature("template")` is
+# false. The proof below needs a real exported TEMPLATE binary (feature true), so it
+# exports one for the HOST platform and runs it. The helpers are host-parameterized;
+# only the Linux/X11 (CI) and macOS (dev) export paths are wired — other hosts skip.
+
+# The proof's project. A macOS arm64/universal export refuses to build unless ETC2
+# ASTC VRAM import is enabled (Godot validates it regardless of whether the project
+# has textures); it is harmless for the Linux/X11 export, so the project enables it
+# on both hosts.
+_GATE_PROJECT_GODOT = project_godot(
+    extra=(
+        'run/main_scene="res://main.tscn"\n\n'
+        "[rendering]\n\n"
+        "textures/vram_compression/import_etc2_astc=true"
+    )
+)
+
+_LINUX_PRESETS = (
+    "[preset.0]\n\n"
+    'name="Linux/X11"\n'
+    'platform="Linux/X11"\n'
+    "runnable=true\n"
+    'export_filter="all_resources"\n'
+    'include_filter=""\n'
+    'exclude_filter=""\n'
+    'export_path="export/game.x86_64"\n\n'
+    "[preset.0.options]\n\n"
+    "binary_format/embed_pck=false\n"  # a sidecar game.pck we can grep for the harness
+)
+
+# The macOS export template (macos.zip) ships a single UNIVERSAL binary
+# (godot_macos_debug.universal), so the preset must request "universal" — a per-arch
+# value errors with "template binary not found". The .app runs natively on any host.
+# The options section must also be non-empty or Godot errors reading its keys.
+_MACOS_PRESETS = (
+    "[preset.0]\n\n"
+    'name="macOS"\n'
+    'platform="macOS"\n'
+    "runnable=true\n"
+    'export_filter="all_resources"\n'
+    'include_filter=""\n'
+    'exclude_filter=""\n'
+    'export_path="export/game.app"\n\n'
+    "[preset.0.options]\n\n"
+    'binary_format/architecture="universal"\n'
+    # macOS export requires a bundle identifier; ad-hoc codesigning (the default,
+    # Gatekeeper-blocked) is fine for a locally-built binary we run ourselves.
+    'application/bundle_identifier="org.godotagent.gatetest"\n'
+)
+
+
+class _ExportTarget(NamedTuple):
+    preset: str  # export_presets.cfg preset name (== platform here)
+    export_path: str  # the preset's export_path, also the raw --export-debug out
+    presets_cfg: str  # the full export_presets.cfg for this host
+
+
+def _host_export_target() -> "_ExportTarget | None":
+    """The host's template-export preset, or None on an unsupported host (skip).
+
+    Only the platforms this test can run on are wired: Linux/X11 (CI) and macOS (the
+    dev machine). The exported artifact must run on THIS host, so the preset is the
+    host platform.
+    """
+    if sys.platform.startswith("linux"):
+        return _ExportTarget("Linux/X11", "export/game.x86_64", _LINUX_PRESETS)
+    if sys.platform == "darwin":
+        return _ExportTarget("macOS", "export/game.app", _MACOS_PRESETS)
+    return None
+
+
+def _locate_exe(project, target: _ExportTarget):
+    """The runnable executable the host export produced, or None if it failed.
+
+    ``--export-debug`` exits 0 even when the export fails (leaving only a partial
+    artifact), so a missing executable is how this test detects a failed export.
+    """
+    artifact = project / target.export_path
+    if sys.platform == "darwin":
+        # A macOS export is a .app bundle; the executable is the lone file under
+        # Contents/MacOS/ (named from the preset, so glob rather than guess it).
+        macos_dir = artifact / "Contents" / "MacOS"
+        exes = sorted(macos_dir.iterdir()) if macos_dir.is_dir() else []
+        return exes[0] if exes else None
+    return artifact if artifact.exists() else None  # Linux: export_path IS the exe
+
+
+def _exported_tree_has_harness(export_dir) -> bool:
+    """Whether the harness script is anywhere in the exported artifact tree.
+
+    The ``res://`` path is stored as plaintext in the pck (a sidecar on Linux,
+    embedded in the .app on macOS), so a recursive byte search finds it regardless of
+    layout — making the negative "no connection" result non-vacuous (the harness
+    really shipped in the template build).
+    """
+    return any(
+        p.is_file() and b"gda_harness.gd" in p.read_bytes()
+        for p in export_dir.rglob("*")
+    )
+
+
+class _SocketProbe:
+    """A listening AF_UNIX socket that records the harness's first connection.
+
+    Plays the daemon's role for the harness's connect attempt: accept once, read the
+    first length-prefixed frame (the harness sends the auth token first — see
+    ``gda_harness.gd`` ``_send_frame``), and record both that a connection arrived and
+    the token bytes. A daemon thread polls ``accept()`` on a short timeout so
+    ``stop()`` unwinds deterministically (closing the listening fd from another thread
+    does not reliably wake a blocked ``accept()``).
+    """
+
+    def __init__(self, sock: socket.socket) -> None:
+        self._sock = sock
+        self.connected = threading.Event()
+        self.token: bytes | None = None
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._accept, daemon=True)
+        self._thread.start()
+
+    def _accept(self) -> None:
+        self._sock.settimeout(0.25)
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            with conn:
+                self.connected.set()
+                try:
+                    conn.settimeout(2.0)
+                    self.token = read_frame(conn)
+                except OSError:
+                    pass
+            return
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=2)
+
+
+@contextmanager
+def _socket_probe(path):
+    """A live listening UDS at ``path``; bind under daemon_runtime_dir (sun_path limit)."""
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.bind(str(path))
+    sock.listen(1)  # the backlog holds a connect that beats accept() — no startup race
+    probe = _SocketProbe(sock)
+    try:
+        yield probe
+    finally:
+        probe.stop()
+        sock.close()
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.e2e
+def test_template_feature_gates_the_harness_only_in_exported_builds(
+    tmp_path, daemon_runtime_dir
+):
+    # ADR-0028 BEHAVIOURAL proof (#301), replacing the test_e2e_export_run tripwire
+    # and completing this file's story. It isolates `OS.has_feature("template")` as
+    # the ONLY variable: the SAME project + `gda-daemon` marker + live socket CONNECTS
+    # under the EDITOR binary (template=false) and stays SILENT under an EXPORTED
+    # TEMPLATE binary (template=true), where the gate short-circuits `_ready()` before
+    # any marker/socket handling.
+    #
+    # Skips LOUDLY when the host is unsupported or export templates for the running
+    # engine version are absent (the static first-statement proof in
+    # tests/test_harness_install.py still guards the gate everywhere). Residual,
+    # documented limitation: the positive control cannot rule out a template build
+    # dropping `--` user args — academic, since feeding user args to exported games is
+    # the documented purpose of OS.get_cmdline_user_args() and gda only ever launches
+    # the editor binary in production (the gate is pure defence-in-depth).
+    target = _host_export_target()
+    if target is None:
+        pytest.skip(
+            f"no template-export path is wired for {sys.platform!r}; the behavioural "
+            "template-gate proof (#301) exports a host template binary. Covered "
+            "statically by test_ready_gates_on_template_feature_as_its_first_statement."
+        )
+
+    (tmp_path / "project.godot").write_text(_GATE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "export_presets.cfg").write_text(target.presets_cfg, encoding="utf-8")
+    install_harness(tmp_path)
+
+    def gda(*args):  # bound `gda export get` for the templates-presence gate
+        return subprocess.run(
+            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(tmp_path)],
+            capture_output=True,
+            text=True,
+        )
+
+    if not templates_installed(gda, preset=target.preset):
+        pytest.skip(
+            f"export templates for the running engine + {target.preset!r} are not "
+            "installed; the template-gate BEHAVIOURAL proof cannot export a template "
+            "binary here (covered statically by "
+            "test_ready_gates_on_template_feature_as_its_first_statement). Install "
+            "matching templates (the install-godot CI action does) to run it. (#301)"
+        )
+
+    # Positive control: the EDITOR binary (template=false) DOES connect — proving the
+    # socket/marker/token rig genuinely drives a harness connection, so the template
+    # binary's later silence is attributable to the gate, not a dead rig.
+    editor_sock = daemon_runtime_dir / "editor.sock"
+    editor_token = "tok-editor"
+    with _socket_probe(editor_sock) as probe:
+        subprocess.run(
+            [str(GODOT), "--headless", "--path", str(tmp_path), "--quit",
+             "--", "gda-daemon", str(editor_sock), editor_token],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert probe.connected.wait(5), "editor binary never connected — the rig is broken"
+        assert probe.token == editor_token.encode(), probe.token
+
+    # Export a real DEBUG TEMPLATE binary that CONTAINS the harness. RAW `--export-debug`
+    # (NOT `gda export run`, which strips the harness per ADR-0018) so the harness
+    # genuinely SHIPS in the template build — the gate, not the strip, must silence it.
+    export_dir = tmp_path / "export"
+    export_dir.mkdir(parents=True, exist_ok=True)
+    artifact = tmp_path / target.export_path
+    exported = subprocess.run(
+        [str(GODOT), "--headless", "--path", str(tmp_path),
+         "--export-debug", target.preset, str(artifact)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    exe = _locate_exe(tmp_path, target)
+    assert exe is not None, (
+        "--export-debug produced no runnable binary — the export failed (it exits 0 "
+        f"even on failure)\n{exported.stdout}{exported.stderr}"
+    )
+    assert _exported_tree_has_harness(export_dir), (
+        "the harness was not packed into the template build — the proof would be vacuous"
+    )
+    exe.chmod(0o755)
+
+    # Negative: the TEMPLATE binary (template=true) stays SILENT despite the marker.
+    tmpl_sock = daemon_runtime_dir / "tmpl.sock"
+    tmpl_token = "tok-template"
+    with _socket_probe(tmpl_sock) as probe:
+        ran = subprocess.run(
+            [str(exe), "--headless", "--quit",
+             "--", "gda-daemon", str(tmpl_sock), tmpl_token],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        out_text = ran.stdout + ran.stderr
+        # The binary booted and ran `_ready` (so the gate executed) and exited clean —
+        # otherwise "no connection" could be a crash before `_ready`, not the gate.
+        assert "SCRIPT ERROR" not in out_text, out_text
+        assert "Parse Error" not in out_text, out_text
+        assert ran.returncode == 0, out_text
+        # The harness never connected: the `template` gate fired before marker handling.
+        assert not probe.connected.wait(1), (
+            "the exported TEMPLATE binary connected — the `template` gate did NOT fire "
+            "before marker/socket handling\n" + out_text
+        )

--- a/tests/test_e2e_harness_install.py
+++ b/tests/test_e2e_harness_install.py
@@ -42,6 +42,7 @@ from gda.binary import resolve_godot_binary
 from gda.daemon.protocol import read_frame
 from gda.harness.install import (
     HARNESS_AUTOLOAD_NAME,
+    HARNESS_FILE,
     HARNESS_RES_PATH,
     install_harness,
 )
@@ -235,25 +236,35 @@ def _locate_exe(project, target: _ExportTarget):
     """
     artifact = project / target.export_path
     if sys.platform == "darwin":
-        # A macOS export is a .app bundle; the executable is the lone file under
-        # Contents/MacOS/ (named from the preset, so glob rather than guess it).
+        # A macOS export is a .app bundle; the executable is the lone real file under
+        # Contents/MacOS/ (named from the preset, so glob rather than guess it). Skip
+        # dotfiles (e.g. a stray .DS_Store) that would sort ahead of the binary.
         macos_dir = artifact / "Contents" / "MacOS"
-        exes = sorted(macos_dir.iterdir()) if macos_dir.is_dir() else []
+        exes = (
+            sorted(
+                p
+                for p in macos_dir.iterdir()
+                if p.is_file() and not p.name.startswith(".")
+            )
+            if macos_dir.is_dir()
+            else []
+        )
         return exes[0] if exes else None
     return artifact if artifact.exists() else None  # Linux: export_path IS the exe
 
 
 def _exported_tree_has_harness(export_dir) -> bool:
-    """Whether the harness script is anywhere in the exported artifact tree.
+    """Whether the harness script is packed into the exported artifact's pck.
 
-    The ``res://`` path is stored as plaintext in the pck (a sidecar on Linux,
-    embedded in the .app on macOS), so a recursive byte search finds it regardless of
-    layout — making the negative "no connection" result non-vacuous (the harness
+    The ``res://`` path is stored as plaintext in the project pack — a sidecar
+    ``game.pck`` on Linux, ``Contents/Resources/<name>.pck`` inside the .app on macOS
+    — so scanning the pck(s) finds it WITHOUT reading the multi-hundred-MB template
+    binary, and keeps the negative "no connection" result non-vacuous (the harness
     really shipped in the template build).
     """
     return any(
-        p.is_file() and b"gda_harness.gd" in p.read_bytes()
-        for p in export_dir.rglob("*")
+        HARNESS_FILE.encode() in p.read_bytes()
+        for p in export_dir.rglob("*.pck")
     )
 
 
@@ -286,12 +297,15 @@ class _SocketProbe:
             except OSError:
                 return
             with conn:
-                self.connected.set()
                 try:
                     conn.settimeout(2.0)
                     self.token = read_frame(conn)
                 except OSError:
                     pass
+                # Signal AFTER the token is read so a waiter gated on `connected` sees
+                # a populated `token` — no read-before-write race in the positive
+                # control (the harness sends the token as its first frame).
+                self.connected.set()
             return
 
     def stop(self) -> None:
@@ -418,7 +432,9 @@ def test_template_feature_gates_the_harness_only_in_exported_builds(
         assert "Parse Error" not in out_text, out_text
         assert ran.returncode == 0, out_text
         # The harness never connected: the `template` gate fired before marker handling.
-        assert not probe.connected.wait(1), (
+        # The binary has already exited, so a 0.5s grace (2 probe accept-poll cycles)
+        # is enough to catch any late backlog connection without padding every run.
+        assert not probe.connected.wait(0.5), (
             "the exported TEMPLATE binary connected — the `template` gate did NOT fire "
             "before marker/socket handling\n" + out_text
         )


### PR DESCRIPTION
## What

Implements #301 — the **behavioural** proof of the gda harness's ADR-0028 `template` gate — and fixes the export-template detection bug (#304) that wiring the proof into Linux CI surfaced.

- **New e2e** `test_template_feature_gates_the_harness_only_in_exported_builds`: exports a real **debug template** binary that ships the harness, runs it headless with a `gda-daemon <socket> <token>` marker against a **live listening** Unix socket, and asserts the harness **never connects** — the `template` gate short-circuits `_ready()` before marker/socket handling.
- **Positive control**: the editor binary (template false) runs against the *identical* socket/marker/token rig and DOES connect (token frame verified), isolating `OS.has_feature("template")` as the only variable — so the template binary's silence is the gate firing, not a dead rig. Anti-vacuous: also asserts the harness is genuinely packed into the exported artifact.
- Host-parameterized: **Linux/X11** (CI) and **macOS** (dev). Skips **loudly** where the host is unsupported or templates are absent (the static first-statement proof in `tests/test_harness_install.py` still guards the gate everywhere).
- **Replaces** the PR #297 tripwire `test_template_gate_behavioural_proof_is_due_once_templates_exist`.
- Promotes `templates_installed` to `tests/support.py` (single source of the e2e template-presence policy, now preset-parameterized).
- **CI**: extends the shared `install-godot` action to download+cache the matching `export_templates.tpz` so the scheduled/dispatch `godot-e2e` job (and `release.yml`) actually run the proof. The version dir is named from the `.tpz`'s `version.txt` (authoritative), and `-rs` is added to the e2e run so a silently-skipped test is visible in the log.
- Installing templates **un-skips** `test_export_run_writes_to_configured_export_path` (gave it exportable content) and tightened `test_e2e_export`'s version-format regex — both branches had never run on a Linux/.0 runner before.

## Fixes #304 — gda mis-detected installed export templates

Running the proof on Linux CI surfaced a real, pre-existing gda bug in how `operations.gd` reconstructs the export-templates path — two facets, both masked because dev ran on case-insensitive macOS at a non-`.0` patch and CI had no templates:

1. **Wrong user-dir case on Linux** — hardcoded capital `"Godot"`, but the engine's user-dir is lowercase `"godot"` on Linux/BSD (only macOS/Windows capitalize it). Case-sensitive Linux never resolved it.
2. **Patch included for `.0` releases** — built `"4.6.0.stable"`, but Godot omits the patch when 0 (`"4.6.stable"`), as `Engine.get_version_info()`'s version string does.

Either made `export get` report `templates_installed=false` and `export run` refuse every Linux/`.0` export as `export_templates_missing`. Without this fix the #301 proof would silently **skip** on Linux CI instead of running. No behaviour change on macOS/Windows at a non-`.0` patch.

## Why

PR #297 added the gate but proved it only **statically** (it is the first `_ready()` statement). The `template == true` branch had never been executed end-to-end — this is the only test that does.

## Verification (real engine, no mocks)

- `pytest -m "not e2e"` → **973 passed** (incl. the static first-statement proof).
- **macOS local** (4.6.3 templates installed): full e2e suite **289 passed / 0 failed**. The editor binary connects; the exported **universal** template binary stays silent under the marker.
- **Linux CI** (`workflow_dispatch`, `run-e2e=true`): the `install-godot` template steps succeed and, after the #304 fix, `gda export get` reports `templates_installed:true` — the export-family e2e (incl. the new proof) **runs and passes**: **286 passed, 3 skipped, 0 failed** (the 3 skips are the headless-Linux windowed-capture tests, unrelated).

Closes #301.
