### PR TITLE
fix(value-coercion): preserve JSON container integer types

### DIFF
--- a/docs/adr/0033-object-typed-property-assignment-via-resource-reference.md
+++ b/docs/adr/0033-object-typed-property-assignment-via-resource-reference.md
@@ -30,12 +30,13 @@ gda node set scene.tscn --node Col --property shape --value res://shapes/box.tre
 
 **Explicit contract edges:**
 
-- **The shared `_coerce_value` is unchanged.** Its `(raw, type)` signature carries only the
-  `Variant.Type` (`TYPE_OBJECT`), not the property's expected class, and it is **byte-identical
-  mirrored** into the [gda harness](../../CONTEXT.md) for `game set` (ADR live layer). Object
-  resolution is therefore a **separate, headless-only step** in `node set` / `resource set` that reads
-  the property's expected-class hint from its property-list entry. Assigning a Resource on a live
-  `game set` is **out of scope**; the mirror stays green.
+- **Object resolution stays outside shared `_coerce_value`.** The shared coercion helper is
+  **byte-identical mirrored** into the [gda harness](../../CONTEXT.md) for `game set` (ADR live layer).
+  Since #427, its `(raw, type, current = null)` signature may use the current value only for
+  typed `Dictionary` / `Array` container assignment; it still does **not** carry the property's
+  expected Resource class. Object resolution is therefore a **separate, headless-only step** in
+  `node set` / `resource set` that reads the expected-class hint from the full property-list entry.
+  Assigning a Resource on a live `game set` is **out of scope**; the mirror stays green.
 - **The `script` property is excluded** from this generic Object path and routed to **`script attach`**
   (#118) — the one authoritative way to bind a script. `node set --property script` returns an
   **actionable** [Operation-reported error code](../../CONTEXT.md) pointing at `script attach`, never a
@@ -49,7 +50,8 @@ gda node set scene.tscn --node Col --property shape --value res://shapes/box.tre
   structured code. The concrete `GdaError` codes are **not fixed here** — since `GdaError.code` is
   public ABI whose authoritative source is the error registry (ADR-0002), the implementation slice
   (#363) mints them and registers them there when it lands (the ADR-0031 pattern).
-- **Value-typed coercion** (scalar / `Vector2` / `Color`) is unchanged.
+- **Value-typed coercion** (scalar / `Vector2` / `Color`, plus JSON container coercion) remains
+  separate from Object reference loading.
 
 ## Considered options
 
@@ -83,4 +85,5 @@ gda node set scene.tscn --node Col --property shape --value res://shapes/box.tre
 - **Ties to ADR-0032:** script-`class_name`-typed property validation will reuse ADR-0032's unified
   `class_name` resolver when that extension (or the deferred inline sub-resource work) lands.
 - **The mirrored `_coerce_value` stays byte-identical**; the mirror test (`operations.gd` ↔
-  `gda_harness.gd`) is unaffected.
+  `gda_harness.gd`) remains the guard. Container type context introduced by #427 is mirrored; Object
+  expected-class context is not.

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -189,6 +189,14 @@ mutation integrity boundary above. The supported target types and the string for
 | `Vector2i` | two comma-separated integers: `x,y` | `[x, y]` |
 | `Color` | `#rrggbb` / `#rrggbbaa`, or 3–4 comma-separated floats in 0..1 (`r,g,b[,a]`) | `[r, g, b, a]` |
 
+For `Dictionary` / `Array` JSON values, JSON integer literals stay Godot `int` and JSON float
+literals stay `float` (for example, `{"a":2,"b":2.0}` keeps distinct `int` and `float` entries).
+When the existing destination is a typed `Dictionary` or typed `Array`, assignment goes through that
+typed container so Godot coerces keys, values, or elements through the declared container type
+(for example, `Dictionary[String, int]` or `Array[int]`). The same JSON container rule is shared by
+`node set`, `resource set`, `project set`, and live `game set`; Object `res://` assignment below is a
+separate headless-only contract.
+
 Whitespace around a value or a component is tolerated. A property of any other type is still
 reported by `node get` — compound values arrive structured through the shared value projection
 (ADR-0035): packed arrays project as JSON arrays, and an `Object` as a reference / inline value
@@ -206,8 +214,9 @@ create` and `resource set` this completes the external sub-resource workflow wit
 32,64` → `node set scene.tscn --node Col --property shape --value res://box.tres`). The result echoes
 `type` `"Object"` and `value` the ADR-0035 **reference projection** (`{type, resource_path}`) of the assigned
 resource — the same shape a subsequent `get` reads back (pass `--project` so `res://` resolves). This
