### PR TITLE
fix(input): document stale tracked mouse position

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,11 @@ flags — `gda --help` is the authoritative list of what is installed.
 | `input action` | Press/release a mapped input action. |
 | `input sequence` | Inject a multi-frame event timeline. |
 
+Mouse events report the injected viewport coordinate through `event.position`.
+Godot may leave `get_mouse_position()` / `get_global_mouse_position()` stale in
+daemon sessions, so game code should read injected mouse coordinates from the
+input event.
+
 **`screen`** — viewport capture
 
 | Command | What it does |

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=235551b65421a770a544d8ae977ae30067c34c56f5adf8eeb1170684191de707 -->
+<!-- gda-readme-i18n: source=README.md sha256=3f25b544e58bf46ffad43fcf05c8fef738fdc63935ff11ee7fc9734a9f1bd3bf -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -511,6 +511,12 @@ flags — `gda --help` es la lista autoritativa de lo que está instalado.
 | `input mouse-move` | Inyecta un movimiento de ratón hacia `(x, y)`. |
 | `input action` | Presiona/suelta una acción de entrada mapeada. |
 | `input sequence` | Inyecta una línea de tiempo de eventos de varios frames. |
+
+Los eventos de ratón informan la coordenada inyectada del viewport mediante
+`event.position`. Godot puede dejar `get_mouse_position()` /
+`get_global_mouse_position()` desactualizados en sesiones del daemon, por lo que
+el código del juego debe leer las coordenadas de ratón inyectadas desde el evento
+de entrada.
 
 **`screen`** — captura del viewport
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=235551b65421a770a544d8ae977ae30067c34c56f5adf8eeb1170684191de707 -->
+<!-- gda-readme-i18n: source=README.md sha256=3f25b544e58bf46ffad43fcf05c8fef738fdc63935ff11ee7fc9734a9f1bd3bf -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -517,6 +517,10 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 | `input mouse-move` | `(x, y)` へのマウス移動を注入します。 |
 | `input action` | マッピング済みの入力アクションを押下/解放します。 |
 | `input sequence` | 複数フレームにわたるイベントのタイムラインを注入します。 |
+
+マウスイベントは、注入されたビューポート座標を `event.position` で報告します。
+Godot は daemon セッション内で `get_mouse_position()` /
+`get_global_mouse_position()` を古い値のままにする場合があるため、ゲームコードは注入されたマウス座標を入力イベントから読み取ってください。
 
 **`screen`** — ビューポートのキャプチャ
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=235551b65421a770a544d8ae977ae30067c34c56f5adf8eeb1170684191de707 -->
+<!-- gda-readme-i18n: source=README.md sha256=3f25b544e58bf46ffad43fcf05c8fef738fdc63935ff11ee7fc9734a9f1bd3bf -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -500,6 +500,9 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 | `input mouse-move` | 注入一次移动到 `(x, y)` 的鼠标移动。 |
 | `input action` | 按下/释放一个已映射的输入动作。 |
 | `input sequence` | 注入一条跨多帧的事件时间线。 |
+
+鼠标事件会通过 `event.position` 报告注入的视口坐标。Godot 在 daemon 会话中可能让
+`get_mouse_position()` / `get_global_mouse_position()` 保持过期状态，因此游戏代码应从输入事件读取注入的鼠标坐标。
 
 **`screen`** — 视口捕获
 

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -634,7 +634,12 @@ headless is unaffected (4.4+, cross-platform).
   `mouse` sub-group, so each maps to a single `<group>_<command>` MCP tool name
   (ADR-0005/0011/0012). Key/mouse events ride the game's real input flow via the
   root viewport's `push_input` (scene-aware); actions go through
