### PR TITLE
feat(resource): resolve class_name Resource in resource create (#342)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -137,8 +137,10 @@ _Avoid_: safe project, sandboxed project
 **Project-code execution surface**:
 The set of points where a single `gda` run triggers the target project's own
 code to run: autoload constructors at engine startup (every `--project` op), the
-`_init` of scripts on nodes that an instantiating operation constructs, and — via
-`gda script run` (ADR-0031) — the **full execution of a named project script**.
+`_init` of scripts on nodes *or resources* that an instantiating operation
+constructs (a `class_name` node via `node add`, or a script-backed `class_name`
+Resource via `resource create`), and — via `gda script run` (ADR-0031) — the
+**full execution of a named project script**.
 All stay within the `Trusted project` assumption (ADR-0009); `script run` widens
 this surface without adding a new trust axis.
 _Avoid_: attack surface, code-execution risk

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -115,7 +115,7 @@ operation, and parse codes the CLI assigns).
 | `invalid_node_name` | `operation` | `operation` | `4` | A requested node name is empty or would be rewritten by Godot. |
 | `duplicate_node_name` | `operation` | `operation` | `4` | The parent node already has a child with the requested name. |
 | `missing_dependency` | `operation` | `operation` | `4` | A scene's declared nodes vanished or degraded on load — an unresolvable instanced sub-scene or an unavailable node class; re-saving would silently drop or downgrade them. |
