### PR TITLE
feat: `gda script run` — user-script passthrough execution (ADR-0031)

### DIFF
--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -181,6 +181,8 @@ from gda.models import (
     ScriptGetResult,
     ScriptListParams,
     ScriptListResult,
+    ScriptRunParams,
+    ScriptRunResult,
     ScriptSetMode,
     ScriptSetParams,
     ScriptSetResult,
@@ -255,6 +257,7 @@ from gda.render import (
     render_script_delete,
     render_script_get,
     render_script_list,
+    render_script_run,
     render_script_set,
     render_script_validate,
     render_shader_create,
@@ -268,6 +271,7 @@ from gda.screen_ops import (
     run_screen_capture_operation,
     run_screen_frames_operation,
 )
+from gda.script_run import run_script_run_operation
 from gda.skill_ops import build_skill_result
 from gda.skill_targets import SkillProvider, SkillScope
 from gda.surface import build_surface_manifest
@@ -564,6 +568,32 @@ EXPORT_RUN_COMMAND: HeadlessCommand[ExportRunResult] = HeadlessCommand(
     kind=ExecutionKind.EXPORT,
     render=render_export_run,
     recipe=_export_run_recipe,
+)
+
+
+def _script_run_recipe(params, *, project, godot):
+    return run_script_run_operation(
+        script=params.path,
+        godot=godot,
+        project=resolve_project_dir(project),
+    )
+
+
+# ``script run`` is the third execution shape (ADR-0031): a user-script passthrough
+# run. Its entry script is the user's own, so it emits no ADR-0002 sentinel, and gda
+# does not know the script's semantics — so it routes through the recipe channel
+# (ADR-0023) like ``export run``, and carries the fourth ``SCRIPT_RUN`` kind, which is
+# self-description only (ADR-0004 / ADR-0012) — dispatch is by ``recipe``, adding no
+# runner-selection branch. The descriptor is defined HERE, not beside the operation
+# (gda.script_run), because its recipe needs cli's project-resolution seam and cli.py
+# is the dispatch composition root (ADR-0023).
+SCRIPT_RUN_COMMAND: HeadlessCommand[ScriptRunResult] = HeadlessCommand(
+    operation="script-run",
+    input_model=ScriptRunParams,
+    output_model=ScriptRunResult,
+    kind=ExecutionKind.SCRIPT_RUN,
+    render=render_script_run,
+    recipe=_script_run_recipe,
 )
 
 
@@ -2586,6 +2616,39 @@ def validate_script(
     _dispatch(
         SCRIPT_VALIDATE_COMMAND,
         ScriptValidateParams(path=path),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+    )
+
+
+@script_app.command(name="run", cls=SCRIPT_RUN_COMMAND.command_class())
+def run_script(
+    path: str = typer.Argument(
+        ...,
+        help="The res:// path of the script to run (e.g. res://tests/logic.gd).",
+    ),
+    json_output: bool = json_option(),
+    schema: bool = SCRIPT_RUN_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Run a user script one-shot and pass its exit_status/stdout/stderr through.
+
+    Runs the user's own res:// script as ``godot --headless --path <project>
+    --script <res://…>`` and returns its result verbatim (ADR-0031). This is the
+    ONE command whose success result can carry a non-zero ``exit_status``: gda does
+    not interpret the script's semantics, so a deliberate ``quit(1)`` (e.g. an
+    assertion-failed logic-seam test) is data the agent reads, not a gda failure —
+    read ``exit_status``, do not assume ``success == zero``. Only a gda-/engine-level
+    failure (binary not launchable, timeout, or a signal crash) is an Error envelope
+    (``binary_not_found`` / ``launch_timeout`` / ``engine_crashed``). A non-res://
+    path or no resolved project is a structured ``invalid_path`` / ``project_not_found``.
+    """
+    _dispatch_recipe(
+        SCRIPT_RUN_COMMAND,
+        ScriptRunParams(path=path),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -43,6 +43,7 @@ from gda.errors import (
     classify_perf_monitor,
     classify_perf_monitors,
     classify_script_validate,
+    script_run_project_not_found_failure,
 )
 from gda.execution import ExecutionKind
 from gda.export_run import (
@@ -572,10 +573,22 @@ EXPORT_RUN_COMMAND: HeadlessCommand[ExportRunResult] = HeadlessCommand(
 
 
 def _script_run_recipe(params, *, project, godot):
+    # Project resolution stays CLI-side (ADR-0006), but ``resolve_project_dir``
+    # RAISES ValueError for an explicit ``--project`` (or ``$GDA_PROJECT``) that is
+    # not a Godot project — a raise that would escape as a traceback before the op's
+    # projectless-None guard runs. Convert it to the SAME structured project_not_found
+    # the None case yields, so "no resolved project" is always a clear structured
+    # error, never a crash (ADR-0031 / #343 AC). (The general cross-cutting fix — a
+    # shared ValueError→envelope layer across every channel — is tracked in #353;
+    # this stays within script run's own slice.)
+    try:
+        resolved = resolve_project_dir(project)
+    except ValueError:
+        return script_run_project_not_found_failure()
     return run_script_run_operation(
         script=params.path,
         godot=godot,
-        project=resolve_project_dir(project),
+        project=resolved,
     )
 
 

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -627,3 +627,37 @@ def export_templates_missing_failure(preset: str, templates_version: str) -> Fai
         f"the running engine version ({templates_version}) are not installed",
         "",
     )
+
+
+def script_path_invalid_failure(path: str) -> Failure:
+    """The ``invalid_path`` failure for a ``script run`` path that is not ``res://`` (ADR-0031).
+
+    ``script run`` is res://-only: a res:// path resolves against the ``--project``
+    context (ADR-0006), and the motivating need is project-scoped. An absolute or
+    otherwise non-``res://`` path is a structured ``invalid_path`` failure decided
+    at the CLI, *before* any engine launch — never a crash or a raw engine failure
+    (an explicit ABI edge of ADR-0031). Kept beside the other pre-run failures so
+    the whole taxonomy reads from one place.
+    """
+    return _failure(
+        "invalid_path",
+        f"script run requires a res:// script path, got: {path!r}",
+        "",
+    )
+
+
+def script_run_project_not_found_failure() -> Failure:
+    """The ``project_not_found`` failure for a ``script run`` with no resolved project (ADR-0031).
+
+    ``script run`` requires a resolved Godot project (ADR-0006): a res:// script
+    path needs a project to resolve against. When none resolves (no ``--project``,
+    no ``$GDA_PROJECT``, and the cwd is not a project), gda fails *before* spawning
+    the engine with this structured failure rather than launching projectless —
+    the other explicit ABI edge of ADR-0031.
+    """
+    return _failure(
+        "project_not_found",
+        "script run requires a resolved Godot project: pass --project, set "
+        "$GDA_PROJECT, or run from a project directory",
+        "",
+    )

--- a/src/gda/execution.py
+++ b/src/gda/execution.py
@@ -25,11 +25,18 @@ class ExecutionKind(str, enum.Enum):
       capability that cannot run through ``operations.gd`` (ADR-0010).
     - ``LIVE`` — a live operation served by ``gda-daemon`` against a running
       engine session, reached through a daemon IPC client (ADR-0017).
+    - ``SCRIPT_RUN`` — a user-script passthrough run: a one-shot ``godot
+      --headless --path <project> --script <res://…>`` whose success result is the
+      user script's own ``{exit_status, stdout, stderr}`` passed through verbatim,
+      only launch/crash being classified (ADR-0031). Like ``EXPORT`` it routes by
+      its ``recipe`` (ADR-0023), so this value is self-description only — it adds
+      no runner-selection branch.
     """
 
     HEADLESS = "headless"
     EXPORT = "export"
     LIVE = "live"
+    SCRIPT_RUN = "script_run"
 
 
 # Phase-2 live requires Godot 4.6+ (the UDS transport landed in 4.6; ADR-0021).

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -1684,6 +1684,54 @@ class ExportRunResult(BaseModel):
     )
 
 
+class ScriptRunParams(BaseModel):
+    """The operation params of ``gda script run`` (issue #343, ADR-0031).
+
+    ``path`` is the ``res://`` path of the user script to run as a one-shot
+    ``godot --headless --path <project> --script <res://…>``. It is res://-only
+    (a res:// path resolves against the ``--project`` context, ADR-0006): an
+    absolute or non-``res://`` path is the ``invalid_path`` failure. A plain
+    ``str`` (NOT ``NormalizedPath``) because a res:// path is an engine-virtual
+    address, not a filesystem path — filesystem normalization would collapse the
+    ``res://`` double slash. The project is process context (``--project``), not
+    an operation param.
+    """
+
+    path: str = Field(
+        description="The res:// path of the script to run (e.g. res://tests/logic.gd)."
+    )
+
+
+class ScriptRunResult(BaseModel):
+    """The result of ``gda script run``: the user script's own run, passed through (ADR-0031).
+
+    This is the **public promotion of the internal Raw-run shape**
+    (:class:`gda.runner.RunResult`): a THIN boundary DTO built from a ``RunResult``
+    by dropping its ``launch_failure`` axis (that becomes the Error envelope) and
+    renaming ``exit_code`` → ``exit_status``. Unlike every other command,
+    ``script run`` does not interpret the user script's semantics — a deliberate
+    ``quit(1)`` is meaningful data the agent reads, not a gda failure — so this is
+    the **one** command whose *success* result can carry a non-zero
+    ``exit_status``. Agents must read ``exit_status`` and must not assume
+    ``success == zero``.
+
+    NOTE: a second passthrough consumer should promote this to a shared
+    ``RawRunResult`` model. Do NOT build that shared abstraction now: there is only
+    one consumer today (``export run`` returns a different domain shape — the
+    produced artifact — and does not reuse the raw run).
+    """
+
+    exit_status: int = Field(
+        description=(
+            "The user script's own process exit code, passed through verbatim — "
+            "non-zero (e.g. a deliberate quit(1)) is still a SUCCESS result, not a "
+            "gda failure (ADR-0031)."
+        )
+    )
+    stdout: str = Field(description="The script's standard output, captured verbatim.")
+    stderr: str = Field(description="The script's standard error, captured verbatim.")
+
+
 class ResourceCreateResult(BaseModel):
     """The result of ``gda resource create``: what was written where (issue #112).
 

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -81,6 +81,7 @@ if TYPE_CHECKING:
         ScriptDeleteResult,
         ScriptGetResult,
         ScriptListResult,
+        ScriptRunResult,
         ScriptSetResult,
         ScriptValidateResult,
         ShaderCreateResult,
@@ -525,6 +526,22 @@ def render_script_validate(validated: "ScriptValidateResult") -> str:
         location = f"line {diag.line}" if diag.line is not None else "unknown line"
         lines.append(f"  {location}: {diag.message}")
     return "\n".join(lines)
+
+
+def render_script_run(ran: "ScriptRunResult") -> str:
+    """Render a passed-through script run: its exit status then its captured output.
+
+    ``script run`` passes the user script's own output through verbatim (ADR-0031),
+    so the human view leads with the ``exit_status`` — which can be non-zero on a
+    SUCCESS (a deliberate ``quit(1)``) — then the script's stdout and stderr as it
+    emitted them (each trailing newline trimmed; empty streams are omitted).
+    """
+    parts = [f"exit_status: {ran.exit_status}"]
+    if ran.stdout:
+        parts.append(ran.stdout.rstrip("\n"))
+    if ran.stderr:
+        parts.append(ran.stderr.rstrip("\n"))
+    return "\n".join(parts)
 
 
 def render_resource_create(created: "ResourceCreateResult") -> str:

--- a/src/gda/script_run.py
+++ b/src/gda/script_run.py
@@ -1,0 +1,147 @@
+"""The ScriptRun operation — ``gda script run``'s user-script passthrough run (ADR-0031).
+
+``gda script run res://path.gd`` runs the user's own script as a one-shot
+``godot --headless --path <project> --script <res://…>`` process and returns a
+structured result. It is the **third execution shape** (ADR-0031): neither the
+ADR-0002 sentinel op-dispatch (the entry script is the user's own, so it cannot
+emit the sentinel) nor the native-export recipe (gda does not know the script's
+semantics, so it has no gda-defined typed result to synthesize). The outcome
+therefore **bifurcates by whose failure it is**:
+
+- **gda-/engine-level failure** — the binary could not be launched, the run timed
+  out, or the engine died on a signal (``exit_code < 0``) → an **Error envelope**,
+  classified by the SAME shared :func:`gda.errors.classify_launch_or_crash` the
+  export channel uses, into its existing codes (``binary_not_found`` /
+  ``launch_timeout`` / ``engine_crashed``). No new GDScript-mirrored codes.
+- **the script ran to completion** — the engine exited normally
+  (``exit_code >= 0``) → a **success** :class:`~gda.models.ScriptRunResult`
+  carrying ``{exit_status, stdout, stderr}`` **passed through verbatim, even when
+  ``exit_status != 0``**. gda does not interpret the script's semantics: a
+  deliberate ``quit(1)`` (e.g. an assertion-failed logic-seam test) is meaningful
+  DATA the agent reads, not a gda failure.
+
+Two explicit pre-run ABI edges (ADR-0031), both decided at the CLI before any
+launch and returned as a structured ``GdaError`` (never a crash): a non-``res://``
+or absolute script path → ``invalid_path``; no resolved project →
+``project_not_found``.
+
+Like ``export run`` (:mod:`gda.export_run`), this module is the recipe's home:
+:func:`run_script_run_operation` RETURNS its outcome
+(``ScriptRunResult | Failure``) instead of emitting or exiting, so the CLI command
+stays the thin shared shape and the recipe gets its own engine-free test surface.
+The engine-touching step delegates to the deep-module headless-launch primitive
+:func:`gda.runner.launch` — the SINGLE home of the spawn / timeout /
+launch-failure / UTF-8-decode normalization — reused, not re-implemented. It is
+injected (``make_launch``) only so the bifurcation is testable without a real
+engine.
+"""
+
+from pathlib import Path
+from typing import Optional, Protocol
+
+from gda.binary import resolve_godot_binary
+from gda.errors import (
+    Failure,
+    classify_launch_or_crash,
+    script_path_invalid_failure,
+    script_run_project_not_found_failure,
+    unresolvable_binary_failure,
+)
+from gda.models import ScriptRunResult
+from gda.runner import RunResult, launch
+
+# A user script is arbitrary project code (it may load resources), so give it a
+# ceiling more generous than a single sentinel op's tight bound but well below the
+# export channel's — enough for a logic-seam test without leaving a hung run to
+# block forever. Bounds a hung engine so the CLI fails loudly (as launch_timeout).
+DEFAULT_SCRIPT_RUN_TIMEOUT_SECONDS = 120.0
+
+# The res:// scheme prefix: script run is res://-only (ADR-0031). A res:// path
+# resolves against the --project context, unlike an absolute/filesystem path.
+_RES_PREFIX = "res://"
+
+
+class LaunchFn(Protocol):
+    """The headless-launch seam — the shape of :func:`gda.runner.launch` (#343).
+
+    Injected into :func:`run_script_run_operation` so the launch/crash bifurcation
+    is exercised with a canned :class:`~gda.runner.RunResult`, without spawning a
+    real engine — the ``script run`` twin of the sentinel channel's ``RunnerFactory``
+    and the export channel's ``ExportRunnerFactory``. The default is the real
+    ``launch`` (the deep module is reused, never re-implemented).
+    """
+
+    def __call__(
+        self,
+        binary: Path,
+        args: list[str],
+        *,
+        cwd: Path | None,
+        timeout: float,
+        timeout_label: str = ...,
+    ) -> RunResult: ...
+
+
+def run_script_run_operation(
+    *,
+    script: str,
+    godot: Optional[str],
+    project: Optional[Path],
+    make_launch: LaunchFn = launch,
+    timeout: float = DEFAULT_SCRIPT_RUN_TIMEOUT_SECONDS,
+) -> ScriptRunResult | Failure:
+    """Run ``script run``'s validate → launch → classify recipe (ADR-0031).
+
+    Returns its outcome instead of emitting or exiting: the passthrough
+    :class:`~gda.models.ScriptRunResult` on a clean engine exit (even a non-zero
+    ``exit_status``) or a :class:`~gda.errors.Failure` — a pre-run ABI-edge
+    failure (``invalid_path`` / ``project_not_found``) or a
+    ``classify_launch_or_crash`` env/crash outcome. ``project`` is the
+    already-resolved directory (resolution stays CLI-side, ADR-0006); ``None``
+    means none resolved. ``make_launch`` is the injected headless-launch seam
+    (defaults to the real deep-module ``launch``).
+    """
+    # Pre-run ABI edges (ADR-0031), decided BEFORE any launch so they never surface
+    # as a crash or a raw engine failure. Path first (it is the direct argument):
+    # res://-only — an absolute or non-res:// path cannot resolve against --path.
+    if not script.startswith(_RES_PREFIX):
+        return script_path_invalid_failure(script)
+    # Then require a resolved project — a res:// path needs one to resolve.
+    if project is None:
+        return script_run_project_not_found_failure()
+
+    try:
+        binary = resolve_godot_binary(godot)
+    except ValueError as exc:
+        # An empty ``--godot ""`` (a natural $GDA_GODOT mistake) makes resolution
+        # raise before a launch — the same environment failure as a missing binary,
+        # mapped to the structured envelope so it never escapes as a raw traceback
+        # (mirrors gda.headless.execute's binary resolution, #33).
+        return unresolvable_binary_failure(str(exc))
+
+    # Build only this channel's argv tail — the user script under the resolved
+    # project — and delegate the spawn / timeout / OSError / UTF-8-decode handling
+    # to the shared launch primitive (the deep module, reused not re-implemented).
+    # cwd=None mirrors the sentinel SubprocessGodotRunner: a res:// script resolves
+    # via --path, so no working directory is needed (unlike the export channel,
+    # whose relative output path needs cwd=project).
+    args = ["--path", str(project), "--script", script]
+    raw = make_launch(
+        binary, args, cwd=None, timeout=timeout, timeout_label="Godot script"
+    )
+
+    # Bifurcate by whose failure it is (ADR-0031): a launch failure or a signal
+    # death (exit_code < 0) is a gda-/engine-level Error envelope, classified by the
+    # SAME shared prefix the export channel uses. Everything else — a clean engine
+    # exit, INCLUDING a non-zero exit_status — is a success passthrough.
+    crash = classify_launch_or_crash(raw, binary)
+    if crash is not None:
+        return crash
+    # The public promotion of the internal Raw run: the thin boundary DTO built by
+    # dropping launch_failure (lifted into the Error envelope above) and renaming
+    # exit_code → exit_status. This is the one success result that can be non-zero.
+    return ScriptRunResult(
+        exit_status=raw.exit_code,
+        stdout=raw.stdout,
+        stderr=raw.stderr,
+    )

--- a/src/gda/script_run.py
+++ b/src/gda/script_run.py
@@ -87,7 +87,7 @@ def run_script_run_operation(
     script: str,
     godot: Optional[str],
     project: Optional[Path],
-    make_launch: LaunchFn = launch,
+    make_launch: Optional[LaunchFn] = None,
     timeout: float = DEFAULT_SCRIPT_RUN_TIMEOUT_SECONDS,
 ) -> ScriptRunResult | Failure:
     """Run ``script run``'s validate → launch → classify recipe (ADR-0031).
@@ -98,9 +98,12 @@ def run_script_run_operation(
     failure (``invalid_path`` / ``project_not_found``) or a
     ``classify_launch_or_crash`` env/crash outcome. ``project`` is the
     already-resolved directory (resolution stays CLI-side, ADR-0006); ``None``
-    means none resolved. ``make_launch`` is the injected headless-launch seam
-    (defaults to the real deep-module ``launch``).
+    means none resolved. ``make_launch`` is the injected headless-launch seam;
+    ``None`` (the default) uses the real deep-module :func:`gda.runner.launch`,
+    resolved at call time — the ``screen_ops`` idiom — so a test can inject a fake
+    OR patch ``gda.script_run.launch``.
     """
+    run_launch = make_launch or launch
     # Pre-run ABI edges (ADR-0031), decided BEFORE any launch so they never surface
     # as a crash or a raw engine failure. Path first (it is the direct argument):
     # res://-only — an absolute or non-res:// path cannot resolve against --path.
@@ -126,7 +129,7 @@ def run_script_run_operation(
     # via --path, so no working directory is needed (unlike the export channel,
     # whose relative output path needs cwd=project).
     args = ["--path", str(project), "--script", script]
-    raw = make_launch(
+    raw = run_launch(
         binary, args, cwd=None, timeout=timeout, timeout_label="Godot script"
     )
 

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -62,7 +62,7 @@ Branch on the stable `category`/`code` and the **exit code**, never on prose:
 | ----- | -------- |
 | `scene` | `create`, `get`, `list`, `get-exports`, `delete` (`.tscn` files) |
 | `node` | `add`, `get`, `list`, `set`, `remove`, `duplicate`, `move`, `connect-signal`, `disconnect-signal` (nodes within a scene) |
-| `script` | `create`, `get`, `list`, `set`, `delete`, `attach`, `validate` (`.gd` files) |
+| `script` | `create`, `get`, `list`, `set`, `delete`, `attach`, `validate`, `run` (`.gd` files; `run` executes a `res://` script one-shot and passes its `exit_status`/`stdout`/`stderr` through — a non-zero `quit()` is still success) |
 | `project` | `info`, `get`, `set`, `list`, `add-autoload`, `remove-autoload`, `find-references`, `dependencies`, `find-unused-resources`, `statistics` |
 | `resource` | `create`, `get`, `set`, `delete`, `uid` (`.tres` files) |
 | `export` | `list`, `get`, `run` (export a preset by name; `--mode` release/debug/pack) |

--- a/tests/test_command_descriptor_registry.py
+++ b/tests/test_command_descriptor_registry.py
@@ -91,6 +91,10 @@ def test_no_renderer_is_orphaned():
 # an asserted INVARIANT over the descriptors, not a dispatch mechanism.
 _RECIPE_OPERATIONS = {
     "export-run",
+    # `script run` is the third execution shape (ADR-0031): a user-script passthrough
+    # run, fulfilled by a CLI-side recipe (it emits no ADR-0002 sentinel) like export
+    # run, so it carries a recipe rather than routing to `cmd.emit`.
+    "script-run",
     "daemon-start",
     "daemon-stop",
     "daemon-status",

--- a/tests/test_e2e_script_run.py
+++ b/tests/test_e2e_script_run.py
@@ -61,8 +61,8 @@ def _run_gda(*args: str, retry: bool = False) -> subprocess.CompletedProcess:
     """Invoke ``gda <args>`` as a subprocess (this checkout's editable gda, ADR-0011).
 
     ``retry`` re-runs once on a transient ``engine_crashed`` — a shared-``user://``
-    log race under parallel e2e, not a gda bug (see the memory note) — so a happy
-    path does not flake.
+    log race under parallel e2e (not a gda bug; the race was fixed in #180) — so a
+    happy path does not flake.
     """
     for attempt in range(2 if retry else 1):
         proc = subprocess.run([*GDA_CMD, *args], capture_output=True, text=True)

--- a/tests/test_e2e_script_run.py
+++ b/tests/test_e2e_script_run.py
@@ -1,0 +1,194 @@
+"""S1 (e2e): script run against the real Godot engine (issue #343, ADR-0031).
+
+``gda script run res://path.gd`` runs the user's OWN script as a one-shot
+``godot --headless --path <project> --script <res://…>`` and passes its result
+through. These tests exercise that REAL path — the real deep-module
+``gda.runner.launch`` spawning the real Godot, classified by the real shared
+``classify_launch_or_crash`` — against a throwaway project, proving the round trip
+ADR-0031 specifies:
+
+- a script that ``quit(0)`` → SUCCESS ``{exit_status: 0, stdout, stderr}`` with the
+  script's printed output read back from ``stdout``;
+- a script that ``quit(1)`` → still a **SUCCESS** carrying ``exit_status != 0`` and
+  a **zero** gda process exit (the crux: gda does not interpret the script's
+  semantics, so a deliberate non-zero quit is data, not a gda failure);
+- the pre-run ABI edges — a non-``res://`` path and no resolved project — are
+  structured ``invalid_path`` / ``project_not_found`` failures decided before any
+  launch;
+- an unlaunchable binary is the shared classifier's ``binary_not_found``.
+
+The launch-timeout and signal-crash arms of the shared classifier are covered by
+``tests/test_script_run_operation.py`` and ``tests/test_classify_launch_or_crash.py``
+(forcing them live is flaky and needs no ``script run``-specific wiring — the
+classifier is the same one ``export run`` uses).
+
+The standalone entry script uses the ``extends SceneTree`` + ``_initialize`` +
+``quit(<code>)`` pattern (the same one ``operations.gd`` runs on), which is how a
+headless one-shot script controls its own exit code.
+"""
+
+import json
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+from tests.support import GDA_CMD
+
+GODOT = resolve_godot_binary()
+
+# A standalone headless script: do work in _initialize, then quit with a chosen
+# code. `extends SceneTree` makes the script the main loop, the pattern a
+# one-shot `--script` run uses to control its exit code (cf. operations.gd).
+HELLO_GD = """\
+extends SceneTree
+
+func _initialize() -> void:
+\tprint("hello from script run")
+\tquit(0)
+"""
+
+FAIL_GD = """\
+extends SceneTree
+
+func _initialize() -> void:
+\tprint("assertion failed: expected 5 got 4")
+\tquit(1)
+"""
+
+
+def _run_gda(*args: str, retry: bool = False) -> subprocess.CompletedProcess:
+    """Invoke ``gda <args>`` as a subprocess (this checkout's editable gda, ADR-0011).
+
+    ``retry`` re-runs once on a transient ``engine_crashed`` — a shared-``user://``
+    log race under parallel e2e, not a gda bug (see the memory note) — so a happy
+    path does not flake.
+    """
+    for attempt in range(2 if retry else 1):
+        proc = subprocess.run([*GDA_CMD, *args], capture_output=True, text=True)
+        if not retry or proc.returncode == 0:
+            return proc
+        try:
+            code = json.loads(proc.stdout)["error"]["code"]
+        except (ValueError, KeyError, TypeError):
+            return proc
+        if code != "engine_crashed":
+            return proc
+    return proc
+
+
+@pytest.mark.e2e
+def test_script_run_passes_a_clean_run_through(godot_project):
+    # Happy path: a script that quit(0) → SUCCESS carrying exit_status 0 and the
+    # script's printed line read back from stdout.
+    (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
+
+    run = _run_gda(
+        "script",
+        "run",
+        "res://hello.gd",
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+        retry=True,
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    data = json.loads(run.stdout)
+    assert data["exit_status"] == 0
+    assert "hello from script run" in data["stdout"]
+    assert "error" not in data
+
+
+@pytest.mark.e2e
+def test_script_run_non_zero_quit_is_success_not_a_gda_failure(godot_project):
+    # THE CRUX (ADR-0031): a deliberate quit(1) — e.g. an assertion-failed logic-seam
+    # test — is a clean engine exit, so it is a SUCCESS result carrying exit_status=1,
+    # and the gda PROCESS still exits 0. gda does not interpret the script's semantics:
+    # the non-zero code and the message are DATA the agent reads, not a gda error.
+    (godot_project / "fail.gd").write_text(FAIL_GD, encoding="utf-8")
+
+    run = _run_gda(
+        "script",
+        "run",
+        "res://fail.gd",
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+        retry=True,
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr  # a SUCCESS, not an envelope
+    data = json.loads(run.stdout)
+    assert "error" not in data
+    assert data["exit_status"] == 1
+    assert "assertion failed" in data["stdout"]
+
+
+@pytest.mark.e2e
+def test_script_run_non_res_path_is_invalid_path(godot_project):
+    # A non-res:// path is a structured invalid_path decided BEFORE any launch — an
+    # explicit ABI edge (ADR-0031), never a crash or raw engine failure.
+    run = _run_gda(
+        "script",
+        "run",
+        "hello.gd",  # not res://
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+    )
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "invalid_path"
+    assert err["category"] == "operation"
+
+
+@pytest.mark.e2e
+def test_script_run_without_a_project_is_project_not_found(tmp_path):
+    # No resolved project (no --project, no $GDA_PROJECT, cwd is projectless) →
+    # structured project_not_found before any launch (the other ABI edge, ADR-0031).
+    projectless = tmp_path / "empty"
+    projectless.mkdir()
+
+    run = subprocess.run(
+        [*GDA_CMD, "script", "run", "res://hello.gd", "--godot", str(GODOT), "--json"],
+        capture_output=True,
+        text=True,
+        cwd=str(projectless),
+    )
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "project_not_found"
+    assert err["category"] == "operation"
+
+
+@pytest.mark.e2e
+def test_script_run_unlaunchable_binary_is_binary_not_found(godot_project):
+    # An unlaunchable --godot binary is the SAME shared classifier's binary_not_found
+    # (the launch-failure family), exactly as export run classifies it — no
+    # GDScript-mirrored code.
+    (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
+
+    run = _run_gda(
+        "script",
+        "run",
+        "res://hello.gd",
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(godot_project / "no-such-godot"),
+        "--json",
+    )
+
+    assert run.returncode == 127, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "binary_not_found"
+    assert err["category"] == "environment"

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -154,13 +154,16 @@ def test_every_input_field_has_a_non_empty_description():
 
 def test_every_entry_carries_an_execution_kind():
     # issue #230: each manifest entry advertises its static execution `kind`
-    # (HEADLESS / EXPORT / LIVE) so gda-mcp / an agent can branch on a command's
-    # channel without inferring it. The enum subclasses `str`, so the value is the
-    # lowercase string, never the Python enum repr.
+    # (HEADLESS / EXPORT / LIVE / SCRIPT_RUN) so gda-mcp / an agent can branch on a
+    # command's channel without inferring it. The enum subclasses `str`, so the value
+    # is the lowercase string, never the Python enum repr. `script_run` is the fourth
+    # value (ADR-0031).
     entries = _manifest()["commands"]
     assert entries
     for entry in entries:
-        assert entry["kind"] in {"headless", "export", "live"}, entry["name"]
+        assert entry["kind"] in {"headless", "export", "live", "script_run"}, entry[
+            "name"
+        ]
 
 
 def test_entry_kind_matches_the_commands_own_schema_kind():
@@ -174,16 +177,18 @@ def test_entry_kind_matches_the_commands_own_schema_kind():
         assert entry["kind"] == own["kind"], entry["name"]
 
 
-def test_all_three_execution_kinds_appear_in_the_aggregate():
-    # The surface spans all three channels: the default HEADLESS commands, the
-    # one EXPORT command (`export run`), and the LIVE commands (`game tree`).
+def test_all_execution_kinds_appear_in_the_aggregate():
+    # The surface spans all four channels: the default HEADLESS commands, the one
+    # EXPORT command (`export run`), the LIVE commands (`game tree`), and the one
+    # SCRIPT_RUN command (`script run`, the user-script passthrough, ADR-0031).
     by_name = {entry["name"]: entry for entry in _manifest()["commands"]}
     assert by_name["scene get"]["kind"] == "headless"
     assert by_name["export run"]["kind"] == "export"
     assert by_name["game tree"]["kind"] == "live"
-    # All three kinds are represented in the aggregate as a whole.
+    assert by_name["script run"]["kind"] == "script_run"
+    # All four kinds are represented in the aggregate as a whole.
     kinds = {entry["kind"] for entry in by_name.values()}
-    assert {"headless", "export", "live"} <= kinds
+    assert {"headless", "export", "live", "script_run"} <= kinds
 
 
 def test_entry_constraints_match_the_commands_own_schema_constraints():
@@ -267,6 +272,7 @@ def test_self_described_manifest_guarantees_a_constrained_entry_kind():
         "headless",
         "export",
         "live",
+        "script_run",
     ]
 
 

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1091,6 +1091,35 @@ def test_export_get_and_list_commands_schema_report_kind_headless():
         assert json.loads(result.stdout)["kind"] == "headless"
 
 
+def test_script_run_command_schema_reports_kind_script_run():
+    # `script run` is the fourth execution shape (ADR-0031): a user-script
+    # passthrough run — neither the operations.gd sentinel nor the native export
+    # recipe — so its schema must say `script_run`, the fourth kind value. Sibling
+    # script commands (get/list/validate/…) stay HEADLESS.
+    result = CliRunner().invoke(app, ["script", "run", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["kind"] == "script_run"
+
+
+def test_script_run_command_schema_is_model_derived():
+    # `script run` self-describes like any command (ADR-0004): input/output from its
+    # typed models, the uniform error envelope. Its output carries the passthrough
+    # {exit_status, stdout, stderr} — the public promotion of the Raw run.
+    from gda.models import ScriptRunParams, ScriptRunResult
+
+    doc = json.loads(CliRunner().invoke(app, ["script", "run", "--schema"]).stdout)
+
+    assert doc["input"] == ScriptRunParams.model_json_schema()
+    assert doc["output"] == ScriptRunResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    # The success output exposes exit_status (can be non-zero on success, ADR-0031).
+    assert set(doc["output"]["properties"]) == {"exit_status", "stdout", "stderr"}
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
 def test_live_command_schema_reports_kind_live_without_a_daemon():
     # `game tree` is a LIVE command served through gda-daemon — but `--schema` is
     # intercepted in parse_args before any execution, so it self-describes with

--- a/tests/test_script_run_commands.py
+++ b/tests/test_script_run_commands.py
@@ -1,0 +1,132 @@
+"""S3: gda script run through the full CLI pipeline against a fake launch (issue #343).
+
+``script run`` is the third execution shape (ADR-0031): a user-script passthrough
+run, fulfilled by the CLI-side recipe ``run_script_run_operation`` rather than the
+operations.gd sentinel. The engine-touching step is the deep-module
+:func:`gda.runner.launch`, which these tests replace with a canned
+:class:`~gda.runner.RunResult` (patched at ``gda.script_run.launch``), so the full
+Typer → recipe → classify → JSON/emit pipeline runs engine-free.
+
+They pin the two behaviors that only show at the CLI boundary: a clean engine exit
+emits the SUCCESS result AND the process exits 0 — even when the script's own
+``exit_status`` is non-zero (the ADR-0031 crux) — while the pre-run ABI edges emit
+the uniform Error envelope. The ``--params-json`` case guards that it drives the
+SAME recipe (ADR-0015), not the wrong runner.
+"""
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.runner import RunResult
+
+
+def _patch_launch(monkeypatch, result: RunResult) -> list:
+    """Replace the deep-module launch with one returning ``result``; record calls."""
+    calls: list = []
+
+    def fake_launch(binary, args, *, cwd, timeout, timeout_label="Godot"):
+        calls.append((binary, args, cwd, timeout, timeout_label))
+        return result
+
+    monkeypatch.setattr("gda.script_run.launch", fake_launch)
+    return calls
+
+
+def _project(tmp_path: Path) -> Path:
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_clean_run_emits_the_passthrough_result(monkeypatch, tmp_path):
+    project = _project(tmp_path)
+    calls = _patch_launch(monkeypatch, RunResult(stdout="hi\n", stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        ["script", "run", "res://logic.gd", "--project", str(project), "--json"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data == {"exit_status": 0, "stdout": "hi\n", "stderr": ""}
+    # The recipe launched `--path <project> --script <res path>` with cwd=None.
+    (_binary, args, cwd, _timeout, _label) = calls[0]
+    assert args == ["--path", str(project), "--script", "res://logic.gd"]
+    assert cwd is None
+
+
+def test_non_zero_script_exit_is_success_process_exits_zero(monkeypatch, tmp_path):
+    # THE CRUX at the CLI boundary: a script quit(1) is a SUCCESS — the JSON carries
+    # exit_status=1 but the gda PROCESS exits 0 (not an error envelope). This is the
+    # one command where success != zero exit_status.
+    project = _project(tmp_path)
+    _patch_launch(monkeypatch, RunResult(stdout="fail\n", stderr="", exit_code=1))
+
+    result = CliRunner().invoke(
+        app,
+        ["script", "run", "res://logic.gd", "--project", str(project), "--json"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert "error" not in data
+    assert data["exit_status"] == 1
+    assert data["stdout"] == "fail\n"
+
+
+def test_params_json_drives_the_same_recipe(monkeypatch, tmp_path):
+    # --params-json (ADR-0015) must drive the SAME recipe — a regression guard that
+    # the generic dispatch hook does not route script run through the wrong runner.
+    project = _project(tmp_path)
+    calls = _patch_launch(monkeypatch, RunResult(stdout="ok\n", stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "run",
+            "--params-json",
+            '{"path": "res://logic.gd"}',
+            "--project",
+            str(project),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout)["exit_status"] == 0
+    assert calls, "the launch seam was never reached via --params-json"
+
+
+def test_non_res_path_emits_invalid_path_envelope(monkeypatch, tmp_path):
+    project = _project(tmp_path)
+    calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        ["script", "run", "logic.gd", "--project", str(project), "--json"],
+    )
+
+    assert result.exit_code != 0
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "invalid_path"
+    assert not calls, "no engine launch on an invalid path"
+
+
+def test_no_resolved_project_emits_project_not_found(monkeypatch, tmp_path):
+    # No --project and a projectless cwd → structured project_not_found, before any
+    # launch. chdir into a dir with no project.godot to make resolution yield None.
+    projectless = tmp_path / "empty"
+    projectless.mkdir()
+    monkeypatch.chdir(projectless)
+    calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["script", "run", "res://logic.gd", "--json"])
+
+    assert result.exit_code != 0
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "project_not_found"
+    assert not calls

--- a/tests/test_script_run_commands.py
+++ b/tests/test_script_run_commands.py
@@ -130,3 +130,41 @@ def test_no_resolved_project_emits_project_not_found(monkeypatch, tmp_path):
     err = json.loads(result.stdout)["error"]
     assert err["code"] == "project_not_found"
     assert not calls
+
+
+def test_explicit_bad_project_is_structured_not_a_traceback(monkeypatch, tmp_path):
+    # An EXPLICIT --project that is not a Godot project makes resolve_project_dir RAISE
+    # ValueError — which the recipe must convert to the SAME structured project_not_found
+    # the None case yields, never letting the raise escape as a traceback (ADR-0031 /
+    # #343 AC). The projectless-cwd None guard alone would MISS this raise path.
+    not_a_project = tmp_path / "not-a-godot-project"
+    not_a_project.mkdir()  # exists, but has no project.godot
+    calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        ["script", "run", "res://logic.gd", "--project", str(not_a_project), "--json"],
+    )
+
+    assert result.exit_code != 0
+    # A structured envelope on stdout, NOT a Rich/Python traceback.
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "project_not_found"
+    assert not calls, "no engine launch when the project cannot resolve"
+
+
+def test_bad_gda_project_env_is_structured_not_a_traceback(monkeypatch, tmp_path):
+    # The same raise path via $GDA_PROJECT (env precedence, not the --project flag):
+    # an env pointing at a non-project also raises ValueError and must yield the
+    # structured project_not_found envelope, not a traceback.
+    not_a_project = tmp_path / "env-not-a-project"
+    not_a_project.mkdir()
+    monkeypatch.setenv("GDA_PROJECT", str(not_a_project))
+    calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
+
+    result = CliRunner().invoke(app, ["script", "run", "res://logic.gd", "--json"])
+
+    assert result.exit_code != 0
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "project_not_found"
+    assert not calls

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -1,0 +1,215 @@
+"""Direct tests for the ScriptRun operation (issue #343, ADR-0031).
+
+``script run`` is the third execution shape: a user-script passthrough run whose
+recipe — validate the res:// path + require a resolved project, then launch
+``godot --headless --path <project> --script <res://…>`` and BIFURCATE by whose
+failure it is — lives in :func:`gda.script_run.run_script_run_operation`, a PURE
+function that RETURNS the outcome (never emits/exits).
+
+These tests drive that function directly with the injected launch seam (a
+``FakeLaunch`` returning a canned :class:`~gda.runner.RunResult`), so the whole
+bifurcation is asserted without a real engine and without CliRunner:
+
+- a clean engine exit (``exit_code >= 0``) — INCLUDING a non-zero ``quit(1)`` —
+  is a SUCCESS ``ScriptRunResult`` with the script's output passed through;
+- a launch failure / signal death is a gda-level Error envelope, classified by
+  the SAME shared ``classify_launch_or_crash`` the export channel uses;
+- the two pre-run ABI edges (non-res:// path, no resolved project) are structured
+  failures decided BEFORE any launch.
+
+They are the recipe's own test surface, complementary to the e2e round-trip in
+``tests/test_e2e_script_run.py`` (real Godot).
+"""
+
+from pathlib import Path
+
+from gda.cli import SCRIPT_RUN_COMMAND  # the single fully-bound descriptor (ADR-0023)
+from gda.errors import Failure
+from gda.execution import ExecutionKind
+from gda.exit_codes import EXIT_NOT_FOUND, EXIT_OPERATION, EXIT_TIMEOUT
+from gda.models import ScriptRunResult
+from gda.runner import LaunchFailure, RunResult
+from gda.script_run import run_script_run_operation
+
+PROJECT = Path("/tmp/project")
+
+
+class FakeLaunch:
+    """A fakeable :func:`gda.runner.launch` that records its call and returns a canned run.
+
+    Satisfies the ``LaunchFn`` seam so the operation's launch/crash bifurcation is
+    exercised without a real engine — the ``script run`` twin of ``FakeRunner`` /
+    ``FakeExportRunner``. Records the ``(binary, args, cwd, timeout, timeout_label)``
+    it was called with so argv-tail construction (and ``cwd=None``) can be asserted.
+    """
+
+    def __init__(self, result: RunResult) -> None:
+        self.result = result
+        self.calls: list[tuple] = []
+
+    def __call__(
+        self,
+        binary: Path,
+        args: list[str],
+        *,
+        cwd: Path | None,
+        timeout: float,
+        timeout_label: str = "Godot",
+    ) -> RunResult:
+        self.calls.append((binary, args, cwd, timeout, timeout_label))
+        return self.result
+
+
+def _run(
+    result: RunResult,
+    *,
+    script: str = "res://tests/logic.gd",
+    project: Path | None = PROJECT,
+    godot: str | None = "/tmp/Godot",
+) -> tuple[ScriptRunResult | Failure, FakeLaunch]:
+    """Invoke the operation with the launch seam pinned to a ``FakeLaunch``."""
+    launch = FakeLaunch(result)
+    outcome = run_script_run_operation(
+        script=script,
+        godot=godot,
+        project=project,
+        make_launch=launch,
+    )
+    return outcome, launch
+
+
+def test_script_run_command_is_the_passthrough_channel():
+    # `script run` is the fourth execution shape — a user-script passthrough that
+    # emits no ADR-0002 sentinel — so it carries the SCRIPT_RUN kind and routes by
+    # its recipe (ADR-0031 / ADR-0023), never `cmd.emit`.
+    assert SCRIPT_RUN_COMMAND.kind is ExecutionKind.SCRIPT_RUN
+    assert SCRIPT_RUN_COMMAND.recipe is not None
+
+
+def test_clean_zero_exit_passes_the_run_through():
+    # The happy path: the engine exits 0, so the operation RETURNS the typed
+    # ScriptRunResult carrying the script's own stdout/stderr verbatim.
+    outcome, launch = _run(RunResult(stdout="hello\n", stderr="warn\n", exit_code=0))
+
+    assert isinstance(outcome, ScriptRunResult)
+    assert outcome.exit_status == 0
+    assert outcome.stdout == "hello\n"
+    assert outcome.stderr == "warn\n"
+    # The argv tail is `--path <project> --script <res path>`, launched with cwd=None
+    # (mirroring the sentinel runner, NOT the export channel's cwd=project).
+    (binary, args, cwd, _timeout, label) = launch.calls[0]
+    assert args == ["--path", str(PROJECT), "--script", "res://tests/logic.gd"]
+    assert cwd is None
+    assert label == "Godot script"
+
+
+def test_non_zero_script_exit_is_a_success_not_a_failure():
+    # THE CRUX (ADR-0031): a deliberate quit(1) is a clean engine exit, so it is a
+    # SUCCESS result carrying exit_status=1 — gda does not interpret the script's
+    # semantics. This is the one command whose success result can be non-zero.
+    outcome, _ = _run(RunResult(stdout="assert failed\n", stderr="", exit_code=1))
+
+    assert isinstance(outcome, ScriptRunResult)
+    assert outcome.exit_status == 1
+    assert outcome.stdout == "assert failed\n"
+
+
+def test_binary_not_found_is_the_shared_classifier_failure():
+    # A synthesized NOT_FOUND launch failure → binary_not_found, via the SAME
+    # classify_launch_or_crash the export channel uses (no GDScript-mirrored code).
+    outcome, _ = _run(
+        RunResult(
+            stdout="",
+            stderr="gda: Godot binary could not be launched\n",
+            exit_code=EXIT_NOT_FOUND,
+            launch_failure=LaunchFailure.NOT_FOUND,
+        )
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "binary_not_found"
+    assert outcome.exit_code == EXIT_NOT_FOUND
+
+
+def test_launch_timeout_is_the_shared_classifier_failure():
+    # A synthesized TIMEOUT launch failure → launch_timeout.
+    outcome, _ = _run(
+        RunResult(
+            stdout="",
+            stderr="gda: Godot script timed out after 120.0s\n",
+            exit_code=EXIT_TIMEOUT,
+            launch_failure=LaunchFailure.TIMEOUT,
+        )
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "launch_timeout"
+    assert outcome.exit_code == EXIT_TIMEOUT
+
+
+def test_signal_death_is_engine_crashed():
+    # A negative exit_code is a signal death (e.g. SIGSEGV) → engine_crashed, an
+    # operation-category gda failure — never a raw negative exit leaking out.
+    outcome, _ = _run(RunResult(stdout="", stderr="", exit_code=-11))
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "engine_crashed"
+    assert outcome.exit_code == EXIT_OPERATION
+    assert "11" in outcome.error.message
+
+
+def test_non_res_path_is_invalid_path_before_any_launch():
+    # A non-res:// path is a structured invalid_path decided BEFORE any launch
+    # (an explicit ABI edge, ADR-0031) — never a crash.
+    outcome, launch = _run(
+        RunResult(stdout="", stderr="", exit_code=0), script="tests/logic.gd"
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "invalid_path"
+    assert not launch.calls, "no engine launch on an invalid path"
+
+
+def test_absolute_path_is_invalid_path():
+    # An absolute filesystem path is likewise res://-only-rejected.
+    outcome, launch = _run(
+        RunResult(stdout="", stderr="", exit_code=0), script="/abs/logic.gd"
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "invalid_path"
+    assert not launch.calls
+
+
+def test_no_resolved_project_is_project_not_found_before_any_launch():
+    # No resolved project → structured project_not_found, before any launch
+    # (the other ABI edge, ADR-0031).
+    outcome, launch = _run(RunResult(stdout="", stderr="", exit_code=0), project=None)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "project_not_found"
+    assert not launch.calls
+
+
+def test_empty_godot_is_a_structured_binary_failure_not_a_traceback():
+    # An empty `--godot ""` makes binary resolution raise before any launch; it is
+    # mapped to the structured binary_not_found envelope, never a raw traceback.
+    outcome, launch = _run(RunResult(stdout="", stderr="", exit_code=0), godot="")
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "binary_not_found"
+    assert not launch.calls
+
+
+def test_result_is_the_thin_promotion_dropping_launch_failure():
+    # The success DTO is the thin boundary promotion of the internal Raw run: it
+    # drops `launch_failure` and renames exit_code→exit_status, carrying nothing
+    # else. (A clean exit never has a launch_failure set anyway.)
+    outcome, _ = _run(RunResult(stdout="out", stderr="err", exit_code=7))
+
+    assert isinstance(outcome, ScriptRunResult)
+    assert outcome.model_dump() == {
+        "exit_status": 7,
+        "stdout": "out",
+        "stderr": "err",
+    }


### PR DESCRIPTION
Closes #343. Follows **ADR-0031** (the third execution shape: a user-script passthrough run).

## What

`gda script run res://path.gd [--project …]` runs the user's own script as a one-shot `godot --headless --path <project> --script <res://…>` and returns a structured result. The outcome **bifurcates by whose failure it is**:

- **Clean engine exit (`exit_code >= 0`)** → SUCCESS `{exit_status, stdout, stderr}` passed through **verbatim, even when `exit_status != 0`**. This is the ONLY gda command whose success result can carry a non-zero `exit_status` — a deliberate `quit(1)` (e.g. an assertion-failed logic-seam test) is *data the agent reads*, not a gda failure.
- **gda-/engine-level failure** (binary not launchable / timeout / signal crash, `exit_code < 0`) → Error envelope via the **shared `classify_launch_or_crash`** already used by `export run`, reusing the existing codes `binary_not_found` / `launch_timeout` / `engine_crashed`. No new GDScript-mirrored codes.
- **non-`res://`/absolute path** → `invalid_path`; **no resolved project** → `project_not_found` — both structured, decided *before* any launch.

## How (mirrors `export run` as the template)

- `ExecutionKind.SCRIPT_RUN` — the fourth `kind`, **self-description only** (dispatch routes by `recipe` per ADR-0023, so it adds no runner-selection branch). Moves as one unit with the `--schema`/manifest `kind` enum and the schema tests that pin the set.
- `ScriptRunResult` — the **thin public promotion of the internal Raw run** (`gda.runner.RunResult`): built by dropping `launch_failure` (→ the Error envelope) and renaming `exit_code`→`exit_status`. A code comment notes a 2nd passthrough consumer should later promote this to a shared `RawRunResult` — not built now (one consumer today; `export run` returns a different domain shape).
- `src/gda/script_run.py` — the recipe: validate `res://` + require a resolved project, then **reuse the deep module `gda.runner.launch()`** for all spawn/timeout/UTF-8-decode/launch-failure normalization (`cwd=None`, mirroring the sentinel `SubprocessGodotRunner` — not the export runner's `cwd=project`).
- `gda script run --schema` self-describes the success result + the uniform error envelope (ADR-0004); `surface.py` carries `kind` automatically; **no `mcp/server.py` edit** needed.

## Tests

- `tests/test_script_run_operation.py` — engine-free bifurcation via an injected launch seam.
- `tests/test_script_run_commands.py` — full Typer→recipe→emit pipeline (the crux: non-zero `exit_status` success with a zero process exit; `--params-json` drives the same recipe).
- `tests/test_e2e_script_run.py` — real-engine round trip (`quit(0)`/`quit(1)`), `invalid_path`, `project_not_found`, `binary_not_found`.
- Schema kind-set (aggregate + per-command), recipe-xor-emit registry, and the SKILL.md surface-sync gate all updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)