### PR TITLE
chore(state): treat STATE.md as a local working aid (gitignore, untrack)

### DIFF
--- a/.agents/skills/state/SKILL.md
+++ b/.agents/skills/state/SKILL.md
@@ -51,8 +51,8 @@ unchanged — at most refresh the date. Don't churn the file with non-progress.
    the next task is noise, not a war-story archive.
 5. **Rewrite `STATE.md`** from the template — **overwrite, never append**; ≤10 lines; terse; drop
    any field you have nothing accurate and useful for. Stamp the date.
-6. **Do not auto-commit.** Leave `STATE.md` in the working tree for the session's normal commit (or
-   commit it on its own). The session author decides when to commit.
+6. **Do not auto-commit.** Just leave the rewritten `STATE.md` in the working tree. Whether it is
+   tracked or kept as a local-only working aid is the project's choice — this skill never commits it.
 
 ## Template
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+# Local working aids — per-checkout, not shared via git
 RULES.md
+STATE.md
 
 # Python
 __pycache__/

--- a/STATE.md
+++ b/STATE.md
@@ -1,8 +1,0 @@
-# STATE — godot-agent
-
-_Cross-session daily report (≤10 lines, rewritten each session via `/state`). Durable decisions live elsewhere, not here._
-
-- **Last session:** added the cross-session `state` mechanism — `state` skill + `STATE.md` + Stop-hook nudge + `@STATE.md` read-loop (#317).
-- **Next up:** #309 (pyright strictness ratchet), #271 (`ExecutionKind`: stop pure-local/recipe commands advertising `kind=headless`).
-
-_Updated: 2026-06-28_


### PR DESCRIPTION
Follow-up to #318. Reclassifies the **`STATE.md` instance** from tracked to a local, per-checkout working aid. The **mechanism stays committed** (the `state` skill, the `Stop`-hook nudge, and the `@STATE.md` read-loop in `AGENTS.md`).

## Why

`STATE.md` is a transient per-session **daily report**. Committing it to `main` mixes a session-scoped handoff note into durable history:

- **Stale-on-merge** — already observed in #318 review: a "Next up: review + merge PR #318" line is wrong on `main` the instant it lands.
- **History noise** — every session produces a "refresh STATE.md" commit (e.g. `bade207`).
- It is a dev aid, not a shipped artifact — same nature as `RULES.md`, which is gitignored.

## What

- `.gitignore`: add `STATE.md` (grouped with `RULES.md` as a local working aid).
- `git rm --cached STATE.md` — untrack it; the local file is kept and keeps working.
- `state` skill: step 6 reworded so it never assumes the file is committed (tracked vs local is the adopting project's choice).

No change needed to the read-loop — `AGENTS.md` already uses `@STATE.md if exists`, and the skill already creates `STATE.md` lazily and never commits it.

## Tradeoff (accepted)

`STATE.md` becomes per-checkout/local and no longer propagates to other clones — which matches the daily-report framing (continuity for the next session on a working checkout, not a shared deliverable). A fresh clone's first session recreates it lazily.