### PR TITLE
docs(i18n): add zh-CN/es/ja READMEs with a strict sync gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Read @RULES.md if exists, to align communication style, collaboration specification, as well as other matters.
 
-Read @CONTEXT.md to align with the project's nature and shared language; consult `docs/adr/` for the architecture and the decisions behind it. README.md is human-facing onboarding (install, usage, contributing) and has grown large — read specific sections on demand (e.g. its "Project status" section for current state) rather than the whole file. README.md is the authoritative source; its translations live under `docs/README.<lang>.md` and are gated by `tests/test_readme_i18n_sync.py`. When you edit README.md, re-translate the affected sections and run `uv run python scripts/update_readme_i18n.py` to re-stamp the freshness markers.
+Read @CONTEXT.md to align with the project's nature and shared language; consult `docs/adr/` for the architecture and the decisions behind it. README.md is human-facing onboarding (install, usage, contributing) and has grown large — read specific sections on demand (e.g. its "Project status" section for current state) rather than the whole file.
 
 Read @STATE.md if exists for the latest session state — a lightweight cross-session daily report (≤10 lines): current milestone/phase, what the last session did, pitfalls worth reusing, and recommended next issues/tasks. Treat it as read-only startup context. Only the **primary worker** updates it, at session end, via the `state` skill; parallel sub-agents and sub-tasks must not write it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Read @RULES.md if exists, to align communication style, collaboration specification, as well as other matters.
 
-Read @CONTEXT.md to align with the project's nature and shared language; consult `docs/adr/` for the architecture and the decisions behind it. README.md is human-facing onboarding (install, usage, contributing) and has grown large — read specific sections on demand (e.g. its "Project status" section for current state) rather than the whole file.
+Read @CONTEXT.md to align with the project's nature and shared language; consult `docs/adr/` for the architecture and the decisions behind it. README.md is human-facing onboarding (install, usage, contributing) and has grown large — read specific sections on demand (e.g. its "Project status" section for current state) rather than the whole file. README.md is the authoritative source; its translations live under `docs/README.<lang>.md` and are gated by `tests/test_readme_i18n_sync.py`. When you edit README.md, re-translate the affected sections and run `uv run python scripts/update_readme_i18n.py` to re-stamp the freshness markers.
 
 Read @STATE.md if exists for the latest session state — a lightweight cross-session daily report (≤10 lines): current milestone/phase, what the last session did, pitfalls worth reusing, and recommended next issues/tasks. Treat it as read-only startup context. Only the **primary worker** updates it, at session end, via the `state` skill; parallel sub-agents and sub-tasks must not write it.
 

