### PR TITLE
[Panda Adventure] S7: Items & Equipment — Bun/Wine consumables + Spacesuit armor

### DIFF
--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -194,22 +194,35 @@ _Avoid_: TDD (reserved repo-wide for Test-Driven Development); time-to-down
 ### Items
 
 **Consumable**:
-An item used up on use. The demo's consumables are the Bun and the Wine.
+An item used up on use. The demo's consumables are the Bun and the Wine. Since S7
+(gADR-0008) a Consumable's use verb is supply-gated: it consumes one from the Item count
+hook (a refused, empty-handed use logs `consumable_blocked`), applies the capped restore,
+and plays the consume flash. Using at full HP/MP still consumes — the gate is supply,
+not need; the cap bounds the effect.
 _Avoid_: potion, drug
 
 **Bun**:
-A Consumable that restores HP.
+A Consumable that restores HP (capped at max HP), used by the `eat_bun` action.
 _Avoid_: mantou, steamed bun, bread
 
 **Wine**:
-A Consumable that restores MP.
+A Consumable that restores MP (capped at max MP), used by the `drink_wine` action.
 _Avoid_: jiu, sake, alcohol
 
 **Wine hook**:
-S3's minimal MP-restore path standing in for the S7 Consumable system: the
-`drink_wine` action restores a config amount of MP (capped at max MP) with no
-inventory and no item count. S7 replaces the hook's supply side, not its effect.
-_Avoid_: inventory, consumable system (that is S7)
+S3's minimal MP-restore path that stood in for the S7 Consumable system: the
+`drink_wine` action restored a config amount of MP with no inventory and no item count.
+CLOSED by S7 (gADR-0008): the action and its capped effect remain, now supply-gated on
+the Item count hook, and the restore amount reads from the items authority
+(`items_config.json` — migrated out of the gravity config). A historical term.
+_Avoid_: inventory, consumable system (that is the S7 whole)
+
+**Items authority**:
+The single authoritative source for every item number (gADR-0008):
+`items_config.json` → the derived `ItemsConfig` — the Consumable restore amounts, the
+consume-flash juice, and the Spacesuit's defense bonus. No item effect reads from any
+other config source.
+_Avoid_: item config scattering, per-slice item keys
 
 **Equipment**:
 An item the Player wields or wears persistently — the Laser Gun, the Gravity Gun, and the
@@ -233,13 +246,17 @@ Item count hook (gADR-0006). A Pickup persists until collected.
 _Avoid_: drop (the table entry / the event), power-up, collectible
 
 **Item count hook**:
-S6b's minimal per-item count Dictionary on the Player where collected Consumable drops land —
-the supply side of the S7 Consumable story, standing in for a real inventory exactly as the
-Wine hook stands in for use-effects: S7 consumes these counts, S6b only fills them.
-_Avoid_: inventory, bag (both are S7+ concepts)
+S6b's per-item count Dictionary on the Player where collected Consumable drops land — the
+supply side of the Consumable story. Since S7 (gADR-0008) both ends are live: S6b's
+collection fills the counts, S7's use verbs consume them (and the HUD BUN/WINE lines
+surface them). Still not a full inventory — no menu, no selector (a later story).
+_Avoid_: inventory, bag (both are menu-story concepts)
 
 **Spacesuit**:
-The Player's armor — the only piece of defensive Equipment in the demo.
+The Player's armor — the only piece of defensive Equipment in the demo. Worn from spawn
+(persistent); its config defense bonus is composed onto the Player's base stat block
+(`ItemSystem.effective_defender`) to feed the damage formula's mitigation term — the
+formula itself is untouched (S7, gADR-0008).
 _Avoid_: armor (generic), suit
 
 ### Level

--- a/examples/platformer/panda-adventure/addons/gda_harness/gda_harness.gd
+++ b/examples/platformer/panda-adventure/addons/gda_harness/gda_harness.gd
@@ -33,6 +33,7 @@ const LOG_MARKER := "<<<GDA:LOG>>>"
 # The live operations this harness serves, keyed by their wire op name (#220, #223).
 const OP_GAME_TREE := "game-tree"
 const OP_GAME_GET := "game-get"
+const OP_GAME_RECT := "game-rect"
 const OP_GAME_SET := "game-set"
 const OP_PERF_MONITORS := "perf-monitors"
 const OP_PERF_MONITOR := "perf-monitor"
@@ -49,6 +50,7 @@ const OP_SCREEN_FRAMES := "screen-frames"
 # relay is mapped by classify_live, not misrouted to contract_violation; a Python
 # mirror test (tests/test_error_registry.py) keeps these in sync with the registry.
 const LIVE_ERROR_NODE_NOT_FOUND := "live_node_not_found"
+const LIVE_ERROR_NOT_CONTROL := "live_not_control"
 const LIVE_ERROR_UNKNOWN_PROPERTY := "live_unknown_property"
 const LIVE_ERROR_UNCOERCIBLE_VALUE := "live_uncoercible_value"
 const LIVE_ERROR_PERF_NODE_NOT_FOUND := "live_perf_node_not_found"
@@ -322,6 +324,8 @@ func _run(request) -> Variant:
 			return _handle_game_tree()
 		OP_GAME_GET:
 			return _handle_game_get(params)
+		OP_GAME_RECT:
+			return _handle_game_rect(params)
 		OP_GAME_SET:
 			return _handle_game_set(params)
 		OP_PERF_MONITORS:
@@ -387,6 +391,30 @@ func _handle_game_get(params: Dictionary) -> String:
 		"name": String(node.name),
 		"type": node.get_class(),
 		"properties": properties,
+	})
+
+
+# game rect: resolve a node by its ABSOLUTE runtime path, require it to be a
+# Control, and report its rendered viewport-space rect. This reads layout output
+# via Control.get_global_rect(), not a storage property surface.
+func _handle_game_rect(params: Dictionary) -> String:
+	var path := _string_param(params, "node")
+	var node := _resolve_runtime_node(path)
+	if node == null:
+		return _error(LIVE_ERROR_NODE_NOT_FOUND,
+				"no node at runtime path: " + path)
+	if not (node is Control):
+		return _error(LIVE_ERROR_NOT_CONTROL,
+				"node at runtime path is not a Control: " + path)
+
+	var control: Control = node as Control
+	var rect := control.get_global_rect()
+	return _ok({
+		"path": path,
+		"name": String(control.name),
+		"type": control.get_class(),
+		"position": _jsonify(rect.position),
+		"size": _jsonify(rect.size),
 	})
 
 

--- a/examples/platformer/panda-adventure/data/generated/gravity_config.tres
+++ b/examples/platformer/panda-adventure/data/generated/gravity_config.tres
@@ -5,7 +5,6 @@
 [resource]
 script = ExtResource("1_gravityconfig")
 mp_cost = 10
-wine_mp_restore = 15
 field_direction = Vector2(0, -1)
 field_strength = 260
 field_radius = 96

--- a/examples/platformer/panda-adventure/data/generated/items_config.tres
+++ b/examples/platformer/panda-adventure/data/generated/items_config.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="ItemsConfig" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://src/resources/items_config.gd" id="1_itemsconfig"]
+
+[resource]
+script = ExtResource("1_itemsconfig")
+bun_hp_restore = 25
+wine_mp_restore = 15
+spacesuit_defense = 2
+bun_flash_color = Color(0.4, 0.95, 0.45, 1)
+wine_flash_color = Color(0.45, 0.6, 1, 1)
+consume_flash_duration = 0.25

