### PR TITLE
fix(export): report native export progress

### DIFF
--- a/src/gda/export_run.py
+++ b/src/gda/export_run.py
@@ -23,8 +23,9 @@ shape as every other command and the recipe gets its own engine-free test
 surface (driven with the two injected seams; see
 ``tests/test_export_run_operation.py``). It is not side-effect-free: phase 1's
 ``HeadlessCommand.execute`` still forwards the ``export-get`` engine stderr to
-this process's stderr as advisory diagnostics; only the public result/error
-envelope and the process exit are deferred to the CLI caller.
+this process's stderr as advisory diagnostics, and phase 3 emits a native-export
+progress line to stderr; only the public result/error envelope and the process
+exit are deferred to the CLI caller.
 
 ``EXPORT_GET_COMMAND`` lives here — a plain sentinel command this operation drives
 directly (``export get`` resolves the preset), so co-locating it avoids an
@@ -34,6 +35,7 @@ root) beside that recipe, where it is the command's single fully-bound descripto
 (ADR-0023).
 """
 
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -182,8 +184,9 @@ def run_export_operation(
     ``ExportRunResult`` on success or a ``Failure`` at any phase — the CLI layer
     owns the public emit/exit channel. Not side-effect-free, though: phase 1's
     ``HeadlessCommand.execute`` still forwards the ``export-get`` engine stderr to
-    this process's stderr as advisory diagnostics; only the public result/error
-    envelope and the exit are deferred to the caller. ``output_override`` is the
+    this process's stderr as advisory diagnostics, and this recipe writes the
+    native export progress line to stderr; only the public result/error envelope
+    and the exit are deferred to the caller. ``output_override`` is the
     already-CLI-normalized
     ``--output`` value (ADR-0006 path normalization stays at the CLI); both
     engine-touching seams (``make_runner`` for ``export-get``, ``make_export_runner``
@@ -271,6 +274,10 @@ def run_export_operation(
     if project is not None:
         uninstall_harness(project)
     try:
+        print(
+            f'gda: exporting preset "{got.name}" ({mode.value}) ...',
+            file=sys.stderr,
+        )
         export_output = export_runner.run(got.name, mode.value, output_path)
     finally:
         if snapshot is not None:

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -150,6 +150,43 @@ def test_export_run_json_reports_configured_path_and_exit_zero(monkeypatch, tmp_
     ]
 
 
+def test_export_run_json_keeps_native_progress_on_stderr(monkeypatch, tmp_path):
+    # issue #431: the native export phase gets a progress line, but JSON stdout
+    # remains exactly one machine-readable result object.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    _, export_runner = _inject(monkeypatch)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--project",
+            str(tmp_path),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    expected = {
+        "preset": "Linux/X11",
+        "platform": "Linux/X11",
+        "mode": "release",
+        "output_path": _configured_output(tmp_path),
+        "created_dirs": [str(tmp_path / "build")],
+        "warnings": [],
+    }
+    assert result.stdout == json.dumps(expected, separators=(",", ":")) + "\n"
+    assert _plain(result.stderr) == (
+        'gda: exporting preset "Linux/X11" (release) ...\n'
+    )
+    assert export_runner.calls == [
+        ("Linux/X11", "release", _configured_output(tmp_path))
+    ]
+
+
 def test_export_run_default_mode_is_release(monkeypatch, tmp_path):
     # #170 adds --mode but keeps release the default: omitting --mode runs the
     # native --export-release invocation and reports mode == "release", the #121

--- a/tests/test_export_run_operation.py
+++ b/tests/test_export_run_operation.py
@@ -107,6 +107,33 @@ def test_success_returns_typed_result_to_configured_path(tmp_path):
     assert export_runner.calls == [("Linux/X11", "release", expected)]
 
 
+def test_export_run_reports_native_export_progress_on_stderr(capsys, tmp_path):
+    # issue #431: after export-get resolves the preset, the long native export
+    # phase gets its own human progress line on stderr, while the operation result
+    # and native runner invocation stay unchanged.
+    project = tmp_path / "project"
+    project.mkdir()
+    get_runner = _get_runner()
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+    outcome = _run(get_runner=get_runner, export_runner=export_runner, project=project)
+
+    expected_output = str(project / "build" / "game.x86_64")
+    assert capsys.readouterr().err == (
+        'gda: exporting preset "Linux/X11" (release) ...\n'
+    )
+    assert outcome == ExportRunResult(
+        preset="Linux/X11",
+        platform="Linux/X11",
+        mode=ExportRunMode.RELEASE,
+        output_path=expected_output,
+        created_dirs=[str(project / "build")],
+        warnings=[],
+    )
+    assert get_runner.calls == [("export-get", {"preset": "Linux/X11"})]
+    assert export_runner.calls == [("Linux/X11", "release", expected_output)]
+
+
 def test_configured_export_path_reports_absolute_project_path(tmp_path):
     # issue #403: a preset export_path keeps Godot's project-relative convention,
     # but the native invocation/result should carry the resolved absolute path so


### PR DESCRIPTION
## Summary
- Emit a stderr progress line immediately before the native export runner starts, using the export-get resolved preset name and selected mode.
- Keep JSON stdout and native export diagnostics/result data unchanged.
- Cover the recipe seam and CLI stdout/stderr separation for #431.

## Tests
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv run pytest tests/test_export_run_operation.py -k progress`
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv run pytest tests/test_export_run_commands.py -k progress`
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv run pytest tests/test_export_run_operation.py tests/test_export_run_commands.py`
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv run pytest tests/test_classify_export_run.py tests/test_launch.py -k export`
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv run ruff check src/gda/export_run.py tests/test_export_run_operation.py tests/test_export_run_commands.py`

Fixes #431