### PR TITLE
ci: add ruff lint and format gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint and format (ruff)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          # The python job already populates the dependency cache for this key;
+          # this job only reads it, so skip a redundant (racing) cache save.
+          save-cache: false
+
+      - name: Lint
+        run: uv run --frozen ruff check .
+
+      - name: Check formatting
+        run: uv run --frozen ruff format --check .
+
   python:
     name: Python unit tests and package build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ RULES.md
 __pycache__/
 *.py[cod]
 .pytest_cache/
+.ruff_cache/
 dist/
 build/
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -609,8 +609,7 @@ Linting and formatting are enforced by [ruff](https://docs.astral.sh/ruff/) — 
 place of flake8 + black + isort, configured under `[tool.ruff]` in `pyproject.toml` and
 pinned via `uv.lock` so local and CI agree. CI's `lint` job runs `ruff check .` and
 `ruff format --check .` on every PR; run `uv run ruff format .` before committing to stay
-green. The rationale (ruff-only, CI-only, rule set, the Typer `F811` exemption) is
-[ADR-0029](docs/adr/0029-lint-and-format-gate.md).
+green.
 
 ```
 src/gda/

--- a/README.md
+++ b/README.md
@@ -609,7 +609,8 @@ Linting and formatting are enforced by [ruff](https://docs.astral.sh/ruff/) — 
 place of flake8 + black + isort, configured under `[tool.ruff]` in `pyproject.toml` and
 pinned via `uv.lock` so local and CI agree. CI's `lint` job runs `ruff check .` and
 `ruff format --check .` on every PR; run `uv run ruff format .` before committing to stay
-green.
+green. The rationale (ruff-only, CI-only, rule set, the Typer `F811` exemption) is
+[ADR-0029](docs/adr/0029-lint-and-format-gate.md).
 
 ```
 src/gda/

--- a/README.md
+++ b/README.md
@@ -596,11 +596,20 @@ uv sync                       # set up the environment
 uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
 uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
 uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
+
+uv run ruff check .           # lint
+uv run ruff format .          # auto-format (append --check to verify without writing)
 ```
 
 The `e2e` tier runs by default with `uv run pytest`, and **fails loudly** — naming the
 resolved path and how to fix it — if no Godot binary is found there, rather than skipping.
 Deselect the whole tier with `-m "not e2e"` (CI's per-PR job uses exactly this).
+
+Linting and formatting are enforced by [ruff](https://docs.astral.sh/ruff/) — one tool in
+place of flake8 + black + isort, configured under `[tool.ruff]` in `pyproject.toml` and
+pinned via `uv.lock` so local and CI agree. CI's `lint` job runs `ruff check .` and
+`ruff format --check .` on every PR; run `uv run ruff format .` before committing to stay
+green.
 
 ```
 src/gda/
@@ -635,6 +644,8 @@ Contributions are welcome. Read [`CONTEXT.md`](CONTEXT.md) to align with the pro
 shared language, and review the relevant [ADRs](docs/adr/) for the area you're touching.
 Issues and PRDs live as [GitHub issues](https://github.com/aigengame/godot-agent/issues).
 Commits follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+Python code is linted and formatted with [ruff](https://docs.astral.sh/ruff/), enforced in
+CI — run `uv run ruff format .` before committing (see **Development** above).
 
 > **Working with an AI coding agent?** This project is built to be agent-navigable —
 > [`AGENTS.md`](AGENTS.md) is the entry point for coding agents, wiring in the project's

--- a/docs/adr/0029-lint-and-format-gate.md
+++ b/docs/adr/0029-lint-and-format-gate.md
@@ -1,0 +1,79 @@
+---
+status: accepted
+---
+
+# Lint and format gate: ruff (`check` + `format`), enforced in CI
+
+CI ([`ci.yml`](../../.github/workflows/ci.yml)) ran only `pytest -m "not e2e"` + `uv build`
+(+ a nightly e2e job) — **no lint or format gate**. Ruff was already used ad-hoc locally via
+`uvx` (a stray `.ruff_cache/`, versions 0.15.16 → 0.15.19, was the evidence) but it was
+**unconfigured, unpinned, and unenforced**: no `[tool.ruff]` config, no declared dependency,
+nothing to catch a finding on a PR. Style and lint therefore drifted silently. The repo
+already records CI/infra decisions as ADRs ([ADR-0007](0007-release-automation-with-release-please.md)
+release automation, [ADR-0016](0016-publish-to-pypi-via-trusted-publishing.md) PyPI
+publishing), so the choice of *what* gate to add — and what to leave out — belongs in the
+record too.
+
+## Decision
+
+**Enforce a lint + format gate with ruff alone (`ruff check` + `ruff format`), in CI only.**
+
+- **One tool, one config.** Ruff subsumes flake8 + black + isort, so none of those are added.
+  A single `[tool.ruff]` block in `pyproject.toml` is the authoritative config — consistent
+  with the project's single-authoritative-source habit, and faster than a multi-tool stack.
+
+- **A parallel `lint` CI job.** It runs `ruff check .` then `ruff format --check .`, reusing
+  the `setup-python-env` composite. It runs alongside the `python` job (fails fast,
+  independent signal) and sets `save-cache: false` because the `python` job already populates
+  that dependency-cache key — this job only reads it.
+
+- **ruff is a pinned dev dependency, locked in `uv.lock`.** `ruff format`'s output can shift
+  between versions, so the exact version is locked and CI resolves it with `uv sync --frozen`.
+  Local and CI then agree byte-for-byte — closing the version-drift the stray cache showed. A
+  ruff upgrade becomes a deliberate `uv.lock` bump, reviewed (and re-formatted) as its own
+  change rather than surprising a PR.
+
+- **Rule set = ruff's default high-signal `E4/E7/E9/F`, made explicit.** Deliberately *not*
+  full `E`: the `E1/E2/E3/E5` whitespace and line-length rules are owned by the formatter, and
+  enabling them fights `ruff format`. `F811` is ignored for [`src/gda/cli.py`](../../src/gda/cli.py):
+  Typer attaches same-named subcommands (`create`, `get`, …) to different sub-apps, so reusing
+  the function name is intentional — the descriptor-driven command surface
+  ([ADR-0023](0023-command-descriptor-single-registration.md)) — and F811 "redefinition" is a
+  false positive for that idiom.
+
+- **CI-only enforcement.** No pre-commit hook: developers run `uv run ruff format .` locally,
+  and the CI `lint` job is the authoritative backstop. The gate adds no new local-tooling
+  framework or convention the repo does not already have.
+
+## Considered options
+
+- **ruff only (chosen).** One binary, one config, formatter + linter + import-sort in a single
+  fast pass; pins cleanly via `uv.lock`.
+- **black + flake8 (+ isort) (rejected).** Three tools, three configs to keep coherent, slower,
+  and redundant with ruff — the opposite of the single-source habit.
+- **A broader rule set — `B` (bugbear), `UP` (pyupgrade), `I` (isort), or full `E` (deferred).**
+  Full `E` conflicts with the formatter; the others add value but also one-time churn and
+  judgement calls. Start with the high-signal default and **ratchet later** (a config-only
+  change) rather than land a large reformat and a rule expansion at once.
+- **Also add a pre-commit hook (deferred).** Better local feedback, but it introduces the
+  pre-commit framework and a new contributor convention the repo lacks today; the CI gate
+  already guarantees correctness. Revisit if local friction shows up.
+- **Gate GDScript too, via gdtoolkit (`gdlint`/`gdformat`) (deferred).** Only two `.gd` files
+  exist (the [gda harness](../../CONTEXT.md)); a separate Godot-ecosystem toolchain for that is
+  out of scope this round and can be its own decision if the GDScript surface grows.
+
+## Consequences
+
+- A one-time mechanical normalization precedes the gate: `ruff format` over the tree (81 files)
+  plus fixing the 5 real findings ruff reported (4 × `F401` unused import, 1 × `F841` unused
+  local). Landed as a separate `style:` commit so the gate-enabling diff stays reviewable.
+- The `cli.py` `F811` per-file-ignore also masks a *genuine* accidental redefinition in that
+  file. Accepted: `cli.py` is the command-registration module, full of intentionally same-named
+  commands, so the idiom dominates; a stray real redefinition there would surface as a failing
+  command, not silently.
+- [README](../../README.md) documents the gate (the **Development** and **Contributing**
+  sections) — `ruff check` / `ruff format` commands and the CI job. No new
+  [CONTEXT.md](../../CONTEXT.md) term: a lint gate is build tooling, not a domain concept.
+- Implemented and verified in PR #305 (tracked by #306): the `lint` job is green, `ruff check`
+  and `ruff format --check` pass under the locked version, a negative test confirms the gate
+  blocks a bad file, and `pytest -m "not e2e"` is unaffected.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ dev = [
     # The MCP SDK is also a dev dependency (not just the `[mcp]` extra) so
     # `uv run pytest` has it for the gda-mcp fast/e2e tiers (ADR-0013).
     "mcp>=1.12,<2",
+    # Lint + format gate (CI `lint` job). Pinned so `ruff format` output stays
+    # stable across the team and CI; the exact version is locked in uv.lock.
+    "ruff>=0.15.19,<0.16",
 ]
 
 [tool.pytest.ini_options]
@@ -64,3 +67,18 @@ testpaths = ["tests"]
 markers = [
     "e2e: tests that spawn a real Godot process (requires a 4.4+ engine)",
 ]
+
+[tool.ruff]
+target-version = "py313"  # ruff's default line-length (88) already matches the codebase
+
+[tool.ruff.lint]
+# Ruff's default high-signal set, made explicit and pinned against version drift.
+# Deliberately NOT full "E": E1/E2/E3/E5 are whitespace/line-length rules the
+# formatter owns — enabling them would conflict with `ruff format`.
+select = ["E4", "E7", "E9", "F"]
+
+[tool.ruff.lint.per-file-ignores]
+# Typer attaches same-named subcommands (create/get/...) to different sub-apps,
+# so reusing the function name is intentional; F811 "redefinition" is a false
+# positive for that idiom (the descriptor-driven command surface, ADR-0023).
+"src/gda/cli.py" = ["F811"]

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -284,17 +284,13 @@ app.add_typer(node_app, name="node")
 # disk (write text / read text back), so they stay headless. C# (.cs) is out of
 # scope for now — it needs the .NET build of Godot (ADR-0003 targets the standard
 # build) and a dedicated decision.
-script_app = typer.Typer(
-    help="Act on script files (.gd).", no_args_is_help=True
-)
+script_app = typer.Typer(help="Act on script files (.gd).", no_args_is_help=True)
 app.add_typer(script_app, name="script")
 
 # The resource command group (issue #112): commands acting on .tres resource
 # files on disk (load/save plumbing), so they stay headless. The group is a
 # .tres tracer; the binary .res form is out of scope for this slice.
-resource_app = typer.Typer(
-    help="Act on resource files (.tres).", no_args_is_help=True
-)
+resource_app = typer.Typer(help="Act on resource files (.tres).", no_args_is_help=True)
 app.add_typer(resource_app, name="resource")
 
 # The export command group (issue #114): read-only discovery of the project's
@@ -328,9 +324,7 @@ app.add_typer(project_app, name="project")
 # create/get/set and attach/validate. This bounds the operation, not the run:
 # every command still goes through the headless runner, so resolving --project
 # still constructs the project's autoloads at engine startup (ADR-0009).
-shader_app = typer.Typer(
-    help="Act on shader files (.gdshader).", no_args_is_help=True
-)
+shader_app = typer.Typer(help="Act on shader files (.gdshader).", no_args_is_help=True)
 app.add_typer(shader_app, name="shader")
 
 theme_app = typer.Typer(
@@ -581,9 +575,7 @@ def _emit(
     (:func:`_dispatch`) and the meta dispatch (:func:`_dispatch_meta`) funnel
     through here; they differ only in how ``project`` is obtained.
     """
-    make_runner = (
-        _make_live_runner if cmd.kind is ExecutionKind.LIVE else _make_runner
-    )
+    make_runner = _make_live_runner if cmd.kind is ExecutionKind.LIVE else _make_runner
     cmd.emit(
         params,
         godot=godot,
@@ -1211,8 +1203,12 @@ INPUT_MOUSE_MOVE_COMMAND: HeadlessCommand[InputMouseResult] = HeadlessCommand(
 
 @input_app.command(name="mouse-move", cls=INPUT_MOUSE_MOVE_COMMAND.command_class())
 def input_mouse_move(
-    x: float = typer.Argument(..., help="The motion's target x position in the viewport."),
-    y: float = typer.Argument(..., help="The motion's target y position in the viewport."),
+    x: float = typer.Argument(
+        ..., help="The motion's target x position in the viewport."
+    ),
+    y: float = typer.Argument(
+        ..., help="The motion's target y position in the viewport."
+    ),
     json_output: bool = json_option(),
     schema: bool = INPUT_MOUSE_MOVE_COMMAND.schema_option(),
     params_json: Optional[str] = params_json_option(),
@@ -1828,11 +1824,13 @@ PROJECT_SET_COMMAND: HeadlessCommand[ProjectSetResult] = HeadlessCommand(
     render=render_project_set,
 )
 
-PROJECT_ADD_AUTOLOAD_COMMAND: HeadlessCommand[ProjectAddAutoloadResult] = HeadlessCommand(
-    operation="project-add-autoload",
-    input_model=ProjectAddAutoloadParams,
-    output_model=ProjectAddAutoloadResult,
-    render=render_project_add_autoload,
+PROJECT_ADD_AUTOLOAD_COMMAND: HeadlessCommand[ProjectAddAutoloadResult] = (
+    HeadlessCommand(
+        operation="project-add-autoload",
+        input_model=ProjectAddAutoloadParams,
+        output_model=ProjectAddAutoloadResult,
+        render=render_project_add_autoload,
+    )
 )
 
 PROJECT_REMOVE_AUTOLOAD_COMMAND: HeadlessCommand[ProjectRemoveAutoloadResult] = (
@@ -2145,9 +2143,7 @@ def set_property(
     """Set a node property, coercing the value to its declared Godot type."""
     _dispatch(
         NODE_SET_COMMAND,
-        NodeSetParams(
-            path=path, node=node, property=property, value=value
-        ),
+        NodeSetParams(path=path, node=node, property=property, value=value),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -2621,7 +2617,8 @@ def project_info(
 @project_app.command(name="get", cls=PROJECT_GET_COMMAND.command_class())
 def project_get(
     setting: str = typer.Argument(
-        ..., help="The project setting's full section/key name (e.g. application/config/name)."
+        ...,
+        help="The project setting's full section/key name (e.g. application/config/name).",
     ),
     json_output: bool = json_option(),
     schema: bool = PROJECT_GET_COMMAND.schema_option(),
@@ -2695,9 +2692,7 @@ def create(
 ) -> None:
     """Create a new .gdshader from a template or verbatim --content."""
     if content is not None and shader_type is not None:
-        raise typer.BadParameter(
-            "--content and --shader-type are mutually exclusive."
-        )
+        raise typer.BadParameter("--content and --shader-type are mutually exclusive.")
     _dispatch(
         SHADER_CREATE_COMMAND,
         ShaderCreateParams(
@@ -2734,7 +2729,9 @@ def get_resource(
 def set_resource(
     path: str = typer.Argument(..., help="The .tres resource file to mutate."),
     property: str = typer.Option(
-        ..., "--property", help="The resource property to set (e.g. interpolation_mode)."
+        ...,
+        "--property",
+        help="The resource property to set (e.g. interpolation_mode).",
     ),
     value: str = typer.Option(
         ...,
@@ -2753,9 +2750,7 @@ def set_resource(
     """Set a .tres property, coercing the value to its declared Godot type, then save."""
     _dispatch(
         RESOURCE_SET_COMMAND,
-        ResourceSetParams(
-            path=path, property=property, value=value
-        ),
+        ResourceSetParams(path=path, property=property, value=value),
         json_output=json_output,
         godot=godot,
         project=project,
@@ -3037,7 +3032,8 @@ def set_shader(
 @project_app.command(name="set", cls=PROJECT_SET_COMMAND.command_class())
 def project_set(
     setting: str = typer.Argument(
-        ..., help="The project setting's full section/key name (e.g. application/config/name)."
+        ...,
+        help="The project setting's full section/key name (e.g. application/config/name).",
     ),
     value: str = typer.Option(
         ...,
@@ -3071,7 +3067,8 @@ def project_add_autoload(
         ..., help="The autoload singleton's global name (the autoload/<name> key)."
     ),
     path: str = typer.Argument(
-        ..., help="The res:// path to the script or scene to autoload (e.g. res://global.gd)."
+        ...,
+        help="The res:// path to the script or scene to autoload (e.g. res://global.gd).",
     ),
     json_output: bool = json_option(),
     schema: bool = PROJECT_ADD_AUTOLOAD_COMMAND.schema_option(),

--- a/src/gda/daemon/diag.py
+++ b/src/gda/daemon/diag.py
@@ -34,7 +34,9 @@ _ERROR_HEADER = re.compile(r"^(ERROR|WARNING|SCRIPT ERROR|SHADER ERROR): (.*)$")
 
 # The engine's follow-on location line: ``   at: <function> (<file>:<line>)``.
 # Leading whitespace varies by ErrorType indent, so it is matched loosely.
-_AT_LINE = re.compile(r"^\s*at:\s*(?P<function>.*?)\s*\((?P<file>.*):(?P<line>\d+)\)\s*$")
+_AT_LINE = re.compile(
+    r"^\s*at:\s*(?P<function>.*?)\s*\((?P<file>.*):(?P<line>\d+)\)\s*$"
+)
 
 # After the ``at:`` line, a runtime GDScript error MAY carry a full call stack:
 # a marker line ``GDScript backtrace (most recent call first):`` then one frame
@@ -296,7 +298,11 @@ def _error_record(seq: int, entry: dict) -> dict:
     # (no follow-on) leaves `source` null rather than an all-null frame.
     has_location = any(entry.get(k) is not None for k in ("function", "file", "line"))
     source = (
-        {"function": entry.get("function"), "file": entry.get("file"), "line": entry.get("line")}
+        {
+            "function": entry.get("function"),
+            "file": entry.get("file"),
+            "line": entry.get("line"),
+        }
         if has_location
         else None
     )

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -88,10 +88,18 @@ class EngineSession:
                 f"the engine session did not return within {int(OP_TIMEOUT)}s",
             )
         except OSError:
-            return error_reply("engine_disconnected", "the engine session dropped the connection")
+            return error_reply(
+                "engine_disconnected", "the engine session dropped the connection"
+            )
         if reply is None:
-            return error_reply("engine_disconnected", "the engine session closed before replying")
-        return {"stdout": reply.decode("utf-8", "replace"), "stderr": "", "exit_code": 0}
+            return error_reply(
+                "engine_disconnected", "the engine session closed before replying"
+            )
+        return {
+            "stdout": reply.decode("utf-8", "replace"),
+            "stderr": "",
+            "exit_code": 0,
+        }
 
     def close(self) -> None:
         if self._conn is not None:
@@ -246,5 +254,3 @@ def _terminate(proc: subprocess.Popen) -> None:
             proc.kill()
         except OSError:
             pass
-
-

--- a/src/gda/daemon_ops.py
+++ b/src/gda/daemon_ops.py
@@ -277,7 +277,9 @@ def run_daemon_stop_operation(project: Optional[Path]) -> "DaemonStopResult | Fa
     return DaemonStopResult(stopped=True, pid=pid)
 
 
-def run_daemon_status_operation(project: Optional[Path]) -> "DaemonStatusResult | Failure":
+def run_daemon_status_operation(
+    project: Optional[Path],
+) -> "DaemonStatusResult | Failure":
     if not _is_unix():
         return _failure(
             "live_unsupported_platform",

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -422,7 +422,9 @@ def _live_error_from_payload(result: RunResult) -> Failure | None:
     return None
 
 
-def classify_live(result: RunResult, binary: Path, output_model: type[M]) -> M | Failure:
+def classify_live(
+    result: RunResult, binary: Path, output_model: type[M]
+) -> M | Failure:
     """Classify a live operation's raw result (ADR-0017).
 
     A live op returns the same ``RunResult`` + ADR-0002 sentinel a headless op
@@ -475,12 +477,16 @@ def classify_logger_tail(result: RunResult, binary: Path) -> LoggerTailResult | 
     return classify_live(result, binary, LoggerTailResult)
 
 
-def classify_perf_monitors(result: RunResult, binary: Path) -> PerfMonitorsResult | Failure:
+def classify_perf_monitors(
+    result: RunResult, binary: Path
+) -> PerfMonitorsResult | Failure:
     """The per-command live classifier for ``gda perf monitors`` (#223, mirrors ``classify_game_tree``)."""
     return classify_live(result, binary, PerfMonitorsResult)
 
 
-def classify_perf_monitor(result: RunResult, binary: Path) -> PerfMonitorResult | Failure:
+def classify_perf_monitor(
+    result: RunResult, binary: Path
+) -> PerfMonitorResult | Failure:
     """The per-command live classifier for ``gda perf monitor`` (#223, mirrors ``classify_game_tree``)."""
     return classify_live(result, binary, PerfMonitorResult)
 
@@ -495,12 +501,16 @@ def classify_input_mouse(result: RunResult, binary: Path) -> InputMouseResult | 
     return classify_live(result, binary, InputMouseResult)
 
 
-def classify_input_action(result: RunResult, binary: Path) -> InputActionResult | Failure:
+def classify_input_action(
+    result: RunResult, binary: Path
+) -> InputActionResult | Failure:
     """The per-command live classifier for ``gda input action`` (#221, mirrors ``classify_game_tree``)."""
     return classify_live(result, binary, InputActionResult)
 
 
-def classify_input_sequence(result: RunResult, binary: Path) -> InputSequenceResult | Failure:
+def classify_input_sequence(
+    result: RunResult, binary: Path
+) -> InputSequenceResult | Failure:
     """The per-command live classifier for ``gda input sequence`` (#221, mirrors ``classify_game_tree``)."""
     return classify_live(result, binary, InputSequenceResult)
 

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -191,9 +191,7 @@ def schema_command_class(
         gda_output_model = output_model
         gda_command = command
 
-        def _parse_relaxed(
-            self, ctx: typer.Context, args: list[str]
-        ) -> list[str]:
+        def _parse_relaxed(self, ctx: typer.Context, args: list[str]) -> list[str]:
             # Parse with required args relaxed, so a probe that omits the
             # individual operation args still succeeds, while Click still rejects
             # unknown options / extra positionals and an eager ``--help`` still
@@ -244,8 +242,7 @@ def schema_command_class(
                 # operation argument may also be given on the command line; the
                 # global flags (--json/--godot/--project/--schema) still compose.
                 if any(
-                    name not in _GLOBAL_OPTION_NAMES
-                    and _from_command_line(ctx, name)
+                    name not in _GLOBAL_OPTION_NAMES and _from_command_line(ctx, name)
                     for name in ctx.params
                 ):
                     emit_failure(conflicting_params_input_failure())
@@ -430,7 +427,5 @@ class HeadlessCommand(Generic[M]):
         renderer, ADR-0023) — the descriptor is in hand here, so there is no
         type-keyed table to consult.
         """
-        result = self.run(
-            params, godot=godot, project=project, make_runner=make_runner
-        )
+        result = self.run(params, godot=godot, project=project, make_runner=make_runner)
         emit_result(result, json_output, self.render)

--- a/src/gda/mcp/server.py
+++ b/src/gda/mcp/server.py
@@ -152,8 +152,7 @@ def dispatch(
             # exit 0 but non-JSON stdout: gda could not have honored ``--json``.
             # Treat as the can't-run / non-envelope edge rather than crash.
             return _synthesized_error(
-                "gda exited 0 but did not emit a JSON result for "
-                f"{' '.join(argv)!r}",
+                f"gda exited 0 but did not emit a JSON result for {' '.join(argv)!r}",
                 result,
             )
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -705,9 +705,7 @@ class NodeSetParams(BaseModel):
             "itself, 'Player/Arm' a nested node."
         )
     )
-    property: str = Field(
-        description="The property to set (e.g. position, visible)."
-    )
+    property: str = Field(description="The property to set (e.g. position, visible).")
     value: str = Field(
         description=(
             "The value to set, as a string. The operation coerces it to the "
@@ -731,7 +729,9 @@ class NodeSetResult(BaseModel):
         description="The addressed node's node path, relative to the scene root."
     )
     property: str
-    type: str = Field(description="The property's declared Godot type the value was coerced to.")
+    type: str = Field(
+        description="The property's declared Godot type the value was coerced to."
+    )
     value: Any = Field(
         description="The coerced value as JSON, as the node now holds it."
     )
@@ -807,9 +807,7 @@ class NodeDuplicateResult(BaseModel):
     path: str = Field(
         description="The new copy's node path, relative to the scene root."
     )
-    name: str = Field(
-        description="The fresh, non-colliding name assigned to the copy."
-    )
+    name: str = Field(description="The fresh, non-colliding name assigned to the copy.")
     type: str = Field(description="The copy's engine class (e.g. Sprite2D).")
 
 
@@ -1020,15 +1018,13 @@ class ScriptCreateResult(BaseModel):
     class_name: str | None = Field(
         default=None,
         description=(
-            "The class_name the written script declares, or null when it "
-            "declares none."
+            "The class_name the written script declares, or null when it declares none."
         ),
     )
     extends: str | None = Field(
         default=None,
         description=(
-            "The base class the written script extends, or null when it "
-            "declares none."
+            "The base class the written script extends, or null when it declares none."
         ),
     )
     created_dirs: list[str] = Field(
@@ -1298,15 +1294,13 @@ class ScriptSetResult(BaseModel):
     class_name: str | None = Field(
         default=None,
         description=(
-            "The class_name the edited source declares, or null when it "
-            "declares none."
+            "The class_name the edited source declares, or null when it declares none."
         ),
     )
     extends: str | None = Field(
         default=None,
         description=(
-            "The base class the edited source extends, or null when it "
-            "declares none."
+            "The base class the edited source extends, or null when it declares none."
         ),
     )
 
@@ -1327,9 +1321,7 @@ class ScriptAttachParams(BaseModel):
     success — check a script with ``script validate`` first.
     """
 
-    path: NormalizedPath = Field(
-        description="The .tscn scene file to mutate."
-    )
+    path: NormalizedPath = Field(description="The .tscn scene file to mutate.")
     node: str = Field(
         description=(
             "Node path relative to the scene root: '.' addresses the root "
@@ -1685,9 +1677,7 @@ class ExportRunResult(BaseModel):
         description="The preset's target platform (e.g. Linux/X11, Web, macOS)."
     )
     mode: ExportRunMode = Field(description="The export flavor that was run.")
-    output_path: str = Field(
-        description="The path the export artifact was written to."
-    )
+    output_path: str = Field(description="The path the export artifact was written to.")
     warnings: list[str] = Field(
         default_factory=list,
         description="The engine's non-fatal export warnings, parsed from stderr; empty on a clean export.",
@@ -1882,7 +1872,9 @@ class ResourceDeleteResult(BaseModel):
     """
 
     path: str
-    type: str = Field(description="The deleted resource's engine class (e.g. Gradient).")
+    type: str = Field(
+        description="The deleted resource's engine class (e.g. Gradient)."
+    )
 
 
 class ResourceUidResult(BaseModel):
@@ -2026,8 +2018,7 @@ class ShaderSetResult(BaseModel):
     shader_type: str | None = Field(
         default=None,
         description=(
-            "The shader_type the edited source declares, or null when it "
-            "declares none."
+            "The shader_type the edited source declares, or null when it declares none."
         ),
     )
 
@@ -2056,9 +2047,7 @@ class ThemeCreateResult(BaseModel):
     """
 
     path: str
-    type: str = Field(
-        description="The resource type written to the .tres (Theme)."
-    )
+    type: str = Field(description="The resource type written to the .tres (Theme).")
     created_dirs: list[str] = Field(
         description=(
             "Parent directories created before saving, from outermost to innermost."
@@ -2129,9 +2118,7 @@ class Dependency(BaseModel):
     """
 
     path: str = Field(description="The res:// path of the referenced resource.")
-    kind: str = Field(
-        description="How the resource is referenced (ext_resource)."
-    )
+    kind: str = Field(description="How the resource is referenced (ext_resource).")
 
 
 class ResourceDependencies(BaseModel):
@@ -2212,7 +2199,9 @@ class Autoload(BaseModel):
     """
 
     name: str
-    path: str = Field(description="The autoload's res:// path (enable marker stripped).")
+    path: str = Field(
+        description="The autoload's res:// path (enable marker stripped)."
+    )
 
 
 class ProjectStatisticsResult(BaseModel):
@@ -2349,7 +2338,9 @@ class ProjectInfoResult(BaseModel):
     them, so a brand-new project still reports a complete, valid result.
     """
 
-    name: str = Field(description="The project name (ProjectSettings application/config/name).")
+    name: str = Field(
+        description="The project name (ProjectSettings application/config/name)."
+    )
     main_scene: str = Field(
         description=(
             "The project's main scene path (application/run/main_scene), or the "
@@ -2377,8 +2368,7 @@ class ProjectGetParams(BaseModel):
 
     setting: str = Field(
         description=(
-            "The project setting's full section/key name, e.g. "
-            "application/config/name."
+            "The project setting's full section/key name, e.g. application/config/name."
         )
     )
 
@@ -2417,8 +2407,7 @@ class ProjectSetParams(BaseModel):
 
     setting: str = Field(
         description=(
-            "The project setting's full section/key name, e.g. "
-            "application/config/name."
+            "The project setting's full section/key name, e.g. application/config/name."
         )
     )
     value: str = Field(
@@ -2440,7 +2429,9 @@ class ProjectSetResult(BaseModel):
     """
 
     setting: str
-    type: str = Field(description="The setting's declared Godot type the value was coerced to.")
+    type: str = Field(
+        description="The setting's declared Godot type the value was coerced to."
+    )
     value: Any = Field(
         description="The coerced value as JSON, as ProjectSettings now holds it."
     )
@@ -2465,8 +2456,7 @@ class ProjectAddAutoloadParams(BaseModel):
     )
     path: NormalizedPath = Field(
         description=(
-            "The res:// path to the script or scene to autoload, e.g. "
-            "res://global.gd."
+            "The res:// path to the script or scene to autoload, e.g. res://global.gd."
         )
     )
 
@@ -2616,8 +2606,12 @@ class GameSetResult(BaseModel):
 
     path: str = Field(description="The addressed node's runtime (absolute) path.")
     property: str
-    type: str = Field(description="The property's declared Godot type the value was coerced to.")
-    value: Any = Field(description="The coerced value as JSON, as the running node now holds it.")
+    type: str = Field(
+        description="The property's declared Godot type the value was coerced to."
+    )
+    value: Any = Field(
+        description="The coerced value as JSON, as the running node now holds it."
+    )
 
 
 # The `diag` command group (Phase 2, ADR-0019): the RUNNING game's runtime
@@ -2641,11 +2635,16 @@ class SourceFrame(BaseModel):
     parse failure).
     """
 
-    function: str | None = Field(default=None, description="The frame's function name, if known.")
-    file: str | None = Field(
-        default=None, description="The frame's source path (e.g. res://main.gd), if known."
+    function: str | None = Field(
+        default=None, description="The frame's function name, if known."
     )
-    line: int | None = Field(default=None, description="The frame's source line, if known.")
+    file: str | None = Field(
+        default=None,
+        description="The frame's source path (e.g. res://main.gd), if known.",
+    )
+    line: int | None = Field(
+        default=None, description="The frame's source line, if known."
+    )
 
 
 class DiagError(BaseModel):
@@ -2666,7 +2665,8 @@ class DiagError(BaseModel):
     )
     message: str = Field(description="The error/warning message the engine logged.")
     function: str | None = Field(
-        default=None, description="The reporting function, if the log had an `at:` line."
+        default=None,
+        description="The reporting function, if the log had an `at:` line.",
     )
     file: str | None = Field(
         default=None, description="The source path (e.g. res://main.gd), if known."
@@ -2756,7 +2756,9 @@ class LogRecord(BaseModel):
     """
 
     seq: int = Field(description="Monotonic ordinal in capture order (0-based).")
-    level: LogLevel = Field(description="Closed, ordered severity: debug < info < warning < error.")
+    level: LogLevel = Field(
+        description="Closed, ordered severity: debug < info < warning < error."
+    )
     message: str = Field(description="The logged message text.")
     source: SourceFrame | None = Field(
         default=None,
@@ -3096,9 +3098,7 @@ class InputMouseClickParams(BaseModel):
         default=MouseButton.LEFT,
         description="Which mouse button to click: left, right, or middle.",
     )
-    double: bool = Field(
-        default=False, description="Mark the event a double click."
-    )
+    double: bool = Field(default=False, description="Mark the event a double click.")
 
 
 class InputMouseMoveParams(BaseModel):
@@ -3121,7 +3121,9 @@ class InputMouseResult(BaseModel):
     and whether it was a ``double`` click (both null for a move).
     """
 
-    kind: str = Field(description="The injected event kind: 'mouse_click' or 'mouse_move'.")
+    kind: str = Field(
+        description="The injected event kind: 'mouse_click' or 'mouse_move'."
+    )
     position: list[float] = Field(
         description="The viewport position the event was injected at, as [x, y]."
     )
@@ -3129,7 +3131,8 @@ class InputMouseResult(BaseModel):
         default=None, description="The clicked button (a click only); null for a move."
     )
     double: bool | None = Field(
-        default=None, description="Whether the click was a double click; null for a move."
+        default=None,
+        description="Whether the click was a double click; null for a move.",
     )
 
 
@@ -3167,10 +3170,14 @@ class InputActionResult(BaseModel):
     action fired against the running ``InputMap`` at a frame boundary (ADR-0020).
     """
 
-    kind: str = Field(default="action", description="The injected event kind ('action').")
+    kind: str = Field(
+        default="action", description="The injected event kind ('action')."
+    )
     action: str = Field(description="The action name that was driven.")
     pressed: bool = Field(description="True for a press, false for a release.")
-    strength: float = Field(description="The press strength applied (0.0 on a release).")
+    strength: float = Field(
+        description="The press strength applied (0.0 on a release)."
+    )
 
 
 # The event types a `gda input sequence` may carry. A sequence event reuses the
@@ -3226,7 +3233,9 @@ class InputSequenceEvent(BaseModel):
         default=False, description="A mouse-click event: mark it a double click."
     )
     # action fields
-    action: str | None = Field(default=None, description="An action event's action name.")
+    action: str | None = Field(
+        default=None, description="An action event's action name."
+    )
     release: bool = Field(
         default=False, description="An action event: release instead of press."
     )
@@ -3404,7 +3413,9 @@ class ScreenFrame(BaseModel):
     an N-frame sequence is path-only so it never blows the agent's context.
     """
 
-    path: str = Field(description="The filesystem path this frame's PNG was written to.")
+    path: str = Field(
+        description="The filesystem path this frame's PNG was written to."
+    )
     width: int = Field(description="The frame's width in pixels.")
     height: int = Field(description="The frame's height in pixels.")
     bytes: int = Field(description="The written PNG's size in bytes.")

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -90,7 +90,7 @@ if TYPE_CHECKING:
         ProjectFindReferencesResult,
         ProjectFindUnusedResourcesResult,
         ProjectStatisticsResult,
-)
+    )
 
 
 @runtime_checkable
@@ -276,9 +276,7 @@ def render_perf_monitor(timeline: "PerfMonitorResult") -> str:
         ]
         return "\n".join([header, *rows])
     header = f"{timeline.node} property {timeline.property} ({timeline.frames} frames)"
-    rows = [
-        f"  frame {s.frame}: {format_value(s.value)}" for s in timeline.samples
-    ]
+    rows = [f"  frame {s.frame}: {format_value(s.value)}" for s in timeline.samples]
     return "\n".join([header, *rows])
 
 
@@ -441,8 +439,7 @@ def render_node_remove(removed: "NodeRemoveResult") -> str:
 def render_node_duplicate(duplicated: "NodeDuplicateResult") -> str:
     """Render a duplicated node as ``duplicated <source> to <path> (<type>)``."""
     return (
-        f"duplicated {duplicated.source_path} to {duplicated.path} "
-        f"({duplicated.type})"
+        f"duplicated {duplicated.source_path} to {duplicated.path} ({duplicated.type})"
     )
 
 
@@ -512,9 +509,7 @@ def render_script_set(edited: "ScriptSetResult") -> str:
 
 def render_script_attach(attached: "ScriptAttachResult") -> str:
     """Render an attached script as ``attached <script> to <node> in <scene>``."""
-    return (
-        f"attached {attached.script} to {attached.node} in {attached.scene_path}"
-    )
+    return f"attached {attached.script} to {attached.node} in {attached.scene_path}"
 
 
 def render_script_validate(validated: "ScriptValidateResult") -> str:
@@ -593,8 +588,7 @@ def render_export_run(ran: "ExportRunResult") -> str:
     non-fatal engine warning (a clean export prints just the header line).
     """
     header = (
-        f"exported {ran.preset} ({ran.platform}, {ran.mode.value}) "
-        f"-> {ran.output_path}"
+        f"exported {ran.preset} ({ran.platform}, {ran.mode.value}) -> {ran.output_path}"
     )
     if not ran.warnings:
         return header

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,6 @@ needs its own ``project.godot`` must build it through this helper (passing its
 extra sections via ``extra``) so the logging stays disabled.
 """
 
-import os
 import shutil
 import tempfile
 from pathlib import Path

--- a/tests/support.py
+++ b/tests/support.py
@@ -561,14 +561,38 @@ LOGGER_TAIL_RESULT = {
 # carrying its verbatim text (even an ``ERROR:`` header stays a plain info line).
 LOGGER_TAIL_RAW_RESULT = {
     "records": [
-        {"seq": 0, "level": "info", "message": "known line",
-         "source": None, "origin": None, "fields": {}},
-        {"seq": 1, "level": "info", "message": "ERROR: boom",
-         "source": None, "origin": None, "fields": {}},
-        {"seq": 2, "level": "info", "message": "   at: _ready (res://main.gd:9)",
-         "source": None, "origin": None, "fields": {}},
-        {"seq": 3, "level": "info", "message": "another line",
-         "source": None, "origin": None, "fields": {}},
+        {
+            "seq": 0,
+            "level": "info",
+            "message": "known line",
+            "source": None,
+            "origin": None,
+            "fields": {},
+        },
+        {
+            "seq": 1,
+            "level": "info",
+            "message": "ERROR: boom",
+            "source": None,
+            "origin": None,
+            "fields": {},
+        },
+        {
+            "seq": 2,
+            "level": "info",
+            "message": "   at: _ready (res://main.gd:9)",
+            "source": None,
+            "origin": None,
+            "fields": {},
+        },
+        {
+            "seq": 3,
+            "level": "info",
+            "message": "another line",
+            "source": None,
+            "origin": None,
+            "fields": {},
+        },
     ],
 }
 

--- a/tests/test_asset_file_commands.py
+++ b/tests/test_asset_file_commands.py
@@ -36,7 +36,14 @@ def test_shader_create_json_maps_success_to_json_object_and_exit_zero(monkeypatc
 
     result = CliRunner().invoke(
         app,
-        ["shader", "create", "/tmp/proj/wave.gdshader", "--shader-type", "canvas_item", "--json"],
+        [
+            "shader",
+            "create",
+            "/tmp/proj/wave.gdshader",
+            "--shader-type",
+            "canvas_item",
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0
@@ -62,10 +69,13 @@ def test_shader_create_default_template_passes_null_content_and_type(monkeypatch
     # The bare template: no --content, no --shader-type. Both pass through as
     # null, so the operation writes its default canvas_item template.
     fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0),
     )
 
-    result = CliRunner().invoke(app, ["shader", "create", "/tmp/proj/wave.gdshader", "--json"])
+    result = CliRunner().invoke(
+        app, ["shader", "create", "/tmp/proj/wave.gdshader", "--json"]
+    )
 
     assert result.exit_code == 0
     assert fake.calls == [
@@ -81,7 +91,11 @@ def test_shader_create_content_passes_verbatim_source(monkeypatch):
         monkeypatch,
         RunResult(
             stdout=sentinel(
-                {"path": "/tmp/proj/x.gdshader", "shader_type": "spatial", "created_dirs": []}
+                {
+                    "path": "/tmp/proj/x.gdshader",
+                    "shader_type": "spatial",
+                    "created_dirs": [],
+                }
             ),
             stderr="",
             exit_code=0,
@@ -117,7 +131,8 @@ def test_shader_create_content_and_type_are_mutually_exclusive(monkeypatch):
     # Verbatim content is not templated, so a shader_type has nowhere to go;
     # supplying both is a usage error (exit 2), never a silent precedence rule.
     fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(
@@ -148,7 +163,9 @@ def test_shader_get_json_emits_source_and_metadata_and_exit_zero(monkeypatch):
     stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(SHADER_GET_RESULT)
     fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
 
-    result = CliRunner().invoke(app, ["shader", "get", "/tmp/proj/wave.gdshader", "--json"])
+    result = CliRunner().invoke(
+        app, ["shader", "get", "/tmp/proj/wave.gdshader", "--json"]
+    )
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -165,7 +182,8 @@ def test_shader_set_search_replace_dispatches_search_and_replace(monkeypatch):
     # pass as null. The CLI resolves the edit mode once and stamps the explicit
     # `mode` discriminator (issue #133) — the SAME ScriptSetMode as script set.
     fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(
@@ -201,7 +219,8 @@ def test_shader_set_search_replace_dispatches_search_and_replace(monkeypatch):
 
 def test_shader_set_line_range_dispatches_start_end_and_content(monkeypatch):
     fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(
@@ -239,12 +258,20 @@ def test_shader_set_line_range_dispatches_start_end_and_content(monkeypatch):
 
 def test_shader_set_full_overwrite_dispatches_content_only(monkeypatch):
     fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(
         app,
-        ["shader", "set", "/tmp/proj/wave.gdshader", "--content", "shader_type spatial;\n", "--json"],
+        [
+            "shader",
+            "set",
+            "/tmp/proj/wave.gdshader",
+            "--content",
+            "shader_type spatial;\n",
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0
@@ -273,17 +300,21 @@ def _assert_set_usage_error(fake, result):
 
 def test_shader_set_no_flags_is_a_usage_error(monkeypatch):
     fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
     )
 
-    result = CliRunner().invoke(app, ["shader", "set", "/tmp/proj/wave.gdshader", "--json"])
+    result = CliRunner().invoke(
+        app, ["shader", "set", "/tmp/proj/wave.gdshader", "--json"]
+    )
 
     _assert_set_usage_error(fake, result)
 
 
 def test_shader_set_search_without_replace_is_a_usage_error(monkeypatch):
     fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(
@@ -295,7 +326,8 @@ def test_shader_set_search_without_replace_is_a_usage_error(monkeypatch):
 
 def test_shader_set_search_replace_and_content_are_mutually_exclusive(monkeypatch):
     fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(
@@ -341,18 +373,23 @@ def test_theme_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch
 
 def test_shader_create_human_output(monkeypatch):
     inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(app, ["shader", "create", "/tmp/proj/wave.gdshader"])
 
     assert result.exit_code == 0
-    assert result.stdout.strip() == "created /tmp/proj/wave.gdshader (shader_type canvas_item)"
+    assert (
+        result.stdout.strip()
+        == "created /tmp/proj/wave.gdshader (shader_type canvas_item)"
+    )
 
 
 def test_shader_get_human_output_renders_metadata_then_source(monkeypatch):
     inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SHADER_GET_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SHADER_GET_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(app, ["shader", "get", "/tmp/proj/wave.gdshader"])
@@ -364,7 +401,8 @@ def test_shader_get_human_output_renders_metadata_then_source(monkeypatch):
 
 def test_shader_set_human_output_renders_metadata(monkeypatch):
     inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(
@@ -377,7 +415,8 @@ def test_shader_set_human_output_renders_metadata(monkeypatch):
 
 def test_theme_create_human_output(monkeypatch):
     inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(THEME_CREATE_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(THEME_CREATE_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(app, ["theme", "create", "/tmp/proj/ui.tres"])

--- a/tests/test_asset_file_errors.py
+++ b/tests/test_asset_file_errors.py
@@ -23,7 +23,8 @@ def _invoke(monkeypatch, argv, code, message, op):
     inject_runner(
         monkeypatch,
         RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n" + error_sentinel(code, message),
+            stdout="Godot Engine v4.6.3.stable.official\n"
+            + error_sentinel(code, message),
             stderr=f"gda: running operation: {op}\n",
             exit_code=1,
         ),
@@ -40,7 +41,16 @@ def _get_argv():
 
 
 def _set_argv():
-    return ["shader", "set", "/x/wave.gdshader", "--search", "a", "--replace", "b", "--json"]
+    return [
+        "shader",
+        "set",
+        "/x/wave.gdshader",
+        "--search",
+        "a",
+        "--replace",
+        "b",
+        "--json",
+    ]
 
 
 def _theme_argv():
@@ -55,8 +65,11 @@ def test_shader_create_collision_reuses_stable_already_exists_code(monkeypatch):
     # already_exists code (the same one scene/script create use), leaving the
     # file untouched — the shader group mints no parallel collision code.
     result = _invoke(
-        monkeypatch, _create_argv(), "already_exists",
-        "shader target already exists: /x/wave.gdshader", "shader-create",
+        monkeypatch,
+        _create_argv(),
+        "already_exists",
+        "shader target already exists: /x/wave.gdshader",
+        "shader-create",
     )
 
     assert result.exit_code == 4
@@ -69,8 +82,11 @@ def test_shader_create_collision_reuses_stable_already_exists_code(monkeypatch):
 
 def test_shader_create_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
     result = _invoke(
-        monkeypatch, _create_argv(), "invalid_path",
-        "shader path must end in .gdshader: /x/wave.txt", "shader-create",
+        monkeypatch,
+        _create_argv(),
+        "invalid_path",
+        "shader path must end in .gdshader: /x/wave.txt",
+        "shader-create",
     )
 
     assert result.exit_code == 4
@@ -81,8 +97,11 @@ def test_shader_create_wrong_extension_reuses_stable_invalid_path_code(monkeypat
 
 def test_shader_create_unwritable_target_reuses_stable_save_failed_code(monkeypatch):
     result = _invoke(
-        monkeypatch, _create_argv(), "save_failed",
-        "failed to save shader to /x/wave.gdshader", "shader-create",
+        monkeypatch,
+        _create_argv(),
+        "save_failed",
+        "failed to save shader to /x/wave.gdshader",
+        "shader-create",
     )
 
     assert result.exit_code == 4
@@ -94,8 +113,11 @@ def test_shader_create_unwritable_target_reuses_stable_save_failed_code(monkeypa
 
 def test_shader_get_missing_file_reuses_stable_path_not_found_code(monkeypatch):
     result = _invoke(
-        monkeypatch, _get_argv(), "path_not_found",
-        "shader file does not exist: /x/wave.gdshader", "shader-get",
+        monkeypatch,
+        _get_argv(),
+        "path_not_found",
+        "shader file does not exist: /x/wave.gdshader",
+        "shader-get",
     )
 
     assert result.exit_code == 4
@@ -107,8 +129,11 @@ def test_shader_get_missing_file_reuses_stable_path_not_found_code(monkeypatch):
 
 def test_shader_get_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
     result = _invoke(
-        monkeypatch, _get_argv(), "invalid_path",
-        "shader path must end in .gdshader: /x/notes.txt", "shader-get",
+        monkeypatch,
+        _get_argv(),
+        "invalid_path",
+        "shader path must end in .gdshader: /x/notes.txt",
+        "shader-get",
     )
 
     assert result.exit_code == 4
@@ -119,8 +144,11 @@ def test_shader_set_missing_file_reuses_stable_path_not_found_code(monkeypatch):
     # set edits an existing shader; a missing target is path_not_found, never a
     # silent create (the same rule as script set).
     result = _invoke(
-        monkeypatch, _set_argv(), "path_not_found",
-        "shader file does not exist: /x/wave.gdshader", "shader-set",
+        monkeypatch,
+        _set_argv(),
+        "path_not_found",
+        "shader file does not exist: /x/wave.gdshader",
+        "shader-set",
     )
 
     assert result.exit_code == 4
@@ -135,8 +163,11 @@ def test_shader_set_no_search_match_maps_to_stable_no_search_match_code(monkeypa
     # registered no_search_match code (reused from script set), so an agent
     # learns the edit landed nowhere rather than parsing prose.
     result = _invoke(
-        monkeypatch, _set_argv(), "no_search_match",
-        'search string not found in shader: "xyzzy"', "shader-set",
+        monkeypatch,
+        _set_argv(),
+        "no_search_match",
+        'search string not found in shader: "xyzzy"',
+        "shader-set",
     )
 
     assert result.exit_code == 4
@@ -146,9 +177,13 @@ def test_shader_set_no_search_match_maps_to_stable_no_search_match_code(monkeypa
     assert "xyzzy" in err["message"]
 
 
-def test_shader_set_invalid_line_range_maps_to_stable_invalid_line_range_code(monkeypatch):
+def test_shader_set_invalid_line_range_maps_to_stable_invalid_line_range_code(
+    monkeypatch,
+):
     result = _invoke(
-        monkeypatch, _set_argv(), "invalid_line_range",
+        monkeypatch,
+        _set_argv(),
+        "invalid_line_range",
         "line range 5..9 is outside the shader's bounds (1..3) or ends before it starts",
         "shader-set",
     )
@@ -164,8 +199,11 @@ def test_shader_set_invalid_line_range_maps_to_stable_invalid_line_range_code(mo
 
 def test_theme_create_collision_reuses_stable_already_exists_code(monkeypatch):
     result = _invoke(
-        monkeypatch, _theme_argv(), "already_exists",
-        "theme target already exists: /x/ui.tres", "theme-create",
+        monkeypatch,
+        _theme_argv(),
+        "already_exists",
+        "theme target already exists: /x/ui.tres",
+        "theme-create",
     )
 
     assert result.exit_code == 4
@@ -177,8 +215,11 @@ def test_theme_create_collision_reuses_stable_already_exists_code(monkeypatch):
 
 def test_theme_create_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
     result = _invoke(
-        monkeypatch, _theme_argv(), "invalid_path",
-        "theme path must end in .tres: /x/ui.txt", "theme-create",
+        monkeypatch,
+        _theme_argv(),
+        "invalid_path",
+        "theme path must end in .tres: /x/ui.txt",
+        "theme-create",
     )
 
     assert result.exit_code == 4
@@ -189,8 +230,11 @@ def test_theme_create_wrong_extension_reuses_stable_invalid_path_code(monkeypatc
 
 def test_theme_create_unwritable_target_reuses_stable_save_failed_code(monkeypatch):
     result = _invoke(
-        monkeypatch, _theme_argv(), "save_failed",
-        "failed to save theme to /x/ui.tres", "theme-create",
+        monkeypatch,
+        _theme_argv(),
+        "save_failed",
+        "failed to save theme to /x/ui.tres",
+        "theme-create",
     )
 
     assert result.exit_code == 4

--- a/tests/test_classify_export_run.py
+++ b/tests/test_classify_export_run.py
@@ -89,9 +89,7 @@ def test_config_error_stderr_still_maps_to_generic_export_failed():
 def test_other_nonzero_maps_to_generic_export_failed():
     # A non-zero export with no recognized signature is the generic export_failed,
     # preserving the engine stderr as diagnostics.
-    outcome = _classify(
-        RunResult(stdout="", stderr="ERROR: disk full\n", exit_code=1)
-    )
+    outcome = _classify(RunResult(stdout="", stderr="ERROR: disk full\n", exit_code=1))
 
     assert isinstance(outcome, Failure)
     assert outcome.error.code == "export_failed"

--- a/tests/test_classify_launch_or_crash.py
+++ b/tests/test_classify_launch_or_crash.py
@@ -64,7 +64,9 @@ def test_signal_death_maps_to_engine_crashed_naming_the_signal():
     # subprocess reports a signal death as a negative return code: the engine ran
     # but was killed (e.g. SIGSEGV) — an operation-category crash, never a raw
     # negative exit code leaking out.
-    failure = classify_launch_or_crash(RunResult(stdout="", stderr="", exit_code=-11), BINARY)
+    failure = classify_launch_or_crash(
+        RunResult(stdout="", stderr="", exit_code=-11), BINARY
+    )
 
     assert isinstance(failure, Failure)
     assert failure.exit_code == EXIT_OPERATION
@@ -76,12 +78,25 @@ def test_signal_death_maps_to_engine_crashed_naming_the_signal():
 def test_clean_exit_returns_none_so_the_channel_tail_takes_over():
     # exit 0 with no launch failure is not an env/crash outcome: the prefix yields
     # to the channel-specific tail (sentinel parse vs synthesize-from-exit-code).
-    assert classify_launch_or_crash(RunResult(stdout="ok", stderr="", exit_code=0), BINARY) is None
+    assert (
+        classify_launch_or_crash(RunResult(stdout="ok", stderr="", exit_code=0), BINARY)
+        is None
+    )
 
 
 def test_genuine_engine_124_127_fall_through_to_the_tail():
     # A genuine engine/wrapper exit of 124/127 — with NO runner-synthesized launch
     # failure — is the engine's own result, not an env failure. The prefix returns
     # None so the tail classifies it as operation, never environment (issue #15).
-    assert classify_launch_or_crash(RunResult(stdout="", stderr="boom\n", exit_code=127), BINARY) is None
-    assert classify_launch_or_crash(RunResult(stdout="", stderr="124\n", exit_code=124), BINARY) is None
+    assert (
+        classify_launch_or_crash(
+            RunResult(stdout="", stderr="boom\n", exit_code=127), BINARY
+        )
+        is None
+    )
+    assert (
+        classify_launch_or_crash(
+            RunResult(stdout="", stderr="124\n", exit_code=124), BINARY
+        )
+        is None
+    )

--- a/tests/test_classify_run.py
+++ b/tests/test_classify_run.py
@@ -78,9 +78,7 @@ def test_engine_returned_124_is_operation_not_environment():
 def test_engine_nonzero_exit_maps_to_operation_failure():
     # The engine launched and ran but the operation reported an error and quit
     # non-zero (its own exit, not the runner's synthetic 124/127).
-    result = RunResult(
-        stdout="", stderr="gda: unknown operation: bogus\n", exit_code=1
-    )
+    result = RunResult(stdout="", stderr="gda: unknown operation: bogus\n", exit_code=1)
 
     outcome = classify_run(result, BINARY, SceneSummary)
 

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -43,8 +43,6 @@ def test_root_version_option_does_not_require_godot(monkeypatch):
 
 
 def test_package_metadata_version_matches_pyproject():
-    pyproject = tomllib.loads(
-        (ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    )
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert version("gda") == pyproject["project"]["version"]

--- a/tests/test_command_descriptor_registry.py
+++ b/tests/test_command_descriptor_registry.py
@@ -79,7 +79,9 @@ def test_no_renderer_is_orphaned():
         f"{sorted(orphaned)}"
     )
     # And nothing claims to be bound that the module does not define (a stale import).
-    assert not (bound - defined), f"descriptors bind undefined renderers: {sorted(bound - defined)}"
+    assert not (bound - defined), (
+        f"descriptors bind undefined renderers: {sorted(bound - defined)}"
+    )
 
 
 # The recipe-bearing commands — those fulfilled by a CLI-side recipe (export run /

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -18,7 +18,7 @@ import subprocess
 import pytest
 
 from gda.daemon.discovery import daemon_paths
-from gda.daemon.protocol import read_frame, write_frame
+from gda.daemon.protocol import write_frame
 from gda.daemon.server import DaemonServer
 from gda.daemon.session import EngineSession, SceneMismatch, launch_session
 from gda.parser import parse_result
@@ -204,7 +204,12 @@ def _launch_with_fake_harness(monkeypatch, tmp_path, *, token, verify, scene):
     monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
     daemon_end, harness_end = socket.socketpair()
     # The harness presents its token, then the scene-verification frame.
-    write_frame(harness_end, token.to_utf8_buffer() if hasattr(token, "to_utf8_buffer") else token.encode("utf-8"))
+    write_frame(
+        harness_end,
+        token.to_utf8_buffer()
+        if hasattr(token, "to_utf8_buffer")
+        else token.encode("utf-8"),
+    )
     if verify is not None:
         write_frame(harness_end, json.dumps(verify).encode("utf-8"))
     try:
@@ -245,7 +250,9 @@ def test_launch_raises_scene_mismatch_when_loaded_scene_differs(monkeypatch, tmp
         )
 
 
-def test_launch_with_no_selector_does_not_require_a_verification_frame(monkeypatch, tmp_path):
+def test_launch_with_no_selector_does_not_require_a_verification_frame(
+    monkeypatch, tmp_path
+):
     # No selector: scene_ok is trivially true (the harness sends it as ok), and the
     # session is verified — the main_scene default is unchanged.
     _project(tmp_path)
@@ -287,7 +294,9 @@ def test_launch_returns_none_on_bad_token(monkeypatch, tmp_path):
 
 def _server_with_session(tmp_path, log_file, alive=True):
     server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
-    server._session = EngineSession(_FakeProc(None if alive else 0), conn=None, log_file=log_file)
+    server._session = EngineSession(
+        _FakeProc(None if alive else 0), conn=None, log_file=log_file
+    )
     return server
 
 
@@ -326,7 +335,9 @@ def test_diag_serves_even_when_the_session_process_has_died(tmp_path):
     # A crash is diagnosable: the daemon serves diag from the remembered log file
     # even after the session process has exited (ADR rationale).
     log_file = tmp_path / "session.log"
-    log_file.write_text("ERROR: crashed\n   at: _ready (res://main.gd:3)\n", encoding="utf-8")
+    log_file.write_text(
+        "ERROR: crashed\n   at: _ready (res://main.gd:3)\n", encoding="utf-8"
+    )
     server = _server_with_session(tmp_path, log_file, alive=False)
 
     reply = server._handle({"op": "diag-errors", "params": {}})
@@ -345,7 +356,9 @@ def test_diag_empty_log_is_an_empty_result_not_an_error(tmp_path):
     assert parse_result(errors_reply["stdout"])["errors"] == []
 
 
-def test_diag_with_no_session_launched_is_engine_session_not_running(monkeypatch, tmp_path):
+def test_diag_with_no_session_launched_is_engine_session_not_running(
+    monkeypatch, tmp_path
+):
     # ADR-0022: diag observes an already-launched session; it does NOT launch one.
     # With NO session launched this daemon lifetime, diag-errors returns a
     # structured `engine_session_not_running` (exit 6) — and crucially it must NOT
@@ -362,12 +375,16 @@ def test_diag_with_no_session_launched_is_engine_session_not_running(monkeypatch
 
     reply = server._handle({"op": op, "params": {}})
 
-    assert parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    assert (
+        parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    )
     # No session was created as a side effect of the read-only diag.
     assert server._session is None
 
 
-def test_diag_with_a_remembered_session_but_missing_file_is_live_log_unavailable(tmp_path):
+def test_diag_with_a_remembered_session_but_missing_file_is_live_log_unavailable(
+    tmp_path,
+):
     # A session was launched (remembered) but its log file is gone/unreadable.
     log_file = tmp_path / "missing.log"  # never created
     server = _server_with_session(tmp_path, log_file, alive=False)

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -586,7 +586,9 @@ def test_status_windowed_is_null_when_the_control_round_trip_fails(
 # --- uninstall recipe (#225, D2) ----------------------------------------------
 
 
-def test_uninstall_refused_while_a_daemon_is_running(tmp_path, short_runtime, monkeypatch):
+def test_uninstall_refused_while_a_daemon_is_running(
+    tmp_path, short_runtime, monkeypatch
+):
     project = _project(tmp_path)
     install_harness(project)
     monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: 999)  # a live daemon

--- a/tests/test_daemon_logger.py
+++ b/tests/test_daemon_logger.py
@@ -35,7 +35,9 @@ def _project(tmp_path):
 
 def _server_with_session(tmp_path, log_file, alive=True):
     server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
-    server._session = EngineSession(_FakeProc(None if alive else 0), conn=None, log_file=log_file)
+    server._session = EngineSession(
+        _FakeProc(None if alive else 0), conn=None, log_file=log_file
+    )
     return server
 
 
@@ -106,7 +108,9 @@ def test_logger_tail_serves_even_when_the_session_process_has_died(tmp_path):
     # A crash is diagnosable: the daemon serves logger-tail from the remembered log
     # file even after the session process has exited (ADR-0022 rationale).
     log_file = tmp_path / "session.log"
-    log_file.write_text("ERROR: crashed\n   at: _ready (res://main.gd:3)\n", encoding="utf-8")
+    log_file.write_text(
+        "ERROR: crashed\n   at: _ready (res://main.gd:3)\n", encoding="utf-8"
+    )
     server = _server_with_session(tmp_path, log_file, alive=False)
 
     reply = server._handle({"op": "logger-tail", "params": {}})
@@ -134,11 +138,15 @@ def test_logger_tail_with_no_session_is_engine_session_not_running(tmp_path):
 
     reply = server._handle({"op": "logger-tail", "params": {}})
 
-    assert parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    assert (
+        parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    )
     assert server._session is None
 
 
-def test_logger_tail_with_a_remembered_session_but_missing_file_is_live_log_unavailable(tmp_path):
+def test_logger_tail_with_a_remembered_session_but_missing_file_is_live_log_unavailable(
+    tmp_path,
+):
     log_file = tmp_path / "missing.log"  # never created
     server = _server_with_session(tmp_path, log_file, alive=False)
 

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -34,7 +34,9 @@ def test_live_op_without_a_launchable_session_is_engine_session_not_running(tmp_
 
     reply = server._handle({"op": "game-tree", "params": {}})
 
-    assert parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    assert (
+        parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    )
 
 
 # --- #278 (review): scene verification happens at LAUNCH (in the harness), never
@@ -49,7 +51,9 @@ def _project_with_marker(tmp_path):
     return daemon_paths(tmp_path)
 
 
-def test_scene_mismatch_at_launch_is_a_typed_live_scene_not_found(tmp_path, monkeypatch):
+def test_scene_mismatch_at_launch_is_a_typed_live_scene_not_found(
+    tmp_path, monkeypatch
+):
     # The harness reported the loaded scene != the requested selector (the no-silent-
     # fallback guarantee, incl. a bad uid Godot replaced with main_scene): the daemon
     # surfaces a typed live_scene_not_found, not a vague launch error.
@@ -59,7 +63,9 @@ def test_scene_mismatch_at_launch_is_a_typed_live_scene_not_found(tmp_path, monk
         raise SceneMismatch("res://B.tscn", "res://main.tscn")
 
     monkeypatch.setattr("gda.daemon.server.launch_session", _mismatch)
-    server = DaemonServer(_project_with_marker(tmp_path), godot="godot", scene="res://B.tscn")
+    server = DaemonServer(
+        _project_with_marker(tmp_path), godot="godot", scene="res://B.tscn"
+    )
     server._harness_listener = object()  # launch_session is patched; value unused
 
     reply = server._handle({"op": "game-tree", "params": {}})
@@ -69,7 +75,9 @@ def test_scene_mismatch_at_launch_is_a_typed_live_scene_not_found(tmp_path, monk
     assert server._session is None
 
 
-def test_a_verified_session_is_reused_without_re_checking_the_scene(tmp_path, monkeypatch):
+def test_a_verified_session_is_reused_without_re_checking_the_scene(
+    tmp_path, monkeypatch
+):
     # Finding 1 fix: scene is verified ONCE at launch. A verified session is cached
     # and reused on later ops — launch_session is called exactly once even across
     # multiple live ops (no per-request disk/scene re-validation), so deleting the
@@ -86,7 +94,9 @@ def test_a_verified_session_is_reused_without_re_checking_the_scene(tmp_path, mo
     # passes and the (patched) launch proceeds; the point is it launches only ONCE.
     (tmp_path / "B.tscn").write_text("[gd_scene format=3]\n", encoding="utf-8")
     monkeypatch.setattr("gda.daemon.server.launch_session", _launch_once)
-    server = DaemonServer(_project_with_marker(tmp_path), godot="godot", scene="res://B.tscn")
+    server = DaemonServer(
+        _project_with_marker(tmp_path), godot="godot", scene="res://B.tscn"
+    )
     server._harness_listener = object()  # launch_session is patched; value unused
 
     server._handle({"op": "game-tree", "params": {}})
@@ -102,7 +112,9 @@ def test_a_generic_launch_failure_is_engine_session_not_running(tmp_path, monkey
     # exists, so the res:// pre-check passes and the (patched) launch is reached.
     (tmp_path / "B.tscn").write_text("[gd_scene format=3]\n", encoding="utf-8")
     monkeypatch.setattr("gda.daemon.server.launch_session", lambda *a, **k: None)
-    server = DaemonServer(_project_with_marker(tmp_path), godot="godot", scene="res://B.tscn")
+    server = DaemonServer(
+        _project_with_marker(tmp_path), godot="godot", scene="res://B.tscn"
+    )
     server._harness_listener = object()  # launch_session is patched; value unused
 
     reply = server._handle({"op": "game-tree", "params": {}})
@@ -118,10 +130,14 @@ def test_missing_res_scene_is_live_scene_not_found_before_launch(tmp_path, monke
     # res:// path, so the harness verification can't see it; the daemon's pre-check
     # surfaces the typed live_scene_not_found and never spawns the engine (#278).
     def _must_not_launch(*a, **k):
-        raise AssertionError("launch_session must not be called for a missing res:// scene")
+        raise AssertionError(
+            "launch_session must not be called for a missing res:// scene"
+        )
 
     monkeypatch.setattr("gda.daemon.server.launch_session", _must_not_launch)
-    server = DaemonServer(_project_with_marker(tmp_path), godot="godot", scene="res://nope.tscn")
+    server = DaemonServer(
+        _project_with_marker(tmp_path), godot="godot", scene="res://nope.tscn"
+    )
     server._harness_listener = object()
 
     reply = server._handle({"op": "game-tree", "params": {}})
@@ -139,8 +155,7 @@ def test_no_scene_selector_runs_main_scene_unchanged(tmp_path):
     reply = server._handle({"op": "game-tree", "params": {}})
 
     assert (
-        parse_result(reply["stdout"])["error"]["code"]
-        == "engine_session_not_running"
+        parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
     )
 
 

--- a/tests/test_diag_commands.py
+++ b/tests/test_diag_commands.py
@@ -28,7 +28,9 @@ def _project(tmp_path):
     return tmp_path
 
 
-def test_diag_errors_emits_structured_errors_json_through_the_live_channel(monkeypatch, tmp_path):
+def test_diag_errors_emits_structured_errors_json_through_the_live_channel(
+    monkeypatch, tmp_path
+):
     fake = inject_live_runner(
         monkeypatch,
         RunResult(stdout=sentinel(DIAG_ERRORS_RESULT), stderr="", exit_code=0),
@@ -60,7 +62,16 @@ def test_diag_errors_passes_limit_through(monkeypatch, tmp_path):
     )
 
     result = CliRunner().invoke(
-        app, ["diag", "errors", "--limit", "5", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        [
+            "diag",
+            "errors",
+            "--limit",
+            "5",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -73,7 +84,16 @@ def test_diag_errors_rejects_a_non_positive_limit_on_the_argv_path(tmp_path):
     # rejects before any dispatch.
     for bad in ("0", "-1"):
         result = CliRunner().invoke(
-            app, ["diag", "errors", "--limit", bad, "--project", str(_project(tmp_path)), "--json"]
+            app,
+            [
+                "diag",
+                "errors",
+                "--limit",
+                bad,
+                "--project",
+                str(_project(tmp_path)),
+                "--json",
+            ],
         )
         assert result.exit_code == 2, (bad, result.stdout + result.stderr)
 
@@ -84,7 +104,9 @@ def test_diag_errors_human_output_renders_levels(monkeypatch, tmp_path):
         RunResult(stdout=sentinel(DIAG_ERRORS_RESULT), stderr="", exit_code=0),
     )
 
-    result = CliRunner().invoke(app, ["diag", "errors", "--project", str(_project(tmp_path))])
+    result = CliRunner().invoke(
+        app, ["diag", "errors", "--project", str(_project(tmp_path))]
+    )
 
     assert result.exit_code == 0, result.stdout + result.stderr
     # Human output names the level and message; the location is shown when present.
@@ -131,7 +153,9 @@ def test_diag_errors_log_unavailable_is_a_typed_live_error(monkeypatch, tmp_path
     assert error["category"] == "live"
 
 
-def test_diag_params_json_rejects_a_non_positive_limit_as_invalid_params(monkeypatch, tmp_path):
+def test_diag_params_json_rejects_a_non_positive_limit_as_invalid_params(
+    monkeypatch, tmp_path
+):
     # The `ge=1` bound on DiagErrorsParams: a zero/negative limit via --params-json
     # is a structured `invalid_params` (reflected in --schema), not a silent "no
     # limit". No dispatch happens — model validation fails first, so no live runner
@@ -139,8 +163,15 @@ def test_diag_params_json_rejects_a_non_positive_limit_as_invalid_params(monkeyp
     for bad in (0, -1):
         result = CliRunner().invoke(
             app,
-            ["diag", "errors", "--params-json", json.dumps({"limit": bad}),
-             "--project", str(_project(tmp_path)), "--json"],
+            [
+                "diag",
+                "errors",
+                "--params-json",
+                json.dumps({"limit": bad}),
+                "--project",
+                str(_project(tmp_path)),
+                "--json",
+            ],
         )
         assert result.exit_code != 0, (bad, result.stdout + result.stderr)
         err = json.loads(result.stdout)["error"]

--- a/tests/test_diag_log_parser.py
+++ b/tests/test_diag_log_parser.py
@@ -179,7 +179,10 @@ def test_parse_errors_backtrace_consumption_stops_before_the_next_error():
     log = BACKTRACE_LOG + "ERROR: second error\n   at: g (res://b.gd:2)\n"
     errors = parse_errors(log)
     assert len(errors) == 2
-    assert errors[0]["message"] == "Invalid call. Nonexistent function 'do_thing' in base 'Nil'."
+    assert (
+        errors[0]["message"]
+        == "Invalid call. Nonexistent function 'do_thing' in base 'Nil'."
+    )
     assert len(errors[0]["callstack"]) == 3
     assert errors[1]["message"] == "second error"
     assert errors[1]["function"] == "g"

--- a/tests/test_e2e_asset_file.py
+++ b/tests/test_e2e_asset_file.py
@@ -108,8 +108,14 @@ def test_shader_set_search_replace_round_trips_through_get(godot_project):
     _gda("shader", "create", str(shader_path), "--json")
 
     edited = _gda(
-        "shader", "set", str(shader_path),
-        "--search", "canvas_item", "--replace", "spatial", "--json",
+        "shader",
+        "set",
+        str(shader_path),
+        "--search",
+        "canvas_item",
+        "--replace",
+        "spatial",
+        "--json",
     )
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
@@ -143,7 +149,12 @@ def test_shader_create_no_clobber_existing_file(godot_project):
     before = shader_path.read_text(encoding="utf-8")
 
     again = _gda(
-        "shader", "create", str(shader_path), "--content", "shader_type spatial;\n", "--json"
+        "shader",
+        "create",
+        str(shader_path),
+        "--content",
+        "shader_type spatial;\n",
+        "--json",
     )
 
     _assert_operation_error(again, "already_exists")
@@ -164,7 +175,14 @@ def test_shader_set_no_search_match_leaves_file_untouched(godot_project):
     before = shader_path.read_text(encoding="utf-8")
 
     edited = _gda(
-        "shader", "set", str(shader_path), "--search", "xyzzy", "--replace", "z", "--json"
+        "shader",
+        "set",
+        str(shader_path),
+        "--search",
+        "xyzzy",
+        "--replace",
+        "z",
+        "--json",
     )
 
     _assert_operation_error(edited, "no_search_match")
@@ -177,8 +195,16 @@ def test_shader_set_invalid_line_range_is_invalid_line_range(godot_project):
     _gda("shader", "create", str(shader_path), "--json")
 
     edited = _gda(
-        "shader", "set", str(shader_path),
-        "--start-line", "50", "--end-line", "99", "--content", "x", "--json",
+        "shader",
+        "set",
+        str(shader_path),
+        "--start-line",
+        "50",
+        "--end-line",
+        "99",
+        "--content",
+        "x",
+        "--json",
     )
 
     _assert_operation_error(edited, "invalid_line_range")

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -56,7 +56,15 @@ def test_daemon_serves_a_real_runtime_tree(tmp_path, daemon_runtime_dir):
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,
@@ -95,7 +103,15 @@ def test_daemon_serves_game_get_set_round_trip(tmp_path, daemon_runtime_dir):
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,
@@ -109,7 +125,13 @@ def test_daemon_serves_game_get_set_round_trip(tmp_path, daemon_runtime_dir):
         # set: mutate the Player's runtime position (a Vector2), coerced harness-side
         # from the CLI string "10,20" exactly as headless `node set` coerces it.
         was_set = run(
-            "game", "set", "/root/Main/Player", "--property", "position", "--value", "10,20"
+            "game",
+            "set",
+            "/root/Main/Player",
+            "--property",
+            "position",
+            "--value",
+            "10,20",
         )
         assert was_set.returncode == 0, was_set.stdout + was_set.stderr
         set_doc = json.loads(was_set.stdout)
@@ -136,7 +158,15 @@ def _gda(tmp_path, env):
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,
@@ -147,7 +177,9 @@ def _gda(tmp_path, env):
 
 
 @pytest.mark.e2e
-def test_daemon_start_re_syncs_harness_after_a_version_bump(tmp_path, daemon_runtime_dir):
+def test_daemon_start_re_syncs_harness_after_a_version_bump(
+    tmp_path, daemon_runtime_dir
+):
     # #225 D1: the daemon self-syncs the installed harness to the running gda's
     # version. A real start installs at HARNESS_VERSION; we then SIMULATE a
     # previously-installed OLDER copy by rewriting its leading version header to a
@@ -163,7 +195,9 @@ def test_daemon_start_re_syncs_harness_after_a_version_bump(tmp_path, daemon_run
         first = run("daemon", "start")
         assert first.returncode == 0, first.stdout + first.stderr
         first_doc = json.loads(first.stdout)
-        assert first_doc["harness_synced"] is False  # a first install is NOT a sync (#247)
+        assert (
+            first_doc["harness_synced"] is False
+        )  # a first install is NOT a sync (#247)
         assert first_doc["harness_version"] == HARNESS_VERSION
         assert installed_harness_version(tmp_path) == HARNESS_VERSION
 
@@ -283,7 +317,9 @@ B_TSCN = (
 
 
 @pytest.mark.e2e
-def test_daemon_start_scene_runs_the_chosen_scene_not_main(tmp_path, daemon_runtime_dir):
+def test_daemon_start_scene_runs_the_chosen_scene_not_main(
+    tmp_path, daemon_runtime_dir
+):
     # #278 (ADR-0017 amendment): `daemon start --scene res://B.tscn` boots the chosen
     # scene B — `game tree` reports B's root (not Main's), proving the engine received
     # `--scene` (before `--path`) — and `project.godot`'s `main_scene` is UNCHANGED
@@ -306,10 +342,9 @@ def test_daemon_start_scene_runs_the_chosen_scene_not_main(tmp_path, daemon_runt
         assert any(c["name"] == "Marker" for c in root.get("children", []))
 
         # main_scene is untouched on disk (running a scene is not setting it).
-        assert (
-            'run/main_scene="res://main.tscn"'
-            in (tmp_path / "project.godot").read_text(encoding="utf-8")
-        )
+        assert 'run/main_scene="res://main.tscn"' in (
+            tmp_path / "project.godot"
+        ).read_text(encoding="utf-8")
     finally:
         run("daemon", "stop")
 

--- a/tests/test_e2e_diag.py
+++ b/tests/test_e2e_diag.py
@@ -74,7 +74,9 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 
 
 @pytest.mark.e2e
-def test_diag_reads_back_a_known_runtime_error_and_log_line(tmp_path, daemon_runtime_dir):
+def test_diag_reads_back_a_known_runtime_error_and_log_line(
+    tmp_path, daemon_runtime_dir
+):
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
     (tmp_path / "main.gd").write_text(MAIN_GD, encoding="utf-8")
@@ -83,7 +85,15 @@ def test_diag_reads_back_a_known_runtime_error_and_log_line(tmp_path, daemon_run
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,
@@ -150,7 +160,15 @@ def test_diag_reads_back_a_multi_frame_callstack(tmp_path, daemon_runtime_dir):
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,
@@ -192,6 +210,8 @@ def test_diag_reads_back_a_multi_frame_callstack(tmp_path, daemon_runtime_dir):
         assert error["callstack"][0]["file"] == error["file"]
         assert error["callstack"][0]["line"] == error["line"]
         # Every frame points back into the one script.
-        assert all(frame["file"] == "res://main.gd" for frame in error["callstack"]), error
+        assert all(frame["file"] == "res://main.gd" for frame in error["callstack"]), (
+            error
+        )
     finally:
         run("daemon", "stop")

--- a/tests/test_e2e_export.py
+++ b/tests/test_e2e_export.py
@@ -54,6 +54,7 @@ export_path=""
 html/export_icon=true
 """
 
+
 def _expected_templates_version() -> str:
     """The export-templates version-dir name the running engine uses, derived from its
     OWN version info — major.minor[.patch].status with the patch OMITTED when 0 (e.g.
@@ -187,9 +188,9 @@ def test_export_get_reports_preset_details_and_template_status(godot_project):
     # derived from the engine's own version (patch omitted for a .0 release), so a
     # format regression is caught RED here rather than slipping past a loose regex.
     assert isinstance(data["templates_installed"], bool)
-    assert data["templates_version"] == _expected_templates_version(), (
-        data["templates_version"]
-    )
+    assert data["templates_version"] == _expected_templates_version(), data[
+        "templates_version"
+    ]
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -84,6 +84,7 @@ binary_format/embed_pck=false
 
 def _gda_project(project) -> "callable":
     """A ``gda`` bound to ``--godot`` + ``--project`` for the real engine."""
+
     def gda(*args: str) -> subprocess.CompletedProcess:
         return subprocess.run(
             [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
@@ -212,8 +213,15 @@ def test_export_run_pack_writes_pck_without_templates(godot_project):
     gda = _gda_project(godot_project)
 
     run = gda(
-        "export", "run", "--preset", "Linux/X11",
-        "--mode", "pack", "--output", override_rel, "--json",
+        "export",
+        "run",
+        "--preset",
+        "Linux/X11",
+        "--mode",
+        "pack",
+        "--output",
+        override_rel,
+        "--json",
     )
 
     # No skip: pack must RUN to completion regardless of template presence.
@@ -255,8 +263,15 @@ def test_export_run_pack_omits_installed_harness_and_restores_it(godot_project):
     gda = _gda_project(godot_project)
 
     run = gda(
-        "export", "run", "--preset", "Linux/X11",
-        "--mode", "pack", "--output", override_rel, "--json",
+        "export",
+        "run",
+        "--preset",
+        "Linux/X11",
+        "--mode",
+        "pack",
+        "--output",
+        override_rel,
+        "--json",
     )
 
     assert run.returncode == 0, run.stdout + run.stderr
@@ -265,7 +280,8 @@ def test_export_run_pack_omits_installed_harness_and_restores_it(godot_project):
         names = zf.namelist()
         # (a) The harness SCRIPT is absent from the archive.
         assert not any(HARNESS_FILE in n for n in names), (
-            "the exported archive still carries the harness script:\n" + "\n".join(names)
+            "the exported archive still carries the harness script:\n"
+            + "\n".join(names)
         )
         # (b) The packed project settings declare NO GdaHarness autoload — the
         # specific Godot risk (project.binary serializes ProjectSettings wholesale,
@@ -309,8 +325,16 @@ def test_export_run_without_templates_yields_export_templates_missing(
 
     run = subprocess.run(
         [
-            *GDA_CMD, "export", "run", "--preset", "Linux/X11", "--json",
-            "--godot", str(GODOT), "--project", str(godot_project),
+            *GDA_CMD,
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--json",
+            "--godot",
+            str(GODOT),
+            "--project",
+            str(godot_project),
         ],
         capture_output=True,
         text=True,

--- a/tests/test_e2e_harness_install.py
+++ b/tests/test_e2e_harness_install.py
@@ -70,7 +70,9 @@ def _assert_inert_boot(out: str, returncode: int) -> None:
     # Strengthened (#225): the autoload must not have opened a connection — no
     # daemon marker, so it returns early and touches no socket.
     for needle in _CONNECTION_NOISE:
-        assert needle not in out, f"unexpected harness connection activity: {needle}\n{out}"
+        assert needle not in out, (
+            f"unexpected harness connection activity: {needle}\n{out}"
+        )
     assert returncode == 0, out
 
 
@@ -132,14 +134,21 @@ def test_exported_pck_with_harness_runs_inert(tmp_path):
     # RAW engine export (bypasses gda's strip on purpose) so the harness is packed.
     packed = subprocess.run(
         [
-            str(GODOT), "--headless", "--path", str(tmp_path),
-            "--export-pack", "Pack", str(pck),
+            str(GODOT),
+            "--headless",
+            "--path",
+            str(tmp_path),
+            "--export-pack",
+            "Pack",
+            str(pck),
         ],
         capture_output=True,
         text=True,
         timeout=120,
     )
-    assert pck.exists(), f"expected packed .pck at {pck}\n{packed.stdout}{packed.stderr}"
+    assert pck.exists(), (
+        f"expected packed .pck at {pck}\n{packed.stdout}{packed.stderr}"
+    )
     # Non-trivial precondition: the harness path really is inside the pack (the pck
     # file table stores res:// paths as plaintext), so "inert" below is meaningful.
     assert b"gda_harness.gd" in pck.read_bytes(), "the harness was not packed"
@@ -263,8 +272,7 @@ def _exported_tree_has_harness(export_dir) -> bool:
     really shipped in the template build).
     """
     return any(
-        HARNESS_FILE.encode() in p.read_bytes()
-        for p in export_dir.rglob("*.pck")
+        HARNESS_FILE.encode() in p.read_bytes() for p in export_dir.rglob("*.pck")
     )
 
 
@@ -382,13 +390,24 @@ def test_template_feature_gates_the_harness_only_in_exported_builds(
     editor_token = "tok-editor"
     with _socket_probe(editor_sock) as probe:
         subprocess.run(
-            [str(GODOT), "--headless", "--path", str(tmp_path), "--quit",
-             "--", "gda-daemon", str(editor_sock), editor_token],
+            [
+                str(GODOT),
+                "--headless",
+                "--path",
+                str(tmp_path),
+                "--quit",
+                "--",
+                "gda-daemon",
+                str(editor_sock),
+                editor_token,
+            ],
             capture_output=True,
             text=True,
             timeout=60,
         )
-        assert probe.connected.wait(5), "editor binary never connected — the rig is broken"
+        assert probe.connected.wait(5), (
+            "editor binary never connected — the rig is broken"
+        )
         assert probe.token == editor_token.encode(), probe.token
 
     # Export a real DEBUG TEMPLATE binary that CONTAINS the harness. RAW `--export-debug`
@@ -398,8 +417,15 @@ def test_template_feature_gates_the_harness_only_in_exported_builds(
     export_dir.mkdir(parents=True, exist_ok=True)
     artifact = tmp_path / target.export_path
     exported = subprocess.run(
-        [str(GODOT), "--headless", "--path", str(tmp_path),
-         "--export-debug", target.preset, str(artifact)],
+        [
+            str(GODOT),
+            "--headless",
+            "--path",
+            str(tmp_path),
+            "--export-debug",
+            target.preset,
+            str(artifact),
+        ],
         capture_output=True,
         text=True,
         timeout=300,
@@ -419,8 +445,15 @@ def test_template_feature_gates_the_harness_only_in_exported_builds(
     tmpl_token = "tok-template"
     with _socket_probe(tmpl_sock) as probe:
         ran = subprocess.run(
-            [str(exe), "--headless", "--quit",
-             "--", "gda-daemon", str(tmpl_sock), tmpl_token],
+            [
+                str(exe),
+                "--headless",
+                "--quit",
+                "--",
+                "gda-daemon",
+                str(tmpl_sock),
+                tmpl_token,
+            ],
             capture_output=True,
             text=True,
             timeout=60,

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -36,7 +36,7 @@ KEY_PLAYER_GD = (
     "\t\t\tposition.x += 10.0\n"
 )
 KEY_MAIN_TSCN = (
-    '[gd_scene load_steps=2 format=3]\n\n'
+    "[gd_scene load_steps=2 format=3]\n\n"
     '[ext_resource type="Script" path="res://player.gd" id="1"]\n\n'
     '[node name="Main" type="Node2D"]\n\n'
     '[node name="Player" type="Node2D" parent="."]\n'
@@ -56,7 +56,7 @@ MOUSE_PLAYER_GD = (
     "\t\t\tposition = event.position\n"
 )
 MOUSE_MAIN_TSCN = (
-    '[gd_scene load_steps=2 format=3]\n\n'
+    "[gd_scene load_steps=2 format=3]\n\n"
     '[ext_resource type="Script" path="res://player.gd" id="1"]\n\n'
     '[node name="Main" type="Node2D"]\n\n'
     '[node name="Player" type="Node2D" parent="."]\n'
@@ -69,11 +69,11 @@ MOUSE_MAIN_TSCN = (
 ACTION_PLAYER_GD = (
     "extends Node2D\n"
     "func _process(_delta: float) -> void:\n"
-    "\tif Input.is_action_pressed(\"move_right\"):\n"
+    '\tif Input.is_action_pressed("move_right"):\n'
     "\t\tposition.x += 1.0\n"
 )
 ACTION_MAIN_TSCN = (
-    '[gd_scene load_steps=2 format=3]\n\n'
+    "[gd_scene load_steps=2 format=3]\n\n"
     '[ext_resource type="Script" path="res://player.gd" id="1"]\n\n'
     '[node name="Main" type="Node2D"]\n\n'
     '[node name="Player" type="Node2D" parent="."]\n'
@@ -88,7 +88,7 @@ ACTION_PROJECT_GODOT = project_godot(
     extra=(
         'run/main_scene="res://main.tscn"\n\n'
         "[input]\n\n"
-        'move_right={\n'
+        "move_right={\n"
         '"deadzone": 0.5,\n'
         '"events": []\n'
         "}\n"
@@ -111,7 +111,15 @@ def test_daemon_serves_input_key_observed_via_game_get(tmp_path, daemon_runtime_
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,
@@ -125,7 +133,9 @@ def test_daemon_serves_input_key_observed_via_game_get(tmp_path, daemon_runtime_
         before = run("game", "get", "/root/Main/Player", "--property", "position")
         assert before.returncode == 0, before.stdout + before.stderr
         before_x = next(
-            p for p in json.loads(before.stdout)["properties"] if p["name"] == "position"
+            p
+            for p in json.loads(before.stdout)["properties"]
+            if p["name"] == "position"
         )["value"][0]
 
         # Inject a Right key press; the game's _input advances position.x by 10.
@@ -148,7 +158,9 @@ def test_daemon_serves_input_key_observed_via_game_get(tmp_path, daemon_runtime_
 
 
 @pytest.mark.e2e
-def test_daemon_serves_input_mouse_click_observed_via_game_get(tmp_path, daemon_runtime_dir):
+def test_daemon_serves_input_mouse_click_observed_via_game_get(
+    tmp_path, daemon_runtime_dir
+):
     # The mouse leg of the #221 DoD: a real daemon -> engine session ->
     # `input mouse-click <x> <y>` (post-flatten two-token name) pushes an
     # InputEventMouseButton through the real `push_input` viewport path into the
@@ -162,7 +174,15 @@ def test_daemon_serves_input_mouse_click_observed_via_game_get(tmp_path, daemon_
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,
@@ -176,7 +196,9 @@ def test_daemon_serves_input_mouse_click_observed_via_game_get(tmp_path, daemon_
         before = run("game", "get", "/root/Main/Player", "--property", "position")
         assert before.returncode == 0, before.stdout + before.stderr
         before_pos = next(
-            p for p in json.loads(before.stdout)["properties"] if p["name"] == "position"
+            p
+            for p in json.loads(before.stdout)["properties"]
+            if p["name"] == "position"
         )["value"]
         assert before_pos == [0.0, 0.0]
 
@@ -212,7 +234,15 @@ def test_daemon_serves_input_action_observed_via_game_get(tmp_path, daemon_runti
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,
@@ -225,7 +255,9 @@ def test_daemon_serves_input_action_observed_via_game_get(tmp_path, daemon_runti
         before = run("game", "get", "/root/Main/Player", "--property", "position")
         assert before.returncode == 0, before.stdout + before.stderr
         before_x = next(
-            p for p in json.loads(before.stdout)["properties"] if p["name"] == "position"
+            p
+            for p in json.loads(before.stdout)["properties"]
+            if p["name"] == "position"
         )["value"][0]
 
         # Press the action; the Player polls is_action_pressed each frame and moves.
@@ -265,7 +297,15 @@ def test_daemon_serves_input_sequence_across_frames(tmp_path, daemon_runtime_dir
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,
@@ -286,7 +326,9 @@ def test_daemon_serves_input_sequence_across_frames(tmp_path, daemon_runtime_dir
         before = run("game", "get", "/root/Main/Player", "--property", "position")
         assert before.returncode == 0, before.stdout + before.stderr
         before_x = next(
-            p for p in json.loads(before.stdout)["properties"] if p["name"] == "position"
+            p
+            for p in json.loads(before.stdout)["properties"]
+            if p["name"] == "position"
         )["value"][0]
 
         # The whole sequence returns as one blocking result: 3 events over 3 frames.
@@ -309,7 +351,9 @@ def test_daemon_serves_input_sequence_across_frames(tmp_path, daemon_runtime_dir
 
 
 @pytest.mark.e2e
-def test_input_action_unknown_action_reports_live_unknown_action(tmp_path, daemon_runtime_dir):
+def test_input_action_unknown_action_reports_live_unknown_action(
+    tmp_path, daemon_runtime_dir
+):
     # An action absent from the running InputMap is the typed harness op-error,
     # relayed through the daemon (exit-0 sentinel) and mapped by classify_live.
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
@@ -320,7 +364,15 @@ def test_input_action_unknown_action_reports_live_unknown_action(tmp_path, daemo
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,

--- a/tests/test_e2e_logger.py
+++ b/tests/test_e2e_logger.py
@@ -64,7 +64,9 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 
 
 @pytest.mark.e2e
-def test_logger_tail_reads_back_structured_records_and_raw_lines(tmp_path, daemon_runtime_dir):
+def test_logger_tail_reads_back_structured_records_and_raw_lines(
+    tmp_path, daemon_runtime_dir
+):
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
     (tmp_path / "main.gd").write_text(MAIN_GD, encoding="utf-8")
@@ -73,7 +75,15 @@ def test_logger_tail_reads_back_structured_records_and_raw_lines(tmp_path, daemo
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,
@@ -192,7 +202,9 @@ def test_gda_log_is_inert_outside_a_daemon_launched_session(tmp_path):
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
     (tmp_path / "main.gd").write_text(PLAIN_MAIN_GD, encoding="utf-8")
-    install_harness(tmp_path)  # the GdaHarness autoload, exactly as a real project carries it
+    install_harness(
+        tmp_path
+    )  # the GdaHarness autoload, exactly as a real project carries it
 
     proc = subprocess.run(
         [str(GODOT), "--headless", "--path", str(tmp_path)],

--- a/tests/test_e2e_mcp_stdio.py
+++ b/tests/test_e2e_mcp_stdio.py
@@ -54,7 +54,10 @@ def test_info_over_stdio_reports_engine_version():
 
     assert result.isError is False, result.content
     assert result.structuredContent["major"] == 4
-    assert (result.structuredContent["major"], result.structuredContent["minor"]) >= (4, 4)
+    assert (result.structuredContent["major"], result.structuredContent["minor"]) >= (
+        4,
+        4,
+    )
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -57,8 +57,14 @@ def test_node_add_then_list_round_trip(godot_project):
     _create_scene(scene_path)
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Sprite2D", "--name", "Hero", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Sprite2D",
+        "--name",
+        "Hero",
+        "--json",
     )
 
     assert added.returncode == 0, added.stdout + added.stderr
@@ -92,14 +98,28 @@ def test_node_add_under_nested_parent_path(godot_project):
     _create_scene(scene_path)
 
     first = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Sprite2D", "--name", "Hero", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Sprite2D",
+        "--name",
+        "Hero",
+        "--json",
     )
     assert first.returncode == 0, first.stdout + first.stderr
 
     second = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Area2D", "--name", "Hitbox", "--parent", "Hero", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Area2D",
+        "--name",
+        "Hitbox",
+        "--parent",
+        "Hero",
+        "--json",
     )
 
     assert second.returncode == 0, second.stdout + second.stderr
@@ -141,8 +161,14 @@ def test_node_add_builtin_type_reports_null_script_class(godot_project):
     _create_scene(scene_path)
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Sprite2D", "--name", "Hero", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Sprite2D",
+        "--name",
+        "Hero",
+        "--json",
     )
 
     assert added.returncode == 0, added.stdout + added.stderr
@@ -178,8 +204,14 @@ def test_node_add_bad_parent_yields_parent_not_found_and_leaves_file_unchanged(
     before = scene_path.read_text(encoding="utf-8")
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Sprite2D", "--parent", "Bogus/Path", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Sprite2D",
+        "--parent",
+        "Bogus/Path",
+        "--json",
     )
 
     err = _assert_operation_error(added, "parent_not_found")
@@ -194,8 +226,16 @@ def _scene_with_nested_children(godot_project):
     _create_scene(scene_path)
     for name, parent in (("A", "."), ("B", "A")):
         added = _gda(
-            "node", "add", str(scene_path),
-            "--type", "Node2D", "--name", name, "--parent", parent, "--json",
+            "node",
+            "add",
+            str(scene_path),
+            "--type",
+            "Node2D",
+            "--name",
+            name,
+            "--parent",
+            parent,
+            "--json",
         )
         assert added.returncode == 0, added.stdout + added.stderr
     return scene_path
@@ -203,9 +243,7 @@ def _scene_with_nested_children(godot_project):
 
 @pytest.mark.e2e
 @pytest.mark.parametrize("form", ["..", "../A", "/root/A"])
-def test_node_add_parent_path_escaping_or_absolute_stays_rejected(
-    godot_project, form
-):
+def test_node_add_parent_path_escaping_or_absolute_stays_rejected(godot_project, form):
     # Regression pins for issue #66: these forms were already rejected on main
     # before the strictness change — absolute paths by _resolve_parent's
     # explicit check, and leading ".." because a scene loaded for editing has
@@ -215,8 +253,16 @@ def test_node_add_parent_path_escaping_or_absolute_stays_rejected(
     before = scene_path.read_text(encoding="utf-8")
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Marker2D", "--name", "M", "--parent", form, "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Marker2D",
+        "--name",
+        "M",
+        "--parent",
+        form,
+        "--json",
     )
 
     err = _assert_operation_error(added, "parent_not_found")
@@ -240,8 +286,16 @@ def test_node_add_rejects_non_canonical_parent_path(godot_project, form):
     before = scene_path.read_text(encoding="utf-8")
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Marker2D", "--name", "M", "--parent", form, "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Marker2D",
+        "--name",
+        "M",
+        "--parent",
+        form,
+        "--json",
     )
 
     err = _assert_operation_error(added, "parent_not_found")
@@ -256,8 +310,16 @@ def test_node_add_explicit_dot_parent_addresses_the_root(godot_project):
     scene_path = _scene_with_nested_children(godot_project)
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Marker2D", "--name", "M", "--parent", ".", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Marker2D",
+        "--name",
+        "M",
+        "--parent",
+        ".",
+        "--json",
     )
 
     assert added.returncode == 0, added.stdout + added.stderr
@@ -269,15 +331,27 @@ def test_node_add_name_collision_yields_duplicate_node_name(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     first = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Sprite2D", "--name", "Hero", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Sprite2D",
+        "--name",
+        "Hero",
+        "--json",
     )
     assert first.returncode == 0, first.stdout + first.stderr
     before = scene_path.read_text(encoding="utf-8")
 
     again = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Area2D", "--name", "Hero", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Area2D",
+        "--name",
+        "Hero",
+        "--json",
     )
 
     err = _assert_operation_error(again, "duplicate_node_name")
@@ -303,15 +377,29 @@ def test_node_add_collision_with_internal_child_yields_duplicate_node_name(
     )
     assert created.returncode == 0, created.stdout + created.stderr
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "ScrollContainer", "--name", "Scroll", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "ScrollContainer",
+        "--name",
+        "Scroll",
+        "--json",
     )
     assert added.returncode == 0, added.stdout + added.stderr
     before = scene_path.read_text(encoding="utf-8")
 
     colliding = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Control", "--name", "_h_scroll", "--parent", "Scroll", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Control",
+        "--name",
+        "_h_scroll",
+        "--parent",
+        "Scroll",
+        "--json",
     )
 
     err = _assert_operation_error(colliding, "duplicate_node_name")
@@ -338,8 +426,14 @@ def test_node_add_rejects_name_godot_would_rewrite(godot_project):
     _create_scene(scene_path)
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Sprite2D", "--name", "Bad%Name", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Sprite2D",
+        "--name",
+        "Bad%Name",
+        "--json",
     )
 
     err = _assert_operation_error(added, "invalid_node_name")
@@ -367,8 +461,14 @@ def test_node_get_reports_typed_properties(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Sprite2D", "--name", "Hero", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Sprite2D",
+        "--name",
+        "Hero",
+        "--json",
     )
     assert added.returncode == 0, added.stdout + added.stderr
 
@@ -432,11 +532,21 @@ def test_node_set_coerces_and_round_trips_via_get(
     # rules documented in the command catalog.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda("node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json")
+    _gda(
+        "node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json"
+    )
 
     was_set = _gda(
-        "node", "set", str(scene_path),
-        "--node", "Hero", "--property", prop, "--value", value, "--json",
+        "node",
+        "set",
+        str(scene_path),
+        "--node",
+        "Hero",
+        "--property",
+        prop,
+        "--value",
+        value,
+        "--json",
     )
 
     assert was_set.returncode == 0, was_set.stdout + was_set.stderr
@@ -453,12 +563,22 @@ def test_node_set_unknown_property_yields_unknown_property_and_leaves_file_uncha
 ):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda("node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json")
+    _gda(
+        "node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json"
+    )
     before = scene_path.read_text(encoding="utf-8")
 
     was_set = _gda(
-        "node", "set", str(scene_path),
-        "--node", "Hero", "--property", "no_such_prop", "--value", "1", "--json",
+        "node",
+        "set",
+        str(scene_path),
+        "--node",
+        "Hero",
+        "--property",
+        "no_such_prop",
+        "--value",
+        "1",
+        "--json",
     )
 
     err = _assert_operation_error(was_set, "unknown_property")
@@ -475,12 +595,22 @@ def test_node_set_uncoercible_value_yields_uncoercible_value_and_leaves_file_unc
     # the scene file is left untouched.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda("node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json")
+    _gda(
+        "node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json"
+    )
     before = scene_path.read_text(encoding="utf-8")
 
     was_set = _gda(
-        "node", "set", str(scene_path),
-        "--node", "Hero", "--property", "position", "--value", "not_a_vector", "--json",
+        "node",
+        "set",
+        str(scene_path),
+        "--node",
+        "Hero",
+        "--property",
+        "position",
+        "--value",
+        "not_a_vector",
+        "--json",
     )
 
     err = _assert_operation_error(was_set, "uncoercible_value")
@@ -495,8 +625,16 @@ def test_node_set_missing_node_yields_node_not_found(godot_project):
     before = scene_path.read_text(encoding="utf-8")
 
     was_set = _gda(
-        "node", "set", str(scene_path),
-        "--node", "Bogus", "--property", "position", "--value", "1,2", "--json",
+        "node",
+        "set",
+        str(scene_path),
+        "--node",
+        "Bogus",
+        "--property",
+        "position",
+        "--value",
+        "1,2",
+        "--json",
     )
 
     err = _assert_operation_error(was_set, "node_not_found")
@@ -515,9 +653,18 @@ def test_node_set_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
     before = parent.read_text(encoding="utf-8")
 
     was_set = _gda(
-        "node", "set", str(parent),
-        "--node", ".", "--property", "position", "--value", "1,2",
-        "--project", str(godot_project), "--json",
+        "node",
+        "set",
+        str(parent),
+        "--node",
+        ".",
+        "--property",
+        "position",
+        "--value",
+        "1,2",
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     err = _assert_operation_error(was_set, "missing_dependency")
@@ -537,8 +684,14 @@ def test_node_list_reports_all_siblings_at_one_level_in_tree_order(godot_project
     siblings = [("A", "Node2D"), ("B", "Sprite2D"), ("C", "Area2D")]
     for name, node_type in siblings:
         added = _gda(
-            "node", "add", str(scene_path),
-            "--type", node_type, "--name", name, "--json",
+            "node",
+            "add",
+            str(scene_path),
+            "--type",
+            node_type,
+            "--name",
+            name,
+            "--json",
         )
         assert added.returncode == 0, added.stdout + added.stderr
 
@@ -631,16 +784,23 @@ def test_node_add_preserves_editable_instance_overrides(godot_project):
     parent = _write_instance_fixture(godot_project)
 
     added = _gda(
-        "node", "add", str(parent),
-        "--type", "Marker2D", "--name", "M",
-        "--project", str(godot_project), "--json",
+        "node",
+        "add",
+        str(parent),
+        "--type",
+        "Marker2D",
+        "--name",
+        "M",
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     assert added.returncode == 0, added.stdout + added.stderr
     assert json.loads(added.stdout)["path"] == "M"
     saved = parent.read_text(encoding="utf-8")
     # The sub-scene is still an instance, not a flattened copy.
-    assert 'instance=ExtResource(' in saved
+    assert "instance=ExtResource(" in saved
     assert '[editable path="ChildInstance"]' in saved
     # Top-level instance property override.
     assert "position = Vector2(10, 20)" in saved
@@ -686,9 +846,16 @@ def test_node_add_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
     before = parent.read_text(encoding="utf-8")
 
     added = _gda(
-        "node", "add", str(parent),
-        "--type", "Marker2D", "--name", "M",
-        "--project", str(godot_project), "--json",
+        "node",
+        "add",
+        str(parent),
+        "--type",
+        "Marker2D",
+        "--name",
+        "M",
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     err = _assert_operation_error(added, "missing_dependency")
@@ -721,9 +888,16 @@ def test_node_add_refuses_scene_that_instantiates_to_null(godot_project):
     before = parent.read_text(encoding="utf-8")
 
     added = _gda(
-        "node", "add", str(parent),
-        "--type", "Marker2D", "--name", "M",
-        "--project", str(godot_project), "--json",
+        "node",
+        "add",
+        str(parent),
+        "--type",
+        "Marker2D",
+        "--name",
+        "M",
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     err = _assert_operation_error(added, "missing_dependency")
@@ -755,8 +929,14 @@ def test_node_add_refuses_scene_whose_declared_class_is_substituted(godot_projec
     before = scene_path.read_text(encoding="utf-8")
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Marker2D", "--name", "M", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Marker2D",
+        "--name",
+        "M",
+        "--json",
     )
 
     err = _assert_operation_error(added, "missing_dependency")
@@ -795,8 +975,14 @@ def test_node_add_by_class_name_attaches_the_script(godot_project):
     _create_scene(scene_path)
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Hero", "--project", str(godot_project), "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Hero",
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     assert added.returncode == 0, added.stdout + added.stderr
@@ -825,8 +1011,14 @@ def test_node_add_by_unregistered_class_name_yields_invalid_node_type(godot_proj
     _create_scene(scene_path)
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Hero", "--project", str(godot_project), "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Hero",
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     err = _assert_operation_error(added, "invalid_node_type")
@@ -859,8 +1051,14 @@ def test_node_add_by_registered_but_broken_class_name_names_the_script(godot_pro
     before = scene_path.read_text(encoding="utf-8")
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Hero", "--project", str(godot_project), "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Hero",
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     err = _assert_operation_error(added, "uninstantiable_script")
@@ -890,8 +1088,14 @@ def test_node_add_by_non_node_class_name_yields_invalid_node_type(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Loot", "--project", str(godot_project), "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Loot",
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     err = _assert_operation_error(added, "invalid_node_type")
@@ -928,8 +1132,14 @@ def test_node_add_by_class_name_whose_init_requires_args_names_the_constructor(
     before = scene_path.read_text(encoding="utf-8")
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Hero", "--project", str(godot_project), "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Hero",
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     err = _assert_operation_error(added, "uninstantiable_script")
@@ -1003,8 +1213,14 @@ def _scene_with_emitter_and_receiver(godot_project):
     _create_scene(scene_path)
     for node_type, name in (("Timer", "Emitter"), ("Node2D", "Receiver")):
         added = _gda(
-            "node", "add", str(scene_path),
-            "--type", node_type, "--name", name, "--json",
+            "node",
+            "add",
+            str(scene_path),
+            "--type",
+            node_type,
+            "--name",
+            name,
+            "--json",
         )
         assert added.returncode == 0, added.stdout + added.stderr
     return scene_path
@@ -1027,9 +1243,18 @@ def test_node_connect_signal_records_a_connection_that_round_trips(godot_project
     scene_path = _scene_with_emitter_and_receiver(godot_project)
 
     connected = _gda(
-        "node", "connect-signal", str(scene_path),
-        "--from", "Emitter", "--signal", "timeout",
-        "--to", "Receiver", "--method", "on_timeout", "--json",
+        "node",
+        "connect-signal",
+        str(scene_path),
+        "--from",
+        "Emitter",
+        "--signal",
+        "timeout",
+        "--to",
+        "Receiver",
+        "--method",
+        "on_timeout",
+        "--json",
     )
 
     assert connected.returncode == 0, connected.stdout + connected.stderr
@@ -1053,9 +1278,18 @@ def test_node_connect_signal_allows_a_not_yet_defined_target_method(godot_projec
     scene_path = _scene_with_emitter_and_receiver(godot_project)
 
     connected = _gda(
-        "node", "connect-signal", str(scene_path),
-        "--from", "Emitter", "--signal", "timeout",
-        "--to", "Receiver", "--method", "not_yet_written", "--json",
+        "node",
+        "connect-signal",
+        str(scene_path),
+        "--from",
+        "Emitter",
+        "--signal",
+        "timeout",
+        "--to",
+        "Receiver",
+        "--method",
+        "not_yet_written",
+        "--json",
     )
 
     assert connected.returncode == 0, connected.stdout + connected.stderr
@@ -1074,9 +1308,18 @@ def test_node_connect_signal_unknown_signal_yields_signal_not_found(godot_projec
     before = scene_path.read_text(encoding="utf-8")
 
     connected = _gda(
-        "node", "connect-signal", str(scene_path),
-        "--from", "Emitter", "--signal", "no_such_signal",
-        "--to", "Receiver", "--method", "on_timeout", "--json",
+        "node",
+        "connect-signal",
+        str(scene_path),
+        "--from",
+        "Emitter",
+        "--signal",
+        "no_such_signal",
+        "--to",
+        "Receiver",
+        "--method",
+        "on_timeout",
+        "--json",
     )
 
     err = _assert_operation_error(connected, "signal_not_found")
@@ -1091,17 +1334,35 @@ def test_node_connect_signal_already_connected_yields_already_connected(godot_pr
     # unchanged after the second attempt.
     scene_path = _scene_with_emitter_and_receiver(godot_project)
     first = _gda(
-        "node", "connect-signal", str(scene_path),
-        "--from", "Emitter", "--signal", "timeout",
-        "--to", "Receiver", "--method", "on_timeout", "--json",
+        "node",
+        "connect-signal",
+        str(scene_path),
+        "--from",
+        "Emitter",
+        "--signal",
+        "timeout",
+        "--to",
+        "Receiver",
+        "--method",
+        "on_timeout",
+        "--json",
     )
     assert first.returncode == 0, first.stdout + first.stderr
     before = scene_path.read_text(encoding="utf-8")
 
     again = _gda(
-        "node", "connect-signal", str(scene_path),
-        "--from", "Emitter", "--signal", "timeout",
-        "--to", "Receiver", "--method", "on_timeout", "--json",
+        "node",
+        "connect-signal",
+        str(scene_path),
+        "--from",
+        "Emitter",
+        "--signal",
+        "timeout",
+        "--to",
+        "Receiver",
+        "--method",
+        "on_timeout",
+        "--json",
     )
 
     err = _assert_operation_error(again, "already_connected")
@@ -1115,9 +1376,18 @@ def test_node_connect_signal_missing_source_node_yields_node_not_found(godot_pro
     before = scene_path.read_text(encoding="utf-8")
 
     connected = _gda(
-        "node", "connect-signal", str(scene_path),
-        "--from", "Bogus", "--signal", "timeout",
-        "--to", "Receiver", "--method", "on_timeout", "--json",
+        "node",
+        "connect-signal",
+        str(scene_path),
+        "--from",
+        "Bogus",
+        "--signal",
+        "timeout",
+        "--to",
+        "Receiver",
+        "--method",
+        "on_timeout",
+        "--json",
     )
 
     err = _assert_operation_error(connected, "node_not_found")
@@ -1138,7 +1408,7 @@ def test_node_remove_root_yields_cannot_target_root(godot_project):
 
     removed = _gda("node", "remove", str(scene_path), "--node", ".", "--json")
 
-    err = _assert_operation_error(removed, "cannot_target_root")
+    _assert_operation_error(removed, "cannot_target_root")
     assert scene_path.read_text(encoding="utf-8") == before
 
 
@@ -1152,7 +1422,9 @@ def test_node_duplicate_copies_node_under_same_parent_with_fresh_name(godot_proj
     # is reported — verified through a fresh node list. The source survives.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda("node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json")
+    _gda(
+        "node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json"
+    )
 
     duplicated = _gda("node", "duplicate", str(scene_path), "--node", "Hero", "--json")
 
@@ -1183,8 +1455,16 @@ def test_node_duplicate_copies_the_whole_subtree(godot_project):
     _create_scene(scene_path)
     _gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
     _gda(
-        "node", "add", str(scene_path),
-        "--type", "Area2D", "--name", "Hitbox", "--parent", "Hero", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Area2D",
+        "--name",
+        "Hitbox",
+        "--parent",
+        "Hero",
+        "--json",
     )
 
     duplicated = _gda("node", "duplicate", str(scene_path), "--node", "Hero", "--json")
@@ -1255,10 +1535,27 @@ def test_node_move_reparents_node_and_subtree_round_trip(godot_project):
     _create_scene(scene_path)
     _gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
     _gda(
-        "node", "add", str(scene_path),
-        "--type", "Area2D", "--name", "Hitbox", "--parent", "Hero", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Area2D",
+        "--name",
+        "Hitbox",
+        "--parent",
+        "Hero",
+        "--json",
     )
-    _gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Enemies", "--json")
+    _gda(
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Node2D",
+        "--name",
+        "Enemies",
+        "--json",
+    )
 
     moved = _gda(
         "node", "move", str(scene_path), "--node", "Hero", "--to", "Enemies", "--json"
@@ -1326,9 +1623,7 @@ def test_node_move_under_itself_yields_cyclic_target(godot_project):
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda(
-        "node", "move", str(scene_path), "--node", "A", "--to", "A", "--json"
-    )
+    moved = _gda("node", "move", str(scene_path), "--node", "A", "--to", "A", "--json")
 
     _assert_operation_error(moved, "cyclic_target")
     assert scene_path.read_text(encoding="utf-8") == before
@@ -1360,10 +1655,27 @@ def test_node_move_name_collision_at_destination_yields_duplicate_node_name(
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     _gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
-    _gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Enemies", "--json")
     _gda(
-        "node", "add", str(scene_path),
-        "--type", "Sprite2D", "--name", "Hero", "--parent", "Enemies", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Node2D",
+        "--name",
+        "Enemies",
+        "--json",
+    )
+    _gda(
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Sprite2D",
+        "--name",
+        "Hero",
+        "--parent",
+        "Enemies",
+        "--json",
     )
     before = scene_path.read_text(encoding="utf-8")
 
@@ -1381,9 +1693,18 @@ def test_node_connect_signal_missing_target_node_yields_node_not_found(godot_pro
     scene_path = _scene_with_emitter_and_receiver(godot_project)
 
     connected = _gda(
-        "node", "connect-signal", str(scene_path),
-        "--from", "Emitter", "--signal", "timeout",
-        "--to", "Bogus", "--method", "on_timeout", "--json",
+        "node",
+        "connect-signal",
+        str(scene_path),
+        "--from",
+        "Emitter",
+        "--signal",
+        "timeout",
+        "--to",
+        "Bogus",
+        "--method",
+        "on_timeout",
+        "--json",
     )
 
     err = _assert_operation_error(connected, "node_not_found")
@@ -1397,17 +1718,35 @@ def test_node_disconnect_signal_removes_an_existing_connection(godot_project):
     # trip read shows the [connection] is gone from the saved file.
     scene_path = _scene_with_emitter_and_receiver(godot_project)
     connected = _gda(
-        "node", "connect-signal", str(scene_path),
-        "--from", "Emitter", "--signal", "timeout",
-        "--to", "Receiver", "--method", "on_timeout", "--json",
+        "node",
+        "connect-signal",
+        str(scene_path),
+        "--from",
+        "Emitter",
+        "--signal",
+        "timeout",
+        "--to",
+        "Receiver",
+        "--method",
+        "on_timeout",
+        "--json",
     )
     assert connected.returncode == 0, connected.stdout + connected.stderr
     assert _connection_lines(scene_path)  # the connection is there first
 
     disconnected = _gda(
-        "node", "disconnect-signal", str(scene_path),
-        "--from", "Emitter", "--signal", "timeout",
-        "--to", "Receiver", "--method", "on_timeout", "--json",
+        "node",
+        "disconnect-signal",
+        str(scene_path),
+        "--from",
+        "Emitter",
+        "--signal",
+        "timeout",
+        "--to",
+        "Receiver",
+        "--method",
+        "on_timeout",
+        "--json",
     )
 
     assert disconnected.returncode == 0, disconnected.stdout + disconnected.stderr
@@ -1427,9 +1766,18 @@ def test_node_disconnect_signal_absent_connection_yields_connection_not_found(
     before = scene_path.read_text(encoding="utf-8")
 
     disconnected = _gda(
-        "node", "disconnect-signal", str(scene_path),
-        "--from", "Emitter", "--signal", "timeout",
-        "--to", "Receiver", "--method", "on_timeout", "--json",
+        "node",
+        "disconnect-signal",
+        str(scene_path),
+        "--from",
+        "Emitter",
+        "--signal",
+        "timeout",
+        "--to",
+        "Receiver",
+        "--method",
+        "on_timeout",
+        "--json",
     )
 
     err = _assert_operation_error(disconnected, "connection_not_found")
@@ -1460,9 +1808,18 @@ def test_node_disconnect_signal_missing_signal_yields_signal_not_found(godot_pro
     before = scene_path.read_text(encoding="utf-8")
 
     disconnected = _gda(
-        "node", "disconnect-signal", str(scene_path),
-        "--from", "Emitter", "--signal", "no_such_signal",
-        "--to", "Receiver", "--method", "on_timeout", "--json",
+        "node",
+        "disconnect-signal",
+        str(scene_path),
+        "--from",
+        "Emitter",
+        "--signal",
+        "no_such_signal",
+        "--to",
+        "Receiver",
+        "--method",
+        "on_timeout",
+        "--json",
     )
 
     err = _assert_operation_error(disconnected, "signal_not_found")
@@ -1477,9 +1834,7 @@ def test_node_move_root_yields_cannot_target_root(godot_project):
     scene_path = _scene_with_nested_children(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda(
-        "node", "move", str(scene_path), "--node", ".", "--to", "A", "--json"
-    )
+    moved = _gda("node", "move", str(scene_path), "--node", ".", "--to", "A", "--json")
 
     _assert_operation_error(moved, "cannot_target_root")
     assert scene_path.read_text(encoding="utf-8") == before
@@ -1527,23 +1882,37 @@ def test_node_move_preserves_editable_instance_overrides(godot_project):
     parent = _write_instance_fixture(godot_project)
     # A destination parent to reparent the instance under.
     added = _gda(
-        "node", "add", str(parent),
-        "--type", "Node2D", "--name", "Dest",
-        "--project", str(godot_project), "--json",
+        "node",
+        "add",
+        str(parent),
+        "--type",
+        "Node2D",
+        "--name",
+        "Dest",
+        "--project",
+        str(godot_project),
+        "--json",
     )
     assert added.returncode == 0, added.stdout + added.stderr
 
     moved = _gda(
-        "node", "move", str(parent),
-        "--node", "ChildInstance", "--to", "Dest",
-        "--project", str(godot_project), "--json",
+        "node",
+        "move",
+        str(parent),
+        "--node",
+        "ChildInstance",
+        "--to",
+        "Dest",
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     assert moved.returncode == 0, moved.stdout + moved.stderr
     assert json.loads(moved.stdout)["path"] == "Dest/ChildInstance"
     saved = parent.read_text(encoding="utf-8")
     # The sub-scene is still an instance under its new parent, not a flattened copy.
-    assert 'instance=ExtResource(' in saved
+    assert "instance=ExtResource(" in saved
     assert '[editable path="Dest/ChildInstance"]' in saved
     # The override nodes inside the instance keep their override form (parent +
     # index, NO type=) rather than being rewritten as local typed nodes.
@@ -1562,9 +1931,18 @@ def test_node_connect_signal_to_missing_scene_yields_path_not_found(godot_projec
     missing = godot_project / "missing.tscn"
 
     connected = _gda(
-        "node", "connect-signal", str(missing),
-        "--from", "Emitter", "--signal", "timeout",
-        "--to", "Receiver", "--method", "on_timeout", "--json",
+        "node",
+        "connect-signal",
+        str(missing),
+        "--from",
+        "Emitter",
+        "--signal",
+        "timeout",
+        "--to",
+        "Receiver",
+        "--method",
+        "on_timeout",
+        "--json",
     )
 
     err = _assert_operation_error(connected, "path_not_found")
@@ -1579,8 +1957,14 @@ def test_node_add_leaves_no_temp_file_on_success(godot_project):
     _create_scene(scene_path)
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Sprite2D", "--name", "Hero", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Sprite2D",
+        "--name",
+        "Hero",
+        "--json",
     )
 
     assert added.returncode == 0, added.stdout + added.stderr
@@ -1604,8 +1988,14 @@ def test_node_add_with_external_edit_in_window_yields_file_changed_externally(
 
     added = _gda_env(
         {"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
-        "node", "add", str(scene_path),
-        "--type", "Sprite2D", "--name", "Hero", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Sprite2D",
+        "--name",
+        "Hero",
+        "--json",
     )
 
     err = _assert_operation_error(added, "file_changed_externally")
@@ -1642,8 +2032,14 @@ def test_node_add_with_external_edit_during_instantiate_yields_file_changed_exte
 
     added = _gda_env(
         {"GDA_TEST_PERTURB_AFTER_LOAD": "1"},
-        "node", "add", str(scene_path),
-        "--type", "Sprite2D", "--name", "Hero", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Sprite2D",
+        "--name",
+        "Hero",
+        "--json",
     )
 
     err = _assert_operation_error(added, "file_changed_externally")

--- a/tests/test_e2e_op_robustness.py
+++ b/tests/test_e2e_op_robustness.py
@@ -8,7 +8,6 @@ errors (unknown operation, non-JSON params) carry their own stable codes rather
 than the generic operation_failed.
 """
 
-import shutil
 import subprocess
 import time
 
@@ -57,12 +56,22 @@ def test_non_json_params_yield_stable_code():
     # Bypass the runner (which json.dumps its params) to hand the op a
     # syntactically invalid params payload directly.
     proc = subprocess.run(
-        [str(GODOT), "--headless", "--script", str(OPERATIONS_GD), "--", "info", "{not json"],
+        [
+            str(GODOT),
+            "--headless",
+            "--script",
+            str(OPERATIONS_GD),
+            "--",
+            "info",
+            "{not json",
+        ],
         capture_output=True,
         text=True,
         timeout=30,
     )
-    result = RunResult(stdout=proc.stdout, stderr=proc.stderr, exit_code=proc.returncode)
+    result = RunResult(
+        stdout=proc.stdout, stderr=proc.stderr, exit_code=proc.returncode
+    )
 
     outcome = classify_run(result, GODOT, EngineVersion)
     assert isinstance(outcome, Failure)

--- a/tests/test_e2e_params_json.py
+++ b/tests/test_e2e_params_json.py
@@ -64,7 +64,16 @@ def test_scene_create_via_params_json_stdin_creates_the_scene(godot_project):
     params = json.dumps({"path": str(scene_path), "root_type": "Node2D"})
 
     created = subprocess.run(
-        [*GDA_CMD, "scene", "create", "--params-json", "-", "--json", "--godot", str(GODOT)],
+        [
+            *GDA_CMD,
+            "scene",
+            "create",
+            "--params-json",
+            "-",
+            "--json",
+            "--godot",
+            str(GODOT),
+        ],
         input=params,
         capture_output=True,
         text=True,

--- a/tests/test_e2e_perf.py
+++ b/tests/test_e2e_perf.py
@@ -46,7 +46,7 @@ SIGNAL_PLAYER_GD = (
     "\tticked.emit(_n)\n"
 )
 SIGNAL_MAIN_TSCN = (
-    '[gd_scene load_steps=2 format=3]\n\n'
+    "[gd_scene load_steps=2 format=3]\n\n"
     '[ext_resource type="Script" path="res://player.gd" id="1"]\n\n'
     '[node name="Main" type="Node2D"]\n\n'
     '[node name="Player" type="Node2D" parent="."]\n'
@@ -67,7 +67,15 @@ def test_daemon_serves_a_live_perf_snapshot(tmp_path, daemon_runtime_dir):
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,
@@ -104,7 +112,15 @@ def test_daemon_serves_a_property_timeline_over_a_window(tmp_path, daemon_runtim
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,
@@ -116,8 +132,13 @@ def test_daemon_serves_a_property_timeline_over_a_window(tmp_path, daemon_runtim
         assert started.returncode == 0, started.stdout + started.stderr
 
         timeline = run(
-            "perf", "monitor", "/root/Main/Player",
-            "--property", "position", "--frames", "5",
+            "perf",
+            "monitor",
+            "/root/Main/Player",
+            "--property",
+            "position",
+            "--frames",
+            "5",
         )
         assert timeline.returncode == 0, timeline.stdout + timeline.stderr
         doc = json.loads(timeline.stdout)
@@ -149,7 +170,15 @@ def test_daemon_serves_a_signal_timeline_over_a_window(tmp_path, daemon_runtime_
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,
@@ -161,8 +190,13 @@ def test_daemon_serves_a_signal_timeline_over_a_window(tmp_path, daemon_runtime_
         assert started.returncode == 0, started.stdout + started.stderr
 
         timeline = run(
-            "perf", "monitor", "/root/Main/Player",
-            "--signal", "ticked", "--frames", "5",
+            "perf",
+            "monitor",
+            "/root/Main/Player",
+            "--signal",
+            "ticked",
+            "--frames",
+            "5",
         )
         assert timeline.returncode == 0, timeline.stdout + timeline.stderr
         doc = json.loads(timeline.stdout)
@@ -191,7 +225,9 @@ def test_daemon_serves_a_signal_timeline_over_a_window(tmp_path, daemon_runtime_
 
 
 @pytest.mark.e2e
-def test_perf_monitor_missing_node_reports_live_perf_node_not_found(tmp_path, daemon_runtime_dir):
+def test_perf_monitor_missing_node_reports_live_perf_node_not_found(
+    tmp_path, daemon_runtime_dir
+):
     # A path that resolves to no running node is the typed harness op-error,
     # relayed through the daemon (exit-0 sentinel) and mapped by classify_live.
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
@@ -201,7 +237,15 @@ def test_perf_monitor_missing_node_reports_live_perf_node_not_found(tmp_path, da
 
     def run(*args):
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,
@@ -214,7 +258,13 @@ def test_perf_monitor_missing_node_reports_live_perf_node_not_found(tmp_path, da
         from gda.exit_codes import EXIT_LIVE
 
         missing = run(
-            "perf", "monitor", "/root/Main/Ghost", "--property", "position", "--frames", "2"
+            "perf",
+            "monitor",
+            "/root/Main/Ghost",
+            "--property",
+            "position",
+            "--frames",
+            "2",
         )
         assert missing.returncode == EXIT_LIVE, missing.stdout + missing.stderr
         assert json.loads(missing.stdout)["error"]["code"] == "live_perf_node_not_found"

--- a/tests/test_e2e_project.py
+++ b/tests/test_e2e_project.py
@@ -154,9 +154,7 @@ def test_project_set_uncoercible_value_is_a_clean_error(godot_project):
 @pytest.mark.e2e
 def test_project_add_autoload_registers_persists_and_round_trips(godot_project):
     # A real script to autoload must exist in the project (path_not_found otherwise).
-    (godot_project / "global.gd").write_text(
-        "extends Node\n", encoding="utf-8"
-    )
+    (godot_project / "global.gd").write_text("extends Node\n", encoding="utf-8")
 
     added = _gda(
         godot_project,

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -185,9 +185,7 @@ def test_find_references_to_the_main_scene_includes_the_project_level_reference(
     assert proc.returncode == 0, proc.stdout + proc.stderr
     refs = json.loads(proc.stdout)["references"]
     # The main scene is referenced by project.godot's run/main_scene, not a file.
-    assert any(
-        r["path"] == "project.godot" and r["kind"] == "main_scene" for r in refs
-    )
+    assert any(r["path"] == "project.godot" and r["kind"] == "main_scene" for r in refs)
 
 
 @pytest.mark.e2e
@@ -204,9 +202,7 @@ def test_find_references_to_an_unreferenced_resource_is_empty(refgraph_project):
 def test_find_unused_resources_reports_the_orphan_and_is_consistent_with_find_references(
     refgraph_project,
 ):
-    proc = _gda(
-        refgraph_project, "project", "find-unused-resources", "--json"
-    )
+    proc = _gda(refgraph_project, "project", "find-unused-resources", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     unused = json.loads(proc.stdout)["unused"]
@@ -223,9 +219,7 @@ def test_find_unused_resources_reports_the_orphan_and_is_consistent_with_find_re
     # find-references for it returns empty, and a referenced one returns non-empty.
     for path in unused:
         refs = json.loads(
-            _gda(
-                refgraph_project, "project", "find-references", path, "--json"
-            ).stdout
+            _gda(refgraph_project, "project", "find-references", path, "--json").stdout
         )["references"]
         assert refs == [], f"{path} reported unused but has references {refs}"
 
@@ -248,7 +242,9 @@ def test_statistics_reports_counts_autoloads_and_plugins(refgraph_project):
     assert data["total_files"] >= 8
     assert data["total_lines"] > 0
     assert data["scene_count"] == 2  # main.tscn, hero.tscn
-    assert data["script_count"] >= 3  # main.gd, util.gd, game_state.gd (+ plugin.gd? no)
+    assert (
+        data["script_count"] >= 3
+    )  # main.gd, util.gd, game_state.gd (+ plugin.gd? no)
     by_ext = {e["extension"]: e for e in data["by_extension"]}
     assert by_ext["gd"]["files"] >= 3
     assert by_ext["gd"]["lines"] > 0
@@ -353,9 +349,7 @@ def test_find_references_to_a_class_name_excludes_its_own_declaration(
     # `var x: Hero` annotation, Hero.new()) but NEVER hero.gd's own
     # `class_name Hero` declaration line — that is the definition site, not a
     # reference (issue #116 review: false positive).
-    proc = _gda(
-        classname_project, "project", "find-references", "Hero", "--json"
-    )
+    proc = _gda(classname_project, "project", "find-references", "Hero", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -381,9 +375,7 @@ def test_find_references_to_a_class_name_excludes_its_own_declaration(
 def test_find_references_to_an_unreferenced_class_name_is_empty(classname_project):
     # A class declared via class_name that NOTHING consumes returns an empty
     # reference set — its own declaration line must not count as a reference.
-    proc = _gda(
-        classname_project, "project", "find-references", "Lonely", "--json"
-    )
+    proc = _gda(classname_project, "project", "find-references", "Lonely", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert json.loads(proc.stdout)["references"] == []

--- a/tests/test_e2e_resource.py
+++ b/tests/test_e2e_resource.py
@@ -107,7 +107,9 @@ def test_resource_create_then_get_round_trip(godot_project):
     # resource create wrote.
     resource_path = godot_project / "palette.tres"
 
-    created = _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    created = _gda(
+        "resource", "create", str(resource_path), "--type", "Gradient", "--json"
+    )
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)
@@ -137,7 +139,9 @@ def test_resource_create_into_nested_dir_reports_created_dirs(godot_project):
     # outermost to innermost (mirrors scene/script create).
     resource_path = godot_project / "art" / "palettes" / "sunset.tres"
 
-    created = _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    created = _gda(
+        "resource", "create", str(resource_path), "--type", "Gradient", "--json"
+    )
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)
@@ -153,13 +157,13 @@ def test_resource_create_no_clobber_yields_already_exists(godot_project):
     # No-clobber: a create whose target already exists is refused with
     # already_exists, leaving the existing file untouched.
     resource_path = godot_project / "palette.tres"
-    first = _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    first = _gda(
+        "resource", "create", str(resource_path), "--type", "Gradient", "--json"
+    )
     assert first.returncode == 0, first.stdout + first.stderr
     before = resource_path.read_text(encoding="utf-8")
 
-    second = _gda(
-        "resource", "create", str(resource_path), "--type", "Curve", "--json"
-    )
+    second = _gda("resource", "create", str(resource_path), "--type", "Curve", "--json")
 
     err = _assert_operation_error(second, "already_exists")
     assert str(resource_path) in err["message"]
@@ -200,9 +204,7 @@ def test_resource_create_non_resource_type_yields_invalid_resource_type(godot_pr
 def test_resource_create_non_tres_path_yields_invalid_path(godot_project):
     bad_path = godot_project / "palette.txt"
 
-    created = _gda(
-        "resource", "create", str(bad_path), "--type", "Gradient", "--json"
-    )
+    created = _gda("resource", "create", str(bad_path), "--type", "Gradient", "--json")
 
     err = _assert_operation_error(created, "invalid_path")
     assert ".tres" in err["message"]
@@ -239,7 +241,9 @@ def test_resource_set_coerces_persists_and_round_trips_via_get(godot_project):
     # type, saves the .tres, and get reports the coerced value — resource get IS
     # the structured-level verification that set persisted.
     resource_path = godot_project / "palette.tres"
-    created = _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    created = _gda(
+        "resource", "create", str(resource_path), "--type", "Gradient", "--json"
+    )
     assert created.returncode == 0, created.stdout + created.stderr
 
     was_set = _gda(
@@ -309,8 +313,14 @@ def test_resource_set_with_external_edit_in_window_yields_file_changed_externall
 
     was_set = _gda_env(
         {"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
-        "resource", "set", str(resource_path),
-        "--property", "resource_name", "--value", "Sunset", "--json",
+        "resource",
+        "set",
+        str(resource_path),
+        "--property",
+        "resource_name",
+        "--value",
+        "Sunset",
+        "--json",
     )
 
     err = _assert_operation_error(was_set, "file_changed_externally")
@@ -388,7 +398,9 @@ def test_resource_delete_removes_file_and_round_trips_against_get(godot_project)
     # create → delete → get: delete removes the .tres and reports what was removed
     # (path + type); a subsequent get is now path_not_found, closing the lifecycle.
     resource_path = godot_project / "palette.tres"
-    created = _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    created = _gda(
+        "resource", "create", str(resource_path), "--type", "Gradient", "--json"
+    )
     assert created.returncode == 0, created.stdout + created.stderr
     assert resource_path.exists()
 
@@ -514,7 +526,15 @@ def test_resource_uid_projectless_run_is_project_not_found():
     # Resolution queries the project's UID cache, so a projectless run is refused
     # with project_not_found rather than a misleading "no UID" answer.
     proc = subprocess.run(
-        [*GDA_CMD, "resource", "uid", "uid://b00000000000b", "--godot", str(GODOT), "--json"],
+        [
+            *GDA_CMD,
+            "resource",
+            "uid",
+            "uid://b00000000000b",
+            "--godot",
+            str(GODOT),
+            "--json",
+        ],
         capture_output=True,
         text=True,
     )

--- a/tests/test_e2e_scene_exports.py
+++ b/tests/test_e2e_scene_exports.py
@@ -64,9 +64,16 @@ def _build_scene_with_exports(project) -> "tuple":
     script_path.write_text(EXPORTING_SCRIPT, encoding="utf-8")
 
     attached = _gda(
-        "script", "attach", str(scene_path),
-        "--node", ".", "--script", str(script_path),
-        "--project", str(project), "--json",
+        "script",
+        "attach",
+        str(scene_path),
+        "--node",
+        ".",
+        "--script",
+        str(script_path),
+        "--project",
+        str(project),
+        "--json",
     )
     assert attached.returncode == 0, attached.stdout + attached.stderr
     return scene_path, script_path
@@ -81,8 +88,12 @@ def test_scene_get_exports_reports_declared_exports_per_node(godot_project):
     scene_path, _ = _build_scene_with_exports(godot_project)
 
     got = _gda(
-        "scene", "get-exports", str(scene_path),
-        "--project", str(godot_project), "--json",
+        "scene",
+        "get-exports",
+        str(scene_path),
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     assert got.returncode == 0, got.stdout + got.stderr
@@ -126,8 +137,12 @@ def test_scene_get_exports_omits_nodes_without_declared_exports(godot_project):
     assert created.returncode == 0, created.stdout + created.stderr
 
     got = _gda(
-        "scene", "get-exports", str(scene_path),
-        "--project", str(godot_project), "--json",
+        "scene",
+        "get-exports",
+        str(scene_path),
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     assert got.returncode == 0, got.stdout + got.stderr
@@ -150,20 +165,37 @@ def test_scene_get_exports_reports_nested_node_by_path(godot_project):
     script_path.write_text(EXPORTING_SCRIPT, encoding="utf-8")
 
     added = _gda(
-        "node", "add", str(scene_path),
-        "--type", "Node2D", "--name", "Child", "--json",
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Node2D",
+        "--name",
+        "Child",
+        "--json",
     )
     assert added.returncode == 0, added.stdout + added.stderr
     attached = _gda(
-        "script", "attach", str(scene_path),
-        "--node", "Child", "--script", str(script_path),
-        "--project", str(godot_project), "--json",
+        "script",
+        "attach",
+        str(scene_path),
+        "--node",
+        "Child",
+        "--script",
+        str(script_path),
+        "--project",
+        str(godot_project),
+        "--json",
     )
     assert attached.returncode == 0, attached.stdout + attached.stderr
 
     got = _gda(
-        "scene", "get-exports", str(scene_path),
-        "--project", str(godot_project), "--json",
+        "scene",
+        "get-exports",
+        str(scene_path),
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     assert got.returncode == 0, got.stdout + got.stderr
@@ -178,8 +210,12 @@ def test_scene_get_exports_reports_nested_node_by_path(godot_project):
 @pytest.mark.e2e
 def test_scene_get_exports_missing_file_yields_path_not_found(godot_project):
     got = _gda(
-        "scene", "get-exports", str(godot_project / "nope.tscn"),
-        "--project", str(godot_project), "--json",
+        "scene",
+        "get-exports",
+        str(godot_project / "nope.tscn"),
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     err = _assert_operation_error(got, "path_not_found")
@@ -194,8 +230,12 @@ def test_scene_get_exports_non_scene_file_yields_not_a_scene(godot_project):
     notes.write_text("not a scene\n", encoding="utf-8")
 
     got = _gda(
-        "scene", "get-exports", str(notes),
-        "--project", str(godot_project), "--json",
+        "scene",
+        "get-exports",
+        str(notes),
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     _assert_operation_error(got, "not_a_scene")

--- a/tests/test_e2e_scene_security.py
+++ b/tests/test_e2e_scene_security.py
@@ -181,9 +181,16 @@ def test_node_add_executes_pre_existing_scene_script(godot_project):
     scene = _plant_spied_scene(godot_project)
 
     added = _gda(
-        "node", "add", str(scene),
-        "--type", "Sprite2D", "--name", "Hero",
-        "--project", str(godot_project), "--json",
+        "node",
+        "add",
+        str(scene),
+        "--type",
+        "Sprite2D",
+        "--name",
+        "Hero",
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     assert added.returncode == 0, added.stdout + added.stderr
@@ -211,9 +218,14 @@ def test_node_get_executes_pre_existing_scene_script(godot_project):
     scene = _plant_spied_scene(godot_project)
 
     got = _gda(
-        "node", "get", str(scene),
-        "--node", ".",
-        "--project", str(godot_project), "--json",
+        "node",
+        "get",
+        str(scene),
+        "--node",
+        ".",
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     assert got.returncode == 0, got.stdout + got.stderr
@@ -265,9 +277,16 @@ def test_node_add_forged_sentinel_from_scene_script_fails_loudly(godot_project):
     (godot_project / "forged.tscn").write_text(FORGED_TSCN, encoding="utf-8")
 
     added = _gda(
-        "node", "add", str(godot_project / "forged.tscn"),
-        "--type", "Sprite2D", "--name", "Hero",
-        "--project", str(godot_project), "--json",
+        "node",
+        "add",
+        str(godot_project / "forged.tscn"),
+        "--type",
+        "Sprite2D",
+        "--name",
+        "Hero",
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     # The forged result is never accepted: the run fails on the parse boundary.
@@ -334,8 +353,12 @@ def test_autoload_runs_on_scene_get(godot_project):
     (godot_project / "plain.tscn").write_text(PLAIN_TSCN, encoding="utf-8")
 
     got = _gda(
-        "scene", "get", str(godot_project / "plain.tscn"),
-        "--project", str(godot_project), "--json",
+        "scene",
+        "get",
+        str(godot_project / "plain.tscn"),
+        "--project",
+        str(godot_project),
+        "--json",
     )
 
     # The read itself succeeds and reports the declared (script-less) tree.

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -171,7 +171,9 @@ def test_windowed_daemon_captures_a_frame_window(tmp_path, daemon_runtime_dir):
 
 
 @pytest.mark.e2e
-def test_headless_session_reports_live_display_unavailable(tmp_path, daemon_runtime_dir):
+def test_headless_session_reports_live_display_unavailable(
+    tmp_path, daemon_runtime_dir
+):
     # A default (HEADLESS) daemon session has the dummy DisplayServer; a `screen
     # capture` there is refused with the typed live_display_unavailable (the
     # self-revealing remediation: start --windowed). No file is written.

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -91,7 +91,9 @@ def test_script_create_with_extends_parameterizes_the_template(godot_project):
     # --root-type), and get reports it back from the parsed source.
     script_path = godot_project / "sprite.gd"
 
-    created = _gda("script", "create", str(script_path), "--extends", "Node2D", "--json")
+    created = _gda(
+        "script", "create", str(script_path), "--extends", "Node2D", "--json"
+    )
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["extends"] == "Node2D"
@@ -111,9 +113,7 @@ def test_script_create_with_content_round_trips_verbatim_source_and_metadata(
     script_path = godot_project / "hero.gd"
     source = "class_name Hero\nextends Node2D\n\nvar speed := 100\n"
 
-    created = _gda(
-        "script", "create", str(script_path), "--content", source, "--json"
-    )
+    created = _gda("script", "create", str(script_path), "--content", source, "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     create_data = json.loads(created.stdout)
@@ -173,7 +173,9 @@ def test_script_create_existing_path_yields_already_exists_without_overwriting(
     _gda("script", "create", str(script_path), "--extends", "Node2D", "--json")
     before = script_path.read_text(encoding="utf-8")
 
-    again = _gda("script", "create", str(script_path), "--extends", "Sprite2D", "--json")
+    again = _gda(
+        "script", "create", str(script_path), "--extends", "Sprite2D", "--json"
+    )
 
     err = _assert_operation_error(again, "already_exists")
     assert str(script_path) in err["message"]
@@ -314,12 +316,7 @@ def test_script_get_does_not_mistake_declaration_shaped_body_text_for_metadata(
     # is reported, and class_name stays null.
     script_path = godot_project / "doc.gd"
     source = (
-        "extends Node\n"
-        "\n"
-        'var doc := """\n'
-        "class_name Injected\n"
-        "extends Injected\n"
-        '"""\n'
+        'extends Node\n\nvar doc := """\nclass_name Injected\nextends Injected\n"""\n'
     )
 
     created = _gda("script", "create", str(script_path), "--content", source, "--json")
@@ -484,18 +481,30 @@ def test_script_delete_wrong_extension_yields_invalid_path_and_leaves_it(godot_p
 
 
 @pytest.mark.e2e
-def test_script_set_search_replace_edits_in_place_and_round_trips_via_get(godot_project):
+def test_script_set_search_replace_edits_in_place_and_round_trips_via_get(
+    godot_project,
+):
     # search-replace mode (issue #118): every literal occurrence of --search is
     # replaced with --replace; script get round-trips the edited source on disk.
     script_path = godot_project / "hero.gd"
     _gda(
-        "script", "create", str(script_path),
-        "--content", "extends Node\nvar a := Node\n", "--json",
+        "script",
+        "create",
+        str(script_path),
+        "--content",
+        "extends Node\nvar a := Node\n",
+        "--json",
     )
 
     edited = _gda(
-        "script", "set", str(script_path),
-        "--search", "Node", "--replace", "Node2D", "--json",
+        "script",
+        "set",
+        str(script_path),
+        "--search",
+        "Node",
+        "--replace",
+        "Node2D",
+        "--json",
     )
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
@@ -504,7 +513,9 @@ def test_script_set_search_replace_edits_in_place_and_round_trips_via_get(godot_
     assert got.returncode == 0, got.stdout + got.stderr
     # Both occurrences replaced; the edited source IS what get reports.
     assert json.loads(got.stdout)["source"] == "extends Node2D\nvar a := Node2D\n"
-    assert script_path.read_text(encoding="utf-8") == "extends Node2D\nvar a := Node2D\n"
+    assert (
+        script_path.read_text(encoding="utf-8") == "extends Node2D\nvar a := Node2D\n"
+    )
 
 
 @pytest.mark.e2e
@@ -517,14 +528,24 @@ def test_script_set_with_external_edit_in_window_yields_file_changed_externally(
     # (GDA_TEST_PERTURB_BEFORE_SAVE) simulates that edit, and the guard refuses.
     script_path = godot_project / "hero.gd"
     _gda(
-        "script", "create", str(script_path),
-        "--content", "extends Node\nvar a := 1\n", "--json",
+        "script",
+        "create",
+        str(script_path),
+        "--content",
+        "extends Node\nvar a := 1\n",
+        "--json",
     )
 
     edited = _gda_env(
         {"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
-        "script", "set", str(script_path),
-        "--search", "1", "--replace", "2", "--json",
+        "script",
+        "set",
+        str(script_path),
+        "--search",
+        "1",
+        "--replace",
+        "2",
+        "--json",
     )
 
     err = _assert_operation_error(edited, "file_changed_externally")
@@ -542,13 +563,25 @@ def test_script_set_line_range_replaces_the_span_and_round_trips_via_get(godot_p
     # the rest of the file is untouched. Lines are the parts split on "\n".
     script_path = godot_project / "actor.gd"
     _gda(
-        "script", "create", str(script_path),
-        "--content", "extends Node\nvar a := 1\nvar b := 2\nfunc f(): pass\n", "--json",
+        "script",
+        "create",
+        str(script_path),
+        "--content",
+        "extends Node\nvar a := 1\nvar b := 2\nfunc f(): pass\n",
+        "--json",
     )
 
     edited = _gda(
-        "script", "set", str(script_path),
-        "--start-line", "2", "--end-line", "3", "--content", "var x := 9", "--json",
+        "script",
+        "set",
+        str(script_path),
+        "--start-line",
+        "2",
+        "--end-line",
+        "3",
+        "--content",
+        "var x := 9",
+        "--json",
     )
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
@@ -564,13 +597,23 @@ def test_script_set_line_range_defaults_end_to_start_for_a_single_line(godot_pro
     # --end-line defaults to --start-line: a single-line replace.
     script_path = godot_project / "single.gd"
     _gda(
-        "script", "create", str(script_path),
-        "--content", "extends Node\nvar a := 1\nvar b := 2\n", "--json",
+        "script",
+        "create",
+        str(script_path),
+        "--content",
+        "extends Node\nvar a := 1\nvar b := 2\n",
+        "--json",
     )
 
     edited = _gda(
-        "script", "set", str(script_path),
-        "--start-line", "2", "--content", "var a := 99", "--json",
+        "script",
+        "set",
+        str(script_path),
+        "--start-line",
+        "2",
+        "--content",
+        "var a := 99",
+        "--json",
     )
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
@@ -587,8 +630,14 @@ def test_script_set_line_range_preserves_crlf_line_endings(godot_project):
     script_path.write_bytes(b"extends Node\r\nvar a := 1\r\nvar b := 2\r\n")
 
     edited = _gda(
-        "script", "set", str(script_path),
-        "--start-line", "2", "--content", "var x := 9", "--json",
+        "script",
+        "set",
+        str(script_path),
+        "--start-line",
+        "2",
+        "--content",
+        "var x := 9",
+        "--json",
     )
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
@@ -597,7 +646,9 @@ def test_script_set_line_range_preserves_crlf_line_endings(godot_project):
 
 
 @pytest.mark.e2e
-def test_script_set_full_overwrites_the_whole_file_and_round_trips_via_get(godot_project):
+def test_script_set_full_overwrites_the_whole_file_and_round_trips_via_get(
+    godot_project,
+):
     # full mode: --content with no --start-line overwrites the entire file.
     script_path = godot_project / "full.gd"
     _gda("script", "create", str(script_path), "--content", "extends Node\n", "--json")
@@ -622,8 +673,14 @@ def test_script_set_no_search_match_is_refused_and_leaves_file_untouched(godot_p
     before = script_path.read_text(encoding="utf-8")
 
     edited = _gda(
-        "script", "set", str(script_path),
-        "--search", "Sprite2D", "--replace", "Node2D", "--json",
+        "script",
+        "set",
+        str(script_path),
+        "--search",
+        "Sprite2D",
+        "--replace",
+        "Node2D",
+        "--json",
     )
 
     _assert_operation_error(edited, "no_search_match")
@@ -638,14 +695,24 @@ def test_script_set_out_of_bounds_line_range_is_refused_and_leaves_file_untouche
     # the file is left untouched.
     script_path = godot_project / "hero.gd"
     _gda(
-        "script", "create", str(script_path),
-        "--content", "extends Node\nvar a := 1\n", "--json",
+        "script",
+        "create",
+        str(script_path),
+        "--content",
+        "extends Node\nvar a := 1\n",
+        "--json",
     )
     before = script_path.read_text(encoding="utf-8")
 
     edited = _gda(
-        "script", "set", str(script_path),
-        "--start-line", "9", "--content", "var x := 0", "--json",
+        "script",
+        "set",
+        str(script_path),
+        "--start-line",
+        "9",
+        "--content",
+        "var x := 0",
+        "--json",
     )
 
     _assert_operation_error(edited, "invalid_line_range")
@@ -677,8 +744,11 @@ def test_script_validate_valid_script_reports_valid_true_no_diagnostics(godot_pr
     # true, no error_string, no diagnostics — exit 0.
     script_path = godot_project / "ok.gd"
     _gda(
-        "script", "create", str(script_path),
-        "--content", "extends Node\n\nfunc greet() -> String:\n\treturn \"hi\"\n",
+        "script",
+        "create",
+        str(script_path),
+        "--content",
+        'extends Node\n\nfunc greet() -> String:\n\treturn "hi"\n',
         "--json",
     )
 
@@ -700,8 +770,12 @@ def test_script_validate_broken_script_is_success_with_a_real_diagnostic(godot_p
     script_path = godot_project / "broken.gd"
     # `var x =` with no initializer is a parse error the engine reports on its line.
     _gda(
-        "script", "create", str(script_path),
-        "--content", "extends Node\n\nvar x =\n", "--json",
+        "script",
+        "create",
+        str(script_path),
+        "--content",
+        "extends Node\n\nvar x =\n",
+        "--json",
     )
 
     validated = _gda("script", "validate", str(script_path), "--json")
@@ -732,14 +806,20 @@ def test_script_validate_relative_preload_resolves_at_the_real_res_path(godot_pr
     gda = _gda_project(godot_project)
     assert (
         gda(
-            "script", "create", "res://sibling.gd",
-            "--content", "extends Node\nclass_name Sibling\n", "--json",
+            "script",
+            "create",
+            "res://sibling.gd",
+            "--content",
+            "extends Node\nclass_name Sibling\n",
+            "--json",
         ).returncode
         == 0
     )
     assert (
         gda(
-            "script", "create", "res://uses_sibling.gd",
+            "script",
+            "create",
+            "res://uses_sibling.gd",
             "--content",
             'extends Node\n\nconst S = preload("sibling.gd")\n\n'
             "func use() -> void:\n\tvar _x = S.new()\n",
@@ -758,7 +838,9 @@ def test_script_validate_relative_preload_resolves_at_the_real_res_path(godot_pr
 
 
 @pytest.mark.e2e
-def test_script_validate_broken_script_under_project_still_reports_diagnostics(godot_project):
+def test_script_validate_broken_script_under_project_still_reports_diagnostics(
+    godot_project,
+):
     # The #131 regression guard: compiling at the real res:// path must not break a
     # genuinely broken script's verdict — it is still a SUCCESSFUL op (exit 0)
     # reporting valid=false, and the stderr-parsed line/message diagnostic still
@@ -768,8 +850,12 @@ def test_script_validate_broken_script_under_project_still_reports_diagnostics(g
     # `var x =` with no initializer is a parse error the engine reports on its line.
     assert (
         gda(
-            "script", "create", "res://broken.gd",
-            "--content", "extends Node\n\nvar x =\n", "--json",
+            "script",
+            "create",
+            "res://broken.gd",
+            "--content",
+            "extends Node\n\nvar x =\n",
+            "--json",
         ).returncode
         == 0
     )
@@ -821,21 +907,32 @@ def test_script_attach_binds_script_to_node_and_scene_references_it(godot_projec
     # echoes the script's class_name, and the scene still re-loads (node list).
     gda = _gda_project(godot_project)
     assert (
-        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
-        .returncode
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
         == 0
     )
     assert (
         gda(
-            "script", "create", "res://hero.gd",
-            "--content", "class_name Hero\nextends Node2D\n", "--json",
+            "script",
+            "create",
+            "res://hero.gd",
+            "--content",
+            "class_name Hero\nextends Node2D\n",
+            "--json",
         ).returncode
         == 0
     )
 
     attached = gda(
-        "script", "attach", "res://main.tscn",
-        "--node", ".", "--script", "res://hero.gd", "--json",
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://hero.gd",
+        "--json",
     )
 
     assert attached.returncode == 0, attached.stdout + attached.stderr
@@ -858,24 +955,40 @@ def test_script_attach_to_a_descendant_node(godot_project):
     # root. The script lands on that exact node.
     gda = _gda_project(godot_project)
     assert (
-        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
-        .returncode
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
         == 0
     )
     assert (
-        gda("node", "add", "res://main.tscn", "--type", "Sprite2D", "--name", "Hero",
-            "--json").returncode
+        gda(
+            "node",
+            "add",
+            "res://main.tscn",
+            "--type",
+            "Sprite2D",
+            "--name",
+            "Hero",
+            "--json",
+        ).returncode
         == 0
     )
     assert (
-        gda("script", "create", "res://hero.gd", "--extends", "Sprite2D", "--json")
-        .returncode
+        gda(
+            "script", "create", "res://hero.gd", "--extends", "Sprite2D", "--json"
+        ).returncode
         == 0
     )
 
     attached = gda(
-        "script", "attach", "res://main.tscn",
-        "--node", "Hero", "--script", "res://hero.gd", "--json",
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        "Hero",
+        "--script",
+        "res://hero.gd",
+        "--json",
     )
 
     assert attached.returncode == 0, attached.stdout + attached.stderr
@@ -889,19 +1002,27 @@ def test_script_attach_no_class_name_echoes_null_class_name(godot_project):
     # A script with no class_name attaches fine and the result carries null.
     gda = _gda_project(godot_project)
     assert (
-        gda("scene", "create", "res://main.tscn", "--root-type", "Node", "--json")
-        .returncode
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node", "--json"
+        ).returncode
         == 0
     )
     assert (
-        gda("script", "create", "res://plain.gd", "--extends", "Node", "--json")
-        .returncode
+        gda(
+            "script", "create", "res://plain.gd", "--extends", "Node", "--json"
+        ).returncode
         == 0
     )
 
     attached = gda(
-        "script", "attach", "res://main.tscn",
-        "--node", ".", "--script", "res://plain.gd", "--json",
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://plain.gd",
+        "--json",
     )
 
     assert attached.returncode == 0, attached.stdout + attached.stderr
@@ -917,24 +1038,35 @@ def test_script_attach_non_compiling_script_yields_script_compile_failed(godot_p
     # is left untouched.
     gda = _gda_project(godot_project)
     assert (
-        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
-        .returncode
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
         == 0
     )
     # `var x =` has no initializer — a genuine parse error; the script does not
     # compile. script validate would report valid=false on it.
     assert (
         gda(
-            "script", "create", "res://broken.gd",
-            "--content", "extends Node2D\n\nvar x =\n", "--json",
+            "script",
+            "create",
+            "res://broken.gd",
+            "--content",
+            "extends Node2D\n\nvar x =\n",
+            "--json",
         ).returncode
         == 0
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
     attached = gda(
-        "script", "attach", "res://main.tscn",
-        "--node", ".", "--script", "res://broken.gd", "--json",
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://broken.gd",
+        "--json",
     )
 
     err = _assert_operation_error(attached, "script_compile_failed")
@@ -944,7 +1076,9 @@ def test_script_attach_non_compiling_script_yields_script_compile_failed(godot_p
 
 
 @pytest.mark.e2e
-def test_script_attach_incompatible_node_type_yields_incompatible_script_type(godot_project):
+def test_script_attach_incompatible_node_type_yields_incompatible_script_type(
+    godot_project,
+):
     # A script that COMPILES but whose native base is incompatible with the node
     # (an `extends Node3D` script onto a Node2D root) is bounced by set_script for
     # a reason that is NOT a compile error. attach must report the distinct
@@ -953,22 +1087,30 @@ def test_script_attach_incompatible_node_type_yields_incompatible_script_type(go
     # scene is left untouched.
     gda = _gda_project(godot_project)
     assert (
-        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
-        .returncode
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
         == 0
     )
     # A perfectly valid script — it compiles — but extends Node3D, incompatible
     # with the Node2D root.
     assert (
-        gda("script", "create", "res://spatial.gd", "--extends", "Node3D", "--json")
-        .returncode
+        gda(
+            "script", "create", "res://spatial.gd", "--extends", "Node3D", "--json"
+        ).returncode
         == 0
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
     attached = gda(
-        "script", "attach", "res://main.tscn",
-        "--node", ".", "--script", "res://spatial.gd", "--json",
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://spatial.gd",
+        "--json",
     )
 
     err = _assert_operation_error(attached, "incompatible_script_type")
@@ -982,14 +1124,21 @@ def test_script_attach_incompatible_node_type_yields_incompatible_script_type(go
 def test_script_attach_missing_script_yields_path_not_found(godot_project):
     gda = _gda_project(godot_project)
     assert (
-        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
-        .returncode
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
         == 0
     )
 
     attached = gda(
-        "script", "attach", "res://main.tscn",
-        "--node", ".", "--script", "res://nope.gd", "--json",
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://nope.gd",
+        "--json",
     )
 
     err = _assert_operation_error(attached, "path_not_found")
@@ -1000,15 +1149,22 @@ def test_script_attach_missing_script_yields_path_not_found(godot_project):
 def test_script_attach_wrong_script_extension_yields_invalid_path(godot_project):
     gda = _gda_project(godot_project)
     assert (
-        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
-        .returncode
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
         == 0
     )
     (godot_project / "notes.txt").write_text("not a script\n", encoding="utf-8")
 
     attached = gda(
-        "script", "attach", "res://main.tscn",
-        "--node", ".", "--script", "res://notes.txt", "--json",
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://notes.txt",
+        "--json",
     )
 
     err = _assert_operation_error(attached, "invalid_path")
@@ -1016,23 +1172,33 @@ def test_script_attach_wrong_script_extension_yields_invalid_path(godot_project)
 
 
 @pytest.mark.e2e
-def test_script_attach_missing_node_yields_node_not_found_and_leaves_scene(godot_project):
+def test_script_attach_missing_node_yields_node_not_found_and_leaves_scene(
+    godot_project,
+):
     gda = _gda_project(godot_project)
     assert (
-        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
-        .returncode
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
         == 0
     )
     assert (
-        gda("script", "create", "res://hero.gd", "--extends", "Node2D", "--json")
-        .returncode
+        gda(
+            "script", "create", "res://hero.gd", "--extends", "Node2D", "--json"
+        ).returncode
         == 0
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
     attached = gda(
-        "script", "attach", "res://main.tscn",
-        "--node", "Bogus", "--script", "res://hero.gd", "--json",
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        "Bogus",
+        "--script",
+        "res://hero.gd",
+        "--json",
     )
 
     err = _assert_operation_error(attached, "node_not_found")
@@ -1045,14 +1211,21 @@ def test_script_attach_missing_node_yields_node_not_found_and_leaves_scene(godot
 def test_script_attach_missing_scene_yields_path_not_found(godot_project):
     gda = _gda_project(godot_project)
     assert (
-        gda("script", "create", "res://hero.gd", "--extends", "Node2D", "--json")
-        .returncode
+        gda(
+            "script", "create", "res://hero.gd", "--extends", "Node2D", "--json"
+        ).returncode
         == 0
     )
 
     attached = gda(
-        "script", "attach", "res://missing.tscn",
-        "--node", ".", "--script", "res://hero.gd", "--json",
+        "script",
+        "attach",
+        "res://missing.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://hero.gd",
+        "--json",
     )
 
     err = _assert_operation_error(attached, "path_not_found")
@@ -1065,19 +1238,27 @@ def test_script_attach_no_prior_script_reports_null_replaced_script(godot_projec
     # bound and replaced_script is null — the signal that nothing was displaced.
     gda = _gda_project(godot_project)
     assert (
-        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
-        .returncode
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
         == 0
     )
     assert (
-        gda("script", "create", "res://hero.gd", "--extends", "Node2D", "--json")
-        .returncode
+        gda(
+            "script", "create", "res://hero.gd", "--extends", "Node2D", "--json"
+        ).returncode
         == 0
     )
 
     attached = gda(
-        "script", "attach", "res://main.tscn",
-        "--node", ".", "--script", "res://hero.gd", "--json",
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://hero.gd",
+        "--json",
     )
 
     assert attached.returncode == 0, attached.stdout + attached.stderr
@@ -1093,34 +1274,52 @@ def test_script_attach_overwrites_and_reports_the_displaced_script(godot_project
     # saved .tscn now references the NEW script and no longer the old one.
     gda = _gda_project(godot_project)
     assert (
-        gda("scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json")
-        .returncode
-        == 0
-    )
-    assert (
-        gda("script", "create", "res://old.gd", "--extends", "Node2D", "--json")
-        .returncode
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
         == 0
     )
     assert (
         gda(
-            "script", "create", "res://new.gd",
-            "--content", "class_name NewHero\nextends Node2D\n", "--json",
+            "script", "create", "res://old.gd", "--extends", "Node2D", "--json"
+        ).returncode
+        == 0
+    )
+    assert (
+        gda(
+            "script",
+            "create",
+            "res://new.gd",
+            "--content",
+            "class_name NewHero\nextends Node2D\n",
+            "--json",
         ).returncode
         == 0
     )
     # First attach binds old.gd — the node is now already-scripted.
     first = gda(
-        "script", "attach", "res://main.tscn",
-        "--node", ".", "--script", "res://old.gd", "--json",
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://old.gd",
+        "--json",
     )
     assert first.returncode == 0, first.stdout + first.stderr
     assert json.loads(first.stdout)["replaced_script"] is None
 
     # Second attach OVERWRITES old.gd with new.gd and REPORTS the displaced old.gd.
     second = gda(
-        "script", "attach", "res://main.tscn",
-        "--node", ".", "--script", "res://new.gd", "--json",
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://new.gd",
+        "--json",
     )
 
     assert second.returncode == 0, second.stdout + second.stderr
@@ -1147,8 +1346,14 @@ def test_script_attach_both_scene_and_script_missing_reports_the_scene_first(
     gda = _gda_project(godot_project)
 
     attached = gda(
-        "script", "attach", "res://missing.tscn",
-        "--node", ".", "--script", "res://also_missing.gd", "--json",
+        "script",
+        "attach",
+        "res://missing.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://also_missing.gd",
+        "--json",
     )
 
     err = _assert_operation_error(attached, "path_not_found")
@@ -1393,7 +1598,9 @@ def test_script_attach_preserves_sibling_script_on_repack_when_unimported(
         "sibling node A's script was silently re-embedded as a sub_resource:\n" + saved
     )
     # Both nodes keep their script bindings, each referencing its own external script.
-    assert 'path="res://b.gd"' in saved, "the attached b.gd reference is missing:\n" + saved
+    assert 'path="res://b.gd"' in saved, (
+        "the attached b.gd reference is missing:\n" + saved
+    )
     assert saved.count("script = ExtResource(") == 2, (
         "expected exactly two external script bindings to survive:\n" + saved
     )

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -47,7 +47,9 @@ OPERATIONS_GD = ROOT / "src" / "gda" / "ops" / "operations.gd"
 GDA_HARNESS_GD = ROOT / "src" / "gda" / "harness" / "gda_harness.gd"
 
 ADR_REGISTRY_ROW = re.compile(r"^\| `([^`]+)` \| `([^`]+)` \| `([^`]+)` \| `(\d+)` \|")
-GDSCRIPT_OPERATION_CODE = re.compile(r'^const OP_ERROR_[A-Z_]+ := "([a-z_]+)"$', re.MULTILINE)
+GDSCRIPT_OPERATION_CODE = re.compile(
+    r'^const OP_ERROR_[A-Z_]+ := "([a-z_]+)"$', re.MULTILINE
+)
 GDSCRIPT_HARNESS_LIVE_CODE = re.compile(
     r'^const LIVE_ERROR_[A-Z_]+ := "([a-z_]+)"$', re.MULTILINE
 )
@@ -174,7 +176,7 @@ def test_gdscript_harness_live_error_codes_mirror_python_harness_subset():
 
 
 HARNESS_MAX_WINDOW_FRAMES = re.compile(
-    r'^const MAX_WINDOW_FRAMES := (\d+)$', re.MULTILINE
+    r"^const MAX_WINDOW_FRAMES := (\d+)$", re.MULTILINE
 )
 
 

--- a/tests/test_export_commands.py
+++ b/tests/test_export_commands.py
@@ -57,7 +57,9 @@ def test_export_list_passes_resolved_project_to_the_runner(monkeypatch, tmp_path
 
     def record(binary, project):
         seen["project"] = project
-        return FakeRunner(RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0))
+        return FakeRunner(
+            RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+        )
 
     monkeypatch.setattr("gda.cli._make_runner", record)
 
@@ -77,9 +79,7 @@ def test_export_get_json_reports_preset_details_and_template_status(monkeypatch)
     stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
     fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
 
-    result = CliRunner().invoke(
-        app, ["export", "get", "--preset", "Web", "--json"]
-    )
+    result = CliRunner().invoke(app, ["export", "get", "--preset", "Web", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -102,7 +102,15 @@ def test_export_run_json_reports_configured_path_and_exit_zero(monkeypatch, tmp_
 
     result = CliRunner().invoke(
         app,
-        ["export", "run", "--preset", "Linux/X11", "--project", str(tmp_path), "--json"],
+        [
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--project",
+            str(tmp_path),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -127,7 +135,15 @@ def test_export_run_default_mode_is_release(monkeypatch, tmp_path):
 
     result = CliRunner().invoke(
         app,
-        ["export", "run", "--preset", "Linux/X11", "--project", str(tmp_path), "--json"],
+        [
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--project",
+            str(tmp_path),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -146,9 +162,15 @@ def test_export_run_mode_selects_export_flavor(monkeypatch, tmp_path):
         result = CliRunner().invoke(
             app,
             [
-                "export", "run", "--preset", "Linux/X11",
-                "--mode", mode,
-                "--project", str(tmp_path), "--json",
+                "export",
+                "run",
+                "--preset",
+                "Linux/X11",
+                "--mode",
+                mode,
+                "--project",
+                str(tmp_path),
+                "--json",
             ],
         )
 
@@ -173,9 +195,14 @@ def test_export_run_rejects_unknown_mode(monkeypatch, tmp_path):
     result = CliRunner().invoke(
         app,
         [
-            "export", "run", "--preset", "Linux/X11",
-            "--mode", "nonsense",
-            "--project", str(tmp_path),
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--mode",
+            "nonsense",
+            "--project",
+            str(tmp_path),
         ],
     )
 
@@ -192,9 +219,15 @@ def test_export_run_output_overrides_configured_path(monkeypatch, tmp_path):
     result = CliRunner().invoke(
         app,
         [
-            "export", "run", "--preset", "Linux/X11",
-            "--output", "dist/custom.x86_64",
-            "--project", str(tmp_path), "--json",
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--output",
+            "dist/custom.x86_64",
+            "--project",
+            str(tmp_path),
+            "--json",
         ],
     )
 
@@ -216,9 +249,15 @@ def test_export_run_output_expands_leading_tilde(monkeypatch, tmp_path):
     result = CliRunner().invoke(
         app,
         [
-            "export", "run", "--preset", "Linux/X11",
-            "--output", "~/builds/game.x86_64",
-            "--project", str(tmp_path), "--json",
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--output",
+            "~/builds/game.x86_64",
+            "--project",
+            str(tmp_path),
+            "--json",
         ],
     )
 
@@ -241,9 +280,15 @@ def test_export_run_output_overrides_unset_configured_path(monkeypatch, tmp_path
     result = CliRunner().invoke(
         app,
         [
-            "export", "run", "--preset", "Linux/X11",
-            "--output", "dist/custom.x86_64",
-            "--project", str(tmp_path), "--json",
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--output",
+            "dist/custom.x86_64",
+            "--project",
+            str(tmp_path),
+            "--json",
         ],
     )
 
@@ -272,7 +317,15 @@ def test_export_run_surfaces_advisory_warnings(monkeypatch, tmp_path):
 
     result = CliRunner().invoke(
         app,
-        ["export", "run", "--preset", "Linux/X11", "--project", str(tmp_path), "--json"],
+        [
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--project",
+            str(tmp_path),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -294,12 +347,24 @@ def test_export_run_missing_templates_is_structured_preflight(monkeypatch, tmp_p
     # spawning any native export — no stderr string-matching (ADR-0002), no native
     # run. The message names the templates_version the agent must install.
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    get = {**GET_RESULT, "templates_installed": False, "templates_version": "4.6.3.stable"}
+    get = {
+        **GET_RESULT,
+        "templates_installed": False,
+        "templates_version": "4.6.3.stable",
+    }
     _, export_runner = _inject(monkeypatch, get=get)
 
     result = CliRunner().invoke(
         app,
-        ["export", "run", "--preset", "Linux/X11", "--project", str(tmp_path), "--json"],
+        [
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--project",
+            str(tmp_path),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 4
@@ -318,15 +383,25 @@ def test_export_run_pack_skips_template_preflight_when_missing(monkeypatch, tmp_
     # proceeds straight to the native runner. (release/debug, which DO need
     # templates, still fail fast — asserted by the parametric test below.)
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    get = {**GET_RESULT, "templates_installed": False, "templates_version": "4.6.3.stable"}
+    get = {
+        **GET_RESULT,
+        "templates_installed": False,
+        "templates_version": "4.6.3.stable",
+    }
     _, export_runner = _inject(monkeypatch, get=get)
 
     result = CliRunner().invoke(
         app,
         [
-            "export", "run", "--preset", "Linux/X11",
-            "--mode", "pack",
-            "--project", str(tmp_path), "--json",
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--mode",
+            "pack",
+            "--project",
+            str(tmp_path),
+            "--json",
         ],
     )
 
@@ -337,7 +412,9 @@ def test_export_run_pack_skips_template_preflight_when_missing(monkeypatch, tmp_
     assert export_runner.calls == [("Linux/X11", "pack", "build/game.x86_64")]
 
 
-def test_export_run_release_debug_still_require_templates_when_missing(monkeypatch, tmp_path):
+def test_export_run_release_debug_still_require_templates_when_missing(
+    monkeypatch, tmp_path
+):
     # The counterpart guard: release and debug DO need platform templates, so with
     # templates_installed=False they still fail fast with export_templates_missing
     # before any native run — only pack is exempt (#170).
@@ -353,9 +430,15 @@ def test_export_run_release_debug_still_require_templates_when_missing(monkeypat
         result = CliRunner().invoke(
             app,
             [
-                "export", "run", "--preset", "Linux/X11",
-                "--mode", mode,
-                "--project", str(tmp_path), "--json",
+                "export",
+                "run",
+                "--preset",
+                "Linux/X11",
+                "--mode",
+                mode,
+                "--project",
+                str(tmp_path),
+                "--json",
             ],
         )
 
@@ -379,7 +462,15 @@ def test_export_run_generic_failure_is_structured(monkeypatch, tmp_path):
 
     result = CliRunner().invoke(
         app,
-        ["export", "run", "--preset", "Linux/X11", "--project", str(tmp_path), "--json"],
+        [
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--project",
+            str(tmp_path),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 4
@@ -399,7 +490,15 @@ def test_export_run_unset_path_is_structured(monkeypatch, tmp_path):
 
     result = CliRunner().invoke(
         app,
-        ["export", "run", "--preset", "Linux/X11", "--project", str(tmp_path), "--json"],
+        [
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--project",
+            str(tmp_path),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 4
@@ -415,15 +514,18 @@ def test_export_run_unknown_preset_reuses_export_get_error(monkeypatch, tmp_path
     get_runner = FakeRunner(
         RunResult(
             stdout=sentinel(
-                {"error": {"code": "export_preset_not_found", "message": "no such preset"}}
+                {
+                    "error": {
+                        "code": "export_preset_not_found",
+                        "message": "no such preset",
+                    }
+                }
             ),
             stderr="",
             exit_code=4,
         )
     )
-    monkeypatch.setattr(
-        "gda.cli._make_runner", lambda binary, project=None: get_runner
-    )
+    monkeypatch.setattr("gda.cli._make_runner", lambda binary, project=None: get_runner)
     export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
     monkeypatch.setattr(
         "gda.cli._make_export_runner", lambda binary, project=None: export_runner
@@ -480,4 +582,6 @@ def test_export_run_human_output_echoes_artifact(monkeypatch, tmp_path):
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
-    assert "exported Linux/X11 (Linux/X11, release) -> build/game.x86_64" in result.stdout
+    assert (
+        "exported Linux/X11 (Linux/X11, release) -> build/game.x86_64" in result.stdout
+    )

--- a/tests/test_export_run_operation.py
+++ b/tests/test_export_run_operation.py
@@ -115,9 +115,7 @@ def test_phase1_failure_returns_the_failure():
     )
     export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
 
-    outcome = _run(
-        get_runner=get_runner, export_runner=export_runner, preset="Nope"
-    )
+    outcome = _run(get_runner=get_runner, export_runner=export_runner, preset="Nope")
 
     assert isinstance(outcome, Failure)
     assert outcome.error.code == "export_preset_not_found"
@@ -182,9 +180,7 @@ def test_templates_missing_for_release_and_debug():
         get_runner = _get_runner({**GET_RESULT, "templates_installed": False})
         export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
 
-        outcome = _run(
-            get_runner=get_runner, export_runner=export_runner, mode=mode
-        )
+        outcome = _run(get_runner=get_runner, export_runner=export_runner, mode=mode)
 
         assert isinstance(outcome, Failure), mode
         assert outcome.error.code == "export_templates_missing", mode
@@ -291,7 +287,7 @@ def test_export_is_a_noop_when_no_harness_installed(tmp_path):
     # With no harness installed, the strip is a harmless no-op: nothing is created,
     # and the export still runs to completion.
     (tmp_path / "project.godot").write_text(
-        'config_version=5\n\n[application]\n', encoding="utf-8"
+        "config_version=5\n\n[application]\n", encoding="utf-8"
     )
     # Ensure a clean slate (idempotent): no harness present.
     uninstall_harness(tmp_path)
@@ -330,7 +326,7 @@ def test_export_does_not_add_autoload_for_a_stray_harness_file(tmp_path):
     # removes the stray file (so it cannot ship); the byte-exact restore puts the
     # stray file back WITHOUT synthesizing an autoload the project never had.
     (tmp_path / "project.godot").write_text(
-        'config_version=5\n\n[application]\n', encoding="utf-8"
+        "config_version=5\n\n[application]\n", encoding="utf-8"
     )
     stray = tmp_path / "addons" / "gda_harness" / "gda_harness.gd"
     stray.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_game_commands.py
+++ b/tests/test_game_commands.py
@@ -28,7 +28,9 @@ def _project(tmp_path):
     return tmp_path
 
 
-def test_game_tree_emits_runtime_tree_json_through_the_live_channel(monkeypatch, tmp_path):
+def test_game_tree_emits_runtime_tree_json_through_the_live_channel(
+    monkeypatch, tmp_path
+):
     fake = inject_live_runner(
         monkeypatch,
         RunResult(stdout=sentinel(GAME_TREE_RESULT), stderr="", exit_code=0),
@@ -98,7 +100,9 @@ def test_game_tree_on_non_unix_reports_live_unsupported_platform(monkeypatch, tm
 # --- game get (live runtime property read) -----------------------------------
 
 
-def test_game_get_emits_runtime_properties_through_the_live_channel(monkeypatch, tmp_path):
+def test_game_get_emits_runtime_properties_through_the_live_channel(
+    monkeypatch, tmp_path
+):
     fake = inject_live_runner(
         monkeypatch,
         RunResult(stdout=sentinel(GAME_GET_RESULT), stderr="", exit_code=0),
@@ -106,7 +110,14 @@ def test_game_get_emits_runtime_properties_through_the_live_channel(monkeypatch,
 
     result = CliRunner().invoke(
         app,
-        ["game", "get", "/root/Main/Player", "--project", str(_project(tmp_path)), "--json"],
+        [
+            "game",
+            "get",
+            "/root/Main/Player",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -119,7 +130,9 @@ def test_game_get_emits_runtime_properties_through_the_live_channel(monkeypatch,
     assert fake.calls == [("game-get", {"node": "/root/Main/Player", "property": None})]
 
 
-def test_game_get_passes_the_property_filter_through_the_live_channel(monkeypatch, tmp_path):
+def test_game_get_passes_the_property_filter_through_the_live_channel(
+    monkeypatch, tmp_path
+):
     fake = inject_live_runner(
         monkeypatch,
         RunResult(stdout=sentinel(GAME_GET_RESULT), stderr="", exit_code=0),
@@ -128,9 +141,14 @@ def test_game_get_passes_the_property_filter_through_the_live_channel(monkeypatc
     result = CliRunner().invoke(
         app,
         [
-            "game", "get", "/root/Main/Player",
-            "--property", "position",
-            "--project", str(_project(tmp_path)), "--json",
+            "game",
+            "get",
+            "/root/Main/Player",
+            "--property",
+            "position",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -156,7 +174,14 @@ def test_game_get_missing_node_reports_live_node_not_found(monkeypatch, tmp_path
 
     result = CliRunner().invoke(
         app,
-        ["game", "get", "/root/Main/Ghost", "--project", str(_project(tmp_path)), "--json"],
+        [
+            "game",
+            "get",
+            "/root/Main/Ghost",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -178,9 +203,14 @@ def test_game_get_unknown_property_reports_live_unknown_property(monkeypatch, tm
     result = CliRunner().invoke(
         app,
         [
-            "game", "get", "/root/Main/Player",
-            "--property", "nope",
-            "--project", str(_project(tmp_path)), "--json",
+            "game",
+            "get",
+            "/root/Main/Player",
+            "--property",
+            "nope",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -195,7 +225,14 @@ def test_game_get_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_pat
 
     result = CliRunner().invoke(
         app,
-        ["game", "get", "/root/Main/Player", "--project", str(_project(tmp_path)), "--json"],
+        [
+            "game",
+            "get",
+            "/root/Main/Player",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -225,9 +262,16 @@ def test_game_set_mutates_and_echoes_coerced_value_through_the_live_channel(
     result = CliRunner().invoke(
         app,
         [
-            "game", "set", "/root/Main/Player",
-            "--property", "position", "--value", "10,20",
-            "--project", str(_project(tmp_path)), "--json",
+            "game",
+            "set",
+            "/root/Main/Player",
+            "--property",
+            "position",
+            "--value",
+            "10,20",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -260,9 +304,16 @@ def test_game_set_missing_node_reports_live_node_not_found(monkeypatch, tmp_path
     result = CliRunner().invoke(
         app,
         [
-            "game", "set", "/root/Main/Ghost",
-            "--property", "position", "--value", "1,2",
-            "--project", str(_project(tmp_path)), "--json",
+            "game",
+            "set",
+            "/root/Main/Ghost",
+            "--property",
+            "position",
+            "--value",
+            "1,2",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -285,9 +336,16 @@ def test_game_set_unknown_property_reports_live_unknown_property(monkeypatch, tm
     result = CliRunner().invoke(
         app,
         [
-            "game", "set", "/root/Main/Player",
-            "--property", "nope", "--value", "1",
-            "--project", str(_project(tmp_path)), "--json",
+            "game",
+            "set",
+            "/root/Main/Player",
+            "--property",
+            "nope",
+            "--value",
+            "1",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -297,7 +355,9 @@ def test_game_set_unknown_property_reports_live_unknown_property(monkeypatch, tm
     assert error["category"] == "live"
 
 
-def test_game_set_uncoercible_value_reports_live_uncoercible_value(monkeypatch, tmp_path):
+def test_game_set_uncoercible_value_reports_live_uncoercible_value(
+    monkeypatch, tmp_path
+):
     inject_live_runner(
         monkeypatch,
         RunResult(
@@ -310,9 +370,16 @@ def test_game_set_uncoercible_value_reports_live_uncoercible_value(monkeypatch, 
     result = CliRunner().invoke(
         app,
         [
-            "game", "set", "/root/Main/Player",
-            "--property", "position", "--value", "not-a-vector",
-            "--project", str(_project(tmp_path)), "--json",
+            "game",
+            "set",
+            "/root/Main/Player",
+            "--property",
+            "position",
+            "--value",
+            "not-a-vector",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -328,9 +395,16 @@ def test_game_set_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_pat
     result = CliRunner().invoke(
         app,
         [
-            "game", "set", "/root/Main/Player",
-            "--property", "position", "--value", "1,2",
-            "--project", str(_project(tmp_path)), "--json",
+            "game",
+            "set",
+            "/root/Main/Player",
+            "--property",
+            "position",
+            "--value",
+            "1,2",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 

--- a/tests/test_headless_command.py
+++ b/tests/test_headless_command.py
@@ -29,7 +29,9 @@ def test_headless_command_classifies_its_execution_channel_as_headless_by_defaul
 
 def test_headless_command_emit_owns_runner_classification_and_json_output(capsys):
     fake = FakeRunner(
-        RunResult(stdout=sentinel(VERSION_INFO), stderr="engine diagnostic\n", exit_code=0)
+        RunResult(
+            stdout=sentinel(VERSION_INFO), stderr="engine diagnostic\n", exit_code=0
+        )
     )
     seen: dict[str, Path | None] = {}
 

--- a/tests/test_human_output.py
+++ b/tests/test_human_output.py
@@ -134,9 +134,7 @@ HUMAN_CASES = [
                 }
             ],
         },
-        ". (Node2D)\n"
-        "  speed (float) = 3.5\n"
-        "  start (Vector2) = [1.0, 2.0]",
+        ". (Node2D)\n  speed (float) = 3.5\n  start (Vector2) = [1.0, 2.0]",
     ),
     (
         "scene-get-exports-empty",
@@ -201,9 +199,7 @@ HUMAN_CASES = [
                 {"name": "visible", "type": "bool", "value": True},
             ],
         },
-        "Hero (Sprite2D)\n"
-        "  position (Vector2) = [10.0, 20.0]\n"
-        "  visible (bool) = true",
+        "Hero (Sprite2D)\n  position (Vector2) = [10.0, 20.0]\n  visible (bool) = true",
     ),
     (
         # node set whose Vector2 value exercises format_value (-> [x, y]).
@@ -471,7 +467,9 @@ def test_human_mode_cli_output_is_exactly_the_rendered_text(
     # with a fake runner, and assert the exact stdout: the renderer's text plus
     # the single trailing newline typer.echo adds. This pins #139's render
     # dispatch + #140's gda.render end-to-end, per command.
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0))
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(app, argv)
 

--- a/tests/test_info_command.py
+++ b/tests/test_info_command.py
@@ -11,9 +11,8 @@ from tests.support import VERSION_INFO, inject_runner, sentinel
 
 def test_info_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner / warnings around the sentinel, plus diagnostics on stderr.
-    stdout = (
-        "Godot Engine v4.6.3.stable.official\n"
-        "WARNING: benign\n" + sentinel(VERSION_INFO)
+    stdout = "Godot Engine v4.6.3.stable.official\nWARNING: benign\n" + sentinel(
+        VERSION_INFO
     )
     fake = inject_runner(
         monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)

--- a/tests/test_info_errors.py
+++ b/tests/test_info_errors.py
@@ -65,7 +65,9 @@ def test_launch_timeout_maps_to_environment_error_distinct_from_not_found(monkey
     assert "timed out" in result.stderr
 
 
-def test_operation_failure_maps_to_operation_error_distinct_from_environment(monkeypatch):
+def test_operation_failure_maps_to_operation_error_distinct_from_environment(
+    monkeypatch,
+):
     # The engine launched and ran but the GDScript operation reported an error
     # and quit non-zero (no synthetic 124/127, no result sentinel). This is an
     # operation failure, distinct from the environment-error case.
@@ -87,7 +89,9 @@ def test_operation_failure_maps_to_operation_error_distinct_from_environment(mon
     assert "unknown operation" in result.stderr
 
 
-def test_engine_signal_crash_maps_to_operation_error_distinct_from_clean_exit(monkeypatch):
+def test_engine_signal_crash_maps_to_operation_error_distinct_from_clean_exit(
+    monkeypatch,
+):
     # subprocess reports a signal death as a NEGATIVE return code. The engine
     # ran but was killed (e.g. SIGSEGV) — surfaced as an engine_crashed code,
     # distinct from a clean non-zero operation exit, never a raw negative code.
@@ -168,7 +172,9 @@ def _version_payload(major: int, minor: int) -> str:
     )
 
 
-def test_version_below_minimum_maps_to_version_error_distinct_from_environment(monkeypatch):
+def test_version_below_minimum_maps_to_version_error_distinct_from_environment(
+    monkeypatch,
+):
     # The engine launched and reported its version successfully, but it is below
     # the minimum supported version of 4.4 (ADR-0003). This is a version error,
     # distinct from the environment-error case.

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -69,9 +69,17 @@ def test_input_key_threads_modifiers_and_released(monkeypatch, tmp_path):
     CliRunner().invoke(
         app,
         [
-            "input", "key", "A",
-            "--modifiers", "shift", "--modifiers", "ctrl", "--released",
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "key",
+            "A",
+            "--modifiers",
+            "shift",
+            "--modifiers",
+            "ctrl",
+            "--released",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -128,7 +136,9 @@ def test_input_key_schema_reports_kind_live():
 # --- input mouse-click / mouse-move (single-frame) ----------------------------
 
 
-def test_input_mouse_click_injects_a_click_through_the_live_channel(monkeypatch, tmp_path):
+def test_input_mouse_click_injects_a_click_through_the_live_channel(
+    monkeypatch, tmp_path
+):
     fake = inject_live_runner(
         monkeypatch,
         RunResult(stdout=sentinel(INPUT_MOUSE_CLICK_RESULT), stderr="", exit_code=0),
@@ -137,9 +147,16 @@ def test_input_mouse_click_injects_a_click_through_the_live_channel(monkeypatch,
     result = CliRunner().invoke(
         app,
         [
-            "input", "mouse-click", "100", "200",
-            "--button", "right", "--double",
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "mouse-click",
+            "100",
+            "200",
+            "--button",
+            "right",
+            "--double",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -156,7 +173,9 @@ def test_input_mouse_click_injects_a_click_through_the_live_channel(monkeypatch,
     ]
 
 
-def test_input_mouse_move_injects_a_motion_through_the_live_channel(monkeypatch, tmp_path):
+def test_input_mouse_move_injects_a_motion_through_the_live_channel(
+    monkeypatch, tmp_path
+):
     fake = inject_live_runner(
         monkeypatch,
         RunResult(stdout=sentinel(INPUT_MOUSE_MOVE_RESULT), stderr="", exit_code=0),
@@ -165,8 +184,13 @@ def test_input_mouse_move_injects_a_motion_through_the_live_channel(monkeypatch,
     result = CliRunner().invoke(
         app,
         [
-            "input", "mouse-move", "50", "60",
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "mouse-move",
+            "50",
+            "60",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -185,7 +209,15 @@ def test_input_mouse_click_default_button_is_left(monkeypatch, tmp_path):
 
     CliRunner().invoke(
         app,
-        ["input", "mouse-click", "1", "2", "--project", str(_project(tmp_path)), "--json"],
+        [
+            "input",
+            "mouse-click",
+            "1",
+            "2",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert fake.calls[0][1]["button"] == "left"
@@ -201,8 +233,15 @@ def test_input_mouse_click_unknown_button_argv_is_a_usage_error(monkeypatch, tmp
     result = CliRunner().invoke(
         app,
         [
-            "input", "mouse-click", "1", "2", "--button", "scroll",
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "mouse-click",
+            "1",
+            "2",
+            "--button",
+            "scroll",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -249,8 +288,14 @@ def test_input_action_release_and_strength_are_threaded(monkeypatch, tmp_path):
     CliRunner().invoke(
         app,
         [
-            "input", "action", "move_right", "--strength", "0.5",
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "action",
+            "move_right",
+            "--strength",
+            "0.5",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -288,8 +333,14 @@ def test_input_action_strength_over_range_argv_is_a_usage_error(monkeypatch, tmp
     result = CliRunner().invoke(
         app,
         [
-            "input", "action", "jump", "--strength", "2.0",
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "action",
+            "jump",
+            "--strength",
+            "2.0",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -323,8 +374,13 @@ def test_input_sequence_injects_events_across_frames_through_the_live_channel(
     result = CliRunner().invoke(
         app,
         [
-            "input", "sequence", "--events", json.dumps(events),
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "sequence",
+            "--events",
+            json.dumps(events),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -341,15 +397,21 @@ def test_input_sequence_injects_events_across_frames_through_the_live_channel(
     assert [e["frame"] for e in sent_events] == [0, 2, 4]
 
 
-def test_input_sequence_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):
+def test_input_sequence_with_no_daemon_reports_daemon_not_running(
+    monkeypatch, tmp_path
+):
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
 
     result = CliRunner().invoke(
         app,
         [
-            "input", "sequence",
-            "--events", json.dumps([{"type": "key", "key": "Right"}]),
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "sequence",
+            "--events",
+            json.dumps([{"type": "key", "key": "Right"}]),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -357,7 +419,9 @@ def test_input_sequence_with_no_daemon_reports_daemon_not_running(monkeypatch, t
     assert json.loads(result.stdout)["error"]["code"] == "daemon_not_running"
 
 
-def test_input_sequence_invalid_event_spec_reports_the_typed_error(monkeypatch, tmp_path):
+def test_input_sequence_invalid_event_spec_reports_the_typed_error(
+    monkeypatch, tmp_path
+):
     # A request that reached the harness without passing the model (a direct daemon
     # caller) with an unrecognized event type aborts the window with the typed code,
     # relayed exit-0 and mapped by classify_live.
@@ -373,9 +437,13 @@ def test_input_sequence_invalid_event_spec_reports_the_typed_error(monkeypatch, 
     result = CliRunner().invoke(
         app,
         [
-            "input", "sequence",
-            "--events", json.dumps([{"type": "key", "key": "Right"}]),
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "sequence",
+            "--events",
+            json.dumps([{"type": "key", "key": "Right"}]),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -393,7 +461,15 @@ def test_input_sequence_non_json_events_argv_is_a_usage_error(monkeypatch, tmp_p
 
     result = CliRunner().invoke(
         app,
-        ["input", "sequence", "--events", "not json", "--project", str(_project(tmp_path)), "--json"],
+        [
+            "input",
+            "sequence",
+            "--events",
+            "not json",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 2, result.stdout + result.stderr
@@ -408,7 +484,15 @@ def test_input_sequence_empty_events_argv_is_a_usage_error(monkeypatch, tmp_path
 
     result = CliRunner().invoke(
         app,
-        ["input", "sequence", "--events", "[]", "--project", str(_project(tmp_path)), "--json"],
+        [
+            "input",
+            "sequence",
+            "--events",
+            "[]",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 2, result.stdout + result.stderr
@@ -426,9 +510,13 @@ def test_input_sequence_malformed_event_argv_is_a_usage_error(monkeypatch, tmp_p
     result = CliRunner().invoke(
         app,
         [
-            "input", "sequence",
-            "--events", json.dumps([{"type": "key", "frame": 0}]),
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "sequence",
+            "--events",
+            json.dumps([{"type": "key", "frame": 0}]),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -449,9 +537,13 @@ def test_input_sequence_over_window_frame_argv_is_a_usage_error(monkeypatch, tmp
     result = CliRunner().invoke(
         app,
         [
-            "input", "sequence",
-            "--events", json.dumps([{"type": "key", "key": "Right", "frame": 999999}]),
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "sequence",
+            "--events",
+            json.dumps([{"type": "key", "key": "Right", "frame": 999999}]),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -470,11 +562,15 @@ def test_input_sequence_at_the_window_boundary_argv_is_accepted(monkeypatch, tmp
     result = CliRunner().invoke(
         app,
         [
-            "input", "sequence",
-            "--events", json.dumps(
+            "input",
+            "sequence",
+            "--events",
+            json.dumps(
                 [{"type": "key", "key": "Right", "frame": MAX_WINDOW_FRAMES - 1}]
             ),
-            "--project", str(_project(tmp_path)), "--json",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -505,9 +601,13 @@ def test_input_key_params_json_bad_modifier_is_invalid_params(monkeypatch, tmp_p
     result = CliRunner().invoke(
         app,
         [
-            "input", "key",
-            "--params-json", '{"key": "A", "modifiers": ["control"]}',
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "key",
+            "--params-json",
+            '{"key": "A", "modifiers": ["control"]}',
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -515,7 +615,9 @@ def test_input_key_params_json_bad_modifier_is_invalid_params(monkeypatch, tmp_p
     assert fake.calls == []
 
 
-def test_input_action_params_json_strength_over_range_is_invalid_params(monkeypatch, tmp_path):
+def test_input_action_params_json_strength_over_range_is_invalid_params(
+    monkeypatch, tmp_path
+):
     fake = inject_live_runner(
         monkeypatch,
         RunResult(stdout=sentinel(INPUT_ACTION_RESULT), stderr="", exit_code=0),
@@ -524,9 +626,13 @@ def test_input_action_params_json_strength_over_range_is_invalid_params(monkeypa
     result = CliRunner().invoke(
         app,
         [
-            "input", "action",
-            "--params-json", '{"action": "jump", "strength": 2.0}',
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "action",
+            "--params-json",
+            '{"action": "jump", "strength": 2.0}',
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -534,7 +640,9 @@ def test_input_action_params_json_strength_over_range_is_invalid_params(monkeypa
     assert fake.calls == []
 
 
-def test_input_sequence_params_json_empty_events_is_invalid_params(monkeypatch, tmp_path):
+def test_input_sequence_params_json_empty_events_is_invalid_params(
+    monkeypatch, tmp_path
+):
     fake = inject_live_runner(
         monkeypatch,
         RunResult(stdout=sentinel(INPUT_SEQUENCE_RESULT), stderr="", exit_code=0),
@@ -543,9 +651,13 @@ def test_input_sequence_params_json_empty_events_is_invalid_params(monkeypatch, 
     result = CliRunner().invoke(
         app,
         [
-            "input", "sequence",
-            "--params-json", '{"events": []}',
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "sequence",
+            "--params-json",
+            '{"events": []}',
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -553,7 +665,9 @@ def test_input_sequence_params_json_empty_events_is_invalid_params(monkeypatch, 
     assert fake.calls == []
 
 
-def test_input_sequence_params_json_malformed_event_is_invalid_params(monkeypatch, tmp_path):
+def test_input_sequence_params_json_malformed_event_is_invalid_params(
+    monkeypatch, tmp_path
+):
     fake = inject_live_runner(
         monkeypatch,
         RunResult(stdout=sentinel(INPUT_SEQUENCE_RESULT), stderr="", exit_code=0),
@@ -562,9 +676,13 @@ def test_input_sequence_params_json_malformed_event_is_invalid_params(monkeypatc
     result = CliRunner().invoke(
         app,
         [
-            "input", "sequence",
-            "--params-json", '{"events": [{"type": "mouse_click", "x": 1.0}]}',
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "sequence",
+            "--params-json",
+            '{"events": [{"type": "mouse_click", "x": 1.0}]}',
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -572,7 +690,9 @@ def test_input_sequence_params_json_malformed_event_is_invalid_params(monkeypatc
     assert fake.calls == []
 
 
-def test_input_sequence_params_json_over_window_frame_is_invalid_params(monkeypatch, tmp_path):
+def test_input_sequence_params_json_over_window_frame_is_invalid_params(
+    monkeypatch, tmp_path
+):
     # The same window bound as the argv path, surfaced as the structured
     # invalid_params on --params-json (ADR-0015): a frame whose window exceeds
     # MAX_WINDOW_FRAMES never reaches the engine.
@@ -584,10 +704,13 @@ def test_input_sequence_params_json_over_window_frame_is_invalid_params(monkeypa
     result = CliRunner().invoke(
         app,
         [
-            "input", "sequence",
+            "input",
+            "sequence",
             "--params-json",
             json.dumps({"events": [{"type": "key", "key": "Right", "frame": 999999}]}),
-            "--project", str(_project(tmp_path)), "--json",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -595,7 +718,9 @@ def test_input_sequence_params_json_over_window_frame_is_invalid_params(monkeypa
     assert fake.calls == []
 
 
-def test_input_sequence_params_json_at_the_window_boundary_dispatches(monkeypatch, tmp_path):
+def test_input_sequence_params_json_at_the_window_boundary_dispatches(
+    monkeypatch, tmp_path
+):
     # The boundary frame (window == MAX_WINDOW_FRAMES) passes the model and
     # dispatches through the same live seam the argv path uses.
     fake = inject_live_runner(
@@ -606,12 +731,19 @@ def test_input_sequence_params_json_at_the_window_boundary_dispatches(monkeypatc
     result = CliRunner().invoke(
         app,
         [
-            "input", "sequence",
+            "input",
+            "sequence",
             "--params-json",
             json.dumps(
-                {"events": [{"type": "key", "key": "Right", "frame": MAX_WINDOW_FRAMES - 1}]}
+                {
+                    "events": [
+                        {"type": "key", "key": "Right", "frame": MAX_WINDOW_FRAMES - 1}
+                    ]
+                }
             ),
-            "--project", str(_project(tmp_path)), "--json",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -630,9 +762,13 @@ def test_input_key_params_json_dispatches_like_argv(monkeypatch, tmp_path):
     result = CliRunner().invoke(
         app,
         [
-            "input", "key",
-            "--params-json", '{"key": "Right", "modifiers": ["shift"]}',
-            "--project", str(_project(tmp_path)), "--json",
+            "input",
+            "key",
+            "--params-json",
+            '{"key": "Right", "modifiers": ["shift"]}',
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 

--- a/tests/test_logger_commands.py
+++ b/tests/test_logger_commands.py
@@ -29,7 +29,9 @@ def _project(tmp_path):
     return tmp_path
 
 
-def test_logger_tail_emits_structured_records_json_through_the_live_channel(monkeypatch, tmp_path):
+def test_logger_tail_emits_structured_records_json_through_the_live_channel(
+    monkeypatch, tmp_path
+):
     fake = inject_live_runner(
         monkeypatch,
         RunResult(stdout=sentinel(LOGGER_TAIL_RESULT), stderr="", exit_code=0),
@@ -57,15 +59,28 @@ def test_logger_tail_passes_level_and_limit_through(monkeypatch, tmp_path):
 
     result = CliRunner().invoke(
         app,
-        ["logger", "tail", "--level", "warning", "--limit", "5",
-         "--project", str(_project(tmp_path)), "--json"],
+        [
+            "logger",
+            "tail",
+            "--level",
+            "warning",
+            "--limit",
+            "5",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
-    assert fake.calls == [("logger-tail", {"level": "warning", "limit": 5, "raw": False})]
+    assert fake.calls == [
+        ("logger-tail", {"level": "warning", "limit": 5, "raw": False})
+    ]
 
 
-def test_logger_tail_raw_passes_raw_flag_and_returns_verbatim_info_records(monkeypatch, tmp_path):
+def test_logger_tail_raw_passes_raw_flag_and_returns_verbatim_info_records(
+    monkeypatch, tmp_path
+):
     fake = inject_live_runner(
         monkeypatch,
         RunResult(stdout=sentinel(LOGGER_TAIL_RAW_RESULT), stderr="", exit_code=0),
@@ -91,7 +106,16 @@ def test_logger_tail_rejects_a_non_positive_limit_on_the_argv_path(tmp_path):
     # error, not a silently-accepted "no limit". No live runner needed.
     for bad in ("0", "-1"):
         result = CliRunner().invoke(
-            app, ["logger", "tail", "--limit", bad, "--project", str(_project(tmp_path)), "--json"]
+            app,
+            [
+                "logger",
+                "tail",
+                "--limit",
+                bad,
+                "--project",
+                str(_project(tmp_path)),
+                "--json",
+            ],
         )
         assert result.exit_code == 2, (bad, result.stdout + result.stderr)
 
@@ -99,7 +123,16 @@ def test_logger_tail_rejects_a_non_positive_limit_on_the_argv_path(tmp_path):
 def test_logger_tail_rejects_an_unknown_level_on_the_argv_path(tmp_path):
     # `--level` is the closed enum; an out-of-set value is a usage error.
     result = CliRunner().invoke(
-        app, ["logger", "tail", "--level", "trace", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        [
+            "logger",
+            "tail",
+            "--level",
+            "trace",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
     )
     assert result.exit_code == 2, result.stdout + result.stderr
 
@@ -110,7 +143,9 @@ def test_logger_tail_human_output_renders_records(monkeypatch, tmp_path):
         RunResult(stdout=sentinel(LOGGER_TAIL_RESULT), stderr="", exit_code=0),
     )
 
-    result = CliRunner().invoke(app, ["logger", "tail", "--project", str(_project(tmp_path))])
+    result = CliRunner().invoke(
+        app, ["logger", "tail", "--project", str(_project(tmp_path))]
+    )
 
     assert result.exit_code == 0, result.stdout + result.stderr
     # Human output names the level and message; the location is shown when present.
@@ -125,7 +160,9 @@ def test_logger_tail_raw_human_output_renders_lines(monkeypatch, tmp_path):
         RunResult(stdout=sentinel(LOGGER_TAIL_RAW_RESULT), stderr="", exit_code=0),
     )
 
-    result = CliRunner().invoke(app, ["logger", "tail", "--raw", "--project", str(_project(tmp_path))])
+    result = CliRunner().invoke(
+        app, ["logger", "tail", "--raw", "--project", str(_project(tmp_path))]
+    )
 
     assert result.exit_code == 0, result.stdout + result.stderr
     assert "known line" in result.stdout
@@ -165,12 +202,21 @@ def test_logger_tail_log_unavailable_is_a_typed_live_error(monkeypatch, tmp_path
     assert error["category"] == "live"
 
 
-def test_logger_tail_params_json_rejects_a_non_positive_limit_as_invalid_params(monkeypatch, tmp_path):
+def test_logger_tail_params_json_rejects_a_non_positive_limit_as_invalid_params(
+    monkeypatch, tmp_path
+):
     for bad in (0, -1):
         result = CliRunner().invoke(
             app,
-            ["logger", "tail", "--params-json", json.dumps({"limit": bad}),
-             "--project", str(_project(tmp_path)), "--json"],
+            [
+                "logger",
+                "tail",
+                "--params-json",
+                json.dumps({"limit": bad}),
+                "--project",
+                str(_project(tmp_path)),
+                "--json",
+            ],
         )
         assert result.exit_code != 0, (bad, result.stdout + result.stderr)
         err = json.loads(result.stdout)["error"]

--- a/tests/test_logger_parser.py
+++ b/tests/test_logger_parser.py
@@ -298,8 +298,10 @@ def test_gda_log_level_participates_in_the_level_filter():
     # A rich record's level is a real LogLevel, so `--level warning` keeps a
     # warning gda_log record and drops an info one.
     log = (
-        _gda_log_line("info", "low", {}) + "\n"
-        + _gda_log_line("warning", "high", {}) + "\n"
+        _gda_log_line("info", "low", {})
+        + "\n"
+        + _gda_log_line("warning", "high", {})
+        + "\n"
     )
     records = parse_log_records(log, level="warning")
     messages = [r["message"] for r in records]

--- a/tests/test_mcp_dispatch.py
+++ b/tests/test_mcp_dispatch.py
@@ -40,7 +40,9 @@ def test_multiword_command_name_maps_back_to_the_right_argv():
     # (hyphen restored), proving the argv comes from the dump's own name — not a
     # lossy reverse of the underscored tool name.
     runner = FakeGdaRunner(
-        schema_then(lambda args, stdin: gda_result(json.dumps({"path": "x", "exports": []})))
+        schema_then(
+            lambda args, stdin: gda_result(json.dumps({"path": "x", "exports": []}))
+        )
     )
     server = build_server(runner)
 

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -59,7 +59,9 @@ def _failing_server(code: str):
     ],
 )
 def test_each_category_relays_losslessly_as_is_error(code):
-    result = call_tool(_failing_server(code), "scene_create", {"path": "x", "root_type": "Node2D"})
+    result = call_tool(
+        _failing_server(code), "scene_create", {"path": "x", "root_type": "Node2D"}
+    )
 
     # The failure channel: isError, and the error stays OUT of structuredContent.
     assert result.isError is True
@@ -89,7 +91,9 @@ def test_cannot_run_edge_is_synthesized_by_gda_mcp():
     runner = FakeGdaRunner(
         schema_then(
             lambda args, stdin: gda_result(
-                stdout="", stderr="Traceback: ModuleNotFoundError: No module named 'gda'", returncode=1
+                stdout="",
+                stderr="Traceback: ModuleNotFoundError: No module named 'gda'",
+                returncode=1,
             )
         )
     )
@@ -106,7 +110,9 @@ def test_non_envelope_output_edge_is_synthesized():
     # Non-zero exit but stdout is not a GdaError envelope (a Click usage error, a
     # bare string, JSON missing the error shape): also synthesized by gda-mcp.
     runner = FakeGdaRunner(
-        schema_then(lambda args, stdin: gda_result(stdout='{"not":"an envelope"}', returncode=2))
+        schema_then(
+            lambda args, stdin: gda_result(stdout='{"not":"an envelope"}', returncode=2)
+        )
     )
     result = call_tool(build_server(runner), "info", {})
 
@@ -118,7 +124,9 @@ def test_exit_zero_but_non_json_stdout_edge_is_synthesized():
     # The success-path edge: gda exits 0 yet stdout is not JSON (so --json could
     # not have been honored). gda-mcp treats it as an adapter error, not a crash.
     runner = FakeGdaRunner(
-        schema_then(lambda args, stdin: gda_result(stdout="not json at all", returncode=0))
+        schema_then(
+            lambda args, stdin: gda_result(stdout="not json at all", returncode=0)
+        )
     )
     result = call_tool(build_server(runner), "info", {})
 

--- a/tests/test_mcp_packaging.py
+++ b/tests/test_mcp_packaging.py
@@ -43,8 +43,12 @@ def test_gda_core_does_not_import_mcp():
     # MCP cost. Checked in a fresh interpreter (this test process already has mcp
     # loaded from the fast tier) that imports the whole CLI surface.
     proc = subprocess.run(
-        [sys.executable, "-c", "import gda.cli, gda.__main__, sys; "
-         "assert 'mcp' not in sys.modules, sorted(m for m in sys.modules if 'mcp' in m)"],
+        [
+            sys.executable,
+            "-c",
+            "import gda.cli, gda.__main__, sys; "
+            "assert 'mcp' not in sys.modules, sorted(m for m in sys.modules if 'mcp' in m)",
+        ],
         capture_output=True,
         text=True,
     )

--- a/tests/test_mcp_project_context.py
+++ b/tests/test_mcp_project_context.py
@@ -29,9 +29,7 @@ def test_gda_project_env_resolves_to_that_project(tmp_path):
 
 def test_root_resolves_when_gda_project_unset(tmp_path):
     proj = _project(tmp_path)
-    result = resolve_project_dir(
-        env={}, roots=[str(proj)], cwd=Path("/nonexistent")
-    )
+    result = resolve_project_dir(env={}, roots=[str(proj)], cwd=Path("/nonexistent"))
     assert result == proj
 
 

--- a/tests/test_mcp_project_injection.py
+++ b/tests/test_mcp_project_injection.py
@@ -44,6 +44,7 @@ def test_no_tool_inputschema_carries_a_project_field():
         properties = (tool.inputSchema or {}).get("properties", {})
         assert "project" not in properties, tool.name
 
+
 # A tiny stand-in "gda": echoes the GDA_PROJECT the child process actually sees,
 # so the test observes the real subprocess environment without spawning gda.
 _ECHO_GDA_PROJECT = [
@@ -242,7 +243,9 @@ def test_no_roots_capability_degrades_to_no_project_without_error(
     runner = _scene_create_runner()
     server = build_server(runner)
 
-    result = call_tool(server, "scene_create", {"path": "x.tscn", "root_type": "Node2D"})
+    result = call_tool(
+        server, "scene_create", {"path": "x.tscn", "root_type": "Node2D"}
+    )
 
     assert result.isError is False
     _args, _stdin, project = runner.calls[-1]

--- a/tests/test_mcp_registration.py
+++ b/tests/test_mcp_registration.py
@@ -19,6 +19,7 @@ from tests.mcp_support import (
     schema_then,
 )
 
+
 # The fake seam never dispatches in these tests (registration only); a dispatch
 # attempt is a loud failure so a stray call cannot pass silently.
 def _no_dispatch(args, stdin):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -507,7 +507,12 @@ def test_export_list_result_round_trips_enumerated_presets():
     # carries runnable=false, so the listing names every preset the file defines.
     payload = {
         "presets": [
-            {"index": 0, "name": "Linux/X11", "platform": "Linux/X11", "runnable": True},
+            {
+                "index": 0,
+                "name": "Linux/X11",
+                "platform": "Linux/X11",
+                "runnable": True,
+            },
             {"index": 1, "name": "Web", "platform": "Web", "runnable": False},
         ]
     }
@@ -1088,7 +1093,13 @@ def test_diag_error_callstack_defaults_to_empty_for_a_bare_error():
     from gda.models import DiagError
 
     error = DiagError.model_validate(
-        {"level": "error", "message": "boom", "function": None, "file": None, "line": None}
+        {
+            "level": "error",
+            "message": "boom",
+            "function": None,
+            "file": None,
+            "line": None,
+        }
     )
 
     assert error.callstack == []

--- a/tests/test_node_commands.py
+++ b/tests/test_node_commands.py
@@ -116,9 +116,7 @@ def test_node_get_json_emits_typed_properties_and_exit_zero(monkeypatch):
         [10.0, 20.0],
     )
     # The node is addressed by node path, dispatched by the operation name.
-    assert fake.calls == [
-        ("node-get", {"path": "/tmp/proj/main.tscn", "node": "Hero"})
-    ]
+    assert fake.calls == [("node-get", {"path": "/tmp/proj/main.tscn", "node": "Hero"})]
 
 
 def test_node_set_json_echoes_the_coerced_property_and_exit_zero(monkeypatch):
@@ -217,8 +215,14 @@ def test_node_move_json_echoes_the_reparented_node_and_exit_zero(monkeypatch):
     result = CliRunner().invoke(
         app,
         [
-            "node", "move", "/tmp/proj/main.tscn",
-            "--node", "Hero", "--to", "Enemies", "--json",
+            "node",
+            "move",
+            "/tmp/proj/main.tscn",
+            "--node",
+            "Hero",
+            "--to",
+            "Enemies",
+            "--json",
         ],
     )
 

--- a/tests/test_node_errors.py
+++ b/tests/test_node_errors.py
@@ -288,7 +288,9 @@ def test_node_set_uncoercible_value_maps_to_stable_uncoercible_value_code(monkey
     assert "Vector2" in err["message"]
 
 
-def test_node_set_missing_dependency_maps_to_stable_missing_dependency_code(monkeypatch):
+def test_node_set_missing_dependency_maps_to_stable_missing_dependency_code(
+    monkeypatch,
+):
     # node set is a mutating op, so it honors the mutation-integrity boundary
     # (issue #64) via the shared mutate-entry: a scene whose instance vanishes
     # on load is refused with missing_dependency, the same as node add, leaving
@@ -564,7 +566,9 @@ def _invoke_disconnect_signal(monkeypatch, code: str, message: str):
     )
 
 
-def test_connect_signal_missing_signal_maps_to_stable_signal_not_found_code(monkeypatch):
+def test_connect_signal_missing_signal_maps_to_stable_signal_not_found_code(
+    monkeypatch,
+):
     # issue #57's design decision: the signal MUST exist on the source node — a
     # typo or wrong node is a clean signal_not_found error, so an agent branches
     # on a bad signal name rather than parsing prose.

--- a/tests/test_params_json.py
+++ b/tests/test_params_json.py
@@ -213,7 +213,8 @@ def test_wrong_typed_path_is_a_structured_error_not_a_traceback(monkeypatch):
     )
 
     result = CliRunner().invoke(
-        app, ["scene", "create", "--params-json", '{"path": 123, "root_type": "Node2D"}']
+        app,
+        ["scene", "create", "--params-json", '{"path": 123, "root_type": "Node2D"}'],
     )
 
     assert result.exit_code != 0
@@ -231,7 +232,12 @@ def test_node_add_params_json_derives_default_name_like_argv(monkeypatch):
 
     result = CliRunner().invoke(
         app,
-        ["node", "add", "--params-json", '{"path": "/tmp/proj/main.tscn", "type": "Sprite2D"}'],
+        [
+            "node",
+            "add",
+            "--params-json",
+            '{"path": "/tmp/proj/main.tscn", "type": "Sprite2D"}',
+        ],
     )
 
     assert result.exit_code == 0, result.stdout
@@ -244,7 +250,8 @@ def test_script_create_params_json_rejects_content_and_extends(monkeypatch):
     # The content/extends mutual exclusivity is enforced model-side, so
     # --params-json cannot bypass it (it is rejected, not silently resolved).
     inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SCRIPT_CREATE_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SCRIPT_CREATE_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(
@@ -263,7 +270,8 @@ def test_script_create_params_json_rejects_content_and_extends(monkeypatch):
 
 def test_shader_create_params_json_rejects_content_and_shader_type(monkeypatch):
     inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(
@@ -284,12 +292,18 @@ def test_script_set_params_json_rejects_inconsistent_edit_fields(monkeypatch):
     # The edit-mode rule is enforced model-side: a half-specified mode (search
     # without replace) is invalid_params via --params-json, not a silent dispatch.
     inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SCRIPT_SET_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SCRIPT_SET_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(
         app,
-        ["script", "set", "--params-json", '{"path": "/tmp/proj/hero.gd", "search": "a"}'],
+        [
+            "script",
+            "set",
+            "--params-json",
+            '{"path": "/tmp/proj/hero.gd", "search": "a"}',
+        ],
     )
 
     assert result.exit_code != 0
@@ -303,7 +317,8 @@ def test_perf_monitor_params_json_rejects_both_selectors(monkeypatch):
     result = CliRunner().invoke(
         app,
         [
-            "perf", "monitor",
+            "perf",
+            "monitor",
             "--params-json",
             '{"node": "/root/Main/Player", "property": "position", "signal": "hit"}',
         ],
@@ -331,7 +346,8 @@ def test_perf_monitor_params_json_rejects_frames_over_range(monkeypatch):
     result = CliRunner().invoke(
         app,
         [
-            "perf", "monitor",
+            "perf",
+            "monitor",
             "--params-json",
             '{"node": "/root/Main/Player", "property": "position", "frames": 601}',
         ],
@@ -346,7 +362,8 @@ def test_perf_monitor_params_json_rejects_frames_below_range(monkeypatch):
     result = CliRunner().invoke(
         app,
         [
-            "perf", "monitor",
+            "perf",
+            "monitor",
             "--params-json",
             '{"node": "/root/Main/Player", "property": "position", "frames": 0}',
         ],
@@ -360,12 +377,18 @@ def test_script_set_params_json_derives_mode_like_argv(monkeypatch):
     # Parity: the edit mode is derived from the supplied fields model-side, so a
     # --params-json caller need not (and should not) supply it.
     fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SCRIPT_SET_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(SCRIPT_SET_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(
         app,
-        ["script", "set", "--params-json", '{"path": "/tmp/proj/hero.gd", "content": "extends Node\\n"}'],
+        [
+            "script",
+            "set",
+            "--params-json",
+            '{"path": "/tmp/proj/hero.gd", "content": "extends Node\\n"}',
+        ],
     )
 
     assert result.exit_code == 0, result.stdout
@@ -396,10 +419,7 @@ def _params_json_leaves():
     ``--params-json`` is caught here automatically, not only in a hand-kept list.
     """
     root = typer.main.get_command(app)
-    return [
-        (" ".join(name), command.params)
-        for name, command in _leaf_commands(root)
-    ]
+    return [(" ".join(name), command.params) for name, command in _leaf_commands(root)]
 
 
 # ``gda schema`` is the one documented exception (ADR-0015): the parameterless

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -101,7 +101,9 @@ def test_parse_validate_diagnostics_ignores_operations_own_backtrace_frames():
 
     assert len(diagnostics) == 1
     assert diagnostics[0].line == 5
-    assert diagnostics[0].message == 'Parse Error: Unexpected "Identifier" in class body.'
+    assert (
+        diagnostics[0].message == 'Parse Error: Unexpected "Identifier" in class body.'
+    )
 
 
 def test_parse_validate_diagnostics_does_not_borrow_a_later_errors_reload_line():
@@ -126,10 +128,7 @@ def test_parse_validate_diagnostics_empty_message_keeps_line_and_does_not_spill(
     # An empty SCRIPT ERROR message must not swallow the following reload frame
     # (the `[ \t]` bound keeps the capture on its own line): the diagnostic still
     # gets the frame's line, with an empty message rather than the frame text.
-    stderr = (
-        "SCRIPT ERROR: \n"
-        "          at: GDScript::reload (gdscript://-1.gd:4)\n"
-    )
+    stderr = "SCRIPT ERROR: \n          at: GDScript::reload (gdscript://-1.gd:4)\n"
 
     diagnostics = parse_validate_diagnostics(stderr)
 

--- a/tests/test_perf_commands.py
+++ b/tests/test_perf_commands.py
@@ -76,7 +76,9 @@ def test_perf_monitors_schema_is_self_describing():
     assert schema["kind"] == "live"
 
 
-def test_perf_monitors_without_a_project_reports_project_not_found(monkeypatch, tmp_path):
+def test_perf_monitors_without_a_project_reports_project_not_found(
+    monkeypatch, tmp_path
+):
     # No --project and a projectless cwd -> the project resolves to None, which is a
     # project-resolution error, NOT a daemon error (ADR-0021).
     monkeypatch.chdir(tmp_path)  # tmp_path holds no project.godot
@@ -87,7 +89,9 @@ def test_perf_monitors_without_a_project_reports_project_not_found(monkeypatch, 
     assert json.loads(result.stdout)["error"]["code"] == "project_not_found"
 
 
-def test_perf_monitors_on_non_unix_reports_live_unsupported_platform(monkeypatch, tmp_path):
+def test_perf_monitors_on_non_unix_reports_live_unsupported_platform(
+    monkeypatch, tmp_path
+):
     monkeypatch.setattr("gda.live_runner._is_unix", lambda: False)
 
     result = CliRunner().invoke(
@@ -101,18 +105,29 @@ def test_perf_monitors_on_non_unix_reports_live_unsupported_platform(monkeypatch
 # --- perf monitor (time-windowed property/signal timeline) --------------------
 
 
-def test_perf_monitor_property_emits_a_timeline_through_the_live_channel(monkeypatch, tmp_path):
+def test_perf_monitor_property_emits_a_timeline_through_the_live_channel(
+    monkeypatch, tmp_path
+):
     fake = inject_live_runner(
         monkeypatch,
-        RunResult(stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0),
+        RunResult(
+            stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0
+        ),
     )
 
     result = CliRunner().invoke(
         app,
         [
-            "perf", "monitor", "/root/Main/Player",
-            "--property", "position", "--frames", "3",
-            "--project", str(_project(tmp_path)), "--json",
+            "perf",
+            "monitor",
+            "/root/Main/Player",
+            "--property",
+            "position",
+            "--frames",
+            "3",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -136,7 +151,9 @@ def test_perf_monitor_property_emits_a_timeline_through_the_live_channel(monkeyp
     ]
 
 
-def test_perf_monitor_signal_records_emissions_through_the_live_channel(monkeypatch, tmp_path):
+def test_perf_monitor_signal_records_emissions_through_the_live_channel(
+    monkeypatch, tmp_path
+):
     fake = inject_live_runner(
         monkeypatch,
         RunResult(stdout=sentinel(PERF_MONITOR_SIGNAL_RESULT), stderr="", exit_code=0),
@@ -145,9 +162,16 @@ def test_perf_monitor_signal_records_emissions_through_the_live_channel(monkeypa
     result = CliRunner().invoke(
         app,
         [
-            "perf", "monitor", "/root/Main/Player",
-            "--signal", "hit", "--frames", "3",
-            "--project", str(_project(tmp_path)), "--json",
+            "perf",
+            "monitor",
+            "/root/Main/Player",
+            "--signal",
+            "hit",
+            "--frames",
+            "3",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -173,15 +197,22 @@ def test_perf_monitor_signal_records_emissions_through_the_live_channel(monkeypa
 def test_perf_monitor_default_frame_count_is_threaded(monkeypatch, tmp_path):
     fake = inject_live_runner(
         monkeypatch,
-        RunResult(stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0),
+        RunResult(
+            stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0
+        ),
     )
 
     CliRunner().invoke(
         app,
         [
-            "perf", "monitor", "/root/Main/Player",
-            "--property", "position",
-            "--project", str(_project(tmp_path)), "--json",
+            "perf",
+            "monitor",
+            "/root/Main/Player",
+            "--property",
+            "position",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -189,11 +220,15 @@ def test_perf_monitor_default_frame_count_is_threaded(monkeypatch, tmp_path):
     assert fake.calls[0][1]["frames"] == 60
 
 
-def test_perf_monitor_missing_node_reports_live_perf_node_not_found(monkeypatch, tmp_path):
+def test_perf_monitor_missing_node_reports_live_perf_node_not_found(
+    monkeypatch, tmp_path
+):
     inject_live_runner(
         monkeypatch,
         RunResult(
-            stdout=error_sentinel("live_perf_node_not_found", "no node at runtime path"),
+            stdout=error_sentinel(
+                "live_perf_node_not_found", "no node at runtime path"
+            ),
             stderr="",
             exit_code=0,
         ),
@@ -202,9 +237,14 @@ def test_perf_monitor_missing_node_reports_live_perf_node_not_found(monkeypatch,
     result = CliRunner().invoke(
         app,
         [
-            "perf", "monitor", "/root/Main/Ghost",
-            "--property", "position",
-            "--project", str(_project(tmp_path)), "--json",
+            "perf",
+            "monitor",
+            "/root/Main/Ghost",
+            "--property",
+            "position",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -214,11 +254,15 @@ def test_perf_monitor_missing_node_reports_live_perf_node_not_found(monkeypatch,
     assert error["category"] == "live"
 
 
-def test_perf_monitor_unknown_property_reports_live_perf_property_not_found(monkeypatch, tmp_path):
+def test_perf_monitor_unknown_property_reports_live_perf_property_not_found(
+    monkeypatch, tmp_path
+):
     inject_live_runner(
         monkeypatch,
         RunResult(
-            stdout=error_sentinel("live_perf_property_not_found", "no readable property"),
+            stdout=error_sentinel(
+                "live_perf_property_not_found", "no readable property"
+            ),
             stderr="",
             exit_code=0,
         ),
@@ -227,9 +271,14 @@ def test_perf_monitor_unknown_property_reports_live_perf_property_not_found(monk
     result = CliRunner().invoke(
         app,
         [
-            "perf", "monitor", "/root/Main/Player",
-            "--property", "nope",
-            "--project", str(_project(tmp_path)), "--json",
+            "perf",
+            "monitor",
+            "/root/Main/Player",
+            "--property",
+            "nope",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -237,7 +286,9 @@ def test_perf_monitor_unknown_property_reports_live_perf_property_not_found(monk
     assert json.loads(result.stdout)["error"]["code"] == "live_perf_property_not_found"
 
 
-def test_perf_monitor_unknown_signal_reports_live_perf_signal_not_found(monkeypatch, tmp_path):
+def test_perf_monitor_unknown_signal_reports_live_perf_signal_not_found(
+    monkeypatch, tmp_path
+):
     inject_live_runner(
         monkeypatch,
         RunResult(
@@ -250,9 +301,14 @@ def test_perf_monitor_unknown_signal_reports_live_perf_signal_not_found(monkeypa
     result = CliRunner().invoke(
         app,
         [
-            "perf", "monitor", "/root/Main/Player",
-            "--signal", "nope",
-            "--project", str(_project(tmp_path)), "--json",
+            "perf",
+            "monitor",
+            "/root/Main/Player",
+            "--signal",
+            "nope",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -266,9 +322,14 @@ def test_perf_monitor_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp
     result = CliRunner().invoke(
         app,
         [
-            "perf", "monitor", "/root/Main/Player",
-            "--property", "position",
-            "--project", str(_project(tmp_path)), "--json",
+            "perf",
+            "monitor",
+            "/root/Main/Player",
+            "--property",
+            "position",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -287,15 +348,24 @@ def test_perf_monitor_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp
 def test_perf_monitor_argv_both_selectors_is_a_usage_error(monkeypatch, tmp_path):
     fake = inject_live_runner(
         monkeypatch,
-        RunResult(stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0),
+        RunResult(
+            stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0
+        ),
     )
 
     result = CliRunner().invoke(
         app,
         [
-            "perf", "monitor", "/root/Main/Player",
-            "--property", "position", "--signal", "hit",
-            "--project", str(_project(tmp_path)), "--json",
+            "perf",
+            "monitor",
+            "/root/Main/Player",
+            "--property",
+            "position",
+            "--signal",
+            "hit",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -306,14 +376,20 @@ def test_perf_monitor_argv_both_selectors_is_a_usage_error(monkeypatch, tmp_path
 def test_perf_monitor_argv_no_selector_is_a_usage_error(monkeypatch, tmp_path):
     fake = inject_live_runner(
         monkeypatch,
-        RunResult(stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0),
+        RunResult(
+            stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0
+        ),
     )
 
     result = CliRunner().invoke(
         app,
         [
-            "perf", "monitor", "/root/Main/Player",
-            "--project", str(_project(tmp_path)), "--json",
+            "perf",
+            "monitor",
+            "/root/Main/Player",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -324,15 +400,24 @@ def test_perf_monitor_argv_no_selector_is_a_usage_error(monkeypatch, tmp_path):
 def test_perf_monitor_argv_frames_over_range_is_a_usage_error(monkeypatch, tmp_path):
     fake = inject_live_runner(
         monkeypatch,
-        RunResult(stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0),
+        RunResult(
+            stdout=sentinel(PERF_MONITOR_PROPERTY_RESULT), stderr="", exit_code=0
+        ),
     )
 
     result = CliRunner().invoke(
         app,
         [
-            "perf", "monitor", "/root/Main/Player",
-            "--property", "position", "--frames", "601",
-            "--project", str(_project(tmp_path)), "--json",
+            "perf",
+            "monitor",
+            "/root/Main/Player",
+            "--property",
+            "position",
+            "--frames",
+            "601",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 

--- a/tests/test_project_analysis_commands.py
+++ b/tests/test_project_analysis_commands.py
@@ -18,7 +18,6 @@ from tests.support import (
     FIND_REFERENCES_RESULT,
     STATISTICS_RESULT,
     UNUSED_RESULT,
-    FakeRunner,
     inject_runner,
     sentinel,
 )
@@ -83,9 +82,7 @@ def test_find_references_normalizes_filesystem_target_but_not_res_path(monkeypat
         ),
     )
 
-    result = CliRunner().invoke(
-        app, ["project", "find-references", "Hero", "--json"]
-    )
+    result = CliRunner().invoke(app, ["project", "find-references", "Hero", "--json"])
 
     assert result.exit_code == 0
     assert fake.calls == [("project-find-references", {"target": "Hero"})]
@@ -96,9 +93,7 @@ def test_find_unused_resources_json(monkeypatch):
         monkeypatch, RunResult(stdout=sentinel(UNUSED_RESULT), stderr="", exit_code=0)
     )
 
-    result = CliRunner().invoke(
-        app, ["project", "find-unused-resources", "--json"]
-    )
+    result = CliRunner().invoke(app, ["project", "find-unused-resources", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -76,7 +76,9 @@ def test_project_info_json_maps_success_to_json_object_and_exit_zero(monkeypatch
 
 
 def test_project_info_human_output_is_a_readable_block(monkeypatch):
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(INFO_RESULT), stderr="", exit_code=0))
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(INFO_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(app, ["project", "info"])
 
@@ -90,7 +92,9 @@ def test_project_info_human_output_is_a_readable_block(monkeypatch):
 def test_project_info_human_output_shows_none_for_empty_main_scene(monkeypatch):
     # A new project has no main scene; the human block names that explicitly.
     payload = {**INFO_RESULT, "main_scene": ""}
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0))
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(app, ["project", "info"])
 
@@ -118,7 +122,9 @@ def test_project_get_dispatches_setting_param_and_reports_typed_value(monkeypatc
 
 
 def test_project_get_human_output_is_setting_type_value(monkeypatch):
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0))
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(app, ["project", "get", "application/config/name"])
 
@@ -130,7 +136,9 @@ def test_project_get_carries_packed_value_projection(monkeypatch):
     # A packed-type setting (e.g. a Vector2-ish value) is carried as a JSON list,
     # the same projection node get reports — so get / set round-trip the shape.
     payload = {"setting": "some/vec", "type": "Vector2", "value": [10.0, 20.0]}
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0))
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(app, ["project", "get", "some/vec", "--json"])
 
@@ -175,7 +183,9 @@ def test_project_set_dispatches_setting_and_value_and_round_trips(monkeypatch):
 
 
 def test_project_set_human_output_is_set_setting_type_value(monkeypatch):
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0))
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["project", "set", "display/window/size/viewport_width", "--value", "1920"]
@@ -183,8 +193,7 @@ def test_project_set_human_output_is_set_setting_type_value(monkeypatch):
 
     assert result.exit_code == 0
     assert (
-        result.stdout.strip()
-        == "set display/window/size/viewport_width (int) = 1920"
+        result.stdout.strip() == "set display/window/size/viewport_width (int) = 1920"
     )
 
 
@@ -194,9 +203,7 @@ def test_project_set_requires_value(monkeypatch):
     fake = FakeRunner(RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0))
     monkeypatch.setattr("gda.cli._make_runner", lambda binary, project=None: fake)
 
-    result = CliRunner().invoke(
-        app, ["project", "set", "application/config/name"]
-    )
+    result = CliRunner().invoke(app, ["project", "set", "application/config/name"])
 
     assert result.exit_code == 2
     assert fake.calls == []
@@ -244,7 +251,9 @@ def test_project_add_autoload_human_output_names_the_registered_autoload(monkeyp
         RunResult(stdout=sentinel(ADD_AUTOLOAD_RESULT), stderr="", exit_code=0),
     )
 
-    result = CliRunner().invoke(app, ["project", "add-autoload", "Global", "res://global.gd"])
+    result = CliRunner().invoke(
+        app, ["project", "add-autoload", "Global", "res://global.gd"]
+    )
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "added autoload Global = *res://global.gd"
@@ -259,9 +268,7 @@ def test_project_remove_autoload_dispatches_name_and_reports_result(monkeypatch)
         RunResult(stdout=sentinel(REMOVE_AUTOLOAD_RESULT), stderr="", exit_code=0),
     )
 
-    result = CliRunner().invoke(
-        app, ["project", "remove-autoload", "Global", "--json"]
-    )
+    result = CliRunner().invoke(app, ["project", "remove-autoload", "Global", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -269,7 +276,9 @@ def test_project_remove_autoload_dispatches_name_and_reports_result(monkeypatch)
     assert fake.calls == [("project-remove-autoload", {"name": "Global"})]
 
 
-def test_project_remove_autoload_human_output_names_the_unregistered_autoload(monkeypatch):
+def test_project_remove_autoload_human_output_names_the_unregistered_autoload(
+    monkeypatch,
+):
     inject_runner(
         monkeypatch,
         RunResult(stdout=sentinel(REMOVE_AUTOLOAD_RESULT), stderr="", exit_code=0),
@@ -360,7 +369,9 @@ def test_project_remove_autoload_schema_emits_model_derived_contract_without_oth
 def test_sample_project_results_validate_against_emitted_output_schemas():
     # A sample --json payload of each project command satisfies the contract its
     # --schema emits (the other half of the ADR-0004 hard gate, issue #111).
-    info_doc = json.loads(CliRunner().invoke(app, ["project", "info", "--schema"]).stdout)
+    info_doc = json.loads(
+        CliRunner().invoke(app, ["project", "info", "--schema"]).stdout
+    )
     get_doc = json.loads(CliRunner().invoke(app, ["project", "get", "--schema"]).stdout)
     set_doc = json.loads(CliRunner().invoke(app, ["project", "set", "--schema"]).stdout)
     add_doc = json.loads(

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -107,7 +107,9 @@ def _deep_chain(model, depth, **leaf_fields):
     # bypasses pydantic's recursive validation (issue #37): the point is to
     # exercise the RENDER path's recursion in isolation, at a depth past the
     # ~255 pydantic-core ceiling a legitimately deep scene can reach.
-    root = leaf = model.model_construct(name="n0", type="Node", children=[], **leaf_fields)
+    root = leaf = model.model_construct(
+        name="n0", type="Node", children=[], **leaf_fields
+    )
     for i in range(1, depth):
         child = model.model_construct(
             name=f"n{i}", type="Node", children=[], **leaf_fields
@@ -182,7 +184,10 @@ def test_render_game_set_renders_the_set_runtime_property():
         type="Vector2",
         value=[10.0, 20.0],
     )
-    assert render_game_set(result) == "set /root/Main/Player.position (Vector2) = [10.0, 20.0]"
+    assert (
+        render_game_set(result)
+        == "set /root/Main/Player.position (Vector2) = [10.0, 20.0]"
+    )
 
 
 def test_render_perf_monitors_renders_a_sorted_snapshot():
@@ -194,7 +199,9 @@ def test_render_perf_monitors_renders_a_sorted_snapshot():
         },
     )
     # Monitors are listed in a stable (name-sorted) order under the timestamp header.
-    assert render_perf_monitors(result) == "perf @ 500ms\n  fps = 60.0\n  node_count = 3.0"
+    assert (
+        render_perf_monitors(result) == "perf @ 500ms\n  fps = 60.0\n  node_count = 3.0"
+    )
 
 
 def test_render_perf_monitor_property_renders_a_per_frame_timeline():
@@ -239,11 +246,17 @@ def test_render_daemon_start_surfaces_a_version_sync(tmp_path):
         harness_version="3",
         already_running=False,
     )
-    assert render_daemon_start(synced) == "daemon started: pid 42 on /tmp/x.sock (synced harness to v3)"
+    assert (
+        render_daemon_start(synced)
+        == "daemon started: pid 42 on /tmp/x.sock (synced harness to v3)"
+    )
 
     # A first install (changed but not a version-mismatch resync) reads as install.
     installed = synced.model_copy(update={"harness_synced": False})
-    assert render_daemon_start(installed) == "daemon started: pid 42 on /tmp/x.sock (installed harness)"
+    assert (
+        render_daemon_start(installed)
+        == "daemon started: pid 42 on /tmp/x.sock (installed harness)"
+    )
 
 
 def test_render_daemon_status_notes_the_windowed_session(tmp_path):
@@ -252,7 +265,10 @@ def test_render_daemon_status_notes_the_windowed_session(tmp_path):
     windowed = DaemonStatusResult(
         running=True, pid=42, socket_path="/tmp/x.sock", windowed=True
     )
-    assert render_daemon_status(windowed) == "daemon running: pid 42 on /tmp/x.sock [windowed]"
+    assert (
+        render_daemon_status(windowed)
+        == "daemon running: pid 42 on /tmp/x.sock [windowed]"
+    )
 
     headless = windowed.model_copy(update={"windowed": False})
     assert render_daemon_status(headless) == "daemon running: pid 42 on /tmp/x.sock"
@@ -267,8 +283,14 @@ def test_render_daemon_status_notes_the_windowed_session(tmp_path):
 
 def test_render_daemon_uninstall_reports_removal(tmp_path):
     # #225: uninstall renders the paired removal, with the idempotent no-op form.
-    assert render_daemon_uninstall(DaemonUninstallResult(removed=True)) == "harness uninstalled"
-    assert render_daemon_uninstall(DaemonUninstallResult(removed=False)) == "no harness was installed"
+    assert (
+        render_daemon_uninstall(DaemonUninstallResult(removed=True))
+        == "harness uninstalled"
+    )
+    assert (
+        render_daemon_uninstall(DaemonUninstallResult(removed=False))
+        == "no harness was installed"
+    )
 
 
 def test_render_engine_version_renders_the_one_line_version_string():
@@ -319,7 +341,9 @@ def test_render_diag_errors_shows_the_callstack_frames_under_the_error():
     assert "_ready (res://main.gd:3)" in rendered
     # Frames render below the headline, in order.
     assert rendered.index("b (res://main.gd:9)") < rendered.index("a (res://main.gd:6)")
-    assert rendered.index("a (res://main.gd:6)") < rendered.index("_ready (res://main.gd:3)")
+    assert rendered.index("a (res://main.gd:6)") < rendered.index(
+        "_ready (res://main.gd:3)"
+    )
 
 
 def test_render_diag_errors_omits_a_callstack_block_for_a_bare_error():

--- a/tests/test_resource_commands.py
+++ b/tests/test_resource_commands.py
@@ -78,7 +78,9 @@ def test_resource_set_dispatches_path_property_value_and_round_trips(monkeypatch
 
 
 def test_resource_set_human_output_is_set_path_property_type_value(monkeypatch):
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0))
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app,
@@ -217,7 +219,9 @@ def test_resource_create_json_maps_success_to_json_object_and_exit_zero(monkeypa
 
 
 def test_resource_create_human_output_reports_path_and_type(monkeypatch):
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0))
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["resource", "create", "/tmp/proj/palette.tres", "--type", "Gradient"]
@@ -249,7 +253,9 @@ def test_resource_get_json_maps_success_to_json_object_and_exit_zero(monkeypatch
 
 
 def test_resource_get_human_output_lists_typed_properties(monkeypatch):
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0))
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(app, ["resource", "get", "/tmp/proj/palette.tres"])
 
@@ -358,7 +364,8 @@ def test_resource_uid_expands_tilde_for_a_filesystem_target(monkeypatch, tmp_pat
     # works without a shell (issue #32); a uid:// / res:// target is untouched.
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
     fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(PATH_TO_UID_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(PATH_TO_UID_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(
@@ -367,7 +374,7 @@ def test_resource_uid_expands_tilde_for_a_filesystem_target(monkeypatch, tmp_pat
 
     assert result.exit_code == 0
     # The dispatched target is the ~-expanded absolute path, not the literal "~".
-    (operation, params), = fake.calls
+    ((operation, params),) = fake.calls
     assert operation == "resource-uid"
     assert not params["target"].startswith("~")
     assert params["target"].endswith("/data.tres")
@@ -381,7 +388,8 @@ def test_resource_uid_human_output_renders_uid_arrow_path(monkeypatch, tmp_path)
     # for both directions since the result shape is identical.
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
     inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(UID_TO_PATH_RESULT), stderr="", exit_code=0)
+        monkeypatch,
+        RunResult(stdout=sentinel(UID_TO_PATH_RESULT), stderr="", exit_code=0),
     )
 
     result = CliRunner().invoke(

--- a/tests/test_resource_errors.py
+++ b/tests/test_resource_errors.py
@@ -148,9 +148,7 @@ def _invoke_resource_delete(monkeypatch, code: str, message: str):
             exit_code=1,
         ),
     )
-    return CliRunner().invoke(
-        app, ["resource", "delete", "/x/palette.tres", "--json"]
-    )
+    return CliRunner().invoke(app, ["resource", "delete", "/x/palette.tres", "--json"])
 
 
 def test_resource_set_unknown_property_yields_unknown_property(monkeypatch):

--- a/tests/test_resource_models.py
+++ b/tests/test_resource_models.py
@@ -31,7 +31,11 @@ def test_params_carry_the_single_target_argument():
 
 def test_result_validates_a_uid_to_path_payload():
     # The uid->path direction: the sentinel payload the operation emits.
-    payload = {"queried": "uid", "uid": "uid://caax1gby1api1", "path": "res://data.tres"}
+    payload = {
+        "queried": "uid",
+        "uid": "uid://caax1gby1api1",
+        "path": "res://data.tres",
+    }
 
     result = ResourceUidResult.model_validate(payload)
 
@@ -42,7 +46,11 @@ def test_result_validates_a_uid_to_path_payload():
 
 def test_result_validates_a_path_to_uid_payload():
     # The path->uid direction shares the same shape; only `queried` differs.
-    payload = {"queried": "path", "uid": "uid://caax1gby1api1", "path": "res://data.tres"}
+    payload = {
+        "queried": "path",
+        "uid": "uid://caax1gby1api1",
+        "path": "res://data.tres",
+    }
 
     result = ResourceUidResult.model_validate(payload)
 

--- a/tests/test_scene_commands.py
+++ b/tests/test_scene_commands.py
@@ -219,7 +219,9 @@ def test_scene_get_exports_json_emits_per_node_exports_and_exit_zero(monkeypatch
     assert "engine diagnostic" in result.stderr
 
 
-def test_scene_get_exports_expands_user_home_in_filesystem_path_but_not_res(monkeypatch):
+def test_scene_get_exports_expands_user_home_in_filesystem_path_but_not_res(
+    monkeypatch,
+):
     # Path normalization at the CLI layer (issue #32) applies to get-exports too:
     # a filesystem path gets ~ expanded; a res:// path passes through untouched.
     fake = inject_runner(

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -889,9 +889,7 @@ def test_project_find_unused_resources_schema_emits_model_derived_contract():
         ProjectFindUnusedResourcesResult,
     )
 
-    result = CliRunner().invoke(
-        app, ["project", "find-unused-resources", "--schema"]
-    )
+    result = CliRunner().invoke(app, ["project", "find-unused-resources", "--schema"])
 
     assert result.exit_code == 0
     doc = json.loads(result.stdout)
@@ -995,9 +993,7 @@ def test_sample_project_results_validate_against_emitted_output_schemas():
         CliRunner().invoke(app, ["project", "dependencies", "--schema"]).stdout
     )
     unused_doc = json.loads(
-        CliRunner()
-        .invoke(app, ["project", "find-unused-resources", "--schema"])
-        .stdout
+        CliRunner().invoke(app, ["project", "find-unused-resources", "--schema"]).stdout
     )
     stats_doc = json.loads(
         CliRunner().invoke(app, ["project", "statistics", "--schema"]).stdout
@@ -1155,8 +1151,12 @@ def test_sample_game_results_validate_against_emitted_output_schemas():
 def test_perf_commands_schema_report_kind_live_and_are_model_derived():
     # The LIVE perf commands (#223) self-describe like any command — input/output
     # contracts derived from their models, plus the LIVE execution kind (ADR-0017).
-    monitors_doc = json.loads(CliRunner().invoke(app, ["perf", "monitors", "--schema"]).stdout)
-    monitor_doc = json.loads(CliRunner().invoke(app, ["perf", "monitor", "--schema"]).stdout)
+    monitors_doc = json.loads(
+        CliRunner().invoke(app, ["perf", "monitors", "--schema"]).stdout
+    )
+    monitor_doc = json.loads(
+        CliRunner().invoke(app, ["perf", "monitor", "--schema"]).stdout
+    )
 
     for doc in (monitors_doc, monitor_doc):
         assert "input" in doc and "output" in doc
@@ -1172,12 +1172,20 @@ def test_sample_perf_results_validate_against_emitted_output_schemas():
         PERF_MONITORS_RESULT,
     )
 
-    monitors_doc = json.loads(CliRunner().invoke(app, ["perf", "monitors", "--schema"]).stdout)
-    monitor_doc = json.loads(CliRunner().invoke(app, ["perf", "monitor", "--schema"]).stdout)
+    monitors_doc = json.loads(
+        CliRunner().invoke(app, ["perf", "monitors", "--schema"]).stdout
+    )
+    monitor_doc = json.loads(
+        CliRunner().invoke(app, ["perf", "monitor", "--schema"]).stdout
+    )
 
     jsonschema.validate(instance=PERF_MONITORS_RESULT, schema=monitors_doc["output"])
-    jsonschema.validate(instance=PERF_MONITOR_PROPERTY_RESULT, schema=monitor_doc["output"])
-    jsonschema.validate(instance=PERF_MONITOR_SIGNAL_RESULT, schema=monitor_doc["output"])
+    jsonschema.validate(
+        instance=PERF_MONITOR_PROPERTY_RESULT, schema=monitor_doc["output"]
+    )
+    jsonschema.validate(
+        instance=PERF_MONITOR_SIGNAL_RESULT, schema=monitor_doc["output"]
+    )
 
 
 def test_input_commands_schema_report_kind_live_and_are_model_derived():
@@ -1213,10 +1221,18 @@ def test_sample_input_results_validate_against_emitted_output_schemas():
     )
 
     key_doc = json.loads(CliRunner().invoke(app, ["input", "key", "--schema"]).stdout)
-    click_doc = json.loads(CliRunner().invoke(app, ["input", "mouse-click", "--schema"]).stdout)
-    move_doc = json.loads(CliRunner().invoke(app, ["input", "mouse-move", "--schema"]).stdout)
-    action_doc = json.loads(CliRunner().invoke(app, ["input", "action", "--schema"]).stdout)
-    seq_doc = json.loads(CliRunner().invoke(app, ["input", "sequence", "--schema"]).stdout)
+    click_doc = json.loads(
+        CliRunner().invoke(app, ["input", "mouse-click", "--schema"]).stdout
+    )
+    move_doc = json.loads(
+        CliRunner().invoke(app, ["input", "mouse-move", "--schema"]).stdout
+    )
+    action_doc = json.loads(
+        CliRunner().invoke(app, ["input", "action", "--schema"]).stdout
+    )
+    seq_doc = json.loads(
+        CliRunner().invoke(app, ["input", "sequence", "--schema"]).stdout
+    )
 
     jsonschema.validate(instance=INPUT_KEY_RESULT, schema=key_doc["output"])
     jsonschema.validate(instance=INPUT_MOUSE_CLICK_RESULT, schema=click_doc["output"])
@@ -1230,9 +1246,7 @@ def test_schema_kind_is_identical_via_argv_and_params_json_forms():
     # argv form and the `--params-json` form (the --schema check runs first), so
     # the emitted `kind` must be byte-identical between the two — proving the one
     # source of truth is threaded through, not duplicated per path.
-    argv_doc = json.loads(
-        CliRunner().invoke(app, ["scene", "get", "--schema"]).stdout
-    )
+    argv_doc = json.loads(CliRunner().invoke(app, ["scene", "get", "--schema"]).stdout)
     params_json_doc = json.loads(
         CliRunner()
         .invoke(app, ["scene", "get", "--params-json", "{}", "--schema"])
@@ -1316,9 +1330,7 @@ def test_schema_constraints_are_identical_via_argv_and_params_json_forms():
     # byte-identical across the two — proving the one predicate is threaded
     # through, not duplicated per path (#233). Use a LIVE command so the field is
     # populated, not null.
-    argv_doc = json.loads(
-        CliRunner().invoke(app, ["game", "tree", "--schema"]).stdout
-    )
+    argv_doc = json.loads(CliRunner().invoke(app, ["game", "tree", "--schema"]).stdout)
     params_json_doc = json.loads(
         CliRunner()
         .invoke(app, ["game", "tree", "--params-json", "{}", "--schema"])

--- a/tests/test_screen_commands.py
+++ b/tests/test_screen_commands.py
@@ -64,8 +64,15 @@ def test_screen_capture_params_json_supplies_the_output_path(monkeypatch, tmp_pa
 
     result = CliRunner().invoke(
         app,
-        ["screen", "capture", "--params-json", payload,
-         "--project", str(_project(tmp_path)), "--json"],
+        [
+            "screen",
+            "capture",
+            "--params-json",
+            payload,
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -78,8 +85,15 @@ def test_screen_capture_params_json_without_output_is_invalid_params(tmp_path):
     # a STRUCTURED invalid_params, never an AttributeError on a None path.
     result = CliRunner().invoke(
         app,
-        ["screen", "capture", "--params-json", "{}",
-         "--project", str(_project(tmp_path)), "--json"],
+        [
+            "screen",
+            "capture",
+            "--params-json",
+            "{}",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code != 0
@@ -100,8 +114,15 @@ def test_screen_frames_params_json_supplies_the_output_dir(monkeypatch, tmp_path
 
     result = CliRunner().invoke(
         app,
-        ["screen", "frames", "--params-json", payload,
-         "--project", str(_project(tmp_path)), "--json"],
+        [
+            "screen",
+            "frames",
+            "--params-json",
+            payload,
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -145,9 +166,13 @@ def test_screen_capture_writes_a_png_and_returns_its_path(monkeypatch, tmp_path)
     result = CliRunner().invoke(
         app,
         [
-            "screen", "capture",
-            "--output", str(out),
-            "--project", str(_project(tmp_path)), "--json",
+            "screen",
+            "capture",
+            "--output",
+            str(out),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -180,9 +205,14 @@ def test_screen_capture_inline_embeds_the_base64(monkeypatch, tmp_path):
     result = CliRunner().invoke(
         app,
         [
-            "screen", "capture", "--inline",
-            "--output", str(out),
-            "--project", str(_project(tmp_path)), "--json",
+            "screen",
+            "capture",
+            "--inline",
+            "--output",
+            str(out),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -194,7 +224,9 @@ def test_screen_capture_inline_embeds_the_base64(monkeypatch, tmp_path):
     assert out.read_bytes() == _PNG_1X1
 
 
-def test_screen_capture_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):
+def test_screen_capture_with_no_daemon_reports_daemon_not_running(
+    monkeypatch, tmp_path
+):
     # No fake: the real DaemonRunner + discovery run against an empty runtime dir,
     # so no daemon is found — the attach-or-fail typed error (ADR-0017).
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
@@ -202,9 +234,13 @@ def test_screen_capture_with_no_daemon_reports_daemon_not_running(monkeypatch, t
     result = CliRunner().invoke(
         app,
         [
-            "screen", "capture",
-            "--output", str(tmp_path / "shot.png"),
-            "--project", str(_project(tmp_path)), "--json",
+            "screen",
+            "capture",
+            "--output",
+            str(tmp_path / "shot.png"),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -235,9 +271,13 @@ def test_screen_capture_on_headless_session_reports_live_display_unavailable(
     result = CliRunner().invoke(
         app,
         [
-            "screen", "capture",
-            "--output", str(out),
-            "--project", str(_project(tmp_path)), "--json",
+            "screen",
+            "capture",
+            "--output",
+            str(out),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -255,7 +295,9 @@ def test_screen_capture_schema_reports_kind_live_and_is_self_describing():
     assert schema["kind"] == "live"
 
 
-def test_screen_capture_without_a_project_reports_project_not_found(monkeypatch, tmp_path):
+def test_screen_capture_without_a_project_reports_project_not_found(
+    monkeypatch, tmp_path
+):
     monkeypatch.chdir(tmp_path)  # holds no project.godot
 
     result = CliRunner().invoke(
@@ -285,9 +327,15 @@ def test_screen_frames_writes_each_png_and_returns_paths(monkeypatch, tmp_path):
     result = CliRunner().invoke(
         app,
         [
-            "screen", "frames", "--frames", "3",
-            "--output-dir", str(out_dir),
-            "--project", str(_project(tmp_path)), "--json",
+            "screen",
+            "frames",
+            "--frames",
+            "3",
+            "--output-dir",
+            str(out_dir),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -314,9 +362,15 @@ def test_screen_frames_with_no_daemon_reports_daemon_not_running(monkeypatch, tm
     result = CliRunner().invoke(
         app,
         [
-            "screen", "frames", "--frames", "3",
-            "--output-dir", str(tmp_path / "frames"),
-            "--project", str(_project(tmp_path)), "--json",
+            "screen",
+            "frames",
+            "--frames",
+            "3",
+            "--output-dir",
+            str(tmp_path / "frames"),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -329,15 +383,23 @@ def test_screen_frames_argv_frames_over_range_is_a_usage_error(monkeypatch, tmp_
     # an over-range value is a usage error on argv (exit 2), engine never reached.
     fake = inject_live_runner(
         monkeypatch,
-        RunResult(stdout=sentinel(screen_frames_reply([_PNG_B64])), stderr="", exit_code=0),
+        RunResult(
+            stdout=sentinel(screen_frames_reply([_PNG_B64])), stderr="", exit_code=0
+        ),
     )
 
     result = CliRunner().invoke(
         app,
         [
-            "screen", "frames", "--frames", "601",
-            "--output-dir", str(tmp_path / "frames"),
-            "--project", str(_project(tmp_path)), "--json",
+            "screen",
+            "frames",
+            "--frames",
+            "601",
+            "--output-dir",
+            str(tmp_path / "frames"),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
         ],
     )
 
@@ -370,16 +432,22 @@ def test_screen_frames_params_json_over_range_frames_is_invalid_params(
     # not a CLI-only option mutually exclusive with it (PR #248 review).
     fake = inject_live_runner(
         monkeypatch,
-        RunResult(stdout=sentinel(screen_frames_reply([_PNG_B64])), stderr="", exit_code=0),
+        RunResult(
+            stdout=sentinel(screen_frames_reply([_PNG_B64])), stderr="", exit_code=0
+        ),
     )
     payload = json.dumps({"frames": 601, "output_dir": str(tmp_path / "frames")})
 
     result = CliRunner().invoke(
         app,
         [
-            "screen", "frames",
-            "--project", str(_project(tmp_path)), "--json",
-            "--params-json", payload,
+            "screen",
+            "frames",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+            "--params-json",
+            payload,
         ],
     )
 

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -64,7 +64,9 @@ def test_script_create_default_template_passes_null_content_and_extends(monkeypa
     stdout = sentinel({**CREATE_RESULT, "extends": "Node"})
     fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
 
-    result = CliRunner().invoke(app, ["script", "create", "/tmp/proj/hero.gd", "--json"])
+    result = CliRunner().invoke(
+        app, ["script", "create", "/tmp/proj/hero.gd", "--json"]
+    )
 
     assert result.exit_code == 0
     assert fake.calls == [
@@ -78,7 +80,12 @@ def test_script_create_default_template_passes_null_content_and_extends(monkeypa
 def test_script_create_content_passes_verbatim_source(monkeypatch):
     # --content supplies verbatim source; it rides through as the content param.
     stdout = sentinel(
-        {"path": "/tmp/proj/util.gd", "class_name": None, "extends": None, "created_dirs": []}
+        {
+            "path": "/tmp/proj/util.gd",
+            "class_name": None,
+            "extends": None,
+            "created_dirs": [],
+        }
     )
     fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
 
@@ -110,7 +117,9 @@ def test_script_create_content_passes_verbatim_source(monkeypatch):
 def test_script_create_content_and_extends_are_mutually_exclusive(monkeypatch):
     # Verbatim content is not templated, so a base class has nowhere to go;
     # supplying both is a usage error (exit 2), never a silent precedence rule.
-    fake = inject_runner(monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0))
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app,
@@ -148,7 +157,9 @@ def test_script_get_json_emits_source_and_metadata_and_exit_zero(monkeypatch):
     assert fake.calls == [("script-get", {"path": "/tmp/proj/hero.gd"})]
 
 
-def test_script_list_json_enumerates_project_scripts_and_exit_zero(monkeypatch, tmp_path):
+def test_script_list_json_enumerates_project_scripts_and_exit_zero(
+    monkeypatch, tmp_path
+):
     # script list enumerates the resolved project's .gd files (issue #117): each
     # entry carries its res:// path plus the class_name/extends parsed cheaply
     # from the script's raw source.
@@ -484,7 +495,9 @@ def test_script_validate_valid_script_reports_valid_true_no_diagnostics(monkeypa
     stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(payload)
     fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
 
-    result = CliRunner().invoke(app, ["script", "validate", "/tmp/proj/ok.gd", "--json"])
+    result = CliRunner().invoke(
+        app, ["script", "validate", "/tmp/proj/ok.gd", "--json"]
+    )
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -504,7 +517,7 @@ def test_script_validate_invalid_script_is_success_with_parsed_diagnostics(monke
         "error_string": "Parse error.",
     }
     stderr = (
-        'SCRIPT ERROR: Parse Error: Expected expression for variable initial '
+        "SCRIPT ERROR: Parse Error: Expected expression for variable initial "
         'value after "=".\n'
         "          at: GDScript::reload (gdscript://-9223371888644840980.gd:3)\n"
     )
@@ -573,7 +586,9 @@ def test_script_set_end_line_without_start_line_is_a_usage_error(monkeypatch):
 def test_script_validate_human_output_valid(monkeypatch):
     # Without --json, a valid result renders a one-line 'valid <path>'.
     payload = {"path": "/tmp/proj/ok.gd", "valid": True, "error_string": None}
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0))
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(app, ["script", "validate", "/tmp/proj/ok.gd"])
 
@@ -593,7 +608,9 @@ def test_script_validate_human_output_invalid_lists_diagnostics(monkeypatch):
         "SCRIPT ERROR: Parse Error: the message.\n"
         "          at: GDScript::reload (gdscript://-1.gd:3)\n"
     )
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(payload), stderr=stderr, exit_code=0))
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr=stderr, exit_code=0)
+    )
 
     result = CliRunner().invoke(app, ["script", "validate", "/tmp/proj/broken.gd"])
 
@@ -611,25 +628,43 @@ def test_script_attach_human_output(monkeypatch):
         "script": "/tmp/proj/hero.gd",
         "class_name": "Hero",
     }
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0))
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app,
-        ["script", "attach", "/tmp/proj/main.tscn", "--node", "Hero", "--script", "/tmp/proj/hero.gd"],
+        [
+            "script",
+            "attach",
+            "/tmp/proj/main.tscn",
+            "--node",
+            "Hero",
+            "--script",
+            "/tmp/proj/hero.gd",
+        ],
     )
 
     assert result.exit_code == 0
-    assert result.stdout.strip() == "attached /tmp/proj/hero.gd to Hero in /tmp/proj/main.tscn"
+    assert (
+        result.stdout.strip()
+        == "attached /tmp/proj/hero.gd to Hero in /tmp/proj/main.tscn"
+    )
 
 
 def test_script_set_human_output_renders_metadata(monkeypatch):
     # Without --json, set reuses the shared script-metadata renderer.
     payload = {"path": "/tmp/proj/hero.gd", "class_name": "Hero", "extends": "Node2D"}
-    inject_runner(monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0))
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["script", "set", "/tmp/proj/hero.gd", "--content", "x"]
     )
 
     assert result.exit_code == 0
-    assert result.stdout.strip() == "set /tmp/proj/hero.gd (extends Node2D, class_name Hero)"
+    assert (
+        result.stdout.strip()
+        == "set /tmp/proj/hero.gd (extends Node2D, class_name Hero)"
+    )

--- a/tests/test_script_errors.py
+++ b/tests/test_script_errors.py
@@ -27,9 +27,7 @@ def _invoke_script_create(monkeypatch, code: str, message: str):
             exit_code=1,
         ),
     )
-    return CliRunner().invoke(
-        app, ["script", "create", "/x/hero.gd", "--json"]
-    )
+    return CliRunner().invoke(app, ["script", "create", "/x/hero.gd", "--json"])
 
 
 def _invoke_script_get(monkeypatch, code: str, message: str):
@@ -239,7 +237,7 @@ def test_script_set_no_search_match_maps_to_stable_no_search_match_code(monkeypa
     # contain is a new no_search_match code, so an agent learns the edit landed
     # nowhere (and the file was left untouched) rather than parsing prose.
     result = _invoke_script_set(
-        monkeypatch, "no_search_match", "search string not found in script: \"xyzzy\""
+        monkeypatch, "no_search_match", 'search string not found in script: "xyzzy"'
     )
 
     assert result.exit_code == 4
@@ -397,7 +395,9 @@ def test_script_attach_unloadable_resource_reuses_stable_invalid_path_code(monke
     assert "/x/hero.gd" in err["message"]
 
 
-def test_script_attach_non_compiling_script_uses_script_compile_failed_code(monkeypatch):
+def test_script_attach_non_compiling_script_uses_script_compile_failed_code(
+    monkeypatch,
+):
     # A .gd that loads but does not COMPILE cannot be bound: the headless engine
     # silently rejects it from set_script, so attach refuses with the focused
     # script_compile_failed code rather than report a phantom success over a
@@ -415,7 +415,9 @@ def test_script_attach_non_compiling_script_uses_script_compile_failed_code(monk
     assert "/x/hero.gd" in err["message"]
 
 
-def test_script_attach_incompatible_type_uses_incompatible_script_type_code(monkeypatch):
+def test_script_attach_incompatible_type_uses_incompatible_script_type_code(
+    monkeypatch,
+):
     # A script that COMPILES but whose native base is incompatible with the node
     # (e.g. an `extends Node3D` script onto a Node2D) is bounced by set_script for
     # a different reason than a compile error — attach reports the distinct

--- a/tests/test_sentinel_result.py
+++ b/tests/test_sentinel_result.py
@@ -30,7 +30,12 @@ def test_build_result_wraps_payload_in_the_sentinel_with_trailing_newline():
 
 def test_build_result_round_trips_through_parse_result():
     # The write side is the exact inverse of the read side.
-    for payload in ({}, {"a": 1}, {"error": {"code": "x", "message": "m"}}, {"l": [1, 2]}):
+    for payload in (
+        {},
+        {"a": 1},
+        {"error": {"code": "x", "message": "m"}},
+        {"l": [1, 2]},
+    ):
         assert parse_result(build_result(payload)) == payload
 
 
@@ -60,10 +65,17 @@ def test_the_exit_invariant_is_owned_by_the_builders_not_the_caller():
 def test_error_reply_is_a_live_error_envelope_at_exit_live():
     # The single builder the daemon and the live client both synthesize from; the
     # envelope is sentinel-wrapped and carries the live exit code.
-    reply = error_reply("engine_disconnected", "the engine session dropped the connection")
+    reply = error_reply(
+        "engine_disconnected", "the engine session dropped the connection"
+    )
     assert reply == {
         "stdout": build_result(
-            {"error": {"code": "engine_disconnected", "message": "the engine session dropped the connection"}}
+            {
+                "error": {
+                    "code": "engine_disconnected",
+                    "message": "the engine session dropped the connection",
+                }
+            }
         ),
         "stderr": "",
         "exit_code": EXIT_LIVE,

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -94,9 +94,9 @@ def test_skill_schema_reports_kind_headless():
 
 
 def test_skill_sample_result_validates_against_emitted_output_schema():
-    output_schema = json.loads(
-        CliRunner().invoke(app, ["skill", "--schema"]).stdout
-    )["output"]
+    output_schema = json.loads(CliRunner().invoke(app, ["skill", "--schema"]).stdout)[
+        "output"
+    ]
     sample = json.loads(CliRunner().invoke(app, ["skill", "--json"]).stdout)
     jsonschema.validate(instance=sample, schema=output_schema)
 
@@ -210,7 +210,12 @@ def test_skill_params_json_dir_alone_installs(tmp_path):
     # argv `--dir` does — the model normalizes both to the same params.
     result = CliRunner().invoke(
         app,
-        ["skill", "--params-json", json.dumps({"install_dir": str(tmp_path)}), "--json"],
+        [
+            "skill",
+            "--params-json",
+            json.dumps({"install_dir": str(tmp_path)}),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0
@@ -249,9 +254,9 @@ def test_bundled_skill_is_included_in_the_built_wheel(tmp_path):
     assert wheels, f"no wheel built:\n{proc.stdout}{proc.stderr}"
     with zipfile.ZipFile(wheels[-1]) as zf:
         names = zf.namelist()
-    assert any(
-        name.endswith("gda/skill/SKILL.md") for name in names
-    ), f"gda/skill/SKILL.md missing from {wheels[-1].name}: {names}"
+    assert any(name.endswith("gda/skill/SKILL.md") for name in names), (
+        f"gda/skill/SKILL.md missing from {wheels[-1].name}: {names}"
+    )
 
 
 # --- `--provider`/`--scope` convenience install (ADR-0027) -------------------------
@@ -286,7 +291,9 @@ def test_resolve_skill_dir_maps_every_provider_scope(provider, scope, expected):
     assert PROVIDER_SKILL_DIRS[provider][scope] == expected
 
 
-def test_skill_install_provider_claude_project_writes_into_dot_claude(tmp_path, monkeypatch):
+def test_skill_install_provider_claude_project_writes_into_dot_claude(
+    tmp_path, monkeypatch
+):
     # `--provider claude --scope project` resolves to `.claude/skills/gda`, relative to
     # the CWD — install it into a tmp project dir.
     monkeypatch.chdir(tmp_path)
@@ -299,7 +306,9 @@ def test_skill_install_provider_claude_project_writes_into_dot_claude(tmp_path, 
     assert written.read_text(encoding="utf-8") == BUNDLED
 
 
-def test_skill_install_provider_codex_project_uses_agents_namespace(tmp_path, monkeypatch):
+def test_skill_install_provider_codex_project_uses_agents_namespace(
+    tmp_path, monkeypatch
+):
     # Codex follows the cross-agent `.agents/skills` namespace, NOT `.codex/skills`.
     monkeypatch.chdir(tmp_path)
     result = CliRunner().invoke(
@@ -311,7 +320,9 @@ def test_skill_install_provider_codex_project_uses_agents_namespace(tmp_path, mo
     assert written.read_text(encoding="utf-8") == BUNDLED
 
 
-def test_skill_provider_implies_install_and_defaults_to_user_scope(tmp_path, monkeypatch):
+def test_skill_provider_implies_install_and_defaults_to_user_scope(
+    tmp_path, monkeypatch
+):
     # Naming a provider implies an install (like --dir does), and --scope defaults to
     # user — under HOME. Pin HOME at a tmp dir so we never touch the real one.
     monkeypatch.setenv("HOME", str(tmp_path))

--- a/tests/test_skill_surface_sync.py
+++ b/tests/test_skill_surface_sync.py
@@ -77,8 +77,8 @@ def test_skill_md_tables_match_the_command_surface():
                 f"  [{group}] SKILL.md missing {sorted(want - have)} / "
                 f"stale {sorted(have - want)}"
             )
-    assert not diffs, "SKILL.md command tables have drifted from the surface:\n" + "\n".join(
-        diffs
+    assert not diffs, (
+        "SKILL.md command tables have drifted from the surface:\n" + "\n".join(diffs)
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -191,6 +191,7 @@ dev = [
     { name = "jsonschema" },
     { name = "mcp" },
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -206,6 +207,7 @@ dev = [
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "mcp", specifier = ">=1.12,<2" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "ruff", specifier = ">=0.15.19,<0.16" },
 ]
 
 [[package]]
@@ -649,6 +651,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
     { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
     { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #306

## Why

The repo had **no lint/format gate**. CI ran only `pytest -m "not e2e"` + `uv build` (+ nightly e2e) — no ruff/black/flake8 step. Ruff was *not* a declared dependency, there was *no `[tool.ruff]` config*, and no ADR recorded any decision. Yet `.ruff_cache/` (versions 0.15.16 → 0.15.19) showed developers already run `uvx ruff` ad-hoc — the tool was used but **unconfigured, unpinned, and unenforced**, letting style and lint drift silently.

## What

Add a gate using **ruff only** (`check` + `format`). Ruff subsumes flake8 + black + isort, so those are redundant and not added — consistent with the project's single-authoritative-source ethos. Enforcement is **CI-only** this round (no pre-commit, no GDScript tooling).

Two commits:

1. **`style:` normalize formatting and fix lint findings** — mechanical, no behavior change:
   - `ruff format` across the codebase (81 files reformatted, 53 already clean).
   - Auto-fix 4 × `F401` unused imports (`tests/conftest.py`, `tests/test_daemon_diag.py`, `tests/test_e2e_op_robustness.py`, `tests/test_project_analysis_commands.py`).
   - Fix 1 × `F841` unused `err` in `tests/test_e2e_node.py` (drop the assignment, keep the asserting call).

2. **`ci:` add ruff lint and format gate**:
   - New parallel `lint` job: `ruff check .` + `ruff format --check .`, reusing the `setup-python-env` composite (skips the redundant cache save).
   - `pyproject.toml`: ruff pinned as a dev dependency (locked in `uv.lock` → reproducible format output) + `[tool.ruff]` config. Rule set = the default high-signal `E4/E7/E9/F`, made explicit (deliberately *not* full `E`, whose whitespace/line-length rules the formatter owns). `F811` ignored for `src/gda/cli.py` — Typer reuses subcommand function names (`create`/`get` across sub-apps), a false positive for the descriptor-driven command surface (ADR-0023).
   - `.gitignore`: ignore `.ruff_cache/`.

## Verification

- `uv run --frozen ruff check .` → **All checks passed!**
- `uv run --frozen ruff format --check .` → **134 files already formatted** (under the locked 0.15.20).
- `uv run --frozen pytest -m "not e2e"` → **973 passed, 291 deselected**.
- `uv sync --frozen --dev` resolves ruff deterministically (`ruff 0.15.20`).
- Negative test: a deliberately bad file makes both gate commands exit non-zero; passes again once removed.
