### PR TITLE
fix(node): support Control.position writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,11 @@ flags — `gda --help` is the authoritative list of what is installed.
 | `node connect-signal` | Wire a source node's signal to a target node's method. |
 | `node disconnect-signal` | Unwire an existing signal→method connection. |
 
+For `Control` nodes, `node set --property position` writes the underlying
+`offset_left` / `offset_top` / `offset_right` / `offset_bottom` values while
+preserving size. Direct children of a `Container` are layout-managed, so set the
+offset properties explicitly instead.
+
 **`script`** — GDScript files (`.gd`)
 
 | Command | What it does |
@@ -473,6 +478,9 @@ flags — `gda --help` is the authoritative list of what is installed.
 | `game get` | Read a runtime node's live properties by node path; explicit names can address attached-script variables. |
 | `game rect` | Read a runtime Control's rendered viewport rect by node path. |
 | `game set` | Set a runtime node property, or an explicitly named attached-script variable, on the running game. |
+
+Live `game set --property position` follows the same `Control` policy as
+`node set`; `game rect` remains a read-only rendered-geometry query.
 
 **`diag`** — runtime diagnostics
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=3f25b544e58bf46ffad43fcf05c8fef738fdc63935ff11ee7fc9734a9f1bd3bf -->
+<!-- gda-readme-i18n: source=README.md sha256=06067154e90ca388c08772e7be322327d9d2241f6f23aa1056dd57c0d356da3d -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -402,6 +402,11 @@ flags — `gda --help` es la lista autoritativa de lo que está instalado.
 | `node connect-signal` | Conecta la señal de un nodo origen al método de un nodo destino. |
 | `node disconnect-signal` | Desconecta una conexión señal→método existente. |
 
+Para nodos `Control`, `node set --property position` escribe los valores
+subyacentes `offset_left` / `offset_top` / `offset_right` / `offset_bottom`
+preservando el tamaño. Los hijos directos de un `Container` están gestionados por
+layout, así que define esas propiedades offset explícitamente.
+
 **`script`** — archivos GDScript (`.gd`)
 
 | Comando | Qué hace |
@@ -482,6 +487,10 @@ flags — `gda --help` es la lista autoritativa de lo que está instalado.
 | `game get` | Lee las propiedades en vivo de un nodo de runtime por ruta de nodo; los nombres explícitos pueden acceder a variables del script adjunto. |
 | `game rect` | Lee el rectángulo renderizado en viewport de un Control de runtime por ruta de nodo. |
 | `game set` | Define una propiedad de un nodo de runtime, o una variable explícita del script adjunto, en el juego en ejecución. |
+
+`game set --property position` en vivo sigue la misma política de `Control` que
+`node set`; `game rect` sigue siendo una consulta de geometría renderizada de solo
+lectura.
 
 **`diag`** — diagnósticos de runtime
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=3f25b544e58bf46ffad43fcf05c8fef738fdc63935ff11ee7fc9734a9f1bd3bf -->
+<!-- gda-readme-i18n: source=README.md sha256=06067154e90ca388c08772e7be322327d9d2241f6f23aa1056dd57c0d356da3d -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -408,6 +408,11 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 | `node connect-signal` | ソースノードのシグナルをターゲットノードのメソッドに接続します。 |
 | `node disconnect-signal` | 既存のシグナル → メソッド接続を解除します。 |
 
+`Control` ノードでは、`node set --property position` はサイズを保ったまま
+基礎となる `offset_left` / `offset_top` / `offset_right` / `offset_bottom` を
+書き込みます。`Container` の直接の子はレイアウト管理下にあるため、これらの
+offset プロパティを明示的に設定してください。
+
 **`script`** — GDScript ファイル(`.gd`)
 
 | コマンド | 機能 |
@@ -488,6 +493,9 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 | `game get` | ランタイムノードのライブプロパティをノードパスで読み取ります。明示名ならアタッチ済みスクリプト変数も対象にできます。 |
 | `game rect` | ランタイム Control のレンダリング済みビューポート矩形をノードパスで読み取ります。 |
 | `game set` | 実行中ゲームのランタイムノードプロパティ、または明示名のアタッチ済みスクリプト変数を設定します。 |
+
+Live の `game set --property position` は `node set` と同じ `Control` ポリシーに
+従います。`game rect` は引き続き読み取り専用のレンダリングジオメトリ問い合わせです。
 
 **`diag`** — ランタイム診断
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=3f25b544e58bf46ffad43fcf05c8fef738fdc63935ff11ee7fc9734a9f1bd3bf -->
+<!-- gda-readme-i18n: source=README.md sha256=06067154e90ca388c08772e7be322327d9d2241f6f23aa1056dd57c0d356da3d -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -391,6 +391,10 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 | `node connect-signal` | 把源节点的信号接到目标节点的方法上。 |
 | `node disconnect-signal` | 断开一个已有的「信号→方法」连接。 |
 