--- a/examples/platformer/panda-adventure/data/json/gravity_config.json
+++ b/examples/platformer/panda-adventure/data/json/gravity_config.json
@@ -1,6 +1,5 @@
 {
   "mp_cost": 10.0,
-  "wine_mp_restore": 15.0,
   "field_direction": [0.0, -1.0],
   "field_strength": 260.0,
   "field_radius": 96.0,

--- a/examples/platformer/panda-adventure/data/json/items_config.json
+++ b/examples/platformer/panda-adventure/data/json/items_config.json
@@ -1,0 +1,8 @@
+{
+  "bun_hp_restore": 25.0,
+  "wine_mp_restore": 15.0,
+  "spacesuit_defense": 2.0,
+  "bun_flash_color": [0.4, 0.95, 0.45, 1.0],
+  "wine_flash_color": [0.45, 0.6, 1.0, 1.0],
+  "consume_flash_duration": 0.25
+}

--- a/examples/platformer/panda-adventure/data/schema/gravity_config.schema.json
+++ b/examples/platformer/panda-adventure/data/schema/gravity_config.schema.json
@@ -7,7 +7,6 @@
   "additionalProperties": false,
   "required": [
     "mp_cost",
-    "wine_mp_restore",
     "field_direction",
     "field_strength",
     "field_radius",
@@ -23,12 +22,7 @@
   ],
   "properties": {
     "mp_cost": {
-      "description": "MP spent per Gravity Gun fire — the game's only MP sink; strictly positive (a free fire would unbudget the change-gravity pillar).",
-      "type": "number",
-      "exclusiveMinimum": 0.0
-    },
-    "wine_mp_restore": {
-      "description": "MP restored by drinking Wine (the S3 minimal hook; the full Consumable system is S7); strictly positive.",
+      "description": "MP spent per Gravity Gun fire — the game's only MP sink; strictly positive (a free fire would unbudget the change-gravity pillar). The Wine restore that refills this budget lives in items_config.json since S7 (gADR-0008).",
       "type": "number",
       "exclusiveMinimum": 0.0
     },

--- a/examples/platformer/panda-adventure/data/schema/items_config.schema.json
+++ b/examples/platformer/panda-adventure/data/schema/items_config.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aigengame.dev/panda-adventure/data/schema/items_config.schema.json",
+  "title": "Panda Adventure items configuration",
+  "description": "Authoritative config for the S7 Items & Equipment story (gADR-0000, gADR-0008): every item number in one source. The Consumable restore amounts (Bun -> HP, Wine -> MP; `wine_mp_restore` migrated here from gravity_config — gravity keeps only the MP sink), the consume-flash juice (per-item flash color + one shared duration, the hit-flash tween idiom), and the Spacesuit's protective value — the defense bonus composed onto the Player's defender stat block for the S2 damage formula's mitigation term (ItemSystem.effective_defender; the formula itself is untouched). Converted by scripts/build_config.py into the derived data/generated/items_config.tres (ItemsConfig).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "bun_hp_restore",
+    "wine_mp_restore",
+    "spacesuit_defense",
+    "bun_flash_color",
+    "wine_flash_color",
+    "consume_flash_duration"
+  ],
+  "$defs": {
+    "rgba": {
+      "description": "A color as RGBA, each component in 0..1.",
+      "type": "array",
+      "items": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+      "minItems": 4,
+      "maxItems": 4
+    }
+  },
+  "properties": {
+    "bun_hp_restore": {
+      "description": "HP restored by eating a Bun (capped at the stat block's max_hp at use time); strictly positive — a no-op Consumable is a config bug.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "wine_mp_restore": {
+      "description": "MP restored by drinking a Wine (capped at the stat block's max_mp at use time); strictly positive. Migrated from gravity_config.json (the S3 Wine hook's home) so every Consumable effect reads from the one items authority (gADR-0008).",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "spacesuit_defense": {
+      "description": "The Spacesuit's defense bonus, added onto the Player's base defense to form the effective defender for the damage formula's mitigation term (gADR-0008). Non-negative like every stat-block defense; 0 is a legal (purely cosmetic) suit.",
+      "type": "number",
+      "minimum": 0.0
+    },
+    "bun_flash_color": { "$ref": "#/$defs/rgba" },
+    "wine_flash_color": { "$ref": "#/$defs/rgba" },
+    "consume_flash_duration": {
+      "description": "Seconds the consume flash takes to tween back to the Player's own color (shared by both Consumables — two flavors of one verb); strictly positive.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    }
+  }
+}

--- a/examples/platformer/panda-adventure/docs/gadr/0007-visual-smoke-seam.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0007-visual-smoke-seam.md
@@ -79,3 +79,11 @@ Consequences:
   committed one — but it feeds playtests, and a stale build misled one. The
   demo's docs (AGENTS.md) now expect a `gda export run` refresh at wave
   close, and this slice ships one built from current main.
+
+> **Outcome (2026-07-05).** The "container-managed Controls expose no
+> offset/rect to the live reader" constraint that forced the HUD's structural
+> probe boxes was filed as gda #419 and fixed in gda v0.5.0: `gda game rect`
+> reads a Control's rendered viewport rect live. New checkpoints may probe
+> exact per-Control rects (the S7 BUN/WINE item-lines check is the first);
+> the whole-column box stays structural because Label text renders past its
+> container rect regardless.

--- a/examples/platformer/panda-adventure/docs/gadr/0008-consumable-use-and-equipment-mitigation.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0008-consumable-use-and-equipment-mitigation.md
@@ -35,7 +35,11 @@ We decide four things:
   count). Using a Consumable at full HP/MP still consumes it: the gate is
   one-input (supply), the cap already bounds the effect, and the S3 hook set
   the restore-at-cap semantics — a "need" gate would be a second decision
-  axis the GDD never asked for.
+  axis the GDD never asked for. The S4 death latch is not a gate either: in
+  Phase 1 death latches the damage/death records only — movement, firing,
+  and item use all stay live after `player_died` — so an alive-gate on a use
+  verb would be a one-verb outlier, not a contract; the game-over/respawn
+  slice owns that state when it lands.
 - **The Spacesuit composes an effective defender; the formula is untouched.**
   `ItemSystem.effective_defender(base, defense_bonus)` (pure, static) builds
   a FRESH `StatsConfig` copying the base stat block with `defense` raised by

--- a/examples/platformer/panda-adventure/docs/gadr/0008-consumable-use-and-equipment-mitigation.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0008-consumable-use-and-equipment-mitigation.md
@@ -1,0 +1,102 @@
+---
+status: accepted
+---
+
+# Consumable use and equipment mitigation: one items authority, composed defense
+
+S7 closes the two item stories the earlier slices left half-built: the
+**Consumable system** (the Bun restores HP, the Wine restores MP) on top of
+S6b's supply side (drops land in the Player's `_items` count hook), and the
+**Spacesuit** as the defensive Equipment feeding the S2 damage formula's
+mitigation term. gADR-0001 fixed the stat split (immutable `StatsConfig` /
+runtime `StatsSystem` / pure `CombatSystem`), gADR-0006 fixed the supply seam
+("S7 wires `drink_wine`/eat-bun to CONSUME these counts"); this decision fixes
+WHERE the item numbers live, HOW a use verb consumes the hook, and HOW worn
+Equipment reaches the mitigation term without touching the formula.
+
+We decide four things:
+
+- **Items get their own authoritative source.** A new `items_config.json` →
+  `ItemsConfig` Resource carries every item number: the consumable restore
+  amounts (`bun_hp_restore`, `wine_mp_restore`), the use juice (per-item flash
+  colors + one shared `consume_flash_duration`), and the Spacesuit's
+  protective value (`spacesuit_defense`). `wine_mp_restore` **migrates out of
+  `gravity_config.json`**: it lived there only because S3's minimal Wine hook
+  rode the MP-economy slice, and leaving it would split the Consumable
+  authority across two sources. Gravity config keeps only the MP *sink*
+  (`mp_cost`); every item *effect* reads from the one items source.
+- **A use verb consumes the Item count hook, gated on supply, not need.**
+  Each Consumable keeps its own InputMap action (`drink_wine`, new `eat_bun`)
+  and the same shape: refuse when the count is 0 (log `consumable_blocked
+  {item, count}` — the `gravity_blocked` pattern), else decrement the count,
+  apply the capped restore (`StatsSystem.restore_hp`/`restore_mp` — the cap
+  stays a parameter from the immutable stat block), play the consume flash,
+  and log the use (`bun_eaten`/`wine_drunk` with before/after + the remaining
+  count). Using a Consumable at full HP/MP still consumes it: the gate is
+  one-input (supply), the cap already bounds the effect, and the S3 hook set
+  the restore-at-cap semantics — a "need" gate would be a second decision
+  axis the GDD never asked for.
+- **The Spacesuit composes an effective defender; the formula is untouched.**
+  `ItemSystem.effective_defender(base, defense_bonus)` (pure, static) builds
+  a FRESH `StatsConfig` copying the base stat block with `defense` raised by
+  the bonus. The Player's `take_hit` feeds that composed block to
+  `CombatSystem.compute_damage` as the defender — the formula, its scales,
+  and the cached base `.tres` (load()-aliased, gADR-0001) all stay untouched.
+  The Spacesuit is worn from spawn (persistent Equipment, GDD), so the
+  composed block is built once at ready and logged (`spacesuit_equipped
+  {defense_bonus, defense_total}`).
+- **The HUD surfaces the Consumable counts.** Two Labels (`BUN n` / `WINE n`)
+  extend the S6a Stats column via the same pull/format/pulse machinery. The
+  GDD's HUD contract is "read live state without leaving the action" — a
+  Consumable the player cannot see the supply of is not usable in the moment;
+  the full inventory *menu* stays a later concern (GDD "HUD & UI").
+
+## Considered options
+
+- **Items config as its own source with the Wine migration (chosen).** One
+  authority for every item number; the balancing pipeline tunes consumables
+  and armor in one file; gravity config stops carrying a non-gravity value.
+  Costs a one-time migration touch on the S3 seams (schema, resource, data
+  seam, e2e derivations) — paid once, here.
+- **Extend existing configs instead (rejected).** `bun_hp_restore` into
+  combat config, `spacesuit_defense` into combat config, Wine staying in
+  gravity config keeps every file stable but scatters the Items & Equipment
+  domain across three sources with no single authority — exactly the drift
+  shape gADR-0004/0006 removed for rewards and drops.
+- **Spacesuit as a defense-bonus parameter on `compute_damage` (rejected).**
+  Widens the pure formula's signature for one caller and leaks Equipment into
+  a seam every existing test and the balancing sim pin; the composed-defender
+  shape keeps the formula's symmetric stat-block contract byte-identical.
+- **Spacesuit by raising `player_stats.defense` in JSON (rejected).** Bakes
+  worn Equipment into the actor's base stat block: no un-equipped baseline
+  exists, and a later equip/unequip slice would have to un-bake it. The
+  composition keeps base and bonus separately authored.
+- **Mutating the cached StatsConfig at runtime (rejected).** `load()` aliases
+  every consumer of the `.tres` (gADR-0001's one-mutable-Resource rejection);
+  raising defense in place would silently harden every OTHER consumer of the
+  player stat block.
+- **A generic `use_item` action with a selector (rejected for Phase 1).** Two
+  Consumables do not need an inventory cursor; per-item actions keep the
+  input surface flat and the e2e deterministic. A selector belongs to the
+  inventory-menu story, out of Phase-1 scope.
+
+## Consequences
+
+- Retuning any item number (restores, armor, flash juice) is a JSON-only
+  change in one file; a non-positive restore or a negative defense fails the
+  fast tier, not the runtime.
+- The enemy→Player damage derivations in the e2e seams gain the Spacesuit
+  term: expected contact damage reads
+  `attack * attack_scale - (player defense + spacesuit_defense) *
+  defense_scale` (floored at `min_damage`) — every expectation still derives
+  from the authoritative JSON.
+- Wine beats in existing e2es need supply: `drink_wine` no longer restores
+  from thin air, so tests seed `_items` through the live seam (`gda game
+  set`, runtime state injection — config data stays shipped) or collect a
+  retuned-to-certain drop (the gADR-0006 chance-retune precedent).
+- `ItemSystem` is pure/static like its siblings, so the offline balancing
+  sim can consume counts and compose defenders with the real rules.
+- The Wine hook and Item count hook glossary entries close their "until S7"
+  clauses: supply (S6b) → use (S7) is now one observable loop —
+  `item_collected` → `bun_eaten`/`wine_drunk`/`consumable_blocked` — and the
+  HUD BUN/WINE readouts agree with the log trail.

--- a/examples/platformer/panda-adventure/docs/project-manifest-notes.md
+++ b/examples/platformer/panda-adventure/docs/project-manifest-notes.md
@@ -15,15 +15,17 @@ longer by hand-editing. The `data/generated/*.tres` it loads are derived artifac
 that are COMMITTED (a freshness gate keeps them byte-identical to a fresh build),
 regenerated from JSON via `scripts/build_config.py` (gADR-0000).
 
-**`[input]`.** S1 player-traversal actions plus the S2 `fire` action and the S3
-weapon/consumable actions. `move_left`/`move_right`/`jump`/`fire`/
-`switch_weapon`/`drink_wine` are consumed by PlayerController (`Input.get_axis`
-/ `is_action_just_pressed`) and driven in the live e2e by `gda input action`.
-Each movement action binds an arrow key plus a WASD/Space alternative; `fire`
-binds J plus F; `switch_weapon` binds Q plus Tab; `drink_wine` binds R. `fire`
-fires the CURRENT weapon — Laser Gun by default, Gravity Gun after
-`switch_weapon` (gADR-0002). Originally hand-serialized (Godot's own
-`var_to_str` output); since gda #380 landed, actions are authored with
+**`[input]`.** S1 player-traversal actions plus the S2 `fire` action, the S3
+weapon/consumable actions, and the S7 `eat_bun`. `move_left`/`move_right`/
+`jump`/`fire`/`switch_weapon`/`drink_wine`/`eat_bun` are consumed by
+PlayerController (`Input.get_axis` / `is_action_just_pressed`) and driven in
+the live e2e by `gda input action`. Each movement action binds an arrow key
+plus a WASD/Space alternative; `fire` binds J plus F; `switch_weapon` binds Q
+plus Tab; `drink_wine` binds R; `eat_bun` binds E. `fire` fires the CURRENT
+weapon — Laser Gun by default, Gravity Gun after `switch_weapon` (gADR-0002).
+Both consumable verbs are supply-gated on the S6b item counts since S7
+(gADR-0008). Originally hand-serialized (Godot's own `var_to_str` output);
+since gda #380 landed, actions are authored with
 `gda project add-input-action <name> --key <k>...` instead.
 
 **`[layer_names]`.** S2+S3 collision topology — structural wiring, not balance

--- a/examples/platformer/panda-adventure/project.godot
+++ b/examples/platformer/panda-adventure/project.godot
@@ -59,6 +59,11 @@ drink_wine={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":82,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+eat_bun={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":69,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 

--- a/examples/platformer/panda-adventure/scenes/hud.tscn
+++ b/examples/platformer/panda-adventure/scenes/hud.tscn
@@ -24,3 +24,9 @@ layout_mode = 2
 
 [node name="WeaponLabel" type="Label" parent="Stats" unique_id=1749857655]
 layout_mode = 2
+
+[node name="BunLabel" type="Label" parent="Stats" unique_id=1502238084]
+layout_mode = 2
+
+[node name="WineLabel" type="Label" parent="Stats" unique_id=1079145550]
+layout_mode = 2

--- a/examples/platformer/panda-adventure/scripts/build_config.py
+++ b/examples/platformer/panda-adventure/scripts/build_config.py
@@ -8,7 +8,7 @@ Godot Resources under ``data/generated/`` that the runtime ``load()``s. Every
 byte-identical to a fresh build), never hand-edited: changing config means
 changing the JSON.
 
-Six sources feed the outputs (``specs_for``/``SPECS``):
+Seven sources feed the outputs (``specs_for``/``SPECS``):
 
 - ``player_config.json`` -> ``player_config.tres`` (``PlayerConfig``, S1)
 - ``combat_config.json`` -> ``stats_player.tres`` + ``stats_enemy.tres``
@@ -36,6 +36,10 @@ Six sources feed the outputs (``specs_for``/``SPECS``):
   length + 1, config never code — plus the Drop/Pickup blockout and juice,
   gADR-0006) — S6b. The curve's strict monotonicity is a cross-field rule
   enforced by ``validate_progression_semantics``.
+- ``items_config.json`` -> ``items_config.tres`` (``ItemsConfig``: the
+  Consumable restore amounts — ``wine_mp_restore`` migrated here from
+  ``gravity_config.json`` — the consume-flash juice, and the Spacesuit's
+  defense bonus, gADR-0008) — S7.
 
 Dogfooding note: since gda's ADR-0032 static class_name scan (issue #360), ``gda
 resource create --type PlayerConfig`` CAN instantiate a project-local class in
@@ -132,7 +136,6 @@ _COMBAT_FIELDS: list[tuple[str, str]] = [
 
 _GRAVITY_FIELDS: list[tuple[str, str]] = [
     ("mp_cost", "float"),
-    ("wine_mp_restore", "float"),
     ("field_direction", "vec2"),
     ("field_strength", "float"),
     ("field_radius", "float"),
@@ -204,6 +207,18 @@ _HUD_FIELDS: list[tuple[str, str]] = [
     ("margin", "vec2"),
     ("value_punch_scale", "vec2"),
     ("value_tween_duration", "float"),
+]
+
+# The S7 Items & Equipment numbers (gADR-0008): the Consumable restore
+# amounts (wine_mp_restore migrated from _GRAVITY_FIELDS — one items
+# authority), the consume-flash juice, and the Spacesuit's defense bonus.
+_ITEMS_FIELDS: list[tuple[str, str]] = [
+    ("bun_hp_restore", "float"),
+    ("wine_mp_restore", "float"),
+    ("spacesuit_defense", "float"),
+    ("bun_flash_color", "color"),
+    ("wine_flash_color", "color"),
+    ("consume_flash_duration", "float"),
 ]
 
 # The S6b progression loop (gADR-0006): the leveling curve (cumulative EXP
@@ -321,6 +336,15 @@ _STATIC_SPECS: list[TresSpec] = [
         script_class="ProgressionConfig",
         ext_id="1_progressionconfig",
         fields=_PROGRESSION_FIELDS,
+    ),
+    TresSpec(
+        json_rel="data/json/items_config.json",
+        schema_rel="data/schema/items_config.schema.json",
+        out_rel="data/generated/items_config.tres",
+        script_res_path="res://src/resources/items_config.gd",
+        script_class="ItemsConfig",
+        ext_id="1_itemsconfig",
+        fields=_ITEMS_FIELDS,
     ),
 ]
 

--- a/examples/platformer/panda-adventure/src/controllers/hud_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/hud_controller.gd
@@ -1,9 +1,10 @@
 class_name HudController
 extends CanvasLayer
 
-## Drives the HUD blockout (S6a, gADR-0004; +Level since S6b, gADR-0006): six
-## Labels in a screen-space column surfacing the Player's live HP, MP, Level,
-## EXP, Gold, and Current weapon — the GDD's "HUD & UI" contract — so the
+## Drives the HUD blockout (S6a, gADR-0004; +Level since S6b, gADR-0006;
+## +Consumable counts since S7, gADR-0008): eight Labels in a screen-space
+## column surfacing the Player's live HP, MP, Level, EXP, Gold, Current
+## weapon, and the Bun/Wine supply — the GDD's "HUD & UI" contract — so the
 ## player reads state without leaving the action. A CanvasLayer renders in
 ## screen space, untouched by the S1 follow-camera.
 ##
@@ -27,10 +28,10 @@ const GameLogScript := preload("res://src/util/game_log.gd")
 
 const HUD_CONFIG_PATH := "res://data/generated/hud_config.tres"
 
-# The six surfaced values, in display order: each maps a snapshot to its
+# The eight surfaced values, in display order: each maps a snapshot to its
 # Label node name. Structural wiring (what the HUD shows is the GDD contract),
 # not config numbers.
-const LINES := ["hp", "mp", "level", "exp", "gold", "weapon"]
+const LINES := ["hp", "mp", "level", "exp", "gold", "weapon", "bun", "wine"]
 
 var _config: HudConfigScript
 # Whether the first snapshot has been rendered (it populates silently and logs
@@ -58,11 +59,11 @@ static func format_weapon(weapon: String) -> String:
 	return weapon.replace("_", " ").to_upper()
 
 
-## Pure mapping from the Player's hud_state() snapshot to the six display
+## Pure mapping from the Player's hud_state() snapshot to the eight display
 ## strings, keyed like LINES. The single place the snapshot's shape meets the
 ## format decisions, so the seam can pin the whole readout at once. The Level
-## readout (S6b) reuses format_amount: an integer level passes through floori
-## unchanged.
+## readout (S6b) reuses format_amount (an integer level passes through floori
+## unchanged), and so do the S7 Consumable counts (integers by construction).
 static func format_lines(state: Dictionary) -> Dictionary:
 	return {
 		"hp": format_bar("HP", state["hp"], state["max_hp"]),
@@ -71,6 +72,8 @@ static func format_lines(state: Dictionary) -> Dictionary:
 		"exp": format_amount("EXP", state["exp"]),
 		"gold": format_amount("GOLD", state["gold"]),
 		"weapon": format_weapon(state["weapon"]),
+		"bun": format_amount("BUN", state["bun"]),
+		"wine": format_amount("WINE", state["wine"]),
 	}
 
 
@@ -117,6 +120,8 @@ func _process(_delta: float) -> void:
 			"exp": state["exp"],
 			"gold": state["gold"],
 			"weapon": state["weapon"],
+			"bun": state["bun"],
+			"wine": state["wine"],
 		})
 
 

