### PR TITLE
[Panda Adventure] P2-R1: Extract the Warp driver from enemy_controller (#452)

### DIFF
--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -100,6 +100,15 @@ gravity, the Boss bends time.
 _Avoid_: slow zone (generic), stun/root/freeze (input still registers — the body is slowed,
 not locked), aura (it does not follow the Boss)
 
+**Warp driver**:
+The enemy-owned module that drives the Warp rotation — the three-phase (tell → blink → recovery)
+orchestration state machine wrapped around the pure `WarpSystem` decisions (the gate and the
+far-side landing formula). It reads the clock, stamps the cooldown, runs the phases, tweens,
+logs, relocates the Boss, and drops the Time Dilation Field; the single hook home the Boss's
+animation and VFX edges attach to, exposing a public phase read instead of `_physics_process`
+internals.
+_Avoid_: warp system (the pure statics it calls), warp AI (it is orchestration, not decision)
+
 ### Weapons
 
 **Laser Gun**:

--- a/examples/platformer/panda-adventure/src/controllers/enemy_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/enemy_controller.gd
@@ -36,18 +36,15 @@ const CombatConfigScript := preload("res://src/resources/combat_config.gd")
 const StatsSystemScript := preload("res://src/systems/stats_system.gd")
 const CombatSystemScript := preload("res://src/systems/combat_system.gd")
 const EnemyAIScript := preload("res://src/systems/enemy_ai.gd")
-const WarpSystemScript := preload("res://src/systems/warp_system.gd")
 const GravitySystemScript := preload("res://src/systems/gravity_system.gd")
 const GravityConfigScript := preload("res://src/resources/gravity_config.gd")
-const LevelConfigScript := preload("res://src/resources/level_config.gd")
 const GameLogScript := preload("res://src/util/game_log.gd")
 const GeneratedConfigScript := preload("res://src/util/generated_config.gd")
+const EnemyWarpDriverScript := preload("res://src/controllers/enemy_warp_driver.gd")
 const EnemyProjectileScene := preload("res://scenes/enemy_projectile.tscn")
-const TimeFieldScene := preload("res://scenes/time_field.tscn")
 
 const COMBAT_CONFIG_PATH := "res://data/generated/combat_config.tres"
 const GRAVITY_CONFIG_PATH := "res://data/generated/gravity_config.tres"
-const LEVEL_CONFIG_PATH := "res://data/generated/level_config.tres"
 
 var _kind: EnemyConfigScript
 var _combat: CombatConfigScript
@@ -76,23 +73,16 @@ var _suspended := false
 # The derived GravityConfig, lazily loaded (load() is cached) so the gravity
 # block stays independent of _ready (the S3 pattern).
 var _gravity_config: GravityConfigScript
-# S8 Warp rotation state (gADR-0009). When this enemy last STARTED a warp
-# (-INF = never, the is_attack_ready sentinel: the first warp is gated by
-# distance alone); the current phase ("" = none, "tell", "recovery") and when
-# it ends. Phases suspend steering and attack — the tell is the telegraph,
-# the recovery is the fair-exchange window.
-var _last_warp_time := -INF
-var _warp_phase := ""
-var _warp_phase_until := 0.0
-# The spawn-telegraph numbers, cached from play_spawn_tween so the blink can
-# replay the SAME rematerialize squash at its landing (the schedule owns
-# them, gADR-0005 — an enemy spawned outside the wave system just skips it).
+# The Warp driver (S8, gADR-0009): the enemy-owned three-phase (tell -> blink ->
+# recovery) rotation state machine. Constructed for every kind; a kind without
+# the Warp kit never opens its gate, so it stays inert. Holds the warp state and
+# the four rotation methods that used to interleave this _physics_process.
+var _warp: EnemyWarpDriverScript
+# The spawn-telegraph numbers, cached from play_spawn_tween so the Warp driver's
+# blink can replay the SAME rematerialize squash at its landing (the schedule
+# owns them, gADR-0005 — an enemy spawned outside the wave system just skips it).
 var _spawn_squash := Vector2.ONE
 var _spawn_tween_duration := 0.0
-# The derived LevelConfig (the level authority: the authored Arena interval,
-# gADR-0010 — was the PlayerConfig platform extent until S9), lazily loaded
-# for the landing's arena clamp.
-var _level_config: LevelConfigScript
 
 
 ## Hand this enemy its Enemy Kind. Called by the spawner BEFORE add_child, so
@@ -115,6 +105,7 @@ func _ready() -> void:
 	add_to_group("gravity_affectable")
 	_stats = StatsSystemScript.new()
 	_stats.init_from(_kind)
+	_warp = EnemyWarpDriverScript.new(self)
 	_apply_blockout(_kind)
 	GameLogScript.emit("info", "enemy_ready", {
 		"max_hp": _kind.max_hp,
@@ -166,13 +157,10 @@ func _physics_process(delta: float) -> void:
 	# and attack (vertical settling only); otherwise the pure gate may open a
 	# new cast. Gravity Fields still act above — a suspension mid-tell moves
 	# the Boss, never cancels the warp.
-	if _warp_phase != "":
-		_warp_tick(delta, player)
+	if _warp.is_active():
+		_warp.tick(delta, player)
 		return
-	if player != null and WarpSystemScript.should_warp(
-		position, player.position, _kind, _last_warp_time, _now()
-	):
-		_begin_warp_tell()
+	if _warp.try_begin(player):
 		return
 	var move_dir := 0.0
 	if player != null:
@@ -192,89 +180,6 @@ func _physics_process(delta: float) -> void:
 		position, player.position, _kind, _last_attack_time, _now()
 	):
 		_attack(player)
-
-
-## Start the Warp tell (gADR-0009): stamp the cooldown at the DECISION moment
-## (the cooldown spans the whole rotation), telegraph with a charge-shrink
-## tween toward the spawn squash, and suspend normal AI until the tell ends.
-func _begin_warp_tell() -> void:
-	_last_warp_time = _now()
-	_warp_phase = "tell"
-	_warp_phase_until = _now() + _kind.warp_tell_duration
-	velocity = Vector2.ZERO
-	GameLogScript.emit("info", "warp_tell", {"x": position.x, "y": position.y})
-	var visual := $Visual as ColorRect
-	var tween := create_tween()
-	tween.tween_property(visual, "scale", _spawn_squash, _kind.warp_tell_duration)
-
-
-## Advance the in-flight Warp phase each physics frame: hold (with vertical
-## settling only — a blink may land above the platform) until the phase ends,
-## then tell -> blink + field drop, recovery -> normal AI resumes next frame.
-func _warp_tick(delta: float, player: Node2D) -> void:
-	velocity.x = 0.0
-	if is_on_floor():
-		if velocity.y > 0.0:
-			velocity.y = 0.0
-	else:
-		velocity.y += _kind.gravity * delta
-		if velocity.y > _kind.max_fall_speed:
-			velocity.y = _kind.max_fall_speed
-	move_and_slide()
-	if _now() < _warp_phase_until:
-		return
-	if _warp_phase == "tell":
-		_blink(player)
-	else:
-		_warp_phase = ""
-
-
-## The blink itself: relocate to the pure far-side landing, drop the Time
-## Dilation Field there at the SAME instant (the zone is the warp's wake,
-## gADR-0009), replay the spawn squash as the rematerialize telegraph, and
-## enter the no-attack recovery window. A Player gone from the tree (never in
-## Phase 1 — death latches, the node stays) just cancels the cast.
-func _blink(player: Node2D) -> void:
-	if player == null:
-		_warp_phase = ""
-		($Visual as ColorRect).scale = Vector2.ONE
-		return
-	var bounds := _arena_bounds()
-	var landing := WarpSystemScript.warp_landing(
-		position, player.position, _kind, bounds.x, bounds.y
-	)
-	GameLogScript.emit("info", "warp_blink", {
-		"from_x": position.x,
-		"from_y": position.y,
-		"to_x": landing.x,
-		"to_y": landing.y,
-	})
-	position = landing
-	velocity = Vector2.ZERO
-	var field := TimeFieldScene.instantiate()
-	field.configure(_kind)
-	field.position = landing
-	get_parent().add_child(field)
-	play_spawn_tween(_spawn_squash, _spawn_tween_duration)
-	_warp_phase = "recovery"
-	_warp_phase_until = _now() + _kind.warp_recovery_duration
-
-
-## The landing clamp's x range (min, max): the authored Arena interval — the
-## level authority's arena_min_x/arena_max_x (gADR-0010, replacing the S8
-## platform-extent derivation: a multi-segment Great Wall has no single
-## extent) — inset by half this kind's width so the body lands ON the
-## rampart, never half off the Arena's edge.
-func _arena_bounds() -> Vector2:
-	if _level_config == null:
-		_level_config = GeneratedConfigScript.load_config(LEVEL_CONFIG_PATH)
-		if _level_config == null:
-			return Vector2(position.x, position.x)  # degenerate: land in place
-	var half_body := _kind.size.x / 2.0
-	return Vector2(
-		_level_config.arena_min_x + half_body,
-		_level_config.arena_max_x - half_body
-	)
 
 
 ## Gravity-response contract (gADR-0002, owned and documented by S3): buffer a

--- a/examples/platformer/panda-adventure/src/controllers/enemy_warp_driver.gd
+++ b/examples/platformer/panda-adventure/src/controllers/enemy_warp_driver.gd
@@ -1,0 +1,164 @@
+class_name EnemyWarpDriver
+extends RefCounted
+
+## Drives one enemy's Warp rotation (S8, gADR-0009): the three-phase
+## (tell -> blink -> recovery) orchestration state machine, extracted from
+## EnemyController so the Boss animation (P2-S6) and warp VFX (P2-S7) hook ONE
+## home with a public phase() read instead of reaching into _physics_process.
+##
+## Decisions stay PURE in WarpSystem (the gate and the far-side landing formula,
+## gADR-0009 — untouched): this driver only ORCHESTRATES node ops through its
+## owning EnemyController — reads the real clock, stamps the cooldown, runs the
+## tell/recovery phases, tweens, logs, relocates the body, and drops the Time
+## Dilation Field. The spawn-telegraph numbers it replays at the landing are
+## SHARED with the non-warp spawn telegraph, so they live on the enemy and are
+## read back through the owner (play_spawn_tween / the cached squash).
+##
+## The owner reference is untyped on purpose: typing it as EnemyController would
+## preload back into the controller that preloads this driver (a cycle), and the
+## driver only needs the enemy's CharacterBody2D surface (position/velocity/
+## move_and_slide/is_on_floor/create_tween/get_parent/get_node) plus a few enemy
+## members (_kind, _now, _spawn_squash, play_spawn_tween). A kind without the
+## Warp kit (WarpSystem.has_warp false) never opens the gate, so the driver stays
+## inert — try_begin always returns false and no phase ever runs.
+
+const WarpSystemScript := preload("res://src/systems/warp_system.gd")
+const LevelConfigScript := preload("res://src/resources/level_config.gd")
+const GeneratedConfigScript := preload("res://src/util/generated_config.gd")
+const GameLogScript := preload("res://src/util/game_log.gd")
+const TimeFieldScene := preload("res://scenes/time_field.tscn")
+
+const LEVEL_CONFIG_PATH := "res://data/generated/level_config.tres"
+
+# The owning enemy (an EnemyController / CharacterBody2D); see the header for why
+# it is untyped.
+var _enemy
+
+# When this enemy last STARTED a warp (-INF = never, the is_attack_ready
+# sentinel: the first warp is gated by distance alone); the current phase
+# ("" = none, "tell", "recovery") and when it ends. Phases suspend steering and
+# attack — the tell is the telegraph, the recovery is the fair-exchange window.
+var _last_warp_time := -INF
+var _phase := ""
+var _phase_until := 0.0
+
+# The derived LevelConfig (the level authority: the authored Arena interval,
+# gADR-0010 — was the PlayerConfig platform extent until S9), lazily loaded for
+# the landing's arena clamp.
+var _level_config: LevelConfigScript
+
+
+func _init(enemy) -> void:
+	_enemy = enemy
+
+
+## Whether a Warp phase is currently in flight (its steering/attack suspension is
+## active). The public read the animation and VFX edges hook.
+func is_active() -> bool:
+	return _phase != ""
+
+
+## The current Warp phase: "" (none), "tell", or "recovery".
+func phase() -> String:
+	return _phase
+
+
+## Open the Warp gate if the pure decision allows it (WarpSystem.should_warp:
+## has-kit, inside Aggro but outside the trigger range, cooldown elapsed). Begins
+## the tell and returns true when a new cast starts; false otherwise (no player,
+## no kit, or gate closed). Called from the enemy's AI path once no phase is in
+## flight.
+func try_begin(player: Node2D) -> bool:
+	if player == null:
+		return false
+	if not WarpSystemScript.should_warp(
+		_enemy.position, player.position, _enemy._kind, _last_warp_time, _enemy._now()
+	):
+		return false
+	_begin_tell()
+	return true
+
+
+## Advance the in-flight Warp phase each physics frame: hold (with vertical
+## settling only — a blink may land above the platform) until the phase ends,
+## then tell -> blink + field drop, recovery -> normal AI resumes next frame.
+func tick(delta: float, player: Node2D) -> void:
+	var velocity: Vector2 = _enemy.velocity
+	velocity.x = 0.0
+	if _enemy.is_on_floor():
+		if velocity.y > 0.0:
+			velocity.y = 0.0
+	else:
+		velocity.y += _enemy._kind.gravity * delta
+		if velocity.y > _enemy._kind.max_fall_speed:
+			velocity.y = _enemy._kind.max_fall_speed
+	_enemy.velocity = velocity
+	_enemy.move_and_slide()
+	if _enemy._now() < _phase_until:
+		return
+	if _phase == "tell":
+		_blink(player)
+	else:
+		_phase = ""
+
+
+## Start the Warp tell (gADR-0009): stamp the cooldown at the DECISION moment
+## (the cooldown spans the whole rotation), telegraph with a charge-shrink tween
+## toward the spawn squash, and suspend normal AI until the tell ends.
+func _begin_tell() -> void:
+	_last_warp_time = _enemy._now()
+	_phase = "tell"
+	_phase_until = _enemy._now() + _enemy._kind.warp_tell_duration
+	_enemy.velocity = Vector2.ZERO
+	GameLogScript.emit("info", "warp_tell", {"x": _enemy.position.x, "y": _enemy.position.y})
+	var visual := _enemy.get_node("Visual") as ColorRect
+	var tween: Tween = _enemy.create_tween()
+	tween.tween_property(visual, "scale", _enemy._spawn_squash, _enemy._kind.warp_tell_duration)
+
+
+## The blink itself: relocate to the pure far-side landing, drop the Time
+## Dilation Field there at the SAME instant (the zone is the warp's wake,
+## gADR-0009), replay the spawn squash as the rematerialize telegraph, and enter
+## the no-attack recovery window. A Player gone from the tree (never in Phase 1 —
+## death latches, the node stays) just cancels the cast.
+func _blink(player: Node2D) -> void:
+	if player == null:
+		_phase = ""
+		(_enemy.get_node("Visual") as ColorRect).scale = Vector2.ONE
+		return
+	var bounds := _arena_bounds()
+	var landing := WarpSystemScript.warp_landing(
+		_enemy.position, player.position, _enemy._kind, bounds.x, bounds.y
+	)
+	GameLogScript.emit("info", "warp_blink", {
+		"from_x": _enemy.position.x,
+		"from_y": _enemy.position.y,
+		"to_x": landing.x,
+		"to_y": landing.y,
+	})
+	_enemy.position = landing
+	_enemy.velocity = Vector2.ZERO
+	var field := TimeFieldScene.instantiate()
+	field.configure(_enemy._kind)
+	field.position = landing
+	_enemy.get_parent().add_child(field)
+	_enemy.play_spawn_tween(_enemy._spawn_squash, _enemy._spawn_tween_duration)
+	_phase = "recovery"
+	_phase_until = _enemy._now() + _enemy._kind.warp_recovery_duration
+
+
+## The landing clamp's x range (min, max): the authored Arena interval — the
+## level authority's arena_min_x/arena_max_x (gADR-0010, replacing the S8
+## platform-extent derivation: a multi-segment Great Wall has no single extent) —
+## inset by half this kind's width so the body lands ON the rampart, never half
+## off the Arena's edge.
+func _arena_bounds() -> Vector2:
+	if _level_config == null:
+		_level_config = GeneratedConfigScript.load_config(LEVEL_CONFIG_PATH)
+		if _level_config == null:
+			return Vector2(_enemy.position.x, _enemy.position.x)  # degenerate: land in place
+	var half_body: float = _enemy._kind.size.x / 2.0
+	return Vector2(
+		_level_config.arena_min_x + half_body,
+		_level_config.arena_max_x - half_body
+	)


### PR DESCRIPTION
## Summary

Extracts the Boss's **Warp rotation** — the three-phase (tell → blink → recovery) orchestration state machine (S8, gADR-0009) — out of `enemy_controller.gd`'s `_physics_process` into a new enemy-owned **Warp driver** module, so P2-S6 (#447 boss animation) and P2-S7 (#448 warp VFX) later hook ONE home with a public `phase()` read instead of reaching into physics-frame internals.

- **New `src/controllers/enemy_warp_driver.gd`** (`RefCounted`, constructed by the enemy with an untyped owner back-reference to avoid a circular preload) holds the warp-only state (`_last_warp_time`, `_phase`, `_phase_until`, the lazy `_level_config`) and the four relocated methods (`_begin_tell` / `tick` / `_blink` / `_arena_bounds`) behind a small surface: `is_active()` / `phase()` / `try_begin(player)` / `tick(delta, player)`.
- **`_physics_process` shrinks** to the two-branch delegation (`is_active` → `tick`, else `try_begin`), preserving the explanatory suspension-ordering comment.
- The **shared** spawn-telegraph numbers (`_spawn_squash` / `_spawn_tween_duration`, also fed by the non-warp spawn telegraph via `play_spawn_tween`) stay on the enemy and are read back through the owner.
- `WarpSystem` and its logic-seam tests are **untouched** — pure decisions (the gate, the far-side landing formula) stay there per gADR-0009.
- Glossary: adds a **Warp driver** entry to `GAME-CONTEXT.md` (Boss abilities). No gADR — gADR-0009's design is unchanged.

### Invariants preserved verbatim (test-pinned)

- Gravity-field suspension still acts **ABOVE** the warp branches (a suspension mid-tell moves the Boss, never cancels the warp).
- An in-flight phase suspends steering/attack and returns before the AI path; the `should_warp` gate opens only when no phase is in flight.
- Observable log sequence `warp_tell → warp_blink(from→to) → player_time_dilated → …release`, the deterministic landing formula, and **exactly one** `warp_blink` record per rotation — all byte-compatible (emit points moved with the code).
- Non-boss kinds keep the zero-cost path (`has_warp` false ⇒ the driver stays inert).

## Test plan

- Fast suite: `uv run pytest examples/platformer/panda-adventure/tests -m "not e2e" -q` → **296 passed, 16 deselected**.
- Targeted e2e (foreground, serial): `test_boss_e2e.py` (warp sequence, landing formula, single-blink) + `test_gravity_e2e.py` (suspension-above-warp ordering) + `test_level_e2e.py` (full playthrough through the Boss wave) → **4 passed**.
- GDScript parse gate on both touched controllers → clean.

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)