### PR TITLE
fix(input): add physics-clock input sequence duration

### DIFF
--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -547,17 +547,25 @@ headless is unaffected (4.4+, cross-platform).
   `input mouse-click <x> <y> [--button left|right|middle] [--double]` /
   `input mouse-move <x> <y>`, and `input action <NAME> [--release] [--strength F]`
   each inject one event at a frame boundary (ADR-0020); the multi-frame
-  `input sequence --events <JSON>` applies a list of events across frames at their
-  relative frame offsets and returns as one blocking payload, on the gda harness's
-  time-windowed multi-frame base (the same base `perf monitor` uses, #223). The
+  `input sequence --events <JSON>` applies a list of events across one selected
+  clock and returns as one blocking payload, on the gda harness's time-windowed
+  multi-frame base (the same base `perf monitor` uses, #223). Existing sequence
+  event `frame` offsets are explicitly the harness/process-frame clock advanced by
+  the harness `_process` loop; they are preserved for compatibility and are **not**
+  Godot's fixed physics frames. For deterministic simulation-duration input, use
+  `physics_frame` offsets instead: press an action at `physics_frame: 0` and release
+  it at `physics_frame: N` to hold it for N Godot physics ticks (for the default
+  60 Hz physics clock, N = 30 is 0.5 seconds of physics simulation). A sequence must
+  use one clock throughout; mixing `frame` and `physics_frame` is rejected. The
   mouse ops are flat two-token commands (`mouse-click` / `mouse-move`), not a nested
   `mouse` sub-group, so each maps to a single `<group>_<command>` MCP tool name
   (ADR-0005/0011/0012). Key/mouse events ride the game's real input flow via the
   root viewport's `push_input` (scene-aware); actions go through
   `Input.action_press`/`action_release` against the running `InputMap`. The modifier
   set, mouse-button enum, action strength range (0..1), per-event shape, and the
-  sequence's frame window (`max(frame)+1` ≤ the per-window ceiling, the same bound
-  `perf monitor` enforces, #223) are bounded **model-side** (ADR-0015), so an
+  sequence's selected-clock window (`max(frame)+1` or `max(physics_frame)+1` ≤ the
+  per-window ceiling, the same bound `perf monitor` enforces, #223) are bounded
+  **model-side** (ADR-0015), so an
   out-of-contract request is a structured `invalid_params` (or argv usage error)
   before it reaches the harness. The two failures that need the live engine
   to decide are deferred to the harness: a key name the engine cannot resolve to a

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -1386,9 +1386,12 @@ def input_sequence(
         "--events",
         help=(
             "The events to inject, as a JSON array of event objects, each with a "
-            "'type' (key/mouse_click/mouse_move/action), an optional relative "
-            "'frame' offset, and the type's fields (e.g. "
-            '\'[{"type":"key","key":"Right","frame":0}]\').'
+            "'type' (key/mouse_click/mouse_move/action), either a relative "
+            "'frame' harness/process-frame offset or a 'physics_frame' physics-clock "
+            "offset, and the type's fields (e.g. "
+            '\'[{"type":"action","action":"move_right","physics_frame":0},'
+            '{"type":"action","action":"move_right","release":true,'
+            '"physics_frame":30}]\').'
         ),
     ),
     json_output: bool = json_option(),
@@ -1400,12 +1403,16 @@ def input_sequence(
     """Inject a sequence of events across frames in one blocking call (live).
 
     Routes through gda-daemon to the engine session (kind = LIVE, ADR-0017) and
-    applies the `--events` across frames at their relative frame offsets, returned
-    as one blocking result (reuses #223's time-windowed multi-frame base). A
-    malformed `--events` (not a JSON array, an empty list, or an ill-formed event)
-    is a usage error; with no daemon it reports `daemon_not_running`. An event's
-    action absent from the InputMap is `live_unknown_action`, an unresolvable key
-    `live_invalid_key`.
+    applies the `--events` across one selected clock, returned as one blocking
+    result (reuses #223's time-windowed multi-frame base). Existing `frame` offsets
+    are harness/process-frame ticks from the `_process` loop, not Godot physics
+    frames. Use `physics_frame` offsets instead when a press/release window must map
+    deterministically to physics simulation ticks, e.g. press an action at
+    `physics_frame: 0` and release it at `physics_frame: 30` for a 30-physics-frame
+    hold. A malformed `--events` (not a JSON array, an empty list, an ill-formed
+    event, or mixed `frame`/`physics_frame` clocks) is a usage error; with no daemon
+    it reports `daemon_not_running`. An event's action absent from the InputMap is
+    `live_unknown_action`, an unresolvable key `live_invalid_key`.
     """
     # --events is a JSON array on the argv path; the model is the source of truth for
     # the per-event shape (ADR-0015), so a parse or validation failure is a usage

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -65,6 +65,8 @@ const LIVE_ERROR_DISPLAY_UNAVAILABLE := "live_display_unavailable"
 # rejected before it reaches the harness — the harness no longer clamps. Mirrored
 # in src/gda/models.py (MAX_WINDOW_FRAMES); a test keeps the two in sync.
 const MAX_WINDOW_FRAMES := 600
+const WINDOW_CLOCK_PROCESS := "process"
+const WINDOW_CLOCK_PHYSICS := "physics"
 
 var _peer: StreamPeerUDS = null
 var _authed := false
@@ -84,8 +86,8 @@ var _pending = null
 var _pending_frames := 0
 # The active time-windowed collection, or null when none is running (#223). A
 # multi-frame handler sets this from _run instead of returning a payload; the
-# _process loop then advances it one frame per tick until it finalizes. See
-# _begin_window / _advance_window.
+# _process or _physics_process loop then advances it one frame per selected clock
+# tick until it finalizes. See _begin_window / _advance_window.
 var _window_state = null
 
 
@@ -157,12 +159,13 @@ func _process(_delta: float) -> void:
 			_send_scene_verification()
 			_scene_verified = true
 		return
-	# A time-windowed op owns the connection until it finalizes (#223): advance it
-	# one frame and serve nothing else this tick, so per-frame samples stay
-	# frame-coherent (ADR-0020) and the single-writer order is preserved (one op at
-	# a time). _advance_window replies once and clears _window_state when done.
+	# A time-windowed op owns the connection until it finalizes (#223): process-clock
+	# windows advance here, physics-clock windows advance in _physics_process. Either
+	# way, serve nothing else this tick so the single-writer order is preserved (one
+	# op at a time). _advance_window replies once and clears _window_state when done.
 	if _window_state != null:
-		_advance_window()
+		if _window_clock() == WINDOW_CLOCK_PROCESS:
+			_advance_window()
 		return
 	# Read one pending request when a full length prefix is available; the body
 	# follows in the same daemon write, so get_data does not block in practice.
@@ -186,6 +189,14 @@ func _process(_delta: float) -> void:
 			_pending = null
 			if reply != null:
 				_send_frame((reply as String).to_utf8_buffer())
+
+
+func _physics_process(_delta: float) -> void:
+	if _window_state == null:
+		return
+	if _window_clock() != WINDOW_CLOCK_PHYSICS:
+		return
+	_advance_window()
 
 
 func _send_frame(payload: PackedByteArray) -> void:
@@ -228,27 +239,41 @@ func _scene_matches(requested: String, current_path: String) -> bool:
 # --- Time-windowed multi-frame base (#223) ------------------------------------
 # A multi-frame handler does not return a finished payload from _run; instead it
 # calls _begin_window with a per-frame `sample` Callable and a `finalize` Callable,
-# returning null so _process keeps ticking. Each subsequent frame, _advance_window
-# calls `sample` once (frame-coherent, ADR-0020) and accumulates its return into a
-# samples Array; once `frames` samples are collected (or an error sample is
-# returned) it calls `finalize(samples)` for the final payload and replies once.
-# A truly stalled engine never runs _advance_window at all, so the window has no
-# timeout of its own — the daemon-level `live_timeout` is the stalled-engine guard.
-# #221's capture op reuses this same base by adding its own sample/finalize
-# Callables — no _process change.
+# returning null so _process or _physics_process keeps ticking on the selected
+# clock. Each subsequent selected-clock frame, _advance_window calls `sample` once
+# (frame-coherent, ADR-0020) and accumulates its return into a samples Array; once
+# `frames` samples are collected (or an error sample is returned) it calls
+# `finalize(samples)` for the final payload and replies once. A truly stalled
+# engine never runs _advance_window at all, so the window has no timeout of its own
+# — the daemon-level `live_timeout` is the stalled-engine guard. #221's capture op
+# reuses this same base by adding its own sample/finalize Callables — no _process
+# change.
 
-# Open a window: store its frame budget, sampler, and finalizer, then let
-# _process drive it. `frames` is the number of per-frame samples to collect; it is
-# already bounded to 1..MAX_WINDOW_FRAMES model-side (PerfMonitorParams, ADR-0015),
-# so the harness does not clamp. Returns null so _run's caller does not reply now.
-func _begin_window(frames: int, sample: Callable, finalize: Callable) -> Variant:
+# Open a window: store its frame budget, sampler, finalizer, and selected clock,
+# then let _process or _physics_process drive it. `frames` is the number of
+# per-frame samples to collect; it is already bounded to 1..MAX_WINDOW_FRAMES
+# model-side (PerfMonitorParams / InputSequenceParams, ADR-0015), so the harness
+# does not clamp. Returns null so _run's caller does not reply now.
+func _begin_window(
+		frames: int,
+		sample: Callable,
+		finalize: Callable,
+		clock: String = WINDOW_CLOCK_PROCESS) -> Variant:
 	_window_state = {
 		"budget": frames,
+		"clock": clock,
 		"samples": [],
 		"sample": sample,
 		"finalize": finalize,
 	}
 	return null
+
+
+func _window_clock() -> String:
+	if _window_state == null:
+		return WINDOW_CLOCK_PROCESS
+	var state: Dictionary = _window_state
+	return String(state.get("clock", WINDOW_CLOCK_PROCESS))
 
 
 # Advance the active window one frame. Collects one sample; finalizes once the
@@ -567,8 +592,10 @@ func _signal_arg_count(node: Node, signal_name: String) -> int:
 # (ADR-0015), so the harness only decides what needs the live engine: a key name
 # the engine cannot resolve (live_invalid_key) and an action the running InputMap
 # does not declare (live_unknown_action). `input sequence` reuses the time-windowed
-# multi-frame base (#223): each frame, the sampler applies the events due at that
-# frame index, and finalize returns the applied-events summary.
+# multi-frame base (#223): each selected-clock frame, the sampler applies the events
+# due at that index, and finalize returns the applied-events summary. Existing
+# `frame` offsets use the harness/process clock; #391's `physics_frame` offsets use
+# Godot's fixed physics clock.
 
 
 # The root Viewport push_input targets, the same surface real OS input flows
@@ -716,33 +743,44 @@ func _handle_input_action(params: Dictionary) -> String:
 	})
 
 
-# input sequence: inject a list of events across frames, returned as ONE blocking
-# result via the time-windowed multi-frame base (#223). The window spans one past
-# the largest event frame; each frame the sampler applies the events due at that
-# frame index. An event whose type the harness does not recognize aborts the window
-# with live_invalid_event_spec (the defensive arm — the model bounds the type).
+# input sequence: inject a list of events across either process or physics frames,
+# returned as ONE blocking result via the time-windowed multi-frame base (#223). The
+# window spans one past the largest selected-clock offset; each selected-clock frame
+# the sampler applies the events due at that index. An event whose type the harness
+# does not recognize aborts the window with live_invalid_event_spec (the defensive
+# arm — the model bounds the type).
 func _handle_input_sequence(params: Dictionary) -> Variant:
 	var raw_events: Variant = params.get("events", [])
 	if typeof(raw_events) != TYPE_ARRAY or (raw_events as Array).is_empty():
 		return _error(LIVE_ERROR_INVALID_EVENT_SPEC,
 				"input sequence needs a non-empty events list")
 	var events: Array = raw_events
-	# The window runs for as many frames as the largest event frame requires (at
-	# least one), so every event's relative frame index lands within the window.
-	var max_frame := 0
+	# The window runs for as many selected-clock frames as the largest event offset
+	# requires (at least one), so every event's relative index lands within it.
+	var uses_physics := false
+	var uses_process := false
+	var max_offset := 0
 	for event in events:
 		if typeof(event) == TYPE_DICTIONARY:
-			max_frame = maxi(max_frame, _int_param(event, "frame", 0))
-	var total_frames := max_frame + 1
+			if _sequence_event_uses_physics(event):
+				uses_physics = true
+			else:
+				uses_process = true
+			max_offset = maxi(max_offset, _sequence_event_offset(event))
+	if uses_physics and uses_process:
+		return _error(LIVE_ERROR_INVALID_EVENT_SPEC,
+				"input sequence cannot mix frame and physics_frame offsets")
+	var clock := WINDOW_CLOCK_PHYSICS if uses_physics else WINDOW_CLOCK_PROCESS
+	var total_frames := max_offset + 1
 	var frame_box := {"n": 0}
-	# The sampler applies every event due at the current frame index, then advances
-	# the frame clock. A bad event type aborts the window with a typed error sample.
+	# The sampler applies every event due at the current selected-clock index, then
+	# advances that clock. A bad event type aborts the window with a typed error sample.
 	var sample := func() -> Variant:
 		var current := int(frame_box["n"])
 		for event in events:
 			if typeof(event) != TYPE_DICTIONARY:
 				continue
-			if _int_param(event, "frame", 0) != current:
+			if _sequence_event_offset(event) != current:
 				continue
 			var err: Variant = _apply_sequence_event(event)
 			if err != null:
@@ -752,10 +790,21 @@ func _handle_input_sequence(params: Dictionary) -> Variant:
 	var finalize := func(_samples: Array) -> String:
 		return _ok({
 			"kind": "sequence",
+			"clock": clock,
 			"events": events.size(),
 			"frames": total_frames,
 		})
-	return _begin_window(total_frames, sample, finalize)
+	return _begin_window(total_frames, sample, finalize, clock)
+
+
+func _sequence_event_uses_physics(event: Dictionary) -> bool:
+	return event.has("physics_frame") and event.get("physics_frame") != null
+
+
+func _sequence_event_offset(event: Dictionary) -> int:
+	if _sequence_event_uses_physics(event):
+		return _int_param(event, "physics_frame", 0)
+	return _int_param(event, "frame", 0)
 
 
 # Apply one sequence event at a frame boundary. Returns null on success, or a typed
@@ -1245,4 +1294,3 @@ func _coerce_color(raw: String) -> Variant:
 		return Color(out[0], out[1], out[2])
 	return Color(out[0], out[1], out[2], out[3])
 # --- END shared coercion ---
-

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -3515,10 +3515,11 @@ class InputActionResult(BaseModel):
 
 
 # The event types a `gda input sequence` may carry. A sequence event reuses the
-# single-frame ops' shapes (key / mouse click / mouse move / action) plus a `frame`
-# delay; the harness applies each event at its relative frame index. Bounding the
-# type model-side keeps an unknown type a usage/invalid_params error rather than a
-# request the harness must defend against (it still does, as live_invalid_event_spec).
+# single-frame ops' shapes (key / mouse click / mouse move / action) plus either a
+# process-clock `frame` offset (the original #221 behavior) or a physics-clock
+# `physics_frame` offset (#391). Bounding the type model-side keeps an unknown type
+# a usage/invalid_params error rather than a request the harness must defend
+# against (it still does, as live_invalid_event_spec).
 class InputEventType(str, Enum):
     """The kind of one event in a ``gda input sequence`` (#221)."""
 
@@ -3529,11 +3530,15 @@ class InputEventType(str, Enum):
 
 
 class InputSequenceEvent(BaseModel):
-    """One event in a ``gda input sequence``, applied at its relative frame (#221).
+    """One event in a ``gda input sequence``, applied at its relative clock offset.
 
     A tagged union over the single-frame ops: ``type`` selects the event shape and
-    ``frame`` is its 0-based relative frame offset within the window (events due at
-    the same frame index are applied together). The type-specific fields mirror the
+    either ``frame`` or ``physics_frame`` places it within the window. ``frame`` is
+    the original harness/process-frame clock, advanced by the harness ``_process``
+    loop; it is not Godot's fixed physics clock. ``physics_frame`` is the explicit
+    physics-clock offset, advanced by Godot ``_physics_process`` ticks, for sequences
+    that need deterministic simulation-duration input holds. Events due at the same
+    clock index are applied together. The type-specific fields mirror the
     single-frame params — ``key``/``modifiers``/``released`` for a key, ``x``/``y``/
     ``button``/``double`` for a mouse click, ``x``/``y`` for a mouse move,
     ``action``/``release``/``strength`` for an action. The required fields per type
@@ -3544,10 +3549,24 @@ class InputSequenceEvent(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     type: InputEventType = Field(description="The event kind.")
-    frame: int = Field(
-        default=0,
+    frame: int | None = Field(
+        default=None,
         ge=0,
-        description="The 0-based relative frame offset to apply this event at.",
+        description=(
+            "The 0-based relative harness/process-frame offset to apply this event at. "
+            "This is the original `input sequence` clock, driven by the harness "
+            "`_process` loop; it is not Godot's fixed physics clock. Omit both "
+            "`frame` and `physics_frame` to use process frame 0."
+        ),
+    )
+    physics_frame: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "The 0-based relative physics-frame offset to apply this event at, driven "
+            "by Godot `_physics_process` ticks. Use this instead of `frame` when an "
+            "input hold must map to a deterministic physics simulation duration."
+        ),
     )
     # key fields
     key: str | None = Field(default=None, description="A key event's key name.")
@@ -3582,10 +3601,17 @@ class InputSequenceEvent(BaseModel):
 
     @model_validator(mode="after")
     def _check_event_shape(self) -> "InputSequenceEvent":
+        # Each event uses exactly one clock. No supplied clock keeps the original
+        # shorthand: process frame 0. Enforced model-side (ADR-0015) so argv JSON and
+        # --params-json reject the same malformed event before it reaches the harness.
+        if self.frame is not None and self.physics_frame is not None:
+            raise ValueError(
+                "a sequence event cannot set both 'frame' and 'physics_frame'."
+            )
+        if self.frame is None and self.physics_frame is None:
+            self.frame = 0
         # Each event type requires its own fields; the shared bounds (modifier set,
-        # strength range, button enum) are enforced by the fields above. Enforced
-        # model-side (ADR-0015) so the argv JSON and --params-json paths reject the
-        # same malformed event before it reaches the harness.
+        # strength range, button enum) are enforced by the fields above.
         if self.type is InputEventType.KEY:
             if not self.key:
                 raise ValueError("a 'key' sequence event requires 'key'.")
@@ -3603,43 +3629,67 @@ class InputSequenceEvent(BaseModel):
 
 
 class InputSequenceParams(BaseModel):
-    """The params of ``gda input sequence``: inject events across frames (#221).
+    """The params of ``gda input sequence``: inject events across process or physics frames.
 
     A multi-frame op (the time-windowed harness base, #223): ``events`` is a list of
-    :class:`InputSequenceEvent`, each applied at its relative ``frame`` index, and
-    the whole sequence returns as ONE blocking result (ADR-0017 one-shot RPC). The
-    window runs for as many frames as the largest event ``frame`` requires (at least
-    one). ``events`` must be non-empty; each event is validated model-side
-    (ADR-0015).
+    :class:`InputSequenceEvent`, each applied at either its relative ``frame`` index
+    (the original harness/process-frame clock) or its relative ``physics_frame``
+    index (the explicit Godot physics clock added for #391), and the whole sequence
+    returns as ONE blocking result (ADR-0017 one-shot RPC). A sequence must use one
+    clock throughout; mixing ``frame`` and ``physics_frame`` in the same request is
+    rejected. The window runs for as many selected-clock frames as the largest event
+    offset requires (at least one). ``events`` must be non-empty; each event is
+    validated model-side (ADR-0015).
 
-    The window the sequence requests — ``max(frame) + 1`` frames — is bounded
-    model-side to ``MAX_WINDOW_FRAMES`` (#223). The time-windowed harness base has
-    no harness-side timeout (it relies on its driver's model bounds, as
-    ``PerfMonitorParams`` enforces via ``frames``), so an unbounded event ``frame``
-    would let a single valid request monopolise the serialised live session until
-    ``live_timeout``. Rejecting it here makes it a structured ``invalid_params`` on
-    ``--params-json`` and a usage error (exit 2) on argv, never a live stall
-    (ADR-0015).
+    The window the sequence requests — ``max(offset) + 1`` frames on the selected
+    clock — is bounded model-side to ``MAX_WINDOW_FRAMES`` (#223). The time-windowed
+    harness base has no harness-side timeout (it relies on its driver's model
+    bounds, as ``PerfMonitorParams`` enforces via ``frames``), so an unbounded event
+    offset would let a single valid request monopolise the serialised live session
+    until ``live_timeout``. Rejecting it here makes it a structured
+    ``invalid_params`` on ``--params-json`` and a usage error (exit 2) on argv, never
+    a live stall (ADR-0015).
     """
 
     events: list[InputSequenceEvent] = Field(
         min_length=1,
-        description="The events to inject, each at its relative frame offset.",
+        description=(
+            "The events to inject, each at its relative process-clock `frame` "
+            "offset or physics-clock `physics_frame` offset."
+        ),
     )
 
     @model_validator(mode="after")
     def _check_window(self) -> "InputSequenceParams":
-        # The window spans one past the largest event frame (mirrors the harness's
-        # `max_frame + 1`). Bounding it to MAX_WINDOW_FRAMES — the same per-window
-        # ceiling perf enforces — keeps a sequence from holding the single-writer
-        # live session for an unbounded number of frames.
-        window = max(event.frame for event in self.events) + 1
+        # The window spans one past the largest event offset on exactly one clock
+        # (mirrors the harness's `max_offset + 1`). Bounding it to MAX_WINDOW_FRAMES
+        # — the same per-window ceiling perf enforces — keeps a sequence from
+        # holding the single-writer live session for an unbounded number of frames.
+        uses_physics = [event.physics_frame is not None for event in self.events]
+        if any(uses_physics) and not all(uses_physics):
+            raise ValueError(
+                "a sequence cannot mix process-clock 'frame' events with "
+                "physics-clock 'physics_frame' events."
+            )
+        selected_clock = "physics_frame" if all(uses_physics) else "frame"
+        window = (
+            max(
+                (
+                    event.physics_frame
+                    if selected_clock == "physics_frame"
+                    else event.frame
+                )
+                or 0
+                for event in self.events
+            )
+            + 1
+        )
         if window > MAX_WINDOW_FRAMES:
             raise ValueError(
                 f"the sequence requests a {window}-frame window (one past its "
-                f"largest event frame), exceeding the maximum of "
+                f"largest {selected_clock} offset), exceeding the maximum of "
                 f"{MAX_WINDOW_FRAMES} (the gda harness's per-window ceiling). "
-                "Use smaller relative frame offsets."
+                "Use smaller relative offsets."
             )
         return self
 
@@ -3647,14 +3697,25 @@ class InputSequenceParams(BaseModel):
 class InputSequenceResult(BaseModel):
     """The result of ``gda input sequence``: what the harness injected (#221).
 
-    Echoes the number of ``events`` applied and the number of ``frames`` the window
-    spanned (one past the largest event frame), confirming the whole sequence was
+    Echoes the ``clock`` used (``process`` for the original harness/process-frame
+    clock, ``physics`` for the explicit Godot physics clock), the number of
+    ``events`` applied, and the number of ``frames`` the window spanned on that
+    clock (one past the largest selected offset), confirming the whole sequence was
     injected over the window at frame boundaries (ADR-0020).
     """
 
     kind: str = Field(default="sequence", description="The op kind ('sequence').")
+    clock: str = Field(
+        default="process",
+        description=(
+            "The sequence clock: 'process' for harness/process-frame offsets, or "
+            "'physics' for Godot physics-frame offsets."
+        ),
+    )
     events: int = Field(description="The number of events injected.")
-    frames: int = Field(description="The number of frames the window spanned.")
+    frames: int = Field(
+        description="The number of selected-clock frames the window spanned."
+    )
 
 
 # --- screen (runtime viewport capture, #222) ----------------------------------

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -86,6 +86,15 @@ the first live op. `screen capture` needs a windowed session
 | `input` | `key`, `mouse-click`, `mouse-move`, `action`, `sequence` |
 | `screen` | `capture`, `frames` (viewport PNGs; needs `--windowed`) |
 
+For `gda input sequence`, event `frame` offsets are the original
+harness/process-frame clock from the harness `_process` loop; they are not Godot's
+fixed physics frames. When input timing must map to physics simulation, use
+`physics_frame` offsets instead. To hold an action for N physics frames, press at
+`{"type":"action","action":"move_right","physics_frame":0}` and release at
+`{"type":"action","action":"move_right","release":true,"physics_frame":N}` in the
+same sequence. At Godot's default 60 Hz physics clock, N=30 is 0.5 seconds of
+physics simulation. Do not mix `frame` and `physics_frame` in one sequence.
+
 ### Structured logging from game code
 
 To emit a record `gda logger tail` reads back as a rich, field-carrying `LogRecord`,

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -80,6 +80,14 @@ ACTION_MAIN_TSCN = (
     'script = ExtResource("1")\n'
 )
 
+PHYSICS_ACTION_PLAYER_GD = (
+    "extends Node2D\n"
+    "const SPEED := 120.0\n"
+    "func _physics_process(delta: float) -> void:\n"
+    '\tif Input.is_action_pressed("move_right"):\n'
+    "\t\tposition.x += SPEED * delta\n"
+)
+
 PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
 # A project.godot whose [input] section declares `move_right` so the running
@@ -87,6 +95,19 @@ PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 ACTION_PROJECT_GODOT = project_godot(
     extra=(
         'run/main_scene="res://main.tscn"\n\n'
+        "[input]\n\n"
+        "move_right={\n"
+        '"deadzone": 0.5,\n'
+        '"events": []\n'
+        "}\n"
+    )
+)
+
+PHYSICS_ACTION_PROJECT_GODOT = project_godot(
+    extra=(
+        'run/main_scene="res://main.tscn"\n\n'
+        "[physics]\n\n"
+        "common/physics_ticks_per_second=60\n\n"
         "[input]\n\n"
         "move_right={\n"
         '"deadzone": 0.5,\n'
@@ -414,6 +435,93 @@ def test_daemon_serves_input_sequence_across_frames(tmp_path, daemon_runtime_dir
         )["value"][0]
         # Each of the 3 Right presses advances position.x by 10.
         assert after_x == before_x + 30.0
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_input_sequence_physics_frame_hold_matches_predicted_displacement(
+    tmp_path, daemon_runtime_dir
+):
+    # #391: `physics_frame` offsets are driven by Godot's physics clock, not the
+    # harness/process clock. Holding `move_right` for N physics frames should move a
+    # player that integrates in _physics_process by speed * (N / physics_fps), without
+    # first measuring an idle/process-to-physics ratio.
+    (tmp_path / "project.godot").write_text(
+        PHYSICS_ACTION_PROJECT_GODOT, encoding="utf-8"
+    )
+    (tmp_path / "main.tscn").write_text(ACTION_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "player.gd").write_text(PHYSICS_ACTION_PLAYER_GD, encoding="utf-8")
+
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    hold_frames = 12
+    physics_fps = 60
+    speed = 120.0
+    expected_delta = speed * (hold_frames / physics_fps)
+    tolerance = 0.1
+    events = json.dumps(
+        [
+            {
+                "type": "action",
+                "action": "move_right",
+                "physics_frame": 0,
+            },
+            {
+                "type": "action",
+                "action": "move_right",
+                "release": True,
+                "physics_frame": hold_frames,
+            },
+        ]
+    )
+
+    try:
+        assert run("daemon", "start").returncode == 0
+
+        before = run("game", "get", "/root/Main/Player", "--property", "position")
+        assert before.returncode == 0, before.stdout + before.stderr
+        before_x = next(
+            p
+            for p in json.loads(before.stdout)["properties"]
+            if p["name"] == "position"
+        )["value"][0]
+
+        seq = run("input", "sequence", "--events", events)
+        assert seq.returncode == 0, seq.stdout + seq.stderr
+        seq_doc = json.loads(seq.stdout)
+        assert seq_doc["clock"] == "physics"
+        assert seq_doc["events"] == 2
+        # Includes the release tick: press at 0, release at N => N physics frames held.
+        assert seq_doc["frames"] == hold_frames + 1
+
+        after = run("game", "get", "/root/Main/Player", "--property", "position")
+        assert after.returncode == 0, after.stdout + after.stderr
+        after_x = next(
+            p for p in json.loads(after.stdout)["properties"] if p["name"] == "position"
+        )["value"][0]
+
+        actual_delta = after_x - before_x
+        assert abs(actual_delta - expected_delta) <= tolerance, (
+            f"expected {expected_delta} +/- {tolerance}, got {actual_delta}"
+        )
     finally:
         run("daemon", "stop")
 

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -397,6 +397,58 @@ def test_input_sequence_injects_events_across_frames_through_the_live_channel(
     assert [e["frame"] for e in sent_events] == [0, 2, 4]
 
 
+def test_input_sequence_physics_frame_offsets_dispatch_through_the_live_channel(
+    monkeypatch, tmp_path
+):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel(
+                {
+                    **INPUT_SEQUENCE_RESULT,
+                    "clock": "physics",
+                    "events": 2,
+                    "frames": 13,
+                }
+            ),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    events = [
+        {"type": "action", "action": "move_right", "physics_frame": 0},
+        {
+            "type": "action",
+            "action": "move_right",
+            "release": True,
+            "physics_frame": 12,
+        },
+    ]
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "sequence",
+            "--events",
+            json.dumps(events),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["clock"] == "physics"
+    assert data["events"] == 2
+    assert data["frames"] == 13
+    assert fake.calls[0][0] == "input-sequence"
+    sent_events = fake.calls[0][1]["events"]
+    assert [e["physics_frame"] for e in sent_events] == [0, 12]
+    assert [e["frame"] for e in sent_events] == [None, None]
+
+
 def test_input_sequence_with_no_daemon_reports_daemon_not_running(
     monkeypatch, tmp_path
 ):
@@ -551,6 +603,73 @@ def test_input_sequence_over_window_frame_argv_is_a_usage_error(monkeypatch, tmp
     assert fake.calls == []
 
 
+def test_input_sequence_over_window_physics_frame_argv_is_a_usage_error(
+    monkeypatch, tmp_path
+):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_SEQUENCE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "sequence",
+            "--events",
+            json.dumps(
+                [
+                    {
+                        "type": "action",
+                        "action": "move_right",
+                        "physics_frame": 999999,
+                    }
+                ]
+            ),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2, result.stdout + result.stderr
+    assert fake.calls == []
+
+
+def test_input_sequence_mixed_process_and_physics_clocks_argv_is_a_usage_error(
+    monkeypatch, tmp_path
+):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_SEQUENCE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "sequence",
+            "--events",
+            json.dumps(
+                [
+                    {"type": "key", "key": "Right", "frame": 0},
+                    {
+                        "type": "action",
+                        "action": "move_right",
+                        "physics_frame": 1,
+                    },
+                ]
+            ),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2, result.stdout + result.stderr
+    assert fake.calls == []
+
+
 def test_input_sequence_at_the_window_boundary_argv_is_accepted(monkeypatch, tmp_path):
     # The largest accepted relative frame is MAX_WINDOW_FRAMES - 1 (window ==
     # MAX_WINDOW_FRAMES). It passes the model and reaches the live seam unchanged.
@@ -583,7 +702,22 @@ def test_input_sequence_schema_reports_kind_live():
     result = CliRunner().invoke(app, ["input", "sequence", "--schema"])
 
     assert result.exit_code == 0, result.stdout + result.stderr
-    assert json.loads(result.stdout)["kind"] == "live"
+    schema = json.loads(result.stdout)
+    assert schema["kind"] == "live"
+    events_description = schema["input"]["properties"]["events"]["description"]
+    assert "process-clock `frame`" in events_description
+    assert "physics-clock `physics_frame`" in events_description
+    event_props = schema["input"]["$defs"]["InputSequenceEvent"]["properties"]
+    assert "harness/process-frame" in event_props["frame"]["description"]
+    assert "physics-frame" in event_props["physics_frame"]["description"]
+
+
+def test_input_sequence_help_names_process_and_physics_clocks():
+    result = CliRunner().invoke(app, ["input", "sequence", "--help"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "harness/process-frame" in result.stdout
+    assert "physics_frame" in result.stdout
 
 
 # --- model validation via --params-json (ADR-0015) ----------------------------
@@ -718,6 +852,42 @@ def test_input_sequence_params_json_over_window_frame_is_invalid_params(
     assert fake.calls == []
 
 
+def test_input_sequence_params_json_mixed_clock_fields_is_invalid_params(
+    monkeypatch, tmp_path
+):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_SEQUENCE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "sequence",
+            "--params-json",
+            json.dumps(
+                {
+                    "events": [
+                        {
+                            "type": "action",
+                            "action": "move_right",
+                            "frame": 0,
+                            "physics_frame": 0,
+                        }
+                    ]
+                }
+            ),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert fake.calls == []
+
+
 def test_input_sequence_params_json_at_the_window_boundary_dispatches(
     monkeypatch, tmp_path
 ):
@@ -749,6 +919,58 @@ def test_input_sequence_params_json_at_the_window_boundary_dispatches(
 
     assert result.exit_code == 0, result.stdout + result.stderr
     assert fake.calls[0][0] == "input-sequence"
+
+
+def test_input_sequence_params_json_physics_frame_dispatches(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel(
+                {
+                    **INPUT_SEQUENCE_RESULT,
+                    "clock": "physics",
+                    "events": 2,
+                    "frames": 31,
+                }
+            ),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "sequence",
+            "--params-json",
+            json.dumps(
+                {
+                    "events": [
+                        {
+                            "type": "action",
+                            "action": "move_right",
+                            "physics_frame": 0,
+                        },
+                        {
+                            "type": "action",
+                            "action": "move_right",
+                            "release": True,
+                            "physics_frame": 30,
+                        },
+                    ]
+                }
+            ),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout)["clock"] == "physics"
+    assert fake.calls[0][0] == "input-sequence"
+    assert [e["physics_frame"] for e in fake.calls[0][1]["events"]] == [0, 30]
 
 
 def test_input_key_params_json_dispatches_like_argv(monkeypatch, tmp_path):

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1246,6 +1246,14 @@ def test_input_commands_schema_report_kind_live_and_are_model_derived():
         jsonschema.Draft202012Validator.check_schema(doc["input"])
         jsonschema.Draft202012Validator.check_schema(doc["output"])
 
+    sequence_input = docs[-1]["input"]
+    events_description = sequence_input["properties"]["events"]["description"]
+    assert "process-clock `frame`" in events_description
+    assert "physics-clock `physics_frame`" in events_description
+    sequence_event_props = sequence_input["$defs"]["InputSequenceEvent"]["properties"]
+    assert "harness/process-frame" in sequence_event_props["frame"]["description"]
+    assert "physics-frame" in sequence_event_props["physics_frame"]["description"]
+
 
 def test_sample_input_results_validate_against_emitted_output_schemas():
     # A sample --json payload of each input command satisfies the contract its


### PR DESCRIPTION
## Summary

- keep existing `input sequence` `frame` offsets as the harness/process-frame clock and document that contract in schema, help, command catalog, and skill guidance
- add `physics_frame` offsets for sequences that need deterministic Godot physics-clock input timing
- reject mixed `frame` / `physics_frame` requests before they reach the live harness
- return the selected sequence `clock` in the result payload
- add live coverage for a physics-frame action hold whose displacement matches `speed * frames / physics_fps`

## Tests

- `env UV_CACHE_DIR=/tmp/gda-391-orchestrator-input-cache uv run pytest tests/test_input_commands.py`
- `env UV_CACHE_DIR=/tmp/gda-391-orchestrator-schema-cache uv run pytest tests/test_schema_command.py`
- `env UV_CACHE_DIR=/tmp/gda-391-orchestrator-skill-cache uv run pytest tests/test_skill_surface_sync.py`
- `env UV_CACHE_DIR=/tmp/gda-391-orchestrator-e2e-cache uv run pytest tests/test_e2e_input.py`
- `env UV_CACHE_DIR=/tmp/gda-391-orchestrator-ruff-cache uv run ruff check src/gda/models.py src/gda/cli.py tests/test_input_commands.py tests/test_schema_command.py tests/test_e2e_input.py`
- `env UV_CACHE_DIR=/tmp/gda-391-orchestrator-ruff-format-cache uv run ruff format --check src/gda/models.py src/gda/cli.py tests/test_input_commands.py tests/test_schema_command.py tests/test_e2e_input.py`
- `git diff --check`

Closes #391
