### PR TITLE
feat(node): scene instancing via node add --instance

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -157,11 +157,12 @@ _Avoid_: safe project, sandboxed project
 The set of points where a single `gda` run triggers the target project's own
 code to run: autoload constructors at engine startup (every `--project` op), the
 `_init` of scripts on nodes *or resources* that an instantiating operation
-constructs (a `class_name` node via `node add`, or a script-backed `class_name`
-Resource via `resource create`), the `_init` of a **script-backed Resource loaded
-as a value** assigned to an Object-typed property (`node set` / `resource set
---value res://…`, ADR-0033), and — via `gda script run` (ADR-0031) — the
-**full execution of a named project script**.
+constructs (a `class_name` node via `node add`, a script-backed `class_name`
+Resource via `resource create`, or every script inside a **scene composed as an
+instanced child** via `node add --instance`, #399), the `_init` of a
+**script-backed Resource loaded as a value** assigned to an Object-typed
+property (`node set` / `resource set --value res://…`, ADR-0033), and — via
+`gda script run` (ADR-0031) — the **full execution of a named project script**.
 All stay within the `Trusted project` assumption (ADR-0009); `script run` and the
 loaded-value assignment (ADR-0033) widen this surface without adding a new trust axis.
 _Avoid_: attack surface, code-execution risk

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ flags — `gda --help` is the authoritative list of what is installed.
 
 | Command | What it does |
 | ------- | ------------ |
-| `node add` | Add a node under a parent (built-in type or `class_name` script). |
+| `node add` | Add a node under a parent: a built-in type, a `class_name` script, or `--instance` to compose another scene as an instanced child. |
 | `node get` | Read a node's properties (by node path) as typed JSON. |
 | `node list` | List a scene's node tree with each node's path relative to the root. |
 | `node set` | Set a node property, coercing the value to its declared Godot type. |

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=bdfb40b3f5d988d7c078a350821170b3579839c160396778620e9cc635573504 -->
+<!-- gda-readme-i18n: source=README.md sha256=54d955c0d26c2607586676502e2380782317721823423a92bcba9d359467cd81 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -392,7 +392,7 @@ flags — `gda --help` es la lista autoritativa de lo que está instalado.
 
 | Comando | Qué hace |
 | ------- | ------------ |
-| `node add` | Añade un nodo bajo un padre (tipo integrado o script con `class_name`). |
+| `node add` | Añade un nodo bajo un padre: un tipo integrado, un script con `class_name`, o `--instance` para componer otra escena como hijo instanciado. |
 | `node get` | Lee las propiedades de un nodo (por ruta de nodo) como JSON tipado. |
 | `node list` | Lista el árbol de nodos de una escena con la ruta de cada nodo relativa a la raíz. |
 | `node set` | Define una propiedad de nodo, forzando el valor a su tipo de Godot declarado. |

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=bdfb40b3f5d988d7c078a350821170b3579839c160396778620e9cc635573504 -->
+<!-- gda-readme-i18n: source=README.md sha256=54d955c0d26c2607586676502e2380782317721823423a92bcba9d359467cd81 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -398,7 +398,7 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 
 | コマンド | 機能 |
 | ------- | ------------ |
-| `node add` | 親の下にノードを追加します(組み込みタイプまたは `class_name` スクリプト)。 |
+| `node add` | 親の下にノードを追加します: 組み込みタイプ、`class_name` スクリプト、または `--instance` で別のシーンをインスタンス化した子として合成します。 |
 | `node get` | ノードのプロパティを(ノードパスで指定して)型付き JSON として読み取ります。 |
 | `node list` | シーンのノードツリーを、各ノードのルートからの相対パスとともに一覧します。 |
 | `node set` | ノードのプロパティを設定します。値は宣言された Godot の型に変換されます。 |

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=bdfb40b3f5d988d7c078a350821170b3579839c160396778620e9cc635573504 -->
+<!-- gda-readme-i18n: source=README.md sha256=54d955c0d26c2607586676502e2380782317721823423a92bcba9d359467cd81 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -381,7 +381,7 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 
 | 命令 | 作用 |
 | ------- | ------------ |
-| `node add` | 在某个父节点下添加一个节点（内置类型或带 `class_name` 的脚本）。 |
+| `node add` | 在某个父节点下添加一个节点：内置类型、带 `class_name` 的脚本，或用 `--instance` 把另一个场景作为实例化子节点组合进来。 |
 | `node get` | 按节点路径读取一个节点的属性，输出带类型的 JSON。 |
 | `node list` | 列出一个场景的节点树，并给出每个节点相对于根的路径。 |
 | `node set` | 设置一个节点属性，并把值强制转换为它声明的 Godot 类型。 |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -119,7 +119,7 @@ operation, and parse codes the CLI assigns).
 | `ambiguous_class_name` | `operation` | `operation` | `4` | A `class_name` is declared in more than one `.gd` script, so a request naming it (node add, resource create, or find-references) cannot resolve it to a single script; the conflicting script paths are named (ADR-0032). |
 | `node_not_found` | `operation` | `operation` | `4` | A requested node path does not resolve to a node in the scene. |
 | `cannot_target_root` | `operation` | `operation` | `4` | A structural edit targeted the scene root, which has no parent to be removed from, duplicated alongside, or reparented out of. |