-is a **separate, headless-only** step from the shared coercion above — value coercion keys only off
-the Variant type, but resolving an Object needs the expected-class hint on the property-list entry — so
+is a **separate, headless-only** step from the shared coercion above — scalar coercion keys off the
+Variant type and container coercion may use the current typed container value, but neither carries the
+expected-class hint on the property-list entry — so
 assigning a Resource on the live `gda game set` is **out of scope** and the coercion mirror is
 unchanged for Object assignment. Its failure modes are **distinct structured codes**, never `uncoercible_value`: a non-`res://`
 value is `expected_resource_path`; a path that does not load as a Resource is `not_a_resource`; a loaded

--- a/examples/platformer/panda-adventure/addons/gda_harness/gda_harness.gd
+++ b/examples/platformer/panda-adventure/addons/gda_harness/gda_harness.gd
@@ -463,7 +463,8 @@ func _handle_game_set(params: Dictionary) -> String:
 	var source := String(prop_info.get("source", "property"))
 
 	var raw_value := _string_param(params, "value")
-	var coerced: Variant = _coerce_value(raw_value, declared_type)
+	var before: Variant = node.get(prop_name)
+	var coerced: Variant = _coerce_value(raw_value, declared_type, before)
 	if coerced == null:
 		var subject := "script variable " + prop_name \
 				if source == "script variable" else "property " + prop_name
@@ -472,7 +473,6 @@ func _handle_game_set(params: Dictionary) -> String:
 				+ " to " + _type_name(declared_type) + " for " + subject
 				+ " on node " + path)
 
-	var before: Variant = node.get(prop_name)
 	node.set(prop_name, coerced)
 	var current: Variant = node.get(prop_name)
 	if source == "script variable" and before != coerced and current == before:
@@ -1277,7 +1277,9 @@ func _jsonify(value: Variant, depth: int = 0) -> Variant:
 # Returns null when the value cannot be coerced to that type, which the caller
 # reports as the clean uncoercible_value error. null is unambiguous as a
 # failure signal because no supported target type coerces TO null.
-func _coerce_value(raw: String, type: int) -> Variant:
+# `current` lets typed Dictionary/Array properties/settings provide the
+# destination type Godot should assign into; untyped and scalar coercion ignores it.
+func _coerce_value(raw: String, type: int, current: Variant = null) -> Variant:
 	match type:
 		TYPE_BOOL:
 			return _coerce_bool(raw)
@@ -1290,9 +1292,9 @@ func _coerce_value(raw: String, type: int) -> Variant:
 		TYPE_STRING_NAME:
 			return StringName(raw)
 		TYPE_DICTIONARY:
-			return _coerce_dictionary(raw)
+			return _coerce_dictionary(raw, current)
 		TYPE_ARRAY:
-			return _coerce_array(raw)
+			return _coerce_array(raw, current)
 		TYPE_VECTOR2:
 			var parts: Variant = _coerce_float_list(raw, 2)
 			return Vector2(parts[0], parts[1]) if parts != null else null
@@ -1384,16 +1386,42 @@ func _coerce_color(raw: String) -> Variant:
 	return Color(out[0], out[1], out[2], out[3])
 
 
-func _coerce_dictionary(raw: String) -> Variant:
+func _coerce_dictionary(raw: String, current: Variant = null) -> Variant:
 	var parsed: Variant = JSON.parse_string(raw)
-	if parsed is Dictionary:
-		return parsed
-	return null
+	if not (parsed is Dictionary):
+		return null
+	var variant: Variant = str_to_var(raw)
+	if not (variant is Dictionary):
+		return null
+	var dictionary: Dictionary = variant
+	if current is Dictionary:
+		var current_dictionary: Dictionary = current
+		if current_dictionary.is_typed():
+			var typed_dictionary: Dictionary = current_dictionary.duplicate()
+			typed_dictionary.clear()
+			typed_dictionary.assign(dictionary)
+			if typed_dictionary.size() != dictionary.size():
+				return null
+			return typed_dictionary
+	return dictionary
 
 
-func _coerce_array(raw: String) -> Variant:
+func _coerce_array(raw: String, current: Variant = null) -> Variant:
 	var parsed: Variant = JSON.parse_string(raw)
-	if parsed is Array:
-		return parsed
-	return null
+	if not (parsed is Array):
+		return null
+	var variant: Variant = str_to_var(raw)
+	if not (variant is Array):
+		return null
+	var array: Array = variant
+	if current is Array:
+		var current_array: Array = current
+		if current_array.is_typed():
+			var typed_array: Array = current_array.duplicate()
+			typed_array.clear()
+			typed_array.assign(array)
+			if typed_array.size() != array.size():
+				return null
+			return typed_array
+	return array
 # --- END shared coercion ---

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -462,7 +462,8 @@ func _handle_game_set(params: Dictionary) -> String:
 	var source := String(prop_info.get("source", "property"))
 
 	var raw_value := _string_param(params, "value")
-	var coerced: Variant = _coerce_value(raw_value, declared_type)
+	var before: Variant = node.get(prop_name)
+	var coerced: Variant = _coerce_value(raw_value, declared_type, before)
 	if coerced == null:
 		var subject := "script variable " + prop_name \
 				if source == "script variable" else "property " + prop_name