+对于 `Control` 节点，`node set --property position` 会写入底层的
+`offset_left` / `offset_top` / `offset_right` / `offset_bottom`，同时保留尺寸。
+`Container` 的直接子节点由布局管理，因此应显式设置这些 offset 属性。
+
 **`script`** — GDScript 文件（`.gd`）
 
 | 命令 | 作用 |
@@ -471,6 +475,9 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 | `game get` | 按节点路径读取一个运行时节点的实时属性；显式命名时可读取附加脚本变量。 |
 | `game rect` | 按节点路径读取一个运行时 Control 的渲染后视口矩形。 |
 | `game set` | 在正在运行的游戏上设置运行时节点属性，或显式命名的附加脚本变量。 |
+
+Live `game set --property position` 遵循与 `node set` 相同的 `Control` 策略；
+`game rect` 仍然是只读的渲染几何查询。
 
 **`diag`** — 运行时诊断
 

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -204,6 +204,16 @@ projection or the `str()` fallback (see [`project`](#project)) — but `node set
 those remaining types yet and refuses with `uncoercible_value` unless a separate assignment contract
 below applies.
 
+**`Control.position` convenience assignment** (#464): `Control.position` is layout-derived from
+offsets rather than a normal serialized storage field, but it is a common authoring target. For a
+free-positioned `Control`, `gda node set --property position --value x,y` coerces `x,y` as a
+`Vector2`, writes `offset_left` / `offset_top` / `offset_right` / `offset_bottom`, preserves the
+current size, and echoes the resulting `position`. If the `Control` is a direct child of a
+`Container`, the command refuses with `unknown_property` and names the four offset properties as the
+actionable alternative; container-managed layout is not overridden. Live `gda game set` mirrors the
+same policy with `live_unknown_property` for the container-managed case. `gda game rect` remains a
+read-only rendered-geometry query and is not a setter.
+
 **Object-typed property assignment by `res://` reference** (ADR-0033, #363): for an **Object-typed**
 property that expects a Resource (sub)class — e.g. a `CollisionShape2D`'s `shape` (`Shape2D`) — `gda
 node set` and `gda resource set` accept a **`res://….tres` resource path** as `--value`. The path is

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -454,6 +454,28 @@ func _handle_game_set(params: Dictionary) -> String:
 				"no node at runtime path: " + path)
 
 	var prop_name := _string_param(params, "property")
+	if _is_control_position_write(node, prop_name):
+		var control: Control = node as Control
+		if _has_container_parent(control):
+			return _error(LIVE_ERROR_UNKNOWN_PROPERTY,
+					_control_position_unavailable_message("node " + path))
+		var raw_position := _string_param(params, "value")
+		var coerced_position: Variant = _coerce_value(raw_position,
+				TYPE_VECTOR2, control.position)
+		if coerced_position == null:
+			return _error(LIVE_ERROR_UNCOERCIBLE_VALUE,
+					"cannot coerce value " + raw_position.c_escape()
+					+ " to Vector2 for property position on node " + path)
+		var target_position: Vector2 = coerced_position
+		control.set_position(target_position)
+		var current_position: Variant = _jsonify(control.position)
+		return _ok({
+			"path": path,
+			"property": prop_name,
+			"type": _type_name(TYPE_VECTOR2),
+			"value": current_position,
+		})
+
 	var prop_info := _runtime_set_property_info(node, prop_name)
 	if prop_info.is_empty():
 		return _error(LIVE_ERROR_UNKNOWN_PROPERTY,
@@ -503,6 +525,18 @@ func _runtime_set_property_info(node: Node, prop_name: String) -> Dictionary:
 			declared_type = typeof(node.get(prop_name))
 		return {"type": declared_type, "source": "script variable"}
 	return {}
+
+
+func _is_control_position_write(node: Node, prop_name: String) -> bool:
+	return prop_name == "position" and node is Control
+
+
+func _has_container_parent(control: Control) -> bool:
+	return control.get_parent() is Container
+
+
+func _control_position_unavailable_message(subject: String) -> String:
+	return subject + " is a direct child of a Container, so Control.position is not an actionable settable property; address offset_left, offset_top, offset_right, and offset_bottom instead"
 
 
 func _unknown_runtime_property_message(path: String, prop_name: String) -> String:

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -659,6 +659,37 @@ func _op_node_set(params: Dictionary) -> void:
 		return
 
 	var prop_name := _string_param(params, "property")
+	if _is_control_position_write(node, prop_name):
+		var control: Control = node as Control
+		if _has_container_parent(control):
+			root.free()
+			_fail(OP_ERROR_UNKNOWN_PROPERTY,
+					_control_position_unavailable_message("node " + node_path))
+			return
+		var raw_position := _string_param(params, "value")
+		var coerced_position: Variant = _coerce_value(raw_position,
+				TYPE_VECTOR2, control.position)
+		if coerced_position == null:
+			root.free()
+			_fail(OP_ERROR_UNCOERCIBLE_VALUE, "cannot coerce value "
+					+ raw_position.c_escape()
+					+ " to Vector2 for property position on node " + node_path)
+			return
+		var target_position: Vector2 = coerced_position
+		control.set_position(target_position)
+		var stored_position: Variant = _jsonify(control.position)
+		if not _repack_and_save(root, path):
+			return  # _repack_and_save already recorded the failure (and freed root)
+
+		_succeed({
+			"scene_path": path,
+			"path": node_path,
+			"property": prop_name,
+			"type": _type_name(TYPE_VECTOR2),
+			"value": stored_position,
+		})
+		return
+
 	var declared_type := _property_type(node, prop_name)
 	if declared_type == TYPE_NIL:
 		root.free()
@@ -710,6 +741,18 @@ func _op_node_set(params: Dictionary) -> void:
 		"type": _type_name(declared_type),
 		"value": stored_value,
 	})
+
+
+func _is_control_position_write(node: Node, prop_name: String) -> bool:
+	return prop_name == "position" and node is Control
+
+
+func _has_container_parent(control: Control) -> bool:
+	return control.get_parent() is Container
+
+
+func _control_position_unavailable_message(subject: String) -> String:
+	return subject + " is a direct child of a Container, so Control.position is not an actionable settable property; address offset_left, offset_top, offset_right, and offset_bottom instead"
 
 
 # node-remove: load a .tscn, resolve a node by node path, delete it and its

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -156,6 +156,13 @@ Wiring a functional scene means binding scripts, authoring Resources, and settin
 typed properties. Reach for the right command — the generic `node set` does **not**
 cover scripts, and Resource-typed fields take a `res://` path, not a coerced literal.
 
+For `Control` layout, `node set --property position --value "x,y"` is supported on
+free-positioned Controls: gda writes the underlying `offset_left`, `offset_top`,
+`offset_right`, and `offset_bottom` while preserving the current size. Direct
+children of a `Container` are layout-managed; use those offset properties
+explicitly instead. Live `game set --property position` mirrors this policy, while
+`game rect` remains a read-only rendered-geometry query.
+
 **Attach a script — `script attach`, never `node set --property script`.**
 `script attach` is the one authoritative way to bind a `.gd` script to a node: it
 verifies the script compiles, checks its base type against the node, and reports any

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -54,6 +54,15 @@ RECT_MAIN_TSCN = (
     "custom_minimum_size = Vector2(160, 48)\n"
     'text = "HP"\n'
 )
+CONTROL_POSITION_MAIN_TSCN = (
+    "[gd_scene format=3]\n\n"
+    '[node name="Main" type="Control"]\n\n'
+    '[node name="Panel" type="Control" parent="."]\n'
+    "offset_left = 5.0\n"
+    "offset_top = 7.0\n"
+    "offset_right = 105.0\n"
+    "offset_bottom = 57.0\n"
+)
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
@@ -188,6 +197,83 @@ def test_daemon_game_rect_reads_free_positioned_control_rect(
         assert doc["type"] == "VBoxContainer"
         assert doc["position"] == [24.0, 24.0]
         assert doc["size"] == [160.0, 48.0]
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_game_set_control_position_updates_offsets_preserving_size(
+    tmp_path, daemon_runtime_dir
+):
+    # #464: live `game set` mirrors headless `node set` for Control.position by
+    # applying an actionable offset write while preserving the current size.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(CONTROL_POSITION_MAIN_TSCN, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        was_set = run(
+            "game",
+            "set",
+            "/root/Main/Panel",
+            "--property",
+            "position",
+            "--value",
+            "20,30",
+        )
+        assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+        set_doc = json.loads(was_set.stdout)
+        assert set_doc["path"] == "/root/Main/Panel"
+        assert (set_doc["property"], set_doc["type"]) == ("position", "Vector2")
+        assert set_doc["value"] == [20.0, 30.0]
+
+        props = {}
+        for name in ("offset_left", "offset_top", "offset_right", "offset_bottom"):
+            got = run("game", "get", "/root/Main/Panel", "--property", name)
+            assert got.returncode == 0, got.stdout + got.stderr
+            props[name] = json.loads(got.stdout)["properties"][0]["value"]
+        assert props == {
+            "offset_left": 20.0,
+            "offset_top": 30.0,
+            "offset_right": 120.0,
+            "offset_bottom": 80.0,
+        }
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_game_set_container_managed_control_position_names_offset_alternatives(
+    tmp_path, daemon_runtime_dir
+):
+    # A Container owns direct-child layout; `game set position` reports an
+    # actionable live error instead of claiming a write the next layout pass owns.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(RECT_MAIN_TSCN, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        was_set = run(
+            "game",
+            "set",
+            "/root/Main/HUD/Stats",
+            "--property",
+            "position",
+            "--value",
+            "20,30",
+        )
+        assert was_set.returncode == 6, was_set.stdout + was_set.stderr
+        error = json.loads(was_set.stdout)["error"]
+        assert error["category"] == "live"
+        assert error["code"] == "live_unknown_property"
+        for name in ("offset_left", "offset_top", "offset_right", "offset_bottom"):
+            assert name in error["message"]
     finally:
         run("daemon", "stop")
 

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -1034,6 +1034,84 @@ def test_node_set_coerces_and_round_trips_via_get(
 
 
 @pytest.mark.e2e
+def test_node_set_control_position_updates_offsets_preserving_size(godot_project):
+    scene_path = godot_project / "main.tscn"
+    scene_path.write_text(
+        "[gd_scene format=3]\n\n"
+        '[node name="Main" type="Control"]\n\n'
+        '[node name="Panel" type="Control" parent="."]\n'
+        "offset_left = 5.0\n"
+        "offset_top = 7.0\n"
+        "offset_right = 105.0\n"
+        "offset_bottom = 57.0\n",
+        encoding="utf-8",
+    )
+
+    was_set = _gda(
+        "node",
+        "set",
+        str(scene_path),
+        "--node",
+        "Panel",
+        "--property",
+        "position",
+        "--value",
+        "20,30",
+        "--json",
+    )
+
+    assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+    set_data = json.loads(was_set.stdout)
+    assert (set_data["property"], set_data["type"]) == ("position", "Vector2")
+    assert set_data["value"] == [20.0, 30.0]
+    props = {
+        name: _get_property(scene_path, "Panel", name)["value"]
+        for name in ("offset_left", "offset_top", "offset_right", "offset_bottom")
+    }
+    assert props == {
+        "offset_left": 20.0,
+        "offset_top": 30.0,
+        "offset_right": 120.0,
+        "offset_bottom": 80.0,
+    }
+
+
+@pytest.mark.e2e
+def test_node_set_container_managed_control_position_names_offset_alternatives(
+    godot_project,
+):
+    scene_path = godot_project / "main.tscn"
+    scene_path.write_text(
+        "[gd_scene format=3]\n\n"
+        '[node name="Main" type="Control"]\n\n'
+        '[node name="HUD" type="VBoxContainer" parent="."]\n\n'
+        '[node name="Stats" type="Label" parent="HUD"]\n'
+        "custom_minimum_size = Vector2(160, 48)\n"
+        'text = "HP"\n',
+        encoding="utf-8",
+    )
+    before = scene_path.read_text(encoding="utf-8")
+
+    was_set = _gda(
+        "node",
+        "set",
+        str(scene_path),
+        "--node",
+        "HUD/Stats",
+        "--property",
+        "position",
+        "--value",
+        "20,30",
+        "--json",
+    )
+
+    err = _assert_operation_error(was_set, "unknown_property")
+    for name in ("offset_left", "offset_top", "offset_right", "offset_bottom"):
+        assert name in err["message"]
+    assert scene_path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
 def test_node_set_coerces_json_dictionary_and_array_via_get(godot_project):
     # #422 extends the shared coercion block, so the headless operations.gd side
     # must accept the same JSON container forms the live harness accepts.

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -1064,8 +1064,14 @@ def test_node_set_control_position_updates_offsets_preserving_size(godot_project
     set_data = json.loads(was_set.stdout)
     assert (set_data["property"], set_data["type"]) == ("position", "Vector2")
     assert set_data["value"] == [20.0, 30.0]
+
+    def property_value(name: str):
+        prop = _get_property(scene_path, "Panel", name)
+        assert prop is not None
+        return prop["value"]
+
     props = {
-        name: _get_property(scene_path, "Panel", name)["value"]
+        name: property_value(name)
         for name in ("offset_left", "offset_top", "offset_right", "offset_bottom")
     }
     assert props == {

--- a/tests/test_harness_coercion_mirror.py
+++ b/tests/test_harness_coercion_mirror.py
@@ -1,4 +1,4 @@
-"""Drift check: the shared coercion block is byte-identical in both .gd files.
+"""Drift checks for headless/live duplicated property-write policy.
 
 ``operations.gd`` (the headless op dispatcher, run via ``godot --headless
 --script <abs-fs-path>``) and ``gda_harness.gd`` (the live res:// autoload) need
@@ -7,11 +7,11 @@ exactly as headless ``node set`` does. No single ``preload()`` reaches both
 runtime contexts and ``install.py`` copies one file, so the block is DUPLICATED
 verbatim rather than extracted into a shared module (keystone decision, #220).
 
-This test is the drift guard: it extracts the marker-delimited block from both
-files and asserts they are byte-identical (modulo leading tabs, which differ only
+These tests are the drift guard: they extract duplicated shared helpers from both
+files and assert they are byte-identical (modulo leading tabs, which differ only
 if a copy is re-indented). Modeled on the registry drift checks in
-``tests/test_error_registry.py``. An edit to one block that is not mirrored in
-the other fails here.
+``tests/test_error_registry.py``. An edit to one copy that is not mirrored in the
+other fails here.
 """
 
 import re
@@ -25,6 +25,11 @@ GDA_HARNESS_GD = ROOT / "src" / "gda" / "harness" / "gda_harness.gd"
 BLOCK = re.compile(
     r"^# --- BEGIN shared coercion .*?$\n(?P<body>.*?)^# --- END shared coercion ---$",
     re.MULTILINE | re.DOTALL,
+)
+CONTROL_POSITION_POLICY_HELPERS = (
+    "_is_control_position_write",
+    "_has_container_parent",
+    "_control_position_unavailable_message",
 )
 
 
@@ -43,9 +48,43 @@ def _shared_block(path: Path) -> str:
     return "\n".join(line.lstrip("\t") for line in body.splitlines())
 
 
+def _top_level_function(path: Path, name: str) -> str:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    start = next(
+        (index for index, line in enumerate(lines) if line.startswith(f"func {name}(")),
+        None,
+    )
+    assert start is not None, f"expected function {name} in {path.name}"
+
+    block: list[str] = []
+    for index in range(start, len(lines)):
+        line = lines[index]
+        if index > start and line and not line.startswith("\t"):
+            break
+        block.append(line.lstrip("\t"))
+    while block and block[-1] == "":
+        block.pop()
+    return "\n".join(block)
+
+
+def _control_position_policy(path: Path) -> str:
+    return "\n\n".join(
+        _top_level_function(path, name) for name in CONTROL_POSITION_POLICY_HELPERS
+    )
+
+
 def test_shared_coercion_block_is_byte_identical_across_the_two_gd_files():
     operations_block = _shared_block(OPERATIONS_GD)
     harness_block = _shared_block(GDA_HARNESS_GD)
 
     assert operations_block, "the operations.gd shared block must be non-empty"
     assert operations_block == harness_block
+
+
+def test_control_position_policy_is_byte_identical_across_the_two_gd_files():
+    operations_policy = _control_position_policy(OPERATIONS_GD)
+    harness_policy = _control_position_policy(GDA_HARNESS_GD)
+
+    assert operations_policy, "the operations.gd Control-position policy must exist"
+    assert operations_policy == harness_policy


### PR DESCRIPTION
## Summary

- Makes `Control.position` actionable for non-container-managed Controls in both headless `node set` and live `game set`.
- Writes through Control positioning while preserving the current size, resulting in updated `offset_left`, `offset_top`, `offset_right`, and `offset_bottom`.
- Keeps direct Container children non-actionable and returns structured `unknown_property` / `live_unknown_property` messages that name the writable offset alternatives.

Closes #464

## Validation

- `env UV_CACHE_DIR=/tmp/codex-uv-cache uv run pytest tests/test_harness_coercion_mirror.py`
- `git diff --check origin/main...HEAD`
- `env UV_CACHE_DIR=/tmp/codex-uv-cache uv run pytest tests/test_e2e_node.py::test_node_set_control_position_updates_offsets_preserving_size tests/test_e2e_node.py::test_node_set_container_managed_control_position_names_offset_alternatives tests/test_e2e_daemon.py::test_daemon_game_set_control_position_updates_offsets_preserving_size tests/test_e2e_daemon.py::test_daemon_game_set_container_managed_control_position_names_offset_alternatives tests/test_harness_coercion_mirror.py`
