### PR TITLE
fix(cli): structured project_not_found for an invalid --project, all channels (#353)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -107,7 +107,7 @@ operation, and parse codes the CLI assigns).
 | `save_failed` | `operation` | `operation` | `4` | A scene could not be packed or saved. |
 | `delete_failed` | `operation` | `operation` | `4` | A file could not be removed from disk. |
 | `file_changed_externally` | `operation` | `operation` | `4` | A read-modify-write operation's target file changed on disk between the read and the write, so the write was refused to avoid clobbering the external edit. |
-| `project_not_found` | `operation` | `operation` | `4` | gda ran without a usable resolved Godot project: an operation needed one and none was resolved, or an explicit `--project`/`$GDA_PROJECT` was empty or is not a Godot project (no `project.godot`). |
+| `project_not_found` | `operation` | `operation` | `4` | gda ran without a usable resolved Godot project: an operation needed one and none was resolved, or an explicit `--project` was empty, or a `--project`/`$GDA_PROJECT` does not name a Godot project (no `project.godot`). |
 | `path_not_found` | `operation` | `operation` | `4` | A requested file does not exist. |
 | `not_a_scene` | `operation` | `operation` | `4` | A requested file cannot be loaded as a `PackedScene`. |
 | `parent_not_found` | `operation` | `operation` | `4` | A requested parent node path does not resolve to a node in the scene. |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -107,7 +107,7 @@ operation, and parse codes the CLI assigns).
 | `save_failed` | `operation` | `operation` | `4` | A scene could not be packed or saved. |
 | `delete_failed` | `operation` | `operation` | `4` | A file could not be removed from disk. |
 | `file_changed_externally` | `operation` | `operation` | `4` | A read-modify-write operation's target file changed on disk between the read and the write, so the write was refused to avoid clobbering the external edit. |
-| `project_not_found` | `operation` | `operation` | `4` | An operation that enumerates a project's `res://` tree ran without a resolved Godot project. |
+| `project_not_found` | `operation` | `operation` | `4` | gda ran without a usable resolved Godot project: an operation needed one and none was resolved, or an explicit `--project`/`$GDA_PROJECT` was empty or is not a Godot project (no `project.godot`). |
 | `path_not_found` | `operation` | `operation` | `4` | A requested file does not exist. |
 | `not_a_scene` | `operation` | `operation` | `4` | A requested file cannot be loaded as a `PackedScene`. |
 | `parent_not_found` | `operation` | `operation` | `4` | A requested parent node path does not resolve to a node in the scene. |

--- a/docs/adr/0023-command-descriptor-single-registration.md
+++ b/docs/adr/0023-command-descriptor-single-registration.md
@@ -57,6 +57,16 @@ absorbs the two missing facts.**
   frozensets** and the per-command identity-branching inside the old daemon
   dispatch (each daemon command now carries its own recipe).
 
