### PR TITLE
docs(skill): make push + PR creation the orchestrator's job in subagent-worktree-parallel

### DIFF
--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -93,16 +93,17 @@ You are implementing <slice> in an ISOLATED git worktree.
   logic in your worktree. A thin per-slice wrapper over an existing module is fine; a
   second copy of its logic is not. If the right change belongs in a shared file, make it
   there and flag it in your report — don't dodge it to stay disjoint.
-- When done: open the PR (or commit + push). Report the branch, the PR URL, the exact
-  test command + its result counts, and any deep module you reused or shared file you had
-  to touch.
+- When done: **commit and push your branch — do NOT open the PR.** The orchestrator opens
+  every PR so `Closes #N` and the PR conventions are applied in one place. Report the
+  branch name, the issue number your slice closes, the exact test command + its result
+  counts, and any deep module you reused or shared file you had to touch.
 ```
 
 Worktree setup / cleanup:
 
 ```bash
 git worktree add -b feat/<slice> ../wt-<slice> origin/main   # worktree on a FRESH branch off main
-# ... agent implements, commits, pushes, opens PR ...
+# ... agent implements, commits, pushes; the orchestrator opens the PR ...
 git worktree remove ../wt-<slice>                            # ONLY after its PR is merged
 ```
 
@@ -219,10 +220,15 @@ the grep heuristic might miss in another language.
 - **Commit early.** Truncation/kill only loses *uncommitted* work; an agent cut off
   before committing can leave a broken, unsaved file in its worktree.
 - **"Completed but no artifact" = needs-takeover.** Never trust a completion claim —
-  independently verify with `git status` (clean?), `git log` (recent commits?), the PR
-  list (opened?), and remote-tracking (pushed?). Also seen: an agent reports done while
-  its test run is "still settling" (no counts), or committed but never pushed — both are
-  takeover, re-run and finish it yourself.
+  independently verify with `git status` (clean?), `git log` (recent commits?), and
+  remote-tracking (pushed?). Also seen: an agent reports done while its test run is "still
+  settling" (no counts), or committed but never pushed — both are takeover, re-run and
+  finish it yourself.
+- **The orchestrator opens the PR — with `Closes #N`.** PR creation is the lead's, not the
+  subagent's (§3). Once a slice's commits verify, open its PR yourself and confirm the body
+  carries the closing keyword `Closes #N`, so the issue auto-closes on merge. Do not
+  delegate this and spot-check it afterward: even when the brief demands it, subagent-authored
+  PRs reliably bury or omit the keyword — owning PR creation removes the failure mode.
 - **Verify the shared checkout after every worktree agent.** Confirm the main checkout is
   still on its branch and clean (`git -C <main> branch --show-current`, `git status
   --short`, no stray branches) before relying on it — worktree agents have leaked git
@@ -250,6 +256,7 @@ design decision (an ADR) of its own.
 - [ ] Merge order decided (tracer first); after each resolution, audit for the marker-free traps.
 - [ ] Shared-global-resource tests will run serially across worktrees.
 - [ ] Orchestrator will independently re-verify before each merge.
+- [ ] PR creation is the orchestrator's: subagents commit + push only; the lead opens each PR with `Closes #N`.
 - [ ] If append hotspots keep causing conflicts, consider splitting them (ADR).
 
 ## 10. Cost / benefit

--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -94,9 +94,11 @@ You are implementing <slice> in an ISOLATED git worktree.
   second copy of its logic is not. If the right change belongs in a shared file, make it
   there and flag it in your report — don't dodge it to stay disjoint.
 - When done: **commit and push your branch — do NOT open the PR.** The orchestrator opens
