### PR TITLE
fix(ops): gate the built-in-class ClassDB probe on class_exists

### DIFF
--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -240,7 +240,11 @@ func _op_scene_create(params: Dictionary) -> void:
 		_fail(OP_ERROR_INVALID_PATH, "missing required param: path")
 		return
 	var root_type := _string_param(params, "root_type")
-	if root_type.is_empty() or not ClassDB.can_instantiate(root_type) \
+	# class_exists gates can_instantiate: probing a name ClassDB does not know
+	# logs a spurious engine ERROR (issue #377); the miss still fails as
+	# invalid_root_type through the same else path.
+	if root_type.is_empty() or not ClassDB.class_exists(root_type) \
+			or not ClassDB.can_instantiate(root_type) \
 			or not ClassDB.is_parent_class(root_type, "Node"):
 		_fail(OP_ERROR_INVALID_ROOT_TYPE, "not an instantiable Node class: " + root_type)
 		return
@@ -3705,7 +3709,10 @@ func _fail_node_not_found_labeled(label: String, node_path: String) -> void:
 func _instantiate_node_type(type: String) -> Node:
 	# Tier 1 (built-in engine class) stays here, per-site with the Node base-class
 	# check; the class_name → script-path step is the unified resolver (ADR-0032).
-	if not type.is_empty() and ClassDB.can_instantiate(type) and ClassDB.is_parent_class(type, "Node"):
+	# class_exists gates can_instantiate: probing a class ClassDB does not know
+	# (a project-local class_name) logs a spurious engine ERROR (issue #377).
+	if not type.is_empty() and ClassDB.class_exists(type) and ClassDB.can_instantiate(type) \
+			and ClassDB.is_parent_class(type, "Node"):
 		return ClassDB.instantiate(type)
 	var resolution := _resolve_project_class_script(type)
 	match resolution["status"]:
@@ -3775,7 +3782,10 @@ func _instantiate_resource_type(type: String) -> Resource:
 	# Tier 1 (built-in engine class) stays here, per-site with the Resource
 	# base-class check; the class_name → script-path step is the unified resolver
 	# (ADR-0032), the same one node add and find-references route through.
-	if not type.is_empty() and ClassDB.can_instantiate(type) and ClassDB.is_parent_class(type, "Resource"):
+	# class_exists gates can_instantiate: probing a class ClassDB does not know
+	# (a project-local class_name) logs a spurious engine ERROR (issue #377).
+	if not type.is_empty() and ClassDB.class_exists(type) and ClassDB.can_instantiate(type) \
+			and ClassDB.is_parent_class(type, "Resource"):
 		return ClassDB.instantiate(type)
 	var resolution := _resolve_project_class_script(type)
 	match resolution["status"]:

--- a/tests/test_e2e_classname_resolution.py
+++ b/tests/test_e2e_classname_resolution.py
@@ -21,7 +21,11 @@ when the cache misses. These tests exercise the change through the REAL engine
 (c) a ``class_name`` declared in more than one ``.gd`` → ``ambiguous_class_name``
     naming the conflicting paths, for all three commands;
 (d) a truly unknown ``--type`` still errors with an ACTIONABLE message that names