@@ -471,7 +472,6 @@ func _handle_game_set(params: Dictionary) -> String:
 				+ " to " + _type_name(declared_type) + " for " + subject
 				+ " on node " + path)
 
-	var before: Variant = node.get(prop_name)
 	node.set(prop_name, coerced)
 	var current: Variant = node.get(prop_name)
 	if source == "script variable" and before != coerced and current == before:
@@ -1276,7 +1276,9 @@ func _jsonify(value: Variant, depth: int = 0) -> Variant:
 # Returns null when the value cannot be coerced to that type, which the caller
 # reports as the clean uncoercible_value error. null is unambiguous as a
 # failure signal because no supported target type coerces TO null.
-func _coerce_value(raw: String, type: int) -> Variant:
+# `current` lets typed Dictionary/Array properties/settings provide the
+# destination type Godot should assign into; untyped and scalar coercion ignores it.
+func _coerce_value(raw: String, type: int, current: Variant = null) -> Variant:
 	match type:
 		TYPE_BOOL:
 			return _coerce_bool(raw)
@@ -1289,9 +1291,9 @@ func _coerce_value(raw: String, type: int) -> Variant:
 		TYPE_STRING_NAME:
 			return StringName(raw)
 		TYPE_DICTIONARY:
-			return _coerce_dictionary(raw)
+			return _coerce_dictionary(raw, current)
 		TYPE_ARRAY:
-			return _coerce_array(raw)
+			return _coerce_array(raw, current)
 		TYPE_VECTOR2:
 			var parts: Variant = _coerce_float_list(raw, 2)
 			return Vector2(parts[0], parts[1]) if parts != null else null
@@ -1383,16 +1385,42 @@ func _coerce_color(raw: String) -> Variant:
 	return Color(out[0], out[1], out[2], out[3])
 
 
-func _coerce_dictionary(raw: String) -> Variant:
+func _coerce_dictionary(raw: String, current: Variant = null) -> Variant:
 	var parsed: Variant = JSON.parse_string(raw)
-	if parsed is Dictionary:
-		return parsed
-	return null
+	if not (parsed is Dictionary):
+		return null
+	var variant: Variant = str_to_var(raw)
+	if not (variant is Dictionary):
+		return null
+	var dictionary: Dictionary = variant
+	if current is Dictionary:
+		var current_dictionary: Dictionary = current
+		if current_dictionary.is_typed():
+			var typed_dictionary: Dictionary = current_dictionary.duplicate()
+			typed_dictionary.clear()
+			typed_dictionary.assign(dictionary)
+			if typed_dictionary.size() != dictionary.size():
+				return null
+			return typed_dictionary
+	return dictionary
 
 
-func _coerce_array(raw: String) -> Variant:
+func _coerce_array(raw: String, current: Variant = null) -> Variant:
 	var parsed: Variant = JSON.parse_string(raw)
-	if parsed is Array:
-		return parsed
-	return null
+	if not (parsed is Array):
+		return null
+	var variant: Variant = str_to_var(raw)
+	if not (variant is Array):
+		return null
+	var array: Array = variant
+	if current is Array:
+		var current_array: Array = current
+		if current_array.is_typed():
+			var typed_array: Array = current_array.duplicate()
+			typed_array.clear()
+			typed_array.assign(array)
+			if typed_array.size() != array.size():
+				return null
+			return typed_array
+	return array
 # --- END shared coercion ---

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -927,7 +927,10 @@ class NodeSetParams(BaseModel):
         description=(
             "The value to set, as a string. The operation coerces it to the "
             "property's declared Godot type (see the command catalog's "
-            "'Property value coercion'); an uncoercible value is a clean error."
+            "'Property value coercion'). For Dictionary/Array JSON values, JSON "
+            "integer literals stay int and JSON float literals stay float; typed "
+            "containers assign entries through their declared container type. An "
+            "uncoercible value is a clean error."
         )
     )
 
@@ -2130,7 +2133,10 @@ class ResourceSetParams(BaseModel):
         description=(
             "The value to set, as a string. The operation coerces it to the "
             "property's declared Godot type (see the command catalog's 'Property "
-            "value coercion'); an uncoercible value is a clean error."
+            "value coercion'). For Dictionary/Array JSON values, JSON integer "
+            "literals stay int and JSON float literals stay float; typed "
+            "containers assign entries through their declared container type. An "
+            "uncoercible value is a clean error."
         )
     )
 
@@ -2780,7 +2786,10 @@ class ProjectSetParams(BaseModel):
         description=(
             "The value to set, as a string. The operation coerces it to the "
             "setting's declared Godot type (see the command catalog's 'Property "
-            "value coercion'); an uncoercible value is a clean error."
+            "value coercion'). For Dictionary/Array JSON values, JSON integer "
+            "literals stay int and JSON float literals stay float; typed "
+            "containers assign entries through their declared container type. An "
+            "uncoercible value is a clean error."
         )
     )
 
