### PR TITLE
docs(skill): deep-module guardrail for subagent-worktree-parallel (#351)

### DIFF
--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -29,6 +29,28 @@ edits, where all the integration cost concentrates:
 A wave whose slices all hammer the same hotspot is *not* a good parallel candidate —
 expect a conflict-heavy serial merge, or fix it structurally first (§8).
 
+**Guardrail: disjointness is a merge-cost heuristic, not an architecture goal.** When
+slicing for disjointness would suppress or distort a sound design decision, the design
+wins:
+
+- **Don't avoid a shared file just to keep a slice disjoint.** If a legitimate change
+  belongs in a registry, a model module, or a *deep module*, put it there and
+  **serialize that slice's merge** — don't sacrifice reusability (or bend scope) to
+  manufacture disjointness. "I deliberately kept this out of `models.py` to decouple the
+  slices" is the smell.
+- **Don't let isolation hide a re-implemented deep module.** Worktree isolation defers
+  duplicated/forked logic to merge or review, so parallel fan-out actively tempts each
+  subagent to re-build shared logic in its own worktree. Before calling a slice's
+  addition "new", confirm it isn't a thin projection of an existing deep module — *reuse
+  the module*; a per-slice boundary DTO layered over it is fine, a second copy of its
+  logic is not. Bake "did this reuse the existing deep module?" into the DoD and the
+  review.
+
+This is the **complement of §8**: §8 *splits* hotspots so slices stop colliding; this
+guardrail stops you from *degrading* a deep module to fake disjointness in the first
+place. Splitting a shared file is a structural fix; suppressing a sound change to dodge
+it is not.
+
 ## 2. Wave sizing
 
 - **≤ ~5 independent slices per wave.** (A run that tried ~9 at once hit two failure

--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -34,7 +34,8 @@ slicing for disjointness would suppress or distort a sound design decision, the 
 wins:
 
 - **Don't avoid a shared file just to keep a slice disjoint.** If a legitimate change
-  belongs in a registry, a model module, or a *deep module*, put it there and
+  belongs in a registry, a model module, or a *deep module* (a unit with a small
+  interface over substantial implementation that is meant to be reused), put it there and
   **serialize that slice's merge** — don't sacrifice reusability (or bend scope) to
   manufacture disjointness. "I deliberately kept this out of `models.py` to decouple the
   slices" is the smell.
@@ -42,9 +43,10 @@ wins:
   duplicated/forked logic to merge or review, so parallel fan-out actively tempts each
   subagent to re-build shared logic in its own worktree. Before calling a slice's
   addition "new", confirm it isn't a thin projection of an existing deep module — *reuse
-  the module*; a per-slice boundary DTO layered over it is fine, a second copy of its
-  logic is not. Bake "did this reuse the existing deep module?" into the DoD and the
-  review.
+  the module*; a thin per-slice data shape (a DTO/wrapper) layered over it is fine, a
+  second copy of its logic is not. Bake "did this reuse the existing deep module?" into
+  the subagent DoD and the review — wire it into the operational surfaces, not just this
+  prose (the dispatch-prompt DoD in §3 and the pre-launch checklist in §9).
 
 This is the **complement of §8**: §8 *splits* hotspots so slices stop colliding; this
 guardrail stops you from *degrading* a deep module to fake disjointness in the first
@@ -79,8 +81,14 @@ You are implementing <slice> in an ISOLATED git worktree.
 - Definition of Done: the INTEGRATION-tier test passes (the tier that actually exercises
   the integration boundary — integration / e2e / compile / a parse `--check-only`), not
   just the fast tier that stubs it. Do not satisfy DoD with `-m "not <integration>"`.
-- When done: open the PR (or commit + push). Report the branch, the PR URL, and the
-  exact test command + its result counts.
+- Also part of DoD — deep-module reuse: if your change belongs in a shared/deep module (a
+  central helper, model, or a spawn/launch primitive), REUSE it — do NOT re-implement its
+  logic in your worktree. A thin per-slice wrapper over an existing module is fine; a
+  second copy of its logic is not. If the right change belongs in a shared file, make it
+  there and flag it in your report — don't dodge it to stay disjoint.
+- When done: open the PR (or commit + push). Report the branch, the PR URL, the exact
+  test command + its result counts, and any deep module you reused or shared file you had
+  to touch.
 ```
 
 Worktree setup / cleanup:
@@ -219,6 +227,7 @@ design decision (an ADR) of its own.
 - [ ] Slices in this wave are independent (no shared module/group); coupled ones serialized.
 - [ ] Wave ≤ ~5; will merge before the next wave.
 - [ ] Each subagent's DoD includes the integration tier (not just the stubbed fast tier).
+- [ ] Each subagent's DoD includes deep-module reuse — no re-implementing shared logic, and no dodging a legitimate shared-file edit, to fake disjointness (§1).
 - [ ] Agents pinned to their own worktree; will commit early; "done but no artifact" = takeover.
 - [ ] Merge order decided (tracer first); after each resolution, audit for the marker-free traps.
 - [ ] Shared-global-resource tests will run serially across worktrees.

--- a/.agents/skills/subagent-worktree-parallel/SKILL.md
+++ b/.agents/skills/subagent-worktree-parallel/SKILL.md
@@ -40,7 +40,8 @@ the cost/benefit table).
   legitimate shared-module edit, deep-module *reuse*, or a single source for a public
   shape. When they conflict, **serialize that slice's merge** rather than degrade the
   architecture; and make "did this slice *reuse* the existing deep module (not
-  re-implement it in isolation)?" part of each subagent's DoD. (REFERENCE §1)
+  re-implement it in isolation)?" part of each subagent's DoD — wired into the
+  dispatch-prompt DoD and the pre-launch checklist, not just prose. (REFERENCE §1, §3, §9)
 
 ## Workflow
 

--- a/.agents/skills/subagent-worktree-parallel/SKILL.md
+++ b/.agents/skills/subagent-worktree-parallel/SKILL.md
@@ -35,6 +35,12 @@ the cost/benefit table).
   exercises the boundary (integration / e2e / compile or a parse `--check-only`).
 - **The orchestrator independently re-verifies before merging.** Subagent implements;
   the lead re-runs tests and spot-checks the diff. "Done but no artifact" = needs takeover.
+- **Disjointness is a merge-cost heuristic, not an architecture goal.** Never let "keep
+  slices disjoint / avoid the append hotspot" suppress a sound design decision — a
+  legitimate shared-module edit, deep-module *reuse*, or a single source for a public
+  shape. When they conflict, **serialize that slice's merge** rather than degrade the
+  architecture; and make "did this slice *reuse* the existing deep module (not
+  re-implement it in isolation)?" part of each subagent's DoD. (REFERENCE §1)
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

Adds the reverse guardrail the `subagent-worktree-parallel` skill was missing: **file-disjointness is a merge-cost heuristic, not an architecture goal.** When keeping slices disjoint would suppress or distort a sound design decision, the design wins — serialize that slice's merge instead of degrading the architecture.

Two facets:
1. Never let "keep slices disjoint / avoid the append hotspot" suppress a legitimate shared-module edit, deep-module *reuse*, or a single source for a public shape.
2. Worktree isolation hides re-implemented/forked deep-module logic until merge/review — bake "did this slice reuse the existing deep module?" into subagent DoD.

- `SKILL.md`: one line under "Core principles (non-negotiable)".
- `REFERENCE.md`: detail in §1, explicitly framed as the **complement of §8** ("kill the hotspots"), not a contradiction.

## Why

Exposed while planning the #342–#345 parallel wave: "keep slices disjoint" briefly drove an architecture/scope framing (avoiding `models.py`; treating a slice's result model as newly-invented rather than a thin projection of the deep module `launch()`/`RunResult`). Both were corrected in planning; this encodes the lesson.

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)