--- a/examples/platformer/panda-adventure/src/controllers/player_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/player_controller.gd
@@ -19,6 +19,12 @@ extends CharacterBody2D
 ## minimal Wine hook; the full Consumable system is S7). See the S3 block at
 ## the end of this file.
 ##
+## S7 adds the Consumable use verbs + the Spacesuit (gADR-0008): `eat_bun` and
+## `drink_wine` consume the S6b item-count hook (supply-gated, capped restore,
+## consume flash), and the worn Spacesuit composes the effective defender
+## (base defense + config bonus) that take_hit feeds the damage formula's
+## mitigation term. See the S7 block at the end of this file.
+##
 ## Movement params and visuals are data (gADR-0000): a derived PlayerConfig
 ## Resource, never hardcoded. compute_velocity is static and node-free so the
 ## logic seam can exercise it headless (tests/gdscript/test_player_logic.gd via
@@ -114,6 +120,7 @@ func _ready() -> void:
 		"jump_velocity": _config.jump_velocity,
 		"max_hp": _stats_config.max_hp,
 	})
+	_equip_spacesuit()
 
 
 ## Apply the data-driven blockout: the Player block (visual + collision centered
@@ -157,6 +164,8 @@ func _physics_process(delta: float) -> void:
 		_switch_weapon()
 	if Input.is_action_just_pressed("drink_wine"):
 		_drink_wine()
+	if Input.is_action_just_pressed("eat_bun"):
+		_eat_bun()
 	if Input.is_action_just_pressed("fire"):
 		_fire_current_weapon()
 
@@ -192,7 +201,10 @@ func take_hit(attacker: StatsConfigScript) -> void:
 	if CombatSystemScript.is_invulnerable(_last_hit_time, now, _combat.iframe_duration):
 		return
 	_last_hit_time = now
-	var damage := CombatSystemScript.compute_damage(attacker, _stats_config, _combat)
+	# The defender is the SPACESUIT-composed stat block (S7, gADR-0008): base
+	# defense + the worn Equipment's bonus, feeding the formula's mitigation
+	# term with the formula itself untouched.
+	var damage := CombatSystemScript.compute_damage(attacker, _defender_stats(), _combat)
 	_stats.apply_damage(damage)
 	GameLogScript.emit("info", "player_hit", {"damage": damage, "hp_left": _stats.hp})
 	_play_hit_flash()
@@ -300,18 +312,24 @@ func _fire_gravity_gun() -> void:
 	})
 
 
-## Drink Wine — the S3 minimal MP-restore hook (the full Consumable system with
-## inventory/counts is S7, so nothing is consumed from anywhere yet): restore
-## the config amount, capped at the stat block's max_mp.
+## Drink Wine — restore MP capped at the stat block's max_mp. Since S7 the S3
+## hook is supply-gated (gADR-0008): one Wine is consumed from the item-count
+## hook (or the use is refused, consumable_blocked) and the restore amount
+## reads from the one items authority (ItemsConfig — migrated out of
+## GravityConfig). The use juice + count land in the log record.
 func _drink_wine() -> void:
-	var cfg := _gravity_config()
+	var cfg := _items_config()
 	if cfg == null or _stats == null or _stats_config == null:
+		return
+	if not _try_consume(ITEM_WINE):
 		return
 	var mp_before := _stats.mp
 	_stats.restore_mp(cfg.wine_mp_restore, _stats_config.max_mp)
+	_play_consume_flash(cfg.wine_flash_color)
 	GameLogScript.emit("info", "wine_drunk", {
 		"mp_before": mp_before,
 		"mp_after": _stats.mp,
+		"count": _items[ITEM_WINE],
 	})
 
 
@@ -371,6 +389,10 @@ func hud_state() -> Dictionary:
 		"exp": _stats.exp_points,
 		"gold": _stats.gold,
 		"weapon": _weapon,
+		# S7 (gADR-0008): the Consumable supply, so the HUD can surface what
+		# the use verbs can spend.
+		"bun": int(_items.get(ITEM_BUN, 0)),
+		"wine": int(_items.get(ITEM_WINE, 0)),
 	}
 
 
@@ -471,3 +493,112 @@ func _progression_config() -> ProgressionConfigScript:
 				% PROGRESSION_CONFIG_PATH
 			)
 	return _progression_cfg
+
+
+# --- S7 Consumable use + Spacesuit Equipment (gADR-0008) ----------------------
+# Kept as ONE self-contained append-only block (the S3/S4 parallel-merge
+# pattern): the use verbs that CONSUME the S6b item-count hook (supply-gated,
+# capped restore, consume flash — pure gating in ItemSystem) and the worn
+# Spacesuit's composed defender feeding take_hit's mitigation term.
+
+const ItemsConfigScript := preload("res://src/resources/items_config.gd")
+const ItemSystemScript := preload("res://src/systems/item_system.gd")
+const ITEMS_CONFIG_PATH := "res://data/generated/items_config.tres"
+
+# The two Consumables' item names — the CLOSED Phase-1 drop vocabulary's
+# non-gold entries (gADR-0006). Structural identifiers (they name _items keys
+# and log values, not tunable numbers — the WEAPON_* pattern).
+const ITEM_BUN := "bun"
+const ITEM_WINE := "wine"
+
+# The Spacesuit-composed effective defender (base stat block + config defense
+# bonus), built once at ready — the Spacesuit is worn from spawn (persistent
+# Equipment, GDD). Null until _equip_spacesuit (or when config failed to
+# load); _defender_stats falls back to the bare stat block.
+var _defender: StatsConfigScript
+# The derived ItemsConfig, lazily loaded (load() is cached) so _ready's S2
+# load block stays untouched (the S3 GravityConfig pattern).
+var _items_cfg: ItemsConfigScript
+
+
+## Wear the Spacesuit: compose the effective defender (pure ItemSystem
+## decision — the base .tres is load()-aliased immutable config and is never
+## mutated, gADR-0001) and log the module entry with the config bonus.
+func _equip_spacesuit() -> void:
+	var cfg := _items_config()
+	if cfg == null or _stats_config == null:
+		return
+	_defender = ItemSystemScript.effective_defender(_stats_config, cfg.spacesuit_defense)
+	GameLogScript.emit("info", "spacesuit_equipped", {
+		"defense_bonus": cfg.spacesuit_defense,
+		"defense_total": _defender.defense,
+	})
+
+
+## The defender stat block take_hit feeds the damage formula: the
+## Spacesuit-composed block, or the bare base block until/unless the suit
+## initialized (the formula contract is unchanged either way).
+func _defender_stats() -> StatsConfigScript:
+	return _defender if _defender != null else _stats_config
+
+
+## Eat a Bun — restore HP capped at the stat block's max_hp, consuming one
+## from the item-count hook (or refusing, consumable_blocked). Gated on the
+## death latch: a restored corpse would contradict player_died (respawn is a
+## later slice's story).
+func _eat_bun() -> void:
+	var cfg := _items_config()
+	if cfg == null or _stats == null or _stats_config == null or _dead:
+		return
+	if not _try_consume(ITEM_BUN):
+		return
+	var hp_before := _stats.hp
+	_stats.restore_hp(cfg.bun_hp_restore, _stats_config.max_hp)
+	_play_consume_flash(cfg.bun_flash_color)
+	GameLogScript.emit("info", "bun_eaten", {
+		"hp_before": hp_before,
+		"hp_after": _stats.hp,
+		"count": _items[ITEM_BUN],
+	})
+
+
+## The shared Consumable supply gate (gADR-0008): consume one `item` from the
+## S6b item-count hook and report true, or refuse (nothing consumed, one
+## consumable_blocked record — the gravity_blocked pattern) when none is
+## held. Supply is the only input; the restore caps bound the effect.
+func _try_consume(item: String) -> bool:
+	var count := int(_items.get(item, 0))
+	if not ItemSystemScript.can_consume(count):
+		GameLogScript.emit("info", "consumable_blocked", {"item": item, "count": count})
+		return false
+	_items[item] = ItemSystemScript.consumed(count)
+	return true
+
+
+## The consume "juice": flash the Player block to the used item's config
+## color and tween back to its own color (the hit-flash idiom; one shared
+## duration — two flavors of one verb, gADR-0008).
+func _play_consume_flash(flash_color: Color) -> void:
+	var cfg := _items_config()
+	if cfg == null:
+		return
+	var visual := $Visual as ColorRect
+	visual.color = flash_color
+	var tween := create_tween()
+	var recover := tween.tween_property(
+		visual, "color", _config.player_color, cfg.consume_flash_duration
+	)
+	recover.set_trans(Tween.TRANS_SINE)
+
+
+## The derived ItemsConfig with the standard loud guard, lazily loaded so the
+## S2 _ready block stays untouched (the S3 GravityConfig pattern).
+func _items_config() -> ItemsConfigScript:
+	if _items_cfg == null:
+		_items_cfg = load(ITEMS_CONFIG_PATH)
+		if _items_cfg == null:
+			push_error(
+				"PlayerController: could not load %s — run scripts/build_config.py."
+				% ITEMS_CONFIG_PATH
+			)
+	return _items_cfg