-| `cyclic_target` | `operation` | `operation` | `4` | A node move targeted the node itself or one of its own descendants, which would detach the moved subtree from the scene. |
+| `cyclic_target` | `operation` | `operation` | `4` | The write would create a cycle: a node move targeted the node itself or one of its own descendants, or a scene instancing (node add --instance) targeted the host scene itself. |
 | `unknown_property` | `operation` | `operation` | `4` | A requested property does not exist as a settable property on the target node or resource. |
 | `uncoercible_value` | `operation` | `operation` | `4` | A supplied value cannot be coerced to the property's declared Godot type. |
 | `expected_resource_path` | `operation` | `operation` | `4` | An Object-typed property was given a value that is not a `res://` resource path; assign an existing Resource by its `res://` path (ADR-0033, #363). |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -126,6 +126,21 @@ arguments — is a script problem, not an unknown type, and is refused with the 
 `uninstantiable_script` error (exit 4) naming the script: repair the script (or re-import),
 don't change the type name. Either way the scene file is left untouched.
 
+**Scene instancing** (#399): `node add --instance <scene>` composes an existing scene as an
+instanced child — Godot's standard composition primitive — instead of constructing a typed
+node; `--type` and `--instance` are mutually exclusive (exactly one, enforced model-side so
+argv and `--params-json` agree). The write produces the canonical serialization the editor
+produces: an `ext_resource type="PackedScene"` entry plus an `instance=ExtResource(...)`
+node stub with no `type=` attribute, the instance's internals referenced, never inlined
+(pre-existing `ext_resource` ids stay byte-identical per the mutation-write rule above).
+The default `--name` is the instanced scene's filename stem. The result echoes the composed
+`res://` path as `instance` and reports `type` as the instanced scene's resolved root class.
+Failures follow the dependency ladder: a missing scene file is `missing_dependency` naming
+the path, a file that loads as something else is `not_a_scene`, and instancing the host into
+itself is refused as `cyclic_target` — all exit 4, file untouched. Instantiating the
+composed scene runs the `_init` of scripts inside it: the same trust boundary as the
+`class_name` path (#62).
+
 **Property reporting and value coercion** (established by #55): `gda node get` instantiates the
 scene and reports the addressed node's **storage** properties (the ones that serialize into the
 `.tscn`) as typed JSON — each a `{name, type, value}` triple where `type` is the property's
@@ -249,7 +264,7 @@ reuses `path_not_found` / `not_a_scene`. All failures exit 4 and leave the file 
 
 | Command | Description |
 | --- | --- |
-| `gda node add` | Add a node (by type or `class_name` script) into a scene |
+| `gda node add` | Add a node (by type, `class_name` script, or `--instance` scene composition) into a scene |
 | `gda node remove` | Remove a node from a scene |
 | `gda node get` | Read a node's properties (typed JSON) |
 | `gda node list` | List nodes in a scene (optionally filtered by type/group) |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -136,8 +136,12 @@ node stub with no `type=` attribute, the instance's internals referenced, never 
 The default `--name` is the instanced scene's filename stem. The result echoes the composed
 `res://` path as `instance` and reports `type` as the instanced scene's resolved root class.
 Failures follow the dependency ladder: a missing scene file is `missing_dependency` naming
-the path, a file that loads as something else is `not_a_scene`, and instancing the host into
-itself is refused as `cyclic_target` — all exit 4, file untouched. Instantiating the
+the path; a file not recognized as a PackedScene is `not_a_scene` (the wrong KIND of file);
+a scene-typed file that fails to load, or whose declared nodes vanish/degrade on
+instantiation because a nested dependency is missing (the #64 hazard, guarded for the
+instanced scene too), is `missing_dependency` naming the instance path with diagnostics
+carrying the nested culprit; instancing the host into itself is refused as `cyclic_target`
+— all exit 4, file untouched. Instantiating the
 composed scene runs the `_init` of scripts inside it: the same trust boundary as the
 `class_name` path (#62).
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -2143,12 +2143,21 @@ def delete(
 @node_app.command(cls=NODE_ADD_COMMAND.command_class())
 def add(
     path: str = typer.Argument(..., help="The .tscn scene file to mutate."),
-    node_type: str = typer.Option(
-        ...,
+    node_type: Optional[str] = typer.Option(
+        None,
         "--type",
         help=(
             "Node type to add: a Godot node class (e.g. Sprite2D), or a "
-            "class_name registered in the project's global class list."
+            "class_name registered in the project's global class list. "
+            "Exactly one of --type/--instance must be given."
+        ),
+    ),
+    instance: Optional[str] = typer.Option(
+        None,
+        "--instance",
+        help=(
+            "Scene file to add as an instanced child (e.g. res://hud.tscn). "
+            "Exactly one of --type/--instance must be given."
         ),
     ),
     parent: str = typer.Option(
@@ -2162,7 +2171,10 @@ def add(
     name: Optional[str] = typer.Option(
         None,
         "--name",
-        help="Name for the new node. Defaults to the type name.",
+        help=(
+            "Name for the new node. Defaults to the type name, or the "
+            "instanced scene's filename stem."
+        ),
     ),
     json_output: bool = json_option(),
     schema: bool = NODE_ADD_COMMAND.schema_option(),
@@ -2177,6 +2189,7 @@ def add(
             path=path,
             parent=parent,
             type=node_type,
+            instance=instance,
             name=name,
         ),
         json_output=json_output,

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -2183,15 +2183,22 @@ def add(
     project: Optional[str] = project_option(),
 ) -> None:
     """Add a node to a scene file under the given parent node path."""
-    _dispatch(
-        NODE_ADD_COMMAND,
-        NodeAddParams(
+    # The exactly-one-of --type/--instance rule lives on the model (ADR-0015);
+    # the argv path keeps usage-error ergonomics (exit 2), --params-json
+    # surfaces the same rule as a structured invalid_params.
+    try:
+        params = NodeAddParams(
             path=path,
             parent=parent,
             type=node_type,
             instance=instance,
             name=name,
-        ),
+        )
+    except (ValueError, ValidationError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    _dispatch(
+        NODE_ADD_COMMAND,
+        params,
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -256,8 +256,9 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
-        "A node move targeted the node itself or one of its own descendants,"
-        " which would detach the moved subtree from the scene.",
+        "The write would create a cycle: a node move targeted the node itself"
+        " or one of its own descendants, or a scene instancing (node add"
+        " --instance) targeted the host scene itself.",
     ),
     ErrorCodeSpec(
         "unknown_property",

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -667,15 +667,28 @@ class NodeAddParams(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _default_name(self) -> "NodeAddParams":
-        # Derive the default node name model-side (ADR-0015), so the argv and
-        # --params-json paths agree instead of the CLI deriving it: the type
-        # name, or the instanced scene's filename stem (#399).
+    def _exactly_one_mode_and_default_name(self) -> "NodeAddParams":
+        # Exactly one of type/instance selects what is added (#399). Enforced
+        # model-side (ADR-0015) so the argv and --params-json paths agree: the
+        # argv path converts the ValueError to a usage error, --params-json
+        # surfaces it as a structured invalid_params.
+        if self.type is None and self.instance is None:
+            raise ValueError(
+                "node add needs exactly one of --type or --instance "
+                "(neither was given)."
+            )
+        if self.type is not None and self.instance is not None:
+            raise ValueError(
+                "--type and --instance are mutually exclusive; pass exactly one."
+            )
+        # Derive the default node name model-side too, so the CLI never
+        # derives it: the type name, or the instanced scene's filename stem.
         if self.name is None:
-            if self.type is not None:
-                self.name = self.type
-            elif self.instance is not None:
-                self.name = derive_scene_root_name(self.instance)
+            self.name = (
+                self.type
+                if self.type is not None
+                else derive_scene_root_name(self.instance or "")
+            )
         return self
 
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -620,14 +620,16 @@ class SceneDeleteResult(BaseModel):
 
 
 class NodeAddParams(BaseModel):
-    """The operation params of ``gda node add`` (issue #53).
+    """The operation params of ``gda node add`` (issue #53; instancing #399).
 
     ``path`` is the ``.tscn`` scene file to mutate. ``parent`` addresses the
-    parent node by node path. ``type`` is resolved first as a built-in Godot
-    node class, then as a ``class_name`` registered in the project's global
-    class list. ``name`` is explicit so the operation never silently derives a
-    name Godot later sanitizes; when the CLI caller omits ``--name``, it uses
-    the type name.
+    parent node by node path. Exactly one of ``type``/``instance`` selects what
+    is added: ``type`` is resolved first as a built-in Godot node class, then
+    as a ``class_name`` registered in the project's global class list;
+    ``instance`` composes an existing scene as an instanced child (#399).
+    ``name`` is explicit so the operation never silently derives a name Godot
+    later sanitizes; when the CLI caller omits ``--name``, it uses the type
+    name, or the instanced scene's filename stem.
     """
 
     path: NormalizedPath = Field(description="The .tscn scene file to mutate.")
@@ -638,26 +640,42 @@ class NodeAddParams(BaseModel):
             "root itself, 'Player/Arm' a nested node."
         ),
     )
-    type: str = Field(
+    type: str | None = Field(
+        default=None,
         description=(
             "Node type to add: a Godot node class (e.g. Sprite2D), or a "
-            "class_name registered in the project's global class list."
-        )
+            "class_name registered in the project's global class list. "
+            "Exactly one of type/instance must be given."
+        ),
+    )
+    instance: NormalizedPath | None = Field(
+        default=None,
+        description=(
+            "Scene file to add as an instanced child (e.g. res://hud.tscn) — "
+            "composes the scene under the parent, serialized as an "
+            "instance=ExtResource(...) entry. Exactly one of type/instance "
+            "must be given."
+        ),
     )
     name: str | None = Field(
         default=None,
         description=(
-            "Name for the new node. If omitted, the type name is used. Must be "
-            "non-empty and must not contain '.', ':', '@', '/', '\"', or '%'."
+            "Name for the new node. If omitted, the type name (or the "
+            "instanced scene's filename stem) is used. Must be non-empty and "
+            "must not contain '.', ':', '@', '/', '\"', or '%'."
         ),
     )
 
     @model_validator(mode="after")
     def _default_name(self) -> "NodeAddParams":
-        # Derive the default node name from the type model-side (ADR-0015), so the
-        # argv and --params-json paths agree instead of the CLI deriving it.
+        # Derive the default node name model-side (ADR-0015), so the argv and
+        # --params-json paths agree instead of the CLI deriving it: the type
+        # name, or the instanced scene's filename stem (#399).
         if self.name is None:
-            self.name = self.type
+            if self.type is not None:
+                self.name = self.type
+            elif self.instance is not None:
+                self.name = derive_scene_root_name(self.instance)
         return self
 
 
@@ -685,6 +703,14 @@ class NodeAddResult(BaseModel):
             "The class_name of the script attached to the created node, when "
             "the requested type resolved to a script class; null for a "
             "built-in type."
+        ),
+    )
+    instance: str | None = Field(
+        default=None,
+        description=(
+            "The res:// path of the scene this node instances, when the node "
+            "was added via --instance (#399); null for a type addition. For "
+            "an instance, `type` reports the instanced scene's root class."
         ),
     )
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -524,7 +524,7 @@ func _op_node_add(params: Dictionary) -> void:
 	var instance_path := _string_param(params, "instance")
 	var node: Node = null
 	if instance_path != "":
-		node = _instantiate_scene_instance(instance_path)
+		node = _instantiate_scene_instance(instance_path, path)
 	else:
 		node = _instantiate_node_type(type)
 	if node == null:
@@ -4157,8 +4157,15 @@ func _instantiate_node_type(type: String) -> Node:
 # mirrors the dependency precedent (#392/#396): a missing file is the
 # composition's missing dependency, a file that loads as something else is
 # not_a_scene, and a scene that loads but instantiates to nothing (its own
-# dependencies broken) is missing_dependency again.
-func _instantiate_scene_instance(instance_path: String) -> Node:
+# dependencies broken) is missing_dependency again. The direct self-cycle
+# (instancing the host into itself) is refused up front as cyclic_target — the
+# write would serialize a self-reference that can never finish loading; deeper
+# A→B→A cycles stay the engine's load-time problem, outside this guard.
+func _instantiate_scene_instance(instance_path: String, host_path: String) -> Node:
+	if ProjectSettings.globalize_path(instance_path) == ProjectSettings.globalize_path(host_path):
+		_fail(OP_ERROR_CYCLIC_TARGET, "cannot instance a scene into itself: " + instance_path
+				+ " — the composition would create a cycle")
+		return null
 	if not ResourceLoader.exists(instance_path):
 		_fail(OP_ERROR_MISSING_DEPENDENCY, "instanced scene not found: " + instance_path
 				+ " — --instance must reference an existing scene file; check the path and --project")

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -4156,11 +4156,15 @@ func _instantiate_node_type(type: String) -> Node:
 # execution surface as the class_name path (ADR-0009). The failure ladder
 # mirrors the dependency precedent (#392/#396): a missing file is the
 # composition's missing dependency, a file that loads as something else is
-# not_a_scene, and a scene that loads but instantiates to nothing (its own
-# dependencies broken) is missing_dependency again. The direct self-cycle
-# (instancing the host into itself) is refused up front as cyclic_target — the
-# write would serialize a self-reference that can never finish loading; deeper
-# A→B→A cycles stay the engine's load-time problem, outside this guard.
+# not_a_scene (keyed on the RECOGNIZED type — the wrong KIND of file), while a
+# scene-typed file that fails to load, instantiates to nothing, or silently
+# drops declared nodes (the engine instantiates around a missing nested
+# dependency, the #64 hazard) is dependency-shaped: missing_dependency naming
+# the instance path the caller passed, with the engine diagnostics carrying
+# the nested culprit (PR #404 review). The direct self-cycle (instancing the
+# host into itself) is refused up front as cyclic_target — the write would
+# serialize a self-reference that can never finish loading; deeper A→B→A
+# cycles stay the engine's load-time problem, outside this guard.
 func _instantiate_scene_instance(instance_path: String, host_path: String) -> Node:
 	if ProjectSettings.globalize_path(instance_path) == ProjectSettings.globalize_path(host_path):
 		_fail(OP_ERROR_CYCLIC_TARGET, "cannot instance a scene into itself: " + instance_path
@@ -4170,10 +4174,14 @@ func _instantiate_scene_instance(instance_path: String, host_path: String) -> No
 		_fail(OP_ERROR_MISSING_DEPENDENCY, "instanced scene not found: " + instance_path
 				+ " — --instance must reference an existing scene file; check the path and --project")
 		return null
-	var packed := ResourceLoader.load(instance_path, "PackedScene") as PackedScene
-	if packed == null:
+	if not ResourceLoader.exists(instance_path, "PackedScene"):
 		_fail(OP_ERROR_NOT_A_SCENE, "not a scene: " + instance_path
 				+ " — --instance must reference a PackedScene (.tscn/.scn)")
+		return null
+	var packed := ResourceLoader.load(instance_path, "PackedScene") as PackedScene
+	if packed == null:
+		_fail(OP_ERROR_MISSING_DEPENDENCY, "instanced scene failed to load: " + instance_path
+				+ " — a dependency is missing or the file is broken; see diagnostics")
 		return null
 	# GEN_EDIT_STATE_INSTANCE retains the child's scene_instance_state — what
 	# the packer's states-stack walk keys on to emit the canonical instance
@@ -4186,6 +4194,17 @@ func _instantiate_scene_instance(instance_path: String, host_path: String) -> No
 	if child == null:
 		_fail(OP_ERROR_MISSING_DEPENDENCY, "scene failed to instantiate: " + instance_path
 				+ " — an instanced sub-scene is unresolvable or empty; check the scene's dependencies and --project")
+		return null
+	# The #64 vanished-node guard, applied to the INSTANCED scene: the engine
+	# instantiates around a missing nested dependency (or substitutes an
+	# unavailable class), so composing the degraded tree would bake the loss
+	# into the host. Refuse instead, naming what did not materialize.
+	var unmaterialized := _unmaterialized_node_paths(packed.get_state(), child)
+	if not unmaterialized.is_empty():
+		child.free()
+		_fail(OP_ERROR_MISSING_DEPENDENCY, "instanced scene nodes vanished or degraded on load: "
+				+ instance_path + " (" + ", ".join(unmaterialized)
+				+ ") — check the scene's dependencies and --project")
 		return null
 	return child
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -521,10 +521,15 @@ func _op_node_add(params: Dictionary) -> void:
 		return
 
 	var type := _string_param(params, "type")
-	var node := _instantiate_node_type(type)
+	var instance_path := _string_param(params, "instance")
+	var node: Node = null
+	if instance_path != "":
+		node = _instantiate_scene_instance(instance_path)
+	else:
+		node = _instantiate_node_type(type)
 	if node == null:
 		root.free()
-		return  # _instantiate_node_type already recorded the failure
+		return  # the instantiation helper already recorded the failure
 
 	# A parentless node never has its name rewritten: _is_valid_node_name already
 	# rejected the chars Godot sanitizes, and the @-dedup suffix is only appended
@@ -547,6 +552,7 @@ func _op_node_add(params: Dictionary) -> void:
 		"name": node_name,
 		"type": node_type,
 		"script_class": script_class,
+		"instance": instance_path if instance_path != "" else null,
 	})
 
 
@@ -4139,6 +4145,42 @@ func _instantiate_node_type(type: String) -> Node:
 			_fail(OP_ERROR_INVALID_NODE_TYPE, "not an instantiable Node class, and no .gd script declares class_name " + type
 					+ " (check for a misspelled name, or declare it with `class_name " + type + "`)")
 			return null
+
+
+# node-add --instance (#399): materialize the scene to compose as a child of
+# the host. Instantiation stamps the child root's scene_file_path — the marker
+# PackedScene.pack() keys on to serialize the child as an
+# instance=ExtResource(...) stub — its descendants stay owned by the instanced
+# root, so they are referenced, never inlined into the host. Instantiating runs
+# the _init of any script inside the instanced scene: the same Project-code
+# execution surface as the class_name path (ADR-0009). The failure ladder
+# mirrors the dependency precedent (#392/#396): a missing file is the
+# composition's missing dependency, a file that loads as something else is
+# not_a_scene, and a scene that loads but instantiates to nothing (its own
+# dependencies broken) is missing_dependency again.
+func _instantiate_scene_instance(instance_path: String) -> Node:
+	if not ResourceLoader.exists(instance_path):
+		_fail(OP_ERROR_MISSING_DEPENDENCY, "instanced scene not found: " + instance_path
+				+ " — --instance must reference an existing scene file; check the path and --project")
+		return null
+	var packed := ResourceLoader.load(instance_path, "PackedScene") as PackedScene
+	if packed == null:
+		_fail(OP_ERROR_NOT_A_SCENE, "not a scene: " + instance_path
+				+ " — --instance must reference a PackedScene (.tscn/.scn)")
+		return null
+	# GEN_EDIT_STATE_INSTANCE retains the child's scene_instance_state — what
+	# the packer's states-stack walk keys on to emit the canonical instance
+	# stub: no type= attribute, and properties diffed against the instanced
+	# scene's own state rather than class defaults. Editor-build-only, which is
+	# the build gda drives (issue #164's documented assumption); a plain
+	# instantiate() would leave the state empty and serialize a non-canonical
+	# type= + class-default property dump alongside the instance= reference.
+	var child := packed.instantiate(PackedScene.GEN_EDIT_STATE_INSTANCE)
+	if child == null:
+		_fail(OP_ERROR_MISSING_DEPENDENCY, "scene failed to instantiate: " + instance_path
+				+ " — an instanced sub-scene is unresolvable or empty; check the scene's dependencies and --project")
+		return null
+	return child
 
 
 # Instantiate a class_name from its resolved script. Resolution (ADR-0032:

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -409,8 +409,15 @@ def render_scene_delete(removed: "SceneDeleteResult") -> str:
 
 
 def render_node_add(added: "NodeAddResult") -> str:
-    """Render an added node as ``added <path> (<type>) to <scene>``."""
-    return f"added {added.path} ({added.type}) to {added.scene_path}"
+    """Render an added node as ``added <path> (<type>) to <scene>``.
+
+    A composition (#399) names its source too:
+    ``added <path> (<type>, instance of <src>) to <scene>``.
+    """
+    what = added.type
+    if added.instance is not None:
+        what = f"{added.type}, instance of {added.instance}"
+    return f"added {added.path} ({what}) to {added.scene_path}"
 
 
 def render_node_list(listed: "NodeListResult") -> str:

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -340,7 +340,7 @@ def test_node_add_instance_preserves_existing_ext_resource_ids(godot_project):
     scene_path.write_text(
         "\n".join(
             [
-                '[gd_scene load_steps=2 format=3]',
+                "[gd_scene load_steps=2 format=3]",
                 "",
                 '[ext_resource type="Script" path="res://hero.gd" id="1_lkauy"]',
                 "",

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -454,6 +454,66 @@ def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dic
 
 
 @pytest.mark.e2e
+def test_node_add_instance_missing_scene_yields_missing_dependency(godot_project):
+    # The #392/#396 dependency precedent applied to composition (#399): a
+    # missing instanced-scene path is a structured missing_dependency naming
+    # the path — never a silent or prose-only failure — and the host file
+    # stays untouched.
+    gda = _gda_project(godot_project)
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    before = scene_path.read_text(encoding="utf-8")
+
+    added = gda(
+        "node", "add", "res://main.tscn", "--instance", "res://ghost.tscn", "--json"
+    )
+
+    err = _assert_operation_error(added, "missing_dependency")
+    assert "res://ghost.tscn" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_node_add_instance_non_scene_file_yields_not_a_scene(godot_project):
+    # --instance must reference a PackedScene: a file that exists but loads as
+    # something else (a script here) is refused with not_a_scene, naming the
+    # offending path.
+    gda = _gda_project(godot_project)
+    (godot_project / "hero.gd").write_text("extends Node2D\n", encoding="utf-8")
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    before = scene_path.read_text(encoding="utf-8")
+
+    added = gda(
+        "node", "add", "res://main.tscn", "--instance", "res://hero.gd", "--json"
+    )
+
+    err = _assert_operation_error(added, "not_a_scene")
+    assert "res://hero.gd" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_node_add_instance_of_the_host_itself_yields_cyclic_target(godot_project):
+    # Instancing a scene into itself would serialize a self-reference that can
+    # never finish loading. The direct cycle is refused up front with the
+    # registered cyclic_target code, leaving the file untouched (deeper A→B→A
+    # cycles remain the engine's load-time problem, out of gda's guard).
+    gda = _gda_project(godot_project)
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    before = scene_path.read_text(encoding="utf-8")
+
+    added = gda(
+        "node", "add", "res://main.tscn", "--instance", "res://main.tscn", "--json"
+    )
+
+    err = _assert_operation_error(added, "cyclic_target")
+    assert "res://main.tscn" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
 def test_node_add_to_missing_scene_yields_path_not_found(godot_project):
     missing = godot_project / "missing.tscn"
 

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -442,6 +442,19 @@ def test_node_add_instance_composes_a_scene_and_round_trips(godot_project):
     child = json.loads(got.stdout)
     assert child["type"] == "CanvasLayer"
 
+    # Static reads reflect the composition (#399's last acceptance criterion):
+    # the instanced child appears in the host's tree under both readers. Its
+    # static `type` is deliberately NOT asserted here — surfacing it is the
+    # companion issue #400.
+    listed = gda("node", "list", "res://main.tscn", "--json")
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    children = json.loads(listed.stdout)["root"]["children"]
+    assert [c["name"] for c in children] == ["hud"]
+    assert children[0]["path"] == "hud"
+    read = gda("scene", "get", "res://main.tscn", "--json")
+    assert read.returncode == 0, read.stdout + read.stderr
+    assert [c["name"] for c in json.loads(read.stdout)["root"]["children"]] == ["hud"]
+
     assert _no_gda_temp_siblings(godot_project)
 
 
@@ -470,6 +483,44 @@ def test_node_add_instance_missing_scene_yields_missing_dependency(godot_project
 
     err = _assert_operation_error(added, "missing_dependency")
     assert "res://ghost.tscn" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_node_add_instance_with_broken_dependency_yields_missing_dependency(
+    godot_project,
+):
+    # PR #404 review: a --instance target that IS a scene file but whose own
+    # dependency graph is broken (an ext_resource pointing at a missing nested
+    # scene) is a dependency-shaped failure, not a "wrong kind of file" one:
+    # missing_dependency naming the instance path the caller passed (engine
+    # diagnostics name the nested culprit), never not_a_scene.
+    gda = _gda_project(godot_project)
+    (godot_project / "hud.tscn").write_text(
+        "\n".join(
+            [
+                "[gd_scene load_steps=2 format=3]",
+                "",
+                '[ext_resource type="PackedScene" path="res://ghost-child.tscn" id="1_ghost"]',
+                "",
+                '[node name="Hud" type="CanvasLayer"]',
+                "",
+                '[node name="Ghost" parent="." instance=ExtResource("1_ghost")]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    before = scene_path.read_text(encoding="utf-8")
+
+    added = gda(
+        "node", "add", "res://main.tscn", "--instance", "res://hud.tscn", "--json"
+    )
+
+    err = _assert_operation_error(added, "missing_dependency")
+    assert "res://hud.tscn" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
 

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -316,6 +316,84 @@ def test_node_add_builtin_type_reports_null_script_class(godot_project):
     assert data["script_class"] is None
 
 
+@pytest.mark.e2e
+def test_node_add_instance_composes_a_scene_and_round_trips(godot_project):
+    # Issue #399: `node add --instance` is the structured way to author a scene
+    # instance — Godot's standard composition primitive. The write must produce
+    # the canonical serialization (an ext_resource for the scene plus an
+    # instance=ExtResource(...) node entry, exactly what the editor writes),
+    # and the composed scene must LOAD: node get instantiates the host, so it
+    # proves the engine resolves the instanced child to its real root class.
+    gda = _gda_project(godot_project)
+    (godot_project / "hud.tscn").write_text(
+        "\n".join(
+            [
+                "[gd_scene format=3]",
+                "",
+                '[node name="Hud" type="CanvasLayer"]',
+                "",
+                '[node name="Score" type="Label" parent="."]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    main = godot_project / "main.tscn"
+    main.write_text(
+        "\n".join(
+            [
+                "[gd_scene format=3]",
+                "",
+                '[node name="Main" type="Node2D"]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    added = gda(
+        "node", "add", "res://main.tscn", "--instance", "res://hud.tscn", "--json"
+    )
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    data = json.loads(added.stdout)
+    # The result identifies the composition: default name = filename stem,
+    # type = the instanced scene's resolved ROOT class, instance = the source.
+    assert data["scene_path"] == "res://main.tscn"
+    assert (data["path"], data["name"]) == ("hud", "hud")
+    assert data["type"] == "CanvasLayer"
+    assert data["script_class"] is None
+    assert data["instance"] == "res://hud.tscn"
+
+    saved = main.read_text(encoding="utf-8")
+    ext = re.search(
+        r'\[ext_resource type="PackedScene" path="res://hud\.tscn" id="([^"]+)"\]',
+        saved,
+    )
+    assert ext, saved
+    hud_entry = re.search(r'\[node name="hud" parent="\."[^\]]*\]', saved)
+    assert hud_entry, saved
+    assert f'instance=ExtResource("{ext.group(1)}")' in hud_entry.group(0)
+    # Canonical instance stub, as the editor writes it: no type= attribute —
+    # the type lives in the instanced scene (surfacing it on static reads is
+    # the companion issue #400). Engine-managed attrs (e.g. unique_id) may
+    # appear; only type= would mark a non-canonical dump.
+    assert "type=" not in hud_entry.group(0), saved
+    # The instanced scene's INTERNALS are referenced, never inlined into the
+    # host (the write-side mirror of instance semantics): no Label node entry.
+    assert 'type="Label"' not in saved
+
+    # Round-trip: the composed scene instantiates in the engine — the child
+    # resolves to the instanced scene's real root class, and its internal
+    # nodes exist under it.
+    got = gda("node", "get", "res://main.tscn", "--node", "hud", "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    child = json.loads(got.stdout)
+    assert child["type"] == "CanvasLayer"
+
+    assert _no_gda_temp_siblings(godot_project)
+
+
 def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
     assert proc.returncode == 4, proc.stdout + proc.stderr
     err = json.loads(proc.stdout)["error"]

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -317,6 +317,57 @@ def test_node_add_builtin_type_reports_null_script_class(godot_project):
 
 
 @pytest.mark.e2e
+def test_node_add_instance_preserves_existing_ext_resource_ids(godot_project):
+    # Acceptance criterion of #399, pinning the #393 contract for the
+    # composition write: instancing a scene into a host must keep every
+    # pre-existing ext_resource id (and the ExtResource("...") references
+    # pointing at them) byte-identical, while the newly introduced PackedScene
+    # ext_resource receives a fresh non-colliding id.
+    gda = _gda_project(godot_project)
+    (godot_project / "hero.gd").write_text("extends Node2D\n", encoding="utf-8")
+    (godot_project / "hud.tscn").write_text(
+        "\n".join(
+            [
+                "[gd_scene format=3]",
+                "",
+                '[node name="Hud" type="CanvasLayer"]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    scene_path = godot_project / "main.tscn"
+    scene_path.write_text(
+        "\n".join(
+            [
+                '[gd_scene load_steps=2 format=3]',
+                "",
+                '[ext_resource type="Script" path="res://hero.gd" id="1_lkauy"]',
+                "",
+                '[node name="main" type="Node2D"]',
+                'script = ExtResource("1_lkauy")',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    added = gda(
+        "node", "add", "res://main.tscn", "--instance", "res://hud.tscn", "--json"
+    )
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    saved = scene_path.read_text(encoding="utf-8")
+    assert 'path="res://hero.gd" id="1_lkauy"' in saved
+    assert 'script = ExtResource("1_lkauy")' in saved
+    hud_id_match = re.search(r'path="res://hud\.tscn" id="([^"]+)"', saved)
+    assert hud_id_match, saved
+    hud_id = hud_id_match.group(1)
+    assert hud_id != "1_lkauy"
+    assert f'instance=ExtResource("{hud_id}")' in saved
+
+
+@pytest.mark.e2e
 def test_node_add_instance_composes_a_scene_and_round_trips(godot_project):
     # Issue #399: `node add --instance` is the structured way to author a scene
     # instance — Godot's standard composition primitive. The write must produce

--- a/tests/test_human_output.py
+++ b/tests/test_human_output.py
@@ -156,6 +156,19 @@ HUMAN_CASES = [
         "added Hero (Sprite2D) to /tmp/proj/main.tscn",
     ),
     (
+        "node-add-instance",
+        ["node", "add", "/tmp/proj/main.tscn", "--instance", "res://hud.tscn"],
+        {
+            "scene_path": "/tmp/proj/main.tscn",
+            "path": "hud",
+            "name": "hud",
+            "type": "CanvasLayer",
+            "script_class": None,
+            "instance": "res://hud.tscn",
+        },
+        "added hud (CanvasLayer, instance of res://hud.tscn) to /tmp/proj/main.tscn",
+    ),
+    (
         "node-list",
         ["node", "list", "/tmp/proj/main.tscn"],
         {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -220,6 +220,7 @@ def test_node_add_result_round_trips():
         "name": "Hero",
         "type": "Sprite2D",
         "script_class": None,
+        "instance": None,
     }
 
     added = NodeAddResult.model_validate(payload)
@@ -235,6 +236,7 @@ def test_node_add_result_carries_the_class_name_of_a_script_addition():
         "name": "Hero",
         "type": "Node2D",
         "script_class": "Hero",
+        "instance": None,
     }
 
     added = NodeAddResult.model_validate(payload)

--- a/tests/test_node_commands.py
+++ b/tests/test_node_commands.py
@@ -82,6 +82,46 @@ def test_node_add_instance_json_dispatches_instance_param_and_echoes_source(
     ]
 
 
+def test_node_add_type_and_instance_together_is_a_usage_error(monkeypatch):
+    # --type and --instance are mutually exclusive modes (issue #399): mixing
+    # them is a usage error (exit 2) that fires before any dispatch — the
+    # engine is never reached. The rule lives model-side (ADR-0015), so the
+    # --params-json path surfaces the same violation as invalid_params.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(ADD_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "node",
+            "add",
+            "/tmp/proj/main.tscn",
+            "--type",
+            "Sprite2D",
+            "--instance",
+            "res://hud.tscn",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert fake.calls == []
+
+
+def test_node_add_without_type_or_instance_is_a_usage_error(monkeypatch):
+    # No mode at all is a usage error too: add always needs exactly one of
+    # --type/--instance.
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(ADD_RESULT), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["node", "add", "/tmp/proj/main.tscn", "--json"])
+
+    assert result.exit_code == 2
+    assert fake.calls == []
+
+
 def test_node_add_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
     stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(ADD_RESULT)

--- a/tests/test_node_commands.py
+++ b/tests/test_node_commands.py
@@ -26,6 +26,62 @@ from tests.support import (
 )
 
 
+# Canned node-add result for the --instance mode (issue #399): the op reports
+# the instanced scene's res:// path alongside the resolved root type.
+ADD_INSTANCE_RESULT = {
+    "scene_path": "/tmp/proj/main.tscn",
+    "path": "hud",
+    "name": "hud",
+    "type": "CanvasLayer",
+    "script_class": None,
+    "instance": "res://hud.tscn",
+}
+
+
+def test_node_add_instance_json_dispatches_instance_param_and_echoes_source(
+    monkeypatch,
+):
+    # Issue #399: `node add --instance` composes an existing .tscn as a child of
+    # the host scene — Godot's standard composition primitive. The dispatch
+    # carries the instance path instead of a type, the name defaults to the
+    # instanced scene's filename stem (model-side, ADR-0015), and the result
+    # echoes the instanced res:// path alongside the resolved root type.
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(ADD_INSTANCE_RESULT)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "node",
+            "add",
+            "/tmp/proj/main.tscn",
+            "--instance",
+            "res://hud.tscn",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["scene_path"] == "/tmp/proj/main.tscn"
+    # The instanced child is addressable like any added node; its reported type
+    # is the instanced scene's ROOT class, resolved by the engine.
+    assert (data["path"], data["name"], data["type"]) == ("hud", "hud", "CanvasLayer")
+    assert data["instance"] == "res://hud.tscn"
+    assert fake.calls == [
+        (
+            "node-add",
+            {
+                "path": "/tmp/proj/main.tscn",
+                "parent": ".",
+                "type": None,
+                "instance": "res://hud.tscn",
+                "name": "hud",
+            },
+        )
+    ]
+
+
 def test_node_add_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
     stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(ADD_RESULT)
@@ -66,6 +122,7 @@ def test_node_add_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
                 "path": "/tmp/proj/main.tscn",
                 "parent": ".",
                 "type": "Sprite2D",
+                "instance": None,
                 "name": "Hero",
             },
         )
@@ -263,6 +320,7 @@ def test_node_add_defaults_parent_to_root_and_name_to_type(monkeypatch):
                 "path": "/tmp/proj/main.tscn",
                 "parent": ".",
                 "type": "Sprite2D",
+                "instance": None,
                 "name": "Sprite2D",
             },
         )


### PR DESCRIPTION
Closes #399

## What

`gda node add --instance res://….tscn` composes an existing scene as an instanced child of a host scene — the structured op for Godot's standard composition primitive, previously only possible by hand-editing the `.tscn` (Panda Adventure S6a pain, #335 / PR #398).

- **CLI/model**: `--instance` is mutually exclusive with `--type` (exactly-one enforced model-side per ADR-0015, so argv and `--params-json` agree; argv keeps usage-error ergonomics). Default `--name` = the instanced scene's filename stem. `NodeAddResult` gains `instance` (the composed `res://` path); `type` reports the instanced scene's resolved root class.
- **Op**: loads the referenced `PackedScene` and instantiates it with `GEN_EDIT_STATE_INSTANCE`, so the packer emits the **canonical instance stub** — `instance=ExtResource(...)` with no `type=` attribute, properties diffed against the instanced scene's own state, internals referenced, never inlined. Editor-build-only, the build gda drives (#164's documented assumption).
- **Failure ladder** (#392/#396 precedent): missing scene → `missing_dependency` naming the path; loads-but-not-a-scene → `not_a_scene`; instancing the host into itself → `cyclic_target` (registry description broadened, code/category/exit ABI unchanged; ADR-0002 table mirrored). File untouched in all cases.
- **#393 contract pinned**: pre-existing `ext_resource` ids and their references stay byte-identical; the new PackedScene entry gets a fresh non-colliding id.
- **Docs**: README table row (EN + zh-CN/es/ja, re-stamped), command-catalog "Scene instancing" spec paragraph, CONTEXT.md Project-code execution surface names the composed scene's scripts.

## Acceptance criteria (#399)

- [x] One structured op instances an existing `.tscn` under a named parent, headless
- [x] The serialization loads identically to an editor-authored instance (e2e round-trips via `node get`, which instantiates the host)
- [x] Missing/invalid instanced path → structured error naming the path
- [x] Pre-existing `ext_resource` ids unchanged (per #393)
- [x] `scene get`/`node list` reflect the instanced child (its `type` on static reads is companion issue #400, out of scope here)

## Verification

- Fast suite: 1056 passed; ruff + format + pyright clean; demo fast tests 132 passed
- e2e (serial, local): `test_e2e_node.py` + `test_e2e_scene.py` — 107 passed, including 6 new instance tests (compose+round-trip, id stability, missing_dependency, not_a_scene, cyclic_target)

## Notes

- Dogfooding observation, pre-existing and unrelated to this change: ANY mutating re-save adds a non-canonical `type=` (and full class-default diff) to *pre-existing* instance children of the host, because `_load_for_mutation` instantiates the host with `GEN_EDIT_STATE_DISABLED`. Loads fine, but non-canonical churn — filed as #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
