### PR TITLE
fix(export): resolve export output paths

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -139,6 +139,7 @@ operation, and parse codes the CLI assigns).
 | `export_preset_not_found` | `operation` | `operation` | `4` | No export preset with the requested name exists in export_presets.cfg. |
 | `export_path_unset` | `operation` | `classifier` | `4` | An export run has no destination — neither a `--output` override nor a configured `export_path` (#170). |
 | `export_templates_missing` | `operation` | `classifier` | `4` | A release/debug export needs the export templates for the running engine version, which are not installed (pack needs no platform templates and is exempt; #170). |
+| `export_output_parent_failed` | `operation` | `classifier` | `4` | An export run could not create the output parent directory before native export (#402). |
 | `export_failed` | `operation` | `classifier` | `4` | A native Godot export run failed (the engine reported the export did not complete). |
 | `invalid_uid` | `operation` | `operation` | `4` | A requested `uid://` value is not a syntactically valid resource UID. |
 | `unknown_uid` | `operation` | `operation` | `4` | A syntactically valid resource UID is not registered in the engine's UID cache. |

--- a/docs/adr/0006-project-context-and-path-resolution.md
+++ b/docs/adr/0006-project-context-and-path-resolution.md
@@ -40,6 +40,13 @@ inventing its own.
 This applies to every path-taking command, not just `scene` — it is the project
 of record for the whole Phase-1 surface.
 
+`gda export run --output` is the one export-specific filesystem carve-out: the
+native export process runs with the Godot project as its cwd, so a relative
+`--output` is resolved against the invoker's cwd before the native export is
+spawned. Preset-configured `export_path` values are not CLI paths and keep
+Godot's project-relative export semantics; in particular, `~` in a preset value
+is a literal path component, not shell-style home expansion.
+
 ## Consequences
 
 - `res://` resolves deterministically against the chosen project regardless of

--- a/docs/adr/0010-headless-operation-execution-mechanism.md
+++ b/docs/adr/0010-headless-operation-execution-mechanism.md
@@ -73,7 +73,11 @@ native run:
   structured fields, with **no** native export spawned — in particular
   `export_templates_missing` is *not* inferred from the engine's "due to configuration
   errors" stderr (which would violate ADR-0002 and also misfires for a
-  merely-misconfigured preset).
+  merely-misconfigured preset). After those checks pass, `gda` creates any missing
+  filesystem parent directories for the resolved output path; if that preflight cannot
+  create the parent, it returns the classifier-source `export_output_parent_failed`
+  before Godot runs, rather than letting locale/version-dependent engine prose decide
+  the public error.
 - **Native run (classifier on exit code).** Only the export execution itself uses the
   native CLI mode. A clean exit is the typed success result (with any advisory
   `WARNING` lines parsed off stderr as best-effort diagnostics); any non-zero exit is

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -527,6 +527,14 @@ a missing action is `unknown_setting`, mirroring `remove-autoload`. A failed sav
 | `gda export run` | Run an export preset via headless CLI |
 | `gda export get` | Export-template install status / preset info |
 
+`gda export run` resolves its effective destination before the native export:
+`--output` wins over the preset's `export_path`; a relative `--output` resolves
+against the invoker's current working directory, while a preset `export_path`
+keeps Godot's project-relative convention. The JSON `output_path` is the resolved
+absolute artifact path. Missing output parent directories are created before the
+native export and reported in `created_dirs`, outermost to innermost; an
+uncreatable parent is reported as `invalid_path` before Godot runs.
+
 ### Asset-file groups (create/edit files; headless)
 
 These create or edit resource files (`.gdshader`, `.tres`) and so are headless.

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -530,10 +530,12 @@ a missing action is `unknown_setting`, mirroring `remove-autoload`. A failed sav
 `gda export run` resolves its effective destination before the native export:
 `--output` wins over the preset's `export_path`; a relative `--output` resolves
 against the invoker's current working directory, while a preset `export_path`
-keeps Godot's project-relative convention. The JSON `output_path` is the resolved
-absolute artifact path. Missing output parent directories are created before the
-native export and reported in `created_dirs`, outermost to innermost; an
-uncreatable parent is reported as `invalid_path` before Godot runs.
+keeps Godot's project-relative convention (including a literal `~` path
+component; no shell-style home expansion). The JSON `output_path` is the
+resolved absolute artifact path. Missing output parent directories are created
+before the native export and reported in `created_dirs`, outermost to innermost;
+an uncreatable parent is reported as `export_output_parent_failed` before Godot
+runs.
 
 ### Asset-file groups (create/edit files; headless)
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -3108,13 +3108,17 @@ def run_export(
         "--mode",
         help="The export flavor to run (release/debug/pack); default release.",
     ),
-    # --output (#170): override the preset's configured export_path. A filesystem
-    # path normalized ONCE at the CLI layer (ADR-0006: ~ expanded), like every
-    # other path-taking command.
+    # --output (#170/#403): override the preset's configured export_path. A
+    # filesystem path is normalized ONCE at the params-model layer: ~ expands and
+    # relative paths resolve against the invoker's cwd before the native export
+    # runner changes cwd to the project.
     output: Optional[str] = typer.Option(
         None,
         "--output",
-        help="Override the preset's configured export_path; write the artifact here instead.",
+        help=(
+            "Override the preset's configured export_path; relative filesystem "
+            "paths resolve against the invoker's current working directory."
+        ),
     ),
     json_output: bool = json_option(),
     schema: bool = EXPORT_RUN_COMMAND.schema_option(),