-  `Input.action_press`/`action_release` against the running `InputMap`. The modifier
+  `Input.action_press`/`action_release` against the running `InputMap`. For mouse
+  ops and sequence mouse events, the reliable injected coordinate is
+  `InputEventMouseButton.position` / `InputEventMouseMotion.position`; Godot may
+  leave `Viewport.get_mouse_position()` and `Node2D.get_global_mouse_position()`
+  stale in daemon sessions, so game code should read the injected coordinate from
+  the input event. The modifier
   set, mouse-button enum, action strength range (0..1), per-event shape, and the
   sequence's selected-clock window (`max(frame)+1` or `max(physics_frame)+1` ≤ the
   per-window ceiling, the same bound `perf monitor` enforces, #223) are bounded

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -1323,7 +1323,10 @@ def input_mouse_click(
 
     Routes through gda-daemon to the engine session (kind = LIVE, ADR-0017) and
     pushes an InputEventMouseButton at the viewport position into the running
-    game's root viewport. With no daemon it reports `daemon_not_running`.
+    game's root viewport. Read the injected coordinate from the mouse event's
+    position; Godot may leave Viewport.get_mouse_position() /
+    Node2D.get_global_mouse_position() stale in daemon sessions. With no daemon it
+    reports `daemon_not_running`.
     """
     _dispatch(
         INPUT_MOUSE_CLICK_COMMAND,
@@ -1362,7 +1365,10 @@ def input_mouse_move(
 
     Routes through gda-daemon to the engine session (kind = LIVE, ADR-0017) and
     pushes an InputEventMouseMotion to the viewport position into the running
-    game's root viewport. With no daemon it reports `daemon_not_running`.
+    game's root viewport. Read the injected coordinate from the mouse event's
+    position; Godot may leave Viewport.get_mouse_position() /
+    Node2D.get_global_mouse_position() stale in daemon sessions. With no daemon it
+    reports `daemon_not_running`.
     """
     _dispatch(
         INPUT_MOUSE_MOVE_COMMAND,

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -1471,10 +1471,13 @@ def input_sequence(
     frames. Use `physics_frame` offsets instead when a press/release window must map
     deterministically to physics simulation ticks, e.g. press an action at
     `physics_frame: 0` and release it at `physics_frame: 30` for a 30-physics-frame
-    hold. A malformed `--events` (not a JSON array, an empty list, an ill-formed
-    event, or mixed `frame`/`physics_frame` clocks) is a usage error; with no daemon
-    it reports `daemon_not_running`. An event's action absent from the InputMap is
-    `live_unknown_action`, an unresolvable key `live_invalid_key`.
+    hold. For sequence `mouse_click` and `mouse_move` events, read the injected
+    coordinate from the mouse event's position; Godot may leave
+    Viewport.get_mouse_position() / Node2D.get_global_mouse_position() stale in
+    daemon sessions. A malformed `--events` (not a JSON array, an empty list, an
+    ill-formed event, or mixed `frame`/`physics_frame` clocks) is a usage error; with
+    no daemon it reports `daemon_not_running`. An event's action absent from the
+    InputMap is `live_unknown_action`, an unresolvable key `live_invalid_key`.
     """
     # --events is a JSON array on the argv path; the model is the source of truth for
     # the per-event shape (ADR-0015), so a parse or validation failure is a usage

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -689,6 +689,12 @@ func _input_viewport() -> Viewport:
 	return get_tree().root
 
 
+func _prepare_mouse_input() -> Viewport:
+	var viewport := _input_viewport()
+	viewport.notify_mouse_entered()
+	return viewport
+
+
 # Resolve a key name to a Godot keycode via the engine's own name table. Returns
 # KEY_NONE (0) for a name the engine does not recognize — the one runtime failure
 # the model cannot pre-validate (the keycode table is the engine's), surfaced as
@@ -734,20 +740,24 @@ func _mouse_button_index(button: String) -> int:
 # Push a mouse-button event at a viewport position. Shared by the single-frame
 # click op and a sequence mouse-click event.
 func _push_mouse_click(pos: Vector2, button: String, double: bool) -> void:
+	var viewport := _prepare_mouse_input()
 	var event := InputEventMouseButton.new()
 	event.button_index = _mouse_button_index(button)
 	event.position = pos
 	event.pressed = true
 	event.double_click = double
-	_input_viewport().push_input(event)
+	viewport.push_input(event, true)
 
 
 # Push a mouse-motion event to a viewport position. Shared by the single-frame move
 # op and a sequence mouse-move event.
 func _push_mouse_move(pos: Vector2) -> void:
+	var viewport := _prepare_mouse_input()
+	var previous := viewport.get_mouse_position()
 	var event := InputEventMouseMotion.new()
 	event.position = pos
-	_input_viewport().push_input(event)
+	event.relative = pos - previous
+	viewport.push_input(event, true)
 
 
 # input key: inject one InputEventKey (press or release) into the running game's

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -689,6 +689,9 @@ func _input_viewport() -> Viewport:
 	return get_tree().root
 
 
+var _last_injected_mouse_position: Variant = null
+
+
 func _prepare_mouse_input() -> Viewport:
 	var viewport := _input_viewport()
 	viewport.notify_mouse_entered()
@@ -747,6 +750,7 @@ func _push_mouse_click(pos: Vector2, button: String, double: bool) -> void:
 	event.pressed = true
 	event.double_click = double
 	viewport.push_input(event, true)
+	_last_injected_mouse_position = pos
 
 
 # Push a mouse-motion event to a viewport position. Shared by the single-frame move
@@ -754,10 +758,13 @@ func _push_mouse_click(pos: Vector2, button: String, double: bool) -> void:
 func _push_mouse_move(pos: Vector2) -> void:
 	var viewport := _prepare_mouse_input()
 	var previous := viewport.get_mouse_position()
+	if _last_injected_mouse_position is Vector2:
+		previous = _last_injected_mouse_position
 	var event := InputEventMouseMotion.new()
 	event.position = pos
 	event.relative = pos - previous
 	viewport.push_input(event, true)
+	_last_injected_mouse_position = pos
 
 
 # input key: inject one InputEventKey (press or release) into the running game's

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -3522,7 +3522,10 @@ class PerfMonitorResult(BaseModel):
 #
 # Live input injection into the RUNNING game's engine session via the gda harness
 # (ADR-0017, ADR-0019). Key/mouse events ride the game's real input flow via the
-# root viewport's push_input; actions go through Input.action_press/release. Every
+# root viewport's push_input; actions go through Input.action_press/release. Mouse
+# event.position is the reliable injected coordinate; Godot does not expose a
+# reliable daemon-session seam for updating Viewport.get_mouse_position() /
+# Node2D.get_global_mouse_position(), so those tracked positions may stay stale. Every
 # rule that bounds a request — the modifier set, the mouse button enum, the action
 # strength range, and the well-formedness of a sequence event — is enforced
 # MODEL-SIDE (ADR-0015), so the argv path and the --params-json path reject the
@@ -3625,11 +3628,25 @@ class InputMouseClickParams(BaseModel):
     Pushes an ``InputEventMouseButton`` at viewport position ``(x, y)`` into the
     running game's root viewport. ``button`` selects which button (left/right/
     middle); ``double`` marks the event a double click. A single-frame op (the
-    press is injected at one frame boundary, ADR-0020).
+    press is injected at one frame boundary, ADR-0020). The injected coordinate is
+    reliable as ``InputEventMouseButton.position``. Godot does not reliably update
+    the engine-tracked mouse position in daemon sessions, so
+    ``Viewport.get_mouse_position()`` / ``Node2D.get_global_mouse_position()`` may
+    remain stale; read the mouse event position for the injected coordinate.
     """
 
-    x: float = Field(description="The click's x position in the viewport.")
-    y: float = Field(description="The click's y position in the viewport.")
+    x: float = Field(
+        description=(
+            "The click's x position in the viewport. Read it from the mouse event; "
+            "engine-tracked mouse positions may remain stale."
+        )
+    )
+    y: float = Field(
+        description=(
+            "The click's y position in the viewport. Read it from the mouse event; "
+            "engine-tracked mouse positions may remain stale."
+        )
+    )
     button: MouseButton = Field(
         default=MouseButton.LEFT,
         description="Which mouse button to click: left, right, or middle.",
@@ -3642,11 +3659,25 @@ class InputMouseMoveParams(BaseModel):
 
     Pushes an ``InputEventMouseMotion`` to viewport position ``(x, y)`` into the
     running game's root viewport — the runtime counterpart of moving the cursor
-    over the game. A single-frame op.
+    over the game. A single-frame op. The injected coordinate is reliable as
+    ``InputEventMouseMotion.position``. Godot does not reliably update the
+    engine-tracked mouse position in daemon sessions, so
+    ``Viewport.get_mouse_position()`` / ``Node2D.get_global_mouse_position()`` may
+    remain stale; read the mouse event position for the injected coordinate.
     """
 
-    x: float = Field(description="The motion's target x position in the viewport.")
-    y: float = Field(description="The motion's target y position in the viewport.")
+    x: float = Field(
+        description=(
+            "The motion's target x position in the viewport. Read it from the "
+            "mouse event; engine-tracked mouse positions may remain stale."
+        )
+    )
+    y: float = Field(
+        description=(
+            "The motion's target y position in the viewport. Read it from the "
+            "mouse event; engine-tracked mouse positions may remain stale."
+        )
+    )
 
 
 class InputMouseResult(BaseModel):
@@ -3654,14 +3685,19 @@ class InputMouseResult(BaseModel):
 
     Echoes the event ``kind`` (``mouse_click`` or ``mouse_move``), the viewport
     ``position`` it was pushed at as ``[x, y]``, and — for a click — the ``button``
-    and whether it was a ``double`` click (both null for a move).
+    and whether it was a ``double`` click (both null for a move). This echoed
+    position mirrors the mouse event's position; engine-tracked mouse positions may
+    remain stale.
     """
 
     kind: str = Field(
         description="The injected event kind: 'mouse_click' or 'mouse_move'."
     )
     position: list[float] = Field(
-        description="The viewport position the event was injected at, as [x, y]."
+        description=(
+            "The viewport position the event was injected at, as [x, y]. This "
+            "mirrors event.position; engine-tracked mouse positions may remain stale."
+        )
     )
     button: str | None = Field(
         default=None, description="The clicked button (a click only); null for a move."
@@ -3746,6 +3782,8 @@ class InputSequenceEvent(BaseModel):
     ``action``/``release``/``strength`` for an action. The required fields per type
     and the shared bounds (modifier set, button enum, strength range) are validated
     model-side (ADR-0015) so a malformed event is rejected before the harness runs.
+    Mouse event coordinates are reliable as the event's ``position``; engine-tracked
+    mouse positions may remain stale for sequence mouse events too.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -3779,8 +3817,20 @@ class InputSequenceEvent(BaseModel):
         default=False, description="A key event: inject a release instead of a press."
     )
     # mouse fields
-    x: float | None = Field(default=None, description="A mouse event's x position.")
-    y: float | None = Field(default=None, description="A mouse event's y position.")
+    x: float | None = Field(
+        default=None,
+        description=(
+            "A mouse event's x position. Read it from the event; engine-tracked "
+            "mouse positions may remain stale."
+        ),
+    )
+    y: float | None = Field(
+        default=None,
+        description=(
+            "A mouse event's y position. Read it from the event; engine-tracked "
+            "mouse positions may remain stale."
+        ),
+    )
     button: MouseButton | None = Field(
         default=None, description="A mouse-click event's button."
     )

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -95,6 +95,13 @@ fixed physics frames. When input timing must map to physics simulation, use
 same sequence. At Godot's default 60 Hz physics clock, N=30 is 0.5 seconds of
 physics simulation. Do not mix `frame` and `physics_frame` in one sequence.
 
+For `gda input mouse-click`, `gda input mouse-move`, and mouse events inside
+`gda input sequence`, the reliable injected coordinate is the mouse event's
+`position` (`InputEventMouseButton.position` / `InputEventMouseMotion.position`).
+Godot may leave `Viewport.get_mouse_position()` and
+`Node2D.get_global_mouse_position()` stale in daemon sessions, so game code that
+needs the injected coordinate should read it from the input event.
+
 ### Structured logging from game code
 
 To emit a record `gda logger tail` reads back as a rich, field-carrying `LogRecord`,

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -67,16 +67,18 @@ TRACKED_MOUSE_PLAYER_GD = (
     "extends Node2D\n"
     "@export var last_event_type: String = \"\"\n"
     "@export var last_event_position: Vector2 = Vector2(-1, -1)\n"
+    "@export var last_event_relative: Vector2 = Vector2(-1, -1)\n"
     "@export var last_global_mouse_position: Vector2 = Vector2(-1, -1)\n"
     "@export var last_viewport_mouse_position: Vector2 = Vector2(-1, -1)\n"
     "func _input(event: InputEvent) -> void:\n"
     "\tif event is InputEventMouseButton and event.pressed:\n"
-    "\t\t_capture_mouse(\"click\", event.position)\n"
+    "\t\t_capture_mouse(\"click\", event.position, Vector2.ZERO)\n"
     "\telif event is InputEventMouseMotion:\n"
-    "\t\t_capture_mouse(\"move\", event.position)\n"
-    "func _capture_mouse(kind: String, event_position: Vector2) -> void:\n"
+    "\t\t_capture_mouse(\"move\", event.position, event.relative)\n"
+    "func _capture_mouse(kind: String, event_position: Vector2, event_relative: Vector2) -> void:\n"
     "\tlast_event_type = kind\n"
     "\tlast_event_position = event_position\n"
+    "\tlast_event_relative = event_relative\n"
     "\tlast_global_mouse_position = get_global_mouse_position()\n"
     "\tlast_viewport_mouse_position = get_viewport().get_mouse_position()\n"
 )
@@ -299,10 +301,11 @@ def test_mouse_input_reports_event_position_when_tracked_mouse_position_is_stale
         return json.loads(got.stdout)["properties"][0]["value"]
 
     def assert_event_position_with_stale_tracked_mouse(
-        kind: str, expected: list[float]
+        kind: str, expected: list[float], relative: list[float]
     ) -> None:
         assert player_property("last_event_type") == kind
         assert player_property("last_event_position") == expected
+        assert player_property("last_event_relative") == relative
         assert player_property("last_global_mouse_position") == [0.0, 0.0]
         assert player_property("last_viewport_mouse_position") == [0.0, 0.0]
 
@@ -311,16 +314,22 @@ def test_mouse_input_reports_event_position_when_tracked_mouse_position_is_stale
 
         click = run("input", "mouse-click", "123", "45")
         assert click.returncode == 0, click.stdout + click.stderr
-        assert_event_position_with_stale_tracked_mouse("click", [123.0, 45.0])
+        assert_event_position_with_stale_tracked_mouse(
+            "click", [123.0, 45.0], [0.0, 0.0]
+        )
 
         move = run("input", "mouse-move", "50", "60")
         assert move.returncode == 0, move.stdout + move.stderr
-        assert_event_position_with_stale_tracked_mouse("move", [50.0, 60.0])
+        assert_event_position_with_stale_tracked_mouse(
+            "move", [50.0, 60.0], [-73.0, 15.0]
+        )
 
         events = json.dumps([{"type": "mouse_move", "x": 77, "y": 88, "frame": 0}])
         seq = run("input", "sequence", "--events", events)
         assert seq.returncode == 0, seq.stdout + seq.stderr
-        assert_event_position_with_stale_tracked_mouse("move", [77.0, 88.0])
+        assert_event_position_with_stale_tracked_mouse(
+            "move", [77.0, 88.0], [27.0, 28.0]
+        )
     finally:
         run("daemon", "stop")
 

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -63,6 +63,25 @@ MOUSE_MAIN_TSCN = (
     'script = ExtResource("1")\n'
 )
 
+TRACKED_MOUSE_PLAYER_GD = (
+    "extends Node2D\n"
+    "@export var last_event_type: String = \"\"\n"
+    "@export var last_event_position: Vector2 = Vector2(-1, -1)\n"
+    "@export var last_global_mouse_position: Vector2 = Vector2(-1, -1)\n"
+    "@export var last_viewport_mouse_position: Vector2 = Vector2(-1, -1)\n"
+    "func _input(event: InputEvent) -> void:\n"
+    "\tif event is InputEventMouseButton and event.pressed:\n"
+    "\t\t_capture_mouse(\"click\", event.position)\n"
+    "\telif event is InputEventMouseMotion:\n"
+    "\t\t_capture_mouse(\"move\", event.position)\n"
+    "func _capture_mouse(kind: String, event_position: Vector2) -> void:\n"
+    "\tlast_event_type = kind\n"
+    "\tlast_event_position = event_position\n"
+    "\tlast_global_mouse_position = get_global_mouse_position()\n"
+    "\tlast_viewport_mouse_position = get_viewport().get_mouse_position()\n"
+)
+TRACKED_MOUSE_MAIN_TSCN = MOUSE_MAIN_TSCN
+
 # A Player that polls a `move_right` input action each frame: while the action is
 # pressed it advances, so an injected `input action move_right` (a press held until
 # released) moves the node. The action is registered in project.godot's input map.
@@ -238,6 +257,70 @@ def test_daemon_serves_input_mouse_click_observed_via_game_get(
             p for p in json.loads(after.stdout)["properties"] if p["name"] == "position"
         )["value"]
         assert after_pos == [123.0, 45.0]
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_mouse_input_reports_event_position_when_tracked_mouse_position_is_stale(
+    tmp_path, daemon_runtime_dir
+):
+    # #462: in the default daemon session, Godot accepts the injected event position
+    # but does not expose a reliable seam for updating the engine-tracked mouse
+    # position. Pin that limitation so the documented workaround remains true.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(TRACKED_MOUSE_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "player.gd").write_text(
+        TRACKED_MOUSE_PLAYER_GD, encoding="utf-8"
+    )
+
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    def player_property(name: str):
+        got = run("game", "get", "/root/Main/Player", "--property", name)
+        assert got.returncode == 0, got.stdout + got.stderr
+        return json.loads(got.stdout)["properties"][0]["value"]
+
+    def assert_event_position_with_stale_tracked_mouse(
+        kind: str, expected: list[float]
+    ) -> None:
+        assert player_property("last_event_type") == kind
+        assert player_property("last_event_position") == expected
+        assert player_property("last_global_mouse_position") == [0.0, 0.0]
+        assert player_property("last_viewport_mouse_position") == [0.0, 0.0]
+
+    try:
+        assert run("daemon", "start").returncode == 0
+
+        click = run("input", "mouse-click", "123", "45")
+        assert click.returncode == 0, click.stdout + click.stderr
+        assert_event_position_with_stale_tracked_mouse("click", [123.0, 45.0])
+
+        move = run("input", "mouse-move", "50", "60")
+        assert move.returncode == 0, move.stdout + move.stderr
+        assert_event_position_with_stale_tracked_mouse("move", [50.0, 60.0])
+
+        events = json.dumps([{"type": "mouse_move", "x": 77, "y": 88, "frame": 0}])
+        seq = run("input", "sequence", "--events", events)
+        assert seq.returncode == 0, seq.stdout + seq.stderr
+        assert_event_position_with_stale_tracked_mouse("move", [77.0, 88.0])
     finally:
         run("daemon", "stop")
 

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -65,16 +65,16 @@ MOUSE_MAIN_TSCN = (
 
 TRACKED_MOUSE_PLAYER_GD = (
     "extends Node2D\n"
-    "@export var last_event_type: String = \"\"\n"
+    '@export var last_event_type: String = ""\n'
     "@export var last_event_position: Vector2 = Vector2(-1, -1)\n"
     "@export var last_event_relative: Vector2 = Vector2(-1, -1)\n"
     "@export var last_global_mouse_position: Vector2 = Vector2(-1, -1)\n"
     "@export var last_viewport_mouse_position: Vector2 = Vector2(-1, -1)\n"
     "func _input(event: InputEvent) -> void:\n"
     "\tif event is InputEventMouseButton and event.pressed:\n"
-    "\t\t_capture_mouse(\"click\", event.position, Vector2.ZERO)\n"
+    '\t\t_capture_mouse("click", event.position, Vector2.ZERO)\n'
     "\telif event is InputEventMouseMotion:\n"
-    "\t\t_capture_mouse(\"move\", event.position, event.relative)\n"
+    '\t\t_capture_mouse("move", event.position, event.relative)\n'
     "func _capture_mouse(kind: String, event_position: Vector2, event_relative: Vector2) -> void:\n"
     "\tlast_event_type = kind\n"
     "\tlast_event_position = event_position\n"
@@ -272,9 +272,7 @@ def test_mouse_input_reports_event_position_when_tracked_mouse_position_is_stale
     # position. Pin that limitation so the documented workaround remains true.
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(TRACKED_MOUSE_MAIN_TSCN, encoding="utf-8")
-    (tmp_path / "player.gd").write_text(
-        TRACKED_MOUSE_PLAYER_GD, encoding="utf-8"
-    )
+    (tmp_path / "player.gd").write_text(TRACKED_MOUSE_PLAYER_GD, encoding="utf-8")
 
     env = {**os.environ}
 

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -734,6 +734,20 @@ def test_input_sequence_help_names_process_and_physics_clocks():
     assert "physics_frame" in result.stdout
 
 
+def test_input_sequence_help_documents_mouse_tracked_position_limitation():
+    result = CliRunner().invoke(app, ["input", "sequence", "--help"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "mouse_click" in result.stdout
+    assert "mouse_move" in result.stdout
+    assert "mouse event" in result.stdout
+    assert "position" in result.stdout
+    assert "get_mouse_position()" in result.stdout
+    assert "get_global_mouse_position()" in result.stdout
+    assert "stale in" in result.stdout
+    assert "daemon sessions" in result.stdout
+
+
 # --- model validation via --params-json (ADR-0015) ----------------------------
 # The model is the input source of truth for BOTH paths; an out-of-contract
 # --params-json object surfaces as the structured invalid_params error (exit 0,

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -173,6 +173,20 @@ def test_input_mouse_click_injects_a_click_through_the_live_channel(
     ]
 
 
+def test_input_mouse_help_documents_tracked_position_limitation():
+    click = CliRunner().invoke(app, ["input", "mouse-click", "--help"])
+    move = CliRunner().invoke(app, ["input", "mouse-move", "--help"])
+
+    assert click.exit_code == 0, click.stdout + click.stderr
+    assert move.exit_code == 0, move.stdout + move.stderr
+    for result in (click, move):
+        assert "mouse event" in result.stdout
+        assert "position" in result.stdout
+        assert "get_mouse_position()" in result.stdout
+        assert "get_global_mouse_position()" in result.stdout
+        assert "stale in daemon sessions" in result.stdout
+
+
 def test_input_mouse_move_injects_a_motion_through_the_live_channel(
     monkeypatch, tmp_path
 ):

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1313,13 +1313,17 @@ def test_input_commands_schema_report_kind_live_and_are_model_derived():
 
     click_input = docs[1]["input"]
     move_input = docs[2]["input"]
-    assert "engine-tracked mouse positions may remain stale" in (
-        click_input["properties"]["x"]["description"]
+    assert (
+        "engine-tracked mouse positions may remain stale"
+        in (click_input["properties"]["x"]["description"])
     )
-    assert "engine-tracked mouse positions may remain stale" in (
-        move_input["properties"]["x"]["description"]
+    assert (
+        "engine-tracked mouse positions may remain stale"
+        in (move_input["properties"]["x"]["description"])
     )
-    assert "event.position" in docs[1]["output"]["properties"]["position"]["description"]
+    assert (
+        "event.position" in docs[1]["output"]["properties"]["position"]["description"]
+    )
 
     sequence_input = docs[-1]["input"]
     events_description = sequence_input["properties"]["events"]["description"]
@@ -1328,8 +1332,9 @@ def test_input_commands_schema_report_kind_live_and_are_model_derived():
     sequence_event_props = sequence_input["$defs"]["InputSequenceEvent"]["properties"]
     assert "harness/process-frame" in sequence_event_props["frame"]["description"]
     assert "physics-frame" in sequence_event_props["physics_frame"]["description"]
-    assert "engine-tracked mouse positions may remain stale" in (
-        sequence_event_props["x"]["description"]
+    assert (
+        "engine-tracked mouse positions may remain stale"
+        in (sequence_event_props["x"]["description"])
     )
 
 

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1311,6 +1311,16 @@ def test_input_commands_schema_report_kind_live_and_are_model_derived():
         jsonschema.Draft202012Validator.check_schema(doc["input"])
         jsonschema.Draft202012Validator.check_schema(doc["output"])
 
+    click_input = docs[1]["input"]
+    move_input = docs[2]["input"]
+    assert "engine-tracked mouse positions may remain stale" in (
+        click_input["properties"]["x"]["description"]
+    )
+    assert "engine-tracked mouse positions may remain stale" in (
+        move_input["properties"]["x"]["description"]
+    )
+    assert "event.position" in docs[1]["output"]["properties"]["position"]["description"]
+
     sequence_input = docs[-1]["input"]
     events_description = sequence_input["properties"]["events"]["description"]
     assert "process-clock `frame`" in events_description
@@ -1318,6 +1328,9 @@ def test_input_commands_schema_report_kind_live_and_are_model_derived():
     sequence_event_props = sequence_input["$defs"]["InputSequenceEvent"]["properties"]
     assert "harness/process-frame" in sequence_event_props["frame"]["description"]
     assert "physics-frame" in sequence_event_props["physics_frame"]["description"]
+    assert "engine-tracked mouse positions may remain stale" in (
+        sequence_event_props["x"]["description"]
+    )
 
 
 def test_sample_input_results_validate_against_emitted_output_schemas():


### PR DESCRIPTION
## Summary

- Documents the Godot daemon-session limitation that injected mouse events carry the requested coordinate in `event.position`, while `Viewport.get_mouse_position()` / `Node2D.get_global_mouse_position()` can remain stale.
- Applies the docs-backed mouse injection setup with `notify_mouse_entered()`, viewport-local event positions, `push_input(..., true)`, and motion `relative` computed from the last injected mouse position.
- Pins click, move, and sequence mouse events with a live e2e regression.

Closes #462

## Validation

- `env UV_CACHE_DIR=/tmp/codex-uv-cache uv run pytest tests/test_input_commands.py tests/test_schema_command.py::test_input_commands_schema_report_kind_live_and_are_model_derived tests/test_readme_i18n_sync.py tests/test_skill_command.py`
- `env UV_CACHE_DIR=/tmp/codex-uv-cache uv run ruff check src/gda/models.py src/gda/cli.py tests/test_e2e_input.py tests/test_input_commands.py tests/test_schema_command.py`
- `git diff --check origin/main...HEAD`
- `env UV_CACHE_DIR=/tmp/codex-uv-cache uv run pytest tests/test_e2e_input.py`