-  every PR so `Closes #N` and the PR conventions are applied in one place. Report the
-  branch name, the issue number your slice closes, the exact test command + its result
-  counts, and any deep module you reused or shared file you had to touch.
+  every PR so the close-vs-reference keyword and PR conventions are applied in one place.
+  Report the branch name, the commit SHA, the exact test command + its result counts, the
+  linked issue/spec and **whether your slice fully satisfies it or only advances it** (so the
+  lead can choose `Closes #N` vs `Refs #N`), and any deep module you reused or shared file
+  you had to touch.
 ```
 
 Worktree setup / cleanup:
@@ -224,11 +226,14 @@ the grep heuristic might miss in another language.
   remote-tracking (pushed?). Also seen: an agent reports done while its test run is "still
   settling" (no counts), or committed but never pushed — both are takeover, re-run and
   finish it yourself.
-- **The orchestrator opens the PR — with `Closes #N`.** PR creation is the lead's, not the
-  subagent's (§3). Once a slice's commits verify, open its PR yourself and confirm the body
-  carries the closing keyword `Closes #N`, so the issue auto-closes on merge. Do not
-  delegate this and spot-check it afterward: even when the brief demands it, subagent-authored
-  PRs reliably bury or omit the keyword — owning PR creation removes the failure mode.
+- **The orchestrator opens the PR — and decides `Closes #N` vs `Refs #N`.** PR creation is
+  the lead's, not the subagent's (§3). Once a slice's pushed commits verify, open its PR
+  yourself. Use the closing keyword `Closes #N` **only when that PR fully satisfies the
+  linked issue** (all acceptance criteria, verified); for a tracer, round-out, or
+  stacked/multi-wave slice that only *advances* the issue, use a non-closing `Refs #N` so a
+  partial merge does not close it prematurely. Do not delegate the keyword to the subagent
+  and spot-check it after: even when the brief demands it, subagent-authored PRs reliably
+  bury or omit it — owning PR creation removes the failure mode.
 - **Verify the shared checkout after every worktree agent.** Confirm the main checkout is
   still on its branch and clean (`git -C <main> branch --show-current`, `git status
   --short`, no stray branches) before relying on it — worktree agents have leaked git
@@ -256,7 +261,7 @@ design decision (an ADR) of its own.
 - [ ] Merge order decided (tracer first); after each resolution, audit for the marker-free traps.
 - [ ] Shared-global-resource tests will run serially across worktrees.
 - [ ] Orchestrator will independently re-verify before each merge.
-- [ ] PR creation is the orchestrator's: subagents commit + push only; the lead opens each PR with `Closes #N`.
+- [ ] PR creation is the orchestrator's: subagents commit + push only; the lead opens each PR and chooses `Closes #N` (only if the slice fully satisfies its issue) vs `Refs #N`.
 - [ ] If append hotspots keep causing conflicts, consider splitting them (ADR).
 
 ## 10. Cost / benefit

--- a/.agents/skills/subagent-worktree-parallel/SKILL.md
+++ b/.agents/skills/subagent-worktree-parallel/SKILL.md
@@ -36,14 +36,19 @@ the cost/benefit table).
 - **The orchestrator independently re-verifies before merging.** Subagent implements and
   **commits** (its own branch, in its worktree); the lead re-runs tests and spot-checks the
   diff. "Done but no artifact" = needs takeover.