--- a/examples/platformer/panda-adventure/src/controllers/player_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/player_controller.gd
@@ -543,12 +543,13 @@ func _defender_stats() -> StatsConfigScript:
 
 
 ## Eat a Bun — restore HP capped at the stat block's max_hp, consuming one
-## from the item-count hook (or refusing, consumable_blocked). Gated on the
-## death latch: a restored corpse would contradict player_died (respawn is a
-## later slice's story).
+## from the item-count hook (or refusing, consumable_blocked). Supply is the
+## ONLY gate (gADR-0008): the S4 death latch stops the damage/death records,
+## not verbs — like moving and firing, item use stays live after player_died
+## until a later slice owns game-over/respawn.
 func _eat_bun() -> void:
 	var cfg := _items_config()
-	if cfg == null or _stats == null or _stats_config == null or _dead:
+	if cfg == null or _stats == null or _stats_config == null:
 		return
 	if not _try_consume(ITEM_BUN):
 		return

--- a/examples/platformer/panda-adventure/src/resources/gravity_config.gd
+++ b/examples/platformer/panda-adventure/src/resources/gravity_config.gd
@@ -17,10 +17,10 @@ extends Resource
 ## The @export fields carry NO default literals on purpose: a default would read
 ## as a second config source competing with the authoritative JSON (gADR-0000).
 
-# MP economy — firing the Gravity Gun is the game's only MP sink; Wine is the
-# S3 minimal restore hook (the full Consumable system is S7).
+# MP economy — firing the Gravity Gun is the game's only MP sink. The Wine
+# restore that refills this budget lives in ItemsConfig since S7 (gADR-0008:
+# one items authority; wine_mp_restore migrated out of this source).
 @export var mp_cost: float
-@export var wine_mp_restore: float
 
 # Gravity Field params — the data-driven effect (gADR-0002): velocity =
 # direction.normalized() * strength (px/s), acting within radius for duration

--- a/examples/platformer/panda-adventure/src/resources/items_config.gd
+++ b/examples/platformer/panda-adventure/src/resources/items_config.gd
@@ -1,0 +1,32 @@
+class_name ItemsConfig
+extends Resource
+
+## Typed items configuration for S7 (Consumable use + Spacesuit Equipment,
+## gADR-0008): every item number in one authoritative source.
+##
+## This Resource is a DERIVED artifact: it is regenerated from the authoritative
+## data/json/items_config.json by scripts/build_config.py (validated against
+## data/schema/items_config.schema.json) and emitted to
+## data/generated/items_config.tres. Never hand-edit the generated .tres or
+## hardcode these values — change the JSON (gADR-0000).
+##
+## The @export fields carry NO default literals on purpose: a default would read
+## as a second config source competing with the authoritative JSON (gADR-0000).
+
+# Consumable restore amounts — applied capped at the stat block's max at use
+# time (StatsSystem.restore_hp / restore_mp). wine_mp_restore migrated here
+# from gravity_config (the S3 Wine hook's home): gravity keeps only the MP
+# sink, items keep every item effect (gADR-0008).
+@export var bun_hp_restore: float
+@export var wine_mp_restore: float
+
+# The Spacesuit's protective value: the defense bonus composed onto the
+# Player's base stat block (ItemSystem.effective_defender) to feed the damage
+# formula's mitigation term — the formula itself is untouched (gADR-0008).
+@export var spacesuit_defense: float
+
+# Consume juice: per-item flash color, one shared tween-back duration (two
+# flavors of one verb — the hit-flash idiom on the Player block).
+@export var bun_flash_color: Color
+@export var wine_flash_color: Color
+@export var consume_flash_duration: float

--- a/examples/platformer/panda-adventure/src/systems/item_system.gd
+++ b/examples/platformer/panda-adventure/src/systems/item_system.gd
@@ -1,0 +1,42 @@
+class_name ItemSystem
+extends RefCounted
+
+## The pure Items & Equipment decisions for S7 (gADR-0008): Consumable supply
+## gating and worn-Equipment defense composition.
+##
+## Every function here is static, deterministic, and node/physics/clock-free —
+## the CombatSystem purity contract (gADR-0001), so the offline Monte-Carlo
+## balancing pipeline can consume counts and compose defenders with the real
+## rules. Controllers orchestrate (own the _items Dictionary, mutate their
+## StatsSystem, tween, log); decisions live only here.
+
+const StatsConfigScript := preload("res://src/resources/stats_config.gd")
+
+
+## The Consumable supply gate: a use verb may fire iff at least one is held.
+## Supply is the ONLY input — using at full HP/MP is legal (the restore cap
+## bounds the effect; gADR-0008's one-input gate).
+static func can_consume(count: int) -> bool:
+	return count > 0
+
+
+## The count after one Consumable is used up. Callers gate on can_consume
+## first; the floor at 0 keeps a miscounted hook from ever going negative.
+static func consumed(count: int) -> int:
+	return maxi(count - 1, 0)
+
+
+## Compose the effective defender for the damage formula's mitigation term:
+## a FRESH stat block copying `base` with `defense` raised by the worn
+## Equipment's bonus (the Spacesuit). The base Resource is load()-aliased
+## immutable config (gADR-0001) and is NEVER mutated — CombatSystem.
+## compute_damage keeps its symmetric stat-block contract untouched.
+static func effective_defender(
+	base: StatsConfigScript, defense_bonus: float
+) -> StatsConfigScript:
+	var composed := StatsConfigScript.new()
+	composed.max_hp = base.max_hp
+	composed.max_mp = base.max_mp
+	composed.attack = base.attack
+	composed.defense = base.defense + defense_bonus
+	return composed

--- a/examples/platformer/panda-adventure/src/systems/stats_system.gd
+++ b/examples/platformer/panda-adventure/src/systems/stats_system.gd
@@ -46,11 +46,20 @@ func spend_mp(cost: float) -> bool:
 	return true
 
 
-## Restore MP (the S3 Wine hook), capped at the actor's max_mp. The cap is a
-## PARAMETER, passed by the caller from its immutable stat block — config data
-## stays outside this runtime holder (gADR-0001).
+## Restore MP (Wine — the S3 hook, supply-gated since S7/gADR-0008), capped at
+## the actor's max_mp. The cap is a PARAMETER, passed by the caller from its
+## immutable stat block — config data stays outside this runtime holder
+## (gADR-0001).
 func restore_mp(amount: float, max_mp: float) -> void:
 	mp = minf(mp + amount, max_mp)
+
+
+## Restore HP (Bun, S7 — restore_mp's mirror, gADR-0008), capped at the
+## actor's max_hp. The cap is a PARAMETER from the immutable stat block, like
+## every cap here (gADR-0001). Restoring a dead actor is the CALLER's gate
+## (the death latch), not this holder's.
+func restore_hp(amount: float, max_hp: float) -> void:
+	hp = minf(hp + amount, max_hp)
 
 
 ## Accumulate one Kill reward (S6a, gADR-0004): EXP and Gold only ever grow

--- a/examples/platformer/panda-adventure/src/systems/stats_system.gd
+++ b/examples/platformer/panda-adventure/src/systems/stats_system.gd
@@ -56,8 +56,7 @@ func restore_mp(amount: float, max_mp: float) -> void:
 
 ## Restore HP (Bun, S7 — restore_mp's mirror, gADR-0008), capped at the
 ## actor's max_hp. The cap is a PARAMETER from the immutable stat block, like
-## every cap here (gADR-0001). Restoring a dead actor is the CALLER's gate
-## (the death latch), not this holder's.
+## every cap here (gADR-0001).
 func restore_hp(amount: float, max_hp: float) -> void:
 	hp = minf(hp + amount, max_hp)
 

--- a/examples/platformer/panda-adventure/tests/gdscript/test_items_logic.gd
+++ b/examples/platformer/panda-adventure/tests/gdscript/test_items_logic.gd
@@ -1,0 +1,144 @@
+extends SceneTree
+
+## Logic seam (b) for S7: exercise the PURE Consumable-use and
+## Equipment-mitigation decisions headless (gADR-0008) — ItemSystem's supply
+## gate + count decrement + effective-defender composition,
+## StatsSystem.restore_hp (the Bun's capped restore, restore_mp's mirror), and
+## the composed defender feeding CombatSystem.compute_damage's mitigation term
+## with the formula untouched — every value injected as a parameter
+## (node/physics/clock-free).
+##
+## Run via gda (ADR-0031):
+##   gda script run res://tests/gdscript/test_items_logic.gd
+##
+## preload() the scripts (a headless runtime has no editor-generated
+## global_script_class_cache), construct in-memory stat blocks with KNOWN
+## values, and assert each rule. Prints "LOGIC_SEAM: PASS" + quit(0) on
+## success, else push_error + quit(1).
+
+const StatsConfigScript := preload("res://src/resources/stats_config.gd")
+const CombatConfigScript := preload("res://src/resources/combat_config.gd")
+const StatsSystemScript := preload("res://src/systems/stats_system.gd")
+const CombatSystemScript := preload("res://src/systems/combat_system.gd")
+const ItemSystemScript := preload("res://src/systems/item_system.gd")
+
+# A known stat block: values chosen exactly representable.
+const MAX_HP := 100.0
+const MAX_MP := 50.0
+const BASE_DEFENSE := 1.0
+
+
+func _make_block() -> StatsConfigScript:
+	var block := StatsConfigScript.new()
+	block.max_hp = MAX_HP
+	block.max_mp = MAX_MP
+	block.attack = 10.0
+	block.defense = BASE_DEFENSE
+	return block
+
+
+func _make_params() -> CombatConfigScript:
+	var params := CombatConfigScript.new()
+	params.attack_scale = 1.0
+	params.defense_scale = 1.0
+	params.min_damage = 1.0
+	return params
+
+
+func _fail(msg: String) -> void:
+	push_error("LOGIC_SEAM: " + msg)
+	quit(1)
+
+
+func _init() -> void:
+	# Behavior 1 — the supply gate is one-input (gADR-0008): empty refuses,
+	# any held count permits.
+	if ItemSystemScript.can_consume(0):
+		_fail("can_consume(0) must refuse — nothing held")
+		return
+	if not ItemSystemScript.can_consume(1) or not ItemSystemScript.can_consume(3):
+		_fail("can_consume must permit any positive count")
+		return
+
+	# Behavior 2 — consumed decrements by exactly one and floors at 0 (a
+	# miscounted hook can never go negative).
+	if ItemSystemScript.consumed(3) != 2 or ItemSystemScript.consumed(1) != 0:
+		_fail("consumed should decrement by exactly one")
+		return
+	if ItemSystemScript.consumed(0) != 0:
+		_fail("consumed must floor at 0")
+		return
+
+	# Behavior 3 — restore_hp (the Bun's effect): a partial restore adds the
+	# amount, a big restore caps at max_hp (the cap is a parameter, gADR-0001).
+	var stats := StatsSystemScript.new()
+	stats.init_from(_make_block())
+	stats.apply_damage(40.0)
+	stats.restore_hp(25.0, MAX_HP)
+	if not is_equal_approx(stats.hp, 85.0):
+		_fail("restore_hp should add the amount below the cap (60+25=85)")
+		return
+	stats.restore_hp(25.0, MAX_HP)
+	if not is_equal_approx(stats.hp, MAX_HP):
+		_fail("restore_hp must cap at max_hp (85+25 -> 100)")
+		return
+	stats.restore_hp(25.0, MAX_HP)
+	if not is_equal_approx(stats.hp, MAX_HP):
+		_fail("restore_hp at full HP must stay at the cap")
+		return
+
+	# Behavior 4 — restore_hp never touches the other stats (restore_mp's
+	# mirror keeps the same single-stat contract).
+	if not is_equal_approx(stats.mp, MAX_MP):
+		_fail("restore_hp must not touch MP")
+		return
+
+	# Behavior 5 — effective_defender composes a FRESH block: defense = base
+	# + bonus, every other stat copied, and the base is NOT mutated (the
+	# load()-alias safety this composition exists for, gADR-0001/gADR-0008).
+	var base := _make_block()
+	var composed: StatsConfigScript = ItemSystemScript.effective_defender(base, 2.0)
+	if not is_equal_approx(composed.defense, BASE_DEFENSE + 2.0):
+		_fail("effective_defender should raise defense by the bonus")
+		return
+	if (
+		not is_equal_approx(composed.max_hp, base.max_hp)
+		or not is_equal_approx(composed.max_mp, base.max_mp)
+		or not is_equal_approx(composed.attack, base.attack)
+	):
+		_fail("effective_defender must copy the non-defense stats unchanged")
+		return
+	if not is_equal_approx(base.defense, BASE_DEFENSE):
+		_fail("effective_defender must NEVER mutate the base block")
+		return
+	if composed == base:
+		_fail("effective_defender must return a fresh block, not the base")
+		return
+
+	# Behavior 6 — a zero bonus composes an equivalent defender (a purely
+	# cosmetic suit is legal config).
+	var bare: StatsConfigScript = ItemSystemScript.effective_defender(base, 0.0)
+	if not is_equal_approx(bare.defense, BASE_DEFENSE):
+		_fail("a zero-bonus suit should leave defense at the base value")
+		return
+
+	# Behavior 7 — the composed defender feeds the UNTOUCHED formula's
+	# mitigation term: damage drops by exactly bonus * defense_scale.
+	var params := _make_params()
+	var attacker := _make_block()  # attack 10
+	var raw: float = CombatSystemScript.compute_damage(attacker, base, params)
+	var mitigated: float = CombatSystemScript.compute_damage(attacker, composed, params)
+	if not is_equal_approx(raw - mitigated, 2.0):
+		_fail("the Spacesuit bonus should reduce damage by bonus * defense_scale")
+		return
+
+	# Behavior 8 — the min_damage floor survives any suit: an overwhelming
+	# bonus cannot push damage below the formula's floor.
+	var fortress: StatsConfigScript = ItemSystemScript.effective_defender(base, 1000.0)
+	var floored: float = CombatSystemScript.compute_damage(attacker, fortress, params)
+	if not is_equal_approx(floored, params.min_damage):
+		_fail("min_damage must floor the mitigated damage")
+		return
+
+	print("LOGIC_SEAM: PASS")
+	quit(0)

