### PR TITLE
fix(scene): preserve ext_resource ids on mutation

### DIFF
--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -107,6 +107,13 @@ registered `missing_dependency` error (exit 4), leaving the file untouched. Rela
 of scripts already attached in the scene (#62) — treat headless mutation of an untrusted scene
 as running its code.
 
+Scene mutation writes also preserve existing `.tscn` `ext_resource` ids and matching
+`ExtResource("...")` references after Godot's text saver re-serializes the file. Matching is by
+the resource path's canonical `res://` form, so relative `path="..."` entries keep their old ids
+after Godot writes them as `res://...`. Other text-saver canonicalization remains Godot-owned:
+non-resource-id formatting may change, and duplicate `ext_resource` entries for the same path may
+collapse to one canonical entry; when that happens, `gda` keeps the first old id for that path.
+
 **Type resolution** (sharpened by #65): `node add --type` resolves a built-in `Node` class
 first, then a `class_name` from the project's global class list (which exists only after a
 project import — pass `--project`). A type that resolves to neither is refused with

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3254,6 +3254,27 @@ func _quoted_attr(line: String, attr: String) -> String:
 	return _first_quoted_after(line, idx + attr.length())
 
 
+# Like _quoted_attr, but matches a full attribute name. This matters for
+# ext_resource id="..." because uid="..." also contains the substring "id=".
+func _quoted_named_attr(line: String, attr_name: String) -> String:
+	var needle := attr_name + "="
+	var from := 0
+	while true:
+		var idx := line.find(needle, from)
+		if idx == -1:
+			return ""
+		var left_ok := (
+				idx == 0
+				or line[idx - 1] == " "
+				or line[idx - 1] == "\t"
+				or line[idx - 1] == "["
+		)
+		if left_ok:
+			return _first_quoted_after(line, idx + needle.length())
+		from = idx + 1
+	return ""
+
+
 # The contents of the first quoted string (single or double quotes) at/after
 # `from` in `text`, or "" when there is none. Used to pull the literal-string
 # argument out of preload("...") / load("...") / path="..." without compiling.
@@ -4537,15 +4558,175 @@ func _remove_quiet(path: String) -> void:
 		DirAccess.remove_absolute(path)
 
 
+# Restore ext_resource ids that already existed in the target .tscn before
+# ResourceSaver re-serialized it. Scope is deliberately narrow: match resources by
+# their normalized ext_resource path, rewrite only id="..." attributes and
+# ExtResource("...") references, and leave all other saver canonicalization alone
+# (issue #393). If ResourceSaver collapses duplicate entries for the same path, keep
+# the first old id for that canonical path rather than accepting a freshly generated
+# id.
+func _restore_existing_ext_resource_ids(
+		scene_path: String,
+		original_text: String,
+		saved_text: String) -> String:
+	if original_text.is_empty() or saved_text.is_empty():
+		return saved_text
+	var base_dir := scene_path.get_base_dir()
+	var original_ids := _ext_resource_ids_by_path(original_text, base_dir)
+	if original_ids.is_empty():
+		return saved_text
+	var saved_entries := _ext_resource_entries_from_text(saved_text, base_dir)
+	if saved_entries.is_empty():
+		return saved_text
+
+	var reserved_ids := {}
+	for entry in saved_entries:
+		var ref_path := String(entry["normalized_path"])
+		if original_ids.has(ref_path):
+			for old_id in original_ids[ref_path]:
+				reserved_ids[String(old_id)] = true
+	if reserved_ids.is_empty():
+		return saved_text
+
+	var used_ids := {}
+	var id_remap := {}
+	var path_positions := {}
+	for entry in saved_entries:
+		var saved_id := String(entry["id"])
+		var ref_path := String(entry["normalized_path"])
+		var final_id := saved_id
+		if original_ids.has(ref_path):
+			var position := int(path_positions.get(ref_path, 0))
+			var old_ids: Array = original_ids[ref_path]
+			if position < old_ids.size():
+				final_id = String(old_ids[position])
+			path_positions[ref_path] = position + 1
+		elif reserved_ids.has(final_id):
+			final_id = _fresh_ext_resource_id(saved_id, used_ids, reserved_ids)
+		if used_ids.has(final_id):
+			final_id = _fresh_ext_resource_id(saved_id, used_ids, reserved_ids)
+		used_ids[final_id] = true
+		if final_id != saved_id:
+			id_remap[saved_id] = final_id
+
+	if id_remap.is_empty():
+		return saved_text
+	return _replace_ext_resource_ids(saved_text, id_remap)
+
+
+func _raw_ext_resource_entries_from_text(text: String) -> Array:
+	var entries: Array = []
+	for line in text.split("\n"):
+		var stripped := line.strip_edges()
+		if not stripped.begins_with("[ext_resource"):
+			continue
+		var ref_path := _quoted_named_attr(stripped, "path")
+		var id := _quoted_named_attr(stripped, "id")
+		if ref_path.is_empty() or id.is_empty():
+			continue
+		entries.append({"path": ref_path, "id": id})
+	return entries
+
+
+func _ext_resource_entries_from_text(text: String, base_dir: String) -> Array:
+	var entries: Array = []
+	for entry in _raw_ext_resource_entries_from_text(text):
+		var ref_path := String(entry["path"])
+		entries.append({
+			"path": ref_path,
+			"normalized_path": _normalize_ext_resource_path(ref_path, base_dir),
+			"id": String(entry["id"]),
+		})
+	return entries
+
+
+func _normalize_ext_resource_path(ref_path: String, base_dir: String) -> String:
+	if ref_path.begins_with("res://") or ref_path.begins_with("uid://") or ref_path.begins_with("user://"):
+		return ref_path
+	return base_dir.path_join(ref_path).simplify_path()
+
+
+func _ext_resource_ids_by_path(text: String, base_dir: String) -> Dictionary:
+	var by_path := {}
+	for entry in _ext_resource_entries_from_text(text, base_dir):
+		var ref_path := String(entry["normalized_path"])
+		if not by_path.has(ref_path):
+			by_path[ref_path] = []
+		(by_path[ref_path] as Array).append(String(entry["id"]))
+	return by_path
+
+
+func _fresh_ext_resource_id(seed: String, used_ids: Dictionary, reserved_ids: Dictionary) -> String:
+	var base := seed if not seed.is_empty() else "resource"
+	var index := 2
+	var candidate := base + "_gda" + str(index)
+	while used_ids.has(candidate) or reserved_ids.has(candidate):
+		index += 1
+		candidate = base + "_gda" + str(index)
+	return candidate
+
+
+func _replace_ext_resource_ids(text: String, id_remap: Dictionary) -> String:
+	var updated := text
+	var placeholders := {}
+	var index := 0
+	for saved_id in id_remap:
+		var placeholder := "__GDA_EXT_RESOURCE_ID_" + str(index) + "__"
+		while updated.find(placeholder) != -1:
+			index += 1
+			placeholder = "__GDA_EXT_RESOURCE_ID_" + str(index) + "__"
+		placeholders[placeholder] = String(id_remap[saved_id])
+		updated = _replace_ext_resource_id_attr(
+				updated,
+				String(saved_id),
+				placeholder)
+		updated = updated.replace(
+				'ExtResource("' + String(saved_id) + '")',
+				'ExtResource("' + placeholder + '")')
+		index += 1
+	for placeholder in placeholders:
+		updated = _replace_ext_resource_id_attr(
+				updated,
+				String(placeholder),
+				String(placeholders[placeholder]))
+		updated = updated.replace(
+				'ExtResource("' + String(placeholder) + '")',
+				'ExtResource("' + String(placeholders[placeholder]) + '")')
+	return updated
+
+
+func _replace_ext_resource_id_attr(text: String, old_id: String, new_id: String) -> String:
+	var old_attr := 'id="' + old_id + '"'
+	var new_attr := 'id="' + new_id + '"'
+	var lines := text.split("\n")
+	for index in lines.size():
+		var line := String(lines[index])
+		if line.strip_edges().begins_with("[ext_resource"):
+			lines[index] = line.replace(old_attr, new_attr)
+	return "\n".join(lines)
+
+
 # Save `res` to `path` atomically: ResourceSaver.save to a sibling temp, then rename
 # the temp over the target. Returns OK on success, or the first non-OK Error (with
 # the temp removed and the target untouched).
 func _atomic_save_resource(res: Resource, path: String) -> int:
+	var should_restore_ext_ids := (
+			path.get_extension().to_lower() == "tscn" and FileAccess.file_exists(path)
+	)
+	var original_text := FileAccess.get_file_as_string(path) if should_restore_ext_ids else ""
 	var tmp := _atomic_temp_path(path)
 	var save_err := ResourceSaver.save(res, tmp)
 	if save_err != OK:
 		_remove_quiet(tmp)
 		return save_err
+	if should_restore_ext_ids:
+		var saved_text := FileAccess.get_file_as_string(tmp)
+		var stable_text := _restore_existing_ext_resource_ids(path, original_text, saved_text)
+		if stable_text != saved_text:
+			var rewrite_err := _atomic_write_text(tmp, stable_text)
+			if rewrite_err != OK:
+				_remove_quiet(tmp)
+				return rewrite_err
 	var rename_err := DirAccess.rename_absolute(tmp, path)
 	if rename_err != OK:
 		_remove_quiet(tmp)

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -8,6 +8,7 @@ verification of ``node add``'s effect.
 
 import json
 import os
+import re
 import subprocess
 
 import pytest
@@ -37,6 +38,19 @@ def _gda_env(extra_env: dict, *args: str) -> subprocess.CompletedProcess:
         text=True,
         env={**os.environ, **extra_env},
     )
