### PR TITLE
refactor(panda-adventure): centralize derived-.tres loading behind GeneratedConfig (#451)

### DIFF
--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -267,13 +267,16 @@ _Avoid_: particles (an implementation), juice (broader — includes camera/audio
 feel), effects system
 
 **Derived-Resource loader**:
-The single seam every controller loads a derived `.tres` config through — one canonical
-loud guard that returns the loaded Resource or, on a null load, emits the one
+The single seam every static-path derived-`.tres` config load routes through — one
+canonical loud guard that returns the loaded Resource or, on a null load, emits the one
 pipeline-pointing `push_error` (naming the missing path) and returns null. The read-side
 home of gADR-0000's "Resource is a derived artifact" contract: a committed `.tres` is
-expected present, so a null load means a half-checkout or a skipped build, not a gameplay
-condition. Centralizing it leaves one remediation string to update when the builder moves
-(gADR-0011), not one copy per controller.
+promised present, so a null load means a half-checkout or a skipped build, not a gameplay
+condition — one remediation string to update when the builder moves (gADR-0011), not one
+copy per controller. A data-keyed lookup — a path built from authored data, like the wave
+schedule's per-kind EnemyConfig — is deliberately outside the seam: its null means the
+authored data references a kind that does not exist, a reference-integrity fault owned by
+its caller, not a pipeline fault.
 _Avoid_: config loader (generic), resource manager
 
 ### Tooling

--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -266,6 +266,16 @@ mechanic: a VFX carries no gameplay or damage semantics of its own.
 _Avoid_: particles (an implementation), juice (broader — includes camera/audio
 feel), effects system
 
+**Derived-Resource loader**:
+The single seam every controller loads a derived `.tres` config through — one canonical
+loud guard that returns the loaded Resource or, on a null load, emits the one
+pipeline-pointing `push_error` (naming the missing path) and returns null. The read-side
+home of gADR-0000's "Resource is a derived artifact" contract: a committed `.tres` is
+expected present, so a null load means a half-checkout or a skipped build, not a gameplay
+condition. Centralizing it leaves one remediation string to update when the builder moves
+(gADR-0011), not one copy per controller.
+_Avoid_: config loader (generic), resource manager
+
 ### Tooling
 
 **Panda Adventure Editor**:

--- a/examples/platformer/panda-adventure/src/controllers/end_screen_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/end_screen_controller.gd
@@ -22,6 +22,7 @@ extends CanvasLayer
 
 const LevelConfigScript := preload("res://src/resources/level_config.gd")
 const GameLogScript := preload("res://src/util/game_log.gd")
+const GeneratedConfigScript := preload("res://src/util/generated_config.gd")
 
 const LEVEL_CONFIG_PATH := "res://data/generated/level_config.tres"
 
@@ -35,14 +36,8 @@ var _config: LevelConfigScript
 
 
 func _ready() -> void:
-	_config = load(LEVEL_CONFIG_PATH)
+	_config = GeneratedConfigScript.load_config(LEVEL_CONFIG_PATH)
 	if _config == null:
-		# The derived .tres is committed; guard loudly rather than crash,
-		# pointing at the pipeline that regenerates it from JSON.
-		push_error(
-			"EndScreenController: could not load %s — run scripts/build_config.py."
-			% LEVEL_CONFIG_PATH
-		)
 		return
 	# Above the HUD's default layer (structural: the closure overlay outranks
 	# the readout), hidden until an End state shows it.

--- a/examples/platformer/panda-adventure/src/controllers/enemy_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/enemy_controller.gd
@@ -41,6 +41,7 @@ const GravitySystemScript := preload("res://src/systems/gravity_system.gd")
 const GravityConfigScript := preload("res://src/resources/gravity_config.gd")
 const LevelConfigScript := preload("res://src/resources/level_config.gd")
 const GameLogScript := preload("res://src/util/game_log.gd")
+const GeneratedConfigScript := preload("res://src/util/generated_config.gd")
 const EnemyProjectileScene := preload("res://scenes/enemy_projectile.tscn")
 const TimeFieldScene := preload("res://scenes/time_field.tscn")
 
@@ -101,14 +102,13 @@ func setup(kind: EnemyConfigScript) -> void:
 
 
 func _ready() -> void:
-	_combat = load(COMBAT_CONFIG_PATH)
-	if _kind == null or _combat == null:
-		# The derived .tres are committed and the spawner must setup() first;
-		# guard loudly rather than crash, pointing at the pipeline.
-		push_error(
-			"EnemyController: missing kind (setup() before add_child) or %s — run scripts/build_config.py."
-			% COMBAT_CONFIG_PATH
-		)
+	_combat = GeneratedConfigScript.load_config(COMBAT_CONFIG_PATH)
+	if _combat == null:
+		return
+	if _kind == null:
+		# The spawner must setup() before add_child; guard loudly rather than
+		# crash on an enemy that was never handed its kind (not a pipeline fault).
+		push_error("EnemyController: missing kind — setup() must run before add_child.")
 		return
 	# Gravity-response contract (gADR-0002): the S3 Gravity Field acts on this
 	# group via apply_gravity_field.
@@ -267,12 +267,8 @@ func _blink(player: Node2D) -> void:
 ## rampart, never half off the Arena's edge.
 func _arena_bounds() -> Vector2:
 	if _level_config == null:
-		_level_config = load(LEVEL_CONFIG_PATH)
+		_level_config = GeneratedConfigScript.load_config(LEVEL_CONFIG_PATH)
 		if _level_config == null:
-			push_error(
-				"EnemyController: could not load %s — run scripts/build_config.py."
-				% LEVEL_CONFIG_PATH
-			)
 			return Vector2(position.x, position.x)  # degenerate: land in place
 	var half_body := _kind.size.x / 2.0
 	return Vector2(
@@ -293,12 +289,8 @@ func apply_gravity_field(field_velocity: Vector2, _delta: float) -> void:
 ## lazily loaded like the S3 block on the other responders.
 func _gravity_clamp() -> float:
 	if _gravity_config == null:
-		_gravity_config = load(GRAVITY_CONFIG_PATH)
+		_gravity_config = GeneratedConfigScript.load_config(GRAVITY_CONFIG_PATH)
 		if _gravity_config == null:
-			push_error(
-				"EnemyController: could not load %s — run scripts/build_config.py."
-				% GRAVITY_CONFIG_PATH
-			)
 			return 0.0
 	return _gravity_config.enemy_max_gravity_offset
 

--- a/examples/platformer/panda-adventure/src/controllers/gravity_field_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/gravity_field_controller.gd
@@ -25,6 +25,7 @@ extends Area2D
 const GravityConfigScript := preload("res://src/resources/gravity_config.gd")
 const GravitySystemScript := preload("res://src/systems/gravity_system.gd")
 const GameLogScript := preload("res://src/util/game_log.gd")
+const GeneratedConfigScript := preload("res://src/util/generated_config.gd")
 
 const CONFIG_PATH := "res://data/generated/gravity_config.tres"
 
@@ -33,13 +34,8 @@ var _field_velocity := Vector2.ZERO
 
 
 func _ready() -> void:
-	_config = load(CONFIG_PATH)
+	_config = GeneratedConfigScript.load_config(CONFIG_PATH)
 	if _config == null:
-		# The derived .tres is committed; guard loudly rather than crash on a
-		# half-checkout, pointing at the pipeline that regenerates it from JSON.
-		push_error(
-			"GravityFieldController: could not load %s — run scripts/build_config.py." % CONFIG_PATH
-		)
 		queue_free()
 		return
 	_field_velocity = GravitySystemScript.compute_field_velocity(

--- a/examples/platformer/panda-adventure/src/controllers/hud_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/hud_controller.gd
@@ -25,6 +25,7 @@ extends CanvasLayer
 
 const HudConfigScript := preload("res://src/resources/hud_config.gd")
 const GameLogScript := preload("res://src/util/game_log.gd")
+const GeneratedConfigScript := preload("res://src/util/generated_config.gd")
 
 const HUD_CONFIG_PATH := "res://data/generated/hud_config.tres"
 
@@ -78,14 +79,8 @@ static func format_lines(state: Dictionary) -> Dictionary:
 
 
 func _ready() -> void:
-	_config = load(HUD_CONFIG_PATH)
+	_config = GeneratedConfigScript.load_config(HUD_CONFIG_PATH)
 	if _config == null:
-		# The derived .tres is committed; guard loudly rather than crash,
-		# pointing at the pipeline that regenerates it from JSON.
-		push_error(
-			"HudController: could not load %s — run scripts/build_config.py."
-			% HUD_CONFIG_PATH
-		)
 		return
 	($Stats as VBoxContainer).position = _config.margin
 

--- a/examples/platformer/panda-adventure/src/controllers/level_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/level_controller.gd
@@ -41,6 +41,7 @@ const WaveSystemScript := preload("res://src/systems/wave_system.gd")
 const GameStateSystemScript := preload("res://src/systems/game_state_system.gd")
 const EconomySystemScript := preload("res://src/systems/economy_system.gd")
 const GameLogScript := preload("res://src/util/game_log.gd")
+const GeneratedConfigScript := preload("res://src/util/generated_config.gd")
 const EnemyScene := preload("res://scenes/enemy.tscn")
 const PickupScene := preload("res://scenes/pickup.tscn")
 const PlatformScene := preload("res://scenes/platform.tscn")
@@ -74,19 +75,16 @@ var _level_cfg: LevelConfigScript
 
 
 func _ready() -> void:
-	var config: PlayerConfigScript = load(CONFIG_PATH)
+	var config: PlayerConfigScript = GeneratedConfigScript.load_config(CONFIG_PATH)
 	if config == null:
-		push_error(
-			"LevelController: could not load %s — run scripts/build_config.py."
-			% CONFIG_PATH
-		)
 		return
-	_level_cfg = load(LEVEL_CONFIG_PATH)
-	if _level_cfg == null or _level_cfg.platforms.is_empty():
-		push_error(
-			"LevelController: could not load %s (or it has no platforms) — run scripts/build_config.py."
-			% LEVEL_CONFIG_PATH
-		)
+	_level_cfg = GeneratedConfigScript.load_config(LEVEL_CONFIG_PATH)
+	if _level_cfg == null:
+		return
+	if _level_cfg.platforms.is_empty():
+		# Loaded but empty: the JSON source has no platforms — a data fault the
+		# seam's load guard can't see, so guard it here (not a pipeline fault).
+		push_error("LevelController: %s has no platforms." % LEVEL_CONFIG_PATH)
 		return
 	_apply_level(_level_cfg)
 	var player := get_tree().get_first_node_in_group("player")
@@ -94,12 +92,13 @@ func _ready() -> void:
 		# The lose edge (S9, gADR-0010): the Player's S4 death latch now
 		# reports here, folding into the End state exactly once.
 		player.died.connect(_on_player_died)
-	_schedule = load(SCHEDULE_PATH)
-	if _schedule == null or _schedule.waves.is_empty():
-		push_error(
-			"LevelController: could not load %s (or it has no waves) — run scripts/build_config.py."
-			% SCHEDULE_PATH
-		)
+	_schedule = GeneratedConfigScript.load_config(SCHEDULE_PATH)
+	if _schedule == null:
+		return
+	if _schedule.waves.is_empty():
+		# Loaded but empty: the JSON source has no waves — a data fault the seam's
+		# load guard can't see, so guard it here (not a pipeline fault).
+		push_error("LevelController: %s has no waves." % SCHEDULE_PATH)
 		return
 	_start_wave(0)
 
@@ -266,12 +265,7 @@ func _spawn_drops(kind: EnemyConfigScript, source_name: String, death_position: 
 ## (the S3 GravityConfig pattern) so _ready's load block stays untouched.
 func _progression_config() -> ProgressionConfigScript:
 	if _progression_cfg == null:
-		_progression_cfg = load(PROGRESSION_CONFIG_PATH)
-		if _progression_cfg == null:
-			push_error(
-				"LevelController: could not load %s — run scripts/build_config.py."
-				% PROGRESSION_CONFIG_PATH
-			)
+		_progression_cfg = GeneratedConfigScript.load_config(PROGRESSION_CONFIG_PATH)
 	return _progression_cfg
 
 

--- a/examples/platformer/panda-adventure/src/controllers/level_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/level_controller.gd
@@ -168,6 +168,9 @@ func _start_wave(index: int) -> void:
 	var wave: Dictionary = _schedule.waves[index]
 	var spawns: Array = wave["spawns"]
 	for spawn: Dictionary in spawns:
+		# Deliberately NOT routed through the Derived-Resource loader: a
+		# data-keyed reference-integrity lookup — null means the schedule names
+		# an unknown kind (fix the schedule), not a pipeline fault.
 		var kind: EnemyConfigScript = load(ENEMY_KIND_TRES % spawn["kind"])
 		if kind == null:
 			push_error(

--- a/examples/platformer/panda-adventure/src/controllers/obstacle_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/obstacle_controller.gd
@@ -15,6 +15,7 @@ extends StaticBody2D
 const GravityConfigScript := preload("res://src/resources/gravity_config.gd")
 const GravitySystemScript := preload("res://src/systems/gravity_system.gd")
 const GameLogScript := preload("res://src/util/game_log.gd")
+const GeneratedConfigScript := preload("res://src/util/generated_config.gd")
 
 const CONFIG_PATH := "res://data/generated/gravity_config.tres"
 
@@ -25,13 +26,8 @@ var _gravity_offset := Vector2.ZERO
 
 
 func _ready() -> void:
-	_config = load(CONFIG_PATH)
+	_config = GeneratedConfigScript.load_config(CONFIG_PATH)
 	if _config == null:
-		# The derived .tres is committed; guard loudly rather than crash on a
-		# half-checkout, pointing at the pipeline that regenerates it from JSON.
-		push_error(
-			"ObstacleController: could not load %s — run scripts/build_config.py." % CONFIG_PATH
-		)
 		return
 	position = _config.obstacle_position
 	_apply_blockout(_config)

--- a/examples/platformer/panda-adventure/src/controllers/pickup_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/pickup_controller.gd
@@ -22,6 +22,7 @@ extends Area2D
 
 const ProgressionConfigScript := preload("res://src/resources/progression_config.gd")
 const GameLogScript := preload("res://src/util/game_log.gd")
+const GeneratedConfigScript := preload("res://src/util/generated_config.gd")
 
 const PROGRESSION_CONFIG_PATH := "res://data/generated/progression_config.tres"
 
@@ -41,14 +42,13 @@ func setup(item: String, amount: int) -> void:
 
 
 func _ready() -> void:
-	_config = load(PROGRESSION_CONFIG_PATH)
-	if _config == null or _item.is_empty():
-		# The derived .tres is committed and the spawner must setup() first;
-		# guard loudly rather than crash, pointing at the pipeline.
-		push_error(
-			"PickupController: missing drop (setup() before add_child) or %s — run scripts/build_config.py."
-			% PROGRESSION_CONFIG_PATH
-		)
+	_config = GeneratedConfigScript.load_config(PROGRESSION_CONFIG_PATH)
+	if _config == null:
+		return
+	if _item.is_empty():
+		# The spawner must setup() before add_child; guard loudly rather than
+		# crash on a drop that was never injected (not a pipeline fault).
+		push_error("PickupController: missing drop — setup() must run before add_child.")
 		return
 	_apply_blockout()
 	body_entered.connect(_on_body_entered)

--- a/examples/platformer/panda-adventure/src/controllers/player_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/player_controller.gd
@@ -40,6 +40,7 @@ const CombatConfigScript := preload("res://src/resources/combat_config.gd")
 const StatsSystemScript := preload("res://src/systems/stats_system.gd")
 const CombatSystemScript := preload("res://src/systems/combat_system.gd")
 const GameLogScript := preload("res://src/util/game_log.gd")
+const GeneratedConfigScript := preload("res://src/util/generated_config.gd")
 const ProjectileScene := preload("res://scenes/projectile.tscn")
 
 const CONFIG_PATH := "res://data/generated/player_config.tres"
@@ -116,16 +117,10 @@ static func compute_facing(facing: float, input_dir: float) -> float:
 
 
 func _ready() -> void:
-	_config = load(CONFIG_PATH)
-	_stats_config = load(STATS_PATH)
-	_combat = load(COMBAT_CONFIG_PATH)
+	_config = GeneratedConfigScript.load_config(CONFIG_PATH)
+	_stats_config = GeneratedConfigScript.load_config(STATS_PATH)
+	_combat = GeneratedConfigScript.load_config(COMBAT_CONFIG_PATH)
 	if _config == null or _stats_config == null or _combat == null:
-		# The derived .tres are committed; guard loudly rather than crash on a
-		# half-checkout, pointing at the pipeline that regenerates them from JSON.
-		push_error(
-			"PlayerController: could not load %s / %s / %s — run scripts/build_config.py."
-			% [CONFIG_PATH, STATS_PATH, COMBAT_CONFIG_PATH]
-		)
 		return
 	# S4: enemies find their target by this group (EnemyController._player).
 	add_to_group("player")
@@ -378,12 +373,7 @@ func _drink_wine() -> void:
 ## S2 _ready block stays untouched.
 func _gravity_config() -> GravityConfigScript:
 	if _gravity_cfg == null:
-		_gravity_cfg = load(GRAVITY_CONFIG_PATH)
-		if _gravity_cfg == null:
-			push_error(
-				"PlayerController: could not load %s — run scripts/build_config.py."
-				% GRAVITY_CONFIG_PATH
-			)
+		_gravity_cfg = GeneratedConfigScript.load_config(GRAVITY_CONFIG_PATH)
 	return _gravity_cfg
 
 
@@ -527,12 +517,7 @@ func _play_level_up_flash() -> void:
 ## so the S2 _ready block stays untouched (the S3 GravityConfig pattern).
 func _progression_config() -> ProgressionConfigScript:
 	if _progression_cfg == null:
-		_progression_cfg = load(PROGRESSION_CONFIG_PATH)
-		if _progression_cfg == null:
-			push_error(
-				"PlayerController: could not load %s — run scripts/build_config.py."
-				% PROGRESSION_CONFIG_PATH
-			)
+		_progression_cfg = GeneratedConfigScript.load_config(PROGRESSION_CONFIG_PATH)
 	return _progression_cfg
 
 
@@ -637,10 +622,5 @@ func _play_consume_flash(flash_color: Color) -> void:
 ## S2 _ready block stays untouched (the S3 GravityConfig pattern).
 func _items_config() -> ItemsConfigScript:
 	if _items_cfg == null:
-		_items_cfg = load(ITEMS_CONFIG_PATH)
-		if _items_cfg == null:
-			push_error(
-				"PlayerController: could not load %s — run scripts/build_config.py."
-				% ITEMS_CONFIG_PATH
-			)
+		_items_cfg = GeneratedConfigScript.load_config(ITEMS_CONFIG_PATH)
 	return _items_cfg

--- a/examples/platformer/panda-adventure/src/controllers/projectile_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/projectile_controller.gd
@@ -24,6 +24,7 @@ extends Area2D
 
 const StatsConfigScript := preload("res://src/resources/stats_config.gd")
 const CombatConfigScript := preload("res://src/resources/combat_config.gd")
+const GeneratedConfigScript := preload("res://src/util/generated_config.gd")
 
 const CONFIG_PATH := "res://data/generated/combat_config.tres"
 
@@ -60,14 +61,8 @@ func configure(color: Color, size: Vector2, speed: float, lifetime: float) -> vo
 
 func _ready() -> void:
 	if not _configured:
-		var config: CombatConfigScript = load(CONFIG_PATH)
+		var config: CombatConfigScript = GeneratedConfigScript.load_config(CONFIG_PATH)
 		if config == null:
-			# The derived .tres is committed; guard loudly rather than crash on a
-			# half-checkout, pointing at the pipeline that regenerates it from JSON.
-			push_error(
-				"ProjectileController: could not load %s — run scripts/build_config.py."
-				% CONFIG_PATH
-			)
 			queue_free()
 			return
 		configure(

--- a/examples/platformer/panda-adventure/src/util/generated_config.gd
+++ b/examples/platformer/panda-adventure/src/util/generated_config.gd
@@ -1,0 +1,24 @@
+class_name GeneratedConfig
+extends RefCounted
+
+## The single seam for loading a derived .tres config (gADR-0000: a Resource is a
+## derived artifact, regenerated from JSON by scripts/build_config.py). Every
+## controller routes its config load through here, so the loud guard and the
+## pipeline-pointing remediation live in ONE place instead of duplicated across
+## the controllers — one string to update when the builder moves (gADR-0011),
+## and the read-side home of gADR-0000's "Resource is a derived artifact" contract.
+##
+## Returns the loaded Resource, or null after emitting the ONE canonical
+## push_error naming the missing path. A committed .tres is expected to be
+## present, so a null load means a half-checkout or a skipped build, not a
+## gameplay condition. Callers keep their typed config vars and null-guard the
+## return (behavior identical to the old inline load-then-guard idiom).
+
+
+static func load_config(path: String) -> Resource:
+	var config: Resource = load(path)
+	if config == null:
+		# The derived .tres is committed; guard loudly rather than crash on a
+		# half-checkout, pointing at the pipeline that regenerates it from JSON.
+		push_error("GeneratedConfig: could not load %s — run scripts/build_config.py." % path)
+	return config


### PR DESCRIPTION
## Summary

Every controller loaded its derived `.tres` config with a duplicated load-then-loud-guard idiom — 20 `load()` sites, 6 near-identical lazy loaders, and 17 verbatim copies of the `run scripts/build_config.py.` remediation string across 9 controllers.

This introduces ONE seam, `src/util/generated_config.gd`, mirroring the `game_log.gd` static-util idiom:

- `GeneratedConfig.load_config(path: String) -> Resource` returns the loaded resource, or emits the ONE canonical `push_error` naming the missing path (`run scripts/build_config.py.` remediation byte-preserved) and returns `null`.
- Every controller config load — eager `_ready` loads AND lazy loaders — routes through it. Lazy loaders collapse to a cached call; controllers keep their typed `_config` variables and null-guards on the return.
- The remediation string now lives in ONE place — the read-side home of gADR-0000's "Resource is a derived artifact" contract — so the pipeline pointer is one string to update when the builder generalizes into the Tool Script pipeline (gADR-0011 / #439), not 17.

Compound guards that combined a load-null check with a distinct condition are split so the load routes through the seam and the non-load condition keeps its own loud guard (with a message that no longer carries the now-inapplicable pipeline pointer):

- Player's three-config `_ready` guard → three `load_config` calls + the combined null-guard.
- Level's empty-platforms / empty-waves → seam load, then a separate emptiness guard.
- Pickup / Enemy's `setup()`-ordering (missing drop / missing kind) → seam load, then a separate setup-ordering guard.

**Deliberately kept raw:** Level's per-kind wave-schedule lookup (`load(ENEMY_KIND_TRES % ...)`) stays a raw `load()`. Its `unknown enemy kind '%s' in wave %d` guard is a wave-schedule reference-integrity check (`continue`, not `return`; remediation = fix the schedule, not `build_config`) — not the derived-config loud-guard idiom, and it carries none of the remediation string. Routing it through the seam would attach a semantically wrong `build_config` pointer and double-log in the corrupt-schedule path.

Behavior-preserving: no gameplay change. The loaded `.tres` files, load order, and null-handling semantics are identical; only degenerate-path (never-tested) error message wording changes. Added a `Derived-Resource loader` glossary entry to `GAME-CONTEXT.md` (Pipelines section). No gADR — this centralizes an existing gADR-0000 contract.

`grep -rn "run scripts/build_config" src/controllers/` → zero hits (the string now lives only in the seam).

## Test plan

- Fast suite: `uv run pytest examples/platformer/panda-adventure/tests -m "not e2e" -q` → **296 passed, 16 deselected**
- Targeted e2e (serial, real Godot): `uv run pytest tests/test_level_e2e.py tests/test_boss_e2e.py -q` → **3 passed**
- `grep -rn "run scripts/build_config" src/controllers/` → **0 hits**

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)