--- a/examples/platformer/panda-adventure/tests/gdscript/test_reward_hud_logic.gd
+++ b/examples/platformer/panda-adventure/tests/gdscript/test_reward_hud_logic.gd
@@ -104,9 +104,10 @@ func _init() -> void:
 		_fail("format_weapon should render gravity_gun as GRAVITY GUN")
 		return
 
-	# Behavior 9 — format_lines maps a full hud_state() snapshot to the six
+	# Behavior 9 — format_lines maps a full hud_state() snapshot to the eight
 	# display strings in one place (the whole readout pinned at once; the
-	# snapshot carries the S6b Level since gADR-0006).
+	# snapshot carries the S6b Level since gADR-0006 and the S7 Consumable
+	# counts since gADR-0008 — integers, format_amount passes them through).
 	var lines: Dictionary = HudControllerScript.format_lines({
 		"hp": 95.0,
 		"max_hp": MAX_HP,
@@ -116,6 +117,8 @@ func _init() -> void:
 		"exp": 50.0,
 		"gold": 25.0,
 		"weapon": "gravity_gun",
+		"bun": 2,
+		"wine": 0,
 	})
 	var expected := {
 		"hp": "HP 95/100",
@@ -124,6 +127,8 @@ func _init() -> void:
 		"exp": "EXP 50",
 		"gold": "GOLD 25",
 		"weapon": "GRAVITY GUN",
+		"bun": "BUN 2",
+		"wine": "WINE 0",
 	}
 	for key: String in expected:
 		if lines.get(key) != expected[key]:

--- a/examples/platformer/panda-adventure/tests/test_enemies_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_enemies_e2e.py
@@ -74,11 +74,17 @@ def _make_project_copy(dst: Path, mutate_enemies) -> Path:
 
 
 def _expected_player_damage(kind: dict, combat: dict, player_stats: dict) -> float:
-    """The data-driven formula with the roles swapped: enemy kind -> Player."""
+    """The data-driven formula with the roles swapped: enemy kind -> Player.
+
+    The Player defends with the SPACESUIT-composed block since S7
+    (gADR-0008): base defense + the items config's suit bonus.
+    """
+    items = build_config.load_json(GAME_DIR / "data" / "json" / "items_config.json")
     return max(
         combat["min_damage"],
         kind["attack"] * combat["attack_scale"]
-        - player_stats["defense"] * combat["defense_scale"],
+        - (player_stats["defense"] + items["spacesuit_defense"])
+        * combat["defense_scale"],
     )
 
 

