### PR TITLE
[Panda Adventure] wave-0 prep: harness v5 sync + manifest comment migration/canonicalization

### DIFF
--- a/examples/platformer/panda-adventure/addons/gda_harness/gda_harness.gd
+++ b/examples/platformer/panda-adventure/addons/gda_harness/gda_harness.gd
@@ -1,4 +1,4 @@
-# gda-harness-version: 4
+# gda-harness-version: 5
 extends Node
 
 # The gda harness (ADR-0017, ADR-0018). Installed as a project [autoload] by
@@ -1037,14 +1037,34 @@ func _type_name(type: int) -> String:
 	return type_string(type)
 
 
-# Project a Godot property value into JSON-safe form for the result payload
-# (issue #55). Scalars pass through; the packed value types node set supports
-# become flat number arrays so node get's output is exactly the projection node
-# set accepts back: Vector2 → [x, y], Vector2i likewise, Color → [r, g, b, a].
-# Any other type degrades to its string form rather than crashing JSON.stringify
-# on an unencodable Variant — node get reports the whole storage surface, but
-# only the coercible types claim a structured projection.
-func _jsonify(value: Variant) -> Variant:
+# The value projection's hard recursion depth cap (ADR-0035): a compound value
+# nested deeper than this degrades to its string form instead of recursing on.
+# Deliberately NO visited-set — references are not descended and non-whitelisted
+# Objects stop at str(), so on-disk stored values are acyclic trees; the cap is
+# the backstop against a pathological self-referential Dictionary live-side.
+const JSONIFY_MAX_DEPTH := 16
+
+# The Object/Resource base bookkeeping properties an inline value projection
+# excludes (ADR-0035): every InputEvent IS a Resource, so without the exclusion
+# a path-less value Object would emit an empty resource_path and masquerade as
+# a reference projection; the exclusion also drops noise.
+const JSONIFY_BOOKKEEPING_PROPS: Array[String] = [
+	"resource_path", "resource_name", "resource_local_to_scene", "script",
+]
+
+# The read-side Value projection (ADR-0035, grown from issue #55): render a
+# Godot Variant into the structured JSON a result's value field carries.
+# Scalars pass through; the fixed-shape value types node set supports become
+# flat number arrays so node get's output is exactly the projection node set
+# accepts back: Vector2 → [x, y], Vector2i likewise, Color → [r, g, b, a].
+# A Dictionary projects to a JSON object (keys stringified), an Array and the
+# packed-array family to a JSON array, each value re-entering the projection;
+# an Object renders as a reference projection, an inline value projection, or
+# the str() fallback (the TYPE_OBJECT arm below). Any other type degrades to
+# its string form rather than crashing JSON.stringify on an unencodable
+# Variant, and the depth cap bounds the recursion on the compound arms — so
+# the projection is always JSON-encodable.
+func _jsonify(value: Variant, depth: int = 0) -> Variant:
 	match typeof(value):
 		TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING, TYPE_STRING_NAME:
 			return value
@@ -1054,6 +1074,66 @@ func _jsonify(value: Variant) -> Variant:
 			return [value.x, value.y]
 		TYPE_COLOR:
 			return [value.r, value.g, value.b, value.a]
