### PR TITLE
docs(example): bootstrap Panda Adventure subproject domain context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Local working aids — per-checkout, not shared via git
 RULES.md
 STATE.md
-
+*.local.md
 # Python
 __pycache__/
 *.py[cod]

--- a/examples/platformer/panda-adventure/AGENTS.md
+++ b/examples/platformer/panda-adventure/AGENTS.md
@@ -9,8 +9,10 @@ Align with the repo-root `AGENTS.md` for everything **except domain docs**:
 
 - `RULES.md` — communication & collaboration conventions.
 - Issue tracker — game issues go to the same `aigengame/godot-agent` tracker, with titles
-  prefixed **`[Panda Adventure]`** to distinguish them from `gda`-tool issues. See the repo-root
-  `../../../docs/agents/issue-tracker.md` (these docs are inherited, not duplicated here).
+  prefixed **`[Panda Adventure]`** to distinguish them from `gda`-tool issues. (The prefix is for
+  **game-self** issues only; `gda`-feedback issues are filed **unprefixed** — see *gda feedback*
+  below.) See the repo-root `../../../docs/agents/issue-tracker.md` (these docs are inherited, not
+  duplicated here).
 - Triage labels. See the repo-root `../../../docs/agents/triage-labels.md`.
 
 ## Agent skills
@@ -53,3 +55,17 @@ See `./docs/agents/domain.md` for the authoritative detail.
 - **Logger-based feedback development** — game code logs at module (and key function) entry/exit so
   the agent can observe runtime behavior in a closed loop — enough to trace behavior, not noisy
   per-call spam. Log output conforms to the `gda logger tail` protocol so the agent can parse it.
+
+## gda feedback (dogfooding)
+
+Building this demo is also a way to **validate and improve `gda`**: driving the tool surfaces real
+gaps. Whenever you hit one while developing the game, **proactively file it as a separate issue** on
+the `aigengame/godot-agent` tracker so the demo doubles as a `gda` quality signal. Categories:
+
+- **Quality defect** — a `gda` capability that is claimed but unusable or behaves incorrectly.
+- **Feature improvement** — a `gda` capability that works but is incomplete or awkward.
+- **Performance** — a `gda` capability that works but is slow/janky.
+- **New-feature need** — a capability `gda` lacks that would meaningfully speed up development.
+
+These are **`gda`-tool issues, not game issues** — file them as regular `gda` issues **without** the
+`[Panda Adventure]` prefix, so they land in the tool's own issue view rather than the game's.

