### PR TITLE
fix(daemon): session-launch diagnostics + typed live_windowed_unavailable (#345)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -160,6 +160,7 @@ operation, and parse codes the CLI assigns).
 | `live_invalid_event_spec` | `live` | `classifier` | `6` | A live input sequence event has a type the harness does not recognize (Phase 2, #221). |
 | `live_display_unavailable` | `live` | `classifier` | `6` | A live `screen` capture ran on a headless engine session (the dummy DisplayServer cannot read pixels); start the daemon windowed with `gda daemon start --windowed` (Phase 2, #222). |
 | `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
+| `live_windowed_unavailable` | `environment` | `classifier` | `127` | A windowed live session (`gda daemon start --windowed`) was requested but the host has no usable DisplayServer (no on-console GUI session / no `$DISPLAY`), so the session cannot come up; refused before spawning Godot (Phase 2, #345). |
 
 ## Considered options
 

--- a/docs/adr/0022-runtime-diagnostics-via-daemon-owned-session-log.md
+++ b/docs/adr/0022-runtime-diagnostics-via-daemon-owned-session-log.md
@@ -113,4 +113,10 @@ parse.
 > the `engine_session_not_running` error's advisory `diagnostics`. NOTE: a
 > windowed-no-`DisplayServer` abort happens BEFORE Godot installs its file logger, so
 > for that case the tail is usually empty (the child-signal reason carries it); it
-> carries content for a post-logger crash. The decision above is otherwise unchanged.
+> carries content for a post-logger crash. To keep that tail HONEST, `launch_session`
+> now truncates the Session log at the START of each launch attempt, before spawning —
+> so "truncated each launch" holds even for a pre-logger abort (Godot's own
+> `FileAccess::WRITE` truncation only happens once its logger installs, which a
+> pre-logger crash never reaches). A failed pre-logger launch therefore reads EMPTY
+> rather than a PREVIOUS session's stale output; a post-logger failure reads only the
+> current session. The decision above is otherwise unchanged.

--- a/docs/adr/0022-runtime-diagnostics-via-daemon-owned-session-log.md
+++ b/docs/adr/0022-runtime-diagnostics-via-daemon-owned-session-log.md
@@ -102,3 +102,15 @@ parse.
   project's own semantics — so the ADR-0009 / ADR-0017 trust and editor-context
   boundaries are unchanged: `diag` introspects the running game's reported output,
   not the editor.
+
+> **Outcome (2026-07-01, #345) — the read path also serves the FAILED-LAUNCH case.**
+> The `diag` / `logger tail` read path above observes an already-launched session by
+> reading `session.log_file` off the remembered session object. #345 reuses the SAME
+> daemon-owned Session log for a session that never came up: when `launch_session`
+> returns no session, the daemon best-effort tails that log via the DETERMINISTIC
+> path (`server._session_log_path()`, computed from the project slug — no live
+> session object required) and threads it, alongside the child-liveness reason, into
+> the `engine_session_not_running` error's advisory `diagnostics`. NOTE: a
+> windowed-no-`DisplayServer` abort happens BEFORE Godot installs its file logger, so
+> for that case the tail is usually empty (the child-signal reason carries it); it
+> carries content for a post-logger crash. The decision above is otherwise unchanged.

--- a/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
+++ b/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
@@ -17,7 +17,6 @@ an active window-server session) and runs for real on a genuine desktop.
 
 from __future__ import annotations
 
-import ctypes
 import json
 import os
 import shutil
@@ -28,6 +27,7 @@ import sys
 import pytest
 
 from gda.binary import resolve_godot_binary
+from gda.display import windowed_unavailable_reason
 
 import build_config
 
@@ -46,9 +46,12 @@ _COPY_IGNORE = shutil.ignore_patterns(
     "tests", ".godot", "build", "generated", "__pycache__"
 )
 
-# Daemon error codes that mean "this environment cannot show a window" (the live
-# session never came up / has no display) — a skip signal, not a test failure.
-_NO_DISPLAY_CODES = {"engine_session_not_running", "live_display_unavailable"}
+# Daemon error codes that mean "this environment cannot show a window" (the windowed
+# start was refused pre-launch, or the live session has no display) — a skip signal,
+# not a test failure. `live_windowed_unavailable` is the typed pre-launch refusal gda
+# now returns for `daemon start --windowed` on a display-less host (#345), replacing
+# the generic `engine_session_not_running` this used to key on.
+_NO_DISPLAY_CODES = {"live_windowed_unavailable", "live_display_unavailable"}
 
 
 def _error_code(stdout: str) -> str | None:
@@ -57,67 +60,6 @@ def _error_code(stdout: str) -> str | None:
         return json.loads(stdout).get("error", {}).get("code")
     except (ValueError, AttributeError):
         return None
-
-
-def _macos_has_usable_window_server() -> bool | None:
-    """Whether THIS process has a usable macOS window-server session (else None).
-
-    ``CGSessionCopyCurrentDictionary`` (CoreGraphics, via ctypes — no extra dep)
-    returns a non-NULL session dict only when the calling process is attached to an
-    active window-server session; it is NULL over SSH and in headless / sandbox
-    sessions **even when ``launchctl managername`` reports "Aqua"**. That NULL is
-    exactly what predicts a windowed Godot will abort during AppKit / window-server
-    registration, so it lets us skip BEFORE spawning (and crashing) the engine.
-    Returns None if the probe itself can't run (then the caller falls through and
-    attempts, with the runtime fallback as a backstop).
-    """
-    try:
-        cg = ctypes.cdll.LoadLibrary(
-            "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
-        )
-        cg.CGSessionCopyCurrentDictionary.restype = ctypes.c_void_p
-        session = cg.CGSessionCopyCurrentDictionary()
-    except Exception:
-        return None
-    if not session:
-        return False
-    try:  # release the copied CFDictionary to avoid a leak
-        cf = ctypes.cdll.LoadLibrary(
-            "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
-        )
-        cf.CFRelease.argtypes = [ctypes.c_void_p]
-        cf.CFRelease(ctypes.c_void_p(session))
-    except Exception:
-        pass
-    return True
-
-
-def _windowed_capture_unsupported_reason() -> str | None:
-    """Why windowed viewport capture can't run in THIS environment (else None).
-
-    A windowed engine session needs a usable window server. Headless Linux has none
-    unless run under a virtual framebuffer (``xvfb-run`` sets ``DISPLAY``). On macOS
-    the reliable signal is an active window-server session
-    (``CGSessionCopyCurrentDictionary``) — NOT ``launchctl managername``, which
-    reports "Aqua" even in headless / sandbox sessions where a windowed Godot still
-    aborts in AppKit registration. Where a window server IS usable (a real desktop),
-    the test runs for real and a failure is a real failure; this gates — and skips
-    BEFORE spawning Godot — only environments (SSH / CI / sandbox) that cannot show
-    a window, so no Godot process is launched (or crashed) there.
-    """
-    if sys.platform.startswith("linux"):
-        if not os.environ.get("DISPLAY"):
-            return "headless Linux has no DisplayServer (run under xvfb-run, which sets DISPLAY)"
-        return None
-    if sys.platform == "darwin":
-        if _macos_has_usable_window_server() is False:
-            return (
-                "no usable macOS window-server session "
-                "(CGSessionCopyCurrentDictionary returned NULL — e.g. SSH / CI / "
-                "sandbox); a windowed Godot session cannot register with the window "
-                "server here"
-            )
-    return None
 
 
 def _make_project_copy(dst):
@@ -134,8 +76,10 @@ def _make_project_copy(dst):
 @pytest.mark.e2e
 def test_windowed_daemon_captures_the_running_viewport(tmp_path, daemon_runtime_dir):
     # Skip (visibly, via -rs) where no DisplayServer is usable — a windowed session
-    # can't launch there. Runs for real on a genuine desktop (macOS Aqua / Linux+DISPLAY).
-    reason = _windowed_capture_unsupported_reason()
+    # can't launch there. Uses gda's shared display helper (the same one gda's
+    # `daemon start --windowed` precondition keys on, #345), so the pre-check and the
+    # tool agree. Runs for real on a genuine desktop (macOS Aqua / Linux+DISPLAY).
+    reason = windowed_unavailable_reason()
     if reason is not None:
         pytest.skip(reason)
     project = _make_project_copy(tmp_path / "game")
@@ -161,7 +105,15 @@ def test_windowed_daemon_captures_the_running_viewport(tmp_path, daemon_runtime_
 
     try:
         started = run("daemon", "start", "--windowed")
-        assert started.returncode == 0, started.stdout + started.stderr
+        if started.returncode != 0:
+            # gda refuses `daemon start --windowed` pre-launch with the typed
+            # live_windowed_unavailable where no DisplayServer is usable (#345); the
+            # pre-check above should have caught it, but honor it as a skip if it slips
+            # through (env race), not a failure.
+            code = _error_code(started.stdout)
+            if code in _NO_DISPLAY_CODES:
+                pytest.skip(f"windowed session unavailable in this environment ({code})")
+            raise AssertionError(started.stdout + started.stderr)
         assert json.loads(started.stdout)["windowed"] is True
 
         # `screen capture` writes a real PNG of the running game's viewport. The

--- a/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
+++ b/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
@@ -112,7 +112,9 @@ def test_windowed_daemon_captures_the_running_viewport(tmp_path, daemon_runtime_
             # through (env race), not a failure.
             code = _error_code(started.stdout)
             if code in _NO_DISPLAY_CODES:
-                pytest.skip(f"windowed session unavailable in this environment ({code})")
+                pytest.skip(
+                    f"windowed session unavailable in this environment ({code})"
+                )
             raise AssertionError(started.stdout + started.stderr)
         assert json.loads(started.stdout)["windowed"] is True
 

--- a/src/gda/daemon/protocol.py
+++ b/src/gda/daemon/protocol.py
@@ -74,21 +74,29 @@ def result_reply(payload: Any) -> dict:
     return _reply(payload, 0)
 
 
-def error_reply(code: str, message: str) -> dict:
+def error_reply(code: str, message: str, diagnostics: str = "") -> dict:
     """A daemon→CLI reply carrying a LIVE error envelope (exit ``EXIT_LIVE``).
 
     The single builder for a daemon- or client-synthesized live failure (no session,
     dropped connection, timeout, op error): the same ADR-0002 envelope a real op
     error uses, so ``classify_live`` maps the ``code`` through the normal pipeline.
+
+    ``diagnostics`` is optional best-effort advisory detail (e.g. why an engine
+    session failed to launch, #345). It rides the reply's EXISTING ``stderr`` field
+    — the wire envelope shape ``{stdout, stderr, exit_code}`` is unchanged — so it
+    flows the established ``stderr`` → ``RunResult.stderr`` → ``GdaError.diagnostics``
+    path, staying within ADR-0002's advisory-stderr carve-out.
     """
-    return _reply(error_envelope(code, message), EXIT_LIVE)
+    return _reply(error_envelope(code, message), EXIT_LIVE, stderr=diagnostics)
 
 
-def _reply(payload: Any, exit_code: int) -> dict:
+def _reply(payload: Any, exit_code: int, stderr: str = "") -> dict:
     """The shared reply-dict shape: a sentinel-wrapped ``payload`` + ``exit_code``.
 
     Private so the two public builders own the ADR-0002 exit invariant —
     :func:`result_reply` is exit ``0`` (success), :func:`error_reply` is ``EXIT_LIVE``
     (live error) — and no caller can pair a success payload with a non-zero exit.
+    ``stderr`` defaults to empty (a success carries none); ``error_reply`` uses it to
+    carry optional advisory diagnostics without changing the wire shape (#345).
     """
-    return {"stdout": build_result(payload), "stderr": "", "exit_code": exit_code}
+    return {"stdout": build_result(payload), "stderr": stderr, "exit_code": exit_code}

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -12,11 +12,18 @@ import os
 import secrets
 import signal
 import socket
+from typing import Callable, Optional
 
 from gda.daemon.diag import parse_errors, parse_log_records
 from gda.daemon.discovery import DaemonPaths, acquire_pidfile, ensure_runtime_dir
 from gda.daemon.protocol import error_reply, read_message, result_reply, write_message
-from gda.daemon.session import EngineSession, SceneMismatch, launch_session
+from gda.daemon.session import (
+    EngineSession,
+    SceneMismatch,
+    WindowedDisplayUnavailable,
+    launch_session,
+)
+from gda.display import windowed_unavailable_reason
 
 # Control ops on the CLI socket — daemon lifetime, not project domain ops.
 STATUS_OP = "__status__"
@@ -41,6 +48,7 @@ class DaemonServer:
         godot: str = "",
         windowed: bool = False,
         scene: str | None = None,
+        display_check: Optional[Callable[[], Optional[str]]] = None,
     ) -> None:
         self.paths = paths
         self.godot = godot
@@ -54,6 +62,11 @@ class DaemonServer:
         # Godot's `--scene` engine option instead of the project's main_scene; None
         # runs main_scene unchanged. Fixed for the daemon's life (ADR-0020).
         self.scene = scene
+        # The pre-launch host-display precondition seam (#345): returns the reason a
+        # windowed session cannot come up on this host, or None when it can. Injectable
+        # so tests drive the guard without a real display; defaults to the shared
+        # gda.display probe. Consulted only for a windowed session.
+        self._display_check = display_check or windowed_unavailable_reason
         self._token = secrets.token_hex(16)
         self._stopping = False
         self._listener: socket.socket | None = None
@@ -165,6 +178,17 @@ class DaemonServer:
                 "gda never falls back — fix the path/UID or omit --scene to run the "
                 "project's main_scene",
             )
+        except WindowedDisplayUnavailable as unavailable:
+            # The authoritative no-display guard fired at the launch boundary (#345):
+            # no windowed engine was spawned. Surface the typed
+            # live_windowed_unavailable, carrying the probe's reason as diagnostics.
+            return error_reply(
+                "live_windowed_unavailable",
+                "a windowed engine session cannot launch: the host has no usable "
+                f"DisplayServer ({unavailable.reason}). Run the daemon headless, or "
+                "start it on a host with an on-console GUI session / $DISPLAY",
+                diagnostics=unavailable.reason,
+            )
         if session is None:
             return error_reply(
                 "engine_session_not_running",
@@ -231,6 +255,18 @@ class DaemonServer:
             self._session = None
         if not self.godot:
             return None
+        # The AUTHORITATIVE no-display guard (#345): a windowed session needs a usable
+        # host DisplayServer, else a windowed Godot aborts during DisplayServer
+        # registration. This is the launch boundary — where the lazy session launch
+        # actually happens — so refuse HERE, BEFORE launch_session is ever called, with
+        # a typed WindowedDisplayUnavailable (mirroring the SceneMismatch pattern). The
+        # daemon maps it to live_windowed_unavailable. `daemon start --windowed` runs
+        # the same check as an OPTIONAL fail-fast, but this is the one that guarantees a
+        # doomed windowed engine is never spawned even when start slipped through.
+        if self.windowed:
+            reason = self._display_check()
+            if reason is not None:
+                raise WindowedDisplayUnavailable(reason)
         # A res:// / filesystem scene selector that names no file is rejected HERE,
         # at the launch boundary (NOT per-request — finding 1), as a typed
         # SceneMismatch. Godot does not fall-back-and-run for a missing res:// path:

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -149,8 +149,9 @@ class DaemonServer:
         # The scene selector is verified ONCE at launch (in the harness): a mismatch
         # is a typed live_scene_not_found, never a silent fall back to main_scene and
         # never a per-request re-check (#278, ADR-0017 amendment, ADR-0020).
+        launch_diagnostics: list[str] = []
         try:
-            session = self._ensure_session()
+            session = self._ensure_session(launch_diagnostics)
         except SceneMismatch as mismatch:
             detail = (
                 f"no scene named {mismatch.requested!r} exists in the project"
@@ -168,7 +169,8 @@ class DaemonServer:
             return error_reply(
                 "engine_session_not_running",
                 "the gda-daemon could not launch an engine session (no Godot binary, "
-                "or the harness did not connect)",
+                "or the engine died / the harness did not connect)",
+                diagnostics=self._launch_failure_diagnostics(launch_diagnostics),
             )
         return session.request(op, request.get("params", {}))
 
@@ -219,7 +221,9 @@ class DaemonServer:
         )
         return result_reply({"records": records})
 
-    def _ensure_session(self) -> EngineSession | None:
+    def _ensure_session(
+        self, diagnostics: list[str] | None = None
+    ) -> EngineSession | None:
         if self._session is not None and self._session.alive():
             return self._session
         if self._session is not None:
@@ -249,8 +253,35 @@ class DaemonServer:
             log_file=self._session_log_path(),
             windowed=self.windowed,
             scene=self.scene,
+            diagnostics=diagnostics,
         )
         return self._session
+
+    def _launch_failure_diagnostics(self, child_diagnostics: list[str]) -> str:
+        """Best-effort diagnostics for a failed engine-session launch (#345).
+
+        Combines the child-liveness reason ``launch_session`` observed (the engine
+        died by signal, or the harness never connected) with a tail of the daemon-
+        owned Session log, read via the DETERMINISTIC :meth:`_session_log_path` —
+        which needs no live session object, extending ADR-0022's read path to the
+        failed-launch case. NOTE: a windowed-no-``DisplayServer`` abort happens
+        BEFORE Godot installs its file logger, so this tail is usually EMPTY for that
+        case (the child-signal reason carries it); it carries content for a
+        post-logger crash.
+        """
+        parts = [reason for reason in child_diagnostics if reason]
+        tail = self._read_session_log_tail()
+        if tail:
+            parts.append(f"session log tail:\n{tail}")
+        return "\n".join(parts)
+
+    def _read_session_log_tail(self, max_bytes: int = 2000) -> str:
+        """The trailing bytes of the daemon-owned Session log, or "" if unreadable."""
+        try:
+            data = self._session_log_path().read_bytes()
+        except OSError:
+            return ""
+        return data.decode("utf-8", "replace").strip()[-max_bytes:]
 
     def _session_log_path(self):
         """The daemon-owned Session-log path for this project (#224).

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -53,6 +53,24 @@ class SceneMismatch(Exception):
         self.current = current
 
 
+class WindowedDisplayUnavailable(Exception):
+    """A windowed session cannot launch: the host has no usable ``DisplayServer``.
+
+    Raised at the AUTHORITATIVE session-launch boundary (``_ensure_session``, where
+    the lazy launch happens) BEFORE :func:`launch_session` is ever called, when a
+    windowed daemon's pre-launch host-display check fails — a windowed Godot would
+    abort during ``DisplayServer`` registration otherwise (#345). Mirrors
+    :class:`SceneMismatch`: a typed launch-boundary signal the daemon maps to the
+    ``live_windowed_unavailable`` error code, distinct from a generic launch failure
+    (``launch_session`` returns ``None``). ``reason`` is the host-display probe's
+    human-readable explanation.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
 class EngineSession:
     """A launched engine run plus the daemon's connection to its harness.
 
@@ -184,6 +202,20 @@ def launch_session(
             diagnostics.append(message)
 
     log_args = ["--log-file", str(log_file)] if log_file is not None else []
+    if log_file is not None:
+        # Truncate the Session log BEFORE spawning (#345 finding 2). Godot's
+        # ``--log-file`` logger opens the path with ``FileAccess::WRITE`` (truncating)
+        # only once it installs, but a PRE-LOGGER abort — a windowed-no-DisplayServer
+        # crash, and others — dies before that, leaving a PREVIOUS session's output on
+        # disk. Without this, the failed-launch diagnostics tail would attach that
+        # stale content. Truncating here makes "truncated each launch" (ADR-0022 /
+        # CONTEXT.md Session log) hold even for a pre-logger abort: a pre-logger
+        # failure then reads EMPTY (honest), a post-logger one reads only the current
+        # session. Best-effort — a truncate failure must not abort the launch.
+        try:
+            log_file.write_bytes(b"")
+        except OSError:
+            pass
     headless_args = [] if windowed else ["--headless"]
     # `--scene <path|UID>` is an ENGINE option, so it sits before `--path` (and so
     # before the `--` payload separator) alongside the other engine args (#278).

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -176,6 +176,7 @@ def launch_session(
     harness never connected is the "harness hung" case. That distinction tells a
     crashed windowed process apart from a stuck harness.
     """
+
     def _record(message: str) -> None:
         # Collect a best-effort launch-failure reason for the daemon to surface
         # (#345); a no-op when the caller passed no sink.

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -126,6 +126,7 @@ def launch_session(
     timeout: float = CONNECT_TIMEOUT,
     windowed: bool = False,
     scene: Optional[str] = None,
+    diagnostics: Optional[list[str]] = None,
 ) -> Optional[EngineSession]:
     """Launch an engine session and wait for the harness to connect.
 
@@ -163,7 +164,24 @@ def launch_session(
     ``user://logs`` contention (#180) by isolation, and the session REMEMBERS the
     path so the daemon can serve ``gda diag`` from it (ADR: runtime-diagnostics-
     via-daemon-owned-session-log). The session still relays live ops to the harness.
+
+    On a failed launch (a ``None`` return) an optional ``diagnostics`` sink collects
+    a best-effort reason string so the daemon can surface it instead of an empty
+    ``engine_session_not_running`` (#345). Because the child is spawned with
+    ``stderr=DEVNULL`` (redirecting it to a pipe risks a fill-buffer deadlock, out of
+    scope here), the one cause signal we keep is the child's LIVENESS at the failure
+    boundary: a child that already exited names its exit — a negative return code is
+    a signal death (e.g. a windowed session that could not bring up a
+    ``DisplayServer`` aborts with ``SIGABRT``) — while a child still alive when the
+    harness never connected is the "harness hung" case. That distinction tells a
+    crashed windowed process apart from a stuck harness.
     """
+    def _record(message: str) -> None:
+        # Collect a best-effort launch-failure reason for the daemon to surface
+        # (#345); a no-op when the caller passed no sink.
+        if diagnostics is not None:
+            diagnostics.append(message)
+
     log_args = ["--log-file", str(log_file)] if log_file is not None else []
     headless_args = [] if windowed else ["--headless"]
     # `--scene <path|UID>` is an ENGINE option, so it sits before `--path` (and so
@@ -195,6 +213,10 @@ def launch_session(
     try:
         conn, _ = harness_listener.accept()
     except OSError:  # includes socket.timeout
+        # No harness connected within the timeout. Poll the child BEFORE tearing it
+        # down: this is where a windowed-no-DisplayServer abort (child died by
+        # signal) is told apart from a genuinely hung harness (child still alive).
+        _record(_child_exit_diagnostic(proc, timeout))
         _terminate(proc)
         return None
 
@@ -204,10 +226,8 @@ def launch_session(
     except OSError:
         presented = None
     if presented is None or presented.decode("utf-8", "replace") != token:
-        try:
-            conn.close()
-        except OSError:
-            pass
+        _record("the harness connected but presented an invalid auth token")
+        _close(conn)
         _terminate(proc)
         return None
 
@@ -221,6 +241,7 @@ def launch_session(
     except OSError:
         verify_frame = None
     if verify_frame is None:
+        _record("the harness connected but closed before the scene-verification frame")
         _close(conn)
         _terminate(proc)
         return None
@@ -234,6 +255,31 @@ def launch_session(
         _terminate(proc)
         raise SceneMismatch(scene if scene is not None else "", str(current))
     return EngineSession(proc, conn, log_file=log_file)
+
+
+def _child_exit_diagnostic(proc: subprocess.Popen, timeout: float) -> str:
+    """A best-effort launch-failure reason from the child's liveness (#345).
+
+    Called on a failure path BEFORE terminating the child (spawned with
+    ``stderr=DEVNULL``, so its liveness is the one cause signal we keep). A child
+    that has ALREADY exited means the engine died before the harness could connect:
+    a negative return code is a signal death (a windowed session that could not
+    register a ``DisplayServer`` aborts with ``SIGABRT``); a positive one is a plain
+    non-zero exit. A child STILL alive is the "engine up, harness never connected"
+    case — a hung/broken harness autoload. This is the signal that tells a crashed
+    windowed process apart from a stuck harness.
+    """
+    code = proc.poll()
+    if code is None:
+        return f"the engine started but the harness did not connect within {timeout:.0f}s; session terminated"
+    if code < 0:
+        signum = -code
+        try:
+            name = signal.Signals(signum).name
+        except ValueError:
+            name = f"signal {signum}"
+        return f"the engine child aborted by signal {name} ({signum}) before the harness connected"
+    return f"the engine child exited with status {code} before the harness connected"
 
 
 def _close(conn: socket.socket) -> None:

--- a/src/gda/daemon_ops.py
+++ b/src/gda/daemon_ops.py
@@ -28,6 +28,7 @@ from gda.daemon.discovery import (
     daemon_pid,
     within_uds_limit,
 )
+from gda.display import windowed_unavailable_reason
 from gda.daemon.protocol import read_message, write_message
 from gda.daemon.server import STATUS_OP, STOP_OP
 from gda.errors import Failure, _failure, unresolvable_binary_failure
@@ -56,6 +57,10 @@ _VERSION_RE = re.compile(r"(\d+)\.(\d+)")
 # Seams tests override to avoid launching a real process / running the engine.
 SpawnDaemon = Callable[[Path, str, bool, Optional[str]], None]
 VersionCheck = Callable[[str], Optional[tuple]]
+# The pre-launch host-display precondition seam (#345): returns the reason a
+# windowed session cannot come up here, or None when it can. Injected in unit tests
+# so a display-less CI host does not spuriously refuse a windowed start.
+DisplayCheck = Callable[[], Optional[str]]
 
 
 def _is_unix() -> bool:
@@ -154,6 +159,7 @@ def run_daemon_start_operation(
     scene: Optional[str] = None,
     spawn: Optional[SpawnDaemon] = None,
     version_check: Optional[VersionCheck] = None,
+    display_check: Optional[DisplayCheck] = None,
 ) -> "DaemonStartResult | Failure":
     if not _is_unix():
         return _failure(
@@ -233,6 +239,18 @@ def run_daemon_start_operation(
             f"domain sockets, added in {minimum}); the engine reports {found}",
             "",
         )
+
+    if windowed:
+        # A windowed session needs a usable host DisplayServer; without one Godot
+        # aborts during DisplayServer registration (before its file logger is even
+        # installed), so the failure would otherwise surface only as a generic
+        # engine_session_not_running at lazy launch (#345 Part A). Refuse fast HERE —
+        # pre-launch, pre-harness-install, WITHOUT spawning — with the typed
+        # live_windowed_unavailable (ENVIRONMENT / 127), mirroring the platform
+        # precondition above. `daemon start` is where `windowed` already flows in.
+        reason = (display_check or windowed_unavailable_reason)()
+        if reason is not None:
+            return _failure("live_windowed_unavailable", reason, "")
 
     installed = install_harness(project)
     (spawn or _spawn_daemon)(project, str(binary), windowed, scene)

--- a/src/gda/display.py
+++ b/src/gda/display.py
@@ -1,0 +1,113 @@
+"""Host DisplayServer probe for windowed live sessions (#345).
+
+A windowed [Engine session](../../CONTEXT.md) (``gda daemon start --windowed``)
+needs a usable host ``DisplayServer`` to bring up a real viewport; on a host with
+none, Godot aborts during ``DisplayServer`` / AppKit registration BEFORE its file
+logger is installed, so the failure is otherwise only a generic
+``engine_session_not_running`` with an empty log tail (#345 Part A). This module
+answers, PRE-LAUNCH, whether THIS host can show a window, so ``gda daemon start
+--windowed`` can refuse fast with the typed ``live_windowed_unavailable``
+(ENVIRONMENT / exit 127) instead of spawning a doomed engine.
+
+Platform-dispatched (live is UNIX-only via ``live_unsupported_platform``, ADR-0021,
+so Windows is a documented, unreachable-today stub seam — a single clean slot, not a
+refactor):
+
+- **macOS**: ``CGSessionCopyCurrentDictionary`` (CoreGraphics via ``ctypes`` — no
+  extra dependency) returns a non-NULL session dict only for an on-console GUI
+  session; it is NULL over SSH and in headless / sandbox sessions **even when**
+  ``launchctl managername`` reports "Aqua". So we deliberately do NOT use
+  ``launchctl`` or ``$DISPLAY`` on macOS — that NULL is exactly what predicts a
+  windowed Godot will abort during window-server registration.
+- **Linux**: a non-empty ``$DISPLAY`` (X11) or ``$WAYLAND_DISPLAY`` (Wayland), so a
+  run under ``xvfb-run`` (which sets ``DISPLAY``) passes.
+- **Windows**: unreachable today; the stub reports "usable" so it never spuriously
+  gates on a path live never reaches.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import sys
+
+
+def has_usable_display() -> bool:
+    """Whether THIS host has a usable ``DisplayServer`` for a windowed session (#345)."""
+    if sys.platform == "darwin":
+        return _macos_has_window_server()
+    if sys.platform.startswith("linux"):
+        return _linux_has_display()
+    return _other_platform_has_display()
+
+
+def windowed_unavailable_reason() -> str | None:
+    """Why a windowed live session can't come up on THIS host, or ``None`` if it can.
+
+    The single decision point both the ``gda daemon start --windowed`` precondition
+    (``daemon_ops``) and the windowed e2e gates key on, so they agree: ``None`` means
+    "a windowed session can launch here", a string is the skip/refusal reason.
+    """
+    if has_usable_display():
+        return None
+    if sys.platform == "darwin":
+        return (
+            "no usable macOS window-server session (CGSessionCopyCurrentDictionary "
+            "returned NULL — e.g. SSH / CI / sandbox); a windowed Godot session cannot "
+            "register with the window server here"
+        )
+    if sys.platform.startswith("linux"):
+        return (
+            "headless Linux has no DisplayServer ($DISPLAY / $WAYLAND_DISPLAY unset); "
+            "run under a virtual framebuffer such as xvfb-run, which sets DISPLAY"
+        )
+    return "this host has no usable DisplayServer for a windowed session"
+
+
+def _macos_has_window_server() -> bool:
+    """An on-console macOS GUI session probe via CoreGraphics (no extra dependency).
+
+    ``CGSessionCopyCurrentDictionary`` returns a non-NULL dict only when the calling
+    process is attached to an active window-server session; it is NULL over SSH and
+    in headless / sandbox sessions even when ``launchctl managername`` reports "Aqua".
+    Returns ``True`` on that non-NULL dict (and releases it), ``False`` on NULL. If the
+    probe itself cannot run, err towards ``True`` so a real desktop is never falsely
+    gated out — the pre-launch check stays advisory, and #345 Part A still catches a
+    genuine no-display abort at the session-launch site.
+    """
+    try:
+        cg = ctypes.cdll.LoadLibrary(
+            "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
+        )
+        cg.CGSessionCopyCurrentDictionary.restype = ctypes.c_void_p
+        session = cg.CGSessionCopyCurrentDictionary()
+    except Exception:
+        return True
+    if not session:
+        return False
+    try:  # release the copied CFDictionary to avoid a leak
+        cf = ctypes.cdll.LoadLibrary(
+            "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+        )
+        cf.CFRelease.argtypes = [ctypes.c_void_p]
+        cf.CFRelease(ctypes.c_void_p(session))
+    except Exception:
+        pass
+    return True
+
+
+def _linux_has_display() -> bool:
+    """A non-empty ``$DISPLAY`` (X11) or ``$WAYLAND_DISPLAY`` (Wayland) — so xvfb-run passes."""
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+def _other_platform_has_display() -> bool:
+    """Windows stub seam — unreachable today (live is UNIX-only, ADR-0021).
+
+    Live operations gate on a UNIX platform (``live_unsupported_platform``) long
+    before this is reached, so a windowed session never launches on Windows. Left as
+    a single clean slot to fill when/if a native Windows display probe (e.g.
+    ``GetSystemMetrics(SM_CMONITORS)``) is ever wired in; reports "usable" so it never
+    spuriously gates on an unreachable path.
+    """
+    return True

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -615,6 +615,22 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "Live operations require a UNIX platform (macOS/Linux); they use Unix"
         " domain sockets, which are unavailable here.",
     ),
+    # A pre-launch DISPLAY precondition, not a live-runtime failure: a windowed
+    # engine session needs a usable host DisplayServer, and a host with none makes a
+    # windowed Godot abort during DisplayServer registration. So `gda daemon start
+    # --windowed` refuses BEFORE spawning — an ENVIRONMENT-category code in the
+    # binary_not_found (exit 127) bucket, mirroring `live_unsupported_platform`,
+    # decided pre-launch and classifier-source (no operation reports it), NOT
+    # GDScript-mirrored (#345).
+    ErrorCodeSpec(
+        "live_windowed_unavailable",
+        ErrorCategory.ENVIRONMENT,
+        EXIT_NOT_FOUND,
+        ErrorCodeSource.CLASSIFIER,
+        "A windowed live session was requested (`gda daemon start --windowed`) but"
+        " the host has no usable DisplayServer (no on-console GUI session / no"
+        " $DISPLAY), so the session cannot come up; refused before spawning Godot.",
+    ),
 )
 
 ERROR_CODE_BY_CODE: dict[str, ErrorCodeSpec] = {spec.code: spec for spec in ERROR_CODES}

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -398,12 +398,17 @@ def classify_info(result: RunResult, binary: Path) -> EngineVersion | Failure:
 
 # Codes the daemon IPC client / the daemon surface through the live sentinel that
 # classify_run would otherwise misroute. The LIVE codes are live-runtime failures;
-# ``live_unsupported_platform`` is an ENVIRONMENT-category pre-launch precondition
-# (ADR-0021) but still arrives via the live path, so classify_live must surface it
-# too (else classify_run falls back to operation_failed for a non-operation code).
+# ``live_unsupported_platform`` and ``live_windowed_unavailable`` are
+# ENVIRONMENT-category pre-launch preconditions but still arrive via the live path
+# (``live_windowed_unavailable`` is raised at the daemon's session-launch boundary and
+# relayed as a live reply, #345), so classify_live must surface them too — else
+# classify_run falls back to operation_failed for a non-operation code.
 # ``project_not_found`` is deliberately NOT here — it is an operation-source code
 # classify_run already maps, so it falls through to the shared decision tree.
-_LIVE_CLIENT_CODES = LIVE_ERROR_CODES | {"live_unsupported_platform"}
+_LIVE_CLIENT_CODES = LIVE_ERROR_CODES | {
+    "live_unsupported_platform",
+    "live_windowed_unavailable",
+}
 
 
 def _live_error_from_payload(result: RunResult) -> Failure | None:

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -359,6 +359,38 @@ def test_failed_launch_records_harness_hung_when_child_still_alive(
     assert "harness did not connect" in diagnostics[0]
 
 
+def test_failed_launch_diagnostics_excludes_stale_session_log(
+    monkeypatch, tmp_path, daemon_runtime_dir
+):
+    # #345 finding 2: a PRE-LOGGER abort (a windowed-no-DisplayServer crash, and
+    # others) dies before Godot installs its --log-file logger, so nothing truncates
+    # the deterministic session-log path. If a PREVIOUS session left content there, it
+    # must NOT leak into the current failure's diagnostics. launch_session truncates
+    # the log BEFORE spawning, so the tail reads EMPTY for a pre-logger abort.
+    server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
+    log_path = server._session_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("STALE-PREVIOUS-SESSION-OUTPUT", encoding="utf-8")
+
+    # A REAL launch_session runs (truncating the log), spawns a fake child that dies
+    # pre-logger by SIGABRT and writes nothing, and no harness connects -> None.
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(-6))
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    server._harness_listener = cast(socket.socket, _NoAcceptListener())
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+    assert reply is not None
+    assert (
+        parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    )
+    # The child-signal reason is present; the STALE log content is gone (truncated).
+    assert "SIGABRT" in reply["stderr"]
+    assert "STALE-PREVIOUS-SESSION-OUTPUT" not in reply["stderr"]
+    # The file on disk was truncated by the launch attempt, honoring "truncated each
+    # launch" even for a pre-logger abort (ADR-0022 / CONTEXT.md Session log).
+    assert log_path.read_bytes() == b""
+
+
 # --- Slice 2: the daemon serves diag from the remembered log file ---
 
 

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -292,6 +292,73 @@ def test_launch_returns_none_on_bad_token(monkeypatch, tmp_path):
     assert outcome is None
 
 
+# --- #345: a failed launch records a best-effort diagnostic in the sink ---------
+# The child is spawned with stderr=DEVNULL, so launch_session polls the child at the
+# failure boundary: a child that already died names its signal (a windowed-no-display
+# abort is SIGABRT); a child still alive is the harness-never-connected case.
+
+
+class _NoAcceptListener:
+    """A harness listener whose accept() times out at once (no harness connects)."""
+
+    def settimeout(self, _):
+        pass
+
+    def accept(self):
+        raise TimeoutError
+
+
+def test_failed_launch_records_signal_death_when_child_already_died(
+    monkeypatch, tmp_path
+):
+    project = _project(tmp_path)
+    # A child that reports it aborted by SIGABRT (returncode -6) — what a windowed
+    # session with no usable DisplayServer does before the harness can connect.
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(-6))
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+
+    diagnostics: list[str] = []
+    outcome = launch_session(
+        project,
+        "godot",
+        cast(socket.socket, _NoAcceptListener()),
+        tmp_path / "h.sock",
+        "tok",
+        timeout=0.1,
+        diagnostics=diagnostics,
+    )
+
+    assert outcome is None
+    assert diagnostics, "a failed launch must record a diagnostic"
+    assert "SIGABRT" in diagnostics[0]
+    assert "(6)" in diagnostics[0]
+
+
+def test_failed_launch_records_harness_hung_when_child_still_alive(
+    monkeypatch, tmp_path
+):
+    project = _project(tmp_path)
+    # A child still alive (poll() is None) when the harness never connected: the
+    # "engine up, harness hung" case, distinct from a crashed child.
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(None))
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+
+    diagnostics: list[str] = []
+    outcome = launch_session(
+        project,
+        "godot",
+        cast(socket.socket, _NoAcceptListener()),
+        tmp_path / "h.sock",
+        "tok",
+        timeout=0.1,
+        diagnostics=diagnostics,
+    )
+
+    assert outcome is None
+    assert diagnostics
+    assert "harness did not connect" in diagnostics[0]
+
+
 # --- Slice 2: the daemon serves diag from the remembered log file ---
 
 

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -200,12 +200,62 @@ def test_start_windowed_threads_mode_into_spawn_and_result(
         windowed=True,
         spawn=lambda p, b, windowed, scene: spawned.append((p, b, windowed)),
         version_check=_OK_VERSION,
+        # A display IS usable here (inject the #345 precondition so this fast unit
+        # test is display-independent — a headless CI host must not refuse the start).
+        display_check=lambda: None,
     )
 
     assert isinstance(started, DaemonStartResult), started
     assert started.windowed is True
     # The windowed mode is threaded into the spawn (the daemon argv carries it).
     assert spawned[0][2] is True
