### PR TITLE
fix(ops): gate reference-scan decode on extension before reading

### DIFF
--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -2905,7 +2905,15 @@ func _resolve_ref_path(ref: String, base_dir: String) -> String:
 # a preload/load/extends names one of those paths, or — when the target is a
 # class_name — when the file uses the class token as an identifier. The context is
 # the matched line, trimmed, so an agent locates the reference without re-reading.
+# Dispatches on extension BEFORE reading (issue #378): only the reference-bearing
+# text formats (_has_outgoing_references' .tscn/.tres/.gd set) are ever decoded,
+# so a binary artifact in the walked tree (an exported .pck/.app under build/)
+# never hits the engine's UTF-8 decode and never spams a per-file "Unicode
+# parsing error" to stderr. The graph universe is unchanged — only the decode
+# narrows, mirroring the ext-first shape of _outgoing_references_of.
 func _collect_references_from(path: String, target_paths: Dictionary, target_class: String, references: Array) -> void:
+	if not _has_outgoing_references(path):
+		return
 	var ext := path.get_extension().to_lower()
 	var text := FileAccess.get_file_as_string(path)
 	if text.is_empty():

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -106,7 +106,13 @@ script="plugin.gd"
 
 @pytest.fixture
 def refgraph_project(tmp_path):
-    """A fixture project with real cross-references for the analysis commands."""
+    """A fixture project with real cross-references for the analysis commands.
+
+    Also plants binary artifacts (issue #378): an exported-build stand-in with
+    invalid-UTF-8 bytes under ``build/`` and an unreferenced binary asset. The
+    scan must never UTF-8-decode them (no engine ``Unicode parsing error`` on
+    stderr) while still enumerating them as graph nodes.
+    """
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
     (tmp_path / "hero.tscn").write_text(HERO_TSCN, encoding="utf-8")
@@ -115,6 +121,16 @@ def refgraph_project(tmp_path):
     (tmp_path / "game_state.gd").write_text(GAME_STATE_GD, encoding="utf-8")
     (tmp_path / "icon.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
     (tmp_path / "orphan.tres").write_text(ORPHAN_TRES, encoding="utf-8")
+    # An unreferenced binary ASSET: skipped decode must not drop it from the
+    # graph universe — it stays a find-unused candidate (issue #378).
+    (tmp_path / "orphan.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+    # A binary build artifact whose bytes are invalid UTF-8 (0xf3 lead byte
+    # followed by a non-continuation byte — the exact shape the issue-#378 repro
+    # decoded into "Unicode parsing error: Byte d is not a correct continuation
+    # byte after f3").
+    build = tmp_path / "build"
+    build.mkdir()
+    (build / "fake.pck").write_bytes(b"\xf3\x0d\x00\xff" * 8)
     addons = tmp_path / "addons" / "widget"
     addons.mkdir(parents=True)
     (addons / "plugin.cfg").write_text(PLUGIN_CFG, encoding="utf-8")
@@ -229,6 +245,40 @@ def test_find_unused_resources_reports_the_orphan_and_is_consistent_with_find_re
         ).stdout
     )["references"]
     assert hero_refs != []  # referenced, hence not in unused
+
+
+@pytest.mark.e2e
+def test_find_references_skips_decoding_binary_artifacts(refgraph_project):
+    # The fixture plants build/fake.pck with invalid-UTF-8 bytes. The scan must
+    # dispatch on extension BEFORE reading, so the binary is never UTF-8-decoded
+    # — no engine "Unicode parsing error" on stderr (issue #378) — while the
+    # references over the text formats stay byte-for-byte unchanged.
+    proc = _gda(
+        refgraph_project, "project", "find-references", "res://util.gd", "--json"
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "Unicode parsing error" not in proc.stderr, proc.stderr
+    refs = json.loads(proc.stdout)["references"]
+    assert {(r["path"], r["kind"]) for r in refs} == {("res://main.gd", "preload")}
+
+
+@pytest.mark.e2e
+def test_find_unused_resources_skips_decoding_but_keeps_binary_graph_nodes(
+    refgraph_project,
+):
+    # Same clean-stderr guarantee for find-unused-resources (shared graph), AND
+    # the graph universe must not shrink (issue #378): binaries are skipped only
+    # for DECODING — they stay enumerated as graph nodes, so the unreferenced
+    # binary asset (orphan.png) and the build artifact are still unused
+    # candidates.
+    proc = _gda(refgraph_project, "project", "find-unused-resources", "--json")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "Unicode parsing error" not in proc.stderr, proc.stderr
+    unused = json.loads(proc.stdout)["unused"]
+    assert "res://orphan.png" in unused
+    assert "res://build/fake.pck" in unused
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
## Summary

`project find-references` UTF-8-decoded **every** file the tree walk collected before dispatching on extension, so binary artifacts inside the project (e.g. an exported `.app`/`.pck` under `build/`) produced one engine `Unicode parsing error` line each per run. The scan now dispatches on extension first: only the reference-bearing text formats (`.tscn`/`.tres`/`.gd`) are ever decoded.

## Changes

- `operations.gd`: `_collect_references_from` returns early via the existing `_has_outgoing_references` predicate (the `.tscn/.tres/.gd` set) **before** `FileAccess.get_file_as_string`, mirroring the ext-first shape `_outgoing_references_of` already had. No parser logic duplicated; parse branches unchanged byte-for-byte.
- The walker (`_collect_resource_paths`) and graph-eligibility predicate (`_is_graph_resource_path`) are untouched — assets remain graph nodes and unused-candidates; only the decode narrows.
- Tests (`test_e2e_project_analysis.py`): the `refgraph_project` fixture now plants a binary `build/fake.pck` (the issue's exact invalid-UTF-8 byte shape) and an unreferenced `orphan.png`, so **all** existing reference-result tests run with binaries present; two new tests assert clean stderr + exact unchanged reference set for `find-references`, and clean stderr + intact unused-candidate reporting (both the orphan asset and the binary) for `find-unused-resources`. Red-verified: the pre-fix code reproduced the exact `Unicode parsing error: Byte d is not a correct continuation byte after f3` spam.

One honest note vs the issue text: pre-fix, `find-unused-resources` did **not** reproduce the spam — its graph path already went through the ext-gated `_outgoing_references_of`. Its new test therefore serves as the clean-stderr regression plus the graph-universe guard.

## Verification

- Full suite in an isolated worktree: fast tier **1025 passed**; full e2e tier **326 passed, 1 skipped** (the documented Linux-only export-template skip), real Godot engine.
- `uv run ruff check` / `uv run pyright` clean.

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)