--- a/examples/platformer/panda-adventure/AGENTS.md
+++ b/examples/platformer/panda-adventure/AGENTS.md
@@ -1,0 +1,53 @@
+This directory is **Panda Adventure** — a 2D-platformer game demo, built with `gda`
+(see the `/gda` Skill) by driving the Godot Engine. It is a subproject of the parent
+`godot-agent` repo, but a **different domain**: its shared language is about the game
+(pandas, gravity guns, enemy waves), not about `gda`'s CLI, daemon, or headless runners.
+
+## Inherited from the repo root
+
+Align with the repo-root `AGENTS.md` for everything **except domain docs**:
+
+- `RULES.md` — communication & collaboration conventions.
+- Issue tracker — game issues go to the same `aigengame/godot-agent` tracker, with titles
+  prefixed **`[Panda Adventure]`** to distinguish them from `gda`-tool issues. See `docs/agents/issue-tracker.md`.
+- Triage labels. See `docs/agents/triage-labels.md`.
+
+## Agent skills
+
+### Domain docs (local override)
+
+**This section supersedes the repo-root "Domain docs" convention** (`Single-context: one
+CONTEXT.md + docs/adr/ at the repo root`) for all **game-domain** knowledge. The game's
+domain context is confined to this directory and must **not** pollute the parent's docs.
+
+Local layout (analogue of the parent's):
+
+| Parent (gda domain) | Here (game domain) | Holds |
+|---|---|---|
+| `CONTEXT.md` | `GAME-CONTEXT.md` | the game's shared language / glossary |
+| `docs/adr/NNNN-*.md` | `docs/gadr/NNNN-*.md` | game decision records (gADR), same numbering |
+| — | `docs/gdd/` | committed game design doc(s) |
+
+**Skill remap.** The domain skills hardcode `CONTEXT.md` / `docs/adr/` as literals. When you
+run one **inside this subproject**, restate and apply this remap before acting:
+
+- any skill's `CONTEXT.md` → `GAME-CONTEXT.md`
+- any skill's `docs/adr/` → `docs/gadr/`
+- `CONTEXT-MAP.md` → not applicable (single local context — ignore)
+
+Applies to `grill-with-docs`, `improve-codebase-architecture`, and `reconcile`. `to-prd` /
+`to-issues` already defer abstractly to "the project's domain glossary" — point them here.
+
+**Hard prohibition.** Game work must **never** read or write the parent root `CONTEXT.md` or
+`docs/adr/` — those are the `gda` tool's domain. Game terms and decisions live only under this
+directory.
+
+See `./docs/agents/domain.md` for the authoritative detail.
+
+## Development conventions
+
+- **Architecture** — layered (Resource / Controller / CanvasItem) and data-driven, with JSON as
+  the single authoritative config source converted to Godot `Resource`. See `docs/gadr/0000-architecture-design.md`.
+- **Logger-based feedback development** — game code logs at function/module entry and exit so the
+  agent can observe runtime behavior in a closed loop. Log output conforms to the `gda logger tail`
+  protocol so the agent can parse it.

--- a/examples/platformer/panda-adventure/AGENTS.md
+++ b/examples/platformer/panda-adventure/AGENTS.md
@@ -9,8 +9,9 @@ Align with the repo-root `AGENTS.md` for everything **except domain docs**:
 
 - `RULES.md` — communication & collaboration conventions.
 - Issue tracker — game issues go to the same `aigengame/godot-agent` tracker, with titles
-  prefixed **`[Panda Adventure]`** to distinguish them from `gda`-tool issues. See `docs/agents/issue-tracker.md`.
-- Triage labels. See `docs/agents/triage-labels.md`.
+  prefixed **`[Panda Adventure]`** to distinguish them from `gda`-tool issues. See the repo-root
+  `../../../docs/agents/issue-tracker.md` (these docs are inherited, not duplicated here).
+- Triage labels. See the repo-root `../../../docs/agents/triage-labels.md`.
 
 ## Agent skills
 
@@ -38,9 +39,10 @@ run one **inside this subproject**, restate and apply this remap before acting:
 Applies to `grill-with-docs`, `improve-codebase-architecture`, and `reconcile`. `to-prd` /
 `to-issues` already defer abstractly to "the project's domain glossary" — point them here.
 
-**Hard prohibition.** Game work must **never** read or write the parent root `CONTEXT.md` or
-`docs/adr/` — those are the `gda` tool's domain. Game terms and decisions live only under this
-directory.
+**Isolation boundary.** Never **write** game terms or decisions into the parent root `CONTEXT.md`
+or `docs/adr/` — game-domain language and decisions live only under this directory. You **may
+read** the parent `gda` docs when the work concerns the `gda` tool itself (its CLI, schema, daemon,
+or `logger` protocol); just don't treat them as the game's domain authority.
 
 See `./docs/agents/domain.md` for the authoritative detail.
 
@@ -48,6 +50,6 @@ See `./docs/agents/domain.md` for the authoritative detail.
 
 - **Architecture** — layered (Resource / Controller / CanvasItem) and data-driven, with JSON as
   the single authoritative config source converted to Godot `Resource`. See `docs/gadr/0000-architecture-design.md`.
-- **Logger-based feedback development** — game code logs at function/module entry and exit so the
-  agent can observe runtime behavior in a closed loop. Log output conforms to the `gda logger tail`
-  protocol so the agent can parse it.
+- **Logger-based feedback development** — game code logs at module (and key function) entry/exit so
+  the agent can observe runtime behavior in a closed loop — enough to trace behavior, not noisy
+  per-call spam. Log output conforms to the `gda logger tail` protocol so the agent can parse it.

--- a/examples/platformer/panda-adventure/CLAUDE.md
+++ b/examples/platformer/panda-adventure/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -1,0 +1,116 @@
+# Panda Adventure — Game Context
+
+The shared language of **Panda Adventure**: the game-domain glossary for this demo.
+
+This is the subproject-local analogue of the repo-root `CONTEXT.md`, scoped to this directory
+so game-domain terms never pollute the parent `gda` project. Terms are added lazily as they
+get resolved (via `grill-with-docs`, remapped to this file).
+
+See `docs/agents/domain.md` for the local domain-doc convention and the skill remap.
+
+## Language
+
+### Actors
+
+**Player**:
+The single protagonist the user controls — a spacesuit-wearing panda warrior fighting for the
+Animal Federation.
+_Avoid_: hero, character; Panda (flavor, not the canonical term)
+
+**NPC**:
+A non-combatant animal citizen of the Animal Federation (owl, elephant, rabbit, and the like) who
+populates the setting but takes no part in combat in this demo.
+_Avoid_: villager, friendly, ally
+
+### Enemies
+
+**Enemy**:
+A hostile actor the player fights. Every enemy is characterized by three orthogonal axes —
+Faction, Tier, and Archetype — plus a stat block. A wave is a composition of specific values
+of each.
+_Avoid_: mob; Monster as the category name (Monster is one Faction)
+
+**Faction**:
+An enemy's visual-and-lore family: Monster, Xenomorph, Alien, or Robot. Cosmetic and narrative
+only — Faction by itself implies neither difficulty nor behavior.
+_Avoid_: race, type; using 形象 as a difficulty word
+
+**Tier**:
+An enemy's power-and-reward grade: Minion, Elite, or Boss. Drives the stat budget and the
+EXP/Gold reward. Independent of Faction and Archetype.
+_Avoid_: 小怪 as a synonym for the Monster Faction; "level" (collides with the player's level)
+
+**Archetype**:
+An enemy's combat style: Melee, Ranged, or Tank. Drives AI behavior and attack pattern.
+Independent of Faction and Tier.
+_Avoid_: class, role; using 流派 loosely
+
+### Weapons
+
+**Laser Gun**:
+The player's primary weapon — a hitscan/projectile gun that deals damage to enemies.
+_Avoid_: blaster, rifle
+
+**Gravity Gun**:
+The player's utility weapon. Fired at the environment, it creates a Gravity Field rather than
+dealing direct damage. The player's own gravity is never affected by it.
+_Avoid_: gravity flip (the player is never flipped); grav tool
+
+**Gravity Field**:
+A localized region of altered gravity produced by the Gravity Gun. It acts only on
+gravity-affectable obstacles and on enemies within its range (lifting, slamming, or
+redirecting them) — never on the player. The basis of the "改变重力" core-loop pillar.
+_Avoid_: global gravity, gravity flip, zero-g (it is a local field, not a world toggle)
+
+### Stats
+
+**MP**:
+The player's resource for the Gravity Gun: firing it (creating a Gravity Field) spends MP, and
+the Gravity Gun is the only thing that spends MP. Restored by drinking Wine. (HP, EXP, and Gold
+keep their conventional meanings and are not glossed here.)
+_Avoid_: mana, energy
+
+### Combat
+
+**TTK** (Time To Kill):
+How long it takes the player to kill a given enemy. Paired with TTD to tune combat pacing.
+_Avoid_: DPS (a rate, not a time)
+
+**TTD** (Time To Die):
+How long it takes an enemy or a wave to kill the player — the player's survival time. The
+symmetric counterpart of TTK.
+_Avoid_: TDD (reserved repo-wide for Test-Driven Development); time-to-down
+
+### Items
+
+**Consumable**:
+An item used up on use. The demo's consumables are the Bun and the Wine.
+_Avoid_: potion, drug
+
+**Bun**:
+A Consumable that restores HP.
+_Avoid_: mantou, steamed bun, bread
+
+**Wine**:
+A Consumable that restores MP.
+_Avoid_: jiu, sake, alcohol
+
+**Equipment**:
+An item the Player wields or wears persistently — the Laser Gun, the Gravity Gun, and the
+Spacesuit. Contrast with Consumable.
+_Avoid_: gear, loadout
+
+**Spacesuit**:
+The Player's armor — the only piece of defensive Equipment in the demo.
+_Avoid_: armor (generic), suit
+
+### Level
+
+**Wave**:
+A timed segment of the demo level that spawns a specific composition of enemies
+(Faction × Tier × Archetype). The demo has four.
+_Avoid_: round, stage; level (the demo is a single level)
+
+<!-- Format reminder — **Term**: one/two-sentence definition (what it IS, not what it does);
+     _Avoid_: rejected synonyms. Group natural clusters under ### subheadings. -->
+

--- a/examples/platformer/panda-adventure/docs/agents/domain.md
+++ b/examples/platformer/panda-adventure/docs/agents/domain.md
@@ -45,8 +45,10 @@ and apply this remap before acting:
 Applies to `grill-with-docs`, `improve-codebase-architecture`, and `reconcile`. `to-prd` and
 `to-issues` defer abstractly to "the project's domain glossary" — point them at `GAME-CONTEXT.md`.
 
-**Hard prohibition.** Game work must **never** read or write the parent root `CONTEXT.md` or
-`docs/adr/`; those are the `gda` tool's domain. Game terms and decisions live only here.
+**Isolation boundary.** Never **write** game terms or decisions into the parent root `CONTEXT.md`
+or `docs/adr/`; game-domain language and decisions live only here. You **may read** the parent
+`gda` docs when the work concerns the `gda` tool itself (its CLI, schema, daemon, `logger`
+protocol) — just don't treat them as the game's domain authority.
 
 ## Use the glossary's vocabulary
 

--- a/examples/platformer/panda-adventure/docs/agents/domain.md
+++ b/examples/platformer/panda-adventure/docs/agents/domain.md
@@ -1,0 +1,65 @@
+# Domain Docs — Panda Adventure (local override)
+
+How the engineering skills should consume **this subproject's** domain documentation. This
+is the authoritative copy of the local convention; `../../AGENTS.md` carries the short pointer.
+
+It **overrides** the repo-root domain-doc convention (`/CONTEXT.md` + `/docs/adr/`) for all
+game-domain knowledge. The game's context is confined to this directory.
+
+## Before exploring, read these
+
+- **`GAME-CONTEXT.md`** at this subproject's root — the game's glossary / shared language.
+- **`docs/gadr/`** — game decision records (gADR); read the ones touching the area you'll work in.
+- **`docs/gdd/`** — the committed game design doc(s).
+
+If any of these don't exist yet, **proceed silently**. Don't flag their absence; don't
+suggest creating them upfront. They are created lazily when a term or decision actually gets
+resolved.
+
+## File structure
+
+This is a single local context, scoped to this subdirectory:
+
+```
+examples/platformer/panda-adventure/
+├── GAME-CONTEXT.md          # game glossary  (analogue of the repo-root CONTEXT.md)
+└── docs/
+    ├── gadr/                # game decision records (analogue of docs/adr/)
+    │   ├── 0000-architecture-design.md
+    │   └── ...
+    └── gdd/                 # committed game design doc(s)
+```
+
+## Skill remap
+
+The domain skills hardcode `CONTEXT.md` / `docs/adr/` as string literals — they have no way
+to discover this layout on their own. When running one **inside this subproject**, restate
+and apply this remap before acting:
+
+| In the skill body | Use here |
+|---|---|
+| `CONTEXT.md` | `GAME-CONTEXT.md` |
+| `docs/adr/` | `docs/gadr/` |
+| `CONTEXT-MAP.md` | not applicable — single local context, ignore |
+
+Applies to `grill-with-docs`, `improve-codebase-architecture`, and `reconcile`. `to-prd` and
+`to-issues` defer abstractly to "the project's domain glossary" — point them at `GAME-CONTEXT.md`.
+
+**Hard prohibition.** Game work must **never** read or write the parent root `CONTEXT.md` or
+`docs/adr/`; those are the `gda` tool's domain. Game terms and decisions live only here.
+
+## Use the glossary's vocabulary
+
+When your output names a game concept (an issue title, a refactor proposal, a test name), use
+the term as defined in `GAME-CONTEXT.md`. Don't drift to synonyms the glossary avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing
+language the game doesn't use (reconsider) or there's a real gap (note it for `grill-with-docs`,
+remapped to `GAME-CONTEXT.md`).
+
+## Flag gADR conflicts
+
+If your output contradicts an existing gADR, surface it explicitly rather than silently
+overriding:
+
+> _Contradicts gADR-0000 (architecture design) — but worth reopening because…_

--- a/examples/platformer/panda-adventure/docs/gadr/0000-architecture-design.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0000-architecture-design.md
@@ -1,0 +1,35 @@
+---
+status: accepted
+---
+
+# Architecture: layered and data-driven, with JSON as the authoritative config source
+
+Panda Adventure is authored by an AI agent driving Godot through `gda`, and its numeric
+configuration is the **output of an offline Python data-design pipeline** (design + TTK/TTD
+balancing + Monte-Carlo combat simulation), not hand-tuned in the editor. We therefore adopt a
+layered, data-driven architecture: **Resource** (data) / **Controller** (logic) / **CanvasItem**
+(view) are kept separate; no configuration is hardcoded in code; and **JSON is the single
+authoritative source** for all config/stat data, converted by a JSON→Resource pipeline into
+Godot `Resource`s that the runtime consumes. The Godot `Resource` is a **derived artifact**, not
+a source of truth.
+
+## Considered options
+
+- **JSON authoritative → Resource (chosen).** The source of truth lives *upstream* of Godot,
+  where the balancing/simulation pipeline emits it. JSON is also what an agent writes, diffs,
+  and reviews reliably, and what the Phase-2 Python asset pipelines consume; a JSON Schema gives
+  the agent validation.
+- **Native Godot `.tres`/`.res` authored in the editor (rejected).** Godot's own data-driven
+  path, but it puts the source of truth *inside* the editor — exactly where this project does
+  **not** author. It is editor-bound and a poor diff/review target for an agent, and it can't be
+  the head of a Python balancing pipeline.
+- **Hardcoded constants in GDScript (rejected).** Violates the data-driven principle; couples
+  tuning to code and breaks the offline balancing loop.
+
+## Consequences
+
+- `Resource` files are **regenerated from JSON** (e.g. at build) and are never hand-edited;
+  changing config means changing the JSON.
+- A JSON→Resource conversion step (with JSON Schema validation) is required machinery.
+- Drift between JSON and Resource is prevented by treating the Resource strictly as a derived
+  output of the authoritative JSON.

--- a/examples/platformer/panda-adventure/docs/gdd/0000-gdd.md
+++ b/examples/platformer/panda-adventure/docs/gdd/0000-gdd.md
@@ -1,0 +1,218 @@
+---
+status: draft
+---
+
+# Panda Adventure — Game Design Document (Qualitative)
+
+> This is the **qualitative** GDD: it captures the game's design intent, mechanics,
+> relationships, structure, and pacing — the *what it is and why it's designed this way*.
+> It deliberately holds **no balance numbers** (HP/MP/damage values, formulas, leveling
+> constants, drop rates, stat blocks). Per `docs/gadr/0000-architecture-design.md`
+> (gADR-0000), all such numbers are **data**: JSON is the single authoritative config
+> source, converted to a derived Godot `Resource`, and produced by the offline balancing
+> pipeline — freezing them in prose would create a second, drifting source of truth.
+> Vocabulary follows `GAME-CONTEXT.md` exactly. Requirements and user stories live in the
+> per-phase PRDs on the issue tracker; this document is the complementary design-rationale
+> layer and does not restate them.
+
+## Overview
+
+**Panda Adventure** is a single-player **2D-platformer** demo. The Player is a spacesuit-wearing
+panda warrior fighting for the **Animal Federation**. Space enemies — drawn from the Monster,
+Xenomorph, Alien, and Robot **Faction**s — have overrun the Federation's space territory, and the
+Player is dispatched to clear them out. The wider Federation is populated by non-combatant animal
+citizens (owls, elephants, rabbits, and the like) who establish the setting but take no part in
+combat in this demo.
+
+- **Genre / pillars:** 2D-platformer built on three interlocking verbs — jump, shoot, and
+  change-gravity (see *Core Loop*).
+- **Target session length:** a short arc of roughly ten minutes — long enough to teach all three
+  pillars and pay them off against a Boss, short enough to invite an immediate retry.
+- **Player profile:** players who enjoy 2D-adventure games — platform-jumping, plus light
+  exploration and collection alongside the combat.
+- **Setting & story:** a space-opera frontier; the Player polices the edge of the Animal
+  Federation's holdings, pushing the invading Factions back.
+- **Art-direction intent:** stylized space opera that blends fantasy and realism — fantastical
+  premise rendered with grounded, readable forms.
+
+**MVP form — a blockout.** The first deliverable is a *blockout*, not finished art. Every visual
+element (background, platforms, the Player, enemies, and props) is represented by a colored
+geometric block backed by a physics body (`CollisionObject2D` + `CollisionShape2D`), and every
+animation is a property-tween (property interpolation) rather than authored sprite frames. The
+blockout still respects deliberate scale ratios between blocks; those proportion rules are
+specified qualitatively in *Level & Blockout*. Finished textures, sprite frames, audio, and fonts
+are a later concern and replace the blocks without changing this design.
+
+## Core Loop
+
+The moment-to-moment loop is built from three pillars the Player threads together continuously:
+
+1. **Jump.** Platformer traversal — moving and jumping across the level's platforms to reposition,
+   dodge, and reach enemies.
+2. **Shoot.** The **Laser Gun** is the primary weapon: the Player fires it to deal damage and
+   eliminate enemies.
+3. **Change-gravity.** The **Gravity Gun** is the utility weapon. Fired at the environment, it does
+   **not** deal direct damage; instead it creates a **Gravity Field** — a *localized* region of
+   altered gravity. The Gravity Field acts **only** on gravity-affectable obstacles and on enemies
+   within its range (lifting, slamming, or redirecting them). It **never** affects the Player: the
+   Player's own gravity is never changed or flipped. This pillar turns the level itself into a
+   weapon — repositioning hazards and enemies rather than damaging them directly — and rewards
+   players who combine it with the Laser Gun (e.g. suspend a cluster of enemies in a Gravity Field,
+   then shoot them).
+
+Movement ties the pillars together: the Player moves, jumps, **switches weapon** between the Laser
+Gun and the Gravity Gun, and shoots, all fluidly. Switching weapon is a core verb, not a menu
+detour — the two guns are meant to be alternated mid-encounter.
+
+**Emotional goal.** The loop aims for excitement and challenge that leaves the player thinking
+*"I'll definitely win the next run!"* — a tight, legible failure state that makes one-more-try
+irresistible rather than punishing.
+
+## Stats & Economy
+
+The Player is described by four qualitative resources. Their *roles* are design; their *values*,
+curves, and rates are data-driven config (JSON→Resource), tuned via the Monte-Carlo balancing
+pipeline against TTK/TTD targets.
+
+- **HP** — survival headroom. Depleting it is the loss condition; restored by the **Bun**
+  Consumable.
+- **MP** — **the Gravity Gun's resource, and nothing else's.** Firing the Gravity Gun (creating a
+  Gravity Field) is the *only* thing that spends MP; the Laser Gun and movement cost no MP. MP is
+  restored by drinking **Wine**. This makes the change-gravity pillar a *budgeted* ability — the
+  Player must choose when a Gravity Field is worth the MP, which is what gives the pillar tactical
+  weight rather than spammability.
+- **EXP** — progression. Defeating enemies grants EXP, which drives the Player's leveling. The
+  leveling curve is a tuned function, authored as data-driven config (JSON→Resource), not frozen
+  here.
+- **Gold** — the soft currency, granted by defeated enemies alongside EXP.
+
+**Economy intent.** **Tier** sets an enemy's reward budget: tougher Tiers (Elite, Boss) yield more
+EXP and Gold than Minions, so the risk the Player takes maps to the reward. Drops and their rates
+are economy data produced by the balancing pipeline, not fixed in this document. The intent is a
+clean reinforcement loop — fight enemies, earn EXP/Gold and drops, grow stronger, take on harder
+Waves.
+
+## Combat
+
+Combat resolves around two qualitative concepts and one balancing method.
+
+- **Damage & i-frames.** When the Laser Gun (or an enemy attack) connects, damage is computed from
+  the attacker's and defender's stats; the resulting numbers and the damage computation itself are
+  data-driven config (JSON→Resource), not specified here. On taking a hit, an actor enters a brief
+  window of invulnerability (**i-frames**) so that a single overlap cannot chain into repeated
+  hits in consecutive frames — this keeps damage legible and fair. Collision layers and masks
+  govern what can damage what.
+- **TTK / TTD balancing.** The combat is tuned against two paired times: **TTK** (Time To Kill —
+  how long the Player needs to kill a given enemy) and **TTD** (Time To Die — how long an enemy or
+  a Wave needs to kill the Player). Together they define whether an encounter feels trivial,
+  tense, or unfair.
+- **Method, not values.** TTK/TTD targets are validated by **Monte-Carlo combat simulation** in the
+  offline balancing pipeline: candidate stat sets are simulated across many runs, the resulting
+  TTK/TTD distributions are checked against the design targets for each Wave, and the JSON config
+  is adjusted until they land. The GDD owns the *intent* (what each encounter should feel like);
+  the pipeline owns the *numbers* that achieve it.
+
+## Enemies
+
+Every **Enemy** is described by three **orthogonal** axes plus a stat block. The axes are
+independent — any combination is, in principle, expressible — which is what lets a Wave compose
+varied encounters from a small vocabulary:
+
+- **Faction** — the visual-and-lore family: **Monster**, **Xenomorph**, **Alien**, or **Robot**.
+  Cosmetic and narrative only; Faction alone implies neither difficulty nor behavior.
+- **Tier** — the power-and-reward grade: **Minion**, **Elite**, or **Boss**. Drives the stat
+  budget and the EXP/Gold reward (the budget itself is data).
+- **Archetype** — the combat style, which drives AI behavior and attack pattern:
+  - **Melee** — closes the distance and attacks at point-blank range.
+  - **Ranged** — keeps its distance and attacks from afar; tends to be more mobile.
+  - **Tank** — soaks damage and holds ground, pressuring the Player by attrition.
+
+A **Wave** is a specific composition of (Faction × Tier × Archetype) values, spawned as a timed
+segment of the level. The AI system drives each enemy according to its Archetype.
+
+### The four-Wave demo arc
+
+The single demo level escalates across four Waves. Durations below are **pacing targets** (the
+felt rhythm of the encounter), not hard timers; enemy stat values are config, not specified here.
+The four beats together fill the ~10-minute session and form a teaching staircase:
+
+1. **Onboarding — melee Minions.** *Monster* Faction, *Minion* Tier, *Melee* Archetype, arriving
+   few-at-first then building up. Mid-low difficulty, ~3 minutes. Intent: let the Player get
+   comfortable with movement, jumping, and the Laser Gun against the gentlest threat.
+2. **First Elite — ranged pressure.** *Robot* Faction, *Elite* Tier, *Ranged* Archetype, with high
+   mobility. Mid-high difficulty, ~2 minutes. Intent: teach the Player to deal with ranged attacks
+   — closing distance, using cover and platforms, and timing the Gravity Gun against a mobile
+   shooter.
+3. **Mixed swarm — combined arms.** *Xenomorph* Faction, a *Minion* swarm mixing *Melee* and
+   *Ranged* Archetypes. Mid-high difficulty, ~2 minutes. Intent: force the Player to think
+   strategically about an enemy *combination* — prioritizing targets and using the Gravity Field
+   to control a crowd rather than fighting one threat at a time.
+4. **Boss fight — the payoff.** *Alien* Faction, *Boss* Tier, with a signature time-warping
+   superpower; durable and hard-hitting. High difficulty, ~3 minutes. Intent: deliver the climactic
+   challenge and thrill of a Boss duel, demanding everything the prior Waves taught.
+
+## Items & Equipment
+
+Items split into two design categories with distinct intent.
+
+**Consumables** — used up on use, the Player's in-the-moment recovery levers:
+
+- **Bun** — restores **HP**. The Player's answer to attrition; spend it to survive a Wave.
+- **Wine** — restores **MP**. The Player's answer to running dry on the Gravity Gun; spend it to
+  keep the change-gravity pillar available. Because MP is the Gravity Gun's *only* fuel, Wine is
+  what sustains that pillar over a long encounter.
+
+**Equipment** — wielded or worn persistently:
+
+- **Laser Gun** — primary weapon; deals damage and eliminates enemies. The backbone of the
+  shoot pillar.
+- **Gravity Gun** — utility weapon; creates a **Gravity Field** (local, affecting gravity-affectable
+  obstacles and in-range enemies, **never the Player**) instead of dealing direct damage. Its cost
+  is **MP** — the only MP sink in the game — which is what makes it a deliberate, budgeted tool that
+  enriches play rather than a second damage gun.
+- **Spacesuit** — the Player's armor and the only piece of defensive Equipment in the demo. It is
+  the Player's persistent survivability layer (its protective values are config).
+
+## Level & Blockout
+
+The demo is a **single level**. There is no second level; the four Waves all play out
+within it.
+
+- **Setting.** The edge of a black hole somewhere in the galaxy — a dramatic, hazardous frontier
+  backdrop that motivates both the space-opera tone and the change-gravity pillar.
+- **Platform motif.** Platforms follow a **Great-Wall** style — long, rampart-like spans the Player
+  traverses and fights along, evoking a fortified border at the edge of the void.
+
+**Blockout scale-ratio rules.** In the MVP blockout, elements are colored physics-body blocks, and
+their *relative proportions* are part of this design (exact pixel dimensions are TBD — authored
+alongside the blockout, not invented here). The rules:
+
+- Enemy size reads Tier at a glance: an **Elite** block is visibly larger than a **Minion** block,
+  and the **Boss** block is the largest enemy on screen.
+- The **Player** block is the reference height for the actors; Minions sit near it, Elites above it,
+  the Boss well above it.
+- **Platform** thickness and span are sized relative to the Player's height — thick and long enough
+  to read as the Great-Wall rampart and to land on reliably, proportioned to the Player rather than
+  to an absolute pixel value.
+- **Props** and decorative blocks are scaled to stay legible against the Player and the platforms,
+  never competing with actors for visual priority.
+
+These are *proportion* rules, not measurements: they keep the blockout readable and the eventual
+art swap faithful, while the concrete dimensions are settled when the blockout is built.
+
+## HUD & UI
+
+The HUD surfaces the Player's live state at a glance, so the player never has to look away from the
+action to read it:
+
+- **HP** and **MP** — the two spendable survival resources, shown prominently (HP for staying
+  alive, MP because it gates the Gravity Gun).
+- **EXP** and **Gold** — progression and currency, shown as accumulating feedback on success.
+- **Current weapon** — which of the Laser Gun / Gravity Gun is active, since switching weapon is a
+  core verb and the player must know their current state at all times.
+
+**UI intent.** The HUD is diegetic-light and unobtrusive, prioritizing combat readability over
+information density; menus and other UI exist to serve the loop (start, retry, and inventory of
+Consumables/Equipment) without interrupting the *one-more-try* rhythm. Concrete layout, styling,
+and fonts are a later (asset) concern; this document fixes only *what* the UI must communicate and
+*why*.

--- a/examples/platformer/panda-adventure/docs/gdd/0000-gdd.md
+++ b/examples/platformer/panda-adventure/docs/gdd/0000-gdd.md
@@ -11,9 +11,10 @@ status: draft
 > (gADR-0000), all such numbers are **data**: JSON is the single authoritative config
 > source, converted to a derived Godot `Resource`, and produced by the offline balancing
 > pipeline — freezing them in prose would create a second, drifting source of truth.
-> Vocabulary follows `GAME-CONTEXT.md` exactly. Requirements and user stories live in the
-> per-phase PRDs on the issue tracker; this document is the complementary design-rationale
-> layer and does not restate them.
+> Game-domain vocabulary follows `GAME-CONTEXT.md`; general game-dev terms (e.g. i-frames) are
+> used as-is and are not glossary entries. Requirements and user stories live in the per-phase
+> PRDs on the issue tracker; this document is the complementary design-rationale layer and does
+> not restate them.
 
 ## Overview
 
@@ -132,9 +133,11 @@ segment of the level. The AI system drives each enemy according to its Archetype
 
 ### The four-Wave demo arc
 
-The single demo level escalates across four Waves. Durations below are **pacing targets** (the
-felt rhythm of the encounter), not hard timers; enemy stat values are config, not specified here.
-The four beats together fill the ~10-minute session and form a teaching staircase:
+The single demo level escalates across four Waves. The durations below are **non-authoritative
+pacing targets** — the intended *felt rhythm* of each encounter, not hard timers and not a balance
+source; the actual play time emerges from TTK/TTD tuning (data-driven, per gADR-0000). Enemy stat
+values are config, not specified here. The four beats together aim to fill the ~10-minute session
+and form a teaching staircase:
 
 1. **Onboarding — melee Minions.** *Monster* Faction, *Minion* Tier, *Melee* Archetype, arriving
    few-at-first then building up. Mid-low difficulty, ~3 minutes. Intent: let the Player get
@@ -147,9 +150,11 @@ The four beats together fill the ~10-minute session and form a teaching staircas
    *Ranged* Archetypes. Mid-high difficulty, ~2 minutes. Intent: force the Player to think
    strategically about an enemy *combination* — prioritizing targets and using the Gravity Field
    to control a crowd rather than fighting one threat at a time.
-4. **Boss fight — the payoff.** *Alien* Faction, *Boss* Tier, with a signature time-warping
-   superpower; durable and hard-hitting. High difficulty, ~3 minutes. Intent: deliver the climactic
-   challenge and thrill of a Boss duel, demanding everything the prior Waves taught.
+4. **Boss fight — the payoff.** *Alien* Faction, *Boss* Tier — durable and hard-hitting, with a
+   signature **time-warp ability** as its design hook (part of the demo finale, not a post-demo
+   mechanic; its concrete behavior is owned and detailed by the Phase 1 PRD). High difficulty,
+   ~3-minute pacing target. Intent: deliver the climactic challenge and thrill of a Boss duel,
+   demanding everything the prior Waves taught.
 
 ## Items & Equipment
 


### PR DESCRIPTION
## Summary

Bootstraps the **Panda Adventure** 2D-platformer example subproject with a domain context **fully isolated** from the parent `gda` project — game-domain knowledge is confined to `examples/platformer/panda-adventure/` and never touches the repo-root `CONTEXT.md` / `docs/adr/`.

## What's included

- **Isolation mechanism** — `AGENTS.md` + `docs/agents/domain.md` override the repo-root domain-doc convention and remap the domain skills (`CONTEXT.md` → `GAME-CONTEXT.md`, `docs/adr/` → `docs/gadr/`). `RULES.md`, the issue tracker (game issues prefixed `[Panda Adventure]`), and triage labels are still inherited.
- **`GAME-CONTEXT.md`** — game glossary (Player, NPC, Enemy / Faction / Tier / Archetype, Laser Gun, Gravity Gun, Gravity Field, MP, TTK / TTD, Consumables / Equipment, Wave).
- **`docs/gadr/0000-architecture-design.md`** (gADR-0000) — layered (Resource / Controller / CanvasItem), data-driven, with JSON as the single authoritative config source → derived Godot `Resource`.
- **`docs/gdd/0000-gdd.md`** — the qualitative Game Design Document (no balance numbers; data-driven per gADR-0000).
- **`.gitignore`** — `*.local.md` rule backing the local working-draft pattern (e.g. `PRD-draft.local.md`).

## Scope / non-goals

- Parent `gda` domain docs are **unmodified** (verified — changes are confined to `examples/` plus the one `.gitignore` rule).
- No game code yet — this PR is the domain-context + design foundation.
- Per-phase requirements live as PRDs: #323 (Phase 1 MVP), #324 (Phase 2 assets & pipelines), #325 (Phase 3 playtest & polish).

Closes #326