--- a/examples/platformer/panda-adventure/tests/test_gravity_data_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_gravity_data_seam.py
@@ -29,7 +29,6 @@ def _valid_config() -> dict:
     """A fresh copy of a schema-valid gravity config to mutate into invalid variants."""
     return {
         "mp_cost": 10.0,
-        "wine_mp_restore": 15.0,
         "field_direction": [0.0, -1.0],
         "field_strength": 260.0,
         "field_radius": 96.0,
@@ -79,7 +78,7 @@ def _with(value: object, key: str) -> dict:
         _without("field_direction"),  # missing field param
         _without("obstacle_position"),  # missing obstacle placement
         _with(0, "mp_cost"),  # a free fire would unbudget the pillar
-        _with(-5.0, "wine_mp_restore"),  # restore must be strictly positive
+        _with(15.0, "wine_mp_restore"),  # migrated to items_config (gADR-0008)
         _with(0, "field_strength"),  # strength strictly positive
         _with(0, "field_radius"),  # radius strictly positive
         _with(0, "field_duration"),  # effect window strictly positive
@@ -136,7 +135,6 @@ def test_gravity_config_round_trips(gda) -> None:
     # Scalar float fields.
     for float_field in (
         "mp_cost",
-        "wine_mp_restore",
         "field_strength",
         "field_radius",
         "field_duration",

--- a/examples/platformer/panda-adventure/tests/test_gravity_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_gravity_e2e.py
@@ -22,7 +22,10 @@ session:
   (#406). The clamp math itself is pinned headless in the logic seam;
 - repeated fires drain MP to 0; at 0 MP the fire is refused
   (``gravity_blocked``, no new field) — the MP gate;
-- ``drink_wine`` restores MP (``wine_drunk``) and the Gravity Gun fires again;
+- with no Wine held, ``drink_wine`` is REFUSED too (``consumable_blocked`` —
+  the S7 supply gate, gADR-0008): MP stays drained and the Gravity Gun stays
+  blocked. The restore/re-arm half of the economy loop lives in
+  ``test_items_e2e.py``, where the supply exists;
 - switching back re-arms the Laser Gun (``laser_fired`` again) — the weapon
   toggle round-trips.
 
@@ -91,7 +94,6 @@ def test_daemon_serves_gravity_loop(tmp_path, daemon_runtime_dir):
     )
     mp_max = combat["player_stats"]["max_mp"]
     mp_cost = gravity["mp_cost"]
-    wine_restore = gravity["wine_mp_restore"]
     obstacle_pos = gravity["obstacle_position"]
     enemy_pos = combat["enemy_position"]
     enemy_clamp = gravity["enemy_max_gravity_offset"]
@@ -470,22 +472,27 @@ def test_daemon_serves_gravity_loop(tmp_path, daemon_runtime_dir):
             "a refused fire must not spawn a field"
         )
 
-        # --- Wine restores MP (capped at max), re-arming the Gravity Gun.
+        # --- With no Wine held, drink_wine is REFUSED (the S7 supply gate,
+        # gADR-0008): nothing restored, the budget stays drained, and the
+        # Gravity Gun stays blocked. The restore/re-arm half lives in
+        # test_items_e2e.py, where the supply exists.
         tap("drink_wine")
-        drunk = poll(lambda: records("wine_drunk"))
-        assert drunk, "no gda_log 'wine_drunk' record"
-        assert drunk[-1]["fields"]["mp_before"] == pytest.approx(leftover)
-        restored = min(leftover + wine_restore, mp_max)
-        assert drunk[-1]["fields"]["mp_after"] == pytest.approx(restored)
-
-        # Config sanity for the next step: one Wine must re-arm at least one fire.
-        assert restored >= mp_cost, "gravity_config: wine_mp_restore < mp_cost"
-        tap("fire")
-        assert poll(lambda: len(records("gravity_fired")) >= total_fires + 1), (
-            "after Wine the Gravity Gun should fire again"
+        wine_blocked = poll(
+            lambda: [
+                r
+                for r in records("consumable_blocked")
+                if r["fields"]["item"] == "wine"
+            ]
         )
-        assert records("gravity_fired")[-1]["fields"]["mp_after"] == pytest.approx(
-            restored - mp_cost
+        assert wine_blocked, "no gda_log 'consumable_blocked' record for wine"
+        assert wine_blocked[-1]["fields"]["count"] == 0
+        assert not records("wine_drunk"), "a refused drink must not restore MP"
+        tap("fire")
+        assert poll(lambda: len(records("gravity_blocked")) >= 2), (
+            "with the budget still drained the Gravity Gun must stay blocked"
+        )
+        assert len(records("gravity_fired")) == total_fires, (
+            "a refused drink must not re-arm the Gravity Gun"
         )
 
         # --- Switch back: `fire` drives the Laser Gun again (the toggle

--- a/examples/platformer/panda-adventure/tests/test_items_data_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_items_data_seam.py
@@ -1,0 +1,140 @@
+"""Data seam (a) for S7 Items & Equipment (Consumables + Spacesuit).
+
+Proves the JSON -> Resource pipeline (gADR-0000) for the S7 items config: the
+authoritative ``items_config.json`` validates against its schema, bad config
+is rejected, and the derived ``ItemsConfig`` ``.tres`` round-trips back
+through gda with its declared Godot types. This source is the ONE items
+authority (gADR-0008): ``wine_mp_restore`` lives here — migrated out of
+``gravity_config.json``, whose seam now rejects the stray key. The
+byte-stable freshness gate is NOT duplicated here:
+``test_combat_data_seam.py`` parametrizes it over ``build_config.SPECS``, so
+the items spec is covered there automatically — this file only pins that the
+spec IS registered. Fast tier — never ``e2e``; the round-trip drives one-shot
+``gda`` headless ops under the ``engine`` gate.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import jsonschema
+import pytest
+
+import build_config
+
+ITEMS_JSON_PATH = build_config.GAME_DIR / "data/json/items_config.json"
+ITEMS_SCHEMA_PATH = build_config.GAME_DIR / "data/schema/items_config.schema.json"
+ITEMS_TRES_REL = "data/generated/items_config.tres"
+
+
+def _valid_config() -> dict:
+    """A fresh copy of a schema-valid items config to mutate into invalid variants."""
+    return {
+        "bun_hp_restore": 25.0,
+        "wine_mp_restore": 15.0,
+        "spacesuit_defense": 2.0,
+        "bun_flash_color": [0.4, 0.95, 0.45, 1.0],
+        "wine_flash_color": [0.45, 0.6, 1.0, 1.0],
+        "consume_flash_duration": 0.25,
+    }
+
+
+def _items_schema() -> dict:
+    return build_config.load_schema(ITEMS_SCHEMA_PATH)
+
+
+def test_sample_json_passes_schema() -> None:
+    """The authoritative items config validates against its schema."""
+    config = build_config.load_json(ITEMS_JSON_PATH)
+    assert build_config.validate_config(config, _items_schema()) is config
+
+
+def test_items_spec_registered_for_freshness_gate() -> None:
+    """The items spec is in SPECS, so the parametrized freshness gate covers it."""
+    assert ITEMS_TRES_REL in [spec.out_rel for spec in build_config.SPECS]
+
+
+def test_wine_restore_has_one_authority() -> None:
+    """The Wine restore lives ONLY in the items source (the gADR-0008 migration):
+    present here, absent from the gravity source it migrated out of."""
+    items = build_config.load_json(ITEMS_JSON_PATH)
+    gravity = build_config.load_json(
+        build_config.GAME_DIR / "data/json/gravity_config.json"
+    )
+    assert "wine_mp_restore" in items
+    assert "wine_mp_restore" not in gravity
+
+
+def _without(key: str) -> dict:
+    bad = _valid_config()
+    del bad[key]
+    return bad
+
+
+def _with(value: object, key: str) -> dict:
+    bad = copy.deepcopy(_valid_config())
+    bad[key] = value
+    return bad
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        _without("bun_hp_restore"),  # missing Consumable effect
+        _without("wine_mp_restore"),  # missing Consumable effect
+        _without("spacesuit_defense"),  # missing Equipment value
+        _without("consume_flash_duration"),  # missing juice number
+        _with(0, "bun_hp_restore"),  # a no-op Consumable is a config bug
+        _with(-5.0, "wine_mp_restore"),  # restore strictly positive
+        _with(-1.0, "spacesuit_defense"),  # defense non-negative (0 is legal)
+        _with(0, "consume_flash_duration"),  # tween strictly positive
+        _with([0.4, 0.95, 0.45], "bun_flash_color"),  # color: too few components
+        _with([0.45, 0.6, 1.5, 1.0], "wine_flash_color"),  # color: out of 0..1
+        _with("armored", "spacesuit_defense"),  # wrong type
+        {**_valid_config(), "extra": 1},  # unexpected extra top-level key
+    ],
+)
+def test_invalid_json_rejected(bad: dict) -> None:
+    """An items config that violates the schema raises jsonschema.ValidationError."""
+    with pytest.raises(jsonschema.ValidationError):
+        build_config.validate_config(bad, _items_schema())
+
+
+def test_zero_defense_suit_is_legal() -> None:
+    """A purely cosmetic (0-defense) Spacesuit is legal config — the bound is
+    non-negative, not strictly positive (unlike the restores)."""
+    config = _with(0.0, "spacesuit_defense")
+    assert build_config.validate_config(config, _items_schema()) is config
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: the derived items .tres loads back through gda with its
+# declared Godot types, compared to the AUTHORITATIVE JSON (never hardcoded).
+# ---------------------------------------------------------------------------
+
+
+def _properties_by_name(get_result: dict) -> dict:
+    """Index a ``gda resource get`` result's ``properties`` list by name."""
+    return {p["name"]: p["value"] for p in get_result["properties"]}
+
+
+@pytest.mark.engine
+def test_items_config_round_trips(gda) -> None:
+    """The ItemsConfig .tres round-trips every field through gda."""
+    config = build_config.load_json(ITEMS_JSON_PATH)
+    result = gda("resource", "get", f"res://{ITEMS_TRES_REL}", "--json")
+    assert result.returncode == 0, result.stdout + result.stderr
+    props = _properties_by_name(json.loads(result.stdout))
+
+    # Colors are float32 in Godot — compare with a tolerance.
+    for color_field in ("bun_flash_color", "wine_flash_color"):
+        assert props[color_field] == pytest.approx(config[color_field], abs=1e-5)
+    # Scalar float fields.
+    for float_field in (
+        "bun_hp_restore",
+        "wine_mp_restore",
+        "spacesuit_defense",
+        "consume_flash_duration",
+    ):
+        assert props[float_field] == pytest.approx(config[float_field])

--- a/examples/platformer/panda-adventure/tests/test_items_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_items_e2e.py
@@ -365,9 +365,9 @@ def test_daemon_serves_consumable_use_and_spacesuit(tmp_path, daemon_runtime_dir
         tap("fire")
         assert poll(lambda: records("gravity_fired")), "no gravity_fired record"
         mp_now = max_mp - mp_cost
-        assert poll(
-            lambda: label("Mp") == f"MP {round(mp_now)}/{round(max_mp)}"
-        ), "HUD should surface the MP spend"
+        assert poll(lambda: label("Mp") == f"MP {round(mp_now)}/{round(max_mp)}"), (
+            "HUD should surface the MP spend"
+        )
         tap("drink_wine")
         drunk = poll(lambda: records("wine_drunk"))
         assert drunk, "no gda_log 'wine_drunk' record"
@@ -391,9 +391,9 @@ def test_daemon_serves_consumable_use_and_spacesuit(tmp_path, daemon_runtime_dir
         # use -> empty), not a one-way faucet.
         blocked_before = len(records("consumable_blocked"))
         tap("drink_wine")
-        assert poll(
-            lambda: len(records("consumable_blocked")) == blocked_before + 1
-        ), "the emptied wine supply must refuse"
+        assert poll(lambda: len(records("consumable_blocked")) == blocked_before + 1), (
+            "the emptied wine supply must refuse"
+        )
         assert records("consumable_blocked")[-1]["fields"] == {
             "item": "wine",
             "count": 0,

--- a/examples/platformer/panda-adventure/tests/test_items_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_items_e2e.py
@@ -1,0 +1,414 @@
+"""Integration seam (c) for S7 Consumable use + Spacesuit Equipment — THE gate.
+
+The full S7 loop through the gda CLI against a running Engine session
+(gADR-0008), on a DETERMINISTIC single-wave project copy:
+
+- boot: the Spacesuit is worn from spawn — ``spacesuit_equipped`` carries the
+  config bonus and the composed total; the HUD column carries the S7 BUN/WINE
+  lines at their zero supply;
+- supply gating: with nothing held, ``eat_bun``/``drink_wine`` are REFUSED
+  (``consumable_blocked``, nothing restored, readouts unchanged) — the use
+  verbs consume the S6b item-count hook, never thin air;
+- mitigation: the aggroed minion's contact damage lands MITIGATED — the
+  ``player_hit`` amount is the S2 formula fed the Spacesuit-composed defender
+  (base + ``spacesuit_defense``), asserted against the authoritative JSON;
+- supply: killing the minion drops its RECONFIGURED table (Bun + Wine, both
+  certain — the gADR-0006 chance-retune precedent), collection lands both in
+  the hook and the BUN/WINE readouts tick up;
+- use: ``eat_bun`` restores HP (capped add over the damage taken above,
+  ``bun_eaten`` with before/after + remaining count, the HP readout agrees);
+  a Gravity fire spends MP, ``drink_wine`` restores it (``wine_drunk``,
+  capped at max) and RE-ARMS the Gravity Gun (the S3 economy loop, now
+  supply-gated — one Wine covers at least one fire, a config sanity this
+  test pins); the emptied supply refuses again.
+
+Every expectation derives from the AUTHORITATIVE JSON configs (the copy's,
+for the reconfigured drops/waves), never hardcoded. Per RULES.md, mocks
+cannot replace this end-to-end proof.
+
+Isolation: the throwaway-copy pattern (``daemon start`` mutates
+``project.godot``); the copy is reconfigured for determinism by data (the
+waves-e2e precedent): ONE wave (no wave-2 Elite to interfere with the
+collection walk — the shipped Elite spawns inside aggro of the kill spot)
+whose minion drop table is exactly one Bun + one Wine at chance 1.0.
+Posix-only (AF_UNIX); fully headless. The windowed visual half (the BUN/WINE
+lines actually RENDER) lives in the consolidated Visual-smoke seam
+(gADR-0007), ``test_visual_smoke_e2e.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+import build_config
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+GDA_CMD = [sys.executable, "-m", "gda"]
+GODOT = resolve_godot_binary()
+GAME_DIR = build_config.GAME_DIR
+
+_COPY_IGNORE = shutil.ignore_patterns(
+    "tests", ".godot", "build", "generated", "__pycache__"
+)
+
+_HUD_LABEL = "/root/Main/Hud/Stats/%sLabel"
+
+
+def _make_project_copy(dst: Path) -> dict:
+    """Copy the game, reconfigure it for S7 determinism, build its config.
+
+    Returns the copy's enemies document (the authority the expectations
+    derive from). Two data-only edits (the waves-e2e reconfiguration
+    precedent): the schedule shrinks to its first wave alone (the shipped
+    wave-2 Elite spawns within aggro of the kill spot and would interfere
+    with the collection walk), and the minion Tier's drop table becomes
+    exactly one Bun + one Wine, both certain (the gADR-0006 chance-retune
+    precedent) — the Consumable supply this test consumes.
+    """
+    shutil.copytree(GAME_DIR, dst, ignore=_COPY_IGNORE)
+    enemies_path = dst / "data" / "json" / "enemies_config.json"
+    enemies = json.loads(enemies_path.read_text(encoding="utf-8"))
+    enemies["waves"] = [enemies["waves"][0]]
+    minion_tier = enemies["kinds"][enemies["waves"][0]["spawns"][0]["kind"]]["tier"]
+    enemies["tiers"][minion_tier]["drops"] = [
+        {"item": "bun", "amount": 1, "chance": 1.0},
+        {"item": "wine", "amount": 1, "chance": 1.0},
+    ]
+    enemies_path.write_text(json.dumps(enemies, indent=2) + "\n", encoding="utf-8")
+    build_config.build_all(root=dst)
+    return enemies
+
+
+@pytest.mark.e2e
+def test_daemon_serves_consumable_use_and_spacesuit(tmp_path, daemon_runtime_dir):
+    project = tmp_path / "game"
+    enemies = _make_project_copy(project)
+    # Every expectation derives from the AUTHORITATIVE JSON (the copy's, for
+    # the reconfigured waves/drops), never hardcoded.
+    combat = build_config.load_json(GAME_DIR / "data" / "json" / "combat_config.json")
+    gravity = build_config.load_json(GAME_DIR / "data" / "json" / "gravity_config.json")
+    items = build_config.load_json(GAME_DIR / "data" / "json" / "items_config.json")
+    player_cfg = build_config.load_json(
+        GAME_DIR / "data" / "json" / "player_config.json"
+    )
+    default_spawn = enemies["waves"][0]["spawns"][0]
+    kind = enemies["kinds"][default_spawn["kind"]]
+    drops = enemies["tiers"][kind["tier"]]["drops"]
+    player_stats = combat["player_stats"]
+    max_hp = player_stats["max_hp"]
+    max_mp = player_stats["max_mp"]
+    mp_cost = gravity["mp_cost"]
+    bun_restore = items["bun_hp_restore"]
+    wine_restore = items["wine_mp_restore"]
+    suit_bonus = items["spacesuit_defense"]
+    # The symmetric damage formula, enemy->Player: the defender is the
+    # SPACESUIT-COMPOSED stat block (base defense + suit bonus, gADR-0008).
+    contact_damage = max(
+        combat["min_damage"],
+        kind["attack"] * combat["attack_scale"]
+        - (player_stats["defense"] + suit_bonus) * combat["defense_scale"],
+    )
+    # The suit must actually mitigate on the shipped numbers, or the
+    # mitigation assert below would pass vacuously through the min floor.
+    unmitigated = max(
+        combat["min_damage"],
+        kind["attack"] * combat["attack_scale"]
+        - player_stats["defense"] * combat["defense_scale"],
+    )
+    assert contact_damage < unmitigated, (
+        "config sanity: the shipped spacesuit_defense must visibly mitigate "
+        "the minion's contact damage"
+    )
+    laser_damage = max(
+        combat["min_damage"],
+        player_stats["attack"] * combat["attack_scale"]
+        - kind["defense"] * combat["defense_scale"],
+    )
+    shots_to_kill = math.ceil(kind["max_hp"] / laser_damage)
+    iframe = combat["iframe_duration"]
+    rest_y = (
+        player_cfg["platform_position"][1]
+        - player_cfg["platform_size"][1] / 2.0
+        - player_cfg["player_size"][1] / 2.0
+    )
+    start_x = player_cfg["player_start"][0]
+    enemy_x = default_spawn["position"][0]
+    # The S6a-proven walk target: inside the minion's Aggro Range with margin
+    # on both sides; the minion closes the rest (gADR-0003 dynamics).
+    target_x = enemy_x - kind["aggro_range"] + 40.0
+    ticks_per_px = 1.0 / (player_cfg["move_speed"] / 60.0)
+    env = {**os.environ}
+
+    def run(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(project),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    def records(message: str) -> list[dict]:
+        proc = run("logger", "tail")
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        return [
+            r
+            for r in json.loads(proc.stdout)["records"]
+            if r["message"] == message and r["origin"] == "gda_log"
+        ]
+
+    def poll(predicate, timeout: float = 20.0, interval: float = 0.5):
+        deadline = time.monotonic() + timeout
+        result = predicate()
+        while not result and time.monotonic() < deadline:
+            time.sleep(interval)
+            result = predicate()
+        return result
+
+    def prop(path: str, name: str):
+        got = run("game", "get", path, "--property", name)
+        assert got.returncode == 0, got.stdout + got.stderr
+        for p in json.loads(got.stdout)["properties"]:
+            if p["name"] == name:
+                return p["value"]
+        raise AssertionError(f"{name} not returned for {path}")
+
+    def label(key: str) -> str:
+        return prop(_HUD_LABEL % key, "text")
+
+    def tap(action: str) -> None:
+        seq = run(
+            "input",
+            "sequence",
+            "--events",
+            json.dumps(
+                [
+                    {"type": "action", "action": action, "frame": 0},
+                    {"type": "action", "action": action, "release": True, "frame": 4},
+                ]
+            ),
+        )
+        assert seq.returncode == 0, seq.stdout + seq.stderr
+
+    def walk_right(px: float) -> None:
+        """Hold move_right for the physics ticks that cover ``px`` pixels."""
+        seq = run(
+            "input",
+            "sequence",
+            "--events",
+            json.dumps(
+                [
+                    {"type": "action", "action": "move_right", "physics_frame": 0},
+                    {
+                        "type": "action",
+                        "action": "move_right",
+                        "release": True,
+                        "physics_frame": max(round(px * ticks_per_px), 1),
+                    },
+                ]
+            ),
+        )
+        assert seq.returncode == 0, seq.stdout + seq.stderr
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        # The first live op launches the Engine session; the tree also proves
+        # the S7 BUN/WINE lines are instanced in the HUD column.
+        tree = run("game", "tree")
+        assert tree.returncode == 0, tree.stdout + tree.stderr
+        assert '"BunLabel"' in tree.stdout, tree.stdout
+        assert '"WineLabel"' in tree.stdout, tree.stdout
+
+        # --- Boot: the Spacesuit is worn from spawn (persistent Equipment) —
+        # the module-entry record carries the config bonus and the composed
+        # total (base defense + bonus, gADR-0008).
+        equipped = poll(lambda: records("spacesuit_equipped"))
+        assert equipped, "no gda_log 'spacesuit_equipped' record"
+        assert len(equipped) == 1, f"the suit is worn exactly once: {equipped}"
+        assert equipped[0]["fields"]["defense_bonus"] == pytest.approx(suit_bonus)
+        assert equipped[0]["fields"]["defense_total"] == pytest.approx(
+            player_stats["defense"] + suit_bonus
+        )
+
+        # The HUD boots with the S7 supply lines at zero.
+        ready = poll(lambda: records("hud_ready"))
+        assert ready, "no gda_log 'hud_ready' record"
+        assert ready[0]["fields"]["bun"] == 0
+        assert ready[0]["fields"]["wine"] == 0
+        assert label("Bun") == "BUN 0"
+        assert label("Wine") == "WINE 0"
+
+        # Let the Player settle on the platform so the walk starts from rest.
+        assert poll(
+            lambda: abs(prop("/root/Main/Player", "position")[1] - rest_y) <= 2.0
+        ), "Player did not land"
+
+        # --- Supply gating: with nothing held, BOTH use verbs refuse — one
+        # consumable_blocked each, nothing restored, nothing consumed.
+        tap("eat_bun")
+        blocked = poll(lambda: records("consumable_blocked"))
+        assert blocked, "no gda_log 'consumable_blocked' record for the empty bun"
+        assert blocked[-1]["fields"] == {"item": "bun", "count": 0}
+        tap("drink_wine")
+        assert poll(lambda: len(records("consumable_blocked")) >= 2), (
+            "the empty wine must refuse too"
+        )
+        assert records("consumable_blocked")[-1]["fields"] == {
+            "item": "wine",
+            "count": 0,
+        }
+        assert not records("bun_eaten") and not records("wine_drunk"), (
+            "a refused use must not restore anything"
+        )
+        assert label("Hp") == f"HP {round(max_hp)}/{round(max_hp)}"
+        assert label("Mp") == f"MP {round(max_mp)}/{round(max_mp)}"
+
+        # --- Mitigation: walk into the minion's Aggro Range (deterministic
+        # physics-clock hold), let it close and land contact hits — the
+        # player_hit amount is the UNTOUCHED formula fed the suit-composed
+        # defender, mitigated by exactly the config bonus.
+        walk_right(target_x - start_x)
+        player_x = prop("/root/Main/Player", "position")[0]
+        assert abs(player_x - target_x) <= 20.0, (
+            f"physics-clock walk missed its target: x={player_x}, want ~{target_x}"
+        )
+        assert poll(lambda: records("player_hit"), timeout=30.0), (
+            "the aggroed minion never landed a contact hit"
+        )
+        assert records("player_hit")[0]["fields"]["damage"] == pytest.approx(
+            contact_damage
+        ), "the Spacesuit must mitigate the contact damage via the formula"
+
+        # --- The kill drops the reconfigured table: one Bun + one Wine, both
+        # certain; walking across the row collects both into the hook and the
+        # BUN/WINE readouts tick up.
+        for _ in range(shots_to_kill * 2):
+            if records("enemy_died"):
+                break
+            time.sleep(iframe + 0.3)
+            tap("fire")
+            poll(lambda: bool(records("enemy_died")), timeout=3.0)
+        assert poll(lambda: records("enemy_died")), "the Enemy never died"
+        spawned = poll(lambda: len(records("pickup_spawned")) == len(drops))
+        assert spawned, (
+            f"expected {len(drops)} pickup_spawned records, "
+            f"got {records('pickup_spawned')}"
+        )
+        xs = [r["fields"]["x"] for r in records("pickup_spawned")]
+        player_x = prop("/root/Main/Player", "position")[0]
+        walk_right(max(xs) - player_x + 30.0)
+        collected = poll(lambda: len(records("item_collected")) == len(drops))
+        assert collected, (
+            f"expected {len(drops)} item_collected records, "
+            f"got {records('item_collected')}"
+        )
+        assert {r["fields"]["item"] for r in records("item_collected")} == {
+            "bun",
+            "wine",
+        }
+        assert poll(lambda: label("Bun") == "BUN 1"), (
+            f"BUN readout never showed the supply: {label('Bun')}"
+        )
+        assert poll(lambda: label("Wine") == "WINE 1"), (
+            f"WINE readout never showed the supply: {label('Wine')}"
+        )
+
+        # --- Bun use: the minion is dead (single-wave copy — the damage
+        # trail is final), so the restore math is exact: hp_before is the
+        # trail's value, hp_after the capped add. One Bun is consumed.
+        hp_now = max_hp - contact_damage * len(records("player_hit"))
+        assert hp_now < max_hp, "the mitigation beat must have cost some HP"
+        tap("eat_bun")
+        eaten = poll(lambda: records("bun_eaten"))
+        assert eaten, "no gda_log 'bun_eaten' record"
+        fields = eaten[0]["fields"]
+        assert fields["hp_before"] == pytest.approx(hp_now)
+        assert fields["hp_after"] == pytest.approx(min(hp_now + bun_restore, max_hp))
+        assert fields["count"] == 0
+        expected_hp = min(hp_now + bun_restore, max_hp)
+        assert poll(
+            lambda: label("Hp") == f"HP {math.ceil(expected_hp)}/{round(max_hp)}"
+        ), f"HP readout disagrees with the restore: {label('Hp')}"
+        assert poll(lambda: label("Bun") == "BUN 0"), (
+            f"BUN readout must show the consumed supply: {label('Bun')}"
+        )
+
+        # --- Wine use: a Gravity fire spends MP first (the S3 economy), the
+        # Wine restores it capped at max and RE-ARMS the gun — one Wine
+        # covers at least one fire (config sanity pinned here since the S7
+        # gating moved the re-arm proof out of the S3 e2e).
+        assert wine_restore >= mp_cost, "items_config: wine_mp_restore < mp_cost"
+        tap("switch_weapon")
+        assert poll(lambda: records("weapon_switched")), "no weapon_switched record"
+        tap("fire")
+        assert poll(lambda: records("gravity_fired")), "no gravity_fired record"
+        mp_now = max_mp - mp_cost
+        assert poll(
+            lambda: label("Mp") == f"MP {round(mp_now)}/{round(max_mp)}"
+        ), "HUD should surface the MP spend"
+        tap("drink_wine")
+        drunk = poll(lambda: records("wine_drunk"))
+        assert drunk, "no gda_log 'wine_drunk' record"
+        fields = drunk[0]["fields"]
+        assert fields["mp_before"] == pytest.approx(mp_now)
+        assert fields["mp_after"] == pytest.approx(min(mp_now + wine_restore, max_mp))
+        assert fields["count"] == 0
+        expected_mp = min(mp_now + wine_restore, max_mp)
+        assert poll(
+            lambda: label("Mp") == f"MP {math.ceil(expected_mp)}/{round(max_mp)}"
+        ), f"MP readout disagrees with the restore: {label('Mp')}"
+        assert poll(lambda: label("Wine") == "WINE 0"), (
+            f"WINE readout must show the consumed supply: {label('Wine')}"
+        )
+        tap("fire")
+        assert poll(lambda: len(records("gravity_fired")) >= 2), (
+            "after Wine the Gravity Gun should fire again"
+        )
+
+        # --- Emptied supply refuses again: the loop is closed (collect ->
+        # use -> empty), not a one-way faucet.
+        blocked_before = len(records("consumable_blocked"))
+        tap("drink_wine")
+        assert poll(
+            lambda: len(records("consumable_blocked")) == blocked_before + 1
+        ), "the emptied wine supply must refuse"
+        assert records("consumable_blocked")[-1]["fields"] == {
+            "item": "wine",
+            "count": 0,
+        }
+
+        # --- The supply->use trace is ORDERED: collection precedes use,
+        # use precedes the post-use refusal.
+        proc = run("logger", "tail")
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        trace = [
+            r["message"]
+            for r in json.loads(proc.stdout)["records"]
+            if r["origin"] == "gda_log"
+        ]
+        assert trace.index("item_collected") < trace.index("bun_eaten"), trace
+        assert trace.index("bun_eaten") < trace.index("wine_drunk"), trace
+    finally:
+        run("daemon", "stop")

--- a/examples/platformer/panda-adventure/tests/test_items_logic_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_items_logic_seam.py
@@ -1,0 +1,46 @@
+"""Logic seam (b) for S7 Consumable use + Spacesuit Equipment (gADR-0008).
+
+Exercises the pure S7 decisions — ``ItemSystem``'s supply gate, count
+decrement, and effective-defender composition, ``StatsSystem.restore_hp``
+(the Bun's capped restore, ``restore_mp``'s mirror), and the composed
+defender feeding ``CombatSystem.compute_damage``'s mitigation term with the
+formula untouched — headless, through ``gda script run`` (ADR-0031), with
+every value injected as a parameter. Fast tier (``engine`` marker), never
+``e2e``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+_LOGIC_SCRIPT = "res://tests/gdscript/test_items_logic.gd"
+
+
+def _run(gda) -> subprocess.CompletedProcess:
+    return gda("script", "run", _LOGIC_SCRIPT, "--json")
+
+
+@pytest.mark.engine
+def test_logic_seam_items_decisions(gda) -> None:
+    """The pure items rules hold for every behavior the GDScript seam asserts.
+
+    The seam covers: the one-input supply gate (empty refuses, held permits);
+    the exactly-one decrement with its 0 floor; ``restore_hp``'s add / cap /
+    at-cap-stays behaviors and its isolation from MP; the effective-defender
+    composition (defense = base + bonus, other stats copied, the base NEVER
+    mutated, a fresh instance returned, zero-bonus equivalence); the
+    mitigation drop of exactly ``bonus * defense_scale`` through the
+    untouched formula; and the ``min_damage`` floor under an overwhelming
+    bonus. We read gda's passed-through ``exit_status`` (0 == all assertions
+    held) and require the PASS marker in stdout.
+    """
+    result = _run(gda)
+    # gda itself succeeded (the script launched and ran to completion).
+    assert result.returncode == 0, result.stdout + result.stderr
+    doc = json.loads(result.stdout)
+    # The script's own exit_status is passed through: 0 == every assertion held.
+    assert doc["exit_status"] == 0, doc["stdout"] + doc["stderr"]
+    assert "LOGIC_SEAM: PASS" in doc["stdout"], doc["stdout"] + doc["stderr"]

--- a/examples/platformer/panda-adventure/tests/test_reward_hud_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_reward_hud_e2e.py
@@ -9,9 +9,11 @@ dormant melee minion is both the damage source and the kill target):
   (read via ``gda game get`` on its ``text``) renders the AUTHORITATIVE
   JSON's boot values — full HP/MP, EXP/Gold at 0, the Laser Gun current;
 - the HUD tracks the weapon toggle both ways (``switch_weapon`` ->
-  ``GRAVITY GUN`` -> back), the MP spend (a Gravity Gun fire drops the MP
-  readout by ``mp_cost``) and the Wine restore (back up, capped at max) —
-  the S3 economy surfaced live;
+  ``GRAVITY GUN`` -> back) and the MP spend (a Gravity Gun fire drops the MP
+  readout by ``mp_cost``) — the S3 economy surfaced live. The Wine RESTORE
+  needs supply since S7 (gADR-0008): with none held ``drink_wine`` is
+  refused (``consumable_blocked``) and the readout stays put; the restore
+  readout lives in ``test_items_e2e.py``, where the supply exists;
 - walking into the minion's Aggro Range brings it to point-blank and its
   contact hits show up in the HP readout (recomputed from the ``player_hit``
   records — the HUD must agree with the log trail);
@@ -89,6 +91,7 @@ def test_daemon_serves_kill_reward_and_hud(tmp_path, daemon_runtime_dir):
     enemies = build_config.load_json(GAME_DIR / "data" / "json" / "enemies_config.json")
     combat = build_config.load_json(GAME_DIR / "data" / "json" / "combat_config.json")
     gravity = build_config.load_json(GAME_DIR / "data" / "json" / "gravity_config.json")
+    items = build_config.load_json(GAME_DIR / "data" / "json" / "items_config.json")
     player_cfg = build_config.load_json(
         GAME_DIR / "data" / "json" / "player_config.json"
     )
@@ -99,8 +102,8 @@ def test_daemon_serves_kill_reward_and_hud(tmp_path, daemon_runtime_dir):
     max_hp = player_stats["max_hp"]
     max_mp = player_stats["max_mp"]
     mp_cost = gravity["mp_cost"]
-    mp_after_wine = min(max_mp - mp_cost + gravity["wine_mp_restore"], max_mp)
-    # The symmetric damage formula, both directions (gADR-0001).
+    # The symmetric damage formula, both directions (gADR-0001). The Player
+    # defends with the SPACESUIT-composed block since S7 (gADR-0008).
     laser_damage = max(
         combat["min_damage"],
         player_stats["attack"] * combat["attack_scale"]
@@ -109,7 +112,8 @@ def test_daemon_serves_kill_reward_and_hud(tmp_path, daemon_runtime_dir):
     contact_damage = max(
         combat["min_damage"],
         kind["attack"] * combat["attack_scale"]
-        - player_stats["defense"] * combat["defense_scale"],
+        - (player_stats["defense"] + items["spacesuit_defense"])
+        * combat["defense_scale"],
     )
     shots_to_kill = math.ceil(kind["max_hp"] / laser_damage)
     iframe = combat["iframe_duration"]
@@ -205,7 +209,7 @@ def test_daemon_serves_kill_reward_and_hud(tmp_path, daemon_runtime_dir):
         root = json.loads(tree.stdout)["root"]
         hud = _find_node(root, "Hud")
         assert hud is not None and hud["type"] == "CanvasLayer", root
-        for key in ("Hp", "Mp", "Exp", "Gold", "Weapon"):
+        for key in ("Hp", "Mp", "Exp", "Gold", "Weapon", "Bun", "Wine"):
             assert _find_node(hud, f"{key}Label") is not None, hud
 
         # Its boot record carries the initial snapshot from the data.
@@ -241,11 +245,17 @@ def test_daemon_serves_kill_reward_and_hud(tmp_path, daemon_runtime_dir):
         assert poll(
             lambda: label("Mp") == f"MP {round(max_mp - mp_cost)}/{round(max_mp)}"
         ), "HUD should surface the MP spend"
+        # With no Wine held the restore is REFUSED (the S7 supply gate,
+        # gADR-0008): the MP readout stays on the spent value. The restore
+        # readout is proven in test_items_e2e.py, where the supply exists.
         tap("drink_wine")
-        assert poll(lambda: records("wine_drunk")), "no wine_drunk record"
-        assert poll(
-            lambda: label("Mp") == f"MP {round(mp_after_wine)}/{round(max_mp)}"
-        ), "HUD should surface the Wine restore"
+        assert poll(lambda: records("consumable_blocked")), (
+            "no consumable_blocked record for the supply-less wine"
+        )
+        assert not records("wine_drunk"), "a refused drink must not restore MP"
+        assert label("Mp") == f"MP {round(max_mp - mp_cost)}/{round(max_mp)}", (
+            "a refused drink must leave the MP readout on the spent value"
+        )
         tap("switch_weapon")
         assert poll(lambda: label("Weapon") == "LASER GUN"), (
             "HUD should show the Laser Gun after switching back"

--- a/examples/platformer/panda-adventure/tests/test_visual_smoke_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_visual_smoke_e2e.py
@@ -9,6 +9,10 @@ assertion). Checkpoints over the current player-visible surface:
 
 - the HUD column is visible at boot (absorbs S6a's per-feature windowed
   check from ``test_reward_hud_e2e.py`` — the seam's first checkpoint);
+- the S7 BUN/WINE supply lines are visible at boot, probed at their LIVE
+  rendered rects (``gda game rect``, the gda #419 capability — the
+  container-managed Labels' rects are readable now, so the item-lines region
+  is exact, not structural);
 - Wave 1's Enemy Kind blockout and the Obstacle blockout are visible at
   their config spawn regions (S4/S3);
 - the Gravity Field's translucent blockout is visible while active after a
@@ -87,14 +91,15 @@ _REGION_PAD = 24.0
 # (Platform top, Obstacle bottom) so the blend reference stays unoccluded.
 _PROBE_CLEARANCE = 8.0
 # The probe box over the HUD column, anchored at the config margin (the S6a
-# probe grown to six lines). A fixed box, not the live VBox rect: Labels
-# render text past their container rect (no clip), and container-managed
-# Controls expose no offset/rect properties to the live reader — the rendered
-# extent is only ever approximated structurally.
-_HUD_PROBE_SIZE = (280.0, 190.0)
+# probe, grown to the eight-line column since S7). A fixed box padded past
+# the live VBox rect: Labels render text past their container rect (no
+# clip), so the whole-column extent stays a structural approximation. (The
+# per-Label rendered rects ARE readable live since gda #419 — `game rect` —
+# which the S7 item-lines check below uses for its exact region.)
+_HUD_PROBE_SIZE = (280.0, 250.0)
 # The HUD column's line order (hud_controller.LINES): hp, mp, level, exp,
-# gold, weapon — the EXP/GOLD readout band is lines 3..4 of 6.
-_HUD_LINES = 6
+# gold, weapon, bun, wine — the EXP/GOLD readout band is lines 3..4 of 8.
+_HUD_LINES = 8
 _EXP_LINE = 3
 _GOLD_LINE = 4
 # Padding on the readout band, absorbing the VBox's row separation.
@@ -103,9 +108,13 @@ _READOUT_PAD = 6.0
 # --- Presence thresholds ---
 
 # Non-background pixels the HUD column region must show (S6a precedent):
-# six lines of light text light up thousands; 200 stays far from
+# eight lines of light text light up thousands; 200 stays far from
 # antialiasing noise while failing hard on an invisible/mispositioned HUD.
 _MIN_HUD_PIXELS = 200
+# Non-background pixels the two S7 item lines ("BUN 0" / "WINE 0") must show
+# inside their live-read rects: two short text lines at the whole-column
+# threshold's per-line rate (~33), held conservative.
+_MIN_ITEM_PIXELS = 60
 # Per-channel delta that counts a pixel as "not background" / "changed"
 # (S6a precedent).
 _CHANNEL_DELTA = 0.15
@@ -248,6 +257,15 @@ def test_player_visible_surface_renders_in_the_windowed_viewport(
     def label(key: str) -> str:
         return prop(_HUD_LABEL % key, "text")
 
+    def rendered_rect(path: str) -> list[float]:
+        """A Control's LIVE rendered viewport rect ([x, y, w, h]) via
+        `gda game rect` (gda #419) — exact even for container-managed
+        Controls, whose offsets the property reader cannot see."""
+        got = run("game", "rect", path)
+        assert got.returncode == 0, got.stdout + got.stderr
+        doc = json.loads(got.stdout)
+        return [*doc["position"], *doc["size"]]
+
     def tap(action: str) -> None:
         seq = run(
             "input",
@@ -314,6 +332,10 @@ def test_player_visible_surface_renders_in_the_windowed_viewport(
         assert (stats_left, stats_top) == pytest.approx(tuple(hud_cfg["margin"])), (
             "the rendered HUD column is not anchored at the config margin"
         )
+        # The S7 item lines' LIVE rendered rects (gda #419): the exact region
+        # the BUN/WINE presence check probes in the boot capture.
+        bun_rect = rendered_rect(_HUD_LABEL % "Bun")
+        wine_rect = rendered_rect(_HUD_LABEL % "Wine")
         boot_png, boot_doc = capture("boot")
         dims = (boot_doc["width"], boot_doc["height"])
 
@@ -433,6 +455,15 @@ def test_player_visible_surface_renders_in_the_windowed_viewport(
     # live Stats offsets) + the structural probe size.
     hud_region = [stats_left, stats_top, _HUD_PROBE_SIZE[0], _HUD_PROBE_SIZE[1]]
 
+    # The S7 item-lines region: the UNION of the two Labels' live rendered
+    # rects (gda #419 — exact, no structural row math). Both sit at the
+    # column's tail, so the union is one contiguous two-line band.
+    item_x0 = min(bun_rect[0], wine_rect[0])
+    item_y0 = min(bun_rect[1], wine_rect[1])
+    item_x1 = max(bun_rect[0] + bun_rect[2], wine_rect[0] + wine_rect[2])
+    item_y1 = max(bun_rect[1] + bun_rect[3], wine_rect[1] + wine_rect[3])
+    item_region = [item_x0, item_y0, item_x1 - item_x0, item_y1 - item_y0]
+
     # The EXP/Gold readout band: lines _EXP_LINE.._GOLD_LINE of the HUD
     # column's uniform row stack, full probe width (Label text renders past
     # the 1px-wide shrink-wrapped VBox rect), padded for the row separation.
@@ -458,6 +489,19 @@ def test_player_visible_surface_renders_in_the_windowed_viewport(
             },
             _MIN_HUD_PIXELS,
             "the HUD column is not visibly rendering at boot",
+        ),
+        (
+            {
+                "name": "item_lines",
+                "mode": "background_delta",
+                "image": "boot",
+                "rect": pad_rect(item_region, 4.0),
+                # Same top-right background sample as the hud_column check.
+                "reference": [dims[0] - 8, 8],
+                "min_delta": _CHANNEL_DELTA,
+            },
+            _MIN_ITEM_PIXELS,
+            "the S7 BUN/WINE supply lines are not visibly rendering at boot",
         ),
         (
             {


### PR DESCRIPTION
Closes #337

## What this delivers

The full **Consumable system** and the **Spacesuit** (gADR-0008, new in this PR):

- **One items authority.** New `items_config.json` → `ItemsConfig` (schema + builder spec + derived `.tres`): the Consumable restore amounts, the consume-flash juice, and `spacesuit_defense`. **`wine_mp_restore` migrated out of `gravity_config.json`** — gravity keeps only the MP sink; the gravity seams now reject the stray key (one authority, no drift).
- **Supply-gated use verbs.** `eat_bun` (new action, key E) and `drink_wine` consume the S6b item-count hook via pure `ItemSystem` gating: refused empty-handed (`consumable_blocked`), else decrement + capped restore (`StatsSystem.restore_hp` mirrors `restore_mp`) + consume flash + use record with the remaining count. Using at full HP/MP still consumes — the gate is supply, not need (gADR-0008 records the option analysis).
- **Spacesuit = composed defender; the S2 formula untouched (per AC).** `ItemSystem.effective_defender(base, bonus)` builds a fresh `StatsConfig` (the `load()`-aliased base is never mutated, gADR-0001); `take_hit` feeds it to the unchanged `CombatSystem.compute_damage`. Worn from spawn, logged `spacesuit_equipped {defense_bonus, defense_total}`.
- **HUD supply lines.** BUN/WINE count Labels extend the Stats column (pull/format/pulse machinery unchanged). *Scope note:* the issue AC doesn't literally ask for this; the GDD HUD contract ("read live state without leaving the action") makes an invisible supply fail the "full Consumable system" bar, so it ships here — flagged for review.

## Acceptance criteria → proof

- **Bun restores HP; Wine restores MP — the full Consumable system**: `test_items_e2e.py` proves the closed loop live (refused empty → kill → drop → collect → `bun_eaten`/`wine_drunk` exact capped math + readouts → gravity re-arm → refused again); logic seam pins the pure gating/restore/composition rules; data seam pins the config pipeline + the wine-authority migration.
- **Spacesuit reduces incoming damage via S2's mitigation term (no formula rework)**: the on-the-wire `player_hit` damage is asserted against the JSON-derived composed-defender formula (`test_items_e2e.py`, plus the updated derivations in `test_reward_hud_e2e.py` / `test_enemies_e2e.py`); the formula body is untouched (diff shows only the defender argument at the call site).
- **DoD**: three seams green + the visual-smoke seam extended — a new `item_lines` checkpoint probes the BUN/WINE Labels' **live rendered rects via `gda game rect` (gda #419, first use)** inside the existing single windowed session (no new capture; `_HUD_LINES` 6→8 fixes the row-pitch derivation the extra lines would have shifted). Blockout+tween: per-item consume flash colors, one shared duration, all config. Logger: `bun_eaten`/`wine_drunk`/`consumable_blocked`/`spacesuit_equipped` in the `gda logger tail` protocol. Config data-driven end-to-end (gADR-0000).

## Also in this PR

- gADR-0008 (design record: config home, gating semantics, composition vs formula-param vs stat-bump, HUD lines).
- GAME-CONTEXT.md: Wine hook CLOSED (historical), Item count hook both ends live, Spacesuit composition, new "Items authority" term; gADR-0007 gains a dated #419 outcome note.
- Committed gda harness synced to v5 (re-materialized by gda 0.5.0's `daemon start`, per AGENTS.md).
- S3/S6a e2es re-scoped where the free restore died: the empty-handed refusal is asserted there; the restore/re-arm half lives in the items e2e (documented in each header).

## Verification

- Full local suite **249 passed** (236 fast + 13 e2e, serial), including the windowed visual smoke on a real desktop (25s).
- `build/PandaAdventure.app` re-exported at wave close (gda `export run`, absolute artifact path per #402/#403) and pty-smoked: boots logging `player_ready` → `spacesuit_equipped` → `hud_ready {bun: 0, wine: 0, ...}`.
- Dogfooding: filed gda #422 (`game get/set` cannot address plain script variables — hit while designing the e2e seeding; worked around with the sanctioned drop-table reconfiguration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)