### PR TITLE
[Panda Adventure] P2-R2: Extract the Game-flow director from level_controller (#453)

### DIFF
--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -489,6 +489,17 @@ re-derives from config — a fresh run, never an in-place respawn (gADR-0010).
 _Avoid_: respawn (the rejected in-place variant), restart level (the demo is a
 single level)
 
+**Game-flow director**:
+The level-owned module holding the `End state`'s consequences — the `World
+freeze`, the `End screen` reveal, the verdict logs (`game_won`/`game_lost`), and
+`Retry` — around the pure GameStateSystem's decisions. Extracted from the
+LevelController so geometry and the Wave director stay that node's job (#453),
+it is the one seam the P2-S10 game shell extends: pause is a sibling of the World
+freeze, quit-to-title a sibling of Retry. Carries gADR-0010's never-a-tree-pause
+invariant.
+_Avoid_: game manager (the global-singleton connotation), state machine (that
+names the pure GameStateSystem)
+
 <!-- Format reminder — **Term**: one/two-sentence definition (what it IS, not what it does);
      _Avoid_: rejected synonyms. Group natural clusters under ### subheadings. -->
 

--- a/examples/platformer/panda-adventure/src/controllers/game_flow_director.gd
+++ b/examples/platformer/panda-adventure/src/controllers/game_flow_director.gd
@@ -1,0 +1,127 @@
+class_name GameFlowDirector
+extends RefCounted
+
+## Owns the run's End state (S9, gADR-0010), extracted from LevelController so
+## the P2-S10 game shell (#449) extends ONE seam: pause is a sibling of the
+## World freeze, quit-to-title a sibling of Retry. The level keeps the geometry
+## and the Wave director (its primary job) and forwards the two upstream edges;
+## the game-flow consequences — the World freeze, the End screen reveal, the
+## verdict log, and Retry — live here.
+##
+## Decisions stay PURE in GameStateSystem (the first-transition latch, gADR-0010
+## — untouched): this director only ORCHESTRATES: it folds each edge through the
+## pure state machine, logs the verdict exactly once, freezes the world at a
+## frame boundary, reveals the End screen, and serves the retry poll. The
+## verdict facts (the won run's wave total, the lost run's current wave) are
+## Wave-director facts, so the level passes them IN through the edges rather than
+## this director reaching across into the Wave director's private schedule.
+##
+## The owner reference is untyped on purpose (the EnemyWarpDriver precedent):
+## typing it as LevelController would preload back into the controller that
+## preloads this director (a cycle), and this project has no editor-generated
+## global_script_class_cache, so a bare LevelController type name would not
+## resolve in a headless runtime. The director only needs the level's Node2D/
+## SceneTree surface — get_children() (the World freeze), get_node_or_null()
+## (the "EndScreen" overlay), and get_tree().reload_current_scene() (Retry).
+
+const GameStateSystemScript := preload("res://src/systems/game_state_system.gd")
+const GameLogScript := preload("res://src/util/game_log.gd")
+
+# The owning level (a LevelController / Node2D); see the header for why it is
+# untyped.
+var _level
+
+# The run's game-flow state (gADR-0010): playing until the schedule clears (won)
+# or the Player dies (lost). The pure GameStateSystem owns the transitions, this
+# director owns the consequences. Runtime state; a Retry reload resets it by
+# constructing a fresh director.
+var _state := GameStateSystemScript.STATE_PLAYING
+
+
+func _init(level) -> void:
+	_level = level
+
+
+## The lose edge: the Player's S4 death latch fired (exactly once). `wave` is the
+## 1-based wave the death happened on (the game_lost verdict field).
+func on_player_died(wave: int) -> void:
+	_enter_end_state(GameStateSystemScript.EVENT_PLAYER_DIED, {"wave": wave})
+
+
+## The win edge: the SCHEDULE cleared — never "the Boss died"; the Boss slot
+## stays demo composition (gADR-0005). `total_waves` is the schedule's wave count
+## (the game_won verdict field).
+func on_all_waves_cleared(total_waves: int) -> void:
+	_enter_end_state(
+		GameStateSystemScript.EVENT_ALL_WAVES_CLEARED, {"waves": total_waves}
+	)
+
+
+## Whether Retry is live: only an End state accepts the retry action — mid-run,
+## Enter does nothing (gADR-0010). The public flow-state read the game shell
+## (#449) hooks; the retry poll gates on it.
+func can_retry() -> bool:
+	return GameStateSystemScript.can_retry(_state)
+
+
+## The retry poll hook, called from the level's _process each frame. Retry is
+## live ONLY in an End state (gADR-0010): mid-run, Enter does nothing. The level
+## stays processing through the World freeze (only its CHILDREN are disabled), so
+## this read survives it.
+func poll_retry() -> void:
+	if not can_retry():
+		return
+	if Input.is_action_just_pressed("retry"):
+		_retry()
+
+
+## Fold one game-flow event through the pure GameStateSystem (gADR-0010). On the
+## FIRST transition into an End state: log the verdict (the durable observable for
+## gda logger tail), then apply the consequences at the frame boundary — both
+## edges arrive from physics callbacks (an enemy's attack, the last death's wave
+## fold), so the freeze is deferred rather than flipping process modes
+## mid-callback. The latch lives in the pure decision: a second event never
+## re-enters. The verdict fields are the edge-specific facts the level passed in.
+func _enter_end_state(event: String, verdict_fields: Dictionary) -> void:
+	var decision: Dictionary = GameStateSystemScript.resolve_event(_state, event)
+	if not decision["changed"]:
+		return
+	_state = decision["state"]
+	var verdict := "game_won" if _state == GameStateSystemScript.STATE_WON else "game_lost"
+	GameLogScript.emit("info", verdict, verdict_fields)
+	_apply_end_state.call_deferred()
+
+
+## The End state's consequences, applied at the frame boundary: freeze the world,
+## then show the End screen (its fade tween runs on the un-frozen CanvasLayer).
+## Split from _enter_end_state so the deferral covers both.
+func _apply_end_state() -> void:
+	_freeze_world()
+	# _level is untyped (see the header), so type the read explicitly.
+	var end_screen: Node = _level.get_node_or_null("EndScreen")
+	if end_screen != null and end_screen.has_method("show_end"):
+		end_screen.show_end(_state == GameStateSystemScript.STATE_WON)
+
+
+## The World freeze (gADR-0010): disable processing on every non-CanvasLayer
+## child of the level — actors, bolts, fields, pickups halt where they are (the
+## finale's time-stopped tableau) while the HUD keeps its final readout and the
+## End screen runs its fade. NEVER get_tree().paused: the gda harness autoload
+## serves the live IPC channel from _process under the default pause mode, so a
+## tree pause would sever gda's live channel exactly when an e2e wants to observe
+## the End state and press retry. The level itself stays processing — only
+## children are disabled — so the retry poll survives.
+func _freeze_world() -> void:
+	for child in _level.get_children():
+		if child is CanvasLayer:
+			continue
+		child.process_mode = Node.PROCESS_MODE_DISABLED
+
+
+## Retry (gADR-0010): log the restart (before the scene dies), then reload the
+## level scene — the whole run re-derives from config, with zero reset code to
+## drift. The gda session survives the reload (same process), so the fresh boot
+## records land in the same session log.
+func _retry() -> void:
+	GameLogScript.emit("info", "game_retried", {"from_state": _state})
+	_level.get_tree().reload_current_scene()

--- a/examples/platformer/panda-adventure/src/controllers/level_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/level_controller.gd
@@ -77,6 +77,11 @@ var _level_cfg: LevelConfigScript
 
 
 func _ready() -> void:
+	# The Game-flow director owns the End state; this node forwards the edges
+	# (S9, gADR-0010; extracted #453). Constructed BEFORE the config guards —
+	# its _init has zero config dependencies, and _process calls its retry poll
+	# unconditionally, so a guard's early return must still leave it in place.
+	_flow = GameFlowDirectorScript.new(self)
 	var config: PlayerConfigScript = GeneratedConfigScript.load_config(CONFIG_PATH)
 	if config == null:
 		return
@@ -89,9 +94,6 @@ func _ready() -> void:
 		push_error("LevelController: %s has no platforms." % LEVEL_CONFIG_PATH)
 		return
 	_apply_level(_level_cfg)
-	# The Game-flow director owns the End state; this node forwards the edges
-	# (S9, gADR-0010; extracted #453).
-	_flow = GameFlowDirectorScript.new(self)
 	var player := get_tree().get_first_node_in_group("player")
 	if player != null:
 		# The lose edge (S9, gADR-0010): the Player's S4 death latch now

--- a/examples/platformer/panda-adventure/src/controllers/level_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/level_controller.gd
@@ -7,14 +7,16 @@ extends Node2D
 ## Wave's Spawn Roster, folding deaths through the pure WaveSystem, and
 ## advancing on clear — wires each spawn's death to the Kill reward
 ## (gADR-0004) and to its Drop-table roll (gADR-0006: pickups scattered at
-## the death position), and emits the boot log. Since S9 it also owns the
-## run's End state (gADR-0010): the schedule's all-cleared decision and the
-## Player's death fold through the pure GameStateSystem into won/lost, which
-## freezes the world (never a tree pause — that would sever the gda
-## harness's live channel), shows the End screen, and arms Retry (the
-## `retry` action reloads the scene, so the whole run re-derives from
-## config). The Player self-configures (PlayerController); this owns the
-## rest of the level so config application stays out of the physics body.
+## the death position), and emits the boot log. Since S9 the run's End state
+## (gADR-0010) is delegated to a level-owned Game-flow director (#453): this
+## node forwards the two upstream edges — the schedule's all-cleared decision
+## and the Player's death — and the director folds them through the pure
+## GameStateSystem into won/lost, freezes the world (never a tree pause —
+## that would sever the gda harness's live channel), shows the End screen,
+## and arms Retry (the `retry` action reloads the scene, so the whole run
+## re-derives from config). The Player self-configures (PlayerController);
+## this owns the rest of the level so config application stays out of the
+## physics body.
 ##
 ## Visuals and geometry are data (gADR-0000): the derived LevelConfig /
 ## PlayerConfig / WaveScheduleConfig / EnemyConfig Resources, never
@@ -38,8 +40,8 @@ const EnemyConfigScript := preload("res://src/resources/enemy_config.gd")
 const WaveScheduleConfigScript := preload("res://src/resources/wave_schedule_config.gd")
 const ProgressionConfigScript := preload("res://src/resources/progression_config.gd")
 const WaveSystemScript := preload("res://src/systems/wave_system.gd")
-const GameStateSystemScript := preload("res://src/systems/game_state_system.gd")
 const EconomySystemScript := preload("res://src/systems/economy_system.gd")
+const GameFlowDirectorScript := preload("res://src/controllers/game_flow_director.gd")
 const GameLogScript := preload("res://src/util/game_log.gd")
 const GeneratedConfigScript := preload("res://src/util/generated_config.gd")
 const EnemyScene := preload("res://scenes/enemy.tscn")
@@ -64,11 +66,11 @@ var _alive := 0
 # The derived ProgressionConfig (S6b: the pickup scatter spacing), lazily
 # loaded (load() is cached) so _ready's load block stays untouched.
 var _progression_cfg: ProgressionConfigScript
-# The run's game-flow state (S9, gADR-0010): playing until the schedule
-# clears (won) or the Player dies (lost) — the pure GameStateSystem owns the
-# transitions, this node owns the consequences (freeze, End screen, Retry).
-# Runtime state; a Retry reload resets it by construction.
-var _state := GameStateSystemScript.STATE_PLAYING
+# The run's game-flow director (S9, gADR-0010): the End state and its
+# consequences — the World freeze, the End screen, the verdict log, Retry —
+# extracted here so the geometry + Wave director stay this node's job (#453).
+# Constructed in _ready; a Retry reload rebuilds it by construction.
+var _flow: GameFlowDirectorScript
 # The derived LevelConfig (S9): the Great-Wall blockout, the Arena, and the
 # End screen numbers.
 var _level_cfg: LevelConfigScript
@@ -87,6 +89,9 @@ func _ready() -> void:
 		push_error("LevelController: %s has no platforms." % LEVEL_CONFIG_PATH)
 		return
 	_apply_level(_level_cfg)
+	# The Game-flow director owns the End state; this node forwards the edges
+	# (S9, gADR-0010; extracted #453).
+	_flow = GameFlowDirectorScript.new(self)
 	var player := get_tree().get_first_node_in_group("player")
 	if player != null:
 		# The lose edge (S9, gADR-0010): the Player's S4 death latch now
@@ -112,13 +117,10 @@ func _ready() -> void:
 
 
 func _process(_delta: float) -> void:
-	# Retry is live ONLY in an End state (gADR-0010): mid-run, Enter does
-	# nothing. This node stays processing through the World freeze (only
-	# CHILDREN are disabled), so the retry read survives it.
-	if not GameStateSystemScript.can_retry(_state):
-		return
-	if Input.is_action_just_pressed("retry"):
-		_retry()
+	# Forward the retry poll to the Game-flow director (gADR-0010; #453). Retry
+	# is live ONLY in an End state; this node stays processing through the World
+	# freeze (only CHILDREN are disabled), so the director's read survives it.
+	_flow.poll_retry()
 
 
 ## Apply the data-driven Great-Wall blockout (S9, gADR-0010): the backdrop
@@ -221,8 +223,9 @@ func _on_enemy_died(enemy: Node2D, kind: EnemyConfigScript) -> void:
 		})
 		# The win edge (S9, gADR-0010): the SCHEDULE clearing wins the run —
 		# never "the Boss died"; the Boss slot stays demo composition
-		# (gADR-0005).
-		_enter_end_state(GameStateSystemScript.EVENT_ALL_WAVES_CLEARED)
+		# (gADR-0005). Forwarded to the Game-flow director with the wave total
+		# (the game_won verdict field).
+		_flow.on_all_waves_cleared(_schedule.waves.size())
 
 
 ## Award one Kill reward (S6a, gADR-0004): the dying kind's Tier-derived
@@ -273,65 +276,15 @@ func _progression_config() -> ProgressionConfigScript:
 
 
 # --- S9 End state + Retry (gADR-0010) ------------------------------------------
-# Kept as ONE self-contained append-only block (the S3/S4 parallel-merge
-# pattern): the two upstream edges fold through the pure GameStateSystem; the
-# consequences — the World freeze, the End screen, the verdict log, Retry —
-# live here.
+# The End-state consequences — the World freeze, the End screen, the verdict
+# log, Retry — moved to the level-owned Game-flow director (game_flow_director.gd,
+# #453); this node forwards the two upstream edges (the lose edge below, the win
+# edge in _on_enemy_died) and the retry poll (in _process), keeping the geometry
+# + Wave director as its job. The never-a-tree-pause invariant travels with the
+# World freeze in the director.
 
 
-## The lose edge: the Player's S4 death latch fired (exactly once).
+## The lose edge: the Player's S4 death latch fired (exactly once). Forwarded to
+## the Game-flow director with the current wave (the game_lost verdict field).
 func _on_player_died() -> void:
-	_enter_end_state(GameStateSystemScript.EVENT_PLAYER_DIED)
-
-
-## Fold one game-flow event through the pure GameStateSystem (gADR-0010). On
-## the FIRST transition into an End state: log the verdict (the durable
-## observable for gda logger tail), then apply the consequences at the frame
-## boundary — both edges arrive from physics callbacks (an enemy's attack, the
-## last death's wave fold), so the freeze is deferred rather than flipping
-## process modes mid-callback. The latch lives in the pure decision: a second
-## event never re-enters.
-func _enter_end_state(event: String) -> void:
-	var decision: Dictionary = GameStateSystemScript.resolve_event(_state, event)
-	if not decision["changed"]:
-		return
-	_state = decision["state"]
-	if _state == GameStateSystemScript.STATE_WON:
-		GameLogScript.emit("info", "game_won", {"waves": _schedule.waves.size()})
-	else:
-		GameLogScript.emit("info", "game_lost", {"wave": _wave_index + 1})
-	_apply_end_state.call_deferred()
-
-
-## The End state's consequences, applied at the frame boundary: freeze the
-## world, then show the End screen (its fade tween runs on the un-frozen
-## CanvasLayer). Split from _enter_end_state so the deferral covers both.
-func _apply_end_state() -> void:
-	_freeze_world()
-	var end_screen := get_node_or_null("EndScreen")
-	if end_screen != null and end_screen.has_method("show_end"):
-		end_screen.show_end(_state == GameStateSystemScript.STATE_WON)
-
-
-## The World freeze (gADR-0010): disable processing on every non-CanvasLayer
-## child — actors, bolts, fields, pickups halt where they are (the finale's
-## time-stopped tableau) while the HUD keeps its final readout and the End
-## screen runs its fade. NEVER get_tree().paused: the gda harness autoload
-## serves the live IPC channel from _process under the default pause mode, so
-## a tree pause would sever gda's live channel exactly when an e2e wants to
-## observe the End state and press retry. This node itself stays processing —
-## only children are disabled — so the Retry read in _process survives.
-func _freeze_world() -> void:
-	for child in get_children():
-		if child is CanvasLayer:
-			continue
-		child.process_mode = Node.PROCESS_MODE_DISABLED
-
-
-## Retry (gADR-0010): log the restart (before the scene dies), then reload the
-## level scene — the whole run re-derives from config, with zero reset code to
-## drift. The gda session survives the reload (same process), so the fresh
-## boot records land in the same session log.
-func _retry() -> void:
-	GameLogScript.emit("info", "game_retried", {"from_state": _state})
-	get_tree().reload_current_scene()
+	_flow.on_player_died(_wave_index + 1)


### PR DESCRIPTION
## Summary

Extracts the already-fenced **S9 End state + Retry** block of `level_controller.gd` into a level-owned **Game-flow director** (`src/controllers/game_flow_director.gd`), following the `EnemyWarpDriver` construction precedent — `RefCounted`, untyped owner back-reference to avoid a preload cycle, header documenting the owner surface it reaches.

- **Director owns** the game-flow state + the consequences: the World freeze, the End screen reveal, the verdict logs (`game_won`/`game_lost`/`game_retried`), and Retry.
- **Decisions stay pure** in `GameStateSystem` (untouched; first-transition latch preserved).
- **Level keeps** the geometry and the Wave director (explicitly *not* split) and forwards the two upstream edges + the retry poll.
- **Verdict facts** (won-run wave total, lost-run current wave) are Wave-director facts, so the level passes them in through the edges rather than the director reaching across into the Wave director's private schedule.

**Public surface:** `on_player_died(wave)`, `on_all_waves_cleared(total_waves)`, `can_retry()`, `poll_retry()`.

**Invariants held:** the never-a-tree-pause World freeze (gADR-0010) travels verbatim with its explanatory comment; the `game_won`/`game_lost` log edges, the End-screen reveal, and the retry (Enter) → fresh-scene-reload flow are behavior-preserving.

Why now: P2-S10 (#449 game shell) extends exactly this seam — pause is a sibling of the World freeze, quit-to-title a sibling of Retry.

Adds a `Game-flow director` glossary entry (`GAME-CONTEXT.md`, Game flow section). No gADR — gADR-0010's decisions are unchanged.

## Test plan

- Fast suite: `uv run pytest examples/platformer/panda-adventure/tests -m "not e2e" -q` → **296 passed, 16 deselected**
- Targeted e2e (foreground, serial): `uv run pytest examples/platformer/panda-adventure/tests/test_level_e2e.py -q` → **2 passed** (win-freeze-retry AND lose-freeze-retry paths)

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)