### PR TITLE
feat(project): add `gda project list` to enumerate ProjectSettings keys (#312)

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ flags — `gda --help` is the authoritative list of what is installed.
 | ------- | ------------ |
 | `project info` | Report project metadata (name, main scene, viewport, engine version). |
 | `project get` | Read a single project setting by section/key as typed JSON. |
+| `project list` | List the project's settings keys (customized by default; `--all` adds engine defaults, `--section` filters by prefix). |
 | `project set` | Set a project setting, coercing the value to its declared type. |
 | `project add-autoload` | Register an autoload singleton (name → script/scene). |
 | `project remove-autoload` | Unregister an autoload singleton by name. |

--- a/README.md
+++ b/README.md
@@ -133,10 +133,11 @@ gda scene get scenes/main.tscn --json
 > directory) — only `res://` resolution needs a project. See [Configuration](#configuration).
 
 **Drive a *running* game live.** Live ops run the project's **main scene**, so point it at the
-one you just built, then start the daemon (macOS/Linux, Godot 4.6+):
+one you just built via Godot's `application/run/main_scene` project setting (the editor's
+*Application → Run → Main Scene*), then start the daemon (macOS/Linux, Godot 4.6+):
 
 ```bash
-gda project set application/run/main_scene --value res://scenes/main.tscn --json
+gda project set application/run/main_scene --value res://scenes/main.tscn --json  # a Godot project setting key
 gda daemon start             # start the daemon for $GDA_PROJECT (installs the in-game harness)
 gda game tree --json         # the runtime scene tree, after _ready
 gda perf monitors --json     # live engine counters: fps, memory, node count

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -402,10 +402,24 @@ an unknown key is `unknown_setting`, never a silent create, so the type to coerc
 A value that cannot be coerced to the setting's type is `uncoercible_value` (exit 4, the #55 code,
 `project.godot` left untouched); a failed save is `save_failed`.
 
+**Listing settings** (established by #312): `gda project list` enumerates the project's
+`ProjectSettings` keys so an agent can **discover** which settings exist — the list half of the
+`list → get → set` workflow (`get`/`set` both require you to already know the `section/key`). Each
+entry reuses the **same** `{setting, type, value}` projection `project get` reports — so a listed
+entry round-trips through `project get` — **plus** an `is_default` boolean: `false` when the key is
+customized (written in `project.godot`), `true` when it is at the engine's built-in default. By
+default the listing is only the project's **customized** settings (small and useful); `--all` widens
+it to the engine's built-in defaults too, and `--section <prefix>` restricts it to keys whose name
+begins with that `section/` prefix (e.g. `application/`, `display/`) — the two compose. Internal
+engine-bookkeeping settings and the non-setting properties the engine's property list also returns
+are filtered out, so only real `ProjectSettings` keys appear. Like the rest of the group it requires
+a resolved project (`project_not_found`, exit 4, otherwise) and never instantiates a scene.
+
 | Command | Description |
 | --- | --- |
 | `gda project info` | Project metadata (name, main scene, viewport, engine version) |
 | `gda project get` | Read a project setting by section/key (typed JSON) |
+| `gda project list` | List the project's settings keys (customized by default; `--all` adds defaults, `--section` filters) |
 | `gda project set` | Modify a project setting (value coerced to its declared type) |
 | `gda project add-autoload` / `remove-autoload` | Register / unregister an autoload singleton |
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -140,6 +140,8 @@ from gda.models import (
     ProjectGetResult,
     ProjectInfoParams,
     ProjectInfoResult,
+    ProjectListParams,
+    ProjectListResult,
     ProjectRemoveAutoloadParams,
     ProjectRemoveAutoloadResult,
     ProjectSetParams,
@@ -232,6 +234,7 @@ from gda.render import (
     render_project_find_unused_resources,
     render_project_get,
     render_project_info,
+    render_project_list,
     render_project_remove_autoload,
     render_project_set,
     render_project_statistics,
@@ -1827,6 +1830,13 @@ PROJECT_GET_COMMAND: HeadlessCommand[ProjectGetResult] = HeadlessCommand(
     render=render_project_get,
 )
 
+PROJECT_LIST_COMMAND: HeadlessCommand[ProjectListResult] = HeadlessCommand(
+    operation="project-list",
+    input_model=ProjectListParams,
+    output_model=ProjectListResult,
+    render=render_project_list,
+)
+
 PROJECT_SET_COMMAND: HeadlessCommand[ProjectSetResult] = HeadlessCommand(
     operation="project-set",
     input_model=ProjectSetParams,
@@ -2640,6 +2650,40 @@ def project_get(
     _dispatch(
         PROJECT_GET_COMMAND,
         ProjectGetParams(setting=setting),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+    )
+
+
+@project_app.command(name="list", cls=PROJECT_LIST_COMMAND.command_class())
+def project_list(
+    all_settings: bool = typer.Option(
+        False,
+        "--all",
+        help=(
+            "Also list the engine's built-in default settings, not just the "
+            "project's customized ones."
+        ),
+    ),
+    section: Optional[str] = typer.Option(
+        None,
+        "--section",
+        help=(
+            "Restrict to keys whose name begins with this section/ prefix "
+            "(e.g. application/, display/)."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = PROJECT_LIST_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """List the project's settings keys (customized only by default; --all adds defaults)."""
+    _dispatch(
+        PROJECT_LIST_COMMAND,
+        ProjectListParams(include_defaults=all_settings, section=section),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -2394,6 +2394,75 @@ class ProjectGetResult(BaseModel):
     )
 
 
+class ProjectListParams(BaseModel):
+    """The operation params of ``gda project list`` (issue #312).
+
+    Enumerates the project's ``ProjectSettings`` keys so an agent can DISCOVER
+    which settings exist — the list half of the ``list → get → set`` workflow
+    (``get``/``set`` both require you to already know the ``section/key``).
+    ``include_defaults`` (the CLI ``--all`` flag) widens the listing from only the
+    project's customized (non-default) settings to the engine's built-in defaults
+    too; ``section`` restricts it to keys whose name begins with that ``section/``
+    prefix (e.g. ``application/``, ``display/``), and the two compose. The project
+    is process context (``--project``), not an operation param (ADR-0006).
+    """
+
+    include_defaults: bool = Field(
+        default=False,
+        description=(
+            "Also list the engine's built-in default settings, not just the "
+            "project's customized (non-default) ones. The CLI --all flag."
+        ),
+    )
+    section: str | None = Field(
+        default=None,
+        description=(
+            "Restrict the listing to keys whose name begins with this section/ "
+            "prefix, e.g. application/ or display/. Null lists every section."
+        ),
+    )
+
+
+class ListedProjectSetting(BaseModel):
+    """One enumerated project setting of ``gda project list`` (issue #312).
+
+    Reuses the same ``{setting, type, value}`` projection ``project get`` reports
+    for a single setting — so a listed entry round-trips through ``project get`` —
+    plus ``is_default``: ``false`` when the key is customized (written in
+    ``project.godot``), ``true`` when it is at the engine's built-in default.
+    """
+
+    setting: str
+    type: str = Field(
+        description="The setting's declared Godot type name (e.g. String, int, Vector2)."
+    )
+    value: Any = Field(
+        description=(
+            "The setting's value as JSON: a scalar for a scalar type, a list for "
+            "a packed type (Vector2 → [x, y], Color → [r, g, b, a])."
+        )
+    )
+    is_default: bool = Field(
+        description=(
+            "True when the setting is at the engine's built-in default; false when "
+            "it is customized in project.godot."
+        )
+    )
+
+
+class ProjectListResult(BaseModel):
+    """The result of ``gda project list``: the project's enumerated settings (#312).
+
+    ``settings`` is the discovered keys, each a ``{setting, type, value,
+    is_default}`` entry sorted by name. A project with no customized settings and
+    no ``include_defaults`` is a valid, EMPTY listing — ``settings == []`` — not a
+    failure. Internal engine-bookkeeping and non-setting properties are filtered
+    out, so only real ``ProjectSettings`` keys appear.
+    """
+
+    settings: list[ListedProjectSetting]
+
+
 class ProjectSetParams(BaseModel):
     """The operation params of ``gda project set`` (issue #111).
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -162,6 +162,8 @@ func _initialize() -> void:
 			_op_project_info(params)
 		"project-get":
 			_op_project_get(params)
+		"project-list":
+			_op_project_list(params)
 		"project-set":
 			_op_project_set(params)
 		"project-add-autoload":
@@ -2133,6 +2135,86 @@ func _op_project_get(params: Dictionary) -> void:
 		"type": _type_name(typeof(value)),
 		"value": _jsonify(value),
 	})
+
+
+# project-list: enumerate the project's ProjectSettings keys so an agent can
+# DISCOVER which settings exist (issue #312) — the list half of the list → get →
+# set workflow, since get/set both require you to already know the section/key.
+# Each entry reuses the same {setting, type, value} projection project get reports
+# (so a listed entry round-trips through project get), plus an is_default flag:
+# false when the key is CUSTOMIZED (written in project.godot), true when it is at
+# the engine's built-in default.
+#
+# Scope: by default only customized settings are listed (keeping the default
+# output small and agent-useful); include_defaults widens it to the engine's
+# built-in defaults too, and a non-empty section restricts to keys whose name
+# begins with that section/ prefix — the two compose. Internal engine-bookkeeping
+# settings (PROPERTY_USAGE_INTERNAL — features/tags/translation remaps/…) and the
+# non-setting properties get_property_list() also returns (the ProjectSettings
+# category, the `script` property) are filtered out, so only real ProjectSettings
+# keys appear; the has_setting check is what distinguishes a real setting.
+#
+# Like every --project op it needs a project (project_not_found otherwise) and
+# runs the project's autoloads at startup (#61, ADR-0009); enumerating settings
+# never instantiates a scene, so it is a state-read at the operation level.
+func _op_project_list(params: Dictionary) -> void:
+	_diag("running operation: project-list")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "project list requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+	var include_defaults := bool(params.get("include_defaults", false))
+	var section := _string_param(params, "section")
+	var customized := _customized_settings()
+
+	var names: Array[String] = []
+	for prop in ProjectSettings.get_property_list():
+		var key := String(prop.get("name", ""))
+		# Only entries ProjectSettings tracks as real settings answer has_setting —
+		# this drops the category header and the `script` property.
+		if not ProjectSettings.has_setting(key):
+			continue
+		# Internal engine bookkeeping is not an agent-facing setting key.
+		if int(prop.get("usage", 0)) & PROPERTY_USAGE_INTERNAL:
+			continue
+		var is_default := not customized.has(key)
+		if is_default and not include_defaults:
+			continue
+		if not section.is_empty() and not key.begins_with(section):
+			continue
+		names.append(key)
+
+	# Sort by name so the listing is stable regardless of registration order.
+	names.sort()
+	var settings: Array = []
+	for key in names:
+		var value: Variant = ProjectSettings.get_setting(key)
+		settings.append({
+			"setting": key,
+			"type": _type_name(typeof(value)),
+			"value": _jsonify(value),
+			"is_default": not customized.has(key),
+		})
+
+	_succeed({"settings": settings})
+
+
+# The set of project setting names CUSTOMIZED in res://project.godot — the keys
+# actually written there, as opposed to the engine's built-in defaults. Read by
+# parsing project.godot with ConfigFile (the engine exposes no get_initial_value
+# binding to compare a current value against its default): each [section] key
+# becomes the full "section/key" setting name (a sectionless key like
+# config_version maps to its bare name, harmlessly — it is not a real setting).
+# project list reports is_default=false for these keys and true for the rest.
+func _customized_settings() -> Dictionary:
+	var customized := {}
+	var cfg := ConfigFile.new()
+	if cfg.load("res://project.godot") != OK:
+		return customized
+	for section in cfg.get_sections():
+		for key in cfg.get_section_keys(section):
+			var name := key if section.is_empty() else section + "/" + key
+			customized[name] = true
+	return customized
 
 
 # project-set: write one project setting, coercing the CLI string value to the

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
         ProjectAddAutoloadResult,
         ProjectGetResult,
         ProjectInfoResult,
+        ProjectListResult,
         ProjectRemoveAutoloadResult,
         ProjectSetResult,
         ResourceCreateResult,
@@ -622,6 +623,25 @@ def render_project_get(got: "ProjectGetResult") -> str:
 def render_project_set(was_set: "ProjectSetResult") -> str:
     """Render a set setting as ``set <setting> (<type>) = <value>``."""
     return f"set {was_set.setting} ({was_set.type}) = {format_value(was_set.value)}"
+
+
+def render_project_list(listed: "ProjectListResult") -> str:
+    """Render enumerated settings as ``<setting> (<type>) = <value>`` lines.
+
+    An engine-default entry is tagged ``[default]`` so customized vs default reads
+    at a glance; the same ``<setting> (<type>) = <value>`` shape ``project get``
+    renders. An empty listing is named explicitly rather than printing nothing.
+    """
+    if not listed.settings:
+        return "(no settings)"
+    lines = []
+    for entry in listed.settings:
+        default_marker = " [default]" if entry.is_default else ""
+        lines.append(
+            f"{entry.setting} ({entry.type}) = {format_value(entry.value)}"
+            f"{default_marker}"
+        )
+    return "\n".join(lines)
 
 
 def render_project_add_autoload(added: "ProjectAddAutoloadResult") -> str:

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -63,7 +63,7 @@ Branch on the stable `category`/`code` and the **exit code**, never on prose:
 | `scene` | `create`, `get`, `list`, `get-exports`, `delete` (`.tscn` files) |
 | `node` | `add`, `get`, `list`, `set`, `remove`, `duplicate`, `move`, `connect-signal`, `disconnect-signal` (nodes within a scene) |
 | `script` | `create`, `get`, `list`, `set`, `delete`, `attach`, `validate` (`.gd` files) |
-| `project` | `info`, `get`, `set`, `add-autoload`, `remove-autoload`, `find-references`, `dependencies`, `find-unused-resources`, `statistics` |
+| `project` | `info`, `get`, `set`, `list`, `add-autoload`, `remove-autoload`, `find-references`, `dependencies`, `find-unused-resources`, `statistics` |
 | `resource` | `create`, `get`, `set`, `delete`, `uid` (`.tres` files) |
 | `export` | `list`, `get`, `run` (export a preset by name; `--mode` release/debug/pack) |
 | `shader` | `create`, `get`, `set` (`.gdshader` files) |

--- a/tests/test_e2e_project.py
+++ b/tests/test_e2e_project.py
@@ -115,6 +115,31 @@ def test_project_set_string_setting_round_trips(godot_project):
 
 
 @pytest.mark.e2e
+def test_project_list_bare_reports_only_customized_settings(godot_project):
+    # A bare list reports only the settings the fixture's project.godot actually
+    # writes (customized), each as {setting, type, value, is_default} with
+    # is_default false — NOT the hundreds of engine built-in defaults.
+    listed = _gda(godot_project, "project", "list", "--json")
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    settings = json.loads(listed.stdout)["settings"]
+    by_name = {entry["setting"]: entry for entry in settings}
+
+    # config/name is customized in the fixture's project.godot.
+    assert "application/config/name" in by_name
+    name_entry = by_name["application/config/name"]
+    assert name_entry["type"] == "String"
+    assert name_entry["value"] == "gda-e2e-fixture"
+    assert name_entry["is_default"] is False
+    # Every bare-scope entry is customized (none are defaults).
+    assert all(entry["is_default"] is False for entry in settings)
+    # A built-in default the fixture never set is absent from the bare listing.
+    assert "display/window/size/viewport_width" not in by_name
+    # The customized listing stays small — not the engine's hundreds of defaults.
+    assert len(settings) < 50
+
+
+@pytest.mark.e2e
 def test_project_get_unknown_setting_is_a_clean_error(godot_project):
     got = _gda(godot_project, "project", "get", "application/bogus/key", "--json")
 

--- a/tests/test_e2e_project.py
+++ b/tests/test_e2e_project.py
@@ -140,6 +140,96 @@ def test_project_list_bare_reports_only_customized_settings(godot_project):
 
 
 @pytest.mark.e2e
+def test_project_list_all_includes_engine_defaults(godot_project):
+    # --all widens the listing to the engine's built-in defaults too, so a setting
+    # the project never customized appears, flagged is_default true, alongside the
+    # customized ones (is_default false).
+    listed = _gda(godot_project, "project", "list", "--all", "--json")
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    settings = json.loads(listed.stdout)["settings"]
+    by_name = {entry["setting"]: entry for entry in settings}
+
+    # A built-in default the fixture never set is now present and flagged default.
+    assert "display/window/size/viewport_width" in by_name
+    assert by_name["display/window/size/viewport_width"]["is_default"] is True
+    assert by_name["display/window/size/viewport_width"]["type"] == "int"
+    # The customized config/name is still present and still flagged customized.
+    assert by_name["application/config/name"]["is_default"] is False
+    # --all is the engine's hundreds of registered settings, far more than bare.
+    assert len(settings) > 100
+    # Internal / non-setting entries are filtered out: no category header, no
+    # `script` property, no PROPERTY_USAGE_INTERNAL keys like application/config/features.
+    assert "script" not in by_name
+    assert "ProjectSettings" not in by_name
+    assert "application/config/features" not in by_name
+
+
+@pytest.mark.e2e
+def test_project_list_section_filters_to_a_prefix_and_composes_with_all(godot_project):
+    # --section restricts to keys under a section/ prefix; with --all it scopes the
+    # engine defaults to that section too.
+    listed = _gda(
+        godot_project,
+        "project",
+        "list",
+        "--all",
+        "--section",
+        "application/",
+        "--json",
+    )
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    settings = json.loads(listed.stdout)["settings"]
+    names = [entry["setting"] for entry in settings]
+
+    assert names, "section filter should still find application/* keys"
+    # Every reported key is under the requested prefix.
+    assert all(name.startswith("application/") for name in names)
+    assert "application/config/name" in names
+    # A different section is excluded by the prefix filter.
+    assert not any(name.startswith("display/") for name in names)
+
+
+@pytest.mark.e2e
+def test_project_list_entry_round_trips_through_project_get(godot_project):
+    # A listed entry reports the SAME {type, value} projection project get reports
+    # for that key — so an agent can list to discover, then get to read one.
+    listed = _gda(godot_project, "project", "list", "--all", "--json")
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    entry = next(
+        e
+        for e in json.loads(listed.stdout)["settings"]
+        if e["setting"] == "display/window/size/viewport_width"
+    )
+
+    got = _gda(
+        godot_project, "project", "get", "display/window/size/viewport_width", "--json"
+    )
+    assert got.returncode == 0, got.stdout + got.stderr
+    got_data = json.loads(got.stdout)
+    assert entry["type"] == got_data["type"]
+    assert entry["value"] == got_data["value"]
+
+
+@pytest.mark.e2e
+def test_project_list_without_project_is_a_clean_error():
+    # Projectless: ProjectSettings would report only the engine's bare defaults,
+    # not the agent's project, so it is refused with project_not_found (exit 4),
+    # consistent with the rest of the project group.
+    proc = subprocess.run(
+        [*GDA_CMD, "project", "list", "--json", "--godot", str(GODOT)],
+        capture_output=True,
+        text=True,
+        cwd="/tmp",
+    )
+
+    assert proc.returncode == 4
+    err = json.loads(proc.stdout)["error"]
+    assert err["code"] == "project_not_found"
+
+
+@pytest.mark.e2e
 def test_project_get_unknown_setting_is_a_clean_error(godot_project):
     got = _gda(godot_project, "project", "get", "application/bogus/key", "--json")
 

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -21,6 +21,8 @@ from gda.models import (
     ProjectGetResult,
     ProjectInfoParams,
     ProjectInfoResult,
+    ProjectListParams,
+    ProjectListResult,
     ProjectRemoveAutoloadParams,
     ProjectRemoveAutoloadResult,
     ProjectSetParams,
@@ -47,6 +49,23 @@ SET_RESULT = {
     "setting": "display/window/size/viewport_width",
     "type": "int",
     "value": 1920,
+}
+
+LIST_RESULT = {
+    "settings": [
+        {
+            "setting": "application/config/name",
+            "type": "String",
+            "value": "My Game",
+            "is_default": False,
+        },
+        {
+            "setting": "display/window/size/viewport_width",
+            "type": "int",
+            "value": 1152,
+            "is_default": True,
+        },
+    ],
 }
 
 
@@ -209,6 +228,82 @@ def test_project_set_requires_value(monkeypatch):
     assert fake.calls == []
 
 
+# --- project list ---------------------------------------------------------
+
+
+def test_project_list_bare_dispatches_customized_scope_and_maps_entries(monkeypatch):
+    # A bare list lists only customized settings: include_defaults defaults False,
+    # section None. Each entry rides through as {setting, type, value, is_default}.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["project", "list", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data == LIST_RESULT
+    assert fake.calls == [
+        ("project-list", {"include_defaults": False, "section": None})
+    ]
+
+
+def test_project_list_all_flag_widens_scope_to_engine_defaults(monkeypatch):
+    # --all sets include_defaults True so the engine's built-in defaults are listed
+    # too, not just the project's customized settings.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["project", "list", "--all", "--json"])
+
+    assert result.exit_code == 0
+    assert fake.calls == [("project-list", {"include_defaults": True, "section": None})]
+
+
+def test_project_list_section_filter_rides_through_as_a_param(monkeypatch):
+    # --section restricts the listing to keys under a section/ prefix; it composes
+    # with --all (both ride through as operation params).
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["project", "list", "--all", "--section", "application/", "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        ("project-list", {"include_defaults": True, "section": "application/"})
+    ]
+
+
+def test_project_list_human_output_lines_settings_and_marks_defaults(monkeypatch):
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["project", "list"])
+
+    assert result.exit_code == 0
+    lines = result.stdout.strip().splitlines()
+    assert lines[0] == 'application/config/name (String) = "My Game"'
+    # An engine-default entry is tagged so customized vs default reads at a glance.
+    assert lines[1] == "display/window/size/viewport_width (int) = 1152 [default]"
+
+
+def test_project_list_human_output_names_an_empty_listing(monkeypatch):
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel({"settings": []}), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(app, ["project", "list"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "(no settings)"
+
+
 # --- project add-autoload -------------------------------------------------
 
 
@@ -339,6 +434,21 @@ def test_project_set_schema_emits_model_derived_contract_without_other_args():
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
 
+def test_project_list_schema_emits_model_derived_contract_without_other_args():
+    result = CliRunner().invoke(app, ["project", "list", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ProjectListParams.model_json_schema()
+    assert doc["output"] == ProjectListResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    # The two scope params are part of the self-described input contract.
+    assert "include_defaults" in doc["input"]["properties"]
+    assert "section" in doc["input"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
 def test_project_add_autoload_schema_emits_model_derived_contract_without_other_args():
     result = CliRunner().invoke(app, ["project", "add-autoload", "--schema"])
 
@@ -373,6 +483,9 @@ def test_sample_project_results_validate_against_emitted_output_schemas():
         CliRunner().invoke(app, ["project", "info", "--schema"]).stdout
     )
     get_doc = json.loads(CliRunner().invoke(app, ["project", "get", "--schema"]).stdout)
+    list_doc = json.loads(
+        CliRunner().invoke(app, ["project", "list", "--schema"]).stdout
+    )
     set_doc = json.loads(CliRunner().invoke(app, ["project", "set", "--schema"]).stdout)
     add_doc = json.loads(
         CliRunner().invoke(app, ["project", "add-autoload", "--schema"]).stdout
@@ -383,6 +496,7 @@ def test_sample_project_results_validate_against_emitted_output_schemas():
 
     jsonschema.validate(instance=INFO_RESULT, schema=info_doc["output"])
     jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
+    jsonschema.validate(instance=LIST_RESULT, schema=list_doc["output"])
     jsonschema.validate(instance=SET_RESULT, schema=set_doc["output"])
     jsonschema.validate(instance=ADD_AUTOLOAD_RESULT, schema=add_doc["output"])
     jsonschema.validate(instance=REMOVE_AUTOLOAD_RESULT, schema=remove_doc["output"])
@@ -398,6 +512,7 @@ def test_project_schema_spawns_no_godot(monkeypatch):
     for command in (
         ["project", "info"],
         ["project", "get"],
+        ["project", "list"],
         ["project", "set"],
         ["project", "add-autoload"],
         ["project", "remove-autoload"],


### PR DESCRIPTION
## Summary

Adds `gda project list` — the **list** half of the `list → get → set` project-settings workflow. Until now `project get`/`set` both required you to already know the `section/key`, and `project info` reported only a fixed handful — so an agent had no way to **discover** which `ProjectSettings` keys exist without an editor UI. This closes that gap.

Closes #312.

## Behavior

- Bare `gda project list --json` → only the project's **customized** (non-default) settings — the keys actually written in `project.godot`, keeping default output small and agent-useful.
- `--all` → also include the engine's built-in default keys.
- `--section <prefix>` → restrict to keys whose name begins with that `section/` prefix (e.g. `application/`, `display/`); composes with `--all`.
- Each entry reuses the **same** `{setting, type, value}` projection `project get` reports (a listed entry round-trips through `project get`) **plus** an `is_default` boolean.
- Internal engine-bookkeeping (`PROPERTY_USAGE_INTERNAL`) and the non-setting properties `get_property_list()` returns (the category header, the `script` property) are filtered out — only real `ProjectSettings` keys appear.
- Requires a resolved project → `project_not_found` (exit 4) otherwise; never instantiates a scene (a state-read, consistent with the rest of the `project` group).
- Self-describes via `--schema` and ships a human renderer, registered through the single `HeadlessCommand` descriptor (ADR-0023 — no parallel registries).

`is_default` is derived by parsing `project.godot` with `ConfigFile` (the engine exposes no `get_initial_value` binding to compare a current value against its default).

## Also in this PR

- **docs(readme):** clarifies in the Quick start "drive a running game live" step that `application/run/main_scene` is Godot's own `ProjectSettings` key (the editor's *Application → Run → Main Scene*), not gda-invented syntax. (Carried along per request; thematically related — both are about project-settings discoverability.)

## Test evidence (independently re-run on review)

- `ruff check .` → All checks passed; `ruff format --check .` → 134 files already formatted
- `pyright` → 0 errors, 0 warnings
- `pytest -m "not e2e"` → 981 passed
- `pytest tests/test_e2e_project.py -m e2e` (serial) → **17 passed**, incl. 5 new e2e tests: bare-customized-only, `--all` includes defaults + filters internal/category/`script`, `--section` composes with `--all`, round-trip through `project get`, projectless → `project_not_found`.
- Manual smoke: `--schema` emits the full input/output/error contract (`kind: headless`); human renderer tags engine defaults `[default]`.

## Docs

`docs/command-catalog.md` (project section + table) and the `project` row in `SKILL.md` updated to include `project list`.
