### PR TITLE
docs(example): Wave count is data-driven (glossary)

### DIFF
--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -108,7 +108,7 @@ _Avoid_: armor (generic), suit
 
 **Wave**:
 A timed segment of the demo level that spawns a specific composition of enemies
-(Faction × Tier × Archetype). The demo has four.
+(Faction × Tier × Archetype). The demo defaults to four; the count is data-driven, not hardcoded.
 _Avoid_: round, stage; level (the demo is a single level)
 
 <!-- Format reminder — **Term**: one/two-sentence definition (what it IS, not what it does);


### PR DESCRIPTION
Reword the `GAME-CONTEXT.md` **Wave** entry from "The demo has four" to "defaults to four; the count is data-driven, not hardcoded", aligning the glossary with the configurable wave-spawn system in #334 (gADR-0000: no hardcoded config).

One-line glossary precision tweak; the demo still defaults to four Waves.