-- **Push and PR creation are the orchestrator's, not the subagent's.** A PR is a *merging*
-  artifact, not a *doing* one — so the subagent stops at commit, and the lead pushes the
-  branch and opens the PR. That keeps PR conventions applied in one place (`Closes #N`, base
-  branch, labels, footer) and lets the lead re-verify a slice against its spec *before* the
-  PR even exists. Subagent-authored PRs reliably omit the `Closes #N` keyword even when the
-  brief demands it, so owning PR creation closes that gap by construction rather than by a
-  fragile after-the-fact check. (Exception: a subagent may `git push` its branch — or open a
-  *draft* — early so CI runs during the wave, but the canonical PR and its body stay the lead's.)
+- **PR creation and its body are the orchestrator's, not the subagent's.** A PR is a
+  *merging* artifact, not a *doing* one: the subagent commits **and pushes** its branch but
+  does **not** open the PR — the lead opens every PR and owns its body, base, labels, and the
+  close-vs-reference keyword. That applies PR conventions in one place and lets the lead
+  re-verify a slice against its spec *before* the PR exists. Subagent-authored PRs reliably
+  omit or misplace the close keyword even when the brief demands it, so owning PR creation
+  closes that gap by construction rather than by a fragile after-the-fact check.
+- **`Closes #N` is a per-PR decision the lead makes after verifying — not a default.** Tag a
+  PR `Closes #N` only when it *fully* satisfies the linked issue (all acceptance criteria,
+  verified). A tracer, a round-out, or a stacked/multi-wave slice that only *advances* an
+  issue must use a non-closing `Refs #N`, or the first partial merge closes the issue
+  prematurely. The subagent reports whether its slice fully satisfies the issue; the lead
+  decides the keyword.
 - **Disjointness is a merge-cost heuristic, not an architecture goal.** Never let "keep
   slices disjoint / avoid the append hotspot" suppress a sound design decision — a
   legitimate shared-module edit, deep-module *reuse*, or a single source for a public
@@ -66,16 +71,17 @@ decompose + dependency analysis → plan waves → fan out (implement) → merge
 2. **Plan waves.** Group independent slices into waves of ≤ ~5; sequence coupled slices
    tracer-first. Decide the merge order now. (REFERENCE §2)
 3. **Fan out to implement.** Launch one subagent per slice in its own git worktree, each
-   with a dispatch prompt that pins it to its worktree, tells it to commit early and stop
-   at push (the orchestrator opens the PR), and bakes the integration-tier test into its
-   DoD. (REFERENCE §3)
+   with a dispatch prompt that pins it to its worktree, tells it to commit early and push its
+   branch but not open the PR (the orchestrator does), and bakes the integration-tier test
+   into its DoD. (REFERENCE §3)
 4. **Merge serially in dependency order.** Tracer first → rebase followers onto the new
    base → independent groups can merge in any order. Re-poll mergeability after each
    merge. Watch for the two marker-free conflict traps. (REFERENCE §4, §5)
 5. **Verify, open PRs, take over.** Re-run the integration tier yourself (a *clean* rebase
    still needs it); run shared-global-resource tests serially; treat any "completed but no
-   commit/push" report as needs-takeover, not success. **You** (not the subagent) push and
-   open each PR, with `Closes #N` in the body. (REFERENCE §6, §7)
+   commit/push" report as needs-takeover, not success. **You** (not the subagent) open each
+   PR, choosing `Closes #N` only when the slice fully satisfies its issue (else `Refs #N`).
+   (REFERENCE §6, §7)
 
 This path is **not one-shot**: independent review sends merged-ready slices back, and
 remediation reshapes the plan. Re-derive the overlap map and merge order as fixes land,

--- a/.agents/skills/subagent-worktree-parallel/SKILL.md
+++ b/.agents/skills/subagent-worktree-parallel/SKILL.md
@@ -33,8 +33,17 @@ the cost/benefit table).
 - **The integration-tier test is the Definition of Done.** A fast tier that stubs the
   integration boundary passes even on a broken merge. DoD must run the tier that really
   exercises the boundary (integration / e2e / compile or a parse `--check-only`).
