### PR TITLE
[Panda Adventure] S2: Laser Gun combat + data-driven StatsSystem

### DIFF
--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -51,6 +51,12 @@ _Avoid_: class, role; using 流派 loosely
 The player's primary weapon — a hitscan/projectile gun that deals damage to enemies.
 _Avoid_: blaster, rifle
 
+**Projectile**:
+The bolt the Laser Gun fires — a block that flies straight, damages the first Enemy it
+overlaps (via the damage formula), and despawns on any contact or after its config
+lifetime. The only thing that damages an Enemy in S2.
+_Avoid_: bullet, laser (that names the weapon), missile
+
 **Gravity Gun**:
 The player's utility weapon. Fired at the environment, it creates a Gravity Field rather than
 dealing direct damage. The player's own gravity is never affected by it.
@@ -70,7 +76,25 @@ the Gravity Gun is the only thing that spends MP. Restored by drinking Wine. (HP
 keep their conventional meanings and are not glossed here.)
 _Avoid_: mana, energy
 
+**Stat Block**:
+The per-actor-kind data-driven combat config — max HP/MP, attack, defense — carried as the
+`StatsConfig` Resource derived from JSON (gADR-0001). Player and every Enemy kind carry the
+SAME shape: the symmetric attacker/defender contract of the damage formula.
+_Avoid_: attribute sheet, stat table
+
+**StatsSystem**:
+The runtime holder of one actor's live HP/MP/EXP/Gold, instantiated per actor from its Stat
+Block and mutated only in memory — never persisted back to config (gADR-0001).
+_Avoid_: stats manager, game state
+
 ### Combat
+
+**CombatSystem**:
+The pure decision functions of combat — the damage formula, the i-frame window check, and
+the death rule — static, deterministic, and clock-free, shared unchanged by the runtime
+controllers and the offline Monte-Carlo balancing sim (gADR-0001). Controllers orchestrate
+(clock, mutation, tween, log); decisions live only here.
+_Avoid_: damage manager, battle system
 
 **TTK** (Time To Kill):
 How long it takes the player to kill a given enemy. Paired with TTD to tune combat pacing.