--- a/README.md
+++ b/README.md
@@ -657,14 +657,6 @@ Python code is linted and formatted with [ruff](https://docs.astral.sh/ruff/) an
 with [pyright](https://microsoft.github.io/pyright/), both enforced in CI — run
 `uv run ruff format .` and `uv run pyright` before committing (see **Development** above).
 
-This README is the authoritative source; translations live under `docs/README.<lang>.md`
-([简体中文](docs/README.zh-CN.md), [Español](docs/README.es.md), [日本語](docs/README.ja.md)).
-A sync gate (`tests/test_readme_i18n_sync.py`, run in CI) fails when this file changes
-without the translations being refreshed. If you edit this README, re-translate the
-affected sections, then run `uv run python scripts/update_readme_i18n.py` to re-stamp each
-translation's freshness marker. The gate proves a translation was *reviewed against* the
-current English — not that it is accurate, which only a human reviewer can judge.
-
 > **Working with an AI coding agent?** This project is built to be agent-navigable —
 > [`AGENTS.md`](AGENTS.md) is the entry point for coding agents, wiring in the project's
 > rules, domain docs, and skills.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![godot-agent title image](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)
 
+**Read this in:** [简体中文](docs/README.zh-CN.md) · [Español](docs/README.es.md) · [日本語](docs/README.ja.md)
+
 > **`gda` gives your AI coding agent — or your shell scripts and CI — structured, machine-readable
 > control of the [Godot Engine](https://godotengine.org).** Create scenes, edit nodes & scripts,
 > and export builds headlessly, then drive a *running* game live: runtime tree, input,
@@ -654,6 +656,14 @@ Commits follow the [Conventional Commits](https://www.conventionalcommits.org/) 
 Python code is linted and formatted with [ruff](https://docs.astral.sh/ruff/) and type-checked
 with [pyright](https://microsoft.github.io/pyright/), both enforced in CI — run
 `uv run ruff format .` and `uv run pyright` before committing (see **Development** above).
+
+This README is the authoritative source; translations live under `docs/README.<lang>.md`
+([简体中文](docs/README.zh-CN.md), [Español](docs/README.es.md), [日本語](docs/README.ja.md)).
+A sync gate (`tests/test_readme_i18n_sync.py`, run in CI) fails when this file changes
+without the translations being refreshed. If you edit this README, re-translate the
+affected sections, then run `uv run python scripts/update_readme_i18n.py` to re-stamp each
+translation's freshness marker. The gate proves a translation was *reviewed against* the
+current English — not that it is accurate, which only a human reviewer can judge.
 
 > **Working with an AI coding agent?** This project is built to be agent-navigable —
 > [`AGENTS.md`](AGENTS.md) is the entry point for coding agents, wiring in the project's

--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ result it can act on — never engine logs it has to scrape. It runs in **two mo
 
 ---
 
+## Contents
+
+- [Why `gda`?](#why-gda)
+- [Capabilities at a glance](#capabilities-at-a-glance)
+- [Installation](#installation)
+- [Quick start](#quick-start)
+- [Choose your integration](#choose-your-integration)
+- [How it works](#how-it-works)
+- [Command reference](#command-reference)
+- [Configuration](#configuration)
+- [Contributing](#contributing)
+- [License](#license)
+
+---
+
 ## Why `gda`?
 
 - **🤖 Structured output, built for agents.** Every command emits **exactly one** JSON

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=6fb0da04e0265ed7c55f7bceeee9088a764838c27f9b5bf0121339bfb0bb244e -->
+<!-- gda-readme-i18n: source=README.md sha256=6636b90927355b348b5c9501140f1e09f0fba731175e0ff8e4afc8eeb349c6ba -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -660,14 +660,6 @@ Los commits siguen la especificación [Conventional Commits](https://www.convent
 El código Python se lintea y formatea con [ruff](https://docs.astral.sh/ruff/) y se comprueban sus tipos
 con [pyright](https://microsoft.github.io/pyright/), ambos aplicados en CI — ejecuta
 `uv run ruff format .` y `uv run pyright` antes de hacer commit (consulta **Desarrollo** arriba).
-
-Este README es la fuente autoritativa; las traducciones viven en `docs/README.<lang>.md`
-([简体中文](README.zh-CN.md), [Español](README.es.md), [日本語](README.ja.md)).
-Una puerta de sincronización (`tests/test_readme_i18n_sync.py`, ejecutada en CI) falla cuando este archivo cambia
-sin que se actualicen las traducciones. Si editas este README, vuelve a traducir las
-secciones afectadas y luego ejecuta `uv run python scripts/update_readme_i18n.py` para volver a sellar el
-marcador de frescura de cada traducción. La puerta demuestra que una traducción fue *revisada contra* el
-inglés actual — no que sea precisa, lo cual solo un revisor humano puede juzgar.
 
 > **¿Trabajas con un agente de programación con IA?** Este proyecto está construido para ser navegable por agentes —
 > [`AGENTS.md`](../AGENTS.md) es el punto de entrada para los agentes de programación, integrando las reglas del

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,0 +1,678 @@
+<!-- gda-readme-i18n: source=README.md sha256=6fb0da04e0265ed7c55f7bceeee9088a764838c27f9b5bf0121339bfb0bb244e -->
+
+# godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
+
+![godot-agent title image](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)
+
+**Otros idiomas:** [English](../README.md) · [简体中文](README.zh-CN.md) · **Español** · [日本語](README.ja.md)
+
+> **`gda` da a tu agente de programación con IA — o a tus scripts de shell y a tu CI — control
+> estructurado y legible por máquina del [Godot Engine](https://godotengine.org).** Crea escenas, edita nodos y scripts,
+> y exporta builds en modo headless; luego controla un juego *en ejecución* en vivo: árbol de runtime, entrada,
+> capturas de pantalla, rendimiento — una sola superficie de comandos, tres formas de entrar.
+
+[![pre-1.0](https://img.shields.io/badge/status-pre--1.0-orange)](https://pypi.org/project/gda/)
+[![CI](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
+[![Python](https://img.shields.io/badge/python-3.13%2B-blue)](https://www.python.org/)
+[![Godot](https://img.shields.io/badge/godot-4.4%2B%20(live%204.6%2B)-478CBF)](https://godotengine.org)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%C2%B7%20Linux%20%C2%B7%20Windows-lightgrey)](#how-it-works)
+[![MCP](https://img.shields.io/badge/MCP-server-000)](https://modelcontextprotocol.io)
+[![License](https://img.shields.io/badge/license-MIT-green)](../LICENSE)
+
+Los agentes de IA son excelentes escribiendo GDScript y pésimos *viendo qué pasó*. `gda`
+cierra ese ciclo: tu agente emite una operación y recibe a cambio un único resultado JSON
+limpio sobre el que actuar — nunca registros del motor que tenga que rascar. Funciona en **dos modos**:
+
+- **Headless** — de una sola pasada y sin estado, sin configuración. Sin plugin de editor, sin daemon,
+  nada que instalar en tu proyecto. Crea y edita escenas, nodos, scripts, recursos,
+  shaders y temas; analiza el proyecto; exporta builds.
+- **Live** — controla un juego *en ejecución* a través de un daemon en segundo plano para todo lo que solo
+  un motor en vivo puede hacer: leer el árbol de escena de runtime, leer/escribir propiedades de runtime, simular
+  entrada, capturar pantallas y muestrear el rendimiento.
+
+> `gda` está en **pre-1.0**: hoy cada comando funciona de extremo a extremo, pero la superficie de la CLI
+> todavía puede cambiar antes de 1.0.
+
+---
+
+## ¿Por qué `gda`?
+
+- **🤖 Salida estructurada, pensada para agentes.** Cada comando emite **exactamente un** objeto JSON
+  en stdout (`--json`); los banners del motor, las advertencias y `print()` van a stderr. Tu
+  agente analiza un único resultado, no un muro de registros.
+- **📐 Tipado y autodescriptivo.** La entrada y la salida de cada comando son modelos tipados que
+  además respaldan un `--schema` legible por máquina (un contrato JSON-Schema), de modo que un agente puede
+  descubrir y validar toda la superficie de forma programática en lugar de adivinar.
+- **🔀 CLI, Skill y MCP — la elección de tu agente.** Controla Godot desde una terminal o tu CI con la
+  CLI `gda` directa, entrega a tu agente una **Skill** incluida (`gda skill`) que le enseña cómo y cuándo
+  usar la CLI, o expón las mismas operaciones como herramientas **MCP** (`gda-mcp`, generadas a partir de
+  los propios esquemas de la CLI). Una sola superficie de comandos, tres formas de entrar — elige la que tu agente admita.
+- **🧩 Comandos nativos de Godot.** Agrupados por objeto de Godot (`gda scene create`,
+  `gda node add`, `gda game set`) con un vocabulario de verbos minúsculo y consistente — curva de aprendizaje
+  nula si ya conoces Godot.
+- **⚡ Headless por defecto, en vivo cuando lo necesites.** Las operaciones headless no requieren daemon
+  ni editor — solo un binario de Godot. Las operaciones live añaden control en tiempo real de un juego
+  en ejecución a través de un daemon sobre socket de dominio Unix, direccionadas con la misma gramática de la CLI.
+- **🛡️ Falla de forma ruidosa, nunca en silencio.** Un motor ausente o colgado queda acotado por un timeout
+  y se mapea a un **código de salida no nulo estable** más un sobre estructurado `{"error": {…}}`
+  — de modo que un shell o un agente puede bifurcar según la categoría del fallo sin analizar prosa.
+
+---
+
+## Capacidades de un vistazo
+
+| Lo que necesitas | Usa |
+| --- | --- |
+| Construir archivos del proyecto desde un agente o script | `scene` / `node` / `script` / `resource` / `shader` / `theme` — crear y editar en modo headless |
+| Analizar resultados en lugar de rascar registros del motor | `--json` (un objeto limpio) y `--schema` (un contrato JSON-Schema) |
+| Entregar a un agente herramientas de Godot | la **Skill** incluida (`gda skill`) o el servidor **`gda-mcp`** |
+| Automatizar CI, exportaciones y análisis del proyecto | comandos headless — sin editor, sin plugin, solo un binario de Godot |
+| Depurar el comportamiento en runtime de un juego *en ejecución* | `gda daemon start`, luego `game` / `diag` / `logger` / `perf` / `input` / `screen` |
+
+---
+
+## Instalación
+
+**Requisitos:** Python 3.13+ y un binario de [Godot](https://godotengine.org) — 4.4+ para
+los comandos headless, 4.6+ en macOS/Linux para los comandos live (daemon).
+
+Instala la CLI desde PyPI en tu `PATH`:
+
+```bash
+uv tool install gda      # or: pipx install gda
+gda --help
+```
+
+<details>
+<summary>Otras formas de instalar (pip, desde el código fuente)</summary>
+
+En un entorno existente:
+
+```bash
+pip install gda
+```
+
+Desde el código fuente (para desarrollo o cambios no publicados):
+
+```bash
+git clone https://github.com/aigengame/godot-agent.git
+cd godot-agent
+uv sync                  # create the environment + install dependencies
+uv run gda --help
+```
+</details>
+
+---
+
+## Inicio rápido
+
+**Apunta `gda` a tu binario de Godot** y luego pregúntale al motor su versión — sin necesidad de proyecto:
+
+```bash
+export GDA_GODOT="/path/to/Godot"   # or pass --godot to any command
+gda info --json
+# {"major":4,"minor":6,"patch":3,"status":"stable","string":"4.6.3-stable (official)",…}
+```
+
+stdout siempre es JSON limpio que puedes canalizar; todos los diagnósticos del motor y de los scripts van a stderr:
+
+```bash
+gda info --json | jq .major   # → 4
+```
+
+**Construye una escena en modo headless.** Apunta `gda` a un proyecto de Godot (un directorio con `project.godot`)
+una vez; las rutas relativas se resuelven entonces *dentro* de él, y los nodos se direccionan por su ruta relativa
+a la raíz de la escena:
+
+```bash
+export GDA_PROJECT="/path/to/your/godot-project"   # or pass --project to any command
+gda scene create scenes/main.tscn --root-type Node2D --json
+gda node add  scenes/main.tscn --type Sprite2D --name Hero --json
+gda node set  scenes/main.tscn --node Hero --property position --value 10,20 --json
+gda scene get scenes/main.tscn --json
+# {"path":"scenes/main.tscn","root":{"name":"main","type":"Node2D","children":[{"name":"Hero",…}]}}
+```
+
+> ¿Sin proyecto? `gda` igualmente se ejecuta **sin proyecto** (projectless) sobre rutas simples del sistema de
+> archivos (relativas a tu directorio actual) — solo la resolución de `res://` necesita un proyecto. Consulta [Configuración](#configuration).
+
+**Controla un juego *en ejecución* en vivo.** Las operaciones live ejecutan la **escena principal** del proyecto, así que
+apúntala a la que acabas de construir mediante el ajuste de proyecto `application/run/main_scene` de Godot (el
+*Application → Run → Main Scene* del editor), y luego arranca el daemon (macOS/Linux, Godot 4.6+):
+
+```bash
+gda project set application/run/main_scene --value res://scenes/main.tscn --json  # a Godot project setting key
+gda daemon start             # start the daemon for $GDA_PROJECT (installs the in-game harness)
+gda game tree --json         # the runtime scene tree, after _ready
+gda perf monitors --json     # live engine counters: fps, memory, node count
+gda daemon stop
+```
+
+(`gda screen capture` también funciona en vivo, pero necesita una sesión con ventana — arranca el daemon
+con `gda daemon start --windowed`.)
+
+---
+
+## Elige tu integración
+
+`gda` expone la **misma superficie de comandos** de tres formas — elige la que tu agente (o tú) admita:
+
+| Punto de entrada | Ideal para | Cómo |
+| --- | --- | --- |
+| **CLI** (`gda`) | humanos, scripts de shell, CI y agentes que pueden ejecutar comandos | `gda <group> <command> --json` |
+| **Skill** (`gda skill`) | agentes de programación que admiten Agent Skills y prefieren un flujo de CLI ligero en tokens | imprimir/instalar `SKILL.md` (abajo) |
+| **MCP** (`gda-mcp`) | agentes que invocan herramientas mediante el Model Context Protocol | ejecutar el servidor stdio (abajo) |
+
+### Úsalo como Skill
+
+`gda` incluye una **Skill** para agentes — un `SKILL.md` que enseña a un agente de IA *cómo y cuándo* manejar
+Godot desde la CLI. Es la forma más ligera de entrar (no hay servidor que registrar), viene incluida en el paquete y
+queda fijada a la versión de tu instalación. Imprímela, o instálala en el directorio de skills de tu agente:
+
+```bash
+gda skill                                              # print SKILL.md (redirect it anywhere)
+gda skill --install --provider claude --scope user     # resolve a known agent's skills dir
+gda skill --install --dir ~/.claude/skills/gda         # …or give the directory yourself
+```
+
+`--install --provider <claude|codex> --scope <project|user>` resuelve el directorio de skills de un agente
+conocido (`--scope` es `user` por defecto); `--dir` es la alternativa neutral para cualquier otro agente —
+no hay valor predeterminado integrado. Las [recetas de skills](gda-skill.md) listan el directorio de cada agente
+(el `~/.claude/skills/` de Claude Code, el `~/.agents/skills/` de Codex, …). O bien obtén el mismo archivo directamente
+del repositorio, si prefieres no pasar por `gda skill` — aun así instalas `gda`, ya que la Skill
+lo maneja:
+
+```bash
+curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \
+  https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md
+```
+
+### Úsalo como servidor MCP
+
+`gda` incluye un servidor [MCP](https://modelcontextprotocol.io) por stdio detrás de un extra `[mcp]`,
+de modo que cualquier agente MCP (Claude Code, Codex, Cursor, …) puede manejar Godot. Pruébalo sin instalar nada:
+
+```bash
+uvx --from "gda[mcp]" gda-mcp
+```
+
+El servidor resuelve dos piezas de contexto — qué **proyecto** de Godot manejar y qué **binario** de Godot
+ejecutar (MCP no puede pasar flags por llamada):
+
+- **Proyecto** — define `GDA_PROJECT` cuando tu cliente no pueda anunciar **roots** de workspace; de lo contrario,
+  `gda-mcp` detecta automáticamente el proyecto a partir de los roots que envía el cliente (la carpeta que tienes abierta). Un
+  `GDA_PROJECT` *definido pero inválido* es un error reportado, no una alternativa silenciosa. Consulta
+  [Configuración](#configuration) para conocer el orden completo de resolución CLI vs MCP.
+- **Motor** — define `GDA_GODOT` con tu binario de Godot, p. ej. `"GDA_GODOT": "/path/to/Godot"`.
+
+
+#### Registrar con agentes de programación
+
+<details>
+<summary>Claude Code</summary>
+
+Ámbito de proyecto, `.mcp.json` en la raíz del repositorio (detecta automáticamente el proyecto vía `roots`):
+
+```json
+{
+  "mcpServers": {
+    "gda-mcp": {
+      "command": "uvx",
+      "args": ["--from", "gda[mcp]", "gda-mcp"]
+    }
+  }
+}
+```
+
+Ámbito de usuario (todos los proyectos) — la CLI, que escribe `~/.claude.json`:
+
+```bash
+claude mcp add --scope user gda-mcp -- uvx --from "gda[mcp]" gda-mcp
+```
+
+</details>
+
+<details>
+<summary>Codex</summary>
+
+Ámbito de proyecto, `.codex/config.toml` en la raíz del repositorio (el proyecto debe ser de confianza):
+
+```toml
+[mcp_servers.gda-mcp]
+command = "uvx"
+args = ["--from", "gda[mcp]", "gda-mcp"]
+
+[mcp_servers.gda-mcp.env]
+GDA_PROJECT = "/absolute/path/to/your/godot/project"
+```
+
+Ámbito de usuario (disponible en todas partes, pero fijado a un solo proyecto) — la misma tabla en
+`~/.codex/config.toml`, o añádela con la CLI. Codex no tiene variable de workspace, así que
+`GDA_PROJECT` es una ruta absoluta; usa el ámbito de proyecto si trabajas en varios proyectos:
+
+```bash
+codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- \
+  uvx --from "gda[mcp]" gda-mcp
+```
+
+</details>
+
+<details>
+<summary>Cursor</summary>
+
+Ámbito de proyecto, `.cursor/mcp.json` en la raíz del repositorio (`${workspaceFolder}`
+sigue al proyecto abierto):
+
+```json
+{
+  "mcpServers": {
+    "gda-mcp": {
+      "type": "stdio",
+      "command": "/path/to/uvx",
+      "args": ["--from", "gda[mcp]", "gda-mcp"],
+      "env": {
+        "GDA_PROJECT": "${workspaceFolder}"
+      }
+    }
+  }
+}
+```
+
+Ámbito de usuario (disponible en todas partes, pero fijado a un solo proyecto) — la misma configuración en
+`~/.cursor/mcp.json` con `GDA_PROJECT` definido como una ruta absoluta (`${workspaceFolder}` solo
+funciona en el ámbito de proyecto; usa el ámbito de proyecto para varios proyectos). Cursor no tiene comando `mcp add`
+— regístralo mediante el JSON de arriba o la interfaz Settings → MCP.
+
+> Cursor se lanza desde la GUI con un `PATH` mínimo, así que un `uvx` a secas puede no resolverse — de ahí el
+> `command` absoluto de arriba; rellénalo con la salida de `which uvx`. Las recetas completas — inyección de PATH,
+> Claude Desktop, ámbito de usuario vs proyecto, fijación de proyecto por agente — están en las
+> [recetas de registro](gda-mcp-registration.md).
+</details>
+
+---
+
+<a id="how-it-works"></a>
+## Cómo funciona
+
+`gda` son tres componentes que sirven operaciones en dos modos:
+
+| Componente       | Rol                                                                   |
+| ---------------- | --------------------------------------------------------------------- |
+| **`gda`**        | La CLI orientada a agentes — expone Godot con salida estructurada `--json`. |
+| **`gda-mcp`**    | Un servidor MCP que expone las mismas operaciones como herramientas, a partir de `--schema`. |
+| **`gda-daemon`** | Un proceso por proyecto que supervisa un juego en ejecución para las operaciones live. |
+
+- **Las operaciones headless** se ejecutan de una sola pasada — sin daemon, nada que instalar (crear una escena, editar
+  un script, exportar, analizar).
+- **Las operaciones live** requieren un juego en ejecución — `gda-daemon` lo lanza, inyecta un harness inerte
+  dentro del juego e intermedia las peticiones a través de un socket de dominio Unix (árbol de runtime, entrada,
+  capturas de pantalla, rendimiento, diagnósticos).
+
+El harness dentro del juego que `gda-daemon` inyecta es **solo para desarrollo**: `gda export run` lo elimina por
+completo del artefacto y, si se compila de cualquier otra forma (GUI del editor, `godot --export` directo), igualmente
+se autodeshabilita en el juego exportado — de modo que un juego publicado nunca *ejecuta* nada relacionado con el daemon
+(y a través de `gda export run`, ni siquiera lo lleva).
+
+**Soporte de plataformas y versiones:**
+
+| Modo | Godot | Plataformas |
+| ---- | ----- | --------- |
+| **Headless** | 4.4+ | macOS · Linux · Windows¹ |
+| **Live** (vía `gda-daemon`) | 4.6+ | macOS · Linux² |
+
+¹ Headless es multiplataforma por diseño (procesos de una sola pasada, sin dependencias específicas de
+  plataforma) — Windows conserva toda la superficie headless, aunque la CI todavía no la ejercita.
+² Las operaciones live usan sockets de dominio Unix, por lo que Windows todavía no es compatible.
+
+---
+
+## Referencia de comandos
+
+Los comandos de `gda` están **agrupados por objeto de dominio de Godot** y usan un vocabulario de verbos pequeño
+y consistente, de modo que el mismo verbo significa lo mismo en cada grupo:
+
+| Verbo               | Significado                                                       |
+| ------------------- | ----------------------------------------------------------------- |
+| `create` / `delete` | Crear / eliminar una entidad **independiente** (escena, script, recurso).  |
+| `add` / `remove`    | Añadir / quitar una **subentidad** dentro de un contenedor (nodo → escena).  |
+| `get` / `list`      | Leer una entidad / enumerar muchas.                               |
+| `set`               | Mutar una propiedad.                                              |
+| verbos de dominio   | `play`, `run`, `export`, `import`, … conservan su significado natural. |
+
+Cada comando admite `--json` y `--schema` — excepto el propio `gda schema`, que emite
+el manifiesto agregado como JSON directamente. Los comandos que leen o mutan una ruta `res://`
+resuelven un [contexto de proyecto](#configuration). Ejecuta `gda <group> <command> --help` para ver todos los
+flags — `gda --help` es la lista autoritativa de lo que está instalado.
+
+**¿Nuevo por aquí?** Un buen primer recorrido: `gda info` → `gda scene create` → `gda node add` →
+`gda script validate` → `gda export run`; luego pasa a vivo con `gda daemon start` → `gda game tree`.
+
+**Meta** — sobre `gda` / el propio motor
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `gda info`   | Informa la información de versión del motor Godot. |
+| `gda schema` | Emite toda la superficie de comandos como un único manifiesto JSON legible por máquina. |
+| `gda skill`  | Emite o instala la Agent Skill incluida (`SKILL.md`) que enseña a un agente cómo manejar `gda`. |
+
+### Comandos headless — Godot 4.4+, todas las plataformas
+
+**`scene`** — archivos de escena (`.tscn`)
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `scene create` | Crea un nuevo `.tscn` con el tipo de nodo raíz indicado. |
+| `scene get` | Lee una escena e informa su árbol de nodos estructurado. |
+| `scene list` | Enumera las escenas `.tscn` del proyecto resuelto. |
+| `scene get-exports` | Lista las propiedades `@export` que declaran los scripts de los nodos de una escena. |
+| `scene delete` | Elimina un archivo de escena e informa qué se eliminó. |
+
+**`node`** — nodos dentro de un archivo de escena
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `node add` | Añade un nodo bajo un padre (tipo integrado o script con `class_name`). |
+| `node get` | Lee las propiedades de un nodo (por ruta de nodo) como JSON tipado. |
+| `node list` | Lista el árbol de nodos de una escena con la ruta de cada nodo relativa a la raíz. |
+| `node set` | Define una propiedad de nodo, forzando el valor a su tipo de Godot declarado. |
+| `node remove` | Elimina un nodo (y su subárbol) por ruta de nodo. |
+| `node duplicate` | Duplica un nodo (y su subárbol) bajo su padre. |
+| `node move` | Reasigna un nodo (y su subárbol) a un nuevo padre. |
+| `node connect-signal` | Conecta la señal de un nodo origen al método de un nodo destino. |
+| `node disconnect-signal` | Desconecta una conexión señal→método existente. |
+
+**`script`** — archivos GDScript (`.gd`)
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `script create` | Crea un nuevo script `.gd` a partir de una plantilla o de `--content` literal. |
+| `script get` | Lee el código fuente de un script más sus metadatos `class_name` / `extends`. |
+| `script list` | Enumera los scripts `.gd` del proyecto resuelto. |
+| `script set` | Edita un script mediante buscar-reemplazar, rango de líneas o sobrescritura completa. |
+| `script delete` | Elimina un archivo de script e informa qué se eliminó. |
+| `script attach` | Adjunta un script `.gd` a un nodo (por ruta de nodo) en una escena. |
+| `script validate` | Comprueba la sintaxis/compilación de un script `.gd`. |
+
+**`project`** — el proyecto en su conjunto (ajustes, autoloads, análisis estático)
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `project info` | Informa los metadatos del proyecto (nombre, escena principal, viewport, versión del motor). |
+| `project get` | Lee un único ajuste del proyecto por sección/clave como JSON tipado. |
+| `project list` | Lista las claves de ajustes del proyecto (las personalizadas por defecto; `--all` añade los valores predeterminados del motor, `--section` filtra por prefijo). |
+| `project set` | Define un ajuste del proyecto, forzando el valor a su tipo declarado. |
+| `project add-autoload` | Registra un singleton autoload (nombre → script/escena). |
+| `project remove-autoload` | Cancela el registro de un singleton autoload por nombre. |
+| `project find-references` | Encuentra todos los archivos del proyecto que referencian un recurso dado. |
+| `project dependencies` | Mapea cada escena/recurso a los recursos de los que depende. |
+| `project find-unused-resources` | Encuentra archivos de recurso que nada referencia. |
+| `project statistics` | Informa los recuentos de archivos/líneas del proyecto, los autoloads y más. |
+
+**`resource`** — archivos de recurso (`.tres`)
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `resource create` | Crea un nuevo recurso `.tres` del tipo indicado. |
+| `resource get` | Lee las propiedades de un recurso `.tres` como JSON tipado. |
+| `resource set` | Define una propiedad `.tres`, forzando el valor a su tipo declarado. |
+| `resource delete` | Elimina un archivo de recurso `.tres` e informa qué se eliminó. |
+| `resource uid` | Resuelve un UID de recurso ↔ su ruta `res://` en ambas direcciones. |
+
+**`export`** — presets de exportación y artefactos
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `export list` | Enumera los presets de exportación del proyecto (nombre, plataforma, …). |
+| `export get` | Informa los detalles de un preset más el estado de instalación de la plantilla de exportación. |
+| `export run` | Exporta un preset con nombre (`release` / `debug` / `pack`) a un destino. |
+
+**`shader`** — archivos de shader (`.gdshader`)
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `shader create` | Crea un nuevo `.gdshader` a partir de una plantilla o de `--content` literal. |
+| `shader get` | Lee el código fuente de un shader más su `shader_type`. |
+| `shader set` | Edita un `.gdshader` mediante buscar-reemplazar, rango de líneas o sobrescritura completa. |
+
+**`theme`** — recursos de tema (`.tres`)
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `theme create` | Crea un recurso Theme `.tres` nuevo y cargable (sin sobrescribir). |
+
+### Comandos live — vía `gda-daemon`; Godot 4.6+, macOS/Linux
+
+**`daemon`** — el ciclo de vida del runtime live
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `daemon start` | Arranca el daemon por proyecto e instala el harness dentro del juego; la sesión del motor se lanza en la primera operación live (`--windowed` para la captura de `screen`). |
+| `daemon stop` | Detiene el daemon del proyecto y cualquier sesión del motor en ejecución. |
+| `daemon status` | Informa el estado del daemon (en ejecución, modo con ventana, sesión). |
+| `daemon uninstall` | Elimina el harness `gda` dentro del juego (entrada de autoload + archivos) del proyecto — un desmontaje explícito de herramientas de desarrollo; `gda export run` ya lo elimina automáticamente de los artefactos exportados. |
+
+**`game`** — el grafo de escena en runtime del juego en ejecución
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `game tree` | Lee el árbol de escena en runtime del juego en ejecución (después de `_ready`). |
+| `game get` | Lee las propiedades en vivo de un nodo de runtime por ruta de nodo. |
+| `game set` | Define una propiedad de un nodo de runtime en el juego en ejecución. |
+
+**`diag`** — diagnósticos de runtime
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `diag errors` | Sigue (tail) los errores de runtime del juego en ejecución (categorizados). |
+
+**`logger`** — registro de runtime estructurado
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `logger tail` | Sigue (tail) todo el registro de runtime del juego en ejecución como registros estructurados (`--level`, `--limit`, `--raw`). |
+
+**`perf`** — monitorización de rendimiento
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `perf monitors` | Toma una instantánea de los contadores de rendimiento del motor (fps, memoria, nodos, …). |
+| `perf monitor` | Muestrea una propiedad o señal de nodo a lo largo de una ventana de frames (línea de tiempo). |
+
+**`input`** — simulación de entrada
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `input key` | Inyecta un evento de tecla (con modificadores). |
+| `input mouse-click` | Inyecta un clic de ratón en `(x, y)`. |
+| `input mouse-move` | Inyecta un movimiento de ratón hacia `(x, y)`. |
+| `input action` | Presiona/suelta una acción de entrada mapeada. |
+| `input sequence` | Inyecta una línea de tiempo de eventos de varios frames. |
+
+**`screen`** — captura del viewport
+
+| Comando | Qué hace |
+| ------- | ------------ |
+| `screen capture` | Captura un frame del viewport a un PNG. |
+| `screen frames` | Captura una secuencia PNG de N frames. |
+
+### Flags globales
+
+| Flag       | Descripción                                                        |
+| ---------- | ------------------------------------------------------------------- |
+| `--json`    | Emite el resultado como un único objeto JSON en stdout. Sin él, los comandos imprimen una representación concisa y legible para humanos. |
+| `--schema`  | Emite el contrato JSON Schema de entrada/salida del comando (sin lanzar Godot). |
+| `--godot`   | Ruta al binario de Godot (anula `$GDA_GODOT` y el valor por defecto). |
+| `--project` | Directorio del proyecto de Godot para la resolución de `res://` (anula `$GDA_PROJECT`; por defecto, el directorio actual si es un proyecto). Solo comandos de dominio. Resolver un proyecto ejecuta el código de ese proyecto — consulta [Ejecución del código del proyecto](#configuration). |
+| `--help`    | Muestra el uso de `gda` o de cualquier comando.                     |
+
+---
+
+<a id="configuration"></a>
+## Configuración
+
+`gda` encuentra el binario de Godot a partir del flag **`--godot <path>`**, o bien de la
+variable de entorno **`GDA_GODOT`** — define una de las dos para que `gda` pueda localizar tu motor.
+
+Los comandos de dominio resuelven un **proyecto de Godot** (para que las rutas `res://` y las referencias entre
+recursos de una escena se resuelvan de forma determinista) en este orden:
+
+1. El flag **`--project <dir>`**.
+2. La variable de entorno **`GDA_PROJECT`**.
+3. El **directorio actual**, cuando es un proyecto de Godot (contiene `project.godot`).
+
+Un directorio indicado debe ser un proyecto, o `gda` lo reporta como un error. Cuando ninguno resuelve,
+`gda` se ejecuta **sin proyecto** (projectless) — solo se resuelven rutas del sistema de archivos (absolutas o
+relativas al cwd), no `res://`. El **servidor MCP** no tiene flags, así que resuelve un proyecto de forma un poco distinta:
+
+| Contexto | Orden de resolución del proyecto |
+| --- | --- |
+| **CLI** | `--project` → `GDA_PROJECT` (ambos estrictos — lo inválido se reporta) → cwd si contiene `project.godot`, si no, sin proyecto |
+| **MCP** (`gda-mcp`) | `GDA_PROJECT` (estricto — definido pero inválido se reporta, no se omite) → un `root` de workspace del cliente *válido* → un cwd del servidor *válido*, si no, sin proyecto |
+
+<details>
+<summary>Ejecución del código del proyecto — qué se ejecuta cuando apuntas a un proyecto</summary>
+
+Resolver un proyecto para que las rutas `res://` funcionen ejecuta Godot contra ese proyecto, y Godot ejecuta
+parte del propio código del proyecto como parte de ello. En concreto:
+
+- **Los autoloads se ejecutan en cada operación `--project`.** Cuando se resuelve un proyecto, el motor
+  construye los singletons autoload del proyecto al arrancar — antes de que se ejecute el trabajo propio del comando
+  — de modo que su `_init` (y `_ready`) se ejecuta en **cada** operación, incluidas las de solo lectura
+  como `scene get` y `node list`. Sin un proyecto resuelto, no se registra ningún autoload, así que
+  no se ejecutan.
+- **Los comandos que instancian una escena ejecutan los constructores de los scripts adjuntos de esa escena.**
+  Un comando que necesita un árbol de nodos vivo — todo comando que muta (`node add`, `node set`,
+  `node remove`, …) y `node get` (que informa los valores predeterminados de propiedades en runtime que los datos
+  almacenados no llevan) — carga e instancia la escena, lo que construye cada nodo y ejecuta el
+  `_init` de cualquier script adjunto a un nodo en ella. Los comandos que solo leen los datos almacenados de la escena
+  (`scene get`, `scene list`, `node list`) la recorren sin instanciar, así que no
+  ejecutan esos scripts.
+
+`gda` trata el proyecto objetivo como de confianza, por lo que esto es intencionado — consulta
+[ADR-0009](adr/0009-trust-boundary-trusted-project.md) para el modelo de confianza.
+</details>
+
+---
+
+<details>
+<summary><strong>Bajo el capó</strong> — el contrato de salida estructurada y los códigos de salida</summary>
+
+Godot en modo headless intercala su banner, sus advertencias y la salida de `print()` en stdout. `gda`
+resuelve esto con un contrato de centinelas
+([ADR-0002](adr/0002-headless-structured-output-contract.md)):
+
+- El payload de GDScript emite **exactamente un** resultado, envuelto en centinelas únicos en stdout:
+
+  ```
+  <<<GDA:RESULT>>>{ …json… }<<<GDA:END>>>
+  ```
+
+- Enruta **todos** sus propios diagnósticos a stderr; stdout no transporta nada más que el contrato.
+- `gda` extrae y analiza solo los bytes entre los centinelas, ignorando el ruido del motor circundante,
+  y expone stderr para su inspección.
+
+Esto es lo que hace que la salida de `gda` sea segura de consumir de forma programática, y se generaliza al
+protocolo por mensaje que el daemon usa para las operaciones live.
+
+**Códigos de salida (la ABI de la CLI).** Una ejecución fallida de `gda` termina con un código pequeño y estable
+para que un shell o un agente pueda bifurcar según la **categoría del fallo sin analizar el error JSON**:
+
+| Código de salida | Categoría     | Cuándo                                                                |
+| --------- | ------------- | --------------------------------------------------------------------- |
+| `0`       | —             | Éxito.                                                               |
+| `127`     | `environment` | No se pudo lanzar el binario de Godot (convención de shell: no encontrado). |
+| `124`     | `environment` | Godot se lanzó pero no retornó antes del timeout del runner (convención de shell: tiempo agotado). |
+| `3`       | `version`     | La versión de Godot detectada está por debajo del mínimo soportado.   |
+| `4`       | `operation`   | El motor se ejecutó pero la operación falló — un error de operación registrado, una caída del motor o una salida no nula no estructurada. |
+| `5`       | `parse`       | El proceso declaró éxito pero violó el contrato de salida estructurada. |
+| `6`       | `live`        | Una operación live falló — p. ej. no hay daemon/sesión en ejecución, o un timeout live. |
+
+Estos valores son la ABI pública; su fuente autoritativa es
+[`src/gda/exit_codes.py`](../src/gda/exit_codes.py). El sobre `{"error": {category, code, …}}`
+lleva un **`code` más fino** dentro de cada categoría (p. ej. `path_not_found`,
+`already_exists`, `node_not_found` se ubican todos bajo `operation` / salida `4`). El registro
+completo vive en
+[la tabla `GdaError.code` de ADR-0002](adr/0002-headless-structured-output-contract.md#gdaerrorcode-registry).
+</details>
+
+<details>
+<summary><strong>Desarrollo</strong></summary>
+
+```bash
+uv sync                       # set up the environment
+
+uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
+uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
+uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
+
+uv run ruff check .           # lint
+uv run ruff format .          # auto-format (append --check to verify without writing)
+uv run pyright                # type-check (src/ + tests/, basic mode)
+```
+
+El nivel `e2e` se ejecuta por defecto con `uv run pytest` y **falla de forma ruidosa** — nombrando la
+ruta resuelta y cómo arreglarlo — si no se encuentra ahí ningún binario de Godot, en lugar de omitirse.
+Deselecciona todo el nivel con `-m "not e2e"` (el job por PR de la CI usa exactamente esto).
+
+El linting y el formateo los aplica [ruff](https://docs.astral.sh/ruff/) — una sola herramienta en
+lugar de flake8 + black + isort, configurada bajo `[tool.ruff]` en `pyproject.toml` y
+fijada vía `uv.lock` para que local y CI coincidan. El job `lint` de la CI ejecuta `ruff check .` y
+`ruff format --check .` en cada PR; ejecuta `uv run ruff format .` antes de hacer commit para mantenerte
+en verde.
+
+Los tipos los comprueba [pyright](https://microsoft.github.io/pyright/) en modo `basic`, cubriendo
+`src/` y `tests/` y configurado bajo `[tool.pyright]` en `pyproject.toml` (también fijado vía
+`uv.lock`). El job `type-check` de la CI ejecuta `uv run --frozen pyright` en cada PR.
+
+```
+src/gda/
+  cli.py            # CLI entrypoint (Typer): all command groups, --json / --schema
+  surface.py        # walks the live Typer tree → the `gda schema` manifest
+  headless.py       # the per-command descriptor (one HeadlessCommand per command)
+  binary.py         # Godot binary resolution (flag > $GDA_GODOT > default)
+  runner.py         # the one-shot headless spawn seam (Protocol + subprocess impl)
+  live_runner.py    # the live-operation client that talks to gda-daemon
+  models.py         # typed I/O models (Pydantic) backing --json and --schema
+  errors.py / error_codes.py / exit_codes.py   # failure classification + the CLI ABI
+  render.py         # human-readable (non-JSON) rendering
+  ops/operations.gd # the headless GDScript payload, dispatched by operation name
+  daemon/           # gda-daemon: server, session supervision, IPC protocol, discovery
+  harness/          # the inert in-game `gda` autoload injected into a live session
+  mcp/              # gda-mcp: the schema → MCP-tool server
+tests/              # unit + e2e tests against a real engine (shared fixtures in conftest.py)
+docs/adr/           # architecture decision records
+CONTEXT.md          # the project's shared domain language
+```
+
+`gda` tiene dos fronteras externas, cada una detrás de una costura (seam) por la que inyectan las pruebas
+rápidas: lanzar un proceso headless de una sola pasada (`runner.py`) y comunicarse con un juego en ejecución
+a través del daemon (`live_runner.py`). La suite e2e maneja un motor real a través de ambas.
+</details>
+
+---
+
+## Contribuir
+
+Las contribuciones son bienvenidas. Lee [`CONTEXT.md`](../CONTEXT.md) para alinearte con el lenguaje
+compartido del proyecto, y revisa los [ADRs](adr/) relevantes para el área que estás tocando.
+Las issues y los PRDs viven como [issues de GitHub](https://github.com/aigengame/godot-agent/issues).
+Los commits siguen la especificación [Conventional Commits](https://www.conventionalcommits.org/).
+El código Python se lintea y formatea con [ruff](https://docs.astral.sh/ruff/) y se comprueban sus tipos
+con [pyright](https://microsoft.github.io/pyright/), ambos aplicados en CI — ejecuta
+`uv run ruff format .` y `uv run pyright` antes de hacer commit (consulta **Desarrollo** arriba).
+
+Este README es la fuente autoritativa; las traducciones viven en `docs/README.<lang>.md`
+([简体中文](README.zh-CN.md), [Español](README.es.md), [日本語](README.ja.md)).
+Una puerta de sincronización (`tests/test_readme_i18n_sync.py`, ejecutada en CI) falla cuando este archivo cambia
+sin que se actualicen las traducciones. Si editas este README, vuelve a traducir las
+secciones afectadas y luego ejecuta `uv run python scripts/update_readme_i18n.py` para volver a sellar el
+marcador de frescura de cada traducción. La puerta demuestra que una traducción fue *revisada contra* el
+inglés actual — no que sea precisa, lo cual solo un revisor humano puede juzgar.
+
+> **¿Trabajas con un agente de programación con IA?** Este proyecto está construido para ser navegable por agentes —
+> [`AGENTS.md`](../AGENTS.md) es el punto de entrada para los agentes de programación, integrando las reglas del
+> proyecto, la documentación de dominio y las skills.
+
+## Licencia
+
+Publicado bajo la [Licencia MIT](../LICENSE). Copyright (c) 2026 aigengame.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=6636b90927355b348b5c9501140f1e09f0fba731175e0ff8e4afc8eeb349c6ba -->
+<!-- gda-readme-i18n: source=README.md sha256=4ef9cb754f81a9c5c4ff9b88782dd72a6577f3a6c5fea7170390d9c59b5972cd -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -35,6 +35,22 @@ limpio sobre el que actuar — nunca registros del motor que tenga que rascar. F
 
 ---
 
+## Índice
+
+- [¿Por qué `gda`?](#why-gda)
+- [Capacidades de un vistazo](#capabilities-at-a-glance)
+- [Instalación](#installation)
+- [Inicio rápido](#quick-start)
+- [Elige tu integración](#choose-your-integration)
+- [Cómo funciona](#how-it-works)
+- [Referencia de comandos](#command-reference)
+- [Configuración](#configuration)
+- [Contribuir](#contributing)
+- [Licencia](#license)
+
+---
+
+<a id="why-gda"></a>
 ## ¿Por qué `gda`?
 
 - **🤖 Salida estructurada, pensada para agentes.** Cada comando emite **exactamente un** objeto JSON
@@ -59,6 +75,7 @@ limpio sobre el que actuar — nunca registros del motor que tenga que rascar. F
 
 ---
 
+<a id="capabilities-at-a-glance"></a>
 ## Capacidades de un vistazo
 
 | Lo que necesitas | Usa |
@@ -71,6 +88,7 @@ limpio sobre el que actuar — nunca registros del motor que tenga que rascar. F
 
 ---
 
+<a id="installation"></a>
 ## Instalación
 
 **Requisitos:** Python 3.13+ y un binario de [Godot](https://godotengine.org) — 4.4+ para
@@ -104,6 +122,7 @@ uv run gda --help
 
 ---
 
+<a id="quick-start"></a>
 ## Inicio rápido
 
 **Apunta `gda` a tu binario de Godot** y luego pregúntale al motor su versión — sin necesidad de proyecto:
@@ -153,6 +172,7 @@ con `gda daemon start --windowed`.)
 
 ---
 
+<a id="choose-your-integration"></a>
 ## Elige tu integración
 
 `gda` expone la **misma superficie de comandos** de tres formas — elige la que tu agente (o tú) admita:
@@ -326,6 +346,7 @@ se autodeshabilita en el juego exportado — de modo que un juego publicado nunc
 
 ---
 
+<a id="command-reference"></a>
 ## Referencia de comandos
 
 Los comandos de `gda` están **agrupados por objeto de dominio de Godot** y usan un vocabulario de verbos pequeño
@@ -651,6 +672,7 @@ a través del daemon (`live_runner.py`). La suite e2e maneja un motor real a tra
 
 ---
 
+<a id="contributing"></a>
 ## Contribuir
 
 Las contribuciones son bienvenidas. Lee [`CONTEXT.md`](../CONTEXT.md) para alinearte con el lenguaje
@@ -665,6 +687,7 @@ con [pyright](https://microsoft.github.io/pyright/), ambos aplicados en CI — e
 > [`AGENTS.md`](../AGENTS.md) es el punto de entrada para los agentes de programación, integrando las reglas del
 > proyecto, la documentación de dominio y las skills.
 
+<a id="license"></a>
 ## Licencia
 
 Publicado bajo la [Licencia MIT](../LICENSE). Copyright (c) 2026 aigengame.

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,0 +1,683 @@
+<!-- gda-readme-i18n: source=README.md sha256=6fb0da04e0265ed7c55f7bceeee9088a764838c27f9b5bf0121339bfb0bb244e -->
+
+# godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
+
+![godot-agent title image](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)
+
+**他の言語:** [English](../README.md) · [简体中文](README.zh-CN.md) · [Español](README.es.md) · **日本語**
+
+> **`gda` は、あなたの AI コーディングエージェント — あるいはシェルスクリプトや CI — に、[Godot Engine](https://godotengine.org) を構造化された機械可読な形で制御する手段を与えます。** シーンの作成、ノードやスクリプトの編集、ビルドのエクスポートを Headless で行い、さらに *実行中の* ゲームを Live で操作します。ランタイムツリー、入力、スクリーンショット、パフォーマンス — 単一のコマンド体系を、3 つの入口から。
+
+[![pre-1.0](https://img.shields.io/badge/status-pre--1.0-orange)](https://pypi.org/project/gda/)
+[![CI](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
+[![Python](https://img.shields.io/badge/python-3.13%2B-blue)](https://www.python.org/)
+[![Godot](https://img.shields.io/badge/godot-4.4%2B%20(live%204.6%2B)-478CBF)](https://godotengine.org)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%C2%B7%20Linux%20%C2%B7%20Windows-lightgrey)](#how-it-works)
+[![MCP](https://img.shields.io/badge/MCP-server-000)](https://modelcontextprotocol.io)
+[![License](https://img.shields.io/badge/license-MIT-green)](../LICENSE)
+
+AI エージェントは GDScript を書くのは得意ですが、*何が起きたかを見る* のはとても苦手です。`gda`
+はそのループを閉じます。エージェントは 1 つの操作を発行すると、そのまま処理に使える 1 つの
+クリーンな JSON 結果を受け取ります — かき集める必要のあるエンジンログではなく。`gda` は **2 つの
+モード** で動作します。
+
+- **Headless** — ワンショットかつステートレスで、セットアップ不要。エディタプラグインもデーモンも、
+  プロジェクトにインストールするものは何もありません。シーン、ノード、スクリプト、リソース、
+  シェーダー、テーマの作成と編集、プロジェクトの解析、ビルドのエクスポートが行えます。
+- **Live** — バックグラウンドのデーモンを通じて *実行中の* ゲームを操作し、ライブのエンジンでしか
+  できないことすべてを行います。ランタイムのシーンツリーの読み取り、ランタイムプロパティの取得・
+  設定、入力のシミュレート、スクリーンショットの取得、パフォーマンスのサンプリングなど。
+
+> `gda` は **pre-1.0** です。現時点ですべてのコマンドがエンドツーエンドで動作しますが、CLI の
+> コマンド体系は 1.0 までにまだ変わる可能性があります。
+
+---
+
+## なぜ `gda`？
+
+- **🤖 エージェントのために設計された構造化出力。** すべてのコマンドは stdout に **ちょうど 1 つ**
+  の JSON オブジェクトを出力します (`--json`)。エンジンのバナー、警告、`print()` は stderr に
+  流れます。エージェントが解析するのは大量のログではなく、1 つの結果だけです。
+- **📐 型付き、かつ自己記述的。** すべてのコマンドの入力と出力は型付きモデルであり、それが機械
+  可読な `--schema`(JSON Schema による契約)の裏付けにもなっています。そのためエージェントは、
+  推測ではなくプログラム的にコマンド体系全体を発見し検証できます。
+- **🔀 CLI、Skill、MCP — エージェントが選べる。** 生の `gda` CLI を使ってターミナルや CI から Godot を
+  操作する、CLI の使い方とタイミングを教える同梱の **Skill**(`gda skill`)をエージェントに渡す、
+  あるいは同じ操作を **MCP** ツール(`gda-mcp`、CLI 自身のスキーマから生成)として公開する。
+  単一のコマンド体系を 3 つの入口から — エージェントが対応している方法を選んでください。
+- **🧩 Godot ネイティブなコマンド。** Godot のオブジェクトごとにグループ化され(`gda scene create`、
+  `gda node add`、`gda game set`)、小さく一貫した動詞の語彙を使います。すでに Godot を知っていれば
+  学習コストはゼロです。
+- **⚡ デフォルトは Headless、必要なときに Live。** Headless 操作にデーモンもエディタも不要で、
+  必要なのは Godot バイナリだけです。Live 操作は、Unix ドメインソケットのデーモンを介して実行中
+  ゲームのリアルタイム制御を加え、同じ CLI の文法で指定できます。
+- **🛡️ 静かに失敗せず、はっきり失敗する。** 見つからない、あるいはハングしたエンジンはタイムアウト
+  で境界が区切られ、**安定した非ゼロの終了コード** と構造化された `{"error": {…}}` エンベロープに
+  マッピングされます。これにより、シェルやエージェントは文章を解析することなく失敗のカテゴリで
+  分岐できます。
+
+---
+
+## ひと目でわかる機能
+
+| やりたいこと | 使うもの |
+| --- | --- |
+| エージェントやスクリプトからプロジェクトファイルを構築する | `scene` / `node` / `script` / `resource` / `shader` / `theme` — Headless で作成・編集 |
+| エンジンログをかき集めず、結果を解析する | `--json`(1 つのクリーンなオブジェクト)と `--schema`(JSON Schema による契約) |
+| エージェントに Godot のツールを渡す | 同梱の **Skill**(`gda skill`)または **`gda-mcp`** サーバー |
+| CI、エクスポート、プロジェクト解析を自動化する | Headless コマンド — エディタもプラグインも不要、必要なのは Godot バイナリだけ |
+| *実行中の* ゲームのランタイム挙動をデバッグする | `gda daemon start`、その後 `game` / `diag` / `logger` / `perf` / `input` / `screen` |
+
+---
+
+## インストール
+
+**要件:** Python 3.13 以上、および [Godot](https://godotengine.org) バイナリ — Headless コマンドには
+4.4 以上、macOS/Linux での Live(デーモン)コマンドには 4.6 以上。
+
+PyPI から CLI を `PATH` 上にインストールします。
+
+```bash
+uv tool install gda      # or: pipx install gda
+gda --help
+```
+
+<details>
+<summary>その他のインストール方法(pip、ソースから)</summary>
+
+既存の環境へインストールする場合:
+
+```bash
+pip install gda
+```
+
+ソースから(開発用または未リリースの変更):
+
+```bash
+git clone https://github.com/aigengame/godot-agent.git
+cd godot-agent
+uv sync                  # create the environment + install dependencies
+uv run gda --help
+```
+</details>
+
+---
+
+## クイックスタート
+
+**`gda` に Godot バイナリの場所を教え**、エンジンにバージョンを尋ねます — プロジェクトは不要です。
+
+```bash
+export GDA_GODOT="/path/to/Godot"   # or pass --godot to any command
+gda info --json
+# {"major":4,"minor":6,"patch":3,"status":"stable","string":"4.6.3-stable (official)",…}
+```
+
+stdout は常にパイプ可能なクリーンな JSON です。エンジンとスクリプトの診断出力はすべて stderr に
+流れます。
+
+```bash
+gda info --json | jq .major   # → 4
+```
+
+**シーンを Headless で構築します。** 一度 `gda` に Godot プロジェクト(`project.godot` を含む
+ディレクトリ)を指定すれば、相対パスはその *内部* で解決され、ノードはシーンルートからの相対パスで
+指定されます。
+
+```bash
+export GDA_PROJECT="/path/to/your/godot-project"   # or pass --project to any command
+gda scene create scenes/main.tscn --root-type Node2D --json
+gda node add  scenes/main.tscn --type Sprite2D --name Hero --json
+gda node set  scenes/main.tscn --node Hero --property position --value 10,20 --json
+gda scene get scenes/main.tscn --json
+# {"path":"scenes/main.tscn","root":{"name":"main","type":"Node2D","children":[{"name":"Hero",…}]}}
+```
+
+> プロジェクトがない? `gda` はそれでも、プレーンなファイルシステムパス(カレントディレクトリからの
+> 相対)に対して **projectless(プロジェクトなし)** で動作します — プロジェクトが必要なのは `res://`
+> の解決だけです。[Configuration](#configuration) を参照してください。
+
+**実行中のゲームを Live で操作します。** Live 操作はプロジェクトの **メインシーン** を実行します。
+そのため、いま構築したシーンを Godot の `application/run/main_scene` プロジェクト設定(エディタの
+*Application → Run → Main Scene*)で指定し、デーモンを起動します(macOS/Linux、Godot 4.6 以上)。
+
+```bash
+gda project set application/run/main_scene --value res://scenes/main.tscn --json  # a Godot project setting key
+gda daemon start             # start the daemon for $GDA_PROJECT (installs the in-game harness)
+gda game tree --json         # the runtime scene tree, after _ready
+gda perf monitors --json     # live engine counters: fps, memory, node count
+gda daemon stop
+```
+
+(`gda screen capture` も Live で動作しますが、ウィンドウ付きのセッションが必要です — `gda daemon
+start --windowed` でデーモンを起動してください。)
+
+---
+
+## 統合方法を選ぶ
+
+`gda` は **同じコマンド体系** を 3 通りで公開します — エージェント(またはあなた)が対応している
+方法を選んでください。
+
+| 入口 | 適した用途 | 方法 |
+| --- | --- | --- |
+| **CLI**(`gda`) | 人間、シェルスクリプト、CI、コマンドを実行できるエージェント | `gda <group> <command> --json` |
+| **Skill**(`gda skill`) | Agent Skills に対応し、トークン消費の少ない CLI ワークフローを好むコーディングエージェント | `SKILL.md` を出力/インストール(下記) |
+| **MCP**(`gda-mcp`) | Model Context Protocol 経由でツールを呼び出すエージェント | stdio サーバーを実行(下記) |
+
+### Skill として使う
+
+`gda` はエージェント **Skill** を同梱しています — `SKILL.md` であり、AI エージェントに CLI から Godot を
+操作する *方法とタイミング* を教えます。これは最も軽量な入口で(登録するサーバーがありません)、
+パッケージに同梱され、インストール済みのバージョンに固定されています。出力するか、エージェントの
+スキルディレクトリにインストールします。
+
+```bash
+gda skill                                              # print SKILL.md (redirect it anywhere)
+gda skill --install --provider claude --scope user     # resolve a known agent's skills dir
+gda skill --install --dir ~/.claude/skills/gda         # …or give the directory yourself
+```
+
+`--install --provider <claude|codex> --scope <project|user>` は既知のエージェントのスキルディレクトリを
+解決します(`--scope` のデフォルトは `user`)。`--dir` はその他すべてのエージェント向けの中立的な
+フォールバックで、組み込みのデフォルトはありません。[skill recipes](gda-skill.md) には各エージェントの
+ディレクトリが記載されています(Claude Code の `~/.claude/skills/`、Codex の `~/.agents/skills/` など)。
+あるいは `gda skill` を経由したくない場合は、同じファイルをリポジトリから直接取得することもできます —
+Skill はそれを駆動するので、`gda` 自体のインストールは引き続き必要です。
+
+```bash
+curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \
+  https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md
+```
+
+### MCP サーバーとして使う
+
+`gda` は `[mcp]` エクストラの背後に stdio の [MCP](https://modelcontextprotocol.io) サーバーを同梱しており、
+あらゆる MCP エージェント(Claude Code、Codex、Cursor など)が Godot を操作できます。インストールせずに
+試すには:
+
+```bash
+uvx --from "gda[mcp]" gda-mcp
+```
+
+サーバーは 2 つのコンテキストを解決します — どの Godot **プロジェクト** を操作するか、そしてどの Godot
+**バイナリ** を実行するか(MCP は呼び出しごとのフラグを渡せません)。
+
+- **プロジェクト** — クライアントがワークスペースの **roots** を提示できない場合は `GDA_PROJECT` を
+  設定します。そうでなければ、`gda-mcp` はクライアントが送る roots(あなたが開いているフォルダ)から
+  プロジェクトを自動検出します。*設定されているが無効な* `GDA_PROJECT` は、静かにフォールバックする
+  のではなくエラーとして報告されます。CLI と MCP の完全な解決順序については
+  [Configuration](#configuration) を参照してください。
+- **エンジン** — `GDA_GODOT` に Godot バイナリを設定します。例: `"GDA_GODOT": "/path/to/Godot"`。
+
+
+#### コーディングエージェントへの登録
+
+<details>
+<summary>Claude Code</summary>
+
+プロジェクトスコープ。リポジトリルートの `.mcp.json`(`roots` 経由でプロジェクトを自動検出):
+
+```json
+{
+  "mcpServers": {
+    "gda-mcp": {
+      "command": "uvx",
+      "args": ["--from", "gda[mcp]", "gda-mcp"]
+    }
+  }
+}
+```
+
+ユーザースコープ(すべてのプロジェクト)— `~/.claude.json` に書き込む CLI:
+
+```bash
+claude mcp add --scope user gda-mcp -- uvx --from "gda[mcp]" gda-mcp
+```
+
+</details>
+
+<details>
+<summary>Codex</summary>
+
+プロジェクトスコープ。リポジトリルートの `.codex/config.toml`(プロジェクトが信頼済みである必要が
+あります):
+
+```toml
+[mcp_servers.gda-mcp]
+command = "uvx"
+args = ["--from", "gda[mcp]", "gda-mcp"]
+
+[mcp_servers.gda-mcp.env]
+GDA_PROJECT = "/absolute/path/to/your/godot/project"
+```
+
+ユーザースコープ(どこでも利用可能だが、1 つのプロジェクトに固定)— `~/.codex/config.toml` に同じ
+テーブルを置くか、CLI で追加します。Codex にはワークスペース変数がないため、`GDA_PROJECT` は絶対
+パスになります。複数のプロジェクトをまたいで作業する場合はプロジェクトスコープを使ってください。
+
+```bash
+codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- \
+  uvx --from "gda[mcp]" gda-mcp
+```
+
+</details>
+
+<details>
+<summary>Cursor</summary>
+
+プロジェクトスコープ。リポジトリルートの `.cursor/mcp.json`(`${workspaceFolder}` が開いている
+プロジェクトを追跡):
+
+```json
+{
+  "mcpServers": {
+    "gda-mcp": {
+      "type": "stdio",
+      "command": "/path/to/uvx",
+      "args": ["--from", "gda[mcp]", "gda-mcp"],
+      "env": {
+        "GDA_PROJECT": "${workspaceFolder}"
+      }
+    }
+  }
+}
+```
+
+ユーザースコープ(どこでも利用可能だが、1 つのプロジェクトに固定)— `~/.cursor/mcp.json` に同じ設定を
+置き、`GDA_PROJECT` を絶対パスに設定します(`${workspaceFolder}` はプロジェクトスコープでのみ機能
+します。複数のプロジェクトにはプロジェクトスコープを使ってください)。Cursor には `mcp add` コマンドが
+ないため、上記の JSON か Settings → MCP の UI から登録します。
+
+> Cursor は最小限の `PATH` で GUI から起動されるため、素の `uvx` は解決できないことがあります —
+> 上記で絶対パスの `command` を使っているのはこのためです。`which uvx` の出力で埋めてください。
+> 完全なレシピ — PATH の注入、Claude Desktop、ユーザースコープ対プロジェクトスコープ、エージェント
+> ごとのプロジェクト固定 — は [registration recipes](gda-mcp-registration.md) にあります。
+</details>
+
+---
+
+<a id="how-it-works"></a>
+## 仕組み
+
+`gda` は、2 つのモードで操作を提供する 3 つのコンポーネントから成ります。
+
+| コンポーネント | 役割 |
+| ---------------- | --------------------------------------------------------------------- |
+| **`gda`**        | エージェント向けの CLI — Godot を構造化された `--json` 出力で公開します。 |
+| **`gda-mcp`**    | 同じ操作を `--schema` からツールとして公開する MCP サーバー。 |
+| **`gda-daemon`** | Live 操作のために実行中ゲームを監督する、プロジェクトごとのプロセス。 |
+
+- **Headless 操作** はワンショットで実行されます — デーモンも、インストールするものも不要です
+  (シーンの作成、スクリプトの編集、エクスポート、解析)。
+- **Live 操作** には実行中のゲームが必要です — `gda-daemon` がそれを起動し、不活性なゲーム内ハーネスを
+  注入し、Unix ドメインソケット経由でリクエストを仲介します(ランタイムツリー、入力、スクリーン
+  ショット、パフォーマンス、診断)。
+
+`gda-daemon` が注入するゲーム内ハーネスは **開発専用** です。`gda export run` は成果物からそれを完全に
+取り除きます。また、それ以外の方法(エディタの GUI、素の `godot --export`)でビルドしても、エクスポート
+済みゲーム内で自己無効化します — そのため、出荷されるゲームがデーモン関連のものを *実行する* ことは
+決してありません(そして `gda export run` 経由なら、そもそも同梱すらされません)。
+
+**プラットフォームとバージョンのサポート:**
+
+| モード | Godot | プラットフォーム |
+| ---- | ----- | --------- |
+| **Headless** | 4.4+ | macOS · Linux · Windows¹ |
+| **Live**(`gda-daemon` 経由) | 4.6+ | macOS · Linux² |
+
+¹ Headless は設計上クロスプラットフォームです(ワンショットのプロセスで、プラットフォーム固有の
+  依存がありません)— Windows でも Headless の全機能が使えますが、CI ではまだ検証されていません。
+² Live 操作は Unix ドメインソケットを使うため、Windows はまだサポートされていません。
+
+---
+
+## コマンドリファレンス
+
+`gda` のコマンドは **Godot のドメインオブジェクトごとにグループ化** され、小さく一貫した動詞の語彙を
+使います。そのため同じ動詞は、どのグループでも同じ意味を持ちます。
+
+| 動詞                | 意味                                                           |
+| ------------------- | ----------------------------------------------------------------- |
+| `create` / `delete` | **独立した** エンティティ(シーン、スクリプト、リソース)を作成/削除します。 |
+| `add` / `remove`    | コンテナ内の **サブエンティティ**(ノード → シーン)を追加/削除します。 |
+| `get` / `list`      | 1 つのエンティティを読み取る/複数を列挙します。 |
+| `set`               | プロパティを変更します。 |
+| ドメイン固有の動詞  | `play`、`run`、`export`、`import` など、本来の意味のまま使います。 |
+
+すべてのコマンドは `--json` と `--schema` をサポートします — ただし `gda schema` 自体は例外で、集約
+マニフェストを直接 JSON として出力します。`res://` パスを読み取りまたは変更するコマンドは
+[project context](#configuration) を解決します。完全なフラグについては `gda <group> <command> --help`
+を実行してください — `gda --help` がインストール済みのものを示す信頼できる一覧です。
+
+**はじめての方へ:** おすすめの最初の流れ: `gda info` → `gda scene create` → `gda node add` →
+`gda script validate` → `gda export run`。その後 `gda daemon start` → `gda game tree` で Live に進みます。
+
+**Meta** — `gda` やエンジン自体について
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `gda info`   | Godot エンジンのバージョン情報を報告します。 |
+| `gda schema` | コマンド体系全体を 1 つの機械可読な JSON マニフェストとして出力します。 |
+| `gda skill`  | エージェントに `gda` の操作方法を教える同梱の Agent Skill(`SKILL.md`)を出力またはインストールします。 |
+
+### Headless コマンド — Godot 4.4 以上、全プラットフォーム
+
+**`scene`** — シーンファイル(`.tscn`)
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `scene create` | 指定したルートノードタイプで新しい `.tscn` を作成します。 |
+| `scene get` | シーンを読み取り、その構造化されたノードツリーを報告します。 |
+| `scene list` | 解決済みプロジェクト内の `.tscn` シーンを列挙します。 |
+| `scene get-exports` | シーンのノードのスクリプトが宣言する `@export` プロパティを一覧します。 |
+| `scene delete` | シーンファイルを削除し、削除された内容を報告します。 |
+
+**`node`** — シーンファイル内のノード
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `node add` | 親の下にノードを追加します(組み込みタイプまたは `class_name` スクリプト)。 |
+| `node get` | ノードのプロパティを(ノードパスで指定して)型付き JSON として読み取ります。 |
+| `node list` | シーンのノードツリーを、各ノードのルートからの相対パスとともに一覧します。 |
+| `node set` | ノードのプロパティを設定します。値は宣言された Godot の型に変換されます。 |
+| `node remove` | ノード(およびそのサブツリー)をノードパスで指定して削除します。 |
+| `node duplicate` | ノード(およびそのサブツリー)を親の下に複製します。 |
+| `node move` | ノード(およびそのサブツリー)を新しい親の下に付け替えます。 |
+| `node connect-signal` | ソースノードのシグナルをターゲットノードのメソッドに接続します。 |
+| `node disconnect-signal` | 既存のシグナル → メソッド接続を解除します。 |
+
+**`script`** — GDScript ファイル(`.gd`)
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `script create` | テンプレートまたはそのままの `--content` から新しい `.gd` スクリプトを作成します。 |
+| `script get` | スクリプトのソースと、その `class_name` / `extends` メタデータを読み取ります。 |
+| `script list` | 解決済みプロジェクト内の `.gd` スクリプトを列挙します。 |
+| `script set` | 検索置換、行範囲指定、または全体上書きでスクリプトを編集します。 |
+| `script delete` | スクリプトファイルを削除し、削除された内容を報告します。 |
+| `script attach` | シーン内のノードに(ノードパスで指定して)`.gd` スクリプトをアタッチします。 |
+| `script validate` | `.gd` スクリプトの構文/コンパイルチェックを行います。 |
+
+**`project`** — プロジェクト全体(設定、オートロード、静的解析)
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `project info` | プロジェクトのメタデータ(名前、メインシーン、ビューポート、エンジンバージョン)を報告します。 |
+| `project get` | 単一のプロジェクト設定を section/key で指定し、型付き JSON として読み取ります。 |
+| `project list` | プロジェクトの設定キーを一覧します(デフォルトはカスタマイズ済みのもの。`--all` でエンジンのデフォルトを追加、`--section` でプレフィックスによりフィルタ)。 |
+| `project set` | プロジェクト設定を設定します。値は宣言された型に変換されます。 |
+| `project add-autoload` | オートロードのシングルトンを登録します(名前 → スクリプト/シーン)。 |
+| `project remove-autoload` | オートロードのシングルトンを名前で指定して登録解除します。 |
+| `project find-references` | 指定したリソースを参照するすべてのプロジェクトファイルを見つけます。 |
+| `project dependencies` | 各シーン/リソースを、それが依存するリソースに対応付けます。 |
+| `project find-unused-resources` | どこからも参照されていないリソースファイルを見つけます。 |
+| `project statistics` | プロジェクトのファイル数/行数、オートロードなどを報告します。 |
+
+**`resource`** — リソースファイル(`.tres`)
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `resource create` | 指定したタイプの新しい `.tres` リソースを作成します。 |
+| `resource get` | `.tres` リソースのプロパティを型付き JSON として読み取ります。 |
+| `resource set` | `.tres` のプロパティを設定します。値は宣言された型に変換されます。 |
+| `resource delete` | `.tres` リソースファイルを削除し、削除された内容を報告します。 |
+| `resource uid` | リソースの UID とその `res://` パスを双方向で相互変換します。 |
+
+**`export`** — エクスポートのプリセットと成果物
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `export list` | プロジェクトのエクスポートプリセット(名前、プラットフォームなど)を列挙します。 |
+| `export get` | 1 つのプリセットの詳細と、エクスポートテンプレートのインストール状況を報告します。 |
+| `export run` | 名前付きプリセット(`release` / `debug` / `pack`)を指定先にエクスポートします。 |
+
+**`shader`** — シェーダーファイル(`.gdshader`)
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `shader create` | テンプレートまたはそのままの `--content` から新しい `.gdshader` を作成します。 |
+| `shader get` | シェーダーのソースと、その `shader_type` を読み取ります。 |
+| `shader set` | 検索置換、行範囲指定、または全体上書きで `.gdshader` を編集します。 |
+
+**`theme`** — テーマリソース(`.tres`)
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `theme create` | ロード可能な新しい `.tres` テーマリソースを作成します(既存を上書きしません)。 |
+
+### Live コマンド — `gda-daemon` 経由、Godot 4.6 以上、macOS/Linux
+
+**`daemon`** — Live ランタイムのライフサイクル
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `daemon start` | プロジェクトごとのデーモンを起動し、ゲーム内ハーネスをインストールします。エンジンセッションは最初の Live 操作で起動します(`screen` キャプチャには `--windowed`)。 |
+| `daemon stop` | プロジェクトのデーモンと、実行中のエンジンセッションを停止します。 |
+| `daemon status` | デーモンの状態(実行中か、ウィンドウモードか、セッション)を報告します。 |
+| `daemon uninstall` | ゲーム内の `gda` ハーネス(オートロードのエントリ + ファイル)をプロジェクトから削除します — 明示的な開発ツールの撤去です。`gda export run` はエクスポート済み成果物からこれをすでに自動で取り除きます。 |
+
+**`game`** — 実行中ゲームのランタイムシーングラフ
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `game tree` | 実行中ゲームのランタイムシーンツリーを読み取ります(`_ready` の後)。 |
+| `game get` | ランタイムノードのライブプロパティをノードパスで指定して読み取ります。 |
+| `game set` | 実行中ゲームのランタイムノードのプロパティを設定します。 |
+
+**`diag`** — ランタイム診断
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `diag errors` | 実行中ゲームのランタイムエラーを(カテゴリ分けして)追尾します。 |
+
+**`logger`** — 構造化されたランタイムログ
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `logger tail` | 実行中ゲームのランタイムログ全体を、構造化されたレコードとして追尾します(`--level`、`--limit`、`--raw`)。 |
+
+**`perf`** — パフォーマンス監視
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `perf monitors` | エンジンのパフォーマンスカウンタ(fps、メモリ、ノード数など)のスナップショットを取得します。 |
+| `perf monitor` | ノードのプロパティまたはシグナルを、フレームのウィンドウ(タイムライン)にわたってサンプリングします。 |
+
+**`input`** — 入力シミュレーション
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `input key` | キーイベントを(修飾キー付きで)注入します。 |
+| `input mouse-click` | `(x, y)` の位置にマウスクリックを注入します。 |
+| `input mouse-move` | `(x, y)` へのマウス移動を注入します。 |
+| `input action` | マッピング済みの入力アクションを押下/解放します。 |
+| `input sequence` | 複数フレームにわたるイベントのタイムラインを注入します。 |
+
+**`screen`** — ビューポートのキャプチャ
+
+| コマンド | 機能 |
+| ------- | ------------ |
+| `screen capture` | ビューポートの 1 フレームを PNG にキャプチャします。 |
+| `screen frames` | N フレームの PNG シーケンスをキャプチャします。 |
+
+### グローバルフラグ
+
+| フラグ       | 説明                                                          |
+| ---------- | ------------------------------------------------------------------- |
+| `--json`    | 結果を stdout に単一の JSON オブジェクトとして出力します。指定しない場合、コマンドは簡潔な人間可読のレンダリングを出力します。 |
+| `--schema`  | コマンドの入出力 JSON Schema 契約を出力します(Godot は起動されません)。 |
+| `--godot`   | Godot バイナリへのパス(`$GDA_GODOT` とデフォルトを上書きします)。 |
+| `--project` | `res://` 解決のための Godot プロジェクトディレクトリ(`$GDA_PROJECT` を上書き。プロジェクトであればカレントディレクトリがデフォルト)。ドメインコマンドのみ。プロジェクトの解決はそのプロジェクトのコードを実行します — [Project code execution](#configuration) を参照してください。 |
+| `--help`    | `gda` または任意のコマンドの使い方を表示します。 |
+
+---
+
+<a id="configuration"></a>
+## 設定
+
+`gda` は Godot バイナリを **`--godot <path>`** フラグから、なければ **`GDA_GODOT`** 環境変数から
+見つけます — `gda` がエンジンを見つけられるよう、どちらかを設定してください。
+
+ドメインコマンドは、次の順序で **Godot プロジェクト** を解決します(`res://` パスやシーンのリソース間
+参照が決定的に解決されるように)。
+
+1. **`--project <dir>`** フラグ。
+2. **`GDA_PROJECT`** 環境変数。
+3. **カレントディレクトリ**(Godot プロジェクトである、つまり `project.godot` を含む場合)。
+
+明示的に指定したディレクトリはプロジェクトでなければならず、そうでなければ `gda` はエラーとして
+報告します。どれも解決されない場合、`gda` は **projectless(プロジェクトなし)** で動作します —
+`res://` ではなく、ファイルシステムパス(絶対パスまたは cwd 相対)のみが解決されます。**MCP サーバー**
+にはフラグがないため、プロジェクトの解決方法が少し異なります。
+
+| コンテキスト | プロジェクトの解決順序 |
+| --- | --- |
+| **CLI** | `--project` → `GDA_PROJECT`(どちらも厳格 — 無効ならエラー報告)→ `project.godot` を持つなら cwd、なければ projectless |
+| **MCP**(`gda-mcp`) | `GDA_PROJECT`(厳格 — 設定済みだが無効ならスキップせずエラー報告)→ *有効な* クライアントワークスペースの `root` → *有効な* サーバーの cwd、なければ projectless |
+
+<details>
+<summary>Project code execution — プロジェクトを指定したときに何が実行されるか</summary>
+
+`res://` パスを機能させるためにプロジェクトを解決すると、そのプロジェクトに対して Godot が実行され、
+その一環として Godot はプロジェクト自身のコードの一部を実行します。具体的には:
+
+- **オートロードはすべての `--project` 操作で実行されます。** プロジェクトが解決されると、エンジンは
+  起動時に — コマンド自身の処理が走る前に — プロジェクトのオートロードシングルトンを構築します。
+  そのため、それらの `_init`(および `_ready`)は、`scene get` や `node list` のような読み取り専用の
+  ものも含め、**すべての** 操作で実行されます。プロジェクトが解決されない場合、オートロードは
+  登録されないため実行されません。
+- **シーンをインスタンス化するコマンドは、そのシーンにアタッチされたスクリプトのコンストラクタを
+  実行します。** ライブのノードツリーを必要とするコマンド — すべての変更系コマンド(`node add`、
+  `node set`、`node remove` など)、および `node get`(保存データには含まれないランタイムプロパティの
+  デフォルトを報告します)— はシーンを読み込んでインスタンス化します。これにより各ノードが構築され、
+  その中のノードにアタッチされたスクリプトの `_init` が実行されます。保存されたシーンデータを読み取る
+  だけのコマンド(`scene get`、`scene list`、`node list`)はインスタンス化せずに走査するため、それらの
+  スクリプトを実行しません。
+
+`gda` は対象プロジェクトを信頼済みとして扱うため、これは設計どおりの挙動です — 信頼モデルについては
+[ADR-0009](adr/0009-trust-boundary-trusted-project.md) を参照してください。
+</details>
+
+---
+
+<details>
+<summary><strong>内部の仕組み</strong> — 構造化出力の契約と終了コード</summary>
+
+Headless の Godot は、バナー、警告、`print()` の出力を stdout に混在させます。`gda` はこれをセンチネル
+契約で解決します([ADR-0002](adr/0002-headless-structured-output-contract.md))。
+
+- GDScript ペイロードは **ちょうど 1 つ** の結果を、stdout 上で一意なセンチネルに包んで出力します。
+
+  ```
+  <<<GDA:RESULT>>>{ …json… }<<<GDA:END>>>
+  ```
+
+- 自身の診断出力は **すべて** stderr に流し、stdout は契約以外に何も載せません。
+- `gda` はセンチネル間のバイトだけを抽出して解析し、周囲のエンジンノイズを無視します。そして検査用に
+  stderr を提示します。
+
+これが `gda` の出力をプログラム的に安全に扱える理由であり、デーモンが Live 操作に使うメッセージごとの
+プロトコルにも一般化されています。
+
+**終了コード(CLI ABI)。** 失敗した `gda` の実行は、小さく安定したコードで終了します。これにより、
+シェルやエージェントは **JSON エラーを解析せずに** 失敗の **カテゴリ** で分岐できます。
+
+| 終了コード | カテゴリ      | 条件                                                                  |
+| --------- | ------------- | --------------------------------------------------------------------- |
+| `0`       | —             | 成功。                                                              |
+| `127`     | `environment` | Godot バイナリを起動できませんでした(シェルの慣例: not found)。 |
+| `124`     | `environment` | Godot は起動したが、ランナーのタイムアウト前に戻りませんでした(シェルの慣例: timed out)。 |
+| `3`       | `version`     | 検出された Godot のバージョンが、サポートされる最小値を下回っています。 |
+| `4`       | `operation`   | エンジンは動作したが操作が失敗しました — 登録済みの操作エラー、エンジンのクラッシュ、または非構造の非ゼロ終了。 |
+| `5`       | `parse`       | プロセスは成功を主張したが、構造化出力の契約に違反しました。 |
+| `6`       | `live`        | Live 操作が失敗しました — 例: 実行中のデーモン/セッションがない、または Live のタイムアウト。 |
+
+これらの値は公開 ABI であり、その信頼できる出典は [`src/gda/exit_codes.py`](../src/gda/exit_codes.py)
+です。`{"error": {category, code, …}}` エンベロープは、各カテゴリ内に **より細かい `code`** を持ちます
+(例: `path_not_found`、`already_exists`、`node_not_found` はいずれも `operation` / 終了コード `4` の下に
+あります)。完全なレジストリは
+[ADR-0002 の `GdaError.code` テーブル](adr/0002-headless-structured-output-contract.md#gdaerrorcode-registry)
+にあります。
+</details>
+
+<details>
+<summary><strong>開発</strong></summary>
+
+```bash
+uv sync                       # set up the environment
+
+uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
+uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
+uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
+
+uv run ruff check .           # lint
+uv run ruff format .          # auto-format (append --check to verify without writing)
+uv run pyright                # type-check (src/ + tests/, basic mode)
+```
+
+`e2e` ティアは `uv run pytest` でデフォルトで実行され、そこに Godot バイナリが見つからない場合は、
+スキップするのではなく **はっきり失敗します** — 解決されたパスと修正方法を示して。ティア全体を除外
+するには `-m "not e2e"` を使います(CI の PR ごとのジョブはまさにこれを使っています)。
+
+リンティングとフォーマットは [ruff](https://docs.astral.sh/ruff/) で強制されます — flake8 + black + isort を
+1 つのツールで置き換えるもので、`pyproject.toml` の `[tool.ruff]` 配下で設定され、ローカルと CI が
+一致するよう `uv.lock` で固定されています。CI の `lint` ジョブは、すべての PR で `ruff check .` と
+`ruff format --check .` を実行します。グリーンを保つため、コミット前に `uv run ruff format .` を実行して
+ください。
+
+型は [pyright](https://microsoft.github.io/pyright/) の `basic` モードでチェックされ、`src/` と `tests/` を
+対象に、`pyproject.toml` の `[tool.pyright]` 配下で設定されています(これも `uv.lock` で固定)。CI の
+`type-check` ジョブは、すべての PR で `uv run --frozen pyright` を実行します。
+
+```
+src/gda/
+  cli.py            # CLI entrypoint (Typer): all command groups, --json / --schema
+  surface.py        # walks the live Typer tree → the `gda schema` manifest
+  headless.py       # the per-command descriptor (one HeadlessCommand per command)
+  binary.py         # Godot binary resolution (flag > $GDA_GODOT > default)
+  runner.py         # the one-shot headless spawn seam (Protocol + subprocess impl)
+  live_runner.py    # the live-operation client that talks to gda-daemon
+  models.py         # typed I/O models (Pydantic) backing --json and --schema
+  errors.py / error_codes.py / exit_codes.py   # failure classification + the CLI ABI
+  render.py         # human-readable (non-JSON) rendering
+  ops/operations.gd # the headless GDScript payload, dispatched by operation name
+  daemon/           # gda-daemon: server, session supervision, IPC protocol, discovery
+  harness/          # the inert in-game `gda` autoload injected into a live session
+  mcp/              # gda-mcp: the schema → MCP-tool server
+tests/              # unit + e2e tests against a real engine (shared fixtures in conftest.py)
+docs/adr/           # architecture decision records
+CONTEXT.md          # the project's shared domain language
+```
+
+`gda` には 2 つの外部境界があり、それぞれ高速なテストが注入するシーム(継ぎ目)の背後にあります。
+ワンショットの Headless プロセスを起動すること(`runner.py`)と、デーモン経由で実行中ゲームと対話する
+こと(`live_runner.py`)です。e2e スイートは、その両方にわたって実際のエンジンを駆動します。
+</details>
+
+---
+
+## コントリビューション
+
+コントリビューションを歓迎します。プロジェクトの共有言語に合わせるため [`CONTEXT.md`](../CONTEXT.md) を
+読み、触れる領域に関連する [ADR](adr/) を確認してください。Issue と PRD は
+[GitHub issues](https://github.com/aigengame/godot-agent/issues) として管理されています。コミットは
+[Conventional Commits](https://www.conventionalcommits.org/) 仕様に従います。Python コードは
+[ruff](https://docs.astral.sh/ruff/) でリント・フォーマットされ、[pyright](https://microsoft.github.io/pyright/)
+で型チェックされます。どちらも CI で強制されます — コミット前に `uv run ruff format .` と
+`uv run pyright` を実行してください(上記の **開発** を参照)。
+
+この README が信頼できる出典です。翻訳は `docs/README.<lang>.md` 配下にあります([简体中文](README.zh-CN.md)、
+[Español](README.es.md)、[日本語](README.ja.md))。同期ゲート(`tests/test_readme_i18n_sync.py`、CI で実行)は、
+このファイルが変更されたのに翻訳が更新されていない場合に失敗します。この README を編集したら、影響を
+受けるセクションを翻訳し直し、`uv run python scripts/update_readme_i18n.py` を実行して各翻訳の鮮度
+マーカーを再スタンプしてください。このゲートが証明するのは、翻訳が現在の英語版に *照らしてレビュー
+された* ことであり、正確であることではありません — 正確さは人間のレビュアーだけが判断できます。
+
+> **AI コーディングエージェントと作業していますか?** このプロジェクトはエージェントが辿りやすいように
+> 作られています — [`AGENTS.md`](../AGENTS.md) がコーディングエージェントの入口で、プロジェクトの
+> ルール、ドメインドキュメント、スキルを束ねています。
+
+## ライセンス
+
+[MIT ライセンス](../LICENSE) の下でリリースされています。Copyright (c) 2026 aigengame.

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=6636b90927355b348b5c9501140f1e09f0fba731175e0ff8e4afc8eeb349c6ba -->
+<!-- gda-readme-i18n: source=README.md sha256=4ef9cb754f81a9c5c4ff9b88782dd72a6577f3a6c5fea7170390d9c59b5972cd -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -33,6 +33,22 @@ AI エージェントは GDScript を書くのは得意ですが、*何が起き
 
 ---
 
+## 目次
+
+- [なぜ `gda`？](#why-gda)
+- [ひと目でわかる機能](#capabilities-at-a-glance)
+- [インストール](#installation)
+- [クイックスタート](#quick-start)
+- [統合方法を選ぶ](#choose-your-integration)
+- [仕組み](#how-it-works)
+- [コマンドリファレンス](#command-reference)
+- [設定](#configuration)
+- [コントリビューション](#contributing)
+- [ライセンス](#license)
+
+---
+
+<a id="why-gda"></a>
 ## なぜ `gda`？
 
 - **🤖 エージェントのために設計された構造化出力。** すべてのコマンドは stdout に **ちょうど 1 つ**
@@ -58,6 +74,7 @@ AI エージェントは GDScript を書くのは得意ですが、*何が起き
 
 ---
 
+<a id="capabilities-at-a-glance"></a>
 ## ひと目でわかる機能
 
 | やりたいこと | 使うもの |
@@ -70,6 +87,7 @@ AI エージェントは GDScript を書くのは得意ですが、*何が起き
 
 ---
 
+<a id="installation"></a>
 ## インストール
 
 **要件:** Python 3.13 以上、および [Godot](https://godotengine.org) バイナリ — Headless コマンドには
@@ -103,6 +121,7 @@ uv run gda --help
 
 ---
 
+<a id="quick-start"></a>
 ## クイックスタート
 
 **`gda` に Godot バイナリの場所を教え**、エンジンにバージョンを尋ねます — プロジェクトは不要です。
@@ -154,6 +173,7 @@ start --windowed` でデーモンを起動してください。)
 
 ---
 
+<a id="choose-your-integration"></a>
 ## 統合方法を選ぶ
 
 `gda` は **同じコマンド体系** を 3 通りで公開します — エージェント(またはあなた)が対応している
@@ -332,6 +352,7 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 
 ---
 
+<a id="command-reference"></a>
 ## コマンドリファレンス
 
 `gda` のコマンドは **Godot のドメインオブジェクトごとにグループ化** され、小さく一貫した動詞の語彙を
@@ -657,6 +678,7 @@ CONTEXT.md          # the project's shared domain language
 
 ---
 
+<a id="contributing"></a>
 ## コントリビューション
 
 コントリビューションを歓迎します。プロジェクトの共有言語に合わせるため [`CONTEXT.md`](../CONTEXT.md) を
@@ -671,6 +693,7 @@ CONTEXT.md          # the project's shared domain language
 > 作られています — [`AGENTS.md`](../AGENTS.md) がコーディングエージェントの入口で、プロジェクトの
 > ルール、ドメインドキュメント、スキルを束ねています。
 
+<a id="license"></a>
 ## ライセンス
 
 [MIT ライセンス](../LICENSE) の下でリリースされています。Copyright (c) 2026 aigengame.

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -154,7 +154,7 @@ gda scene get scenes/main.tscn --json
 
 > プロジェクトがない? `gda` はそれでも、プレーンなファイルシステムパス(カレントディレクトリからの
 > 相対)に対して **projectless(プロジェクトなし)** で動作します — プロジェクトが必要なのは `res://`
-> の解決だけです。[Configuration](#configuration) を参照してください。
+> の解決だけです。[設定](#configuration) を参照してください。
 
 **実行中のゲームを Live で操作します。** Live 操作はプロジェクトの **メインシーン** を実行します。
 そのため、いま構築したシーンを Godot の `application/run/main_scene` プロジェクト設定(エディタの
@@ -200,7 +200,7 @@ gda skill --install --dir ~/.claude/skills/gda         # …or give the director
 
 `--install --provider <claude|codex> --scope <project|user>` は既知のエージェントのスキルディレクトリを
 解決します(`--scope` のデフォルトは `user`)。`--dir` はその他すべてのエージェント向けの中立的な
-フォールバックで、組み込みのデフォルトはありません。[skill recipes](gda-skill.md) には各エージェントの
+フォールバックで、組み込みのデフォルトはありません。[Skill レシピ](gda-skill.md) には各エージェントの
 ディレクトリが記載されています(Claude Code の `~/.claude/skills/`、Codex の `~/.agents/skills/` など)。
 あるいは `gda skill` を経由したくない場合は、同じファイルをリポジトリから直接取得することもできます —
 Skill はそれを駆動するので、`gda` 自体のインストールは引き続き必要です。
@@ -227,7 +227,7 @@ uvx --from "gda[mcp]" gda-mcp
   設定します。そうでなければ、`gda-mcp` はクライアントが送る roots(あなたが開いているフォルダ)から
   プロジェクトを自動検出します。*設定されているが無効な* `GDA_PROJECT` は、静かにフォールバックする
   のではなくエラーとして報告されます。CLI と MCP の完全な解決順序については
-  [Configuration](#configuration) を参照してください。
+  [設定](#configuration) を参照してください。
 - **エンジン** — `GDA_GODOT` に Godot バイナリを設定します。例: `"GDA_GODOT": "/path/to/Godot"`。
 
 
@@ -312,7 +312,7 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 > Cursor は最小限の `PATH` で GUI から起動されるため、素の `uvx` は解決できないことがあります —
 > 上記で絶対パスの `command` を使っているのはこのためです。`which uvx` の出力で埋めてください。
 > 完全なレシピ — PATH の注入、Claude Desktop、ユーザースコープ対プロジェクトスコープ、エージェント
-> ごとのプロジェクト固定 — は [registration recipes](gda-mcp-registration.md) にあります。
+> ごとのプロジェクト固定 — は [登録レシピ](gda-mcp-registration.md) にあります。
 </details>
 
 ---
@@ -368,7 +368,7 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 
 すべてのコマンドは `--json` と `--schema` をサポートします — ただし `gda schema` 自体は例外で、集約
 マニフェストを直接 JSON として出力します。`res://` パスを読み取りまたは変更するコマンドは
-[project context](#configuration) を解決します。完全なフラグについては `gda <group> <command> --help`
+[プロジェクトコンテキスト](#configuration) を解決します。完全なフラグについては `gda <group> <command> --help`
 を実行してください — `gda --help` がインストール済みのものを示す信頼できる一覧です。
 
 **はじめての方へ:** おすすめの最初の流れ: `gda info` → `gda scene create` → `gda node add` →
@@ -529,7 +529,7 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 | `--json`    | 結果を stdout に単一の JSON オブジェクトとして出力します。指定しない場合、コマンドは簡潔な人間可読のレンダリングを出力します。 |
 | `--schema`  | コマンドの入出力 JSON Schema 契約を出力します(Godot は起動されません)。 |
 | `--godot`   | Godot バイナリへのパス(`$GDA_GODOT` とデフォルトを上書きします)。 |
-| `--project` | `res://` 解決のための Godot プロジェクトディレクトリ(`$GDA_PROJECT` を上書き。プロジェクトであればカレントディレクトリがデフォルト)。ドメインコマンドのみ。プロジェクトの解決はそのプロジェクトのコードを実行します — [Project code execution](#configuration) を参照してください。 |
+| `--project` | `res://` 解決のための Godot プロジェクトディレクトリ(`$GDA_PROJECT` を上書き。プロジェクトであればカレントディレクトリがデフォルト)。ドメインコマンドのみ。プロジェクトの解決はそのプロジェクトのコードを実行します — [プロジェクトコードの実行](#configuration) を参照してください。 |
 | `--help`    | `gda` または任意のコマンドの使い方を表示します。 |
 
 ---
@@ -558,7 +558,7 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 | **MCP**(`gda-mcp`) | `GDA_PROJECT`(厳格 — 設定済みだが無効ならスキップせずエラー報告)→ *有効な* クライアントワークスペースの `root` → *有効な* サーバーの cwd、なければ projectless |
 
 <details>
-<summary>Project code execution — プロジェクトを指定したときに何が実行されるか</summary>
+<summary>プロジェクトコードの実行 — プロジェクトを指定したときに何が実行されるか</summary>
 
 `res://` パスを機能させるためにプロジェクトを解決すると、そのプロジェクトに対して Godot が実行され、
 その一環として Godot はプロジェクト自身のコードの一部を実行します。具体的には:

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=6fb0da04e0265ed7c55f7bceeee9088a764838c27f9b5bf0121339bfb0bb244e -->
+<!-- gda-readme-i18n: source=README.md sha256=6636b90927355b348b5c9501140f1e09f0fba731175e0ff8e4afc8eeb349c6ba -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -666,13 +666,6 @@ CONTEXT.md          # the project's shared domain language
 [ruff](https://docs.astral.sh/ruff/) でリント・フォーマットされ、[pyright](https://microsoft.github.io/pyright/)
 で型チェックされます。どちらも CI で強制されます — コミット前に `uv run ruff format .` と
 `uv run pyright` を実行してください(上記の **開発** を参照)。
-
-この README が信頼できる出典です。翻訳は `docs/README.<lang>.md` 配下にあります([简体中文](README.zh-CN.md)、
-[Español](README.es.md)、[日本語](README.ja.md))。同期ゲート(`tests/test_readme_i18n_sync.py`、CI で実行)は、
-このファイルが変更されたのに翻訳が更新されていない場合に失敗します。この README を編集したら、影響を
-受けるセクションを翻訳し直し、`uv run python scripts/update_readme_i18n.py` を実行して各翻訳の鮮度
-マーカーを再スタンプしてください。このゲートが証明するのは、翻訳が現在の英語版に *照らしてレビュー
-された* ことであり、正確であることではありません — 正確さは人間のレビュアーだけが判断できます。
 
 > **AI コーディングエージェントと作業していますか?** このプロジェクトはエージェントが辿りやすいように
 > 作られています — [`AGENTS.md`](../AGENTS.md) がコーディングエージェントの入口で、プロジェクトの

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=6636b90927355b348b5c9501140f1e09f0fba731175e0ff8e4afc8eeb349c6ba -->
+<!-- gda-readme-i18n: source=README.md sha256=4ef9cb754f81a9c5c4ff9b88782dd72a6577f3a6c5fea7170390d9c59b5972cd -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -34,6 +34,22 @@ AI agent 擅长编写 GDScript，却拙于*看到发生了什么*。`gda` 帮你
 
 ---
 
+## 目录
+
+- [为什么选择 `gda`？](#why-gda)
+- [能力速览](#capabilities-at-a-glance)
+- [安装](#installation)
+- [快速上手](#quick-start)
+- [选择你的集成方式](#choose-your-integration)
+- [工作原理](#how-it-works)
+- [命令参考](#command-reference)
+- [配置](#configuration)
+- [贡献](#contributing)
+- [许可证](#license)
+
+---
+
+<a id="why-gda"></a>
 ## 为什么选择 `gda`？
 
 - **🤖 结构化输出，为 agent 而生。** 每条命令在 stdout 上只输出**恰好一个** JSON
@@ -56,6 +72,7 @@ AI agent 擅长编写 GDScript，却拙于*看到发生了什么*。`gda` 帮你
 
 ---
 
+<a id="capabilities-at-a-glance"></a>
 ## 能力速览
 
 | 你的需求 | 用这个 |
@@ -68,6 +85,7 @@ AI agent 擅长编写 GDScript，却拙于*看到发生了什么*。`gda` 帮你
 
 ---
 
+<a id="installation"></a>
 ## 安装
 
 **环境要求：** Python 3.13+，以及一个 [Godot](https://godotengine.org) 二进制文件——
@@ -101,6 +119,7 @@ uv run gda --help
 
 ---
 
+<a id="quick-start"></a>
 ## 快速上手
 
 **让 `gda` 指向你的 Godot 二进制文件**，然后问引擎要它的版本——不需要项目：
@@ -149,6 +168,7 @@ gda daemon stop
 
 ---
 
+<a id="choose-your-integration"></a>
 ## 选择你的集成方式
 
 `gda` 用三种方式暴露**同一套命令界面**——你的 agent（或你自己）支持哪种就挑哪种：
@@ -316,6 +336,7 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 
 ---
 
+<a id="command-reference"></a>
 ## 命令参考
 
 `gda` 命令**按 Godot 领域对象分组**，并使用一套精简、一致的动词词汇，因此同一个动词
@@ -636,6 +657,7 @@ e2e 套件会驱动一个真实引擎跨越这两者。
 
 ---
 
+<a id="contributing"></a>
 ## 贡献
 
 欢迎贡献。请阅读 [`CONTEXT.md`](../CONTEXT.md) 以对齐项目的共享语言，并查阅你所触及领域的
@@ -649,6 +671,7 @@ Python 代码用 [ruff](https://docs.astral.sh/ruff/) 做 lint 和格式化、�
 > [`AGENTS.md`](../AGENTS.md) 是编程 agent 的入口，把项目的规则、领域文档和 skill 都
 > 串接了进来。
 
+<a id="license"></a>
 ## 许可证
 
 基于 [MIT License](../LICENSE) 发布。Copyright (c) 2026 aigengame。

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,0 +1,661 @@
+<!-- gda-readme-i18n: source=README.md sha256=6fb0da04e0265ed7c55f7bceeee9088a764838c27f9b5bf0121339bfb0bb244e -->
+
+# godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
+
+![godot-agent title image](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)
+
+**其他语言:** [English](../README.md) · **简体中文** · [Español](README.es.md) · [日本語](README.ja.md)
+
+> **`gda` 让你的 AI 编程 agent——或者你的 shell 脚本和 CI——以结构化、机器可读的方式
+> 操控 [Godot Engine](https://godotengine.org)。** 以 Headless 方式创建场景、编辑节点和脚本、
+> 导出构建产物，然后实时操控*正在运行*的游戏：运行时树、输入、
+> 截图、性能——一套命令界面，三种接入方式。
+
+[![pre-1.0](https://img.shields.io/badge/status-pre--1.0-orange)](https://pypi.org/project/gda/)
+[![CI](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
+[![Python](https://img.shields.io/badge/python-3.13%2B-blue)](https://www.python.org/)
+[![Godot](https://img.shields.io/badge/godot-4.4%2B%20(live%204.6%2B)-478CBF)](https://godotengine.org)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%C2%B7%20Linux%20%C2%B7%20Windows-lightgrey)](#how-it-works)
+[![MCP](https://img.shields.io/badge/MCP-server-000)](https://modelcontextprotocol.io)
+[![License](https://img.shields.io/badge/license-MIT-green)](../LICENSE)
+
+AI agent 擅长编写 GDScript，却拙于*看到发生了什么*。`gda` 帮你闭合这个回路：你的 agent
+发出一个操作，拿回一个干净的 JSON 结果就能据此行动——而不是一堆它得费劲去扒拉的引擎日志。
+它有**两种模式**：
+
+- **Headless（无头）** — 一次性、无状态、零配置。无需编辑器插件、无需 daemon，
+  无需往你的项目里安装任何东西。创建和编辑场景、节点、脚本、资源、着色器和主题；
+  分析项目；导出构建产物。
+- **Live（实时）** — 通过一个后台 daemon 操控*正在运行*的游戏，完成所有只有活引擎才能做的事：
+  读取运行时场景树、读写运行时属性、模拟输入、捕获截图、采样性能。
+
+> `gda` 目前处于 **pre-1.0** 阶段：今天每条命令都能端到端跑通，但在 1.0 之前 CLI 界面
+> 仍可能变化。
+
+---
+
+## 为什么选择 `gda`？
+
+- **🤖 结构化输出，为 agent 而生。** 每条命令在 stdout 上只输出**恰好一个** JSON
+  对象（`--json`）；引擎横幅、警告和 `print()` 都走 stderr。你的 agent 解析的是一个结果，
+  而不是一墙日志。
+- **📐 带类型、可自描述。** 每条命令的输入和输出都是带类型的模型，它们同时支撑起一份机器可读的
+  `--schema`（JSON-Schema 契约），让 agent 可以用程序化的方式发现并校验整个命令界面，而不必靠猜。
+- **🔀 CLI、Skill、MCP——交给你的 agent 自选。** 用原生的 `gda` CLI 从终端或 CI 操控 Godot，
+  把随包附带的 **Skill**（`gda skill`）交给你的 agent、教它何时以及如何使用 CLI，或者把同一套操作以
+  **MCP** 工具的形式暴露出来（`gda-mcp`，由 CLI 自身的 schema 生成）。一套命令界面，三种接入方式——
+  你的 agent 支持哪种就挑哪种。
+- **🧩 Godot 原生命令。** 按 Godot 对象分组（`gda scene create`、
+  `gda node add`、`gda game set`），配上一套精简、一致的动词词汇——只要你已经懂 Godot，
+  就几乎没有学习成本。
+- **⚡ 默认 Headless，需要时再 Live。** Headless 操作不需要 daemon、也不需要编辑器——
+  只要一个 Godot 二进制文件。Live 操作则通过一个基于 Unix 域套接字的 daemon，为正在运行的游戏
+  加上实时控制能力，用的还是同一套 CLI 语法。
+- **🛡️ 出错就大声报，绝不悄悄吞。** 引擎缺失或卡死会被超时兜住，并映射为一个**稳定的非零退出码**
+  外加一个结构化的 `{"error": {…}}` 信封——这样 shell 或 agent 无需解析散文就能按失败类别分支处理。
+
+---
+
+## 能力速览
+
+| 你的需求 | 用这个 |
+| --- | --- |
+| 从 agent 或脚本生成项目文件 | `scene` / `node` / `script` / `resource` / `shader` / `theme`——以 Headless 方式创建和编辑 |
+| 解析结果，而不是扒拉引擎日志 | `--json`（一个干净的对象）和 `--schema`（JSON-Schema 契约） |
+| 把 Godot 工具交给 agent | 随包附带的 **Skill**（`gda skill`）或 **`gda-mcp`** 服务器 |
+| 自动化 CI、导出和项目分析 | Headless 命令——无需编辑器、无需插件，只要一个 Godot 二进制文件 |
+| 调试*正在运行*的游戏的运行时行为 | `gda daemon start`，然后用 `game` / `diag` / `logger` / `perf` / `input` / `screen` |
+
+---
+
+## 安装
+
+**环境要求：** Python 3.13+，以及一个 [Godot](https://godotengine.org) 二进制文件——
+Headless 命令需要 4.4+，macOS/Linux 上的 Live（daemon）命令需要 4.6+。
+
+把 CLI 从 PyPI 安装到你的 `PATH` 上：
+
+```bash
+uv tool install gda      # or: pipx install gda
+gda --help
+```
+
+<details>
+<summary>其他安装方式（pip、从源码）</summary>
+
+安装到已有环境中：
+
+```bash
+pip install gda
+```
+
+从源码安装（用于开发或获取尚未发布的改动）：
+
+```bash
+git clone https://github.com/aigengame/godot-agent.git
+cd godot-agent
+uv sync                  # create the environment + install dependencies
+uv run gda --help
+```
+</details>
+
+---
+
+## 快速上手
+
+**让 `gda` 指向你的 Godot 二进制文件**，然后问引擎要它的版本——不需要项目：
+
+```bash
+export GDA_GODOT="/path/to/Godot"   # or pass --godot to any command
+gda info --json
+# {"major":4,"minor":6,"patch":3,"status":"stable","string":"4.6.3-stable (official)",…}
+```
+
+stdout 永远是干净、可管道传递的 JSON；所有引擎和脚本的诊断信息都走 stderr：
+
+```bash
+gda info --json | jq .major   # → 4
+```
+
+**以 Headless 方式构建一个场景。** 让 `gda` 指向一个 Godot 项目（一个含有 `project.godot` 的目录）
+一次；之后相对路径都会在它*内部*解析，而节点则通过相对于场景根的路径来寻址：
+
+```bash
+export GDA_PROJECT="/path/to/your/godot-project"   # or pass --project to any command
+gda scene create scenes/main.tscn --root-type Node2D --json
+gda node add  scenes/main.tscn --type Sprite2D --name Hero --json
+gda node set  scenes/main.tscn --node Hero --property position --value 10,20 --json
+gda scene get scenes/main.tscn --json
+# {"path":"scenes/main.tscn","root":{"name":"main","type":"Node2D","children":[{"name":"Hero",…}]}}
+```
+
+> 没有项目？`gda` 仍可在普通文件系统路径上以**无项目（projectless）**方式运行（相对于你的当前目录）——
+> 只有 `res://` 解析才需要项目。参见[配置](#configuration)。
+
+**实时操控*正在运行*的游戏。** Live 操作会运行项目的**主场景**，所以先通过 Godot 的
+`application/run/main_scene` 项目设置（也就是编辑器里的 *Application → Run → Main Scene*）
+把它指向你刚构建好的那个场景，然后启动 daemon（macOS/Linux，Godot 4.6+）：
+
+```bash
+gda project set application/run/main_scene --value res://scenes/main.tscn --json  # a Godot project setting key
+gda daemon start             # start the daemon for $GDA_PROJECT (installs the in-game harness)
+gda game tree --json         # the runtime scene tree, after _ready
+gda perf monitors --json     # live engine counters: fps, memory, node count
+gda daemon stop
+```
+
+（`gda screen capture` 也能实时工作，但需要一个带窗口的会话——用
+`gda daemon start --windowed` 启动 daemon。）
+
+---
+
+## 选择你的集成方式
+
+`gda` 用三种方式暴露**同一套命令界面**——你的 agent（或你自己）支持哪种就挑哪种：
+
+| 入口 | 适合 | 怎么用 |
+| --- | --- | --- |
+| **CLI**（`gda`） | 人类、shell 脚本、CI，以及能运行命令的 agent | `gda <group> <command> --json` |
+| **Skill**（`gda skill`） | 支持 Agent Skills、偏好省 token 的 CLI 工作流的编程 agent | 打印/安装 `SKILL.md`（见下文） |
+| **MCP**（`gda-mcp`） | 通过 Model Context Protocol 调用工具的 agent | 运行 stdio 服务器（见下文） |
+
+### 作为 Skill 使用
+
+`gda` 附带一个 agent **Skill**——一份 `SKILL.md`，教 AI agent *何时*以及*如何*从 CLI 操控
+Godot。这是最轻量的接入方式（没有服务器要注册），随包附带，并与你的安装版本锁定。把它打印出来，
+或安装到你的 agent 的 skills 目录里：
+
+```bash
+gda skill                                              # print SKILL.md (redirect it anywhere)
+gda skill --install --provider claude --scope user     # resolve a known agent's skills dir
+gda skill --install --dir ~/.claude/skills/gda         # …or give the directory yourself
+```
+
+`--install --provider <claude|codex> --scope <project|user>` 会解析出某个已知 agent 的 skills
+目录（`--scope` 默认为 `user`）；`--dir` 则是面向任何其他 agent 的中立兜底——没有内置默认值。
+[skill recipes](gda-skill.md) 列出了每个 agent 的目录（Claude Code 的 `~/.claude/skills/`、
+Codex 的 `~/.agents/skills/` 等）。或者，如果你不想走 `gda skill`，也可以直接从仓库获取同一个文件——
+你仍然需要安装 `gda`，因为 Skill 靠它来驱动：
+
+```bash
+curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \
+  https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md
+```
+
+### 作为 MCP 服务器使用
+
+`gda` 在 `[mcp]` 这个 extra 之下附带了一个 stdio [MCP](https://modelcontextprotocol.io) 服务器，
+因此任何 MCP agent（Claude Code、Codex、Cursor 等）都能操控 Godot。无需安装即可一试：
+
+```bash
+uvx --from "gda[mcp]" gda-mcp
+```
+
+服务器需要解析两项上下文——操控哪个 Godot**项目**，以及运行哪个 Godot**二进制文件**
+（MCP 无法逐次调用传递 flag）：
+
+- **项目** — 当你的客户端无法公布工作区 **roots** 时，设置 `GDA_PROJECT`；否则 `gda-mcp`
+  会从客户端发来的 roots（你打开的那个文件夹）自动检测项目。*已设置但无效*的 `GDA_PROJECT`
+  会被当作一个上报的错误，而不是悄悄兜底。完整的 CLI 与 MCP 解析顺序参见[配置](#configuration)。
+- **引擎** — 把 `GDA_GODOT` 设为你的 Godot 二进制文件，例如 `"GDA_GODOT": "/path/to/Godot"`。
+
+
+#### 在编程 agent 中注册
+
+<details>
+<summary>Claude Code</summary>
+
+项目级，仓库根目录下的 `.mcp.json`（通过 `roots` 自动检测项目）：
+
+```json
+{
+  "mcpServers": {
+    "gda-mcp": {
+      "command": "uvx",
+      "args": ["--from", "gda[mcp]", "gda-mcp"]
+    }
+  }
+}
+```
+
+用户级（适用于每个项目）——使用 CLI，它会写入 `~/.claude.json`：
+
+```bash
+claude mcp add --scope user gda-mcp -- uvx --from "gda[mcp]" gda-mcp
+```
+
+</details>
+
+<details>
+<summary>Codex</summary>
+
+项目级，仓库根目录下的 `.codex/config.toml`（项目必须是受信任的）：
+
+```toml
+[mcp_servers.gda-mcp]
+command = "uvx"
+args = ["--from", "gda[mcp]", "gda-mcp"]
+
+[mcp_servers.gda-mcp.env]
+GDA_PROJECT = "/absolute/path/to/your/godot/project"
+```
+
+用户级（处处可用，但固定指向单一项目）——把同一段配置表放进 `~/.codex/config.toml`，
+或用 CLI 添加。Codex 没有工作区变量，所以 `GDA_PROJECT` 是一个绝对路径；如果你要跨多个项目工作，
+请用项目级：
+
+```bash
+codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- \
+  uvx --from "gda[mcp]" gda-mcp
+```
+
+</details>
+
+<details>
+<summary>Cursor</summary>
+
+项目级，仓库根目录下的 `.cursor/mcp.json`（`${workspaceFolder}`
+会跟踪当前打开的项目）：
+
+```json
+{
+  "mcpServers": {
+    "gda-mcp": {
+      "type": "stdio",
+      "command": "/path/to/uvx",
+      "args": ["--from", "gda[mcp]", "gda-mcp"],
+      "env": {
+        "GDA_PROJECT": "${workspaceFolder}"
+      }
+    }
+  }
+}
+```
+
+用户级（处处可用，但固定指向单一项目）——把同样的配置放进 `~/.cursor/mcp.json`，并把
+`GDA_PROJECT` 设为一个绝对路径（`${workspaceFolder}` 只在项目级有效；多项目请用项目级）。
+Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP 界面来注册。
+
+> Cursor 是以一个极简 `PATH` 由 GUI 启动的，所以裸的 `uvx` 可能解析不到——这正是上面用绝对路径
+> `command` 的原因；用 `which uvx` 的输出来填它。完整的配方——PATH 注入、Claude Desktop、
+> 用户级与项目级、各 agent 的项目固定方式——都在[注册配方](gda-mcp-registration.md)里。
+</details>
+
+---
+
+<a id="how-it-works"></a>
+## 工作原理
+
+`gda` 由三个组件构成，以两种模式服务各类操作：
+
+| 组件             | 职责                                                                  |
+| ---------------- | --------------------------------------------------------------------- |
+| **`gda`**        | 面向 agent 的 CLI——以结构化的 `--json` 输出暴露 Godot。 |
+| **`gda-mcp`**    | 一个 MCP 服务器，从 `--schema` 出发，把同一套操作以工具形式暴露。 |
+| **`gda-daemon`** | 一个按项目运行的进程，为 Live 操作监管一个正在运行的游戏。 |
+
+- **Headless 操作**一次性运行——没有 daemon、无需安装任何东西（创建场景、编辑脚本、导出、分析）。
+- **Live 操作**需要一个正在运行的游戏——`gda-daemon` 启动它、注入一个惰性的游戏内 harness，
+  并通过 Unix 域套接字中转请求（运行时树、输入、截图、性能、诊断）。
+
+`gda-daemon` 注入的游戏内 harness **仅用于开发**：`gda export run` 会把它从产物中彻底剥除；
+而即便用其他方式构建（编辑器 GUI、裸的 `godot --export`），它在导出后的游戏里也会自我禁用——
+所以一个发行版游戏永远不会*运行*任何与 daemon 相关的东西（而经由 `gda export run`，
+它甚至根本不会被携带进去）。
+
+**平台与版本支持：**
+
+| 模式 | Godot | 平台 |
+| ---- | ----- | --------- |
+| **Headless** | 4.4+ | macOS · Linux · Windows¹ |
+| **Live**（经由 `gda-daemon`） | 4.6+ | macOS · Linux² |
+
+¹ Headless 在设计上就是跨平台的（一次性进程，无平台相关依赖）——Windows 保有完整的
+  headless 命令界面，尽管 CI 还没有对它做验证。
+² Live 操作使用 Unix 域套接字，所以暂不支持 Windows。
+
+---
+
+## 命令参考
+
+`gda` 命令**按 Godot 领域对象分组**，并使用一套精简、一致的动词词汇，因此同一个动词
+在每个分组里含义都一样：
+
+| 动词                | 含义                                                              |
+| ------------------- | ----------------------------------------------------------------- |
+| `create` / `delete` | 创建 / 删除一个**独立**实体（场景、脚本、资源）。 |
+| `add` / `remove`    | 在容器内增加 / 移除一个**子实体**（节点 → 场景）。 |
+| `get` / `list`      | 读取单个实体 / 枚举多个。 |
+| `set`               | 修改一个属性。 |
+| 领域动词        | `play`、`run`、`export`、`import` 等，保留它们的自然含义。 |
+
+每条命令都支持 `--json` 和 `--schema`——只有 `gda schema` 自己例外，它会直接把聚合清单
+作为 JSON 输出。读取或修改 `res://` 路径的命令会解析一个[项目上下文](#configuration)。
+运行 `gda <group> <command> --help` 查看完整 flag——`gda --help` 是已安装命令的权威清单。
+
+**第一次用？** 一条不错的上手路径：`gda info` → `gda scene create` → `gda node add` →
+`gda script validate` → `gda export run`；然后用 `gda daemon start` → `gda game tree` 进入 Live。
+
+**Meta** — 关于 `gda` / 引擎本身
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `gda info`   | 报告 Godot 引擎的版本信息。 |
+| `gda schema` | 把整个命令界面作为一份机器可读的 JSON 清单输出。 |
+| `gda skill`  | 输出或安装随包附带的 Agent Skill（`SKILL.md`），它教 agent 如何操控 `gda`。 |
+
+### Headless 命令 — Godot 4.4+，全平台
+
+**`scene`** — 场景文件（`.tscn`）
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `scene create` | 用指定的根节点类型创建一个新的 `.tscn`。 |
+| `scene get` | 读取一个场景并报告其结构化的节点树。 |
+| `scene list` | 枚举已解析项目中的 `.tscn` 场景。 |
+| `scene get-exports` | 列出场景里各节点脚本声明的 `@export` 属性。 |
+| `scene delete` | 删除一个场景文件并报告删除了什么。 |
+
+**`node`** — 场景文件内的节点
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `node add` | 在某个父节点下添加一个节点（内置类型或带 `class_name` 的脚本）。 |
+| `node get` | 按节点路径读取一个节点的属性，输出带类型的 JSON。 |
+| `node list` | 列出一个场景的节点树，并给出每个节点相对于根的路径。 |
+| `node set` | 设置一个节点属性，并把值强制转换为它声明的 Godot 类型。 |
+| `node remove` | 按节点路径移除一个节点（及其子树）。 |
+| `node duplicate` | 在父节点下复制一个节点（及其子树）。 |
+| `node move` | 把一个节点（及其子树）重新挂到一个新的父节点下。 |
+| `node connect-signal` | 把源节点的信号接到目标节点的方法上。 |
+| `node disconnect-signal` | 断开一个已有的「信号→方法」连接。 |
+
+**`script`** — GDScript 文件（`.gd`）
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `script create` | 从模板或原样的 `--content` 创建一个新的 `.gd` 脚本。 |
+| `script get` | 读取一个脚本的源码及其 `class_name` / `extends` 元数据。 |
+| `script list` | 枚举已解析项目中的 `.gd` 脚本。 |
+| `script set` | 通过搜索替换、行范围或整体覆写来编辑一个脚本。 |
+| `script delete` | 删除一个脚本文件并报告删除了什么。 |
+| `script attach` | 按节点路径把一个 `.gd` 脚本附加到场景里的某个节点上。 |
+| `script validate` | 对一个 `.gd` 脚本做语法 / 编译检查。 |
+
+**`project`** — 作为整体的项目（设置、autoload、静态分析）
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `project info` | 报告项目元数据（名称、主场景、视口、引擎版本）。 |
+| `project get` | 按 section/key 读取单个项目设置，输出带类型的 JSON。 |
+| `project list` | 列出项目的设置键（默认只列已自定义的；`--all` 加上引擎默认值，`--section` 按前缀过滤）。 |
+| `project set` | 设置一个项目设置，并把值强制转换为它声明的类型。 |
+| `project add-autoload` | 注册一个 autoload 单例（名称 → 脚本/场景）。 |
+| `project remove-autoload` | 按名称注销一个 autoload 单例。 |
+| `project find-references` | 找出引用了给定资源的每一个项目文件。 |
+| `project dependencies` | 把每个场景/资源映射到它所依赖的资源。 |
+| `project find-unused-resources` | 找出没有任何东西引用的资源文件。 |
+| `project statistics` | 报告项目的文件/行数统计、autoload 等信息。 |
+
+**`resource`** — 资源文件（`.tres`）
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `resource create` | 创建一个给定类型的新 `.tres` 资源。 |
+| `resource get` | 读取一个 `.tres` 资源的属性，输出带类型的 JSON。 |
+| `resource set` | 设置一个 `.tres` 属性，并把值强制转换为它声明的类型。 |
+| `resource delete` | 删除一个 `.tres` 资源文件并报告删除了什么。 |
+| `resource uid` | 在资源 UID 与其 `res://` 路径之间双向解析。 |
+
+**`export`** — 导出预设与产物
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `export list` | 枚举项目的导出预设（名称、平台等）。 |
+| `export get` | 报告某个预设的详情以及导出模板的安装状态。 |
+| `export run` | 把一个具名预设（`release` / `debug` / `pack`）导出到目标位置。 |
+
+**`shader`** — 着色器文件（`.gdshader`）
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `shader create` | 从模板或原样的 `--content` 创建一个新的 `.gdshader`。 |
+| `shader get` | 读取一个着色器的源码及其 `shader_type`。 |
+| `shader set` | 通过搜索替换、行范围或整体覆写来编辑一个 `.gdshader`。 |
+
+**`theme`** — 主题资源（`.tres`）
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `theme create` | 创建一个可加载的全新 `.tres` Theme 资源（不覆盖已有文件）。 |
+
+### Live 命令 — 经由 `gda-daemon`；Godot 4.6+，macOS/Linux
+
+**`daemon`** — Live 运行时的生命周期
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `daemon start` | 启动按项目运行的 daemon 并安装游戏内 harness；引擎会话会在第一个 Live 操作时启动（`screen` 截图需加 `--windowed`）。 |
+| `daemon stop` | 停止项目的 daemon 以及任何正在运行的引擎会话。 |
+| `daemon status` | 报告 daemon 的状态（是否运行、窗口模式、会话）。 |
+| `daemon uninstall` | 从项目中移除游戏内 `gda` harness（autoload 条目 + 文件）——一次显式的开发工具拆除；`gda export run` 在导出产物时已经会自动剥除它。 |
+
+**`game`** — 正在运行的游戏的运行时场景图
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `game tree` | 读取正在运行的游戏的运行时场景树（在 `_ready` 之后）。 |
+| `game get` | 按节点路径读取一个运行时节点的实时属性。 |
+| `game set` | 在正在运行的游戏上设置一个运行时节点属性。 |
+
+**`diag`** — 运行时诊断
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `diag errors` | 跟踪（tail）正在运行的游戏的运行时错误（已分类）。 |
+
+**`logger`** — 结构化运行时日志
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `logger tail` | 以结构化记录的形式跟踪正在运行的游戏的整个运行时日志（`--level`、`--limit`、`--raw`）。 |
+
+**`perf`** — 性能监控
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `perf monitors` | 对引擎的性能计数器拍一张快照（fps、内存、节点数等）。 |
+| `perf monitor` | 在一个帧窗口内对某个节点属性或信号采样（时间线）。 |
+
+**`input`** — 输入模拟
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `input key` | 注入一个按键事件（带修饰键）。 |
+| `input mouse-click` | 在 `(x, y)` 处注入一次鼠标点击。 |
+| `input mouse-move` | 注入一次移动到 `(x, y)` 的鼠标移动。 |
+| `input action` | 按下/释放一个已映射的输入动作。 |
+| `input sequence` | 注入一条跨多帧的事件时间线。 |
+
+**`screen`** — 视口捕获
+
+| 命令 | 作用 |
+| ------- | ------------ |
+| `screen capture` | 把一帧视口捕获为一张 PNG。 |
+| `screen frames` | 捕获一个 N 帧的 PNG 序列。 |
+
+### 全局 flag
+
+| Flag       | 说明                                                               |
+| ---------- | ------------------------------------------------------------------- |
+| `--json`    | 在 stdout 上把结果作为单个 JSON 对象输出。不加它时，命令会打印一份简洁的、给人看的渲染结果。 |
+| `--schema`  | 输出该命令的输入/输出 JSON Schema 契约（不会启动 Godot）。 |
+| `--godot`   | Godot 二进制文件的路径（覆盖 `$GDA_GODOT` 和默认值）。 |
+| `--project` | 用于 `res://` 解析的 Godot 项目目录（覆盖 `$GDA_PROJECT`；若当前目录本身是个项目则默认用它）。仅限领域命令。解析一个项目会运行该项目的代码——参见[项目代码执行](#configuration)。 |
+| `--help`    | 显示 `gda` 或任意命令的用法。                                |
+
+---
+
+<a id="configuration"></a>
+## 配置
+
+`gda` 会从 **`--godot <path>`** flag 找到 Godot 二进制文件，否则就用
+**`GDA_GODOT`** 环境变量——设置其中之一，`gda` 才能定位到你的引擎。
+
+领域命令会按以下顺序解析一个 **Godot 项目**（以便 `res://` 路径以及场景的跨资源
+引用能够确定性地解析）：
+
+1. **`--project <dir>`** flag。
+2. **`GDA_PROJECT`** 环境变量。
+3. **当前目录**，当它本身是个 Godot 项目时（含有 `project.godot`）。
+
+显式指定的目录必须是个项目，否则 `gda` 会把它当作错误上报。当没有任何一项解析成功时，
+`gda` 会以**无项目（projectless）**方式运行——只有文件系统路径（绝对路径或相对于 cwd 的路径）
+能解析，`res://` 不行。**MCP 服务器**没有 flag，所以它解析项目的方式略有不同：
+
+| 上下文 | 项目解析顺序 |
+| --- | --- |
+| **CLI** | `--project` → `GDA_PROJECT`（两者都严格——无效即上报）→ 含有 `project.godot` 的 cwd，否则无项目 |
+| **MCP**（`gda-mcp`） | `GDA_PROJECT`（严格——已设置但无效会被上报，而非跳过）→ 一个*有效的*客户端工作区 `root` → 一个*有效的*服务器 cwd，否则无项目 |
+
+<details>
+<summary>项目代码执行——当你指向一个项目时会运行什么</summary>
+
+为了让 `res://` 路径生效而解析一个项目，会让 Godot 针对该项目运行，而 Godot 作为其中一环
+会运行该项目自己的一部分代码。具体来说：
+
+- **每个 `--project` 操作都会运行 autoload。** 当一个项目被解析时，引擎会在启动阶段——
+  在命令本身的工作开始之前——构造该项目的 autoload 单例，因此它们的 `_init`（以及 `_ready`）
+  会在**每一个**操作上执行，包括 `scene get`、`node list` 这类只读操作。如果没有解析到项目，
+  就不会注册任何 autoload，它们也就不会运行。
+- **会实例化场景的命令，会执行该场景所附脚本的构造函数。**
+  任何需要一棵活节点树的命令——每一个会改动状态的命令（`node add`、`node set`、
+  `node remove` 等），以及 `node get`（它会报告存储数据本身不携带的运行时属性默认值）——
+  都会加载并实例化该场景，这会构造每个节点，并运行其中任何附加在节点上的脚本的 `_init`。
+  只读取已存储场景数据的命令（`scene get`、`scene list`、`node list`）只是遍历它而不实例化，
+  所以不会运行那些脚本。
+
+`gda` 把目标项目视为受信任的，所以这是有意为之——信任模型参见
+[ADR-0009](adr/0009-trust-boundary-trusted-project.md)。
+</details>
+
+---
+
+<details>
+<summary><strong>底层原理</strong> — 结构化输出契约与退出码</summary>
+
+Headless 的 Godot 会把它的横幅、警告和 `print()` 输出交错混进 stdout。`gda`
+用一套哨兵（sentinel）契约来解决这个问题
+（[ADR-0002](adr/0002-headless-structured-output-contract.md)）：
+
+- GDScript 负载在 stdout 上只输出**恰好一个**结果，用唯一的哨兵包裹起来：
+
+  ```
+  <<<GDA:RESULT>>>{ …json… }<<<GDA:END>>>
+  ```
+
+- 它把自己**全部**的诊断信息都导向 stderr；stdout 上除了契约什么都不带。
+- `gda` 只提取并解析两个哨兵之间的字节，忽略周围的引擎噪声，并把 stderr 暴露出来供检查。
+
+正是这一点让 `gda` 的输出可以安全地被程序化消费，而且它还推广成了 daemon 为 Live 操作
+所用的逐消息协议。
+
+**退出码（CLI ABI）。** 一次失败的 `gda` 运行会以一个小而稳定的退出码退出，这样 shell
+或 agent 就能**在不解析 JSON 错误的情况下**按失败**类别**分支处理：
+
+| 退出码 | 类别      | 何时                                                                  |
+| --------- | ------------- | --------------------------------------------------------------------- |
+| `0`       | —             | 成功。                                                              |
+| `127`     | `environment` | Godot 二进制文件无法启动（shell 惯例：not found）。 |
+| `124`     | `environment` | Godot 启动了，但在 runner 超时之前没有返回（shell 惯例：timed out）。 |
+| `3`       | `version`     | 检测到的 Godot 版本低于受支持的最低版本。            |
+| `4`       | `operation`   | 引擎运行了，但操作失败了——一个已注册的操作错误、一次引擎崩溃，或一次非结构化的非零退出。 |
+| `5`       | `parse`       | 进程声称成功，却违反了结构化输出契约。 |
+| `6`       | `live`        | 一个 Live 操作失败了——例如没有正在运行的 daemon/会话，或一次 Live 超时。 |
+
+这些值就是公开 ABI；其权威来源是
+[`src/gda/exit_codes.py`](../src/gda/exit_codes.py)。`{"error": {category, code, …}}`
+信封在每个类别之内还携带一个**更细的 `code`**（例如 `path_not_found`、
+`already_exists`、`node_not_found` 都归在 `operation` / 退出码 `4` 之下）。完整的
+注册表见
+[ADR-0002 的 `GdaError.code` 表](adr/0002-headless-structured-output-contract.md#gdaerrorcode-registry)。
+</details>
+
+<details>
+<summary><strong>开发</strong></summary>
+
+```bash
+uv sync                       # set up the environment
+
+uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
+uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
+uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
+
+uv run ruff check .           # lint
+uv run ruff format .          # auto-format (append --check to verify without writing)
+uv run pyright                # type-check (src/ + tests/, basic mode)
+```
+
+`e2e` 这一层在 `uv run pytest` 时默认运行，并且会**大声报错**——指出解析到的路径以及如何修复——
+如果在那里找不到 Godot 二进制文件，而不是悄悄跳过。用 `-m "not e2e"` 可以把整层排除掉
+（CI 的每个 PR 任务正是这么做的）。
+
+Lint 和格式化由 [ruff](https://docs.astral.sh/ruff/) 强制执行——用一个工具取代
+flake8 + black + isort，配置在 `pyproject.toml` 的 `[tool.ruff]` 下，并通过 `uv.lock`
+锁定版本，让本地和 CI 保持一致。CI 的 `lint` 任务会在每个 PR 上运行 `ruff check .` 和
+`ruff format --check .`；提交前先运行 `uv run ruff format .` 以保持绿色。
+
+类型由 [pyright](https://microsoft.github.io/pyright/) 以 `basic` 模式检查，覆盖
+`src/` 和 `tests/`，配置在 `pyproject.toml` 的 `[tool.pyright]` 下（同样通过
+`uv.lock` 锁定版本）。CI 的 `type-check` 任务会在每个 PR 上运行 `uv run --frozen pyright`。
+
+```
+src/gda/
+  cli.py            # CLI entrypoint (Typer): all command groups, --json / --schema
+  surface.py        # walks the live Typer tree → the `gda schema` manifest
+  headless.py       # the per-command descriptor (one HeadlessCommand per command)
+  binary.py         # Godot binary resolution (flag > $GDA_GODOT > default)
+  runner.py         # the one-shot headless spawn seam (Protocol + subprocess impl)
+  live_runner.py    # the live-operation client that talks to gda-daemon
+  models.py         # typed I/O models (Pydantic) backing --json and --schema
+  errors.py / error_codes.py / exit_codes.py   # failure classification + the CLI ABI
+  render.py         # human-readable (non-JSON) rendering
+  ops/operations.gd # the headless GDScript payload, dispatched by operation name
+  daemon/           # gda-daemon: server, session supervision, IPC protocol, discovery
+  harness/          # the inert in-game `gda` autoload injected into a live session
+  mcp/              # gda-mcp: the schema → MCP-tool server
+tests/              # unit + e2e tests against a real engine (shared fixtures in conftest.py)
+docs/adr/           # architecture decision records
+CONTEXT.md          # the project's shared domain language
+```
+
+`gda` 有两条外部边界，每条背后都有一个接缝（seam）供快速测试注入：启动一个一次性的
+headless 进程（`runner.py`），以及通过 daemon 与正在运行的游戏对话（`live_runner.py`）。
+e2e 套件会驱动一个真实引擎跨越这两者。
+</details>
+
+---
+
+## 贡献
+
+欢迎贡献。请阅读 [`CONTEXT.md`](../CONTEXT.md) 以对齐项目的共享语言，并查阅你所触及领域的
+相关 [ADR](adr/)。Issue 和 PRD 以 [GitHub issues](https://github.com/aigengame/godot-agent/issues)
+的形式存在。提交遵循 [Conventional Commits](https://www.conventionalcommits.org/) 规范。
+Python 代码用 [ruff](https://docs.astral.sh/ruff/) 做 lint 和格式化、用
+[pyright](https://microsoft.github.io/pyright/) 做类型检查，二者都在 CI 中强制执行——
+提交前先运行 `uv run ruff format .` 和 `uv run pyright`（见上面的**开发**部分）。
+
+本 README 是权威来源；译文位于 `docs/README.<lang>.md`
+（[简体中文](README.zh-CN.md)、[Español](README.es.md)、[日本語](README.ja.md)）。
+一道同步闸门（`tests/test_readme_i18n_sync.py`，在 CI 中运行）会在本文件变更而译文未刷新时失败。
+如果你修改了本 README，请重新翻译受影响的章节，然后运行
+`uv run python scripts/update_readme_i18n.py` 来为每份译文重新打上新鲜度标记。这道闸门只能证明
+某份译文是*对照*当前英文*审阅过*的——而不能证明它准确，后者只有人工审阅者才能判断。
+
+> **正在和 AI 编程 agent 协作？** 本项目从设计上就便于 agent 导航——
+> [`AGENTS.md`](../AGENTS.md) 是编程 agent 的入口，把项目的规则、领域文档和 skill 都
+> 串接了进来。
+
+## 许可证
+
+基于 [MIT License](../LICENSE) 发布。Copyright (c) 2026 aigengame。

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -193,7 +193,7 @@ gda skill --install --dir ~/.claude/skills/gda         # …or give the director
 
 `--install --provider <claude|codex> --scope <project|user>` 会解析出某个已知 agent 的 skills
 目录（`--scope` 默认为 `user`）；`--dir` 则是面向任何其他 agent 的中立兜底——没有内置默认值。
-[skill recipes](gda-skill.md) 列出了每个 agent 的目录（Claude Code 的 `~/.claude/skills/`、
+[Skill 配方](gda-skill.md) 列出了每个 agent 的目录（Claude Code 的 `~/.claude/skills/`、
 Codex 的 `~/.agents/skills/` 等）。或者，如果你不想走 `gda skill`，也可以直接从仓库获取同一个文件——
 你仍然需要安装 `gda`，因为 Skill 靠它来驱动：
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=6fb0da04e0265ed7c55f7bceeee9088a764838c27f9b5bf0121339bfb0bb244e -->
+<!-- gda-readme-i18n: source=README.md sha256=6636b90927355b348b5c9501140f1e09f0fba731175e0ff8e4afc8eeb349c6ba -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -644,13 +644,6 @@ e2e 套件会驱动一个真实引擎跨越这两者。
 Python 代码用 [ruff](https://docs.astral.sh/ruff/) 做 lint 和格式化、用
 [pyright](https://microsoft.github.io/pyright/) 做类型检查，二者都在 CI 中强制执行——
 提交前先运行 `uv run ruff format .` 和 `uv run pyright`（见上面的**开发**部分）。
-
-本 README 是权威来源；译文位于 `docs/README.<lang>.md`
-（[简体中文](README.zh-CN.md)、[Español](README.es.md)、[日本語](README.ja.md)）。
-一道同步闸门（`tests/test_readme_i18n_sync.py`，在 CI 中运行）会在本文件变更而译文未刷新时失败。
-如果你修改了本 README，请重新翻译受影响的章节，然后运行
-`uv run python scripts/update_readme_i18n.py` 来为每份译文重新打上新鲜度标记。这道闸门只能证明
-某份译文是*对照*当前英文*审阅过*的——而不能证明它准确，后者只有人工审阅者才能判断。
 
 > **正在和 AI 编程 agent 协作？** 本项目从设计上就便于 agent 导航——
 > [`AGENTS.md`](../AGENTS.md) 是编程 agent 的入口，把项目的规则、领域文档和 skill 都

--- a/scripts/update_readme_i18n.py
+++ b/scripts/update_readme_i18n.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Re-stamp the README translation sync markers with the current English hash.
+
+The English ``README.md`` is the authoritative source; each translated README
+under ``docs/README.<lang>.md`` carries a leading marker recording the sha256 of
+the English README it was translated from (see ``tests/test_readme_i18n_sync.py``):
+
+    <!-- gda-readme-i18n: source=README.md sha256=<64-hex> -->
+
+Run this after re-translating the affected files to "re-bless" them:
+
+    uv run python scripts/update_readme_i18n.py
+
+The marker format is mirrored in ``tests/test_readme_i18n_sync.py``; keep them in
+sync if it ever changes.
+"""
+
+import hashlib
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+TRANSLATIONS = [ROOT / "docs" / f"README.{lang}.md" for lang in ("zh-CN", "es", "ja")]
+
+MARKER_RE = re.compile(r"<!--\s*gda-readme-i18n:.*?-->", re.DOTALL)
+
+
+def main() -> None:
+    digest = hashlib.sha256(README.read_bytes()).hexdigest()
+    marker = f"<!-- gda-readme-i18n: source=README.md sha256={digest} -->"
+
+    for path in TRANSLATIONS:
+        if not path.exists():
+            print(f"skipped (missing): {path.relative_to(ROOT)}")
+            continue
+        text = path.read_text(encoding="utf-8")
+        if MARKER_RE.search(text):
+            text = MARKER_RE.sub(marker, text, count=1)
+        else:
+            text = f"{marker}\n\n{text}"
+        path.write_text(text, encoding="utf-8")
+        print(f"stamped {path.relative_to(ROOT)} -> {digest[:12]}…")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_readme_i18n.py
+++ b/scripts/update_readme_i18n.py
@@ -34,12 +34,10 @@ def main() -> None:
         if not path.exists():
             print(f"skipped (missing): {path.relative_to(ROOT)}")
             continue
-        text = path.read_text(encoding="utf-8")
-        if MARKER_RE.search(text):
-            text = MARKER_RE.sub(marker, text, count=1)
-        else:
-            text = f"{marker}\n\n{text}"
-        path.write_text(text, encoding="utf-8")
+        # Strip any existing marker wherever it sits, then re-attach the canonical
+        # marker as the leading line — the gate requires a *leading* marker.
+        body = MARKER_RE.sub("", path.read_text(encoding="utf-8")).lstrip("\n")
+        path.write_text(f"{marker}\n\n{body}", encoding="utf-8")
         print(f"stamped {path.relative_to(ROOT)} -> {digest[:12]}…")
 
 

--- a/tests/test_readme_i18n_sync.py
+++ b/tests/test_readme_i18n_sync.py
@@ -1,0 +1,90 @@
+"""README translation freshness gate.
+
+The English ``README.md`` is the single authoritative source; the translated
+READMEs under ``docs/README.<lang>.md`` must be re-translated whenever it changes.
+Each translation records, in a leading HTML-comment marker, the sha256 of the
+English ``README.md`` it was translated from:
+
+    <!-- gda-readme-i18n: source=README.md sha256=<64-hex> -->
+
+This test recomputes that hash and asserts every translation's recorded hash
+matches, so a stale translation fails CI. After updating a translation, re-stamp
+the markers with ``uv run python scripts/update_readme_i18n.py``.
+
+Note: this gate guarantees a translation was *reviewed against the current
+English*, not that the translation is *accurate* — natural-language correctness
+cannot be machine-verified.
+
+The marker format is mirrored in ``scripts/update_readme_i18n.py``; keep them in
+sync if it ever changes.
+"""
+
+import hashlib
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+
+# Language code -> translated README path. The codes double as the switcher link
+# targets asserted by test_english_readme_links_to_all_translations.
+TRANSLATIONS = {
+    lang: ROOT / "docs" / f"README.{lang}.md" for lang in ("zh-CN", "es", "ja")
+}
+
+MARKER_RE = re.compile(
+    r"<!--\s*gda-readme-i18n:\s*source=README\.md\s+sha256=([0-9a-f]{64})\s*-->"
+)
+
+
+def _english_hash() -> str:
+    return hashlib.sha256(README.read_bytes()).hexdigest()
+
+
+def _recorded_hash(text: str) -> str | None:
+    match = MARKER_RE.search(text)
+    return match.group(1) if match else None
+
+
+def test_all_translations_present():
+    missing = sorted(lang for lang, path in TRANSLATIONS.items() if not path.exists())
+
+    assert not missing, (
+        f"missing translated READMEs for: {missing}. "
+        "Create docs/README.<lang>.md for each, then run "
+        "`uv run python scripts/update_readme_i18n.py`."
+    )
+
+
+def test_translations_are_in_sync_with_english_readme():
+    expected = _english_hash()
+    stale = {
+        lang: _recorded_hash(path.read_text(encoding="utf-8"))
+        for lang, path in TRANSLATIONS.items()
+        if path.exists()
+        and _recorded_hash(path.read_text(encoding="utf-8")) != expected
+    }
+
+    assert not stale, (
+        "Translated READMEs are out of sync with README.md.\n"
+        f"  expected sha256={expected}\n"
+        + "\n".join(
+            f"  {lang}: recorded={recorded}" for lang, recorded in sorted(stale.items())
+        )
+        + "\nRe-translate each stale file, then run "
+        "`uv run python scripts/update_readme_i18n.py` to re-stamp the markers."
+    )
+
+
+def test_english_readme_links_to_all_translations():
+    text = README.read_text(encoding="utf-8")
+    missing = sorted(
+        f"docs/README.{lang}.md"
+        for lang in TRANSLATIONS
+        if f"docs/README.{lang}.md" not in text
+    )
+
+    assert not missing, (
+        f"README.md is missing language-switcher links to: {missing}. "
+        "Keep the switcher complete so every translation is discoverable."
+    )

--- a/tests/test_readme_i18n_sync.py
+++ b/tests/test_readme_i18n_sync.py
@@ -43,8 +43,23 @@ def _english_hash() -> str:
 
 
 def _recorded_hash(text: str) -> str | None:
-    match = MARKER_RE.search(text)
+    # `.match` anchors at the start of the file: the marker must be the *leading*
+    # content, not buried somewhere in the body.
+    match = MARKER_RE.match(text)
     return match.group(1) if match else None
+
+
+def test_marker_is_the_leading_line():
+    misplaced = sorted(
+        lang
+        for lang, path in TRANSLATIONS.items()
+        if path.exists() and not MARKER_RE.match(path.read_text(encoding="utf-8"))
+    )
+
+    assert not misplaced, (
+        f"the gda-readme-i18n marker must be the leading content in: {misplaced}. "
+        "Run `uv run python scripts/update_readme_i18n.py` to normalize it to the top."
+    )
 
 
 def test_all_translations_present():

--- a/tests/test_readme_i18n_sync.py
+++ b/tests/test_readme_i18n_sync.py
@@ -21,6 +21,7 @@ sync if it ever changes.
 
 import hashlib
 import re
+import unicodedata
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -87,4 +88,71 @@ def test_english_readme_links_to_all_translations():
     assert not missing, (
         f"README.md is missing language-switcher links to: {missing}. "
         "Keep the switcher complete so every translation is discoverable."
+    )
+
+
+# --- In-page anchor integrity (Table of Contents and other "](#...)" links) ---
+
+_FENCE_RE = re.compile(r"^\s*```")
+_HEADING_RE = re.compile(r"^#{1,6}\s+(.*?)\s*$", re.MULTILINE)
+_ANCHOR_ID_RE = re.compile(r'<a id="([^"]+)">')
+_INPAGE_LINK_RE = re.compile(r"\]\(#([^)]+)\)")
+
+
+def _outside_code_fences(text: str) -> str:
+    """Drop fenced code blocks so their `# comment` lines aren't read as headings."""
+    lines, in_fence = [], False
+    for line in text.splitlines():
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            lines.append(line)
+    return "\n".join(lines)
+
+
+def _github_heading_slug(heading: str) -> str:
+    """Approximate GitHub's heading-anchor slug (exact for ASCII headings).
+
+    Lowercase, drop everything that is not a letter/number/mark/space/hyphen
+    (so backticks, `?`, `¿`, … go), then spaces -> hyphens. Translated headings
+    rely on explicit <a id> anchors instead, so CJK edge cases don't gate links.
+    """
+    kept = [
+        ch
+        for ch in heading.strip().lower()
+        if ch in " -" or unicodedata.category(ch)[0] in ("L", "N", "M")
+    ]
+    return "".join(kept).replace(" ", "-")
+
+
+def _anchor_targets(text: str) -> set[str]:
+    body = _outside_code_fences(text)
+    targets = set(_ANCHOR_ID_RE.findall(body))
+    targets.update(_github_heading_slug(h) for h in _HEADING_RE.findall(body))
+    return targets
+
+
+def test_in_page_anchor_links_resolve():
+    files = {"README.md": README} | {
+        f"docs/README.{lang}.md": path for lang, path in TRANSLATIONS.items()
+    }
+    broken = {}
+    for name, path in files.items():
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        body = _outside_code_fences(text)
+        targets = _anchor_targets(text)
+        unresolved = sorted(
+            {slug for slug in _INPAGE_LINK_RE.findall(body) if slug not in targets}
+        )
+        if unresolved:
+            broken[name] = unresolved
+
+    assert not broken, (
+        "In-page anchor links with no matching heading slug or <a id> anchor:\n"
+        + "\n".join(f"  {name}: {slugs}" for name, slugs in sorted(broken.items()))
+        + "\nFix the link, the heading, or add an <a id> anchor (translated "
+        "headings link to stable English ids via explicit anchors)."
     )


### PR DESCRIPTION
Closes #322

## What

Add translated READMEs for **Simplified Chinese**, **Spanish**, and **Japanese** under `docs/README.<lang>.md`, keeping the English `README.md` as the single authoritative source. A strict, CI-enforced **sync gate** prevents translations from silently drifting when the English README changes.

| File | Language |
| --- | --- |
| `docs/README.zh-CN.md` | 简体中文 |
| `docs/README.es.md` | Español |
| `docs/README.ja.md` | 日本語 |

English README links to all three via a switcher row; each translation links back.

## Translation policy

- **Verbatim** (copy-paste safety + a stable contract): the H1 positioning line, every fenced code block (incl. `#` comments — byte-identical across all three, verified), and `gda` / command / flag / env / domain terms from `CONTEXT.md`.
- **Localized** (natural, idiomatic — not machine-stiff): prose, the "Why" bullets, headings, and table descriptions.
- **Relative links rewritten** for the `docs/` location (e.g. `LICENSE` → `../LICENSE`, `docs/adr/…` → `adr/…`, `src/gda/exit_codes.py` → `../src/gda/exit_codes.py`).
- **Anchor stability:** the two headings targeted by in-page links (`#how-it-works`, `#configuration`) carry explicit `<a id>` anchors so those links survive heading translation.

## Sync mechanism

Each translation records, in a leading HTML-comment marker, the `sha256` of the English README it was translated from:

```
<!-- gda-readme-i18n: source=README.md sha256=<64-hex> -->
```

- **`tests/test_readme_i18n_sync.py`** recomputes the English hash and fails when any translation's recorded hash is stale (also checks all translations exist and that the English switcher links to each). Pure-Python, **no `e2e` marker**, so it runs in CI's per-PR `python` job. Follows the repo's existing strict doc-sync pattern (`test_error_registry.py`, `test_skill_surface_sync.py`).
- **`scripts/update_readme_i18n.py`** re-stamps the markers after a re-translation: `uv run python scripts/update_readme_i18n.py`.
- **Honest limitation:** the gate proves a translation was *reviewed against the current English*, not that it is *accurate* — natural-language correctness can't be machine-verified (stated in the Contributing note).

## Verification

- `uv run pytest -m "not e2e"` → **984 passed** (new gate included).
- `uv run ruff check .` / `ruff format --check .` / `uv run pyright` → all green.
- Structural parity vs English confirmed (19 headings, 7 `<details>`/`<summary>`, 144 table rows, 7 badges) and all 34 code blocks byte-identical, for every translation.
- **Negative probe:** tampering with `README.md` makes the gate fail and name the stale languages + the re-bless command; restoring brings it back green.
