### PR TITLE
[Panda Adventure] S6b: Leveling curve + drop tables

### DIFF
--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -138,8 +138,24 @@ _Avoid_: stats manager, game state
 The EXP and Gold awarded to the Player when an Enemy dies, keyed by the enemy's Tier in the
 authoritative per-Tier reward table and resolved to per-kind derived fields by the builder
 (gADR-0004). Accumulated onto the Player's StatsSystem; the risk→reward half of the
-death/reward story.
-_Avoid_: drop (that is the S7 item story), loot, bounty
+death/reward story. Instant and guaranteed — contrast the Drop table's Pickups, which
+must be collected (gADR-0006).
+_Avoid_: drop (that is the Drop-table story, S6b), loot, bounty
+
+**Level**:
+The Player's progression grade, derived PURELY from the accumulated EXP total against the
+Leveling curve (GrowthSystem — level 1 at start, one level per threshold reached, gADR-0006).
+Readout-only in Phase 1: a level-up changes no stat yet, it logs, flashes, and ticks the HUD's
+LV line.
+_Avoid_: rank; tier (that is the enemy axis); using "level" for the demo's stage (the demo is
+a single level in the map sense — context disambiguates)
+
+**Leveling curve**:
+The data-driven, strictly increasing array of cumulative EXP thresholds the Player levels up
+along — entry k is the total EXP that reaches level k+2, so the max level is the array's
+length + 1: config, never code (gADR-0006, the waves.size() idiom). Authored in
+`progression_config.json` and derived to the `ProgressionConfig` Resource.
+_Avoid_: XP table, growth formula (it is authored data, not a formula)
 
 ### UI
 
@@ -199,6 +215,28 @@ _Avoid_: inventory, consumable system (that is S7)
 An item the Player wields or wears persistently — the Laser Gun, the Gravity Gun, and the
 Spacesuit. Contrast with Consumable.
 _Avoid_: gear, loadout
