### PR TITLE
[Panda Adventure] S3: Gravity Gun + Gravity Field + MP economy

### DIFF
--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -68,6 +68,26 @@ gravity-affectable obstacles and on enemies within its range (lifting, slamming,
 redirecting them) — never on the player. The basis of the "改变重力" core-loop pillar.
 _Avoid_: global gravity, gravity flip, zero-g (it is a local field, not a world toggle)
 
+**Gravity Field params**:
+The data-driven description of one field's effect (gADR-0002): a velocity vector —
+direction (normalized) × strength — applied within a radius for a duration. Lift
+(upward) is the shipped fire default; slam and redirect are other data values of the
+SAME params, never separate mechanics.
+_Avoid_: field modes, gravity types, effect kinds
+
+**Gravity-affectable**:
+The opt-in response contract for any body a Gravity Field can act on: it joins the
+`gravity_affectable` group and implements `apply_gravity_field(field_velocity, delta)`,
+integrating the field velocity its own way (gADR-0002). The Enemy and the Obstacle are
+the S3 members; the Player never is (excluded by collision mask, not code).
+_Avoid_: pushable, liftable, physics-enabled
+
+**Current weapon**:
+The Player's weapon-switch state: which Equipment gun `fire` fires. Toggled between
+the Laser Gun and the Gravity Gun by the `switch_weapon` action; the spawn default is
+the Laser Gun.
+_Avoid_: active gun, weapon slot, loadout state
+
 ### Stats
 
 **MP**:
@@ -119,6 +139,12 @@ _Avoid_: mantou, steamed bun, bread
 A Consumable that restores MP.
 _Avoid_: jiu, sake, alcohol
 
+**Wine hook**:
+S3's minimal MP-restore path standing in for the S7 Consumable system: the
+`drink_wine` action restores a config amount of MP (capped at max MP) with no
+inventory and no item count. S7 replaces the hook's supply side, not its effect.
+_Avoid_: inventory, consumable system (that is S7)
+
 **Equipment**:
 An item the Player wields or wears persistently — the Laser Gun, the Gravity Gun, and the
 Spacesuit. Contrast with Consumable.
@@ -134,6 +160,12 @@ _Avoid_: armor (generic), suit
 A timed segment of the demo level that spawns a specific composition of enemies
 (Faction × Tier × Archetype). The demo defaults to four; the count is data-driven, not hardcoded.
 _Avoid_: round, stage; level (the demo is a single level)
+
+**Obstacle**:
+A gravity-affectable environment block on the terrain layer that a Gravity Field can
+lift, slam, or redirect — the level-as-a-weapon half of the change-gravity pillar. A
+prop, not an actor: it never attacks, damages, or moves on its own.
+_Avoid_: crate (flavor), prop (generic), hazard
 
 <!-- Format reminder — **Term**: one/two-sentence definition (what it IS, not what it does);
      _Avoid_: rejected synonyms. Group natural clusters under ### subheadings. -->

