### PR TITLE
ci: extend the pyright type-check gate to tests/ (Stage 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           save-cache: false
 
       - name: Type check
-        # Scope (src) and mode (basic) come from [tool.pyright] in pyproject (ADR-0030).
+        # Scope (src + tests) and mode (basic) come from [tool.pyright] in pyproject (ADR-0030).
         run: uv run --frozen pyright
 
   python:

--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ green.
 
 Types are checked by [pyright](https://microsoft.github.io/pyright/) in `basic` mode, covering
 `src/` and `tests/` and configured under `[tool.pyright]` in `pyproject.toml` (also pinned via
-`uv.lock`). CI's `type-check` job runs `uv run pyright` on every PR.
+`uv.lock`). CI's `type-check` job runs `uv run --frozen pyright` on every PR.
 
 ```
 src/gda/

--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on t
 
 uv run ruff check .           # lint
 uv run ruff format .          # auto-format (append --check to verify without writing)
-uv run pyright                # type-check (src/, basic mode)
+uv run pyright                # type-check (src/ + tests/, basic mode)
 ```
 
 The `e2e` tier runs by default with `uv run pytest`, and **fails loudly** — naming the
@@ -612,9 +612,9 @@ pinned via `uv.lock` so local and CI agree. CI's `lint` job runs `ruff check .` 
 `ruff format --check .` on every PR; run `uv run ruff format .` before committing to stay
 green.
 
-Types are checked by [pyright](https://microsoft.github.io/pyright/) in `basic` mode, scoped to
-`src/` and configured under `[tool.pyright]` in `pyproject.toml` (also pinned via `uv.lock`).
-CI's `type-check` job runs `uv run pyright` on every PR.
+Types are checked by [pyright](https://microsoft.github.io/pyright/) in `basic` mode, covering
+`src/` and `tests/` and configured under `[tool.pyright]` in `pyproject.toml` (also pinned via
+`uv.lock`). CI's `type-check` job runs `uv run pyright` on every PR.
 
 ```
 src/gda/

--- a/docs/adr/0030-type-check-gate.md
+++ b/docs/adr/0030-type-check-gate.md
@@ -4,6 +4,12 @@ status: accepted
 
 # Type-check gate: pyright (`basic`), `src/` first, enforced in CI
 
+> **Outcome (Stage 2, 2026-06-27):** the gate now also covers `tests/` (#308) — `[tool.pyright]`
+> `include` is `["src", "tests"]` and the whole repo type-checks clean (the 109 test findings were
+> resolved with union-narrowing helpers, not-None asserts, `cast`s for intentional test doubles,
+> and `ListRootsFnT`-typed in-memory callbacks). The "`tests/` out of scope / Stage 2 / src-only
+> end-state" framing below is the point-in-time Stage-1 record.
+
 CI gates lint + format (ruff, [ADR-0029](0029-lint-and-format-gate.md)), tests, and build —
 but nothing checks types. There is no type-checker config, no type-checker dev dependency,
 and no `py.typed`. Yet `src/` is heavily annotated (0 `type: ignore`) and the structured-output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,10 +88,10 @@ select = ["E4", "E7", "E9", "F"]
 "src/gda/cli.py" = ["F811"]
 
 [tool.pyright]
-# Type-check gate (ADR-0030). Scoped to the shipped library; `basic` mode is the
-# starting point — a strictness ratchet and a possible `ty` migration are tracked
-# separately. The Typer same-named-subcommand idiom (see the ruff F811 ignore
-# above, ADR-0023) is suppressed inline at the command defs, not here.
-include = ["src"]
+# Type-check gate (ADR-0030). Covers the shipped library (src/) and the tests/;
+# `basic` mode is the starting point — a strictness ratchet and a possible `ty`
+# migration are tracked separately. The Typer same-named-subcommand idiom (see the
+# ruff F811 ignore above, ADR-0023) is suppressed inline at the command defs.
+include = ["src", "tests"]
 pythonVersion = "3.13"
 typeCheckingMode = "basic"

--- a/tests/mcp_support.py
+++ b/tests/mcp_support.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Callable, Optional
 
 import anyio
+from mcp.types import CallToolResult, TextContent
 
 from gda.cli import app
 from gda.mcp.runner import GdaResult
@@ -80,6 +81,21 @@ def schema_then(dispatch: Responder) -> Responder:
 def gda_result(stdout: str = "", stderr: str = "", returncode: int = 0) -> GdaResult:
     """Terse :class:`GdaResult` factory for canned seam responses."""
     return GdaResult(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def tool_text(result: CallToolResult, index: int = 0) -> str:
+    """The text of a ``CallToolResult`` content block (the first by default).
+
+    A gda-mcp tool reply carries its JSON envelope as a ``TextContent`` block, so a
+    test reads ``.text`` off it. This narrows the MCP content union
+    (``TextContent | ImageContent | …``) to ``TextContent`` once, here, instead of
+    a per-assertion ``isinstance``.
+    """
+    block = result.content[index]
+    assert isinstance(block, TextContent), (
+        f"expected TextContent, got {type(block).__name__}"
+    )
+    return block.text
 
 
 def list_tools(server):

--- a/tests/mcp_support.py
+++ b/tests/mcp_support.py
@@ -18,7 +18,9 @@ from pathlib import Path
 from typing import Callable, Optional
 
 import anyio
+from mcp.client.session import ListRootsFnT
 from mcp.types import CallToolResult, TextContent
+from pydantic import FileUrl
 
 from gda.cli import app
 from gda.mcp.runner import GdaResult
@@ -118,12 +120,17 @@ def call_tool(server, name: str, arguments: dict, *, roots: Optional[list[str]] 
     """
     from mcp.shared.memory import create_connected_server_and_client_session as connect
 
-    list_roots_callback = None
+    list_roots_callback: ListRootsFnT | None = None
     if roots is not None:
         from mcp.types import ListRootsResult, Root
 
-        async def list_roots_callback(_context):
-            return ListRootsResult(roots=[Root(uri=Path(r).as_uri()) for r in roots])
+        # The param is named ``context`` to match the ListRootsFnT Protocol.
+        async def _list_roots(context):
+            return ListRootsResult(
+                roots=[Root(uri=FileUrl(Path(r).as_uri())) for r in roots]
+            )
+
+        list_roots_callback = _list_roots
 
     async def _inner():
         async with connect(server, list_roots_callback=list_roots_callback) as session:
@@ -154,10 +161,13 @@ def roots_changed_call(
 
     holder = {"roots": roots_before}
 
-    async def list_roots_callback(_context):
+    # The param is named ``context`` to match the ListRootsFnT Protocol.
+    async def _list_roots(context):
         return ListRootsResult(
-            roots=[Root(uri=Path(r).as_uri()) for r in holder["roots"]]
+            roots=[Root(uri=FileUrl(Path(r).as_uri())) for r in holder["roots"]]
         )
+
+    list_roots_callback: ListRootsFnT = _list_roots
 
     async def _inner():
         async with connect(server, list_roots_callback=list_roots_callback) as session:

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -14,6 +14,7 @@ import json
 import os
 import socket
 import subprocess
+from typing import cast
 
 import pytest
 
@@ -74,7 +75,7 @@ def test_launch_session_passes_log_file_arg_and_remembers_path(monkeypatch, tmp_
     launch_session(
         project,
         "godot",
-        _NoAcceptListener(),
+        cast(socket.socket, _NoAcceptListener()),
         tmp_path / "h.sock",
         "tok",
         log_file=log_file,
@@ -90,7 +91,9 @@ def test_launch_session_passes_log_file_arg_and_remembers_path(monkeypatch, tmp_
 
 def test_engine_session_exposes_its_log_file_path(tmp_path):
     log_file = tmp_path / "s.log"
-    session = EngineSession(_FakeProc(), conn=None, log_file=log_file)
+    session = EngineSession(
+        cast(subprocess.Popen, _FakeProc()), conn=None, log_file=log_file
+    )
     assert session.log_file == log_file
 
 
@@ -122,7 +125,7 @@ def _capture_launch_argv(monkeypatch, project, **launch_kw):
     launch_session(
         project,
         "godot",
-        _NoAcceptListener(),
+        cast(socket.socket, _NoAcceptListener()),
         project / "h.sock",
         "tok",
         timeout=0.1,
@@ -216,7 +219,7 @@ def _launch_with_fake_harness(monkeypatch, tmp_path, *, token, verify, scene):
         return launch_session(
             tmp_path,
             "godot",
-            _OneShotListener(daemon_end),
+            cast(socket.socket, _OneShotListener(daemon_end)),
             tmp_path / "h.sock",
             token,
             timeout=1.0,
@@ -278,7 +281,7 @@ def test_launch_returns_none_on_bad_token(monkeypatch, tmp_path):
         outcome = launch_session(
             tmp_path,
             "godot",
-            _OneShotListener(daemon_end),
+            cast(socket.socket, _OneShotListener(daemon_end)),
             tmp_path / "h.sock",
             "tok",
             timeout=1.0,
@@ -295,7 +298,9 @@ def test_launch_returns_none_on_bad_token(monkeypatch, tmp_path):
 def _server_with_session(tmp_path, log_file, alive=True):
     server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
     server._session = EngineSession(
-        _FakeProc(None if alive else 0), conn=None, log_file=log_file
+        cast(subprocess.Popen, _FakeProc(None if alive else 0)),
+        conn=None,
+        log_file=log_file,
     )
     return server
 

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -308,6 +308,7 @@ def test_diag_errors_reads_structured_errors_from_the_log(tmp_path):
     server = _server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "diag-errors", "params": {}})
+    assert reply is not None
     payload = parse_result(reply["stdout"])
 
     assert payload["errors"][0]["level"] == "error"
@@ -325,6 +326,7 @@ def test_diag_errors_limit_tails_the_most_recent_n(tmp_path):
     server = _server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "diag-errors", "params": {"limit": 1}})
+    assert reply is not None
     payload = parse_result(reply["stdout"])
 
     assert len(payload["errors"]) == 1
@@ -341,6 +343,7 @@ def test_diag_serves_even_when_the_session_process_has_died(tmp_path):
     server = _server_with_session(tmp_path, log_file, alive=False)
 
     reply = server._handle({"op": "diag-errors", "params": {}})
+    assert reply is not None
     payload = parse_result(reply["stdout"])
 
     assert payload["errors"][0]["message"] == "crashed"
@@ -352,6 +355,7 @@ def test_diag_empty_log_is_an_empty_result_not_an_error(tmp_path):
     server = _server_with_session(tmp_path, log_file)
 
     errors_reply = server._handle({"op": "diag-errors", "params": {}})
+    assert errors_reply is not None
 
     assert parse_result(errors_reply["stdout"])["errors"] == []
 
@@ -374,6 +378,7 @@ def test_diag_with_no_session_launched_is_engine_session_not_running(
     monkeypatch.setattr("gda.daemon.server.launch_session", _boom)
 
     reply = server._handle({"op": op, "params": {}})
+    assert reply is not None
 
     assert (
         parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
@@ -390,5 +395,6 @@ def test_diag_with_a_remembered_session_but_missing_file_is_live_log_unavailable
     server = _server_with_session(tmp_path, log_file, alive=False)
 
     reply = server._handle({"op": "diag-errors", "params": {}})
+    assert reply is not None
 
     assert parse_result(reply["stdout"])["error"]["code"] == "live_log_unavailable"

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -97,12 +97,14 @@ def test_start_reports_not_synced_when_version_already_matches(
     monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
 
     first = _start(project)
+    assert not isinstance(first, Failure)
     assert first.installed_harness is True
     assert first.harness_synced is False  # first install is not a resync (#247)
 
     # A second start at the same HARNESS_VERSION must NOT re-sync (no rewrite), but
     # still reports the installed version.
     again = _start(project)
+    assert not isinstance(again, Failure)
     assert again.harness_synced is False
     assert again.installed_harness is False
     assert again.harness_version == HARNESS_VERSION

--- a/tests/test_daemon_logger.py
+++ b/tests/test_daemon_logger.py
@@ -9,6 +9,8 @@ log file, plus the same no-session / missing-file typed errors ``diag`` returns.
 """
 
 import os
+import subprocess
+from typing import cast
 
 import pytest
 
@@ -36,7 +38,9 @@ def _project(tmp_path):
 def _server_with_session(tmp_path, log_file, alive=True):
     server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
     server._session = EngineSession(
-        _FakeProc(None if alive else 0), conn=None, log_file=log_file
+        cast(subprocess.Popen, _FakeProc(None if alive else 0)),
+        conn=None,
+        log_file=log_file,
     )
     return server
 

--- a/tests/test_daemon_logger.py
+++ b/tests/test_daemon_logger.py
@@ -49,6 +49,7 @@ def test_logger_tail_reads_structured_records_from_the_log(tmp_path):
     server = _server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {}})
+    assert reply is not None
     payload = parse_result(reply["stdout"])
 
     records = payload["records"]
@@ -68,6 +69,7 @@ def test_logger_tail_raw_returns_verbatim_info_records(tmp_path):
     server = _server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {"raw": True}})
+    assert reply is not None
     payload = parse_result(reply["stdout"])
 
     messages = [r["message"] for r in payload["records"]]
@@ -85,6 +87,7 @@ def test_logger_tail_level_filters_by_minimum_severity(tmp_path):
     server = _server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {"level": "warning"}})
+    assert reply is not None
     payload = parse_result(reply["stdout"])
 
     levels = {r["level"] for r in payload["records"]}
@@ -98,6 +101,7 @@ def test_logger_tail_limit_tails_the_most_recent_n(tmp_path):
     server = _server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {"limit": 1}})
+    assert reply is not None
     payload = parse_result(reply["stdout"])
 
     assert len(payload["records"]) == 1
@@ -114,6 +118,7 @@ def test_logger_tail_serves_even_when_the_session_process_has_died(tmp_path):
     server = _server_with_session(tmp_path, log_file, alive=False)
 
     reply = server._handle({"op": "logger-tail", "params": {}})
+    assert reply is not None
     payload = parse_result(reply["stdout"])
 
     crashed = next(r for r in payload["records"] if "crashed" in r["message"])
@@ -126,6 +131,7 @@ def test_logger_tail_empty_log_is_an_empty_result_not_an_error(tmp_path):
     server = _server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {}})
+    assert reply is not None
     payload = parse_result(reply["stdout"])
 
     assert payload["records"] == []
@@ -137,6 +143,7 @@ def test_logger_tail_with_no_session_is_engine_session_not_running(tmp_path):
     server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
 
     reply = server._handle({"op": "logger-tail", "params": {}})
+    assert reply is not None
 
     assert (
         parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
@@ -151,5 +158,6 @@ def test_logger_tail_with_a_remembered_session_but_missing_file_is_live_log_unav
     server = _server_with_session(tmp_path, log_file, alive=False)
 
     reply = server._handle({"op": "logger-tail", "params": {}})
+    assert reply is not None
 
     assert parse_result(reply["stdout"])["error"]["code"] == "live_log_unavailable"

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -6,6 +6,8 @@ engine), so the no-session and control-op paths stay covered in the fast suite.
 
 import os
 import socket
+import subprocess
+from typing import cast
 
 import pytest
 
@@ -33,6 +35,7 @@ def test_live_op_without_a_launchable_session_is_engine_session_not_running(tmp_
     server = DaemonServer(daemon_paths(tmp_path), godot="")
 
     reply = server._handle({"op": "game-tree", "params": {}})
+    assert reply is not None
 
     assert (
         parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
@@ -81,9 +84,11 @@ def test_scene_mismatch_at_launch_is_a_typed_live_scene_not_found(
     server = DaemonServer(
         _project_with_marker(tmp_path), godot="godot", scene="res://B.tscn"
     )
-    server._harness_listener = object()  # launch_session is patched; value unused
+    # launch_session is patched; the listener value is unused (just non-None).
+    server._harness_listener = cast(socket.socket, object())
 
     reply = server._handle({"op": "game-tree", "params": {}})
+    assert reply is not None
 
     assert parse_result(reply["stdout"])["error"]["code"] == "live_scene_not_found"
     # The half-alive (wrong-scene) session was NOT cached for reuse.
@@ -98,8 +103,12 @@ def test_a_verified_session_is_reused_without_re_checking_the_scene(
     # multiple live ops (no per-request disk/scene re-validation), so deleting the
     # scene file after launch cannot break a live op.
     calls = {"n": 0}
-    served = EngineSession(_FakeProc(), conn=None)
-    served.request = lambda op, params: {"stdout": "ok", "stderr": "", "exit_code": 0}
+    served = EngineSession(cast(subprocess.Popen, _FakeProc()), conn=None)
+    monkeypatch.setattr(
+        served,
+        "request",
+        lambda op, params: {"stdout": "ok", "stderr": "", "exit_code": 0},
+    )
 
     def _launch_once(*a, **k):
         calls["n"] += 1
@@ -112,7 +121,8 @@ def test_a_verified_session_is_reused_without_re_checking_the_scene(
     server = DaemonServer(
         _project_with_marker(tmp_path), godot="godot", scene="res://B.tscn"
     )
-    server._harness_listener = object()  # launch_session is patched; value unused
+    # launch_session is patched; the listener value is unused (just non-None).
+    server._harness_listener = cast(socket.socket, object())
 
     server._handle({"op": "game-tree", "params": {}})
     server._handle({"op": "game-tree", "params": {}})
@@ -130,9 +140,11 @@ def test_a_generic_launch_failure_is_engine_session_not_running(tmp_path, monkey
     server = DaemonServer(
         _project_with_marker(tmp_path), godot="godot", scene="res://B.tscn"
     )
-    server._harness_listener = object()  # launch_session is patched; value unused
+    # launch_session is patched; the listener value is unused (just non-None).
+    server._harness_listener = cast(socket.socket, object())
 
     reply = server._handle({"op": "game-tree", "params": {}})
+    assert reply is not None
 
     assert (
         parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
@@ -153,9 +165,10 @@ def test_missing_res_scene_is_live_scene_not_found_before_launch(tmp_path, monke
     server = DaemonServer(
         _project_with_marker(tmp_path), godot="godot", scene="res://nope.tscn"
     )
-    server._harness_listener = object()
+    server._harness_listener = cast(socket.socket, object())
 
     reply = server._handle({"op": "game-tree", "params": {}})
+    assert reply is not None
 
     assert parse_result(reply["stdout"])["error"]["code"] == "live_scene_not_found"
     assert server._session is None
@@ -168,6 +181,7 @@ def test_no_scene_selector_runs_main_scene_unchanged(tmp_path):
     server = DaemonServer(daemon_paths(tmp_path), godot="")
 
     reply = server._handle({"op": "game-tree", "params": {}})
+    assert reply is not None
 
     assert (
         parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
@@ -177,9 +191,12 @@ def test_no_scene_selector_runs_main_scene_unchanged(tmp_path):
 def test_control_ops_report_liveness_and_request_stop(tmp_path):
     server = DaemonServer(daemon_paths(tmp_path), godot="")
 
-    assert server._handle({"op": "__status__"})["ok"] is True
+    status = server._handle({"op": "__status__"})
+    assert status is not None
+    assert status["ok"] is True
 
     stop = server._handle({"op": "__stop__"})
+    assert stop is not None
     assert stop["ok"] is True
     assert server._stopping is True
 
@@ -189,10 +206,14 @@ def test_status_op_reports_the_declared_display_mode(tmp_path):
     # STATUS_OP (#251) — the daemon is the only authority for the mode it was
     # started with — so the control reply must carry `windowed`.
     headless = DaemonServer(daemon_paths(tmp_path), godot="")
-    assert headless._handle({"op": "__status__"})["windowed"] is False
+    headless_status = headless._handle({"op": "__status__"})
+    assert headless_status is not None
+    assert headless_status["windowed"] is False
 
     windowed = DaemonServer(daemon_paths(tmp_path), godot="", windowed=True)
-    assert windowed._handle({"op": "__status__"})["windowed"] is True
+    windowed_status = windowed._handle({"op": "__status__"})
+    assert windowed_status is not None
+    assert windowed_status["windowed"] is True
 
 
 def test_engine_session_request_times_out_as_live_timeout(monkeypatch):
@@ -200,7 +221,7 @@ def test_engine_session_request_times_out_as_live_timeout(monkeypatch):
     # hang the daemon forever (ADR-0021).
     monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
     daemon_end, silent_harness = socket.socketpair()
-    session = EngineSession(_FakeProc(), daemon_end)
+    session = EngineSession(cast(subprocess.Popen, _FakeProc()), daemon_end)
     try:
         reply = session.request("game-tree", {})
         assert parse_result(reply["stdout"])["error"]["code"] == "live_timeout"

--- a/tests/test_e2e_export.py
+++ b/tests/test_e2e_export.py
@@ -77,7 +77,7 @@ def _expected_templates_version() -> str:
     return f"{base}.{v['status']}"
 
 
-def _gda_project(project) -> "callable":
+def _gda_project(project):
     """A ``gda`` bound to ``--project`` for res:// resolution of the cfg."""
 
     def gda(*args: str) -> subprocess.CompletedProcess:

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -82,7 +82,7 @@ binary_format/embed_pck=false
 """
 
 
-def _gda_project(project) -> "callable":
+def _gda_project(project):
     """A ``gda`` bound to ``--godot`` + ``--project`` for the real engine."""
 
     def gda(*args: str) -> subprocess.CompletedProcess:

--- a/tests/test_e2e_mcp_live.py
+++ b/tests/test_e2e_mcp_live.py
@@ -40,6 +40,7 @@ from gda.mcp.runner import SubprocessGdaRunner
 from gda.mcp.server import build_server
 
 from .conftest import project_godot
+from .mcp_support import tool_text
 
 GODOT = resolve_godot_binary()
 
@@ -133,7 +134,7 @@ def test_mcp_live_game_tree_relays_daemon_not_running_verbatim(
         assert result.structuredContent is None
         # The full GdaError envelope crossed verbatim as text content.
         assert result.content, "expected the GdaError envelope as text content"
-        payload = json.loads(result.content[0].text)
+        payload = json.loads(tool_text(result))
         # Assert the COMPLETE envelope shape, not a subset: lossless routing is the
         # property #227 exists to prove, so a relay that silently dropped a field
         # (most plausibly `diagnostics`) or wrapped it differently must fail here.

--- a/tests/test_e2e_mcp_live.py
+++ b/tests/test_e2e_mcp_live.py
@@ -97,11 +97,13 @@ def test_mcp_live_game_tree_routes_through_daemon_to_a_real_tree(
         # daemon_start succeeded through the generic dispatcher (exit 0 → result
         # dict wrapped as structuredContent by the SDK).
         assert started.isError is False, started.content
+        assert started.structuredContent is not None
         assert started.structuredContent["installed_harness"] is True
 
         # The live op routed CLI → daemon → engine session and returned the live
         # runtime tree — exactly what a headless tool's success looks like.
         assert tree.isError is False, tree.content
+        assert tree.structuredContent is not None
         root = tree.structuredContent["root"]
         assert root["name"] == "Main"
         assert root["type"] == "Node2D"

--- a/tests/test_e2e_mcp_project_context.py
+++ b/tests/test_e2e_mcp_project_context.py
@@ -15,8 +15,10 @@ from pathlib import Path
 
 import anyio
 import pytest
+from mcp.client.session import ListRootsFnT
 from mcp.shared.memory import create_connected_server_and_client_session as connect
 from mcp.types import ListRootsResult, Root
+from pydantic import FileUrl
 
 from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
 from gda.mcp.runner import SubprocessGdaRunner
@@ -27,11 +29,15 @@ GODOT = resolve_godot_binary()
 
 def _call_tool(server, name, arguments, *, roots=None):
     """Drive one tool call over a real in-memory MCP session (optionally advertising roots)."""
-    list_roots_callback = None
+    list_roots_callback: ListRootsFnT | None = None
     if roots is not None:
+        # The param is named ``context`` to match the ListRootsFnT Protocol.
+        async def _list_roots(context):
+            return ListRootsResult(
+                roots=[Root(uri=FileUrl(Path(r).as_uri())) for r in roots]
+            )
 
-        async def list_roots_callback(_ctx):
-            return ListRootsResult(roots=[Root(uri=Path(r).as_uri()) for r in roots])
+        list_roots_callback = _list_roots
 
     async def _drive():
         async with connect(server, list_roots_callback=list_roots_callback) as session:
@@ -91,4 +97,5 @@ def test_meta_command_tolerates_a_pinned_project(godot_project, monkeypatch):
     result = _call_tool(server, "info", {}, roots=[str(godot_project)])
 
     assert result.isError is False, result.content
+    assert result.structuredContent is not None
     assert result.structuredContent["major"] == 4

--- a/tests/test_e2e_mcp_stdio.py
+++ b/tests/test_e2e_mcp_stdio.py
@@ -53,6 +53,7 @@ def test_info_over_stdio_reports_engine_version():
     result = _call("info", {})
 
     assert result.isError is False, result.content
+    assert result.structuredContent is not None
     assert result.structuredContent["major"] == 4
     assert (result.structuredContent["major"], result.structuredContent["minor"]) >= (
         4,
@@ -67,6 +68,7 @@ def test_scene_create_over_stdio_creates_a_scene_file(tmp_path):
     result = _call("scene_create", {"path": str(scene), "root_type": "Node2D"})
 
     assert result.isError is False, result.content
+    assert result.structuredContent is not None
     # The verbatim --params-json dispatch produced gda's typed result…
     assert result.structuredContent["root_type"] == "Node2D"
     # root_name derived model-side from the filename, same as the argv path.

--- a/tests/test_e2e_mcp_tracer.py
+++ b/tests/test_e2e_mcp_tracer.py
@@ -42,6 +42,7 @@ def test_info_tracer_real_chain(monkeypatch):
     # structuredContent (the SDK checked it against info's outputSchema).
     assert result.isError is False, result.content
     version = result.structuredContent
+    assert version is not None
     assert version["major"] == 4
     assert (version["major"], version["minor"]) >= (4, 4)  # ADR-0003 minimum
     assert isinstance(version["string"], str)

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -554,7 +554,9 @@ def test_node_set_coerces_and_round_trips_via_get(
     assert (set_data["property"], set_data["type"]) == (prop, want_type)
     assert set_data["value"] == want_value
     # The change is on disk, verified through a fresh get.
-    assert _get_property(scene_path, "Hero", prop)["value"] == want_value
+    got_property = _get_property(scene_path, "Hero", prop)
+    assert got_property is not None
+    assert got_property["value"] == want_value
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_resource.py
+++ b/tests/test_e2e_resource.py
@@ -60,7 +60,7 @@ def _import_project(project) -> None:
     )
 
 
-def _gda_project(project) -> "callable":
+def _gda_project(project):
     """A ``gda`` bound to ``--godot`` and ``--project`` for res:// / UID resolution."""
 
     def gda(*args: str) -> subprocess.CompletedProcess:

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -342,7 +342,7 @@ def test_scene_create_unknown_root_type_yields_structured_error_end_to_end(
     assert not target.exists()
 
 
-def _gda_project(project) -> "callable":
+def _gda_project(project):
     """A ``_gda`` bound to ``--project`` for res:// enumeration/resolution."""
 
     def gda(*args: str) -> subprocess.CompletedProcess:

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -28,7 +28,7 @@ def _gda(*args: str) -> subprocess.CompletedProcess:
     )
 
 
-def _gda_project(project) -> "callable":
+def _gda_project(project):
     """A ``_gda`` bound to ``--project`` for res:// enumeration/resolution."""
 
     def gda(*args: str) -> subprocess.CompletedProcess:

--- a/tests/test_export_runner.py
+++ b/tests/test_export_runner.py
@@ -57,6 +57,7 @@ def test_export_runs_with_project_as_cwd(monkeypatch):
     assert rec.kwargs is not None
     assert rec.kwargs.get("cwd") == str(project)
     # The command still carries --path <project> and the export flags.
+    assert rec.cmd is not None
     assert "--path" in rec.cmd and str(project) in rec.cmd
     assert rec.cmd[-3:] == ["--export-release", "Linux/X11", "build/game.x86_64"]
 
@@ -72,6 +73,7 @@ def test_export_without_project_passes_no_cwd(monkeypatch):
 
     assert rec.kwargs is not None
     assert rec.kwargs.get("cwd") is None
+    assert rec.cmd is not None
     assert "--path" not in rec.cmd
 
 
@@ -104,7 +106,7 @@ def test_export_timeout_keeps_the_export_worded_diagnostic(monkeypatch):
     from gda.runner import LaunchFailure
 
     def fake_run(*args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
 
     monkeypatch.setattr(runner_mod.subprocess, "run", fake_run)
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -57,7 +57,7 @@ def test_non_executable_file_binary_maps_to_not_found_not_traceback(tmp_path):
 
 def test_timeout_maps_to_synthesized_timeout_result(monkeypatch):
     def fake_run(*args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
@@ -75,7 +75,7 @@ def test_timeout_label_customizes_the_diagnostic(monkeypatch):
     # byte-compatible with the pre-#185 "Godot export timed out" wording — the
     # stderr the classifier carries into the public GdaError.diagnostics (#185).
     def fake_run(*args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 

--- a/tests/test_mcp_dispatch.py
+++ b/tests/test_mcp_dispatch.py
@@ -31,6 +31,7 @@ def test_scene_create_input_object_builds_params_json_dispatch():
     assert result.structuredContent == SCENE_CREATE_RESULT
     # The seam was driven with the gda command argv + verbatim object on stdin.
     dispatch_args, dispatch_stdin, _ = runner.calls[-1]
+    assert dispatch_stdin is not None
     assert dispatch_args == ["scene", "create", "--params-json", "-", "--json"]
     assert json.loads(dispatch_stdin) == arguments
 
@@ -63,7 +64,9 @@ def test_no_param_tool_dispatches_an_empty_params_object():
     result = call_tool(server, "info", {})
 
     assert result.isError is False
+    assert result.structuredContent is not None
     assert result.structuredContent["string"] == VERSION_INFO["string"]
     dispatch_args, dispatch_stdin, _ = runner.calls[-1]
+    assert dispatch_stdin is not None
     assert dispatch_args == ["info", "--params-json", "-", "--json"]
     assert json.loads(dispatch_stdin) == {}

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -20,7 +20,13 @@ import pytest
 from gda.error_codes import ERROR_CODE_BY_CODE
 from gda.mcp.server import build_server
 from gda.models import GdaError, GdaErrorEnvelope
-from tests.mcp_support import FakeGdaRunner, call_tool, gda_result, schema_then
+from tests.mcp_support import (
+    FakeGdaRunner,
+    call_tool,
+    gda_result,
+    schema_then,
+    tool_text,
+)
 
 
 def _gda_envelope_json(code: str) -> str:
@@ -69,7 +75,7 @@ def test_each_category_relays_losslessly_as_is_error(code):
     # Lossless: the single content block parses back to gda's exact envelope —
     # all four fields, and crucially the stable code, preserved verbatim.
     assert len(result.content) == 1
-    relayed = json.loads(result.content[0].text)
+    relayed = json.loads(tool_text(result))
     assert relayed == json.loads(_gda_envelope_json(code))
     assert relayed["error"]["code"] == code
     assert relayed["error"]["category"] == ERROR_CODE_BY_CODE[code].category.value
@@ -79,7 +85,7 @@ def test_relayed_content_is_not_flattened_to_prose():
     # ADR-0011: the envelope must arrive as JSON an agent can branch on, never a
     # prose string the SDK would synthesize from a raised exception.
     result = call_tool(_failing_server("path_not_found"), "scene_create", {"path": "x"})
-    text = result.content[0].text
+    text = tool_text(result)
     parsed = json.loads(text)  # must be valid JSON, not prose
     assert set(parsed["error"]) >= {"category", "code", "message", "diagnostics"}
 
@@ -101,7 +107,7 @@ def test_cannot_run_edge_is_synthesized_by_gda_mcp():
 
     assert result.isError is True
     assert result.structuredContent is None
-    body = json.loads(result.content[0].text)
+    body = json.loads(tool_text(result))
     assert body["error"]["category"] == "adapter"  # gda-mcp's own, not a gda category
     assert "ModuleNotFoundError" in body["error"]["diagnostics"]
 
@@ -117,7 +123,7 @@ def test_non_envelope_output_edge_is_synthesized():
     result = call_tool(build_server(runner), "info", {})
 
     assert result.isError is True
-    assert json.loads(result.content[0].text)["error"]["category"] == "adapter"
+    assert json.loads(tool_text(result))["error"]["category"] == "adapter"
 
 
 def test_exit_zero_but_non_json_stdout_edge_is_synthesized():
@@ -131,4 +137,4 @@ def test_exit_zero_but_non_json_stdout_edge_is_synthesized():
     result = call_tool(build_server(runner), "info", {})
 
     assert result.isError is True
-    assert json.loads(result.content[0].text)["error"]["category"] == "adapter"
+    assert json.loads(tool_text(result))["error"]["category"] == "adapter"

--- a/tests/test_mcp_runner.py
+++ b/tests/test_mcp_runner.py
@@ -10,8 +10,12 @@ fast: the bad binary fails to exec immediately, no Godot involved.
 
 import json
 
+from mcp.types import CallToolResult
+
 from gda.mcp.runner import SubprocessGdaRunner
 from gda.mcp.server import dispatch
+
+from tests.mcp_support import tool_text
 
 # A command that cannot be exec'd at all — the unlaunchable-binary case a bad
 # GDA_BIN override produces.
@@ -35,8 +39,9 @@ def test_dispatch_synthesizes_is_error_for_a_launch_failure():
     outcome = dispatch(_UNLAUNCHABLE, ["info"], {})
 
     # A CallToolResult (failure channel), not a raised exception or a result dict.
+    assert isinstance(outcome, CallToolResult)
     assert outcome.isError is True
     assert outcome.structuredContent is None
-    body = json.loads(outcome.content[0].text)
+    body = json.loads(tool_text(outcome))
     assert body["error"]["category"] == "adapter"  # gda-mcp's own synthesized error
     assert "/does/not/exist/gda" in body["error"]["diagnostics"]


### PR DESCRIPTION
Closes #308

## Why

Stage 1 (#307/#310) gated `src/` under pyright `basic`. This extends the gate to **`tests/`** so the whole repo is type-checked on every PR — the staged rollout from ADR-0030.

## What

Resolved the **109** `tests/` findings honestly (no blanket ignores), then flipped `[tool.pyright]` `include` to `["src", "tests"]`. Patterns:

- **MCP content-union access** → a shared `tool_text()` helper in `mcp_support.py` (narrows `TextContent | ImageContent | …` to `TextContent`); `isinstance(outcome, CallToolResult)` where `dispatch` returns a union.
- **Optional narrowing** → not-None asserts for `structuredContent`, daemon `_handle` replies (`reply["stdout"]`), `dispatch_stdin`, `rec.cmd`, `_get_property(...)`, and `Failure`-narrowing for `_start(...)` results.
- **In-memory MCP `list_roots_callback`** → typed as `ListRootsFnT` with its param named `context` (the Protocol match was the real fix), and `Root(uri=FileUrl(...))`.
- **Intentional test doubles** → `cast(...)` the `_FakeProc` / listener fakes to their typed params (`proc: Popen`, `harness_listener: socket`), `monkeypatch.setattr` for a method stub.
- Dropped a broken `-> "callable"` return annotation (resolved to the builtin) on a shared e2e helper (5 files).
- `kwargs["timeout"]` instead of `.get(...)` in the runner/launch timeout fakes.

## Verification

- `uv run --frozen pyright` → **0 errors** whole-repo (gate now covers `src/` + `tests/`).
- `uv run --frozen pytest -m "not e2e"` → **974 passed** (asserts/casts are runtime no-ops; `monkeypatch.setattr` preserved).
- `uv run --frozen ruff check .` / `ruff format --check .` → clean.
- README + ADR-0030 updated (gate now covers `src/` + `tests/`).

Stage 3 (#309 — strictness ratchet + `ty` migration watch) remains, HITL/deferred.
