### PR TITLE
fix(scene): surface static scene instance identity

### DIFF
--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -61,6 +61,16 @@ they are provenance, not status markers.
 | `gda scene list` | Enumerate scenes in the project |
 | `gda scene get-exports` | List `@export` properties declared by a scene's nodes |
 
+**Static instance reporting** (established by #400): `scene get` reads the stored
+`SceneState` without instantiating the host scene, but an instanced node is still
+identifiable. Its `type` is resolved to the referenced scene's root node type
+when the referenced `PackedScene` loads, and the node carries `instance_path`
+plus `instance_status` (`resolved` or `missing`) so agents can distinguish an
+instance from a plain typed node. `scene list` applies the same rule to an
+inherited/instanced root through `root_type`, `root_instance_path`, and
+`root_instance_status`. A missing referenced scene keeps the marker and reports
+`missing` rather than silently appearing as only `type: ""`.
+
 **Export reporting** (established by #58): `gda scene get-exports` loads a scene, instantiates
 it, and reports — per node, keyed by the same canonical node path `node get`/`node set`
 address by (`.` for the root) — the `@export` properties the node's attached script declares:

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -352,15 +352,44 @@ class SceneCreateResult(BaseModel):
     )
 
 
+class SceneInstanceStatus(str, Enum):
+    """Whether a statically-read instanced scene reference resolved."""
+
+    RESOLVED = "resolved"
+    MISSING = "missing"
+
+
 class SceneNode(BaseModel):
-    """One node of a scene's structured tree: name, type, nested children.
+    """One node of a scene's structured tree: name, type, instance marker, children.
 
     Recursive on purpose — the tree IS the contract: ``gda scene get`` reports
     arbitrarily nested scenes through this one shape.
     """
 
     name: str
-    type: str
+    type: str = Field(
+        description=(
+            "Godot node class. For an instanced scene node, this is the "
+            "instanced scene's root class when it can be resolved statically."
+        )
+    )
+    instance_path: str | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "The referenced PackedScene path when this node is an instanced "
+            "scene; null for a plain typed node."
+        ),
+    )
+    instance_status: SceneInstanceStatus | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Whether the instanced scene reference resolved. Null for a plain "
+            "typed node; 'missing' means instance_path is visible but could not "
+            "be loaded as a PackedScene."
+        ),
+    )
     children: list["SceneNode"] = []
 
 
@@ -586,7 +615,30 @@ class ListedScene(BaseModel):
     )
     root_type: str | None = Field(
         default=None,
-        description="The scene root node's type, or null if the file could not be loaded as a scene.",
+        description=(
+            "The scene root node's type, resolving an inherited/instanced root "
+            "to the referenced scene's root type when possible; null if the "
+            "file could not be loaded as a scene."
+        ),
+    )
+    root_instance_path: str | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "The referenced PackedScene path when the scene root inherits or "
+            "instances another scene; null for a plain typed root or an "
+            "unloadable scene."
+        ),
+    )
+    root_instance_status: SceneInstanceStatus | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Whether the root instance reference resolved. Null for a plain "
+            "typed root or an unloadable scene; 'missing' means "
+            "root_instance_path is visible but could not be loaded as a "
+            "PackedScene."
+        ),
     )
 
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -307,10 +307,11 @@ func _op_scene_get(params: Dictionary) -> void:
 	var packed: PackedScene = _load_scene(params)
 	if packed == null:
 		return  # _load_scene already recorded the failure
+	var path := _string_param(params, "path")
 
 	_succeed({
-		"path": _string_param(params, "path"),
-		"root": _tree_from_state(packed.get_state()),
+		"path": path,
+		"root": _tree_from_state(packed.get_state(), false, _scene_instance_paths_by_node_path(path)),
 	})
 
 
@@ -565,10 +566,11 @@ func _op_node_list(params: Dictionary) -> void:
 	var packed: PackedScene = _load_scene(params)
 	if packed == null:
 		return  # _load_scene already recorded the failure
+	var path := _string_param(params, "path")
 
 	_succeed({
-		"scene_path": _string_param(params, "path"),
-		"root": _tree_from_state(packed.get_state(), true),
+		"scene_path": path,
+		"root": _tree_from_state(packed.get_state(), true, _scene_instance_paths_by_node_path(path)),
 	})
 
 
@@ -3484,10 +3486,19 @@ func _scene_summary(path: String) -> Dictionary:
 	var state := packed.get_state()
 	if state == null or state.get_node_count() == 0:
 		return {"path": path, "root_name": null, "root_type": null}
+	var root_fields := _state_node_projection_fields(state, 0)
+	var instance_paths := _scene_instance_paths_by_node_path(path)
+	if instance_paths.has("."):
+		var instance_path := String(instance_paths["."])
+		root_fields["instance_path"] = instance_path
+		if not root_fields.has("instance_status"):
+			root_fields["instance_status"] = _scene_instance_status_for_path(instance_path)
 	return {
 		"path": path,
 		"root_name": String(state.get_node_name(0)),
-		"root_type": String(state.get_node_type(0)),
+		"root_type": root_fields["type"],
+		"root_instance_path": root_fields.get("instance_path", null),
+		"root_instance_status": root_fields.get("instance_status", null),
 	}
 
 
@@ -4366,18 +4377,94 @@ func _normalize_state_path(state: SceneState, index: int) -> String:
 # each node's path in the emitted tree (node-list's addressing contract),
 # normalized to the root-relative form node add accepts and reports: the
 # state's "./Hero" prefix form becomes "Hero", the root stays ".".
-func _tree_from_state(state: SceneState, with_paths := false) -> Dictionary:
+func _packed_scene_root_type(packed: PackedScene, depth := 0) -> String:
+	if packed == null or depth > 16:
+		return ""
+	var state := packed.get_state()
+	if state == null or state.get_node_count() == 0:
+		return ""
+	var root_type := String(state.get_node_type(0))
+	if not root_type.is_empty():
+		return root_type
+	var root_instance := state.get_node_instance(0)
+	if root_instance != null:
+		return _packed_scene_root_type(root_instance, depth + 1)
+	return ""
+
+
+func _state_node_projection_fields(state: SceneState, index: int) -> Dictionary:
+	var fields := {"type": String(state.get_node_type(index))}
+	var instance := state.get_node_instance(index)
+	if instance != null:
+		fields["instance_status"] = "resolved"
+		var instance_path := String(instance.resource_path)
+		if not instance_path.is_empty():
+			fields["instance_path"] = instance_path
+		var root_type := _packed_scene_root_type(instance)
+		if fields["type"].is_empty() and not root_type.is_empty():
+			fields["type"] = root_type
+		return fields
+
+	var placeholder_path := String(state.get_node_instance_placeholder(index))
+	if not placeholder_path.is_empty():
+		fields["instance_path"] = placeholder_path
+		fields["instance_status"] = "missing"
+	return fields
+
+
+func _scene_instance_status_for_path(path: String) -> String:
+	return "resolved" if ResourceLoader.exists(path, "PackedScene") else "missing"
+
+
+# SceneState exposes whether a node is an instance and can resolve the root type,
+# but the public PackedScene object it returns does not reliably carry the
+# original ext_resource path. Recover that marker from the .tscn header text and
+# merge it into the SceneState projection.
+func _scene_instance_paths_by_node_path(path: String) -> Dictionary:
+	var text := FileAccess.get_file_as_string(path)
+	if text.is_empty():
+		return {}
+	var ext_resources_by_id := {}
+	for entry in _ext_resource_entries_from_text(text, path.get_base_dir()):
+		ext_resources_by_id[String(entry["id"])] = String(entry["normalized_path"])
+
+	var instance_paths := {}
+	for line in text.split("\n"):
+		var stripped := line.strip_edges()
+		if not stripped.begins_with("[node ") or stripped.find("instance=ExtResource(") == -1:
+			continue
+		var id := _first_quoted_after(stripped, stripped.find("instance=ExtResource("))
+		if id.is_empty() or not ext_resources_by_id.has(id):
+			continue
+		var node_path := _scene_node_path_from_header(stripped)
+		if not node_path.is_empty():
+			instance_paths[node_path] = ext_resources_by_id[id]
+	return instance_paths
+
+
+func _tree_from_state(state: SceneState, with_paths := false, instance_paths_by_node_path := {}) -> Dictionary:
 	var by_path := {}
 	var root: Dictionary = {}
 	for i in state.get_node_count():
+		var projection_fields := _state_node_projection_fields(state, i)
 		var state_path := String(state.get_node_path(i))
+		var normalized_path := _normalize_state_path(state, i)
+		if instance_paths_by_node_path.has(normalized_path):
+			var instance_path := String(instance_paths_by_node_path[normalized_path])
+			projection_fields["instance_path"] = instance_path
+			if not projection_fields.has("instance_status"):
+				projection_fields["instance_status"] = _scene_instance_status_for_path(instance_path)
 		var node := {
 			"name": String(state.get_node_name(i)),
-			"type": String(state.get_node_type(i)),
+			"type": projection_fields["type"],
 			"children": [],
 		}
+		if projection_fields.has("instance_path"):
+			node["instance_path"] = projection_fields["instance_path"]
+		if projection_fields.has("instance_status"):
+			node["instance_status"] = projection_fields["instance_status"]
 		if with_paths:
-			node["path"] = _normalize_state_path(state, i)
+			node["path"] = normalized_path
 		by_path[state_path] = node
 		if i == 0:
 			root = node

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -442,18 +442,24 @@ def test_node_add_instance_composes_a_scene_and_round_trips(godot_project):
     child = json.loads(got.stdout)
     assert child["type"] == "CanvasLayer"
 
-    # Static reads reflect the composition (#399's last acceptance criterion):
-    # the instanced child appears in the host's tree under both readers. Its
-    # static `type` is deliberately NOT asserted here — surfacing it is the
-    # companion issue #400.
+    # Static reads reflect the composition (#399's last acceptance criterion)
+    # and surface the instance identity (#400): the child is an instance of the
+    # source scene, and its static type resolves to that scene's root class.
     listed = gda("node", "list", "res://main.tscn", "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     children = json.loads(listed.stdout)["root"]["children"]
     assert [c["name"] for c in children] == ["hud"]
     assert children[0]["path"] == "hud"
+    assert children[0]["type"] == "CanvasLayer"
+    assert children[0]["instance_path"] == "res://hud.tscn"
+    assert children[0]["instance_status"] == "resolved"
     read = gda("scene", "get", "res://main.tscn", "--json")
     assert read.returncode == 0, read.stdout + read.stderr
-    assert [c["name"] for c in json.loads(read.stdout)["root"]["children"]] == ["hud"]
+    scene_child = json.loads(read.stdout)["root"]["children"][0]
+    assert scene_child["name"] == "hud"
+    assert scene_child["type"] == "CanvasLayer"
+    assert scene_child["instance_path"] == "res://hud.tscn"
+    assert scene_child["instance_status"] == "resolved"
 
     assert _no_gda_temp_siblings(godot_project)
 

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -262,6 +262,44 @@ NESTED_TSCN = """\
 """
 
 
+INSTANCED_HUD_TSCN = """\
+[gd_scene format=3]
+
+[node name="HudRoot" type="CanvasLayer"]
+"""
+
+
+HOST_WITH_INSTANCED_CHILD_TSCN = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/hud.tscn" id="1_hud"]
+
+[node name="Main" type="Node2D"]
+
+[node name="Hud" parent="." instance=ExtResource("1_hud")]
+"""
+
+
+HOST_WITH_MISSING_INSTANCED_CHILD_TSCN = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/missing_hud.tscn" id="1_missing"]
+
+[node name="Main" type="Node2D"]
+
+[node name="Hud" parent="." instance=ExtResource("1_missing")]
+"""
+
+
+INHERITED_HUD_ROOT_TSCN = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/hud.tscn" id="1_hud"]
+
+[node name="InheritedHud" instance=ExtResource("1_hud")]
+"""
+
+
 @pytest.mark.e2e
 def test_scene_get_reports_nested_tree(godot_project):
     # Guards the SceneState parent/child reconstruction (issue #30): a scene
@@ -278,6 +316,50 @@ def test_scene_get_reports_nested_tree(godot_project):
     assert (hero["name"], hero["type"]) == ("Hero", "Sprite2D")
     hitbox = hero["children"][0]
     assert (hitbox["name"], hitbox["type"]) == ("Hitbox", "Area2D")
+
+
+@pytest.mark.e2e
+def test_scene_get_marks_instanced_child_and_resolves_its_root_type(godot_project):
+    # issue #400: SceneState.get_node_type() is empty for instanced nodes.
+    # Static reads still need to identify the node as an instance and expose the
+    # instanced scene's root type without instantiating the host scene.
+    (godot_project / "scenes").mkdir()
+    (godot_project / "scenes" / "hud.tscn").write_text(
+        INSTANCED_HUD_TSCN, encoding="utf-8"
+    )
+    (godot_project / "main.tscn").write_text(
+        HOST_WITH_INSTANCED_CHILD_TSCN, encoding="utf-8"
+    )
+    gda = _gda_project(godot_project)
+
+    got = gda("scene", "get", "res://main.tscn", "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    hud = json.loads(got.stdout)["root"]["children"][0]
+    assert hud["name"] == "Hud"
+    assert hud["type"] == "CanvasLayer"
+    assert hud["instance_path"] == "res://scenes/hud.tscn"
+    assert hud["instance_status"] == "resolved"
+
+
+@pytest.mark.e2e
+def test_scene_get_marks_missing_instanced_child_reference(godot_project):
+    # issue #400: when the referenced scene is missing, the static read must
+    # still expose the instance marker so agents can branch on a broken
+    # instance instead of seeing only type="".
+    (godot_project / "main.tscn").write_text(
+        HOST_WITH_MISSING_INSTANCED_CHILD_TSCN, encoding="utf-8"
+    )
+    gda = _gda_project(godot_project)
+
+    got = gda("scene", "get", "res://main.tscn", "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    hud = json.loads(got.stdout)["root"]["children"][0]
+    assert hud["name"] == "Hud"
+    assert hud["type"] == ""
+    assert hud["instance_path"] == "res://scenes/missing_hud.tscn"
+    assert hud["instance_status"] == "missing"
 
 
 @pytest.mark.e2e
@@ -384,6 +466,31 @@ def test_scene_list_enumerates_created_scenes(godot_project):
     assert by_path["res://main.tscn"]["root_type"] == "Node2D"
     assert by_path["res://main.tscn"]["root_name"] == "main"
     assert by_path["res://ui/menu.tscn"]["root_type"] == "Control"
+
+
+@pytest.mark.e2e
+def test_scene_list_marks_inherited_scene_root_and_resolves_its_type(godot_project):
+    # issue #400 also affects scene list: an inherited scene root has an empty
+    # SceneState node type, so the listing needs the same instance marker and
+    # root-type resolution as scene get.
+    (godot_project / "scenes").mkdir()
+    (godot_project / "scenes" / "hud.tscn").write_text(
+        INSTANCED_HUD_TSCN, encoding="utf-8"
+    )
+    (godot_project / "inherited_hud.tscn").write_text(
+        INHERITED_HUD_ROOT_TSCN, encoding="utf-8"
+    )
+    gda = _gda_project(godot_project)
+
+    listed = gda("scene", "list", "--json")
+
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    scenes = json.loads(listed.stdout)["scenes"]
+    summary = {s["path"]: s for s in scenes}["res://inherited_hud.tscn"]
+    assert summary["root_name"] == "InheritedHud"
+    assert summary["root_type"] == "CanvasLayer"
+    assert summary["root_instance_path"] == "res://scenes/hud.tscn"
+    assert summary["root_instance_status"] == "resolved"
 
 
 @pytest.mark.e2e

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -162,6 +162,32 @@ def test_scene_get_result_round_trips_a_nested_tree():
     assert json.loads(scene.model_dump_json()) == payload
 
 
+def test_scene_get_result_round_trips_an_instanced_node_marker():
+    payload = {
+        "path": "/p/main.tscn",
+        "root": {
+            "name": "main",
+            "type": "Node2D",
+            "children": [
+                {
+                    "name": "Hud",
+                    "type": "CanvasLayer",
+                    "instance_path": "res://scenes/hud.tscn",
+                    "instance_status": "resolved",
+                    "children": [],
+                }
+            ],
+        },
+    }
+
+    scene = SceneGetResult.model_validate(payload)
+
+    hud = scene.root.children[0]
+    assert hud.instance_path == "res://scenes/hud.tscn"
+    assert hud.instance_status == "resolved"
+    assert json.loads(scene.model_dump_json()) == payload
+
+
 def test_scene_list_result_round_trips_enumerated_scenes():
     # The scene-list operation enumerates the project's .tscn files (issue #54):
     # each entry carries its res:// path plus the root's name/type read cheaply
@@ -180,6 +206,26 @@ def test_scene_list_result_round_trips_enumerated_scenes():
     assert listed.scenes[0].path == "res://main.tscn"
     assert listed.scenes[1].root_type == "Control"
     assert listed.scenes[2].root_name is None
+    assert json.loads(listed.model_dump_json()) == payload
+
+
+def test_scene_list_result_round_trips_an_inherited_root_marker():
+    payload = {
+        "scenes": [
+            {
+                "path": "res://inherited_hud.tscn",
+                "root_name": "InheritedHud",
+                "root_type": "CanvasLayer",
+                "root_instance_path": "res://scenes/hud.tscn",
+                "root_instance_status": "resolved",
+            }
+        ]
+    }
+
+    listed = SceneListResult.model_validate(payload)
+
+    assert listed.scenes[0].root_instance_path == "res://scenes/hud.tscn"
+    assert listed.scenes[0].root_instance_status == "resolved"
     assert json.loads(listed.model_dump_json()) == payload
 
 

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -123,6 +123,10 @@ def test_scene_get_schema_emits_model_derived_contract_without_other_args():
     assert doc["input"] == SceneGetParams.model_json_schema()
     assert doc["output"] == SceneGetResult.model_json_schema()
     assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    scene_node = doc["output"]["$defs"]["SceneNode"]["properties"]
+    assert "instanced scene" in scene_node["type"]["description"]
+    assert "referenced PackedScene path" in scene_node["instance_path"]["description"]
+    assert "missing" in scene_node["instance_status"]["description"]
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
@@ -169,6 +173,13 @@ def test_scene_list_schema_emits_model_derived_contract_without_a_project():
     assert doc["output"] == SceneListResult.model_json_schema()
     assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     assert doc["input"].get("properties", {}) == {}
+    listed_scene = doc["output"]["$defs"]["ListedScene"]["properties"]
+    assert "inherited/instanced root" in listed_scene["root_type"]["description"]
+    assert (
+        "referenced PackedScene path"
+        in listed_scene["root_instance_path"]["description"]
+    )
+    assert "missing" in listed_scene["root_instance_status"]["description"]
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 


### PR DESCRIPTION
## Summary

- Resolve static `scene get` / `node list` projection for instanced scene nodes by reporting the referenced scene root type.
- Add explicit instance markers: `instance_path` / `instance_status` for tree nodes and `root_instance_path` / `root_instance_status` for `scene list` inherited roots.
- Preserve an explicit `missing` status for broken instance references instead of silently returning only `type: ""`.
- Update model/schema descriptions and command catalog docs for the new contract.

## Root Cause

Godot `SceneState.get_node_type()` returns an empty type for instanced nodes because the class is defined by the referenced `PackedScene`. The previous static projection read only that declared node type and did not carry the instance reference identity, so agents could not distinguish an instance from a plain node with an empty type.

## Validation

- `uv run pytest -m "not e2e"`
- `uv run pytest tests/test_e2e_scene.py tests/test_e2e_node.py::test_node_add_instance_composes_a_scene_and_round_trips tests/test_models.py tests/test_schema_command.py tests/test_node_commands.py::test_node_list_json_emits_node_tree_with_paths_and_exit_zero`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `git diff --check`

Fixes: #400