### PR TITLE
feat(ops): assign a Resource to an Object-typed property by res:// ref (#363)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -121,6 +121,11 @@ operation, and parse codes the CLI assigns).
 | `cyclic_target` | `operation` | `operation` | `4` | A node move targeted the node itself or one of its own descendants, which would detach the moved subtree from the scene. |
 | `unknown_property` | `operation` | `operation` | `4` | A requested property does not exist as a settable property on the target node or resource. |
 | `uncoercible_value` | `operation` | `operation` | `4` | A supplied value cannot be coerced to the property's declared Godot type. |
+| `expected_resource_path` | `operation` | `operation` | `4` | An Object-typed property was given a value that is not a `res://` resource path; assign an existing Resource by its `res://` path (ADR-0033, #363). |
+| `not_a_resource` | `operation` | `operation` | `4` | A `res://` value for an Object-typed property does not load as a Resource (the path is missing or does not name a resource) (ADR-0033, #363). |
+| `resource_type_mismatch` | `operation` | `operation` | `4` | A `res://` resource's type is incompatible with the Object-typed property's expected engine class (ADR-0033, #363). |
+| `use_script_attach` | `operation` | `operation` | `4` | The `script` property is bound with `gda script attach` (which verifies the script compiles and its base type matches), not with `node set` / `resource set` (ADR-0033, #363). |
+| `unsupported_property_type` | `operation` | `operation` | `4` | An Object-typed property expects a type `node set` / `resource set` cannot yet assign a `res://` resource to: a script `class_name`-typed property (deferred to the ADR-0032 resolver) or an Object property with no declared engine class (ADR-0033, #363). |
 | `no_search_match` | `operation` | `operation` | `4` | A search-replace script edit found no occurrence of the search string. |
 | `invalid_line_range` | `operation` | `operation` | `4` | A line-range script edit specified lines outside the script's bounds, or end before start. |
 | `script_compile_failed` | `operation` | `operation` | `4` | A script could not be attached to a node because it does not compile. |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -142,6 +142,26 @@ Whitespace around a value or a component is tolerated. A property of any other t
 reported by `node get` (its value degrades to a string projection), but `node set` cannot coerce
 to it yet and refuses with `uncoercible_value` — the coercible set grows as later slices need it.
 
+**Object-typed property assignment by `res://` reference** (ADR-0033, #363): for an **Object-typed**
+property that expects a Resource (sub)class — e.g. a `CollisionShape2D`'s `shape` (`Shape2D`) — `gda
+node set` and `gda resource set` accept a **`res://….tres` resource path** as `--value`. The path is
+`load()`ed, **type-checked** against the property's declared **engine** class, and assigned as an
+**external reference** (`ext_resource`); the resource is **not inlined**. Combined with `resource
+create` and `resource set` this completes the external sub-resource workflow with no new command
+(`resource create res://box.tres --type RectangleShape2D` → `resource set … --property size --value
+32,64` → `node set scene.tscn --node Col --property shape --value res://box.tres`). The result echoes
+`type` `"Object"` and `value` the assigned `res://` path (pass `--project` so `res://` resolves). This
+is a **separate, headless-only** step from the shared coercion above — value coercion keys only off
+the Variant type, but resolving an Object needs the expected-class hint on the property-list entry — so
+assigning a Resource on the live `gda game set` is **out of scope** and the coercion mirror is
+untouched. Its failure modes are **distinct structured codes**, never `uncoercible_value`: a non-`res://`
+value is `expected_resource_path`; a path that does not load as a Resource is `not_a_resource`; a loaded
+resource whose type is incompatible with the property's expected class is `resource_type_mismatch`. The
+**`script` property is excluded** and routed to `script attach` (#118) — setting it returns the
+actionable `use_script_attach` error, never a second script-binding entry. A property typed as a script
+`class_name` (rather than an engine class) is **deferred** (its validation will reuse ADR-0032's
+resolver) and refused with `unsupported_property_type`.
+
 This coercion contract — the accepted string forms above, the declared-type target, and the
 `unknown_property` / `uncoercible_value` failures — is **shared by other property-bearing
 commands**, not specific to nodes. `gda resource set` (#120) applies the same #55 coercion to the

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -263,6 +263,52 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCodeSource.OPERATION,
         "A supplied value cannot be coerced to the property's declared Godot type.",
     ),
+    # Object-typed property assignment via a res:// resource reference (ADR-0033,
+    # #363): node set / resource set assign an EXISTING Resource, referenced by a
+    # res:// path, to an Object-typed property that expects a Resource (sub)class.
+    # These five distinguish the failure modes from the generic uncoercible_value —
+    # each is an operation-source code, so all are GDScript-mirrored in operations.gd.
+    ErrorCodeSpec(
+        "expected_resource_path",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "An Object-typed property was given a value that is not a res:// resource "
+        "path; assign an existing Resource by its res:// path.",
+    ),
+    ErrorCodeSpec(
+        "not_a_resource",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A res:// value for an Object-typed property does not load as a Resource "
+        "(the path is missing or does not name a resource).",
+    ),
+    ErrorCodeSpec(
+        "resource_type_mismatch",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A res:// resource's type is incompatible with the Object-typed property's "
+        "expected engine class.",
+    ),
+    ErrorCodeSpec(
+        "use_script_attach",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "The script property is bound with `gda script attach` (which verifies the "
+        "script compiles and its base type matches), not with node set / resource set.",
+    ),
+    ErrorCodeSpec(
+        "unsupported_property_type",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "An Object-typed property expects a type node set / resource set cannot yet "
+        "assign a res:// resource to: a script class_name-typed property (deferred to "
+        "the ADR-0032 resolver) or an Object property with no declared engine class.",
+    ),
     ErrorCodeSpec(
         "no_search_match",
         ErrorCategory.OPERATION,

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -48,6 +48,12 @@ const OP_ERROR_CANNOT_TARGET_ROOT := "cannot_target_root"
 const OP_ERROR_CYCLIC_TARGET := "cyclic_target"
 const OP_ERROR_UNKNOWN_PROPERTY := "unknown_property"
 const OP_ERROR_UNCOERCIBLE_VALUE := "uncoercible_value"
+# Object-typed property assignment via a res:// resource reference (ADR-0033, #363).
+const OP_ERROR_EXPECTED_RESOURCE_PATH := "expected_resource_path"
+const OP_ERROR_NOT_A_RESOURCE := "not_a_resource"
+const OP_ERROR_RESOURCE_TYPE_MISMATCH := "resource_type_mismatch"
+const OP_ERROR_USE_SCRIPT_ATTACH := "use_script_attach"
+const OP_ERROR_UNSUPPORTED_PROPERTY_TYPE := "unsupported_property_type"
 const OP_ERROR_NO_SEARCH_MATCH := "no_search_match"
 const OP_ERROR_INVALID_LINE_RANGE := "invalid_line_range"
 const OP_ERROR_SCRIPT_COMPILE_FAILED := "script_compile_failed"
@@ -616,20 +622,36 @@ func _op_node_set(params: Dictionary) -> void:
 		return
 
 	var raw_value := _string_param(params, "value")
-	var coerced: Variant = _coerce_value(raw_value, declared_type)
-	if coerced == null:
-		root.free()
-		_fail(OP_ERROR_UNCOERCIBLE_VALUE, "cannot coerce value " + raw_value.c_escape()
-				+ " to " + _type_name(declared_type) + " for property " + prop_name
-				+ " on node " + node_path)
-		return
+	var stored_value: Variant
+	if declared_type == TYPE_OBJECT:
+		# Object-typed property: assign an EXISTING Resource referenced by a res://
+		# path (ADR-0033, #363). A separate, headless-only step from the shared
+		# _coerce_value (it needs the expected-class hint the (raw, type) signature
+		# cannot carry); it records its own distinct structured failure.
+		var resolved := _resolve_object_value(prop_name,
+				_storage_property_entry(node, prop_name), raw_value, "node " + node_path)
+		if resolved == null:
+			root.free()
+			return  # _resolve_object_value already recorded the failure
+		node.set(prop_name, resolved)
+		# The assigned reference round-trips as its res:// path; the loaded resource
+		# carries a resource_path, so re-packing serializes it as an ext_resource.
+		stored_value = resolved.resource_path
+	else:
+		var coerced: Variant = _coerce_value(raw_value, declared_type)
+		if coerced == null:
+			root.free()
+			_fail(OP_ERROR_UNCOERCIBLE_VALUE, "cannot coerce value " + raw_value.c_escape()
+					+ " to " + _type_name(declared_type) + " for property " + prop_name
+					+ " on node " + node_path)
+			return
 
-	node.set(prop_name, coerced)
+		node.set(prop_name, coerced)
 
-	# Read the value back off the node before re-saving frees the tree — the node
-	# now holds the coerced value in its canonical form, the same projection
-	# node-get reports.
-	var stored_value: Variant = _jsonify(node.get(prop_name))
+		# Read the value back off the node before re-saving frees the tree — the node
+		# now holds the coerced value in its canonical form, the same projection
+		# node-get reports.
+		stored_value = _jsonify(node.get(prop_name))
 	if not _repack_and_save(root, path):
 		return  # _repack_and_save already recorded the failure (and freed root)
 
@@ -1620,14 +1642,33 @@ func _op_resource_set(params: Dictionary) -> void:
 		return
 
 	var raw_value := _string_param(params, "value")
-	var coerced: Variant = _coerce_value(raw_value, declared_type)
-	if coerced == null:
-		_fail(OP_ERROR_UNCOERCIBLE_VALUE, "cannot coerce value " + raw_value.c_escape()
-				+ " to " + _type_name(declared_type) + " for property " + prop_name
-				+ " on resource " + path)
-		return
+	var stored_value: Variant
+	if declared_type == TYPE_OBJECT:
+		# Object-typed property: assign an EXISTING Resource referenced by a res://
+		# path (ADR-0033, #363) — the resource-on-resource counterpart of node set's
+		# Object branch. Headless-only, separate from the shared _coerce_value; it
+		# records its own distinct structured failure.
+		var resolved := _resolve_object_value(prop_name,
+				_storage_property_entry(resource, prop_name), raw_value, "resource " + path)
+		if resolved == null:
+			return  # _resolve_object_value already recorded the failure
+		resource.set(prop_name, resolved)
+		# The assigned reference round-trips as its res:// path; the loaded resource
+		# carries a resource_path, so re-saving serializes it as an ext_resource.
+		stored_value = resolved.resource_path
+	else:
+		var coerced: Variant = _coerce_value(raw_value, declared_type)
+		if coerced == null:
+			_fail(OP_ERROR_UNCOERCIBLE_VALUE, "cannot coerce value " + raw_value.c_escape()
+					+ " to " + _type_name(declared_type) + " for property " + prop_name
+					+ " on resource " + path)
+			return
+		resource.set(prop_name, coerced)
+		# Read the value back off the resource before reporting — it now holds the
+		# coerced value in its canonical form, the same projection resource get
+		# reports, so a set round-trips through a get.
+		stored_value = _jsonify(resource.get(prop_name))
 
-	resource.set(prop_name, coerced)
 	# Recheck before the write (issue #226): refuse if a concurrent editor changed the
 	# .tres in the read->write window.
 	if not _check_unchanged():
@@ -1637,10 +1678,6 @@ func _op_resource_set(params: Dictionary) -> void:
 		_fail(OP_ERROR_SAVE_FAILED, _save_failure_message("resource", path, save_err))
 		return
 
-	# Read the value back off the resource before reporting — it now holds the
-	# coerced value in its canonical form, the same projection resource get
-	# reports, so a set round-trips through a get.
-	var stored_value: Variant = _jsonify(resource.get(prop_name))
 	_succeed({
 		"path": path,
 		"property": prop_name,
@@ -3742,6 +3779,106 @@ func _tree_from_state(state: SceneState, with_paths := false) -> Dictionary:
 			if parent != null:
 				parent["children"].append(node)
 	return root
+
+
+# --- Object-typed property assignment via a res:// resource reference (ADR-0033, #363) ---
+#
+# node set / resource set assign an EXISTING Resource — referenced by a `res://`
+# path — to an Object-typed property that expects a Resource (sub)class (e.g.
+# CollisionShape2D.shape). This is a SEPARATE, headless-only step from the shared
+# _coerce_value block below: value coercion keys only off the Variant.Type, but
+# resolving an Object needs the property's expected-CLASS hint, which lives on the
+# property-list entry — so this deliberately is NOT mirrored into the harness (a
+# live `game set` Object assignment is out of scope, ADR-0033) and the byte-identical
+# coercion mirror stays untouched.
+#
+# The full storage-property list entry (name/type/hint/hint_string/class_name/usage)
+# for `prop_name` on `target` (a Node or a Resource — both are Objects with a
+# property list), or an empty Dictionary when the target has no storage property by
+# that name. The shared _property_type returns only the Variant.Type, which cannot
+# carry the expected-class hint the Object step needs, so this reads the whole entry.
+func _storage_property_entry(target: Object, prop_name: String) -> Dictionary:
+	for prop in target.get_property_list():
+		if String(prop.get("name", "")) == prop_name and _is_storage_property(prop):
+			return prop
+	return {}
+
+
+# The engine/script class an Object-typed property expects, read off its
+# property-list entry. Godot records it in the entry's `class_name` (a StringName,
+# e.g. &"Shape2D" for CollisionShape2D.shape, &"PlayerConfig" for a script
+# class_name-typed export) and mirrors it in `hint_string` under
+# PROPERTY_HINT_RESOURCE_TYPE. Returns "" when neither names a class.
+func _object_expected_class(prop_entry: Dictionary) -> String:
+	var cls := String(prop_entry.get("class_name", ""))
+	if not cls.is_empty():
+		return cls
+	if int(prop_entry.get("hint", PROPERTY_HINT_NONE)) == PROPERTY_HINT_RESOURCE_TYPE:
+		return String(prop_entry.get("hint_string", ""))
+	return ""
+
+
+# Resolve a `res://` --value into the EXISTING Resource to assign to an Object-typed
+# property (ADR-0033). Returns the loaded Resource on success, or null AFTER recording
+# a DISTINCT structured failure (the caller stops; unlike _coerce_value's null, the
+# caller must NOT fall back to uncoercible_value). `subject` names the target in
+# messages ("node Player/Col" / "resource res://foo.tres"). The failure modes:
+#   - the `script` property is bound only by `script attach` (#118) → use_script_attach;
+#   - a non-`res://` value → expected_resource_path;
+#   - a property typed as a script class_name (not an engine class) is deferred to the
+#     ADR-0032 resolver → unsupported_property_type (type-check scope is engine classes);
+#   - a path that does not load as a Resource → not_a_resource;
+#   - a loaded Resource whose type is incompatible with the expected class →
+#     resource_type_mismatch.
+func _resolve_object_value(prop_name: String, prop_entry: Dictionary, raw_value: String, subject: String) -> Resource:
+	# The `script` property is bound with `script attach` — the one authoritative
+	# script-binding path (compile + base-type verification + replaced-script report,
+	# #118). Route it there rather than adding a second, unverified attach entry.
+	if prop_name == "script":
+		_fail(OP_ERROR_USE_SCRIPT_ATTACH, "property script on " + subject
+				+ " is bound with `gda script attach`, not `set` — it verifies the script"
+				+ " compiles and its base type matches, and reports any replaced script")
+		return null
+
+	# An Object-typed property takes an existing Resource by its res:// path. A
+	# non-res:// value is a distinct structured failure, never the generic
+	# uncoercible_value.
+	if not raw_value.begins_with("res://"):
+		_fail(OP_ERROR_EXPECTED_RESOURCE_PATH, "property " + prop_name + " on " + subject
+				+ " expects a Resource; assign an existing resource by its res:// path"
+				+ " (e.g. res://shapes/box.tres), not " + raw_value.c_escape())
+		return null
+
+	# Type-check scope is ENGINE-class-typed Object properties (e.g. shape: Shape2D).
+	# A property typed as a script `class_name` names a class ClassDB does not know;
+	# its validation is deferred to the ADR-0032 class_name resolver (ADR-0033), so
+	# refuse it distinctly rather than mis-type-check it against the engine hierarchy.
+	var expected_class := _object_expected_class(prop_entry)
+	if expected_class.is_empty() or not ClassDB.class_exists(expected_class):
+		var named := expected_class if not expected_class.is_empty() else "an unspecified Object type"
+		_fail(OP_ERROR_UNSUPPORTED_PROPERTY_TYPE, "property " + prop_name + " on " + subject
+				+ " expects " + named + ", which is not an engine class — assigning a Resource to"
+				+ " a script class_name-typed property is not yet supported (deferred, ADR-0033)")
+		return null
+
+	# Load the referenced resource. A missing path, or a file that is not a resource,
+	# yields null here (the engine logs why to stderr) → a distinct structured failure,
+	# never uncoercible_value. res:// resolution needs project context (pass --project).
+	var loaded := ResourceLoader.load(raw_value) as Resource
+	if loaded == null:
+		_fail(OP_ERROR_NOT_A_RESOURCE, "value does not load as a Resource: " + raw_value
+				+ " — check the res:// path exists and names a resource (pass --project so res:// resolves)")
+		return null
+
+	# is_class walks the engine class hierarchy, so a RectangleShape2D satisfies a
+	# Shape2D-typed property while a Gradient does not.
+	if not loaded.is_class(expected_class):
+		_fail(OP_ERROR_RESOURCE_TYPE_MISMATCH, "resource " + raw_value + " is a "
+				+ loaded.get_class() + ", incompatible with property " + prop_name + " on "
+				+ subject + " (expects " + expected_class + ")")
+		return null
+
+	return loaded
 
 
 # --- BEGIN shared coercion (keep byte-identical: operations.gd <-> gda_harness.gd) ---

--- a/tests/test_e2e_object_property.py
+++ b/tests/test_e2e_object_property.py
@@ -1,0 +1,342 @@
+"""S1 (e2e): assign an EXISTING Resource by res:// path to an Object-typed property.
+
+The Object-assignment slice (issue #363, ADR-0033): ``gda node set`` and ``gda
+resource set`` accept a ``res://….tres`` ``--value`` for an Object-typed property
+that expects a Resource (sub)class (e.g. ``CollisionShape2D.shape``). The path is
+``load()``ed, type-checked against the property's declared ENGINE class, and
+assigned as an EXTERNAL reference (``ext_resource``) — never inlined. Combined with
+``resource create`` and ``resource set`` this completes the external sub-resource
+workflow with no new command:
+
+    gda resource create res://shapes/box.tres --type RectangleShape2D
+    gda resource set    res://shapes/box.tres --property size  --value 32,64
+    gda node set res://main.tscn --node Col --property shape --value res://shapes/box.tres
+
+These tests dispatch through the real engine (``operations.gd``), not a stub: the
+happy path proves the saved file reloads with the resource wired as an
+``ext_resource``, and each failure mode proves a DISTINCT structured code (never
+the generic ``uncoercible_value``), leaving the target file untouched.
+"""
+
+import json
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+from tests.support import GDA_CMD
+
+GODOT = resolve_godot_binary()
+
+
+def _gda_project(project):
+    """A ``gda`` bound to ``--godot`` and ``--project`` so ``res://`` resolves."""
+
+    def gda(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
+            capture_output=True,
+            text=True,
+        )
+
+    return gda
+
+
+def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
+    assert proc.returncode == 4, proc.stdout + proc.stderr
+    err = json.loads(proc.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == code
+    return err
+
+
+def _scene_with_collision_shape(gda, project):
+    """A scene ``res://main.tscn`` whose root has a ``CollisionShape2D`` 'Col'.
+
+    ``Col.shape`` is an engine-class-typed Object property (expects ``Shape2D``) —
+    the canonical target for the Object-assignment slice.
+    """
+    created = gda(
+        "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+    )
+    assert created.returncode == 0, created.stdout + created.stderr
+    added = gda(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--type",
+        "CollisionShape2D",
+        "--name",
+        "Col",
+        "--json",
+    )
+    assert added.returncode == 0, added.stdout + added.stderr
+    return project / "main.tscn"
+
+
+def _box_shape(gda, project):
+    """A ``res://box.tres`` RectangleShape2D (a Shape2D) with a set size."""
+    created = gda(
+        "resource", "create", "res://box.tres", "--type", "RectangleShape2D", "--json"
+    )
+    assert created.returncode == 0, created.stdout + created.stderr
+    was_set = gda(
+        "resource",
+        "set",
+        "res://box.tres",
+        "--property",
+        "size",
+        "--value",
+        "32,64",
+        "--json",
+    )
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    return project / "box.tres"
+
+
+@pytest.mark.e2e
+def test_node_set_object_property_wires_ext_resource_end_to_end(godot_project):
+    # The core acceptance criterion (ADR-0033): the full create → set → node set
+    # workflow wires CollisionShape2D.shape to an existing RectangleShape2D by its
+    # res:// path, and the saved scene reloads with the resource attached as an
+    # EXTERNAL reference (ext_resource), never inlined.
+    gda = _gda_project(godot_project)
+    scene_path = _scene_with_collision_shape(gda, godot_project)
+    _box_shape(gda, godot_project)
+
+    was_set = gda(
+        "node",
+        "set",
+        "res://main.tscn",
+        "--node",
+        "Col",
+        "--property",
+        "shape",
+        "--value",
+        "res://box.tres",
+        "--json",
+    )
+
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    data = json.loads(was_set.stdout)
+    assert data["property"] == "shape"
+    # The declared Godot type is Object; the assigned value round-trips as the
+    # res:// reference (not an inlined blob).
+    assert data["type"] == "Object"
+    assert data["value"] == "res://box.tres"
+
+    # The mutation is on disk as an EXTERNAL reference: an [ext_resource ...] entry
+    # for the .tres and a `shape = ExtResource(...)` binding — not an inlined
+    # [sub_resource].
+    saved = scene_path.read_text(encoding="utf-8")
+    assert 'ext_resource type="Shape2D" path="res://box.tres"' in saved
+    assert "shape = ExtResource(" in saved
+    assert "[sub_resource" not in saved
+
+    # The saved scene reloads cleanly (the ext_resource resolves), so node get sees
+    # the addressed node again — proving the wiring is not a torn file.
+    got = gda("node", "get", "res://main.tscn", "--node", "Col", "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    assert json.loads(got.stdout)["type"] == "CollisionShape2D"
+
+
+@pytest.mark.e2e
+def test_resource_set_object_property_wires_ext_resource(godot_project):
+    # The resource-on-resource half (ADR-0033): resource set assigns an existing
+    # Gradient to GradientTexture1D.gradient (an engine-class-typed Object property)
+    # by res:// path, saved as an ext_resource on the .tres.
+    gda = _gda_project(godot_project)
+    tex = gda(
+        "resource", "create", "res://tex.tres", "--type", "GradientTexture1D", "--json"
+    )
+    assert tex.returncode == 0, tex.stdout + tex.stderr
+    grad = gda("resource", "create", "res://grad.tres", "--type", "Gradient", "--json")
+    assert grad.returncode == 0, grad.stdout + grad.stderr
+
+    was_set = gda(
+        "resource",
+        "set",
+        "res://tex.tres",
+        "--property",
+        "gradient",
+        "--value",
+        "res://grad.tres",
+        "--json",
+    )
+
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    data = json.loads(was_set.stdout)
+    assert data["property"] == "gradient"
+    assert data["type"] == "Object"
+    assert data["value"] == "res://grad.tres"
+
+    saved = (godot_project / "tex.tres").read_text(encoding="utf-8")
+    assert 'ext_resource type="Gradient" path="res://grad.tres"' in saved
+    assert "gradient = ExtResource(" in saved
+
+
+@pytest.mark.e2e
+def test_node_set_object_type_mismatch_yields_resource_type_mismatch(godot_project):
+    # A res:// resource whose type is incompatible with the property's expected
+    # engine class is a DISTINCT resource_type_mismatch — not uncoercible_value —
+    # naming both the actual and the expected class; the scene is left untouched.
+    gda = _gda_project(godot_project)
+    scene_path = _scene_with_collision_shape(gda, godot_project)
+    grad = gda("resource", "create", "res://grad.tres", "--type", "Gradient", "--json")
+    assert grad.returncode == 0, grad.stdout + grad.stderr
+    before = scene_path.read_text(encoding="utf-8")
+
+    was_set = gda(
+        "node",
+        "set",
+        "res://main.tscn",
+        "--node",
+        "Col",
+        "--property",
+        "shape",
+        "--value",
+        "res://grad.tres",
+        "--json",
+    )
+
+    err = _assert_operation_error(was_set, "resource_type_mismatch")
+    assert "Gradient" in err["message"]
+    assert "Shape2D" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_node_set_object_non_res_value_yields_expected_resource_path(godot_project):
+    # A non-res:// value for an Object-typed property is a DISTINCT
+    # expected_resource_path (a comma-form scalar that would coerce for a Vector2 is
+    # NOT accepted here) — not uncoercible_value; the scene is left untouched.
+    gda = _gda_project(godot_project)
+    scene_path = _scene_with_collision_shape(gda, godot_project)
+    before = scene_path.read_text(encoding="utf-8")
+
+    was_set = gda(
+        "node",
+        "set",
+        "res://main.tscn",
+        "--node",
+        "Col",
+        "--property",
+        "shape",
+        "--value",
+        "32,64",
+        "--json",
+    )
+
+    err = _assert_operation_error(was_set, "expected_resource_path")
+    assert "res://" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_node_set_object_missing_resource_yields_not_a_resource(godot_project):
+    # A res:// value that does not load as a Resource (here: no such path) is a
+    # DISTINCT not_a_resource — not uncoercible_value; the scene is left untouched.
+    gda = _gda_project(godot_project)
+    scene_path = _scene_with_collision_shape(gda, godot_project)
+    before = scene_path.read_text(encoding="utf-8")
+
+    was_set = gda(
+        "node",
+        "set",
+        "res://main.tscn",
+        "--node",
+        "Col",
+        "--property",
+        "shape",
+        "--value",
+        "res://nope.tres",
+        "--json",
+    )
+
+    err = _assert_operation_error(was_set, "not_a_resource")
+    assert "res://nope.tres" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_node_set_non_resource_file_yields_not_a_resource(godot_project):
+    # A res:// path that exists but is NOT a resource (a plain text file) also fails
+    # not_a_resource — the failure is "does not load as a Resource", not merely
+    # "missing path".
+    gda = _gda_project(godot_project)
+    scene_path = _scene_with_collision_shape(gda, godot_project)
+    (godot_project / "notes.txt").write_text("not a resource\n", encoding="utf-8")
+    before = scene_path.read_text(encoding="utf-8")
+
+    was_set = gda(
+        "node",
+        "set",
+        "res://main.tscn",
+        "--node",
+        "Col",
+        "--property",
+        "shape",
+        "--value",
+        "res://notes.txt",
+        "--json",
+    )
+
+    err = _assert_operation_error(was_set, "not_a_resource")
+    assert "res://notes.txt" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_node_set_script_property_yields_use_script_attach(godot_project):
+    # The script property is EXCLUDED from the generic Object path and routed to
+    # `script attach` (#118) — the one authoritative script-binding path. Setting it
+    # returns an ACTIONABLE structured error naming `script attach`, never a second
+    # attach entry; the scene is left untouched.
+    gda = _gda_project(godot_project)
+    scene_path = _scene_with_collision_shape(gda, godot_project)
+    (godot_project / "foo.gd").write_text("extends Node2D\n", encoding="utf-8")
+    before = scene_path.read_text(encoding="utf-8")
+
+    was_set = gda(
+        "node",
+        "set",
+        "res://main.tscn",
+        "--node",
+        "Col",
+        "--property",
+        "script",
+        "--value",
+        "res://foo.gd",
+        "--json",
+    )
+
+    err = _assert_operation_error(was_set, "use_script_attach")
+    assert "script attach" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_node_set_value_typed_coercion_is_unchanged(godot_project):
+    # Regression: the Object branch must not disturb value-typed coercion — a
+    # Vector2 property still coerces from the comma form and round-trips as a JSON
+    # number pair (the #55 contract, unchanged by ADR-0033).
+    gda = _gda_project(godot_project)
+    _scene_with_collision_shape(gda, godot_project)
+
+    was_set = gda(
+        "node",
+        "set",
+        "res://main.tscn",
+        "--node",
+        "Col",
+        "--property",
+        "position",
+        "--value",
+        "3,4",
+        "--json",
+    )
+
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    data = json.loads(was_set.stdout)
+    assert data["type"] == "Vector2"
+    assert data["value"] == [3.0, 4.0]

--- a/tests/test_e2e_object_property.py
+++ b/tests/test_e2e_object_property.py
@@ -42,6 +42,23 @@ def _gda_project(project):
     return gda
 
 
+def _import_project(project) -> None:
+    """Run a one-shot headless import so the project's class_name list is written.
+
+    A script ``class_name`` only registers in
+    ``.godot/global_script_class_list.cfg`` after a project scan — the realistic
+    precondition for resolving ``Player`` / ``PlayerConfig`` by class_name
+    (mirrors the node/resource class_name e2e tests).
+    """
+    imported = subprocess.run(
+        [str(GODOT), "--headless", "--path", str(project), "--import"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert imported.returncode == 0, imported.stdout + imported.stderr
+
+
 def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
     assert proc.returncode == 4, proc.stdout + proc.stderr
     err = json.loads(proc.stdout)["error"]
@@ -340,3 +357,77 @@ def test_node_set_value_typed_coercion_is_unchanged(godot_project):
     data = json.loads(was_set.stdout)
     assert data["type"] == "Vector2"
     assert data["value"] == [3.0, 4.0]
+
+
+# A script-defined custom Resource, and a node script that exports a property
+# typed as that script `class_name`. The exported `config: PlayerConfig` is an
+# Object-typed property whose expected class is a SCRIPT class_name — not an
+# engine class — which ADR-0033 defers.
+PLAYER_CONFIG_GD = """\
+class_name PlayerConfig
+extends Resource
+
+@export var hp: int = 5
+"""
+
+PLAYER_GD = """\
+class_name Player
+extends Node2D
+
+@export var config: PlayerConfig
+"""
+
+
+@pytest.mark.e2e
+def test_node_set_script_class_name_typed_property_is_deferred(godot_project):
+    # ADR-0033 DEFERS script-class_name-typed Object properties (their validation
+    # will reuse ADR-0032's class_name resolver): only ENGINE-class-typed Object
+    # properties are in scope this slice. A node whose script exports a
+    # script-class_name-typed Object property (config: PlayerConfig) refuses a
+    # res:// assignment with the DISTINCT, public unsupported_property_type code —
+    # never a misleading resource_type_mismatch — naming the class and the deferral,
+    # and leaves the scene untouched. Pins the deferred branch as a checked-in
+    # contract (the code is public ABI), dispatching through operations.gd.
+    gda = _gda_project(godot_project)
+    (godot_project / "player_config.gd").write_text(PLAYER_CONFIG_GD, encoding="utf-8")
+    (godot_project / "player.gd").write_text(PLAYER_GD, encoding="utf-8")
+    _import_project(godot_project)
+
+    created = gda(
+        "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+    )
+    assert created.returncode == 0, created.stdout + created.stderr
+    # Add the scripted node by its class_name so it carries the config export.
+    added = gda(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--type",
+        "Player",
+        "--name",
+        "Player",
+        "--json",
+    )
+    assert added.returncode == 0, added.stdout + added.stderr
+    cfg = gda(
+        "resource", "create", "res://cfg.tres", "--type", "PlayerConfig", "--json"
+    )
+    assert cfg.returncode == 0, cfg.stdout + cfg.stderr
+    before = (godot_project / "main.tscn").read_text(encoding="utf-8")
+
+    was_set = gda(
+        "node",
+        "set",
+        "res://main.tscn",
+        "--node",
+        "Player",
+        "--property",
+        "config",
+        "--value",
+        "res://cfg.tres",
+        "--json",
+    )
+
+    err = _assert_operation_error(was_set, "unsupported_property_type")
+    assert "PlayerConfig" in err["message"]
+    assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before


### PR DESCRIPTION
## What

Implements **#363** per **ADR-0033**: headless `node set` and `resource set` assign an **existing** Resource — referenced by a `res://….tres` path — to an **Object-typed property that expects a Resource (sub)class** (e.g. `CollisionShape2D.shape`). The path is `load()`ed, **type-checked** against the property's declared **engine** class, and assigned as an **external `ext_resource` reference** (never inlined), then saved.

This completes the external sub-resource workflow with **no new command**:

```
gda resource create res://shapes/box.tres --type RectangleShape2D
gda resource set    res://shapes/box.tres --property size  --value 32,64
gda node set res://main.tscn --node Col --property shape --value res://shapes/box.tres
```

## How

- **Separate, headless-only Object-resolution step** in `_op_node_set` / `_op_resource_set`, taken only when the declared property type is `TYPE_OBJECT`. It reads the property's expected-class hint (`class_name` / `hint_string`) off the property-list entry — which the shared `_coerce_value(raw, type)` signature cannot carry — via two new helpers (`_storage_property_entry`, `_object_expected_class`) and the resolver `_resolve_object_value`.
- **The shared `_coerce_value` block is untouched** (byte-identical harness mirror stays green); live `game set` Object assignment is out of scope.
- **`script` property excluded** and routed to `script attach` (#118) via an actionable error, never a second script-binding entry.
- **Type-check scope: engine-class-typed** Object properties. A script-`class_name`-typed property (e.g. `config: PlayerConfig`) is **deferred** (validation will reuse ADR-0032's resolver) and refused distinctly.
- Assigned resources round-trip as their `res://` reference; because the loaded resource carries a `resource_path`, the text saver serializes it as an `ext_resource` (verified end to end).

## Error codes minted & registered (ADR-0002, public ABI)

`expected_resource_path` · `not_a_resource` · `resource_type_mismatch` · `use_script_attach` · `unsupported_property_type` — added to `operations.gd` consts, `error_codes.py`, and the ADR-0002 table (the GDScript↔Python mirror derives automatically).

## Tests

- New `tests/test_e2e_object_property.py` (8 e2e, dispatch through `operations.gd`): the create→set→node set wiring of `CollisionShape2D.shape` (saved scene reloads with the `ext_resource`); the resource-on-resource `GradientTexture1D.gradient` wiring; type-mismatch; non-`res://`; missing / non-resource path; `script` → `use_script_attach`; and a value-typed-coercion-unchanged regression.
- Fast tier: `1024 passed`. `test_harness_coercion_mirror.py` + `test_error_registry.py` green. `ruff` + `pyright` clean.

Refs #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)