+		TYPE_DICTIONARY:
+			# The cap guards only the compound arms: a scalar is never
+			# stringified by depth, however deep it sits.
+			if depth >= JSONIFY_MAX_DEPTH:
+				return str(value)
+			var out := {}
+			# Insertion-ordered iteration; keys are coerced to strings, so two
+			# keys that collide after stringification resolve last-wins by
+			# assignment order (deterministic, ADR-0035).
+			for key in value.keys():
+				out[str(key)] = _jsonify(value[key], depth + 1)
+			return out
+		TYPE_ARRAY, TYPE_PACKED_BYTE_ARRAY, TYPE_PACKED_INT32_ARRAY, \
+		TYPE_PACKED_INT64_ARRAY, TYPE_PACKED_FLOAT32_ARRAY, \
+		TYPE_PACKED_FLOAT64_ARRAY, TYPE_PACKED_STRING_ARRAY, \
+		TYPE_PACKED_VECTOR2_ARRAY, TYPE_PACKED_VECTOR3_ARRAY, \
+		TYPE_PACKED_COLOR_ARRAY, TYPE_PACKED_VECTOR4_ARRAY:
+			if depth >= JSONIFY_MAX_DEPTH:
+				return str(value)
+			var items := []
+			# Element-wise re-entry: a PackedVector2Array element projects as
+			# [x, y]; an element type with no structured arm of its own (e.g.
+			# Vector3) stays str(), per the fixed-shape list above.
+			for element in value:
+				items.append(_jsonify(element, depth + 1))
+			return items
+		TYPE_OBJECT:
+			# A freed live Object (harness side) must not be introspected.
+			if not is_instance_valid(value):
+				return str(value)
+			if depth >= JSONIFY_MAX_DEPTH:
+				return str(value)
+			# Reference projection: a Resource with a res:// path is named by
+			# type and path, never inlined — the read-side mirror of ADR-0033's
+			# write-side reference. A sub-resource path (res://x.tscn::…)
+			# counts as a reference too.
+			if value is Resource and String(value.resource_path).begins_with("res://"):
+				return {"type": value.get_class(), "resource_path": value.resource_path}
+			# Inline value projection: a whitelisted path-less value Object
+			# (InputEvent subclasses initially) projects its own storage
+			# properties. The whitelist is the risk-isolation boundary that
+			# keeps this shared projection safe on the live side, where an
+			# arbitrary Object could be a whole scene tree (ADR-0035).
+			if value is InputEvent:
+				var projected := {}
+				for prop in value.get_property_list():
+					if not _is_storage_property(prop):
+						continue
+					var prop_name := String(prop.get("name", ""))
+					if prop_name in JSONIFY_BOOKKEEPING_PROPS:
+						continue
+					projected[prop_name] = _jsonify(value.get(prop_name), depth + 1)
+				# Assigned AFTER the loop so the discriminator shadows a
+				# storage property named "type" (ADR-0035 documents the
+				# shadowing — order matters).
+				projected["type"] = value.get_class()
+				return projected
+			# String fallback: any other Object (not whitelisted, no res://
+			# path — e.g. a live Node) keeps the existing str() form.
+			return str(value)
 		_:
 			return str(value)
 

