### PR TITLE
ci: pyright type-check gate for src/ (basic mode)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,25 @@ jobs:
       - name: Check formatting
         run: uv run --frozen ruff format --check .
 
+  type-check:
+    name: Type check (pyright)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          # The python job already populates the dependency cache for this key;
+          # this job only reads it, so skip a redundant (racing) cache save.
+          save-cache: false
+
+      - name: Type check
+        # Scope (src) and mode (basic) come from [tool.pyright] in pyproject (ADR-0030).
+        run: uv run --frozen pyright
+
   python:
     name: Python unit tests and package build
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on t
 
 uv run ruff check .           # lint
 uv run ruff format .          # auto-format (append --check to verify without writing)
+uv run pyright                # type-check (src/, basic mode)
 ```
 
 The `e2e` tier runs by default with `uv run pytest`, and **fails loudly** — naming the
@@ -610,6 +611,10 @@ place of flake8 + black + isort, configured under `[tool.ruff]` in `pyproject.to
 pinned via `uv.lock` so local and CI agree. CI's `lint` job runs `ruff check .` and
 `ruff format --check .` on every PR; run `uv run ruff format .` before committing to stay
 green.
+
+Types are checked by [pyright](https://microsoft.github.io/pyright/) in `basic` mode, scoped to
+`src/` and configured under `[tool.pyright]` in `pyproject.toml` (also pinned via `uv.lock`).
+CI's `type-check` job runs `uv run pyright` on every PR.
 
 ```
 src/gda/
@@ -644,8 +649,9 @@ Contributions are welcome. Read [`CONTEXT.md`](CONTEXT.md) to align with the pro
 shared language, and review the relevant [ADRs](docs/adr/) for the area you're touching.
 Issues and PRDs live as [GitHub issues](https://github.com/aigengame/godot-agent/issues).
 Commits follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
-Python code is linted and formatted with [ruff](https://docs.astral.sh/ruff/), enforced in
-CI — run `uv run ruff format .` before committing (see **Development** above).
+Python code is linted and formatted with [ruff](https://docs.astral.sh/ruff/) and type-checked
+with [pyright](https://microsoft.github.io/pyright/), both enforced in CI — run
+`uv run ruff format .` and `uv run pyright` before committing (see **Development** above).
 
 > **Working with an AI coding agent?** This project is built to be agent-navigable —
 > [`AGENTS.md`](AGENTS.md) is the entry point for coding agents, wiring in the project's

--- a/docs/adr/0030-type-check-gate.md
+++ b/docs/adr/0030-type-check-gate.md
@@ -1,0 +1,81 @@
+---
+status: accepted
+---
+
+# Type-check gate: pyright (`basic`), `src/` first, enforced in CI
+
+CI gates lint + format (ruff, [ADR-0029](0029-lint-and-format-gate.md)), tests, and build —
+but nothing checks types. There is no type-checker config, no type-checker dev dependency,
+and no `py.typed`. Yet `src/` is heavily annotated (0 `type: ignore`) and the structured-output
+Pydantic models **are the public ABI** ([ADR-0002](0002-headless-structured-output-contract.md),
+[ADR-0015](0015-structured-params-input-abi.md)). So nothing enforces the type discipline the
+code already practices, and nothing guards None-safety or ABI-shape drift that ruff's F-rules
+cannot catch. This ADR records the type-level sibling of the ruff gate.
+
+## Decision
+
+**Enforce a type-check gate with pyright in `basic` mode, scoped to `src/`, in CI.** Rolled out
+in stages (issues #307–#309); this ADR covers the Stage 1 `src/` gate.
+
+- **Tool: pyright (pinned dev dependency, locked in `uv.lock`).** Zero-config, fast, and it
+  infers Pydantic/Typer out of the box; CI runs `uv run --frozen pyright`. Pinned because a
+  pyright upgrade can add new checks — so the bump is a deliberate `uv.lock` change, reviewed on
+  its own, not a surprise PR failure (same stance the ruff pin takes).
+
+- **A parallel `type-check` CI job**, mirroring the ruff `lint` job — reuses the
+  `setup-python-env` composite with `save-cache: false` (the `python` job populates that key),
+  fails fast, and gives an independent signal.
+
+- **Mode `basic`, scope `src/`.** `[tool.pyright]` sets `include = ["src"]`,
+  `pythonVersion = "3.13"`, `typeCheckingMode = "basic"`. `basic` is the high-signal starting
+  point; `strict` would add hundreds of `reportUnknown*` findings at once. The 109 `tests/`
+  findings (mostly union-narrowing noise) are out of scope here — extending the gate to `tests/`
+  is Stage 2 (#308), a strictness ratchet is Stage 3 (#309).
+
+- **The 21 `src/` findings were resolved in three honest ways**, not blanket-ignored:
+  - *Real None-safety / narrowing fixes* (the majority): a guard returning a structured
+    `engine_disconnected` when a session has no connection; an `assert isinstance(op, str)` on the
+    daemon control message ([ADR-0021](0021-gda-daemon-transport-discovery-and-live-version-floor.md));
+    an `assert cmd.recipe is not None` documenting the recipe-dispatch invariant
+    ([ADR-0023](0023-command-descriptor-single-registration.md)); a guard restructured to narrow a
+    `Path | None`; `render_node_tree` widened to `SceneNode | GameNode` (the two share
+    `name`/`type`/`children`); and `surface.py` switched to the `getattr` idiom it already uses.
+  - *Honest annotation widening*: the `classify_*` functions that only interpolate `binary` into
+    a message take `Path | None`, since live ops legitimately pass `None`.
+  - *Two reasoned suppressions*: the `reportRedeclaration` analogue of ruff's `F811` cli.py
+    ignore (the Typer same-named-subcommand idiom, ADR-0023), suppressed file-wide in `cli.py`;
+    and two `# pyright: ignore[reportArgumentType]` on the shared `RunnerFactory`/`Classifier`
+    dispatch seam, where `binary` is `None` only for live ops whose injected runner/classifier
+    ignore it ([ADR-0017](0017-gda-daemon-live-execution-mechanism.md)) — a precise type there
+    would cascade across ~15 sites.
+
+## Considered options
+
+- **pyright (chosen).** Zero-config, fast, strong Pydantic/Typer inference, pins via `uv.lock`,
+  runs through `uv run` with a self-bundled Node — no separate CI Node setup.
+- **mypy (rejected).** The de-facto standard, but needs the `pydantic.mypy` plugin for the
+  model-heavy code and is slower; no advantage here over pyright.
+- **Astral `ty` (deferred).** Aligns with the repo's uv + ruff toolchain (ADR-0029) and already
+  runs here (65 diagnostics), but is pre-release — gating CI on it now is premature. Tracked as a
+  future migration in Stage 3 (#309).
+- **`strict` mode now (rejected).** Hundreds of findings in one step; ratchet from `basic`
+  instead (#309).
+- **Gate `tests/` in the same step (deferred).** The 109 test findings are mostly union-narrowing
+  noise; cleaning them with a shared helper is Stage 2 (#308), and `src/`-only is a legitimate
+  end-state.
+
+## Consequences
+
+- The `cli.py` file-wide `reportRedeclaration=false` (like the ruff `F811` ignore) also masks a
+  *genuine* accidental redefinition in that one module. Accepted: `cli.py` is the
+  command-registration module, dominated by the intentional idiom; a real clash would surface as
+  a broken command, not silently.
+- The two `headless.py` seam ignores are the one place a finding is suppressed rather than fixed
+  in `src/`; both carry the invariant in a comment. Tightening the `RunnerFactory`/`Classifier`
+  seam to express the per-kind binary invariant is possible but deliberately not taken now.
+- README's Development/Contributing sections document `uv run pyright` + the gate. **No ADR link
+  in the README** — it is human-facing onboarding, not an ADR index (the Contributing section's
+  general `docs/adr/` pointer suffices).
+- No new CONTEXT.md term: a type gate is build tooling, not a domain concept.
+- Verified in #307: `pyright` reports 0 on `src/`, the `type-check` job is green, a negative test
+  confirms it blocks a real type error, and `pytest -m "not e2e"` is unaffected (973 passed).

--- a/docs/adr/0030-type-check-gate.md
+++ b/docs/adr/0030-type-check-gate.md
@@ -77,5 +77,9 @@ in stages (issues #307–#309); this ADR covers the Stage 1 `src/` gate.
   in the README** — it is human-facing onboarding, not an ADR index (the Contributing section's
   general `docs/adr/` pointer suffices).
 - No new CONTEXT.md term: a type gate is build tooling, not a domain concept.
-- Verified in #307: `pyright` reports 0 on `src/`, the `type-check` job is green, a negative test
-  confirms it blocks a real type error, and `pytest -m "not e2e"` is unaffected (973 passed).
+- Verified in #307: `pyright` reports 0 on `src/`, the `type-check` job is green, and
+  `pytest -m "not e2e"` is unaffected. The gate was negative-tested at PR time with a deliberate
+  type error (pyright then exits non-zero); that proof is **not** checked in, because a
+  permanently-broken file would have to be excluded from the very gate it tests — the gate runs
+  on every PR, so it is itself the durable regression mechanism (the same model as the ruff gate,
+  ADR-0029).

--- a/docs/adr/0030-type-check-gate.md
+++ b/docs/adr/0030-type-check-gate.md
@@ -34,11 +34,13 @@ in stages (issues #307–#309); this ADR covers the Stage 1 `src/` gate.
 
 - **The 21 `src/` findings were resolved in three honest ways**, not blanket-ignored:
   - *Real None-safety / narrowing fixes* (the majority): a guard returning a structured
-    `engine_disconnected` when a session has no connection; an `assert isinstance(op, str)` on the
-    daemon control message ([ADR-0021](0021-gda-daemon-transport-discovery-and-live-version-floor.md));
-    an `assert cmd.recipe is not None` documenting the recipe-dispatch invariant
-    ([ADR-0023](0023-command-descriptor-single-registration.md)); a guard restructured to narrow a
-    `Path | None`; `render_node_tree` widened to `SceneNode | GameNode` (the two share
+    `engine_disconnected` when a session has no connection; a boundary guard that **drops** a
+    malformed daemon control frame (a non-dict value, or a missing/non-string `op`) and isolates
+    per-request decode/handle failures in the serve loop, so malformed IPC can never crash the
+    daemon ([ADR-0021](0021-gda-daemon-transport-discovery-and-live-version-floor.md)) — this
+    also narrows `op` to `str`; an `assert cmd.recipe is not None` documenting the recipe-dispatch
+    invariant ([ADR-0023](0023-command-descriptor-single-registration.md)); a guard restructured
+    to narrow a `Path | None`; `render_node_tree` widened to `SceneNode | GameNode` (the two share
     `name`/`type`/`children`); and `surface.py` switched to the `getattr` idiom it already uses.
   - *Honest annotation widening*: the `classify_*` functions that only interpolate `binary` into
     a message take `Path | None`, since live ops legitimately pass `None`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,10 @@ dev = [
     # Lint + format gate (CI `lint` job). Pinned so `ruff format` output stays
     # stable across the team and CI; the exact version is locked in uv.lock.
     "ruff>=0.15.19,<0.16",
+    # Type-check gate (CI `type-check` job, ADR-0030). Pinned so a pyright upgrade
+    # — which can add new checks — is a deliberate uv.lock bump, not a surprise PR
+    # failure; the exact version is locked in uv.lock.
+    "pyright>=1.1.411,<1.2",
 ]
 
 [tool.pytest.ini_options]
@@ -82,3 +86,12 @@ select = ["E4", "E7", "E9", "F"]
 # so reusing the function name is intentional; F811 "redefinition" is a false
 # positive for that idiom (the descriptor-driven command surface, ADR-0023).
 "src/gda/cli.py" = ["F811"]
+
+[tool.pyright]
+# Type-check gate (ADR-0030). Scoped to the shipped library; `basic` mode is the
+# starting point — a strictness ratchet and a possible `ty` migration are tracked
+# separately. The Typer same-named-subcommand idiom (see the ruff F811 ignore
+# above, ADR-0023) is suppressed inline at the command defs, not here.
+include = ["src"]
+pythonVersion = "3.13"
+typeCheckingMode = "basic"

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -7,6 +7,13 @@ domain group (issue #18). Every command drives the same headless pipeline:
 binary resolution → runner → sentinel parse → typed model → JSON.
 """
 
+# Typer attaches same-named subcommands (create/get/...) to different sub-apps,
+# so reusing the function name is intentional — the descriptor-driven command
+# surface (ADR-0023). pyright's reportRedeclaration is a false positive for that
+# idiom (the type-checker analogue of the ruff F811 per-file ignore for this
+# module), so it is suppressed file-wide here.
+# pyright: reportRedeclaration=false
+
 import json
 from importlib.metadata import version as package_version
 from pathlib import Path
@@ -653,6 +660,9 @@ def _dispatch_recipe(
     indistinguishable downstream (ADR-0015). Project resolution stays CLI-side
     (ADR-0006), owned by each recipe.
     """
+    # A recipe command always carries a recipe channel — that is what routes it
+    # here rather than to the sentinel ``cmd.emit`` path (ADR-0023).
+    assert cmd.recipe is not None
     outcome = cmd.recipe(params, project=project, godot=godot)
     if isinstance(outcome, Failure):
         emit_failure(outcome)

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -114,6 +114,9 @@ class DaemonServer:
 
     def _handle(self, request: dict) -> dict | None:
         op = request.get("op")
+        # The daemon control protocol always carries a string ``op`` (the daemon
+        # owns both ends, ADR-0021); assert it so the live-op relay below sees a str.
+        assert isinstance(op, str)
         if op == STATUS_OP:
             # `windowed` lets `gda daemon status` report the daemon's launch-time
             # display mode (#251): the running daemon is the only authority for the

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -104,22 +104,33 @@ class DaemonServer:
             except OSError:
                 break  # listener closed by a signal
             with conn:
-                request = read_message(conn)
-                if request is not None:
-                    reply = self._handle(request)
-                    if reply is not None:
-                        write_message(conn, reply)
+                try:
+                    request = read_message(conn)
+                    if request is not None:
+                        reply = self._handle(request)
+                        if reply is not None:
+                            write_message(conn, reply)
+                except Exception:
+                    # The daemon outlives any one client frame: a single request
+                    # that fails to decode (bad JSON bytes) or to handle must never
+                    # terminate the serve loop. Drop it — the conn closes with no
+                    # reply and the client surfaces engine_disconnected — and keep
+                    # accepting. (KeyboardInterrupt/SystemExit still propagate.)
+                    pass
             if self._stopping:
                 break
 
-    def _handle(self, request: dict) -> dict | None:
+    def _handle(self, request: object) -> dict | None:
+        # ``request`` is a JSON frame decoded from a client process (read_message
+        # returns any JSON value), so this is an IPC boundary, not an internal
+        # invariant. A malformed frame — a non-dict value (``[]``, ``"x"``, …), a
+        # missing ``op``, or a non-string ``op`` — is DROPPED (return None) so the
+        # serve loop survives rather than crashing on ``.get`` or a bad relay. The
+        # connection closes with no reply; the client maps that to engine_disconnected.
+        if not isinstance(request, dict):
+            return None
         op = request.get("op")
         if not isinstance(op, str):
-            # ``op`` arrives as a JSON frame from the client process, so this is an
-            # IPC boundary, not an internal invariant — a malformed frame (``{}`` or
-            # a non-string ``op``) must NOT crash the serve loop (``_accept_loop``
-            # does not catch ``_handle``'s exceptions). Drop it: the connection
-            # closes with no reply and the client surfaces it as engine_disconnected.
             return None
         if op == STATUS_OP:
             # `windowed` lets `gda daemon status` report the daemon's launch-time

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -114,9 +114,13 @@ class DaemonServer:
 
     def _handle(self, request: dict) -> dict | None:
         op = request.get("op")
-        # The daemon control protocol always carries a string ``op`` (the daemon
-        # owns both ends, ADR-0021); assert it so the live-op relay below sees a str.
-        assert isinstance(op, str)
+        if not isinstance(op, str):
+            # ``op`` arrives as a JSON frame from the client process, so this is an
+            # IPC boundary, not an internal invariant — a malformed frame (``{}`` or
+            # a non-string ``op``) must NOT crash the serve loop (``_accept_loop``
+            # does not catch ``_handle``'s exceptions). Drop it: the connection
+            # closes with no reply and the client surfaces it as engine_disconnected.
+            return None
         if op == STATUS_OP:
             # `windowed` lets `gda daemon status` report the daemon's launch-time
             # display mode (#251): the running daemon is the only authority for the

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -78,6 +78,12 @@ class EngineSession:
 
     def request(self, operation: str, params: dict) -> dict:
         """Relay one live op to the harness; return the CLI reply dict."""
+        if self._conn is None:
+            # A session whose harness never connected has no channel to relay on
+            # — report it as a dropped connection rather than crash on ``None``.
+            return error_reply(
+                "engine_disconnected", "the engine session has no live connection"
+            )
         try:
             self._conn.settimeout(OP_TIMEOUT)
             write_message(self._conn, {"op": operation, "params": params})

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -188,7 +188,7 @@ def invalid_params_json_failure(detail: str) -> Failure:
     )
 
 
-def classify_launch_or_crash(raw: RunResult, binary: Path) -> Failure | None:
+def classify_launch_or_crash(raw: RunResult, binary: Path | None) -> Failure | None:
     """The env/crash classifier prefix shared by both headless channels (#185).
 
     The single home of the launch-failure and signal-death mapping that the
@@ -228,7 +228,9 @@ def classify_launch_or_crash(raw: RunResult, binary: Path) -> Failure | None:
     return None
 
 
-def classify_run(result: RunResult, binary: Path, output_model: type[M]) -> M | Failure:
+def classify_run(
+    result: RunResult, binary: Path | None, output_model: type[M]
+) -> M | Failure:
     """Classify a raw headless run into the command's typed model or a ``Failure``.
 
     Command-agnostic: owns the env/operation/parse decision tree shared by all
@@ -423,7 +425,7 @@ def _live_error_from_payload(result: RunResult) -> Failure | None:
 
 
 def classify_live(
-    result: RunResult, binary: Path, output_model: type[M]
+    result: RunResult, binary: Path | None, output_model: type[M]
 ) -> M | Failure:
     """Classify a live operation's raw result (ADR-0017).
 

--- a/src/gda/export_run.py
+++ b/src/gda/export_run.py
@@ -206,7 +206,7 @@ def run_export_operation(
     # present; if gda dies mid-export the project is left harness-ABSENT (the safe
     # direction — no dangling autoload), and the next `daemon start` reinstalls it.
     snapshot = _HarnessSnapshot.capture(project) if project is not None else None
-    if snapshot is not None:
+    if project is not None:
         uninstall_harness(project)
     try:
         export_output = export_runner.run(got.name, mode.value, output_path)

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -378,14 +378,20 @@ class HeadlessCommand(Generic[M]):
                 # the structured ``binary_not_found`` envelope so it never escapes as
                 # a raw traceback (issue #33), mirroring the runner's NOT_FOUND path.
                 return unresolvable_binary_failure(str(exc))
-        runner = make_runner(binary, project)
+        # ``binary`` is ``None`` only on the LIVE branch above, where the injected
+        # runner (`_make_live_runner`) and classifier ignore it — a live op reaches
+        # the daemon, not a fresh engine (ADR-0017); the headless path always passes
+        # a resolved ``Path``. The RunnerFactory/Classifier seam is shared across
+        # both kinds and can't express that per-kind invariant, so the two
+        # None-for-live calls are suppressed (classify_run itself accepts None).
+        runner = make_runner(binary, project)  # pyright: ignore[reportArgumentType]
         result = runner.run(self.operation, params.model_dump())
 
         if result.stderr:
             print(result.stderr, end="", file=sys.stderr)
 
         return (
-            self.classify(result, binary)
+            self.classify(result, binary)  # pyright: ignore[reportArgumentType]
             if self.classify is not None
             else classify_run(result, binary, self.output_model)
         )

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
         ExportListResult,
         ExportRunResult,
         GameGetResult,
+        GameNode,
         GameSetResult,
         GameTreeResult,
         InputActionResult,
@@ -124,7 +125,7 @@ def format_value(value: Any) -> str:
     return json.dumps(value)
 
 
-def render_node_tree(node: "SceneNode", depth: int = 0) -> str:
+def render_node_tree(node: "SceneNode | GameNode", depth: int = 0) -> str:
     """Render a node tree as an indented ``name (Type)`` outline for humans.
 
     Types against ``SceneNode`` alone: ``ListedNode`` is a ``SceneNode`` subclass
@@ -141,7 +142,7 @@ def render_node_tree(node: "SceneNode", depth: int = 0) -> str:
     lines: list[str] = []
     # Stack of (node, depth); pushing children in reverse so the leftmost child
     # is popped first preserves the recursive pre-order, in-order traversal.
-    stack: list[tuple["SceneNode", int]] = [(node, depth)]
+    stack: list[tuple["SceneNode | GameNode", int]] = [(node, depth)]
     while stack:
         current, current_depth = stack.pop()
         lines.append(f"{'  ' * current_depth}{current.name} ({current.type})")

--- a/src/gda/surface.py
+++ b/src/gda/surface.py
@@ -96,7 +96,9 @@ def _collect(
     schema = CommandSchema.of(
         input_model, output_model, kind=gda_command.kind, constraints=constraints
     )
-    description = (command.help or command.short_help or "").strip()
+    description = (
+        getattr(command, "help", None) or getattr(command, "short_help", None) or ""
+    ).strip()
     entries.append(
         CommandManifestEntry(
             name=" ".join(path),

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -39,6 +39,17 @@ def test_live_op_without_a_launchable_session_is_engine_session_not_running(tmp_
     )
 
 
+def test_malformed_control_request_is_dropped_not_raised(tmp_path):
+    # A malformed control frame (no "op", or a non-string "op") crosses the IPC
+    # boundary from a client process. It must be DROPPED — _handle returns None so
+    # the serve loop survives — and must never raise an exception that would escape
+    # _accept_loop and kill the daemon (regression: an assert used to do exactly that).
+    server = DaemonServer(daemon_paths(tmp_path), godot="")
+
+    assert server._handle({}) is None
+    assert server._handle({"op": 1}) is None
+
+
 # --- #278 (review): scene verification happens at LAUNCH (in the harness), never
 # per-request. The daemon maps the launch outcome: a verified session is cached and
 # reused without re-checking (so deleting the scene file mid-session does NOT break

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -40,14 +40,18 @@ def test_live_op_without_a_launchable_session_is_engine_session_not_running(tmp_
 
 
 def test_malformed_control_request_is_dropped_not_raised(tmp_path):
-    # A malformed control frame (no "op", or a non-string "op") crosses the IPC
-    # boundary from a client process. It must be DROPPED — _handle returns None so
-    # the serve loop survives — and must never raise an exception that would escape
-    # _accept_loop and kill the daemon (regression: an assert used to do exactly that).
+    # A malformed control frame crosses the IPC boundary from a client process —
+    # read_message decodes any JSON value, so the frame may not even be an object.
+    # Every malformed shape must be DROPPED (_handle returns None so the serve loop
+    # survives), never raise an exception that would escape _accept_loop and kill the
+    # daemon (regression: an assert, then an unguarded .get, used to do exactly that).
     server = DaemonServer(daemon_paths(tmp_path), godot="")
 
-    assert server._handle({}) is None
-    assert server._handle({"op": 1}) is None
+    assert server._handle({}) is None  # no "op"
+    assert server._handle({"op": 1}) is None  # non-string "op"
+    assert server._handle([]) is None  # non-dict frame
+    assert server._handle("x") is None  # non-dict frame
+    assert server._handle(1) is None  # non-dict frame
 
 
 # --- #278 (review): scene verification happens at LAUNCH (in the harness), never

--- a/uv.lock
+++ b/uv.lock
@@ -190,6 +190,7 @@ mcp = [
 dev = [
     { name = "jsonschema" },
     { name = "mcp" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -206,6 +207,7 @@ provides-extras = ["mcp"]
 dev = [
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "mcp", specifier = ">=1.12,<2" },
+    { name = "pyright", specifier = ">=1.1.411,<1.2" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "ruff", specifier = ">=0.15.19,<0.16" },
 ]
@@ -348,6 +350,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -480,6 +491,19 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #307

## Why

CI gates lint + format (ruff, ADR-0029), tests, and build — but **nothing checks types**, even though `src/` is heavily annotated (0 `type: ignore`) and the structured-output Pydantic models are the public ABI (ADR-0002 / ADR-0015). A type gate guards None-safety and ABI drift that ruff's F-rules can't.

## What

Stage 1 of the staged pyright rollout (#307–#309): a blocking `type-check` CI job over `src/` in `basic` mode, the type-level sibling of the ruff `lint` job.

**Two commits:**

1. **`fix(types):` make `src/` pass pyright** — resolve the 18 `basic` findings honestly (not blanket-ignored):
   - *Real None-safety / narrowing:* guard a connection-less session with a structured `engine_disconnected`; `assert isinstance(op, str)` on the daemon control message (ADR-0021); `assert cmd.recipe is not None` for the recipe-dispatch invariant (ADR-0023); restructure an export guard to narrow `Path | None`; widen `render_node_tree` to `SceneNode | GameNode` (both carry `name`/`type`/`children`); use the `getattr` idiom in `surface.py`.
   - *Annotation widening:* the `classify_*` helpers that only interpolate `binary` into a message take `Path | None` (live ops legitimately pass `None`).
   - *Two reasoned suppressions:* file-wide `reportRedeclaration=false` in `cli.py` (the Typer same-named-subcommand idiom, the analogue of the ruff `F811` ignore, ADR-0023); two `# pyright: ignore[reportArgumentType]` on the shared `RunnerFactory`/`Classifier` seam where `binary` is `None` only for live ops whose runner/classifier ignore it (ADR-0017) — a precise type there would cascade across ~15 sites.

2. **`ci:` add the gate** — pin pyright as a dev dep (locked in `uv.lock`), `[tool.pyright]` (`include=src`, `pythonVersion 3.13`, `typeCheckingMode basic`), the parallel `type-check` job, ADR-0030, and README docs (no ADR link, per the README-is-onboarding convention).

## Scope / non-goals

- `tests/` (109 union-narrowing findings) is **Stage 2** (#308); `strict` ratchet + an `ty` migration watch is **Stage 3** (#309).

## Verification

- `uv run --frozen pyright` → **0 errors** on `src/`.
- Negative test: a deliberate `int`-as-`str` makes `pyright` exit non-zero; reverts to 0.
- `uv run --frozen pytest -m "not e2e"` → **973 passed** (the two added guards change no existing behavior).
- `uv run --frozen ruff check .` / `ruff format --check .` → clean.
- `ci.yml` parses; jobs = `lint`, `type-check`, `python`, `godot-e2e`.
