### PR TITLE
docs(panda-adventure): Phase 2 scoping — glossary terms + gADR-0011/0012

### DIFF
--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -175,8 +175,8 @@ The Player's progression grade, derived PURELY from the accumulated EXP total ag
 Leveling curve (GrowthSystem — level 1 at start, one level per threshold reached, gADR-0006).
 Readout-only in Phase 1: a level-up changes no stat yet, it logs, flashes, and ticks the HUD's
 LV line.
-_Avoid_: rank; tier (that is the enemy axis); using "level" for the demo's stage (the demo is
-a single level in the map sense — context disambiguates)
+_Avoid_: rank; tier (that is the enemy axis); using "level" for the demo's stage (that stage
+is the proper noun Level 1)
 
 **Leveling curve**:
 The data-driven, strictly increasing array of cumulative EXP thresholds the Player levels up
@@ -218,6 +218,81 @@ _Avoid_: DPS (a rate, not a time)
 How long it takes an enemy or a wave to kill the player — the player's survival time. The
 symmetric counterpart of TTK.
 _Avoid_: TDD (reserved repo-wide for Test-Driven Development); time-to-down
+
+### Pipelines
+
+**Tool Script**:
+A reusable Python pipeline script that produces or processes project content — the
+asset pipelines (preprocess → generate → postprocess) and the Balancing pipeline
+alike. Designed game-agnostic — a reusable, input-driven core with per-game
+configuration, with pluggable output emitters (JSON/XML/Resource/…) for reuse
+beyond this demo. In this project its structured output always lands in the JSON
+authority (config numbers or asset references) and flows through the JSON →
+Resource derivation — never bypassing JSON to write `.tres` directly; generated
+asset files land under the assets tree and are referenced from config, never
+hardcoded.
+_Avoid_: build script (that names the JSON→Resource builder), helper script, tool
+(too generic)
+
+**Asset pipeline**:
+The Tool Script family that produces the game's binary assets — textures, sprite
+frames, audio, fonts. Preprocess builds a style-and-size **asset spec** (the shared
+style descriptor plus the Scale spec's target dimensions and format/licensing
+constraints); the acquire stage fulfills it in one of two modes — online
+search-and-download from open-asset sites, or generation (built-in model or
+external MCP backend); postprocess conforms the result (crop/transform/normalize
+to the spec) and records provenance and license in the asset manifest. Artifacts
+are asset files PLUS their JSON references — asset references are data
+(gADR-0000); the view resolves assets from config, never hardcoded paths.
+_Avoid_: art pipeline (audio and fonts too), downloader / generator (each names
+only one acquire mode)
+
+**Scale spec**:
+The unified size/scale standard every visual element conforms to — the anchor
+dimensions and inter-element proportion rules that asset generation, post-processing,
+and wiring all target. Two layers: the qualitative proportion rules and anchor
+rationale live in the GDD (extending its blockout scale-ratio rules); the
+authoritative numeric table is data (JSON), consumed by the pipelines and the game
+alike (gADR-0000: numbers are not in the GDD). An early Phase 2 deliverable — not
+yet authored.
+_Avoid_: art bible (broader), size chart, blockout ratios (the Phase 1 subset)
+
+**VFX**:
+The view-layer presentation effects — hit flashes, explosions, pickup glints, Warp
+telegraphs and the like — produced as assets by the visual pipeline (sprite-frame
+animations, particle textures) and fired from the view-integration hooks. Never a
+mechanic: a VFX carries no gameplay or damage semantics of its own.
+_Avoid_: particles (an implementation), juice (broader — includes camera/audio
+feel), effects system
+
+### Tooling
+
+**Panda Adventure Editor**:
+The in-game visual editing-and-debugging tool — a separate entry scene of the same
+Godot project that a human (HITL) launches to edit Level 1's content, tune numbers,
+and playtest in place; agents keep driving `gda` instead. It writes only the JSON
+authority — spatial content (platform segments, Arena, backdrop, Wave/Spawn
+rosters) by direct manipulation, numbers by structured forms as the hand-tune
+channel — and re-derives Resources through the one Python builder, never a second
+derivation path. Ships with instant edit↔play switching and a minimal debug
+palette (wave jump, god-mode, spawn-on-demand).
+_Avoid_: level editor (it also debugs and tunes), editor plugin (the rejected
+form), the editor (ambiguous with the Godot editor)
+
+### Balancing
+
+**Balancing pipeline**:
+The numeric-design pipeline that computes and sets the game's tuning numbers — Stat
+Blocks, wave frequency/density, TTK/TTD targets, difficulty and Leveling curves —
+against design intent: built and first-tuned in Phase 2, re-tuned against playtest
+feedback in Phase 3. Twin engines, both Python inside the Tool Script framework —
+Monte-Carlo encounter simulation validates encounter-level numbers; a
+system-dynamics model (first-order nonlinear ODEs over the growth/economy stocks
+and flows) predicts long-term balance trajectories. Deliberately isolated from the
+game's GDScript (reusable across games): it reads and writes the same JSON
+authority the game derives from, and never imports game code.
+_Avoid_: balance patch, number tweaking; balancing sim (that names only the
+Monte-Carlo half)
 
 ### Items
 
