### PR TITLE
feat(node): add child index insertion and reorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,13 +383,13 @@ flags — `gda --help` is the authoritative list of what is installed.
 
 | Command | What it does |
 | ------- | ------------ |
-| `node add` | Add a node under a parent: a built-in type, a `class_name` script, or `--instance` to compose another scene as an instanced child. |
+| `node add` | Add a node under a parent, optionally at `--index`: a built-in type, a `class_name` script, or `--instance` to compose another scene as an instanced child. |
 | `node get` | Read a node's properties (by node path) as typed JSON. |
 | `node list` | List a scene's node tree with each node's path relative to the root. |
 | `node set` | Set a node property, coercing the value to its declared Godot type. |
 | `node remove` | Remove a node (and its subtree) by node path. |
 | `node duplicate` | Duplicate a node (and its subtree) under its parent. |
-| `node move` | Reparent a node (and its subtree) under a new parent. |
+| `node move` | Reparent a node (and its subtree) under a new parent, or reorder it with `--index`. |
 | `node connect-signal` | Wire a source node's signal to a target node's method. |
 | `node disconnect-signal` | Unwire an existing signal→method connection. |
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=54d955c0d26c2607586676502e2380782317721823423a92bcba9d359467cd81 -->
+<!-- gda-readme-i18n: source=README.md sha256=6d608025337e57ffee1ef9386f71745eafa6bbee170a3b0df84680307db5b8ec -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -392,13 +392,13 @@ flags — `gda --help` es la lista autoritativa de lo que está instalado.
 
 | Comando | Qué hace |
 | ------- | ------------ |
-| `node add` | Añade un nodo bajo un padre: un tipo integrado, un script con `class_name`, o `--instance` para componer otra escena como hijo instanciado. |
+| `node add` | Añade un nodo bajo un padre, opcionalmente en `--index`: un tipo integrado, un script con `class_name`, o `--instance` para componer otra escena como hijo instanciado. |
 | `node get` | Lee las propiedades de un nodo (por ruta de nodo) como JSON tipado. |
 | `node list` | Lista el árbol de nodos de una escena con la ruta de cada nodo relativa a la raíz. |
 | `node set` | Define una propiedad de nodo, forzando el valor a su tipo de Godot declarado. |
 | `node remove` | Elimina un nodo (y su subárbol) por ruta de nodo. |
 | `node duplicate` | Duplica un nodo (y su subárbol) bajo su padre. |
-| `node move` | Reasigna un nodo (y su subárbol) a un nuevo padre. |
+| `node move` | Reasigna un nodo (y su subárbol) a un nuevo padre, o lo reordena con `--index`. |
 | `node connect-signal` | Conecta la señal de un nodo origen al método de un nodo destino. |
 | `node disconnect-signal` | Desconecta una conexión señal→método existente. |
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=54d955c0d26c2607586676502e2380782317721823423a92bcba9d359467cd81 -->
+<!-- gda-readme-i18n: source=README.md sha256=6d608025337e57ffee1ef9386f71745eafa6bbee170a3b0df84680307db5b8ec -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -398,13 +398,13 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 
 | コマンド | 機能 |
 | ------- | ------------ |
-| `node add` | 親の下にノードを追加します: 組み込みタイプ、`class_name` スクリプト、または `--instance` で別のシーンをインスタンス化した子として合成します。 |
+| `node add` | 親の下にノードを追加します。必要なら `--index` で位置を指定できます: 組み込みタイプ、`class_name` スクリプト、または `--instance` で別のシーンをインスタンス化した子として合成します。 |
 | `node get` | ノードのプロパティを(ノードパスで指定して)型付き JSON として読み取ります。 |
 | `node list` | シーンのノードツリーを、各ノードのルートからの相対パスとともに一覧します。 |
 | `node set` | ノードのプロパティを設定します。値は宣言された Godot の型に変換されます。 |
 | `node remove` | ノード(およびそのサブツリー)をノードパスで指定して削除します。 |
 | `node duplicate` | ノード(およびそのサブツリー)を親の下に複製します。 |
