### PR TITLE
feat(harness): public is_daemon_launched() predicate for log gating (#362)

### DIFF
--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -953,14 +953,18 @@ func _error(code: String, message: String) -> String:
 
 # The PUBLIC, stable predicate reporting whether gda-daemon launched this run (#362)
 # — the SAME condition `gda_log()` gates on (`_daemon_launched`). Game code should
-# branch on THIS, not on harness *presence*: once installed, `/root/GdaHarness` exists
-# in every run, but the harness only captures logs when the daemon launched the
-# session, so gating on presence silently drops every record in a plain/editor/exported
-# run. A game-side logging helper instead gates on this predicate and falls back to
-# `print()` when it is false. It is a PURE READ — no connection, no output, no state
-# change — so the ADR-0018 inert-when-dormant guarantee holds: it returns false in a
-# human editor run, a plain run, and an exported build (where `_ready` returns at the
-# `template` gate before `_daemon_launched` is ever set), with no side effect in any.
+# branch on THIS, not on harness *presence*: where the harness IS installed it only
+# captures logs when the daemon launched the session, so gating on presence silently
+# drops every record in a plain/editor run. (A supported `gda export run` artifact
+# OMITS the harness entirely per ADR-0028, so this predicate is not even present to
+# call there — game code must resolve the autoload by node path and null-check it, as
+# the `GdaHarness` global does not parse when absent.) A game-side logging helper gates
+# on this predicate and falls back to `print()` when the node is absent or the predicate
+# is false. It is a PURE READ — no connection, no output, no state change — so the
+# ADR-0018 inert-when-dormant guarantee holds: it returns false in a human editor run, a
+# plain run, and an export that BYPASSED `gda export run` (the harness physically present
+# but inert — `_ready` returns at the `template` gate before `_daemon_launched` is ever
+# set), with no side effect in any.
 func is_daemon_launched() -> bool:
 	return _daemon_launched
 

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -951,6 +951,20 @@ func _error(code: String, message: String) -> String:
 	return RESULT_BEGIN + JSON.stringify({"error": {"code": code, "message": message}}) + RESULT_END
 
 
+# The PUBLIC, stable predicate reporting whether gda-daemon launched this run (#362)
+# — the SAME condition `gda_log()` gates on (`_daemon_launched`). Game code should
+# branch on THIS, not on harness *presence*: once installed, `/root/GdaHarness` exists
+# in every run, but the harness only captures logs when the daemon launched the
+# session, so gating on presence silently drops every record in a plain/editor/exported
+# run. A game-side logging helper instead gates on this predicate and falls back to
+# `print()` when it is false. It is a PURE READ — no connection, no output, no state
+# change — so the ADR-0018 inert-when-dormant guarantee holds: it returns false in a
+# human editor run, a plain run, and an exported build (where `_ready` returns at the
+# `template` gate before `_daemon_launched` is ever set), with no side effect in any.
+func is_daemon_launched() -> bool:
+	return _daemon_launched
+
+
 # The active opt-in rich-log protocol (#282, ADR-0026). Project code in a live
 # session calls `GdaHarness.gda_log(level, message, fields)` to emit ONE fully
 # structured, field-carrying log record. It prints a single `<<<GDA:LOG>>>{json}`

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -41,7 +41,7 @@ HARNESS_RES_PATH = f"res://{HARNESS_RES_DIR}/{HARNESS_FILE}"
 # copy to it (#225). The installed copy declares its version in a leading header
 # (`# gda-harness-version: <N>`); a mismatch re-materializes via the content
 # compare. NOT the package version — the harness changes far less often.
-HARNESS_VERSION = "3"
+HARNESS_VERSION = "4"
 
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -90,17 +90,21 @@ the first live op. `screen capture` needs a windowed session
 
 To emit a record `gda logger tail` reads back as a rich, field-carrying `LogRecord`,
 call the harness autoload from your GDScript — but **gate it on the daemon-launched
-predicate, not on harness presence**. Once installed, `/root/GdaHarness` exists in
-*every* run, yet it only captures logs when `gda-daemon` launched the session; gating
-on presence silently drops every record in a plain run, a human editor run, or an
-exported build. Gate on `GdaHarness.is_daemon_launched()` (a pure read) and fall back
-to `print()` when it is false, so no record is lost:
+predicate, not on harness presence**. The harness is present only where it was
+installed, and a supported `gda export run` artifact omits it entirely (ADR-0028), so
+resolve it by node path and null-check it — never the `GdaHarness` global, which fails
+to *parse* when the autoload is absent (a stripped export build, a project before
+`gda daemon start`, or after `gda daemon uninstall`), taking the whole script down with
+it. Even where it is present, it only captures logs when `gda-daemon` launched the
+session. Resolve the node, then gate on `is_daemon_launched()` (a pure read), falling
+back to `print()` when it is absent or dormant so no record is lost:
 
 ```gdscript
-if GdaHarness.is_daemon_launched():
-    GdaHarness.gda_log("info", "player spawned", {"hp": 100})
+var harness := get_node_or_null("/root/GdaHarness")
+if harness != null and harness.is_daemon_launched():
+    harness.gda_log("info", "player spawned", {"hp": 100})
 else:
-    print("player spawned")  # dormant: gda_log() would be a silent no-op
+    print("player spawned")  # absent or dormant: gda_log() would be a silent no-op
 ```
 
 ## Worked example

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -86,6 +86,23 @@ the first live op. `screen capture` needs a windowed session
 | `input` | `key`, `mouse-click`, `mouse-move`, `action`, `sequence` |
 | `screen` | `capture`, `frames` (viewport PNGs; needs `--windowed`) |
 
+### Structured logging from game code
+
+To emit a record `gda logger tail` reads back as a rich, field-carrying `LogRecord`,
+call the harness autoload from your GDScript — but **gate it on the daemon-launched
+predicate, not on harness presence**. Once installed, `/root/GdaHarness` exists in
+*every* run, yet it only captures logs when `gda-daemon` launched the session; gating
+on presence silently drops every record in a plain run, a human editor run, or an
+exported build. Gate on `GdaHarness.is_daemon_launched()` (a pure read) and fall back
+to `print()` when it is false, so no record is lost:
+
+```gdscript
+if GdaHarness.is_daemon_launched():
+    GdaHarness.gda_log("info", "player spawned", {"hp": 100})
+else:
+    print("player spawned")  # dormant: gda_log() would be a silent no-op
+```
+
 ## Worked example
 
 Headless: build and export a scene.

--- a/tests/test_e2e_logger.py
+++ b/tests/test_e2e_logger.py
@@ -47,6 +47,12 @@ extends Node2D
 
 func _ready() -> void:
 	GdaHarness.gda_log("warning", "known gda_log", {"k": 1})
+	# #362: the recommended pattern — gate the structured log on the daemon-launched
+	# predicate. In this daemon-launched session it is true, so this record emits;
+	# `logger tail` reading it back proves the public predicate observes the SAME
+	# condition gda_log() gates on.
+	if GdaHarness.is_daemon_launched():
+		GdaHarness.gda_log("info", "predicate gated log", {})
 	print("known line")
 	push_warning("known warning")
 	push_error("known error")
@@ -127,6 +133,15 @@ def test_logger_tail_reads_back_structured_records_and_raw_lines(
         assert rich[0]["fields"] == {"k": 1}
         assert rich[0]["source"] is None
 
+        # #362: the log gated on `GdaHarness.is_daemon_launched()` emitted, so the
+        # public predicate returned true in this daemon-launched session — the same
+        # condition gda_log() gates on, now observable by game code without reaching
+        # into the private `_daemon_launched` var.
+        records = poll_records([], "predicate gated log")
+        gated = [r for r in records if "predicate gated log" in r["message"]]
+        assert gated, records
+        assert gated[0]["origin"] == "gda_log"
+
         # Default: structured records. The known print is a plain `info` record.
         records = poll_records([], "known line")
         info = [r for r in records if "known line" in r["message"]]
@@ -179,11 +194,15 @@ def test_logger_tail_reads_back_structured_records_and_raw_lines(
 
 # A main scene that calls gda_log() in a PLAIN run (no daemon). It prints a marker so
 # the test can confirm the game actually ran, then quits so the headless run returns.
+# #362: it also asserts the PUBLIC predicate reports the dormant state (false in a
+# plain run), the fact game code branches on with a print() fallback.
 PLAIN_MAIN_GD = """\
 extends Node2D
 
 func _ready() -> void:
 	GdaHarness.gda_log("warning", "should-not-leak", {"k": 1})
+	if not GdaHarness.is_daemon_launched():
+		print("PREDICATE-FALSE-CONFIRMED")
 	print("PLAIN-RUN-RAN")
 	get_tree().quit()
 """
@@ -215,3 +234,7 @@ def test_gda_log_is_inert_outside_a_daemon_launched_session(tmp_path):
     out = proc.stdout + proc.stderr
     assert "PLAIN-RUN-RAN" in out, out  # the game actually ran its _ready
     assert "<<<GDA:LOG>>>" not in out, out  # gda_log() was inert (no daemon) — no leak
+    # #362: the public predicate reported the dormant state — false in a plain run — so
+    # game code can gate its logging on it (and fall back to print) without touching
+    # the private `_daemon_launched` var.
+    assert "PREDICATE-FALSE-CONFIRMED" in out, out

--- a/tests/test_harness_install.py
+++ b/tests/test_harness_install.py
@@ -49,6 +49,19 @@ def test_install_materializes_harness_and_writes_autoload_entry(tmp_path):
     assert _autoload_line() in text
 
 
+def test_installed_harness_carries_the_daemon_launched_predicate(tmp_path):
+    # #362: the public `is_daemon_launched()` predicate must travel into the INSTALLED
+    # copy — install copies the bundled source verbatim, so the change is not confined
+    # to the in-repo file. Game code gates its logging on this predicate, so a project
+    # that installed the harness must carry it.
+    (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
+
+    install_harness(tmp_path)
+
+    body = _harness_file(tmp_path).read_text(encoding="utf-8")
+    assert "func is_daemon_launched() -> bool:" in body
+
+
 def test_install_is_idempotent(tmp_path):
     (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
 


### PR DESCRIPTION
Refs #362

## What

Adds a **public, pure-read predicate** `GdaHarness.is_daemon_launched()` on the harness autoload, returning `true` iff `gda-daemon` launched this run — the *same* condition `gda_log()` already gates on (`_daemon_launched`). Game code can now gate structured logging on the **daemon-launched state**, not on harness *presence*, and fall back to `print()` when dormant instead of silently dropping every record.

Per the Agent Brief, direction 3 from the issue (degrading `gda_log()` to `print()` when dormant) is **rejected** — a print is a non-inert side effect that breaks ADR-0018. This change fixes *discoverability* of the condition, not the condition's behavior. No error codes added.

## Changes

- **`src/gda/harness/gda_harness.gd`** — new `func is_daemon_launched() -> bool` returning the existing private `_daemon_launched` (deep-module reuse — no duplicated launch-marker / inert-gating logic). A pure read: no connection, no print, no state change. Returns `false` in a human editor run, a plain run, and an exported build (where `_ready` returns at the `template` gate before `_daemon_launched` is set), preserving the ADR-0018 inert-when-dormant guarantee.
- **`src/gda/harness/install.py`** — `HARNESS_VERSION` `3` → `4` so already-installed copies self-sync the new body (the version header stays honest with the changed harness).
- **`src/gda/skill/SKILL.md`** — new *Structured logging from game code* subsection in the **logging area** documenting the "gate on `is_daemon_launched()`, not presence" pattern with a snippet.
- **`tests/test_harness_install.py`** — fast test: the **installed** copy carries the predicate.
- **`tests/test_e2e_logger.py`** — e2e: (a) a daemon-launched session → a `gda_log` gated on the predicate emits and `gda logger tail` reads it back (predicate true); (b) a plain run → predicate false, `gda_log()` stays a no-op (no `<<<GDA:LOG>>>` leak), and the fallback path fires.

## Tests

- Fast tier: `uv run pytest -m "not e2e"` → **1025 passed**.
- e2e: `pytest tests/test_e2e_logger.py -m e2e` → **2 passed**; `tests/test_e2e_harness_install.py -m e2e` → **3 passed** (installed harness with the new body still boots inert).
- Lint/format/type: `ruff check` clean, `ruff format --check` clean, `pyright` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)