### PR TITLE
chore(release): feat bumps minor before 1.0.0

### DIFF
--- a/docs/adr/0007-release-automation-with-release-please.md
+++ b/docs/adr/0007-release-automation-with-release-please.md
@@ -32,6 +32,11 @@ Pre-1.0 bump semantics follow the SemVer 0.x convention via
 bump minor, `feat`/`fix` bump patch. Nothing crosses 1.0 until we say so with
 `release-as`.
 
+> **Superseded in part by [ADR-0034](0034-pre-1.0-feature-bumps-minor.md):**
+> `bump-patch-for-minor-pre-major` is removed, so pre-1.0 a `feat` now bumps the
+> **minor** and only a `fix` bumps the patch. `bump-minor-pre-major` and the
+> "nothing crosses 1.0 without `release-as`" rule are unchanged.
+
 The build chain lives in the **same workflow** as release-please, gated on its
 `release_created` output, because tags created with the default `GITHUB_TOKEN`
 do not trigger other workflows (GitHub's recursion guard). For the same reason

--- a/docs/adr/0034-pre-1.0-feature-bumps-minor.md
+++ b/docs/adr/0034-pre-1.0-feature-bumps-minor.md
@@ -8,9 +8,10 @@ status: accepted
 semantics via release-please's `bump-minor-pre-major` **and**
 `bump-patch-for-minor-pre-major`: breaking changes bump the minor, while both
 `feat` and `fix` bump the **patch**. Under that rule every feature and every fix
-collapse onto the same digit, so across 0.1.29 → 0.1.50 the minor never moved and
-the version number carried no signal about whether a release added features or
-only fixed bugs — all the information lived in a monotonic patch counter.
+collapse onto the same digit, so across the entire `0.1.x` series the minor never
+moved and the version number carried no signal about whether a release added
+features or only fixed bugs — all the information lived in a monotonic patch
+counter.
 
 ## Decision
 
@@ -37,9 +38,10 @@ Release PR is still the only release path, and forcing a version still uses
 - The minor digit carries signal again: a reader tells a feature release
   (`0.2.0`) from a bugfix release (`0.2.1`) at a glance, restoring the SemVer 0.x
   distinction the previous config erased.
-- The next feature release moves `0.1.50` → **`0.2.0`** rather than `0.1.51`. A
-  one-time visible jump, not a break: no version-bearing file is hand-edited;
-  release-please computes it from the accumulated commits as before (ADR-0008).
+- The next feature release lands as **`0.2.0`** — up from the current `0.1.x`,
+  instead of another `0.1.x` patch bump. A one-time visible jump, not a break: no
+  version-bearing file is hand-edited; release-please computes it from the
+  accumulated commits as before (ADR-0008).
 - This changes only *which digit* moves, not release frequency. Cadence is still
   governed by when the Release PR is merged (ADR-0007). Accumulating several
   commits into one Release PR now collapses them into a single **minor** bump

--- a/docs/adr/0034-pre-1.0-feature-bumps-minor.md
+++ b/docs/adr/0034-pre-1.0-feature-bumps-minor.md
@@ -1,0 +1,48 @@
+---
+status: accepted
+---
+
+# Pre-1.0 feature releases bump the minor version
+
+[ADR-0007](0007-release-automation-with-release-please.md) set the pre-1.0 bump
+semantics via release-please's `bump-minor-pre-major` **and**
+`bump-patch-for-minor-pre-major`: breaking changes bump the minor, while both
+`feat` and `fix` bump the **patch**. Under that rule every feature and every fix
+collapse onto the same digit, so across 0.1.29 → 0.1.50 the minor never moved and
+the version number carried no signal about whether a release added features or
+only fixed bugs — all the information lived in a monotonic patch counter.
+
+## Decision
+
+**Before 1.0.0, a `feat` bumps the minor version and a `fix` bumps the patch
+version.** `bump-patch-for-minor-pre-major` is removed from
+`release-please-config.json`; `bump-minor-pre-major` is kept.
+
+Resulting pre-1.0 semantics:
+
+- `fix` → patch (`0.2.0` → `0.2.1`)
+- `feat` → minor (`0.1.x` → `0.2.0`)
+- breaking (`feat!` / `BREAKING CHANGE`) → minor, still, via `bump-minor-pre-major`.
+  Pre-1.0 a breaking change is not distinguished from a feature at the version
+  level — the standard SemVer 0.x meaning of "the public API is not yet stable".
+
+This supersedes **only** the bump-semantics paragraph of ADR-0007. Every other
+part of ADR-0007 / [ADR-0008](0008-single-authoritative-version-source.md) is
+unchanged: release-please remains the single version authority, merging the
+Release PR is still the only release path, and forcing a version still uses
+`release-as`.
+
+## Consequences
+
+- The minor digit carries signal again: a reader tells a feature release
+  (`0.2.0`) from a bugfix release (`0.2.1`) at a glance, restoring the SemVer 0.x
+  distinction the previous config erased.
+- The next feature release moves `0.1.50` → **`0.2.0`** rather than `0.1.51`. A
+  one-time visible jump, not a break: no version-bearing file is hand-edited;
+  release-please computes it from the accumulated commits as before (ADR-0008).
+- This changes only *which digit* moves, not release frequency. Cadence is still
+  governed by when the Release PR is merged (ADR-0007). Accumulating several
+  commits into one Release PR now collapses them into a single **minor** bump
+  instead of a single patch bump.
+- Crossing 1.0.0 stays an explicit, separate decision via `release-as`; this ADR
+  only fixes the 0.x digit semantics until then, it does not bring 1.0 closer.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": false,
   "draft": true,
   "changelog-sections": [


### PR DESCRIPTION
## What

Restore the SemVer 0.x **feat-vs-fix** signal in the version number: remove
`bump-patch-for-minor-pre-major` from `release-please-config.json` (keep
`bump-minor-pre-major`).

Pre-1.0 bump semantics after this change:

| commit | before | after |
| --- | --- | --- |
| `fix` | patch | patch |
| `feat` | **patch** | **minor** |
| `feat!` / breaking | minor | minor |

## Why

Because `feat` and `fix` both bumped the patch, the minor digit never moved
across the whole `0.1.x` series and the version carried no signal about whether
a release added features or only fixed bugs. This restores that distinction.

This is **orthogonal to release cadence** (how often the Release PR is merged) —
it changes only *which digit* moves, not the release frequency.

## Effect

- The next feature release lands as **`0.2.0`** — up from the current `0.1.x`,
  instead of another `0.1.x` patch bump. A one-time visible jump, not a break:
  no version-bearing file is hand-edited; release-please computes it from the
  accumulated commits as usual (ADR-0008).
- If a Release PR is currently accumulating and contains any `feat`, its target
  version recomputes to `0.2.0` once this lands.

## Decision record

- New **ADR-0034** — _Pre-1.0 feature releases bump the minor version_.
- ADR-0007 gets a `Superseded in part by ADR-0034` note on its bump-semantics
  paragraph; its original decision prose is preserved. Every other part of
  ADR-0007 / ADR-0008 (single version authority, Release-PR-only path,
  `release-as`) is unchanged.
- `Refs #72` — this reverses that issue's accepted bump-semantics criterion
  ("`feat`/`fix` bump patch"); #72 is annotated with a pointer to ADR-0034.

This `chore(release):` change does not itself trigger a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)