### PR TITLE
feat(ops): ADR-0035 value projection — compound Variants to structured JSON

### DIFF
--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -153,7 +153,8 @@ node set` and `gda resource set` accept a **`res://….tres` resource path** as 
 create` and `resource set` this completes the external sub-resource workflow with no new command
 (`resource create res://box.tres --type RectangleShape2D` → `resource set … --property size --value
 32,64` → `node set scene.tscn --node Col --property shape --value res://box.tres`). The result echoes
-`type` `"Object"` and `value` the assigned `res://` path (pass `--project` so `res://` resolves). This
+`type` `"Object"` and `value` the ADR-0035 **reference projection** (`{type, resource_path}`) of the assigned
+resource — the same shape a subsequent `get` reads back (pass `--project` so `res://` resolves). This
 is a **separate, headless-only** step from the shared coercion above — value coercion keys only off
 the Variant type, but resolving an Object needs the expected-class hint on the property-list entry — so
 assigning a Resource on the live `gda game set` is **out of scope** and the coercion mirror is

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -139,8 +139,11 @@ mutation integrity boundary above. The supported target types and the string for
 | `Color` | `#rrggbb` / `#rrggbbaa`, or 3–4 comma-separated floats in 0..1 (`r,g,b[,a]`) | `[r, g, b, a]` |
 
 Whitespace around a value or a component is tolerated. A property of any other type is still
