### PR TITLE
fix(export): absolutize project so a relative --project works (#344)

### DIFF
--- a/src/gda/export_runner.py
+++ b/src/gda/export_runner.py
@@ -55,13 +55,22 @@ class SubprocessExportRunner:
     these flags entirely and the engine reports it as a usage error, surfaced as a
     generic export failure by the classifier.
 
-    The process is spawned with ``cwd = <project>`` when a project is resolved.
-    Godot writes the export artifact via ``FileAccess``/``DirAccess`` with NO
-    project globalization (verified against the engine source), so a *relative*
-    output path — the common case, since a preset's configured ``export_path`` is
-    stored project-relative (e.g. ``build/game.x86_64``) — resolves against the
-    process CWD. Running from the project root makes that relative path land
-    inside the project, exactly as the editor resolves it (issue #121).
+    The project is absolutized once and used for BOTH the spawn's
+    ``cwd = <project>`` and the ``--path <project>`` flag when a project is
+    resolved. This matters twice:
+
+    - Godot writes the export artifact via ``FileAccess``/``DirAccess`` with NO
+      project globalization (verified against the engine source), so a *relative*
+      output path — the common case, since a preset's configured ``export_path``
+      is stored project-relative (e.g. ``build/game.x86_64``) — resolves against
+      the process CWD. Running from the project root makes that relative path land
+      inside the project, exactly as the editor resolves it (issue #121).
+    - Because the spawn's ``cwd`` is the project, ``--path`` MUST be absolute. A
+      *relative* ``--project`` would otherwise be re-resolved by the engine
+      against that child CWD — ``<project>/<project>`` — so ``project.godot`` is
+      not found and the export fails with an empty ``export_failed``. Absolutizing
+      the path keeps ``cwd`` and ``--path`` naming the same directory, so a
+      relative ``--project`` resolves exactly as an absolute one (issue #344).
     """
 
     binary: Path
@@ -74,8 +83,15 @@ class SubprocessExportRunner:
         # UTF-8-decode handling to the shared launch primitive (#185).
         flag = EXPORT_MODE_FLAGS[mode]
         args: list[str] = []
-        if self.project is not None:
-            args += ["--path", str(self.project)]
+        # Absolutize the project ONCE and use the same path for cwd and --path:
+        # this channel sets cwd = <project>, so a relative --path would be
+        # re-resolved against that child CWD (<project>/<project>) and Godot would
+        # not find project.godot (#344). ``absolute()`` (not ``resolve()``) keeps
+        # the codebase's symlink-agnostic path handling — resolve_project_dir only
+        # expands ``~`` — so an absolute --project is passed through verbatim.
+        project = self.project.absolute() if self.project is not None else None
+        if project is not None:
+            args += ["--path", str(project)]
         args += [flag, preset, output_path]
         # Pass the export-specific timeout label: on a timeout the primitive's
         # stderr is carried into GdaError.diagnostics and serialized in
@@ -84,7 +100,7 @@ class SubprocessExportRunner:
         return launch(
             self.binary,
             args,
-            cwd=self.project,
+            cwd=project,
             timeout=self.timeout,
             timeout_label="Godot export",
         )

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -236,6 +236,61 @@ def test_export_run_pack_writes_pck_without_templates(godot_project):
 
 
 @pytest.mark.e2e
+def test_export_run_pack_accepts_a_relative_project(godot_project):
+    # Regression for #344: `gda export run` with a RELATIVE --project must resolve
+    # the SAME project as an absolute one. The native export runner spawns Godot
+    # with cwd = <project>, so before the fix a relative --path was re-resolved by
+    # the engine against that child CWD (<project>/<project>) — project.godot not
+    # found → empty export_failed. Pack needs no export templates, so this RUNS
+    # deterministically on a template-less host and proves the real bug is gone on
+    # disk (an absolute --project already works via test_..._pack_writes_pck_...).
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    # all_resources needs at least one exportable file (see the pack test above).
+    (godot_project / "main.gd").write_text(
+        "extends Node\n\nfunc _ready() -> void:\n\tpass\n", encoding="utf-8"
+    )
+    override_rel = "dist/packed.pck"
+    artifact = godot_project / override_rel
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+
+    # Drive gda from the project's PARENT with a RELATIVE --project (the failing
+    # case) — NOT the absolute path _gda_project passes.
+    run = subprocess.run(
+        [
+            *GDA_CMD,
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--mode",
+            "pack",
+            "--output",
+            override_rel,
+            "--json",
+            "--godot",
+            str(GODOT),
+            "--project",
+            godot_project.name,  # RELATIVE; resolved against the cwd below
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(godot_project.parent),
+    )
+
+    # No skip: pack must RUN to completion regardless of template presence. Before
+    # the fix this returned 4 with an empty export_failed (project.godot not found).
+    assert run.returncode == 0, run.stdout + run.stderr
+    data = json.loads(run.stdout)
+    assert data["mode"] == "pack"
+    assert data["output_path"] == override_rel
+    # The .pck landed INSIDE the project — the relative --project resolved to the
+    # same directory an absolute one would, exactly as the editor resolves it.
+    assert artifact.exists(), f"expected .pck at {artifact} for a relative --project"
+
+
+@pytest.mark.e2e
 def test_export_run_pack_omits_installed_harness_and_restores_it(godot_project):
     # ADR-0018: `gda export run` must NEVER carry the dev-only harness into the
     # artifact — and without the developer having to `gda daemon uninstall` first.

--- a/tests/test_export_runner.py
+++ b/tests/test_export_runner.py
@@ -62,6 +62,64 @@ def test_export_runs_with_project_as_cwd(monkeypatch):
     assert rec.cmd[-3:] == ["--export-release", "Linux/X11", "build/game.x86_64"]
 
 
+def _path_arg(cmd: list[str]) -> str:
+    """The value following ``--path`` in a spawned argv."""
+    return cmd[cmd.index("--path") + 1]
+
+
+def test_relative_project_is_absolutized_so_cwd_and_path_agree(monkeypatch):
+    # Regression for #344: this channel spawns with cwd = <project>, so a RELATIVE
+    # --project passed as --path verbatim would be re-resolved by the engine
+    # against the child CWD (<project>/<project>) — project.godot not found →
+    # empty export_failed. The runner must absolutize the project so --path and
+    # cwd name the SAME absolute directory (reaching the resolution an absolute
+    # --project reaches).
+    rec = _RecordingRun()
+    monkeypatch.setattr(runner_mod.subprocess, "run", rec)
+    relative = Path("relproj")
+    expected = str(relative.absolute())
+
+    runner = SubprocessExportRunner(Path("/x/Godot"), project=relative)
+    runner.run("Linux/X11", "release", "build/game.x86_64")
+
+    assert rec.kwargs is not None and rec.cmd is not None
+    # --path carries the ABSOLUTE project, not the relative string the engine
+    # would mis-resolve against the child cwd.
+    passed_path = _path_arg(rec.cmd)
+    assert Path(passed_path).is_absolute()
+    assert passed_path == expected
+    # cwd and --path name the SAME directory — the invariant the bug violated.
+    assert rec.kwargs.get("cwd") == passed_path == expected
+
+
+def test_relative_and_absolute_project_reach_the_same_resolution(monkeypatch, tmp_path):
+    # The deterministic core of #344, independent of export templates: a RELATIVE
+    # --project and the EQUIVALENT absolute --project produce the identical spawn
+    # (same cwd, same --path). Building the absolute path from Path.cwd() — the
+    # same base .absolute() uses — keeps the two naming one directory regardless
+    # of any symlink in the tmp prefix.
+    monkeypatch.chdir(tmp_path)
+    abs_project = Path.cwd() / "proj"
+    abs_project.mkdir()
+
+    def _spawn(project: Path) -> tuple[list[str], dict]:
+        rec = _RecordingRun()
+        monkeypatch.setattr(runner_mod.subprocess, "run", rec)
+        SubprocessExportRunner(Path("/x/Godot"), project=project).run(
+            "Linux/X11", "release", "build/game.x86_64"
+        )
+        assert rec.cmd is not None and rec.kwargs is not None
+        return rec.cmd, rec.kwargs
+
+    rel_cmd, rel_kwargs = _spawn(Path("proj"))
+    abs_cmd, abs_kwargs = _spawn(abs_project)
+
+    # Relative resolves to the same absolute cwd and --path as absolute does.
+    assert rel_kwargs["cwd"] == abs_kwargs["cwd"] == str(abs_project)
+    assert _path_arg(rel_cmd) == _path_arg(abs_cmd) == str(abs_project)
+    assert Path(rel_kwargs["cwd"]).is_absolute()
+
+
 def test_export_without_project_passes_no_cwd(monkeypatch):
     # Projectless runs (no resolved project) spawn with the default cwd — there is
     # no project root to resolve a relative path against.


### PR DESCRIPTION
## Root cause

`gda export run` fails with a **relative** `--project` while an absolute one works.

`SubprocessExportRunner.run` (`src/gda/export_runner.py`) spawns the native export with **both** `cwd = <project>` **and** `--path <project>`. `resolve_project_dir` never absolutizes the project (it only expands `~`), so for a relative `--project` the child process CWDs into `<project>`, and the engine then re-resolves `--path <project>` against that new CWD → `<project>/<project>` → `project.godot` not found → `export_failed` with an **empty** diagnostics.

The sentinel channel is immune because it spawns with `cwd=None` (`src/gda/runner.py`); only the export channel sets `cwd`, so only it must keep `cwd` and `--path` in agreement.

## Fix (minimal, single file)

In `SubprocessExportRunner.run`, absolutize the project **once** via `Path.absolute()` and use the same path for **both** `cwd` and `--path`, so a relative `--project` reaches the exact resolution an absolute one does.

- Used `Path.absolute()` rather than `Path.resolve()`: it fully fixes the bug (a relative path becomes absolute), keeps the codebase's symlink-agnostic path handling (`resolve_project_dir` only `~`-expands; the sentinel runner passes paths verbatim), and passes an absolute `--project` through unchanged — so the existing `test_export_runs_with_project_as_cwd` (which hardcodes `/tmp/proj`) stays green rather than being rewritten to `/private/tmp/proj` on macOS.
- The shared `launch()` primitive (`runner.py`) is **untouched** — the double-application was in the export caller's argument, not the primitive.
- The class docstring is updated to explain why `--path` must be absolute when `cwd` is the project.

## Tests

- **Unit** (`tests/test_export_runner.py`): a relative `--project` yields an absolute `--path` equal to `cwd`; relative vs absolute produce the identical spawn.
- **E2e** (`tests/test_e2e_export_run.py`): a `--mode pack` export driven from the project's **parent** with a **relative** `--project` runs to exit 0 and writes the `.pck` inside the project. Pack needs no export templates, so it runs **deterministically** on a template-less host (no silent skip masquerading as a pass).
- Both suites were confirmed to **fail without the fix**.

Test commands run (from the worktree, via `uv run`):
- `uv run pytest tests/ -k export -rs -m "not e2e"` → **83 passed**
- `GDA_GODOT=… uv run pytest tests/ -k export -rs -p no:xdist` (incl. e2e) → **105 passed, 1 skipped** (the 1 skip is the pre-existing Linux-only XDG templates test, unrelated)
- ruff check + format + pyright on changed files → clean

Fixes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)