-| `uninstantiable_script` | `operation` | `operation` | `4` | A registered `class_name`'s script can no longer be loaded, compiled, or constructed, so it cannot be instantiated as a node. |
+| `uninstantiable_script` | `operation` | `operation` | `4` | A registered `class_name`'s script can no longer be loaded, compiled, or constructed, so it cannot be instantiated as a node or a resource. |
 | `node_not_found` | `operation` | `operation` | `4` | A requested node path does not resolve to a node in the scene. |
 | `cannot_target_root` | `operation` | `operation` | `4` | A structural edit targeted the scene root, which has no parent to be removed from, duplicated alongside, or reparented out of. |
 | `cyclic_target` | `operation` | `operation` | `4` | A node move targeted the node itself or one of its own descendants, which would detach the moved subtree from the scene. |

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -2598,7 +2598,11 @@ def create(
     resource_type: str = typer.Option(
         ...,
         "--type",
-        help="Godot resource class of the new .tres (e.g. Gradient, Curve).",
+        help=(
+            "Resource type of the new .tres: a built-in Resource class (e.g. "
+            "Gradient, Curve) or a registered Resource class_name (a GDScript "
+            "class_name Foo extends Resource)."
+        ),
     ),
     json_output: bool = json_option(),
     schema: bool = RESOURCE_CREATE_COMMAND.schema_option(),

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -224,7 +224,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A registered class_name's script can no longer be loaded, compiled,"
-        " or constructed, so it cannot be instantiated as a node.",
+        " or constructed, so it cannot be instantiated as a node or a resource.",
     ),
     ErrorCodeSpec(
         "node_not_found",

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -1445,16 +1445,19 @@ class ResourceCreateParams(BaseModel):
 
     ``path`` is the target ``.tres`` resource file, addressed by its ``res://``
     or filesystem path (resource-file addressing — by file path). ``type`` is
-    the Godot resource class to instantiate and save (e.g. ``Gradient``,
-    ``Curve``); it must be an instantiable ``Resource`` subclass, mirroring
-    ``scene create``'s ``root_type`` check against ``Node``.
+    the Resource type to instantiate and save: a built-in Resource class (e.g.
+    ``Gradient``, ``Curve``) OR a project-defined ``class_name`` (a GDScript
+    ``class_name Foo extends Resource``), resolved the same way ``node add``
+    resolves ``--type`` (issue #342) — mirroring ``scene create``'s ``root_type``
+    check against ``Node``.
     """
 
     path: NormalizedPath = Field(description="Target .tres resource path to write.")
     type: str = Field(
         description=(
-            "The Godot resource class to create (e.g. Gradient, Curve). Must be "
-            "an instantiable Resource subclass."
+            "The Resource type to create: a built-in Resource class (e.g. "
+            "Gradient, Curve) or a registered Resource class_name (a GDScript "
+            "class_name Foo extends Resource)."
         )
     )
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -1466,6 +1466,11 @@ func _op_script_validate(params: Dictionary) -> void:
 # Resource runs the script's _init at construction (its constructor is project
 # code, within the Trusted project assumption, ADR-0009); a built-in class
 # constructs an engine class and runs none.
+#
+# The no-clobber check runs BEFORE construction, so an existing target is refused
+# without ever executing a script-backed type's _init: a broken constructor over
+# an existing file stays already_exists (no-clobber), never uninstantiable_script,
+# and no _init side effect runs against a target that would not be written anyway.
 func _op_resource_create(params: Dictionary) -> void:
 	_diag("running operation: resource-create")
 	var path := _string_param(params, "path")
@@ -1475,13 +1480,13 @@ func _op_resource_create(params: Dictionary) -> void:
 	if not _is_resource_path(path):
 		_fail(OP_ERROR_INVALID_PATH, "resource path must end in .tres: " + path)
 		return
+	if FileAccess.file_exists(path) or DirAccess.dir_exists_absolute(path):
+		_fail(OP_ERROR_ALREADY_EXISTS, "resource target already exists: " + path)
+		return
 	var type := _string_param(params, "type")
 	var resource: Resource = _instantiate_resource_type(type)
 	if resource == null:
 		return  # _instantiate_resource_type already recorded the failure
-	if FileAccess.file_exists(path) or DirAccess.dir_exists_absolute(path):
-		_fail(OP_ERROR_ALREADY_EXISTS, "resource target already exists: " + path)
-		return
 
 	var created_dirs: Variant = _ensure_parent_dirs(path)
 	if created_dirs == null:

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -1456,11 +1456,16 @@ func _op_script_validate(params: Dictionary) -> void:
 # Establishes the .tres load/save plumbing the rest of the group reuses.
 #
 # No-clobber: an existing target is refused with already_exists, leaving it
-# untouched (mirrors scene-create / script-create). The type must be an
-# instantiable Resource subclass — an unknown type or a non-Resource class (e.g.
-# a Node) is refused with invalid_resource_type, parallel to scene-create's
-# invalid_root_type check against Node. A plain Resource holds data, so creating
-# one runs no project code (it constructs an engine class, not a script).
+# untouched (mirrors scene-create / script-create). The type must resolve to an
+# instantiable Resource — a built-in Resource class OR a project-defined
+# class_name (GDScript `class_name Foo extends Resource`), resolved the same way
+# node add resolves --type (issue #342). An unknown type or a non-Resource class
+# (e.g. a Node) is refused with invalid_resource_type; a registered class_name
+# whose script broke since the project scan is uninstantiable_script — parallel
+# to node add's invalid_node_type / uninstantiable_script split. A script-backed
+# Resource runs the script's _init at construction (its constructor is project
+# code, within the Trusted project assumption, ADR-0009); a built-in class
+# constructs an engine class and runs none.
 func _op_resource_create(params: Dictionary) -> void:
 	_diag("running operation: resource-create")
 	var path := _string_param(params, "path")
@@ -1471,15 +1476,13 @@ func _op_resource_create(params: Dictionary) -> void:
 		_fail(OP_ERROR_INVALID_PATH, "resource path must end in .tres: " + path)
 		return
 	var type := _string_param(params, "type")
-	if type.is_empty() or not ClassDB.can_instantiate(type) \
-			or not ClassDB.is_parent_class(type, "Resource"):
-		_fail(OP_ERROR_INVALID_RESOURCE_TYPE, "not an instantiable Resource class: " + type)
-		return
+	var resource: Resource = _instantiate_resource_type(type)
+	if resource == null:
+		return  # _instantiate_resource_type already recorded the failure
 	if FileAccess.file_exists(path) or DirAccess.dir_exists_absolute(path):
 		_fail(OP_ERROR_ALREADY_EXISTS, "resource target already exists: " + path)
 		return
 
-	var resource: Resource = ClassDB.instantiate(type)
 	var created_dirs: Variant = _ensure_parent_dirs(path)
 	if created_dirs == null:
 		return  # _ensure_parent_dirs already recorded the failure
@@ -3615,6 +3618,57 @@ func _instantiate_script_class(type: String, script_path: String) -> Node:
 # the failure structurally instead of degrading into an unstructured abort.
 func _new_script_instance(script: Script) -> Variant:
 	return script.new()
+
+
+# Instantiate a resource by type: a built-in Resource class first, then a
+# class_name from the project's global class list (script classes register only
+# once the project has been imported/scanned). The Resource-side twin of
+# _instantiate_node_type (issue #342): records the failure itself and returns
+# null when the type resolves to nothing instantiable as a Resource, telling
+# apart the two distinct failure modes — a type that resolves to nothing is
+# invalid_resource_type, while a registered class_name whose script broke since
+# registration is uninstantiable_script (repair the script, not the type name).
+func _instantiate_resource_type(type: String) -> Resource:
+	if not type.is_empty() and ClassDB.can_instantiate(type) and ClassDB.is_parent_class(type, "Resource"):
+		return ClassDB.instantiate(type)
+	for entry in ProjectSettings.get_global_class_list():
+		if String(entry.get("class", "")) == type:
+			return _instantiate_resource_script_class(type, String(entry.get("path", "")))
+	_fail(OP_ERROR_INVALID_RESOURCE_TYPE, "not an instantiable Resource class or registered class_name: " + type)
+	return null
+
+
+# Instantiate a registered class_name from its script as a Resource. The
+# Resource-side twin of _instantiate_script_class (issue #342): registration only
+# proves the script was valid when the project was last scanned — the script on
+# disk may have broken since, so each step is checked and a failure reported as
+# the script problem it is, never as an unknown type. Reuses _new_script_instance
+# so a constructor error stays observable as null rather than aborting the frame.
+func _instantiate_resource_script_class(type: String, script_path: String) -> Resource:
+	var script := ResourceLoader.load(script_path) as Script
+	if script == null:
+		_fail(OP_ERROR_UNINSTANTIABLE_SCRIPT, "registered class_name " + type
+				+ " script failed to load: " + script_path
+				+ " — broken or removed since the project scan; see diagnostics")
+		return null
+	if not script.can_instantiate():
+		_fail(OP_ERROR_UNINSTANTIABLE_SCRIPT, "registered class_name " + type
+				+ " script cannot be instantiated: " + script_path
+				+ " — it no longer compiles; see diagnostics")
+		return null
+	var instance: Variant = _new_script_instance(script)
+	if instance == null:
+		_fail(OP_ERROR_UNINSTANTIABLE_SCRIPT, "registered class_name " + type
+				+ " script constructor failed: " + script_path
+				+ " — its _init may require arguments; see diagnostics")
+		return null
+	if instance is Resource:
+		return instance
+	if instance is Object and not (instance is RefCounted):
+		instance.free()
+	_fail(OP_ERROR_INVALID_RESOURCE_TYPE, "registered class_name " + type
+			+ " is not a Resource-derived script: " + script_path)
+	return null
 
 
 # The class_name of the node's attached script, or null for a plain built-in

--- a/tests/test_e2e_resource.py
+++ b/tests/test_e2e_resource.py
@@ -272,6 +272,64 @@ def test_resource_create_by_class_name_round_trips_typed_fields(godot_project):
     assert by_name["speed"]["value"] == 2.5
 
 
+@pytest.mark.e2e
+def test_resource_create_by_class_name_round_trips_a_set_via_get(godot_project):
+    # #342's full CRUD contract: a script-backed custom .tres round-trips through
+    # resource set/get, not only create/get. set coerces the CLI string to a
+    # custom exported field's declared type, saves the .tres, and get reports the
+    # persisted value — resource get IS the structured-level proof that set landed
+    # on a custom Resource type.
+    (godot_project / "panda_stats.gd").write_text(PANDA_STATS_GD, encoding="utf-8")
+    _import_project(godot_project)
+    resource_path = godot_project / "panda.tres"
+    created = _gda(
+        "resource",
+        "create",
+        str(resource_path),
+        "--type",
+        "PandaStats",
+        "--project",
+        str(godot_project),
+        "--json",
+    )
+    assert created.returncode == 0, created.stdout + created.stderr
+
+    was_set = _gda(
+        "resource",
+        "set",
+        str(resource_path),
+        "--property",
+        "speed",
+        "--value",
+        "9.5",
+        "--project",
+        str(godot_project),
+        "--json",
+    )
+
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    set_data = json.loads(was_set.stdout)
+    # set reports the coerced value against the script-declared type.
+    assert set_data["property"] == "speed"
+    assert set_data["type"] == "float"
+    assert set_data["value"] == 9.5
+
+    got = _gda(
+        "resource",
+        "get",
+        str(resource_path),
+        "--project",
+        str(godot_project),
+        "--json",
+    )
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    by_name = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
+    # Round-trip: get reports the value set persisted to the custom .tres.
+    assert by_name["speed"]["type"] == "float"
+    assert by_name["speed"]["value"] == 9.5
+
+
 # A registered class_name whose script is healthy but NOT Resource-derived: a
 # true type error (instantiable, but never savable as a .tres).
 WIDGET_NODE_GD = """\
@@ -356,6 +414,60 @@ def test_resource_create_by_registered_but_broken_class_name_names_the_script(
     assert "Stats" in err["message"]
     assert "stats.gd" in err["message"]
     assert not resource_path.exists()
+
+
+# A registered class_name that compiles and registers fine but cannot be
+# constructed without arguments: script.new() has no args to give _init. Over an
+# existing target its constructor must never run at all.
+NEEDS_ARGS_STATS_GD = """\
+class_name NeedsArgsStats
+extends Resource
+
+
+func _init(scale: float) -> void:
+\tpass
+"""
+
+
+@pytest.mark.e2e
+def test_resource_create_over_existing_target_refuses_before_constructing(
+    godot_project,
+):
+    # No-clobber must win WITHOUT running the requested type's constructor (issue
+    # #342 review): an existing target is refused with already_exists even when
+    # --type is a registered class_name whose _init would fail. A broken
+    # constructor over an existing file must stay already_exists, never turn into
+    # uninstantiable_script — and getting already_exists (not uninstantiable_script)
+    # is itself the proof that _init never ran, so no side effect touched the file.
+    (godot_project / "needs_args_stats.gd").write_text(
+        NEEDS_ARGS_STATS_GD, encoding="utf-8"
+    )
+    _import_project(godot_project)
+    resource_path = godot_project / "occupied.tres"
+    # Occupy the target first with a plain built-in resource.
+    first = _gda(
+        "resource", "create", str(resource_path), "--type", "Gradient", "--json"
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+    before = resource_path.read_text(encoding="utf-8")
+
+    second = _gda(
+        "resource",
+        "create",
+        str(resource_path),
+        "--type",
+        "NeedsArgsStats",
+        "--project",
+        str(godot_project),
+        "--json",
+    )
+
+    err = _assert_operation_error(second, "already_exists")
+    assert str(resource_path) in err["message"]
+    # The existing file is untouched — no clobber — and, because the code is
+    # already_exists rather than uninstantiable_script, the broken constructor
+    # never ran.
+    assert resource_path.read_text(encoding="utf-8") == before
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_resource.py
+++ b/tests/test_e2e_resource.py
@@ -200,6 +200,164 @@ def test_resource_create_non_resource_type_yields_invalid_resource_type(godot_pr
     assert not resource_path.exists()
 
 
+# --- resource create by class_name (issue #342): resolve a project-defined
+# GDScript `class_name Foo extends Resource` the same way node add resolves a
+# class_name --type, so a custom Resource type creates and saves as a .tres. ---
+
+
+# A project-defined custom Resource with typed exported fields at explicit,
+# non-default values — the round-trip payload the positive test asserts.
+PANDA_STATS_GD = """\
+class_name PandaStats
+extends Resource
+
+@export var tint: Color = Color(0.25, 0.5, 0.75, 1.0)
+@export var offset: Vector2 = Vector2(3, 4)
+@export var speed: float = 2.5
+"""
+
+
+@pytest.mark.e2e
+def test_resource_create_by_class_name_round_trips_typed_fields(godot_project):
+    # The class_name half of --type's contract for resources (issue #342): a
+    # class_name registered in the project's global class list resolves like a
+    # built-in Resource type. create instantiates the script-backed Resource and
+    # saves it as a .tres (recording the script as an ExtResource); get loads it
+    # back and reports the exported fields with their declared Godot types and
+    # values — create → get IS the round-trip proof for a custom Resource type.
+    (godot_project / "panda_stats.gd").write_text(PANDA_STATS_GD, encoding="utf-8")
+    _import_project(godot_project)
+    resource_path = godot_project / "panda.tres"
+
+    created = _gda(
+        "resource",
+        "create",
+        str(resource_path),
+        "--type",
+        "PandaStats",
+        "--project",
+        str(godot_project),
+        "--json",
+    )
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    data = json.loads(created.stdout)
+    assert data["path"] == str(resource_path)
+    # create echoes the requested type (the class_name), and the written .tres is
+    # a real Godot resource carrying the script class.
+    assert data["type"] == "PandaStats"
+    assert resource_path.exists()
+    assert 'script_class="PandaStats"' in resource_path.read_text(encoding="utf-8")
+
+    got = _gda(
+        "resource",
+        "get",
+        str(resource_path),
+        "--project",
+        str(godot_project),
+        "--json",
+    )
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    got_data = json.loads(got.stdout)
+    # get reports the engine base class as type (a script-backed Resource's
+    # get_class() is "Resource"); the exported fields carry the declared types.
+    assert got_data["type"] == "Resource"
+    by_name = {p["name"]: p for p in got_data["properties"]}
+    assert by_name["tint"]["type"] == "Color"
+    assert by_name["tint"]["value"] == [0.25, 0.5, 0.75, 1.0]
+    assert by_name["offset"]["type"] == "Vector2"
+    assert by_name["offset"]["value"] == [3.0, 4.0]
+    assert by_name["speed"]["type"] == "float"
+    assert by_name["speed"]["value"] == 2.5
+
+
+# A registered class_name whose script is healthy but NOT Resource-derived: a
+# true type error (instantiable, but never savable as a .tres).
+WIDGET_NODE_GD = """\
+class_name WidgetNode
+extends Node2D
+"""
+
+
+@pytest.mark.e2e
+def test_resource_create_by_non_resource_class_name_yields_invalid_resource_type(
+    godot_project,
+):
+    # The boundary of issue #342's distinction: a registered class_name whose
+    # script is fine but not Resource-derived is a true type error — it stays
+    # invalid_resource_type (not uninstantiable_script), with a message naming
+    # the script and the real cause rather than "not a registered class_name".
+    (godot_project / "widget_node.gd").write_text(WIDGET_NODE_GD, encoding="utf-8")
+    _import_project(godot_project)
+    resource_path = godot_project / "widget.tres"
+
+    created = _gda(
+        "resource",
+        "create",
+        str(resource_path),
+        "--type",
+        "WidgetNode",
+        "--project",
+        str(godot_project),
+        "--json",
+    )
+
+    err = _assert_operation_error(created, "invalid_resource_type")
+    assert "WidgetNode" in err["message"]
+    assert "not a Resource-derived script" in err["message"]
+    assert "widget_node.gd" in err["message"]
+    # Nothing was written for the rejected type.
+    assert not resource_path.exists()
+
+
+# The same class_name, valid at import then broken on disk: a parse error the
+# import-time scan never saw, so the stale global class list still maps it.
+STATS_GD = """\
+class_name Stats
+extends Resource
+"""
+
+BROKEN_STATS_GD = """\
+class_name Stats
+extends Resource
+func broken( -> void:
+"""
+
+
+@pytest.mark.e2e
+def test_resource_create_by_registered_but_broken_class_name_names_the_script(
+    godot_project,
+):
+    # Issue #342's broken-class_name mode (mirrors node add's #65 split): the
+    # class_name IS in the global class list (the import scanned a then-valid
+    # script), but the script on disk has since broken. Reporting
+    # invalid_resource_type ("not a registered class_name") would misdiagnose a
+    # script problem as an unknown type — the agent fix is to repair the script,
+    # not the type name. The failure must surface as the distinct
+    # uninstantiable_script code naming the script, with nothing written.
+    (godot_project / "stats.gd").write_text(STATS_GD, encoding="utf-8")
+    _import_project(godot_project)
+    (godot_project / "stats.gd").write_text(BROKEN_STATS_GD, encoding="utf-8")
+    resource_path = godot_project / "stats.tres"
+
+    created = _gda(
+        "resource",
+        "create",
+        str(resource_path),
+        "--type",
+        "Stats",
+        "--project",
+        str(godot_project),
+        "--json",
+    )
+
+    err = _assert_operation_error(created, "uninstantiable_script")
+    assert "Stats" in err["message"]
+    assert "stats.gd" in err["message"]
+    assert not resource_path.exists()
+
+
 @pytest.mark.e2e
 def test_resource_create_non_tres_path_yields_invalid_path(godot_project):
     bad_path = godot_project / "palette.txt"


### PR DESCRIPTION
## What

`gda resource create --type <T>` could only instantiate a Godot built-in Resource class via `ClassDB` — a project-defined GDScript `class_name Foo extends Resource` was rejected with `invalid_resource_type`. This makes `resource create` resolve `--type` the same way `node add` already resolves it: ClassDB first, then the project's global class list (issue #342).

## How

All in `src/gda/ops/operations.gd`, mirroring the existing node-side resolvers:

- `_op_resource_create` now resolves `--type` through a new `_instantiate_resource_type(type)` instead of gating on `ClassDB` alone.
- `_instantiate_resource_type` / `_instantiate_resource_script_class` are the Resource-side twins of `_instantiate_node_type` / `_instantiate_script_class` (ClassDB → `ProjectSettings.get_global_class_list()` → load script → guarded construction → validate the instance `is Resource`).
- **Reuses** the shared, type-agnostic `_new_script_instance(script)` guard — no duplicated constructor-isolation logic.
- Failure split mirrors node add: an unknown / non-Resource `class_name` → `invalid_resource_type`; a registered-but-broken / non-instantiable script → `uninstantiable_script`. No new error code (both already exist and have GDScript mirror constants).

A script-backed Resource runs the script's `_init` at construction — project code within the Trusted-project assumption (ADR-0009), same as node add.

## Scope

No Python / `cli.py` / `models.py` / `error_codes.py` change: `ResourceCreateParams.type` is already free-form, and no `script_class` field was added to `ResourceCreateResult` (out of scope for this issue). The create result echoes the requested type in its existing `type` field.

## Tests

Added to `tests/test_e2e_resource.py` (real headless Godot, scaffold → `--import` → invoke, patterned on `test_e2e_node.py`):

- **Positive** — `class_name PandaStats extends Resource` with typed `Color` / `Vector2` / `float` exports: `create` → `get` round-trips each field with its declared type and value.
- **Negative** — a non-Resource `class_name` (`extends Node2D`) → `invalid_resource_type` (message names the script + "not a Resource-derived script").
- **Negative** — a registered-but-broken script → `uninstantiable_script`.

`uv run pytest tests/test_e2e_resource.py -rs` → **27 passed** (3 new + 24 existing).

Closes #342