### PR TITLE
docs(adr): ADR-0035 read-side value projection for compound Variants

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -104,6 +104,23 @@ launch), survives the session process so a crash stays diagnosable until relaunc
 (ADR-0022).
 _Avoid_: console output, stdout dump
 
+### Structured output
+
+**Value projection**:
+The read-side contract for rendering a Godot value into the structured JSON a
+successful result carries. Scalars and the small fixed-shape value types pass
+through directly; a `Dictionary`/`Array` (and the packed-array family) projects
+recursively; and an `Object` is rendered by one of three **descriptor kinds** — a
+**reference descriptor** for a `Resource` that has a `res://` path (named by type
+and path, never inlined — the read-side mirror of ADR-0033's write-side
+reference), an **inline value descriptor** for a whitelisted path-less value
+`Object` (named by type plus its projected fields), or a plain **string
+fallback** for anything else. One projection shared across every read
+(`project`/`node`/`resource get`, and the live `game` reads) so a value reads the
+same everywhere; the whitelist is the boundary that keeps the shared projection
+safe on the live side (ADR-0035).
+_Avoid_: value rendering, str dump, serialization
+
 ### Failure reporting
 
 **Gda error code**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -110,16 +110,18 @@ _Avoid_: console output, stdout dump
 The read-side contract for rendering a Godot value into the structured JSON a
 successful result carries. Scalars and the small fixed-shape value types pass
 through directly; a `Dictionary`/`Array` (and the packed-array family) projects
-recursively; and an `Object` is rendered by one of three **descriptor kinds** — a
-**reference descriptor** for a `Resource` that has a `res://` path (named by type
+recursively; and an `Object` is rendered by one of three **projection kinds** — a
+**reference projection** for a `Resource` that has a `res://` path (named by type
 and path, never inlined — the read-side mirror of ADR-0033's write-side
-reference), an **inline value descriptor** for a whitelisted path-less value
+reference), an **inline value projection** for a whitelisted path-less value
 `Object` (named by type plus its projected fields), or a plain **string
-fallback** for anything else. One projection shared across every read
-(`project`/`node`/`resource get`, and the live `game` reads) so a value reads the
-same everywhere; the whitelist is the boundary that keeps the shared projection
-safe on the live side (ADR-0035).
-_Avoid_: value rendering, str dump, serialization
+fallback** for anything else. One projection shared across **every value gda
+emits** — the `get` reads (`project`/`node`/`resource get`), the value echoed by
+`node set`/`resource set`, the per-entry value of `project list` and `scene
+get-exports`, and the live `game get` read — so a value reads the same
+everywhere; the whitelist is the boundary that keeps the shared projection safe
+on the live side (ADR-0035).
+_Avoid_: value rendering, str dump, serialization, descriptor
 
 ### Failure reporting
 