+  > **Outcome (2026-07-01, #353/#357):** project resolution moved OUT of the recipe
+  > into the shared `_dispatch_recipe` tail — it resolves once (via the same
+  > `_resolve_project_or_fail` the sentinel `_dispatch` uses) and hands the recipe an
+  > ALREADY-resolved project, so an invalid `--project` is a structured
+  > `project_not_found` on the recipe channel exactly as on the sentinel one, with no
+  > per-recipe resolution. A recipe now **produces the outcome from a resolved project**
+  > (it no longer resolves). A `projectless: bool` descriptor field excludes pure meta
+  > emitters (e.g. `gda skill`, ADR-0024) from resolution, so an inherited invalid
+  > `$GDA_PROJECT` cannot make a projectless meta command fail.
+
 **2. The render map and dispatch routing are projections of the descriptor, not
 parallel registries.** On the `cmd.emit` path the descriptor is already in hand, so
 rendering and channel selection read off `cmd` directly. Where a whole-surface view

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -716,16 +716,21 @@ def _dispatch_recipe(
     renders identically to a sentinel one; only outcome production differs. Shared by
     the argv bodies and the ``--params-json`` path, so the two forms are
     indistinguishable downstream (ADR-0015). Project resolution stays CLI-side
-    (ADR-0006) and happens HERE, once, for every recipe — so an invalid
-    ``--project`` yields the structured ``project_not_found`` envelope on this
-    channel exactly as on the sentinel one, and no recipe re-resolves (#353).
+    (ADR-0006) and happens HERE, once, for every PROJECT-USING recipe — so an
+    invalid ``--project`` yields the structured ``project_not_found`` envelope on
+    this channel exactly as on the sentinel one, and no recipe re-resolves (#353).
+    A ``projectless`` recipe (a pure meta emitter like ``gda skill``, ADR-0024) is
+    NOT resolved: it takes no project, so an inherited invalid ``$GDA_PROJECT``
+    must not make it fail (#357).
     """
     # A recipe command always carries a recipe channel — that is what routes it
-    # here rather than to the sentinel ``cmd.emit`` path (ADR-0023). The recipe
-    # receives the ALREADY-resolved project (or a structured project_not_found is
-    # emitted before it runs); it never touches ``resolve_project_dir`` itself.
+    # here rather than to the sentinel ``cmd.emit`` path (ADR-0023). A project-using
+    # recipe receives the ALREADY-resolved project (or a structured project_not_found
+    # is emitted before it runs); a projectless meta recipe receives None and never
+    # touches ``resolve_project_dir``.
     assert cmd.recipe is not None
-    outcome = cmd.recipe(params, project=_resolve_project_or_fail(project), godot=godot)
+    resolved = None if cmd.projectless else _resolve_project_or_fail(project)
+    outcome = cmd.recipe(params, project=resolved, godot=godot)
     if isinstance(outcome, Failure):
         emit_failure(outcome)
     emit_result(outcome, json_output, cmd.render)
@@ -795,6 +800,10 @@ SKILL_COMMAND: HeadlessCommand[SkillResult] = HeadlessCommand(
     output_model=SkillResult,
     render=render_skill,
     recipe=_skill_recipe,
+    # A pure meta emitter (ADR-0024): no --project, resolves none — so the recipe
+    # dispatcher must not resolve a project for it (an inherited invalid $GDA_PROJECT
+    # must not make `gda skill` fail, #357).
+    projectless=True,
 )
 
 GAME_TREE_COMMAND: HeadlessCommand[GameTreeResult] = HeadlessCommand(

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -43,7 +43,7 @@ from gda.errors import (
     classify_perf_monitor,
     classify_perf_monitors,
     classify_script_validate,
-    script_run_project_not_found_failure,
+    invalid_project_failure,
 )
 from gda.execution import ExecutionKind
 from gda.export_run import (
@@ -487,8 +487,10 @@ def _make_live_runner(binary: Optional[Path], project: Optional[Path]) -> GodotR
 
 # --- Recipe channels (ADR-0023) -----------------------------------------------
 # Each recipe command (export run / the daemon lifecycle / screen) carries one of
-# these on its descriptor (``recipe=``). A recipe PRODUCES the outcome — resolve the
-# project (kept CLI-side, ADR-0006) + run the CLI-side operation — and RETURNS the
+# these on its descriptor (``recipe=``). A recipe PRODUCES the outcome — run the
+# CLI-side operation over the ALREADY-resolved ``project`` (resolution happens once
+# in :func:`_dispatch_recipe`, kept CLI-side per ADR-0006, so an invalid --project is
+# a structured project_not_found before any recipe runs, #353) — and RETURNS the
 # typed result or a Failure; emission stays the shared tail (:func:`_dispatch_recipe`
 # → ``cmd.render``), so a recipe command renders exactly like a sentinel one. The
 # runner seams (``_make_*``) are referenced at call time so test monkeypatches on
@@ -499,7 +501,7 @@ def _make_live_runner(binary: Optional[Path], project: Optional[Path]) -> GodotR
 
 def _daemon_start_recipe(params, *, project, godot):
     return run_daemon_start_operation(
-        resolve_project_dir(project),
+        project,
         godot,
         windowed=params.windowed,
         scene=params.scene,
@@ -507,20 +509,20 @@ def _daemon_start_recipe(params, *, project, godot):
 
 
 def _daemon_stop_recipe(params, *, project, godot):
-    return run_daemon_stop_operation(resolve_project_dir(project))
+    return run_daemon_stop_operation(project)
 
 
 def _daemon_status_recipe(params, *, project, godot):
-    return run_daemon_status_operation(resolve_project_dir(project))
+    return run_daemon_status_operation(project)
 
 
 def _daemon_uninstall_recipe(params, *, project, godot):
-    return run_daemon_uninstall_operation(resolve_project_dir(project))
+    return run_daemon_uninstall_operation(project)
 
 
 def _screen_capture_recipe(params, *, project, godot):
     return run_screen_capture_operation(
-        resolve_project_dir(project),
+        project,
         Path(params.output),
         inline=params.inline,
         make_runner=_make_live_runner,
@@ -529,7 +531,7 @@ def _screen_capture_recipe(params, *, project, godot):
 
 def _screen_frames_recipe(params, *, project, godot):
     return run_screen_frames_operation(
-        resolve_project_dir(project),
+        project,
         params.frames,
         Path(params.output_dir),
         make_runner=_make_live_runner,
@@ -549,7 +551,7 @@ def _export_run_recipe(params, *, project, godot):
         mode=params.mode,
         output_override=params.output,
         godot=godot,
-        project=resolve_project_dir(project),
+        project=project,
         make_runner=_make_runner,
         make_export_runner=_make_export_runner,
     )
@@ -573,22 +575,16 @@ EXPORT_RUN_COMMAND: HeadlessCommand[ExportRunResult] = HeadlessCommand(
 
 
 def _script_run_recipe(params, *, project, godot):
-    # Project resolution stays CLI-side (ADR-0006), but ``resolve_project_dir``
-    # RAISES ValueError for an explicit ``--project`` (or ``$GDA_PROJECT``) that is
-    # not a Godot project — a raise that would escape as a traceback before the op's
-    # projectless-None guard runs. Convert it to the SAME structured project_not_found
-    # the None case yields, so "no resolved project" is always a clear structured
-    # error, never a crash (ADR-0031 / #343 AC). (The general cross-cutting fix — a
-    # shared ValueError→envelope layer across every channel — is tracked in #353;
-    # this stays within script run's own slice.)
-    try:
-        resolved = resolve_project_dir(project)
-    except ValueError:
-        return script_run_project_not_found_failure()
+    # ``project`` arrives ALREADY resolved by _dispatch_recipe — an invalid
+    # --project/$GDA_PROJECT was converted to a structured project_not_found before
+    # this runs, so no per-recipe ValueError handling is needed here (#353 folded in
+    # script run's former try/except). A projectless None remains the op's own ABI
+    # edge: run_script_run_operation returns script_run_project_not_found_failure()
+    # for it (ADR-0031).
     return run_script_run_operation(
         script=params.path,
         godot=godot,
-        project=resolved,
+        project=project,
     )
 
 
@@ -638,6 +634,22 @@ def _emit(
     )
 
 
+def _resolve_project_or_fail(project: Optional[str]) -> Optional[Path]:
+    """Resolve ``--project`` (ADR-0006), or emit a structured ``project_not_found``
+    and exit — never leak the raise as a traceback (#353).
+
+    ``resolve_project_dir`` raises ``ValueError`` for an explicit ``--project`` or
+    ``$GDA_PROJECT`` that is empty or is not a Godot project. This is the ONE shared
+    project-resolution point on the CLI dispatch path, so converting the raise here
+    gives every channel — sentinel (:func:`_dispatch`) and recipe
+    (:func:`_dispatch_recipe`) — the structured envelope in a single place.
+    """
+    try:
+        return resolve_project_dir(project)
+    except ValueError as exc:
+        emit_failure(invalid_project_failure(str(exc)))
+
+
 def _dispatch(
     cmd: HeadlessCommand[M],
     params: BaseModel,
@@ -661,7 +673,7 @@ def _dispatch(
         params,
         json_output=json_output,
         godot=godot,
-        project=resolve_project_dir(project),
+        project=_resolve_project_or_fail(project),
     )
 
 
@@ -704,12 +716,16 @@ def _dispatch_recipe(
     renders identically to a sentinel one; only outcome production differs. Shared by
     the argv bodies and the ``--params-json`` path, so the two forms are
     indistinguishable downstream (ADR-0015). Project resolution stays CLI-side
-    (ADR-0006), owned by each recipe.
+    (ADR-0006) and happens HERE, once, for every recipe — so an invalid
+    ``--project`` yields the structured ``project_not_found`` envelope on this
+    channel exactly as on the sentinel one, and no recipe re-resolves (#353).
     """
     # A recipe command always carries a recipe channel — that is what routes it
-    # here rather than to the sentinel ``cmd.emit`` path (ADR-0023).
+    # here rather than to the sentinel ``cmd.emit`` path (ADR-0023). The recipe
+    # receives the ALREADY-resolved project (or a structured project_not_found is
+    # emitted before it runs); it never touches ``resolve_project_dir`` itself.
     assert cmd.recipe is not None
-    outcome = cmd.recipe(params, project=project, godot=godot)
+    outcome = cmd.recipe(params, project=_resolve_project_or_fail(project), godot=godot)
     if isinstance(outcome, Failure):
         emit_failure(outcome)
     emit_result(outcome, json_output, cmd.render)

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -165,7 +165,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
-        "gda ran without a usable resolved Godot project: an operation needed one and none was resolved, or an explicit --project/$GDA_PROJECT was empty or is not a Godot project (no project.godot).",
+        "gda ran without a usable resolved Godot project: an operation needed one and none was resolved, or an explicit --project was empty, or a --project/$GDA_PROJECT does not name a Godot project (no project.godot).",
     ),
     ErrorCodeSpec(
         "path_not_found",

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -165,7 +165,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
-        "An operation that enumerates a project's res:// tree ran without a resolved Godot project.",
+        "gda ran without a usable resolved Godot project: an operation needed one and none was resolved, or an explicit --project/$GDA_PROJECT was empty or is not a Godot project (no project.godot).",
     ),
     ErrorCodeSpec(
         "path_not_found",

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -666,3 +666,18 @@ def script_run_project_not_found_failure() -> Failure:
         "$GDA_PROJECT, or run from a project directory",
         "",
     )
+
+
+def invalid_project_failure(reason: str) -> Failure:
+    """The ``project_not_found`` failure for an explicit ``--project``/``$GDA_PROJECT``
+    that is empty or is not a Godot project (#353).
+
+    ``resolve_project_dir`` raises ``ValueError`` with a descriptive ``reason`` (the
+    offending path, the missing ``project.godot``, or an empty value). Converting it
+    to this structured envelope at the shared CLI dispatch layer — the single place
+    project resolution happens (ADR-0006) — means *every* channel yields the
+    structured ``project_not_found`` error instead of leaking the raise as a Rich/
+    Python traceback. It is the general, cross-cutting form of ``script run``'s own
+    projectless ABI edge (#343); the two share the one ``project_not_found`` code.
+    """
+    return _failure("project_not_found", reason, "")

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -334,6 +334,13 @@ class HeadlessCommand(Generic[M]):
     # means the command runs through ``emit`` with its ``kind``-selected runner — so a
     # single ``recipe is None`` test selects the channel, no identity table.
     recipe: "Recipe | None" = None
+    # A projectless recipe is a pure meta emitter (ADR-0024/0005, e.g. ``gda skill``):
+    # it takes no ``--project`` and resolves none, so the recipe dispatcher must NOT
+    # resolve a project for it — otherwise an inherited ``$GDA_PROJECT`` that is not a
+    # project would make a projectless meta command fail (#353/#357). Project-using
+    # recipes leave this ``False`` and receive a resolved project (or a structured
+    # ``project_not_found``). Meaningless for the sentinel channel (``recipe is None``).
+    projectless: bool = False
 
     def schema_option(self) -> bool:
         """Return the Typer ``--schema`` flag for this command."""

--- a/tests/test_invalid_project_is_structured.py
+++ b/tests/test_invalid_project_is_structured.py
@@ -1,0 +1,86 @@
+"""An invalid ``--project`` yields a structured GdaError across every channel (#353).
+
+``resolve_project_dir`` RAISES ``ValueError`` for an explicit ``--project`` (or
+``$GDA_PROJECT``) that is empty or is not a Godot project. gda must convert that
+raise into a structured ``project_not_found`` envelope at the shared dispatch
+layer — never let it escape as a Rich/Python traceback — for BOTH the sentinel
+channel (``_dispatch``) and the recipe channel (``_dispatch_recipe``), honoring
+the ADR-0002 structured-output contract. This is the general, cross-cutting form
+of the per-command handling ``script run`` already had (#343), now folded into
+one place.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+
+
+def test_sentinel_command_with_invalid_project_is_structured(tmp_path):
+    # A SENTINEL command (`scene list` → _dispatch) with an explicit --project that
+    # is not a Godot project must surface a structured project_not_found envelope,
+    # not the raw ValueError traceback the un-guarded _dispatch would leak.
+    not_a_project = tmp_path / "not-a-godot-project"
+    not_a_project.mkdir()  # exists, but has no project.godot
+
+    result = CliRunner().invoke(
+        app, ["scene", "list", "--project", str(not_a_project), "--json"]
+    )
+
+    assert result.exit_code != 0
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "project_not_found"
+
+
+def test_empty_project_is_structured():
+    # An explicit but EMPTY --project is a deliberate mistake resolve_project_dir
+    # raises on ("explicit project path is empty") — it, too, must be structured.
+    result = CliRunner().invoke(app, ["scene", "list", "--project", "", "--json"])
+
+    assert result.exit_code != 0
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "project_not_found"
+
+
+def test_bad_gda_project_env_is_structured(tmp_path, monkeypatch):
+    # The same raise via $GDA_PROJECT precedence (no --project flag), on the recipe
+    # channel: an env pointing at a non-project must also be structured.
+    not_a_project = tmp_path / "env-not-a-project"
+    not_a_project.mkdir()
+    monkeypatch.setenv("GDA_PROJECT", str(not_a_project))
+
+    result = CliRunner().invoke(
+        app, ["export", "run", "--preset", "Linux/X11", "--mode", "pack", "--json"]
+    )
+
+    assert result.exit_code != 0
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "project_not_found"
+
+
+def test_recipe_command_with_invalid_project_is_structured(tmp_path):
+    # A RECIPE command (`export run` → _dispatch_recipe) with an invalid --project
+    # must also surface the structured envelope, not the raw ValueError the recipe's
+    # own resolve_project_dir would leak.
+    not_a_project = tmp_path / "not-a-godot-project"
+    not_a_project.mkdir()
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--mode",
+            "pack",
+            "--project",
+            str(not_a_project),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code != 0
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "project_not_found"

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -52,6 +52,22 @@ def test_skill_json_emits_name_version_content():
     assert data.get("installed_path") is None
 
 
+def test_skill_ignores_an_invalid_inherited_gda_project(tmp_path, monkeypatch):
+    # `gda skill` is a projectless meta emitter (ADR-0024): it reads the bundled
+    # SKILL.md and never resolves a Godot project. An inherited $GDA_PROJECT that
+    # is not a project must NOT make it fail — it stays projectless, unlike the
+    # project-using recipes that structure an invalid --project as project_not_found
+    # (#353). Guards against the shared-resolver refactor over-reaching to meta.
+    not_a_project = tmp_path / "not-a-godot-project"
+    not_a_project.mkdir()
+    monkeypatch.setenv("GDA_PROJECT", str(not_a_project))
+
+    result = CliRunner().invoke(app, ["skill", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["name"] == "gda"
+
+
 def test_skill_json_content_round_trips_the_bundled_file():
     data = json.loads(CliRunner().invoke(app, ["skill", "--json"]).stdout)
     assert data["content"] == SKILL_MD.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

`resolve_project_dir()` raises `ValueError` for an explicit `--project`/`$GDA_PROJECT` that is empty or is not a Godot project. No channel converted it, so `gda <cmd> --project <bad> --json` leaked a Rich/Python traceback instead of a `{"error": …}` envelope — violating the ADR-0002 structured-output contract, on **every** `--project` command.

- New `_resolve_project_or_fail()` — the **one shared** project-resolution point on the CLI dispatch path (ADR-0006). It catches the `ValueError` and emits a structured `project_not_found` (`invalid_project_failure`).
- `_dispatch` (sentinel) and `_dispatch_recipe` (recipe) both route through it. `_dispatch_recipe` resolves **once** and passes the already-resolved project to the recipe.
- All 8 recipes (`export run`, `script run`, daemon ×4, screen ×2) now receive a resolved project and no longer resolve themselves. `script run`'s former per-command `ValueError` handling (#343) is **folded into the shared layer** — no duplicated logic.
- `project_not_found`'s registry + ADR-0002 `Meaning` generalized to the widened sense (drift test green; category/source/exit unchanged).

Before → after (`--json`):
```
gda scene list  --project /tmp/not-a-project --json   # sentinel: traceback → {"error":{"code":"project_not_found",…}}
gda export run  --project /tmp/not-a-project --json   # recipe:   traceback → structured
gda daemon status --project /tmp/not-a-project --json # (bonus)   traceback → structured
```

## Tests

New `tests/test_invalid_project_is_structured.py`: sentinel + recipe with an invalid `--project`, empty `--project`, and a bad `$GDA_PROJECT` all yield the structured envelope. #343's existing `script run` bad-project tests are the DRY regression guard (still green after removing its try/except). Full non-e2e suite: 1023 passed; ruff/pyright clean.

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)