### PR TITLE
feat(input): add sequence mouse drag gesture

### DIFF
--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -629,7 +629,11 @@ headless is unaffected (4.4+, cross-platform).
   `physics_frame` offsets instead: press an action at `physics_frame: 0` and release
   it at `physics_frame: N` to hold it for N Godot physics ticks (for the default
   60 Hz physics clock, N = 30 is 0.5 seconds of physics simulation). A sequence must
-  use one clock throughout; mixing `frame` and `physics_frame` is rejected. The
+  use one clock throughout; mixing `frame` and `physics_frame` is rejected. For a
+  mouse drag, use sequence-only `{"type":"mouse_button", "pressed":true, ...}` /
+  `{"type":"mouse_button", "release":true, ...}` phase events around
+  `mouse_move` events in the same sequence; those motion events carry the held
+  mouse button mask for `_input(event)` drag handlers. The
   mouse ops are flat two-token commands (`mouse-click` / `mouse-move`), not a nested
   `mouse` sub-group, so each maps to a single `<group>_<command>` MCP tool name
   (ADR-0005/0011/0012). Key/mouse events ride the game's real input flow via the

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -1448,12 +1448,12 @@ def input_sequence(
         "--events",
         help=(
             "The events to inject, as a JSON array of event objects, each with a "
-            "'type' (key/mouse_click/mouse_move/action), either a relative "
+            "'type' (key/mouse_click/mouse_button/mouse_move/action), either a relative "
             "'frame' harness/process-frame offset or a 'physics_frame' physics-clock "
             "offset, and the type's fields (e.g. "
-            '\'[{"type":"action","action":"move_right","physics_frame":0},'
-            '{"type":"action","action":"move_right","release":true,'
-            '"physics_frame":30}]\').'
+            '\'[{"type":"mouse_button","x":10,"y":10,"pressed":true},'
+            '{"type":"mouse_move","x":40,"y":20,"frame":1},'
+            '{"type":"mouse_button","x":40,"y":20,"release":true,"frame":2}]\').'
         ),
     ),
     json_output: bool = json_option(),
