### PR TITLE
feat(project): structured InputMap action authoring (add-input-action / remove-input-action)

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,8 @@ flags — `gda --help` is the authoritative list of what is installed.
 | `project set` | Set a project setting, coercing the value to its declared type. |
 | `project add-autoload` | Register an autoload singleton (name → script/scene). |
 | `project remove-autoload` | Unregister an autoload singleton by name. |
+| `project add-input-action` | Register an InputMap action bound to keys (`--key` name or keycode, `--deadzone`, `--physical`). |
+| `project remove-input-action` | Unregister an InputMap action by name. |
 | `project find-references` | Find every project file that references a given resource. |
 | `project dependencies` | Map each scene/resource to the resources it depends on. |
 | `project find-unused-resources` | Find resource files that nothing references. |

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=4ef9cb754f81a9c5c4ff9b88782dd72a6577f3a6c5fea7170390d9c59b5972cd -->
+<!-- gda-readme-i18n: source=README.md sha256=bdfb40b3f5d988d7c078a350821170b3579839c160396778620e9cc635573504 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -424,6 +424,8 @@ flags — `gda --help` es la lista autoritativa de lo que está instalado.
 | `project set` | Define un ajuste del proyecto, forzando el valor a su tipo declarado. |
 | `project add-autoload` | Registra un singleton autoload (nombre → script/escena). |
 | `project remove-autoload` | Cancela el registro de un singleton autoload por nombre. |
+| `project add-input-action` | Registra una acción del InputMap vinculada a teclas (`--key` nombre o keycode, `--deadzone`, `--physical`). |
+| `project remove-input-action` | Cancela el registro de una acción del InputMap por nombre. |
 | `project find-references` | Encuentra todos los archivos del proyecto que referencian un recurso dado. |
 | `project dependencies` | Mapea cada escena/recurso a los recursos de los que depende. |
 | `project find-unused-resources` | Encuentra archivos de recurso que nada referencia. |

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=4ef9cb754f81a9c5c4ff9b88782dd72a6577f3a6c5fea7170390d9c59b5972cd -->
+<!-- gda-readme-i18n: source=README.md sha256=bdfb40b3f5d988d7c078a350821170b3579839c160396778620e9cc635573504 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -430,6 +430,8 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 | `project set` | プロジェクト設定を設定します。値は宣言された型に変換されます。 |
 | `project add-autoload` | オートロードのシングルトンを登録します(名前 → スクリプト/シーン)。 |
 | `project remove-autoload` | オートロードのシングルトンを名前で指定して登録解除します。 |
+| `project add-input-action` | キーに割り当てた InputMap アクションを登録します(`--key` はキー名またはキーコード、`--deadzone`、`--physical`)。 |
+| `project remove-input-action` | InputMap アクションを名前で指定して登録解除します。 |
 | `project find-references` | 指定したリソースを参照するすべてのプロジェクトファイルを見つけます。 |
 | `project dependencies` | 各シーン/リソースを、それが依存するリソースに対応付けます。 |
 | `project find-unused-resources` | どこからも参照されていないリソースファイルを見つけます。 |

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=4ef9cb754f81a9c5c4ff9b88782dd72a6577f3a6c5fea7170390d9c59b5972cd -->
+<!-- gda-readme-i18n: source=README.md sha256=bdfb40b3f5d988d7c078a350821170b3579839c160396778620e9cc635573504 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -413,6 +413,8 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 | `project set` | 设置一个项目设置，并把值强制转换为它声明的类型。 |
 | `project add-autoload` | 注册一个 autoload 单例（名称 → 脚本/场景）。 |
 | `project remove-autoload` | 按名称注销一个 autoload 单例。 |
+| `project add-input-action` | 注册一个绑定按键的 InputMap 动作（`--key` 键名或键码、`--deadzone`、`--physical`）。 |
+| `project remove-input-action` | 按名称注销一个 InputMap 动作。 |
 | `project find-references` | 找出引用了给定资源的每一个项目文件。 |
 | `project dependencies` | 把每个场景/资源映射到它所依赖的资源。 |
 | `project find-unused-resources` | 找出没有任何东西引用的资源文件。 |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -145,6 +145,7 @@ operation, and parse codes the CLI assigns).
 | `no_uid_assigned` | `operation` | `operation` | `4` | A resource path exists but has no UID assigned in the engine's UID cache. |
 | `unknown_setting` | `operation` | `operation` | `4` | A requested project setting does not exist in the project's ProjectSettings. |
 | `invalid_target` | `operation` | `operation` | `4` | A project find-references target is empty or not a valid `res://` path or `class_name`. |
+| `invalid_key` | `operation` | `operation` | `4` | An input-action key could not be resolved to a Godot keycode (unknown key name or non-positive keycode). |
 | `contract_violation` | `parse` | `parser` | `5` | The process claimed success but violated the structured-output contract. |
 | `tree_too_deep` | `parse` | `classifier` | `5` | The engine emitted a valid result tree that nests past gda's recursion limit; the payload is contract-conformant, the limit is wrapper-side (shares the `parse` exit code; the `code` distinguishes it from `contract_violation`). |
 | `daemon_not_running` | `live` | `classifier` | `6` | A live command found no running gda-daemon for the project; start one with `gda daemon start` (Phase 2, ADR-0017 / ADR-0021). |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -435,6 +435,21 @@ engine-bookkeeping settings and the non-setting properties the engine's property
 are filtered out, so only real `ProjectSettings` keys appear. Like the rest of the group it requires
 a resolved project (`project_not_found`, exit 4, otherwise) and never instantiates a scene.
 