--- a/docs/adr/0035-value-projection-compound-variants-to-structured-json.md
+++ b/docs/adr/0035-value-projection-compound-variants-to-structured-json.md
@@ -1,0 +1,85 @@
+---
+status: accepted
+---
+
+# Value projection: compound Variants (`Dictionary`/`Array`/`Object`) to structured JSON on the read side
+
+`project get` / `node get` / `resource get` (and the live `game` reads) project a value into the
+result's `value` field through the shared `_jsonify` helper (#55): scalars and a few fixed-shape value
+types (`Vector2`, `Vector2i`, `Color`) pass through, but **every other type — `Dictionary`, `Array`,
+and any `Object` — degrades to the Variant's `str()` debug string**. So a compound-valued setting
+(surfaced dogfooding Panda Adventure S2's `fire` InputMap action, #381) reads back as
+`"{ \"deadzone\": 0.5, \"events\": [InputEventKey: keycode=74 (J), …] }"` — an agent cannot index the
+deadzone or enumerate the bound keys, and the event list is not even valid JSON. For a tool whose
+positioning is structured, machine-readable output, compound values are exactly where the structure is
+missing. `_jsonify` is **byte-identical mirrored** into the [gda harness](../../CONTEXT.md) (the
+`--- shared coercion ---` block, enforced by `tests/test_harness_coercion_mirror.py`), so it is also the
+projector for the live `game get` / `game call` reads — where a value can be an **arbitrary runtime
+Object (a live `Node`) or a cyclic graph**.
+
+## Decision
+
+Extend the shared, mirrored `_jsonify` into a **`Value projection`** (see `CONTEXT.md`): the one
+read-side contract for turning a Godot Variant into structured JSON, applied uniformly across every
+read surface (headless `project`/`node`/`resource get` + set-echo + `project list`, and the live
+`game` reads).
+
+- **Containers project recursively.** `Dictionary` → a JSON object (keys coerced to strings); `Array`
+  and the **packed-array family** (`PackedInt32Array`, `PackedStringArray`, `PackedVector2Array`, …) → a
+  JSON array. Each element/value re-enters the projection.
+- **Objects render as one of three descriptor kinds:**
+  - **Reference descriptor** — an `Object` that is a `Resource` with a `res://` path:
+    `{"type": "<Class>", "resource_path": "res://…"}`, **not inlined**. The read-side mirror of
+    ADR-0033's write-side `res://`-reference model — read and write name an external resource the same
+    way, and a `project get` of a resource-valued setting stays a small, bounded payload.
+  - **Inline value descriptor** — a **whitelisted** path-less value `Object` (`InputEvent` subclasses
+    initially, e.g. the `InputEventKey`s inside an InputMap action): `{"type": "<Class>", <its storage
+    properties, each re-projected>}`, reusing the same storage-property model `node get` already
+    exposes.
+  - **String fallback** — any other `Object` (not whitelisted, no `res://` path — the typical live
+    `game get` `Node`): the existing `str()` form, unchanged.
+- **Bounded, not cycle-tracked.** A hard recursion **depth cap** degrades an over-deep node to its
+  string form; there is **no visited-set**. The structural bounds (references are not descended,
+  non-whitelisted Objects stop at `str()`) already make on-disk stored values acyclic trees; the depth
+  cap is the backstop against a pathological self-referential `Dictionary` on the live side. The
+  projection is **always JSON-encodable** — it never hands `JSON.stringify` an unencodable Variant.
+- **Scalars are unchanged** — no regression to the existing round-trip.
+- **The whitelist is the risk-isolation boundary.** Because the projector is shared with the live
+  harness, projecting *arbitrary* Objects would blow up on a returned `Node` (whole scene tree, cycles,
+  huge payloads). The whitelist admits only small, path-less value Objects, so headless and live share
+  one projection while the live-only risk stays isolated behind the list.
+- **Both `.gd` files change byte-identically**; the mirror invariant and
+  `tests/test_harness_coercion_mirror.py` are preserved, not bypassed.
+
+## Considered options
+
+- **A `project get`-only compound renderer, leaving the shared `_jsonify` untouched** — **rejected.**
+  The `str()` degradation #381 reports for `project get` exists **identically** for `node get` /
+  `resource get` / `game get`; a second, project-get-only projector would split the read contract and
+  let the same value read two different ways depending on the command.
+- **A curated per-type field table for each supported Object class** — **rejected.** It needs a
+  registry to maintain and does not generalize to new types; the generic storage-property projection
+  reuses the model `node get` already defines, and the whitelist (not a field map) becomes the single
+  control point.
+- **Inline a `res://` Resource's contents instead of referencing it by path** — **rejected.** It
+  produces large payloads and breaks read/write symmetry with ADR-0033, which references external
+  resources rather than inlining them.
+- **Visited-set cycle detection** — **rejected.** The bookkeeping complicates the byte-identical mirror
+  for a case the depth cap already renders safe (no crash, no hang); the shared block stays simple.
+
+## Consequences
+
+- **New public output ABI.** Agents and tooling may rely on the projected shapes — indexing
+  `value.deadzone`, `value.events[0].keycode`, and the descriptor fields (`type`, `resource_path`).
+  This is why the decision is recorded.
+- **Uniform read contract + a live-side gain.** A value reads the same across `project`/`node`/`resource
+  get` and the live `game` reads; `game get` / `game call` of a whitelisted value Object now gains
+  structure too, with the live-only risk isolated behind the whitelist.
+- **The mirrored shared-coercion block grows**; `operations.gd` ↔ `gda_harness.gd` stay byte-identical
+  and the mirror test is unaffected.
+- **No new `Gda error code`.** This is a read projection; a missing setting is still the existing
+  `unknown_setting`.
+- **Ties to ADR-0033 (write-side reference model) and #55 (`_jsonify` origin).** The deferred inline
+  sub-resource work of ADR-0033 has a read-side counterpart here: a path-less inline value Object is
+  projected (whitelisted), not referenced.
+- **`CONTEXT.md` gains the `Value projection` glossary term** in this same change.

--- a/docs/adr/0035-value-projection-compound-variants-to-structured-json.md
+++ b/docs/adr/0035-value-projection-compound-variants-to-structured-json.md
@@ -4,7 +4,7 @@ status: accepted
 
 # Value projection: compound Variants (`Dictionary`/`Array`/`Object`) to structured JSON on the read side
 
-`project get` / `node get` / `resource get` (and the live `game` reads) project a value into the
+`project get` / `node get` / `resource get` (and the live `game get` read) project a value into the
 result's `value` field through the shared `_jsonify` helper (#55): scalars and a few fixed-shape value
 types (`Vector2`, `Vector2i`, `Color`) pass through, but **every other type — `Dictionary`, `Array`,
 and any `Object` — degrades to the Variant's `str()` debug string**. So a compound-valued setting
@@ -14,30 +14,45 @@ deadzone or enumerate the bound keys, and the event list is not even valid JSON.
 positioning is structured, machine-readable output, compound values are exactly where the structure is
 missing. `_jsonify` is **byte-identical mirrored** into the [gda harness](../../CONTEXT.md) (the
 `--- shared coercion ---` block, enforced by `tests/test_harness_coercion_mirror.py`), so it is also the
-projector for the live `game get` / `game call` reads — where a value can be an **arbitrary runtime
-Object (a live `Node`) or a cyclic graph**.
+projector for the live `game get` read (and any future live value-returning operation) — where a value
+can be an **arbitrary runtime Object (a live `Node`) or a cyclic graph**.
 
 ## Decision
 
 Extend the shared, mirrored `_jsonify` into a **`Value projection`** (see `CONTEXT.md`): the one
-read-side contract for turning a Godot Variant into structured JSON, applied uniformly across every
-read surface (headless `project`/`node`/`resource get` + set-echo + `project list`, and the live
-`game` reads).
+read-side contract for turning a Godot Variant into structured JSON, applied uniformly to **every value
+gda emits through `_jsonify`** — the headless `get` reads (`project`/`node`/`resource get`), the value
+echoed back by `node set` / `resource set`, the per-entry `value` of `project list` and `scene
+get-exports`, and the live `game get` read (and any future live value-returning op).
 
 - **Containers project recursively.** `Dictionary` → a JSON object (keys coerced to strings); `Array`
   and the **packed-array family** (`PackedInt32Array`, `PackedStringArray`, `PackedVector2Array`, …) → a
   JSON array. Each element/value re-enters the projection.
-- **Objects render as one of three descriptor kinds:**
-  - **Reference descriptor** — an `Object` that is a `Resource` with a `res://` path:
+- **Objects render as one of three projection kinds:**
+  - **Reference projection** — an `Object` that is a `Resource` with a non-empty `res://` path:
     `{"type": "<Class>", "resource_path": "res://…"}`, **not inlined**. The read-side mirror of
     ADR-0033's write-side `res://`-reference model — read and write name an external resource the same
     way, and a `project get` of a resource-valued setting stays a small, bounded payload.
-  - **Inline value descriptor** — a **whitelisted** path-less value `Object` (`InputEvent` subclasses
-    initially, e.g. the `InputEventKey`s inside an InputMap action): `{"type": "<Class>", <its storage
-    properties, each re-projected>}`, reusing the same storage-property model `node get` already
+  - **Inline value projection** — a **whitelisted** path-less value `Object` (`InputEvent` subclasses
+    initially, e.g. the `InputEventKey`s inside an InputMap action): `{"type": "<Class>", <its own
+    storage properties, each re-projected>}`, reusing the same storage-property model `node get`
     exposes.
   - **String fallback** — any other `Object` (not whitelisted, no `res://` path — the typical live
     `game get` `Node`): the existing `str()` form, unchanged.
+- **Reserved keys and collision rules** (the shape is public ABI, so these are fixed here, not left to
+  the implementation):
+  - Every Object projection carries a `type` discriminator; a **reference projection additionally
+    carries `resource_path`**, and an agent distinguishes the two kinds by the presence of
+    `resource_path`.
+  - To keep that branch unambiguous, the **inline value projection excludes the `Object`/`Resource`
+    base bookkeeping** properties (`resource_path`, `resource_name`, `resource_local_to_scene`,
+    `script`). Every `InputEvent` **is a `Resource`**, so without this exclusion a path-less value
+    Object would emit an empty `resource_path` and masquerade as a reference; the exclusion also drops
+    noise. A whitelisted class's own storage property named `type` is **shadowed** by the discriminator
+    — documented, not silent.
+  - `Dictionary` keys are coerced to strings. If two keys collide after stringification — only possible
+    for a **non-string-keyed** Dictionary, never the settings case — the **last entry in Godot's
+    insertion-ordered iteration wins** (deterministic, documented), rather than an undefined clobber.
 - **Bounded, not cycle-tracked.** A hard recursion **depth cap** degrades an over-deep node to its
   string form; there is **no visited-set**. The structural bounds (references are not descended,
   non-whitelisted Objects stop at `str()`) already make on-disk stored values acyclic trees; the depth
@@ -55,8 +70,8 @@ read surface (headless `project`/`node`/`resource get` + set-echo + `project lis
 
 - **A `project get`-only compound renderer, leaving the shared `_jsonify` untouched** — **rejected.**
   The `str()` degradation #381 reports for `project get` exists **identically** for `node get` /
-  `resource get` / `game get`; a second, project-get-only projector would split the read contract and
-  let the same value read two different ways depending on the command.
+  `resource get` / `game get` / `project list`; a second, project-get-only projector would split the
+  read contract and let the same value read two different ways depending on the command.
 - **A curated per-type field table for each supported Object class** — **rejected.** It needs a
   registry to maintain and does not generalize to new types; the generic storage-property projection
   reuses the model `node get` already defines, and the whitelist (not a field map) becomes the single
@@ -66,20 +81,33 @@ read surface (headless `project`/`node`/`resource get` + set-echo + `project lis
   resources rather than inlining them.
 - **Visited-set cycle detection** — **rejected.** The bookkeeping complicates the byte-identical mirror
   for a case the depth cap already renders safe (no crash, no hang); the shared block stays simple.
+- **Nesting the inline projection's fields under a `properties` sub-object** — **rejected** in favor of
+  the base-bookkeeping exclusion above: excluding `resource_path`/`resource_name`/… keeps the flat,
+  directly-indexable `value.events[0].keycode` shape #381 targets while still removing the
+  reference/inline ambiguity.
 
 ## Consequences
 
 - **New public output ABI.** Agents and tooling may rely on the projected shapes — indexing
-  `value.deadzone`, `value.events[0].keycode`, and the descriptor fields (`type`, `resource_path`).
+  `value.deadzone`, `value.events[0].keycode`, and the projection fields (`type`, `resource_path`).
   This is why the decision is recorded.
-- **Uniform read contract + a live-side gain.** A value reads the same across `project`/`node`/`resource
-  get` and the live `game` reads; `game get` / `game call` of a whitelisted value Object now gains
-  structure too, with the live-only risk isolated behind the whitelist.
+- **Carrying the ABI into the `--schema` / model chain (ADR-0004).** The top-level `value` field stays
+  `Any` — a setting's or property's value shape is not statically knowable, so it cannot be fully typed;
+  this is a **deliberate, bounded exception** to ADR-0004's model-driven-output rule, limited to the one
+  dynamically-typed `value` field. The *stable* parts are modeled and surfaced: the implementation must
+  (a) update the `value` descriptions on `ProjectGetResult`, `ListedProjectSetting`, `NodeProperty`, and
+  `GameGetResult` (which today describe only scalars and packed Vector/Color lists), (b) define the
+  reference / inline value projection shapes as **named result models** so they are documented and
+  consumable rather than prose-only, and (c) cover them with `--schema` / round-trip / mirror tests. The
+  #381 implementation brief names these surfaces.
+- **Uniform read contract + a live-side gain.** A value reads the same across the whole read surface;
+  `game get` of a whitelisted value Object now gains structure too, with the live-only risk isolated
+  behind the whitelist.
 - **The mirrored shared-coercion block grows**; `operations.gd` ↔ `gda_harness.gd` stay byte-identical
   and the mirror test is unaffected.
 - **No new `Gda error code`.** This is a read projection; a missing setting is still the existing
   `unknown_setting`.
-- **Ties to ADR-0033 (write-side reference model) and #55 (`_jsonify` origin).** The deferred inline
-  sub-resource work of ADR-0033 has a read-side counterpart here: a path-less inline value Object is
-  projected (whitelisted), not referenced.
+- **Ties to ADR-0033 (write-side reference model), ADR-0004 (self-description), and #55 (`_jsonify`
+  origin).** The deferred inline sub-resource work of ADR-0033 has a read-side counterpart here: a
+  path-less inline value Object is projected (whitelisted), not referenced.
 - **`CONTEXT.md` gains the `Value projection` glossary term** in this same change.


### PR DESCRIPTION
## What

Records **ADR-0035 — read-side value projection for compound Variants**, and adds the `Value projection` glossary term to `CONTEXT.md`.

This is the decision record produced while triaging #381 (found dogfooding Panda Adventure S2's `fire` InputMap action). It does **not** implement #381 — it lands the ADR the implementation depends on, so the `ready-for-agent` brief on #381 has an authoritative contract to build against.

## Decision (summary)

The shared, byte-identical-mirrored `_jsonify` becomes the one read-side value projection across `project`/`node`/`resource get` and the live `game` reads:

- `Dictionary` / `Array` / the packed-array family project recursively (dict keys stringified).
- An `Object` renders as one of three **descriptor kinds**: a **reference descriptor** (a `Resource` with a `res://` path — referenced, not inlined; the read-side mirror of ADR-0033's write-side reference), an **inline value descriptor** (a whitelisted path-less value Object like `InputEventKey`, via the existing storage-property model), or a **string fallback**.
- Bounded by a hard recursion depth cap; **no visited-set**. Output is always JSON-encodable.
- The inline-Object **whitelist is the risk-isolation boundary** — a non-whitelisted live Object (e.g. a `Node` from `game get`) falls back to `str()`, so the shared headless/live projector never blows up on a runtime scene tree or cycle.

New **public output ABI**, which is why it is recorded. No new `Gda error code`.

## Scope

- `docs/adr/0035-value-projection-compound-variants-to-structured-json.md` (new)
- `CONTEXT.md` — new `Value projection` term under a `Structured output` subsection

Implementation is tracked by #381 (`ready-for-agent`); the independent write-side companion is #380.

Refs #381, #380. Read-side companion to ADR-0033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