-reported by `node get` (its value degrades to a string projection), but `node set` cannot coerce
-to it yet and refuses with `uncoercible_value` — the coercible set grows as later slices need it.
+reported by `node get` — compound values arrive structured through the shared value projection
+(ADR-0035): a `Dictionary` as a JSON object, an `Array`/packed array as a JSON array, an `Object` as
+a reference / inline value projection or the `str()` fallback (see [`project`](#project)) — but
+`node set` cannot coerce to it yet and refuses with `uncoercible_value` — the coercible set grows as
+later slices need it.
 
 **Object-typed property assignment by `res://` reference** (ADR-0033, #363): for an **Object-typed**
 property that expects a Resource (sub)class — e.g. a `CollisionShape2D`'s `shape` (`Shape2D`) — `gda
@@ -410,9 +413,14 @@ valid result.
 **Reading and writing settings** (established by #111): `gda project get SECTION/KEY` reads one
 setting by its full `section/key` name (e.g. `application/config/name`) and reports it as a
 `{setting, type, value}` triple — `type` is the setting's declared Godot type name and `value` its
-JSON projection, the **same projection** `node get` reports for a node property. A setting that does
-not exist is a clean `unknown_setting` error (exit 4), distinguishing a typo'd key from a setting
-genuinely holding null. `gda project set SECTION/KEY --value <string>` writes a setting, **coercing**
+JSON projection, the **same projection** `node get` reports for a node property. Compound values
+arrive **structured** (ADR-0035): a `Dictionary` projects to a JSON object, an `Array` or packed
+array to a JSON array, and an embedded `Object` renders as a **reference projection**
+(`{type, resource_path}` for a Resource with a `res://` path), an **inline value projection**
+(`{type, …storage properties}` for a whitelisted path-less value Object — `InputEvent` subclasses,
+e.g. the `InputEventKey`s of an `input/*` action), or the `str()` fallback for any other Object. A
+setting that does not exist is a clean `unknown_setting` error (exit 4), distinguishing a typo'd key
+from a setting genuinely holding null. `gda project set SECTION/KEY --value <string>` writes a setting, **coercing**
 the CLI value to the setting's **declared type** — read off the setting's current value, exactly as
 `node set` reads it off the node's property list — using the **same coercion rules** the node group
 established (#55; see "Property value coercion" under [`node`](#node)). It then persists

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -1036,14 +1036,34 @@ func _type_name(type: int) -> String:
 	return type_string(type)
 
 
-# Project a Godot property value into JSON-safe form for the result payload
-# (issue #55). Scalars pass through; the packed value types node set supports
-# become flat number arrays so node get's output is exactly the projection node
-# set accepts back: Vector2 → [x, y], Vector2i likewise, Color → [r, g, b, a].
-# Any other type degrades to its string form rather than crashing JSON.stringify
-# on an unencodable Variant — node get reports the whole storage surface, but
-# only the coercible types claim a structured projection.
-func _jsonify(value: Variant) -> Variant:
+# The value projection's hard recursion depth cap (ADR-0035): a compound value
+# nested deeper than this degrades to its string form instead of recursing on.
+# Deliberately NO visited-set — references are not descended and non-whitelisted
+# Objects stop at str(), so on-disk stored values are acyclic trees; the cap is
+# the backstop against a pathological self-referential Dictionary live-side.
+const JSONIFY_MAX_DEPTH := 16
+
+# The Object/Resource base bookkeeping properties an inline value projection
+# excludes (ADR-0035): every InputEvent IS a Resource, so without the exclusion
+# a path-less value Object would emit an empty resource_path and masquerade as
+# a reference projection; the exclusion also drops noise.
+const JSONIFY_BOOKKEEPING_PROPS: Array[String] = [
+	"resource_path", "resource_name", "resource_local_to_scene", "script",
+]
+
+# The read-side Value projection (ADR-0035, grown from issue #55): render a
+# Godot Variant into the structured JSON a result's value field carries.
+# Scalars pass through; the fixed-shape value types node set supports become
+# flat number arrays so node get's output is exactly the projection node set
+# accepts back: Vector2 → [x, y], Vector2i likewise, Color → [r, g, b, a].
+# A Dictionary projects to a JSON object (keys stringified), an Array and the
+# packed-array family to a JSON array, each value re-entering the projection;
+# an Object renders as a reference projection, an inline value projection, or
+# the str() fallback (the TYPE_OBJECT arm below). Any other type degrades to
+# its string form rather than crashing JSON.stringify on an unencodable
+# Variant, and the depth cap bounds the recursion on the compound arms — so
+# the projection is always JSON-encodable.
+func _jsonify(value: Variant, depth: int = 0) -> Variant:
 	match typeof(value):
 		TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING, TYPE_STRING_NAME:
 			return value
@@ -1053,6 +1073,66 @@ func _jsonify(value: Variant) -> Variant:
 			return [value.x, value.y]
 		TYPE_COLOR:
 			return [value.r, value.g, value.b, value.a]
+		TYPE_DICTIONARY:
+			# The cap guards only the compound arms: a scalar is never
+			# stringified by depth, however deep it sits.
+			if depth >= JSONIFY_MAX_DEPTH:
+				return str(value)
+			var out := {}
+			# Insertion-ordered iteration; keys are coerced to strings, so two
+			# keys that collide after stringification resolve last-wins by
+			# assignment order (deterministic, ADR-0035).
+			for key in value.keys():
+				out[str(key)] = _jsonify(value[key], depth + 1)
+			return out
+		TYPE_ARRAY, TYPE_PACKED_BYTE_ARRAY, TYPE_PACKED_INT32_ARRAY, \
+		TYPE_PACKED_INT64_ARRAY, TYPE_PACKED_FLOAT32_ARRAY, \
+		TYPE_PACKED_FLOAT64_ARRAY, TYPE_PACKED_STRING_ARRAY, \
+		TYPE_PACKED_VECTOR2_ARRAY, TYPE_PACKED_VECTOR3_ARRAY, \
+		TYPE_PACKED_COLOR_ARRAY, TYPE_PACKED_VECTOR4_ARRAY:
+			if depth >= JSONIFY_MAX_DEPTH:
+				return str(value)
+			var items := []
+			# Element-wise re-entry: a PackedVector2Array element projects as
+			# [x, y]; an element type with no structured arm of its own (e.g.
+			# Vector3) stays str(), per the fixed-shape list above.
+			for element in value:
+				items.append(_jsonify(element, depth + 1))
+			return items
+		TYPE_OBJECT:
+			# A freed live Object (harness side) must not be introspected.
+			if not is_instance_valid(value):
+				return str(value)
+			if depth >= JSONIFY_MAX_DEPTH:
+				return str(value)
+			# Reference projection: a Resource with a res:// path is named by
+			# type and path, never inlined — the read-side mirror of ADR-0033's
+			# write-side reference. A sub-resource path (res://x.tscn::…)
+			# counts as a reference too.
+			if value is Resource and String(value.resource_path).begins_with("res://"):
+				return {"type": value.get_class(), "resource_path": value.resource_path}
+			# Inline value projection: a whitelisted path-less value Object
+			# (InputEvent subclasses initially) projects its own storage
+			# properties. The whitelist is the risk-isolation boundary that
+			# keeps this shared projection safe on the live side, where an
+			# arbitrary Object could be a whole scene tree (ADR-0035).
+			if value is InputEvent:
+				var projected := {}
+				for prop in value.get_property_list():
+					if not _is_storage_property(prop):
+						continue
+					var prop_name := String(prop.get("name", ""))
+					if prop_name in JSONIFY_BOOKKEEPING_PROPS:
+						continue
+					projected[prop_name] = _jsonify(value.get(prop_name), depth + 1)
+				# Assigned AFTER the loop so the discriminator shadows a
+				# storage property named "type" (ADR-0035 documents the
+				# shadowing — order matters).
+				projected["type"] = value.get_class()
+				return projected
+			# String fallback: any other Object (not whitelisted, no res://
+			# path — e.g. a live Node) keeps the existing str() form.
+			return str(value)
 		_:
 			return str(value)
 

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -41,7 +41,7 @@ HARNESS_RES_PATH = f"res://{HARNESS_RES_DIR}/{HARNESS_FILE}"
 # copy to it (#225). The installed copy declares its version in a leading header
 # (`# gda-harness-version: <N>`); a mismatch re-materializes via the content
 # compare. NOT the package version — the harness changes far less often.
-HARNESS_VERSION = "4"
+HARNESS_VERSION = "5"
 
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -377,6 +377,103 @@ class SceneGetResult(BaseModel):
     root: SceneNode
 
 
+# The one read-side value projection every value gda emits goes through
+# (ADR-0035): the shared field description for the dynamically-shaped `value`
+# fields. The field itself stays `Any` — a value's shape is not statically
+# knowable, a deliberate, bounded exception to ADR-0004's model-driven-output
+# rule — so the stable parts are surfaced here and by the two named projection
+# models (ReferenceProjection / InlineValueProjection) below.
+_VALUE_PROJECTION_DESC = (
+    "Rendered through the one recursive read-side value projection "
+    "(ADR-0035): a scalar for a scalar type; a flat number list for a "
+    "fixed-shape type (Vector2 → [x, y], Color → [r, g, b, a]); a JSON "
+    "object for a Dictionary (keys stringified); a JSON array for an Array "
+    "or packed array (elements re-projected). An Object value renders as a "
+    "ReferenceProjection ({type, resource_path}) for a Resource with a "
+    "res:// path, an InlineValueProjection ({type, …storage properties}) "
+    "for a whitelisted path-less value Object (InputEvent subclasses), or "
+    "its str() form for any other Object — branch on the presence of "
+    "resource_path."
+)
+
+# The set-echo variant: the set commands echo the value they set through the
+# SAME projection (they read it back off the subject and _jsonify it).
+_SET_ECHO_VALUE_DESC = (
+    "The coerced value as JSON, in the same recursive value projection the "
+    "corresponding get reports (ADR-0035)."
+)
+
+# node/resource set additionally have the ADR-0033 Object-typed set path;
+# its echo flows through the same projection, so the assigned resource echoes
+# as the reference projection a subsequent get reads back.
+_OBJECT_SET_ECHO_DESC = _SET_ECHO_VALUE_DESC + (
+    " Setting an Object-typed property by res:// path (ADR-0033) echoes the "
+    "assigned resource as a ReferenceProjection ({type, resource_path}) — "
+    "the same shape a subsequent get reads back."
+)
+
+
+class ReferenceProjection(BaseModel):
+    """A Resource value named by type and ``res://`` path (ADR-0035).
+
+    The read-side mirror of ADR-0033's write-side ``res://`` reference: a
+    value that is a ``Resource`` with a ``res://`` ``resource_path`` projects
+    to ``{type, resource_path}`` — never inlined, so a resource-valued read
+    stays a small, bounded payload and read/write name an external resource
+    the same way. Distinguished from :class:`InlineValueProjection` by the
+    PRESENCE of ``resource_path`` (an inline projection excludes the Resource
+    base bookkeeping, so it never carries one).
+    """
+
+    type: str = Field(
+        description="The referenced resource's engine class (e.g. RectangleShape2D)."
+    )
+    resource_path: str = Field(
+        description=(
+            "The res:// path naming the resource; a sub-resource path "
+            "(res://scene.tscn::id) counts as a reference too."
+        )
+    )
+
+
+class InlineValueProjection(BaseModel):
+    """A whitelisted path-less value Object projected inline (ADR-0035).
+
+    A small path-less value ``Object`` on the projection whitelist
+    (``InputEvent`` subclasses initially — e.g. the ``InputEventKey`` entries
+    of an InputMap action) projects to ``{"type": <Class>, <its storage
+    properties, each re-projected>}``. The ``Object``/``Resource`` base
+    bookkeeping (``resource_path``, ``resource_name``,
+    ``resource_local_to_scene``, ``script``) is excluded — so an inline
+    projection never masquerades as a :class:`ReferenceProjection` — and the
+    ``type`` discriminator is assigned last, shadowing any storage property of
+    that name. The storage properties vary per class, hence ``extra="allow"``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: str = Field(
+        description="The value Object's engine class (e.g. InputEventKey)."
+    )
+
+
+def _projected_value_schema_extra(schema: dict[str, Any]) -> None:
+    """Attach the named Object-projection shapes to a projected ``value`` field.
+
+    A projected ``value`` stays ``Any`` — its shape is not statically knowable,
+    the ADR-0035 bounded exception to ADR-0004 — so the stable projection
+    shapes cannot ride along as the field's type (a union would materialize
+    matching dicts as model instances and change the runtime payload).
+    Attaching their schemas as the field's ``$defs`` keeps ReferenceProjection
+    and InlineValueProjection named and consumable in every emitted command
+    schema (``--schema`` / gda-mcp) instead of prose-only.
+    """
+    schema["$defs"] = {
+        "ReferenceProjection": ReferenceProjection.model_json_schema(),
+        "InlineValueProjection": InlineValueProjection.model_json_schema(),
+    }
+
+
 class SceneExport(BaseModel):
     """One ``@export`` property a node's attached script declares (issue #58).
 
@@ -386,9 +483,9 @@ class SceneExport(BaseModel):
     ``@export_range`` yields ``PROPERTY_HINT_RANGE``); ``hint_string`` is its
     companion string (the range bounds, the enum members, the file filter, …) —
     together they capture HOW the export is meant to be edited. ``value`` is the
-    property's current value in the same JSON projection ``node get`` reports — a
-    scalar for a scalar type, a list for a packed type (Vector2 → ``[x, y]``) —
-    which on a freshly-instantiated node is the export's default.
+    property's current value in the same recursive JSON value projection
+    ``node get`` reports (ADR-0035), which on a freshly-instantiated node is
+    the export's default.
     """
 
     name: str
@@ -407,9 +504,9 @@ class SceneExport(BaseModel):
     value: Any = Field(
         description=(
             "The export's current value as JSON (its default on a freshly-loaded "
-            "node): a scalar for a scalar type, a list for a packed type "
-            "(Vector2 → [x, y], Color → [r, g, b, a])."
-        )
+            "node). " + _VALUE_PROJECTION_DESC
+        ),
+        json_schema_extra=_projected_value_schema_extra,
     )
 
 
@@ -633,86 +730,6 @@ class NodeListResult(BaseModel):
     root: ListedNode
 
 
-# The one read-side value projection every value gda emits goes through
-# (ADR-0035): the shared field description for the dynamically-shaped `value`
-# fields. The field itself stays `Any` — a value's shape is not statically
-# knowable, a deliberate, bounded exception to ADR-0004's model-driven-output
-# rule — so the stable parts are surfaced here and by the two named projection
-# models (ReferenceProjection / InlineValueProjection) below.
-_VALUE_PROJECTION_DESC = (
-    "Rendered through the one recursive read-side value projection "
-    "(ADR-0035): a scalar for a scalar type; a flat number list for a "
-    "fixed-shape type (Vector2 → [x, y], Color → [r, g, b, a]); a JSON "
-    "object for a Dictionary (keys stringified); a JSON array for an Array "
-    "or packed array (elements re-projected). An Object value renders as a "
-    "ReferenceProjection ({type, resource_path}) for a Resource with a "
-    "res:// path, an InlineValueProjection ({type, …storage properties}) "
-    "for a whitelisted path-less value Object (InputEvent subclasses), or "
-    "its str() form for any other Object — branch on the presence of "
-    "resource_path."
-)
-
-# The set-echo variant: the set commands echo the value they set through the
-# SAME projection (they read it back off the subject and _jsonify it).
-_SET_ECHO_VALUE_DESC = (
-    "The coerced value as JSON, in the same recursive value projection the "
-    "corresponding get reports (ADR-0035)."
-)
-
-# node/resource set additionally have the ADR-0033 Object-typed set path,
-# whose echo deliberately does NOT flow through the projection.
-_OBJECT_SET_ECHO_DESC = _SET_ECHO_VALUE_DESC + (
-    " One asymmetry: setting an Object-typed property by res:// path "
-    "(ADR-0033) echoes the assigned res:// path as a plain string, while a "
-    "subsequent get reads it back as a ReferenceProjection "
-    "({type, resource_path})."
-)
-
-
-class ReferenceProjection(BaseModel):
-    """A Resource value named by type and ``res://`` path (ADR-0035).
-
-    The read-side mirror of ADR-0033's write-side ``res://`` reference: a
-    value that is a ``Resource`` with a ``res://`` ``resource_path`` projects
-    to ``{type, resource_path}`` — never inlined, so a resource-valued read
-    stays a small, bounded payload and read/write name an external resource
-    the same way. Distinguished from :class:`InlineValueProjection` by the
-    PRESENCE of ``resource_path`` (an inline projection excludes the Resource
-    base bookkeeping, so it never carries one).
-    """
-
-    type: str = Field(
-        description="The referenced resource's engine class (e.g. RectangleShape2D)."
-    )
-    resource_path: str = Field(
-        description=(
-            "The res:// path naming the resource; a sub-resource path "
-            "(res://scene.tscn::id) counts as a reference too."
-        )
-    )
-
-
-class InlineValueProjection(BaseModel):
-    """A whitelisted path-less value Object projected inline (ADR-0035).
-
-    A small path-less value ``Object`` on the projection whitelist
-    (``InputEvent`` subclasses initially — e.g. the ``InputEventKey`` entries
-    of an InputMap action) projects to ``{"type": <Class>, <its storage
-    properties, each re-projected>}``. The ``Object``/``Resource`` base
-    bookkeeping (``resource_path``, ``resource_name``,
-    ``resource_local_to_scene``, ``script``) is excluded — so an inline
-    projection never masquerades as a :class:`ReferenceProjection` — and the
-    ``type`` discriminator is assigned last, shadowing any storage property of
-    that name. The storage properties vary per class, hence ``extra="allow"``.
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    type: str = Field(
-        description="The value Object's engine class (e.g. InputEventKey)."
-    )
-
-
 class NodeProperty(BaseModel):
     """One of a node's properties as ``gda node get`` reports it (issue #55).
 
@@ -730,7 +747,8 @@ class NodeProperty(BaseModel):
         description="The property's declared Godot type name (e.g. int, Vector2, Color)."
     )
     value: Any = Field(
-        description="The property's value as JSON. " + _VALUE_PROJECTION_DESC
+        description="The property's value as JSON. " + _VALUE_PROJECTION_DESC,
+        json_schema_extra=_projected_value_schema_extra,
     )
 
 
@@ -815,7 +833,8 @@ class NodeSetResult(BaseModel):
         description=(
             "The coerced value as JSON, as the node now holds it. "
             + _OBJECT_SET_ECHO_DESC
-        )
+        ),
+        json_schema_extra=_projected_value_schema_extra,
     )
 
 
@@ -1989,7 +2008,8 @@ class ResourceSetResult(BaseModel):
         description=(
             "The coerced value as JSON, as the resource now holds it. "
             + _OBJECT_SET_ECHO_DESC
-        )
+        ),
+        json_schema_extra=_projected_value_schema_extra,
     )
 
 
@@ -2523,7 +2543,8 @@ class ProjectGetResult(BaseModel):
         description="The setting's declared Godot type name (e.g. String, int, Vector2)."
     )
     value: Any = Field(
-        description="The setting's value as JSON. " + _VALUE_PROJECTION_DESC
+        description="The setting's value as JSON. " + _VALUE_PROJECTION_DESC,
+        json_schema_extra=_projected_value_schema_extra,
     )
 
 
@@ -2570,7 +2591,8 @@ class ListedProjectSetting(BaseModel):
         description="The setting's declared Godot type name (e.g. String, int, Vector2)."
     )
     value: Any = Field(
-        description="The setting's value as JSON. " + _VALUE_PROJECTION_DESC
+        description="The setting's value as JSON. " + _VALUE_PROJECTION_DESC,
+        json_schema_extra=_projected_value_schema_extra,
     )
     is_default: bool = Field(
         description=(
@@ -2635,7 +2657,8 @@ class ProjectSetResult(BaseModel):
         description=(
             "The coerced value as JSON, as ProjectSettings now holds it. "
             + _SET_ECHO_VALUE_DESC
-        )
+        ),
+        json_schema_extra=_projected_value_schema_extra,
     )
 
 
@@ -2821,7 +2844,8 @@ class GameSetResult(BaseModel):
         description=(
             "The coerced value as JSON, as the running node now holds it. "
             + _SET_ECHO_VALUE_DESC
-        )
+        ),
+        json_schema_extra=_projected_value_schema_extra,
     )
 
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -633,14 +633,96 @@ class NodeListResult(BaseModel):
     root: ListedNode
 
 
+# The one read-side value projection every value gda emits goes through
+# (ADR-0035): the shared field description for the dynamically-shaped `value`
+# fields. The field itself stays `Any` — a value's shape is not statically
+# knowable, a deliberate, bounded exception to ADR-0004's model-driven-output
+# rule — so the stable parts are surfaced here and by the two named projection
+# models (ReferenceProjection / InlineValueProjection) below.
+_VALUE_PROJECTION_DESC = (
+    "Rendered through the one recursive read-side value projection "
+    "(ADR-0035): a scalar for a scalar type; a flat number list for a "
+    "fixed-shape type (Vector2 → [x, y], Color → [r, g, b, a]); a JSON "
+    "object for a Dictionary (keys stringified); a JSON array for an Array "
+    "or packed array (elements re-projected). An Object value renders as a "
+    "ReferenceProjection ({type, resource_path}) for a Resource with a "
+    "res:// path, an InlineValueProjection ({type, …storage properties}) "
+    "for a whitelisted path-less value Object (InputEvent subclasses), or "
+    "its str() form for any other Object — branch on the presence of "
+    "resource_path."
+)
+
+# The set-echo variant: the set commands echo the value they set through the
+# SAME projection (they read it back off the subject and _jsonify it).
+_SET_ECHO_VALUE_DESC = (
+    "The coerced value as JSON, in the same recursive value projection the "
+    "corresponding get reports (ADR-0035)."
+)
+
+# node/resource set additionally have the ADR-0033 Object-typed set path,
+# whose echo deliberately does NOT flow through the projection.
+_OBJECT_SET_ECHO_DESC = _SET_ECHO_VALUE_DESC + (
+    " One asymmetry: setting an Object-typed property by res:// path "
+    "(ADR-0033) echoes the assigned res:// path as a plain string, while a "
+    "subsequent get reads it back as a ReferenceProjection "
+    "({type, resource_path})."
+)
+
+
+class ReferenceProjection(BaseModel):
+    """A Resource value named by type and ``res://`` path (ADR-0035).
+
+    The read-side mirror of ADR-0033's write-side ``res://`` reference: a
+    value that is a ``Resource`` with a ``res://`` ``resource_path`` projects
+    to ``{type, resource_path}`` — never inlined, so a resource-valued read
+    stays a small, bounded payload and read/write name an external resource
+    the same way. Distinguished from :class:`InlineValueProjection` by the
+    PRESENCE of ``resource_path`` (an inline projection excludes the Resource
+    base bookkeeping, so it never carries one).
+    """
+
+    type: str = Field(
+        description="The referenced resource's engine class (e.g. RectangleShape2D)."
+    )
+    resource_path: str = Field(
+        description=(
+            "The res:// path naming the resource; a sub-resource path "
+            "(res://scene.tscn::id) counts as a reference too."
+        )
+    )
+
+
+class InlineValueProjection(BaseModel):
+    """A whitelisted path-less value Object projected inline (ADR-0035).
+
+    A small path-less value ``Object`` on the projection whitelist
+    (``InputEvent`` subclasses initially — e.g. the ``InputEventKey`` entries
+    of an InputMap action) projects to ``{"type": <Class>, <its storage
+    properties, each re-projected>}``. The ``Object``/``Resource`` base
+    bookkeeping (``resource_path``, ``resource_name``,
+    ``resource_local_to_scene``, ``script``) is excluded — so an inline
+    projection never masquerades as a :class:`ReferenceProjection` — and the
+    ``type`` discriminator is assigned last, shadowing any storage property of
+    that name. The storage properties vary per class, hence ``extra="allow"``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: str = Field(
+        description="The value Object's engine class (e.g. InputEventKey)."
+    )
+
+
 class NodeProperty(BaseModel):
     """One of a node's properties as ``gda node get`` reports it (issue #55).
 
     ``type`` is the property's declared Godot type name (``int``, ``Vector2``,
-    ``Color``, …). ``value`` is the property's value in its JSON projection —
-    left as arbitrary JSON so every Godot type is carried uniformly through one
-    field: a scalar stays a scalar, a Vector2 becomes ``[x, y]``, a Color
-    ``[r, g, b, a]`` — the same projection ``node set`` accepts back.
+    ``Color``, …). ``value`` is the property's value in its recursive JSON
+    value projection (ADR-0035) — left as arbitrary JSON so every Godot type
+    is carried uniformly through one field: a scalar stays a scalar, a Vector2
+    becomes ``[x, y]``, a Dictionary a JSON object, an Object a
+    :class:`ReferenceProjection` / :class:`InlineValueProjection` / ``str()``
+    fallback.
     """
 
     name: str
@@ -648,10 +730,7 @@ class NodeProperty(BaseModel):
         description="The property's declared Godot type name (e.g. int, Vector2, Color)."
     )
     value: Any = Field(
-        description=(
-            "The property's value as JSON: a scalar for a scalar type, a list "
-            "for a packed type (Vector2 → [x, y], Color → [r, g, b, a])."
-        )
+        description="The property's value as JSON. " + _VALUE_PROJECTION_DESC
     )
 
 
@@ -733,7 +812,10 @@ class NodeSetResult(BaseModel):
         description="The property's declared Godot type the value was coerced to."
     )
     value: Any = Field(
-        description="The coerced value as JSON, as the node now holds it."
+        description=(
+            "The coerced value as JSON, as the node now holds it. "
+            + _OBJECT_SET_ECHO_DESC
+        )
     )
 
 
@@ -1904,7 +1986,10 @@ class ResourceSetResult(BaseModel):
         description="The property's declared Godot type the value was coerced to."
     )
     value: Any = Field(
-        description="The coerced value as JSON, as the resource now holds it."
+        description=(
+            "The coerced value as JSON, as the resource now holds it. "
+            + _OBJECT_SET_ECHO_DESC
+        )
     )
 
 