+**Input actions** (established by #380): `gda project add-input-action NAME --key K...` registers an
+InputMap action under `input/<name>` — the compound `{deadzone, events}` entry `project set` cannot
+express — with **key events only** for this slice (mouse/joypad kinds may extend it later). `--key`
+is repeatable and accepts a Godot key **name** (`J`, `Space`, `Escape`) or a raw base-10 **keycode**;
+an unresolvable token is a clean `invalid_key` error (exit 4, nothing saved). `--deadzone` overrides
+Godot's `0.5` default; `--physical` binds physical keycodes (keyboard position, layout-independent)
+instead of layout keycodes. The action is built from real `InputEventKey` objects and persisted via
+`ProjectSettings.save()`, so the serialization is exactly the engine's own `var_to_str` form — the
+editor and a running game load it identically to a hand-authored entry, and the action is immediately
+driveable by `gda input action NAME` in a live session started afterwards. Adding an existing action
+name is `already_exists` (never a silent clobber — remove first to replace; note the engine registers
+the built-in `ui_*` actions as defaults, so adding e.g. `ui_accept` reports `already_exists` by
+design). `gda project remove-input-action NAME` unregisters the action and persists `project.godot`;
+a missing action is `unknown_setting`, mirroring `remove-autoload`. A failed save is `save_failed`.
+
 | Command | Description |
 | --- | --- |
 | `gda project info` | Project metadata (name, main scene, viewport, engine version) |
@@ -442,6 +457,7 @@ a resolved project (`project_not_found`, exit 4, otherwise) and never instantiat
 | `gda project list` | List the project's settings keys (customized by default; `--all` adds defaults, `--section` filters) |
 | `gda project set` | Modify a project setting (value coerced to its declared type) |
 | `gda project add-autoload` / `remove-autoload` | Register / unregister an autoload singleton |
+| `gda project add-input-action` / `remove-input-action` | Register / unregister an InputMap action (key events) |
 
 ### `resource`
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -137,6 +137,8 @@ from gda.models import (
     NodeSetResult,
     ProjectAddAutoloadParams,
     ProjectAddAutoloadResult,
+    ProjectAddInputActionParams,
+    ProjectAddInputActionResult,
     ProjectGetParams,
     ProjectGetResult,
     ProjectInfoParams,
@@ -145,6 +147,8 @@ from gda.models import (
     ProjectListResult,
     ProjectRemoveAutoloadParams,
     ProjectRemoveAutoloadResult,
+    ProjectRemoveInputActionParams,
+    ProjectRemoveInputActionResult,
     ProjectSetParams,
     ProjectSetResult,
     ResourceCreateParams,
@@ -232,6 +236,7 @@ from gda.render import (
     render_perf_monitor,
     render_perf_monitors,
     render_project_add_autoload,
+    render_project_add_input_action,
     render_project_dependencies,
     render_project_find_references,
     render_project_find_unused_resources,
@@ -239,6 +244,7 @@ from gda.render import (
     render_project_info,
     render_project_list,
     render_project_remove_autoload,
+    render_project_remove_input_action,
     render_project_set,
     render_project_statistics,
     render_resource_create,
@@ -1930,6 +1936,24 @@ PROJECT_REMOVE_AUTOLOAD_COMMAND: HeadlessCommand[ProjectRemoveAutoloadResult] = 
     )
 )
 
+PROJECT_ADD_INPUT_ACTION_COMMAND: HeadlessCommand[ProjectAddInputActionResult] = (
+    HeadlessCommand(
+        operation="project-add-input-action",
+        input_model=ProjectAddInputActionParams,
+        output_model=ProjectAddInputActionResult,
+        render=render_project_add_input_action,
+    )
+)
+
+PROJECT_REMOVE_INPUT_ACTION_COMMAND: HeadlessCommand[ProjectRemoveInputActionResult] = (
+    HeadlessCommand(
+        operation="project-remove-input-action",
+        input_model=ProjectRemoveInputActionParams,
+        output_model=ProjectRemoveInputActionResult,
+        render=render_project_remove_input_action,
+    )
+)
+
 SHADER_CREATE_COMMAND: HeadlessCommand[ShaderCreateResult] = HeadlessCommand(
     operation="shader-create",
     input_model=ShaderCreateParams,
@@ -3268,6 +3292,77 @@ def project_remove_autoload(
     _dispatch(
         PROJECT_REMOVE_AUTOLOAD_COMMAND,
         ProjectRemoveAutoloadParams(name=name),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+    )
+
+
+@project_app.command(
+    name="add-input-action", cls=PROJECT_ADD_INPUT_ACTION_COMMAND.command_class()
+)
+def project_add_input_action(
+    name: str = typer.Argument(
+        ..., help="The input action's name (the input/<name> key)."
+    ),
+    keys: list[str] = typer.Option(
+        ...,
+        "--key",
+        help=(
+            "A key to bind (repeatable, at least one): a Godot key name "
+            "(e.g. J, Space, Escape) or a base-10 keycode integer."
+        ),
+    ),
+    deadzone: float = typer.Option(
+        0.5,
+        "--deadzone",
+        help="The action's deadzone, 0..1 (Godot's default is 0.5).",
+    ),
+    physical: bool = typer.Option(
+        False,
+        "--physical",
+        help=(
+            "Bind physical keycodes (keyboard position, layout-independent) "
+            "instead of layout keycodes."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = PROJECT_ADD_INPUT_ACTION_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Register an InputMap action bound to one or more keys, then save project.godot."""
+    try:
+        params = ProjectAddInputActionParams(
+            name=name, keys=keys, deadzone=deadzone, physical=physical
+        )
+    except (ValueError, ValidationError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    _dispatch(
+        PROJECT_ADD_INPUT_ACTION_COMMAND,
+        params,
+        json_output=json_output,
+        godot=godot,
+        project=project,
+    )
+
+
+@project_app.command(
+    name="remove-input-action", cls=PROJECT_REMOVE_INPUT_ACTION_COMMAND.command_class()
+)
+def project_remove_input_action(
+    name: str = typer.Argument(..., help="The name of the input action to unregister."),
+    json_output: bool = json_option(),
+    schema: bool = PROJECT_REMOVE_INPUT_ACTION_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Unregister an InputMap action by name, then save project.godot."""
+    _dispatch(
+        PROJECT_REMOVE_INPUT_ACTION_COMMAND,
+        ProjectRemoveInputActionParams(name=name),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -445,6 +445,13 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A project find-references target is empty or not a valid res:// path or class_name.",
     ),
     ErrorCodeSpec(
+        "invalid_key",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "An input-action key could not be resolved to a Godot keycode (unknown key name or non-positive keycode).",
+    ),
+    ErrorCodeSpec(
         "contract_violation",
         ErrorCategory.PARSE,
         EXIT_PARSE,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -2624,6 +2624,105 @@ class ProjectRemoveAutoloadResult(BaseModel):
     name: str = Field(description="The unregistered autoload's global name.")
 
 
+class ProjectAddInputActionParams(BaseModel):
+    """The operation params of ``gda project add-input-action`` (issue #380).
+
+    Registers an InputMap action: ``name`` is the action name (the key under the
+    ``input/`` section of ``project.godot``), bound to one or more keyboard keys.
+    The operation builds real ``InputEventKey`` events and persists the action
+    via ``ProjectSettings`` — never a hand-built string — so the serialization is
+    exactly the engine's own ``var_to_str`` form. The project is process context
+    (``--project``), not an operation param (ADR-0006).
+    """
+
+    name: str = Field(
+        description=(
+            "The input action's name — the key under the project's input/ section "
+            "and the name gda input action drives it by."
+        )
+    )
+    keys: list[str] = Field(
+        min_length=1,
+        description=(
+            "The keys to bind (at least one): each item is a Godot key NAME "
+            "(e.g. J, Space, Escape) or a base-10 keycode integer string."
+        ),
+    )
+    deadzone: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "The action's deadzone, 0..1 (the editor slider's bounds); "
+            "Godot's default is 0.5."
+        ),
+    )
+    physical: bool = Field(
+        default=False,
+        description=(
+            "Bind physical_keycode (keyboard position, layout-independent) "
+            "instead of keycode."
+        ),
+    )
+
+
+class InputActionKeyEvent(BaseModel):
+    """One key binding of a registered InputMap action (issue #380).
+
+    ``kind`` discriminates the event type so mouse/joypad kinds can extend the
+    shape later without breaking; this slice emits only ``key`` events. ``key``
+    echoes the raw ``--key`` token, ``keycode`` the Godot keycode it resolved to,
+    and ``physical`` whether it was bound as ``physical_keycode``.
+    """
+
+    kind: str = Field(
+        default="key", description="The event kind ('key' for this slice)."
+    )
+    key: str = Field(description="The raw --key token as given (name or keycode).")
+    keycode: int = Field(description="The Godot keycode the token resolved to.")
+    physical: bool = Field(
+        description="True when bound as physical_keycode instead of keycode."
+    )
+
+
+class ProjectAddInputActionResult(BaseModel):
+    """The result of ``gda project add-input-action``: the action it registered.
+
+    Echoes the action's ``name``, the ``deadzone`` persisted, and the resolved
+    key ``events`` exactly as they were bound — so an agent can confirm each key
+    token mapped to the intended keycode without re-reading ``project.godot``.
+    """
+
+    name: str = Field(description="The registered input action's name.")
+    deadzone: float = Field(description="The deadzone persisted with the action.")
+    events: list[InputActionKeyEvent] = Field(
+        description="The key events bound to the action, in --key order."
+    )
+
+
+class ProjectRemoveInputActionParams(BaseModel):
+    """The operation params of ``gda project remove-input-action`` (issue #380).
+
+    Unregisters an InputMap action by its ``name`` (the key under the ``input/``
+    section), then saves ``project.godot``. The project is process context
+    (``--project``), not an operation param (ADR-0006), so only ``name`` is an
+    input.
+    """
+
+    name: str = Field(description="The name of the input action to unregister.")
+
+
+class ProjectRemoveInputActionResult(BaseModel):
+    """The result of ``gda project remove-input-action``: the action it removed.
+
+    Echoes the ``name`` of the input action that was unregistered, so an agent
+    can confirm which action was removed; a subsequent ``project get`` of
+    ``input/<name>`` reports ``unknown_setting``.
+    """
+
+    name: str = Field(description="The unregistered input action's name.")
+
+
 class GameNode(BaseModel):
     """One node of the RUNNING game's runtime scene tree (Phase 2, ADR-0019).
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -70,6 +70,7 @@ const OP_ERROR_UNKNOWN_UID := "unknown_uid"
 const OP_ERROR_NO_UID_ASSIGNED := "no_uid_assigned"
 const OP_ERROR_UNKNOWN_SETTING := "unknown_setting"
 const OP_ERROR_INVALID_TARGET := "invalid_target"
+const OP_ERROR_INVALID_KEY := "invalid_key"
 
 const NODE_NAME_INVALID_CHARS := [".", ":", "@", "/", "\"", "%"]
 
@@ -86,6 +87,12 @@ const PROJECT_VIEWPORT_HEIGHT_SETTING := "display/window/size/viewport_height"
 # "enabled as a singleton" — the normal, accessible form gda writes.
 const AUTOLOAD_SETTING_PREFIX := "autoload/"
 const AUTOLOAD_ENABLED_PREFIX := "*"
+
+# InputMap actions live under the "input/<name>" section of project.godot
+# (issue #380). The value is a Dictionary of {deadzone, events} where the events
+# are real InputEventKey Objects, persisted via ProjectSettings.save() so the
+# serialization is exactly the engine's own var_to_str form.
+const INPUT_SETTING_PREFIX := "input/"
 
 # The exit code the process will use. Defaults to failure, so an operation that
 # aborts before recording an outcome (e.g. an uncaught runtime error) still
@@ -186,6 +193,10 @@ func _initialize() -> void:
 			_op_project_add_autoload(params)
 		"project-remove-autoload":
 			_op_project_remove_autoload(params)
+		"project-add-input-action":
+			_op_project_add_input_action(params)
+		"project-remove-input-action":
+			_op_project_remove_input_action(params)
 		"shader-create":
 			_op_shader_create(params)
 		"shader-get":
@@ -2407,6 +2418,146 @@ func _op_project_remove_autoload(params: Dictionary) -> void:
 
 	_succeed({
 		"name": autoload_name,
+	})
+
+
+# Resolve one --key token to a Godot keycode (issue #380). A base-10 integer
+# spelling is taken as a raw keycode and must be positive; anything else is
+# looked up as a Godot key NAME via OS.find_keycode_from_string (e.g. "J",
+# "Space", "Escape"). Returns KEY_NONE (0) when the token is unresolvable —
+# unambiguous as a failure signal because no valid keycode is 0 or negative —
+# which the caller reports as the registered invalid_key error naming the token.
+func _resolve_input_keycode(token: String) -> int:
+	var trimmed := token.strip_edges()
+	if trimmed.is_valid_int():
+		var keycode := trimmed.to_int()
+		return keycode if keycode > 0 else KEY_NONE
+	return OS.find_keycode_from_string(trimmed)
+
+
+# project-add-input-action: register an InputMap action under input/<name> with
+# one or more keyboard key bindings, then persist project.godot (issue #380).
+#
+# The stored value is the InputMap Dictionary shape — {deadzone, events} with
+# real InputEventKey Objects, deadzone first (Godot's own key order) — set via
+# ProjectSettings.set_setting and serialized by ProjectSettings.save() (the
+# engine's own var_to_str form). gda never hand-builds the Object(InputEventKey,
+# …) string, so the persisted entry is byte-equivalent to a hand-authored one.
+#
+# Failure modes use registered codes: an empty name is invalid_path (the
+# missing-required-param convention the autoload ops set); malformed keys /
+# deadzone / physical params are invalid_params; an action name already present
+# is already_exists (add never silently clobbers — remove first to replace).
+# NOTE: the engine registers the built-in ui_* actions (input/ui_accept, …) as
+# ProjectSettings defaults, so has_setting answers true for them and adding e.g.
+# ui_accept reports already_exists by design. An unresolvable key token is
+# invalid_key (nothing saved); a failed save is save_failed.
+func _op_project_add_input_action(params: Dictionary) -> void:
+	_diag("running operation: project-add-input-action")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "project add-input-action requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+	var action_name := _string_param(params, "name")
+	if action_name.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: name")
+		return
+	# Defensive params reads: the params arrive as arbitrary JSON, so a wrong
+	# shape surfaces as a structured failure rather than a runtime error.
+	var raw_keys: Variant = params.get("keys")
+	if not (raw_keys is Array) or (raw_keys as Array).is_empty():
+		_fail(OP_ERROR_INVALID_PARAMS, "keys must be a non-empty array of key names or keycodes")
+		return
+	var raw_deadzone: Variant = params.get("deadzone", 0.5)
+	if not (raw_deadzone is float or raw_deadzone is int):
+		_fail(OP_ERROR_INVALID_PARAMS, "deadzone must be a number in 0..1")
+		return
+	var deadzone := float(raw_deadzone)
+	var physical := bool(params.get("physical", false))
+
+	var setting := INPUT_SETTING_PREFIX + action_name
+	if ProjectSettings.has_setting(setting):
+		_fail(OP_ERROR_ALREADY_EXISTS, "input action already registered: " + action_name
+				+ " — add-input-action never overwrites; remove it first to replace it")
+		return
+
+	# Resolve every key token before touching ProjectSettings, so a bad token
+	# fails the whole add cleanly with nothing saved. `events` stays an UNTYPED
+	# Array: a typed Array[InputEventKey] would serialize with an
+	# `Array[InputEventKey](...)` annotation, not the plain `[Object(...)]` form
+	# the editor writes — untyped keeps the persisted entry byte-equivalent.
+	var events := []
+	var reported_events := []
+	for raw_token in (raw_keys as Array):
+		if not (raw_token is String):
+			_fail(OP_ERROR_INVALID_PARAMS, "keys must be a non-empty array of key names or keycodes")
+			return
+		var token: String = raw_token
+		var keycode := _resolve_input_keycode(token)
+		if keycode == KEY_NONE:
+			_fail(OP_ERROR_INVALID_KEY, "cannot resolve key to a Godot keycode: " + token)
+			return
+		var event := InputEventKey.new()
+		# --physical binds the keyboard POSITION (physical_keycode) instead of
+		# the layout symbol (keycode) — set only the requested one, exactly as
+		# the editor's "Physical" toggle does, never both.
+		if physical:
+			event.physical_keycode = keycode as Key
+		else:
+			event.keycode = keycode as Key
+		events.append(event)
+		reported_events.append({
+			"kind": "key",
+			"key": token,
+			"keycode": keycode,
+			"physical": physical,
+		})
+
+	# deadzone first — the key order Godot itself writes for an input action.
+	ProjectSettings.set_setting(setting, {"deadzone": deadzone, "events": events})
+	var save_err := ProjectSettings.save()
+	if save_err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, "failed to save project settings after registering input action "
+				+ action_name + ": " + error_string(save_err))
+		return
+
+	_succeed({
+		"name": action_name,
+		"deadzone": deadzone,
+		"events": reported_events,
+	})
+
+
+# project-remove-input-action: unregister an InputMap action by name (clearing
+# the input/<name> setting), then persist project.godot (issue #380). An action
+# that is not registered is a clean unknown_setting error — the same code
+# `project get` of a missing setting reports, since an input action IS a project
+# setting — not a silent no-op. A failed save is save_failed.
+func _op_project_remove_input_action(params: Dictionary) -> void:
+	_diag("running operation: project-remove-input-action")
+	if not _has_project():
+		_fail(OP_ERROR_PROJECT_NOT_FOUND, "project remove-input-action requires a Godot project; none was resolved — pass --project, set $GDA_PROJECT, or run from a project directory")
+		return
+	var action_name := _string_param(params, "name")
+	if action_name.is_empty():
+		_fail(OP_ERROR_INVALID_PATH, "missing required param: name")
+		return
+
+	var setting := INPUT_SETTING_PREFIX + action_name
+	if not ProjectSettings.has_setting(setting):
+		_fail(OP_ERROR_UNKNOWN_SETTING, "input action not registered: " + action_name)
+		return
+
+	# Clearing the setting (assigning null) removes it from ProjectSettings, so it
+	# is dropped from project.godot on save rather than persisted as an empty key.
+	ProjectSettings.set_setting(setting, null)
+	var save_err := ProjectSettings.save()
+	if save_err != OK:
+		_fail(OP_ERROR_SAVE_FAILED, "failed to save project settings after removing input action "
+				+ action_name + ": " + error_string(save_err))
+		return
+
+	_succeed({
+		"name": action_name,
 	})
 
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -2497,6 +2497,11 @@ func _op_project_add_input_action(params: Dictionary) -> void:
 			_fail(OP_ERROR_INVALID_KEY, "cannot resolve key to a Godot keycode: " + token)
 			return
 		var event := InputEventKey.new()
+		# Match from ANY device, the editor's convention (InputMap::ALL_DEVICES,
+		# -1): InputMap matching filters on device, and a real keyboard event
+		# carries DEVICE_ID_KEYBOARD (16), so the InputEventKey.new() default of
+		# device 0 would never match a physical key press.
+		event.device = -1
 		# --physical binds the keyboard POSITION (physical_keycode) instead of
 		# the layout symbol (keycode) — set only the requested one, exactly as
 		# the editor's "Physical" toggle does, never both.

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -58,10 +58,12 @@ if TYPE_CHECKING:
         PerfMonitorResult,
         PerfMonitorsResult,
         ProjectAddAutoloadResult,
+        ProjectAddInputActionResult,
         ProjectGetResult,
         ProjectInfoResult,
         ProjectListResult,
         ProjectRemoveAutoloadResult,
+        ProjectRemoveInputActionResult,
         ProjectSetResult,
         ResourceCreateResult,
         ResourceDeleteResult,
@@ -669,6 +671,26 @@ def render_project_add_autoload(added: "ProjectAddAutoloadResult") -> str:
 def render_project_remove_autoload(removed: "ProjectRemoveAutoloadResult") -> str:
     """Render an unregistered autoload as ``removed autoload <name>``."""
     return f"removed autoload {removed.name}"
+
+
+def render_project_add_input_action(added: "ProjectAddInputActionResult") -> str:
+    """Render a registered input action with its resolved key bindings.
+
+    e.g. ``added input action jump (deadzone 0.5): J -> 74, Space -> 32``; a
+    physical binding is marked ``(physical)`` after its keycode.
+    """
+    bindings = ", ".join(
+        f"{event.key} -> {event.keycode}" + (" (physical)" if event.physical else "")
+        for event in added.events
+    )
+    return f"added input action {added.name} (deadzone {added.deadzone}): {bindings}"
+
+
+def render_project_remove_input_action(
+    removed: "ProjectRemoveInputActionResult",
+) -> str:
+    """Render an unregistered input action as ``removed input action <name>``."""
+    return f"removed input action {removed.name}"
 
 
 @runtime_checkable

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -63,7 +63,7 @@ Branch on the stable `category`/`code` and the **exit code**, never on prose:
 | `scene` | `create`, `get`, `list`, `get-exports`, `delete` (`.tscn` files) |
 | `node` | `add`, `get`, `list`, `set`, `remove`, `duplicate`, `move`, `connect-signal`, `disconnect-signal` (nodes within a scene) |
 | `script` | `create`, `get`, `list`, `set`, `delete`, `attach`, `validate`, `run` (`.gd` files; `run` executes a `res://` script one-shot and passes its `exit_status`/`stdout`/`stderr` through — a non-zero `quit()` is still success) |
-| `project` | `info`, `get`, `set`, `list`, `add-autoload`, `remove-autoload`, `find-references`, `dependencies`, `find-unused-resources`, `statistics` |
+| `project` | `info`, `get`, `set`, `list`, `add-autoload`, `remove-autoload`, `add-input-action`, `remove-input-action`, `find-references`, `dependencies`, `find-unused-resources`, `statistics` |
 | `resource` | `create`, `get`, `set`, `delete`, `uid` (`.tres` files) |
 | `export` | `list`, `get`, `run` (export a preset by name; `--mode` release/debug/pack) |
 | `shader` | `create`, `get`, `set` (`.gdshader` files) |

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -284,6 +284,74 @@ def test_daemon_serves_input_action_observed_via_game_get(tmp_path, daemon_runti
 
 
 @pytest.mark.e2e
+def test_add_input_action_makes_the_action_immediately_driveable(
+    tmp_path, daemon_runtime_dir
+):
+    # Issue #380's acceptance criterion: an action registered HEADLESSLY by
+    # `gda project add-input-action` is immediately driveable by `gda input action`
+    # in a live session. The fixture project declares NO [input] section — the
+    # action exists only because add-input-action persisted it. Ordering matters:
+    # the InputMap loads from project.godot at engine launch, so the headless add
+    # runs BEFORE `daemon start`.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(ACTION_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "player.gd").write_text(ACTION_PLAYER_GD, encoding="utf-8")
+
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    # Register the action headlessly FIRST — before any engine session exists.
+    added = run("project", "add-input-action", "move_right", "--key", "Right")
+    assert added.returncode == 0, added.stdout + added.stderr
+    assert json.loads(added.stdout)["name"] == "move_right"
+
+    try:
+        assert run("daemon", "start").returncode == 0
+
+        before = run("game", "get", "/root/Main/Player", "--property", "position")
+        assert before.returncode == 0, before.stdout + before.stderr
+        before_x = next(
+            p
+            for p in json.loads(before.stdout)["properties"]
+            if p["name"] == "position"
+        )["value"][0]
+
+        # The freshly-registered action is in the running InputMap: pressing it
+        # moves the Player (which polls is_action_pressed each frame).
+        pressed = run("input", "action", "move_right")
+        assert pressed.returncode == 0, pressed.stdout + pressed.stderr
+        assert json.loads(pressed.stdout)["pressed"] is True
+
+        after = run("game", "get", "/root/Main/Player", "--property", "position")
+        assert after.returncode == 0, after.stdout + after.stderr
+        after_x = next(
+            p for p in json.loads(after.stdout)["properties"] if p["name"] == "position"
+        )["value"][0]
+        assert after_x > before_x
+
+        released = run("input", "action", "move_right", "--release")
+        assert released.returncode == 0, released.stdout + released.stderr
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
 def test_daemon_serves_input_sequence_across_frames(tmp_path, daemon_runtime_dir):
     # `input sequence` applies multiple key events across frames via the time-windowed
     # multi-frame base (#223), returned as ONE blocking result. Three Right presses at

--- a/tests/test_e2e_project.py
+++ b/tests/test_e2e_project.py
@@ -418,6 +418,9 @@ def test_project_add_input_action_persists_var_to_str_form_and_reports_keycodes(
     assert "Object(InputEventKey" in normalized
     assert '"keycode":74' in normalized
     assert '"keycode":32' in normalized
+    # The editor's device convention (InputMap ALL_DEVICES): a real keyboard
+    # event carries its own device id, so a device-pinned event would not fire.
+    assert '"device":-1' in normalized
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_project.py
+++ b/tests/test_e2e_project.py
@@ -369,6 +369,155 @@ def test_project_remove_autoload_unknown_name_is_a_clean_error(godot_project):
     assert "Nonexistent" in err["message"]
 
 
+def _normalized_project_godot(project) -> str:
+    # The var_to_str assertions key on token sequences, not layout: Godot writes
+    # the action dict across lines with quoted keys, so strip ALL whitespace and
+    # compare against the whitespace-free form.
+    text = (project / "project.godot").read_text(encoding="utf-8")
+    return "".join(text.split())
+
+
+@pytest.mark.e2e
+def test_project_add_input_action_persists_var_to_str_form_and_reports_keycodes(
+    godot_project,
+):
+    # A key NAME and a raw base-10 keycode mix in one action; --deadzone overrides
+    # Godot's 0.5 default. The result reports each token's resolved keycode, and
+    # project.godot carries the engine's own var_to_str serialization — an [input]
+    # section with real Object(InputEventKey, ...) literals (issue #380). The
+    # stored-value SHAPE via `project get` is deliberately NOT asserted here (the
+    # read-side projection of a compound setting is #381, independent).
+    added = _gda(
+        godot_project,
+        "project",
+        "add-input-action",
+        "jump",
+        "--key",
+        "J",
+        "--key",
+        "32",
+        "--deadzone",
+        "0.2",
+        "--json",
+    )
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    data = json.loads(added.stdout)
+    assert data["name"] == "jump"
+    assert data["deadzone"] == 0.2
+    assert data["events"] == [
+        {"kind": "key", "key": "J", "keycode": 74, "physical": False},
+        {"kind": "key", "key": "32", "keycode": 32, "physical": False},
+    ]
+
+    normalized = _normalized_project_godot(godot_project)
+    assert "[input]" in normalized
+    assert "jump={" in normalized
+    # deadzone first — Godot's own key order for an input action.
+    assert '"deadzone":0.2' in normalized
+    assert "Object(InputEventKey" in normalized
+    assert '"keycode":74' in normalized
+    assert '"keycode":32' in normalized
+
+
+@pytest.mark.e2e
+def test_project_add_input_action_physical_binds_physical_keycode(godot_project):
+    # --physical binds the keyboard POSITION: the persisted event carries the
+    # keycode in physical_keycode, and the layout keycode stays unset (0).
+    added = _gda(
+        godot_project,
+        "project",
+        "add-input-action",
+        "move_up",
+        "--key",
+        "W",
+        "--physical",
+        "--json",
+    )
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    data = json.loads(added.stdout)
+    assert data["events"] == [
+        {"kind": "key", "key": "W", "keycode": 87, "physical": True}
+    ]
+
+    normalized = _normalized_project_godot(godot_project)
+    assert "Object(InputEventKey" in normalized
+    assert '"physical_keycode":87' in normalized
+    # The layout keycode is NOT also set — physical binds only the position.
+    assert '"keycode":87' not in normalized
+
+
+@pytest.mark.e2e
+def test_project_add_input_action_duplicate_name_is_a_clean_error(godot_project):
+    first = _gda(
+        godot_project, "project", "add-input-action", "fire", "--key", "F", "--json"
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+    before = _normalized_project_godot(godot_project)
+
+    dup = _gda(
+        godot_project, "project", "add-input-action", "fire", "--key", "J", "--json"
+    )
+    assert dup.returncode == 4
+    err = json.loads(dup.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "already_exists"
+
+    # The original registration is untouched: project.godot is byte-identical.
+    assert _normalized_project_godot(godot_project) == before
+
+
+@pytest.mark.e2e
+def test_project_add_input_action_unknown_key_is_a_clean_error(godot_project):
+    bad = _gda(
+        godot_project,
+        "project",
+        "add-input-action",
+        "jump",
+        "--key",
+        "NotAKeyName",
+        "--json",
+    )
+
+    assert bad.returncode == 4
+    err = json.loads(bad.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "invalid_key"
+    assert "NotAKeyName" in err["message"]
+
+    # Nothing was saved: project.godot gained no [input] section.
+    assert "[input]" not in _normalized_project_godot(godot_project)
+
+
+@pytest.mark.e2e
+def test_project_remove_input_action_unregisters_and_persists(godot_project):
+    added = _gda(
+        godot_project, "project", "add-input-action", "jump", "--key", "J", "--json"
+    )
+    assert added.returncode == 0, added.stdout + added.stderr
+
+    removed = _gda(godot_project, "project", "remove-input-action", "jump", "--json")
+    assert removed.returncode == 0, removed.stdout + removed.stderr
+    assert json.loads(removed.stdout) == {"name": "jump"}
+
+    # The action is gone from project.godot — no lingering InputEventKey literal.
+    normalized = _normalized_project_godot(godot_project)
+    assert "jump={" not in normalized
+    assert "Object(InputEventKey" not in normalized
+
+
+@pytest.mark.e2e
+def test_project_remove_input_action_unknown_name_is_a_clean_error(godot_project):
+    bad = _gda(godot_project, "project", "remove-input-action", "nonexistent", "--json")
+
+    assert bad.returncode == 4
+    err = json.loads(bad.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == "unknown_setting"
+    assert "nonexistent" in err["message"]
+
+
 @pytest.mark.e2e
 def test_project_info_without_project_is_a_clean_error():
     # Projectless: ProjectSettings would report only the engine's bare defaults,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,9 +22,11 @@ from gda.models import (
     NodeRemoveResult,
     NodeSetResult,
     ProjectAddAutoloadResult,
+    ProjectAddInputActionResult,
     ProjectGetResult,
     ProjectInfoResult,
     ProjectRemoveAutoloadResult,
+    ProjectRemoveInputActionResult,
     ProjectSetResult,
     ResourceCreateResult,
     ResourceGetResult,
@@ -966,6 +968,41 @@ def test_project_remove_autoload_result_round_trips_the_unregistered_name():
     removed = ProjectRemoveAutoloadResult.model_validate(payload)
 
     assert removed.name == "Global"
+    assert json.loads(removed.model_dump_json()) == payload
+
+
+def test_project_add_input_action_result_round_trips_the_registered_action():
+    # project add-input-action echoes the action it registered (issue #380): the
+    # name, the persisted deadzone, and each key event with the raw token, the
+    # resolved keycode, and whether it was bound as physical_keycode. `kind`
+    # discriminates the event type so mouse/joypad kinds can extend it later.
+    payload = {
+        "name": "jump",
+        "deadzone": 0.2,
+        "events": [
+            {"kind": "key", "key": "J", "keycode": 74, "physical": False},
+            {"kind": "key", "key": "4194320", "keycode": 4194320, "physical": True},
+        ],
+    }
+
+    added = ProjectAddInputActionResult.model_validate(payload)
+
+    assert added.name == "jump"
+    assert added.deadzone == 0.2
+    assert [event.keycode for event in added.events] == [74, 4194320]
+    assert added.events[0].kind == "key"
+    assert added.events[1].physical is True
+    assert json.loads(added.model_dump_json()) == payload
+
+
+def test_project_remove_input_action_result_round_trips_the_unregistered_name():
+    # project remove-input-action echoes the name it unregistered (issue #380),
+    # so an agent can confirm which action was removed.
+    payload = {"name": "jump"}
+
+    removed = ProjectRemoveInputActionResult.model_validate(payload)
+
+    assert removed.name == "jump"
     assert json.loads(removed.model_dump_json()) == payload
 
 

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -17,6 +17,8 @@ from gda.models import (
     GdaErrorEnvelope,
     ProjectAddAutoloadParams,
     ProjectAddAutoloadResult,
+    ProjectAddInputActionParams,
+    ProjectAddInputActionResult,
     ProjectGetParams,
     ProjectGetResult,
     ProjectInfoParams,
@@ -25,6 +27,8 @@ from gda.models import (
     ProjectListResult,
     ProjectRemoveAutoloadParams,
     ProjectRemoveAutoloadResult,
+    ProjectRemoveInputActionParams,
+    ProjectRemoveInputActionResult,
     ProjectSetParams,
     ProjectSetResult,
 )
@@ -385,6 +389,204 @@ def test_project_remove_autoload_human_output_names_the_unregistered_autoload(
     assert result.stdout.strip() == "removed autoload Global"
 
 
+# --- project add-input-action ----------------------------------------------
+
+
+ADD_INPUT_ACTION_RESULT = {
+    "name": "jump",
+    "deadzone": 0.5,
+    "events": [
+        {"kind": "key", "key": "J", "keycode": 74, "physical": False},
+        {"kind": "key", "key": "Space", "keycode": 32, "physical": False},
+    ],
+}
+
+REMOVE_INPUT_ACTION_RESULT = {
+    "name": "jump",
+}
+
+
+def test_project_add_input_action_dispatches_full_params_and_reports_result(
+    monkeypatch,
+):
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "project",
+            "add-input-action",
+            "jump",
+            "--key",
+            "J",
+            "--key",
+            "Space",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["name"] == "jump"
+    assert data["deadzone"] == 0.5
+    # Each event echoes the raw token and the keycode it resolved to.
+    assert data["events"][0] == {
+        "kind": "key",
+        "key": "J",
+        "keycode": 74,
+        "physical": False,
+    }
+    # The FULL params model rides through: name, the repeatable keys in order,
+    # the default deadzone, and the default physical=False.
+    assert fake.calls == [
+        (
+            "project-add-input-action",
+            {
+                "name": "jump",
+                "keys": ["J", "Space"],
+                "deadzone": 0.5,
+                "physical": False,
+            },
+        )
+    ]
+
+
+def test_project_add_input_action_dispatches_deadzone_and_physical_overrides(
+    monkeypatch,
+):
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "project",
+            "add-input-action",
+            "jump",
+            "--key",
+            "74",
+            "--deadzone",
+            "0.2",
+            "--physical",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        (
+            "project-add-input-action",
+            {"name": "jump", "keys": ["74"], "deadzone": 0.2, "physical": True},
+        )
+    ]
+
+
+def test_project_add_input_action_requires_at_least_one_key(monkeypatch):
+    # --key is required: an add with no keys is a usage error (exit 2), not a
+    # dispatch of an empty key list.
+    fake = FakeRunner(
+        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0)
+    )
+    monkeypatch.setattr("gda.cli._make_runner", lambda binary, project=None: fake)
+
+    result = CliRunner().invoke(app, ["project", "add-input-action", "jump"])
+
+    assert result.exit_code == 2
+    assert fake.calls == []
+
+
+def test_project_add_input_action_rejects_out_of_range_deadzone(monkeypatch):
+    # The deadzone bounds (0..1, the editor slider's) are validated model-side
+    # (ADR-0015) and surface as a clean usage error before any dispatch.
+    fake = FakeRunner(
+        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0)
+    )
+    monkeypatch.setattr("gda.cli._make_runner", lambda binary, project=None: fake)
+
+    result = CliRunner().invoke(
+        app,
+        ["project", "add-input-action", "jump", "--key", "J", "--deadzone", "1.5"],
+    )
+
+    assert result.exit_code == 2
+    assert fake.calls == []
+
+
+def test_project_add_input_action_human_output_lists_resolved_bindings(monkeypatch):
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app, ["project", "add-input-action", "jump", "--key", "J", "--key", "Space"]
+    )
+
+    assert result.exit_code == 0
+    assert (
+        result.stdout.strip()
+        == "added input action jump (deadzone 0.5): J -> 74, Space -> 32"
+    )
+
+
+def test_project_add_input_action_human_output_marks_physical_bindings(monkeypatch):
+    payload = {
+        "name": "jump",
+        "deadzone": 0.5,
+        "events": [{"kind": "key", "key": "J", "keycode": 74, "physical": True}],
+    }
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["project", "add-input-action", "jump", "--key", "J", "--physical"]
+    )
+
+    assert result.exit_code == 0
+    assert (
+        result.stdout.strip()
+        == "added input action jump (deadzone 0.5): J -> 74 (physical)"
+    )
+
+
+# --- project remove-input-action --------------------------------------------
+
+
+def test_project_remove_input_action_dispatches_name_and_reports_result(monkeypatch):
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(REMOVE_INPUT_ACTION_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app, ["project", "remove-input-action", "jump", "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == REMOVE_INPUT_ACTION_RESULT
+    assert fake.calls == [("project-remove-input-action", {"name": "jump"})]
+
+
+def test_project_remove_input_action_human_output_names_the_removed_action(
+    monkeypatch,
+):
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(REMOVE_INPUT_ACTION_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(app, ["project", "remove-input-action", "jump"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "removed input action jump"
+
+
 # --- ADR-0004 --schema hard gate -----------------------------------------
 
 
@@ -476,6 +678,37 @@ def test_project_remove_autoload_schema_emits_model_derived_contract_without_oth
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
 
+def test_project_add_input_action_schema_emits_model_derived_contract_without_other_args():
+    result = CliRunner().invoke(app, ["project", "add-input-action", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ProjectAddInputActionParams.model_json_schema()
+    assert doc["output"] == ProjectAddInputActionResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "name" in doc["input"]["properties"]
+    assert "keys" in doc["input"]["properties"]
+    assert "deadzone" in doc["input"]["properties"]
+    assert "physical" in doc["input"]["properties"]
+    # The key list is bounded model-side: at least one key (ADR-0015).
+    assert doc["input"]["properties"]["keys"]["minItems"] == 1
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_project_remove_input_action_schema_emits_model_derived_contract_without_other_args():
+    result = CliRunner().invoke(app, ["project", "remove-input-action", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ProjectRemoveInputActionParams.model_json_schema()
+    assert doc["output"] == ProjectRemoveInputActionResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert "name" in doc["input"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
 def test_sample_project_results_validate_against_emitted_output_schemas():
     # A sample --json payload of each project command satisfies the contract its
     # --schema emits (the other half of the ADR-0004 hard gate, issue #111).
@@ -493,6 +726,12 @@ def test_sample_project_results_validate_against_emitted_output_schemas():
     remove_doc = json.loads(
         CliRunner().invoke(app, ["project", "remove-autoload", "--schema"]).stdout
     )
+    add_input_doc = json.loads(
+        CliRunner().invoke(app, ["project", "add-input-action", "--schema"]).stdout
+    )
+    remove_input_doc = json.loads(
+        CliRunner().invoke(app, ["project", "remove-input-action", "--schema"]).stdout
+    )
 
     jsonschema.validate(instance=INFO_RESULT, schema=info_doc["output"])
     jsonschema.validate(instance=GET_RESULT, schema=get_doc["output"])
@@ -500,6 +739,12 @@ def test_sample_project_results_validate_against_emitted_output_schemas():
     jsonschema.validate(instance=SET_RESULT, schema=set_doc["output"])
     jsonschema.validate(instance=ADD_AUTOLOAD_RESULT, schema=add_doc["output"])
     jsonschema.validate(instance=REMOVE_AUTOLOAD_RESULT, schema=remove_doc["output"])
+    jsonschema.validate(
+        instance=ADD_INPUT_ACTION_RESULT, schema=add_input_doc["output"]
+    )
+    jsonschema.validate(
+        instance=REMOVE_INPUT_ACTION_RESULT, schema=remove_input_doc["output"]
+    )
 
 
 def test_project_schema_spawns_no_godot(monkeypatch):
@@ -516,6 +761,8 @@ def test_project_schema_spawns_no_godot(monkeypatch):
         ["project", "set"],
         ["project", "add-autoload"],
         ["project", "remove-autoload"],
+        ["project", "add-input-action"],
+        ["project", "remove-input-action"],
     ):
         result = CliRunner().invoke(app, [*command, "--schema"])
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Two new `project`-group headless commands for structured InputMap authoring in `project.godot`, mirroring the `add-autoload` / `remove-autoload` anatomy end-to-end:

```
gda project add-input-action fire --key J --key F [--deadzone 0.5] [--physical]
gda project remove-input-action fire
```

`--key` accepts a Godot key name (`J`, `Space`) and/or a raw keycode; `--physical` binds `physical_keycode` (only — never both). The op builds real `InputEventKey` objects into `{deadzone, events}` and persists via `ProjectSettings.set_setting()` + `save()`, so the serialization is the engine's own `var_to_str` form by construction — never a hand-built string.

## Semantics (per the issue)

- Existing action name → structured `already_exists` (never a silent clobber; built-in `ui_*` defaults answer `has_setting` and are protected by design).
- Removing a missing action → `unknown_setting`.
- Unresolvable key token → new operation error code **`invalid_key`**, registered in all three synchronized places (Python registry, `OP_ERROR_INVALID_KEY`, ADR-0002 table).
- The result model carries a `kind: "key"` discriminator per event so mouse/joypad kinds can extend the shape later without breaking.

## One finding beyond the spec

`InputEventKey.new()` defaults `device` to `0`, but InputMap matching filters on device and a real keyboard event carries `DEVICE_ID_KEYBOARD` — a device-0 event would persist fine yet **never fire from a physical keyboard**. The ops set `device = -1` (the editor's `ALL_DEVICES` convention), making the persisted entry byte-identical to an editor-authored one (verified against the Godot source and a manual diff on a scratch project); the e2e pins `"device":-1`.

## Surfaces

CLI descriptors + Typer commands, params/result models, renderers, GDScript ops + dispatch, `SKILL.md` project row (surface-sync gated), `docs/command-catalog.md`, `README.md` + zh-CN/es/ja mirrors re-stamped.

## Verification

- Fast tier **1039 passed** (includes the error-registry / skill-surface-sync / README-i18n / schema gates).
- Targeted e2e `test_e2e_project.py` + `test_e2e_input.py`: **30 passed** (agent run and an independent orchestrator re-run), real Godot engine — including the acceptance e2e: an action added headlessly is immediately driveable live via `gda input action` after `daemon start`.
- `uv run ruff check` / `ruff format --check` / `pyright` clean.

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)