### PR TITLE
docs(skill): document the scene-authoring command set

### DIFF
--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -2220,8 +2220,9 @@ def set_property(
         help=(
             "The value to set, as a string. Coerced to the property's declared "
             "Godot type: Vector2/Vector2i/Color take comma-separated components "
-            '(e.g. "48,72", "0.2,0.6,1,1"), and an Object-typed property takes a '
-            "res:// path to an existing Resource. An uncoercible value is a clean error."
+            '(e.g. "48,72", "0.2,0.6,1,1"), and a property expecting a Resource '
+            "(sub)class takes a res:// path to an existing Resource of that class. "
+            "An uncoercible value is a clean error."
         ),
     ),
     json_output: bool = json_option(),
@@ -2900,8 +2901,9 @@ def set_resource(
         help=(
             "The value to set, as a string. Coerced to the property's declared "
             "Godot type: Vector2/Vector2i/Color take comma-separated components "
-            '(e.g. "48,72", "0.2,0.6,1,1"), and an Object-typed property takes a '
-            "res:// path to an existing Resource. An uncoercible value is a clean error."
+            '(e.g. "48,72", "0.2,0.6,1,1"), and a property expecting a Resource '
+            "(sub)class takes a res:// path to an existing Resource of that class. "
+            "An uncoercible value is a clean error."
         ),
     ),
     json_output: bool = json_option(),

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -2219,7 +2219,9 @@ def set_property(
         "--value",
         help=(
             "The value to set, as a string. Coerced to the property's declared "
-            "Godot type; an uncoercible value is a clean error."
+            "Godot type: Vector2/Vector2i/Color take comma-separated components "
+            '(e.g. "48,72", "0.2,0.6,1,1"), and an Object-typed property takes a '
+            "res:// path to an existing Resource. An uncoercible value is a clean error."
         ),
     ),
     json_output: bool = json_option(),
@@ -2897,7 +2899,9 @@ def set_resource(
         "--value",
         help=(
             "The value to set, as a string. Coerced to the property's declared "
-            "Godot type; an uncoercible value is a clean error."
+            "Godot type: Vector2/Vector2i/Color take comma-separated components "
+            '(e.g. "48,72", "0.2,0.6,1,1"), and an Object-typed property takes a '
+            "res:// path to an existing Resource. An uncoercible value is a clean error."
         ),
     ),
     json_output: bool = json_option(),

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -182,9 +182,12 @@ forms — several of which are not obvious from `--help`:
   `--value "0.2,0.6,1,1"`.
 - An **Object-typed** (Resource) property — a `res://….tres` path, as above.
 