-| `node move` | ノード(およびそのサブツリー)を新しい親の下に付け替えます。 |
+| `node move` | ノード(およびそのサブツリー)を新しい親の下に付け替えるか、`--index` で兄弟順を並べ替えます。 |
 | `node connect-signal` | ソースノードのシグナルをターゲットノードのメソッドに接続します。 |
 | `node disconnect-signal` | 既存のシグナル → メソッド接続を解除します。 |
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=54d955c0d26c2607586676502e2380782317721823423a92bcba9d359467cd81 -->
+<!-- gda-readme-i18n: source=README.md sha256=6d608025337e57ffee1ef9386f71745eafa6bbee170a3b0df84680307db5b8ec -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -381,13 +381,13 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 
 | 命令 | 作用 |
 | ------- | ------------ |
-| `node add` | 在某个父节点下添加一个节点：内置类型、带 `class_name` 的脚本，或用 `--instance` 把另一个场景作为实例化子节点组合进来。 |
+| `node add` | 在某个父节点下添加一个节点，可用 `--index` 指定位置：内置类型、带 `class_name` 的脚本，或用 `--instance` 把另一个场景作为实例化子节点组合进来。 |
 | `node get` | 按节点路径读取一个节点的属性，输出带类型的 JSON。 |
 | `node list` | 列出一个场景的节点树，并给出每个节点相对于根的路径。 |
 | `node set` | 设置一个节点属性，并把值强制转换为它声明的 Godot 类型。 |
 | `node remove` | 按节点路径移除一个节点（及其子树）。 |
 | `node duplicate` | 在父节点下复制一个节点（及其子树）。 |
-| `node move` | 把一个节点（及其子树）重新挂到一个新的父节点下。 |
+| `node move` | 把一个节点（及其子树）重新挂到新的父节点下，或用 `--index` 调整同级顺序。 |
 | `node connect-signal` | 把源节点的信号接到目标节点的方法上。 |
 | `node disconnect-signal` | 断开一个已有的「信号→方法」连接。 |
 

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -114,6 +114,7 @@ operation, and parse codes the CLI assigns).
 | `invalid_node_type` | `operation` | `operation` | `4` | A requested node type is neither an instantiable `Node` class nor a registered `class_name`. |
 | `invalid_node_name` | `operation` | `operation` | `4` | A requested node name is empty or would be rewritten by Godot. |
 | `duplicate_node_name` | `operation` | `operation` | `4` | The parent node already has a child with the requested name. |