+
+
+def _gda_project(project):
+    """``gda`` bound to ``--project`` so ``res://`` ext_resources resolve."""
+
+    def gda(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
+            capture_output=True,
+            text=True,
+        )
+
+    return gda
 
 
 def _no_gda_temp_siblings(project) -> bool:
@@ -134,6 +148,131 @@ def test_node_add_under_nested_parent_path(godot_project):
     assert hero["path"] == "Hero"
     assert hero["children"][0]["path"] == "Hero/Hitbox"
     assert hero["children"][0]["type"] == "Area2D"
+
+
+@pytest.mark.e2e
+def test_node_add_preserves_existing_ext_resource_ids_on_scene_repack(godot_project):
+    # Issue #393: a shared scene mutation must not let Godot's text saver re-key
+    # pre-existing ext_resource ids and every ExtResource("...") reference that
+    # points at them. Drive `gda` over a real .tscn write rather than a
+    # string helper: node add exercises the shared _load_for_mutation ->
+    # _repack_and_save tail, then script attach proves a newly introduced resource
+    # still receives a fresh non-colliding id.
+    gda = _gda_project(godot_project)
+    scene_path = godot_project / "main.tscn"
+    (godot_project / "hero.gd").write_text("extends Node2D\n", encoding="utf-8")
+    (godot_project / "enemy.gd").write_text("extends Node2D\n", encoding="utf-8")
+    (godot_project / "obstacle.gd").write_text("extends Node2D\n", encoding="utf-8")
+    scene_path.write_text(
+        "\n".join(
+            [
+                '[gd_scene load_steps=3 format=3 uid="uid://stableids"]',
+                "",
+                '[ext_resource type="Script" uid="uid://bhero" path="res://hero.gd" id="1_lkauy"]',
+                '[ext_resource type="Script" path="enemy.gd" id="2_85amh"]',
+                "",
+                '[node name="main" type="Node2D"]',
+                'script = ExtResource("1_lkauy")',
+                "",
+                '[node name="Enemy" type="Node2D" parent="."]',
+                'script = ExtResource("2_85amh")',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    added = gda(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--type",
+        "Node2D",
+        "--name",
+        "Obstacle",
+        "--json",
+    )
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    after_add = scene_path.read_text(encoding="utf-8")
+    assert 'path="res://hero.gd" id="1_lkauy"' in after_add
+    assert 'path="res://enemy.gd" id="2_85amh"' in after_add
+    assert 'script = ExtResource("1_lkauy")' in after_add
+    assert 'script = ExtResource("2_85amh")' in after_add
+    assert '[node name="Obstacle" type="Node2D" parent="."' in after_add
+
+    attached = gda(
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        "Obstacle",
+        "--script",
+        "res://obstacle.gd",
+        "--json",
+    )
+
+    assert attached.returncode == 0, attached.stdout + attached.stderr
+    saved = scene_path.read_text(encoding="utf-8")
+    assert 'path="res://hero.gd" id="1_lkauy"' in saved
+    assert 'path="res://enemy.gd" id="2_85amh"' in saved
+    assert 'script = ExtResource("1_lkauy")' in saved
+    assert 'script = ExtResource("2_85amh")' in saved
+    obstacle_id_match = re.search(
+        r'path="res://obstacle\.gd" id="([^"]+)"',
+        saved,
+    )
+    assert obstacle_id_match, saved
+    obstacle_id = obstacle_id_match.group(1)
+    assert obstacle_id not in {"1_lkauy", "2_85amh"}
+    assert f'script = ExtResource("{obstacle_id}")' in saved
+
+
+@pytest.mark.e2e
+def test_node_add_preserves_first_id_when_duplicate_ext_resource_path_is_canonicalized(
+    godot_project,
+):
+    # ResourceSaver canonicalizes duplicate ext_resources for the same path down to
+    # one entry. gda should keep the first old id for that canonical path instead of
+    # accepting a new random id.
+    gda = _gda_project(godot_project)
+    scene_path = godot_project / "main.tscn"
+    (godot_project / "hero.gd").write_text("extends Node2D\n", encoding="utf-8")
+    scene_path.write_text(
+        "\n".join(
+            [
+                "[gd_scene load_steps=3 format=3]",
+                "",
+                '[ext_resource type="Script" path="res://hero.gd" id="1_first"]',
+                '[ext_resource type="Script" path="res://hero.gd" id="2_second"]',
+                "",
+                '[node name="main" type="Node2D"]',
+                'script = ExtResource("1_first")',
+                "",
+                '[node name="Twin" type="Node2D" parent="."]',
+                'script = ExtResource("2_second")',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    added = gda(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--type",
+        "Marker2D",
+        "--name",
+        "M",
+        "--json",
+    )
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    saved = scene_path.read_text(encoding="utf-8")
+    assert 'path="res://hero.gd" id="1_first"' in saved
+    assert 'script = ExtResource("1_first")' in saved
+    assert "2_second" not in saved
 
 
 @pytest.mark.e2e
@@ -1856,10 +1995,12 @@ def test_node_move_to_current_parent_is_a_noop_preserving_sibling_order(godot_pr
             "node", "add", str(scene_path), "--type", "Node2D", "--name", name, "--json"
         )
         assert added.returncode == 0, added.stdout + added.stderr
+    before = scene_path.read_text(encoding="utf-8")
 
     moved = _gda("node", "move", str(scene_path), "--node", "A", "--to", ".", "--json")
 
     assert moved.returncode == 0, moved.stdout + moved.stderr
+    assert scene_path.read_text(encoding="utf-8") == before
     data = json.loads(moved.stdout)
     # The node is reported at its (unchanged) home.
     assert data["new_parent"] == "."


### PR DESCRIPTION
## Summary

- preserve existing `.tscn` `ext_resource` ids after Godot re-serializes an edited scene
- remap only ext_resource `id` attributes plus matching `ExtResource("...")` references, so unrelated saved ids are not rewritten
- add a live `node add` regression that verifies pre-existing ids and references stay stable
- strengthen the unrelated/no-op move coverage to assert byte stability

## Tests

- `env UV_CACHE_DIR=/tmp/gda-393-orchestrator-uv-cache uv run pytest -q tests/test_e2e_node.py::test_node_add_preserves_existing_ext_resource_ids_on_scene_repack tests/test_e2e_node.py::test_node_move_to_current_parent_is_a_noop_preserving_sibling_order tests/test_e2e_node.py::test_node_add_with_external_edit_in_window_yields_file_changed_externally tests/test_e2e_node.py::test_node_add_with_external_edit_during_instantiate_yields_file_changed_externally tests/test_e2e_script.py::test_script_attach_preserves_sibling_script_on_repack_when_unimported tests/test_e2e_script.py::test_node_add_preserves_sibling_script_on_repack_when_unimported tests/test_e2e_object_property.py::test_node_set_object_property_wires_ext_resource_end_to_end`
- `env UV_CACHE_DIR=/tmp/gda-393-orchestrator-uv-cache uv run ruff check tests/test_e2e_node.py`
- `env UV_CACHE_DIR=/tmp/gda-393-orchestrator-uv-cache uv run ruff format --check tests/test_e2e_node.py`
- `git diff --check`

Closes #393