+
+
+def test_windowed_start_without_a_display_is_live_windowed_unavailable(
+    tmp_path, short_runtime, monkeypatch
+):
+    # #345 Part B: a windowed start on a host with no usable DisplayServer is refused
+    # BEFORE spawning Godot (and before installing the harness) with the typed
+    # live_windowed_unavailable (ENVIRONMENT / exit 127) — mirroring the platform
+    # precondition — rather than spawning a doomed engine that aborts during
+    # DisplayServer registration.
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
+    spawned: list = []
+
+    outcome = daemon_ops.run_daemon_start_operation(
+        project,
+        None,
+        windowed=True,
+        spawn=lambda p, b, w, s: spawned.append((p, b, w, s)),
+        version_check=_OK_VERSION,
+        display_check=lambda: "no usable DisplayServer (test)",
+    )
+
+    assert isinstance(outcome, Failure), outcome
+    assert outcome.error.code == "live_windowed_unavailable"
+    assert outcome.error.category.value == "environment"
+    assert outcome.exit_code == 127  # EXIT_NOT_FOUND
+    assert spawned == []  # never spawned Godot
+    # Pre-harness-install too: a doomed windowed start must not mutate the project.
+    assert not (project / HARNESS_RES_DIR / HARNESS_FILE).exists()
+
+
+def test_headless_start_never_consults_the_display_check(
+    tmp_path, short_runtime, fake_ready, monkeypatch
+):
+    # The precondition is windowed-only: a default (headless) start must not consult
+    # the display check at all — a headless session needs no window server.
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
+
+    def _boom() -> str:
+        raise AssertionError("a headless start must not run the display check")
+
+    started = _start(project, display_check=_boom)
+
+    assert isinstance(started, DaemonStartResult), started
+    assert started.windowed is False
 
 
 # `daemon start --scene <path|UID>` is a START-TIME selector: the daemon holds it