@@ -3135,14 +3139,17 @@ def run_export(
     (issue #187), so this command is the same thin shape as every other: build
     params → invoke the operation → emit.
 
-    ``--mode`` selects the export flavor (release/debug/pack; default release) and
-    ``--output`` overrides the preset's configured ``export_path``; both are
-    reflected in the native invocation and the reported result (#170).
+    ``--mode`` selects the export flavor (release/debug/pack; default release).
+    ``--output`` overrides the preset's configured ``export_path`` and resolves a
+    relative filesystem path against the invoker's current working directory;
+    preset ``export_path`` values keep Godot's project-relative convention. The
+    reported ``output_path`` is the resolved artifact path, and missing output
+    parent directories are created and reported in ``created_dirs`` (#402/#403).
     """
     # Build the params model from the argv options (the single source of truth,
-    # ADR-0015): ExportRunParams.output is a NormalizedPath, so the model ~-expands
-    # it (ADR-0006) — argv and --params-json normalize identically. Dispatch through
-    # the descriptor's recipe (ADR-0023), exactly like every other recipe command.
+    # ADR-0015): ExportRunParams.output is an ExportOutputPath, so argv and
+    # --params-json normalize identically. Dispatch through the descriptor's
+    # recipe (ADR-0023), exactly like every other recipe command.
     _dispatch_recipe(
         EXPORT_RUN_COMMAND,
         ExportRunParams(preset=preset, mode=mode, output=output),

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -405,6 +405,13 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "An export run needs the export templates for the running engine version, which are not installed.",
     ),
     ErrorCodeSpec(
+        "export_output_parent_failed",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.CLASSIFIER,
+        "An export run could not create the output parent directory before native export.",
+    ),
+    ErrorCodeSpec(
         "export_failed",
         ErrorCategory.OPERATION,
         EXIT_OPERATION,

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -550,6 +550,7 @@ def classify_export_run(
     platform: str,
     mode: ExportRunMode,
     output_path: str,
+    created_dirs: list[str],
 ) -> ExportRunResult | Failure:
     """Classify a native Godot export into a typed result or a ``Failure`` (issue #121).
 
@@ -589,7 +590,18 @@ def classify_export_run(
         platform=platform,
         mode=mode,
         output_path=output_path,
+        created_dirs=created_dirs,
         warnings=parse_export_warnings(output.stderr),
+    )
+
+
+def export_output_parent_failure(output_path: str, parent_path: str) -> Failure:
+    """The ``invalid_path`` failure for an uncreatable export output parent (#402)."""
+    return _failure(
+        "invalid_path",
+        "export output parent directory is not creatable: "
+        f"{parent_path} (for output path {output_path})",
+        "",
     )
 
 

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -596,9 +596,9 @@ def classify_export_run(
 
 
 def export_output_parent_failure(output_path: str, parent_path: str) -> Failure:
-    """The ``invalid_path`` failure for an uncreatable export output parent (#402)."""
+    """The classifier-source failure for an uncreatable export output parent (#402)."""
     return _failure(
-        "invalid_path",
+        "export_output_parent_failed",
         "export output parent directory is not creatable: "
         f"{parent_path} (for output path {output_path})",
         "",

--- a/src/gda/export_run.py
+++ b/src/gda/export_run.py
@@ -9,9 +9,9 @@ sentinel pipeline:
 
 1. **resolve** the preset via the existing ``export-get`` sentinel op — reusing
    #114's clean preset/project errors;
-2. **structured preflight** (effective destination + template readiness,
-   ADR-0010) that fails fast — ``export_path_unset`` / ``export_templates_missing``
-   — with NO native run;
+2. **structured preflight** (effective destination + template readiness + output
+   parent dirs, ADR-0010) that fails fast — ``export_path_unset`` /
+   ``export_templates_missing`` / ``invalid_path`` — with NO native run;
 3. the native ``--export-<mode>`` run, whose raw outcome
    :func:`gda.errors.classify_export_run` turns into the typed result.
 
@@ -42,6 +42,7 @@ from gda.binary import resolve_godot_binary
 from gda.errors import (
     Failure,
     classify_export_run,
+    export_output_parent_failure,
     export_path_unset_failure,
     export_templates_missing_failure,
 )
@@ -117,6 +118,53 @@ EXPORT_GET_COMMAND: HeadlessCommand[ExportGetResult] = HeadlessCommand(
 )
 
 
+def _resolve_configured_export_path(path: str, project: Optional[Path]) -> str:
+    """Resolve a preset export_path to the absolute artifact path (#403)."""
+    if not path or "://" in path:
+        return path
+    expanded = Path(path).expanduser()
+    if expanded.is_absolute():
+        return str(expanded)
+    base = Path.cwd() if project is None else project
+    if not base.is_absolute():
+        base = Path.cwd() / base
+    return str(base / expanded)
+
+
+def _ensure_output_parent_dirs(output_path: str) -> list[str] | Failure:
+    """Create the export destination's missing filesystem parent dirs (#402)."""
+    if "://" in output_path:
+        return []
+
+    parent = Path(output_path).parent
+    if str(parent) in {"", "."}:
+        return []
+    if parent.exists():
+        if parent.is_dir():
+            return []
+        return export_output_parent_failure(output_path, str(parent))
+
+    missing: list[Path] = []
+    cursor = parent
+    while not cursor.exists():
+        missing.append(cursor)
+        if cursor.parent == cursor:
+            break
+        cursor = cursor.parent
+
+    if cursor.exists() and not cursor.is_dir():
+        return export_output_parent_failure(output_path, str(cursor))
+
+    created_dirs = [str(path) for path in reversed(missing)]
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return export_output_parent_failure(output_path, str(parent))
+    if not parent.is_dir():
+        return export_output_parent_failure(output_path, str(parent))
+    return created_dirs
+
+
 def run_export_operation(
     *,
     preset: str,
@@ -154,13 +202,19 @@ def run_export_operation(
     if isinstance(got, Failure):
         return got
 
-    # Resolve the effective destination: --output (already CLI-normalized) wins
-    # over the preset's configured export_path (#170). This is what the native
-    # export writes to AND what the result reports as output_path.
-    output_path = output_override if output_override is not None else got.export_path
+    # Resolve the effective destination: --output (already CLI-normalized and
+    # invoker-cwd absolute for relative filesystem paths, #403) wins over the
+    # preset's configured export_path (#170). A configured relative export_path
+    # keeps Godot's project-relative convention, but we pass/report the absolute
+    # artifact path so the result is self-describing for consumers.
+    output_path = (
+        output_override
+        if output_override is not None
+        else _resolve_configured_export_path(got.export_path, project)
+    )
 
-    # Phase 2 (structured preflight, BEFORE any native run; ADR-0010). Two
-    # fail-fast checks, both decided from export get's structured fields rather
+    # Phase 2 (structured preflight, BEFORE any native run; ADR-0010). The first
+    # two fail-fast checks are decided from export get's structured fields rather
     # than from the engine's stderr (which ADR-0002 forbids parsing for codes):
     #
     #  - There must be a destination, for EVERY mode. --output supplies one
@@ -182,10 +236,17 @@ def run_export_operation(
     #    export_templates_missing, decided here rather than by string-matching the
     #    engine's "due to configuration errors" stderr (which also fires for a
     #    merely-misconfigured preset).
+    #  - Once the export is otherwise runnable, create the destination's missing
+    #    parent directories before the native export so a missing directory never
+    #    falls through to locale/version-dependent engine prose (#402). An
+    #    uncreatable parent is a structured invalid_path.
     if not output_path:
         return export_path_unset_failure(got.name)
     if mode is not ExportRunMode.PACK and not got.templates_installed:
         return export_templates_missing_failure(got.name, got.templates_version)
+    created_dirs = _ensure_output_parent_dirs(output_path)
+    if isinstance(created_dirs, Failure):
+        return created_dirs
 
     # Phase 3 (native run + classify): run the native export and classify its raw
     # outcome. The export-get resolved name (got.name) is authoritative throughout
@@ -220,4 +281,5 @@ def run_export_operation(
         platform=got.platform,
         mode=mode,
         output_path=output_path,
+        created_dirs=created_dirs,
     )

--- a/src/gda/export_run.py
+++ b/src/gda/export_run.py
@@ -11,7 +11,8 @@ sentinel pipeline:
    #114's clean preset/project errors;
 2. **structured preflight** (effective destination + template readiness + output
    parent dirs, ADR-0010) that fails fast — ``export_path_unset`` /
-   ``export_templates_missing`` / ``invalid_path`` — with NO native run;
+   ``export_templates_missing`` / ``export_output_parent_failed`` — with NO
+   native run;
 3. the native ``--export-<mode>`` run, whose raw outcome
    :func:`gda.errors.classify_export_run` turns into the typed result.
 
@@ -122,13 +123,13 @@ def _resolve_configured_export_path(path: str, project: Optional[Path]) -> str:
     """Resolve a preset export_path to the absolute artifact path (#403)."""
     if not path or "://" in path:
         return path
-    expanded = Path(path).expanduser()
-    if expanded.is_absolute():
-        return str(expanded)
+    configured = Path(path)
+    if configured.is_absolute():
+        return str(configured)
     base = Path.cwd() if project is None else project
     if not base.is_absolute():
         base = Path.cwd() / base
-    return str(base / expanded)
+    return str(base / configured)
 
 
 def _ensure_output_parent_dirs(output_path: str) -> list[str] | Failure:
@@ -239,7 +240,7 @@ def run_export_operation(
     #  - Once the export is otherwise runnable, create the destination's missing
     #    parent directories before the native export so a missing directory never
     #    falls through to locale/version-dependent engine prose (#402). An
-    #    uncreatable parent is a structured invalid_path.
+    #    uncreatable parent is a structured export_output_parent_failed.
     if not output_path:
         return export_path_unset_failure(got.name)
     if mode is not ExportRunMode.PACK and not got.templates_installed:

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -294,6 +294,26 @@ def normalize_path(path: str) -> str:
 NormalizedPath = Annotated[str, AfterValidator(normalize_path)]
 
 
+def normalize_export_output_path(path: str) -> str:
+    """Normalize an ``export run --output`` artifact path (#403).
+
+    Export runs the native Godot export with cwd set to the project directory.
+    A relative ``--output`` must therefore be made absolute against the invoker's
+    cwd before the runner sees it, or Godot writes into the project tree while
+    the result echoes an unlocatable relative string. Virtual paths keep the
+    shared path convention and pass through unchanged.
+    """
+    if "://" in path:
+        return path
+    expanded = Path(path).expanduser()
+    if expanded.is_absolute():
+        return str(expanded)
+    return str(Path.cwd() / expanded)
+
+
+ExportOutputPath = Annotated[str, AfterValidator(normalize_export_output_path)]
+
+
 def derive_scene_root_name(path: str) -> str:
     """Derive the default scene root name from the target file name."""
     filename = path.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
@@ -1845,9 +1865,13 @@ class ExportRunParams(BaseModel):
         default=ExportRunMode.RELEASE,
         description="The export flavor to run (release/debug/pack); default release.",
     )
-    output: NormalizedPath | None = Field(
+    output: ExportOutputPath | None = Field(
         default=None,
-        description="Override the preset's configured export_path; write the artifact here instead.",
+        description=(
+            "Override the preset's configured export_path; a relative filesystem "
+            "path is resolved against the invoker's current working directory "
+            "before export."
+        ),
     )
 
 
@@ -1856,9 +1880,12 @@ class ExportRunResult(BaseModel):
 
     Echoes the addressed preset's ``preset`` name and target ``platform`` (read
     from ``export_presets.cfg``), the ``mode`` that was run (the selected flavor,
-    ``release`` by default; #170), and the ``output_path`` the artifact was
-    written to — the effective destination, i.e. the ``--output`` override when
-    given, else the preset's *configured* ``export_path`` (#170).
+    ``release`` by default; #170), and the resolved absolute ``output_path`` the
+    artifact was written to — the effective destination, i.e. the ``--output``
+    override when given, else the preset's configured ``export_path`` resolved
+    against the project directory (#403). ``created_dirs`` lists output parent
+    directories created before the native export, from outermost to innermost
+    (#402).
     ``warnings`` carries the engine's non-fatal export warnings (e.g. a missing
     optional icon), parsed best-effort from the export's stderr; an export that
     succeeds cleanly reports ``warnings == []``. Unlike the sentinel operations,
@@ -1872,7 +1899,14 @@ class ExportRunResult(BaseModel):
         description="The preset's target platform (e.g. Linux/X11, Web, macOS)."
     )
     mode: ExportRunMode = Field(description="The export flavor that was run.")
-    output_path: str = Field(description="The path the export artifact was written to.")
+    output_path: str = Field(
+        description="The resolved absolute path the export artifact was written to."
+    )
+    created_dirs: list[str] = Field(
+        description=(
+            "Output parent directories created before export, from outermost to innermost."
+        )
+    )
     warnings: list[str] = Field(
         default_factory=list,
         description="The engine's non-fatal export warnings, parsed from stderr; empty on a clean export.",

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -125,7 +125,7 @@ export GDA_GODOT="/path/to/Godot"
 gda scene create game/main.tscn --root-type Node2D --project game --json
 gda node add  game/main.tscn --type Sprite2D --name Hero --project game --json
 gda node set  game/main.tscn --node Hero --property position --value "100,50" --project game --json
-gda export run --preset "Linux/X11" --output build/game.zip --project game --json  # --preset: a name from 'gda export list'
+gda export run --preset "Linux/X11" --output "$PWD/game/build/game.zip" --project game --json  # --preset: a name from 'gda export list'
 ```
 
 Live: observe the running game, then tear down.

--- a/tests/test_classify_export_run.py
+++ b/tests/test_classify_export_run.py
@@ -32,7 +32,8 @@ def _classify(output: RunResult) -> ExportRunResult | Failure:
         preset="Linux/X11",
         platform="Linux/X11",
         mode=ExportRunMode.RELEASE,
-        output_path="build/game.x86_64",
+        output_path="/tmp/project/build/game.x86_64",
+        created_dirs=[],
     )
 
 
@@ -45,7 +46,8 @@ def test_clean_export_synthesizes_success_result():
         preset="Linux/X11",
         platform="Linux/X11",
         mode=ExportRunMode.RELEASE,
-        output_path="build/game.x86_64",
+        output_path="/tmp/project/build/game.x86_64",
+        created_dirs=[],
         warnings=[],
     )
 

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -2,8 +2,8 @@
 
 Unlike every other command, ``export run`` does not route through operations.gd:
 the export subsystem is editor-only, so the export is a native ``--export-release``
-invocation, and ``gda`` synthesizes the typed result from the subprocess's exit
-code (#121 fixes the mode to release; --mode/--output are deferred to #170). These
+invocation by default, and ``gda`` synthesizes the typed result from the subprocess's exit
+code (#121; ``--mode`` / ``--output`` are selectable via #170). These
 tests exercise that REAL path — the real ``SubprocessExportRunner`` spawning the
 real Godot, classified by the real ``classify_export_run`` — plus the real
 ``export get`` structured template-readiness preflight.
@@ -22,8 +22,10 @@ so when templates are absent that release test asserts the structured
 project data only (a PCK/ZIP) and needs **no** platform export templates, so the
 pack test must RUN — not skip — on a template-less machine: it asserts exit 0 and
 the ``.pck`` on disk, giving the on-disk verification a release export cannot give
-here. The structured-failure paths that need no templates (unknown preset, unset
-path) run unconditionally.
+here. ``--output`` relative paths resolve against the invoker's cwd (#403); preset
+``export_path`` values keep Godot's project-relative convention. The
+structured-failure paths that need no templates (unknown preset, unset path) run
+unconditionally.
 """
 
 import json
@@ -116,8 +118,8 @@ def test_export_run_unknown_preset_reuses_export_get_error(godot_project):
 @pytest.mark.e2e
 def test_export_run_unset_path_yields_export_path_unset(godot_project):
     # A preset whose configured export_path is empty is export_path_unset —
-    # reported before any export runs, so it needs no templates (--output, which
-    # could have supplied a path, is deferred to #170).
+    # reported before any export runs, so it needs no templates. --output could
+    # have supplied the effective destination, but this call intentionally omits it.
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
@@ -136,7 +138,7 @@ def test_export_run_writes_to_configured_export_path(godot_project):
     # PRIMARY acceptance behavior (#121): `gda export run --preset NAME` (no
     # --output) exports to the preset's CONFIGURED export_path. The preset writes
     # to res://build/game.x86_64, so the artifact lands at <project>/build/... and
-    # the reported output_path is the configured string verbatim.
+    # the reported output_path is the resolved absolute artifact path.
     #
     # The configured parent directory is created first (a real export writes the
     # binary there). When templates are absent the real export cannot complete —
@@ -156,7 +158,6 @@ def test_export_run_writes_to_configured_export_path(godot_project):
     )
     configured_rel = "build/game.x86_64"
     artifact = godot_project / configured_rel
-    artifact.parent.mkdir(parents=True, exist_ok=True)  # the preset's configured dir
     gda = _gda_project(godot_project)
 
     run = gda("export", "run", "--preset", "Linux/X11", "--json")
@@ -180,8 +181,10 @@ def test_export_run_writes_to_configured_export_path(godot_project):
     assert data["preset"] == "Linux/X11"
     assert data["platform"] == "Linux/X11"
     assert data["mode"] == "release"
-    # (b) The reported output_path equals the preset's configured export_path.
-    assert data["output_path"] == configured_rel
+    # (b) The reported output_path is the preset export_path resolved against the
+    # project directory, and the missing parent directory was created pre-export.
+    assert data["output_path"] == str(artifact)
+    assert data["created_dirs"] == [str(artifact.parent)]
     assert isinstance(data["warnings"], list)
     # (a) The artifact was actually written to the configured path on disk.
     assert artifact.exists(), f"expected artifact at configured path {artifact}"
@@ -206,9 +209,7 @@ def test_export_run_pack_writes_pck_without_templates(godot_project):
     (godot_project / "main.gd").write_text(
         "extends Node\n\nfunc _ready() -> void:\n\tpass\n", encoding="utf-8"
     )
-    override_rel = "dist/packed.pck"
-    artifact = godot_project / override_rel
-    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact = godot_project / "dist" / "packed.pck"
     configured = godot_project / "build/game.x86_64"
     gda = _gda_project(godot_project)
 
@@ -220,7 +221,7 @@ def test_export_run_pack_writes_pck_without_templates(godot_project):
         "--mode",
         "pack",
         "--output",
-        override_rel,
+        str(artifact),
         "--json",
     )
 
@@ -230,7 +231,8 @@ def test_export_run_pack_writes_pck_without_templates(godot_project):
     assert data["mode"] == "pack"
     # The reported output_path is the override, and the .pck lands there on disk —
     # NOT at the preset's configured export_path.
-    assert data["output_path"] == override_rel
+    assert data["output_path"] == str(artifact)
+    assert data["created_dirs"] == [str(artifact.parent)]
     assert artifact.exists(), f"expected .pck at the override path {artifact}"
     assert not configured.exists(), "the override must not write the configured path"
 
@@ -251,9 +253,7 @@ def test_export_run_pack_accepts_a_relative_project(godot_project):
     (godot_project / "main.gd").write_text(
         "extends Node\n\nfunc _ready() -> void:\n\tpass\n", encoding="utf-8"
     )
-    override_rel = "dist/packed.pck"
-    artifact = godot_project / override_rel
-    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact = godot_project / "dist" / "packed.pck"
 
     # Drive gda from the project's PARENT with a RELATIVE --project (the failing
     # case) — NOT the absolute path _gda_project passes.
@@ -267,7 +267,7 @@ def test_export_run_pack_accepts_a_relative_project(godot_project):
             "--mode",
             "pack",
             "--output",
-            override_rel,
+            str(artifact),
             "--json",
             "--godot",
             str(GODOT),
@@ -284,7 +284,8 @@ def test_export_run_pack_accepts_a_relative_project(godot_project):
     assert run.returncode == 0, run.stdout + run.stderr
     data = json.loads(run.stdout)
     assert data["mode"] == "pack"
-    assert data["output_path"] == override_rel
+    assert data["output_path"] == str(artifact)
+    assert data["created_dirs"] == [str(artifact.parent)]
     # The .pck landed INSIDE the project — the relative --project resolved to the
     # same directory an absolute one would, exactly as the editor resolves it.
     assert artifact.exists(), f"expected .pck at {artifact} for a relative --project"
@@ -312,9 +313,7 @@ def test_export_run_pack_omits_installed_harness_and_restores_it(godot_project):
     assert harness_file.exists(), "precondition: harness installed on disk"
     assert HARNESS_AUTOLOAD_NAME in project_godot.read_text(encoding="utf-8")
 
-    override_rel = "dist/packed.zip"
-    artifact = godot_project / override_rel
-    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact = godot_project / "dist" / "packed.zip"
     gda = _gda_project(godot_project)
 
     run = gda(
@@ -325,11 +324,14 @@ def test_export_run_pack_omits_installed_harness_and_restores_it(godot_project):
         "--mode",
         "pack",
         "--output",
-        override_rel,
+        str(artifact),
         "--json",
     )
 
     assert run.returncode == 0, run.stdout + run.stderr
+    data = json.loads(run.stdout)
+    assert data["output_path"] == str(artifact)
+    assert data["created_dirs"] == [str(artifact.parent)]
     assert artifact.exists(), f"expected .zip at the override path {artifact}"
     with zipfile.ZipFile(artifact) as zf:
         names = zf.namelist()

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -657,8 +657,9 @@ def test_export_run_help_documents_output_resolution():
 
     assert result.exit_code == 0
     help_text = _plain(result.stdout)
+    normalized = " ".join(help_text.split())
     assert "--output" in help_text
-    assert "invoker's current working directory" in help_text
+    assert "invoker's current working directory" in normalized
 
 
 def test_export_run_human_output_echoes_artifact(monkeypatch, tmp_path):

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -26,6 +26,7 @@ Typer → resolve → preflight → export → classify → JSON pipeline runs e
 """
 
 import json
+import re
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -47,6 +48,12 @@ GET_RESULT = {
     "templates_installed": True,
     "templates_version": "4.6.3.stable",
 }
+
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _plain(text: str) -> str:
+    return ANSI_ESCAPE.sub("", text)
 
 
 def _inject(monkeypatch, *, get=GET_RESULT, export=None):
@@ -649,8 +656,9 @@ def test_export_run_help_documents_output_resolution():
     result = CliRunner().invoke(app, ["export", "run", "--help"])
 
     assert result.exit_code == 0
-    assert "--output" in result.stdout
-    assert "invoker's current working directory" in result.stdout
+    help_text = _plain(result.stdout)
+    assert "--output" in help_text
+    assert "invoker's current working directory" in help_text
 
 
 def test_export_run_human_output_echoes_artifact(monkeypatch, tmp_path):

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -3,9 +3,10 @@
 ``export run`` is the first command that does NOT route through operations.gd:
 the Godot export subsystem is editor-only C++, unreachable from a ``--script``
 SceneTree run, so the actual export is a native ``--export-release`` invocation
-(#121 fixes the mode to release; --mode/--output are deferred to #170). ``gda``
+(#121), selectable by ``--mode`` (#170). ``--output`` overrides the preset path
+and resolves relative filesystem paths against the invoker cwd (#403). ``gda``
 synthesizes the typed result from that subprocess's exit code, not from an
-ADR-0002 sentinel.
+ADR-0002 sentinel, after creating missing output parent dirs (#402).
 
 The command runs in three steps, the engine-touching ones behind injectable seams:
 
@@ -15,7 +16,8 @@ The command runs in three steps, the engine-touching ones behind injectable seam
 2. a structured preflight (on export-get's ``templates_installed`` and the
    configured ``export_path``) fails fast — export_templates_missing /
    export_path_unset — before any native export is spawned.
-3. the native ``ExportRunner`` performs the export to the configured path; its
+3. missing output parent directories are created and reported; then the native
+   ``ExportRunner`` performs the export to the effective path; its
    raw ``{stdout, stderr, exit_code}`` is classified into success or a
    ``GdaError``.
 
@@ -66,6 +68,14 @@ def _inject(monkeypatch, *, get=GET_RESULT, export=None):
     return get_runner, export_runner
 
 
+def _configured_output(project: Path) -> str:
+    return str(project / "build" / "game.x86_64")
+
+
+def _cwd_output(*parts: str) -> str:
+    return str(Path.cwd().joinpath(*parts))
+
+
 def test_export_run_params_json_drives_the_native_export_runner(monkeypatch, tmp_path):
     # export run is the native-export recipe (run_export_operation), NOT the
     # sentinel pipeline. --params-json (ADR-0015) must drive that SAME recipe, so
@@ -88,8 +98,12 @@ def test_export_run_params_json_drives_the_native_export_runner(monkeypatch, tmp
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
-    assert json.loads(result.stdout)["mode"] == "release"
-    assert export_runner.calls == [("Linux/X11", "release", "build/game.x86_64")]
+    data = json.loads(result.stdout)
+    assert data["mode"] == "release"
+    assert data["created_dirs"] == [str(tmp_path / "build")]
+    assert export_runner.calls == [
+        ("Linux/X11", "release", _configured_output(tmp_path))
+    ]
 
 
 def test_export_run_json_reports_configured_path_and_exit_zero(monkeypatch, tmp_path):
@@ -118,12 +132,15 @@ def test_export_run_json_reports_configured_path_and_exit_zero(monkeypatch, tmp_
     assert data["preset"] == "Linux/X11"
     assert data["platform"] == "Linux/X11"
     assert data["mode"] == "release"
-    # The reported output_path is the preset's configured export_path verbatim.
-    assert data["output_path"] == "build/game.x86_64"
+    # The reported output_path is the preset's configured export_path resolved
+    # against the project directory.
+    assert data["output_path"] == _configured_output(tmp_path)
+    assert data["created_dirs"] == [str(tmp_path / "build")]
     assert data["warnings"] == []
-    # The export ran for the preset, in release mode, to the CONFIGURED path
-    # (no --output override — that flag is deferred to #170).
-    assert export_runner.calls == [("Linux/X11", "release", "build/game.x86_64")]
+    # The export ran for the preset, in release mode, to the resolved configured path.
+    assert export_runner.calls == [
+        ("Linux/X11", "release", _configured_output(tmp_path))
+    ]
 
 
 def test_export_run_default_mode_is_release(monkeypatch, tmp_path):
@@ -148,7 +165,9 @@ def test_export_run_default_mode_is_release(monkeypatch, tmp_path):
 
     assert result.exit_code == 0, result.stdout + result.stderr
     assert json.loads(result.stdout)["mode"] == "release"
-    assert export_runner.calls == [("Linux/X11", "release", "build/game.x86_64")]
+    assert export_runner.calls == [
+        ("Linux/X11", "release", _configured_output(tmp_path))
+    ]
 
 
 def test_export_run_mode_selects_export_flavor(monkeypatch, tmp_path):
@@ -178,7 +197,9 @@ def test_export_run_mode_selects_export_flavor(monkeypatch, tmp_path):
         data = json.loads(result.stdout)
         assert data["mode"] == mode
         # The native export was driven with the selected mode, to the configured path.
-        assert export_runner.calls == [("Linux/X11", mode, "build/game.x86_64")]
+        assert export_runner.calls == [
+            ("Linux/X11", mode, _configured_output(tmp_path))
+        ]
 
 
 def test_export_run_rejects_unknown_mode(monkeypatch, tmp_path):
@@ -213,6 +234,7 @@ def test_export_run_output_overrides_configured_path(monkeypatch, tmp_path):
     # --output (issue #170) overrides the preset's configured export_path: the
     # native export is driven to the override, NOT the configured "build/game.x86_64",
     # and the result's output_path reports the effective destination.
+    monkeypatch.chdir(tmp_path)
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
     _, export_runner = _inject(monkeypatch)
 
@@ -233,16 +255,55 @@ def test_export_run_output_overrides_configured_path(monkeypatch, tmp_path):
 
     assert result.exit_code == 0, result.stdout + result.stderr
     data = json.loads(result.stdout)
-    # The reported output_path is the override (the effective destination).
-    assert data["output_path"] == "dist/custom.x86_64"
+    # The reported output_path is the override, resolved against the invoker cwd.
+    expected = _cwd_output("dist", "custom.x86_64")
+    assert data["output_path"] == expected
+    assert data["created_dirs"] == [str(tmp_path / "dist")]
     assert data["mode"] == "release"
-    assert export_runner.calls == [("Linux/X11", "release", "dist/custom.x86_64")]
+    assert export_runner.calls == [("Linux/X11", "release", expected)]
+
+
+def test_export_run_relative_output_resolves_against_invoker_cwd(monkeypatch, tmp_path):
+    # issue #403: export run's native process runs with cwd=<project>, so a
+    # relative --output must be absolutized against the invoker cwd before it
+    # reaches Godot. The JSON result reports the same absolute artifact path.
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    invoker_cwd = tmp_path / "caller"
+    invoker_cwd.mkdir()
+    monkeypatch.chdir(invoker_cwd)
+    _, export_runner = _inject(monkeypatch)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--output",
+            "./dist/custom.x86_64",
+            "--project",
+            str(project),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    expected = str(invoker_cwd / "dist" / "custom.x86_64")
+    data = json.loads(result.stdout)
+    assert data["output_path"] == expected
+    assert data["created_dirs"] == [str(invoker_cwd / "dist")]
+    assert export_runner.calls == [("Linux/X11", "release", expected)]
 
 
 def test_export_run_output_expands_leading_tilde(monkeypatch, tmp_path):
     # ADR-0006: --output is a filesystem path normalized ONCE at the CLI layer, so
     # a literal `~` is expanded to the user's home before it reaches the runner —
     # the artifact lands in $HOME, not a literal "~" directory.
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
     _, export_runner = _inject(monkeypatch)
 
@@ -262,10 +323,11 @@ def test_export_run_output_expands_leading_tilde(monkeypatch, tmp_path):
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
-    expanded = str((Path.home() / "builds/game.x86_64"))
+    expanded = str(home / "builds/game.x86_64")
     data = json.loads(result.stdout)
     # Both the native invocation and the reported destination carry the expanded path.
     assert data["output_path"] == expanded
+    assert data["created_dirs"] == [str(home), str(home / "builds")]
     assert export_runner.calls == [("Linux/X11", "release", expanded)]
 
 
@@ -273,6 +335,7 @@ def test_export_run_output_overrides_unset_configured_path(monkeypatch, tmp_path
     # --output supplies a destination even when the preset's configured export_path
     # is empty: the export_path_unset preflight no longer fires (there IS a place to
     # write), and the export runs to the override.
+    monkeypatch.chdir(tmp_path)
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
     get = {**GET_RESULT, "export_path": ""}
     _, export_runner = _inject(monkeypatch, get=get)
@@ -294,8 +357,10 @@ def test_export_run_output_overrides_unset_configured_path(monkeypatch, tmp_path
 
     assert result.exit_code == 0, result.stdout + result.stderr
     data = json.loads(result.stdout)
-    assert data["output_path"] == "dist/custom.x86_64"
-    assert export_runner.calls == [("Linux/X11", "release", "dist/custom.x86_64")]
+    expected = _cwd_output("dist", "custom.x86_64")
+    assert data["output_path"] == expected
+    assert data["created_dirs"] == [str(tmp_path / "dist")]
+    assert export_runner.calls == [("Linux/X11", "release", expected)]
 
 
 def test_export_run_surfaces_advisory_warnings(monkeypatch, tmp_path):
@@ -409,7 +474,7 @@ def test_export_run_pack_skips_template_preflight_when_missing(monkeypatch, tmp_
     data = json.loads(result.stdout)
     assert data["mode"] == "pack"
     # The preflight was skipped for pack: the native export actually ran.
-    assert export_runner.calls == [("Linux/X11", "pack", "build/game.x86_64")]
+    assert export_runner.calls == [("Linux/X11", "pack", _configured_output(tmp_path))]
 
 
 def test_export_run_release_debug_still_require_templates_when_missing(
@@ -567,8 +632,25 @@ def test_export_run_schema_emits_contract_without_engine(monkeypatch):
     assert "preset" in schema["input"]["properties"]
     assert "mode" in schema["input"]["properties"]
     assert "output" in schema["input"]["properties"]
+    assert (
+        "invoker's current working directory"
+        in schema["input"]["properties"]["output"]["description"]
+    )
     assert "output_path" in schema["output"]["properties"]
+    assert (
+        "resolved absolute path"
+        in schema["output"]["properties"]["output_path"]["description"]
+    )
+    assert "created_dirs" in schema["output"]["properties"]
     assert "warnings" in schema["output"]["properties"]
+
+
+def test_export_run_help_documents_output_resolution():
+    result = CliRunner().invoke(app, ["export", "run", "--help"])
+
+    assert result.exit_code == 0
+    assert "--output" in result.stdout
+    assert "invoker's current working directory" in result.stdout
 
 
 def test_export_run_human_output_echoes_artifact(monkeypatch, tmp_path):
@@ -583,5 +665,6 @@ def test_export_run_human_output_echoes_artifact(monkeypatch, tmp_path):
 
     assert result.exit_code == 0, result.stdout + result.stderr
     assert (
-        "exported Linux/X11 (Linux/X11, release) -> build/game.x86_64" in result.stdout
+        f"exported Linux/X11 (Linux/X11, release) -> {_configured_output(tmp_path)}"
+        in result.stdout
     )

--- a/tests/test_export_run_operation.py
+++ b/tests/test_export_run_operation.py
@@ -282,7 +282,28 @@ def test_configured_export_path_parent_dirs_are_created_and_reported(tmp_path):
     assert export_runner.calls == [("Linux/X11", "release", str(expected))]
 
 
-def test_uncreatable_output_parent_returns_invalid_path_before_native_run(tmp_path):
+def test_configured_export_path_keeps_literal_tilde_project_relative(tmp_path):
+    # A preset export_path is Godot configuration, not a CLI path: "~" remains a
+    # literal project-relative path component instead of expanding to $HOME.
+    project = tmp_path / "project"
+    project.mkdir()
+    get_runner = _get_runner({**GET_RESULT, "export_path": "~/build/game.zip"})
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+    outcome = _run(
+        get_runner=get_runner,
+        export_runner=export_runner,
+        project=project,
+    )
+
+    expected = project / "~" / "build" / "game.zip"
+    assert isinstance(outcome, ExportRunResult)
+    assert outcome.output_path == str(expected)
+    assert outcome.created_dirs == [str(project / "~"), str(project / "~" / "build")]
+    assert export_runner.calls == [("Linux/X11", "release", str(expected))]
+
+
+def test_uncreatable_output_parent_returns_export_failure_before_native_run(tmp_path):
     # If a path component that must be a directory is already a file, report a
     # typed operation error naming the output path instead of delegating to
     # Godot's locale/version-dependent stderr.
@@ -300,7 +321,7 @@ def test_uncreatable_output_parent_returns_invalid_path_before_native_run(tmp_pa
     )
 
     assert isinstance(outcome, Failure)
-    assert outcome.error.code == "invalid_path"
+    assert outcome.error.code == "export_output_parent_failed"
     assert str(output) in outcome.error.message
     assert str(blocking_file) in outcome.error.message
     assert outcome.error.diagnostics == ""

--- a/tests/test_export_run_operation.py
+++ b/tests/test_export_run_operation.py
@@ -2,7 +2,8 @@
 
 ``export run`` is the one command whose recipe — resolve the preset via
 ``export-get`` → structured preflight (effective destination + template
-readiness, ADR-0010) → native ``--export-<mode>`` run → classify — used to live
+readiness + output parent dirs, ADR-0010) → native ``--export-<mode>`` run →
+classify — used to live
 inside the Typer function and could only be exercised through a CliRunner. The
 recipe now lives in :func:`gda.export_run.run_export_operation`, a PURE function
 that RETURNS the outcome (never emits/exits).
@@ -68,6 +69,7 @@ def _run(
     preset: str = "Linux/X11",
     mode: ExportRunMode = ExportRunMode.RELEASE,
     output_override: str | None = None,
+    project: Path = Path("/tmp/project"),
 ):
     """Invoke the operation with both seams pinned to the given fakes."""
     return run_export_operation(
@@ -75,31 +77,87 @@ def _run(
         mode=mode,
         output_override=output_override,
         godot="/tmp/Godot",
-        project=Path("/tmp/project"),
+        project=project,
         make_runner=lambda binary, project=None: get_runner,
         make_export_runner=lambda binary, project=None: export_runner,
     )
 
 
-def test_success_returns_typed_result_to_configured_path():
+def test_success_returns_typed_result_to_configured_path(tmp_path):
     # The happy path: export-get resolves the preset, the preflight passes, the
     # native export exits clean, and the operation RETURNS the typed
     # ExportRunResult (not an emitted envelope) targeting the configured path.
+    project = tmp_path / "project"
+    project.mkdir()
     get_runner = _get_runner()
     export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
 
-    outcome = _run(get_runner=get_runner, export_runner=export_runner)
+    outcome = _run(get_runner=get_runner, export_runner=export_runner, project=project)
+    expected = str(project / "build" / "game.x86_64")
 
     assert isinstance(outcome, ExportRunResult)
     assert outcome.preset == "Linux/X11"
     assert outcome.platform == "Linux/X11"
     assert outcome.mode is ExportRunMode.RELEASE
-    assert outcome.output_path == "build/game.x86_64"
+    assert outcome.output_path == expected
     assert outcome.warnings == []
     # Phase sequencing: export-get ran first, then the native export to the
     # configured path keyed on the export-get-resolved name.
     assert get_runner.calls == [("export-get", {"preset": "Linux/X11"})]
-    assert export_runner.calls == [("Linux/X11", "release", "build/game.x86_64")]
+    assert export_runner.calls == [("Linux/X11", "release", expected)]
+
+
+def test_configured_export_path_reports_absolute_project_path(tmp_path):
+    # issue #403: a preset export_path keeps Godot's project-relative convention,
+    # but the native invocation/result should carry the resolved absolute path so
+    # consumers can locate the artifact without knowing the export runner cwd.
+    project = tmp_path / "project"
+    project.mkdir()
+    get_runner = _get_runner()
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+    outcome = run_export_operation(
+        preset="Linux/X11",
+        mode=ExportRunMode.RELEASE,
+        output_override=None,
+        godot="/tmp/Godot",
+        project=project,
+        make_runner=lambda binary, project=None: get_runner,
+        make_export_runner=lambda binary, project=None: export_runner,
+    )
+
+    assert isinstance(outcome, ExportRunResult)
+    expected = str(project / "build" / "game.x86_64")
+    assert outcome.output_path == expected
+    assert export_runner.calls == [("Linux/X11", "release", expected)]
+
+
+def test_configured_export_path_with_relative_project_reports_absolute_path(
+    monkeypatch, tmp_path
+):
+    # issue #403 also applies when --project was given as a relative path:
+    # resolve_project_dir preserves that relative path, so export run must anchor
+    # it to the invoker cwd before resolving the preset's export_path.
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(tmp_path)
+    get_runner = _get_runner()
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+    outcome = run_export_operation(
+        preset="Linux/X11",
+        mode=ExportRunMode.RELEASE,
+        output_override=None,
+        godot="/tmp/Godot",
+        project=Path("project"),
+        make_runner=lambda binary, project=None: get_runner,
+        make_export_runner=lambda binary, project=None: export_runner,
+    )
+
+    expected = str(project / "build" / "game.x86_64")
+    assert isinstance(outcome, ExportRunResult)
+    assert outcome.output_path == expected
+    assert export_runner.calls == [("Linux/X11", "release", expected)]
 
 
 def test_phase1_failure_returns_the_failure():
@@ -137,39 +195,116 @@ def test_export_path_unset_when_no_override_and_empty_configured_path():
     assert export_runner.calls == []
 
 
-def test_output_override_supplies_destination_when_configured_path_empty():
+def test_output_override_supplies_destination_when_configured_path_empty(tmp_path):
     # An --output override supplies a destination even when the configured
     # export_path is empty: the unset preflight does NOT fire and the export runs
     # to the override (override-wins-over-configured).
     get_runner = _get_runner({**GET_RESULT, "export_path": ""})
     export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+    output = str(tmp_path / "dist" / "custom.x86_64")
 
     outcome = _run(
         get_runner=get_runner,
         export_runner=export_runner,
-        output_override="dist/custom.x86_64",
+        output_override=output,
+        project=tmp_path / "project",
     )
 
     assert isinstance(outcome, ExportRunResult)
-    assert outcome.output_path == "dist/custom.x86_64"
-    assert export_runner.calls == [("Linux/X11", "release", "dist/custom.x86_64")]
+    assert outcome.output_path == output
+    assert export_runner.calls == [("Linux/X11", "release", output)]
 
 
-def test_output_override_wins_over_configured_path():
+def test_output_override_wins_over_configured_path(tmp_path):
     # When BOTH a configured export_path and an --output override exist, the
     # override wins, for both the native invocation and the reported output_path.
+    get_runner = _get_runner()
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+    output = str(tmp_path / "dist" / "custom.x86_64")
+
+    outcome = _run(
+        get_runner=get_runner,
+        export_runner=export_runner,
+        output_override=output,
+        project=tmp_path / "project",
+    )
+
+    assert isinstance(outcome, ExportRunResult)
+    assert outcome.output_path == output
+    assert export_runner.calls == [("Linux/X11", "release", output)]
+
+
+def test_output_override_parent_dirs_are_created_and_reported(tmp_path):
+    # issue #402: the native export should not be allowed to fail with raw engine
+    # prose just because the requested destination's parent dirs are missing.
+    # The structured preflight creates them before the native run and reports
+    # exactly what it created, outermost to innermost.
+    get_runner = _get_runner({**GET_RESULT, "export_path": ""})
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+    output = tmp_path / "dist" / "nested" / "custom.x86_64"
+
+    outcome = _run(
+        get_runner=get_runner,
+        export_runner=export_runner,
+        output_override=str(output),
+        project=tmp_path / "project",
+    )
+
+    assert isinstance(outcome, ExportRunResult)
+    assert output.parent.is_dir()
+    assert outcome.created_dirs == [
+        str(tmp_path / "dist"),
+        str(tmp_path / "dist" / "nested"),
+    ]
+    assert export_runner.calls == [("Linux/X11", "release", str(output))]
+
+
+def test_configured_export_path_parent_dirs_are_created_and_reported(tmp_path):
+    # issue #402 composes with #403: the preset's configured relative export_path
+    # is first resolved against the project directory, then that absolute parent
+    # directory is created before the native export runs.
+    project = tmp_path / "project"
+    project.mkdir()
     get_runner = _get_runner()
     export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
 
     outcome = _run(
         get_runner=get_runner,
         export_runner=export_runner,
-        output_override="dist/custom.x86_64",
+        project=project,
     )
 
+    expected = project / "build" / "game.x86_64"
     assert isinstance(outcome, ExportRunResult)
-    assert outcome.output_path == "dist/custom.x86_64"
-    assert export_runner.calls == [("Linux/X11", "release", "dist/custom.x86_64")]
+    assert expected.parent.is_dir()
+    assert outcome.output_path == str(expected)
+    assert outcome.created_dirs == [str(project / "build")]
+    assert export_runner.calls == [("Linux/X11", "release", str(expected))]
+
+
+def test_uncreatable_output_parent_returns_invalid_path_before_native_run(tmp_path):
+    # If a path component that must be a directory is already a file, report a
+    # typed operation error naming the output path instead of delegating to
+    # Godot's locale/version-dependent stderr.
+    get_runner = _get_runner({**GET_RESULT, "export_path": ""})
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+    blocking_file = tmp_path / "dist"
+    blocking_file.write_text("not a directory\n", encoding="utf-8")
+    output = blocking_file / "custom.x86_64"
+
+    outcome = _run(
+        get_runner=get_runner,
+        export_runner=export_runner,
+        output_override=str(output),
+        project=tmp_path / "project",
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "invalid_path"
+    assert str(output) in outcome.error.message
+    assert str(blocking_file) in outcome.error.message
+    assert outcome.error.diagnostics == ""
+    assert export_runner.calls == []
 
 
 def test_templates_missing_for_release_and_debug():
@@ -189,20 +324,26 @@ def test_templates_missing_for_release_and_debug():
         assert export_runner.calls == [], mode
 
 
-def test_pack_is_exempt_from_templates_preflight():
+def test_pack_is_exempt_from_templates_preflight(tmp_path):
     # --mode pack produces project data only and needs NO platform templates: with
     # templates_installed=False, pack does NOT emit export_templates_missing — it
     # proceeds straight to the native runner.
+    project = tmp_path / "project"
+    project.mkdir()
     get_runner = _get_runner({**GET_RESULT, "templates_installed": False})
     export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
 
     outcome = _run(
-        get_runner=get_runner, export_runner=export_runner, mode=ExportRunMode.PACK
+        get_runner=get_runner,
+        export_runner=export_runner,
+        mode=ExportRunMode.PACK,
+        project=project,
     )
+    expected = str(project / "build" / "game.x86_64")
 
     assert isinstance(outcome, ExportRunResult)
     assert outcome.mode is ExportRunMode.PACK
-    assert export_runner.calls == [("Linux/X11", "pack", "build/game.x86_64")]
+    assert export_runner.calls == [("Linux/X11", "pack", expected)]
 
 
 # --- Transactional harness strip (ADR-0018: a shipped build must never carry the
@@ -225,10 +366,11 @@ def _project_with_harness(tmp_path: Path) -> Path:
 
 def _run_export_in(project: Path, export_runner) -> object:
     """Invoke run_export_operation against a real ``project`` with seams pinned."""
+    output = project / "build" / "game.zip"
     return run_export_operation(
         preset="Linux/X11",
         mode=ExportRunMode.PACK,  # pack: no template preflight, runs the native seam
-        output_override="build/game.zip",
+        output_override=str(output),
         godot="/tmp/Godot",
         project=project,
         make_runner=lambda binary, project=None: _get_runner(),
@@ -298,7 +440,9 @@ def test_export_is_a_noop_when_no_harness_installed(tmp_path):
     assert isinstance(outcome, ExportRunResult)
     assert not (tmp_path / "addons" / "gda_harness").exists()
     assert "GdaHarness" not in (tmp_path / "project.godot").read_text(encoding="utf-8")
-    assert export_runner.calls == [("Linux/X11", "pack", "build/game.zip")]
+    assert export_runner.calls == [
+        ("Linux/X11", "pack", str(tmp_path / "build" / "game.zip"))
+    ]
 
 
 def test_export_restores_a_stale_harness_body_unchanged_not_a_fresh_install(tmp_path):
@@ -345,10 +489,12 @@ def test_export_does_not_add_autoload_for_a_stray_harness_file(tmp_path):
     assert stray.read_bytes() == b"extends Node\n# stray, no autoload entry\n"
 
 
-def test_native_nonzero_exit_returns_export_failed():
+def test_native_nonzero_exit_returns_export_failed(tmp_path):
     # A non-zero native export with no recognized stderr signature is classified
     # as the generic export_failed Failure; the engine's stderr is preserved as
     # advisory diagnostics.
+    project = tmp_path / "project"
+    project.mkdir()
     get_runner = _get_runner()
     export_runner = FakeExportRunner(
         RunResult(
@@ -356,7 +502,7 @@ def test_native_nonzero_exit_returns_export_failed():
         )
     )
 
-    outcome = _run(get_runner=get_runner, export_runner=export_runner)
+    outcome = _run(get_runner=get_runner, export_runner=export_runner, project=project)
 
     assert isinstance(outcome, Failure)
     assert outcome.error.code == "export_failed"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -651,14 +651,16 @@ def test_export_run_result_round_trips_each_mode():
             "preset": "Linux/X11",
             "platform": "Linux/X11",
             "mode": mode.value,
-            "output_path": "build/game.x86_64",
+            "output_path": "/tmp/project/build/game.x86_64",
+            "created_dirs": [],
             "warnings": [],
         }
 
         ran = ExportRunResult.model_validate(payload)
 
         assert ran.mode is mode
-        assert ran.output_path == "build/game.x86_64"
+        assert ran.output_path == "/tmp/project/build/game.x86_64"
+        assert ran.created_dirs == []
         assert json.loads(ran.model_dump_json()) == payload
 
 
@@ -671,6 +673,7 @@ def test_export_run_result_reports_overridden_output_path():
         "platform": "Linux/X11",
         "mode": "pack",
         "output_path": "/tmp/dist/game.pck",
+        "created_dirs": ["/tmp/dist"],
         "warnings": ["No export template found at the expected icon path."],
     }
 
@@ -678,6 +681,7 @@ def test_export_run_result_reports_overridden_output_path():
 
     assert ran.mode is ExportRunMode.PACK
     assert ran.output_path == "/tmp/dist/game.pck"
+    assert ran.created_dirs == ["/tmp/dist"]
     assert ran.warnings == ["No export template found at the expected icon path."]
     assert json.loads(ran.model_dump_json()) == payload
 


### PR DESCRIPTION
## Summary

- Resolve `gda export run --output` relative filesystem paths against the invoker cwd before the native export runner switches to the project directory.
- Report preset `export_path` destinations as resolved absolute artifact paths while keeping Godot's project-relative preset convention.
- Create missing output parent directories before native export and return them in `created_dirs`.
- Update schema/help/docs/skill guidance plus unit and e2e coverage.

## Validation

- `env UV_CACHE_DIR=/tmp/gda-uv-cache uv run ruff check src/gda/cli.py src/gda/errors.py src/gda/export_run.py src/gda/models.py tests/test_classify_export_run.py tests/test_e2e_export_run.py tests/test_export_run_commands.py tests/test_export_run_operation.py tests/test_models.py`
- `env UV_CACHE_DIR=/tmp/gda-uv-cache uv run pyright src/gda tests/test_export_run_operation.py tests/test_export_run_commands.py tests/test_classify_export_run.py tests/test_models.py`
- `env UV_CACHE_DIR=/tmp/gda-uv-cache uv run pytest -m "not e2e"`
- `env UV_CACHE_DIR=/tmp/gda-uv-cache uv run pytest -m e2e tests/test_e2e_export_run.py` (7 passed, 1 skipped)

Fixes #402
Fixes #403