### PR TITLE
feat(game): add rendered Control rect live command

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ flags — `gda --help` is the authoritative list of what is installed.
 | ------- | ------------ |
 | `game tree` | Read the running game's runtime scene tree (after `_ready`). |
 | `game get` | Read a runtime node's live properties by node path. |
+| `game rect` | Read a runtime Control's rendered viewport rect by node path. |
 | `game set` | Set a runtime node property on the running game. |
 
 **`diag`** — runtime diagnostics

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=6d608025337e57ffee1ef9386f71745eafa6bbee170a3b0df84680307db5b8ec -->
+<!-- gda-readme-i18n: source=README.md sha256=6e5b0755318c784495719397c6afdf6496a75c9d031dc676ff5e1a59d70d692a -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -480,6 +480,7 @@ flags — `gda --help` es la lista autoritativa de lo que está instalado.
 | ------- | ------------ |
 | `game tree` | Lee el árbol de escena en runtime del juego en ejecución (después de `_ready`). |
 | `game get` | Lee las propiedades en vivo de un nodo de runtime por ruta de nodo. |
+| `game rect` | Lee el rectángulo renderizado en viewport de un Control de runtime por ruta de nodo. |
 | `game set` | Define una propiedad de un nodo de runtime en el juego en ejecución. |
 
 **`diag`** — diagnósticos de runtime

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=6d608025337e57ffee1ef9386f71745eafa6bbee170a3b0df84680307db5b8ec -->
+<!-- gda-readme-i18n: source=README.md sha256=6e5b0755318c784495719397c6afdf6496a75c9d031dc676ff5e1a59d70d692a -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -486,6 +486,7 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 | ------- | ------------ |
 | `game tree` | 実行中ゲームのランタイムシーンツリーを読み取ります(`_ready` の後)。 |
 | `game get` | ランタイムノードのライブプロパティをノードパスで指定して読み取ります。 |
+| `game rect` | ランタイム Control のレンダリング済みビューポート矩形をノードパスで読み取ります。 |
 | `game set` | 実行中ゲームのランタイムノードのプロパティを設定します。 |
 
 **`diag`** — ランタイム診断

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=6d608025337e57ffee1ef9386f71745eafa6bbee170a3b0df84680307db5b8ec -->
+<!-- gda-readme-i18n: source=README.md sha256=6e5b0755318c784495719397c6afdf6496a75c9d031dc676ff5e1a59d70d692a -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -469,6 +469,7 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 | ------- | ------------ |
 | `game tree` | 读取正在运行的游戏的运行时场景树（在 `_ready` 之后）。 |
 | `game get` | 按节点路径读取一个运行时节点的实时属性。 |
