### PR TITLE
test(e2e): resolve gda-mcp deterministically from the venv scripts dir, not PATH which()

### DIFF
--- a/tests/test_e2e_mcp_stdio.py
+++ b/tests/test_e2e_mcp_stdio.py
@@ -14,8 +14,8 @@ never hardcodes it (Design decision 1).
 """
 
 import os
+import shutil
 import sysconfig
-from pathlib import Path
 
 import anyio
 import pytest
@@ -33,14 +33,17 @@ def _server_params() -> StdioServerParameters:
     # this gate exists to validate ADR-0013 *packaging + launch* — that the generated
     # `gda-mcp = gda.mcp:main` entry-point wrapper actually starts and speaks MCP (#193).
     # Resolve it DETERMINISTICALLY from the running interpreter's own scripts dir
-    # (`.venv/bin` under `uv run pytest`) rather than `shutil.which("gda-mcp")`: a PATH
-    # lookup returns whatever is first on PATH, which can be a stale global uv-tool
-    # install or another worktree's editable `gda-mcp` — the same "wrong global" trap
-    # that `tests/support.py::GDA_CMD` avoids for the `gda` CLI by keying off
-    # `sys.executable`. `sysconfig.get_path("scripts")` points at the bin dir of the
-    # exact interpreter running the suite, so we launch THIS checkout's console script.
-    gda_mcp = Path(sysconfig.get_path("scripts")) / "gda-mcp"
-    assert gda_mcp.is_file(), f"`gda-mcp` console script not found at {gda_mcp}"
+    # (`.venv/bin` under `uv run pytest`) — NOT an unbounded `shutil.which("gda-mcp")`,
+    # whose PATH lookup returns whatever is first on PATH (a stale global uv-tool install
+    # or another worktree's editable `gda-mcp` — the "wrong global" trap that
+    # `tests/support.py::GDA_CMD` avoids for the `gda` CLI by keying off `sys.executable`).
+    # `shutil.which(..., path=scripts_dir)` restricts the lookup to that one directory yet
+    # still applies the platform's launcher rules (POSIX `gda-mcp`, Windows `gda-mcp.exe`
+    # via PATHEXT) — so this headless gate stays cross-platform (only live daemon ops are
+    # Unix-only) while still launching THIS checkout's console script.
+    scripts_dir = sysconfig.get_path("scripts")
+    gda_mcp = shutil.which("gda-mcp", path=scripts_dir)
+    assert gda_mcp, f"`gda-mcp` console script not found in {scripts_dir}"
     # Full env + a pinned Godot, so the server's nested `-m gda` resolves the
     # same engine deterministically.
     env = {**os.environ, GODOT_BIN_ENV: str(GODOT)}

--- a/tests/test_e2e_mcp_stdio.py
+++ b/tests/test_e2e_mcp_stdio.py
@@ -14,7 +14,8 @@ never hardcodes it (Design decision 1).
 """
 
 import os
-import shutil
+import sysconfig
+from pathlib import Path
 
 import anyio
 import pytest
@@ -28,12 +29,22 @@ GODOT = resolve_godot_binary()
 
 
 def _server_params() -> StdioServerParameters:
-    gda_mcp = shutil.which("gda-mcp")
-    assert gda_mcp, "the `gda-mcp` console script is not on PATH"
+    # Spawn the REAL `gda-mcp` console script (deliberately NOT `python -m gda.mcp`):
+    # this gate exists to validate ADR-0013 *packaging + launch* — that the generated
+    # `gda-mcp = gda.mcp:main` entry-point wrapper actually starts and speaks MCP (#193).
+    # Resolve it DETERMINISTICALLY from the running interpreter's own scripts dir
+    # (`.venv/bin` under `uv run pytest`) rather than `shutil.which("gda-mcp")`: a PATH
+    # lookup returns whatever is first on PATH, which can be a stale global uv-tool
+    # install or another worktree's editable `gda-mcp` — the same "wrong global" trap
+    # that `tests/support.py::GDA_CMD` avoids for the `gda` CLI by keying off
+    # `sys.executable`. `sysconfig.get_path("scripts")` points at the bin dir of the
+    # exact interpreter running the suite, so we launch THIS checkout's console script.
+    gda_mcp = Path(sysconfig.get_path("scripts")) / "gda-mcp"
+    assert gda_mcp.is_file(), f"`gda-mcp` console script not found at {gda_mcp}"
     # Full env + a pinned Godot, so the server's nested `-m gda` resolves the
     # same engine deterministically.
     env = {**os.environ, GODOT_BIN_ENV: str(GODOT)}
-    return StdioServerParameters(command=gda_mcp, args=[], env=env)
+    return StdioServerParameters(command=str(gda_mcp), args=[], env=env)
 
 
 def _call(tool: str, arguments: dict):


### PR DESCRIPTION
## What

`tests/test_e2e_mcp_stdio.py` located the `gda-mcp` console script it spawns with `shutil.which("gda-mcp")`. This replaces that PATH lookup with a deterministic resolution from the running interpreter's scripts dir.

## Why

`shutil.which("gda-mcp")` returns *whatever is first on PATH*, which can be a **stale global uv-tool install** (e.g. a PyPI `gda-mcp` at an older version) or **another worktree's editable `gda-mcp`** — not this checkout's. That is the exact "wrong global" trap `tests/support.py::GDA_CMD` already avoids for the `gda` CLI by keying off `sys.executable` (`[sys.executable, "-m", "gda"]`) instead of a PATH lookup. Under `uv run pytest` it usually resolves the right one (`.venv/bin` is first on PATH), but it is fragile to PATH ordering — so the gate could silently exercise stale/wrong MCP code.

`sysconfig.get_path("scripts")` is the bin dir of the *exact* interpreter running the suite (`.venv/bin` under `uv run pytest`), so we launch **this checkout's** script deterministically.

Crucially, this keeps spawning the **real console-script entry-point wrapper** (`gda-mcp = gda.mcp:main`) rather than switching to `python -m gda.mcp` — so the gate still validates **ADR-0013 packaging + launch** (that the generated console script actually starts and speaks MCP, #193). The `assert` now checks the resolved path is a real file, with an actionable message.

## Changes (test-only)

- `tests/test_e2e_mcp_stdio.py` — `_server_params()` resolves `gda-mcp` via `Path(sysconfig.get_path("scripts")) / "gda-mcp"` instead of `shutil.which`; imports updated (`sysconfig` + `pathlib.Path`, dropped `shutil`); a clear comment explains the determinism rationale and why it stays a console-script spawn.

## Verification

- `uv run pytest tests/test_e2e_mcp_stdio.py -m e2e` → **2 passed** (real `gda-mcp` console script over stdio → real `gda` → headless Godot).
- Resolution check: `sysconfig.get_path("scripts")/"gda-mcp"` → `.venv/bin/gda-mcp` (exists).
- `ruff check` / `ruff format --check` / `pyright` on the file → clean.

No linked issue, so no closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)