@@ -289,6 +364,16 @@ _Avoid_: armor (generic), suit
 
 ### Level
 
+**Level 1**:
+The demo's single playable level as a product — the same Great-Wall arc as the
+Phase 1 blockout (same layout, Wave schedule, and Boss finale), productionized by
+the Phase 2 pipelines: real visuals/audio/UI wired in and numbers initial-tuned.
+A proper noun in the map sense; the Player's progression grade stays **Level**.
+The numbering anticipates architecture-level multi-level extensibility only (one
+`Level authority` config per level) — additional levels stay out of scope.
+_Avoid_: the demo level (its pre-name), stage, map; level (lowercase — collides
+with the Player grade)
+
 **Wave**:
 A segment of the demo level that spawns a specific composition of enemies
 (Faction × Tier × Archetype) — one Spawn Roster in the Wave schedule. Waves advance in
@@ -309,6 +394,17 @@ data-driven arrival point. A property of the demo composition, not a schedule in
 (a reconfigured schedule need not end on a Boss); the Boss's behavior — Tank band AI plus
 the Warp kit — is S8's (gADR-0009).
 _Avoid_: final boss wave (as a system rule), boss fight (that is the S8 behavior)
+
+**View skin**:
+The derived rendering layer that dresses the data-authored level geometry: tile
+placements and backdrop layers computed as a pure function of the `Level authority`'s
+segments — never a second, hand-authored terrain source (gADR-0010 untouched:
+collision and geometry stay the segments'). The Phase 2 upgrade path of the
+`Great-Wall blockout`: its tile vocabulary must compose the wall's presentation —
+spans, parapets, corners, towers — AND the background efficiently, in one consistent
+style.
+_Avoid_: tilemap (an implementation node, not the concept), decoration layer,
+second terrain authority
 
 **Obstacle**:
 A gravity-affectable environment block on the terrain layer that a Gravity Field can

--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -199,8 +199,9 @@ _Avoid_: status bar, overlay UI, GUI (the HUD is one specific surface, not all U
 **CombatSystem**:
 The pure decision functions of combat — the damage formula, the i-frame window check, and
 the death rule — static, deterministic, and clock-free, shared unchanged by the runtime
-controllers and the offline Monte-Carlo balancing sim (gADR-0001). Controllers orchestrate
-(clock, mutation, tween, log); decisions live only here.
+controllers (gADR-0001). For the Balancing pipeline it is the parity fixtures' ground-truth
+oracle — no longer the sim engine (gADR-0011). Controllers orchestrate (clock, mutation,
+tween, log); decisions live only here.
 _Avoid_: damage manager, battle system
 
 **EnemyAI**:
@@ -223,7 +224,7 @@ _Avoid_: TDD (reserved repo-wide for Test-Driven Development); time-to-down
 
 **Tool Script**:
 A reusable Python pipeline script that produces or processes project content — the
-asset pipelines (preprocess → generate → postprocess) and the Balancing pipeline
+asset pipelines (preprocess → acquire → postprocess) and the Balancing pipeline
 alike. Designed game-agnostic — a reusable, input-driven core with per-game
 configuration, with pluggable output emitters (JSON/XML/Resource/…) for reuse
 beyond this demo. In this project its structured output always lands in the JSON

--- a/examples/platformer/panda-adventure/docs/gadr/0000-architecture-design.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0000-architecture-design.md
@@ -33,3 +33,10 @@ a source of truth.
 - A JSON→Resource conversion step (with JSON Schema validation) is required machinery.
 - Drift between JSON and Resource is prevented by treating the Resource strictly as a derived
   output of the authoritative JSON.
+
+> **Clarification (2026-07-06, gADR-0011/0012).** "Not hand-tuned in the editor"
+> means not hand-edited in the **Godot editor** and never authored in `.tres` —
+> the JSON authority stays the only authoring surface. It does not preclude the
+> Panda Adventure Editor's structured hand-tune channel (gADR-0012), which writes
+> that same JSON authority and coexists with the Balancing pipeline under
+> gADR-0011's validate/solve collision rules.

--- a/examples/platformer/panda-adventure/docs/gadr/0001-stats-config-vs-runtime-state.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0001-stats-config-vs-runtime-state.md
@@ -64,3 +64,9 @@ We split three ways:
   not a tunable); S6a adds accumulation without touching the split.
 - In code the EXP field is `exp_points` (`exp` would shadow the built-in
   `exp()`); docs and the glossary keep saying EXP.
+
+> **Amendment (2026-07-06, gADR-0011).** The first consequence is superseded: the
+> Monte-Carlo balancing pipeline is now Python and does not reuse `CombatSystem` +
+> `StatsSystem` directly. The seam's balancing role becomes generating the golden
+> parity fixtures (ground truth, via `gda script run`) that pin the Python model.
+> The static, clock-free decision shape and its testability rationale stand.

--- a/examples/platformer/panda-adventure/docs/gadr/0003-enemy-taxonomy-and-archetype-ai.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0003-enemy-taxonomy-and-archetype-ai.md
@@ -105,3 +105,8 @@ The model:
   block) — the spec derivation and the freshness gate follow the JSON, so a
   kind missing its committed `.tres` (or violating a cross-field rule) fails
   the fast tier, not the runtime.