--- a/examples/platformer/panda-adventure/data/generated/gravity_config.tres
+++ b/examples/platformer/panda-adventure/data/generated/gravity_config.tres
@@ -1,0 +1,20 @@
+[gd_resource type="Resource" script_class="GravityConfig" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://src/resources/gravity_config.gd" id="1_gravityconfig"]
+
+[resource]
+script = ExtResource("1_gravityconfig")
+mp_cost = 10
+wine_mp_restore = 15
+field_direction = Vector2(0, -1)
+field_strength = 260
+field_radius = 96
+field_duration = 2
+field_color = Color(0.35, 0.65, 1, 0.35)
+field_fade_duration = 0.25
+field_spawn_offset = Vector2(120, 0)
+enemy_max_gravity_offset = 120
+obstacle_color = Color(0.62, 0.45, 0.25, 1)
+obstacle_size = Vector2(40, 40)
+obstacle_position = Vector2(320, 360)
+obstacle_max_gravity_offset = 160

--- a/examples/platformer/panda-adventure/data/json/gravity_config.json
+++ b/examples/platformer/panda-adventure/data/json/gravity_config.json
@@ -1,0 +1,16 @@
+{
+  "mp_cost": 10.0,
+  "wine_mp_restore": 15.0,
+  "field_direction": [0.0, -1.0],
+  "field_strength": 260.0,
+  "field_radius": 96.0,
+  "field_duration": 2.0,
+  "field_color": [0.35, 0.65, 1.0, 0.35],
+  "field_fade_duration": 0.25,
+  "field_spawn_offset": [120.0, 0.0],
+  "enemy_max_gravity_offset": 120.0,
+  "obstacle_color": [0.62, 0.45, 0.25, 1.0],
+  "obstacle_size": [40.0, 40.0],
+  "obstacle_position": [320.0, 360.0],
+  "obstacle_max_gravity_offset": 160.0
+}

--- a/examples/platformer/panda-adventure/data/schema/gravity_config.schema.json
+++ b/examples/platformer/panda-adventure/data/schema/gravity_config.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aigengame.dev/panda-adventure/data/schema/gravity_config.schema.json",
+  "title": "Panda Adventure gravity configuration",
+  "description": "Authoritative config for S3 Gravity Gun + Gravity Field + MP economy (gADR-0000: JSON is the single source of truth). The field's EFFECT is data (gADR-0002): a velocity vector (direction x strength) applied within a radius for a duration — lift is the shipped default, slam/redirect are other values of the same params, not code paths. Converted by scripts/build_config.py into the derived data/generated/gravity_config.tres (GravityConfig).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "mp_cost",
+    "wine_mp_restore",
+    "field_direction",
+    "field_strength",
+    "field_radius",
+    "field_duration",
+    "field_color",
+    "field_fade_duration",
+    "field_spawn_offset",
+    "enemy_max_gravity_offset",
+    "obstacle_color",
+    "obstacle_size",
+    "obstacle_position",
+    "obstacle_max_gravity_offset"
+  ],
+  "properties": {
+    "mp_cost": {
+      "description": "MP spent per Gravity Gun fire — the game's only MP sink; strictly positive (a free fire would unbudget the change-gravity pillar).",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "wine_mp_restore": {
+      "description": "MP restored by drinking Wine (the S3 minimal hook; the full Consumable system is S7); strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "field_direction": {
+      "description": "Direction of the field velocity as (x, y); normalized at runtime, so only the direction matters. Godot is +Y-down: lift = [0, -1] (the shipped fire default), slam = [0, 1], redirect = a horizontal or diagonal vector (gADR-0002).",
+      "type": "array",
+      "items": { "type": "number" },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "field_strength": {
+      "description": "Magnitude of the field velocity in px/s; strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "field_radius": {
+      "description": "Radius of the circular field area in pixels; strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "field_duration": {
+      "description": "Seconds the field ACTS before expiring (the effect window; the fade-out after it is visual only); strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "field_color": {
+      "description": "Field block color as RGBA, each component in 0..1; the alpha carries the field's translucency.",
+      "type": "array",
+      "items": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+      "minItems": 4,
+      "maxItems": 4
+    },
+    "field_fade_duration": {
+      "description": "Seconds of the spawn fade-in and expiry fade-out tweens (the field's blockout animation); strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "field_spawn_offset": {
+      "description": "Field spawn offset (x, y) in pixels from the Player origin; x is scaled by facing (the Projectile's spawn pattern).",
+      "type": "array",
+      "items": { "type": "number" },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "enemy_max_gravity_offset": {
+      "description": "Max total displacement (px) Gravity Fields can accumulate on the static Enemy — the clamp of its clamped-displacement integration (gADR-0002); strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "obstacle_color": {
+      "description": "Obstacle block color as RGBA, each component in 0..1.",
+      "type": "array",
+      "items": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+      "minItems": 4,
+      "maxItems": 4
+    },
+    "obstacle_size": {
+      "description": "Obstacle block size (width, height) in pixels; each strictly positive.",
+      "type": "array",
+      "items": { "type": "number", "exclusiveMinimum": 0.0 },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "obstacle_position": {
+      "description": "Obstacle center position (x, y) in pixels — the StaticBody2D origin. Placed clear of the Laser Gun's bolt line so the floating block never shields the Enemy.",
+      "type": "array",
+      "items": { "type": "number" },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "obstacle_max_gravity_offset": {
+      "description": "Max total displacement (px) Gravity Fields can accumulate on the Obstacle — the clamp of its clamped-displacement integration (gADR-0002); strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    }
+  }
+}

--- a/examples/platformer/panda-adventure/docs/gadr/0002-gravity-field-and-response-contract.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0002-gravity-field-and-response-contract.md
@@ -1,0 +1,96 @@
+---
+status: accepted
+---
+
+# Gravity Field: data-driven effect and the gravity-response contract
+
+S3 (issue #332) introduces the change-gravity pillar: the Gravity Gun spends MP
+and spawns a local Gravity Field that lifts/slams/redirects gravity-affectable
+obstacles and in-range enemies — never the Player. Two decisions fix HOW the
+field's effect is expressed and HOW bodies respond, because S4's Archetype
+enemies (which rewrite `EnemyController`) and every future obstacle/prop kind
+must keep interoperating with the field without touching it.
+
+## Decision 1 — the field's effect is data: velocity × radius × duration
+
+A Gravity Field's effect is fully described by config (`GravityConfig`, a
+derived Resource from `gravity_config.json`, gADR-0000): a **velocity vector**
+— `field_direction` (normalized, so strength stays the single magnitude
+authority) × `field_strength` (px/s) — applied within a circular
+`field_radius` for a bounded `field_duration`. **Lift** (upward, `[0, -1]`) is
+the shipped fire default; **slam** (`[0, 1]`) and **redirect**
+(horizontal/diagonal) are different DATA values of the same params, not extra
+code paths. This is the deliberate reading of the GDD's "lifting, slamming, or
+redirecting": one mechanism, three tunings — the pure decision is
+`GravitySystem.compute_field_velocity`.
+
+## Decision 2 — the gravity-response contract
+
+Any body a Gravity Field can act on:
+
+- joins the **`"gravity_affectable"`** group, and
+- implements **`func apply_gravity_field(field_velocity: Vector2, delta: float) -> void`**.
+
+The field calls the method **each physics frame** for every overlapping body
+that satisfies **both** requirements (the pure filter
+`GravityFieldController.should_affect` — a same-named method on a non-member
+is NOT driven); the body integrates the velocity **its own way**. The field knows
+no body kinds; bodies know no fields. S3 ships two responders, both static
+bodies integrating by **clamped position displacement** (the accumulated
+offset's length never exceeds a per-kind config max — pure decision:
+`GravitySystem.compute_clamped_offset`, so a field can move a block but never
+fling it off-level): `EnemyController` (S4's rewrite must preserve the group
+join in `_ready` plus the one method — kept as one self-contained block) and
+`ObstacleController`. A future `CharacterBody2D`/`RigidBody2D` responder
+integrates into its own velocity instead — same contract, different
+integration.
+
+**Never the Player — by mask, not code.** The field is an `Area2D` on layer 5
+`gravity_field`, masking `terrain|enemy` only: the Player's layer is invisible
+to it (the Projectile's mask-guarantee pattern). The gravity-affectable
+Obstacle lives on `terrain`, so plain terrain (the Platform) overlaps too and
+is filtered out by the group + method contract check.
+
+**MP economy.** Firing routes through `StatsSystem.spend_mp` — an
+all-or-nothing gate (at insufficient MP nothing is spent, no field spawns, so
+at 0 MP the Gravity Gun cannot fire). Wine restores through
+`StatsSystem.restore_mp`, capped at the stat block's `max_mp` — the cap is a
+parameter passed by the caller from its immutable `StatsConfig`, keeping
+config outside the runtime holder (gADR-0001). The S3 Wine hook is
+inventory-less (`drink_wine` restores directly); S7 owns the Consumable
+system's supply side.
+
+**Weapon switch.** `fire` fires the CURRENT weapon; `switch_weapon` toggles
+between the Laser Gun and the Gravity Gun (pure decision:
+`PlayerController.compute_next_weapon`; the spawn default is the Laser Gun, so
+pre-S3 combat flows are unchanged).
+
+## Considered options
+
+- **Group + duck-typed method (chosen).** Mirrors S2's `take_hit` duck-typing;
+  no base class or interface script to inherit, so S4 can rewrite
+  `EnemyController`'s hierarchy freely; new responder kinds are a group join +
+  one method + a config row, with zero field changes.
+- **A shared gravity-body base class (rejected).** GDScript single inheritance
+  would force Enemy and Obstacle under one parent and fight S4's Archetype
+  hierarchy; the contract is one method — a class is more coupling than
+  content.
+- **The field displaces bodies directly (rejected).** The field would need to
+  know each body kind's clamp and physics; response belongs to the body
+  (tell-don't-ask), and a per-kind integration is exactly what S4's moving
+  enemies will need.
+- **A global gravity toggle (rejected).** The GDD explicitly makes the field
+  LOCAL and the Player exempt; world-gravity flips are a different (rejected)
+  game.
+
+## Consequences
+
+- S4's enemy rewrite carries the self-contained gravity block over verbatim;
+  its moving enemies may re-integrate (velocity instead of displacement)
+  without touching the field or this contract.
+- Field tuning (including switching the default from lift to slam/redirect) is
+  a JSON edit; the logic seam pins the velocity/clamp math, the e2e pins the
+  live loop (spend → spawn → lift → clamp → block at 0 MP → Wine).
+- The collision-layer story completes: layer 5 `gravity_field` is the field's
+  own layer; what the field can act on is its mask (`terrain|enemy`), and the
+  Player's exemption is topology, not a code check.

--- a/examples/platformer/panda-adventure/docs/project-manifest-notes.md
+++ b/examples/platformer/panda-adventure/docs/project-manifest-notes.md
@@ -15,18 +15,24 @@ longer by hand-editing. The `data/generated/*.tres` it loads are derived artifac
 that are COMMITTED (a freshness gate keeps them byte-identical to a fresh build),
 regenerated from JSON via `scripts/build_config.py` (gADR-0000).
 
-**`[input]`.** S1 player-traversal actions plus the S2 `fire` action.
-`move_left`/`move_right`/`jump`/`fire` are consumed by PlayerController
-(`Input.get_axis` / `is_action_just_pressed`) and driven in the live e2e by
-`gda input action`. Each movement action binds an arrow key plus a WASD/Space
-alternative; `fire` binds J plus F. Originally hand-serialized (Godot's own
+**`[input]`.** S1 player-traversal actions plus the S2 `fire` action and the S3
+weapon/consumable actions. `move_left`/`move_right`/`jump`/`fire`/
+`switch_weapon`/`drink_wine` are consumed by PlayerController (`Input.get_axis`
+/ `is_action_just_pressed`) and driven in the live e2e by `gda input action`.
+Each movement action binds an arrow key plus a WASD/Space alternative; `fire`
+binds J plus F; `switch_weapon` binds Q plus Tab; `drink_wine` binds R. `fire`
+fires the CURRENT weapon — Laser Gun by default, Gravity Gun after
+`switch_weapon` (gADR-0002). Originally hand-serialized (Godot's own
 `var_to_str` output); since gda #380 landed, actions are authored with
 `gda project add-input-action <name> --key <k>...` instead.
 
-**`[layer_names]`.** S2 collision topology — structural wiring, not balance data
-(gADR-0000 governs config NUMBERS; what-can-damage-what lives here and in the
-scenes): 1 `terrain`, 2 `player`, 3 `enemy`, 4 `projectile`, 5 `gravity_field`
-(reserved for S3's Gravity Field).
+**`[layer_names]`.** S2+S3 collision topology — structural wiring, not balance
+data (gADR-0000 governs config NUMBERS; what-can-act-on-what lives here and in
+the scenes): 1 `terrain`, 2 `player`, 3 `enemy`, 4 `projectile`, 5
+`gravity_field`. Layer 5 is IN USE since S3: the Gravity Field Area2D
+(`gravity_field.tscn`, runtime-instanced by PlayerController) sits ON layer 5
+and masks `terrain|enemy` (5) — the Player's layer is invisible to it, which is
+the never-on-the-Player guarantee (gADR-0002, the Projectile's mask pattern).
 
 **`[debug]`.** Godot's default desktop file logging is disabled so no engine
 launch writes a shared `user://logs/godot.log` (the #180 RotatedFileLogger race
@@ -44,12 +50,20 @@ see `AGENTS.md` ("The gda daemon harness is COMMITTED").
 
 ## `scenes/main.tscn`
 
-Panda Adventure's main scene (S1 player traversal + S2 combat), hand-bootstrapped,
-now edited via gda scene ops. **Structure only**: every visual (color/size/position)
-and the collision-shape sizes are applied at RUNTIME from the derived config
-Resources by the controllers (gADR-0000 — no config baked into the scene). The
-`RectangleShape2D` sub-resources start at a placeholder size that `_ready`
-overwrites from config. Collision topology (S2, see `[layer_names]` above):
-Platform=`terrain`(1), Player=`player`(2) masking terrain only (passes through the
-Enemy — contact damage is S4). The Enemy is runtime-instanced by LevelController
-from `enemy.tscn`; Projectiles are runtime-instanced by PlayerController.
+Panda Adventure's main scene (S1 player traversal + S2 combat + S3 gravity),
+hand-bootstrapped, now edited via gda scene ops. **Structure only**: every visual
+(color/size/position) and the collision-shape sizes are applied at RUNTIME from
+the derived config Resources by the controllers (gADR-0000 — no config baked into
+the scene). The `RectangleShape2D` sub-resources start at a placeholder size that
+`_ready` overwrites from config. Collision topology (S2+S3, see `[layer_names]`
+above): Platform=`terrain`(1), Player=`player`(2) masking terrain only (passes
+through the Enemy — contact damage is S4), Obstacle=`terrain`(1) masking nothing.
+The Enemy is runtime-instanced by LevelController from `enemy.tscn`; Projectiles
+and Gravity Fields are runtime-instanced by PlayerController (from
+`projectile.tscn` / `gravity_field.tscn`).
+
+The S3 `Obstacle` (StaticBody2D + Visual + Collision, script
+`obstacle_controller.gd`) is the gravity-affectable environment prop: it floats
+clear of the Laser Gun's bolt line (placement is config —
+`GravityConfig.obstacle_position`, applied in `_ready`), the Player walks and
+jumps under it, and only a Gravity Field moves it (gADR-0002).

--- a/examples/platformer/panda-adventure/project.godot
+++ b/examples/platformer/panda-adventure/project.godot
@@ -48,6 +48,17 @@ fire={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":70,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+switch_weapon={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":81,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194306,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+drink_wine={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":82,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 

--- a/examples/platformer/panda-adventure/scenes/gravity_field.tscn
+++ b/examples/platformer/panda-adventure/scenes/gravity_field.tscn
@@ -1,0 +1,12 @@
+[gd_scene format=3]
+
+[ext_resource type="Script" path="res://src/controllers/gravity_field_controller.gd" id="1_5jdl6"]
+
+[node name="GravityField" type="Area2D" unique_id=1961673278]
+collision_layer = 16
+collision_mask = 5
+script = ExtResource("1_5jdl6")
+
+[node name="Visual" type="ColorRect" parent="." unique_id=1335456989]
+
+[node name="Collision" type="CollisionShape2D" parent="." unique_id=233160367]

--- a/examples/platformer/panda-adventure/scenes/main.tscn
+++ b/examples/platformer/panda-adventure/scenes/main.tscn
@@ -1,18 +1,19 @@
 [gd_scene format=3]
 
-[ext_resource type="Script" path="res://src/controllers/level_controller.gd" id="1_lkauy"]
-[ext_resource type="Script" path="res://src/controllers/player_controller.gd" id="2_85amh"]
+[ext_resource type="Script" path="res://src/controllers/level_controller.gd" id="1_f5q0d"]
+[ext_resource type="Script" path="res://src/controllers/player_controller.gd" id="2_idpsm"]
+[ext_resource type="Script" path="res://src/controllers/obstacle_controller.gd" id="3_e5m6w"]
 
 [sub_resource type="RectangleShape2D" id="PlayerShape"]
 
 [sub_resource type="RectangleShape2D" id="PlatformShape"]
 
 [node name="Main" type="Node2D" unique_id=1303069056]
-script = ExtResource("1_lkauy")
+script = ExtResource("1_f5q0d")
 
 [node name="Player" type="CharacterBody2D" parent="." unique_id=190221684]
 collision_layer = 2
-script = ExtResource("2_85amh")
+script = ExtResource("2_idpsm")
 
 [node name="Visual" type="ColorRect" parent="Player" unique_id=1589511213]
 
@@ -27,3 +28,11 @@ shape = SubResource("PlayerShape")
 
 [node name="Collision" type="CollisionShape2D" parent="Platform" unique_id=1288880102]
 shape = SubResource("PlatformShape")
+
+[node name="Obstacle" type="StaticBody2D" parent="." unique_id=809261887]
+collision_mask = 0
+script = ExtResource("3_e5m6w")
+
+[node name="Visual" type="ColorRect" parent="Obstacle" unique_id=356445025]
+
+[node name="Collision" type="CollisionShape2D" parent="Obstacle" unique_id=1884195731]

--- a/examples/platformer/panda-adventure/scripts/build_config.py
+++ b/examples/platformer/panda-adventure/scripts/build_config.py
@@ -8,12 +8,14 @@ Godot Resources under ``data/generated/`` that the runtime ``load()``s. Every
 byte-identical to a fresh build), never hand-edited: changing config means
 changing the JSON.
 
-Two sources feed four outputs (the ``SPECS`` table):
+Three sources feed five outputs (the ``SPECS`` table):
 
 - ``player_config.json`` -> ``player_config.tres`` (``PlayerConfig``, S1)
 - ``combat_config.json`` -> ``stats_player.tres`` + ``stats_enemy.tres``
   (``StatsConfig`` stat blocks, gADR-0001) and ``combat_config.tres``
   (``CombatConfig``) — S2
+- ``gravity_config.json`` -> ``gravity_config.tres`` (``GravityConfig``,
+  gADR-0002) — S3
 
 Dogfooding note: since gda's ADR-0032 static class_name scan (issue #360), ``gda
 resource create --type PlayerConfig`` CAN instantiate a project-local class in
@@ -102,6 +104,23 @@ _COMBAT_FIELDS: list[tuple[str, str]] = [
     ("hit_flash_duration", "float"),
 ]
 
+_GRAVITY_FIELDS: list[tuple[str, str]] = [
+    ("mp_cost", "float"),
+    ("wine_mp_restore", "float"),
+    ("field_direction", "vec2"),
+    ("field_strength", "float"),
+    ("field_radius", "float"),
+    ("field_duration", "float"),
+    ("field_color", "color"),
+    ("field_fade_duration", "float"),
+    ("field_spawn_offset", "vec2"),
+    ("enemy_max_gravity_offset", "float"),
+    ("obstacle_color", "color"),
+    ("obstacle_size", "vec2"),
+    ("obstacle_position", "vec2"),
+    ("obstacle_max_gravity_offset", "float"),
+]
+
 _PLAYER_SPEC = TresSpec(
     json_rel="data/json/player_config.json",
     schema_rel="data/schema/player_config.schema.json",
@@ -142,6 +161,15 @@ SPECS: list[TresSpec] = [
         script_class="CombatConfig",
         ext_id="1_combatconfig",
         fields=_COMBAT_FIELDS,
+    ),
+    TresSpec(
+        json_rel="data/json/gravity_config.json",
+        schema_rel="data/schema/gravity_config.schema.json",
+        out_rel="data/generated/gravity_config.tres",
+        script_res_path="res://src/resources/gravity_config.gd",
+        script_class="GravityConfig",
+        ext_id="1_gravityconfig",
+        fields=_GRAVITY_FIELDS,
     ),
 ]
 

--- a/examples/platformer/panda-adventure/src/controllers/enemy_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/enemy_controller.gd
@@ -46,6 +46,7 @@ func _ready() -> void:
 	_stats = StatsSystemScript.new()
 	_stats.init_from(_stats_config)
 	_apply_blockout(_combat)
+	add_to_group("gravity_affectable")  # gADR-0002 contract; see the S3 block below
 	GameLogScript.emit("info", "enemy_ready", {
 		"max_hp": _stats_config.max_hp,
 		"x": position.x,
@@ -105,3 +106,38 @@ func _play_hit_flash() -> void:
 		visual, "color", _combat.enemy_color, _combat.hit_flash_duration
 	)
 	recover.set_trans(Tween.TRANS_SINE)
+
+
+# --- S3 gravity-response contract (gADR-0002) --------------------------------
+# Kept as ONE self-contained block (plus the group join in _ready) so S4's
+# Archetype rewrite can carry it over verbatim: any body a Gravity Field acts
+# on joins "gravity_affectable" and implements apply_gravity_field.
+
+const GravityConfigScript := preload("res://src/resources/gravity_config.gd")
+const GravitySystemScript := preload("res://src/systems/gravity_system.gd")
+const GRAVITY_CONFIG_PATH := "res://data/generated/gravity_config.tres"
+
+# Lazily loaded (load() is cached) so this block stays independent of _ready.
+var _gravity_config: GravityConfigScript
+# Total displacement Gravity Fields have accumulated on this body — clamped at
+# config.enemy_max_gravity_offset, so a field can never fling it off-level.
+var _gravity_offset := Vector2.ZERO
+
+
+## Gravity-response contract (gADR-0002): a Gravity Field feeds this body its
+## field velocity each overlapping physics frame; this static Enemy integrates
+## it as clamped position displacement (pure decision in GravitySystem).
+func apply_gravity_field(field_velocity: Vector2, delta: float) -> void:
+	if _gravity_config == null:
+		_gravity_config = load(GRAVITY_CONFIG_PATH)
+		if _gravity_config == null:
+			push_error(
+				"EnemyController: could not load %s — run scripts/build_config.py."
+				% GRAVITY_CONFIG_PATH
+			)
+			return
+	var next := GravitySystemScript.compute_clamped_offset(
+		_gravity_offset, field_velocity, delta, _gravity_config.enemy_max_gravity_offset
+	)
+	position += next - _gravity_offset
+	_gravity_offset = next

--- a/examples/platformer/panda-adventure/src/controllers/gravity_field_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/gravity_field_controller.gd
@@ -1,0 +1,118 @@
+class_name GravityFieldController
+extends Area2D
+
+## Drives one Gravity Field: the localized region of altered gravity the
+## Gravity Gun spawns. Each physics frame it feeds its data-driven field
+## velocity to every overlapping gravity-affectable body — the gADR-0002
+## response contract: bodies opt in via the "gravity_affectable" group and
+## `apply_gravity_field(field_velocity, delta)`; the field calls the method,
+## the body integrates the velocity its own way.
+##
+## It NEVER acts on the Player — collision topology, not code: the field sits
+## on layer 5 `gravity_field` and masks terrain|enemy only, so the Player's
+## layer is invisible to it (the Projectile's mask-guarantee pattern). Plain
+## terrain (the Platform) does overlap and is filtered out by should_affect
+## (group + method, the full opt-in contract).
+##
+## Everything numeric is data (gADR-0000): the derived GravityConfig. The
+## EFFECT is data too (gADR-0002): velocity = direction x strength, bounded by
+## radius (CircleShape2D) and duration — lift is the shipped default,
+## slam/redirect are config values. The blockout "animation" is the spawn
+## fade-in / expiry fade-out modulate tween (property interpolation, GDD).
+## Cross-script references use preload() (no editor class cache in this
+## never-imported project).
+
+const GravityConfigScript := preload("res://src/resources/gravity_config.gd")
+const GravitySystemScript := preload("res://src/systems/gravity_system.gd")
+const GameLogScript := preload("res://src/util/game_log.gd")
+
+const CONFIG_PATH := "res://data/generated/gravity_config.tres"
+
+var _config: GravityConfigScript
+var _field_velocity := Vector2.ZERO
+
+
+func _ready() -> void:
+	_config = load(CONFIG_PATH)
+	if _config == null:
+		# The derived .tres is committed; guard loudly rather than crash on a
+		# half-checkout, pointing at the pipeline that regenerates it from JSON.
+		push_error(
+			"GravityFieldController: could not load %s — run scripts/build_config.py." % CONFIG_PATH
+		)
+		queue_free()
+		return
+	_field_velocity = GravitySystemScript.compute_field_velocity(
+		_config.field_direction, _config.field_strength
+	)
+	_apply_blockout(_config)
+	_play_spawn_tween()
+	# Bounded lifetime: act for field_duration, then fade out and free.
+	get_tree().create_timer(_config.field_duration).timeout.connect(_expire)
+	GameLogScript.emit("info", "gravity_field_spawned", {
+		"x": position.x,
+		"y": position.y,
+		"velocity_x": _field_velocity.x,
+		"velocity_y": _field_velocity.y,
+		"radius": _config.field_radius,
+		"duration": _config.field_duration,
+	})
+
+
+## Pure contract filter (gADR-0002): a body is affected only when it opted in
+## on BOTH axes — "gravity_affectable" group membership AND the
+## apply_gravity_field method. Either alone is not the contract: a same-named
+## method on a non-member must not be driven, and a member without the method
+## has nothing to call. Static and field-state-free so the logic seam exercises
+## exactly the rule the overlap loop runs.
+static func should_affect(body: Node) -> bool:
+	return body.is_in_group("gravity_affectable") and body.has_method("apply_gravity_field")
+
+
+## Feed the field velocity to every overlapping gravity-affectable body, each
+## physics frame while the field is live. Per-frame — so NOT logged (spawn and
+## expiry are the log events; gda logger tail must stay legible, not per-frame
+## spam). should_affect — group AND method — is the contract filter (gADR-0002);
+## the mask already guarantees the Player is never among the overlaps.
+func _physics_process(delta: float) -> void:
+	if _config == null:
+		return
+	for body in get_overlapping_bodies():
+		if should_affect(body):
+			body.apply_gravity_field(_field_velocity, delta)
+
+
+## Apply the data-driven blockout: a translucent square block over a circular
+## collision area of the config radius, both centered on the Area2D origin.
+## The collision shape is CREATED here (CircleShape2D.new sized from config):
+## gda cannot author inline sub-resources (#365), so the scene ships shape=null.
+func _apply_blockout(config: GravityConfigScript) -> void:
+	var side := config.field_radius * 2.0
+
+	var visual := $Visual as ColorRect
+	visual.color = config.field_color
+	visual.size = Vector2(side, side)
+	visual.position = -Vector2(config.field_radius, config.field_radius)
+
+	var shape := CircleShape2D.new()
+	shape.radius = config.field_radius
+	($Collision as CollisionShape2D).shape = shape
+
+
+## The blockout "animation", spawn half: fade the field block in from
+## transparent to its config color (a property-tween, per the GDD).
+func _play_spawn_tween() -> void:
+	var visual := $Visual as ColorRect
+	visual.modulate.a = 0.0
+	var tween := create_tween()
+	tween.tween_property(visual, "modulate:a", 1.0, _config.field_fade_duration)
+
+
+## Expiry: stop acting IMMEDIATELY (field_duration bounds the effect window;
+## the fade-out after it is visual only), then tween the block out and free.
+func _expire() -> void:
+	set_physics_process(false)
+	GameLogScript.emit("info", "gravity_field_expired", {"x": position.x, "y": position.y})
+	var tween := create_tween()
+	tween.tween_property($Visual, "modulate:a", 0.0, _config.field_fade_duration)
+	tween.tween_callback(queue_free)

--- a/examples/platformer/panda-adventure/src/controllers/obstacle_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/obstacle_controller.gd
@@ -1,0 +1,69 @@
+class_name ObstacleController
+extends StaticBody2D
+
+## Drives the S3 Obstacle block: a gravity-affectable environment prop, floating
+## on the terrain layer, that a Gravity Field can lift/slam/redirect. It applies
+## its data-driven blockout + placement in _ready and joins the
+## "gravity_affectable" group — the gADR-0002 response contract — integrating
+## the field velocity as clamped position displacement (the pure decision in
+## GravitySystem). It never moves on its own and damages nothing.
+##
+## All numbers come from the derived GravityConfig (gADR-0000). Cross-script
+## references use preload() (no editor class cache in this never-imported
+## project).
+
+const GravityConfigScript := preload("res://src/resources/gravity_config.gd")
+const GravitySystemScript := preload("res://src/systems/gravity_system.gd")
+const GameLogScript := preload("res://src/util/game_log.gd")
+
+const CONFIG_PATH := "res://data/generated/gravity_config.tres"
+
+var _config: GravityConfigScript
+# Total displacement Gravity Fields have accumulated on this body — clamped at
+# config.obstacle_max_gravity_offset (gADR-0002), so it can never leave level.
+var _gravity_offset := Vector2.ZERO
+
+
+func _ready() -> void:
+	_config = load(CONFIG_PATH)
+	if _config == null:
+		# The derived .tres is committed; guard loudly rather than crash on a
+		# half-checkout, pointing at the pipeline that regenerates it from JSON.
+		push_error(
+			"ObstacleController: could not load %s — run scripts/build_config.py." % CONFIG_PATH
+		)
+		return
+	position = _config.obstacle_position
+	_apply_blockout(_config)
+	add_to_group("gravity_affectable")
+	GameLogScript.emit("info", "obstacle_ready", {"x": position.x, "y": position.y})
+
+
+## Gravity-response contract (gADR-0002): a Gravity Field feeds this body its
+## field velocity each overlapping physics frame; this static block integrates
+## it as clamped position displacement.
+func apply_gravity_field(field_velocity: Vector2, delta: float) -> void:
+	if _config == null:
+		return
+	var next := GravitySystemScript.compute_clamped_offset(
+		_gravity_offset, field_velocity, delta, _config.obstacle_max_gravity_offset
+	)
+	position += next - _gravity_offset
+	_gravity_offset = next
+
+
+## Apply the data-driven blockout: the Obstacle block centered on the body
+## origin. The collision shape is CREATED here (RectangleShape2D.new sized from
+## config): gda cannot author inline sub-resources (#365), so the scene ships
+## shape=null.
+func _apply_blockout(config: GravityConfigScript) -> void:
+	var half := config.obstacle_size / 2.0
+
+	var visual := $Visual as ColorRect
+	visual.color = config.obstacle_color
+	visual.size = config.obstacle_size
+	visual.position = -half
+
+	var shape := RectangleShape2D.new()
+	shape.size = config.obstacle_size
+	($Collision as CollisionShape2D).shape = shape

--- a/examples/platformer/panda-adventure/src/controllers/player_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/player_controller.gd
@@ -12,6 +12,13 @@ extends CharacterBody2D
 ## Player owns its live StatsSystem (all four stats; HP untouched until S4's
 ## enemy->Player damage).
 ##
+## S3 adds the Gravity Gun + weapon switch + MP economy (gADR-0002):
+## `switch_weapon` toggles which gun `fire` fires (the Laser Gun is the spawn
+## default), the Gravity Gun spends MP (StatsSystem.spend_mp — at 0 MP it
+## cannot fire) to spawn a Gravity Field, and `drink_wine` restores MP (the
+## minimal Wine hook; the full Consumable system is S7). See the S3 block at
+## the end of this file.
+##
 ## Movement params and visuals are data (gADR-0000): a derived PlayerConfig
 ## Resource, never hardcoded. compute_velocity is static and node-free so the
 ## logic seam can exercise it headless (tests/gdscript/test_player_logic.gd via
@@ -137,8 +144,12 @@ func _physics_process(delta: float) -> void:
 	if is_on_floor() and not was_on_floor:
 		_play_landing_tween()
 
+	if Input.is_action_just_pressed("switch_weapon"):
+		_switch_weapon()
+	if Input.is_action_just_pressed("drink_wine"):
+		_drink_wine()
 	if Input.is_action_just_pressed("fire"):
-		_fire()
+		_fire_current_weapon()
 
 
 ## Fire the Laser Gun: spawn one Projectile bolt aimed by the facing, offset
@@ -169,3 +180,101 @@ func _play_landing_tween() -> void:
 	var recover := tween.tween_property(visual, "scale", Vector2.ONE, _config.landing_tween_duration)
 	recover.set_trans(Tween.TRANS_SINE)
 	GameLogScript.emit("info", "player_land", {"floor_y": position.y})
+
+
+# --- S3 Gravity Gun + weapon switch + MP economy (gADR-0002) ------------------
+# Kept as ONE self-contained block: S4 adds take_hit/i-frames to this file in
+# parallel, so the S3 additions stay append-only (GDScript accepts class-level
+# declarations after methods).
+
+const GravityConfigScript := preload("res://src/resources/gravity_config.gd")
+const GravityFieldScene := preload("res://scenes/gravity_field.tscn")
+const GRAVITY_CONFIG_PATH := "res://data/generated/gravity_config.tres"
+
+# The two Equipment guns `fire` can drive. Structural identifiers (they name
+# code paths and log values, not tunable numbers — gADR-0000 governs numbers).
+const WEAPON_LASER := "laser_gun"
+const WEAPON_GRAVITY := "gravity_gun"
+
+# Current weapon — which gun `fire` fires. The spawn default is the Laser Gun.
+var _weapon := WEAPON_LASER
+# The derived GravityConfig, lazily loaded (load() is cached) so _ready's S2
+# load block stays untouched for the parallel S4 merge.
+var _gravity_cfg: GravityConfigScript
+
+
+## Pure weapon-switch decision: toggle between the two guns. Anything outside
+## the two-gun set falls back to the spawn default (Laser Gun), so the state
+## can never leave the set.
+static func compute_next_weapon(weapon: String) -> String:
+	return WEAPON_GRAVITY if weapon == WEAPON_LASER else WEAPON_LASER
+
+
+## `fire` fires the CURRENT weapon: the Laser Gun spawns a Projectile (_fire,
+## S2 unchanged), the Gravity Gun spends MP to spawn a Gravity Field.
+func _fire_current_weapon() -> void:
+	if _weapon == WEAPON_GRAVITY:
+		_fire_gravity_gun()
+	else:
+		_fire()
+
+
+func _switch_weapon() -> void:
+	_weapon = compute_next_weapon(_weapon)
+	GameLogScript.emit("info", "weapon_switched", {"weapon": _weapon})
+
+
+## Fire the Gravity Gun: spend MP first (StatsSystem.spend_mp is the gate — on
+## insufficient MP nothing is spent and no field spawns), then spawn one
+## Gravity Field offset from the Player origin by the config offset (x scaled
+## by the facing, the Projectile's spawn pattern). The field is a child of the
+## Player's PARENT (the level), so it stays fixed in world space.
+func _fire_gravity_gun() -> void:
+	var cfg := _gravity_config()
+	if cfg == null or _stats == null:
+		return
+	var mp_before := _stats.mp
+	if not _stats.spend_mp(cfg.mp_cost):
+		GameLogScript.emit("info", "gravity_blocked", {
+			"mp": _stats.mp,
+			"mp_cost": cfg.mp_cost,
+		})
+		return
+	var field := GravityFieldScene.instantiate()
+	var offset := cfg.field_spawn_offset
+	field.position = position + Vector2(_facing * offset.x, offset.y)
+	get_parent().add_child(field)
+	GameLogScript.emit("info", "gravity_fired", {
+		"mp_before": mp_before,
+		"mp_after": _stats.mp,
+		"field_x": field.position.x,
+		"field_y": field.position.y,
+	})
+
+
+## Drink Wine — the S3 minimal MP-restore hook (the full Consumable system with
+## inventory/counts is S7, so nothing is consumed from anywhere yet): restore
+## the config amount, capped at the stat block's max_mp.
+func _drink_wine() -> void:
+	var cfg := _gravity_config()
+	if cfg == null or _stats == null or _stats_config == null:
+		return
+	var mp_before := _stats.mp
+	_stats.restore_mp(cfg.wine_mp_restore, _stats_config.max_mp)
+	GameLogScript.emit("info", "wine_drunk", {
+		"mp_before": mp_before,
+		"mp_after": _stats.mp,
+	})
+
+
+## The derived GravityConfig with the standard loud guard, lazily loaded so the
+## S2 _ready block stays untouched.
+func _gravity_config() -> GravityConfigScript:
+	if _gravity_cfg == null:
+		_gravity_cfg = load(GRAVITY_CONFIG_PATH)
+		if _gravity_cfg == null:
+			push_error(
+				"PlayerController: could not load %s — run scripts/build_config.py."
+				% GRAVITY_CONFIG_PATH
+			)
+	return _gravity_cfg

--- a/examples/platformer/panda-adventure/src/resources/gravity_config.gd
+++ b/examples/platformer/panda-adventure/src/resources/gravity_config.gd
@@ -1,0 +1,49 @@
+class_name GravityConfig
+extends Resource
+
+## Typed gravity configuration for S3 (Gravity Gun + Gravity Field + MP economy).
+##
+## This Resource is a DERIVED artifact: it is regenerated from the authoritative
+## data/json/gravity_config.json by scripts/build_config.py (validated against
+## data/schema/gravity_config.schema.json) and emitted to
+## data/generated/gravity_config.tres. Never hand-edit the generated .tres or
+## hardcode these values — change the JSON (gADR-0000).
+##
+## The field's EFFECT is data (gADR-0002): direction x strength is the field
+## velocity, radius/duration bound it in space and time — lift is the shipped
+## fire default; slam/redirect are different values of the same fields, never
+## separate code paths.
+##
+## The @export fields carry NO default literals on purpose: a default would read
+## as a second config source competing with the authoritative JSON (gADR-0000).
+
+# MP economy — firing the Gravity Gun is the game's only MP sink; Wine is the
+# S3 minimal restore hook (the full Consumable system is S7).
+@export var mp_cost: float
+@export var wine_mp_restore: float
+
+# Gravity Field params — the data-driven effect (gADR-0002): velocity =
+# direction.normalized() * strength (px/s), acting within radius for duration
+# seconds. Godot is +Y-down: lift = (0, -1), slam = (0, 1).
+@export var field_direction: Vector2
+@export var field_strength: float
+@export var field_radius: float
+@export var field_duration: float
+
+# Field blockout + juice: the translucent block color, the spawn/expiry fade
+# tween seconds, and the spawn offset from the Player origin (x scaled by
+# facing, like the Projectile).
+@export var field_color: Color
+@export var field_fade_duration: float
+@export var field_spawn_offset: Vector2
+
+# Gravity-response clamp for the static Enemy (gADR-0002): the max total
+# displacement fields can accumulate on it (clamped-displacement integration).
+@export var enemy_max_gravity_offset: float
+
+# Obstacle block — the gravity-affectable environment prop (terrain layer):
+# blockout, placement, and its own displacement clamp.
+@export var obstacle_color: Color
+@export var obstacle_size: Vector2
+@export var obstacle_position: Vector2
+@export var obstacle_max_gravity_offset: float

--- a/examples/platformer/panda-adventure/src/systems/gravity_system.gd
+++ b/examples/platformer/panda-adventure/src/systems/gravity_system.gd
@@ -1,0 +1,34 @@
+class_name GravitySystem
+extends RefCounted
+
+## The pure gravity-field decisions for S3 (gADR-0002): the field velocity and
+## the clamped-displacement integration.
+##
+## Every function here is static, deterministic, and node/physics/clock-free —
+## the gADR-0001 decision shape. The Gravity Field controller and the
+## gravity-affectable bodies orchestrate (overlap scan, position mutation,
+## tween, log); decisions live only here, so the logic seam (and any future
+## balancing sim) exercises the same rules the runtime uses.
+
+
+## The field's velocity from its data params: direction, normalized so strength
+## stays the single magnitude authority, scaled by strength (px/s). Lift, slam,
+## and redirect are DATA — different directions through this one function,
+## never separate code paths (gADR-0002). A zero direction yields a null field
+## (Vector2.ZERO) rather than a NaN from normalizing a zero vector.
+static func compute_field_velocity(direction: Vector2, strength: float) -> Vector2:
+	if direction.is_zero_approx():
+		return Vector2.ZERO
+	return direction.normalized() * strength
+
+
+## Clamped-displacement integration for a static gravity-affectable body: one
+## physics frame advances the accumulated offset by field_velocity * delta, and
+## the TOTAL offset length is clamped to max_offset — a field can lift, slam,
+## or redirect a static block, but never fling it off-level. The body applies
+## the delta between the returned and the stored offset to its position, then
+## stores the new offset.
+static func compute_clamped_offset(
+	offset: Vector2, field_velocity: Vector2, delta: float, max_offset: float
+) -> Vector2:
+	return (offset + field_velocity * delta).limit_length(max_offset)

--- a/examples/platformer/panda-adventure/src/systems/stats_system.gd
+++ b/examples/platformer/panda-adventure/src/systems/stats_system.gd
@@ -32,3 +32,21 @@ func init_from(config: StatsConfigScript) -> void:
 ## Deduct damage from HP, clamping at 0 (HP never goes negative).
 func apply_damage(amount: float) -> void:
 	hp = maxf(hp - amount, 0.0)
+
+
+## Spend MP on a Gravity Gun fire — the game's only MP sink (S3, issue #332).
+## All-or-nothing gate: when the full cost is affordable it is deducted and
+## true is returned; otherwise NOTHING is spent and false is returned (so at
+## 0 MP the Gravity Gun cannot fire, and MP never goes negative).
+func spend_mp(cost: float) -> bool:
+	if mp < cost:
+		return false
+	mp -= cost
+	return true
+
+
+## Restore MP (the S3 Wine hook), capped at the actor's max_mp. The cap is a
+## PARAMETER, passed by the caller from its immutable stat block — config data
+## stays outside this runtime holder (gADR-0001).
+func restore_mp(amount: float, max_mp: float) -> void:
+	mp = minf(mp + amount, max_mp)

--- a/examples/platformer/panda-adventure/tests/gdscript/test_gravity_logic.gd
+++ b/examples/platformer/panda-adventure/tests/gdscript/test_gravity_logic.gd
@@ -1,0 +1,182 @@
+extends SceneTree
+
+## Logic seam (b) for S3: exercise the PURE gravity decisions headless —
+## PlayerController.compute_next_weapon (weapon-switch state), StatsSystem's
+## spend_mp / restore_mp (the MP economy rules), GravitySystem's
+## compute_field_velocity / compute_clamped_offset (the field's data-driven
+## effect and the clamped-displacement integration, gADR-0002), and
+## GravityFieldController.should_affect (the opt-in contract filter: group AND
+## method — either alone is not the contract). All static or
+## node/physics/clock-free, per the gADR-0001 decision shape.
+##
+## Run via gda (ADR-0031):
+##   gda script run res://tests/gdscript/test_gravity_logic.gd
+##
+## preload() the scripts (a headless runtime has no editor-generated
+## global_script_class_cache, so bare class_name types would not resolve),
+## drive them with KNOWN values, and assert each rule. Prints
+## "LOGIC_SEAM: PASS" + quit(0) on success, else push_error + quit(1).
+
+const StatsSystemScript := preload("res://src/systems/stats_system.gd")
+const GravitySystemScript := preload("res://src/systems/gravity_system.gd")
+const PlayerControllerScript := preload("res://src/controllers/player_controller.gd")
+const GravityFieldControllerScript := preload("res://src/controllers/gravity_field_controller.gd")
+const ObstacleControllerScript := preload("res://src/controllers/obstacle_controller.gd")
+
+# Fixed MP-economy params so every expectation is exact.
+const MP_MAX := 50.0
+const MP_COST := 10.0
+const WINE_RESTORE := 15.0
+
+
+func _fail(msg: String) -> void:
+	push_error("LOGIC_SEAM: " + msg)
+	quit(1)
+
+
+func _init() -> void:
+	# Behavior 1 — weapon-switch state: `fire` fires the CURRENT weapon, and
+	# compute_next_weapon toggles it between the two Equipment guns; anything
+	# outside the two-gun set falls back to the spawn default (Laser Gun).
+	var laser: String = PlayerControllerScript.WEAPON_LASER
+	var gravity: String = PlayerControllerScript.WEAPON_GRAVITY
+	if PlayerControllerScript.compute_next_weapon(laser) != gravity:
+		_fail("switch: laser should toggle to gravity")
+		return
+	if PlayerControllerScript.compute_next_weapon(gravity) != laser:
+		_fail("switch: gravity should toggle back to laser")
+		return
+	if PlayerControllerScript.compute_next_weapon("bare_paws") != laser:
+		_fail("switch: unknown state should fall back to the laser default")
+		return
+
+	# Behavior 2 — spend_mp deducts when affordable and reports success. The MP
+	# rules operate on the live mp value alone (init_from is the combat seam's
+	# turf), so the holder is driven directly.
+	var stats := StatsSystemScript.new()
+	stats.mp = MP_MAX
+	if not stats.spend_mp(MP_COST):
+		_fail("spend: affordable cost should succeed")
+		return
+	if not is_equal_approx(stats.mp, MP_MAX - MP_COST):
+		_fail("spend: expected mp=%s, got %s" % [MP_MAX - MP_COST, stats.mp])
+		return
+
+	# Behavior 3 — exact-cost boundary: spending down to exactly 0 succeeds.
+	stats.mp = MP_COST
+	if not stats.spend_mp(MP_COST):
+		_fail("spend: exact-cost spend should succeed")
+		return
+	if not is_zero_approx(stats.mp):
+		_fail("spend: exact-cost spend should leave 0 MP, got %s" % stats.mp)
+		return
+
+	# Behavior 4 — at 0 MP the Gravity Gun cannot fire: refused, nothing spent.
+	if stats.spend_mp(MP_COST):
+		_fail("spend: at 0 MP the spend must be refused")
+		return
+	if not is_zero_approx(stats.mp):
+		_fail("spend: a refused spend must not change MP, got %s" % stats.mp)
+		return
+
+	# Behavior 5 — insufficient (but nonzero) MP: all-or-nothing, no partial spend.
+	stats.mp = MP_COST / 2.0
+	if stats.spend_mp(MP_COST):
+		_fail("spend: insufficient MP must be refused")
+		return
+	if not is_equal_approx(stats.mp, MP_COST / 2.0):
+		_fail("spend: a refused spend must not change MP, got %s" % stats.mp)
+		return
+
+	# Behavior 6 — restore_mp adds the Wine amount, capped at max_mp.
+	stats.mp = 0.0
+	stats.restore_mp(WINE_RESTORE, MP_MAX)
+	if not is_equal_approx(stats.mp, WINE_RESTORE):
+		_fail("restore: expected mp=%s, got %s" % [WINE_RESTORE, stats.mp])
+		return
+	stats.mp = MP_MAX - WINE_RESTORE / 3.0
+	stats.restore_mp(WINE_RESTORE, MP_MAX)
+	if not is_equal_approx(stats.mp, MP_MAX):
+		_fail("restore: overfill should clamp at max_mp, got %s" % stats.mp)
+		return
+	stats.restore_mp(WINE_RESTORE, MP_MAX)
+	if not is_equal_approx(stats.mp, MP_MAX):
+		_fail("restore: at max_mp the cap should hold, got %s" % stats.mp)
+		return
+
+	# Behavior 7 — compute_field_velocity: direction is normalized (strength is
+	# the single magnitude authority) and lift/slam/redirect are DATA — three
+	# directions through the ONE function (gADR-0002).
+	var lift := GravitySystemScript.compute_field_velocity(Vector2(0.0, -1.0), 260.0)
+	if not lift.is_equal_approx(Vector2(0.0, -260.0)):
+		_fail("velocity: lift expected (0, -260), got %s" % lift)
+		return
+	var slam := GravitySystemScript.compute_field_velocity(Vector2(0.0, 2.0), 100.0)
+	if not slam.is_equal_approx(Vector2(0.0, 100.0)):
+		_fail("velocity: slam should normalize a non-unit direction, got %s" % slam)
+		return
+	var redirect := GravitySystemScript.compute_field_velocity(Vector2(3.0, -4.0), 50.0)
+	if not redirect.is_equal_approx(Vector2(30.0, -40.0)):
+		_fail("velocity: redirect expected (30, -40), got %s" % redirect)
+		return
+	var null_field := GravitySystemScript.compute_field_velocity(Vector2.ZERO, 260.0)
+	if not null_field.is_equal_approx(Vector2.ZERO):
+		_fail("velocity: a zero direction must yield a null field, got %s" % null_field)
+		return
+
+	# Behavior 8 — compute_clamped_offset integrates velocity * delta and clamps
+	# the TOTAL offset length, then holds at the clamp (gADR-0002).
+	var v := Vector2(0.0, -260.0)
+	var offset := GravitySystemScript.compute_clamped_offset(Vector2.ZERO, v, 0.5, 200.0)
+	if not offset.is_equal_approx(Vector2(0.0, -130.0)):
+		_fail("offset: one step expected (0, -130), got %s" % offset)
+		return
+	offset = GravitySystemScript.compute_clamped_offset(offset, v, 0.5, 200.0)
+	if not offset.is_equal_approx(Vector2(0.0, -200.0)):
+		_fail("offset: accumulation should clamp at max length, got %s" % offset)
+		return
+	offset = GravitySystemScript.compute_clamped_offset(offset, v, 0.5, 200.0)
+	if not offset.is_equal_approx(Vector2(0.0, -200.0)):
+		_fail("offset: at the clamp further frames must hold, got %s" % offset)
+		return
+	var still := GravitySystemScript.compute_clamped_offset(offset, Vector2.ZERO, 0.5, 200.0)
+	if not still.is_equal_approx(offset):
+		_fail("offset: zero velocity must leave the offset unchanged, got %s" % still)
+		return
+	var diagonal := GravitySystemScript.compute_clamped_offset(
+		Vector2.ZERO, Vector2(300.0, -400.0), 1.0, 250.0
+	)
+	if not diagonal.is_equal_approx(Vector2(150.0, -200.0)):
+		_fail("offset: the clamp is a LENGTH limit, expected (150, -200), got %s" % diagonal)
+		return
+
+	# Behavior 9 — should_affect, the opt-in contract filter (gADR-0002): a
+	# body is affected only with BOTH the "gravity_affectable" group AND the
+	# apply_gravity_field method. An ObstacleController built off-tree has the
+	# method but no group (the join happens in _ready, which never ran), so it
+	# doubles as the method-only double; a plain Node2D in the group is the
+	# group-only double. add_to_group/is_in_group work off-tree (node-local
+	# group data), so no SceneTree attachment is needed.
+	var member: Node = ObstacleControllerScript.new()
+	member.add_to_group("gravity_affectable")
+	var method_only: Node = ObstacleControllerScript.new()
+	var group_only: Node = Node2D.new()
+	group_only.add_to_group("gravity_affectable")
+	var member_ok: bool = GravityFieldControllerScript.should_affect(member)
+	var method_only_ok: bool = GravityFieldControllerScript.should_affect(method_only)
+	var group_only_ok: bool = GravityFieldControllerScript.should_affect(group_only)
+	member.free()
+	method_only.free()
+	group_only.free()
+	if not member_ok:
+		_fail("filter: group + method should be affected")
+		return
+	if method_only_ok:
+		_fail("filter: a same-named method WITHOUT the group must not be affected")
+		return
+	if group_only_ok:
+		_fail("filter: group membership WITHOUT the method must not be affected")
+		return
+
+	print("LOGIC_SEAM: PASS")
+	quit(0)

--- a/examples/platformer/panda-adventure/tests/test_gravity_data_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_gravity_data_seam.py
@@ -1,0 +1,147 @@
+"""Data seam (a) for S3 Gravity Gun / Gravity Field / MP economy.
+
+Proves the JSON -> Resource pipeline (gADR-0000) for the S3 gravity config: the
+authoritative ``gravity_config.json`` validates against its schema, bad config
+is rejected, and the derived ``GravityConfig`` ``.tres`` round-trips back
+through gda with its declared Godot types. The byte-stable freshness gate is
+NOT duplicated here: ``test_combat_data_seam.py`` parametrizes it over
+``build_config.SPECS``, so the gravity spec is covered there automatically —
+this file only pins that the spec IS registered. Fast tier — never ``e2e``;
+the round-trip drives one-shot ``gda`` headless ops under the ``engine`` gate.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import jsonschema
+import pytest
+
+import build_config
+
+GRAVITY_JSON_PATH = build_config.GAME_DIR / "data/json/gravity_config.json"
+GRAVITY_SCHEMA_PATH = build_config.GAME_DIR / "data/schema/gravity_config.schema.json"
+GRAVITY_TRES_REL = "data/generated/gravity_config.tres"
+
+
+def _valid_config() -> dict:
+    """A fresh copy of a schema-valid gravity config to mutate into invalid variants."""
+    return {
+        "mp_cost": 10.0,
+        "wine_mp_restore": 15.0,
+        "field_direction": [0.0, -1.0],
+        "field_strength": 260.0,
+        "field_radius": 96.0,
+        "field_duration": 2.0,
+        "field_color": [0.35, 0.65, 1.0, 0.35],
+        "field_fade_duration": 0.25,
+        "field_spawn_offset": [120.0, 0.0],
+        "enemy_max_gravity_offset": 120.0,
+        "obstacle_color": [0.62, 0.45, 0.25, 1.0],
+        "obstacle_size": [40.0, 40.0],
+        "obstacle_position": [320.0, 360.0],
+        "obstacle_max_gravity_offset": 160.0,
+    }
+
+
+def _gravity_schema() -> dict:
+    return build_config.load_schema(GRAVITY_SCHEMA_PATH)
+
+
+def test_sample_json_passes_schema() -> None:
+    """The authoritative gravity config validates against its schema."""
+    config = build_config.load_json(GRAVITY_JSON_PATH)
+    assert build_config.validate_config(config, _gravity_schema()) is config
+
+
+def test_gravity_spec_registered_for_freshness_gate() -> None:
+    """The gravity spec is in SPECS, so the parametrized freshness gate covers it."""
+    assert GRAVITY_TRES_REL in [spec.out_rel for spec in build_config.SPECS]
+
+
+def _without(key: str) -> dict:
+    bad = _valid_config()
+    del bad[key]
+    return bad
+
+
+def _with(value: object, key: str) -> dict:
+    bad = copy.deepcopy(_valid_config())
+    bad[key] = value
+    return bad
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        _without("mp_cost"),  # missing economy scalar
+        _without("field_direction"),  # missing field param
+        _without("obstacle_position"),  # missing obstacle placement
+        _with(0, "mp_cost"),  # a free fire would unbudget the pillar
+        _with(-5.0, "wine_mp_restore"),  # restore must be strictly positive
+        _with(0, "field_strength"),  # strength strictly positive
+        _with(0, "field_radius"),  # radius strictly positive
+        _with(0, "field_duration"),  # effect window strictly positive
+        _with(0, "field_fade_duration"),  # fade tween strictly positive
+        _with(0, "enemy_max_gravity_offset"),  # clamp strictly positive
+        _with(0, "obstacle_max_gravity_offset"),  # clamp strictly positive
+        _with([0.0], "field_direction"),  # direction: too few components
+        _with([0.0, -1.0, 0.0], "field_direction"),  # direction: too many
+        _with([0.35, 0.65, 1.0], "field_color"),  # color: too few components
+        _with([0.35, 0.65, 1.5, 0.35], "field_color"),  # color: out of 0..1
+        _with([40.0], "obstacle_size"),  # size: too few components
+        _with([0.0, 40.0], "obstacle_size"),  # size: component must be > 0
+        _with([120.0, 0.0, 1.0], "field_spawn_offset"),  # offset: too many
+        _with("strong", "field_strength"),  # wrong type
+        {**_valid_config(), "extra": 1},  # unexpected extra top-level key
+    ],
+)
+def test_invalid_json_rejected(bad: dict) -> None:
+    """A gravity config that violates the schema raises jsonschema.ValidationError."""
+    with pytest.raises(jsonschema.ValidationError):
+        build_config.validate_config(bad, _gravity_schema())
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: the derived gravity .tres loads back through gda with its
+# declared Godot types, compared to the AUTHORITATIVE JSON (never hardcoded).
+# ---------------------------------------------------------------------------
+
+
+def _properties_by_name(get_result: dict) -> dict:
+    """Index a ``gda resource get`` result's ``properties`` list by name."""
+    return {p["name"]: p["value"] for p in get_result["properties"]}
+
+
+@pytest.mark.engine
+def test_gravity_config_round_trips(gda) -> None:
+    """The GravityConfig .tres round-trips every field through gda."""
+    config = build_config.load_json(GRAVITY_JSON_PATH)
+    result = gda("resource", "get", f"res://{GRAVITY_TRES_REL}", "--json")
+    assert result.returncode == 0, result.stdout + result.stderr
+    props = _properties_by_name(json.loads(result.stdout))
+
+    # Colors are float32 in Godot — compare with a tolerance.
+    for color_field in ("field_color", "obstacle_color"):
+        assert props[color_field] == pytest.approx(config[color_field], abs=1e-5)
+    # Vector2 fields.
+    for vec_field in (
+        "field_direction",
+        "field_spawn_offset",
+        "obstacle_size",
+        "obstacle_position",
+    ):
+        assert props[vec_field] == pytest.approx(config[vec_field])
+    # Scalar float fields.
+    for float_field in (
+        "mp_cost",
+        "wine_mp_restore",
+        "field_strength",
+        "field_radius",
+        "field_duration",
+        "field_fade_duration",
+        "enemy_max_gravity_offset",
+        "obstacle_max_gravity_offset",
+    ):
+        assert props[float_field] == pytest.approx(config[float_field])

--- a/examples/platformer/panda-adventure/tests/test_gravity_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_gravity_e2e.py
@@ -1,0 +1,364 @@
+"""Integration seam (c) for S3 Gravity Gun / Gravity Field / MP economy — THE gate.
+
+The full change-gravity loop through the gda CLI against a running Engine
+session:
+
+- ``gda game tree`` shows the scene-authored Obstacle; ``gda logger tail``
+  returns its data-driven ``obstacle_ready`` record;
+- ``fire`` fires the CURRENT weapon: before any switch it spawns a Laser bolt
+  (``laser_fired``), never a Gravity Field — the spawn default;
+- ``switch_weapon`` toggles to the Gravity Gun (``weapon_switched``) and
+  ``fire`` now spends MP (``gravity_fired {mp_before, mp_after}``) and spawns
+  a Gravity Field: the field is in the runtime tree, its ``gravity_field_
+  spawned`` record carries the data-driven velocity/radius/duration, the
+  in-range Obstacle is lifted, the out-of-range Enemy does NOT move (the field
+  is LOCAL), and the Player never moves off its resting y (never affected —
+  the collision mask, gADR-0002);
+- walking into range and firing again lifts the Enemy up to exactly its
+  config displacement clamp (clamped-displacement integration, gADR-0002);
+- repeated fires drain MP to 0; at 0 MP the fire is refused
+  (``gravity_blocked``, no new field) — the MP gate;
+- ``drink_wine`` restores MP (``wine_drunk``) and the Gravity Gun fires again;
+- switching back re-arms the Laser Gun (``laser_fired`` again) — the weapon
+  toggle round-trips.
+
+Every expectation derives from the AUTHORITATIVE JSON configs, never
+hardcoded. Per RULES.md, mocks cannot replace this end-to-end proof.
+
+Isolation: same throwaway-copy pattern as ``test_player_e2e`` (``daemon
+start`` mutates ``project.godot``); posix-only (AF_UNIX); headless —
+Linux-CI-friendly.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+import build_config
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+GDA_CMD = [sys.executable, "-m", "gda"]
+GODOT = resolve_godot_binary()
+GAME_DIR = build_config.GAME_DIR
+
+_COPY_IGNORE = shutil.ignore_patterns(
+    "tests", ".godot", "build", "generated", "__pycache__"
+)
+
+
+def _make_project_copy(dst: Path) -> Path:
+    """Copy the committed game into a throwaway dir and build its config there."""
+    shutil.copytree(GAME_DIR, dst, ignore=_COPY_IGNORE)
+    build_config.build_all(root=dst)
+    return dst
+
+
+def _find_node(node: dict, name: str) -> dict | None:
+    """Depth-first search a ``game tree`` subtree for a node by name."""
+    if node.get("name") == name:
+        return node
+    for child in node.get("children", []):
+        found = _find_node(child, name)
+        if found is not None:
+            return found
+    return None
+
+
+@pytest.mark.e2e
+def test_daemon_serves_gravity_loop(tmp_path, daemon_runtime_dir):
+    project = _make_project_copy(tmp_path / "game")
+    # Every expectation derives from the AUTHORITATIVE JSON, never hardcoded.
+    gravity = build_config.load_json(GAME_DIR / "data" / "json" / "gravity_config.json")
+    combat = build_config.load_json(GAME_DIR / "data" / "json" / "combat_config.json")
+    player_cfg = build_config.load_json(
+        GAME_DIR / "data" / "json" / "player_config.json"
+    )
+    mp_max = combat["player_stats"]["max_mp"]
+    mp_cost = gravity["mp_cost"]
+    wine_restore = gravity["wine_mp_restore"]
+    obstacle_pos = gravity["obstacle_position"]
+    enemy_pos = combat["enemy_position"]
+    enemy_clamp = gravity["enemy_max_gravity_offset"]
+    # The field velocity the runtime derives from the data (direction x strength).
+    direction = gravity["field_direction"]
+    length = math.hypot(*direction)
+    field_velocity = [c / length * gravity["field_strength"] for c in direction]
+    rest_y = (
+        player_cfg["platform_position"][1]
+        - player_cfg["platform_size"][1] / 2.0
+        - player_cfg["player_size"][1] / 2.0
+    )
+    start_x = player_cfg["player_start"][0]
+    env = {**os.environ}
+
+    def run(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(project),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    def records(message: str) -> list[dict]:
+        proc = run("logger", "tail")
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        return [
+            r
+            for r in json.loads(proc.stdout)["records"]
+            if r["message"] == message and r["origin"] == "gda_log"
+        ]
+
+    def poll(predicate, timeout: float = 20.0, interval: float = 0.5):
+        deadline = time.monotonic() + timeout
+        result = predicate()
+        while not result and time.monotonic() < deadline:
+            time.sleep(interval)
+            result = predicate()
+        return result
+
+    def node_position(path: str) -> list[float]:
+        got = run("game", "get", path, "--property", "position")
+        assert got.returncode == 0, got.stdout + got.stderr
+        for p in json.loads(got.stdout)["properties"]:
+            if p["name"] == "position":
+                return p["value"]
+        raise AssertionError(f"position not returned for {path}")
+
+    def tap(action: str) -> None:
+        """One press+release of an InputMap action (one is_action_just_pressed)."""
+        seq = run(
+            "input",
+            "sequence",
+            "--events",
+            json.dumps(
+                [
+                    {"type": "action", "action": action, "frame": 0},
+                    {"type": "action", "action": action, "release": True, "frame": 4},
+                ]
+            ),
+        )
+        assert seq.returncode == 0, seq.stdout + seq.stderr
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        # The scene-authored Obstacle is in the live tree; no field exists yet.
+        tree = run("game", "tree")
+        assert tree.returncode == 0, tree.stdout + tree.stderr
+        root = json.loads(tree.stdout)["root"]
+        obstacle = _find_node(root, "Obstacle")
+        assert obstacle is not None and obstacle["type"] == "StaticBody2D", root
+        assert _find_node(root, "GravityField") is None, root
+
+        # Its boot record carries the data-driven placement.
+        ready = poll(lambda: records("obstacle_ready"))
+        assert ready, "no gda_log 'obstacle_ready' record"
+        assert ready[0]["fields"]["x"] == pytest.approx(obstacle_pos[0])
+        assert ready[0]["fields"]["y"] == pytest.approx(obstacle_pos[1])
+
+        # Let the Player settle on the platform before firing (S1-proven poll).
+        assert poll(
+            lambda: abs(node_position("/root/Main/Player")[1] - rest_y) <= 2.0
+        ), "Player did not land before firing"
+
+        # --- Default weapon: `fire` fires the CURRENT weapon, and the spawn
+        # default is the Laser Gun — a bolt, never a Gravity Field, no MP spent.
+        tap("fire")
+        assert poll(lambda: records("laser_fired")), (
+            "the default-weapon fire should spawn a Laser bolt"
+        )
+        assert not records("gravity_fired"), (
+            "the default-weapon fire must not fire the Gravity Gun"
+        )
+
+        # --- Switch to the Gravity Gun.
+        tap("switch_weapon")
+        switched = poll(lambda: records("weapon_switched"))
+        assert switched, "no gda_log 'weapon_switched' record"
+        assert switched[-1]["fields"]["weapon"] == "gravity_gun"
+
+        # --- First gravity fire: spends MP from the S2 StatsSystem and spawns
+        # a field whose params are the authoritative data.
+        obstacle_before = node_position("/root/Main/Obstacle")
+        tap("fire")
+        fired = poll(lambda: records("gravity_fired"))
+        assert fired, "no gda_log 'gravity_fired' record"
+        assert fired[0]["fields"]["mp_before"] == pytest.approx(mp_max)
+        assert fired[0]["fields"]["mp_after"] == pytest.approx(mp_max - mp_cost)
+
+        spawned = poll(lambda: records("gravity_field_spawned"))
+        assert spawned, "no gda_log 'gravity_field_spawned' record"
+        assert spawned[0]["fields"]["velocity_x"] == pytest.approx(field_velocity[0])
+        assert spawned[0]["fields"]["velocity_y"] == pytest.approx(field_velocity[1])
+        assert spawned[0]["fields"]["radius"] == pytest.approx(gravity["field_radius"])
+        assert spawned[0]["fields"]["duration"] == pytest.approx(
+            gravity["field_duration"]
+        )
+
+        # The field is a real node in the runtime tree (checked within its
+        # config lifetime).
+        def field_in_tree() -> bool:
+            t = run("game", "tree")
+            assert t.returncode == 0, t.stdout + t.stderr
+            return _find_node(json.loads(t.stdout)["root"], "GravityField") is not None
+
+        assert poll(field_in_tree, timeout=gravity["field_duration"], interval=0.2), (
+            "the Gravity Field never appeared in the runtime scene tree"
+        )
+
+        # The in-range Obstacle is lifted (its y decreases: lift is the shipped
+        # upward default) without horizontal drift.
+        assert poll(
+            lambda: node_position("/root/Main/Obstacle")[1] < obstacle_before[1] - 10.0
+        ), "the Gravity Field did not lift the in-range Obstacle"
+        assert node_position("/root/Main/Obstacle")[0] == pytest.approx(
+            obstacle_before[0], abs=1.0
+        )
+
+        # The field is LOCAL: the far-away Enemy does not move...
+        assert node_position("/root/Main/Enemy") == pytest.approx(enemy_pos, abs=1.0), (
+            "the out-of-range Enemy must not be affected"
+        )
+        # ...and it NEVER acts on the Player (mask guarantee): still resting.
+        assert node_position("/root/Main/Player")[1] == pytest.approx(rest_y, abs=2.0)
+
+        # --- Walk into range of the Enemy, fire, and the field lifts it up to
+        # exactly the config displacement clamp (gADR-0002).
+        #
+        # Sequence `frame` offsets are IDLE frames, and a headless session's
+        # idle rate is decoupled from the 60Hz physics clock, so a fixed-length
+        # walk is not portable. Walk in SHORT bounded bursts with position
+        # feedback instead, until the Player is inside the (wide, geometry-
+        # derived) firing window: |field_center_x - enemy_x| within the field
+        # radius plus the Enemy's half width, with a safety margin.
+        reach = gravity["field_radius"] + combat["enemy_size"][0] / 2.0
+        walk_lo = enemy_pos[0] - gravity["field_spawn_offset"][0] - reach + 30.0
+        walk_hi = enemy_pos[0] - gravity["field_spawn_offset"][0] + reach - 30.0
+        walk_mid = (walk_lo + walk_hi) / 2.0
+
+        def burst_right() -> None:
+            seq = run(
+                "input",
+                "sequence",
+                "--events",
+                json.dumps(
+                    [
+                        {"type": "action", "action": "move_right", "frame": 0},
+                        {
+                            "type": "action",
+                            "action": "move_right",
+                            "release": True,
+                            "frame": 12,
+                        },
+                    ]
+                ),
+            )
+            assert seq.returncode == 0, seq.stdout + seq.stderr
+
+        player_x = start_x
+        for _ in range(40):
+            player_x = node_position("/root/Main/Player")[0]
+            if player_x >= walk_mid - 40.0:
+                break
+            burst_right()
+        assert walk_lo <= player_x <= walk_hi, (
+            f"the Player did not stop inside the firing window: x={player_x}, "
+            f"window=[{walk_lo}, {walk_hi}]"
+        )
+
+        tap("fire")
+        assert poll(lambda: len(records("gravity_fired")) >= 2), (
+            "the in-range fire should spend MP and spawn a field"
+        )
+        assert records("gravity_fired")[1]["fields"]["mp_after"] == pytest.approx(
+            mp_max - 2 * mp_cost
+        )
+        assert poll(
+            lambda: (
+                node_position("/root/Main/Enemy")[1]
+                == pytest.approx(enemy_pos[1] - enemy_clamp, abs=3.0)
+            )
+        ), "the in-range Enemy should be lifted to exactly its displacement clamp"
+        assert node_position("/root/Main/Enemy")[0] == pytest.approx(
+            enemy_pos[0], abs=1.0
+        )
+
+        # --- Drain the MP budget: every remaining full-cost fire succeeds...
+        fires_so_far = 2
+        n_more = int((mp_max - fires_so_far * mp_cost) // mp_cost)
+        leftover = mp_max - (fires_so_far + n_more) * mp_cost  # < mp_cost by def
+        for _ in range(n_more):
+            tap("fire")
+        total_fires = fires_so_far + n_more
+        assert poll(lambda: len(records("gravity_fired")) >= total_fires), (
+            f"expected {total_fires} gravity fires before the budget runs dry"
+        )
+        fired = records("gravity_fired")
+        assert len(fired) == total_fires
+        assert fired[-1]["fields"]["mp_after"] == pytest.approx(leftover)
+
+        # ...and the next fire is REFUSED: blocked record, no new field, MP intact.
+        tap("fire")
+        blocked = poll(lambda: records("gravity_blocked"))
+        assert blocked, "at insufficient MP the Gravity Gun must refuse to fire"
+        assert blocked[-1]["fields"]["mp"] == pytest.approx(leftover)
+        assert blocked[-1]["fields"]["mp_cost"] == pytest.approx(mp_cost)
+        assert len(records("gravity_fired")) == total_fires, (
+            "a refused fire must not spawn a field"
+        )
+
+        # --- Wine restores MP (capped at max), re-arming the Gravity Gun.
+        tap("drink_wine")
+        drunk = poll(lambda: records("wine_drunk"))
+        assert drunk, "no gda_log 'wine_drunk' record"
+        assert drunk[-1]["fields"]["mp_before"] == pytest.approx(leftover)
+        restored = min(leftover + wine_restore, mp_max)
+        assert drunk[-1]["fields"]["mp_after"] == pytest.approx(restored)
+
+        # Config sanity for the next step: one Wine must re-arm at least one fire.
+        assert restored >= mp_cost, "gravity_config: wine_mp_restore < mp_cost"
+        tap("fire")
+        assert poll(lambda: len(records("gravity_fired")) >= total_fires + 1), (
+            "after Wine the Gravity Gun should fire again"
+        )
+        assert records("gravity_fired")[-1]["fields"]["mp_after"] == pytest.approx(
+            restored - mp_cost
+        )
+
+        # --- Switch back: `fire` drives the Laser Gun again (the toggle
+        # round-trips; existing combat flows stay reachable).
+        tap("switch_weapon")
+        assert poll(
+            lambda: (
+                records("weapon_switched")
+                and records("weapon_switched")[-1]["fields"]["weapon"] == "laser_gun"
+            )
+        ), "switching back should re-arm the Laser Gun"
+        tap("fire")
+        assert poll(lambda: len(records("laser_fired")) >= 2), (
+            "after switching back, fire should spawn a Laser bolt again"
+        )
+    finally:
+        run("daemon", "stop")

--- a/examples/platformer/panda-adventure/tests/test_gravity_logic_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_gravity_logic_seam.py
@@ -1,0 +1,48 @@
+"""Logic seam (b) for S3 Gravity Gun / Gravity Field / MP economy.
+
+Exercises the pure S3 decisions — ``PlayerController.compute_next_weapon``
+(weapon-switch state), ``StatsSystem.spend_mp`` / ``restore_mp`` (the MP
+economy rules), and ``GravitySystem.compute_field_velocity`` /
+``compute_clamped_offset`` (the field's data-driven effect, gADR-0002) —
+headless, through ``gda script run`` (ADR-0031). Fast tier (``engine``
+marker), never ``e2e``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+_LOGIC_SCRIPT = "res://tests/gdscript/test_gravity_logic.gd"
+
+
+def _run(gda) -> subprocess.CompletedProcess:
+    return gda("script", "run", _LOGIC_SCRIPT, "--json")
+
+
+@pytest.mark.engine
+def test_logic_seam_gravity_decisions(gda) -> None:
+    """The pure S3 rules hold for every behavior the GDScript seam asserts.
+
+    The seam covers: the weapon-switch toggle (laser <-> gravity, unknown falls
+    back to the laser default), spend_mp (affordable / exact-cost boundary /
+    refused at 0 MP / all-or-nothing on insufficient MP), restore_mp (add,
+    clamp at max_mp, hold at the cap), compute_field_velocity (lift/slam/
+    redirect as data through one function, normalization, the zero-direction
+    null field), compute_clamped_offset (integration, the total-length
+    clamp, holding at the clamp, zero velocity, diagonal length-clamping), and
+    should_affect — the opt-in contract filter (gADR-0002): affected only with
+    BOTH the "gravity_affectable" group and the apply_gravity_field method
+    (negative cases: method without group, group without method). We read
+    gda's passed-through ``exit_status`` (0 == all assertions held) and
+    require the PASS marker in stdout.
+    """
+    result = _run(gda)
+    # gda itself succeeded (the script launched and ran to completion).
+    assert result.returncode == 0, result.stdout + result.stderr
+    doc = json.loads(result.stdout)
+    # The script's own exit_status is passed through: 0 == every assertion held.
+    assert doc["exit_status"] == 0, doc["stdout"] + doc["stderr"]
+    assert "LOGIC_SEAM: PASS" in doc["stdout"], doc["stdout"] + doc["stderr"]


### PR DESCRIPTION
## What

S3 slice (#332): the Player switches weapon (`switch_weapon`, Q/Tab) between the Laser Gun and the **Gravity Gun**; `fire` fires the **current** weapon (Laser stays the spawn default, so the S2 combat e2e is untouched). Firing the Gravity Gun spends MP (all-or-nothing `StatsSystem.spend_mp` — at 0 MP it cannot fire) and spawns a local **Gravity Field** (layer 5 `gravity_field`, mask terrain|enemy) that feeds a data-driven field velocity to overlapping bodies implementing the **gravity-response contract**; `drink_wine` (R) restores MP capped at max_mp (minimal Wine hook; Consumables are S7). New `data/json/gravity_config.json` → `GravityConfig` via the TresSpec pipeline (freshness-gated); a gravity-affectable Obstacle joins `scenes/main.tscn`.

## Key decisions (gADR-0002)

- **lift/slam/redirect = one mechanism, three tunings**: the field effect is a data vector (direction × strength × radius × duration); lift is the shipped default, slam/redirect are config values, not code paths.
- **Gravity-response contract (cross-slice ABI, S4 preserves it)**: bodies join group `"gravity_affectable"` and implement `apply_gravity_field(field_velocity: Vector2, delta: float)`; the Player never joins, and the field's mask never includes the player layer — "never on the Player" is topology plus opt-in, not a special case.
- InputMap actions authored with `gda project add-input-action` (#380) — first structured-authoring use on this project, enabled by the #388 manifest canonicalization.

## Acceptance criteria → evidence

All #332 ACs are covered by the three new seams (e2e asserts via `gda logger tail` structured events + `gda game tree`/`get`): field spawn on gravity fire; obstacle + in-range enemy lifted to the clamp, out-of-range enemy unmoved, Player unaffected; MP drain 50→0 then `gravity_blocked` with no new field; Wine 0→15 then an affordable fire; laser→gravity→laser round-trip.

## Verification (orchestrator-independent re-run)

- fast: `pytest -m "not e2e and not engine"` → **69 passed** (was 46)
- engine+e2e: `pytest -m "engine or e2e"` → **13 passed** (was 10), serial via the wave's e2e lock
- No existing test changed or weakened.

## Notes for review

- **Stacked on #388** (wave-0 prep: harness v5 + manifest comment migration) — merge #388 first; I'll rebase this branch after the squash-merge.
- Parallel S4 (#333) rewrites `enemy_controller.gd`; the S3 additions there are deliberately one `_ready` line + one appended self-contained block so the S4 version (which carries the same contract) wins the merge.
- gda feedback captured during the slice (input-sequence physics-frame anchoring; ext_resource id re-keying churn) will be filed separately.

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)