### PR TITLE
fix(script): report missing preload dependencies

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -114,7 +114,7 @@ operation, and parse codes the CLI assigns).
 | `invalid_node_type` | `operation` | `operation` | `4` | A requested node type is neither an instantiable `Node` class nor a registered `class_name`. |
 | `invalid_node_name` | `operation` | `operation` | `4` | A requested node name is empty or would be rewritten by Godot. |
 | `duplicate_node_name` | `operation` | `operation` | `4` | The parent node already has a child with the requested name. |
-| `missing_dependency` | `operation` | `operation` | `4` | A scene's declared nodes vanished or degraded on load — an unresolvable instanced sub-scene or an unavailable node class; re-saving would silently drop or downgrade them. |
+| `missing_dependency` | `operation` | `operation` | `4` | A scene's declared nodes vanished or degraded on load — an unresolvable instanced sub-scene, an unavailable node class, or a GDScript preload target that does not exist; re-saving would silently drop or downgrade scene data. |
 | `uninstantiable_script` | `operation` | `operation` | `4` | A registered `class_name`'s script can no longer be loaded, compiled, or constructed, so it cannot be instantiated as a node or a resource. |
 | `ambiguous_class_name` | `operation` | `operation` | `4` | A `class_name` is declared in more than one `.gd` script, so a request naming it (node add, resource create, or find-references) cannot resolve it to a single script; the conflicting script paths are named (ADR-0032). |
 | `node_not_found` | `operation` | `operation` | `4` | A requested node path does not resolve to a node in the scene. |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -102,8 +102,11 @@ suite). When an instanced sub-scene cannot be resolved on load (a broken depende
 scene *without* it, so a re-save would silently erase the instance and all its overrides;
 likewise, a declared node class unavailable in the running engine (e.g. an absent
 GDExtension) is silently substituted with a placeholder node, and a re-save would rewrite the
-node under the substitute type. Mutating node commands detect both and refuse with the
-registered `missing_dependency` error (exit 4), leaving the file untouched. Related trust boundary: instantiating executes `_init`
+node under the substitute type. A GDScript attached to the scene whose `preload("res://...")`
+target no longer exists is also refused before save with `missing_dependency`, naming the
+missing `res://` path so the dependency can be created first. Mutating node commands detect
+these cases and refuse with the registered `missing_dependency` error (exit 4), leaving the
+file untouched. Related trust boundary: instantiating executes `_init`
 of scripts already attached in the scene (#62) — treat headless mutation of an untrusted scene
 as running its code.
 
@@ -338,7 +341,9 @@ rejection modes so an agent gets the right remediation — a script that does **
 `script_compile_failed` (fix the syntax; check it with `script validate`), while one that compiles
 but whose native base is **incompatible** with the node (e.g. an `extends Node3D` script on a
 `Node2D`) is `incompatible_script_type` (attach it to a compatible node, or change the script's
-`extends`). Other failures reuse existing codes: a missing script is `path_not_found`, a non-`.gd` script is
+`extends`). If the script `preload("res://...")`s a target that does not exist, attach refuses
+with `missing_dependency` and names the missing `res://` path; create preloaded assets before
+attaching scripts that reference them. Other failures reuse existing codes: a missing script is `path_not_found`, a non-`.gd` script is
 `invalid_path`, a node path that resolves to nothing is `node_not_found`, a missing or non-scene
 file is `path_not_found`/`not_a_scene`, and a scene whose instances vanish or degrade on load is
 `missing_dependency` (the mutation-integrity boundary, #64).

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -215,8 +215,9 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
         "A scene's declared nodes vanished or degraded on load — an"
-        " unresolvable instanced sub-scene or an unavailable node class;"
-        " re-saving would silently drop or downgrade them.",
+        " unresolvable instanced sub-scene, an unavailable node class, or a"
+        " GDScript preload target that does not exist; re-saving would silently"
+        " drop or downgrade scene data.",
     ),
     ErrorCodeSpec(
         "uninstantiable_script",

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -1388,6 +1388,9 @@ func _op_script_attach(params: Dictionary) -> void:
 	if not _require_existing_script(script_path):
 		root.free()
 		return  # _require_existing_script already recorded the failure
+	if not _validate_script_preload_dependencies(script_path):
+		root.free()
+		return  # _validate_script_preload_dependencies already recorded the failure
 
 	# load returns a non-null Script even for a .gd that does not compile (compile
 	# errors go to stderr; the resource still loads), so a null here is a genuine
@@ -3587,6 +3590,7 @@ func _load_for_mutation(params: Dictionary) -> Node:
 	# Snapshot every node's external script path NOW — the instant after
 	# instantiate, before any op-specific load can evict a sibling's script object
 	# (issue #164). _repack_and_save re-anchors from this snapshot on the way out.
+	_capture_source_attached_scripts(path)
 	_capture_external_scripts(root)
 	return root
 
@@ -3633,6 +3637,9 @@ func _repack_and_save(root: Node, path: String) -> bool:
 	if not _check_unchanged():
 		root.free()
 		return false
+	if not _validate_scene_script_preload_dependencies(root):
+		root.free()
+		return false
 	_reanchor_external_scripts(root)
 	var repacked := PackedScene.new()
 	var pack_err := repacked.pack(root)
@@ -3659,6 +3666,7 @@ func _repack_and_save(root: Node, path: String) -> bool:
 # carry. A single member is safe here — operations.gd is a one-shot process that
 # runs exactly one operation, so there is no cross-operation state to leak.
 var _captured_external_scripts: Dictionary = {}
+var _source_attached_scripts: Dictionary = {}
 
 
 # --- optimistic staleness guard for headless read-modify-write ops (issue #226) ---
@@ -3762,6 +3770,10 @@ func _capture_external_scripts_into(node: Node, root: Node) -> void:
 		_capture_external_scripts_into(child, root)
 
 
+func _capture_source_attached_scripts(scene_path: String) -> void:
+	_source_attached_scripts = _scene_attached_external_scripts(scene_path)
+
+
 # Repoint every captured node that STILL carries its captured script at the
 # SINGLE canonical cached resource for that script's res:// path, so a re-pack/save
 # never serializes two distinct in-memory objects under one path (issue #164 root
@@ -3798,6 +3810,219 @@ func _reanchor_external_scripts(root: Node) -> void:
 				captured_path, "Script", ResourceLoader.CACHE_MODE_REPLACE)
 		if canonical is Script:
 			node.set_script(canonical)
+
+
+# Validate the executable preload() dependencies that can make GDScript
+# compilation fail. This uses a focused lexer rather than the project-reference
+# graph's raw line scanner: comments and unrelated string literals must not block
+# a valid attach, while a real preload call may split its argument across lines.
+func _validate_script_preload_dependencies(script_path: String) -> bool:
+	for ref_path in _script_executable_preload_paths(script_path):
+		if not ref_path.begins_with("res://"):
+			continue
+		if FileAccess.file_exists(ref_path):
+			continue
+		_fail(OP_ERROR_MISSING_DEPENDENCY, "script preload target does not exist: "
+				+ ref_path + " (referenced by " + script_path
+				+ ") — create the preloaded asset before attaching or saving the script")
+		return false
+	return true
+
+
+func _script_executable_preload_paths(script_path: String) -> Array[String]:
+	var out: Array[String] = []
+	var source := FileAccess.get_file_as_string(script_path)
+	if source.is_empty() and FileAccess.get_open_error() != OK:
+		return out
+	var base_dir := script_path.get_base_dir()
+	var index := 0
+	while index < source.length():
+		var token_index := _find_code_token(source, "preload", index)
+		if token_index == -1:
+			break
+		var after_token := token_index + "preload".length()
+		var open_paren := _skip_gdscript_space_and_comments(source, after_token)
+		if open_paren >= source.length() or source[open_paren] != "(":
+			index = after_token
+			continue
+		var arg_start := _skip_gdscript_space_and_comments(source, open_paren + 1)
+		var literal := _quoted_string_literal_at(source, arg_start)
+		if not bool(literal.get("ok", false)):
+			index = open_paren + 1
+			continue
+		out.append(_resolve_ref_path(String(literal["value"]), base_dir))
+		index = int(literal["end"])
+	return out
+
+
+func _find_code_token(source: String, token: String, from: int) -> int:
+	var index := from
+	while index < source.length():
+		var ch := source[index]
+		if ch == "#":
+			index = _skip_gdscript_line_comment(source, index)
+			continue
+		if ch == "\"" or ch == "'":
+			index = _skip_quoted_string_literal(source, index)
+			continue
+		if source.substr(index, token.length()) == token:
+			var before_ok := (
+					index == 0
+					or (not _is_identifier_char(source[index - 1]) and source[index - 1] != ".")
+			)
+			var after_index := index + token.length()
+			var after_ok := (
+					after_index >= source.length()
+					or not _is_identifier_char(source[after_index])
+			)
+			if before_ok and after_ok:
+				return index
+		index += 1
+	return -1
+
+
+func _skip_gdscript_space_and_comments(source: String, from: int) -> int:
+	var index := from
+	while index < source.length():
+		var ch := source[index]
+		if ch == " " or ch == "\t" or ch == "\r" or ch == "\n":
+			index += 1
+			continue
+		if ch == "#":
+			index = _skip_gdscript_line_comment(source, index)
+			continue
+		break
+	return index
+
+
+func _skip_gdscript_line_comment(source: String, from: int) -> int:
+	var index := from
+	while index < source.length() and source[index] != "\n":
+		index += 1
+	return index
+
+
+func _skip_quoted_string_literal(source: String, from: int) -> int:
+	var literal := _quoted_string_literal_at(source, from)
+	return int(literal["end"])
+
+
+func _quoted_string_literal_at(source: String, from: int) -> Dictionary:
+	if from >= source.length():
+		return {"ok": false, "value": "", "end": source.length()}
+	var quote := source[from]
+	if quote != "\"" and quote != "'":
+		return {"ok": false, "value": "", "end": from}
+	var triple := quote + quote + quote
+	if source.substr(from, 3) == triple:
+		var content_start := from + 3
+		var triple_end := source.find(triple, content_start)
+		if triple_end == -1:
+			return {"ok": false, "value": "", "end": source.length()}
+		return {
+			"ok": true,
+			"value": source.substr(content_start, triple_end - content_start),
+			"end": triple_end + 3,
+		}
+	var out := ""
+	var index := from + 1
+	while index < source.length():
+		var ch := source[index]
+		if ch == "\\":
+			if index + 1 >= source.length():
+				return {"ok": false, "value": "", "end": source.length()}
+			out += source[index + 1]
+			index += 2
+			continue
+		if ch == quote:
+			return {"ok": true, "value": out, "end": index + 1}
+		out += ch
+		index += 1
+	return {"ok": false, "value": "", "end": source.length()}
+
+
+# Mutating scene ops save the current instantiated tree. Validate every
+# file-backed script that would still be saved before packing, so a script whose
+# missing preload left only engine stderr cannot turn into a clean success.
+func _validate_scene_script_preload_dependencies(root: Node) -> bool:
+	for node_path: NodePath in _source_attached_scripts:
+		var node := root.get_node_or_null(node_path)
+		if node == null:
+			continue  # the op intentionally removed this node
+		var source_path: String = _source_attached_scripts[node_path]
+		var current: Variant = node.get_script()
+		if current is Script:
+			var current_path: String = (current as Script).resource_path
+			if not current_path.is_empty() and current_path != source_path:
+				continue  # the op intentionally replaced this node's script
+		if not _validate_script_preload_dependencies(source_path):
+			return false
+	return _validate_node_script_preload_dependencies(root)
+
+
+func _validate_node_script_preload_dependencies(node: Node) -> bool:
+	var script := node.get_script() as Script
+	if script != null:
+		var script_path := script.resource_path
+		if not script_path.is_empty() and not _validate_script_preload_dependencies(script_path):
+			return false
+	for child in node.get_children():
+		if not _validate_node_script_preload_dependencies(child):
+			return false
+	return true
+
+
+# The source scene's file-backed script bindings as {root-relative NodePath ->
+# script res:// path}. This catches scripts that Godot failed to materialize
+# because a preload target was missing: the node may still exist with no script,
+# so walking the instantiated tree alone cannot see the dependency.
+func _scene_attached_external_scripts(scene_path: String) -> Dictionary:
+	var text := FileAccess.get_file_as_string(scene_path)
+	if text.is_empty():
+		return {}
+	var script_resources := _scene_script_ext_resources(text)
+	var attached := {}
+	var current_node_path := ""
+	for line in text.split("\n"):
+		var stripped := line.strip_edges()
+		if stripped.begins_with("[node "):
+			current_node_path = _scene_node_path_from_header(stripped)
+			continue
+		if current_node_path.is_empty():
+			continue
+		if not stripped.begins_with("script") or stripped.find("ExtResource(") == -1:
+			continue
+		var resource_id := _first_quoted_after(stripped, stripped.find("ExtResource("))
+		if script_resources.has(resource_id):
+			attached[NodePath(current_node_path)] = script_resources[resource_id]
+	return attached
+
+
+func _scene_script_ext_resources(text: String) -> Dictionary:
+	var resources := {}
+	for line in text.split("\n"):
+		var stripped := line.strip_edges()
+		if not stripped.begins_with("[ext_resource"):
+			continue
+		if _quoted_attr(stripped, "type=") != "Script":
+			continue
+		var resource_id := _quoted_named_attr(stripped, "id")
+		var path := _quoted_attr(stripped, "path=")
+		if not resource_id.is_empty() and path.begins_with("res://"):
+			resources[resource_id] = path
+	return resources
+
+
+func _scene_node_path_from_header(header: String) -> String:
+	var name := _quoted_attr(header, "name=")
+	if name.is_empty():
+		return ""
+	var parent := _quoted_attr(header, "parent=")
+	if parent.is_empty():
+		return "."
+	if parent == ".":
+		return name
+	return parent + "/" + name
 
 
 # Node paths declared in the scene's state that did not materialize faithfully

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -138,6 +138,8 @@ cover scripts, and Resource-typed fields take a `res://` path, not a coerced lit
 verifies the script compiles, checks its base type against the node, and reports any
 script it displaced. Setting the `script` property with `node set` is refused with an
 actionable `use_script_attach` error that points you back here.
+Create any assets a script `preload("res://...")` references before attaching that
+script; missing preload targets fail as `missing_dependency` and name the missing path.
 
 ```bash
 gda script attach game/main.tscn --node Player --script res://player.gd --project game --json
@@ -194,6 +196,8 @@ assignment is headless-only (`node set` / `resource set`).
 - Node paths are relative to the scene root; `.` is the root itself.
 - `--value` is coerced to the property's declared Godot type — the same coercion
   for `node set`, `resource set`, `project set`, and live `game set`.
+- Create preloaded assets before attaching scripts that reference them; a missing
+  `preload("res://...")` target is reported as `missing_dependency`.
 - For large or scripted input, pass one JSON object with `--params-json '{...}'`
   (or `--params-json -` to read it from stdin) instead of individual flags.
 - Live ops with no daemon report `daemon_not_running` (exit `6`) and name the

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -1004,6 +1004,88 @@ def test_node_add_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
     assert parent.read_text(encoding="utf-8") == before
 
 
+@pytest.mark.e2e
+def test_node_add_refuses_scene_whose_attached_script_preloads_missing_asset(
+    godot_project,
+):
+    # A scene mutation must not report clean success when an already-attached
+    # script has a now-missing preload target. The structured error names the
+    # missing res:// path and the scene remains byte-identical.
+    gda = _gda_project(godot_project)
+    assert (
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
+        == 0
+    )
+    assert (
+        gda(
+            "scene",
+            "create",
+            "res://enemy_projectile.tscn",
+            "--root-type",
+            "Node2D",
+            "--json",
+        ).returncode
+        == 0
+    )
+    (godot_project / "enemy.gd").write_text(
+        'extends Node2D\n\nconst Projectile = preload("res://enemy_projectile.tscn")\n',
+        encoding="utf-8",
+    )
+    attached = gda(
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://enemy.gd",
+        "--json",
+    )
+    assert attached.returncode == 0, attached.stdout + attached.stderr
+    scene_path = godot_project / "main.tscn"
+    scene_text = scene_path.read_text(encoding="utf-8")
+    script_line = next(
+        line
+        for line in scene_text.splitlines()
+        if 'type="Script"' in line and 'path="res://enemy.gd"' in line
+    )
+    if "uid=" not in script_line:
+        scene_text = scene_text.replace(
+            script_line,
+            script_line.replace(
+                'path="res://enemy.gd"',
+                'uid="uid://bpreloadenemy" path="res://enemy.gd"',
+            ),
+        )
+        scene_path.write_text(scene_text, encoding="utf-8")
+    (godot_project / "enemy_projectile.tscn").unlink()
+    before = scene_path.read_text(encoding="utf-8")
+    script_line_before = next(
+        line
+        for line in before.splitlines()
+        if 'type="Script"' in line and 'path="res://enemy.gd"' in line
+    )
+    assert "uid=" in script_line_before
+
+    added = gda(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--type",
+        "Marker2D",
+        "--name",
+        "M",
+        "--json",
+    )
+
+    err = _assert_operation_error(added, "missing_dependency")
+    assert "res://enemy_projectile.tscn" in err["message"]
+    assert "res://enemy.gd" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
 # A child that loads as a valid PackedScene resource but cannot instantiate:
 # its root illegally declares a parent, which SceneState::instantiate refuses
 # with an engine null. The nested null propagates (packed_scene.cpp fails the

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -1076,6 +1076,153 @@ def test_script_attach_non_compiling_script_yields_script_compile_failed(godot_p
 
 
 @pytest.mark.e2e
+def test_script_attach_missing_preload_target_yields_missing_dependency(
+    godot_project,
+):
+    # A missing preload target is a dependency-ordering problem, not generic
+    # prose-only compile stderr: the structured error names the missing res://
+    # path, and the scene is left untouched.
+    gda = _gda_project(godot_project)
+    assert (
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
+        == 0
+    )
+    assert (
+        gda(
+            "script",
+            "create",
+            "res://enemy.gd",
+            "--content",
+            'extends Node2D\n\nconst Projectile = preload("res://missing_projectile.tscn")\n',
+            "--json",
+        ).returncode
+        == 0
+    )
+    before = (godot_project / "main.tscn").read_text(encoding="utf-8")
+
+    attached = gda(
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://enemy.gd",
+        "--json",
+    )
+
+    err = _assert_operation_error(attached, "missing_dependency")
+    assert "res://missing_projectile.tscn" in err["message"]
+    assert "res://enemy.gd" in err["message"]
+    assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_script_attach_ignores_preload_mentions_in_comments_and_strings(
+    godot_project,
+):
+    # The missing-preload gate must follow executable GDScript syntax, not the
+    # project reference graph's raw text scan. Mentioning future assets in comments
+    # or string literals is not a preload dependency and must not block attach.
+    gda = _gda_project(godot_project)
+    assert (
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
+        == 0
+    )
+    assert (
+        gda(
+            "script",
+            "create",
+            "res://enemy.gd",
+            "--content",
+            "\n".join(
+                [
+                    "extends Node2D",
+                    "",
+                    '# preload("res://missing_projectile.tscn")',
+                    'var note := "preload(\\"res://also_missing.tscn\\")"',
+                    "",
+                ]
+            ),
+            "--json",
+        ).returncode
+        == 0
+    )
+
+    attached = gda(
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://enemy.gd",
+        "--json",
+    )
+
+    assert attached.returncode == 0, attached.stdout + attached.stderr
+    saved = (godot_project / "main.tscn").read_text(encoding="utf-8")
+    assert 'path="res://enemy.gd"' in saved
+
+
+@pytest.mark.e2e
+def test_script_attach_multiline_missing_preload_target_yields_missing_dependency(
+    godot_project,
+):
+    # A valid preload call may split the opening paren and string literal across
+    # lines. It should still get the same stable missing_dependency result as the
+    # single-line form.
+    gda = _gda_project(godot_project)
+    assert (
+        gda(
+            "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
+        ).returncode
+        == 0
+    )
+    assert (
+        gda(
+            "script",
+            "create",
+            "res://enemy.gd",
+            "--content",
+            "\n".join(
+                [
+                    "extends Node2D",
+                    "",
+                    "const Projectile = preload(",
+                    '    "res://missing_projectile.tscn"',
+                    ")",
+                    "",
+                ]
+            ),
+            "--json",
+        ).returncode
+        == 0
+    )
+    before = (godot_project / "main.tscn").read_text(encoding="utf-8")
+
+    attached = gda(
+        "script",
+        "attach",
+        "res://main.tscn",
+        "--node",
+        ".",
+        "--script",
+        "res://enemy.gd",
+        "--json",
+    )
+
+    err = _assert_operation_error(attached, "missing_dependency")
+    assert "res://missing_projectile.tscn" in err["message"]
+    assert "res://enemy.gd" in err["message"]
+    assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
 def test_script_attach_incompatible_node_type_yields_incompatible_script_type(
     godot_project,
 ):


### PR DESCRIPTION
## Summary

- reuse the documented `missing_dependency` operation code for missing GDScript `preload("res://...")` targets
- validate preload targets before `script attach` loads/binds the new script
- validate file-backed scripts before scene mutation saves, including source scene bindings that Godot may fail to materialize after a missing preload
- keep failed scene mutations byte-stable by refusing before pack/save
- document the authoring-order tip to create preloaded assets before attaching scripts that reference them

## Stacked Branch

This PR is stacked on #394 (`feat/393-stable-ext-resource-ids`) because both changes touch the shared scene save/mutation path in `src/gda/ops/operations.gd`.

## Tests

- `env UV_CACHE_DIR=/tmp/gda-392-orchestrator-registry-cache uv run pytest tests/test_error_registry.py`
- `env UV_CACHE_DIR=/tmp/gda-392-orchestrator-e2e-node-cache uv run pytest tests/test_e2e_node.py::test_node_add_refuses_scene_whose_attached_script_preloads_missing_asset tests/test_e2e_node.py::test_node_add_preserves_existing_ext_resource_ids_on_scene_repack`
- `env UV_CACHE_DIR=/tmp/gda-392-orchestrator-e2e-script-cache uv run pytest tests/test_e2e_script.py::test_script_attach_missing_preload_target_yields_missing_dependency tests/test_e2e_script.py::test_script_attach_non_compiling_script_yields_script_compile_failed tests/test_e2e_script.py::test_script_attach_incompatible_node_type_yields_incompatible_script_type`
- `env UV_CACHE_DIR=/tmp/gda-392-orchestrator-skill-cache uv run pytest tests/test_skill_surface_sync.py`
- `env UV_CACHE_DIR=/tmp/gda-392-orchestrator-ruff-cache uv run ruff check .`
- `env UV_CACHE_DIR=/tmp/gda-392-orchestrator-ruff-format-cache uv run ruff format --check .`
- `git diff --check`

Closes #392