@@ -1471,10 +1471,12 @@ def input_sequence(
     frames. Use `physics_frame` offsets instead when a press/release window must map
     deterministically to physics simulation ticks, e.g. press an action at
     `physics_frame: 0` and release it at `physics_frame: 30` for a 30-physics-frame
-    hold. For sequence `mouse_click` and `mouse_move` events, read the injected
-    coordinate from the mouse event's position; Godot may leave
-    Viewport.get_mouse_position() / Node2D.get_global_mouse_position() stale in
-    daemon sessions. A malformed `--events` (not a JSON array, an empty list, an
+    hold. A `mouse_button` press followed by `mouse_move` events and a matching
+    `mouse_button` release carries the held-button mask on the motion events for
+    drag handlers. For sequence mouse events, read the injected coordinate from the
+    mouse event's position; Godot may leave Viewport.get_mouse_position() /
+    Node2D.get_global_mouse_position() stale in daemon sessions. A malformed
+    `--events` (not a JSON array, an empty list, an
     ill-formed event, or mixed `frame`/`physics_frame` clocks) is a usage error; with
     no daemon it reports `daemon_not_running`. An event's action absent from the
     InputMap is `live_unknown_action`, an unresolvable key `live_invalid_key`.

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -690,6 +690,7 @@ func _input_viewport() -> Viewport:
 
 
 var _last_injected_mouse_position: Variant = null
+var _injected_mouse_button_mask := 0
 
 
 func _prepare_mouse_input() -> Viewport:
@@ -740,14 +741,42 @@ func _mouse_button_index(button: String) -> int:
 			return MOUSE_BUTTON_LEFT
 
 
+func _mouse_button_mask(button: String) -> int:
+	match button:
+		"right":
+			return MOUSE_BUTTON_MASK_RIGHT
+		"middle":
+			return MOUSE_BUTTON_MASK_MIDDLE
+		_:
+			return MOUSE_BUTTON_MASK_LEFT
+
+
 # Push a mouse-button event at a viewport position. Shared by the single-frame
 # click op and a sequence mouse-click event.
 func _push_mouse_click(pos: Vector2, button: String, double: bool) -> void:
 	var viewport := _prepare_mouse_input()
 	var event := InputEventMouseButton.new()
 	event.button_index = _mouse_button_index(button)
+	event.button_mask = _mouse_button_mask(button)
 	event.position = pos
 	event.pressed = true
+	event.double_click = double
+	viewport.push_input(event, true)
+	_last_injected_mouse_position = pos
+
+
+func _push_mouse_button_phase(pos: Vector2, button: String, pressed: bool, double: bool) -> void:
+	var viewport := _prepare_mouse_input()
+	var mask := _mouse_button_mask(button)
+	if pressed:
+		_injected_mouse_button_mask = _injected_mouse_button_mask | mask
+	else:
+		_injected_mouse_button_mask = _injected_mouse_button_mask & ~mask
+	var event := InputEventMouseButton.new()
+	event.button_index = _mouse_button_index(button)
+	event.button_mask = _injected_mouse_button_mask
+	event.position = pos
+	event.pressed = pressed
 	event.double_click = double
 	viewport.push_input(event, true)
 	_last_injected_mouse_position = pos
@@ -763,6 +792,7 @@ func _push_mouse_move(pos: Vector2) -> void:
 	var event := InputEventMouseMotion.new()
 	event.position = pos
 	event.relative = pos - previous
+	event.button_mask = _injected_mouse_button_mask
 	viewport.push_input(event, true)
 	_last_injected_mouse_position = pos
 
@@ -874,6 +904,7 @@ func _handle_input_sequence(params: Dictionary) -> Variant:
 	var clock := WINDOW_CLOCK_PHYSICS if uses_physics else WINDOW_CLOCK_PROCESS
 	var total_frames := max_offset + 1
 	var frame_box := {"n": 0}
+	_injected_mouse_button_mask = 0
 	# The sampler applies every event due at the current selected-clock index, then
 	# advances that clock. A bad event type aborts the window with a typed error sample.
 	var sample := func() -> Variant:
@@ -885,10 +916,12 @@ func _handle_input_sequence(params: Dictionary) -> Variant:
 				continue
 			var err: Variant = _apply_sequence_event(event)
 			if err != null:
+				_injected_mouse_button_mask = 0
 				return {"error": err}
 		frame_box["n"] = current + 1
 		return current
 	var finalize := func(_samples: Array) -> String:
+		_injected_mouse_button_mask = 0
 		return _ok({
 			"kind": "sequence",
 			"clock": clock,
@@ -933,6 +966,16 @@ func _apply_sequence_event(event: Dictionary) -> Variant:
 			_push_mouse_click(
 					Vector2(_float_param(event, "x", 0.0), _float_param(event, "y", 0.0)),
 					button, bool(event.get("double", false)))
+			return null
+		"mouse_button":
+			var button := _string_param(event, "button")
+			if button.is_empty():
+				button = "left"
+			_push_mouse_button_phase(
+					Vector2(_float_param(event, "x", 0.0), _float_param(event, "y", 0.0)),
+					button,
+					bool(event.get("pressed", false)),
+					bool(event.get("double", false)))
 			return null
 		"mouse_move":
 			_push_mouse_move(

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -3896,7 +3896,9 @@ class InputSequenceEvent(BaseModel):
                 raise ValueError("a 'mouse_click' sequence event requires 'x' and 'y'.")
         elif self.type is InputEventType.MOUSE_BUTTON:
             if self.x is None or self.y is None:
-                raise ValueError("a 'mouse_button' sequence event requires 'x' and 'y'.")
+                raise ValueError(
+                    "a 'mouse_button' sequence event requires 'x' and 'y'."
+                )
             if self.pressed is None and not self.release:
                 raise ValueError(
                     "a 'mouse_button' sequence event requires 'pressed' or 'release'."

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -3901,6 +3901,11 @@ class InputSequenceEvent(BaseModel):
                 raise ValueError(
                     "a 'mouse_button' sequence event requires 'pressed' or 'release'."
                 )
+            if self.pressed is False:
+                raise ValueError(
+                    "a 'mouse_button' sequence event uses 'pressed: true' to press; "
+                    "use 'release: true' to release."
+                )
             if self.pressed is True and self.release:
                 raise ValueError(
                     "a 'mouse_button' sequence event cannot set both 'pressed' and "

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -3753,7 +3753,8 @@ class InputActionResult(BaseModel):
 
 
 # The event types a `gda input sequence` may carry. A sequence event reuses the
-# single-frame ops' shapes (key / mouse click / mouse move / action) plus either a
+# single-frame ops' shapes (key / mouse click / mouse move / action), plus a
+# sequence-only mouse-button phase for press-drag-release gestures, and either a
 # process-clock `frame` offset (the original #221 behavior) or a physics-clock
 # `physics_frame` offset (#391). Bounding the type model-side keeps an unknown type
 # a usage/invalid_params error rather than a request the harness must defend
@@ -3763,6 +3764,7 @@ class InputEventType(str, Enum):
 
     KEY = "key"
     MOUSE_CLICK = "mouse_click"
+    MOUSE_BUTTON = "mouse_button"
     MOUSE_MOVE = "mouse_move"
     ACTION = "action"
 
@@ -3778,10 +3780,12 @@ class InputSequenceEvent(BaseModel):
     that need deterministic simulation-duration input holds. Events due at the same
     clock index are applied together. The type-specific fields mirror the
     single-frame params — ``key``/``modifiers``/``released`` for a key, ``x``/``y``/
-    ``button``/``double`` for a mouse click, ``x``/``y`` for a mouse move,
-    ``action``/``release``/``strength`` for an action. The required fields per type
-    and the shared bounds (modifier set, button enum, strength range) are validated
-    model-side (ADR-0015) so a malformed event is rejected before the harness runs.
+    ``button``/``double`` for a mouse click, ``x``/``y``/``button`` plus exactly one
+    ``pressed``/``release`` phase for a mouse-button event, ``x``/``y`` for a mouse
+    move, ``action``/``release``/``strength`` for an action. The required fields per
+    type and the shared bounds (modifier set, button enum, strength range) are
+    validated model-side (ADR-0015) so a malformed event is rejected before the
+    harness runs.
     Mouse event coordinates are reliable as the event's ``position``; engine-tracked
     mouse positions may remain stale for sequence mouse events too.
     """
@@ -3832,17 +3836,32 @@ class InputSequenceEvent(BaseModel):
         ),
     )
     button: MouseButton | None = Field(
-        default=None, description="A mouse-click event's button."
+        default=None,
+        description=(
+            "A mouse-click or mouse-button event's button; defaults to left for "
+            "mouse-button events."
+        ),
     )
     double: bool = Field(
         default=False, description="A mouse-click event: mark it a double click."
+    )
+    pressed: bool | None = Field(
+        default=None,
+        description=(
+            "A mouse-button event: press the button. Use exactly one of `pressed` "
+            "or `release`."
+        ),
     )
     # action fields
     action: str | None = Field(
         default=None, description="An action event's action name."
     )
     release: bool = Field(
-        default=False, description="An action event: release instead of press."
+        default=False,
+        description=(
+            "An action event: release instead of press. A mouse-button event: "
+            "release the button; use exactly one of `pressed` or `release`."
+        ),
     )
     strength: float = Field(
         default=1.0,
@@ -3862,6 +3881,10 @@ class InputSequenceEvent(BaseModel):
             )
         if self.frame is None and self.physics_frame is None:
             self.frame = 0
+        if self.type is not InputEventType.MOUSE_BUTTON and self.pressed is not None:
+            raise ValueError(
+                "'pressed' is only valid on a 'mouse_button' sequence event."
+            )
         # Each event type requires its own fields; the shared bounds (modifier set,
         # strength range, button enum) are enforced by the fields above.
         if self.type is InputEventType.KEY:
@@ -3871,6 +3894,22 @@ class InputSequenceEvent(BaseModel):
         elif self.type is InputEventType.MOUSE_CLICK:
             if self.x is None or self.y is None:
                 raise ValueError("a 'mouse_click' sequence event requires 'x' and 'y'.")
+        elif self.type is InputEventType.MOUSE_BUTTON:
+            if self.x is None or self.y is None:
+                raise ValueError("a 'mouse_button' sequence event requires 'x' and 'y'.")
+            if self.pressed is None and not self.release:
+                raise ValueError(
+                    "a 'mouse_button' sequence event requires 'pressed' or 'release'."
+                )
+            if self.pressed is True and self.release:
+                raise ValueError(
+                    "a 'mouse_button' sequence event cannot set both 'pressed' and "
+                    "'release'."
+                )
+            if self.release:
+                self.pressed = False
+            if self.button is None:
+                self.button = MouseButton.LEFT
         elif self.type is InputEventType.MOUSE_MOVE:
             if self.x is None or self.y is None:
                 raise ValueError("a 'mouse_move' sequence event requires 'x' and 'y'.")

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -94,6 +94,13 @@ fixed physics frames. When input timing must map to physics simulation, use
 `{"type":"action","action":"move_right","release":true,"physics_frame":N}` in the
 same sequence. At Godot's default 60 Hz physics clock, N=30 is 0.5 seconds of
 physics simulation. Do not mix `frame` and `physics_frame` in one sequence.
+For a drag, use a sequence-only mouse-button phase event followed by motion and
+release events in the same request, for example
+`{"type":"mouse_button","x":10,"y":10,"pressed":true}`, then
+`{"type":"mouse_move","x":40,"y":20,"frame":1}`, then
+`{"type":"mouse_button","x":40,"y":20,"release":true,"frame":2}`. Motion events
+between the press and release carry the held mouse button mask for `_input(event)`
+drag handlers.
 
 For `gda input mouse-click`, `gda input mouse-move`, and mouse events inside
 `gda input sequence`, the reliable injected coordinate is the mouse event's

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -63,6 +63,27 @@ MOUSE_MAIN_TSCN = (
     'script = ExtResource("1")\n'
 )
 
+DRAG_PLAYER_GD = (
+    "extends Node2D\n"
+    "@export var dragging: bool = false\n"
+    "@export var release_seen: bool = false\n"
+    "@export var motion_with_left_mask: bool = false\n"
+    "func _input(event: InputEvent) -> void:\n"
+    "\tif event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:\n"
+    "\t\tif event.pressed:\n"
+    "\t\t\tdragging = true\n"
+    "\t\t\trelease_seen = false\n"
+    "\t\t\tposition = event.position\n"
+    "\t\telse:\n"
+    "\t\t\tdragging = false\n"
+    "\t\t\trelease_seen = true\n"
+    "\telif event is InputEventMouseMotion and dragging:\n"
+    "\t\tif event.button_mask & MOUSE_BUTTON_MASK_LEFT != 0:\n"
+    "\t\t\tmotion_with_left_mask = true\n"
+    "\t\t\tposition = event.position\n"
+)
+DRAG_MAIN_TSCN = MOUSE_MAIN_TSCN
+
 TRACKED_MOUSE_PLAYER_GD = (
     "extends Node2D\n"
     '@export var last_event_type: String = ""\n'
@@ -328,6 +349,68 @@ def test_mouse_input_reports_event_position_when_tracked_mouse_position_is_stale
         assert_event_position_with_stale_tracked_mouse(
             "move", [77.0, 88.0], [27.0, 28.0]
         )
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_input_sequence_drags_mouse_with_held_button_mask(
+    tmp_path, daemon_runtime_dir
+):
+    # #461: a press -> move(s) -> release gesture stays inside one `input sequence`
+    # RPC. The game reads event.position and event.button_mask, not tracked mouse
+    # position, because #462 documents the tracked-position limitation.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(DRAG_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "player.gd").write_text(DRAG_PLAYER_GD, encoding="utf-8")
+
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    def player_property(name: str):
+        got = run("game", "get", "/root/Main/Player", "--property", name)
+        assert got.returncode == 0, got.stdout + got.stderr
+        return json.loads(got.stdout)["properties"][0]["value"]
+
+    events = json.dumps(
+        [
+            {"type": "mouse_button", "x": 10, "y": 10, "pressed": True, "frame": 0},
+            {"type": "mouse_move", "x": 40, "y": 20, "frame": 1},
+            {"type": "mouse_move", "x": 70, "y": 50, "frame": 2},
+            {"type": "mouse_button", "x": 70, "y": 50, "release": True, "frame": 3},
+        ]
+    )
+
+    try:
+        assert run("daemon", "start").returncode == 0
+
+        seq = run("input", "sequence", "--events", events)
+        assert seq.returncode == 0, seq.stdout + seq.stderr
+        seq_doc = json.loads(seq.stdout)
+        assert seq_doc["kind"] == "sequence"
+        assert seq_doc["events"] == 4
+        assert seq_doc["frames"] == 4
+
+        assert player_property("position") == [70.0, 50.0]
+        assert player_property("motion_with_left_mask") is True
+        assert player_property("dragging") is False
+        assert player_property("release_seen") is True
     finally:
         run("daemon", "stop")
 

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -354,9 +354,7 @@ def test_mouse_input_reports_event_position_when_tracked_mouse_position_is_stale
 
 
 @pytest.mark.e2e
-def test_input_sequence_drags_mouse_with_held_button_mask(
-    tmp_path, daemon_runtime_dir
-):
+def test_input_sequence_drags_mouse_with_held_button_mask(tmp_path, daemon_runtime_dir):
     # #461: a press -> move(s) -> release gesture stays inside one `input sequence`
     # RPC. The game reads event.position and event.button_mask, not tracked mouse
     # position, because #462 documents the tracked-position limitation.

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -463,6 +463,59 @@ def test_input_sequence_physics_frame_offsets_dispatch_through_the_live_channel(
     assert [e["frame"] for e in sent_events] == [None, None]
 
 
+def test_input_sequence_accepts_mouse_button_press_move_release(
+    monkeypatch, tmp_path
+):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel(
+                {
+                    **INPUT_SEQUENCE_RESULT,
+                    "events": 4,
+                    "frames": 4,
+                }
+            ),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    events = [
+        {"type": "mouse_button", "x": 10.0, "y": 10.0, "pressed": True, "frame": 0},
+        {"type": "mouse_move", "x": 40.0, "y": 20.0, "frame": 1},
+        {"type": "mouse_move", "x": 70.0, "y": 50.0, "frame": 2},
+        {"type": "mouse_button", "x": 70.0, "y": 50.0, "release": True, "frame": 3},
+    ]
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "sequence",
+            "--events",
+            json.dumps(events),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    sent_events = fake.calls[0][1]["events"]
+    assert [e["type"] for e in sent_events] == [
+        "mouse_button",
+        "mouse_move",
+        "mouse_move",
+        "mouse_button",
+    ]
+    assert sent_events[0]["button"] == "left"
+    assert sent_events[0]["pressed"] is True
+    assert sent_events[0]["release"] is False
+    assert sent_events[3]["button"] == "left"
+    assert sent_events[3]["pressed"] is False
+    assert sent_events[3]["release"] is True
+
+
 def test_input_sequence_with_no_daemon_reports_daemon_not_running(
     monkeypatch, tmp_path
 ):
@@ -722,8 +775,11 @@ def test_input_sequence_schema_reports_kind_live():
     assert "process-clock `frame`" in events_description
     assert "physics-clock `physics_frame`" in events_description
     event_props = schema["input"]["$defs"]["InputSequenceEvent"]["properties"]
+    event_types = schema["input"]["$defs"]["InputEventType"]["enum"]
+    assert "mouse_button" in event_types
     assert "harness/process-frame" in event_props["frame"]["description"]
     assert "physics-frame" in event_props["physics_frame"]["description"]
+    assert "mouse-button event" in event_props["pressed"]["description"]
 
 
 def test_input_sequence_help_names_process_and_physics_clocks():
@@ -732,6 +788,7 @@ def test_input_sequence_help_names_process_and_physics_clocks():
     assert result.exit_code == 0, result.stdout + result.stderr
     assert "harness/process-frame" in result.stdout
     assert "physics_frame" in result.stdout
+    assert "mouse_button" in result.stdout
 
 
 def test_input_sequence_help_documents_mouse_tracked_position_limitation():
@@ -842,6 +899,84 @@ def test_input_sequence_params_json_malformed_event_is_invalid_params(
             "sequence",
             "--params-json",
             '{"events": [{"type": "mouse_click", "x": 1.0}]}',
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert fake.calls == []
+
+
+def test_input_sequence_params_json_mouse_button_without_phase_is_invalid_params(
+    monkeypatch, tmp_path
+):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_SEQUENCE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "sequence",
+            "--params-json",
+            '{"events": [{"type": "mouse_button", "x": 1.0, "y": 2.0}]}',
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert fake.calls == []
+
+
+def test_input_sequence_params_json_mouse_button_conflicting_phase_is_invalid_params(
+    monkeypatch, tmp_path
+):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_SEQUENCE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "sequence",
+            "--params-json",
+            (
+                '{"events": [{"type": "mouse_button", "x": 1.0, "y": 2.0, '
+                '"pressed": true, "release": true}]}'
+            ),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert fake.calls == []
+
+
+def test_input_sequence_params_json_pressed_on_mouse_move_is_invalid_params(
+    monkeypatch, tmp_path
+):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_SEQUENCE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "sequence",
+            "--params-json",
+            '{"events": [{"type": "mouse_move", "x": 1.0, "y": 2.0, "pressed": true}]}',
             "--project",
             str(_project(tmp_path)),
             "--json",

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -463,9 +463,7 @@ def test_input_sequence_physics_frame_offsets_dispatch_through_the_live_channel(
     assert [e["frame"] for e in sent_events] == [None, None]
 
 
-def test_input_sequence_accepts_mouse_button_press_move_release(
-    monkeypatch, tmp_path
-):
+def test_input_sequence_accepts_mouse_button_press_move_release(monkeypatch, tmp_path):
     fake = inject_live_runner(
         monkeypatch,
         RunResult(

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -962,6 +962,34 @@ def test_input_sequence_params_json_mouse_button_conflicting_phase_is_invalid_pa
     assert fake.calls == []
 
 
+def test_input_sequence_params_json_mouse_button_pressed_false_is_invalid_params(
+    monkeypatch, tmp_path
+):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_SEQUENCE_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "sequence",
+            "--params-json",
+            (
+                '{"events": [{"type": "mouse_button", "x": 1.0, "y": 2.0, '
+                '"pressed": false}]}'
+            ),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert fake.calls == []
+
+
 def test_input_sequence_params_json_pressed_on_mouse_move_is_invalid_params(
     monkeypatch, tmp_path
 ):

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1330,12 +1330,15 @@ def test_input_commands_schema_report_kind_live_and_are_model_derived():
     assert "process-clock `frame`" in events_description
     assert "physics-clock `physics_frame`" in events_description
     sequence_event_props = sequence_input["$defs"]["InputSequenceEvent"]["properties"]
+    sequence_event_types = sequence_input["$defs"]["InputEventType"]["enum"]
+    assert "mouse_button" in sequence_event_types
     assert "harness/process-frame" in sequence_event_props["frame"]["description"]
     assert "physics-frame" in sequence_event_props["physics_frame"]["description"]
     assert (
         "engine-tracked mouse positions may remain stale"
         in (sequence_event_props["x"]["description"])
     )
+    assert "mouse-button event" in sequence_event_props["pressed"]["description"]
 
 
 def test_sample_input_results_validate_against_emitted_output_schemas():


### PR DESCRIPTION
## Summary

- Adds a sequence-only `mouse_button` event for explicit mouse press/release phases.
- Carries the currently held injected mouse button mask on sequence `mouse_move` events, so one `gda input sequence` call can express press -> move(s) -> release drag gestures.
- Adds model/schema validation for the new shape and a live e2e with a draggable Node2D that reacts through `event.position` and `event.button_mask`.

Closes #461

## Validation

- `env UV_CACHE_DIR=/tmp/codex-merge-467 uv run pytest tests/test_input_commands.py tests/test_schema_command.py::test_input_commands_schema_report_kind_live_and_are_model_derived tests/test_skill_command.py tests/test_skill_surface_sync.py`
- `env UV_CACHE_DIR=/tmp/codex-merge-467 uv run pytest tests/test_e2e_input.py`
- `env UV_CACHE_DIR=/tmp/codex-merge-467 uv run ruff check src/gda/models.py src/gda/cli.py tests/test_e2e_input.py tests/test_input_commands.py tests/test_schema_command.py`
- `env UV_CACHE_DIR=/tmp/codex-merge-467 uv run ruff format --check src/gda/models.py src/gda/cli.py tests/test_e2e_input.py tests/test_input_commands.py tests/test_schema_command.py`
- `git diff --check origin/main...HEAD`