@@ -3110,7 +3119,10 @@ class GameSetParams(BaseModel):
             "property's declared or inferred target Godot type (the same coercion "
             "the node group established, including JSON objects for Dictionary and "
             "JSON arrays for Array; see the command catalog's 'Property value "
-            "coercion'); an uncoercible value is a clean error."
+            "coercion'). For Dictionary/Array JSON values, JSON integer literals "
+            "stay int and JSON float literals stay float; typed containers assign "
+            "entries through their declared container type. An uncoercible value "
+            "is a clean error."
         )
     )
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -685,7 +685,8 @@ func _op_node_set(params: Dictionary) -> void:
 		# resource_path, so re-packing serializes it as an ext_resource.
 		stored_value = _jsonify(resolved)
 	else:
-		var coerced: Variant = _coerce_value(raw_value, declared_type)
+		var current_value: Variant = node.get(prop_name)
+		var coerced: Variant = _coerce_value(raw_value, declared_type, current_value)
 		if coerced == null:
 			root.free()
 			_fail(OP_ERROR_UNCOERCIBLE_VALUE, "cannot coerce value " + raw_value.c_escape()
@@ -1731,7 +1732,8 @@ func _op_resource_set(params: Dictionary) -> void:
 		# resource_path, so re-saving serializes it as an ext_resource.
 		stored_value = _jsonify(resolved)
 	else:
-		var coerced: Variant = _coerce_value(raw_value, declared_type)
+		var current_value: Variant = resource.get(prop_name)
+		var coerced: Variant = _coerce_value(raw_value, declared_type, current_value)
 		if coerced == null:
 			_fail(OP_ERROR_UNCOERCIBLE_VALUE, "cannot coerce value " + raw_value.c_escape()
 					+ " to " + _type_name(declared_type) + " for property " + prop_name
@@ -2363,9 +2365,10 @@ func _op_project_set(params: Dictionary) -> void:
 				+ " — project set edits an existing setting; it never creates one")
 		return
 
-	var declared_type := typeof(ProjectSettings.get_setting(setting))
+	var current_value: Variant = ProjectSettings.get_setting(setting)
+	var declared_type := typeof(current_value)
 	var raw_value := _string_param(params, "value")
-	var coerced: Variant = _coerce_value(raw_value, declared_type)
+	var coerced: Variant = _coerce_value(raw_value, declared_type, current_value)
 	if coerced == null:
 		_fail(OP_ERROR_UNCOERCIBLE_VALUE, "cannot coerce value " + raw_value.c_escape()
 				+ " to " + _type_name(declared_type) + " for project setting " + setting)
@@ -4768,7 +4771,9 @@ func _jsonify(value: Variant, depth: int = 0) -> Variant:
 # Returns null when the value cannot be coerced to that type, which the caller
 # reports as the clean uncoercible_value error. null is unambiguous as a
 # failure signal because no supported target type coerces TO null.
-func _coerce_value(raw: String, type: int) -> Variant:
+# `current` lets typed Dictionary/Array properties/settings provide the
+# destination type Godot should assign into; untyped and scalar coercion ignores it.
+func _coerce_value(raw: String, type: int, current: Variant = null) -> Variant:
 	match type:
 		TYPE_BOOL:
 			return _coerce_bool(raw)
@@ -4781,9 +4786,9 @@ func _coerce_value(raw: String, type: int) -> Variant:
 		TYPE_STRING_NAME:
 			return StringName(raw)
 		TYPE_DICTIONARY:
-			return _coerce_dictionary(raw)
+			return _coerce_dictionary(raw, current)
 		TYPE_ARRAY:
-			return _coerce_array(raw)
+			return _coerce_array(raw, current)
 		TYPE_VECTOR2:
 			var parts: Variant = _coerce_float_list(raw, 2)
 			return Vector2(parts[0], parts[1]) if parts != null else null
@@ -4875,18 +4880,44 @@ func _coerce_color(raw: String) -> Variant:
 	return Color(out[0], out[1], out[2], out[3])
 
 
-func _coerce_dictionary(raw: String) -> Variant:
+func _coerce_dictionary(raw: String, current: Variant = null) -> Variant:
 	var parsed: Variant = JSON.parse_string(raw)
-	if parsed is Dictionary:
-		return parsed
-	return null
+	if not (parsed is Dictionary):
+		return null
+	var variant: Variant = str_to_var(raw)
+	if not (variant is Dictionary):
+		return null
+	var dictionary: Dictionary = variant
+	if current is Dictionary:
+		var current_dictionary: Dictionary = current
+		if current_dictionary.is_typed():
+			var typed_dictionary: Dictionary = current_dictionary.duplicate()
+			typed_dictionary.clear()
+			typed_dictionary.assign(dictionary)
+			if typed_dictionary.size() != dictionary.size():
+				return null
+			return typed_dictionary
+	return dictionary
 
 
-func _coerce_array(raw: String) -> Variant:
+func _coerce_array(raw: String, current: Variant = null) -> Variant:
 	var parsed: Variant = JSON.parse_string(raw)
-	if parsed is Array:
-		return parsed
-	return null
+	if not (parsed is Array):
+		return null
+	var variant: Variant = str_to_var(raw)
+	if not (variant is Array):
+		return null
+	var array: Array = variant
+	if current is Array:
+		var current_array: Array = current
+		if current_array.is_typed():
+			var typed_array: Array = current_array.duplicate()
+			typed_array.clear()
+			typed_array.assign(array)
+			if typed_array.size() != array.size():
+				return null
+			return typed_array
+	return array
 # --- END shared coercion ---
 
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -671,8 +671,8 @@ func _op_node_set(params: Dictionary) -> void:
 	if declared_type == TYPE_OBJECT:
 		# Object-typed property: assign an EXISTING Resource referenced by a res://
 		# path (ADR-0033, #363). A separate, headless-only step from the shared
-		# _coerce_value (it needs the expected-class hint the (raw, type) signature
-		# cannot carry); it records its own distinct structured failure.
+		# _coerce_value (it needs the expected-class hint that Variant.Type/current
+		# container context cannot carry); it records its own distinct structured failure.
 		var resolved := _resolve_object_value(prop_name,
 				_storage_property_entry(node, prop_name), raw_value, "node " + node_path)
 		if resolved == null:
@@ -4517,11 +4517,11 @@ func _tree_from_state(state: SceneState, with_paths := false, instance_paths_by_
 # node set / resource set assign an EXISTING Resource — referenced by a `res://`
 # path — to an Object-typed property that expects a Resource (sub)class (e.g.
 # CollisionShape2D.shape). This is a SEPARATE, headless-only step from the shared
-# _coerce_value block below: value coercion keys only off the Variant.Type, but
-# resolving an Object needs the property's expected-CLASS hint, which lives on the
-# property-list entry — so this deliberately is NOT mirrored into the harness (a
-# live `game set` Object assignment is out of scope, ADR-0033) and the byte-identical
-# coercion mirror stays untouched.
+# _coerce_value block below: scalar coercion keys off Variant.Type and typed-container
+# coercion may use the current Dictionary/Array value, but resolving an Object needs
+# the property's expected-CLASS hint, which lives on the property-list entry — so this
+# deliberately is NOT mirrored into the harness (a live `game set` Object assignment is
+# out of scope, ADR-0033) and the byte-identical coercion mirror stays untouched.
 #
 # The full storage-property list entry (name/type/hint/hint_string/class_name/usage)
 # for `prop_name` on `target` (a Node or a Resource — both are Objects with a

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -191,8 +191,11 @@ forms — several of which are not obvious from `--help`:
   (`"Vector2(48,72)"`) is **rejected** (`uncoercible_value`).
 - `Color` — `#rrggbb` / `#rrggbbaa`, or 3–4 **comma-separated** floats in 0..1:
   `--value "0.2,0.6,1,1"`.
-- `Dictionary` — a JSON object string: `--value '{"wine":2}'`.
-- `Array` — a JSON array string: `--value '["wine","key"]'`.
+- `Dictionary` — a JSON object string: `--value '{"wine":2}'`. In Dictionary/Array
+  JSON values, JSON integer literals stay int and JSON float literals stay float;
+  typed containers assign entries through their declared container type.
+- `Array` — a JSON array string: `--value '["wine","key"]'`. The same JSON
+  integer/float preservation rule applies to array elements.
 - An **Object-typed** (Resource) property — a `res://….tres` path, as above.
 
 Whitespace is trimmed for the numeric forms — `bool`, `int` / `float`, the

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -408,6 +408,48 @@ def test_daemon_game_set_mutates_explicit_plain_script_dictionary_variable(
 
 
 @pytest.mark.e2e
+def test_daemon_game_set_preserves_json_container_integer_and_float_types(
+    tmp_path, daemon_runtime_dir
+):
+    # #427 live-side parity: the mirrored harness coercion must preserve JSON
+    # integer vs float values in the same session state that game get observes.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "player.gd").write_text(SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        was_set = run(
+            "game",
+            "set",
+            "/root/Main/Player",
+            "--property",
+            "_items",
+            "--value",
+            '{"a":2,"b":2.0,"items":[1,1.5]}',
+        )
+        assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+        set_value = json.loads(was_set.stdout)["value"]
+        assert type(set_value["a"]) is int
+        assert type(set_value["b"]) is float
+        assert type(set_value["items"][0]) is int
+        assert type(set_value["items"][1]) is float
+
+        got = run("game", "get", "/root/Main/Player", "--property", "_items")
+        assert got.returncode == 0, got.stdout + got.stderr
+        got_value = json.loads(got.stdout)["properties"][0]["value"]
+        assert type(got_value["a"]) is int
+        assert type(got_value["b"]) is float
+        assert type(got_value["items"][0]) is int
+        assert type(got_value["items"][1]) is float
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
 def test_daemon_game_get_unknown_explicit_script_variable_reports_unknown_property(
     tmp_path, daemon_runtime_dir
 ):

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -1106,6 +1106,104 @@ def test_node_set_coerces_json_dictionary_and_array_via_get(godot_project):
 
 
 @pytest.mark.e2e
+def test_node_set_preserves_json_container_integer_and_float_types(godot_project):
+    # #427: JSON object/array coercion must preserve number spelling inside the
+    # container. Python's json loader keeps 2 as int and 2.0 as float, so this
+    # verifies the public CLI round-trip without peeking at Godot internals.
+    scene_path = godot_project / "main.tscn"
+    (godot_project / "player.gd").write_text(
+        'extends Node2D\n@export var stats: Dictionary = {"a": 0}\n',
+        encoding="utf-8",
+    )
+    scene_path.write_text(
+        "[gd_scene load_steps=2 format=3]\n\n"
+        '[ext_resource type="Script" path="res://player.gd" id="1"]\n\n'
+        '[node name="Main" type="Node2D"]\n'
+        'script = ExtResource("1")\n',
+        encoding="utf-8",
+    )
+    gda = _gda_project(godot_project)
+
+    was_set = gda(
+        "node",
+        "set",
+        str(scene_path),
+        "--node",
+        ".",
+        "--property",
+        "stats",
+        "--value",
+        '{"a":2,"b":2.0,"items":[1,1.5]}',
+        "--json",
+    )
+
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    set_value = json.loads(was_set.stdout)["value"]
+    assert type(set_value["a"]) is int
+    assert type(set_value["b"]) is float
+    assert type(set_value["items"][0]) is int
+    assert type(set_value["items"][1]) is float
+
+    got = gda("node", "get", str(scene_path), "--node", ".", "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    props = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
+    got_value = props["stats"]["value"]
+    assert type(got_value["a"]) is int
+    assert type(got_value["b"]) is float
+    assert type(got_value["items"][0]) is int
+    assert type(got_value["items"][1]) is float
+
+
+@pytest.mark.e2e
+def test_node_set_typed_dictionary_coerces_entries_to_declared_value_type(
+    godot_project,
+):
+    # Godot 4.4 typed Dictionary support: a Dictionary[String, int] property
+    # should accept JSON floats that Godot can coerce to the declared int value
+    # type, then read back as JSON integers.
+    scene_path = godot_project / "main.tscn"
+    (godot_project / "player.gd").write_text(
+        'extends Node2D\n@export var counts: Dictionary[String, int] = {"seed": 1}\n',
+        encoding="utf-8",
+    )
+    scene_path.write_text(
+        "[gd_scene load_steps=2 format=3]\n\n"
+        '[ext_resource type="Script" path="res://player.gd" id="1"]\n\n'
+        '[node name="Main" type="Node2D"]\n'
+        'script = ExtResource("1")\n',
+        encoding="utf-8",
+    )
+    gda = _gda_project(godot_project)
+
+    was_set = gda(
+        "node",
+        "set",
+        str(scene_path),
+        "--node",
+        ".",
+        "--property",
+        "counts",
+        "--value",
+        '{"a":2.0,"b":3}',
+        "--json",
+    )
+
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    set_value = json.loads(was_set.stdout)["value"]
+    assert set_value == {"a": 2, "b": 3}
+    assert type(set_value["a"]) is int
+    assert type(set_value["b"]) is int
+
+    got = gda("node", "get", str(scene_path), "--node", ".", "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    props = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
+    got_value = props["counts"]["value"]
+    assert got_value == {"a": 2, "b": 3}
+    assert type(got_value["a"]) is int
+    assert type(got_value["b"]) is int
+
+
+@pytest.mark.e2e
 def test_node_set_unknown_property_yields_unknown_property_and_leaves_file_unchanged(
     godot_project,
 ):

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -1204,6 +1204,55 @@ def test_node_set_typed_dictionary_coerces_entries_to_declared_value_type(
 
 
 @pytest.mark.e2e
+def test_node_set_typed_array_coerces_elements_to_declared_element_type(
+    godot_project,
+):
+    # #427 documents typed containers, not only typed Dictionary. Keep the Array
+    # symmetry covered so Array[int] continues to assign through its declared
+    # element type.
+    scene_path = godot_project / "main.tscn"
+    (godot_project / "player.gd").write_text(
+        "extends Node2D\n@export var counts: Array[int] = [1]\n",
+        encoding="utf-8",
+    )
+    scene_path.write_text(
+        "[gd_scene load_steps=2 format=3]\n\n"
+        '[ext_resource type="Script" path="res://player.gd" id="1"]\n\n'
+        '[node name="Main" type="Node2D"]\n'
+        'script = ExtResource("1")\n',
+        encoding="utf-8",
+    )
+    gda = _gda_project(godot_project)
+
+    was_set = gda(
+        "node",
+        "set",
+        str(scene_path),
+        "--node",
+        ".",
+        "--property",
+        "counts",
+        "--value",
+        "[2.0,3]",
+        "--json",
+    )
+
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    set_value = json.loads(was_set.stdout)["value"]
+    assert set_value == [2, 3]
+    assert type(set_value[0]) is int
+    assert type(set_value[1]) is int
+
+    got = gda("node", "get", str(scene_path), "--node", ".", "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    props = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
+    got_value = props["counts"]["value"]
+    assert got_value == [2, 3]
+    assert type(got_value[0]) is int
+    assert type(got_value[1]) is int
+
+
+@pytest.mark.e2e
 def test_node_set_unknown_property_yields_unknown_property_and_leaves_file_unchanged(
     godot_project,
 ):

--- a/tests/test_e2e_project.py
+++ b/tests/test_e2e_project.py
@@ -163,6 +163,42 @@ def test_project_set_coerces_persists_and_round_trips_via_get(godot_project):
 
 
 @pytest.mark.e2e
+def test_project_set_preserves_json_container_integer_and_float_types(godot_project):
+    # #427: project set uses ProjectSettings' current value as the target type
+    # source. A customized Dictionary setting must preserve JSON int vs float
+    # values through set, save, and a fresh project get.
+    (godot_project / "project.godot").write_text(
+        project_godot(extra='[gda]\n\nstats={"seed":1}\n'),
+        encoding="utf-8",
+    )
+
+    was_set = _gda(
+        godot_project,
+        "project",
+        "set",
+        "gda/stats",
+        "--value",
+        '{"a":2,"b":2.0,"items":[1,1.5]}',
+        "--json",
+    )
+
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    set_value = json.loads(was_set.stdout)["value"]
+    assert type(set_value["a"]) is int
+    assert type(set_value["b"]) is float
+    assert type(set_value["items"][0]) is int
+    assert type(set_value["items"][1]) is float
+
+    got = _gda(godot_project, "project", "get", "gda/stats", "--json")
+    assert got.returncode == 0, got.stdout + got.stderr
+    got_value = json.loads(got.stdout)["value"]
+    assert type(got_value["a"]) is int
+    assert type(got_value["b"]) is float
+    assert type(got_value["items"][0]) is int
+    assert type(got_value["items"][1]) is float
+
+
+@pytest.mark.e2e
 def test_project_set_string_setting_round_trips(godot_project):
     # A String-typed setting takes the CLI value verbatim and round-trips.
     was_set = _gda(

--- a/tests/test_e2e_resource.py
+++ b/tests/test_e2e_resource.py
@@ -243,6 +243,14 @@ extends Resource
 """
 
 
+DROP_TABLE_STATS_GD = """\
+class_name DropTableStats
+extends Resource
+
+@export var drop_items: Dictionary = {"seed": 1}
+"""
+
+
 @pytest.mark.e2e
 def test_resource_create_by_class_name_round_trips_typed_fields(godot_project):
     # The class_name half of --type's contract for resources (issue #342): a
@@ -354,6 +362,71 @@ def test_resource_create_by_class_name_round_trips_a_set_via_get(godot_project):
     # Round-trip: get reports the value set persisted to the custom .tres.
     assert by_name["speed"]["type"] == "float"
     assert by_name["speed"]["value"] == 9.5
+
+
+@pytest.mark.e2e
+def test_resource_set_preserves_json_container_integer_and_float_types(
+    godot_project,
+):
+    # #427: resource set writes through ResourceSaver, so verify both the
+    # structured readback and the .tres text preserve JSON integer spelling.
+    (godot_project / "drop_table_stats.gd").write_text(
+        DROP_TABLE_STATS_GD, encoding="utf-8"
+    )
+    _import_project(godot_project)
+    resource_path = godot_project / "drop_table.tres"
+    created = _gda(
+        "resource",
+        "create",
+        str(resource_path),
+        "--type",
+        "DropTableStats",
+        "--project",
+        str(godot_project),
+        "--json",
+    )
+    assert created.returncode == 0, created.stdout + created.stderr
+
+    was_set = _gda(
+        "resource",
+        "set",
+        str(resource_path),
+        "--property",
+        "drop_items",
+        "--value",
+        '{"a":2,"b":2.0,"items":[1,1.5]}',
+        "--project",
+        str(godot_project),
+        "--json",
+    )
+
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    set_value = json.loads(was_set.stdout)["value"]
+    assert type(set_value["a"]) is int
+    assert type(set_value["b"]) is float
+    assert type(set_value["items"][0]) is int
+    assert type(set_value["items"][1]) is float
+
+    text = resource_path.read_text(encoding="utf-8")
+    assert '"a": 2,' in text
+    assert '"a": 2.0' not in text
+    assert '"b": 2.0' in text
+
+    got = _gda(
+        "resource",
+        "get",
+        str(resource_path),
+        "--project",
+        str(godot_project),
+        "--json",
+    )
+    assert got.returncode == 0, got.stdout + got.stderr
+    by_name = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
+    got_value = by_name["drop_items"]["value"]
+    assert type(got_value["a"]) is int
+    assert type(got_value["b"]) is float
+    assert type(got_value["items"][0]) is int
+    assert type(got_value["items"][1]) is float
 
 
 # A registered class_name whose script is healthy but NOT Resource-derived: a

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -15,6 +15,12 @@ from gda.models import EngineVersion, GdaErrorEnvelope, InfoParams
 from tests.support import VERSION_INFO
 
 
+def _assert_json_container_number_rule(description: str) -> None:
+    lower = description.lower()
+    assert "json integer" in lower
+    assert "json float" in lower
+
+
 def test_info_schema_emits_json_object_with_input_output_and_error():
     result = CliRunner().invoke(app, ["info", "--schema"])
 
@@ -317,6 +323,7 @@ def test_node_set_schema_emits_model_derived_contract_without_other_args():
     assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     value_description = doc["input"]["properties"]["value"]["description"]
     assert "coerce" in value_description.lower()
+    _assert_json_container_number_rule(value_description)
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
@@ -870,7 +877,28 @@ def test_resource_set_schema_emits_model_derived_contract_without_other_args():
     assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     value_description = doc["input"]["properties"]["value"]["description"]
     assert "coerce" in value_description.lower()
+    _assert_json_container_number_rule(value_description)
     assert "property" in doc["output"]["properties"]
+    jsonschema.Draft202012Validator.check_schema(doc["input"])
+    jsonschema.Draft202012Validator.check_schema(doc["output"])
+
+
+def test_project_set_schema_emits_model_derived_contract_without_other_args():
+    # The ADR-0004 hard gate for project set: the bare --schema flag — no
+    # setting/--value — short-circuits into the self-description, including the
+    # shared value-coercion contract.
+    from gda.models import ProjectSetParams, ProjectSetResult
+
+    result = CliRunner().invoke(app, ["project", "set", "--schema"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.stdout)
+    assert doc["input"] == ProjectSetParams.model_json_schema()
+    assert doc["output"] == ProjectSetResult.model_json_schema()
+    assert doc["error"] == GdaErrorEnvelope.model_json_schema()
+    value_description = doc["input"]["properties"]["value"]["description"]
+    assert "coerce" in value_description.lower()
+    _assert_json_container_number_rule(value_description)
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
@@ -1191,7 +1219,9 @@ def test_game_get_rect_set_schemas_report_kind_live_and_are_model_derived():
     # The runtime-node param documents the absolute-path addressing agents must use.
     assert "absolute" in get_doc["input"]["properties"]["node"]["description"]
     assert "absolute" in rect_doc["input"]["properties"]["node"]["description"]
-    assert "coerce" in set_doc["input"]["properties"]["value"]["description"].lower()
+    value_description = set_doc["input"]["properties"]["value"]["description"]
+    assert "coerce" in value_description.lower()
+    _assert_json_container_number_rule(value_description)
     jsonschema.Draft202012Validator.check_schema(get_doc["input"])
     jsonschema.Draft202012Validator.check_schema(get_doc["output"])
     jsonschema.Draft202012Validator.check_schema(rect_doc["input"])

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -73,6 +73,14 @@ def test_skill_json_content_round_trips_the_bundled_file():
     assert data["content"] == SKILL_MD.read_text(encoding="utf-8")
 
 
+def test_skill_documents_json_container_number_preservation():
+    # #427: the packaged gda skill is the agent-facing command catalog, so it
+    # must teach the same Dictionary/Array JSON number rule that --schema exposes.
+    lower = BUNDLED.lower()
+    assert "json integer" in lower
+    assert "json float" in lower
+
+
 def test_skill_description_is_within_the_skill_frontmatter_limit():
     # An Agent Skill `description` is the one thing an agent sees when deciding to
     # load the Skill; the SKILL.md spec caps it at 1024 chars.


### PR DESCRIPTION
## Summary
- Preserve JSON integer vs float literals inside Dictionary/Array --value payloads by validating JSON separately from the stored Variant.
- Route node/resource/project/game set coercion through the current container value so typed Dictionary/Array destinations use Godot's declared container types.
- Update --schema and bundled gda skill docs for the JSON container number preservation rule.

## Tests
- env UV_CACHE_DIR=/tmp/gda-uv-cache uv run pytest tests/test_e2e_node.py tests/test_e2e_resource.py tests/test_e2e_project.py tests/test_e2e_daemon.py tests/test_harness_coercion_mirror.py tests/test_schema_command.py tests/test_skill_command.py tests/test_skill_surface_sync.py

Fixes: #427