--- a/examples/platformer/panda-adventure/docs/project-manifest-notes.md
+++ b/examples/platformer/panda-adventure/docs/project-manifest-notes.md
@@ -1,0 +1,55 @@
+# Manifest annotations — `project.godot` & `scenes/main.tscn`
+
+These two files were originally hand-authored with inline `;` comments. gda now
+authors both structurally (`gda project add-input-action` since #380 / PR #385,
+`gda node add`/`node set` for scenes), and the engine's canonical re-serialization
+(`ProjectSettings.save()`, `PackedScene` save) does not preserve `;` comments — so
+the annotations were migrated here once, and the files stay comment-free. Update
+this doc when the rationale behind a setting or the scene structure changes.
+
+## `project.godot`
+
+**File role.** The canonical project root (gda has no `project create`, so it was
+bootstrapped by hand). Later slices extend it — now via gda structured ops, no
+longer by hand-editing. The `data/generated/*.tres` it loads are derived artifacts
+that are COMMITTED (a freshness gate keeps them byte-identical to a fresh build),
+regenerated from JSON via `scripts/build_config.py` (gADR-0000).
+
+**`[input]`.** S1 player-traversal actions plus the S2 `fire` action.
+`move_left`/`move_right`/`jump`/`fire` are consumed by PlayerController
+(`Input.get_axis` / `is_action_just_pressed`) and driven in the live e2e by
+`gda input action`. Each movement action binds an arrow key plus a WASD/Space
+alternative; `fire` binds J plus F. Originally hand-serialized (Godot's own
+`var_to_str` output); since gda #380 landed, actions are authored with
+`gda project add-input-action <name> --key <k>...` instead.
+
+**`[layer_names]`.** S2 collision topology — structural wiring, not balance data
+(gADR-0000 governs config NUMBERS; what-can-damage-what lives here and in the
+scenes): 1 `terrain`, 2 `player`, 3 `enemy`, 4 `projectile`, 5 `gravity_field`
+(reserved for S3's Gravity Field).
+
+**`[debug]`.** Godot's default desktop file logging is disabled so no engine
+launch writes a shared `user://logs/godot.log` (the #180 RotatedFileLogger race
+under concurrent launches). The `.pc` platform override is the operative one on
+desktop: its default is `true` and wins over the base key at startup, so both are
+set off. (The canonical save may drop the base key when it equals the engine
+default — the `.pc` override is what matters.)
+
+**`[rendering]`.** `import_etc2_astc=true`: import ETC2/ASTC compressed textures.
+Required for the macOS universal/arm64 export preset (S0 smoke-test); the exporter
+refuses universal/arm64 builds when this is off. Harmless for desktop running.
+
+**`[autoload]`.** `GdaHarness` is the committed gda daemon harness — intentional,
+see `AGENTS.md` ("The gda daemon harness is COMMITTED").
+
+## `scenes/main.tscn`
+
+Panda Adventure's main scene (S1 player traversal + S2 combat), hand-bootstrapped,
+now edited via gda scene ops. **Structure only**: every visual (color/size/position)
+and the collision-shape sizes are applied at RUNTIME from the derived config
+Resources by the controllers (gADR-0000 — no config baked into the scene). The
+`RectangleShape2D` sub-resources start at a placeholder size that `_ready`
+overwrites from config. Collision topology (S2, see `[layer_names]` above):
+Platform=`terrain`(1), Player=`player`(2) masking terrain only (passes through the
+Enemy — contact damage is S4). The Enemy is runtime-instanced by LevelController
+from `enemy.tscn`; Projectiles are runtime-instanced by PlayerController.

--- a/examples/platformer/panda-adventure/project.godot
+++ b/examples/platformer/panda-adventure/project.godot
@@ -1,9 +1,10 @@
-; Panda Adventure — Godot project manifest (hand-authored).
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
 ;
-; gda has no `project create`, so this is the canonical project root. Keep it
-; minimal: later slices (S1–S9) extend it. The `data/generated/*.tres` the build
-; pipeline emits are derived artifacts that are COMMITTED (a freshness gate keeps
-; them byte-identical to a fresh build), regenerated from JSON via build_config.py.
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
 
 config_version=5
 
@@ -11,15 +12,17 @@ config_version=5
 
 config/name="Panda Adventure"
 run/main_scene="res://scenes/main.tscn"
+config/features=PackedStringArray("4.6")
+
+[autoload]
+
+GdaHarness="*res://addons/gda_harness/gda_harness.gd"
+
+[debug]
+
+file_logging/enable_file_logging.pc=false
 
 [input]
-
-; S1 player-traversal actions plus the S2 `fire` action. move_left/move_right/
-; jump/fire are consumed by PlayerController (Input.get_axis /
-; is_action_just_pressed) and driven in the live e2e by `gda input action`.
-; Each movement action binds an arrow key plus a WASD/Space alternative; fire
-; binds J plus F. Hand-authored (project.godot is the canonical root); the
-; exact InputEventKey serialization was emitted by Godot itself (var_to_str).
 
 move_left={
 "deadzone": 0.5,
@@ -48,31 +51,12 @@ fire={
 
 [layer_names]
 
-; S2 collision topology (structural wiring, not balance data — gADR-0000 governs
-; config NUMBERS; what-can-damage-what lives here and in the scenes). Layer 5 is
-; reserved for S3's Gravity Field.
 2d_physics/layer_1="terrain"
 2d_physics/layer_2="player"
 2d_physics/layer_3="enemy"
 2d_physics/layer_4="projectile"
 2d_physics/layer_5="gravity_field"
 
-[debug]
-
-; Disable Godot's default desktop file logging so no engine launch writes a
-; shared user://logs/godot.log (the #180 RotatedFileLogger race under concurrent
-; launches). The `.pc` platform override is the operative one on desktop: its
-; default is `true` and wins over the base key at startup, so both are set off.
-file_logging/enable_file_logging=false
-file_logging/enable_file_logging.pc=false
-
 [rendering]
 
-; Import ETC2/ASTC compressed textures. Required for the macOS universal/arm64
-; export preset (S0 smoke-test); the exporter refuses universal/arm64 builds when
-; this is off. Harmless for desktop running.
 textures/vram_compression/import_etc2_astc=true
-
-[autoload]
-
-GdaHarness="*res://addons/gda_harness/gda_harness.gd"

--- a/examples/platformer/panda-adventure/scenes/main.tscn
+++ b/examples/platformer/panda-adventure/scenes/main.tscn
@@ -1,42 +1,29 @@
-; Panda Adventure — main scene (S1 player traversal + S2 combat), hand-authored.
-;
-; Structure only: every visual (color/size/position) and the collision-shape
-; sizes are applied at RUNTIME from the derived PlayerConfig Resource by the two
-; controllers (gADR-0000 — no config baked into the scene). The RectangleShape2D
-; sub-resources start at a placeholder size that _ready overwrites from config.
-; Collision topology (S2, see project.godot [layer_names]): Platform=terrain(1),
-; Player=player(2) masking terrain only (passes through the Enemy — contact
-; damage is S4). The Enemy is runtime-instanced by LevelController from
-; enemy.tscn; Projectiles are runtime-instanced by PlayerController.
-[gd_scene load_steps=5 format=3]
+[gd_scene format=3]
 
-[ext_resource type="Script" path="res://src/controllers/level_controller.gd" id="1_level"]
-[ext_resource type="Script" path="res://src/controllers/player_controller.gd" id="2_player"]
+[ext_resource type="Script" path="res://src/controllers/level_controller.gd" id="1_lkauy"]
+[ext_resource type="Script" path="res://src/controllers/player_controller.gd" id="2_85amh"]
 
 [sub_resource type="RectangleShape2D" id="PlayerShape"]
 
 [sub_resource type="RectangleShape2D" id="PlatformShape"]
 
-[node name="Main" type="Node2D"]
-script = ExtResource("1_level")
+[node name="Main" type="Node2D" unique_id=1303069056]
+script = ExtResource("1_lkauy")
 
-[node name="Player" type="CharacterBody2D" parent="."]
+[node name="Player" type="CharacterBody2D" parent="." unique_id=190221684]
 collision_layer = 2
-collision_mask = 1
-script = ExtResource("2_player")
+script = ExtResource("2_85amh")
 
-[node name="Visual" type="ColorRect" parent="Player"]
+[node name="Visual" type="ColorRect" parent="Player" unique_id=1589511213]
 
-[node name="Collision" type="CollisionShape2D" parent="Player"]
+[node name="Collision" type="CollisionShape2D" parent="Player" unique_id=317821343]
 shape = SubResource("PlayerShape")
 
-[node name="Camera2D" type="Camera2D" parent="Player"]
+[node name="Camera2D" type="Camera2D" parent="Player" unique_id=861829757]
 
-[node name="Platform" type="StaticBody2D" parent="."]
-collision_layer = 1
-collision_mask = 1
+[node name="Platform" type="StaticBody2D" parent="." unique_id=1816504183]
 
-[node name="Visual" type="ColorRect" parent="Platform"]
+[node name="Visual" type="ColorRect" parent="Platform" unique_id=898818415]
 
-[node name="Collision" type="CollisionShape2D" parent="Platform"]
+[node name="Collision" type="CollisionShape2D" parent="Platform" unique_id=1288880102]
 shape = SubResource("PlatformShape")


### PR DESCRIPTION
## What

Two mechanical prep commits ahead of the S3/S4/S6a parallel wave:

1. **Sync the committed gda harness to v5** — gda 0.2.0's `daemon start` re-materializes `addons/gda_harness/gda_harness.gd` with the ADR-0035 read-side value projection. Committing it keeps `daemon start` an idempotent no-op per the demo's committed-harness convention (AGENTS.md).
2. **Migrate manifest `;` comments to `docs/project-manifest-notes.md` and canonicalize `project.godot` + `scenes/main.tscn` via gda.** The engine's canonical re-serialization does not preserve `;` comments, which is what kept these two files hand-edit-only. With `gda project add-input-action` (#380) now the intended way S3 authors its InputMap actions, the annotations move to a docs file once, and the committed gda-canonicalized form makes every later slice diff content-only.

## Behavior-equivalent absorptions (called out for review)

- `debug/file_logging/enable_file_logging` base key dropped by the canonical save (equals the engine default; the operative `.pc` override remains) and `config/features=PackedStringArray("4.6")` stamped.
- Scene properties equal to class defaults dropped (`Player collision_mask=1`, `Platform collision_layer/mask=1`); `ext_resource` ids re-keyed to gda's form. Collision topology rationale now lives in the notes doc.

## Verification

Full game suite green after canonicalization: **46 fast + 10 engine/e2e (56/56)**, including the daemon-launched live e2e (player traversal + combat + windowed screenshot), which exercises the canonicalized manifests end-to-end.

## Why now

Unblocks the S3 slice (`gda project add-input-action` for the Gravity Gun / weapon-switch actions) without paying the comment-loss cost mid-slice; both wave-1 worktrees branch from this prep so no slice re-materializes the harness as churn.

Refs #332 (unblocks), #6 (milestone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)