--- a/examples/platformer/panda-adventure/data/generated/combat_config.tres
+++ b/examples/platformer/panda-adventure/data/generated/combat_config.tres
@@ -1,0 +1,20 @@
+[gd_resource type="Resource" script_class="CombatConfig" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://src/resources/combat_config.gd" id="1_combatconfig"]
+
+[resource]
+script = ExtResource("1_combatconfig")
+attack_scale = 1
+defense_scale = 1
+min_damage = 1
+iframe_duration = 0.6
+projectile_color = Color(1, 0.35, 0.25, 1)
+projectile_size = Vector2(18, 6)
+projectile_speed = 900
+projectile_lifetime = 1.5
+projectile_spawn_offset = Vector2(36, 0)
+enemy_color = Color(0.75, 0.2, 0.55, 1)
+enemy_size = Vector2(48, 48)
+enemy_position = Vector2(640, 452)
+hit_flash_color = Color(1, 1, 1, 1)
+hit_flash_duration = 0.12

--- a/examples/platformer/panda-adventure/data/generated/stats_enemy.tres
+++ b/examples/platformer/panda-adventure/data/generated/stats_enemy.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="StatsConfig" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://src/resources/stats_config.gd" id="1_statsconfig"]
+
+[resource]
+script = ExtResource("1_statsconfig")
+max_hp = 25
+max_mp = 0
+attack = 5
+defense = 0

--- a/examples/platformer/panda-adventure/data/generated/stats_player.tres
+++ b/examples/platformer/panda-adventure/data/generated/stats_player.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="StatsConfig" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://src/resources/stats_config.gd" id="1_statsconfig"]
+
+[resource]
+script = ExtResource("1_statsconfig")
+max_hp = 100
+max_mp = 50
+attack = 10
+defense = 0

--- a/examples/platformer/panda-adventure/data/json/combat_config.json
+++ b/examples/platformer/panda-adventure/data/json/combat_config.json
@@ -1,0 +1,18 @@
+{
+  "player_stats": { "max_hp": 100.0, "max_mp": 50.0, "attack": 10.0, "defense": 0.0 },
+  "enemy_stats": { "max_hp": 25.0, "max_mp": 0.0, "attack": 5.0, "defense": 0.0 },
+  "attack_scale": 1.0,
+  "defense_scale": 1.0,
+  "min_damage": 1.0,
+  "iframe_duration": 0.6,
+  "projectile_color": [1.0, 0.35, 0.25, 1.0],
+  "projectile_size": [18.0, 6.0],
+  "projectile_speed": 900.0,
+  "projectile_lifetime": 1.5,
+  "projectile_spawn_offset": [36.0, 0.0],
+  "enemy_color": [0.75, 0.2, 0.55, 1.0],
+  "enemy_size": [48.0, 48.0],
+  "enemy_position": [640.0, 452.0],
+  "hit_flash_color": [1.0, 1.0, 1.0, 1.0],
+  "hit_flash_duration": 0.12
+}

--- a/examples/platformer/panda-adventure/data/schema/combat_config.schema.json
+++ b/examples/platformer/panda-adventure/data/schema/combat_config.schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aigengame.dev/panda-adventure/data/schema/combat_config.schema.json",
+  "title": "Panda Adventure combat configuration",
+  "description": "Authoritative config for S2 Laser Gun combat (gADR-0000: JSON is the single source of truth). Converted by scripts/build_config.py into three derived Resources: data/generated/stats_player.tres and stats_enemy.tres (StatsConfig stat blocks — the same shape for attacker and defender, gADR-0001) and data/generated/combat_config.tres (CombatConfig: damage-formula params, i-frame window, projectile and enemy blockout).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "player_stats",
+    "enemy_stats",
+    "attack_scale",
+    "defense_scale",
+    "min_damage",
+    "iframe_duration",
+    "projectile_color",
+    "projectile_size",
+    "projectile_speed",
+    "projectile_lifetime",
+    "projectile_spawn_offset",
+    "enemy_color",
+    "enemy_size",
+    "enemy_position",
+    "hit_flash_color",
+    "hit_flash_duration"
+  ],
+  "$defs": {
+    "stat_block": {
+      "description": "A per-actor-kind stat block (StatsConfig). Player and Enemy share this shape — the symmetric attacker/defender contract of the damage formula.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_hp", "max_mp", "attack", "defense"],
+      "properties": {
+        "max_hp": {
+          "description": "Maximum (and starting) HP; strictly positive.",
+          "type": "number",
+          "exclusiveMinimum": 0.0
+        },
+        "max_mp": {
+          "description": "Maximum (and starting) MP; non-negative (MP is spent only by the Gravity Gun, S3).",
+          "type": "number",
+          "minimum": 0.0
+        },
+        "attack": {
+          "description": "Attack stat fed to the damage formula when this actor is the attacker; non-negative.",
+          "type": "number",
+          "minimum": 0.0
+        },
+        "defense": {
+          "description": "Defense/mitigation stat fed to the damage formula when this actor is the defender; non-negative. 0 until the Spacesuit exists.",
+          "type": "number",
+          "minimum": 0.0
+        }
+      }
+    }
+  },
+  "properties": {
+    "player_stats": { "$ref": "#/$defs/stat_block" },
+    "enemy_stats": { "$ref": "#/$defs/stat_block" },
+    "attack_scale": {
+      "description": "Damage-formula multiplier on the attacker's attack; strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "defense_scale": {
+      "description": "Damage-formula multiplier on the defender's defense; non-negative.",
+      "type": "number",
+      "minimum": 0.0
+    },
+    "min_damage": {
+      "description": "Damage floor — a landed hit never deals less than this; non-negative.",
+      "type": "number",
+      "minimum": 0.0
+    },
+    "iframe_duration": {
+      "description": "Seconds of invulnerability a defender gets after a landed hit (i-frames); strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "projectile_color": {
+      "description": "Projectile block color as RGBA, each component in 0..1.",
+      "type": "array",
+      "items": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+      "minItems": 4,
+      "maxItems": 4
+    },
+    "projectile_size": {
+      "description": "Projectile block size (width, height) in pixels; each strictly positive.",
+      "type": "array",
+      "items": { "type": "number", "exclusiveMinimum": 0.0 },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "projectile_speed": {
+      "description": "Projectile travel speed in px/s; strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "projectile_lifetime": {
+      "description": "Seconds before an unhit projectile despawns; strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "projectile_spawn_offset": {
+      "description": "Projectile spawn offset (x, y) in pixels from the Player origin; x is scaled by facing.",
+      "type": "array",
+      "items": { "type": "number" },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "enemy_color": {
+      "description": "Enemy block color as RGBA, each component in 0..1.",
+      "type": "array",
+      "items": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+      "minItems": 4,
+      "maxItems": 4
+    },
+    "enemy_size": {
+      "description": "Enemy block size (width, height) in pixels; each strictly positive.",
+      "type": "array",
+      "items": { "type": "number", "exclusiveMinimum": 0.0 },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "enemy_position": {
+      "description": "Enemy center position (x, y) in pixels — the StaticBody2D origin.",
+      "type": "array",
+      "items": { "type": "number" },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "hit_flash_color": {
+      "description": "Enemy block modulate at the moment of a landed hit — the flash the tween recovers from; RGBA in 0..1.",
+      "type": "array",
+      "items": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+      "minItems": 4,
+      "maxItems": 4
+    },
+    "hit_flash_duration": {
+      "description": "Seconds for the hit flash to recover to normal modulate; strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    }
+  }
+}

--- a/examples/platformer/panda-adventure/docs/gadr/0001-stats-config-vs-runtime-state.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0001-stats-config-vs-runtime-state.md
@@ -1,0 +1,66 @@
+---
+status: accepted
+---
+
+# Stats: immutable config stat blocks vs in-memory runtime state
+
+S2 introduces combat stats (HP/MP/EXP/Gold, attack, defense) and the damage
+formula. gADR-0000 already fixes WHERE numbers live (JSON authoritative →
+derived `Resource`); this decision fixes HOW live, mutating stats relate to
+that immutable config, and where combat *decisions* live — because S3 (MP
+spend), S4 (enemy taxonomy + enemy→Player damage), S6a (kill rewards), and the
+offline Monte-Carlo balancing pipeline all build on the same split.
+
+We split three ways:
+
+- **Stat Block (`StatsConfig`)** — the per-actor-kind config: max HP/MP,
+  attack, defense. A derived JSON→Resource artifact (gADR-0000), **immutable at
+  runtime**. Player and every Enemy kind carry the SAME type, which is what
+  makes the damage formula symmetric: enemy→Player damage (S4) is the same
+  function with the roles swapped, no second formula.
+- **StatsSystem** — the runtime holder of one actor's live HP/MP/EXP/Gold.
+  Instantiated fresh per actor (`new()` + `init_from(stat block)`), mutated
+  only in memory, **never `load()`ed from disk and never saved back** — the
+  `.tres` stays a derived artifact with no runtime write path, so config can
+  never drift from JSON via gameplay.
+- **CombatSystem** — the pure combat decisions (damage formula with the
+  defense/mitigation term, the i-frame window check, the death rule). Static,
+  deterministic, node/physics/clock-free: time is a parameter, not a read.
+  Controllers orchestrate (read the real clock, mutate their StatsSystem,
+  tween, log); decisions live only here.
+
+## Considered options
+
+- **Three-way split: config Resource / runtime holder / pure decisions
+  (chosen).** The offline Monte-Carlo balancing sim (gADR-0000) can call the
+  identical decision functions with a simulated clock and in-memory stat
+  blocks — no engine session, no divergence between the sim's rules and the
+  game's. Runtime mutation can never corrupt config.
+- **One mutable Resource loaded from the `.tres` (rejected).** Godot caches
+  `load()`, so mutating a loaded Resource aliases every consumer and invites
+  writing state back to disk; current-HP-in-config also makes a fresh run's
+  state depend on the last run. Both break gADR-0000's derived-artifact
+  guarantee.
+- **A global stats autoload / game-state singleton (rejected for S2).**
+  Nothing needs cross-scene state yet; per-actor ownership keeps the Enemy
+  self-contained (S4 spawns many) and avoids an implicit global the logic
+  seam would have to reset between cases. Revisit only when a slice needs
+  cross-scene persistence (e.g. S6a rewards surviving a scene change).
+- **Decisions as controller methods (rejected).** Instance methods on nodes
+  drag the scene tree into the balancing sim and the logic seam; the S1
+  precedent (`compute_velocity` as a pure static) already proved the
+  static-decision shape.
+
+## Consequences
+
+- The Monte-Carlo balancing pipeline reuses `CombatSystem` + `StatsSystem`
+  unchanged, supplying its own clock and stat blocks; TTK/TTD tuning happens
+  against the real rules.
+- Every new actor kind is config (a new stat-block `.tres` from JSON), not
+  code — S4's taxonomy is more stat blocks, no restructure.
+- The runtime clock is read only in controllers (`_now()`), never inside a
+  decision — i-frame logic stays testable with plain floats.
+- EXP/Gold start at 0 in `init_from` (an accumulation identity — structural,
+  not a tunable); S6a adds accumulation without touching the split.
+- In code the EXP field is `exp_points` (`exp` would shadow the built-in
+  `exp()`); docs and the glossary keep saying EXP.

--- a/examples/platformer/panda-adventure/project.godot
+++ b/examples/platformer/panda-adventure/project.godot
@@ -14,11 +14,12 @@ run/main_scene="res://scenes/main.tscn"
 
 [input]
 
-; S1 player-traversal actions. move_left/move_right/jump are consumed by
-; PlayerController (Input.get_axis / is_action_just_pressed) and driven in the
-; live e2e by `gda input action`. Each binds an arrow key plus a WASD/Space
-; alternative. Hand-authored (project.godot is the canonical root); the exact
-; InputEventKey serialization was emitted by Godot itself (var_to_str).
+; S1 player-traversal actions plus the S2 `fire` action. move_left/move_right/
+; jump/fire are consumed by PlayerController (Input.get_axis /
+; is_action_just_pressed) and driven in the live e2e by `gda input action`.
+; Each movement action binds an arrow key plus a WASD/Space alternative; fire
+; binds J plus F. Hand-authored (project.godot is the canonical root); the
+; exact InputEventKey serialization was emitted by Godot itself (var_to_str).
 
 move_left={
 "deadzone": 0.5,
@@ -38,6 +39,23 @@ jump={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+fire={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":74,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":70,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+
+[layer_names]
+
+; S2 collision topology (structural wiring, not balance data — gADR-0000 governs
+; config NUMBERS; what-can-damage-what lives here and in the scenes). Layer 5 is
+; reserved for S3's Gravity Field.
+2d_physics/layer_1="terrain"
+2d_physics/layer_2="player"
+2d_physics/layer_3="enemy"
+2d_physics/layer_4="projectile"
+2d_physics/layer_5="gravity_field"
 
 [debug]
 

--- a/examples/platformer/panda-adventure/scenes/enemy.tscn
+++ b/examples/platformer/panda-adventure/scenes/enemy.tscn
@@ -1,0 +1,12 @@
+[gd_scene format=3]
+
+[ext_resource type="Script" path="res://src/controllers/enemy_controller.gd" id="1_vlkaa"]
+
+[node name="Enemy" type="StaticBody2D" unique_id=71224729]
+collision_layer = 4
+collision_mask = 0
+script = ExtResource("1_vlkaa")
+
+[node name="Visual" type="ColorRect" parent="." unique_id=888497638]
+
+[node name="Collision" type="CollisionShape2D" parent="." unique_id=1697886712]

--- a/examples/platformer/panda-adventure/scenes/main.tscn
+++ b/examples/platformer/panda-adventure/scenes/main.tscn
@@ -1,9 +1,13 @@
-; Panda Adventure — main scene (S1 player traversal), hand-authored.
+; Panda Adventure — main scene (S1 player traversal + S2 combat), hand-authored.
 ;
 ; Structure only: every visual (color/size/position) and the collision-shape
 ; sizes are applied at RUNTIME from the derived PlayerConfig Resource by the two
 ; controllers (gADR-0000 — no config baked into the scene). The RectangleShape2D
 ; sub-resources start at a placeholder size that _ready overwrites from config.
+; Collision topology (S2, see project.godot [layer_names]): Platform=terrain(1),
+; Player=player(2) masking terrain only (passes through the Enemy — contact
+; damage is S4). The Enemy is runtime-instanced by LevelController from
+; enemy.tscn; Projectiles are runtime-instanced by PlayerController.
 [gd_scene load_steps=5 format=3]
 
 [ext_resource type="Script" path="res://src/controllers/level_controller.gd" id="1_level"]
@@ -17,6 +21,8 @@
 script = ExtResource("1_level")
 
 [node name="Player" type="CharacterBody2D" parent="."]
+collision_layer = 2
+collision_mask = 1
 script = ExtResource("2_player")
 
 [node name="Visual" type="ColorRect" parent="Player"]
@@ -27,6 +33,8 @@ shape = SubResource("PlayerShape")
 [node name="Camera2D" type="Camera2D" parent="Player"]
 
 [node name="Platform" type="StaticBody2D" parent="."]
+collision_layer = 1
+collision_mask = 1
 
 [node name="Visual" type="ColorRect" parent="Platform"]
 

--- a/examples/platformer/panda-adventure/scenes/projectile.tscn
+++ b/examples/platformer/panda-adventure/scenes/projectile.tscn
@@ -1,0 +1,12 @@
+[gd_scene format=3]
+
+[ext_resource type="Script" path="res://src/controllers/projectile_controller.gd" id="1_ms14w"]
+
+[node name="Projectile" type="Area2D" unique_id=397764211]
+collision_layer = 8
+collision_mask = 5
+script = ExtResource("1_ms14w")
+
+[node name="Visual" type="ColorRect" parent="." unique_id=1941608377]
+
+[node name="Collision" type="CollisionShape2D" parent="." unique_id=524550210]

--- a/examples/platformer/panda-adventure/scripts/build_config.py
+++ b/examples/platformer/panda-adventure/scripts/build_config.py
@@ -1,30 +1,35 @@
 #!/usr/bin/env python3
 """JSON -> Resource build pipeline for Panda Adventure (gADR-0000).
 
-The authoritative config lives in ``data/json/player_config.json``. This step
-validates it against ``data/schema/player_config.schema.json`` (raising on
-invalid input) and emits the *derived* Godot Resource
-``data/generated/player_config.tres`` that the runtime ``load()``s. The ``.tres``
-is a committed derived artifact (a freshness gate keeps it byte-identical to a
-fresh build), never hand-edited: changing config means changing the JSON.
+The authoritative config lives in ``data/json/*.json``. This step validates each
+source against its JSON Schema (raising on invalid input) and emits the *derived*
+Godot Resources under ``data/generated/`` that the runtime ``load()``s. Every
+``.tres`` is a committed derived artifact (a freshness gate keeps each one
+byte-identical to a fresh build), never hand-edited: changing config means
+changing the JSON.
 
-Dogfooding note: ``gda resource create --type PlayerConfig`` cannot instantiate a
-GDScript ``class_name`` for THIS project, because gda resolves a registered
-class_name through ``ProjectSettings.get_global_class_list()`` — which is only
-populated once the project has been imported/scanned by the editor
-(``.godot/global_script_class_cache.cfg``). This project is agent-driven and never
-opened in the editor, so that cache does not exist and the class is invisible. So
-this converter emits the ``.tres`` text directly — an ``ext_resource`` to the
-script plus the ``[resource]`` field assignments. The emitted file still loads
-through gda/Godot, which the data-seam round-trip test proves.
+Two sources feed four outputs (the ``SPECS`` table):
 
-Run standalone: ``python scripts/build_config.py`` (writes the .tres, prints a
-one-line summary).
+- ``player_config.json`` -> ``player_config.tres`` (``PlayerConfig``, S1)
+- ``combat_config.json`` -> ``stats_player.tres`` + ``stats_enemy.tres``
+  (``StatsConfig`` stat blocks, gADR-0001) and ``combat_config.tres``
+  (``CombatConfig``) — S2
+
+Dogfooding note: since gda's ADR-0032 static class_name scan (issue #360), ``gda
+resource create --type PlayerConfig`` CAN instantiate a project-local class in
+this never-imported project. This converter still emits the ``.tres`` text
+directly: it is the head of the offline balancing pipeline (pure Python, no
+Godot spawn, byte-stable output for the freshness gate), not a workaround. The
+emitted files load through gda/Godot, which the data-seam round-trip tests prove.
+
+Run standalone: ``python scripts/build_config.py`` (writes every .tres, prints a
+one-line summary per file).
 """
 
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -32,21 +37,32 @@ import jsonschema
 
 # Resolve paths relative to this file so the script works from any CWD.
 GAME_DIR = Path(__file__).resolve().parent.parent
-JSON_PATH = GAME_DIR / "data" / "json" / "player_config.json"
-SCHEMA_PATH = GAME_DIR / "data" / "schema" / "player_config.schema.json"
-GENERATED_TRES = GAME_DIR / "data" / "generated" / "player_config.tres"
 
-# The res:// path + script_class of the Resource the generated .tres references.
-SCRIPT_RES_PATH = "res://src/resources/player_config.gd"
-SCRIPT_CLASS = "PlayerConfig"
-_EXT_ID = "1_playerconfig"
 
-# The .tres field layout: (json key, Godot type). Rendered in THIS order, so a
-# rebuild is byte-stable (the freshness gate depends on it) and adding a config
-# field is a one-line change. Types: "color" (4-array -> Color), "vec2" (2-array
-# -> Vector2), "float" (scalar -> bare number). The schema is the validation
-# authority; this list is the render authority — keep them in step.
-_FIELDS: list[tuple[str, str]] = [
+@dataclass(frozen=True)
+class TresSpec:
+    """One derived ``.tres`` output: its source JSON, schema, and field layout.
+
+    ``json_root`` addresses the sub-object of the source document the fields are
+    read from (``()`` = the document root). ``fields`` is the render authority —
+    ``(json key, Godot type)`` pairs rendered in declaration order, so a rebuild
+    is byte-stable (the freshness gate depends on it) and adding a config field
+    is a one-line change. Types: "color" (4-array -> Color), "vec2" (2-array ->
+    Vector2), "float" (scalar -> bare number). The schema is the validation
+    authority; keep the two in step.
+    """
+
+    json_rel: str
+    schema_rel: str
+    out_rel: str
+    script_res_path: str
+    script_class: str
+    ext_id: str
+    json_root: tuple[str, ...] = ()
+    fields: list[tuple[str, str]] = field(default_factory=list)
+
+
+_PLAYER_FIELDS: list[tuple[str, str]] = [
     ("player_color", "color"),
     ("player_size", "vec2"),
     ("player_start", "vec2"),
@@ -62,6 +78,81 @@ _FIELDS: list[tuple[str, str]] = [
     ("landing_tween_duration", "float"),
 ]
 
+_STAT_BLOCK_FIELDS: list[tuple[str, str]] = [
+    ("max_hp", "float"),
+    ("max_mp", "float"),
+    ("attack", "float"),
+    ("defense", "float"),
+]
+
+_COMBAT_FIELDS: list[tuple[str, str]] = [
+    ("attack_scale", "float"),
+    ("defense_scale", "float"),
+    ("min_damage", "float"),
+    ("iframe_duration", "float"),
+    ("projectile_color", "color"),
+    ("projectile_size", "vec2"),
+    ("projectile_speed", "float"),
+    ("projectile_lifetime", "float"),
+    ("projectile_spawn_offset", "vec2"),
+    ("enemy_color", "color"),
+    ("enemy_size", "vec2"),
+    ("enemy_position", "vec2"),
+    ("hit_flash_color", "color"),
+    ("hit_flash_duration", "float"),
+]
+
+_PLAYER_SPEC = TresSpec(
+    json_rel="data/json/player_config.json",
+    schema_rel="data/schema/player_config.schema.json",
+    out_rel="data/generated/player_config.tres",
+    script_res_path="res://src/resources/player_config.gd",
+    script_class="PlayerConfig",
+    ext_id="1_playerconfig",
+    fields=_PLAYER_FIELDS,
+)
+
+SPECS: list[TresSpec] = [
+    _PLAYER_SPEC,
+    TresSpec(
+        json_rel="data/json/combat_config.json",
+        schema_rel="data/schema/combat_config.schema.json",
+        out_rel="data/generated/stats_player.tres",
+        script_res_path="res://src/resources/stats_config.gd",
+        script_class="StatsConfig",
+        ext_id="1_statsconfig",
+        json_root=("player_stats",),
+        fields=_STAT_BLOCK_FIELDS,
+    ),
+    TresSpec(
+        json_rel="data/json/combat_config.json",
+        schema_rel="data/schema/combat_config.schema.json",
+        out_rel="data/generated/stats_enemy.tres",
+        script_res_path="res://src/resources/stats_config.gd",
+        script_class="StatsConfig",
+        ext_id="1_statsconfig",
+        json_root=("enemy_stats",),
+        fields=_STAT_BLOCK_FIELDS,
+    ),
+    TresSpec(
+        json_rel="data/json/combat_config.json",
+        schema_rel="data/schema/combat_config.schema.json",
+        out_rel="data/generated/combat_config.tres",
+        script_res_path="res://src/resources/combat_config.gd",
+        script_class="CombatConfig",
+        ext_id="1_combatconfig",
+        fields=_COMBAT_FIELDS,
+    ),
+]
+
+# S1 back-compat conveniences (existing tests and callers import these; they are
+# the player spec's paths) plus the S2 combat-source counterparts.
+JSON_PATH = GAME_DIR / _PLAYER_SPEC.json_rel
+SCHEMA_PATH = GAME_DIR / _PLAYER_SPEC.schema_rel
+GENERATED_TRES = GAME_DIR / _PLAYER_SPEC.out_rel
+COMBAT_JSON_PATH = GAME_DIR / "data/json/combat_config.json"
+COMBAT_SCHEMA_PATH = GAME_DIR / "data/schema/combat_config.schema.json"
+
 
 def load_json(path: Path) -> Any:
     """Parse a JSON file into Python data."""
@@ -69,15 +160,16 @@ def load_json(path: Path) -> Any:
 
 
 def load_schema(path: Path = SCHEMA_PATH) -> dict[str, Any]:
-    """Load the player-config JSON Schema."""
+    """Load a JSON Schema (defaults to the S1 player-config schema)."""
     return load_json(path)
 
 
 def validate_config(config: Any, schema: dict[str, Any] | None = None) -> Any:
     """Validate ``config`` against the schema; raise on invalid, else return it.
 
-    Raises :class:`jsonschema.ValidationError` for any schema violation (missing
-    key, wrong type, out-of-range component, wrong array length, wrong sign).
+    Defaults to the player-config schema (S1 back-compat). Raises
+    :class:`jsonschema.ValidationError` for any schema violation (missing key,
+    wrong type, out-of-range component, wrong array length, wrong sign).
     """
     jsonschema.validate(
         instance=config, schema=schema if schema is not None else load_schema()
@@ -112,23 +204,57 @@ def _render_field(key: str, kind: str, value: Any) -> str:
     raise ValueError(f"unknown field kind {kind!r} for {key!r}")
 
 
-def render_tres(config: dict[str, Any]) -> str:
-    """Render a validated player config as ``PlayerConfig`` ``.tres`` text.
+def render_spec(spec: TresSpec, document: dict[str, Any]) -> str:
+    """Render one spec's ``.tres`` text from a validated source document.
 
-    Pure function (no IO): the JSON->Resource conversion seam. Walks ``_FIELDS``
-    in declaration order, mapping each JSON value to its Godot type.
+    Pure function (no IO): the JSON->Resource conversion seam. Descends
+    ``spec.json_root`` into the document, then walks ``spec.fields`` in
+    declaration order, mapping each JSON value to its Godot type.
     """
+    config = document
+    for key in spec.json_root:
+        config = config[key]
     body = "".join(
-        f"{key} = {_render_field(key, kind, config[key])}\n" for key, kind in _FIELDS
+        f"{key} = {_render_field(key, kind, config[key])}\n"
+        for key, kind in spec.fields
     )
     return (
-        f'[gd_resource type="Resource" script_class="{SCRIPT_CLASS}" '
+        f'[gd_resource type="Resource" script_class="{spec.script_class}" '
         f"load_steps=2 format=3]\n\n"
-        f'[ext_resource type="Script" path="{SCRIPT_RES_PATH}" id="{_EXT_ID}"]\n\n'
+        f'[ext_resource type="Script" path="{spec.script_res_path}" '
+        f'id="{spec.ext_id}"]\n\n'
         f"[resource]\n"
-        f'script = ExtResource("{_EXT_ID}")\n'
+        f'script = ExtResource("{spec.ext_id}")\n'
         f"{body}"
     )
+
+
+def render_tres(config: dict[str, Any]) -> str:
+    """Render a validated player config as ``PlayerConfig`` ``.tres`` text (S1)."""
+    return render_spec(_PLAYER_SPEC, config)
+
+
+def build_spec(
+    spec: TresSpec, root: Path = GAME_DIR, out_path: Path | None = None
+) -> Path:
+    """Validate one spec's source JSON and write its derived ``.tres``.
+
+    Paths resolve against ``root`` so the e2e project copies can rebuild in
+    place. Returns the path written; raises
+    :class:`jsonschema.ValidationError` if the JSON is invalid, so a bad config
+    fails the build loudly.
+    """
+    document = load_json(root / spec.json_rel)
+    validate_config(document, load_schema(root / spec.schema_rel))
+    target = out_path if out_path is not None else root / spec.out_rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(render_spec(spec, document), encoding="utf-8")
+    return target
+
+
+def build_all(root: Path = GAME_DIR) -> list[Path]:
+    """Build every declared output under ``root``; returns the paths written."""
+    return [build_spec(spec, root=root) for spec in SPECS]
 
 
 def build(
@@ -136,11 +262,7 @@ def build(
     schema_path: Path = SCHEMA_PATH,
     out_path: Path = GENERATED_TRES,
 ) -> Path:
-    """Validate the authoritative JSON and write the derived ``.tres``.
-
-    Returns the path written. Raises :class:`jsonschema.ValidationError` if the
-    JSON is invalid, so a bad config fails the build loudly.
-    """
+    """Validate the authoritative player JSON and write its ``.tres`` (S1 API)."""
     config = load_json(json_path)
     validate_config(config, load_schema(schema_path))
     out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -149,8 +271,12 @@ def build(
 
 
 def main() -> None:
-    written = build()
-    print(f"build_config: wrote {written.relative_to(GAME_DIR)} from {JSON_PATH.name}")
+    for spec in SPECS:
+        written = build_spec(spec)
+        print(
+            f"build_config: wrote {written.relative_to(GAME_DIR)} "
+            f"from {Path(spec.json_rel).name}"
+        )
 
 
 if __name__ == "__main__":

--- a/examples/platformer/panda-adventure/src/controllers/enemy_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/enemy_controller.gd
@@ -1,0 +1,107 @@
+class_name EnemyController
+extends StaticBody2D
+
+## Drives the S2 static Enemy block: applies its data-driven blockout in _ready,
+## owns its live StatsSystem, and resolves incoming hits — i-frame gate, the
+## symmetric damage formula, a hit-flash property tween (the blockout
+## "animation"), and death at 0 HP (died signal + removal). It does not move or
+## attack; Archetype AI and enemy->Player damage are S4.
+##
+## Decisions stay PURE (CombatSystem, gADR-0001): this controller only
+## orchestrates — it reads the real clock, mutates its StatsSystem, tweens, and
+## logs. Stats and every number come from the derived StatsConfig/CombatConfig
+## Resources (gADR-0000). Cross-script references use preload() (no editor
+## class cache in this never-imported project).
+
+signal died
+
+const StatsConfigScript := preload("res://src/resources/stats_config.gd")
+const CombatConfigScript := preload("res://src/resources/combat_config.gd")
+const StatsSystemScript := preload("res://src/systems/stats_system.gd")
+const CombatSystemScript := preload("res://src/systems/combat_system.gd")
+const GameLogScript := preload("res://src/util/game_log.gd")
+
+const STATS_PATH := "res://data/generated/stats_enemy.tres"
+const CONFIG_PATH := "res://data/generated/combat_config.tres"
+
+var _stats_config: StatsConfigScript
+var _combat: CombatConfigScript
+var _stats: StatsSystemScript
+# When this defender last took a hit (seconds). -INF = never hit, so the first
+# hit always lands (CombatSystem.is_invulnerable's sentinel contract).
+var _last_hit_time := -INF
+
+
+func _ready() -> void:
+	_stats_config = load(STATS_PATH)
+	_combat = load(CONFIG_PATH)
+	if _stats_config == null or _combat == null:
+		# The derived .tres are committed; guard loudly rather than crash on a
+		# half-checkout, pointing at the pipeline that regenerates them from JSON.
+		push_error(
+			"EnemyController: could not load %s / %s — run scripts/build_config.py."
+			% [STATS_PATH, CONFIG_PATH]
+		)
+		return
+	_stats = StatsSystemScript.new()
+	_stats.init_from(_stats_config)
+	_apply_blockout(_combat)
+	GameLogScript.emit("info", "enemy_ready", {
+		"max_hp": _stats_config.max_hp,
+		"x": position.x,
+		"y": position.y,
+	})
+
+
+## Resolve one incoming hit from an attacker's stat block. Inside the i-frame
+## window the hit is ignored — a single overlap cannot chain hits across frames.
+func take_hit(attacker: StatsConfigScript) -> void:
+	if _stats == null:
+		return
+	var now := _now()
+	if CombatSystemScript.is_invulnerable(_last_hit_time, now, _combat.iframe_duration):
+		return
+	_last_hit_time = now
+	var damage := CombatSystemScript.compute_damage(attacker, _stats_config, _combat)
+	_stats.apply_damage(damage)
+	GameLogScript.emit("info", "enemy_hit", {"damage": damage, "hp_left": _stats.hp})
+	_play_hit_flash()
+	if CombatSystemScript.is_dead(_stats.hp):
+		died.emit()
+		GameLogScript.emit("info", "enemy_died", {"x": position.x, "y": position.y})
+		queue_free()
+
+
+## The runtime clock feeding the pure i-frame decision; the Monte-Carlo sim
+## supplies its own simulated time instead.
+func _now() -> float:
+	return Time.get_ticks_msec() / 1000.0
+
+
+## Apply the data-driven blockout: the Enemy block centered on the body origin.
+## The collision shape is CREATED here (RectangleShape2D.new sized from config):
+## gda cannot author inline sub-resources (#365), so the scene ships shape=null.
+func _apply_blockout(config: CombatConfigScript) -> void:
+	var half := config.enemy_size / 2.0
+
+	var visual := $Visual as ColorRect
+	visual.color = config.enemy_color
+	visual.size = config.enemy_size
+	visual.position = -half
+
+	var shape := RectangleShape2D.new()
+	shape.size = config.enemy_size
+	($Collision as CollisionShape2D).shape = shape
+
+
+## The blockout "animation": flash the block to the hit color and tween back to
+## its own color (a property-tween, per the GDD — the S2 sibling of S1's
+## landing squash).
+func _play_hit_flash() -> void:
+	var visual := $Visual as ColorRect
+	visual.color = _combat.hit_flash_color
+	var tween := create_tween()
+	var recover := tween.tween_property(
+		visual, "color", _combat.enemy_color, _combat.hit_flash_duration
+	)
+	recover.set_trans(Tween.TRANS_SINE)

--- a/examples/platformer/panda-adventure/src/controllers/level_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/level_controller.gd
@@ -1,32 +1,43 @@
 class_name LevelController
 extends Node2D
 
-## Scene-level director for S1: applies the data-driven Platform blockout and
-## emits the boot log. The Player self-configures (PlayerController); this owns
-## the rest of the level so config application stays out of the physics body.
+## Scene-level director for S1+S2: applies the data-driven Platform blockout,
+## spawns the S2 Enemy, and emits the boot log. The Player self-configures
+## (PlayerController); this owns the rest of the level so config application
+## stays out of the physics body.
 ##
-## Visuals and geometry are data (gADR-0000): the derived PlayerConfig Resource,
-## never hardcoded. Loaded here and in PlayerController — load() is cached, so
-## both observe the same instance.
+## Visuals and geometry are data (gADR-0000): the derived PlayerConfig /
+## CombatConfig Resources, never hardcoded. Loaded here and in the actor
+## controllers — load() is cached, so all observe the same instance.
+##
+## The Enemy is runtime-instanced from enemy.tscn rather than baked into
+## main.tscn: its placement is config (enemy_position), and S4's wave spawner
+## inherits this exact pattern.
 ##
 ## preload() over the global class_name registry: this project has no
 ## editor-generated global_script_class_cache, so a bare PlayerConfig / GameLog
 ## type name would not resolve in a headless runtime.
 
 const PlayerConfigScript := preload("res://src/resources/player_config.gd")
+const CombatConfigScript := preload("res://src/resources/combat_config.gd")
 const GameLogScript := preload("res://src/util/game_log.gd")
+const EnemyScene := preload("res://scenes/enemy.tscn")
 
 const CONFIG_PATH := "res://data/generated/player_config.tres"
+const COMBAT_CONFIG_PATH := "res://data/generated/combat_config.tres"
 
 
 func _ready() -> void:
 	var config: PlayerConfigScript = load(CONFIG_PATH)
-	if config == null:
+	var combat: CombatConfigScript = load(COMBAT_CONFIG_PATH)
+	if config == null or combat == null:
 		push_error(
-			"LevelController: could not load %s — run scripts/build_config.py." % CONFIG_PATH
+			"LevelController: could not load %s / %s — run scripts/build_config.py."
+			% [CONFIG_PATH, COMBAT_CONFIG_PATH]
 		)
 		return
 	_apply_platform(config)
+	_spawn_enemy(combat)
 
 	# Keep fields JSON-scalar so the GameLog print() fallback's JSON.stringify is
 	# clean (Vector2 is not a JSON type).
@@ -52,3 +63,12 @@ func _apply_platform(config: PlayerConfigScript) -> void:
 	shape.size = config.platform_size
 
 	platform.position = config.platform_position
+
+
+## Spawn the S2 static Enemy at its config position. The instance self-applies
+## its blockout and stats (EnemyController._ready).
+func _spawn_enemy(combat: CombatConfigScript) -> void:
+	var enemy := EnemyScene.instantiate()
+	enemy.name = "Enemy"
+	enemy.position = combat.enemy_position
+	add_child(enemy)

--- a/examples/platformer/panda-adventure/src/controllers/player_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/player_controller.gd
@@ -53,6 +53,14 @@ static func compute_velocity(
 	return v
 
 
+## Pure facing decision: a nonzero horizontal input re-aims the Player
+## (sign-normalized to -1/1), zero input preserves the current facing. Drives
+## the Laser Gun's projectile direction; the spawn facing (1.0, rightward) is
+## structural, not config.
+static func compute_facing(facing: float, input_dir: float) -> float:
+	return signf(input_dir) if input_dir != 0.0 else facing
+
+
 func _ready() -> void:
 	_config = load(CONFIG_PATH)
 	if _config == null:

--- a/examples/platformer/panda-adventure/src/controllers/player_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/player_controller.gd
@@ -6,6 +6,12 @@ extends CharacterBody2D
 ## and applies the result with move_and_slide. A landing squash-stretch tween is
 ## the blockout "animation" (property interpolation, gADR/GDD).
 ##
+## S2 adds the Laser Gun: the `fire` action spawns a Projectile bolt aimed by
+## the facing (pure compute_facing over the same input axis), carrying the
+## Player's StatsConfig stat block as the attacker for the damage formula. The
+## Player owns its live StatsSystem (all four stats; HP untouched until S4's
+## enemy->Player damage).
+##
 ## Movement params and visuals are data (gADR-0000): a derived PlayerConfig
 ## Resource, never hardcoded. compute_velocity is static and node-free so the
 ## logic seam can exercise it headless (tests/gdscript/test_player_logic.gd via
@@ -16,11 +22,22 @@ extends CharacterBody2D
 ## bare PlayerConfig type name would not resolve in a headless runtime.
 
 const PlayerConfigScript := preload("res://src/resources/player_config.gd")
+const StatsConfigScript := preload("res://src/resources/stats_config.gd")
+const CombatConfigScript := preload("res://src/resources/combat_config.gd")
+const StatsSystemScript := preload("res://src/systems/stats_system.gd")
 const GameLogScript := preload("res://src/util/game_log.gd")
+const ProjectileScene := preload("res://scenes/projectile.tscn")
 
 const CONFIG_PATH := "res://data/generated/player_config.tres"
+const STATS_PATH := "res://data/generated/stats_player.tres"
+const COMBAT_CONFIG_PATH := "res://data/generated/combat_config.tres"
 
 var _config: PlayerConfigScript
+var _stats_config: StatsConfigScript
+var _combat: CombatConfigScript
+var _stats: StatsSystemScript
+# Current aim (-1 left / 1 right); spawn faces right (structural, not config).
+var _facing := 1.0
 
 
 ## Pure movement decision (no node/physics access): given the current velocity,
@@ -63,17 +80,23 @@ static func compute_facing(facing: float, input_dir: float) -> float:
 
 func _ready() -> void:
 	_config = load(CONFIG_PATH)
-	if _config == null:
-		# The derived .tres is committed; guard loudly rather than crash on a
-		# half-checkout, pointing at the pipeline that regenerates it from JSON.
+	_stats_config = load(STATS_PATH)
+	_combat = load(COMBAT_CONFIG_PATH)
+	if _config == null or _stats_config == null or _combat == null:
+		# The derived .tres are committed; guard loudly rather than crash on a
+		# half-checkout, pointing at the pipeline that regenerates them from JSON.
 		push_error(
-			"PlayerController: could not load %s — run scripts/build_config.py." % CONFIG_PATH
+			"PlayerController: could not load %s / %s / %s — run scripts/build_config.py."
+			% [CONFIG_PATH, STATS_PATH, COMBAT_CONFIG_PATH]
 		)
 		return
+	_stats = StatsSystemScript.new()
+	_stats.init_from(_stats_config)
 	_apply_blockout(_config)
 	GameLogScript.emit("info", "player_ready", {
 		"move_speed": _config.move_speed,
 		"jump_velocity": _config.jump_velocity,
+		"max_hp": _stats_config.max_hp,
 	})
 
 
@@ -106,12 +129,35 @@ func _physics_process(delta: float) -> void:
 	var jump_pressed := Input.is_action_just_pressed("jump")
 	var was_on_floor := is_on_floor()
 
+	_facing = compute_facing(_facing, input_dir)
 	velocity = compute_velocity(velocity, input_dir, jump_pressed, was_on_floor, _config, delta)
 	move_and_slide()
 
 	# Landing this frame (airborne last frame, on the floor now) → play the squash.
 	if is_on_floor() and not was_on_floor:
 		_play_landing_tween()
+
+	if Input.is_action_just_pressed("fire"):
+		_fire()
+
+
+## Fire the Laser Gun: spawn one Projectile bolt aimed by the facing, offset
+## from the Player origin, carrying the Player's stat block as the attacker.
+## The bolt is a child of the Player's PARENT (the level), so it flies in world
+## space instead of inheriting the Player's movement. One press = one bolt.
+func _fire() -> void:
+	if _stats_config == null or _combat == null:
+		return
+	var bolt := ProjectileScene.instantiate()
+	bolt.setup(Vector2(_facing, 0.0), _stats_config)
+	var offset := _combat.projectile_spawn_offset
+	bolt.position = position + Vector2(_facing * offset.x, offset.y)
+	get_parent().add_child(bolt)
+	GameLogScript.emit("info", "laser_fired", {
+		"facing": _facing,
+		"spawn_x": bolt.position.x,
+		"spawn_y": bolt.position.y,
+	})
 
 
 ## The blockout "animation": a brief squash-stretch of the Player block on landing

--- a/examples/platformer/panda-adventure/src/controllers/projectile_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/projectile_controller.gd
@@ -1,0 +1,81 @@
+class_name ProjectileController
+extends Area2D
+
+## Drives one Laser Gun bolt: applies its data-driven blockout in _ready, flies
+## in a straight line, and resolves the FIRST body it overlaps — an Enemy takes
+## the hit (duck-typed take_hit), terrain just stops it — then despawns. An
+## unhit bolt despawns after its config lifetime.
+##
+## Collision topology (project.godot [layer_names]): layer=projectile(8),
+## mask=terrain|enemy(5) — a bolt can never hit the Player or another bolt, so
+## the mask, not code, is what guarantees body is terrain or an Enemy.
+##
+## The bolt is an Area2D on purpose: it needs overlap detection with zero
+## physics response (no gravity, no sliding, no pushing) — motion is manual in
+## _physics_process. All numbers come from the derived CombatConfig (gADR-0000);
+## the attacker's stat block is INJECTED by the shooter via setup() before the
+## bolt enters the tree, so the damage formula reads real attacker stats
+## (gADR-0001). Cross-script references use preload() (no editor class cache).
+
+const StatsConfigScript := preload("res://src/resources/stats_config.gd")
+const CombatConfigScript := preload("res://src/resources/combat_config.gd")
+
+const CONFIG_PATH := "res://data/generated/combat_config.tres"
+
+var _config: CombatConfigScript
+var _direction := Vector2.RIGHT
+var _attacker: StatsConfigScript
+
+
+## Aim the bolt and hand it the attacker's stat block. Called by the shooter
+## BEFORE add_child, so _ready sees both.
+func setup(direction: Vector2, attacker: StatsConfigScript) -> void:
+	_direction = direction
+	_attacker = attacker
+
+
+func _ready() -> void:
+	_config = load(CONFIG_PATH)
+	if _config == null:
+		# The derived .tres is committed; guard loudly rather than crash on a
+		# half-checkout, pointing at the pipeline that regenerates it from JSON.
+		push_error(
+			"ProjectileController: could not load %s — run scripts/build_config.py." % CONFIG_PATH
+		)
+		queue_free()
+		return
+	_apply_blockout(_config)
+	body_entered.connect(_on_body_entered)
+	# Lifetime despawn. The timeout connection is dropped automatically if the
+	# bolt was already freed by a hit (Godot disconnects a freed target).
+	get_tree().create_timer(_config.projectile_lifetime).timeout.connect(queue_free)
+
+
+func _physics_process(delta: float) -> void:
+	if _config == null:
+		return
+	position += _direction * _config.projectile_speed * delta
+
+
+## Apply the data-driven blockout: the bolt block centered on the Area2D origin.
+## The collision shape is CREATED here (RectangleShape2D.new sized from config):
+## gda cannot author inline sub-resources (#365), so the scene ships shape=null.
+func _apply_blockout(config: CombatConfigScript) -> void:
+	var half := config.projectile_size / 2.0
+
+	var visual := $Visual as ColorRect
+	visual.color = config.projectile_color
+	visual.size = config.projectile_size
+	visual.position = -half
+
+	var shape := RectangleShape2D.new()
+	shape.size = config.projectile_size
+	($Collision as CollisionShape2D).shape = shape
+
+
+func _on_body_entered(body: Node2D) -> void:
+	# The mask guarantees body is terrain or an Enemy; only an Enemy can take a
+	# hit. Either way the bolt is spent — one bolt, at most one hit.
+	if body.has_method("take_hit"):
+		body.take_hit(_attacker)
+	queue_free()

--- a/examples/platformer/panda-adventure/src/resources/combat_config.gd
+++ b/examples/platformer/panda-adventure/src/resources/combat_config.gd
@@ -1,0 +1,43 @@
+class_name CombatConfig
+extends Resource
+
+## Typed combat configuration for S2 (Laser Gun combat).
+##
+## This Resource is a DERIVED artifact: it is regenerated from the authoritative
+## data/json/combat_config.json by scripts/build_config.py (validated against
+## data/schema/combat_config.schema.json) and emitted to
+## data/generated/combat_config.tres. Never hand-edit the generated .tres or
+## hardcode these values — change the JSON (gADR-0000).
+##
+## The @export fields carry NO default literals on purpose (gADR-0000; see
+## PlayerConfig). Fields group into four concerns: the damage-formula params
+## (consumed by CombatSystem.compute_damage), the i-frame window, the Projectile
+## blockout + motion, and the S2 static Enemy blockout + hit-flash juice.
+
+# Damage-formula params — pure inputs to CombatSystem.compute_damage:
+# maxf(min_damage, attack * attack_scale - defense * defense_scale).
+@export var attack_scale: float
+@export var defense_scale: float
+@export var min_damage: float
+
+# Seconds of invulnerability a defender gets after a landed hit (i-frames), so a
+# single overlap cannot chain hits across consecutive frames.
+@export var iframe_duration: float
+
+# Projectile block — the Laser Gun bolt (blockout + manual straight-line motion).
+@export var projectile_color: Color
+@export var projectile_size: Vector2
+@export var projectile_speed: float
+@export var projectile_lifetime: float
+# Spawn offset from the Player origin; x is scaled by the Player's facing.
+@export var projectile_spawn_offset: Vector2
+
+# Enemy block — the S2 static target (S4 replaces placement with wave spawning).
+@export var enemy_color: Color
+@export var enemy_size: Vector2
+@export var enemy_position: Vector2
+
+# Hit "juice": the modulate flash applied on a landed hit and the seconds the
+# tween takes to recover it (the S2 sibling of S1's landing squash).
+@export var hit_flash_color: Color
+@export var hit_flash_duration: float

--- a/examples/platformer/panda-adventure/src/resources/stats_config.gd
+++ b/examples/platformer/panda-adventure/src/resources/stats_config.gd
@@ -1,0 +1,24 @@
+class_name StatsConfig
+extends Resource
+
+## The per-actor-kind stat block for S2 combat (gADR-0001).
+##
+## This Resource is a DERIVED artifact: it is regenerated from the authoritative
+## data/json/combat_config.json (its player_stats / enemy_stats blocks) by
+## scripts/build_config.py and emitted to data/generated/stats_player.tres and
+## stats_enemy.tres. Never hand-edit the generated .tres or hardcode these
+## values — change the JSON (gADR-0000).
+##
+## Player and Enemy carry the SAME type: this is the symmetric attacker/defender
+## shape of the damage formula (CombatSystem.compute_damage), so S4's
+## enemy->Player damage reuses the formula unchanged. Immutable at runtime —
+## live HP/MP mutate on a per-actor StatsSystem instead (gADR-0001).
+##
+## The @export fields carry NO default literals on purpose: a default would read
+## as a second config source competing with the authoritative JSON (gADR-0000).
+
+@export var max_hp: float
+@export var max_mp: float
+@export var attack: float
+# Defense/mitigation term of the damage formula. 0 until the Spacesuit exists.
+@export var defense: float

--- a/examples/platformer/panda-adventure/src/systems/combat_system.gd
+++ b/examples/platformer/panda-adventure/src/systems/combat_system.gd
@@ -1,0 +1,45 @@
+class_name CombatSystem
+extends RefCounted
+
+## The pure combat decisions for S2 (gADR-0001): damage, i-frames, death.
+##
+## Every function here is static, deterministic, and node/physics/clock-free —
+## a pure mapping from stat data (StatsConfig blocks + CombatConfig params) and
+## caller-supplied time to a decision. That purity is load-bearing: the offline
+## Monte-Carlo balancing pipeline (gADR-0000) reuses these functions unchanged,
+## supplying its own simulated clock. Controllers orchestrate (read the real
+## clock, mutate StatsSystem, tween, log); decisions live only here.
+
+const StatsConfigScript := preload("res://src/resources/stats_config.gd")
+const CombatConfigScript := preload("res://src/resources/combat_config.gd")
+
+
+## The data-driven damage formula (issue #331): the attacker's scaled attack
+## minus the defender's scaled mitigation, floored at min_damage. SYMMETRIC by
+## construction — S4's enemy->Player damage is this same call with the roles
+## swapped. The defense term contributes 0 until the Spacesuit exists.
+static func compute_damage(
+	attacker: StatsConfigScript,
+	defender: StatsConfigScript,
+	params: CombatConfigScript,
+) -> float:
+	return maxf(
+		params.min_damage,
+		attacker.attack * params.attack_scale
+			- defender.defense * params.defense_scale,
+	)
+
+
+## True while the defender is inside its post-hit i-frame window, so a single
+## overlap cannot chain hits across consecutive frames. Pure in (last_hit_time,
+## now): the runtime passes its clock, the balancing sim passes a simulated one.
+## A defender that was never hit uses the -INF sentinel (elapsed = INF -> false).
+static func is_invulnerable(
+	last_hit_time: float, now: float, iframe_duration: float
+) -> bool:
+	return (now - last_hit_time) < iframe_duration
+
+
+## The death rule: an actor dies at exactly 0 HP (StatsSystem clamps there).
+static func is_dead(hp: float) -> bool:
+	return hp <= 0.0

--- a/examples/platformer/panda-adventure/src/systems/stats_system.gd
+++ b/examples/platformer/panda-adventure/src/systems/stats_system.gd
@@ -1,0 +1,34 @@
+class_name StatsSystem
+extends Resource
+
+## The runtime holder of one actor's live stats: HP/MP/EXP/Gold (issue #331).
+##
+## Instantiated fresh per actor (`StatsSystemScript.new()` + `init_from(block)`)
+## from that actor's derived StatsConfig stat block — NEVER load()ed from disk
+## and never saved back (gADR-0001): the .tres stays a derived, immutable config
+## artifact; live mutation exists only in memory, per run.
+##
+## All four stats live now, but S2 exercises only HP: MP is spent by the Gravity
+## Gun (S3), EXP/Gold accumulate from kill rewards (S6a). EXP is named
+## `exp_points` in code because `exp` would shadow the built-in exp().
+
+const StatsConfigScript := preload("res://src/resources/stats_config.gd")
+
+var hp: float
+var mp: float
+var exp_points: float
+var gold: float
+
+
+## Initialize live stats from an actor's stat block: full HP/MP, and EXP/Gold at
+## their accumulation identity (0 — structural, not a tunable).
+func init_from(config: StatsConfigScript) -> void:
+	hp = config.max_hp
+	mp = config.max_mp
+	exp_points = 0.0
+	gold = 0.0
+
+
+## Deduct damage from HP, clamping at 0 (HP never goes negative).
+func apply_damage(amount: float) -> void:
+	hp = maxf(hp - amount, 0.0)

--- a/examples/platformer/panda-adventure/tests/gdscript/test_combat_logic.gd
+++ b/examples/platformer/panda-adventure/tests/gdscript/test_combat_logic.gd
@@ -1,0 +1,163 @@
+extends SceneTree
+
+## Logic seam (b) for S2: exercise the PURE combat decisions headless —
+## CombatSystem.compute_damage / is_invulnerable / is_dead, StatsSystem's
+## init_from / apply_damage, and PlayerController.compute_facing. These are the
+## functions the offline Monte-Carlo balancing sim reuses (gADR-0001), so they
+## must stay node/physics/clock-free.
+##
+## Run via gda (ADR-0031):
+##   gda script run res://tests/gdscript/test_combat_logic.gd
+##
+## preload() the scripts (a headless runtime has no editor-generated
+## global_script_class_cache, so bare class_name types would not resolve),
+## construct in-memory configs with KNOWN values, and assert each combat rule.
+## Prints "LOGIC_SEAM: PASS" + quit(0) on success, else push_error + quit(1).
+
+const StatsConfigScript := preload("res://src/resources/stats_config.gd")
+const CombatConfigScript := preload("res://src/resources/combat_config.gd")
+const StatsSystemScript := preload("res://src/systems/stats_system.gd")
+const CombatSystemScript := preload("res://src/systems/combat_system.gd")
+const PlayerControllerScript := preload("res://src/controllers/player_controller.gd")
+
+# Fixed formula params so every expectation is exact (distinct scales prove each
+# term is applied to the right stat).
+const ATTACK_SCALE := 2.0
+const DEFENSE_SCALE := 1.5
+const MIN_DAMAGE := 1.0
+const IFRAME_DURATION := 0.6
+
+# Two DIFFERENT stat blocks so the attacker<->defender symmetry is observable.
+const PLAYER_ATTACK := 10.0
+const PLAYER_DEFENSE := 4.0
+const ENEMY_ATTACK := 6.0
+const ENEMY_DEFENSE := 2.0
+
+
+func _make_params() -> CombatConfigScript:
+	var p := CombatConfigScript.new()
+	p.attack_scale = ATTACK_SCALE
+	p.defense_scale = DEFENSE_SCALE
+	p.min_damage = MIN_DAMAGE
+	p.iframe_duration = IFRAME_DURATION
+	return p
+
+
+func _make_stats(max_hp: float, max_mp: float, attack: float, defense: float) -> StatsConfigScript:
+	var s := StatsConfigScript.new()
+	s.max_hp = max_hp
+	s.max_mp = max_mp
+	s.attack = attack
+	s.defense = defense
+	return s
+
+
+func _fail(msg: String) -> void:
+	push_error("LOGIC_SEAM: " + msg)
+	quit(1)
+
+
+func _init() -> void:
+	var params := _make_params()
+	var player := _make_stats(100.0, 50.0, PLAYER_ATTACK, PLAYER_DEFENSE)
+	var enemy := _make_stats(25.0, 0.0, ENEMY_ATTACK, ENEMY_DEFENSE)
+
+	# Behavior 1 — zero defense: damage is attack * attack_scale, undiminished.
+	var undefended := _make_stats(25.0, 0.0, ENEMY_ATTACK, 0.0)
+	var raw := CombatSystemScript.compute_damage(player, undefended, params)
+	if not is_equal_approx(raw, PLAYER_ATTACK * ATTACK_SCALE):
+		_fail("zero defense: expected %s, got %s" % [PLAYER_ATTACK * ATTACK_SCALE, raw])
+		return
+
+	# Behavior 2 — mitigation: defense * defense_scale is subtracted.
+	var mitigated := CombatSystemScript.compute_damage(player, enemy, params)
+	var expected_pe := PLAYER_ATTACK * ATTACK_SCALE - ENEMY_DEFENSE * DEFENSE_SCALE
+	if not is_equal_approx(mitigated, expected_pe):
+		_fail("mitigation: expected %s, got %s" % [expected_pe, mitigated])
+		return
+
+	# Behavior 3 — floor: when defense swamps attack, damage clamps to min_damage.
+	var weak := _make_stats(100.0, 0.0, 1.0, 0.0)
+	var tank := _make_stats(100.0, 0.0, 0.0, 10.0)
+	var floored := CombatSystemScript.compute_damage(weak, tank, params)
+	if not is_equal_approx(floored, MIN_DAMAGE):
+		_fail("min-damage floor: expected %s, got %s" % [MIN_DAMAGE, floored])
+		return
+
+	# Behavior 4 — symmetry: the SAME function serves both directions (the S4
+	# enemy->Player reuse contract), each direction reading its own stats.
+	var enemy_on_player := CombatSystemScript.compute_damage(enemy, player, params)
+	var expected_ep := ENEMY_ATTACK * ATTACK_SCALE - PLAYER_DEFENSE * DEFENSE_SCALE
+	if not is_equal_approx(enemy_on_player, expected_ep):
+		_fail("symmetry enemy->player: expected %s, got %s" % [expected_ep, enemy_on_player])
+		return
+	if is_equal_approx(enemy_on_player, mitigated):
+		_fail("symmetry: both directions returned %s — stats not per-role" % mitigated)
+		return
+
+	# Behavior 5 — i-frames: invulnerable strictly WITHIN the window, vulnerable
+	# at/after expiry, and the -INF first-hit sentinel is always vulnerable.
+	if not CombatSystemScript.is_invulnerable(10.0, 10.3, IFRAME_DURATION):
+		_fail("i-frame: 0.3s after a hit should be invulnerable")
+		return
+	# Boundary probed with exactly-representable floats (0.5, not 0.6) so the
+	# `elapsed < window` contract is what's tested, not float rounding.
+	if CombatSystemScript.is_invulnerable(10.0, 10.5, 0.5):
+		_fail("i-frame: exactly at window expiry should be vulnerable")
+		return
+	if CombatSystemScript.is_invulnerable(10.0, 11.0, IFRAME_DURATION):
+		_fail("i-frame: past the window should be vulnerable")
+		return
+	if CombatSystemScript.is_invulnerable(-INF, 0.0, IFRAME_DURATION):
+		_fail("i-frame: the -INF first-hit sentinel should never be invulnerable")
+		return
+
+	# Behavior 6 — StatsSystem.init_from: all four stats live (HP/MP from the
+	# stat block, EXP/Gold at their accumulation identity 0).
+	var stats := StatsSystemScript.new()
+	stats.init_from(player)
+	if not is_equal_approx(stats.hp, 100.0):
+		_fail("init_from: expected hp=100, got %s" % stats.hp)
+		return
+	if not is_equal_approx(stats.mp, 50.0):
+		_fail("init_from: expected mp=50, got %s" % stats.mp)
+		return
+	if not (is_zero_approx(stats.exp_points) and is_zero_approx(stats.gold)):
+		_fail("init_from: expected exp=0 gold=0, got %s / %s" % [stats.exp_points, stats.gold])
+		return
+
+	# Behavior 7 — apply_damage: reduces HP; overkill clamps at 0 (never negative).
+	stats.apply_damage(30.0)
+	if not is_equal_approx(stats.hp, 70.0):
+		_fail("apply_damage: expected hp=70, got %s" % stats.hp)
+		return
+	stats.apply_damage(1000.0)
+	if not is_zero_approx(stats.hp):
+		_fail("apply_damage overkill: expected hp=0, got %s" % stats.hp)
+		return
+
+	# Behavior 8 — is_dead: 0 HP and below are dead, any positive HP is alive.
+	if not CombatSystemScript.is_dead(0.0):
+		_fail("is_dead: hp=0 should be dead")
+		return
+	if not CombatSystemScript.is_dead(-5.0):
+		_fail("is_dead: hp<0 should be dead")
+		return
+	if CombatSystemScript.is_dead(0.1):
+		_fail("is_dead: hp>0 should be alive")
+		return
+
+	# Behavior 9 — compute_facing: a nonzero input re-aims (sign-normalized),
+	# zero input preserves the current facing.
+	if not is_equal_approx(PlayerControllerScript.compute_facing(1.0, -0.5), -1.0):
+		_fail("facing: left input should face -1")
+		return
+	if not is_equal_approx(PlayerControllerScript.compute_facing(-1.0, 1.0), 1.0):
+		_fail("facing: right input should face 1")
+		return
+	if not is_equal_approx(PlayerControllerScript.compute_facing(-1.0, 0.0), -1.0):
+		_fail("facing: zero input should keep the current facing")
+		return
+
+	print("LOGIC_SEAM: PASS")
+	quit(0)

--- a/examples/platformer/panda-adventure/tests/test_combat_data_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_combat_data_seam.py
@@ -1,0 +1,207 @@
+"""Data seam (a) for S2 Laser Gun combat.
+
+Proves the JSON -> Resource pipeline (gADR-0000) for the S2 combat config: the
+authoritative ``combat_config.json`` validates against its schema, bad config is
+rejected, and the builder emits three derived ``.tres`` (two ``StatsConfig`` stat
+blocks + one ``CombatConfig``) whose fields round-trip back through gda with
+their declared Godot types. The freshness gate is parametrized over EVERY builder
+output — including the untouched S1 ``player_config.tres``, so it doubles as the
+byte-identity guard on the multi-resource builder generalization. Fast tier —
+never ``e2e``; the round-trip drives one-shot ``gda`` headless ops under the
+``engine`` gate.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import jsonschema
+import pytest
+
+import build_config
+
+
+def _valid_config() -> dict:
+    """A fresh copy of a schema-valid combat config to mutate into invalid variants."""
+    return {
+        "player_stats": {"max_hp": 100.0, "max_mp": 50.0, "attack": 10.0, "defense": 0.0},
+        "enemy_stats": {"max_hp": 25.0, "max_mp": 0.0, "attack": 5.0, "defense": 0.0},
+        "attack_scale": 1.0,
+        "defense_scale": 1.0,
+        "min_damage": 1.0,
+        "iframe_duration": 0.6,
+        "projectile_color": [1.0, 0.35, 0.25, 1.0],
+        "projectile_size": [18.0, 6.0],
+        "projectile_speed": 900.0,
+        "projectile_lifetime": 1.5,
+        "projectile_spawn_offset": [36.0, 0.0],
+        "enemy_color": [0.75, 0.2, 0.55, 1.0],
+        "enemy_size": [48.0, 48.0],
+        "enemy_position": [640.0, 452.0],
+        "hit_flash_color": [1.0, 1.0, 1.0, 1.0],
+        "hit_flash_duration": 0.12,
+    }
+
+
+def _combat_schema() -> dict:
+    return build_config.load_schema(build_config.COMBAT_SCHEMA_PATH)
+
+
+def test_sample_json_passes_schema() -> None:
+    """The authoritative combat config validates against its schema."""
+    config = build_config.load_json(build_config.COMBAT_JSON_PATH)
+    assert build_config.validate_config(config, _combat_schema()) is config
+
+
+def _without(*path: str) -> dict:
+    bad = copy.deepcopy(_valid_config())
+    node = bad
+    for key in path[:-1]:
+        node = node[key]
+    del node[path[-1]]
+    return bad
+
+
+def _with(value: object, *path: str) -> dict:
+    bad = copy.deepcopy(_valid_config())
+    node = bad
+    for key in path[:-1]:
+        node = node[key]
+    node[path[-1]] = value
+    return bad
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        _without("player_stats"),  # missing stat block
+        _without("iframe_duration"),  # missing required scalar
+        _without("player_stats", "max_hp"),  # stat block missing a field
+        _with(0, "player_stats", "max_hp"),  # max_hp must be strictly positive
+        _with(-1.0, "enemy_stats", "defense"),  # defense must be non-negative
+        _with(-0.5, "player_stats", "attack"),  # attack must be non-negative
+        _with({**_valid_config()["player_stats"], "extra": 1}, "player_stats"),  # extra key in block
+        _with(0, "attack_scale"),  # attack_scale strictly positive
+        _with(-1.0, "min_damage"),  # min_damage non-negative
+        _with(0, "iframe_duration"),  # i-frame window strictly positive
+        _with(0, "projectile_speed"),  # speed strictly positive
+        _with(0, "hit_flash_duration"),  # flash duration strictly positive
+        _with([1.0, 0.35, 0.25], "projectile_color"),  # color: too few components
+        _with([1.0, 0.35, 1.5, 1.0], "enemy_color"),  # color: component out of 0..1
+        _with([18.0], "projectile_size"),  # size: too few components
+        _with([0.0, 6.0], "projectile_size"),  # size: component must be > 0
+        _with([640.0], "enemy_position"),  # position: too few components
+        _with([1.0, 2.0, 3.0], "projectile_spawn_offset"),  # offset: too many
+        _with("fast", "projectile_speed"),  # wrong type
+        {**_valid_config(), "extra": 1},  # unexpected extra top-level key
+    ],
+)
+def test_invalid_json_rejected(bad: dict) -> None:
+    """A combat config that violates the schema raises jsonschema.ValidationError."""
+    with pytest.raises(jsonschema.ValidationError):
+        build_config.validate_config(bad, _combat_schema())
+
+
+# ---------------------------------------------------------------------------
+# Freshness gate — parametrized over EVERY builder output (gADR-0000: the
+# committed .tres are derived artifacts; drift from the authoritative JSON is
+# caught here on every PR, pure-Python tier). Covering player_config.tres too
+# makes this the byte-identity guard on the builder's multi-resource refactor.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "spec", build_config.SPECS, ids=lambda spec: spec.out_rel
+)
+def test_generated_resource_is_fresh(spec, tmp_path) -> None:
+    """Each COMMITTED .tres matches a fresh build — JSON stays authoritative."""
+    committed = build_config.GAME_DIR / spec.out_rel
+    assert committed.exists(), (
+        f"committed {spec.out_rel} is missing — run scripts/build_config.py"
+    )
+    fresh = build_config.build_spec(spec, out_path=tmp_path / committed.name)
+    assert fresh.read_text(encoding="utf-8") == committed.read_text(encoding="utf-8"), (
+        f"committed {spec.out_rel} is stale — run scripts/build_config.py"
+    )
+
+
+def test_build_all_writes_every_spec(tmp_path) -> None:
+    """build_all(root) emits every declared output under the given root."""
+    # Stage the authoritative inputs in an isolated root (the e2e project-copy
+    # shape: json+schema present, generated/ absent).
+    for rel in {s.json_rel for s in build_config.SPECS} | {
+        s.schema_rel for s in build_config.SPECS
+    }:
+        src = build_config.GAME_DIR / rel
+        dst = tmp_path / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+    written = build_config.build_all(root=tmp_path)
+
+    assert sorted(p.name for p in written) == sorted(
+        (build_config.GAME_DIR / s.out_rel).name for s in build_config.SPECS
+    )
+    for path in written:
+        assert path.exists() and path.read_text(encoding="utf-8").startswith(
+            "[gd_resource"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: each derived combat .tres loads back through gda with its declared
+# Godot types, compared to the AUTHORITATIVE JSON (never hardcoded values).
+# ---------------------------------------------------------------------------
+
+
+def _properties_by_name(get_result: dict) -> dict:
+    """Index a ``gda resource get`` result's ``properties`` list by name."""
+    return {p["name"]: p["value"] for p in get_result["properties"]}
+
+
+def _get_props(gda, res_path: str) -> dict:
+    result = gda("resource", "get", res_path, "--json")
+    assert result.returncode == 0, result.stdout + result.stderr
+    return _properties_by_name(json.loads(result.stdout))
+
+
+@pytest.mark.engine
+@pytest.mark.parametrize("block", ["player_stats", "enemy_stats"])
+def test_stat_block_round_trips(gda, block: str) -> None:
+    """Each StatsConfig .tres round-trips its four stat fields through gda."""
+    config = build_config.load_json(build_config.COMBAT_JSON_PATH)[block]
+    res_path = f"res://data/generated/stats_{block.removesuffix('_stats')}.tres"
+    props = _get_props(gda, res_path)
+    for field in ("max_hp", "max_mp", "attack", "defense"):
+        assert props[field] == pytest.approx(config[field]), (block, field)
+
+
+@pytest.mark.engine
+def test_combat_config_round_trips(gda) -> None:
+    """The CombatConfig .tres round-trips every field through gda."""
+    config = build_config.load_json(build_config.COMBAT_JSON_PATH)
+    props = _get_props(gda, "res://data/generated/combat_config.tres")
+
+    # Colors are float32 in Godot — compare with a tolerance.
+    for color_field in ("projectile_color", "enemy_color", "hit_flash_color"):
+        assert props[color_field] == pytest.approx(config[color_field], abs=1e-5)
+    # Vector2 fields.
+    for vec_field in (
+        "projectile_size",
+        "projectile_spawn_offset",
+        "enemy_size",
+        "enemy_position",
+    ):
+        assert props[vec_field] == pytest.approx(config[vec_field])
+    # Scalar float fields.
+    for float_field in (
+        "attack_scale",
+        "defense_scale",
+        "min_damage",
+        "iframe_duration",
+        "projectile_speed",
+        "projectile_lifetime",
+        "hit_flash_duration",
+    ):
+        assert props[float_field] == pytest.approx(config[float_field])

--- a/examples/platformer/panda-adventure/tests/test_combat_data_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_combat_data_seam.py
@@ -25,7 +25,12 @@ import build_config
 def _valid_config() -> dict:
     """A fresh copy of a schema-valid combat config to mutate into invalid variants."""
     return {
-        "player_stats": {"max_hp": 100.0, "max_mp": 50.0, "attack": 10.0, "defense": 0.0},
+        "player_stats": {
+            "max_hp": 100.0,
+            "max_mp": 50.0,
+            "attack": 10.0,
+            "defense": 0.0,
+        },
         "enemy_stats": {"max_hp": 25.0, "max_mp": 0.0, "attack": 5.0, "defense": 0.0},
         "attack_scale": 1.0,
         "defense_scale": 1.0,
@@ -81,7 +86,9 @@ def _with(value: object, *path: str) -> dict:
         _with(0, "player_stats", "max_hp"),  # max_hp must be strictly positive
         _with(-1.0, "enemy_stats", "defense"),  # defense must be non-negative
         _with(-0.5, "player_stats", "attack"),  # attack must be non-negative
-        _with({**_valid_config()["player_stats"], "extra": 1}, "player_stats"),  # extra key in block
+        _with(
+            {**_valid_config()["player_stats"], "extra": 1}, "player_stats"
+        ),  # extra key in block
         _with(0, "attack_scale"),  # attack_scale strictly positive
         _with(-1.0, "min_damage"),  # min_damage non-negative
         _with(0, "iframe_duration"),  # i-frame window strictly positive
@@ -111,9 +118,7 @@ def test_invalid_json_rejected(bad: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "spec", build_config.SPECS, ids=lambda spec: spec.out_rel
-)
+@pytest.mark.parametrize("spec", build_config.SPECS, ids=lambda spec: spec.out_rel)
 def test_generated_resource_is_fresh(spec, tmp_path) -> None:
     """Each COMMITTED .tres matches a fresh build — JSON stays authoritative."""
     committed = build_config.GAME_DIR / spec.out_rel

--- a/examples/platformer/panda-adventure/tests/test_combat_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_combat_e2e.py
@@ -97,7 +97,15 @@ def test_daemon_serves_laser_combat(tmp_path, daemon_runtime_dir):
 
     def run(*args: str) -> subprocess.CompletedProcess:
         return subprocess.run(
-            [*GDA_CMD, *args, "--project", str(project), "--godot", str(GODOT), "--json"],
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(project),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
             capture_output=True,
             text=True,
             env=env,

--- a/examples/platformer/panda-adventure/tests/test_combat_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_combat_e2e.py
@@ -1,0 +1,228 @@
+"""Integration seam (c) for S2 Laser Gun combat — THE gate.
+
+The full combat loop through the gda CLI against a running Engine session:
+
+- ``gda game tree`` shows the runtime-spawned Enemy (StaticBody2D) next to the
+  S1 blockout;
+- ``gda input sequence`` presses ``fire`` and the bolt crosses the level into
+  the Enemy: ``gda logger tail`` returns rich ``laser_fired`` and ``enemy_hit``
+  records whose damage/hp match the AUTHORITATIVE JSON through the data-driven
+  formula — proof that the InputMap action, projectile flight, collision
+  layers/masks, and the damage pipeline all work end-to-end;
+- two shots fired a few frames apart (far inside the i-frame window) land
+  exactly ONE hit — the live chained-hit proof (the boundary semantics stay
+  owned by the logic seam);
+- repeated shots spaced past the window drive ``hp_left`` strictly down to 0,
+  ``enemy_died`` appears, and the Enemy leaves the runtime scene tree.
+
+Per RULES.md, mocks cannot replace this end-to-end proof.
+
+Isolation: same throwaway-copy pattern as ``test_player_e2e`` (``daemon start``
+mutates ``project.godot``); posix-only (AF_UNIX); headless — Linux-CI-friendly.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+import build_config
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+GDA_CMD = [sys.executable, "-m", "gda"]
+GODOT = resolve_godot_binary()
+GAME_DIR = build_config.GAME_DIR
+
+_COPY_IGNORE = shutil.ignore_patterns(
+    "tests", ".godot", "build", "generated", "__pycache__"
+)
+
+
+def _make_project_copy(dst: Path) -> Path:
+    """Copy the committed game into a throwaway dir and build its config there."""
+    shutil.copytree(GAME_DIR, dst, ignore=_COPY_IGNORE)
+    build_config.build_all(root=dst)
+    return dst
+
+
+def _find_node(node: dict, name: str) -> dict | None:
+    """Depth-first search a ``game tree`` subtree for a node by name."""
+    if node.get("name") == name:
+        return node
+    for child in node.get("children", []):
+        found = _find_node(child, name)
+        if found is not None:
+            return found
+    return None
+
+
+def _expected_damage(combat: dict) -> float:
+    """The data-driven formula, recomputed from the authoritative JSON."""
+    return max(
+        combat["min_damage"],
+        combat["player_stats"]["attack"] * combat["attack_scale"]
+        - combat["enemy_stats"]["defense"] * combat["defense_scale"],
+    )
+
+
+@pytest.mark.e2e
+def test_daemon_serves_laser_combat(tmp_path, daemon_runtime_dir):
+    project = _make_project_copy(tmp_path / "game")
+    # Every expectation derives from the AUTHORITATIVE JSON, never hardcoded.
+    combat = build_config.load_json(GAME_DIR / "data" / "json" / "combat_config.json")
+    player_cfg = build_config.load_json(
+        GAME_DIR / "data" / "json" / "player_config.json"
+    )
+    damage = _expected_damage(combat)
+    max_hp = combat["enemy_stats"]["max_hp"]
+    hits_to_kill = math.ceil(max_hp / damage)
+    iframe = combat["iframe_duration"]
+    rest_y = (
+        player_cfg["platform_position"][1]
+        - player_cfg["platform_size"][1] / 2.0
+        - player_cfg["player_size"][1] / 2.0
+    )
+    env = {**os.environ}
+
+    def run(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [*GDA_CMD, *args, "--project", str(project), "--godot", str(GODOT), "--json"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    def records(message: str) -> list[dict]:
+        proc = run("logger", "tail")
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        return [
+            r
+            for r in json.loads(proc.stdout)["records"]
+            if r["message"] == message and r["origin"] == "gda_log"
+        ]
+
+    def poll(predicate, timeout: float = 20.0, interval: float = 0.5):
+        deadline = time.monotonic() + timeout
+        result = predicate()
+        while not result and time.monotonic() < deadline:
+            time.sleep(interval)
+            result = predicate()
+        return result
+
+    def player_y() -> float:
+        got = run("game", "get", "/root/Main/Player", "--property", "position")
+        assert got.returncode == 0, got.stdout + got.stderr
+        for p in json.loads(got.stdout)["properties"]:
+            if p["name"] == "position":
+                return p["value"][1]
+        raise AssertionError("position not returned")
+
+    def fire(events: list[dict]) -> None:
+        seq = run("input", "sequence", "--events", json.dumps(events))
+        assert seq.returncode == 0, seq.stdout + seq.stderr
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        # The runtime-spawned Enemy is in the live tree with the S1 blockout.
+        tree = run("game", "tree")
+        assert tree.returncode == 0, tree.stdout + tree.stderr
+        root = json.loads(tree.stdout)["root"]
+        enemy = _find_node(root, "Enemy")
+        assert enemy is not None and enemy["type"] == "StaticBody2D", root
+        assert _find_node(root, "Player") is not None, root
+
+        # Its boot record carries the data-driven stat block.
+        ready = poll(lambda: records("enemy_ready"))
+        assert ready, "no gda_log 'enemy_ready' record"
+        assert ready[0]["fields"]["max_hp"] == pytest.approx(max_hp)
+        assert ready[0]["fields"]["x"] == pytest.approx(combat["enemy_position"][0])
+
+        # Let the Player settle on the platform before firing (S1-proven poll).
+        assert poll(lambda: abs(player_y() - rest_y) <= 2.0), (
+            "Player did not land before firing"
+        )
+
+        # --- i-frame live proof: two shots a few frames apart (~0.13s at 60fps,
+        # far inside the window) must land exactly ONE hit. One input sequence,
+        # so the shot spacing is frame-exact, immune to CLI-call latency.
+        fire(
+            [
+                {"type": "action", "action": "fire", "frame": 0},
+                {"type": "action", "action": "fire", "release": True, "frame": 2},
+                {"type": "action", "action": "fire", "frame": 8},
+                {"type": "action", "action": "fire", "release": True, "frame": 10},
+            ]
+        )
+        assert poll(lambda: len(records("laser_fired")) >= 2), (
+            "both fire presses should each spawn a bolt"
+        )
+        fired = records("laser_fired")
+        assert fired[0]["fields"]["facing"] == pytest.approx(1.0)
+        # Wait for the first hit, then give the second bolt time to arrive and
+        # be i-frame-blocked (arrivals are ~0.13s apart; 2s is far past both).
+        assert poll(lambda: len(records("enemy_hit")) >= 1), (
+            "the first bolt should hit the Enemy"
+        )
+        time.sleep(2.0)
+        hits = records("enemy_hit")
+        assert len(hits) == 1, (
+            f"i-frames should block the chained second hit, got {len(hits)}: {hits}"
+        )
+        assert hits[0]["fields"]["damage"] == pytest.approx(damage)
+        assert hits[0]["fields"]["hp_left"] == pytest.approx(max_hp - damage)
+
+        # --- kill loop: single shots spaced past the i-frame window drive HP
+        # strictly down to 0. CLI-call latency plus an explicit sleep guarantees
+        # the spacing; the loop bound is derived from the config, not guessed.
+        for _ in range(hits_to_kill * 2):
+            if records("enemy_died"):
+                break
+            time.sleep(iframe + 0.3)
+            fire(
+                [
+                    {"type": "action", "action": "fire", "frame": 0},
+                    {"type": "action", "action": "fire", "release": True, "frame": 2},
+                ]
+            )
+            poll(lambda: bool(records("enemy_died")), timeout=3.0)
+        died = poll(lambda: records("enemy_died"))
+        assert died, "the Enemy never died"
+
+        hits = records("enemy_hit")
+        assert len(hits) == hits_to_kill, (
+            f"expected {hits_to_kill} landed hits to kill, got {len(hits)}: {hits}"
+        )
+        hp_trace = [h["fields"]["hp_left"] for h in hits]
+        assert hp_trace == sorted(hp_trace, reverse=True), (
+            f"hp_left should strictly decrease: {hp_trace}"
+        )
+        assert all(a > b for a, b in zip(hp_trace, hp_trace[1:])), (
+            f"hp_left should strictly decrease: {hp_trace}"
+        )
+        assert hp_trace[-1] == pytest.approx(0.0), (
+            f"the killing hit should leave 0 HP: {hp_trace}"
+        )
+
+        # The dead Enemy leaves the runtime tree (queue_free is deferred — poll).
+        def enemy_gone() -> bool:
+            t = run("game", "tree")
+            assert t.returncode == 0, t.stdout + t.stderr
+            return _find_node(json.loads(t.stdout)["root"], "Enemy") is None
+
+        assert poll(enemy_gone), "the dead Enemy is still in the scene tree"
+    finally:
+        run("daemon", "stop")

--- a/examples/platformer/panda-adventure/tests/test_combat_logic_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_combat_logic_seam.py
@@ -1,0 +1,41 @@
+"""Logic seam (b) for S2 Laser Gun combat.
+
+Exercises the pure combat decisions — ``CombatSystem.compute_damage`` /
+``is_invulnerable`` / ``is_dead``, ``StatsSystem.init_from`` / ``apply_damage``,
+and ``PlayerController.compute_facing`` — headless, through ``gda script run``
+(ADR-0031). These are the functions the offline Monte-Carlo balancing sim reuses
+(gADR-0001). Fast tier (``engine`` marker), never ``e2e``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+_LOGIC_SCRIPT = "res://tests/gdscript/test_combat_logic.gd"
+
+
+def _run(gda) -> subprocess.CompletedProcess:
+    return gda("script", "run", _LOGIC_SCRIPT, "--json")
+
+
+@pytest.mark.engine
+def test_logic_seam_combat_decisions(gda) -> None:
+    """The pure combat rules hold for every behavior the GDScript seam asserts.
+
+    The seam covers: raw damage (zero defense), mitigation, the min-damage
+    floor, attacker<->defender symmetry (both directions through the ONE
+    function), the i-frame window (within / at expiry / past / -INF sentinel),
+    StatsSystem init (all four stats) and damage clamping, the is_dead
+    boundary, and facing. We read gda's passed-through ``exit_status`` (0 ==
+    all assertions held) and require the PASS marker in stdout.
+    """
+    result = _run(gda)
+    # gda itself succeeded (the script launched and ran to completion).
+    assert result.returncode == 0, result.stdout + result.stderr
+    doc = json.loads(result.stdout)
+    # The script's own exit_status is passed through: 0 == every assertion held.
+    assert doc["exit_status"] == 0, doc["stdout"] + doc["stderr"]
+    assert "LOGIC_SEAM: PASS" in doc["stdout"], doc["stdout"] + doc["stderr"]

--- a/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
+++ b/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
@@ -65,11 +65,7 @@ def _error_code(stdout: str) -> str | None:
 def _make_project_copy(dst):
     """Copy the committed game into a throwaway dir and build its config there."""
     shutil.copytree(GAME_DIR, dst, ignore=_COPY_IGNORE)
-    build_config.build(
-        json_path=dst / "data" / "json" / "player_config.json",
-        schema_path=dst / "data" / "schema" / "player_config.schema.json",
-        out_path=dst / "data" / "generated" / "player_config.tres",
-    )
+    build_config.build_all(root=dst)
     return dst
 
 

--- a/examples/platformer/panda-adventure/tests/test_game_log_fallback.py
+++ b/examples/platformer/panda-adventure/tests/test_game_log_fallback.py
@@ -43,7 +43,7 @@ def test_plain_run_prints_logs_despite_committed_dormant_harness() -> None:
         "present-but-dormant fallback path"
     )
 
-    build_config.build()  # ensure the derived .tres reflects the current JSON
+    build_config.build_all()  # ensure every derived .tres reflects the current JSON
     godot = resolve_godot_binary()
     result = subprocess.run(
         [str(godot), "--headless", "--path", str(GAME_DIR), "--quit-after", "30"],

--- a/examples/platformer/panda-adventure/tests/test_player_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_player_e2e.py
@@ -55,11 +55,7 @@ _COPY_IGNORE = shutil.ignore_patterns(
 def _make_project_copy(dst: Path) -> Path:
     """Copy the committed game into a throwaway dir and build its config there."""
     shutil.copytree(GAME_DIR, dst, ignore=_COPY_IGNORE)
-    build_config.build(
-        json_path=dst / "data" / "json" / "player_config.json",
-        schema_path=dst / "data" / "schema" / "player_config.schema.json",
-        out_path=dst / "data" / "generated" / "player_config.tres",
-    )
+    build_config.build_all(root=dst)
     return dst
 
 


### PR DESCRIPTION
## What

The first combat slice (milestone #6 / PRD #323, S2): the Laser Gun fires a Projectile via the new `fire` InputMap action; collision layers/masks separate Player/Enemy/Projectile/Terrain (Gravity Field layer reserved for S3); a data-driven, **symmetric** damage formula (defense term = 0 until the Spacesuit) applies damage to a static Enemy's HP behind a data-driven i-frame window; the Enemy dies at 0 HP. StatsSystem holds all four stats (HP/MP/EXP/Gold) per actor — only HP moves in S2 (MP → S3, EXP/Gold → S6a).

## Acceptance criteria → proof

| AC | Where proven |
|---|---|
| Data-driven StatsSystem Resource with HP/MP/EXP/Gold as the single source of truth | `StatsConfig` stat blocks + runtime `StatsSystem` (gADR-0001); JSON→3 new derived `.tres`; data seam (`test_combat_data_seam.py`: schema pass/reject, per-output freshness, gda round-trips) + logic seam behavior 6 |
| Laser Gun fires a projectile via InputMap; layers/masks separate Player/Enemy/Projectile/Terrain | `project.godot` `[layer_names]` + `fire`; gda-authored `projectile.tscn`/`enemy.tscn`; e2e fires the action and the bolt crosses the level into the Enemy |
| Damage formula data-driven, mitigation term, symmetric attacker↔defender shape | `CombatSystem.compute_damage` over two `StatsConfig` blocks + `CombatConfig` params; logic seam behaviors 1–4 prove raw/mitigated/floored damage and BOTH directions through the one function |
| Hit applies damage; data-driven i-frame window; a single overlap cannot chain hits | `EnemyController.take_hit` gates on `is_invulnerable`; logic seam behavior 5 (within/at-expiry/past/-INF); **live proof**: two shots 8 frames apart in one frame-exact input sequence land exactly ONE hit |
| Static Enemy reaches 0 HP and dies | e2e kill loop: `hp_left` strictly decreasing to 0, `enemy_died` record, Enemy leaves `game tree` |
| DoD: 3 seams green; logic seam pure & Monte-Carlo-reusable; blockout+tween; `gda logger tail` conformant; config data-driven | **56/56 tests pass** (full suite, serial); `CombatSystem` static/deterministic/clock-free (time is a parameter); hit-flash property tween; 4 new scalar-field log events; `player_config.tres` byte-identical through the builder generalization |

## Notable decisions

- **gADR-0001** (new): immutable JSON-derived stat blocks / per-actor in-memory `StatsSystem` never saved back / pure `CombatSystem` decisions shared with the offline balancing sim. Glossary gains Projectile, Stat Block, StatsSystem, CombatSystem.
- `build_config.py` generalized to a `TresSpec` table + `build_all()`; the freshness gate is now parametrized over every output, which also guards the committed S1 `.tres` byte-for-byte. S1 API kept as aliases.
- The two new scenes are **gda-authored** (`scene create` / `node add` / `script attach` / `node set` — dogfooding the #360/#363 fixes); shapes ship null and are created at runtime from config (#365). Hand-authored roots (`project.godot`, `main.tscn`) stay hand-edited.
- The Enemy is runtime-instanced by `LevelController` from config position — `main.tscn` diff stays two layer lines, and S4's wave spawner inherits the pattern.
- Player passes through the Enemy (mask excludes it) — intentional; contact damage is S4. No `perf monitor --signal` in the e2e (blocking one-shot window is racy for input-timed death); the `died` signal exists for S6a wiring.

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)