### PR TITLE
refactor(panda-adventure): gate GameLog on the public is_daemon_launched()

### DIFF
--- a/examples/platformer/panda-adventure/addons/gda_harness/gda_harness.gd
+++ b/examples/platformer/panda-adventure/addons/gda_harness/gda_harness.gd
@@ -1,4 +1,4 @@
-# gda-harness-version: 3
+# gda-harness-version: 4
 extends Node
 
 # The gda harness (ADR-0017, ADR-0018). Installed as a project [autoload] by
@@ -950,6 +950,24 @@ func _ok(payload: Dictionary) -> String:
 
 func _error(code: String, message: String) -> String:
 	return RESULT_BEGIN + JSON.stringify({"error": {"code": code, "message": message}}) + RESULT_END
+
+
+# The PUBLIC, stable predicate reporting whether gda-daemon launched this run (#362)
+# — the SAME condition `gda_log()` gates on (`_daemon_launched`). Game code should
+# branch on THIS, not on harness *presence*: where the harness IS installed it only
+# captures logs when the daemon launched the session, so gating on presence silently
+# drops every record in a plain/editor run. (A supported `gda export run` artifact
+# OMITS the harness entirely per ADR-0028, so this predicate is not even present to
+# call there — game code must resolve the autoload by node path and null-check it, as
+# the `GdaHarness` global does not parse when absent.) A game-side logging helper gates
+# on this predicate and falls back to `print()` when the node is absent or the predicate
+# is false. It is a PURE READ — no connection, no output, no state change — so the
+# ADR-0018 inert-when-dormant guarantee holds: it returns false in a human editor run, a
+# plain run, and an export that BYPASSED `gda export run` (the harness physically present
+# but inert — `_ready` returns at the `template` gate before `_daemon_launched` is ever
+# set), with no side effect in any.
+func is_daemon_launched() -> bool:
+	return _daemon_launched
 
 
 # The active opt-in rich-log protocol (#282, ADR-0026). Project code in a live

--- a/examples/platformer/panda-adventure/src/util/game_log.gd
+++ b/examples/platformer/panda-adventure/src/util/game_log.gd
@@ -6,8 +6,8 @@ extends RefCounted
 ## The GdaHarness autoload carries gda_log(). This project COMMITS the harness, so
 ## it is present in every run — but its gda_log() only emits when gda-daemon
 ## launched the run; on a plain run, a headless run, or the editor it is DORMANT
-## and gda_log() is a silent no-op. So we route to the harness only when it is
-## actually daemon-launched (its `_daemon_launched` flag); otherwise we print(),
+## and gda_log() is a silent no-op. So we route to the harness only when it reports
+## is_daemon_launched() (the public predicate, gda #362); otherwise we print(),
 ## which the daemon's log parser also captures as a passive `info` record and which
 ## a human sees on the console. (The harness is still looked up DYNAMICALLY at
 ## /root/GdaHarness — a bare `GdaHarness` global would not compile in the exported
@@ -20,9 +20,7 @@ static func emit(level: String, message: String, fields: Dictionary = {}) -> voi
 		var harness := (loop as SceneTree).root.get_node_or_null("GdaHarness")
 		# Route to the harness ONLY when the daemon launched this run; a committed-
 		# but-dormant harness would otherwise swallow the log (its gda_log no-ops).
-		# get() degrades to null if a future harness renames the flag, so we fall
-		# back to print() rather than crash.
-		if harness != null and harness.get("_daemon_launched"):
+		if harness != null and harness.is_daemon_launched():
 			harness.gda_log(level, message, fields)
 			return
 	print("[%s] %s %s" % [level, message, JSON.stringify(fields)])

--- a/examples/platformer/panda-adventure/tests/test_game_log_fallback.py
+++ b/examples/platformer/panda-adventure/tests/test_game_log_fallback.py
@@ -10,8 +10,8 @@ harness was committed and is fixed in ``src/util/game_log.gd``; this locks it do
 
 The daemon-launched *rich* path (``origin == "gda_log"`` via ``gda logger tail``)
 is covered by ``test_player_e2e.py`` — the complementary half. Engine tier (a real
-``godot``, no daemon); never ``e2e``. Tracks gda-side issue #362 (no public
-daemon-launched predicate), whose fix may let us drop the private-flag gate.
+``godot``, no daemon); never ``e2e``. gda-side issue #362 delivered the public
+``is_daemon_launched()`` predicate, which ``GameLog`` now gates on (no private flag).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What

Game-side adoption of the gda #362 fix (delivered by #367), verified against gda `main` (editable install):

- **`src/util/game_log.gd`** — `GameLog.emit` now gates on the harness's public `is_daemon_launched()` predicate instead of reaching into the private `_daemon_launched` var, matching the snippet the gda skill's logging guidance recommends.
- **`addons/gda_harness/gda_harness.gd`** — sync the committed harness to v4, the re-materialization `gda daemon start` produces after the gda upgrade (committing that diff is this project's documented convention, see the game `AGENTS.md`). v4 carries the new predicate.
- **`tests/test_game_log_fallback.py`** — docstring only: the "#362 may let us drop the private-flag gate" note is now realized.

## Verification (real engine, no mocks)

- **Predicate false path** (plain `godot --headless` run, harness present-but-dormant): `tests/test_game_log_fallback.py` passes — boot records appear as plain `print()` lines, no `<<<GDA:LOG>>>` leak, no script errors.
- **Predicate true path** (daemon-launched session): the daemon live-loop e2e passes, and a manual `gda game tree` + `gda logger tail` session shows `origin == "gda_log"` records (`player_ready`, `boot`) emitted through the new gate.
- Full game suite: **25/25 pass** (23 fast/engine + 2 e2e, run serially).

Refs #362 (already closed — this is the demo-side adoption, no auto-close intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)