-Whitespace around a value or a component is tolerated. The value-typed forms are
-shared by `node set`, `resource set`, `project set`, and live `game set`; the `res://`
-Resource assignment is headless-only (`node set` / `resource set`).
+Whitespace is trimmed for the numeric forms — `bool`, `int` / `float`, the
+`Vector2` / `Vector2i` components, and `Color` (hex or list) — but **not** for
+`String` / `StringName` (taken verbatim) or the `res://` path (matched literally, so a
+leading space fails as `expected_resource_path`). The value-typed forms are shared by
+`node set`, `resource set`, `project set`, and live `game set`; the `res://` Resource
+assignment is headless-only (`node set` / `resource set`).
 
 ## Tips
 

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -127,6 +127,65 @@ gda game tree --project game --json        # the runtime scene tree, after _read
 gda daemon stop --project game --json
 ```
 
+## Scene authoring
+
+Wiring a functional scene means binding scripts, authoring Resources, and setting
+typed properties. Reach for the right command — the generic `node set` does **not**
+cover scripts, and Resource-typed fields take a `res://` path, not a coerced literal.
+
+**Attach a script — `script attach`, never `node set --property script`.**
+`script attach` is the one authoritative way to bind a `.gd` script to a node: it
+verifies the script compiles, checks its base type against the node, and reports any
+script it displaced. Setting the `script` property with `node set` is refused with an
+actionable `use_script_attach` error that points you back here.
+
+```bash
+gda script attach game/main.tscn --node Player --script res://player.gd --project game --json
+```
+
+**Author and populate a Resource — `resource create` / `resource set`.**
+Create a `.tres` (a built-in type, or a project-local `class_name` — resolved without
+opening the editor), then set its properties with the same `--value` coercion below:
+
+```bash
+gda resource create res://shapes/box.tres --type RectangleShape2D --project game --json
+gda resource set    res://shapes/box.tres --property size --value "32,64" --project game --json
+```
+
+**Assign a Resource to an Object-typed property — `--value res://….tres`.**
+For a property that expects a Resource (sub)class — e.g. a `CollisionShape2D`'s
+`shape` — pass the `.tres` path as `--value` to `node set` (or `resource set`). The
+path is loaded, type-checked against the property's expected class, and stored as an
+external `ext_resource` (not inlined). Pass `--project` so `res://` resolves:
+
+```bash
+gda node set game/main.tscn --node Col --property shape --value res://shapes/box.tres --project game --json
+```
+
+Its failures are distinct structured codes, never `uncoercible_value`: a non-`res://`
+value → `expected_resource_path`; a path that is not a Resource → `not_a_resource`; a
+type mismatch → `resource_type_mismatch`; a `class_name`-typed target (not yet
+supported) → `unsupported_property_type`.
+
+### `--value` string forms
+
+`--value` is a **string** coerced to the property's declared Godot type. The accepted
+forms — several of which are not obvious from `--help`:
+
+- `bool` — `true` / `false` (case-insensitive).
+- `int` / `float` — a numeric literal (`7`, `-3`, `1.5`).
+- `String` / `StringName` — the string, verbatim.
+- `Vector2` / `Vector2i` — **comma-separated** components: `--value "48,72"` →
+  `Vector2(48, 72)`. A JSON array (`"[48,72]"`) or a constructor literal
+  (`"Vector2(48,72)"`) is **rejected** (`uncoercible_value`).
+- `Color` — `#rrggbb` / `#rrggbbaa`, or 3–4 **comma-separated** floats in 0..1:
+  `--value "0.2,0.6,1,1"`.
+- An **Object-typed** (Resource) property — a `res://….tres` path, as above.
+
+Whitespace around a value or a component is tolerated. The value-typed forms are
+shared by `node set`, `resource set`, `project set`, and live `game set`; the `res://`
+Resource assignment is headless-only (`node set` / `resource set`).
+
 ## Tips
 
 - Node paths are relative to the scene root; `.` is the root itself.


### PR DESCRIPTION
Closes #364

## What

Addresses the discoverability gap surfaced by #361: an agent reached for `node set --property script` (and other Object-typed properties) and hit a dead end, unaware the dedicated commands already ship. This makes the whole **scene-authoring workflow** legible from the version-locked gda skill (ADR-0024) — and from `--help`.

## Changes

- **`src/gda/skill/SKILL.md`** — new **Scene authoring** section covering the workflow as one unit:
  - Attach a script with `script attach`; `node set --property script` is **not** the way (it returns an actionable `use_script_attach` error).
  - Author/populate a Resource with `resource create` / `resource set`.
  - Assign an existing Resource to an Object-typed property via `node set` / `resource set --value res://….tres` (ADR-0033, #363), stored as an external `ext_resource`; plus its distinct structured failure codes.
  - A `--value` **string forms** list, notably the comma-separated form for `Vector2`/`Color` (`--value "48,72"`, `--value "0.2,0.6,1,1"`) — a JSON array or constructor literal is rejected.
- **`src/gda/cli.py`** — fold the comma value-form and the `res://` Object-typed form into the `--value` `--help` text of `node set` / `resource set`, so the correct form is discoverable from `--help` too, not only from source (folds in #360's secondary note).

The guidance ships via the version-locked `gda skill` channel, so it stays in step with the installed CLI.

## Acceptance criteria

- [x] Skill describes the coherent scene-authoring workflow (`script attach`, `resource create`/`set`, `node set`/`resource set --value res://…`).
- [x] Makes clear `node set --property script` is NOT the way (points to `script attach`).
- [x] Accepted `--value` coercion forms — especially the comma-separated `Vector2`/`Color` form — discoverable from both `--help` and the skill guidance.
- [x] Emitted by the version-locked skill channel (ADR-0024).

## Tests / gates

- `pytest tests/test_skill_surface_sync.py tests/test_skill_command.py -q` → **35 passed**
- `ruff check .` → **All checks passed!**; `ruff format --check .` → **151 files already formatted**
- `pyright` → **0 errors, 0 warnings, 0 informations**
- Spot-verified the emitted `gda skill` output and the updated `gda node set --help` render the new content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
