### PR TITLE
feat(state): cross-session STATE.md daily-report mechanism

### DIFF
--- a/.agents/skills/state/SKILL.md
+++ b/.agents/skills/state/SKILL.md
@@ -78,8 +78,8 @@ _Updated: <YYYY-MM-DD>_
   or not useful to the next session. Never carry a phase forward just because it was there before.
 - **Pitfalls only when they serve "Next up"** — record experience only when this session's work is
   continuous with / related to the recommended next work; otherwise leave it out.
-- **Overwrite, never append** — STATE.md must not become a session-history log. Version-control
-  history already preserves the per-session record.
+- **Overwrite, never append** — STATE.md is a current handoff snapshot, not a session-history log;
+  keep only the latest state.
 - Record only **this session's delta** — not a running journal.
 - Keep it **self-contained**: don't duplicate the project's durable decision/architecture docs, and
   don't hard-depend on any particular tracker or tool.

--- a/.agents/skills/state/SKILL.md
+++ b/.agents/skills/state/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: state
+description: Update STATE.md — the lightweight cross-session "daily report" of project progress. Rewrite (never append) the current milestone/phase, what this session completed or changed, pitfalls worth reusing, and the recommended next issues/tasks. Use at the end of a working session, when wrapping up, or when invoked as /state.
+---
+
+# State
+
+Maintain `STATE.md` at the repo root: a lightweight **cross-session daily report** so the next
+worker learns in ≤10 lines where the project is, what the last session did, which pitfalls to
+reuse, and what to pick up next. This is the feedback loop that makes development experience
+**compound** instead of re-discovering project status every session.
+
+`STATE.md` is **transient** ("where are we now / what next", overwritten each session) and
+**self-contained** — it is not the place for durable decisions, architecture, or a glossary, and
+must not duplicate them. It is **lazily created**: if it doesn't exist yet, the first run creates it.
+
+This skill is **self-sufficient and orthogonal** to whatever else a project happens to use (version
+control, an issue/task tracker, design docs). It assumes such tools *may* exist but depends on no
+particular one — read whatever sources the project has, skip the rest.
+
+**Write sparingly — omit rather than mislead.** Every field in the template is **optional**. Only
+write a line when you have something **accurate** and **useful to the next session**. If a value is
+missing, stale, unverified, or you can't judge whether it helps, **leave it out** — a wrong or
+filler line is worse than a missing one. STATE.md must orient the next worker, never misdirect them.
+
+## When to run
+
+- At the **end of a working session** / wrap-up — your agent runtime may nudge this via a
+  session-end hook, or you run it yourself.
+- On demand, invoked as `/state`.
+
+Update STATE.md **once per session, by the primary worker** — not once per parallel sub-task or subagent — so
+the file is written a single time and never double-written.
+
+**No-op guard:** if the session did no material work (e.g. a trivial Q&A turn), leave `STATE.md`
+unchanged — at most refresh the date. Don't churn the file with non-progress.
+
+## Workflow
+
+1. **Gather what this session actually completed or changed.** The primary source is the **current
+   conversation**. If the project has supporting tools, corroborate lightly (recent version-control
+   history, the issue/task tracker) — treat them as optional, not required.
+2. **State the macro phase only if you know the *current* one.** Do **not** carry the previous
+   STATE.md's phase forward by default — if it may have moved on, or you can't confirm the current
+   stage this session, **omit the line** rather than assert a stale one. (A finished phase written
+   as if current is misdirection.) Use the project's own terms.
+3. **Pick the recommended next work** — the open items a fresh session should start with.
+4. **Add pitfalls/experience only if it serves "Next up".** Include a note **only when this
+   session's work is continuous with or related to the recommended next work**, so the note will
+   actually get reused. If the next work is unrelated, **omit it** — experience that doesn't help
+   the next task is noise, not a war-story archive.
+5. **Rewrite `STATE.md`** from the template — **overwrite, never append**; ≤10 lines; terse; drop
+   any field you have nothing accurate and useful for. Stamp the date.
+6. **Do not auto-commit.** Leave `STATE.md` in the working tree for the session's normal commit (or
+   commit it on its own). The session author decides when to commit.
+
+## Template
+
+```markdown
+# STATE — <project>
+
+_Cross-session daily report (≤10 lines, rewritten each session via `/state`). Durable decisions live elsewhere, not here._
+
+- **Phase/milestone:** <current stage, in the project's own terms — omit if you can't confirm the *current* one>
+- **Last session:** <what was completed/changed; one line, e.g. issue #N>
+- **Pitfalls/experience:** <only if it helps "Next up"; otherwise omit this line>
+- **Next up:** <recommended next items to start, e.g. issue #N>
+
+_Updated: <YYYY-MM-DD>_
+```
+
+(Every bullet is optional — omit any you have nothing accurate and useful for.)
+
+## Guardrails
+
+- **≤10 lines** of content; keep it scannable.
+- **Omit rather than mislead** — every field is optional; drop any line that is stale, unverified,
+  or not useful to the next session. Never carry a phase forward just because it was there before.
+- **Pitfalls only when they serve "Next up"** — record experience only when this session's work is
+  continuous with / related to the recommended next work; otherwise leave it out.
+- **Overwrite, never append** — STATE.md must not become a session-history log. Version-control
+  history already preserves the per-session record.
+- Record only **this session's delta** — not a running journal.
+- Keep it **self-contained**: don't duplicate the project's durable decision/architecture docs, and
+  don't hard-depend on any particular tracker or tool.
+- Use the **project's own vocabulary** consistently.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,14 @@
         "hooks": [
           {
             "type": "command",
+            "command": "echo '{\"systemMessage\": \"Session wrap-up: if you completed or changed issue/task work, run /state to refresh STATE.md (progress + next steps).\"}'"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "echo '{\"systemMessage\": \"Reminder: if a requirement or technical decision changed this session, run /reconcile to sync issues and docs (CONTEXT.md, docs/adr/).\"}'"
           }
         ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ Read @RULES.md if exists, to align communication style, collaboration specificat
 
 Read @CONTEXT.md to align with the project's nature and shared language; consult `docs/adr/` for the architecture and the decisions behind it. README.md is human-facing onboarding (install, usage, contributing) and has grown large — read specific sections on demand (e.g. its "Project status" section for current state) rather than the whole file.
 
+Read @STATE.md if exists for the latest session state — a lightweight cross-session daily report (≤10 lines): current milestone/phase, what the last session did, pitfalls worth reusing, and the recommended next issues/tasks. Update it at session end via the `state` skill.
+
 ## Agent skills
 
 ### Issue tracker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Read @RULES.md if exists, to align communication style, collaboration specificat
 
 Read @CONTEXT.md to align with the project's nature and shared language; consult `docs/adr/` for the architecture and the decisions behind it. README.md is human-facing onboarding (install, usage, contributing) and has grown large — read specific sections on demand (e.g. its "Project status" section for current state) rather than the whole file.
 
-Read @STATE.md if exists for the latest session state — a lightweight cross-session daily report (≤10 lines): current milestone/phase, what the last session did, pitfalls worth reusing, and the recommended next issues/tasks. Update it at session end via the `state` skill.
+Read @STATE.md if exists for the latest session state — a lightweight cross-session daily report (≤10 lines): current milestone/phase, what the last session did, pitfalls worth reusing, and recommended next issues/tasks. Treat it as read-only startup context. Only the **primary worker** updates it, at session end, via the `state` skill; parallel sub-agents and sub-tasks must not write it.
 
 ## Agent skills
 

--- a/STATE.md
+++ b/STATE.md
@@ -1,0 +1,8 @@
+# STATE — godot-agent
+
+_Cross-session daily report (≤10 lines, rewritten each session via `/state`). Durable decisions live elsewhere, not here._
+
+- **Last session:** built the cross-session `state` mechanism (skill + STATE.md + Stop-hook nudge + `@STATE.md` read-loop) and filed tracking issue #317; branch `feat/state-mechanism`, committed, not pushed/PR'd.
+- **Next up:** push + open PR for `feat/state-mechanism` (Closes #317); other open issues: #309 (pyright ratchet), #271 (`ExecutionKind` refinement).
+
+_Updated: 2026-06-28_

--- a/STATE.md
+++ b/STATE.md
@@ -2,7 +2,7 @@
 
 _Cross-session daily report (≤10 lines, rewritten each session via `/state`). Durable decisions live elsewhere, not here._
 
-- **Last session:** built the cross-session `state` mechanism (skill + STATE.md + Stop-hook nudge + `@STATE.md` read-loop), filed #317, opened PR #318 (CI green).
-- **Next up:** review + merge PR #318 (Closes #317); then open issues #309 (pyright ratchet), #271 (`ExecutionKind` refinement).
+- **Last session:** added the cross-session `state` mechanism — `state` skill + `STATE.md` + Stop-hook nudge + `@STATE.md` read-loop (#317).
+- **Next up:** #309 (pyright strictness ratchet), #271 (`ExecutionKind`: stop pure-local/recipe commands advertising `kind=headless`).
 
 _Updated: 2026-06-28_

--- a/STATE.md
+++ b/STATE.md
@@ -2,7 +2,7 @@
 
 _Cross-session daily report (≤10 lines, rewritten each session via `/state`). Durable decisions live elsewhere, not here._
 
-- **Last session:** built the cross-session `state` mechanism (skill + STATE.md + Stop-hook nudge + `@STATE.md` read-loop) and filed tracking issue #317; branch `feat/state-mechanism`, committed, not pushed/PR'd.
-- **Next up:** push + open PR for `feat/state-mechanism` (Closes #317); other open issues: #309 (pyright ratchet), #271 (`ExecutionKind` refinement).
+- **Last session:** built the cross-session `state` mechanism (skill + STATE.md + Stop-hook nudge + `@STATE.md` read-loop), filed #317, opened PR #318 (CI green).
+- **Next up:** review + merge PR #318 (Closes #317); then open issues #309 (pyright ratchet), #271 (`ExecutionKind` refinement).
 
 _Updated: 2026-06-28_


### PR DESCRIPTION
Closes #317

## What

A lightweight, **self-contained** cross-session feedback loop so development experience compounds instead of re-discovering project status every session.

- **`STATE.md`** (repo root): a ≤10-line daily report — current milestone/phase, last session's work, pitfalls worth reusing, recommended next issues/tasks. Overwritten each session, **never appended**. **Lazily created** (`@STATE.md if exists`).
- **`state` skill** (`.agents/skills/state/SKILL.md`): rewrites STATE.md at session wrap-up; invocable as `/state`.
- **`Stop`-hook nudge** (`.claude/settings.json`): an **independent** group prompting `/state` (reconcile's reminder is left untouched). `Stop` fires for the **main agent only**, so parallel subagents never double-write.
- **Read loop**: `AGENTS.md` auto-loads `@STATE.md if exists` at session start.

## Architecture principles

- **Project-independent & orthogonal** — the skill depends on no particular tooling (VCS, the issue/task tracker's form, design docs); it assumes such tools *may* exist but never references a specific one, and works without any.
- **Distinct from durable docs** — STATE.md is transient; decisions/architecture/glossary live elsewhere (no ADR, no glossary entry).
- **Omit rather than mislead (宁缺毋滥)** — every field is optional; write a line only when accurate *and* useful to the next session.
- **Macro phase only if current** — never carry a stale phase forward.
- **Pitfalls only when they serve "Next up"** — record experience only when this session's work is continuous with / related to the recommended next work.

## Verification

- `jq` confirms `settings.json` is valid JSON; both `Stop` groups emit valid `systemMessage`s; reconcile's wording is byte-identical to `main` (feature only *adds* the state hook).
- `state` skill discoverable via the `.claude/skills` symlink; invocable as `/state`.
- Dogfooded `/state` end-to-end (it caught + fixed a brittle tracker query during development); STATE.md stays ≤10 lines, overwrite-not-append.
- Docs/skill/config only — no Python/`src` or test changes, so no `pyright`/`ruff`/e2e impact.