+
+### Drops
+
+**Drop table**:
+A Tier's data-driven list of what a kill may leave behind: `{item, amount, chance}` entries,
+each rolled independently, authored per Tier in the same reward table as the Kill reward and
+resolved to a per-kind derived `drop_table` field by the builder (gADR-0006, extending
+gADR-0004's per-Tier authority). The item vocabulary is closed for Phase 1: gold, Bun, Wine.
+_Avoid_: loot table, drop rates (those are the entries' `chance` fields, not the table)
+
+**Pickup**:
+The world block one resolved drop becomes — spawned on a deterministic row centered on the
+death position, touchable ONLY by the Player (its own collision layer masks nothing else),
+collected by walking into it: gold accumulates onto the Player's Gold, an item lands in the
+Item count hook (gADR-0006). A Pickup persists until collected.
+_Avoid_: drop (the table entry / the event), power-up, collectible
+
+**Item count hook**:
+S6b's minimal per-item count Dictionary on the Player where collected Consumable drops land —
+the supply side of the S7 Consumable story, standing in for a real inventory exactly as the
+Wine hook stands in for use-effects: S7 consumes these counts, S6b only fills them.
+_Avoid_: inventory, bag (both are S7+ concepts)
 
 **Spacesuit**:
 The Player's armor — the only piece of defensive Equipment in the demo.

--- a/examples/platformer/panda-adventure/data/generated/enemy_alien_boss_tank.tres
+++ b/examples/platformer/panda-adventure/data/generated/enemy_alien_boss_tank.tres
@@ -25,3 +25,4 @@ attack_squash = Vector2(1.1, 0.9)
 attack_tween_duration = 0.2
 exp_reward = 200
 gold_reward = 100
+drop_table = [{"item": "gold", "amount": 50, "chance": 1}, {"item": "bun", "amount": 2, "chance": 1}, {"item": "wine", "amount": 2, "chance": 1}]

--- a/examples/platformer/panda-adventure/data/generated/enemy_monster_minion_melee.tres
+++ b/examples/platformer/panda-adventure/data/generated/enemy_monster_minion_melee.tres
@@ -25,3 +25,4 @@ attack_squash = Vector2(1.25, 0.75)
 attack_tween_duration = 0.18
 exp_reward = 10
 gold_reward = 5
+drop_table = [{"item": "gold", "amount": 3, "chance": 1}, {"item": "bun", "amount": 1, "chance": 0.25}]

--- a/examples/platformer/panda-adventure/data/generated/enemy_robot_elite_ranged.tres
+++ b/examples/platformer/panda-adventure/data/generated/enemy_robot_elite_ranged.tres
@@ -25,6 +25,7 @@ attack_squash = Vector2(0.8, 1.2)
 attack_tween_duration = 0.15
 exp_reward = 40
 gold_reward = 20
+drop_table = [{"item": "gold", "amount": 10, "chance": 1}, {"item": "wine", "amount": 1, "chance": 0.5}]
 projectile_color = Color(0.35, 0.8, 1, 1)
 projectile_size = Vector2(14, 6)
 projectile_speed = 520

--- a/examples/platformer/panda-adventure/data/generated/enemy_xenomorph_minion_melee.tres
+++ b/examples/platformer/panda-adventure/data/generated/enemy_xenomorph_minion_melee.tres
@@ -25,3 +25,4 @@ attack_squash = Vector2(1.25, 0.75)
 attack_tween_duration = 0.15
 exp_reward = 10
 gold_reward = 5
+drop_table = [{"item": "gold", "amount": 3, "chance": 1}, {"item": "bun", "amount": 1, "chance": 0.25}]

--- a/examples/platformer/panda-adventure/data/generated/enemy_xenomorph_minion_ranged.tres
+++ b/examples/platformer/panda-adventure/data/generated/enemy_xenomorph_minion_ranged.tres
@@ -25,6 +25,7 @@ attack_squash = Vector2(0.8, 1.2)
 attack_tween_duration = 0.15
 exp_reward = 10
 gold_reward = 5
+drop_table = [{"item": "gold", "amount": 3, "chance": 1}, {"item": "bun", "amount": 1, "chance": 0.25}]
 projectile_color = Color(0.4, 1, 0.7, 1)
 projectile_size = Vector2(12, 5)
 projectile_speed = 460

--- a/examples/platformer/panda-adventure/data/generated/progression_config.tres
+++ b/examples/platformer/panda-adventure/data/generated/progression_config.tres
@@ -1,0 +1,14 @@
+[gd_resource type="Resource" script_class="ProgressionConfig" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://src/resources/progression_config.gd" id="1_progressionconfig"]
+
+[resource]
+script = ExtResource("1_progressionconfig")
+level_curve = [10, 50, 150, 280]
+level_up_flash_color = Color(1, 0.9, 0.3, 1)
+level_up_flash_duration = 0.4
+drop_items = {"gold": {"color": Color(1, 0.85, 0.2, 1), "size": Vector2(14, 14)}, "bun": {"color": Color(0.95, 0.8, 0.55, 1), "size": Vector2(18, 14)}, "wine": {"color": Color(0.7, 0.15, 0.35, 1), "size": Vector2(12, 20)}}
+pickup_spacing = 30
+pickup_spawn_squash = Vector2(0.3, 0.3)
+pickup_spawn_tween_duration = 0.25
+pickup_collect_tween_duration = 0.15

--- a/examples/platformer/panda-adventure/data/json/enemies_config.json
+++ b/examples/platformer/panda-adventure/data/json/enemies_config.json
@@ -1,8 +1,30 @@
 {
   "tiers": {
-    "minion": { "exp_reward": 10.0, "gold_reward": 5.0 },
-    "elite": { "exp_reward": 40.0, "gold_reward": 20.0 },
-    "boss": { "exp_reward": 200.0, "gold_reward": 100.0 }
+    "minion": {
+      "exp_reward": 10.0,
+      "gold_reward": 5.0,
+      "drops": [
+        { "item": "gold", "amount": 3, "chance": 1.0 },
+        { "item": "bun", "amount": 1, "chance": 0.25 }
+      ]
+    },
+    "elite": {
+      "exp_reward": 40.0,
+      "gold_reward": 20.0,
+      "drops": [
+        { "item": "gold", "amount": 10, "chance": 1.0 },
+        { "item": "wine", "amount": 1, "chance": 0.5 }
+      ]
+    },
+    "boss": {
+      "exp_reward": 200.0,
+      "gold_reward": 100.0,
+      "drops": [
+        { "item": "gold", "amount": 50, "chance": 1.0 },
+        { "item": "bun", "amount": 2, "chance": 1.0 },
+        { "item": "wine", "amount": 2, "chance": 1.0 }
+      ]
+    }
   },
   "kinds": {
     "monster_minion_melee": {

--- a/examples/platformer/panda-adventure/data/json/progression_config.json
+++ b/examples/platformer/panda-adventure/data/json/progression_config.json
@@ -1,0 +1,14 @@
+{
+  "level_curve": [10.0, 50.0, 150.0, 280.0],
+  "level_up_flash_color": [1.0, 0.9, 0.3, 1.0],
+  "level_up_flash_duration": 0.4,
+  "drop_items": {
+    "gold": { "color": [1.0, 0.85, 0.2, 1.0], "size": [14.0, 14.0] },
+    "bun": { "color": [0.95, 0.8, 0.55, 1.0], "size": [18.0, 14.0] },
+    "wine": { "color": [0.7, 0.15, 0.35, 1.0], "size": [12.0, 20.0] }
+  },
+  "pickup_spacing": 30.0,
+  "pickup_spawn_squash": [0.3, 0.3],
+  "pickup_spawn_tween_duration": 0.25,
+  "pickup_collect_tween_duration": 0.15
+}

--- a/examples/platformer/panda-adventure/data/schema/enemies_config.schema.json
+++ b/examples/platformer/panda-adventure/data/schema/enemies_config.schema.json
@@ -2,16 +2,16 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://aigengame.dev/panda-adventure/data/schema/enemies_config.schema.json",
   "title": "Panda Adventure enemy taxonomy configuration",
-  "description": "Authoritative config for the S4 Enemy taxonomy (gADR-0000, gADR-0003), the S6a per-Tier Kill reward table (gADR-0004), and the S5 Wave schedule (gADR-0005). `tiers` maps each Tier to its reward budget ({exp_reward, gold_reward}) — the AUTHORITY for what a kill awards; the builder resolves it into per-kind derived exp_reward/gold_reward fields so the runtime stays a dumb kind.<field> read. `kinds` maps each Enemy Kind name to one point in Faction x Tier x Archetype plus its stat block (the same max_hp/max_mp/attack/defense shape as combat_config's stat_block — the symmetric damage-formula contract, gADR-0001), its blockout, and its Archetype-AI params. `waves` is the Wave schedule: the ordered list of Waves the level plays through, each Wave one Spawn Roster (the which-kind-spawns-where entries of gADR-0003); the wave COUNT is the array's length — config, never code. `spawn_squash`/`spawn_tween_duration` are the spawn-telegraph tween numbers (the wave system's juice, gADR-0005). Converted by scripts/build_config.py into one derived EnemyConfig .tres per kind (data/generated/enemy_<kind>.tres) plus data/generated/wave_schedule.tres (WaveScheduleConfig); the per-kind derivation specs are themselves derived from `kinds`, so adding a kind is a JSON-only change. Cross-field rules this schema cannot express — the Steering Band interval, the melee contact-damage bound, spawn->kind referential integrity across every wave, spawn-name uniqueness across the whole schedule, and Tier->reward coverage (every Tier a kind uses must have a `tiers` entry) — are enforced by build_config.validate_enemies_semantics before any resource is derived.",
+  "description": "Authoritative config for the S4 Enemy taxonomy (gADR-0000, gADR-0003), the S6a per-Tier Kill reward table (gADR-0004), and the S5 Wave schedule (gADR-0005). `tiers` maps each Tier to its reward budget ({exp_reward, gold_reward, drops}) — the AUTHORITY for what a kill awards and drops (gADR-0004, gADR-0006); the builder resolves it into per-kind derived exp_reward/gold_reward/drop_table fields so the runtime stays a dumb kind.<field> read. `kinds` maps each Enemy Kind name to one point in Faction x Tier x Archetype plus its stat block (the same max_hp/max_mp/attack/defense shape as combat_config's stat_block — the symmetric damage-formula contract, gADR-0001), its blockout, and its Archetype-AI params. `waves` is the Wave schedule: the ordered list of Waves the level plays through, each Wave one Spawn Roster (the which-kind-spawns-where entries of gADR-0003); the wave COUNT is the array's length — config, never code. `spawn_squash`/`spawn_tween_duration` are the spawn-telegraph tween numbers (the wave system's juice, gADR-0005). Converted by scripts/build_config.py into one derived EnemyConfig .tres per kind (data/generated/enemy_<kind>.tres) plus data/generated/wave_schedule.tres (WaveScheduleConfig); the per-kind derivation specs are themselves derived from `kinds`, so adding a kind is a JSON-only change. Cross-field rules this schema cannot express — the Steering Band interval, the melee contact-damage bound, spawn->kind referential integrity across every wave, spawn-name uniqueness across the whole schedule, and Tier->reward coverage (every Tier a kind uses must have a `tiers` entry) — are enforced by build_config.validate_enemies_semantics before any resource is derived.",
   "type": "object",
   "additionalProperties": false,
   "required": ["tiers", "kinds", "spawn_squash", "spawn_tween_duration", "waves"],
   "$defs": {
     "tier_reward": {
-      "description": "One Tier's Kill reward budget: the EXP and Gold awarded to the Player when an Enemy of this Tier dies (gADR-0004).",
+      "description": "One Tier's Kill reward budget: the EXP and Gold awarded to the Player when an Enemy of this Tier dies (gADR-0004), plus the Tier's Drop table (gADR-0006) — the same per-Tier reward authority extended to drops.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["exp_reward", "gold_reward"],
+      "required": ["exp_reward", "gold_reward", "drops"],
       "properties": {
         "exp_reward": {
           "description": "EXP awarded per kill of this Tier; non-negative.",
@@ -22,6 +22,34 @@
           "description": "Gold awarded per kill of this Tier; non-negative.",
           "type": "number",
           "minimum": 0.0
+        },
+        "drops": {
+          "description": "The Tier's Drop table: what a kill of this Tier may leave behind as Pickups (gADR-0006). May be empty (a Tier that drops nothing); each entry rolls independently.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/drop_entry" }
+        }
+      }
+    },
+    "drop_entry": {
+      "description": "One Drop-table entry: the item a Pickup carries, how much of it, and the independent probability the entry drops at all. Every item name has a pickup blockout style in progression_config.json's drop_items (all Phase-1 items required there — coverage by construction).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["item", "amount", "chance"],
+      "properties": {
+        "item": {
+          "description": "What drops: gold (accumulates onto the Player's Gold), or a Consumable item (bun/wine — counted by the S6b item hook; S7 owns their use-effects).",
+          "enum": ["gold", "bun", "wine"]
+        },
+        "amount": {
+          "description": "How much one Pickup of this entry carries (gold value, or item count); a whole number, at least 1.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "chance": {
+          "description": "Independent drop probability in (0, 1]: 1.0 always drops; a 0 chance would be dead config and is rejected.",
+          "type": "number",
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0
         }
       }
     },

--- a/examples/platformer/panda-adventure/data/schema/progression_config.schema.json
+++ b/examples/platformer/panda-adventure/data/schema/progression_config.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aigengame.dev/panda-adventure/data/schema/progression_config.schema.json",
+  "title": "Panda Adventure progression configuration",
+  "description": "Authoritative config for the S6b progression loop (gADR-0000, gADR-0006): the data-driven leveling curve the Player levels up along, and the Drop/Pickup blockout. `level_curve` is the ordered list of cumulative EXP thresholds — entry k is the total EXP at which the Player reaches level k+2 (level 1 is the start), so the MAX level is the array's length + 1: config, never code (the gADR-0005 waves.size() idiom). That the curve is strictly increasing is a cross-field rule this schema cannot express — enforced by build_config.validate_progression_semantics before the resource derives. `drop_items` fixes the pickup blockout (color/size) for EVERY item name the enemies-config drop tables may reference — all three Phase-1 items are required, so a drop can never reference an unstyled item (coverage by construction, no cross-source validator). The remaining fields are the pickup scatter spacing and the spawn/collect tween juice plus the level-up flash. Converted by scripts/build_config.py into data/generated/progression_config.tres (ProgressionConfig).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "level_curve",
+    "level_up_flash_color",
+    "level_up_flash_duration",
+    "drop_items",
+    "pickup_spacing",
+    "pickup_spawn_squash",
+    "pickup_spawn_tween_duration",
+    "pickup_collect_tween_duration"
+  ],
+  "$defs": {
+    "rgba": {
+      "description": "A color as RGBA, each component in 0..1.",
+      "type": "array",
+      "items": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+      "minItems": 4,
+      "maxItems": 4
+    },
+    "size2": {
+      "description": "A block size (width, height) in pixels; each strictly positive.",
+      "type": "array",
+      "items": { "type": "number", "exclusiveMinimum": 0.0 },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "item_style": {
+      "description": "One droppable item's pickup blockout: the colored block a Pickup renders as (gADR-0006).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["color", "size"],
+      "properties": {
+        "color": { "$ref": "#/$defs/rgba" },
+        "size": { "$ref": "#/$defs/size2" }
+      }
+    }
+  },
+  "properties": {
+    "level_curve": {
+      "description": "Cumulative EXP thresholds, one per level-up: entry k is the total EXP that reaches level k+2. Strictly increasing (enforced by build_config.validate_progression_semantics; not expressible here); the max level is length + 1 — retuning or extending the curve is a JSON-only change.",
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "number", "exclusiveMinimum": 0.0 }
+    },
+    "level_up_flash_color": {
+      "description": "Color the Player block flashes to on a level-up (the positive sibling of the hit flash).",
+      "$ref": "#/$defs/rgba"
+    },
+    "level_up_flash_duration": {
+      "description": "Seconds for the level-up flash to tween back to the Player's own color; strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "drop_items": {
+      "description": "Pickup blockout per droppable item name — the closed Phase-1 item vocabulary (gold, and the S7 Consumables bun/wine). All three are required so every item a drop table can reference has a style.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["gold", "bun", "wine"],
+      "properties": {
+        "gold": { "$ref": "#/$defs/item_style" },
+        "bun": { "$ref": "#/$defs/item_style" },
+        "wine": { "$ref": "#/$defs/item_style" }
+      }
+    },
+    "pickup_spacing": {
+      "description": "Horizontal spacing in pixels between the Pickups of one death's resolved drops (the deterministic scatter row, centered on the death position); strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "pickup_spawn_squash": {
+      "description": "Visual scale a spawned Pickup's block punches FROM at the moment it spawns (the gADR-0005 spawn-telegraph idiom); each component strictly positive.",
+      "type": "array",
+      "items": { "type": "number", "exclusiveMinimum": 0.0 },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "pickup_spawn_tween_duration": {
+      "description": "Seconds for the pickup spawn squash to recover to normal scale; strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "pickup_collect_tween_duration": {
+      "description": "Seconds for a collected Pickup's block to tween to nothing before it frees; strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    }
+  }
+}

--- a/examples/platformer/panda-adventure/docs/gadr/0006-leveling-curve-and-drop-tables.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0006-leveling-curve-and-drop-tables.md
@@ -1,0 +1,133 @@
+---
+status: accepted
+---
+
+# Leveling curve as a pure function of EXP, and per-Tier drop tables collected as Pickups
+
+S6b closes the progression loop the GDD's "Stats & Economy" intends
+("fight enemies, earn EXP/Gold and drops, grow stronger"): accumulating EXP
+levels the Player up along a data-driven Leveling curve, and defeated
+Enemies drop Gold/items as world Pickups per a data-driven Drop table.
+gADR-0000 fixes WHERE numbers live, gADR-0004 fixed the Kill-reward
+authority per Tier and predicted "S6b's leveling curve will be that pure
+decision when it lands"; this decision fixes the SHAPE of that decision,
+WHERE the drop authority lives, and HOW a drop reaches the Player — because
+S7's Consumable supply and the balancing pipeline's economy tuning both
+build on these seams.
+
+The model:
+
+- **The Leveling curve is a cumulative-threshold array; the level is a pure
+  FUNCTION of the EXP total.** A new authoritative `progression_config.json`
+  carries `level_curve` — strictly increasing cumulative EXP thresholds
+  (a builder semantic gate, `validate_progression_semantics`) — and
+  `GrowthSystem.resolve_level(exp_points, level_curve)` returns
+  1 + thresholds reached. The max level is `level_curve.size() + 1` — the
+  gADR-0005 `waves.size()` idiom: count is config, never code. Deriving
+  from the TOTAL (not folding per gain) makes one Boss-sized reward worth
+  every threshold it crosses (a multi-level-up for free) and re-resolution
+  idempotent. The Player re-resolves after each Kill reward, caches the
+  level ONLY to detect the rising edge (one `level_up {from, to,
+  exp_total}` record + a flash tween), and surfaces it as the HUD's LV line
+  (`hud_state().level`, the gADR-0004 snapshot grown by one key).
+- **Leveling is readout-only in Phase 1.** A level-up changes no stat: the
+  issue's contract is "accumulating EXP levels the Player up", and any
+  stat-growth-per-level numbers are balancing-pipeline data that would also
+  rework the S2 damage-formula seam (the attacker stat block is today the
+  immutable derived config). When growth lands (a later slice, with the
+  balancing pipeline), it hooks the same `_level` edge.
+- **The drop authority is the same per-Tier table as the Kill reward.** Each
+  `tiers` entry in `enemies_config.json` gains a required `drops` array —
+  `{item, amount, chance}` entries — and `resolve_enemy_rewards` (the
+  gADR-0004 resolver, extended) copies it into a per-kind derived
+  `drop_table` field: the runtime stays a dumb `kind.<field>` read, one
+  edit retunes a whole Tier, a kind cannot drift off its Tier's budget.
+- **Drop resolution is pure; the rolls are parameters.** `EconomySystem.
+  resolve_drops(drop_table, rolls)` includes entry i iff
+  `rolls[i] <= chance` — INCLUSIVE, so `chance: 1.0` is guaranteed against
+  Godot's 1.0-inclusive `randf()` (a guaranteed entry is what makes the
+  e2e deterministic on shipped data). The spawner (LevelController — it
+  already owns the death edge, gADR-0004) supplies one `randf()` per entry:
+  randomness is orchestration, like the clock (gADR-0001), so the logic
+  seam pins chance boundaries headless. `drop_offset` scatters the drops on
+  a deterministic row centered on the death position — no scatter RNG.
+- **A drop is a world Pickup, not a direct award.** Each resolved drop
+  instances `pickup.tscn` (an Area2D block ON the new `pickup` layer 6,
+  masking ONLY the `player` layer — nothing else can touch it and it blocks
+  nothing) at the death spot; the Player walks into it to collect. This is
+  the GDD's "light exploration and collection" beat, and it is what makes a
+  drop DIFFERENT from the S6a Kill reward: guaranteed instant EXP/Gold per
+  kill, versus loot that must be picked up. The Pickup self-applies its
+  blockout from `drop_items` (per-item color/size in the progression
+  config; the schema REQUIRES a style for the whole item vocabulary, so a
+  drop can never reference an unstyled item — coverage by construction, no
+  cross-source validator) and hands the drop to the Player's
+  `collect_drop(item, amount)` exactly once.
+- **Gold accumulates; items land in the S6b item-count hook.** Collected
+  gold is `StatsSystem.gain_gold` — Gold's second source next to
+  `gain_reward`, logged `gold_collected {amount, gold_total}`. Any other
+  item increments the Player's `_items` count Dictionary, logged
+  `item_collected {item, amount, count}` — the S3 Wine-hook pattern applied
+  to supply: S6b owns drop→acquire, S7 owns the Consumable use-effects that
+  will consume these counts. The item vocabulary is CLOSED for Phase 1
+  ({gold, bun, wine}, a schema enum on both sources): the demo's items are
+  exactly the GDD's.
+
+## Considered options
+
+- **Cumulative thresholds, level derived from the total (chosen).** One
+  array, level a pure function — idempotent, multi-level-safe, and the max
+  level is the array length: the waves.size() precedent.
+- **Per-level increment costs (rejected).** Needs a running fold (level +
+  leftover EXP as state), so the level stops being derivable from the
+  total; nothing gained over thresholds authored cumulatively.
+- **Level stored in StatsSystem (rejected).** The level is DERIVED state —
+  storing it beside `exp_points` invites drift between the two; the holder
+  keeps only independent live stats (gADR-0001), the Player caches the edge.
+- **Stat growth on level-up now (rejected).** Out of the S6b contract;
+  growth numbers are balancing-phase data, and the attacker/defender stat
+  blocks are immutable derived config today — growing them is its own
+  slice against the S2 formula seam, hooked on the same level edge later.
+- **Per-kind drop fields in the JSON (rejected).** The gADR-0004 argument
+  verbatim: kinds triplicate a Tier's table and drift silently; the per-Tier
+  authority already exists — drops extend it.
+- **Direct-award drops, no world Pickups (rejected).** Indistinguishable
+  from a second Kill reward with randomness — no collection verb, no
+  exploration beat; the GDD's economy loop expects loot on the ground.
+- **RNG inside EconomySystem (rejected).** An unpinnable logic seam and an
+  unusable balancing-sim core; rolls are parameters exactly as time is to
+  CombatSystem/EnemyAI.
+- **Drop styles inside enemies_config (rejected).** The pickup blockout
+  belongs to the drop/pickup system, not the enemy taxonomy; keeping it in
+  the progression source with all-items-required styling removes the need
+  for any cross-source coverage validator.
+- **An open item vocabulary (rejected for Phase 1).** A free-form item id
+  would push style coverage into a cross-source semantic rule and buys
+  nothing: the demo's items are exactly Bun/Wine (+ gold).
+
+## Consequences
+
+- Retuning the curve (or its length — the max level), a Tier's drop mix,
+  chances, amounts, or the pickup blockout is a JSON-only change; a
+  non-increasing curve, an unstyled/off-vocabulary item, a 0 chance, or a
+  fractional amount fails the fast tier, not the runtime.
+- Gold now has two observable sources: `reward_gained` (instant, per kill)
+  and `gold_collected` (per Pickup walked over). The full kill flow reads
+  end-to-end in the log: `enemy_died` → `reward_gained` → `level_up` →
+  `pickup_spawned`(×n, one per resolved drop) → `gold_collected` /
+  `item_collected` — and the HUD LV/EXP/GOLD readouts agree (the e2e seam
+  asserts all of it against the authoritative JSON).
+- e2e determinism on a probabilistic system: guaranteed (chance 1.0)
+  entries assert on shipped data; probabilistic entries are retuned to 1.0
+  in the throwaway project copy (the waves-e2e reconfiguration precedent) —
+  never a sleep-and-hope roll.
+- S7 (Consumables) inherits its supply side: Bun/Wine drops already land as
+  `_items` counts; S7 wires `drink_wine`/eat-bun to CONSUME them (replacing
+  the S3 hook's free restore) without touching the drop path. The Boss
+  (S8) inherits a drop table by Tier automatically.
+- Uncollected Pickups persist (no lifetime): a cleared Wave's loot stays
+  collectible at leisure; nothing else can consume or destroy it by
+  construction (the mask).
+- gda gap (dogfooding): `gda node add` appends only — inserting the HUD's
+  LV line between existing Labels took remove+re-add of the trailing three;
+  a child-index/reorder option is filed as a gda feature request.

--- a/examples/platformer/panda-adventure/docs/project-manifest-notes.md
+++ b/examples/platformer/panda-adventure/docs/project-manifest-notes.md
@@ -29,10 +29,13 @@ fires the CURRENT weapon — Laser Gun by default, Gravity Gun after
 **`[layer_names]`.** S2+S3 collision topology — structural wiring, not balance
 data (gADR-0000 governs config NUMBERS; what-can-act-on-what lives here and in
 the scenes): 1 `terrain`, 2 `player`, 3 `enemy`, 4 `projectile`, 5
-`gravity_field`. Layer 5 is IN USE since S3: the Gravity Field Area2D
+`gravity_field`, 6 `pickup`. Layer 5 is IN USE since S3: the Gravity Field Area2D
 (`gravity_field.tscn`, runtime-instanced by PlayerController) sits ON layer 5
 and masks `terrain|enemy` (5) — the Player's layer is invisible to it, which is
 the never-on-the-Player guarantee (gADR-0002, the Projectile's mask pattern).
+Layer 6 is the S6b Pickup (`pickup.tscn`, an Area2D runtime-instanced by
+LevelController per resolved drop, gADR-0006): ON layer 6, masking `player` (2)
+ONLY — nothing but the Player can touch a drop, and a drop blocks nothing.
 
 **`[debug]`.** Godot's default desktop file logging is disabled so no engine
 launch writes a shared `user://logs/godot.log` (the #180 RotatedFileLogger race
@@ -64,7 +67,9 @@ other; Obstacle=`terrain`(1) masking nothing. Enemies are runtime-instanced by
 LevelController from `enemy.tscn` per the Spawn Roster; Projectiles are
 runtime-instanced by PlayerController (`projectile.tscn`, masks terrain|enemy)
 and by Ranged enemies (`enemy_projectile.tscn`, masks terrain|player); Gravity
-Fields by PlayerController (`gravity_field.tscn`).
+Fields by PlayerController (`gravity_field.tscn`); Pickups by LevelController
+per resolved drop (`pickup.tscn`, `pickup`(6) masking `player`(2) only —
+gADR-0006).
 
 The S3 `Obstacle` (StaticBody2D + Visual + Collision, script
 `obstacle_controller.gd`) is the gravity-affectable environment prop: it floats

--- a/examples/platformer/panda-adventure/project.godot
+++ b/examples/platformer/panda-adventure/project.godot
@@ -67,6 +67,7 @@ drink_wine={
 2d_physics/layer_3="enemy"
 2d_physics/layer_4="projectile"
 2d_physics/layer_5="gravity_field"
+2d_physics/layer_6="pickup"
 
 [rendering]
 

--- a/examples/platformer/panda-adventure/scenes/hud.tscn
+++ b/examples/platformer/panda-adventure/scenes/hud.tscn
@@ -13,11 +13,14 @@ layout_mode = 2
 [node name="MpLabel" type="Label" parent="Stats" unique_id=221873651]
 layout_mode = 2
 
-[node name="ExpLabel" type="Label" parent="Stats" unique_id=374950307]
+[node name="LevelLabel" type="Label" parent="Stats" unique_id=549201072]
 layout_mode = 2
 
-[node name="GoldLabel" type="Label" parent="Stats" unique_id=1438675772]
+[node name="ExpLabel" type="Label" parent="Stats" unique_id=1319412645]
 layout_mode = 2
 
-[node name="WeaponLabel" type="Label" parent="Stats" unique_id=1211773034]
+[node name="GoldLabel" type="Label" parent="Stats" unique_id=167964984]
+layout_mode = 2
+
+[node name="WeaponLabel" type="Label" parent="Stats" unique_id=1749857655]
 layout_mode = 2

--- a/examples/platformer/panda-adventure/scenes/pickup.tscn
+++ b/examples/platformer/panda-adventure/scenes/pickup.tscn
@@ -1,0 +1,12 @@
+[gd_scene format=3]
+
+[ext_resource type="Script" path="res://src/controllers/pickup_controller.gd" id="1_0i71o"]
+
+[node name="Pickup" type="Area2D" unique_id=1650646339]
+collision_layer = 32
+collision_mask = 2
+script = ExtResource("1_0i71o")
+
+[node name="Visual" type="ColorRect" parent="." unique_id=1984590977]
+
+[node name="Collision" type="CollisionShape2D" parent="." unique_id=1338133796]

--- a/examples/platformer/panda-adventure/scripts/build_config.py
+++ b/examples/platformer/panda-adventure/scripts/build_config.py
@@ -8,7 +8,7 @@ Godot Resources under ``data/generated/`` that the runtime ``load()``s. Every
 byte-identical to a fresh build), never hand-edited: changing config means
 changing the JSON.
 
-Five sources feed the outputs (``specs_for``/``SPECS``):
+Six sources feed the outputs (``specs_for``/``SPECS``):
 
 - ``player_config.json`` -> ``player_config.tres`` (``PlayerConfig``, S1)
 - ``combat_config.json`` -> ``stats_player.tres`` + ``stats_enemy.tres``
@@ -26,9 +26,16 @@ Five sources feed the outputs (``specs_for``/``SPECS``):
   per-Tier Kill-reward table (``tiers``), resolved into per-kind derived
   ``exp_reward``/``gold_reward`` fields by ``resolve_enemy_rewards`` before
   rendering: the runtime stays a dumb ``kind.<field>`` read while the reward
-  AUTHORITY stays per-Tier data.
+  AUTHORITY stays per-Tier data. Since S6b (gADR-0006) each Tier entry also
+  carries its Drop table (``drops``), resolved into a per-kind derived
+  ``drop_table`` field by the same resolver.
 - ``hud_config.json`` -> ``hud_config.tres`` (``HudConfig``, the HUD blockout
   numbers — gADR-0004) — S6a.
+- ``progression_config.json`` -> ``progression_config.tres``
+  (``ProgressionConfig``: the leveling curve — max level is the curve's
+  length + 1, config never code — plus the Drop/Pickup blockout and juice,
+  gADR-0006) — S6b. The curve's strict monotonicity is a cross-field rule
+  enforced by ``validate_progression_semantics``.
 
 Dogfooding note: since gda's ADR-0032 static class_name scan (issue #360), ``gda
 resource create --type PlayerConfig`` CAN instantiate a project-local class in
@@ -66,7 +73,11 @@ class TresSpec:
     is a one-line change. Types: "color" (4-array -> Color), "vec2" (2-array ->
     Vector2), "float" (scalar -> bare number), "string" (str -> quoted String),
     "wave_list" (waves -> Array of {"spawns": Array of Dictionary}, S5's Wave
-    schedule). The schema is the validation authority; keep the two in step.
+    schedule), "number_list" (number array -> Array, S6b's leveling curve),
+    "drop_list" (drop entries -> Array of Dictionary, S6b's per-kind Drop
+    table), "item_style_map" (item name -> {"color": Color, "size": Vector2},
+    S6b's pickup blockout). The schema is the validation authority; keep the
+    two in step.
     """
 
     json_rel: str
@@ -138,9 +149,10 @@ _GRAVITY_FIELDS: list[tuple[str, str]] = [
 
 # One Enemy Kind's field layout (gADR-0003): the three taxonomy axes, the stat
 # block (same four fields as _STAT_BLOCK_FIELDS — the symmetric damage-formula
-# shape, gADR-0001), the blockout, the Archetype-AI params, and the S6a Kill
-# reward (gADR-0004) — the last two are DERIVED per kind from the top-level
-# per-Tier ``tiers`` table by ``resolve_enemy_rewards``, not authored per kind.
+# shape, gADR-0001), the blockout, the Archetype-AI params, the S6a Kill
+# reward (gADR-0004), and the S6b Drop table (gADR-0006) — the last three are
+# DERIVED per kind from the top-level per-Tier ``tiers`` table by
+# ``resolve_enemy_rewards``, not authored per kind.
 _ENEMY_KIND_FIELDS: list[tuple[str, str]] = [
     ("faction", "string"),
     ("tier", "string"),
@@ -163,6 +175,7 @@ _ENEMY_KIND_FIELDS: list[tuple[str, str]] = [
     ("attack_tween_duration", "float"),
     ("exp_reward", "float"),
     ("gold_reward", "float"),
+    ("drop_table", "drop_list"),
 ]
 
 # Ranged kinds additionally carry their bolt's blockout+motion (schema-enforced
@@ -193,11 +206,29 @@ _HUD_FIELDS: list[tuple[str, str]] = [
     ("value_tween_duration", "float"),
 ]
 
+# The S6b progression loop (gADR-0006): the leveling curve (cumulative EXP
+# thresholds — the max level is the array's length + 1, config never code)
+# plus the level-up flash and the Drop/Pickup blockout and juice.
+_PROGRESSION_FIELDS: list[tuple[str, str]] = [
+    ("level_curve", "number_list"),
+    ("level_up_flash_color", "color"),
+    ("level_up_flash_duration", "float"),
+    ("drop_items", "item_style_map"),
+    ("pickup_spacing", "float"),
+    ("pickup_spawn_squash", "vec2"),
+    ("pickup_spawn_tween_duration", "float"),
+    ("pickup_collect_tween_duration", "float"),
+]
+
 
 # The S4 enemies source (gADR-0003) — one json_rel shared by the derived
 # per-kind specs and the Wave-schedule spec.
 _ENEMIES_JSON_REL = "data/json/enemies_config.json"
 _ENEMIES_SCHEMA_REL = "data/schema/enemies_config.schema.json"
+
+# The S6b progression source (gADR-0006) — carries its own cross-field rule
+# (the strictly increasing leveling curve, validate_progression_semantics).
+_PROGRESSION_JSON_REL = "data/json/progression_config.json"
 
 
 def _enemy_kind_spec(kind: str, archetype: str) -> TresSpec:
@@ -281,6 +312,15 @@ _STATIC_SPECS: list[TresSpec] = [
         script_class="HudConfig",
         ext_id="1_hudconfig",
         fields=_HUD_FIELDS,
+    ),
+    TresSpec(
+        json_rel=_PROGRESSION_JSON_REL,
+        schema_rel="data/schema/progression_config.schema.json",
+        out_rel="data/generated/progression_config.tres",
+        script_res_path="res://src/resources/progression_config.gd",
+        script_class="ProgressionConfig",
+        ext_id="1_progressionconfig",
+        fields=_PROGRESSION_FIELDS,
     ),
 ]
 
@@ -398,19 +438,42 @@ def resolve_enemy_rewards(document: Any) -> Any:
     """Resolve the per-Tier Kill-reward table into per-kind derived fields.
 
     Returns a COPY of the enemies document where every kind carries
-    ``exp_reward``/``gold_reward`` read from ``tiers[kind["tier"]]``
-    (gADR-0004). Runs after schema + semantic validation (which guarantee the
-    tier entry exists), wherever an enemies-sourced spec is rendered, so the
-    derived ``enemy_<kind>.tres`` stays a dumb per-kind read while the JSON
-    keeps a single per-Tier authority — retuning a Tier's reward is one edit,
-    never three.
+    ``exp_reward``/``gold_reward`` (gADR-0004) and ``drop_table`` (the Tier's
+    ``drops``, gADR-0006) read from ``tiers[kind["tier"]]``. Runs after
+    schema + semantic validation (which guarantee the tier entry exists),
+    wherever an enemies-sourced spec is rendered, so the derived
+    ``enemy_<kind>.tres`` stays a dumb per-kind read while the JSON keeps a
+    single per-Tier authority — retuning a Tier's reward or drops is one
+    edit, never three.
     """
     resolved = copy.deepcopy(document)
     for kind in resolved["kinds"].values():
         reward = resolved["tiers"][kind["tier"]]
         kind["exp_reward"] = reward["exp_reward"]
         kind["gold_reward"] = reward["gold_reward"]
+        kind["drop_table"] = reward["drops"]
     return resolved
+
+
+def validate_progression_semantics(document: Any) -> Any:
+    """Enforce the progression cross-field rule vanilla JSON Schema cannot.
+
+    The leveling curve must be STRICTLY increasing (gADR-0006): each entry is
+    a cumulative EXP threshold, so a flat or decreasing step would make a
+    level unreachable-then-instant — a config bug, caught before the resource
+    derives. Raises :class:`jsonschema.ValidationError` (the same failure
+    type as the schema gate) so a bad config fails the build loudly either
+    way.
+    """
+    curve = document["level_curve"]
+    for i in range(1, len(curve)):
+        if curve[i] <= curve[i - 1]:
+            raise jsonschema.ValidationError(
+                f"level_curve must be strictly increasing, but entry {i} "
+                f"({curve[i]}) does not exceed entry {i - 1} ({curve[i - 1]}) "
+                "— each entry is a cumulative EXP threshold (gADR-0006)"
+            )
+    return document
 
 
 def enemy_kind_specs(root: Path = GAME_DIR) -> list[TresSpec]:
@@ -480,6 +543,34 @@ def _render_field(key: str, kind: str, value: Any) -> str:
             for wave in value
         )
         return f"[{waves}]"
+    if kind == "number_list":
+        # A plain number Array (S6b's leveling curve), in source order.
+        return "[{}]".format(", ".join(_num(entry) for entry in value))
+    if kind == "drop_list":
+        # A per-kind Drop table (gADR-0006): an Array of {item, amount,
+        # chance} Dictionaries in source order.
+        drops = ", ".join(
+            '{{"item": "{item}", "amount": {amount}, "chance": {chance}}}'.format(
+                item=entry["item"],
+                amount=_num(entry["amount"]),
+                chance=_num(entry["chance"]),
+            )
+            for entry in value
+        )
+        return f"[{drops}]"
+    if kind == "item_style_map":
+        # The pickup blockout per droppable item (gADR-0006): item name ->
+        # {"color": Color, "size": Vector2}, in source key order (JSON parsing
+        # preserves it — the enemy_kind_specs determinism note).
+        styles = ", ".join(
+            '"{item}": {{"color": {color}, "size": {size}}}'.format(
+                item=item,
+                color=_render_field("color", "color", style["color"]),
+                size=_render_field("size", "vec2", style["size"]),
+            )
+            for item, style in value.items()
+        )
+        return f"{{{styles}}}"
     raise ValueError(f"unknown field kind {kind!r} for {key!r}")
 
 
@@ -541,9 +632,13 @@ def build_spec(
         # The enemies source carries cross-field rules the schema cannot
         # express (gADR-0003) — enforce them before deriving any resource,
         # then resolve the per-Tier rewards into the per-kind derived fields
-        # the specs render (gADR-0004).
+        # the specs render (gADR-0004/gADR-0006).
         validate_enemies_semantics(document)
         document = resolve_enemy_rewards(document)
+    if spec.json_rel == _PROGRESSION_JSON_REL:
+        # The progression source's own cross-field rule: the leveling curve
+        # is strictly increasing (gADR-0006).
+        validate_progression_semantics(document)
     target = out_path if out_path is not None else root / spec.out_rel
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(render_spec(spec, document), encoding="utf-8")

--- a/examples/platformer/panda-adventure/src/controllers/enemy_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/enemy_controller.gd
@@ -190,8 +190,13 @@ func take_hit(attacker: StatsConfigScript) -> void:
 	GameLogScript.emit("info", "enemy_hit", {"damage": damage, "hp_left": _stats.hp})
 	_play_hit_flash()
 	if CombatSystemScript.is_dead(_stats.hp):
-		died.emit()
+		# The death record precedes the signal: signal handlers run
+		# SYNCHRONOUSLY (the spawner awards, levels, and spawns pickups
+		# inside died.emit()), so logging first is what keeps the observable
+		# kill flow causal — enemy_died -> reward_gained -> level_up ->
+		# pickup_spawned -> collections (the gADR-0006 logger contract).
 		GameLogScript.emit("info", "enemy_died", {"x": position.x, "y": position.y})
+		died.emit()
 		queue_free()
 
 

--- a/examples/platformer/panda-adventure/src/controllers/hud_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/hud_controller.gd
@@ -1,11 +1,11 @@
 class_name HudController
 extends CanvasLayer
 
-## Drives the HUD blockout (S6a, gADR-0004): five Labels in a screen-space
-## column surfacing the Player's live HP, MP, EXP, Gold, and Current weapon —
-## the GDD's "HUD & UI" contract — so the player reads state without leaving
-## the action. A CanvasLayer renders in screen space, untouched by the S1
-## follow-camera.
+## Drives the HUD blockout (S6a, gADR-0004; +Level since S6b, gADR-0006): six
+## Labels in a screen-space column surfacing the Player's live HP, MP, Level,
+## EXP, Gold, and Current weapon — the GDD's "HUD & UI" contract — so the
+## player reads state without leaving the action. A CanvasLayer renders in
+## screen space, untouched by the S1 follow-camera.
 ##
 ## Read model: the HUD PULLS the Player's public `hud_state()` snapshot each
 ## process frame (gADR-0004) — at five values a frame that costs nothing and
@@ -27,10 +27,10 @@ const GameLogScript := preload("res://src/util/game_log.gd")
 
 const HUD_CONFIG_PATH := "res://data/generated/hud_config.tres"
 
-# The five surfaced values, in display order: each maps a snapshot to its
+# The six surfaced values, in display order: each maps a snapshot to its
 # Label node name. Structural wiring (what the HUD shows is the GDD contract),
 # not config numbers.
-const LINES := ["hp", "mp", "exp", "gold", "weapon"]
+const LINES := ["hp", "mp", "level", "exp", "gold", "weapon"]
 
 var _config: HudConfigScript
 # Whether the first snapshot has been rendered (it populates silently and logs
@@ -58,13 +58,16 @@ static func format_weapon(weapon: String) -> String:
 	return weapon.replace("_", " ").to_upper()
 
 
-## Pure mapping from the Player's hud_state() snapshot to the five display
+## Pure mapping from the Player's hud_state() snapshot to the six display
 ## strings, keyed like LINES. The single place the snapshot's shape meets the
-## format decisions, so the seam can pin the whole readout at once.
+## format decisions, so the seam can pin the whole readout at once. The Level
+## readout (S6b) reuses format_amount: an integer level passes through floori
+## unchanged.
 static func format_lines(state: Dictionary) -> Dictionary:
 	return {
 		"hp": format_bar("HP", state["hp"], state["max_hp"]),
 		"mp": format_bar("MP", state["mp"], state["max_mp"]),
+		"level": format_amount("LV", state["level"]),
 		"exp": format_amount("EXP", state["exp"]),
 		"gold": format_amount("GOLD", state["gold"]),
 		"weapon": format_weapon(state["weapon"]),
@@ -110,6 +113,7 @@ func _process(_delta: float) -> void:
 		GameLogScript.emit("info", "hud_ready", {
 			"hp": state["hp"],
 			"mp": state["mp"],
+			"level": state["level"],
 			"exp": state["exp"],
 			"gold": state["gold"],
 			"weapon": state["weapon"],

--- a/examples/platformer/panda-adventure/src/controllers/level_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/level_controller.gd
@@ -1,12 +1,14 @@
 class_name LevelController
 extends Node2D
 
-## Scene-level director for S1+S2+S4+S5+S6a: applies the data-driven Platform
-## blockout, plays the Wave schedule (gADR-0005) — spawning each Wave's Spawn
-## Roster, folding deaths through the pure WaveSystem, and advancing on clear
-## — wires each spawn's death to the Kill reward (gADR-0004), and emits the
-## boot log. The Player self-configures (PlayerController); this owns the rest
-## of the level so config application stays out of the physics body.
+## Scene-level director for S1+S2+S4+S5+S6a+S6b: applies the data-driven
+## Platform blockout, plays the Wave schedule (gADR-0005) — spawning each
+## Wave's Spawn Roster, folding deaths through the pure WaveSystem, and
+## advancing on clear — wires each spawn's death to the Kill reward
+## (gADR-0004) and to its Drop-table roll (gADR-0006: pickups scattered at
+## the death position), and emits the boot log. The Player self-configures
+## (PlayerController); this owns the rest of the level so config application
+## stays out of the physics body.
 ##
 ## Visuals and geometry are data (gADR-0000): the derived PlayerConfig /
 ## WaveScheduleConfig / EnemyConfig Resources, never hardcoded. Loaded here and
@@ -25,12 +27,16 @@ extends Node2D
 const PlayerConfigScript := preload("res://src/resources/player_config.gd")
 const EnemyConfigScript := preload("res://src/resources/enemy_config.gd")
 const WaveScheduleConfigScript := preload("res://src/resources/wave_schedule_config.gd")
+const ProgressionConfigScript := preload("res://src/resources/progression_config.gd")
 const WaveSystemScript := preload("res://src/systems/wave_system.gd")
+const EconomySystemScript := preload("res://src/systems/economy_system.gd")
 const GameLogScript := preload("res://src/util/game_log.gd")
 const EnemyScene := preload("res://scenes/enemy.tscn")
+const PickupScene := preload("res://scenes/pickup.tscn")
 
 const CONFIG_PATH := "res://data/generated/player_config.tres"
 const SCHEDULE_PATH := "res://data/generated/wave_schedule.tres"
+const PROGRESSION_CONFIG_PATH := "res://data/generated/progression_config.tres"
 # The per-kind derived EnemyConfig path convention (matches build_config's
 # SPECS outputs) — structural wiring, not a config number.
 const ENEMY_KIND_TRES := "res://data/generated/enemy_%s.tres"
@@ -42,6 +48,9 @@ const ENEMY_KIND_TRES := "res://data/generated/enemy_%s.tres"
 var _schedule: WaveScheduleConfigScript
 var _wave_index := 0
 var _alive := 0
+# The derived ProgressionConfig (S6b: the pickup scatter spacing), lazily
+# loaded (load() is cached) so _ready's load block stays untouched.
+var _progression_cfg: ProgressionConfigScript
 
 
 func _ready() -> void:
@@ -117,9 +126,11 @@ func _start_wave(index: int) -> void:
 		# S6a Kill reward (gADR-0004): the spawner owns the death->reward
 		# wiring, binding the spawned kind so the award reads its Tier-derived
 		# fields — the EnemyController stays reward-agnostic (it only emits
-		# died) and the Player only receives. The same died edge feeds the
-		# wave fold in _on_enemy_died.
-		enemy.died.connect(_on_enemy_died.bind(kind))
+		# died) and the Player only receives. The enemy node itself is bound
+		# too (S6b, gADR-0006): at emit time it is still in the tree
+		# (queue_free is deferred), so its name/position anchor the drops.
+		# The same died edge feeds the wave fold in _on_enemy_died.
+		enemy.died.connect(_on_enemy_died.bind(enemy, kind))
 		add_child(enemy)
 		enemy.play_spawn_tween(_schedule.spawn_squash, _schedule.spawn_tween_duration)
 		_alive += 1
@@ -130,11 +141,13 @@ func _start_wave(index: int) -> void:
 	})
 
 
-## One enemy of the current Wave died: award the Kill reward, then fold the
-## death through the pure WaveSystem (gADR-0005) — advance to the next Wave on
-## clear, or report the whole schedule done after the final one.
-func _on_enemy_died(kind: EnemyConfigScript) -> void:
+## One enemy of the current Wave died: award the Kill reward, roll and spawn
+## its Drop-table drops (S6b, gADR-0006), then fold the death through the pure
+## WaveSystem (gADR-0005) — advance to the next Wave on clear, or report the
+## whole schedule done after the final one.
+func _on_enemy_died(enemy: Node2D, kind: EnemyConfigScript) -> void:
 	_award_kill(kind)
+	_spawn_drops(kind, enemy.name, enemy.position)
 	var decision: Dictionary = WaveSystemScript.resolve_death(
 		_alive, _wave_index, _schedule.waves.size()
 	)
@@ -159,3 +172,43 @@ func _award_kill(kind: EnemyConfigScript) -> void:
 	if player == null or not player.has_method("gain_reward"):
 		return
 	player.gain_reward(kind.exp_reward, kind.gold_reward, kind.tier)
+
+
+## Roll and spawn one death's drops (S6b, gADR-0006): one randf() per
+## Drop-table entry feeds the PURE EconomySystem.resolve_drops (the roll is
+## orchestration, like the clock — the decision stays parameter-injected and
+## testable), and each resolved drop instances pickup.tscn on the
+## deterministic scatter row centered on the death position. Pickup names are
+## derived from the schedule-unique spawn name (gADR-0005), so drops stay
+## addressable. The Pickup self-applies its blockout and logs pickup_spawned
+## (PickupController._ready).
+func _spawn_drops(kind: EnemyConfigScript, source_name: String, death_position: Vector2) -> void:
+	var cfg := _progression_config()
+	if cfg == null:
+		return
+	var rolls: Array = []
+	for _entry in kind.drop_table:
+		rolls.append(randf())
+	var drops: Array = EconomySystemScript.resolve_drops(kind.drop_table, rolls)
+	for i in drops.size():
+		var drop: Dictionary = drops[i]
+		var pickup := PickupScene.instantiate()
+		pickup.setup(drop["item"], drop["amount"])
+		pickup.name = "%sDrop%d" % [source_name, i]
+		pickup.position = death_position + EconomySystemScript.drop_offset(
+			i, drops.size(), cfg.pickup_spacing
+		)
+		add_child(pickup)
+
+
+## The derived ProgressionConfig with the standard loud guard, lazily loaded
+## (the S3 GravityConfig pattern) so _ready's load block stays untouched.
+func _progression_config() -> ProgressionConfigScript:
+	if _progression_cfg == null:
+		_progression_cfg = load(PROGRESSION_CONFIG_PATH)
+		if _progression_cfg == null:
+			push_error(
+				"LevelController: could not load %s — run scripts/build_config.py."
+				% PROGRESSION_CONFIG_PATH
+			)
+	return _progression_cfg

--- a/examples/platformer/panda-adventure/src/controllers/pickup_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/pickup_controller.gd
@@ -1,0 +1,116 @@
+class_name PickupController
+extends Area2D
+
+## One dropped Pickup block (S6b, gADR-0006): carries one resolved drop
+## ({item, amount}) from a defeated Enemy's Drop table, sitting in the world
+## until the Player walks into it. On contact it hands the drop to the
+## Player's collect_drop (gold -> the Player's Gold, an item -> the S6b item
+## count hook), disarms itself, and shrinks away.
+##
+## The drop is INJECTED by the spawner via setup() before add_child (the
+## EnemyController pattern), so one scene serves every item. The blockout
+## (per-item color/size), the spawn squash, and the collect shrink are data
+## (gADR-0000): the derived ProgressionConfig Resource, never hardcoded. The
+## decision of WHAT dropped was the pure EconomySystem's (rolled by the
+## spawner); this controller only orchestrates — blockout, tweens, contact
+## delivery, and logs. Cross-script references use preload() (no editor
+## class cache in this never-imported project).
+##
+## Collision: ON the pickup layer (6), masking ONLY the player layer (2) —
+## enemies, bolts, and Gravity Fields never touch a Pickup, and the Pickup
+## blocks nothing (an Area2D overlap, not a body).
+
+const ProgressionConfigScript := preload("res://src/resources/progression_config.gd")
+const GameLogScript := preload("res://src/util/game_log.gd")
+
+const PROGRESSION_CONFIG_PATH := "res://data/generated/progression_config.tres"
+
+var _item := ""
+var _amount := 0
+var _config: ProgressionConfigScript
+# Collected latch: contact delivers the drop exactly once (the tween-out
+# keeps the node in the tree for a moment after).
+var _collected := false
+
+
+## Hand this Pickup its resolved drop. Called by the spawner BEFORE
+## add_child, so _ready sees the drop (the EnemyController setup() pattern).
+func setup(item: String, amount: int) -> void:
+	_item = item
+	_amount = amount
+
+
+func _ready() -> void:
+	_config = load(PROGRESSION_CONFIG_PATH)
+	if _config == null or _item.is_empty():
+		# The derived .tres is committed and the spawner must setup() first;
+		# guard loudly rather than crash, pointing at the pipeline.
+		push_error(
+			"PickupController: missing drop (setup() before add_child) or %s — run scripts/build_config.py."
+			% PROGRESSION_CONFIG_PATH
+		)
+		return
+	_apply_blockout()
+	body_entered.connect(_on_body_entered)
+	_play_spawn_tween()
+	GameLogScript.emit("info", "pickup_spawned", {
+		"item": _item,
+		"amount": _amount,
+		"x": position.x,
+		"y": position.y,
+	})
+
+
+## Apply the item's data-driven blockout: the pickup block (visual +
+## collision centered on the area origin) styled per drop_items[item]. The
+## collision shape is CREATED here (the EnemyController pattern — gda cannot
+## author inline sub-resources, #365), so the scene ships shape=null.
+func _apply_blockout() -> void:
+	var style: Dictionary = _config.drop_items[_item]
+	var size: Vector2 = style["size"]
+	var half := size / 2.0
+
+	var visual := $Visual as ColorRect
+	visual.color = style["color"]
+	visual.size = size
+	visual.position = -half
+	visual.pivot_offset = half  # scale/tween about the block center
+
+	var shape := RectangleShape2D.new()
+	shape.size = size
+	($Collision as CollisionShape2D).shape = shape
+
+
+## The Player walked into this Pickup (the mask admits nothing else): deliver
+## the drop exactly once, disarm, and shrink away. The Player owns the
+## accumulation and its log (gold_collected / item_collected); this node just
+## hands the drop over.
+func _on_body_entered(body: Node2D) -> void:
+	if _collected or not body.has_method("collect_drop"):
+		return
+	_collected = true
+	set_deferred("monitoring", false)
+	body.collect_drop(_item, _amount)
+	_play_collect_tween()
+
+
+## The spawn telegraph: punch the block's scale from the config squash and
+## tween back to normal (the gADR-0005 spawn idiom).
+func _play_spawn_tween() -> void:
+	var visual := $Visual as ColorRect
+	visual.scale = _config.pickup_spawn_squash
+	var tween := create_tween()
+	var recover := tween.tween_property(visual, "scale", Vector2.ONE, _config.pickup_spawn_tween_duration)
+	recover.set_trans(Tween.TRANS_SINE)
+
+
+## The collect "juice": shrink the block to nothing, then free the node (a
+## property-tween, per the GDD — no sprite frames).
+func _play_collect_tween() -> void:
+	var visual := $Visual as ColorRect
+	var tween := create_tween()
+	var shrink := tween.tween_property(
+		visual, "scale", Vector2.ZERO, _config.pickup_collect_tween_duration
+	)
+	shrink.set_trans(Tween.TRANS_SINE)
+	tween.tween_callback(queue_free)

--- a/examples/platformer/panda-adventure/src/controllers/player_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/player_controller.gd
@@ -336,7 +336,8 @@ func _gravity_config() -> GravityConfigScript:
 
 ## Receive one Kill reward: accumulate the defeated kind's Tier-derived
 ## EXP/Gold onto this Player's own StatsSystem (the only mutation — pure
-## addition, StatsSystem.gain_reward) and log the accumulation trace. The
+## addition, StatsSystem.gain_reward) and log the accumulation trace, then
+## re-resolve the level the new EXP total implies (S6b, gADR-0006). The
 ## amounts and tier come from the defeated kind's derived config, read by the
 ## caller (LevelController) — this method decides nothing.
 func gain_reward(exp_reward: float, gold_reward: float, tier: String) -> void:
@@ -350,12 +351,14 @@ func gain_reward(exp_reward: float, gold_reward: float, tier: String) -> void:
 		"gold_total": _stats.gold,
 		"tier": tier,
 	})
+	_check_level_up()
 
 
 ## The minimal public read surface the HUD pulls each frame (gADR-0004): one
-## snapshot Dictionary of the live stats (+ their config caps) and the Current
-## weapon, so the HUD never reaches into privates. Empty ({}) until _ready has
-## initialized the stats — a puller skips that frame.
+## snapshot Dictionary of the live stats (+ their config caps), the current
+## Level (S6b), and the Current weapon, so the HUD never reaches into
+## privates. Empty ({}) until _ready has initialized the stats — a puller
+## skips that frame.
 func hud_state() -> Dictionary:
 	if _stats == null or _stats_config == null:
 		return {}
@@ -364,7 +367,107 @@ func hud_state() -> Dictionary:
 		"max_hp": _stats_config.max_hp,
 		"mp": _stats.mp,
 		"max_mp": _stats_config.max_mp,
+		"level": _level,
 		"exp": _stats.exp_points,
 		"gold": _stats.gold,
 		"weapon": _weapon,
 	}
+
+
+# --- S6b Leveling curve + drop collection (gADR-0006) -------------------------
+# Kept as ONE self-contained append-only block (the S3/S4 parallel-merge
+# pattern): the level the accumulated EXP implies (a pure GrowthSystem
+# re-resolution after each reward) and the receiving end of a Pickup's drop.
+
+const ProgressionConfigScript := preload("res://src/resources/progression_config.gd")
+const GrowthSystemScript := preload("res://src/systems/growth_system.gd")
+const PROGRESSION_CONFIG_PATH := "res://data/generated/progression_config.tres"
+
+# The Player's current Level — DERIVED runtime state (gADR-0006): always the
+# pure GrowthSystem.resolve_level of the live EXP total, cached only so the
+# old->new edge is detectable for the level_up log + flash. Starts at level 1.
+var _level := 1
+# The S6b item-count hook (item name -> count): where dropped Consumables
+# land until S7's inventory/use story consumes them (the S3 Wine-hook
+# pattern: the supply side exists, the use side is the later slice). Runtime
+# state, never persisted (gADR-0001).
+var _items := {}
+# The derived ProgressionConfig, lazily loaded (load() is cached) so _ready's
+# S2 load block stays untouched (the S3 GravityConfig pattern).
+var _progression_cfg: ProgressionConfigScript
+
+
+## Re-resolve the Level implied by the live EXP total against the data-driven
+## leveling curve (pure GrowthSystem decision; the curve comes from the
+## derived config — max level is curve length + 1, config never code). On a
+## rise: log level_up (from/to covers a multi-threshold jump in one record)
+## and play the flash. EXP only ever grows, so the level never goes down.
+func _check_level_up() -> void:
+	var cfg := _progression_config()
+	if cfg == null or _stats == null:
+		return
+	var resolved := GrowthSystemScript.resolve_level(_stats.exp_points, cfg.level_curve)
+	if resolved <= _level:
+		return
+	var from := _level
+	_level = resolved
+	GameLogScript.emit("info", "level_up", {
+		"from": from,
+		"to": _level,
+		"exp_total": _stats.exp_points,
+	})
+	_play_level_up_flash()
+
+
+## Receive one collected Pickup's drop (called by PickupController on
+## contact): gold accumulates onto this Player's own StatsSystem
+## (StatsSystem.gain_gold — Gold's second source next to the Kill reward),
+## any other item lands in the S6b item-count hook. Each path logs its
+## accumulation trace. The item/amount come from the Pickup's injected drop
+## (resolved from the defeated kind's derived Drop table) — this method
+## decides nothing.
+func collect_drop(item: String, amount: int) -> void:
+	if _stats == null:
+		return
+	if item == "gold":
+		_stats.gain_gold(float(amount))
+		GameLogScript.emit("info", "gold_collected", {
+			"amount": amount,
+			"gold_total": _stats.gold,
+		})
+		return
+	_items[item] = int(_items.get(item, 0)) + amount
+	GameLogScript.emit("info", "item_collected", {
+		"item": item,
+		"amount": amount,
+		"count": _items[item],
+	})
+
+
+## The level-up "juice": flash the Player block to the config level-up color
+## and tween back to its own color (the positive sibling of the hit flash —
+## a property-tween, per the GDD).
+func _play_level_up_flash() -> void:
+	var cfg := _progression_config()
+	if cfg == null:
+		return
+	var visual := $Visual as ColorRect
+	visual.color = cfg.level_up_flash_color
+	var tween := create_tween()
+	var recover := tween.tween_property(
+		visual, "color", _config.player_color, cfg.level_up_flash_duration
+	)
+	recover.set_trans(Tween.TRANS_SINE)
+
+
+## The derived ProgressionConfig with the standard loud guard, lazily loaded
+## so the S2 _ready block stays untouched (the S3 GravityConfig pattern).
+func _progression_config() -> ProgressionConfigScript:
+	if _progression_cfg == null:
+		_progression_cfg = load(PROGRESSION_CONFIG_PATH)
+		if _progression_cfg == null:
+			push_error(
+				"PlayerController: could not load %s — run scripts/build_config.py."
+				% PROGRESSION_CONFIG_PATH
+			)
+	return _progression_cfg

--- a/examples/platformer/panda-adventure/src/resources/enemy_config.gd
+++ b/examples/platformer/panda-adventure/src/resources/enemy_config.gd
@@ -61,3 +61,9 @@ extends "res://src/resources/stats_config.gd"
 # reads dumb fields; retuning a Tier's reward stays a single JSON edit.
 @export var exp_reward: float
 @export var gold_reward: float
+
+# S6b Drop table (gADR-0006): what defeating this kind may leave behind as
+# Pickups — an Array of {"item": String, "amount": int, "chance": float}
+# entries, each rolled independently (EconomySystem.resolve_drops). DERIVED
+# per kind from the same per-Tier table as the rewards above.
+@export var drop_table: Array

--- a/examples/platformer/panda-adventure/src/resources/progression_config.gd
+++ b/examples/platformer/panda-adventure/src/resources/progression_config.gd
@@ -1,0 +1,42 @@
+class_name ProgressionConfig
+extends Resource
+
+## The S6b progression loop's typed config (gADR-0006): the data-driven
+## leveling curve the Player levels up along, and the Drop/Pickup blockout.
+##
+## `level_curve` is the ordered cumulative EXP thresholds — entry k is the
+## total EXP at which the Player reaches level k+2 (level 1 is the start), so
+## the MAX level is level_curve.size() + 1: config, never code (the gADR-0005
+## waves.size() idiom). `drop_items` maps every droppable item name (gold, and
+## the S7 Consumables bun/wine) to its pickup blockout
+## {"color": Color, "size": Vector2}; the schema requires all three, so a drop
+## table can never reference an unstyled item.
+##
+## This Resource is a DERIVED artifact: it is regenerated from the
+## authoritative data/json/progression_config.json by scripts/build_config.py
+## and emitted to data/generated/progression_config.tres. Never hand-edit the
+## generated .tres or hardcode these values — change the JSON (gADR-0000).
+##
+## The @export fields carry NO default literals on purpose (see PlayerConfig).
+
+# The leveling curve: strictly increasing cumulative EXP thresholds
+# (build_config.validate_progression_semantics enforces the monotonicity).
+@export var level_curve: Array
+
+# The level-up "juice": flash the Player block to this color and tween back
+# (the positive sibling of the hit flash).
+@export var level_up_flash_color: Color
+@export var level_up_flash_duration: float
+
+# Pickup blockout per droppable item name.
+@export var drop_items: Dictionary
+
+# The deterministic drop scatter: horizontal spacing between one death's
+# Pickups, centered on the death position (EconomySystem.drop_offset).
+@export var pickup_spacing: float
+
+# Pickup juice: the spawn-telegraph squash (the gADR-0005 idiom) and the
+# collected block's shrink-to-nothing tween.
+@export var pickup_spawn_squash: Vector2
+@export var pickup_spawn_tween_duration: float
+@export var pickup_collect_tween_duration: float

--- a/examples/platformer/panda-adventure/src/systems/economy_system.gd
+++ b/examples/platformer/panda-adventure/src/systems/economy_system.gd
@@ -1,0 +1,34 @@
+class_name EconomySystem
+extends RefCounted
+
+## The pure Drop-table decisions for S6b (gADR-0006): which of a defeated
+## kind's Drop-table entries actually drop, and where each Pickup lands.
+## Static, deterministic, and node/clock/RNG-free (the CombatSystem/WaveSystem
+## decision shape, gADR-0001): the rolls are PARAMETERS — the LevelController
+## supplies randf() per entry at runtime, the logic seam and the offline
+## balancing sim supply chosen values — so chance behavior pins headless.
+## The LevelController orchestrates: it rolls, instances pickup.tscn per
+## resolved drop, and logs the drop_spawned records.
+
+
+## Resolve one death's drops: entry i of `drop_table` (the derived per-kind
+## Array of {"item": String, "amount": int, "chance": float}, gADR-0006)
+## drops iff rolls[i] <= its chance — inclusive, so a chance of 1.0 is a
+## GUARANTEED drop even at the roll domain's top (Godot's randf() is
+## inclusive of 1.0). Returns the resolved drops in table order, each
+## {"item": String, "amount": int} (the chance is consumed by the roll).
+static func resolve_drops(drop_table: Array, rolls: Array) -> Array:
+	var drops: Array = []
+	for i in drop_table.size():
+		var entry: Dictionary = drop_table[i]
+		if float(rolls[i]) <= float(entry["chance"]):
+			drops.append({"item": entry["item"], "amount": entry["amount"]})
+	return drops
+
+
+## The deterministic drop scatter: Pickup `index` of `count` resolved drops
+## sits on a horizontal row centered on the death position, `spacing` px
+## apart — deterministic (no scatter RNG) so a drop's landing spot is
+## data-predictable for tests and for the player's read.
+static func drop_offset(index: int, count: int, spacing: float) -> Vector2:
+	return Vector2((float(index) - float(count - 1) / 2.0) * spacing, 0.0)

--- a/examples/platformer/panda-adventure/src/systems/economy_system.gd
+++ b/examples/platformer/panda-adventure/src/systems/economy_system.gd
@@ -7,8 +7,8 @@ extends RefCounted
 ## decision shape, gADR-0001): the rolls are PARAMETERS — the LevelController
 ## supplies randf() per entry at runtime, the logic seam and the offline
 ## balancing sim supply chosen values — so chance behavior pins headless.
-## The LevelController orchestrates: it rolls, instances pickup.tscn per
-## resolved drop, and logs the drop_spawned records.
+## The LevelController orchestrates: it rolls and instances pickup.tscn per
+## resolved drop; each Pickup logs its own pickup_spawned record.
 
 
 ## Resolve one death's drops: entry i of `drop_table` (the derived per-kind

--- a/examples/platformer/panda-adventure/src/systems/growth_system.gd
+++ b/examples/platformer/panda-adventure/src/systems/growth_system.gd
@@ -1,0 +1,27 @@
+class_name GrowthSystem
+extends RefCounted
+
+## The pure leveling decision for S6b (gADR-0006): the Player's level as a
+## FUNCTION of accumulated EXP against the data-driven leveling curve.
+## Static, deterministic, and node/clock-free (the CombatSystem/WaveSystem
+## decision shape, gADR-0001) — totals in, level out — so the logic seam
+## exercises the curve headless at ANY curve length (the no-hardcoded-count
+## guarantee: the curve is always a parameter, read from the derived
+## ProgressionConfig by the caller). The PlayerController orchestrates: it
+## re-resolves after each Kill reward, detects the old->new edge, logs
+## level_up, and plays the flash tween.
+
+
+## Resolve the level implied by `exp_points` total EXP against `level_curve`
+## (cumulative EXP thresholds, strictly increasing — the builder's semantic
+## gate): level 1 is the start, and each threshold reached is one level-up,
+## so the level is 1 + the thresholds crossed and the MAX level is
+## level_curve.size() + 1 (config, never code). Deriving from the TOTAL —
+## rather than folding per-gain — makes one big reward worth several
+## thresholds a multi-level-up for free, and re-resolution idempotent.
+static func resolve_level(exp_points: float, level_curve: Array) -> int:
+	var level := 1
+	for threshold in level_curve:
+		if exp_points >= float(threshold):
+			level += 1
+	return level

--- a/examples/platformer/panda-adventure/src/systems/stats_system.gd
+++ b/examples/platformer/panda-adventure/src/systems/stats_system.gd
@@ -61,3 +61,13 @@ func restore_mp(amount: float, max_mp: float) -> void:
 func gain_reward(exp_amount: float, gold_amount: float) -> void:
 	exp_points += exp_amount
 	gold += gold_amount
+
+
+## Accumulate collected drop Gold (S6b, gADR-0006): the Pickup path's pure
+## addition — Gold's second source next to the Kill reward's gain_reward,
+## same uncapped accumulation, no EXP side. The amount is a PARAMETER, read
+## by the caller from the collected Pickup (whose value came from the
+## defeated kind's derived drop_table) — drop numbers stay outside this
+## runtime holder (gADR-0001).
+func gain_gold(amount: float) -> void:
+	gold += amount

--- a/examples/platformer/panda-adventure/tests/gdscript/test_progression_logic.gd
+++ b/examples/platformer/panda-adventure/tests/gdscript/test_progression_logic.gd
@@ -1,0 +1,155 @@
+extends SceneTree
+
+## Logic seam (b) for S6b: exercise the PURE progression decisions headless —
+## GrowthSystem.resolve_level (the leveling curve: level as a function of the
+## EXP total, max level = curve length + 1), EconomySystem.resolve_drops (the
+## Drop-table roll: rolls are parameters, roll <= chance drops) and
+## drop_offset (the deterministic scatter row), and StatsSystem.gain_gold
+## (the Pickup path's pure gold accumulation) — with every value injected as
+## a parameter (node/physics/clock/RNG-free), per gADR-0006 on gADR-0001's
+## decision shape.
+##
+## Run via gda (ADR-0031):
+##   gda script run res://tests/gdscript/test_progression_logic.gd
+##
+## preload() the scripts (a headless runtime has no editor-generated
+## global_script_class_cache), construct in-memory curves/tables with KNOWN
+## values, and assert each rule. Prints "LOGIC_SEAM: PASS" + quit(0) on
+## success, else push_error + quit(1).
+
+const StatsConfigScript := preload("res://src/resources/stats_config.gd")
+const StatsSystemScript := preload("res://src/systems/stats_system.gd")
+const GrowthSystemScript := preload("res://src/systems/growth_system.gd")
+const EconomySystemScript := preload("res://src/systems/economy_system.gd")
+
+# A known curve: strictly increasing cumulative thresholds (max level 4).
+const CURVE := [10.0, 50.0, 150.0]
+
+# A known Drop table: a guaranteed entry, a coin-flip entry, a long-shot.
+const TABLE := [
+	{"item": "gold", "amount": 3, "chance": 1.0},
+	{"item": "bun", "amount": 1, "chance": 0.5},
+	{"item": "wine", "amount": 2, "chance": 0.1},
+]
+
+
+func _fail(msg: String) -> void:
+	push_error("LOGIC_SEAM: " + msg)
+	quit(1)
+
+
+func _init() -> void:
+	# Behavior 1 — the start of the curve: level 1 at the accumulation
+	# identity (0 EXP) and anywhere below the first threshold.
+	if GrowthSystemScript.resolve_level(0.0, CURVE) != 1:
+		_fail("0 EXP must be level 1")
+		return
+	if GrowthSystemScript.resolve_level(9.9, CURVE) != 1:
+		_fail("EXP below the first threshold must stay level 1")
+		return
+
+	# Behavior 2 — a threshold REACHED is a level-up (>=, not >): exactly at
+	# the first threshold is level 2.
+	if GrowthSystemScript.resolve_level(10.0, CURVE) != 2:
+		_fail("EXP exactly at a threshold must level up")
+		return
+	if GrowthSystemScript.resolve_level(49.9, CURVE) != 2:
+		_fail("EXP between thresholds must hold the level")
+		return
+
+	# Behavior 3 — level is a FUNCTION of the total: one big total is worth
+	# every threshold it crosses (the multi-level-up rule).
+	if GrowthSystemScript.resolve_level(150.0, CURVE) != 4:
+		_fail("a total crossing several thresholds must yield them all")
+		return
+
+	# Behavior 4 — the cap: the max level is curve length + 1, however far
+	# the EXP total runs past the last threshold (config, never code).
+	if GrowthSystemScript.resolve_level(1000000.0, CURVE) != CURVE.size() + 1:
+		_fail("the max level must be the curve length + 1")
+		return
+
+	# Behavior 5 — the curve LENGTH is the authority (the gADR-0005
+	# waves.size() idiom at this seam): a longer curve raises the cap with no
+	# code change, an empty curve pins level 1.
+	if GrowthSystemScript.resolve_level(1000000.0, [5.0, 10.0, 15.0, 20.0, 25.0]) != 6:
+		_fail("a 5-entry curve must cap at level 6")
+		return
+	if GrowthSystemScript.resolve_level(1000000.0, []) != 1:
+		_fail("an empty curve must pin level 1")
+		return
+
+	# Behavior 6 — resolve_drops includes an entry iff its roll <= chance:
+	# the INCLUSIVE boundary makes chance 1.0 a guaranteed drop even at the
+	# roll domain's top (randf() includes 1.0).
+	var all_top: Array = EconomySystemScript.resolve_drops(TABLE, [1.0, 1.0, 1.0])
+	if all_top.size() != 1 or all_top[0]["item"] != "gold":
+		_fail("at roll 1.0 only the guaranteed entry must drop")
+		return
+	var at_chance: Array = EconomySystemScript.resolve_drops(TABLE, [1.0, 0.5, 0.1])
+	if at_chance.size() != 3:
+		_fail("a roll exactly at an entry's chance must drop (inclusive)")
+		return
+	var above: Array = EconomySystemScript.resolve_drops(TABLE, [1.0, 0.51, 0.11])
+	if above.size() != 1:
+		_fail("a roll above an entry's chance must not drop")
+		return
+
+	# Behavior 7 — resolved drops keep table order and carry {item, amount}
+	# only (the chance is consumed by the roll).
+	var low: Array = EconomySystemScript.resolve_drops(TABLE, [0.0, 0.0, 0.0])
+	if low.size() != 3:
+		_fail("rolls of 0 must drop every entry")
+		return
+	if low[0]["item"] != "gold" or low[1]["item"] != "bun" or low[2]["item"] != "wine":
+		_fail("resolved drops must keep table order")
+		return
+	if low[2]["amount"] != 2 or low[2].has("chance"):
+		_fail("a resolved drop carries item+amount, never the chance")
+		return
+
+	# Behavior 8 — an empty Drop table resolves to no drops (a Tier that
+	# drops nothing is legal config).
+	if not EconomySystemScript.resolve_drops([], []).is_empty():
+		_fail("an empty Drop table must resolve to no drops")
+		return
+
+	# Behavior 9 — the deterministic scatter row: centered on the death
+	# position, spacing apart, no RNG.
+	if EconomySystemScript.drop_offset(0, 1, 30.0) != Vector2.ZERO:
+		_fail("a single drop must sit at the death position")
+		return
+	if EconomySystemScript.drop_offset(0, 2, 30.0) != Vector2(-15.0, 0.0):
+		_fail("two drops must straddle the death position (left)")
+		return
+	if EconomySystemScript.drop_offset(1, 2, 30.0) != Vector2(15.0, 0.0):
+		_fail("two drops must straddle the death position (right)")
+		return
+	if EconomySystemScript.drop_offset(2, 3, 30.0) != Vector2(30.0, 0.0):
+		_fail("three drops must span a centered row")
+		return
+
+	# Behavior 10 — gain_gold accumulates gold ONLY, from the accumulation
+	# identity, leaving EXP and the survival resources untouched (the Pickup
+	# path next to the Kill reward's gain_reward, gADR-0006 on gADR-0001).
+	var block := StatsConfigScript.new()
+	block.max_hp = 100.0
+	block.max_mp = 50.0
+	block.attack = 10.0
+	block.defense = 0.0
+	var stats := StatsSystemScript.new()
+	stats.init_from(block)
+	stats.gain_gold(3.0)
+	stats.gain_gold(50.0)
+	if not is_equal_approx(stats.gold, 53.0):
+		_fail("gain_gold must accumulate: 3+50 gold")
+		return
+	if not is_zero_approx(stats.exp_points):
+		_fail("gain_gold must not touch EXP")
+		return
+	if not is_equal_approx(stats.hp, 100.0) or not is_equal_approx(stats.mp, 50.0):
+		_fail("gain_gold must not touch HP/MP")
+		return
+
+	print("LOGIC_SEAM: PASS")
+	quit(0)

--- a/examples/platformer/panda-adventure/tests/gdscript/test_reward_hud_logic.gd
+++ b/examples/platformer/panda-adventure/tests/gdscript/test_reward_hud_logic.gd
@@ -104,13 +104,15 @@ func _init() -> void:
 		_fail("format_weapon should render gravity_gun as GRAVITY GUN")
 		return
 
-	# Behavior 9 — format_lines maps a full hud_state() snapshot to the five
-	# display strings in one place (the whole readout pinned at once).
+	# Behavior 9 — format_lines maps a full hud_state() snapshot to the six
+	# display strings in one place (the whole readout pinned at once; the
+	# snapshot carries the S6b Level since gADR-0006).
 	var lines: Dictionary = HudControllerScript.format_lines({
 		"hp": 95.0,
 		"max_hp": MAX_HP,
 		"mp": 40.0,
 		"max_mp": MAX_MP,
+		"level": 3,
 		"exp": 50.0,
 		"gold": 25.0,
 		"weapon": "gravity_gun",
@@ -118,6 +120,7 @@ func _init() -> void:
 	var expected := {
 		"hp": "HP 95/100",
 		"mp": "MP 40/50",
+		"level": "LV 3",
 		"exp": "EXP 50",
 		"gold": "GOLD 25",
 		"weapon": "GRAVITY GUN",

--- a/examples/platformer/panda-adventure/tests/test_progression_data_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_progression_data_seam.py
@@ -1,0 +1,322 @@
+"""Data seam (a) for S6b Leveling curve + drop tables (gADR-0006).
+
+Proves the JSON -> Resource pipeline (gADR-0000) for the S6b config surfaces:
+the authoritative ``progression_config.json`` (the leveling curve, the pickup
+blockout styles, and the drop/level-up juice) validates against its schema and
+bad config is rejected; the strictly-increasing-curve rule the schema cannot
+express is enforced by ``build_config.validate_progression_semantics`` and
+gates the build; the per-Tier ``drops`` tables in ``enemies_config.json``
+validate (and bad drop entries are rejected); the builder RESOLVES each
+Tier's ``drops`` into a per-kind derived ``drop_table`` field (the runtime
+reads dumb fields, the authority stays per-Tier — the gADR-0004 reward
+resolution extended); retuning a Tier's drops is one JSON edit; and the
+derived ``ProgressionConfig``/per-kind ``.tres`` round-trip through gda with
+their declared Godot types. Freshness of ``progression_config.tres`` and of
+the ``drop_table`` inside every ``enemy_<kind>.tres`` is covered by
+``test_combat_data_seam.py``'s SPECS-parametrized gate. Fast tier — never
+``e2e``; the round-trips drive one-shot ``gda`` headless ops under the
+``engine`` gate.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import jsonschema
+import pytest
+
+import build_config
+
+PROGRESSION_JSON_PATH = build_config.GAME_DIR / "data/json/progression_config.json"
+PROGRESSION_SCHEMA_PATH = (
+    build_config.GAME_DIR / "data/schema/progression_config.schema.json"
+)
+
+# The kind names, derived from the authoritative JSON (never a static list).
+_KIND_NAMES: list[str] = list(
+    build_config.load_json(build_config.ENEMIES_JSON_PATH)["kinds"]
+)
+
+
+def _progression_config() -> dict:
+    """A fresh copy of the authoritative progression config to mutate."""
+    return copy.deepcopy(build_config.load_json(PROGRESSION_JSON_PATH))
+
+
+def _progression_schema() -> dict:
+    return build_config.load_schema(PROGRESSION_SCHEMA_PATH)
+
+
+def _enemies_config() -> dict:
+    return copy.deepcopy(build_config.load_json(build_config.ENEMIES_JSON_PATH))
+
+
+def _enemies_schema() -> dict:
+    return build_config.load_schema(build_config.ENEMIES_SCHEMA_PATH)
+
+
+# ---------------------------------------------------------------------------
+# The progression source: schema shape + the strictly-increasing-curve rule.
+# ---------------------------------------------------------------------------
+
+
+def test_authoritative_progression_config_validates() -> None:
+    """The shipped progression config passes its schema AND its semantics."""
+    config = build_config.load_json(PROGRESSION_JSON_PATH)
+    assert build_config.validate_config(config, _progression_schema()) is config
+    assert build_config.validate_progression_semantics(config) is config
+
+
+def test_every_shipped_drop_item_has_a_pickup_style() -> None:
+    """Coverage by construction (gADR-0006): the schema requires a style for
+    the whole item vocabulary, so every item any Tier's drops reference is
+    styled — asserted on the SHIPPED data so the two sources cannot drift."""
+    progression = build_config.load_json(PROGRESSION_JSON_PATH)
+    enemies = build_config.load_json(build_config.ENEMIES_JSON_PATH)
+    dropped = {
+        entry["item"] for tier in enemies["tiers"].values() for entry in tier["drops"]
+    }
+    assert dropped <= set(progression["drop_items"])
+
+
+def _prog_without(*path: str) -> dict:
+    bad = _progression_config()
+    node = bad
+    for key in path[:-1]:
+        node = node[key]
+    del node[path[-1]]
+    return bad
+
+
+def _prog_with(value: object, *path: str) -> dict:
+    bad = _progression_config()
+    node = bad
+    for key in path[:-1]:
+        node = node[key]
+    node[path[-1]] = value
+    return bad
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        _prog_without("level_curve"),  # the curve is required
+        _prog_with([], "level_curve"),  # at least one threshold
+        _prog_with([0.0], "level_curve"),  # thresholds strictly positive
+        _prog_with([10.0, "lots"], "level_curve"),  # wrong entry type
+        _prog_without("drop_items"),  # the pickup styles are required
+        _prog_without("drop_items", "wine"),  # the whole item vocabulary is styled
+        _prog_without("drop_items", "gold", "size"),  # a style needs its size
+        _prog_with([1.0, 0.9], "level_up_flash_color"),  # color: 4 components
+        _prog_with(0, "pickup_spacing"),  # spacing strictly positive
+        _prog_with(0, "pickup_spawn_tween_duration"),  # duration strictly positive
+        _prog_with([0.0, 0.3], "pickup_spawn_squash"),  # squash strictly positive
+        _prog_with(
+            {"color": [1, 1, 1, 1], "size": [10.0, 10.0], "extra": 1},
+            "drop_items",
+            "bun",
+        ),  # extra key in a style
+        {**_progression_config(), "extra": 1},  # unexpected extra top-level key
+    ],
+)
+def test_invalid_progression_json_rejected(bad: dict) -> None:
+    """A progression config violating the schema raises ValidationError."""
+    with pytest.raises(jsonschema.ValidationError):
+        build_config.validate_config(bad, _progression_schema())
+
+
+@pytest.mark.parametrize(
+    "curve",
+    [[10.0, 10.0], [10.0, 50.0, 40.0]],
+    ids=["flat-step", "decreasing-step"],
+)
+def test_non_increasing_curve_rejected_by_semantics(curve: list[float]) -> None:
+    """The cross-field rule: a flat/decreasing curve is schema-valid (each
+    entry alone is fine) but must be rejected by
+    ``validate_progression_semantics`` — proven schema-first so this suite
+    would catch the rule silently migrating into the schema."""
+    bad = _prog_with(curve, "level_curve")
+    build_config.validate_config(bad, _progression_schema())
+    with pytest.raises(jsonschema.ValidationError):
+        build_config.validate_progression_semantics(bad)
+
+
+def _stage_inputs(root) -> None:
+    """Copy every spec's authoritative JSON + schema into an isolated root."""
+    for rel in {s.json_rel for s in build_config.SPECS} | {
+        s.schema_rel for s in build_config.SPECS
+    }:
+        src = build_config.GAME_DIR / rel
+        dst = root / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+def test_non_increasing_curve_gates_the_build(tmp_path) -> None:
+    """The curve rule gates the BUILD, not just direct validator calls."""
+    _stage_inputs(tmp_path)
+    progression_path = tmp_path / "data/json/progression_config.json"
+    config = json.loads(progression_path.read_text(encoding="utf-8"))
+    config["level_curve"] = [50.0, 50.0]
+    progression_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(jsonschema.ValidationError):
+        build_config.build_all(root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# The per-Tier drops tables: schema shape + resolution into per-kind derived
+# drop_table fields (the gADR-0004 reward resolution extended, gADR-0006).
+# ---------------------------------------------------------------------------
+
+
+def _with_drop(value: object, tier: str, *path) -> dict:
+    """The enemies config with ``tiers.<tier>.drops[0].<path>`` (or the whole
+    ``drops`` when path is empty) replaced by ``value``."""
+    bad = _enemies_config()
+    node = bad["tiers"][tier]
+    keys = ["drops", *path]
+    for key in keys[:-1]:
+        node = node[key]
+    node[keys[-1]] = value
+    return bad
+
+
+def _without_drops(tier: str) -> dict:
+    bad = _enemies_config()
+    del bad["tiers"][tier]["drops"]
+    return bad
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        _without_drops("minion"),  # every Tier entry carries its drops table
+        _with_drop({"item": "gold"}, "minion"),  # drops must be an array
+        _with_drop([{"item": "gold", "amount": 3}], "minion"),  # chance required
+        _with_drop([{"item": "gold", "chance": 1.0}], "minion"),  # amount required
+        _with_drop([{"amount": 3, "chance": 1.0}], "minion"),  # item required
+        _with_drop(
+            [{"item": "diamond", "amount": 1, "chance": 1.0}], "minion"
+        ),  # off-vocabulary item
+        _with_drop(
+            [{"item": "gold", "amount": 0, "chance": 1.0}], "minion"
+        ),  # amount at least 1
+        _with_drop(
+            [{"item": "gold", "amount": 1.5, "chance": 1.0}], "minion"
+        ),  # amount a whole number
+        _with_drop(
+            [{"item": "gold", "amount": 3, "chance": 0.0}], "minion"
+        ),  # a 0 chance is dead config
+        _with_drop(
+            [{"item": "gold", "amount": 3, "chance": 1.1}], "minion"
+        ),  # chance at most 1
+        _with_drop(
+            [{"item": "gold", "amount": 3, "chance": 1.0, "extra": 1}], "minion"
+        ),  # extra key in an entry
+    ],
+)
+def test_invalid_drop_table_rejected(bad: dict) -> None:
+    """A ``drops`` table violating the schema raises ValidationError."""
+    with pytest.raises(jsonschema.ValidationError):
+        build_config.validate_config(bad, _enemies_schema())
+
+
+def test_empty_drops_table_is_legal() -> None:
+    """A Tier that drops nothing is valid config (the entries roll
+    independently; an empty table simply resolves to no drops)."""
+    config = _with_drop([], "minion")
+    assert build_config.validate_config(config, _enemies_schema()) is config
+    assert build_config.validate_enemies_semantics(config) is config
+
+
+def test_resolve_enemy_rewards_carries_the_tier_drops() -> None:
+    """Every kind gains a drop_table equal to its Tier's drops entry."""
+    config = build_config.load_json(build_config.ENEMIES_JSON_PATH)
+    resolved = build_config.resolve_enemy_rewards(config)
+    for name, kind in resolved["kinds"].items():
+        assert kind["drop_table"] == config["tiers"][kind["tier"]]["drops"], name
+    # The source document is untouched (the resolver returns a copy).
+    assert "drop_table" not in config["kinds"][_KIND_NAMES[0]]
+
+
+def test_retuning_a_tier_drops_is_one_json_edit(tmp_path) -> None:
+    """Changing one Tier's drops re-derives every kind of that Tier.
+
+    The drop AUTHORITY is per-Tier (gADR-0006, the gADR-0004 rule): edit
+    ``tiers.minion.drops`` alone and the rebuilt minion ``.tres`` carries the
+    new table — no per-kind edit, no Python edit.
+    """
+    _stage_inputs(tmp_path)
+    enemies_path = tmp_path / "data/json/enemies_config.json"
+    config = json.loads(enemies_path.read_text(encoding="utf-8"))
+    config["tiers"]["minion"]["drops"] = [{"item": "wine", "amount": 7, "chance": 0.75}]
+    enemies_path.write_text(json.dumps(config), encoding="utf-8")
+
+    build_config.build_all(root=tmp_path)
+
+    minion_tres = (
+        tmp_path / "data/generated/enemy_monster_minion_melee.tres"
+    ).read_text(encoding="utf-8")
+    assert 'drop_table = [{"item": "wine", "amount": 7, "chance": 0.75}]' in minion_tres
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: the derived ProgressionConfig .tres and the per-kind drop_table
+# load back through gda with their declared Godot types, compared to the
+# AUTHORITATIVE JSON (never hardcoded values).
+# ---------------------------------------------------------------------------
+
+
+def _get_props(gda, res_path: str) -> dict:
+    result = gda("resource", "get", res_path, "--json")
+    assert result.returncode == 0, result.stdout + result.stderr
+    return {p["name"]: p["value"] for p in json.loads(result.stdout)["properties"]}
+
+
+@pytest.mark.engine
+def test_progression_config_round_trips(gda) -> None:
+    """The ProgressionConfig .tres round-trips every field through gda.
+
+    gda projects the nested values as structured JSON (ADR-0035): the curve
+    as a number array, each pickup style with its color/size projections —
+    all matching the authoritative JSON.
+    """
+    config = build_config.load_json(PROGRESSION_JSON_PATH)
+    props = _get_props(gda, "res://data/generated/progression_config.tres")
+    assert props["level_curve"] == pytest.approx(config["level_curve"])
+    assert props["level_up_flash_color"] == pytest.approx(
+        config["level_up_flash_color"]
+    )
+    assert props["level_up_flash_duration"] == pytest.approx(
+        config["level_up_flash_duration"]
+    )
+    assert props["pickup_spacing"] == pytest.approx(config["pickup_spacing"])
+    assert props["pickup_spawn_squash"] == pytest.approx(config["pickup_spawn_squash"])
+    assert props["pickup_spawn_tween_duration"] == pytest.approx(
+        config["pickup_spawn_tween_duration"]
+    )
+    assert props["pickup_collect_tween_duration"] == pytest.approx(
+        config["pickup_collect_tween_duration"]
+    )
+    assert set(props["drop_items"]) == set(config["drop_items"])
+    for item, style in config["drop_items"].items():
+        got = props["drop_items"][item]
+        assert got["color"] == pytest.approx(style["color"]), item
+        assert got["size"] == pytest.approx(style["size"]), item
+
+
+@pytest.mark.engine
+@pytest.mark.parametrize("kind", _KIND_NAMES)
+def test_kind_drop_table_round_trips(gda, kind: str) -> None:
+    """Each EnemyConfig .tres round-trips its Tier-resolved drop_table."""
+    config = build_config.load_json(build_config.ENEMIES_JSON_PATH)
+    drops = config["tiers"][config["kinds"][kind]["tier"]]["drops"]
+    props = _get_props(gda, f"res://data/generated/enemy_{kind}.tres")
+    got = props["drop_table"]
+    assert len(got) == len(drops), kind
+    for got_entry, expected in zip(got, drops):
+        assert got_entry["item"] == expected["item"]
+        assert got_entry["amount"] == expected["amount"]
+        assert got_entry["chance"] == pytest.approx(expected["chance"])

--- a/examples/platformer/panda-adventure/tests/test_progression_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_progression_e2e.py
@@ -308,6 +308,26 @@ def test_daemon_serves_leveling_and_drop_collection(tmp_path, daemon_runtime_dir
             assert got["fields"]["amount"] == expected["amount"]
             assert got["fields"]["count"] == expected["amount"]
 
+        # --- The kill-flow trace is ORDERED as the gADR-0006 logger contract
+        # promises — the cause precedes its effects: enemy_died before the
+        # award/level records (the spawner's handlers run synchronously
+        # INSIDE the died signal, so this order is a deliberate emit-before-
+        # signal choice, not a given), every pickup spawned before anything
+        # is collected.
+        proc = run("logger", "tail")
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        trace = [
+            r["message"]
+            for r in json.loads(proc.stdout)["records"]
+            if r["origin"] == "gda_log"
+        ]
+        assert trace.index("enemy_died") < trace.index("reward_gained"), trace
+        assert trace.index("reward_gained") < trace.index("level_up"), trace
+        assert trace.index("level_up") < trace.index("pickup_spawned"), trace
+        last_spawned = len(trace) - 1 - trace[::-1].index("pickup_spawned")
+        assert last_spawned < trace.index("gold_collected"), trace
+        assert last_spawned < trace.index("item_collected"), trace
+
         # The HUD surfaces the full accumulation: kill reward + dropped gold.
         assert poll(lambda: label("Gold") == f"GOLD {int(gold_total)}"), (
             f"Gold readout never showed the drops: {label('Gold')}"

--- a/examples/platformer/panda-adventure/tests/test_progression_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_progression_e2e.py
@@ -1,0 +1,317 @@
+"""Integration seam (c) for S6b Leveling curve + drop tables — THE gate.
+
+The full progression loop through the gda CLI against a running Engine
+session: killing the Wave-1 minion levels the Player up along the
+data-driven leveling curve (level_up log + the HUD LV readout), and the
+kill's Drop table leaves Pickups on the deterministic scatter row that the
+Player walks over to collect — gold accumulating onto the Gold readout,
+the item landing in the S6b item-count hook (gADR-0006):
+
+- boot: ``hud_ready`` carries level 1 and the LV Label renders it — the
+  Player starts at the bottom of the curve;
+- the kill (the S6a-proven walk-aggro-shoot loop) emits ``level_up`` whose
+  from/to match the authoritative curve against the minion Tier's
+  exp_reward, and the LV readout ticks up;
+- one ``pickup_spawned`` record per resolved drop, the scatter row exactly
+  ``pickup_spacing`` apart (drop POSITIONS are deterministic relative to the
+  death spot even though the death spot itself follows the AI dynamics);
+- walking across the drops emits ``gold_collected`` (amount + total = kill
+  gold_reward + dropped gold) and ``item_collected`` (the bun, count 1), and
+  the Gold readout agrees.
+
+Every expectation derives from the AUTHORITATIVE JSON configs, never
+hardcoded. One data seam is exercised e2e as well: the throwaway copy's
+minion bun-drop chance is retuned to 1.0 (a JSON-only edit + rebuild — the
+waves-e2e reconfiguration precedent) so the item path asserts
+deterministically; the shipped 0.25 chance would make the bun a coin toss.
+The gold entry ships at chance 1.0 and is asserted as shipped. Per RULES.md,
+mocks cannot replace this end-to-end proof.
+
+Isolation: same throwaway-copy pattern as ``test_reward_hud_e2e`` (``daemon
+start`` mutates ``project.godot``); posix-only (AF_UNIX); headless. The walk
+uses ``input sequence`` ``physics_frame`` offsets (the physics-clock
+schedule): displacement maps deterministically to held physics ticks
+(move_speed / 60 per tick).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+import build_config
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+GDA_CMD = [sys.executable, "-m", "gda"]
+GODOT = resolve_godot_binary()
+GAME_DIR = build_config.GAME_DIR
+
+_COPY_IGNORE = shutil.ignore_patterns(
+    "tests", ".godot", "build", "generated", "__pycache__"
+)
+
+_HUD_LABEL = "/root/Main/Hud/Stats/%sLabel"
+
+
+def _make_project_copy(dst: Path) -> dict:
+    """Copy the committed game into a throwaway dir, retune the minion's bun
+    drop to a GUARANTEED drop (JSON-only, the per-Tier authority), and build
+    the copy's config there. Returns the copy's enemies document — the
+    authority the assertions below derive from."""
+    shutil.copytree(GAME_DIR, dst, ignore=_COPY_IGNORE)
+    enemies_path = dst / "data" / "json" / "enemies_config.json"
+    enemies = json.loads(enemies_path.read_text(encoding="utf-8"))
+    for entry in enemies["tiers"]["minion"]["drops"]:
+        if entry["item"] != "gold":
+            entry["chance"] = 1.0
+    enemies_path.write_text(json.dumps(enemies), encoding="utf-8")
+    build_config.build_all(root=dst)
+    return enemies
+
+
+@pytest.mark.e2e
+def test_daemon_serves_leveling_and_drop_collection(tmp_path, daemon_runtime_dir):
+    project = tmp_path / "game"
+    enemies = _make_project_copy(project)
+    # Every expectation derives from the AUTHORITATIVE JSON (the copy's, for
+    # the retuned drop chance), never hardcoded.
+    combat = build_config.load_json(GAME_DIR / "data" / "json" / "combat_config.json")
+    player_cfg = build_config.load_json(
+        GAME_DIR / "data" / "json" / "player_config.json"
+    )
+    progression = build_config.load_json(
+        GAME_DIR / "data" / "json" / "progression_config.json"
+    )
+    default_spawn = enemies["waves"][0]["spawns"][0]
+    kind = enemies["kinds"][default_spawn["kind"]]
+    reward = enemies["tiers"][kind["tier"]]
+    drops = reward["drops"]
+    # With every chance at 1.0 the WHOLE table drops, in table order.
+    assert all(entry["chance"] == 1.0 for entry in drops), drops
+    gold_dropped = sum(e["amount"] for e in drops if e["item"] == "gold")
+    item_drops = [e for e in drops if e["item"] != "gold"]
+    assert gold_dropped and item_drops, "the minion table must cover both paths"
+    # The level the kill's EXP reaches on the curve (GrowthSystem's rule:
+    # 1 + thresholds reached) — the shipped curve levels a first minion kill.
+    curve = progression["level_curve"]
+    expected_level = 1 + sum(
+        1 for threshold in curve if reward["exp_reward"] >= threshold
+    )
+    assert expected_level > 1, "the first kill must level up on the shipped curve"
+    spacing = progression["pickup_spacing"]
+    player_stats = combat["player_stats"]
+    laser_damage = max(
+        combat["min_damage"],
+        player_stats["attack"] * combat["attack_scale"]
+        - kind["defense"] * combat["defense_scale"],
+    )
+    shots_to_kill = math.ceil(kind["max_hp"] / laser_damage)
+    iframe = combat["iframe_duration"]
+    rest_y = (
+        player_cfg["platform_position"][1]
+        - player_cfg["platform_size"][1] / 2.0
+        - player_cfg["player_size"][1] / 2.0
+    )
+    start_x = player_cfg["player_start"][0]
+    enemy_x = default_spawn["position"][0]
+    # The S6a-proven walk target: inside the minion's Aggro Range with margin
+    # on both sides; the minion closes the rest (gADR-0003 dynamics).
+    target_x = enemy_x - kind["aggro_range"] + 40.0
+    ticks_per_px = 1.0 / (player_cfg["move_speed"] / 60.0)
+    env = {**os.environ}
+
+    def run(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(project),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    def records(message: str) -> list[dict]:
+        proc = run("logger", "tail")
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        return [
+            r
+            for r in json.loads(proc.stdout)["records"]
+            if r["message"] == message and r["origin"] == "gda_log"
+        ]
+
+    def poll(predicate, timeout: float = 20.0, interval: float = 0.5):
+        deadline = time.monotonic() + timeout
+        result = predicate()
+        while not result and time.monotonic() < deadline:
+            time.sleep(interval)
+            result = predicate()
+        return result
+
+    def prop(path: str, name: str):
+        got = run("game", "get", path, "--property", name)
+        assert got.returncode == 0, got.stdout + got.stderr
+        for p in json.loads(got.stdout)["properties"]:
+            if p["name"] == name:
+                return p["value"]
+        raise AssertionError(f"{name} not returned for {path}")
+
+    def label(key: str) -> str:
+        return prop(_HUD_LABEL % key, "text")
+
+    def tap(action: str) -> None:
+        seq = run(
+            "input",
+            "sequence",
+            "--events",
+            json.dumps(
+                [
+                    {"type": "action", "action": action, "frame": 0},
+                    {"type": "action", "action": action, "release": True, "frame": 4},
+                ]
+            ),
+        )
+        assert seq.returncode == 0, seq.stdout + seq.stderr
+
+    def walk_right(px: float) -> None:
+        """Hold move_right for the physics ticks that cover ``px`` pixels."""
+        seq = run(
+            "input",
+            "sequence",
+            "--events",
+            json.dumps(
+                [
+                    {"type": "action", "action": "move_right", "physics_frame": 0},
+                    {
+                        "type": "action",
+                        "action": "move_right",
+                        "release": True,
+                        "physics_frame": max(round(px * ticks_per_px), 1),
+                    },
+                ]
+            ),
+        )
+        assert seq.returncode == 0, seq.stdout + seq.stderr
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        # The first live op launches the Engine session (the daemon observes,
+        # it does not start one on a diagnostics read); the tree also proves
+        # the S6b LV line is instanced in the HUD column.
+        tree = run("game", "tree")
+        assert tree.returncode == 0, tree.stdout + tree.stderr
+        assert '"LevelLabel"' in tree.stdout, tree.stdout
+
+        # --- Boot: the Player starts at the bottom of the curve — hud_ready
+        # carries level 1 and the LV Label (the S6b line in the HUD column)
+        # renders it.
+        ready = poll(lambda: records("hud_ready"))
+        assert ready, "no gda_log 'hud_ready' record"
+        assert ready[0]["fields"]["level"] == 1
+        assert label("Level") == "LV 1"
+
+        # Let the Player settle on the platform so the walk starts from rest.
+        assert poll(
+            lambda: abs(prop("/root/Main/Player", "position")[1] - rest_y) <= 2.0
+        ), "Player did not land"
+
+        # --- The kill: walk into the minion's Aggro Range (the deterministic
+        # physics-clock hold), let it close, kill it with spaced Laser shots
+        # (past the i-frame window) — the S6a-proven loop.
+        walk_right(target_x - start_x)
+        player_x = prop("/root/Main/Player", "position")[0]
+        assert abs(player_x - target_x) <= 20.0, (
+            f"physics-clock walk missed its target: x={player_x}, want ~{target_x}"
+        )
+        assert poll(lambda: records("player_hit"), timeout=30.0), (
+            "the aggroed minion never landed a contact hit"
+        )
+        for _ in range(shots_to_kill * 2):
+            if records("enemy_died"):
+                break
+            time.sleep(iframe + 0.3)
+            tap("fire")
+            poll(lambda: bool(records("enemy_died")), timeout=3.0)
+        assert poll(lambda: records("enemy_died")), "the Enemy never died"
+
+        # --- The leveling curve: the kill's EXP reaches the curve's first
+        # threshold — one level_up record with the curve-derived from/to and
+        # the EXP total, and the LV readout ticks up.
+        leveled = poll(lambda: records("level_up"))
+        assert leveled, "no gda_log 'level_up' record"
+        assert len(leveled) == 1, f"one threshold crossing, one record: {leveled}"
+        fields = leveled[0]["fields"]
+        assert fields["from"] == 1
+        assert fields["to"] == expected_level
+        assert fields["exp_total"] == pytest.approx(reward["exp_reward"])
+        assert poll(lambda: label("Level") == f"LV {expected_level}"), (
+            f"LV readout never showed the level-up: {label('Level')}"
+        )
+
+        # --- The Drop table: one pickup_spawned per entry (every chance is
+        # 1.0 in this copy), in table order on the deterministic scatter row —
+        # neighbors exactly pickup_spacing apart, anchored on the death spot.
+        spawned = poll(lambda: len(records("pickup_spawned")) == len(drops))
+        assert spawned, (
+            f"expected {len(drops)} pickup_spawned records, "
+            f"got {records('pickup_spawned')}"
+        )
+        pickups = records("pickup_spawned")
+        for got, expected in zip(pickups, drops):
+            assert got["fields"]["item"] == expected["item"]
+            assert got["fields"]["amount"] == expected["amount"]
+        xs = [r["fields"]["x"] for r in pickups]
+        for left, right in zip(xs, xs[1:]):
+            assert right - left == pytest.approx(spacing), xs
+        death = records("enemy_died")[0]["fields"]
+        assert sum(xs) / len(xs) == pytest.approx(death["x"]), (
+            f"the scatter row must center on the death spot: {xs} vs {death}"
+        )
+
+        # --- Collection: walk across the row; gold accumulates onto the
+        # Player's Gold (the second source next to the Kill reward) and the
+        # bun lands in the item-count hook. The readout agrees with the log.
+        player_x = prop("/root/Main/Player", "position")[0]
+        walk_right(max(xs) - player_x + 30.0)
+        collected_gold = poll(lambda: records("gold_collected"), timeout=15.0)
+        assert collected_gold, "no gda_log 'gold_collected' record"
+        gold_total = reward["gold_reward"] + gold_dropped
+        assert collected_gold[-1]["fields"]["gold_total"] == pytest.approx(gold_total)
+        collected_items = poll(
+            lambda: len(records("item_collected")) == len(item_drops), timeout=15.0
+        )
+        assert collected_items, (
+            f"expected {len(item_drops)} item_collected records, "
+            f"got {records('item_collected')}"
+        )
+        for got, expected in zip(records("item_collected"), item_drops):
+            assert got["fields"]["item"] == expected["item"]
+            assert got["fields"]["amount"] == expected["amount"]
+            assert got["fields"]["count"] == expected["amount"]
+
+        # The HUD surfaces the full accumulation: kill reward + dropped gold.
+        assert poll(lambda: label("Gold") == f"GOLD {int(gold_total)}"), (
+            f"Gold readout never showed the drops: {label('Gold')}"
+        )
+        assert label("Exp") == f"EXP {int(reward['exp_reward'])}"
+    finally:
+        run("daemon", "stop")

--- a/examples/platformer/panda-adventure/tests/test_progression_logic_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_progression_logic_seam.py
@@ -1,0 +1,48 @@
+"""Logic seam (b) for S6b Leveling curve + drop tables (gADR-0006).
+
+Exercises the pure S6b decisions — ``GrowthSystem.resolve_level`` (the
+leveling curve: level as a function of the EXP total, max level = curve
+length + 1), ``EconomySystem.resolve_drops``/``drop_offset`` (the Drop-table
+roll with parameter-injected rolls, and the deterministic scatter row), and
+``StatsSystem.gain_gold`` (the Pickup path's gold accumulation) — headless,
+through ``gda script run`` (ADR-0031), with every value injected as a
+parameter. Fast tier (``engine`` marker), never ``e2e``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+_LOGIC_SCRIPT = "res://tests/gdscript/test_progression_logic.gd"
+
+
+def _run(gda) -> subprocess.CompletedProcess:
+    return gda("script", "run", _LOGIC_SCRIPT, "--json")
+
+
+@pytest.mark.engine
+def test_logic_seam_progression_decisions(gda) -> None:
+    """The pure progression rules hold for every behavior the GDScript seam asserts.
+
+    The seam covers: level 1 at the accumulation identity and below the first
+    threshold; a threshold REACHED is a level-up (>=); one total crossing
+    several thresholds yields them all (multi-level-up); the max-level cap is
+    the curve length + 1 and follows the curve's length (the no-hardcoded-
+    count proof, an empty curve pinning level 1); drop inclusion iff
+    roll <= chance (the inclusive boundary that makes chance 1.0 guaranteed
+    against randf()'s 1.0-inclusive domain); resolved drops keeping table
+    order and carrying item+amount only; an empty table resolving empty; the
+    deterministic centered scatter row; and ``gain_gold`` accumulating gold
+    alone. We read gda's passed-through ``exit_status`` (0 == all assertions
+    held) and require the PASS marker in stdout.
+    """
+    result = _run(gda)
+    # gda itself succeeded (the script launched and ran to completion).
+    assert result.returncode == 0, result.stdout + result.stderr
+    doc = json.loads(result.stdout)
+    # The script's own exit_status is passed through: 0 == every assertion held.
+    assert doc["exit_status"] == 0, doc["stdout"] + doc["stderr"]
+    assert "LOGIC_SEAM: PASS" in doc["stdout"], doc["stdout"] + doc["stderr"]

--- a/examples/platformer/panda-adventure/tests/test_reward_hud_data_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_reward_hud_data_seam.py
@@ -189,7 +189,12 @@ def test_retuning_a_tier_is_one_json_edit(tmp_path) -> None:
     _stage_inputs(tmp_path)
     enemies_path = tmp_path / "data/json/enemies_config.json"
     config = json.loads(enemies_path.read_text(encoding="utf-8"))
-    config["tiers"]["minion"] = {"exp_reward": 77.0, "gold_reward": 33.0}
+    config["tiers"]["minion"] = {
+        "exp_reward": 77.0,
+        "gold_reward": 33.0,
+        # Since S6b a Tier entry also carries its drops table (gADR-0006).
+        "drops": config["tiers"]["minion"]["drops"],
+    }
     enemies_path.write_text(json.dumps(config), encoding="utf-8")
 
     build_config.build_all(root=tmp_path)


### PR DESCRIPTION
Closes #336

## What

S6b closes the progression loop on top of S6a (gADR-0006, new):

- **Data-driven leveling curve** — a new authoritative `progression_config.json` carries `level_curve` (strictly increasing cumulative EXP thresholds; **max level = array length + 1** — the gADR-0005 `waves.size()` idiom). `GrowthSystem.resolve_level` derives the Player's level PURELY from the EXP total (multi-level jumps and the cap for free); the Player re-resolves after each Kill reward, logs `level_up {from, to, exp_total}`, plays a flash tween, and the HUD gains the **LV** line.
- **Data-driven drop tables** — each `tiers` entry (the gADR-0004 per-Tier reward authority) gains a required `drops` array (`{item, amount, chance}`), resolved per kind into a derived `drop_table` field by the same resolver. On death the spawner rolls one `randf()` per entry into the pure `EconomySystem.resolve_drops` (**inclusive `roll <= chance`**, so `chance: 1.0` is guaranteed against Godot's 1.0-inclusive `randf()`) and instances `pickup.tscn` per resolved drop on a deterministic scatter row centered on the death spot.
- **Pickups** — Area2D blocks on the new `pickup` layer (6) masking `player` only; per-item blockout from `drop_items` (schema requires the whole closed Phase-1 vocabulary {gold, bun, wine} — style coverage by construction); spawn/collect tweens. Collection: gold → `StatsSystem.gain_gold` (`gold_collected`), items → the Player's **item-count hook** (`item_collected`) — the supply side S7's Consumable use-effects will consume.
- Leveling is **readout-only in Phase 1** (the issue's contract; stat-growth numbers are balancing-phase data hooked on the same level edge later) — recorded with the other options considered in gADR-0006.

## DoD (three seams green, logic seam pure/headless)

- **Logic seam** (`gda script run`, parameter-injected): curve boundaries/cap/length-authority, drop roll boundaries/order/shape, scatter row, `gain_gold` isolation.
- **Data seam**: schema valid/invalid matrices for both sources, the schema-first non-increasing-curve semantic rule + its build gate, per-kind `drop_table` resolution + one-edit Tier retune, gda round-trips (incl. the `drop_items` projection); freshness rides the SPECS-parametrized gate.
- **E2E** (daemon live loop): on a copy with the minion bun chance retuned to 1.0 (waves-e2e reconfiguration precedent), the kill emits `level_up` (curve-derived from/to), LV ticks 1→2, one `pickup_spawned` per drop exactly `pickup_spacing` apart centered on the death spot, and walking the row emits `gold_collected`/`item_collected` with the HUD GOLD/EXP readouts agreeing — all derived from the authoritative JSON.
- Blockout + tween (pickup spawn/collect, level-up flash, LV pulse); logs conform to `gda logger tail`; config data-driven (gADR-0000).

Local runs: fast tier **215 passed**; e2e tier **12 passed** (full suite). One unrelated flake observed once under full-suite load (`test_enemies_e2e` melee scenario measured `d0` after the enemy had already closed — a pre-existing timing sensitivity, not touched by this slice; green in isolation and on the suite re-run).

## Docs

gADR-0006 (decision + considered options), GAME-CONTEXT.md (Level, Leveling curve, Drop table, Pickup, Item count hook; Kill reward's drop pointer repointed S7→S6b), manifest notes (pickup layer 6).

## gda dogfooding

`gda node add` appends only — inserting the HUD LV line between existing Labels took remove+re-add of the trailing three. Filing a separate gda feature request for a child-index/reorder op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)