@@ -2438,10 +2523,7 @@ class ProjectGetResult(BaseModel):
         description="The setting's declared Godot type name (e.g. String, int, Vector2)."
     )
     value: Any = Field(
-        description=(
-            "The setting's value as JSON: a scalar for a scalar type, a list for "
-            "a packed type (Vector2 → [x, y], Color → [r, g, b, a])."
-        )
+        description="The setting's value as JSON. " + _VALUE_PROJECTION_DESC
     )
 
 
@@ -2488,10 +2570,7 @@ class ListedProjectSetting(BaseModel):
         description="The setting's declared Godot type name (e.g. String, int, Vector2)."
     )
     value: Any = Field(
-        description=(
-            "The setting's value as JSON: a scalar for a scalar type, a list for "
-            "a packed type (Vector2 → [x, y], Color → [r, g, b, a])."
-        )
+        description="The setting's value as JSON. " + _VALUE_PROJECTION_DESC
     )
     is_default: bool = Field(
         description=(
@@ -2553,7 +2632,10 @@ class ProjectSetResult(BaseModel):
         description="The setting's declared Godot type the value was coerced to."
     )
     value: Any = Field(
-        description="The coerced value as JSON, as ProjectSettings now holds it."
+        description=(
+            "The coerced value as JSON, as ProjectSettings now holds it. "
+            + _SET_ECHO_VALUE_DESC
+        )
     )
 
 
@@ -2685,6 +2767,12 @@ class GameGetResult(BaseModel):
     no file): echoes the addressed node (runtime ``path``/``name``/``type``) and
     its storage properties, each a typed :class:`NodeProperty`, so an agent reads
     the running node's live state and can feed any property back into ``game set``.