--- a/tests/test_daemon_ops.py
+++ b/tests/test_daemon_ops.py
@@ -83,7 +83,14 @@ def test_daemon_status_reports_a_windowed_daemons_mode(tmp_path, daemon_runtime_
 
     try:
         started = run_daemon_start_operation(
-            project, None, windowed=True, version_check=_OK_VERSION
+            project,
+            None,
+            windowed=True,
+            version_check=_OK_VERSION,
+            # No engine session is launched here (lazy launch), so the start needs no
+            # real display; inject the #345 precondition as "available" to keep this
+            # headless-CI safe (a display-less host would otherwise refuse the start).
+            display_check=lambda: None,
         )
         assert isinstance(started, DaemonStartResult), started
         assert started.windowed is True

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -174,6 +174,35 @@ def test_missing_res_scene_is_live_scene_not_found_before_launch(tmp_path, monke
     assert server._session is None
 
 
+def test_failed_launch_threads_diagnostics_into_the_error_reply(tmp_path, monkeypatch):
+    # #345: a None launch outcome now threads the child-liveness diagnostic
+    # launch_session recorded into the engine_session_not_running reply's `stderr`
+    # (which becomes GdaError.diagnostics via the live path), instead of the old
+    # EMPTY diagnostics. The wire envelope shape {stdout, stderr, exit_code} is
+    # unchanged — the detail rides the existing stderr field.
+    (tmp_path / "B.tscn").write_text("[gd_scene format=3]\n", encoding="utf-8")
+
+    def _fail_launch(*a, diagnostics=None, **k):
+        if diagnostics is not None:
+            diagnostics.append("the engine child aborted by signal SIGABRT (6) ...")
+        return None
+
+    monkeypatch.setattr("gda.daemon.server.launch_session", _fail_launch)
+    server = DaemonServer(
+        _project_with_marker(tmp_path), godot="godot", scene="res://B.tscn"
+    )
+    server._harness_listener = cast(socket.socket, object())
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+    assert reply is not None
+
+    # The wire shape is unchanged: still {stdout, stderr, exit_code}.
+    assert set(reply) == {"stdout", "stderr", "exit_code"}
+    assert parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    # The diagnostic rides the existing stderr field, not a new envelope key.
+    assert "SIGABRT" in reply["stderr"]
+
+
 def test_no_scene_selector_runs_main_scene_unchanged(tmp_path):
     # The selector-less default is unchanged: straight to the launch path (which here
     # is engine_session_not_running with no real binary), no scene verification.

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -198,7 +198,9 @@ def test_failed_launch_threads_diagnostics_into_the_error_reply(tmp_path, monkey
 
     # The wire shape is unchanged: still {stdout, stderr, exit_code}.
     assert set(reply) == {"stdout", "stderr", "exit_code"}
-    assert parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    assert (
+        parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    )
     # The diagnostic rides the existing stderr field, not a new envelope key.
     assert "SIGABRT" in reply["stderr"]
 

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -205,6 +205,89 @@ def test_failed_launch_threads_diagnostics_into_the_error_reply(tmp_path, monkey
     assert "SIGABRT" in reply["stderr"]
 
 
+def test_windowed_no_display_is_live_windowed_unavailable_without_launching(
+    tmp_path, monkeypatch
+):
+    # #345 finding 1: the AUTHORITATIVE no-display guard lives at the session-launch
+    # boundary (_ensure_session), not only the optional `daemon start` fail-fast. A
+    # windowed daemon on a host with no usable DisplayServer refuses a live op with the
+    # typed live_windowed_unavailable AND never calls launch_session — so a doomed
+    # windowed Godot is never spawned, even if `daemon start --windowed` slipped through.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+
+    def _must_not_launch(*a, **k):
+        raise AssertionError("launch_session must not be called with no usable display")
+
+    monkeypatch.setattr("gda.daemon.server.launch_session", _must_not_launch)
+    server = DaemonServer(
+        daemon_paths(tmp_path),
+        godot="godot",
+        windowed=True,
+        display_check=lambda: "no usable DisplayServer (test)",
+    )
+    server._harness_listener = cast(socket.socket, object())
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+    assert reply is not None
+
+    error = parse_result(reply["stdout"])["error"]
+    assert error["code"] == "live_windowed_unavailable"
+    # The probe's reason rides the advisory diagnostics (existing stderr) field.
+    assert "no usable DisplayServer (test)" in reply["stderr"]
+    assert server._session is None  # nothing launched or cached
+
+
+def test_windowed_with_a_usable_display_reaches_launch(tmp_path, monkeypatch):
+    # The guard is display-gated: a usable display (the check returns None) does NOT
+    # short-circuit — the launch proceeds (here to the generic engine_session_not_running
+    # via a patched None launch), proving the guard fires ONLY on no-display.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    calls = {"n": 0}
+
+    def _launch(*a, **k):
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr("gda.daemon.server.launch_session", _launch)
+    server = DaemonServer(
+        daemon_paths(tmp_path),
+        godot="godot",
+        windowed=True,
+        display_check=lambda: None,  # a usable display
+    )
+    server._harness_listener = cast(socket.socket, object())
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+    assert reply is not None
+    assert calls["n"] == 1  # the launch boundary was reached
+    assert (
+        parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    )
+
+
+def test_headless_windowed_false_never_consults_the_display_check(
+    tmp_path, monkeypatch
+):
+    # A default (headless) daemon must never consult the display check — a headless
+    # session needs no window server; only a windowed session is gated.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+
+    def _boom() -> str:
+        raise AssertionError("a headless daemon must not run the display check")
+
+    monkeypatch.setattr("gda.daemon.server.launch_session", lambda *a, **k: None)
+    server = DaemonServer(
+        daemon_paths(tmp_path), godot="godot", windowed=False, display_check=_boom
+    )
+    server._harness_listener = cast(socket.socket, object())
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+    assert reply is not None
+    assert (
+        parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    )
+
+
 def test_no_scene_selector_runs_main_scene_unchanged(tmp_path):
     # The selector-less default is unchanged: straight to the launch path (which here
     # is engine_session_not_running with no real binary), no scene verification.

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -298,7 +298,15 @@ def test_daemon_status_surfaces_the_windowed_display_mode(tmp_path, daemon_runti
         assert headless["windowed"] is False
         assert run("daemon", "stop").returncode == 0
 
-        # A `--windowed` start -> status reports windowed True.
+        # A `--windowed` start -> status reports windowed True. `daemon start
+        # --windowed` now refuses PRE-LAUNCH with live_windowed_unavailable on a host
+        # with no usable DisplayServer (#345), so gate this half on the shared display
+        # helper — the headless portions above already ran.
+        from gda.display import windowed_unavailable_reason
+
+        reason = windowed_unavailable_reason()
+        if reason is not None:
+            pytest.skip(reason)
         assert run("daemon", "start", "--windowed").returncode == 0
         windowed = json.loads(run("daemon", "status").stdout)
         assert windowed["running"] is True

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -22,11 +22,11 @@ within the `sun_path` limit.
 import json
 import os
 import subprocess
-import sys
 
 import pytest
 
 from gda.binary import resolve_godot_binary
+from gda.display import windowed_unavailable_reason
 from tests.support import GDA_CMD
 
 from .conftest import project_godot
@@ -52,18 +52,19 @@ PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
-# A WINDOWED engine session needs a real DisplayServer. macOS always has one (Aqua);
-# headless Linux CI does not — the release/scheduled e2e runners are headless, where
-# launching a windowed session fails with `engine_session_not_running`. So the
-# windowed-capture tests skip there unless run under a virtual framebuffer
-# (`xvfb-run`, which sets DISPLAY); the headless-guard and no-daemon screen tests
-# below still run. The check is forward-compatible: wire Xvfb into CI and DISPLAY is
-# set, so these run rather than skip. (PR #248 follow-up — the release-gate fix that
-# unblocked PyPI publishing; the macOS run already exercises the real windowed path.)
+# A WINDOWED engine session needs a usable host DisplayServer. This is NOT a
+# "macOS always has one" assumption: headless macOS (SSH / CI / sandbox) has no
+# on-console window-server session even though `launchctl managername` reports
+# "Aqua", and a windowed Godot aborts in AppKit registration there — so the gate is
+# the shared `gda.display.windowed_unavailable_reason()` helper (#345), which probes
+# CGSessionCopyCurrentDictionary on macOS and $DISPLAY/$WAYLAND_DISPLAY on Linux,
+# skipping BEFORE spawning (and crashing) Godot. The headless-guard and no-daemon
+# screen tests below still run. Forward-compatible: wire Xvfb into CI (DISPLAY set)
+# and these run rather than skip.
+_NO_DISPLAY_REASON = windowed_unavailable_reason()
 _needs_display = pytest.mark.skipif(
-    sys.platform.startswith("linux") and not os.environ.get("DISPLAY"),
-    reason="windowed capture needs a DisplayServer; headless Linux has none — run "
-    "under xvfb-run, which sets DISPLAY",
+    _NO_DISPLAY_REASON is not None,
+    reason=_NO_DISPLAY_REASON or "the host has a usable DisplayServer",
 )
 
 

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -147,6 +147,33 @@ def test_live_failures_are_registered_classifier_live_codes():
         assert spec.code not in OPERATION_ERROR_CODES
 
 
+def test_live_windowed_unavailable_flows_through_classify_live():
+    # #345 finding 1: live_windowed_unavailable is raised at the daemon's
+    # session-launch boundary and relayed as a LIVE reply, so classify_live must
+    # surface it — it is whitelisted in _LIVE_CLIENT_CODES alongside
+    # live_unsupported_platform (both ENVIRONMENT-category codes arriving via the live
+    # path). Without the whitelist, classify_run would misroute it to operation_failed.
+    from gda.daemon.protocol import error_reply
+    from gda.errors import _LIVE_CLIENT_CODES, Failure, classify_live
+    from gda.models import GameTreeResult
+    from gda.runner import RunResult
+
+    assert "live_windowed_unavailable" in _LIVE_CLIENT_CODES
+
+    reply = error_reply(
+        "live_windowed_unavailable", "no usable DisplayServer", diagnostics="why-here"
+    )
+    outcome = classify_live(RunResult(**reply), None, GameTreeResult)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "live_windowed_unavailable"
+    # It resolves to its REGISTERED environment/127 shape (not the EXIT_LIVE the wire
+    # reply carried, nor an operation_failed fallback).
+    assert outcome.error.category is ErrorCategory.ENVIRONMENT
+    assert outcome.exit_code == 127
+    assert outcome.error.diagnostics == "why-here"
+
+
 def test_harness_live_error_codes_are_registered_live_codes():
     # The per-op LIVE failures the gda harness reports (#220) are registered
     # LIVE-category classifier-source codes: because their category is LIVE,


### PR DESCRIPTION
Closes #345.

When a live Engine session fails to launch, the daemon returned a generic
`engine_session_not_running` with EMPTY `diagnostics`, even when the child died
deterministically — and that one code conflated three causes, one being "a
windowed session can't come up because the host has no usable DisplayServer".
Delivered in two sequenced parts. No new ADR (this applies three existing
patterns).

## Part A — thread diagnostics into the live Error envelope

- `launch_session` now polls the child at each failure boundary BEFORE terminating
  it (the child is spawned with `stderr=DEVNULL`, so its liveness is the one cause
  signal we keep): a child already dead by a negative return code names its signal
  (a windowed-no-DisplayServer abort is `SIGABRT`); a child still alive is the
  "engine up, harness never connected" case. This distinguishes a crashed windowed
  process from a hung harness.
- The daemon best-effort tails the daemon-owned Session log via the DETERMINISTIC
  `server._session_log_path()` (no live session object required — extends ADR-0022's
  read path to the failed-launch case) and threads the combined detail into the
  `engine_session_not_running` reply.
- The detail rides the **existing** reply `stderr` → `RunResult.stderr` →
  `GdaError.diagnostics` path. **The wire envelope shape `{stdout, stderr, exit_code}`
  / `{error:{code,message}}` is unchanged** — staying within ADR-0002's
  advisory-stderr carve-out. Out of scope: redirecting the child stderr to a pipe
  (deadlock risk).

## Part B — typed code + pre-launch host-display precondition

- New error code **`live_windowed_unavailable`** (category **environment**, exit
  **127**, source **classifier**, NOT GDScript-mirrored), mirroring
  `live_unsupported_platform`. Registered in `error_codes.py` **with** the matching
  ADR-0002 registry row in the same commit (the registry drift test needs code +
  table together); deliberately not added to the LIVE-category tuples.
- New `gda.display` module — a platform-dispatched host-display probe reusable by
  `src` and both test suites: macOS `CGSessionCopyCurrentDictionary` (an on-console
  GUI session — NOT `launchctl managername`, which lies "Aqua" on headless macOS),
  Linux `$DISPLAY` / `$WAYLAND_DISPLAY`, and a documented Windows stub seam (live is
  UNIX-only today). Adapted from the ad-hoc probe in the panda-adventure screenshot
  e2e.
- `run_daemon_start_operation` refuses a windowed start pre-spawn (and
  pre-harness-install) when no display is usable, via an injectable `display_check`
  seam.
- Reuse the helper to fix the windowed e2e gates: `tests/test_e2e_screen.py` now
  skips correctly on headless macOS too (not just Linux without `$DISPLAY`), before
  spawning Godot; the example `test_e2e_screenshot.py` keys on
  `live_windowed_unavailable`.

## Doc artifacts (land with the code)

- **ADR-0002**: the `live_windowed_unavailable` registry row (same commit as
  `error_codes.py`).
- **ADR-0022**: a dated `> Outcome` note — the Session-log read path now also serves
  the failed-launch case via the deterministic path (point-in-time decision prose
  preserved).

## Tests

- `uv run pytest tests/test_daemon_server.py tests/test_daemon_diag.py tests/test_error_registry.py -rs` → **42 passed**. Diagnostics are now non-empty and distinguish "child died (signal X)" vs "harness did not connect"; the drift test passes with the new row.
- A windowed launch on a host with no usable DisplayServer returns
  `live_windowed_unavailable` (environment/127) WITHOUT spawning Godot — added
  (`test_windowed_start_without_a_display_is_live_windowed_unavailable`).
- `tests/test_e2e_screen.py` skips the windowed tests on a headless host before any
  spawn (the `skipif` mark resolves at collection; verified).
- Full non-e2e suite: **991 passed**. `ruff` and the `pyright` gate (ADR-0030) both
  clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)