+
+> **Amendment (2026-07-06, gADR-0011).** The balancing consequence is superseded:
+> the sim no longer reuses `EnemyAI` + `CombatSystem` directly — the Balancing
+> pipeline is Python (gADR-0011), and these seams serve as the ground-truth oracle
+> for its golden parity fixtures instead. Per-kind TTK/TTD knobs stand.

--- a/examples/platformer/panda-adventure/docs/gadr/0011-balancing-pipeline-independence.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0011-balancing-pipeline-independence.md
@@ -1,0 +1,49 @@
+---
+status: accepted
+---
+
+# Balancing pipeline independent of game code: isolation and reuse over code-sharing
+
+Phase 2 builds the Balancing pipeline (Monte-Carlo encounter simulation + a
+system-dynamics model of first-order nonlinear ODEs for long-term balance
+prediction) and uses it for Level 1's initial tune; Phase 3 re-tunes against
+playtest feedback (#325's "re-tune" presupposes this initial tune). The Phase 1
+PRD (#323) had seeded the opposite architecture — "the [pure logic seam is] the
+core reused by the Monte-Carlo balancing sim", i.e. the sim would drive the
+shipped GDScript `CombatSystem`/`EnemyAI` statics headless. This record, settled
+in the 2026-07-06 Phase 2 scoping interview, deliberately deviates from that
+seeded path.
+
+We decide four things:
+
+- **Both engines are Python, fully isolated from game code.** The Monte-Carlo
+  sim and the SD-ODE model live in the game-agnostic Tool Script framework and
+  never import or invoke the game's GDScript. Rationale: isolation and
+  reusability — the pipeline is a first-class reusable process asset (input-driven
+  core, per-game configuration) meant to outlive this demo and apply to other
+  game types, feeding the capstone skill. A hybrid (GDScript MC core driven via
+  `gda script run` + Python orchestration) was considered and rejected: it
+  couples the pipeline to this game's engine and code shape.
+- **The single JSON authority is preserved on both ends.** The pipeline reads
+  the same authoritative JSON configs the game derives its Resources from, and
+  writes tuned numbers back to that JSON; it never bypasses JSON to emit `.tres`
+  directly in this project. The framework's pluggable output emitters
+  (JSON/XML/Resource/…) exist for reuse elsewhere, not as a second authoring
+  path here (gADR-0000 intact).
+- **Rule drift is pinned by golden contract fixtures, not by code reuse.** The
+  known cost of reimplementing game rules in Python is silent divergence. The
+  bridge lives only in tests: golden vectors (attacker/defender params → expected
+  damage, TTK, …) are generated FROM the shipped GDScript logic seams via
+  `gda script run` as ground truth; the Python models' tests consume the same
+  fixtures (configurable tolerance). The parity suite is engine-marked in CI, so
+  a rule change on either side goes red until both sides co-evolve. A pure-Python
+  pipeline without a parity gate was rejected as untrustworthy for tuning.
+- **The logic seam's sim role is repurposed, not deleted.** #323's
+  reuse-the-seam intent survives as the parity fixtures' generator: the pure,
+  clock-free statics remain the ground-truth oracle — they are no longer the sim
+  engine itself.
+
+Consequences: gameplay-rule changes now cost a dual-side update (GDScript +
+Python model), surfaced by parity red rather than discovered at playtest; the
+parity tests require Godot (engine tier, not the fast suite); the pipeline can
+be extracted for other games without dragging engine bindings along.

--- a/examples/platformer/panda-adventure/docs/gadr/0012-panda-adventure-editor.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0012-panda-adventure-editor.md
@@ -1,0 +1,47 @@
+---
+status: accepted
+---
+
+# Panda Adventure Editor: an in-game tool mode writing only the JSON authority
+
+Phase 2's scope adds a visual editor for editing and debugging Level 1's content —
+a component absent from every prior record (#324, gADR-0000…0011). This record
+settles its form, user, scope, and authority discipline, decided in the 2026-07-06
+Phase 2 scoping interview.
+
+We decide five things:
+
+- **Form: an in-game tool mode.** A separate entry scene of the SAME Godot
+  project — launch the game into edit mode — NOT a Godot editor plugin and NOT an
+  external web/GUI tool. Rationale: WYSIWYG comes free through the game's own
+  rendering (View skin, Scale spec, real assets — no second renderer to drift);
+  an editor plugin would put a human inside the Godot editor concurrently with
+  `gda`, exactly the "Concurrent external editor" scenario the parent ADR-0018
+  declines to defend; an in-game mode is just a running game, and its debug half
+  can build on `gda` live ops (dogfooding).
+- **Primary user: a human (HITL).** Level editing, balance debugging, playtest
+  reproduction. Agents keep driving `gda` — the Editor adds no agent surface.
+- **Scope.** Edit: the `Level authority`'s spatial content (platform segments,
+  Arena, backdrop) and the Wave schedule / Spawn rosters by direct manipulation;
+  numbers via structured forms — the hand-tune channel — never free-text JSON.
+  Debug: instant edit↔play switching plus a minimal palette (wave jump, god-mode,
+  spawn-on-demand). Out: asset editing (the Asset pipelines own assets),
+  multi-level management (content is Level 1 only).
+- **One derivation path.** The Editor writes ONLY the JSON authority, then
+  re-derives Resources by invoking the SAME Python builder (`OS.execute`; the
+  Editor is a dev-machine tool, so the Python toolchain is present). A GDScript
+  re-implementation of the JSON→Resource derivation (defaults, reward/drop
+  resolution) was rejected: a second derivation path is the same silent-drift
+  failure gADR-0011 pins on the balancing side.
+- **Two writers, one authority, no silent clobber.** The Editor's hand-tune and
+  the Balancing pipeline write the same JSON authority (git records provenance).
+  The pipeline therefore runs in **validate mode** by default (simulate against
+  TTK/TTD targets, report only, write nothing); its **solve mode** writes numbers
+  only through a diff report plus HITL confirmation — a pipeline run never
+  silently overwrites hand-tuned values.
+
+Consequences: the Editor inherits the game's rendering fidelity for free but is
+coupled to the dev machine for derivation (acceptable: it is a dev tool, not a
+shipped mode); the export pipeline must strip or gate the editor entry scene from
+player builds; playtest-driven numeric feel lands as ordinary JSON diffs the
+balancing pipeline can validate rather than fight.

--- a/examples/platformer/panda-adventure/docs/gadr/0012-panda-adventure-editor.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0012-panda-adventure-editor.md
@@ -5,9 +5,10 @@ status: accepted
 # Panda Adventure Editor: an in-game tool mode writing only the JSON authority
 
 Phase 2's scope adds a visual editor for editing and debugging Level 1's content —
-a component absent from every prior record (#324, gADR-0000…0011). This record
-settles its form, user, scope, and authority discipline, decided in the 2026-07-06
-Phase 2 scoping interview.
+a component absent from every record predating the 2026-07-06 amendment (the
+original #324 scope and gADR-0000…0011); the amended #324 now carries the Editor
+track (stories 25–28). This record settles its form, user, scope, and authority
+discipline, decided in the same 2026-07-06 Phase 2 scoping interview.
 
 We decide five things:
 


### PR DESCRIPTION
## Summary

Records the 2026-07-06 Phase 2 scoping interview (`grill-with-docs`) that aligned the four-track Phase 2 scope — asset/balancing pipelines, Level 1 productionization, and the Panda Adventure Editor — with the amended PRD on #324.

- **GAME-CONTEXT.md**: adds `Tool Script`, `Asset pipeline`, `Scale spec`, `VFX`, `Balancing pipeline`, `Panda Adventure Editor`, `Level 1`, `View skin`; sharpens the player-`Level` disambiguation note.
- **gADR-0011** — Balancing pipeline independent of game code: all-Python twin engines (Monte-Carlo + system-dynamics ODE), JSON authority preserved on both ends, rule drift pinned by golden parity fixtures generated from the GDScript logic seams via `gda script run`.
- **gADR-0012** — Panda Adventure Editor: in-game tool mode (over editor-plugin/web forms), human HITL user, JSON-authority-only writes with a single derivation path through the one Python builder, and validate/solve two-writer collision rules against the balancing pipeline.

The PRD itself was amended in place on #324 (title + body, four tracks / 29 stories); #325 (Phase 3) is untouched — playtest re-tuning stays there.

## Test plan

Docs-only change: no runtime surface. Verified glossary cross-references name existing terms and both gADRs follow the house format (status frontmatter + decision bullets + consequences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)