### PR TITLE
docs(adr): add ADR-0032 (class_name static-scan fallback) and ADR-0033 (Object-typed property assignment)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -139,10 +139,12 @@ The set of points where a single `gda` run triggers the target project's own
 code to run: autoload constructors at engine startup (every `--project` op), the
 `_init` of scripts on nodes *or resources* that an instantiating operation
 constructs (a `class_name` node via `node add`, or a script-backed `class_name`
-Resource via `resource create`), and — via `gda script run` (ADR-0031) — the
+Resource via `resource create`), the `_init` of a **script-backed Resource loaded
+as a value** assigned to an Object-typed property (`node set` / `resource set
+--value res://…`, ADR-0033), and — via `gda script run` (ADR-0031) — the
 **full execution of a named project script**.
-All stay within the `Trusted project` assumption (ADR-0009); `script run` widens
-this surface without adding a new trust axis.
+All stay within the `Trusted project` assumption (ADR-0009); `script run` and the
+loaded-value assignment (ADR-0033) widen this surface without adding a new trust axis.
 _Avoid_: attack surface, code-execution risk
 
 **Concurrent external editor**:

--- a/docs/adr/0032-project-local-class-name-resolution-static-fallback.md
+++ b/docs/adr/0032-project-local-class-name-resolution-static-fallback.md
@@ -1,0 +1,93 @@
+---
+status: accepted
+---
+
+# Project-local `class_name` resolution: a gda-owned static scan as a cache-independent fallback
+
+#342 gave `node add --type <class_name>` and `resource create --type <class_name>` the ability to
+resolve a **project-local GDScript `class_name`**, resolving it through
+`ProjectSettings.get_global_class_list()`. That list is populated **only** by the Godot editor scan,
+written into `.godot/global_script_class_cache.cfg`. But gda's core target is a
+[Headless operation](../../CONTEXT.md) on a headless, **editor-never-opened** [Trusted project](../../CONTEXT.md)
+— which has no `.godot/`, so the global class list is **empty** and #342's support is unreachable in
+exactly the workflow gda positions itself for (surfaced dogfooding Panda Adventure S1, #359/#360).
+Three call sites share this single dependency: node instantiation (`_instantiate_node_type`), resource
+instantiation (`_instantiate_resource_type`), and `find-references`' `class_name → script path`
+resolution (#116). The one-shot editor-scan workaround (`godot --headless --editor --quit`) confirms
+the mechanism but is not a workflow gda can adopt on the agent's behalf.
+
+## Decision
+
+gda resolves a project-local `class_name` through **one unified resolver**, shared by all three call
+sites, as a **three-tier chain**:
+
+1. a **built-in engine class** (`ClassDB.can_instantiate`, base-class-checked) — unchanged;
+2. the **editor global class list** (`get_global_class_list`) — the existing cache, kept **first** so
+   an editor-opened project resolves exactly as it does today;
+3. a **gda-owned static scan** of the project's own `.gd` sources — invoked **only when tiers 1–2 do
+   not resolve** the type.
+
+The static scan is a **cache-independent fallback**, not a replacement (cache-first). It walks the
+full `res://` tree **skipping `.godot/`** (reusing the existing recursive walker), parses each `.gd`'s
+`class_name` declaration with the existing **raw-source** parser (`_parse_script_meta`, the same
+never-compiled parse `script get` / `find-references` already use), and builds a `class_name → script
+path` index once per process run. Resolution stays a **static text scan**; the subsequent
+instantiation (and the Node-vs-Resource base-class check) remains **split per site** — only the
+`class_name → path` resolution is unified.
+
+**Explicit contract edges:**
+
+- **Duplicate `class_name`** (declared in more than one `.gd`) is **ambiguous and rejected** with a
+  new [Operation-reported error code](../../CONTEXT.md) `ambiguous_class_name` naming the conflicting
+  script paths — never a nondeterministic "first file wins", which would mask a real project error
+  (the editor reports the same conflict) and depend on traversal order.
+- **A type that resolves through none of the three tiers** stays the existing `invalid_node_type` /
+  `invalid_resource_type`, but with the message **upgraded to be actionable** — it names the
+  missing-class cause (a misspelled name, or a class not declared in a `.gd`) and **no longer implies
+  the missing editor cache as the root cause** (the static scan removed that precondition). This is
+  the retained, defense-in-depth part of the "document + better error" option.
+- **`find-references`** shares the identical resolver and the identical `ambiguous_class_name`
+  semantics, so `find-references Foo` and `resource create --type Foo` agree on whether `Foo` resolves
+  in a never-opened project.
+
+**Scope:** `.gd` only. A `class_name` declared in C# (`.cs`) is **out of scope** (consistent with
+gda's existing boundary); its resolution would need a different mechanism and is not admitted here.
+
+## Considered options
+
+- **Trigger an editor class-list scan** (`godot --headless --editor --quit`) before the lookup —
+  **rejected.** It introduces an `--editor` launch shape gda does not have (breaking the
+  [Headless operation](../../CONTEXT.md) / Headless-launch model of ADR-0010), **writes `.godot/`
+  into the Trusted project** as a side effect (a future hazard against a Concurrent external editor,
+  ADR-0018), and is slow and fragile under headless/CI (a full editor boot + import that can fail on
+  missing assets).
+- **Document + actionable error only** — **rejected as the sole fix.** It leaves gda's core
+  positioning scenario (headless, editor-never-opened) broken. Retained only as the tier-3-miss error
+  message above.
+- **Make the static scan authoritative** (always scan, override the cache for freshness) —
+  **rejected.** It changes behavior for editor-opened projects (regression surface) and discards the
+  cache's coverage of forms a text scan may miss; a cache-first fallback is unobservable for
+  editor-opened projects. The known edge — a **stale** cache that resolves a since-renamed class —
+  stays consistent with today's behavior rather than introducing a new inconsistency, and is judged
+  not worth the merge-and-freshness complexity.
+- **First-file-wins on a duplicate `class_name`** — **rejected** (see the contract edge above).
+
+## Consequences
+
+- **The resolver stays a pure [Headless operation](../../CONTEXT.md)** — no pre-existing engine
+  state, no editor launch, no write into the project — consistent with ADR-0010, and it **removes the
+  hidden editor-cache precondition** from the three sites for the headless workflow.
+- **The [Project-code execution surface](../../CONTEXT.md) (ADR-0009) is unchanged.** The static scan
+  **runs no project code** (it parses raw source, exactly like `script get` / `find-references`); only
+  the subsequent instantiation runs a script's `_init`, which #342 already does. No new trust axis.
+- **Backward compatible.** An editor-opened project resolves via the cache exactly as before; the
+  fallback is unobservable there.
+- **New shared [Gda error code](../../CONTEXT.md)** `ambiguous_class_name` (Operation-reported),
+  emitted uniformly by `node add`, `resource create`, and `find-references`.
+- **Consistency restored** across the three sites: they now agree on `class_name` resolution in a
+  never-opened project, rather than `find-references` reporting "no such class" while a repaired
+  `resource create` resolves it.
+- **Cost.** A never-opened-project miss walks the whole `res://` tree and parses every `.gd`; this is
+  acceptable for one-shot ops and is **not** backed by a persistent gda-owned cache — a gda-owned
+  cache would re-introduce the very ".godot ownership" complexity the editor-scan option was rejected
+  for.

--- a/docs/adr/0033-object-typed-property-assignment-via-resource-reference.md
+++ b/docs/adr/0033-object-typed-property-assignment-via-resource-reference.md
@@ -1,0 +1,79 @@
+---
+status: accepted
+---
+
+# Object-typed property assignment: reference an existing Resource by `res://` path; script property routed to `script attach`; inline sub-resources deferred
+
+`node set` and `resource set` coerce **value-typed** properties (scalars, `Vector2`, `Color`, … via
+the shared comma-form `_coerce_value`) but reject every **Object-typed** property with
+`uncoercible_value`. So an agent can add nodes and resources but cannot give them a Resource-typed
+field — e.g. a `CollisionShape2D`'s `shape` — leaving most functional scenes hand-authored as `.tscn`
+text (surfaced dogfooding Panda Adventure S1, #361). Note the adjacent capability is **not** missing:
+binding a **script** to a node already ships as `script attach` (#118), which verifies compile + base
+compatibility and reports the displaced script. The genuinely missing piece is assigning a
+**Resource** to a Resource-typed property.
+
+## Decision
+
+`node set` / `resource set` accept a **`res://…` resource path** as `--value` for an Object-typed
+property that expects a **Resource (sub)class**. The path is `load()`ed, **type-checked** against the
+property's declared expected class, and assigned as an **external reference** (`ext_resource`) — the
+resource is **not inlined**. Combined with the existing `resource create` (which already builds a
+built-in *or* project-local `class_name` Resource, #342 / ADR-0032) and `resource set`, this completes
+the external sub-resource workflow with **no new command**:
+
+```
+gda resource create res://shapes/box.tres --type RectangleShape2D
+gda resource set    res://shapes/box.tres --property size  --value 32,64
+gda node set scene.tscn --node Col --property shape --value res://shapes/box.tres
+```
+
+**Explicit contract edges:**
+
+- **The shared `_coerce_value` is unchanged.** Its `(raw, type)` signature carries only the
+  `Variant.Type` (`TYPE_OBJECT`), not the property's expected class, and it is **byte-identical
+  mirrored** into the [gda harness](../../CONTEXT.md) for `game set` (ADR live layer). Object
+  resolution is therefore a **separate, headless-only step** in `node set` / `resource set` that reads
+  the property's expected-class hint from its property-list entry. Assigning a Resource on a live
+  `game set` is **out of scope**; the mirror stays green.
+- **The `script` property is excluded** from this generic Object path and routed to **`script attach`**
+  (#118) — the one authoritative way to bind a script. `node set --property script` returns an
+  **actionable** [Operation-reported error code](../../CONTEXT.md) pointing at `script attach`, never a
+  second attach entry that would bypass its compile/base-type verification and `replaced_script`
+  reporting.
+- **Type-check scope: engine-class-typed** Object properties (e.g. `shape: Shape2D`). A property typed
+  as a **script `class_name`** (e.g. `config: PlayerConfig`) is **deferred** — its validation reuses
+  the unified `class_name` resolver of ADR-0032.
+- **Structured failures**, not `uncoercible_value`: a non-`res://` value, a path that does not load as
+  a Resource, and a resource whose type is incompatible with the property each report a distinct,
+  structured code.
+- **Value-typed coercion** (scalar / `Vector2` / `Color`) is unchanged.
+
+## Considered options
+
+- **Create + assign an inline sub-resource** (an embedded `SubResource`, no separate `.tres`) —
+  **deferred**, not rejected. It needs new command surface (an `add-subresource` verb) and **nested
+  addressing** to `set` the sub-resource's own fields afterward. The external `.tres` reference
+  delivers the same "wired scene" value for the highest-value case (mutating existing scenes, per
+  #361's own scope note) at a far smaller change. It can be added later under ADR-0025 if a concrete
+  "must be inline" need appears.
+- **Route the `script` property through the generic Object path too** — **rejected.** It creates two
+  ways to attach a script; `script attach` already owns compile / base-type verification and clobber
+  reporting (#118, #132).
+- **Extend the shared `_coerce_value` to load an Object from a `res://` path** — **rejected.** It lacks
+  the expected-class hint, and the change would ride the harness mirror into live `game set` (out of
+  scope) for no benefit, while breaking the byte-identical mirror.
+
+## Consequences
+
+- **New public value-form ABI:** `node set` / `resource set` accept a `res://` path for Resource-typed
+  properties; agents and tooling may rely on it. This is why the decision is recorded.
+- **The [Project-code execution surface](../../CONTEXT.md) (ADR-0009) is not newly widened.** Loading a
+  `.tres` runs the same resource `_init` that `resource create` / `load` already run, within the
+  Trusted-project assumption — no new trust axis.
+- **A recorded asymmetry:** `script` → `script attach`; every other Resource-typed property → `node
+  set` / `resource set`. Intentional — one authoritative script-attach path.
+- **Ties to ADR-0032:** script-`class_name`-typed property validation will reuse ADR-0032's unified
+  `class_name` resolver when that extension (or the deferred inline sub-resource work) lands.
+- **The mirrored `_coerce_value` stays byte-identical**; the mirror test (`operations.gd` ↔
+  `gda_harness.gd`) is unaffected.

--- a/docs/adr/0033-object-typed-property-assignment-via-resource-reference.md
+++ b/docs/adr/0033-object-typed-property-assignment-via-resource-reference.md
@@ -46,7 +46,9 @@ gda node set scene.tscn --node Col --property shape --value res://shapes/box.tre
   the unified `class_name` resolver of ADR-0032.
 - **Structured failures**, not `uncoercible_value`: a non-`res://` value, a path that does not load as
   a Resource, and a resource whose type is incompatible with the property each report a distinct,
-  structured code.
+  structured code. The concrete `GdaError` codes are **not fixed here** — since `GdaError.code` is
+  public ABI whose authoritative source is the error registry (ADR-0002), the implementation slice
+  (#363) mints them and registers them there when it lands (the ADR-0031 pattern).
 - **Value-typed coercion** (scalar / `Vector2` / `Color`) is unchanged.
 
 ## Considered options
@@ -66,13 +68,18 @@ gda node set scene.tscn --node Col --property shape --value res://shapes/box.tre
 
 ## Consequences
 
-- **New public value-form ABI:** `node set` / `resource set` accept a `res://` path for Resource-typed
-  properties; agents and tooling may rely on it. This is why the decision is recorded.
-- **The [Project-code execution surface](../../CONTEXT.md) (ADR-0009) is not newly widened.** Loading a
-  `.tres` runs the same resource `_init` that `resource create` / `load` already run, within the
-  Trusted-project assumption — no new trust axis.
-- **A recorded asymmetry:** `script` → `script attach`; every other Resource-typed property → `node
-  set` / `resource set`. Intentional — one authoritative script-attach path.
+- **New public value-form ABI:** `node set` / `resource set` accept a `res://` path for
+  **engine-class-typed** Resource/Object properties (script-`class_name`-typed properties are deferred,
+  per the contract edge above); agents and tooling may rely on it. This is why the decision is recorded.
+- **The [Project-code execution surface](../../CONTEXT.md) (ADR-0009) widens.** `node set` / `resource
+  set` gain a new entry point that **loads** an external Resource value (`--value res://…`), so a
+  **script-backed** Resource's `_init` runs on load — from a point the surface did not previously
+  enumerate (it covered `_init` only for a resource an operation *constructs*, e.g. `resource create`).
+  This stays **within** ADR-0009's Trusted-project assumption and adds **no new trust axis** — only a
+  documented widening of the same surface, the ADR-0031 precedent. `CONTEXT.md`'s
+  `Project-code execution surface` glossary entry is aligned in this same change.
+- **A recorded asymmetry:** `script` → `script attach`; every other **engine-class-typed** Resource
+  property → `node set` / `resource set`. Intentional — one authoritative script-attach path.
 - **Ties to ADR-0032:** script-`class_name`-typed property validation will reuse ADR-0032's unified
   `class_name` resolver when that extension (or the deferred inline sub-resource work) lands.
 - **The mirrored `_coerce_value` stays byte-identical**; the mirror test (`operations.gd` ↔


### PR DESCRIPTION
## Summary

Records the two design decisions produced while triaging the Panda Adventure S1 dogfooding feedback (#360, #361). Docs only — no code changes; the implementation lands in the tracked child issues.

- **ADR-0032** — resolve a project-local GDScript `class_name` for `node add` / `resource create` / `find-references` in a **headless, editor-never-opened** project. gda adds a gda-owned **static scan** of the project's `.gd` sources as a **cache-independent fallback**, after (1) built-in engine classes and (2) the editor global class list, invoked only when those miss. Cache-first (editor-opened projects unchanged); a duplicate `class_name` is rejected with a new `ambiguous_class_name` error; all three sites share one resolver. Rejects the `--editor --quit` scan and the doc-only options. Captures the **#360** fix (extends #342, under ADR-0009/0010).
- **ADR-0033** — `node set` / `resource set` accept a `res://….tres` path to assign an **existing Resource** to an **Object-typed property** (external `ext_resource` reference, not inlined). The shared `_coerce_value` harness mirror stays byte-identical; the `script` property is routed to `script attach` (#118); inline sub-resources are **deferred**. Captures the **#361** design, under ADR-0025.

## Follow-up issues (implementation)

- #360 — `class_name` static-scan fallback *(ready-for-agent, ADR-0032)*
- #363 — assign an existing Resource by `res://` path to an Object-typed property *(ready-for-agent, ADR-0033)*
- #364 — gda skill scene-authoring discoverability docs *(ready-for-agent, blocked by #363)*
- #365 — inline sub-resource authoring *(deferred)*
- #361 — closed as split into #363/#364/#365

## Test plan

- [ ] N/A — documentation only (two new ADR files); no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