+| `game rect` | 按节点路径读取一个运行时 Control 的渲染后视口矩形。 |
 | `game set` | 在正在运行的游戏上设置一个运行时节点属性。 |
 
 **`diag`** — 运行时诊断

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -157,6 +157,7 @@ operation, and parse codes the CLI assigns).
 | `daemon_running` | `live` | `classifier` | `6` | A daemon-lifecycle command was refused because a gda-daemon is running for the project; stop it first with `gda daemon stop` (Phase 2, #225). |
 | `daemon_already_running` | `live` | `classifier` | `6` | A `gda daemon start --scene` was refused because a gda-daemon is already running for the project; `--scene` only takes effect at start, so stop it with `gda daemon stop` then start again with `--scene` (Phase 2, #278). |
 | `live_node_not_found` | `live` | `classifier` | `6` | A live game operation's node path does not resolve to a node in the running scene tree (Phase 2, #220). |
+| `live_not_control` | `live` | `classifier` | `6` | A live game rect operation targeted a running node that is not a Control (Phase 2, #419). |
 | `live_unknown_property` | `live` | `classifier` | `6` | A live game get or set targeted a property the running node does not expose for the requested operation (no such readable storage property for get, or no such settable property for set) (Phase 2, #220). |
 | `live_uncoercible_value` | `live` | `classifier` | `6` | A live game set value cannot be coerced to the running property's declared Godot type (Phase 2, #220). |
 | `live_log_unavailable` | `live` | `classifier` | `6` | A live engine session was launched but its diagnostics log file is missing or unreadable, so `gda diag` cannot read the running game's errors/output (Phase 2, #224). |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -586,14 +586,18 @@ headless is unaffected (4.4+, cross-platform).
   tree (shipped — the Phase-2 bootstrap tracer, #7); runtime node property `game get` /
   `game set` (shipped, #220) read and mutate a running node's live properties — the live
   counterparts of headless `node get` / `node set`, applying the **same** value-coercion
-  table and round-tripping `set`→`get`. They address the node by its **runtime (absolute)
-  path** as `game tree` reports it (e.g. `/root/Main/Player`), in contrast to the on-disk
-  node group's **root-relative** path: the live tree has no `.tscn` scene root to be
-  relative to, and the headless resolver rejects absolute paths, so the harness resolves
-  off the running `SceneTree` root. A `set` applies at a frame boundary (ADR-0020) and is
-  bound to the session, not persisted; a missing node is `live_node_not_found`, an absent
-  property `live_unknown_property`, an uncoercible value `live_uncoercible_value`. The
-  on-disk counterparts stay under `scene` / `node` (ADR-0019).
+  table and round-tripping `set`→`get`. `game rect` (shipped, #419) reads a running
+  `Control`'s rendered viewport-space rectangle via `Control.get_global_rect()`, returning
+  `position` and `size` as the existing Vector2 projection. These commands address the
+  node by its **runtime (absolute) path** as `game tree` reports it (e.g.
+  `/root/Main/Player`), in contrast to the on-disk node group's **root-relative** path:
+  the live tree has no `.tscn` scene root to be relative to, and the headless resolver
+  rejects absolute paths, so the harness resolves off the running `SceneTree` root. A
+  `set` applies at a frame boundary (ADR-0020) and is bound to the session, not persisted;
+  a missing node is `live_node_not_found`, an absent property `live_unknown_property`, an
+  uncoercible value `live_uncoercible_value`, and a `game rect` target that is not a
+  `Control` is `live_not_control`. The on-disk counterparts stay under `scene` / `node`
+  (ADR-0019).
 - **`input` (input simulation):** runtime input injection into the running game
   (shipped, #221). Single-frame ops `input key <KEY> [--modifiers …] [--released]`,
   `input mouse-click <x> <y> [--button left|right|middle] [--double]` /

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -32,6 +32,7 @@ from gda.errors import (
     Failure,
     classify_diag_errors,
     classify_game_get,
+    classify_game_rect,
     classify_game_set,
     classify_game_tree,
     classify_info,
@@ -86,6 +87,8 @@ from gda.models import (
     ExportRunResult,
     GameGetParams,
     GameGetResult,
+    GameRectParams,
+    GameRectResult,
     GameSetParams,
     GameSetResult,
     GameTreeParams,
@@ -217,6 +220,7 @@ from gda.render import (
     render_export_list,
     render_export_run,
     render_game_get,
+    render_game_rect,
     render_game_set,
     render_game_tree,
     render_input_action,
@@ -888,6 +892,46 @@ def game_get(
     _dispatch(
         GAME_GET_COMMAND,
         GameGetParams(node=node, property=property),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+    )
+
+
+GAME_RECT_COMMAND: HeadlessCommand[GameRectResult] = HeadlessCommand(
+    operation="game-rect",
+    input_model=GameRectParams,
+    output_model=GameRectResult,
+    render=render_game_rect,
+    classify=classify_game_rect,
+    kind=ExecutionKind.LIVE,
+)
+
+
+@game_app.command(name="rect", cls=GAME_RECT_COMMAND.command_class())
+def game_rect(
+    node: str = typer.Argument(
+        ...,
+        help="Runtime Control path as `game tree` reports it (absolute, e.g. /root/Main/HUD).",
+    ),
+    json_output: bool = json_option(),
+    schema: bool = GAME_RECT_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Read a running Control's rendered viewport rect (live).
+
+    Routes through gda-daemon to the engine session's runtime SceneTree
+    (kind = LIVE, ADR-0017), addressed by the runtime node path `game tree`
+    reports. The returned rect is Control.get_global_rect(): viewport-space
+    top-left position and laid-out size. With no daemon it reports
+    `daemon_not_running`; a path that resolves to no running node is
+    `live_node_not_found`; a non-Control node is `live_not_control`.
+    """
+    _dispatch(
+        GAME_RECT_COMMAND,
+        GameRectParams(node=node),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -561,6 +561,13 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "A live game operation's node path does not resolve to a node in the running scene tree.",
     ),
     ErrorCodeSpec(
+        "live_not_control",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A live game rect operation targeted a running node that is not a Control.",
+    ),
+    ErrorCodeSpec(
         "live_unknown_property",
         ErrorCategory.LIVE,
         EXIT_LIVE,

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -54,6 +54,7 @@ from gda.models import (
     ExportRunMode,
     ExportRunResult,
     GameGetResult,
+    GameRectResult,
     GameSetResult,
     GameTreeResult,
     GdaError,
@@ -454,6 +455,11 @@ def classify_game_tree(result: RunResult, binary: Path) -> GameTreeResult | Fail
 def classify_game_get(result: RunResult, binary: Path) -> GameGetResult | Failure:
     """The per-command live classifier for ``gda game get`` (mirrors ``classify_game_tree``)."""
     return classify_live(result, binary, GameGetResult)
+
+
+def classify_game_rect(result: RunResult, binary: Path) -> GameRectResult | Failure:
+    """The per-command live classifier for ``gda game rect`` (mirrors ``classify_game_tree``)."""
+    return classify_live(result, binary, GameRectResult)
 
 
 def classify_game_set(result: RunResult, binary: Path) -> GameSetResult | Failure:

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -32,6 +32,7 @@ const LOG_MARKER := "<<<GDA:LOG>>>"
 # The live operations this harness serves, keyed by their wire op name (#220, #223).
 const OP_GAME_TREE := "game-tree"
 const OP_GAME_GET := "game-get"
+const OP_GAME_RECT := "game-rect"
 const OP_GAME_SET := "game-set"
 const OP_PERF_MONITORS := "perf-monitors"
 const OP_PERF_MONITOR := "perf-monitor"
@@ -48,6 +49,7 @@ const OP_SCREEN_FRAMES := "screen-frames"
 # relay is mapped by classify_live, not misrouted to contract_violation; a Python
 # mirror test (tests/test_error_registry.py) keeps these in sync with the registry.
 const LIVE_ERROR_NODE_NOT_FOUND := "live_node_not_found"
+const LIVE_ERROR_NOT_CONTROL := "live_not_control"
 const LIVE_ERROR_UNKNOWN_PROPERTY := "live_unknown_property"
 const LIVE_ERROR_UNCOERCIBLE_VALUE := "live_uncoercible_value"
 const LIVE_ERROR_PERF_NODE_NOT_FOUND := "live_perf_node_not_found"
@@ -321,6 +323,8 @@ func _run(request) -> Variant:
 			return _handle_game_tree()
 		OP_GAME_GET:
 			return _handle_game_get(params)
+		OP_GAME_RECT:
+			return _handle_game_rect(params)
 		OP_GAME_SET:
 			return _handle_game_set(params)
 		OP_PERF_MONITORS:
@@ -386,6 +390,30 @@ func _handle_game_get(params: Dictionary) -> String:
 		"name": String(node.name),
 		"type": node.get_class(),
 		"properties": properties,
+	})
+
+
+# game rect: resolve a node by its ABSOLUTE runtime path, require it to be a
+# Control, and report its rendered viewport-space rect. This reads layout output
+# via Control.get_global_rect(), not a storage property surface.
+func _handle_game_rect(params: Dictionary) -> String:
+	var path := _string_param(params, "node")
+	var node := _resolve_runtime_node(path)
+	if node == null:
+		return _error(LIVE_ERROR_NODE_NOT_FOUND,
+				"no node at runtime path: " + path)
+	if not (node is Control):
+		return _error(LIVE_ERROR_NOT_CONTROL,
+				"node at runtime path is not a Control: " + path)
+
+	var control: Control = node as Control
+	var rect := control.get_global_rect()
+	return _ok({
+		"path": path,
+		"name": String(control.name),
+		"type": control.get_class(),
+		"position": _jsonify(rect.position),
+		"size": _jsonify(rect.size),
 	})
 
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -3048,6 +3048,37 @@ class GameGetResult(BaseModel):
     properties: list[NodeProperty]
 
 
+class GameRectParams(BaseModel):
+    """The params of ``gda game rect``: read a running Control's rendered rect (#419).
+
+    Addressed by the same runtime (absolute) node path as ``game get``. The
+    command is intentionally Control-specific: layout-dependent geometry is not
+    a storage-property read and must come from ``Control.get_global_rect()`` in
+    the running SceneTree.
+    """
+
+    node: str = Field(description=_RUNTIME_NODE_DESC)
+
+
+class GameRectResult(BaseModel):
+    """The result of ``gda game rect``: a Control's rendered viewport-space rect.
+
+    ``position`` and ``size`` are the two Vector2 projections from
+    ``Control.get_global_rect()``; no Rect2 projection is added to the shared
+    value projection surface.
+    """
+
+    path: str = Field(description="The addressed node's runtime (absolute) path.")
+    name: str
+    type: str = Field(description="The node's engine class (e.g. VBoxContainer).")
+    position: list[float] = Field(
+        description="The rendered viewport-space top-left point, as [x, y]."
+    )
+    size: list[float] = Field(
+        description="The rendered viewport-space size, as [width, height]."
+    )
+
+
 class GameSetParams(BaseModel):
     """The params of ``gda game set``: mutate a running node's runtime property (#220).
 

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
         ExportRunResult,
         GameGetResult,
         GameNode,
+        GameRectResult,
         GameSetResult,
         GameTreeResult,
         InputActionResult,
@@ -187,6 +188,14 @@ def render_game_get(got: "GameGetResult") -> str:
         for prop in got.properties
     ]
     return "\n".join([header, *lines])
+
+
+def render_game_rect(rect: "GameRectResult") -> str:
+    """Render a Control's runtime rendered rect as one viewport-space line."""
+    return (
+        f"{rect.path} ({rect.type}) "
+        f"position={format_value(rect.position)} size={format_value(rect.size)}"
+    )
 
 
 def render_game_set(was_set: "GameSetResult") -> str:

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -79,7 +79,7 @@ the first live op. `screen capture` needs a windowed session
 | Group | Commands |
 | ----- | -------- |
 | `daemon` | `start`, `stop`, `status`, `uninstall` (lifecycle; installs the in-game harness) |
-| `game` | `tree`, `get`, `set` (the running game's runtime scene graph) |
+| `game` | `tree`, `get`, `rect`, `set` (the running game's runtime scene graph) |
 | `diag` | `errors` (structured runtime errors with callstacks; survive a crash) |
 | `logger` | `tail` (the running game's structured log stream; `--raw` for verbatim lines, `--level <min>` to filter by severity, `--limit N`) |
 | `perf` | `monitors`, `monitor` (counters now / a property-or-signal timeline) |

--- a/tests/support.py
+++ b/tests/support.py
@@ -483,6 +483,16 @@ GAME_SET_RESULT = {
     "value": [10.0, 20.0],
 }
 
+# Sample ``gda game rect`` result — a running Control's rendered viewport-space
+# rectangle, addressed by the absolute runtime path (#419).
+GAME_RECT_RESULT = {
+    "path": "/root/Main/HUD/Stats",
+    "name": "Stats",
+    "type": "VBoxContainer",
+    "position": [24.0, 24.0],
+    "size": [160.0, 48.0],
+}
+
 # Sample ``gda diag errors`` result — the running game's runtime errors,
 # daemon-served from the Session log (#224). Shared by the diag-command
 # success/schema/render tests. ``errors`` carries warnings too, distinguished by

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -42,6 +42,19 @@ MAIN_TSCN = (
 )
 PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
+RECT_MAIN_TSCN = (
+    "[gd_scene format=3]\n\n"
+    '[node name="Main" type="Control"]\n\n'
+    '[node name="HUD" type="VBoxContainer" parent="."]\n'
+    "offset_left = 24.0\n"
+    "offset_top = 24.0\n"
+    "offset_right = 184.0\n"
+    "offset_bottom = 72.0\n\n"
+    '[node name="Stats" type="Label" parent="HUD"]\n'
+    "custom_minimum_size = Vector2(160, 48)\n"
+    'text = "HP"\n'
+)
+
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
 
@@ -149,6 +162,89 @@ def test_daemon_serves_game_get_set_round_trip(tmp_path, daemon_runtime_dir):
         position = next(p for p in get_doc["properties"] if p["name"] == "position")
         assert position["type"] == "Vector2"
         assert position["value"] == [10.0, 20.0]
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_game_rect_reads_free_positioned_control_rect(
+    tmp_path, daemon_runtime_dir
+):
+    # #419: `game rect` reads rendered viewport-space geometry, not storage
+    # properties, so a free-positioned Control reports get_global_rect().
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(RECT_MAIN_TSCN, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        rect = run("game", "rect", "/root/Main/HUD")
+        assert rect.returncode == 0, rect.stdout + rect.stderr
+        doc = json.loads(rect.stdout)
+        assert doc["path"] == "/root/Main/HUD"
+        assert doc["name"] == "HUD"
+        assert doc["type"] == "VBoxContainer"
+        assert doc["position"] == [24.0, 24.0]
+        assert doc["size"] == [160.0, 48.0]
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_game_rect_reads_container_managed_child_rect(
+    tmp_path, daemon_runtime_dir
+):
+    # #419: container-managed Controls have layout output even when a storage
+    # property read is the wrong surface. `game rect` returns the rendered rect.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(RECT_MAIN_TSCN, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        position = run(
+            "game",
+            "get",
+            "/root/Main/HUD/Stats",
+            "--property",
+            "position",
+        )
+        assert position.returncode == 6, position.stdout + position.stderr
+        assert json.loads(position.stdout)["error"]["code"] == "live_unknown_property"
+
+        rect = run("game", "rect", "/root/Main/HUD/Stats")
+        assert rect.returncode == 0, rect.stdout + rect.stderr
+        doc = json.loads(rect.stdout)
+        assert doc["path"] == "/root/Main/HUD/Stats"
+        assert doc["name"] == "Stats"
+        assert doc["type"] == "Label"
+        assert doc["position"] == [24.0, 24.0]
+        assert doc["size"] == [160.0, 48.0]
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_game_rect_rejects_non_control_node(tmp_path, daemon_runtime_dir):
+    # #419: the command is intentionally Control-specific; a live node that
+    # exists but is not a Control gets a typed LIVE error.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        rect = run("game", "rect", "/root/Main/Player")
+        assert rect.returncode == 6, rect.stdout + rect.stderr
+        error = json.loads(rect.stdout)["error"]
+        assert error["code"] == "live_not_control"
+        assert error["category"] == "live"
     finally:
         run("daemon", "stop")
 

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -60,6 +60,7 @@ BARE_FAIL_CODE = re.compile(r'_fail\(\s*"[a-z_]+"')
 # Python daemon client, NOT the harness, so they are not mirrored in GDScript.
 HARNESS_LIVE_ERROR_CODES = (
     "live_node_not_found",
+    "live_not_control",
     "live_unknown_property",
     "live_uncoercible_value",
     "live_perf_node_not_found",

--- a/tests/test_game_commands.py
+++ b/tests/test_game_commands.py
@@ -15,6 +15,7 @@ from gda.exit_codes import EXIT_LIVE
 from gda.runner import RunResult
 from tests.support import (
     GAME_GET_RESULT,
+    GAME_RECT_RESULT,
     GAME_SET_RESULT,
     GAME_TREE_RESULT,
     error_sentinel,
@@ -246,6 +247,91 @@ def test_game_get_schema_is_self_describing():
     schema = json.loads(result.stdout)
     assert "input" in schema and "output" in schema
     assert schema["kind"] == "live"
+
+
+# --- game rect (live rendered Control rect read) -----------------------------
+
+
+def test_game_rect_emits_rendered_control_rect_through_the_live_channel(
+    monkeypatch, tmp_path
+):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(GAME_RECT_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "game",
+            "rect",
+            "/root/Main/HUD/Stats",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data == GAME_RECT_RESULT
+    assert fake.calls == [("game-rect", {"node": "/root/Main/HUD/Stats"})]
+
+
+def test_game_rect_non_control_reports_live_not_control(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("live_not_control", "node is not a Control"),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "game",
+            "rect",
+            "/root/Main/Player",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "live_not_control"
+    assert error["category"] == "live"
+
+
+def test_game_rect_missing_node_reports_live_node_not_found(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel("live_node_not_found", "no node at runtime path"),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "game",
+            "rect",
+            "/root/Main/Ghost",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "live_node_not_found"
+    assert error["category"] == "live"
 
 
 # --- game set (live runtime property write) ----------------------------------

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -22,6 +22,7 @@ from gda.models import (
     DaemonUninstallResult,
     EngineVersion,
     GameGetResult,
+    GameRectResult,
     GameSetResult,
     ListedNode,
     ListedScript,
@@ -47,6 +48,7 @@ from gda.render import (
     render_daemon_uninstall,
     render_engine_version,
     render_game_get,
+    render_game_rect,
     render_game_set,
     render_node_properties,
     render_node_set,
@@ -199,6 +201,20 @@ def test_render_game_get_renders_runtime_properties_by_absolute_path():
     )
     rendered = render_game_get(result)
     assert rendered == "/root/Main/Player (Node2D)\n  position (Vector2) = [10.0, 20.0]"
+
+
+def test_render_game_rect_renders_the_runtime_control_rect():
+    result = GameRectResult(
+        path="/root/Main/HUD/Stats",
+        name="Stats",
+        type="VBoxContainer",
+        position=[24.0, 24.0],
+        size=[160.0, 48.0],
+    )
+    assert (
+        render_game_rect(result) == "/root/Main/HUD/Stats (VBoxContainer) "
+        "position=[24.0, 24.0] size=[160.0, 48.0]"
+    )
 
 
 def test_render_game_set_renders_the_set_runtime_property():

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1159,30 +1159,43 @@ def test_live_command_schema_reports_kind_live_without_a_daemon():
     assert doc["kind"] == "live"
 
 
-def test_game_get_set_schemas_report_kind_live_and_are_model_derived():
-    # The LIVE runtime property commands (#220) self-describe like any command —
+def test_game_get_rect_set_schemas_report_kind_live_and_are_model_derived():
+    # The LIVE runtime property/control commands self-describe like any command —
     # input/output from their typed models, the uniform error envelope, kind=live.
     from gda.models import (
         GameGetParams,
         GameGetResult,
+        GameRectParams,
+        GameRectResult,
         GameSetParams,
         GameSetResult,
     )
 
     get_doc = json.loads(CliRunner().invoke(app, ["game", "get", "--schema"]).stdout)
+    rect_doc = json.loads(CliRunner().invoke(app, ["game", "rect", "--schema"]).stdout)
     set_doc = json.loads(CliRunner().invoke(app, ["game", "set", "--schema"]).stdout)
 
-    assert get_doc["kind"] == set_doc["kind"] == "live"
+    assert get_doc["kind"] == rect_doc["kind"] == set_doc["kind"] == "live"
     assert get_doc["input"] == GameGetParams.model_json_schema()
     assert get_doc["output"] == GameGetResult.model_json_schema()
+    assert rect_doc["input"] == GameRectParams.model_json_schema()
+    assert rect_doc["output"] == GameRectResult.model_json_schema()
     assert set_doc["input"] == GameSetParams.model_json_schema()
     assert set_doc["output"] == GameSetResult.model_json_schema()
-    assert get_doc["error"] == set_doc["error"] == GdaErrorEnvelope.model_json_schema()
+    assert (
+        get_doc["error"]
+        == rect_doc["error"]
+        == set_doc["error"]
+        == GdaErrorEnvelope.model_json_schema()
+    )
     # The runtime-node param documents the absolute-path addressing agents must use.
     assert "absolute" in get_doc["input"]["properties"]["node"]["description"]
+    assert "absolute" in rect_doc["input"]["properties"]["node"]["description"]
     assert "coerce" in set_doc["input"]["properties"]["value"]["description"].lower()
     jsonschema.Draft202012Validator.check_schema(get_doc["input"])
     jsonschema.Draft202012Validator.check_schema(get_doc["output"])
+    jsonschema.Draft202012Validator.check_schema(rect_doc["input"])
+    jsonschema.Draft202012Validator.check_schema(rect_doc["output"])
     jsonschema.Draft202012Validator.check_schema(set_doc["input"])
     jsonschema.Draft202012Validator.check_schema(set_doc["output"])
 
@@ -1192,16 +1205,19 @@ def test_sample_game_results_validate_against_emitted_output_schemas():
     # --schema emits (the ADR-0004 hard gate for the LIVE game group, #220).
     from tests.support import (
         GAME_GET_RESULT,
+        GAME_RECT_RESULT,
         GAME_SET_RESULT,
         GAME_TREE_RESULT,
     )
 
     tree_doc = json.loads(CliRunner().invoke(app, ["game", "tree", "--schema"]).stdout)
     get_doc = json.loads(CliRunner().invoke(app, ["game", "get", "--schema"]).stdout)
+    rect_doc = json.loads(CliRunner().invoke(app, ["game", "rect", "--schema"]).stdout)
     set_doc = json.loads(CliRunner().invoke(app, ["game", "set", "--schema"]).stdout)
 
     jsonschema.validate(instance=GAME_TREE_RESULT, schema=tree_doc["output"])
     jsonschema.validate(instance=GAME_GET_RESULT, schema=get_doc["output"])
+    jsonschema.validate(instance=GAME_RECT_RESULT, schema=rect_doc["output"])
     jsonschema.validate(instance=GAME_SET_RESULT, schema=set_doc["output"])
 
 


### PR DESCRIPTION
## Summary

- Add live `gda game rect <node>` with model-derived schema, JSON output, and human rendering.
- Serve `game-rect` in the harness via `Control.get_global_rect()`, returning `position` and `size` through existing Vector2 projection conventions.
- Register `live_not_control`, mirror it in the harness/ADR registry checks, and sync the bundled skill command table.

## Tests

- `env UV_CACHE_DIR=/tmp/caw-uv-cache uv run pytest tests/test_game_commands.py`
- `env UV_CACHE_DIR=/tmp/caw-uv-cache uv run pytest tests/test_schema_command.py`
- `env UV_CACHE_DIR=/tmp/caw-uv-cache uv run pytest tests/test_error_registry.py`
- `env UV_CACHE_DIR=/tmp/caw-uv-cache CAW_E2E_AGENT=codex uv run pytest tests/test_e2e_daemon.py -k "rect or game_get_set"`
- `env UV_CACHE_DIR=/tmp/caw-uv-cache uv run pytest tests/test_render.py tests/test_command_descriptor_registry.py tests/test_skill_surface_sync.py tests/test_schema_aggregate.py tests/test_mcp_registration.py tests/test_harness_coercion_mirror.py`
- `env UV_CACHE_DIR=/tmp/caw-uv-cache uv run pytest -m "not e2e"`

Fixes: #419