-- **The orchestrator independently re-verifies before merging.** Subagent implements;
-  the lead re-runs tests and spot-checks the diff. "Done but no artifact" = needs takeover.
+- **The orchestrator independently re-verifies before merging.** Subagent implements and
+  **commits** (its own branch, in its worktree); the lead re-runs tests and spot-checks the
+  diff. "Done but no artifact" = needs takeover.
+- **Push and PR creation are the orchestrator's, not the subagent's.** A PR is a *merging*
+  artifact, not a *doing* one — so the subagent stops at commit, and the lead pushes the
+  branch and opens the PR. That keeps PR conventions applied in one place (`Closes #N`, base
+  branch, labels, footer) and lets the lead re-verify a slice against its spec *before* the
+  PR even exists. Subagent-authored PRs reliably omit the `Closes #N` keyword even when the
+  brief demands it, so owning PR creation closes that gap by construction rather than by a
+  fragile after-the-fact check. (Exception: a subagent may `git push` its branch — or open a
+  *draft* — early so CI runs during the wave, but the canonical PR and its body stay the lead's.)
 - **Disjointness is a merge-cost heuristic, not an architecture goal.** Never let "keep
   slices disjoint / avoid the append hotspot" suppress a sound design decision — a
   legitimate shared-module edit, deep-module *reuse*, or a single source for a public
@@ -57,14 +66,16 @@ decompose + dependency analysis → plan waves → fan out (implement) → merge
 2. **Plan waves.** Group independent slices into waves of ≤ ~5; sequence coupled slices
    tracer-first. Decide the merge order now. (REFERENCE §2)
 3. **Fan out to implement.** Launch one subagent per slice in its own git worktree, each
-   with a dispatch prompt that pins it to its worktree, tells it to commit early, and
-   bakes the integration-tier test into its DoD. (REFERENCE §3)
+   with a dispatch prompt that pins it to its worktree, tells it to commit early and stop
+   at push (the orchestrator opens the PR), and bakes the integration-tier test into its
+   DoD. (REFERENCE §3)
 4. **Merge serially in dependency order.** Tracer first → rebase followers onto the new
    base → independent groups can merge in any order. Re-poll mergeability after each
    merge. Watch for the two marker-free conflict traps. (REFERENCE §4, §5)
-5. **Verify + take over.** Re-run the integration tier yourself (a *clean* rebase still
-   needs it); run shared-global-resource tests serially; treat any "completed but no
-   PR/commit/push" report as needs-takeover, not success. (REFERENCE §6, §7)
+5. **Verify, open PRs, take over.** Re-run the integration tier yourself (a *clean* rebase
+   still needs it); run shared-global-resource tests serially; treat any "completed but no
+   commit/push" report as needs-takeover, not success. **You** (not the subagent) push and
+   open each PR, with `Closes #N` in the body. (REFERENCE §6, §7)
 
 This path is **not one-shot**: independent review sends merged-ready slices back, and
 remediation reshapes the plan. Re-derive the overlap map and merge order as fixes land,


### PR DESCRIPTION
## What

Makes the `subagent-worktree-parallel` skill assign **PR creation and its body to the orchestrator** (not the subagents), and makes `Closes #N` a verified per-PR decision rather than a default. Explicit division of labor:

- **Subagent** — implements, tests, **commits, and pushes** its branch. Does not open a PR.
- **Orchestrator** — opens every PR and owns its body, base, labels, and the close-vs-reference keyword.

## Why

A PR is a *merging* artifact, not a *doing* one — so under the skill's own headline principle, "**parallelize the doing; serialize the merging**," it belongs to the orchestrator. The previous guidance was slightly inconsistent with that: the §3 dispatch prompt told each **subagent** to open its own PR, and the orchestrator's verify step only checked that a PR *existed* (`the PR list (opened?)`) — never its body.

That gap has a concrete failure mode: **subagent-authored PRs reliably omit the `Closes #N` keyword even when the brief explicitly demands it**, so the linked issue never auto-closes on merge. This was observed on several merged PRs that silently left their issues open, and reproduced live in this session. Owning PR creation closes the gap **by construction** rather than via a fragile after-the-fact body check, and lets the lead re-verify a slice against its spec *before* the PR even exists.

**`Closes #N` is not a default.** The skill supports tracer-first work, round-outs, stacked PRs, and multi-wave delivery — many slice PRs only *advance* an issue. So the lead tags a PR `Closes #N` only when it **fully** satisfies the linked issue after verification; otherwise a non-closing `Refs #N`, so a partial merge can't close the issue prematurely.

## Changes (docs only)

- **SKILL.md** — two new core principles ("PR creation and its body are the orchestrator's, not the subagent's"; "`Closes #N` is a per-PR decision the lead makes after verifying — not a default"); workflow steps 3 & 5 updated.
- **REFERENCE.md** — §3 dispatch prompt now tells the subagent to commit + push and **not** open the PR (and to report the linked issue/spec plus whether its slice fully satisfies or only advances it, so the lead chooses `Closes #N` vs `Refs #N`); §7 adds an explicit "orchestrator opens the PR and decides `Closes #N` vs `Refs #N`" check; §9 pre-launch checklist gains the ownership item.

One branch = one PR, so there is **no draft-PR exception** — a subagent draft would block the lead's canonical PR; subagents never open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