+    Each value goes through the same recursive value projection the headless reads
+    use (ADR-0035): compound values arrive structured, and a whitelisted value
+    Object (an ``InputEvent`` subclass) as an :class:`InlineValueProjection` —
+    while a NON-whitelisted runtime Object (e.g. a live ``Node``-valued property)
+    stays the ``str()`` fallback, the whitelist being the boundary that keeps the
+    shared projection safe on the live side.
     """
 
     path: str = Field(description="The addressed node's runtime (absolute) path.")
@@ -2730,7 +2818,10 @@ class GameSetResult(BaseModel):
         description="The property's declared Godot type the value was coerced to."
     )
     value: Any = Field(
-        description="The coerced value as JSON, as the running node now holds it."
+        description=(
+            "The coerced value as JSON, as the running node now holds it. "
+            + _SET_ECHO_VALUE_DESC
+        )
     )
 
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -644,9 +644,11 @@ func _op_node_set(params: Dictionary) -> void:
 			root.free()
 			return  # _resolve_object_value already recorded the failure
 		node.set(prop_name, resolved)
-		# The assigned reference round-trips as its res:// path; the loaded resource
-		# carries a resource_path, so re-packing serializes it as an ext_resource.
-		stored_value = resolved.resource_path
+		# The echo is the same reference projection a subsequent get reads back
+		# (ADR-0035): {type, resource_path}. On disk the assignment still
+		# round-trips as its res:// path — the loaded resource carries a
+		# resource_path, so re-packing serializes it as an ext_resource.
+		stored_value = _jsonify(resolved)
 	else:
 		var coerced: Variant = _coerce_value(raw_value, declared_type)
 		if coerced == null:
@@ -1663,9 +1665,11 @@ func _op_resource_set(params: Dictionary) -> void:
 		if resolved == null:
 			return  # _resolve_object_value already recorded the failure
 		resource.set(prop_name, resolved)
-		# The assigned reference round-trips as its res:// path; the loaded resource
-		# carries a resource_path, so re-saving serializes it as an ext_resource.
-		stored_value = resolved.resource_path
+		# The echo is the same reference projection a subsequent get reads back
+		# (ADR-0035): {type, resource_path}. On disk the assignment still
+		# round-trips as its res:// path — the loaded resource carries a
+		# resource_path, so re-saving serializes it as an ext_resource.
+		stored_value = _jsonify(resolved)
 	else:
 		var coerced: Variant = _coerce_value(raw_value, declared_type)
 		if coerced == null:

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -4036,14 +4036,34 @@ func _type_name(type: int) -> String:
 	return type_string(type)
 
 
-# Project a Godot property value into JSON-safe form for the result payload
-# (issue #55). Scalars pass through; the packed value types node set supports
-# become flat number arrays so node get's output is exactly the projection node
-# set accepts back: Vector2 → [x, y], Vector2i likewise, Color → [r, g, b, a].
-# Any other type degrades to its string form rather than crashing JSON.stringify
-# on an unencodable Variant — node get reports the whole storage surface, but
-# only the coercible types claim a structured projection.
-func _jsonify(value: Variant) -> Variant:
+# The value projection's hard recursion depth cap (ADR-0035): a compound value
+# nested deeper than this degrades to its string form instead of recursing on.
+# Deliberately NO visited-set — references are not descended and non-whitelisted
+# Objects stop at str(), so on-disk stored values are acyclic trees; the cap is
+# the backstop against a pathological self-referential Dictionary live-side.
+const JSONIFY_MAX_DEPTH := 16
+
+# The Object/Resource base bookkeeping properties an inline value projection
+# excludes (ADR-0035): every InputEvent IS a Resource, so without the exclusion
+# a path-less value Object would emit an empty resource_path and masquerade as
+# a reference projection; the exclusion also drops noise.
+const JSONIFY_BOOKKEEPING_PROPS: Array[String] = [
+	"resource_path", "resource_name", "resource_local_to_scene", "script",
+]
+
+# The read-side Value projection (ADR-0035, grown from issue #55): render a
+# Godot Variant into the structured JSON a result's value field carries.
+# Scalars pass through; the fixed-shape value types node set supports become
+# flat number arrays so node get's output is exactly the projection node set
+# accepts back: Vector2 → [x, y], Vector2i likewise, Color → [r, g, b, a].
+# A Dictionary projects to a JSON object (keys stringified), an Array and the
+# packed-array family to a JSON array, each value re-entering the projection;
+# an Object renders as a reference projection, an inline value projection, or
+# the str() fallback (the TYPE_OBJECT arm below). Any other type degrades to
+# its string form rather than crashing JSON.stringify on an unencodable
+# Variant, and the depth cap bounds the recursion on the compound arms — so
+# the projection is always JSON-encodable.
+func _jsonify(value: Variant, depth: int = 0) -> Variant:
 	match typeof(value):
 		TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING, TYPE_STRING_NAME:
 			return value
@@ -4053,6 +4073,66 @@ func _jsonify(value: Variant) -> Variant:
 			return [value.x, value.y]
 		TYPE_COLOR:
 			return [value.r, value.g, value.b, value.a]
+		TYPE_DICTIONARY:
+			# The cap guards only the compound arms: a scalar is never
+			# stringified by depth, however deep it sits.
+			if depth >= JSONIFY_MAX_DEPTH:
+				return str(value)
+			var out := {}
+			# Insertion-ordered iteration; keys are coerced to strings, so two
+			# keys that collide after stringification resolve last-wins by
+			# assignment order (deterministic, ADR-0035).
+			for key in value.keys():
+				out[str(key)] = _jsonify(value[key], depth + 1)
+			return out
+		TYPE_ARRAY, TYPE_PACKED_BYTE_ARRAY, TYPE_PACKED_INT32_ARRAY, \
+		TYPE_PACKED_INT64_ARRAY, TYPE_PACKED_FLOAT32_ARRAY, \
+		TYPE_PACKED_FLOAT64_ARRAY, TYPE_PACKED_STRING_ARRAY, \
+		TYPE_PACKED_VECTOR2_ARRAY, TYPE_PACKED_VECTOR3_ARRAY, \
+		TYPE_PACKED_COLOR_ARRAY, TYPE_PACKED_VECTOR4_ARRAY:
+			if depth >= JSONIFY_MAX_DEPTH:
+				return str(value)
+			var items := []
+			# Element-wise re-entry: a PackedVector2Array element projects as
+			# [x, y]; an element type with no structured arm of its own (e.g.
+			# Vector3) stays str(), per the fixed-shape list above.
+			for element in value:
+				items.append(_jsonify(element, depth + 1))
+			return items
+		TYPE_OBJECT:
+			# A freed live Object (harness side) must not be introspected.
+			if not is_instance_valid(value):
+				return str(value)
+			if depth >= JSONIFY_MAX_DEPTH:
+				return str(value)
+			# Reference projection: a Resource with a res:// path is named by
+			# type and path, never inlined — the read-side mirror of ADR-0033's
+			# write-side reference. A sub-resource path (res://x.tscn::…)
+			# counts as a reference too.
+			if value is Resource and String(value.resource_path).begins_with("res://"):
+				return {"type": value.get_class(), "resource_path": value.resource_path}
+			# Inline value projection: a whitelisted path-less value Object
+			# (InputEvent subclasses initially) projects its own storage
+			# properties. The whitelist is the risk-isolation boundary that
+			# keeps this shared projection safe on the live side, where an
+			# arbitrary Object could be a whole scene tree (ADR-0035).
+			if value is InputEvent:
+				var projected := {}
+				for prop in value.get_property_list():
+					if not _is_storage_property(prop):
+						continue
+					var prop_name := String(prop.get("name", ""))
+					if prop_name in JSONIFY_BOOKKEEPING_PROPS:
+						continue
+					projected[prop_name] = _jsonify(value.get(prop_name), depth + 1)
+				# Assigned AFTER the loop so the discriminator shadows a
+				# storage property named "type" (ADR-0035 documents the
+				# shadowing — order matters).
+				projected["type"] = value.get_class()
+				return projected
+			# String fallback: any other Object (not whitelisted, no res://
+			# path — e.g. a live Node) keeps the existing str() form.
+			return str(value)
 		_:
 			return str(value)
 

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -153,6 +153,60 @@ def test_daemon_serves_game_get_set_round_trip(tmp_path, daemon_runtime_dir):
         run("daemon", "stop")
 
 
+# A Player script for the live half of the value projection (ADR-0035, #381):
+# an exported Dictionary (compound -> structured) and an exported Node
+# reference assigned at _ready (a NON-whitelisted runtime Object -> the str()
+# fallback, the live-side risk boundary).
+PROJECTION_PLAYER_GD = (
+    "extends Node2D\n"
+    '@export var stats: Dictionary = {"hp": 5, "label": "panda"}\n'
+    "@export var buddy: Node\n"
+    "func _ready() -> void:\n"
+    "\tbuddy = get_parent()\n"
+)
+PROJECTION_MAIN_TSCN = (
+    "[gd_scene load_steps=2 format=3]\n\n"
+    '[ext_resource type="Script" path="res://player.gd" id="1"]\n\n'
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="Player" type="Node2D" parent="."]\n'
+    'script = ExtResource("1")\n'
+)
+
+
+@pytest.mark.e2e
+def test_daemon_game_get_projects_compound_values_with_live_fallback(
+    tmp_path, daemon_runtime_dir
+):
+    # The live half of ADR-0035, through the byte-identical mirrored harness
+    # projection: `game get` of an exported Dictionary arrives as a structured
+    # JSON object, while a Node-valued property — a non-whitelisted runtime
+    # Object — stays the str() fallback (the whitelist keeps the shared
+    # projection safe against projecting a whole live scene tree).
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(PROJECTION_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "player.gd").write_text(PROJECTION_PLAYER_GD, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        got = run("game", "get", "/root/Main/Player")
+        assert got.returncode == 0, got.stdout + got.stderr
+        props = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
+
+        stats = props["stats"]
+        assert stats["type"] == "Dictionary"
+        assert stats["value"] == {"hp": 5, "label": "panda"}
+
+        # The live Node reference is NOT projected — no structure, no descent
+        # into the runtime tree — just the existing string form.
+        buddy = props["buddy"]
+        assert isinstance(buddy["value"], str)
+    finally:
+        run("daemon", "stop")
+
+
 def _gda(tmp_path, env):
     """A `gda <args> --project <tmp> --godot <GODOT> --json` subprocess helper."""
 

--- a/tests/test_e2e_object_property.py
+++ b/tests/test_e2e_object_property.py
@@ -137,10 +137,14 @@ def test_node_set_object_property_wires_ext_resource_end_to_end(godot_project):
     assert was_set.returncode == 0, was_set.stdout + was_set.stderr
     data = json.loads(was_set.stdout)
     assert data["property"] == "shape"
-    # The declared Godot type is Object; the assigned value round-trips as the
-    # res:// reference (not an inlined blob).
+    # The declared Godot type is Object; the set echoes the assigned resource as
+    # the ADR-0035 reference projection ({type, resource_path}) — the same shape
+    # node get reads back, never an inlined blob.
     assert data["type"] == "Object"
-    assert data["value"] == "res://box.tres"
+    assert data["value"] == {
+        "type": "RectangleShape2D",
+        "resource_path": "res://box.tres",
+    }
 
     # The mutation is on disk as an EXTERNAL reference: an [ext_resource ...] entry
     # for the .tres and a `shape = ExtResource(...)` binding — not an inlined
@@ -156,9 +160,8 @@ def test_node_set_object_property_wires_ext_resource_end_to_end(godot_project):
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
     assert got_data["type"] == "CollisionShape2D"
-    # The read side reports the ADR-0035 reference projection — {type,
-    # resource_path}, the mirror of the write-side res:// reference — while the
-    # set echo above stays the raw path string (the documented asymmetry).
+    # The read side reports the same ADR-0035 reference projection the set
+    # echoed above — one shape for one stored value, whichever way it is read.
     shape = next(p for p in got_data["properties"] if p["name"] == "shape")
     assert shape["value"] == {
         "type": "RectangleShape2D",
@@ -194,7 +197,11 @@ def test_resource_set_object_property_wires_ext_resource(godot_project):
     data = json.loads(was_set.stdout)
     assert data["property"] == "gradient"
     assert data["type"] == "Object"
-    assert data["value"] == "res://grad.tres"
+    # The set echo is the ADR-0035 reference projection, matching the get below.
+    assert data["value"] == {
+        "type": "Gradient",
+        "resource_path": "res://grad.tres",
+    }
 
     saved = (godot_project / "tex.tres").read_text(encoding="utf-8")
     assert 'ext_resource type="Gradient" path="res://grad.tres"' in saved

--- a/tests/test_e2e_object_property.py
+++ b/tests/test_e2e_object_property.py
@@ -154,7 +154,16 @@ def test_node_set_object_property_wires_ext_resource_end_to_end(godot_project):
     # the addressed node again — proving the wiring is not a torn file.
     got = gda("node", "get", "res://main.tscn", "--node", "Col", "--json")
     assert got.returncode == 0, got.stdout + got.stderr
-    assert json.loads(got.stdout)["type"] == "CollisionShape2D"
+    got_data = json.loads(got.stdout)
+    assert got_data["type"] == "CollisionShape2D"
+    # The read side reports the ADR-0035 reference projection — {type,
+    # resource_path}, the mirror of the write-side res:// reference — while the
+    # set echo above stays the raw path string (the documented asymmetry).
+    shape = next(p for p in got_data["properties"] if p["name"] == "shape")
+    assert shape["value"] == {
+        "type": "RectangleShape2D",
+        "resource_path": "res://box.tres",
+    }
 
 
 @pytest.mark.e2e
@@ -190,6 +199,18 @@ def test_resource_set_object_property_wires_ext_resource(godot_project):
     saved = (godot_project / "tex.tres").read_text(encoding="utf-8")
     assert 'ext_resource type="Gradient" path="res://grad.tres"' in saved
     assert "gradient = ExtResource(" in saved
+
+    # resource get reads the assigned value back as the ADR-0035 reference
+    # projection ({type, resource_path}), never an inlined dump.
+    got = gda("resource", "get", "res://tex.tres", "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    gradient = next(
+        p for p in json.loads(got.stdout)["properties"] if p["name"] == "gradient"
+    )
+    assert gradient["value"] == {
+        "type": "Gradient",
+        "resource_path": "res://grad.tres",
+    }
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_project.py
+++ b/tests/test_e2e_project.py
@@ -19,6 +19,8 @@ import pytest
 from gda.binary import resolve_godot_binary
 from tests.support import GDA_CMD
 
+from .conftest import project_godot
+
 GODOT = resolve_godot_binary()
 
 
@@ -28,6 +30,23 @@ def _gda(project, *args: str) -> subprocess.CompletedProcess:
         capture_output=True,
         text=True,
     )
+
+
+# An [input] action holding a real InputEventKey Object literal — the exact
+# on-disk shape the Godot editor writes for an InputMap binding (the #381
+# reproduction: a compound Dictionary value with an embedded value Object).
+INPUT_ACTION_SECTION = (
+    "[input]\n\n"
+    "fire={\n"
+    '"deadzone": 0.5,\n'
+    '"events": [Object(InputEventKey,"resource_local_to_scene":false,'
+    '"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,'
+    '"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,'
+    '"pressed":false,"keycode":74,"physical_keycode":0,"key_label":0,'
+    '"unicode":106,"location":0,"echo":false,"script":null)\n'
+    "]\n"
+    "}\n"
+)
 
 
 @pytest.mark.e2e
@@ -57,6 +76,55 @@ def test_project_get_reads_a_setting_as_typed_json(godot_project):
     assert data["setting"] == "application/config/name"
     assert data["type"] == "String"
     assert data["value"] == "gda-e2e-fixture"
+
+
+@pytest.mark.e2e
+def test_project_get_input_action_projects_a_structured_dictionary(godot_project):
+    # The #381 acceptance case (ADR-0035): an [input] action is a Dictionary
+    # holding an embedded InputEventKey. project get returns an indexable JSON
+    # object — value.deadzone, value.events[0].keycode — with the event as an
+    # inline value projection, not a str() debug dump.
+    (godot_project / "project.godot").write_text(
+        project_godot(extra=INPUT_ACTION_SECTION), encoding="utf-8"
+    )
+
+    got = _gda(godot_project, "project", "get", "input/fire", "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    data = json.loads(got.stdout)
+    assert data["type"] == "Dictionary"
+    value = data["value"]
+    assert value["deadzone"] == 0.5
+    event = value["events"][0]
+    assert event["type"] == "InputEventKey"
+    assert event["keycode"] == 74
+    # The inline value projection excludes the Object/Resource base bookkeeping,
+    # so a path-less value Object never masquerades as a reference projection.
+    excluded_keys = (
+        "resource_path",
+        "resource_name",
+        "resource_local_to_scene",
+        "script",
+    )
+    for excluded in excluded_keys:
+        assert excluded not in event, f"{excluded} must be excluded from the projection"
+
+
+@pytest.mark.e2e
+def test_project_get_packed_string_array_setting_projects_a_json_list(godot_project):
+    # A packed-array-valued setting projects to a JSON array (ADR-0035), not the
+    # Variant str() form.
+    (godot_project / "project.godot").write_text(
+        project_godot(extra='[gda]\n\ntags=PackedStringArray("alpha", "beta")\n'),
+        encoding="utf-8",
+    )
+
+    got = _gda(godot_project, "project", "get", "gda/tags", "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    data = json.loads(got.stdout)
+    assert data["type"] == "PackedStringArray"
+    assert data["value"] == ["alpha", "beta"]
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_resource.py
+++ b/tests/test_e2e_resource.py
@@ -134,6 +134,32 @@ def test_resource_create_then_get_round_trip(godot_project):
 
 
 @pytest.mark.e2e
+def test_resource_get_projects_packed_arrays_as_json_lists(godot_project):
+    # ADR-0035: a Gradient's packed-array properties arrive structured — offsets
+    # (PackedFloat32Array) as a JSON number list, colors (PackedColorArray) as a
+    # list of [r, g, b, a] lists (each Color element re-enters the projection) —
+    # not the Variant str() dump.
+    resource_path = godot_project / "palette.tres"
+    created = _gda(
+        "resource", "create", str(resource_path), "--type", "Gradient", "--json"
+    )
+    assert created.returncode == 0, created.stdout + created.stderr
+
+    got = _gda("resource", "get", str(resource_path), "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    by_name = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
+    assert by_name["offsets"]["type"] == "PackedFloat32Array"
+    assert by_name["offsets"]["value"] == [0.0, 1.0]
+    assert by_name["colors"]["type"] == "PackedColorArray"
+    # A default Gradient runs black -> white; each element is a 4-float list.
+    assert by_name["colors"]["value"] == [
+        [0.0, 0.0, 0.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0],
+    ]
+
+
+@pytest.mark.e2e
 def test_resource_create_into_nested_dir_reports_created_dirs(godot_project):
     # create makes missing parent directories before saving and reports them,
     # outermost to innermost (mirrors scene/script create).

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,6 +12,7 @@ from gda.models import (
     ExportRunResult,
     GdaError,
     GdaErrorEnvelope,
+    InlineValueProjection,
     NodeAddResult,
     NodeConnectSignalResult,
     NodeDisconnectSignalResult,
@@ -19,6 +20,7 @@ from gda.models import (
     NodeGetResult,
     NodeListResult,
     NodeMoveResult,
+    NodeProperty,
     NodeRemoveResult,
     NodeSetResult,
     ProjectAddAutoloadResult,
@@ -26,6 +28,7 @@ from gda.models import (
     ProjectInfoResult,
     ProjectRemoveAutoloadResult,
     ProjectSetResult,
+    ReferenceProjection,
     ResourceCreateResult,
     ResourceGetResult,
     SceneCreateResult,
@@ -1104,3 +1107,91 @@ def test_diag_error_callstack_defaults_to_empty_for_a_bare_error():
 
     assert error.callstack == []
     assert error.function is None
+
+
+# --- value projection models (ADR-0035, #381) --------------------------------
+
+
+def test_reference_projection_round_trips_and_schema_is_valid():
+    # The read-side mirror of ADR-0033: a Resource-valued read renders as
+    # {type, resource_path} — never inlined. The named model surfaces the shape
+    # through the --schema / model chain (ADR-0004) rather than leaving it
+    # prose-only.
+    schema = ReferenceProjection.model_json_schema()
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+    payload = {"type": "RectangleShape2D", "resource_path": "res://box.tres"}
+    ref = ReferenceProjection.model_validate(payload)
+
+    assert ref.type == "RectangleShape2D"
+    assert ref.resource_path == "res://box.tres"
+    dumped = json.loads(ref.model_dump_json())
+    assert dumped == payload
+    jsonschema.validate(dumped, schema)
+
+
+def test_inline_value_projection_preserves_extra_storage_properties():
+    # The whitelisted path-less value Object shape (ADR-0035): `type` is the
+    # declared discriminator; the class's own storage properties ride as extra
+    # fields (extra="allow") and survive a model_dump_json round trip intact.
+    schema = InlineValueProjection.model_json_schema()
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+    payload = {
+        "type": "InputEventKey",
+        "keycode": 74,
+        "physical_keycode": 0,
+        "pressed": False,
+        "device": -1,
+    }
+    inline = InlineValueProjection.model_validate(payload)
+
+    assert inline.type == "InputEventKey"
+    dumped = json.loads(inline.model_dump_json())
+    assert dumped == payload
+    jsonschema.validate(dumped, schema)
+    # The projector excludes the Resource base bookkeeping, so the branch
+    # between the two Object projection kinds stays unambiguous: an inline
+    # projection never carries a resource_path.
+    assert "resource_path" not in dumped
+
+
+def test_node_property_round_trips_an_inline_value_projection_dict():
+    # A NodeProperty whose value is a compound projection stays plain JSON:
+    # `value` is Any (the recorded, bounded ADR-0035 exception to ADR-0004), so
+    # pydantic must NOT materialize the dict into a model instance — the human
+    # renderer json.dumps's it as-is.
+    payload = {
+        "name": "fire",
+        "type": "Dictionary",
+        "value": {
+            "deadzone": 0.5,
+            "events": [{"type": "InputEventKey", "keycode": 74, "pressed": False}],
+        },
+    }
+
+    prop = NodeProperty.model_validate(payload)
+
+    assert isinstance(prop.value, dict)
+    assert prop.value["deadzone"] == 0.5
+    assert prop.value["events"][0]["type"] == "InputEventKey"
+    assert prop.value["events"][0]["keycode"] == 74
+    assert json.loads(prop.model_dump_json()) == payload
+
+
+def test_node_property_round_trips_a_reference_projection_value():
+    # An Object-typed property read back after an ADR-0033 set: the value is
+    # the reference projection dict, distinguished from an inline value
+    # projection by the presence of resource_path.
+    payload = {
+        "name": "shape",
+        "type": "Object",
+        "value": {"type": "RectangleShape2D", "resource_path": "res://box.tres"},
+    }
+
+    prop = NodeProperty.model_validate(payload)
+
+    assert isinstance(prop.value, dict)
+    assert prop.value["type"] == "RectangleShape2D"
+    assert prop.value["resource_path"] == "res://box.tres"
+    assert json.loads(prop.model_dump_json()) == payload

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,9 +10,11 @@ from gda.models import (
     ExportListResult,
     ExportRunMode,
     ExportRunResult,
+    GameSetResult,
     GdaError,
     GdaErrorEnvelope,
     InlineValueProjection,
+    ListedProjectSetting,
     NodeAddResult,
     NodeConnectSignalResult,
     NodeDisconnectSignalResult,
@@ -31,8 +33,10 @@ from gda.models import (
     ReferenceProjection,
     ResourceCreateResult,
     ResourceGetResult,
+    ResourceSetResult,
     SceneCreateResult,
     SceneDeleteResult,
+    SceneExport,
     SceneGetExportsResult,
     SceneGetResult,
     SceneListResult,
@@ -1195,3 +1199,29 @@ def test_node_property_round_trips_a_reference_projection_value():
     assert prop.value["type"] == "RectangleShape2D"
     assert prop.value["resource_path"] == "res://box.tres"
     assert json.loads(prop.model_dump_json()) == payload
+
+
+def test_every_projected_value_field_exposes_the_named_projection_defs():
+    # ADR-0035 carries the projection ABI into the --schema / model chain
+    # (ADR-0004): `value` stays Any (the recorded, bounded exception), so the
+    # stable Object-projection shapes ride the field's $defs instead — named
+    # and consumable in every emitted command schema, not prose-only. Every
+    # model whose `value` flows through the shared projection must expose them.
+    projected_value_models = [
+        NodeProperty,  # node get / resource get / game get per-property value
+        SceneExport,  # scene get-exports per-export value
+        ProjectGetResult,
+        ListedProjectSetting,  # project list per-entry value
+        NodeSetResult,
+        ResourceSetResult,
+        ProjectSetResult,
+        GameSetResult,
+    ]
+    for model in projected_value_models:
+        schema = model.model_json_schema()
+        jsonschema.Draft202012Validator.check_schema(schema)
+        defs = schema["properties"]["value"]["$defs"]
+        assert defs == {
+            "ReferenceProjection": ReferenceProjection.model_json_schema(),
+            "InlineValueProjection": InlineValueProjection.model_json_schema(),
+        }, model.__name__

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -439,6 +439,10 @@ def test_project_get_schema_emits_model_derived_contract_without_other_args():
     assert doc["output"] == ProjectGetResult.model_json_schema()
     assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     assert "section/key" in doc["input"]["properties"]["setting"]["description"]
+    # The emitted command schema exposes the named Object-projection shapes on
+    # the Any-typed value field (ADR-0035 → ADR-0004), not prose alone.
+    value_defs = doc["output"]["properties"]["value"]["$defs"]
+    assert set(value_defs) == {"ReferenceProjection", "InlineValueProjection"}
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -165,6 +165,30 @@ def test_project_get_carries_packed_value_projection(monkeypatch):
     assert json.loads(result.stdout)["value"] == [10.0, 20.0]
 
 
+def test_project_get_carries_compound_value_projection_untouched(monkeypatch):
+    # A compound-valued setting (ADR-0035): the operation projects a Dictionary
+    # to a JSON object — here an InputMap action with an inline-projected
+    # InputEventKey in its events list — and the CLI carries the structure
+    # through --json untouched (value stays Any; nothing re-shapes it).
+    value = {
+        "deadzone": 0.5,
+        "events": [{"type": "InputEventKey", "keycode": 74, "pressed": False}],
+    }
+    payload = {"setting": "input/fire", "type": "Dictionary", "value": value}
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["project", "get", "input/fire", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["value"] == value
+    # The projection is indexable, the point of #381.
+    assert data["value"]["deadzone"] == 0.5
+    assert data["value"]["events"][0]["keycode"] == 74
+
+
 # --- project set ----------------------------------------------------------
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -155,6 +155,30 @@ def test_render_node_properties_routes_value_through_the_helper():
     assert rendered == ". (Node2D)\n  position (Vector2) = [1.0, 2.0]"
 
 
+def test_render_node_properties_renders_a_compound_value_projection():
+    # A dict-valued property (the ADR-0035 compound projection) renders through
+    # the same format_value helper — json.dumps of the projected object, no
+    # per-shape renderer.
+    result = NodeGetResult(
+        scene_path="res://s.tscn",
+        path=".",
+        name="Root",
+        type="Node2D",
+        properties=[
+            NodeProperty(
+                name="fire",
+                type="Dictionary",
+                value={"deadzone": 0.5, "events": [{"type": "InputEventKey"}]},
+            )
+        ],
+    )
+    rendered = render_node_properties(result)
+    assert rendered == (
+        ". (Node2D)\n"
+        '  fire (Dictionary) = {"deadzone": 0.5, "events": [{"type": "InputEventKey"}]}'
+    )
+
+
 def test_render_node_set_routes_value_through_the_helper():
     result = NodeSetResult(
         scene_path="res://s.tscn",

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -140,6 +140,15 @@ def test_scene_get_exports_schema_emits_model_derived_contract_without_other_arg
     assert doc["input"] == SceneGetExportsParams.model_json_schema()
     assert doc["output"] == SceneGetExportsResult.model_json_schema()
     assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    # The per-export value is a listed ADR-0035 read surface: its description
+    # names the recursive value projection and the emitted schema carries the
+    # named Object-projection shapes — a stale scalar-only doc fails here.
+    export_value = doc["output"]["$defs"]["SceneExport"]["properties"]["value"]
+    assert "value projection" in export_value["description"]
+    assert set(export_value["$defs"]) == {
+        "ReferenceProjection",
+        "InlineValueProjection",
+    }
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 


### PR DESCRIPTION
## Summary

Implements ADR-0035: the shared, mirrored `_jsonify` grows into the read-side **Value projection**, so compound values — `Dictionary`, `Array` + the full packed-array family, and whitelisted value `Object`s — return structured, indexable JSON instead of a Variant `str()` debug string, uniformly across every value gda emits through it (`project`/`node`/`resource get`, the `set` echoes, `project list` / `scene get-exports` per-entry values, and the live `game get` read).

```
$ gda project get input/fire --json
… "value": {"deadzone": 0.5, "events": [{"type": "InputEventKey", "keycode": 74, …}]}
```

## Design (as pinned by the ADR)

- **Containers** project recursively (Dictionary → object with stringified keys, last-wins collision; arrays/packed arrays → JSON arrays).
- **Objects** render as one of three kinds: **reference projection** (`{type, resource_path}` for a `res://`-pathed Resource — the read-side mirror of ADR-0033, never inlined), **inline value projection** (whitelisted path-less value Objects — `InputEvent` subclasses initially — via the existing storage-property model, with the `Resource` base bookkeeping excluded and the `type` discriminator assigned last so it shadows), or the existing **`str()` fallback** (e.g. a live `Node`; plus an `is_instance_valid` guard for freed live Objects).
- Bounded by `JSONIFY_MAX_DEPTH := 16` on the compound arms only (scalars are never depth-stringified); no visited-set; always JSON-encodable. Scalars and the fixed-shape types are byte-for-byte unchanged.
- Both `.gd` files changed identically inside the `--- shared coercion ---` block; the mirror gate stays green. `HARNESS_VERSION` bumped 4 → 5 per repo convention so the daemon resyncs installed harness copies.
- Python side: named `ReferenceProjection` / `InlineValueProjection` models; `value` stays `Any` (the ADR's recorded bounded exception — a union type would materialize dicts as models and break rendering) with projection-aware descriptions on every projected value field. **Every emitted command schema now carries the two named projection shapes as the value field's `$defs`** (shared `json_schema_extra` hook), so `--schema` / gda-mcp consumers get them as named, machine-readable models — not prose.
- **The ADR-0033 Object-typed `node set` / `resource set` echo flows through the same projection**: setting a Resource by `res://` path echoes `{type, resource_path}` — the identical shape a subsequent `get` reads back. One shape for one stored value, whichever way it is observed.

## Review response (Pass 1 + Pass 2, all three findings addressed in 26e92cd)

1. **Schema exposure gap** → fixed: all 8 projected value fields (`NodeProperty`, `SceneExport`, `ProjectGetResult`, `ListedProjectSetting`, `NodeSetResult`, `ResourceSetResult`, `ProjectSetResult`, `GameSetResult`) attach the named projection schemas as `$defs`; `gda project get --schema` now emits them, with model-level and command-schema-level test coverage.
2. **Object set-echo asymmetry** → fixed: the echo now routes through `_jsonify` (reference projection), the former asymmetry note is gone from models/tests/catalog, and the e2e pins the projected echo shape on both `node set` and `resource set`.
3. **Stale `SceneExport.value` description** → fixed: description now names the recursive ADR-0035 projection; a schema test on `scene get-exports --schema` fails on stale prose and asserts the `$defs`.

## Verification

- Fast tier **1032 passed** (includes the byte-identity mirror gate and schema gates); both `.gd` files additionally engine-syntax-checked (`--check-only`).
- Targeted e2e **149 passed** across `test_e2e_project.py` / `test_e2e_resource.py` / `test_e2e_object_property.py` / `test_e2e_node.py` / `test_e2e_daemon.py`, with independent orchestrator re-runs (70 + 26 + 28 passed) — covering: InputMap action → indexable `deadzone`/`events[0].keycode` with bookkeeping keys absent, packed arrays → lists, Gradient `offsets`/`colors` structured, reference projection on ADR-0033 set echo AND read-back, live `game get` structured Dictionary + `Node`-value `str()` fallback, and scalar no-regression.
- Full e2e suite passed on Linux CI (workflow-dispatched with `run-e2e=true`).
- `uv run ruff check` / `ruff format --check` / `pyright` clean.

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)