+| `invalid_child_index` | `operation` | `operation` | `4` | A requested child insertion or move index is outside the valid sibling range. |
 | `missing_dependency` | `operation` | `operation` | `4` | A scene's declared nodes vanished or degraded on load — an unresolvable instanced sub-scene, an unavailable node class, or a GDScript preload target that does not exist; re-saving would silently drop or downgrade scene data. |
 | `uninstantiable_script` | `operation` | `operation` | `4` | A registered `class_name`'s script can no longer be loaded, compiled, or constructed, so it cannot be instantiated as a node or a resource. |
 | `ambiguous_class_name` | `operation` | `operation` | `4` | A `class_name` is declared in more than one `.gd` script, so a request naming it (node add, resource create, or find-references) cannot resolve it to a single script; the conflicting script paths are named (ADR-0032). |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -155,6 +155,16 @@ carrying the nested culprit; instancing the host into itself is refused as `cycl
 composed scene runs the `_init` of scripts inside it: the same trust boundary as the
 `class_name` path (#62).
 
+**Sibling order authoring** (#415): `node add --index <n>` inserts the new child at a
+0-based sibling index under `--parent`; omitting `--index` appends as before, and
+`--index child_count` is the explicit append position. Valid `node add` indexes are
+`0..child_count` before insertion. `node move --index <n>` places the moved node at its final
+0-based sibling index under `--to`: for a same-parent move the range is `0..child_count-1`,
+and for a different-parent move it is `0..target_child_count` before the move. Omitting
+`--index` preserves existing behavior: a same-parent move is a successful no-op that leaves
+the file untouched, while a cross-parent move appends under the destination. Negative or
+out-of-range indexes fail with `invalid_child_index` (exit 4), leaving the file untouched.
+
 **Property reporting and value coercion** (established by #55): `gda node get` instantiates the
 scene and reports the addressed node's **storage** properties (the ones that serialize into the
 `.tscn`) as typed JSON — each a `{name, type, value}` triple where `type` is the property's
@@ -233,16 +243,19 @@ corrupting the scene.
   `Hero3`, …), skipping any name already taken — including the engine's internal children. It
   returns the copy's new node path. Duplicating the root (`--node .`) is `cannot_target_root` —
   the root has no parent to host a sibling copy.
-- `gda node move SCENE --node <node-path> --to <new-parent-path>` reparents a node **and its whole
-  subtree** under the target parent, returning the node's new node path. The target is addressed
-  by node path like any other (`--to .` is the root). An invalid target (no such parent) is
+- `gda node move SCENE --node <node-path> --to <new-parent-path> [--index <n>]` reparents a node
+  **and its whole subtree** under the target parent, returning the node's new node path. With
+  `--index`, it also places the moved node at that 0-based destination sibling index; when
+  `--to` is the node's existing parent, `--index` performs a same-parent reorder without
+  remove+re-add churn. The target is addressed by node path like any other (`--to .` is the root).
+  An invalid target (no such parent) is
   `parent_not_found`, and a target that already has a child with the moved node's name is
   `duplicate_node_name` — both the same codes `node add` reports. A **cyclic** target — the moved
   node itself or one of its **own descendants** — would detach the subtree from the scene and is
   refused with the registered `cyclic_target` code. Moving the root (`--node .`) is
   `cannot_target_root` — the root has no parent to be reparented out of. Moving a node to the
-  parent it **already sits under** is a successful **no-op** that leaves the file untouched —
-  re-homing it under the same parent would reorder siblings, which is meaningful in Godot. The
+  parent it **already sits under** without `--index` is a successful **no-op** that leaves the
+  file untouched. The
   reparent preserves the moved node's own **local transform** (a purely structural move, no
   transform churn) and the instance state of any instanced sub-scene it carries — its
   `instance=ExtResource(...)`, its `[editable ...]` marker, and its inherited/override children are
@@ -278,12 +291,12 @@ reuses `path_not_found` / `not_a_scene`. All failures exit 4 and leave the file 
 
 | Command | Description |
 | --- | --- |
-| `gda node add` | Add a node (by type, `class_name` script, or `--instance` scene composition) into a scene |
+| `gda node add` | Add a node (by type, `class_name` script, or `--instance` scene composition) into a scene, optionally at `--index` |
 | `gda node remove` | Remove a node from a scene |
 | `gda node get` | Read a node's properties (typed JSON) |
 | `gda node list` | List nodes in a scene (optionally filtered by type/group) |
 | `gda node set` | Set a node property (type-coerced) |
-| `gda node move` | Reparent a node |
+| `gda node move` | Reparent or reorder a node |
 | `gda node duplicate` | Duplicate a node |
 | `gda node connect-signal` / `disconnect-signal` | Wire / unwire a signal to a method |
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -2176,6 +2176,14 @@ def add(
             "instanced scene's filename stem."
         ),
     ),
+    index: Optional[int] = typer.Option(
+        None,
+        "--index",
+        help=(
+            "0-based sibling index under the parent where the child is inserted. "
+            "Omit to append; child_count appends."
+        ),
+    ),
     json_output: bool = json_option(),
     schema: bool = NODE_ADD_COMMAND.schema_option(),
     params_json: Optional[str] = params_json_option(),
@@ -2193,6 +2201,7 @@ def add(
             type=node_type,
             instance=instance,
             name=name,
+            index=index,
         )
     except (ValueError, ValidationError) as exc:
         raise typer.BadParameter(str(exc)) from exc
@@ -2367,6 +2376,14 @@ def move_node(
             "moved node or one of its descendants (a cyclic target)."
         ),
     ),
+    index: Optional[int] = typer.Option(
+        None,
+        "--index",
+        help=(
+            "Final 0-based sibling index under --to. Omit to append on "
+            "cross-parent moves and no-op on same-parent moves."
+        ),
+    ),
     json_output: bool = json_option(),
     schema: bool = NODE_MOVE_COMMAND.schema_option(),
     params_json: Optional[str] = params_json_option(),
@@ -2376,7 +2393,7 @@ def move_node(
     """Reparent a node (and its subtree) under a new parent node path."""
     _dispatch(
         NODE_MOVE_COMMAND,
-        NodeMoveParams(path=path, node=node, to=to),
+        NodeMoveParams(path=path, node=node, to=to, index=index),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -210,6 +210,13 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "The parent node already has a child with the requested name.",
     ),
     ErrorCodeSpec(
+        "invalid_child_index",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.OPERATION,
+        "A requested child insertion or move index is outside the valid sibling range.",
+    ),
+    ErrorCodeSpec(
         "missing_dependency",
         ErrorCategory.OPERATION,
         EXIT_OPERATION,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -737,6 +737,15 @@ class NodeAddParams(BaseModel):
             "must not contain '.', ':', '@', '/', '\"', or '%'."
         ),
     )
+    index: int | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Optional 0-based sibling index under the parent where the new "
+            "child is inserted. Omit to append. Valid runtime range is "
+            "0..child_count before insertion, so child_count appends."
+        ),
+    )
 
     @model_validator(mode="after")
     def _exactly_one_mode_and_default_name(self) -> "NodeAddParams":
@@ -1047,6 +1056,17 @@ class NodeMoveParams(BaseModel):
             "addresses the root itself, 'Enemies' a nested node. Must not be the "
             "moved node itself or one of its descendants (a cyclic target)."
         )
+    )
+    index: int | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Optional final 0-based sibling index under the destination parent. "
+            "Omit to preserve existing behavior: same-parent move is a no-op, "
+            "and cross-parent move appends. With the same parent, valid runtime "
+            "range is 0..child_count-1; with a different parent, 0..target_child_count "
+            "before the move, so target_child_count appends."
+        ),
     )
 
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -41,6 +41,7 @@ const OP_ERROR_PARENT_NOT_FOUND := "parent_not_found"
 const OP_ERROR_INVALID_NODE_TYPE := "invalid_node_type"
 const OP_ERROR_INVALID_NODE_NAME := "invalid_node_name"
 const OP_ERROR_DUPLICATE_NODE_NAME := "duplicate_node_name"
+const OP_ERROR_INVALID_CHILD_INDEX := "invalid_child_index"
 const OP_ERROR_MISSING_DEPENDENCY := "missing_dependency"
 const OP_ERROR_UNINSTANTIABLE_SCRIPT := "uninstantiable_script"
 const OP_ERROR_AMBIGUOUS_CLASS_NAME := "ambiguous_class_name"
@@ -520,6 +521,15 @@ func _op_node_add(params: Dictionary) -> void:
 		root.free()
 		_fail(OP_ERROR_DUPLICATE_NODE_NAME, "parent " + parent_path + " already has a child named: " + node_name)
 		return
+	var has_index := _has_int_param(params, "index")
+	var insert_index := _int_param(params, "index") if has_index else -1
+	var child_count := parent.get_child_count()
+	if has_index and (insert_index < 0 or insert_index > child_count):
+		root.free()
+		_fail(OP_ERROR_INVALID_CHILD_INDEX, "child index " + str(insert_index)
+				+ " is out of range for parent " + parent_path
+				+ ": expected 0.." + str(child_count))
+		return
 
 	var type := _string_param(params, "type")
 	var instance_path := _string_param(params, "instance")
@@ -538,6 +548,8 @@ func _op_node_add(params: Dictionary) -> void:
 	# assigned name is final; no post-assignment recheck is needed.
 	node.name = node_name
 	parent.add_child(node)
+	if has_index:
+		parent.move_child(node, insert_index)
 	node.owner = root
 
 	# Capture the node's identity off the live tree before re-saving frees it.
@@ -895,15 +907,28 @@ func _op_node_move(params: Dictionary) -> void:
 				+ " — a node cannot become a child of its own subtree")
 		return
 
-	# Same-parent move: the node is already under the requested parent, so this is
-	# a successful no-op. Report its current identity and return WITHOUT reparenting
-	# or re-saving — re-homing it under the same parent would append it to the end
-	# and silently reorder siblings (issue #56 review), and there is nothing to
-	# persist that is not already on disk.
+	var has_index := _has_int_param(params, "index")
+	var requested_index := _int_param(params, "index") if has_index else -1
+
+	# Same-parent move without --index: the node is already under the requested
+	# parent, so this remains the legacy successful no-op. With --index, the same
+	# request becomes an explicit sibling reorder and is persisted with move_child.
 	if node.get_parent() == target:
 		var here_name := String(node.name)
 		var here_type := node.get_class()
-		root.free()
+		var sibling_count := target.get_child_count()
+		if has_index and (requested_index < 0 or requested_index >= sibling_count):
+			root.free()
+			_fail(OP_ERROR_INVALID_CHILD_INDEX, "child index " + str(requested_index)
+					+ " is out of range for parent " + target_path
+					+ ": expected 0.." + str(sibling_count - 1))
+			return
+		if has_index and requested_index != node.get_index():
+			target.move_child(node, requested_index)
+			if not _repack_and_save(root, path):
+				return  # _repack_and_save already recorded the failure (and freed root)
+		else:
+			root.free()
 		_succeed({
 			"scene_path": path,
 			"source_path": node_path,
@@ -923,11 +948,20 @@ func _op_node_move(params: Dictionary) -> void:
 		_fail(OP_ERROR_DUPLICATE_NODE_NAME, "target " + target_path
 				+ " already has a child named: " + node_name)
 		return
+	var target_child_count := target.get_child_count()
+	if has_index and (requested_index < 0 or requested_index > target_child_count):
+		root.free()
+		_fail(OP_ERROR_INVALID_CHILD_INDEX, "child index " + str(requested_index)
+				+ " is out of range for parent " + target_path
+				+ ": expected 0.." + str(target_child_count))
+		return
 
 	# reparent(target, false) preserves the moved node's and its descendants'
 	# owners (so an instanced sub-scene keeps its overrides and editable marker)
 	# and keeps the node's LOCAL transform (a purely structural move, no churn).
 	node.reparent(target, false)
+	if has_index:
+		target.move_child(node, requested_index)
 
 	# Capture the moved node's new identity off the live tree before re-saving.
 	var new_path := String(root.get_path_to(node))
@@ -4611,6 +4645,14 @@ func _string_param(params: Dictionary, key: String) -> String:
 	if value is String:
 		return value
 	return ""
+
+
+func _has_int_param(params: Dictionary, key: String) -> bool:
+	return params.has(key) and params[key] != null
+
+
+func _int_param(params: Dictionary, key: String) -> int:
+	return int(params.get(key, 0))
 
 
 # The Godot type name for a Variant.Type, as node get / node set report it

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -4609,6 +4609,14 @@ func _resolve_object_value(prop_name: String, prop_entry: Dictionary, raw_value:
 	return loaded
 
 
+func _has_int_param(params: Dictionary, key: String) -> bool:
+	return params.has(key) and params[key] != null
+
+
+func _int_param(params: Dictionary, key: String) -> int:
+	return int(params.get(key, 0))
+
+
 # --- BEGIN shared coercion (keep byte-identical: operations.gd <-> gda_harness.gd) ---
 # These pure property-introspection / value-coercion helpers are DUPLICATED
 # verbatim into src/gda/harness/gda_harness.gd: operations.gd runs via
@@ -4645,14 +4653,6 @@ func _string_param(params: Dictionary, key: String) -> String:
 	if value is String:
 		return value
 	return ""
-
-
-func _has_int_param(params: Dictionary, key: String) -> bool:
-	return params.has(key) and params[key] != null
-
-
-func _int_param(params: Dictionary, key: String) -> int:
-	return int(params.get(key, 0))
 
 
 # The Godot type name for a Variant.Type, as node get / node set report it

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -65,6 +65,16 @@ def _create_scene(scene_path) -> None:
     assert created.returncode == 0, created.stdout + created.stderr
 
 
+def _root_children(scene_path) -> list[dict]:
+    listed = _gda("node", "list", str(scene_path), "--json")
+    assert listed.returncode == 0, listed.stdout + listed.stderr
+    return json.loads(listed.stdout)["root"]["children"]
+
+
+def _root_child_names(scene_path) -> list[str]:
+    return [child["name"] for child in _root_children(scene_path)]
+
+
 @pytest.mark.e2e
 def test_node_add_then_list_round_trip(godot_project):
     scene_path = godot_project / "main.tscn"
@@ -100,6 +110,43 @@ def test_node_add_then_list_round_trip(godot_project):
     hero = root["children"][0]
     assert (hero["name"], hero["type"], hero["path"]) == ("Hero", "Sprite2D", "Hero")
     assert hero["children"] == []
+
+
+@pytest.mark.e2e
+def test_node_add_index_inserts_at_zero_based_sibling_position(godot_project):
+    # Issue #415: sibling order is authored structure. `--index 2` inserts the
+    # new child before the old child at index 2; omitting --index remains append.
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    for name in ("HP", "MP", "EXP"):
+        added = _gda(
+            "node",
+            "add",
+            str(scene_path),
+            "--type",
+            "Label",
+            "--name",
+            name,
+            "--json",
+        )
+        assert added.returncode == 0, added.stdout + added.stderr
+
+    inserted = _gda(
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Label",
+        "--name",
+        "Level",
+        "--index",
+        "2",
+        "--json",
+    )
+
+    assert inserted.returncode == 0, inserted.stdout + inserted.stderr
+    assert json.loads(inserted.stdout)["path"] == "Level"
+    assert _root_child_names(scene_path) == ["HP", "MP", "Level", "EXP"]
 
 
 @pytest.mark.e2e
@@ -741,6 +788,48 @@ def test_node_add_name_collision_yields_duplicate_node_name(godot_project):
 
     err = _assert_operation_error(again, "duplicate_node_name")
     assert "Hero" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("index", ["-1", "2"])
+def test_node_add_invalid_index_yields_invalid_child_index_and_leaves_file_unchanged(
+    godot_project,
+    index,
+):
+    # Issue #415: gda's structured index API is explicit 0-based insertion.
+    # Negative indexes are rejected even though Godot's raw move_child accepts
+    # them, and child_count+1 is out of range.
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    first = _gda(
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Label",
+        "--name",
+        "HP",
+        "--json",
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+    before = scene_path.read_text(encoding="utf-8")
+
+    added = _gda(
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Label",
+        "--name",
+        "MP",
+        "--index",
+        index,
+        "--json",
+    )
+
+    err = _assert_operation_error(added, "invalid_child_index")
+    assert index in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
 
@@ -2150,6 +2239,58 @@ def test_node_move_reparents_node_and_subtree_round_trip(godot_project):
 
 
 @pytest.mark.e2e
+def test_node_move_index_places_reparented_node_in_destination_order(godot_project):
+    # Issue #415: for cross-parent moves, --index is interpreted against the
+    # destination parent's children before the move. Index 0 places the moved
+    # subtree before all existing destination children.
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    for name, parent in (
+        ("Hero", "."),
+        ("Hitbox", "Hero"),
+        ("Enemies", "."),
+        ("Slime", "Enemies"),
+        ("Bat", "Enemies"),
+    ):
+        added = _gda(
+            "node",
+            "add",
+            str(scene_path),
+            "--type",
+            "Node2D",
+            "--name",
+            name,
+            "--parent",
+            parent,
+            "--json",
+        )
+        assert added.returncode == 0, added.stdout + added.stderr
+
+    moved = _gda(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        "Hero",
+        "--to",
+        "Enemies",
+        "--index",
+        "0",
+        "--json",
+    )
+
+    assert moved.returncode == 0, moved.stdout + moved.stderr
+    data = json.loads(moved.stdout)
+    assert data["path"] == "Enemies/Hero"
+    root_children = _root_children(scene_path)
+    by_name = {child["name"]: child for child in root_children}
+    assert "Hero" not in by_name
+    enemies_children = by_name["Enemies"]["children"]
+    assert [child["name"] for child in enemies_children] == ["Hero", "Slime", "Bat"]
+    assert enemies_children[0]["children"][0]["path"] == "Enemies/Hero/Hitbox"
+
+
+@pytest.mark.e2e
 def test_node_move_to_root_reparents_under_the_root(godot_project):
     # The target may be the root itself ('.'): a deeply nested node can be moved
     # up to be a direct child of the scene root.
@@ -2167,6 +2308,119 @@ def test_node_move_to_root_reparents_under_the_root(godot_project):
     listed = _gda("node", "list", str(scene_path), "--json")
     names = {c["name"] for c in json.loads(listed.stdout)["root"]["children"]}
     assert names == {"A", "B"}
+
+
+@pytest.mark.e2e
+def test_node_move_index_reorders_same_parent_without_rebuilding_node(godot_project):
+    # Issue #415: same-parent `node move --index` is a reorder, not the legacy
+    # no-op and not remove+re-add. The moved node keeps its subtree and stored
+    # properties while its sibling position changes.
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    for name in ("HP", "MP", "EXP"):
+        added = _gda(
+            "node",
+            "add",
+            str(scene_path),
+            "--type",
+            "Label",
+            "--name",
+            name,
+            "--json",
+        )
+        assert added.returncode == 0, added.stdout + added.stderr
+    set_text = _gda(
+        "node",
+        "set",
+        str(scene_path),
+        "--node",
+        "EXP",
+        "--property",
+        "text",
+        "--value",
+        "xp",
+        "--json",
+    )
+    assert set_text.returncode == 0, set_text.stdout + set_text.stderr
+    child = _gda(
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Marker2D",
+        "--name",
+        "Icon",
+        "--parent",
+        "EXP",
+        "--json",
+    )
+    assert child.returncode == 0, child.stdout + child.stderr
+
+    moved = _gda(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        "EXP",
+        "--to",
+        ".",
+        "--index",
+        "1",
+        "--json",
+    )
+
+    assert moved.returncode == 0, moved.stdout + moved.stderr
+    assert json.loads(moved.stdout)["path"] == "EXP"
+    root_children = _root_children(scene_path)
+    assert [child["name"] for child in root_children] == ["HP", "EXP", "MP"]
+    exp = root_children[1]
+    assert exp["children"][0]["path"] == "EXP/Icon"
+    got = _gda("node", "get", str(scene_path), "--node", "EXP", "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    properties = {
+        prop["name"]: prop["value"] for prop in json.loads(got.stdout)["properties"]
+    }
+    assert properties["text"] == "xp"
+
+
+@pytest.mark.e2e
+def test_node_move_invalid_index_yields_invalid_child_index_and_leaves_file_unchanged(
+    godot_project,
+):
+    # Same-parent move accepts final indexes 0..child_count-1. child_count is
+    # outside that range and must fail before saving anything.
+    scene_path = godot_project / "main.tscn"
+    _create_scene(scene_path)
+    for name in ("HP", "MP", "EXP"):
+        added = _gda(
+            "node",
+            "add",
+            str(scene_path),
+            "--type",
+            "Label",
+            "--name",
+            name,
+            "--json",
+        )
+        assert added.returncode == 0, added.stdout + added.stderr
+    before = scene_path.read_text(encoding="utf-8")
+
+    moved = _gda(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        "EXP",
+        "--to",
+        ".",
+        "--index",
+        "3",
+        "--json",
+    )
+
+    err = _assert_operation_error(moved, "invalid_child_index")
+    assert "3" in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
 
 
 @pytest.mark.e2e

--- a/tests/test_node_commands.py
+++ b/tests/test_node_commands.py
@@ -171,6 +171,46 @@ def test_node_add_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     assert "engine diagnostic" in result.stderr
 
 
+def test_node_add_index_dispatches_destination_index(monkeypatch):
+    # Issue #415: `--index` is part of the structured authoring request, not
+    # prose. The CLI forwards the 0-based insertion index to the operation; the
+    # operation owns range validation because the valid upper bound depends on
+    # the resolved parent at runtime.
+    stdout = sentinel({**ADD_RESULT, "path": "Level", "name": "Level"})
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "node",
+            "add",
+            "/tmp/proj/main.tscn",
+            "--type",
+            "Label",
+            "--name",
+            "Level",
+            "--index",
+            "1",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        (
+            "node-add",
+            {
+                "path": "/tmp/proj/main.tscn",
+                "parent": ".",
+                "type": "Label",
+                "instance": None,
+                "name": "Level",
+                "index": 1,
+            },
+        )
+    ]
+
+
 def test_node_list_json_emits_node_tree_with_paths_and_exit_zero(monkeypatch):
     # node list is the node-group verifier (issue #53): it reports the scene's
     # tree like scene get, but each node carries its node path — the address an
@@ -336,6 +376,43 @@ def test_node_move_json_echoes_the_reparented_node_and_exit_zero(monkeypatch):
         (
             "node-move",
             {"path": "/tmp/proj/main.tscn", "node": "Hero", "to": "Enemies"},
+        )
+    ]
+
+
+def test_node_move_index_dispatches_destination_index(monkeypatch):
+    # Issue #415: `node move --index` requests the moved node's final 0-based
+    # sibling position under --to. The operation validates the range after it
+    # resolves the source and destination parents.
+    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(MOVE_RESULT)
+    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "node",
+            "move",
+            "/tmp/proj/main.tscn",
+            "--node",
+            "Hero",
+            "--to",
+            "Enemies",
+            "--index",
+            "1",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        (
+            "node-move",
+            {
+                "path": "/tmp/proj/main.tscn",
+                "node": "Hero",
+                "to": "Enemies",
+                "index": 1,
+            },
         )
     ]
 

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -263,6 +263,10 @@ def test_node_add_schema_emits_model_derived_contract_without_other_args():
     parent_description = doc["input"]["properties"]["parent"]["description"]
     assert "scene root" in parent_description
     assert "'.'" in parent_description
+    index_description = doc["input"]["properties"]["index"]["description"]
+    assert "0-based" in index_description
+    assert "Omit to append" in index_description
+    assert "child_count" in index_description
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
@@ -399,6 +403,10 @@ def test_node_move_schema_emits_model_derived_contract_without_other_args():
     assert "scene root" in node_description
     to_description = doc["input"]["properties"]["to"]["description"]
     assert "cyclic" in to_description
+    index_description = doc["input"]["properties"]["index"]["description"]
+    assert "0-based" in index_description
+    assert "same-parent move is a no-op" in index_description
+    assert "target_child_count" in index_description
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 


### PR DESCRIPTION
## Summary

Fixes #415.

- add `gda node add --index <n>` for 0-based sibling insertion while preserving append-by-default behavior
- add `gda node move --index <n>` for same-parent reorder and indexed cross-parent placement
- register `invalid_child_index` and sync schema/docs/README summaries

## Validation

- `uv run pytest tests/test_node_commands.py tests/test_node_errors.py tests/test_schema_command.py tests/test_params_json.py tests/test_e2e_node.py`
- `uv run pytest tests/test_readme_i18n_sync.py`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pyright`