-    the missing-class cause and does not cite the editor cache.
+    the missing-class cause and does not cite the editor cache;
+(e) the built-in-class tier probe is gated on ``ClassDB.class_exists()`` (#377),
+    so a static-scan resolution no longer makes the engine log a spurious
+    ``ERROR: Cannot get class`` to stderr (nor into the ``diagnostics`` of
+    unrelated error envelopes), while built-in classes resolve exactly as before.
 """
 
 import json
@@ -333,3 +337,112 @@ def test_node_add_unknown_type_message_is_actionable(uncached_project):
     assert "cache" not in msg.lower()
     assert "editor" not in msg.lower()
     assert "global class list" not in msg.lower()
+
+
+# --- (e) no spurious engine ERROR on the static-scan fallback path (#377) -----
+
+
+@pytest.mark.e2e
+def test_resource_create_project_class_emits_no_engine_error(uncached_project):
+    # Before #377 the built-in-class tier probed ClassDB.can_instantiate() on a
+    # project-local class_name and the engine logged "ERROR: Cannot get class
+    # 'PandaStats'." to stderr on a SUCCESSFUL op. class_exists() now gates the
+    # probe, so the static-scan resolution is silent.
+    assert not (uncached_project / ".godot").exists()
+
+    created = _gda(
+        uncached_project,
+        "resource",
+        "create",
+        str(uncached_project / "quiet.tres"),
+        "--type",
+        "PandaStats",
+        "--json",
+    )
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    assert "ERROR:" not in created.stderr, created.stderr
+
+
+@pytest.mark.e2e
+def test_node_add_project_class_emits_no_engine_error(uncached_project):
+    assert not (uncached_project / ".godot").exists()
+    scene_path = uncached_project / "main.tscn"
+    created = _gda(
+        uncached_project,
+        "scene",
+        "create",
+        str(scene_path),
+        "--root-type",
+        "Node2D",
+        "--json",
+    )
+    assert created.returncode == 0, created.stdout + created.stderr
+
+    added = _gda(
+        uncached_project, "node", "add", str(scene_path), "--type", "Hero", "--json"
+    )
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    assert "ERROR:" not in added.stderr, added.stderr
+
+
+@pytest.mark.e2e
+def test_ambiguous_class_name_carries_no_cannot_get_class(ambiguous_project):
+    # The spurious engine line was also captured verbatim into the diagnostics
+    # of UNRELATED error envelopes on the fallback path — an ambiguous_class_name
+    # failure carried "Cannot get class 'Dup'", pointing away from the real
+    # cause. Neither the envelope's diagnostics nor stderr embeds it now.
+    created = _gda(
+        ambiguous_project,
+        "resource",
+        "create",
+        str(ambiguous_project / "x.tres"),
+        "--type",
+        "Dup",
+        "--json",
+    )
+
+    err = _assert_operation_error(created, "ambiguous_class_name")
+    assert "Cannot get class" not in err.get("diagnostics", "")
+    assert "Cannot get class" not in created.stderr
+
+
+@pytest.mark.e2e
+def test_builtin_classes_resolve_unchanged_and_silent(uncached_project):
+    # Regression for the class_exists() guard: a built-in Node (Sprite2D) and a
+    # built-in Resource (Gradient) still resolve on the ClassDB tier exactly as
+    # before — never reaching the class_name resolver — and stay silent.
+    scene_path = uncached_project / "builtin.tscn"
+    created = _gda(
+        uncached_project,
+        "scene",
+        "create",
+        str(scene_path),
+        "--root-type",
+        "Node2D",
+        "--json",
+    )
+    assert created.returncode == 0, created.stdout + created.stderr
+    assert "ERROR:" not in created.stderr, created.stderr
+
+    added = _gda(
+        uncached_project, "node", "add", str(scene_path), "--type", "Sprite2D", "--json"
+    )
+    assert added.returncode == 0, added.stdout + added.stderr
+    assert json.loads(added.stdout)["type"] == "Sprite2D"
+    assert "ERROR:" not in added.stderr, added.stderr
+
+    resource_path = uncached_project / "builtin.tres"
+    res = _gda(
+        uncached_project,
+        "resource",
+        "create",
+        str(resource_path),
+        "--type",
+        "Gradient",
+        "--json",
+    )
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert json.loads(res.stdout)["type"] == "Gradient"
+    assert "ERROR:" not in res.stderr, res.stderr


### PR DESCRIPTION
## Summary

Gate the tier-1 built-in-class probe on `ClassDB.class_exists()` so resolving a *project-local* `class_name` via the ADR-0032 static-scan fallback no longer makes `ClassDB.can_instantiate()` log a spurious engine `ERROR: Cannot get class '...'` to stderr on a successful operation (and no longer pollutes the `diagnostics` of unrelated error envelopes, e.g. `ambiguous_class_name`).

## Changes

- `operations.gd`: `ClassDB.class_exists(type)` now precedes `ClassDB.can_instantiate(type)` at all three probe sites — `_instantiate_node_type`, `_instantiate_resource_type`, and the `_op_scene_create` root-type check. An unknown name short-circuits to the same fallback/failure path as before; built-in and editor-cache-resolved classes resolve exactly as before.
- Audited every `ClassDB.can_instantiate` call site in the repo's `.gd` sources — these three are all of them (the `Script.can_instantiate()` instance calls are post-resolution compile checks, out of scope).
- New e2e tests in `test_e2e_classname_resolution.py`: successful `node add` / `resource create` with a project-local `class_name` (no `.godot/`) assert **no `ERROR:` on stderr**; the `ambiguous_class_name` envelope no longer embeds "Cannot get class"; built-in classes (`Sprite2D`, `Gradient`, `Node2D` scene root) covered as regressions. Red-verified against the pre-fix code.

## Verification

- Full suite in an isolated worktree: `uv run pytest -rs` — **1353 passed, 1 skipped** (the documented Linux-only export-template skip), real Godot engine.
- `uv run ruff check` / `uv run pyright` clean.

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)