### PR TITLE
docs(skills): fold wave-1 orchestration lessons into subagent-worktree-parallel

### DIFF
--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -299,9 +299,10 @@ the grep heuristic might miss in another language.
   strike mid-fix-round too (session/usage limits, not just truncation) — one real agent
   finished an entire fix round and died with all of it uncommitted.
 - **Takeover recipe for uncommitted work:** review the whole uncommitted diff yourself
-  against the findings it claims to fix, run the full gate set (tests + format/lint/
-  typecheck), then commit and push it under an honest message. Don't re-dispatch what a
-  diff review can verify — and don't commit what you haven't read.
+  against the findings it claims to fix, run the same gates the dispatch DoD requires
+  (§3: the integration tier plus the PR-CI gate list read off the CI workflow), then
+  commit and push it under an honest message. Don't re-dispatch what a diff review can
+  verify — and don't commit what you haven't read.
 - **Trivial mechanical CI failures are the lead's to fix in place.** A formatter diff or
   an import sort on an otherwise-verified branch is cheaper to fix, test, and push
   yourself than to re-dispatch an agent for.

--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -37,7 +37,10 @@ name the owner in both dispatch prompts: the owner edits; every other slice must
 the needed change in its report instead of editing** (the orchestrator then serializes
 or folds it into the owner's slice). This converts a probable merge conflict into an
 explicit coordination point — one real wave ran a view-layer refactor in parallel with a
-consumer of those same files at zero conflicts this way.
+consumer of those same files at zero conflicts this way. Ownership **routes** a
+legitimate shared-file edit through one slice; it never suppresses the edit (the
+disjointness guardrail below still holds) — a non-owner's needed change lands via the
+owner, a lead-reassigned ownership, or a serialized follow-up.
 
 **Guardrail: disjointness is a merge-cost heuristic, not an architecture goal.** When
 slicing for disjointness would suppress or distort a sound design decision, the design
@@ -108,8 +111,11 @@ You are implementing <slice> in an ISOLATED git worktree.
 - Also part of DoD — deep-module reuse: if your change belongs in a shared/deep module (a
   central helper, model, or a spawn/launch primitive), REUSE it — do NOT re-implement its
   logic in your worktree. A thin per-slice wrapper over an existing module is fine; a
-  second copy of its logic is not. If the right change belongs in a shared file, make it
-  there and flag it in your report — don't dodge it to stay disjoint.
+  second copy of its logic is not. If the right change belongs in a shared file, don't
+  dodge it to stay disjoint: when YOU own that file this wave (or it has no owner), make
+  the change there and flag it in your report; when a SIBLING slice owns it, flag it for
+  the owner/orchestrator instead of editing (previous line) — the lead reassigns
+  ownership or serializes the slice, but the change still lands.
 - When done: **commit and push your branch — do NOT open the PR.** The orchestrator opens
   every PR so the close-vs-reference keyword and PR conventions are applied in one place.
   Report the branch name, the commit SHA, the exact test command + its result counts, the

--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -98,9 +98,11 @@ You are implementing <slice> in an ISOLATED git worktree.
 - Definition of Done: the INTEGRATION-tier test passes (the tier that actually exercises
   the integration boundary — integration / e2e / compile / a parse `--check-only`), not
   just the fast tier that stubs it. Do not satisfy DoD with `-m "not <integration>"`.
-- Also part of DoD — mirror the repo's FULL PR-CI gate set: run the formatter CHECK, the
-  linter, and the typecheck exactly as CI invokes them (same commands/flags), not just the
-  test suite. A green test run with a red format check still bounces the PR.
+- Also part of DoD — beyond the test tiers, mirror the repo's NON-TEST PR-CI gates: read
+  the gate list off the CI workflow itself (do not recite it from memory) and run each
+  gate exactly as CI invokes it (same commands/flags) — typically the formatter CHECK,
+  linter, typecheck, and build/packaging. A green test run with a red format check still
+  bounces the PR.
 - If a shared file is OWNED by a sibling slice this wave (the prompt names the owners),
   do NOT edit it — flag the needed change in your report and let the orchestrator route it.
 - Also part of DoD — deep-module reuse: if your change belongs in a shared/deep module (a
@@ -333,7 +335,7 @@ design decision (an ADR) of its own.
 - [ ] Wave ≤ ~5; will merge before the next wave.
 - [ ] Every append hotspot has exactly ONE owner slice this wave; sibling prompts say "flag, don't edit" (§1).
 - [ ] Each subagent's DoD includes the integration tier (not just the stubbed fast tier).
-- [ ] Each subagent's DoD mirrors the repo's full PR-CI gate set — formatter check, lint, typecheck, invoked as CI invokes them (§3).
+- [ ] Each subagent's DoD covers the PR-CI gate list read off the CI workflow itself — the test tiers plus the non-test gates (formatter check, lint, typecheck, build), invoked as CI invokes them (§3).
 - [ ] Each subagent's DoD includes deep-module reuse — no re-implementing shared logic, and no dodging a legitimate shared-file edit, to fake disjointness (§1).
 - [ ] Review/fix rounds restate the dispatch discipline (resume the original agent; one commit per finding); the lead re-verifies, replies finding→resolution on the PR, and updates the PR body (§7).
 - [ ] Agents pinned to their own worktree; will commit early; "done but no artifact" = takeover.

--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -31,6 +31,14 @@ edits, where all the integration cost concentrates:
 A wave whose slices all hammer the same hotspot is *not* a good parallel candidate —
 expect a conflict-heavy serial merge, or fix it structurally first (§8).
 
+**Assign each hotspot exactly one owner slice per wave.** When two slices *could*
+legitimately touch the same shared file (one refactors a module, another instances it),
+name the owner in both dispatch prompts: the owner edits; every other slice must **flag
+the needed change in its report instead of editing** (the orchestrator then serializes
+or folds it into the owner's slice). This converts a probable merge conflict into an
+explicit coordination point — one real wave ran a view-layer refactor in parallel with a
+consumer of those same files at zero conflicts this way.
+
 **Guardrail: disjointness is a merge-cost heuristic, not an architecture goal.** When
 slicing for disjointness would suppress or distort a sound design decision, the design
 wins:
@@ -90,6 +98,11 @@ You are implementing <slice> in an ISOLATED git worktree.
 - Definition of Done: the INTEGRATION-tier test passes (the tier that actually exercises
   the integration boundary — integration / e2e / compile / a parse `--check-only`), not
   just the fast tier that stubs it. Do not satisfy DoD with `-m "not <integration>"`.
+- Also part of DoD — mirror the repo's FULL PR-CI gate set: run the formatter CHECK, the
+  linter, and the typecheck exactly as CI invokes them (same commands/flags), not just the
+  test suite. A green test run with a red format check still bounces the PR.
+- If a shared file is OWNED by a sibling slice this wave (the prompt names the owners),
+  do NOT edit it — flag the needed change in your report and let the orchestrator route it.
 - Also part of DoD — deep-module reuse: if your change belongs in a shared/deep module (a
   central helper, model, or a spawn/launch primitive), REUSE it — do NOT re-implement its
   logic in your worktree. A thin per-slice wrapper over an existing module is fine; a
@@ -249,6 +262,19 @@ the grep heuristic might miss in another language.
   *cross-cutting cause*. Fix it in a shared follow-up rather than band-aiding the one
   slice — especially when sibling slices each grew their own *partial* handling that the
   shared fix should later absorb (otherwise the duplication is what ships).
+- **Sibling worktrees double as flake controls.** When a test fails in one worktree's
+  full run, check the same test across the siblings before blaming the slice: the
+  worktrees differ only by each slice's diff, so the same failure appearing in a sibling
+  whose diff cannot touch that path points at infra, not the change. Adjudicate with:
+  re-run the single test standalone, then demand one fully green full run — an
+  intermittent display/timing-dependent test that passes both is a flake to note, not a
+  blocker (but say so honestly in the PR).
+- **Scale the heaviest gate to the wave, not the PR (a cost decision the lead sets).**
+  When the full integration tier is expensive (long CI runs, real engines/devices), a
+  workable economy is: per-branch risk covered by the lead's local serial runs (above),
+  PR CI running only the cheap tiers, and ONE full-tier run on the merged trunk after
+  the wave's last merge as the wave gate. The trade is deferred detection on the trunk —
+  make it deliberately, not by default.
 - **Close the review loop.** For actionable PR review comments, implement the fix,
   re-run the relevant gates, push, and reply or resolve the thread according to the
   repo's convention. Review remediation can touch shared docs or other hotspots, so
@@ -258,6 +284,19 @@ the grep heuristic might miss in another language.
 
 - **Commit early.** Truncation/kill only loses *uncommitted* work; an agent cut off
   before committing can leave a broken, unsaved file in its worktree.
+- **A review/fix round is a re-dispatch — restate the whole discipline.** Prefer
+  resuming the ORIGINAL implementer (its context is intact), but do not assume it
+  remembers the rules it followed last round: restate worktree pinning, commit-early,
+  and the CI-mirror DoD in the fix brief, and require **one commit per finding**. Kills
+  strike mid-fix-round too (session/usage limits, not just truncation) — one real agent
+  finished an entire fix round and died with all of it uncommitted.
+- **Takeover recipe for uncommitted work:** review the whole uncommitted diff yourself
+  against the findings it claims to fix, run the full gate set (tests + format/lint/
+  typecheck), then commit and push it under an honest message. Don't re-dispatch what a
+  diff review can verify — and don't commit what you haven't read.
+- **Trivial mechanical CI failures are the lead's to fix in place.** A formatter diff or
+  an import sort on an otherwise-verified branch is cheaper to fix, test, and push
+  yourself than to re-dispatch an agent for.
 - **"Completed but no artifact" = needs-takeover.** Never trust a completion claim —
   independently verify with `git status` (clean?), `git log` (recent commits?), and
   remote-tracking (pushed?). Also seen: an agent reports done while its test run is "still
@@ -292,8 +331,11 @@ design decision (an ADR) of its own.
 
 - [ ] Slices in this wave are independent (no shared module/group); coupled ones serialized.
 - [ ] Wave ≤ ~5; will merge before the next wave.
+- [ ] Every append hotspot has exactly ONE owner slice this wave; sibling prompts say "flag, don't edit" (§1).
 - [ ] Each subagent's DoD includes the integration tier (not just the stubbed fast tier).
+- [ ] Each subagent's DoD mirrors the repo's full PR-CI gate set — formatter check, lint, typecheck, invoked as CI invokes them (§3).
 - [ ] Each subagent's DoD includes deep-module reuse — no re-implementing shared logic, and no dodging a legitimate shared-file edit, to fake disjointness (§1).
+- [ ] Review/fix rounds restate the dispatch discipline (resume the original agent; one commit per finding); the lead re-verifies, replies finding→resolution on the PR, and updates the PR body (§7).
 - [ ] Agents pinned to their own worktree; will commit early; "done but no artifact" = takeover.
 - [ ] Merge order decided (tracer first); after each resolution, audit for the marker-free traps.
 - [ ] Stacked followers have an explicit retarget/rebase plan for after the base PR lands

--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -343,7 +343,7 @@ design decision (an ADR) of its own.
 - [ ] Each subagent's DoD includes the integration tier (not just the stubbed fast tier).
 - [ ] Each subagent's DoD covers the PR-CI gate list read off the CI workflow itself — the test tiers plus the non-test gates (formatter check, lint, typecheck, build), invoked as CI invokes them (§3).
 - [ ] Each subagent's DoD includes deep-module reuse — no re-implementing shared logic, and no dodging a legitimate shared-file edit, to fake disjointness (§1).
-- [ ] Review/fix rounds restate the dispatch discipline (resume the original agent; one commit per finding); the lead re-verifies, replies finding→resolution on the PR, and updates the PR body (§7).
+- [ ] Review/fix rounds restate the dispatch discipline (resume the original agent; one commit per finding); actionable review comments are closed with code/tests plus a finding→resolution reply or thread resolution on the review channel — by the lead, who re-verifies and keeps the PR/change description current where the host supports it (§6, §7).
 - [ ] Agents pinned to their own worktree; will commit early; "done but no artifact" = takeover.
 - [ ] Merge order decided (tracer first); after each resolution, audit for the marker-free traps.
 - [ ] Stacked followers have an explicit retarget/rebase plan for after the base PR lands
@@ -352,8 +352,6 @@ design decision (an ADR) of its own.
 - [ ] Orchestrator will independently re-verify before each merge.
 - [ ] Any public-surface change has a docs/schema/help/agent-skill/i18n sync gate in the
       orchestrator's verification plan.
-- [ ] Actionable review comments will be closed with code/tests plus a PR reply or thread
-      resolution, not just a local fix.
 - [ ] PR creation is the orchestrator's: subagents commit + push only; the lead opens each PR and chooses `Closes #N` (only if the slice fully satisfies its issue) vs `Refs #N`.
 - [ ] If append hotspots keep causing conflicts, consider splitting them (ADR).
 

--- a/.agents/skills/subagent-worktree-parallel/SKILL.md
+++ b/.agents/skills/subagent-worktree-parallel/SKILL.md
@@ -30,9 +30,13 @@ the cost/benefit table).
 - **Small batches (≤ ~5), merge before the next wave.** Each rebase then lands on a
   stable base; large waves create a merge *treadmill* (every merge re-conflicts the
   rest) and raise the odds a subagent is truncated at a run limit.
-- **The integration-tier test is the Definition of Done.** A fast tier that stubs the
-  integration boundary passes even on a broken merge. DoD must run the tier that really
-  exercises the boundary (integration / e2e / compile or a parse `--check-only`).
+- **The integration-tier test is the Definition of Done — and so is the repo's full
+  PR-CI gate set.** A fast tier that stubs the integration boundary passes even on a
+  broken merge: DoD must run the tier that really exercises the boundary (integration /
+  e2e / compile or a parse `--check-only`). And DoD must mirror every gate the PR CI
+  runs — formatter *check*, linter, typecheck — invoked exactly as CI invokes them: a
+  green test run with a red format check still bounces the PR (every slice of one real
+  wave tripped this). (REFERENCE §3, §6)
 - **The orchestrator independently re-verifies before merging.** Subagent implements and
   **commits** (its own branch, in its worktree); the lead re-runs tests and spot-checks the
   diff. "Done but no artifact" = needs takeover.
@@ -75,8 +79,9 @@ decompose + dependency analysis → plan waves → fan out (implement) → merge
 1. **Decompose + analyze dependencies.** Split the work into vertical slices. Mark which
    are independent (parallel-safe) vs. coupled (must serialize). Up front, identify the
    **append hotspots** — central registries, enums, dispatch tables, render/plugin maps,
-   shared test files that *every* slice edits — that is where merge cost concentrates.
-   (REFERENCE §1)
+   shared test files that *every* slice edits — that is where merge cost concentrates —
+   and give each hotspot exactly **one owner slice** for the wave; the others flag needed
+   changes instead of editing. (REFERENCE §1)
 2. **Plan waves.** Group independent slices into waves of ≤ ~5; sequence coupled slices
    tracer-first. Decide the merge order now. (REFERENCE §2)
 3. **Fan out to implement.** Launch one subagent per slice in its own git worktree, each
@@ -97,9 +102,14 @@ decompose + dependency analysis → plan waves → fan out (implement) → merge
    (REFERENCE §6, §7)
 
 This path is **not one-shot**: independent review sends merged-ready slices back, and
-remediation reshapes the plan. Re-derive the overlap map and merge order as fixes land,
-verify each slice against its *originating spec* (not just its own green tests), and fix a
-finding at the altitude of its true cause, not where it surfaced. (REFERENCE §1, §6)
+remediation reshapes the plan. A review/fix round is a **re-dispatch** — resume the
+original implementer with its context where possible, restate the full dispatch
+discipline (worktree pinning, commit-early, the CI-mirror DoD), and require **one commit
+per finding** so a mid-round kill is cheap to take over. The lead then re-verifies,
+replies on the PR mapping each finding → resolution, and owns the PR-body update.
+Re-derive the overlap map and merge order as fixes land, verify each slice against its
+*originating spec* (not just its own green tests), and fix a finding at the altitude of
+its true cause, not where it surfaced. (REFERENCE §1, §6, §7)
 
 When append hotspots keep dominating merge cost, the durable fix is architectural —
 split them into per-module fragments that auto-aggregate (REFERENCE §8). Run the

--- a/.agents/skills/subagent-worktree-parallel/SKILL.md
+++ b/.agents/skills/subagent-worktree-parallel/SKILL.md
@@ -30,13 +30,14 @@ the cost/benefit table).
 - **Small batches (≤ ~5), merge before the next wave.** Each rebase then lands on a
   stable base; large waves create a merge *treadmill* (every merge re-conflicts the
   rest) and raise the odds a subagent is truncated at a run limit.
-- **The integration-tier test is the Definition of Done — and so is the repo's full
-  PR-CI gate set.** A fast tier that stubs the integration boundary passes even on a
+- **The integration-tier test is the Definition of Done — and so is the rest of the
+  PR-CI gate list.** A fast tier that stubs the integration boundary passes even on a
   broken merge: DoD must run the tier that really exercises the boundary (integration /
-  e2e / compile or a parse `--check-only`). And DoD must mirror every gate the PR CI
-  runs — formatter *check*, linter, typecheck — invoked exactly as CI invokes them: a
-  green test run with a red format check still bounces the PR (every slice of one real
-  wave tripped this). (REFERENCE §3, §6)
+  e2e / compile or a parse `--check-only`). Beyond the test tiers, DoD must also mirror
+  the repo's non-test PR-CI gates — read the gate list off the CI workflow itself, not
+  from memory: typically the formatter *check*, linter, typecheck, and build/packaging —
+  invoked exactly as CI invokes them. A green test run with a red format check still
+  bounces the PR (every slice of one real wave tripped this). (REFERENCE §3, §6)
 - **The orchestrator independently re-verifies before merging.** Subagent implements and
   **commits** (its own branch, in its worktree); the lead re-runs tests and spot-checks the
   diff. "Done but no artifact" = needs takeover.

--- a/.agents/skills/subagent-worktree-parallel/SKILL.md
+++ b/.agents/skills/subagent-worktree-parallel/SKILL.md
@@ -106,8 +106,9 @@ This path is **not one-shot**: independent review sends merged-ready slices back
 remediation reshapes the plan. A review/fix round is a **re-dispatch** — resume the
 original implementer with its context where possible, restate the full dispatch
 discipline (worktree pinning, commit-early, the CI-mirror DoD), and require **one commit
-per finding** so a mid-round kill is cheap to take over. The lead then re-verifies,
-replies on the PR mapping each finding → resolution, and owns the PR-body update.
+per finding** so a mid-round kill is cheap to take over. The lead then re-verifies and
+closes the loop on the review channel — e.g. a reply mapping each finding → resolution —
+keeping the PR/change description current where the host supports it.
 Re-derive the overlap map and merge order as fixes land, verify each slice against its
 *originating spec* (not just its own green tests), and fix a finding at the altitude of
 its true cause, not where it surfaced. (REFERENCE §1, §6, §7)


### PR DESCRIPTION
## Summary

Folds the orchestration-layer lessons from the Panda Adventure Phase-2 wave-1 fan-out (#436/#437/#438 → PRs #458/#459/#460, three parallel worktree subagents + one review round each) back into the `subagent-worktree-parallel` skill, abstracted project-agnostically. Docs only — no code.

Rebased on top of #470 (the sibling lessons PR from the #461/#462/#464 run): the §6 same-anchor conflict was resolved keep-both, and the overlapping review-loop guidance was editorially folded into one canonical phrasing — the two lesson sets now read as one document.

## What's new in the skill

1. **DoD covers the PR-CI gate list read off the CI workflow itself** — the test tiers plus the non-test gates (formatter *check*, linter, typecheck, build/packaging), invoked exactly as CI invokes them. Evidence: every slice of the wave passed its tests and still tripped CI's format check. (SKILL principle, §3 dispatch template, §9 checklist)
2. **Hotspot ownership** — each append hotspot gets exactly ONE owner slice per wave; sibling prompts say "flag, don't edit"; ownership *routes* a legitimate shared-file edit (via the owner, reassignment, or a serialized follow-up) — it never suppresses it. Evidence: a view-layer refactor ran in parallel with a consumer of the same files at zero merge conflicts. (SKILL workflow, §1, §3, §9)
3. **Review/fix rounds are re-dispatches** — resume the original implementer (context intact), restate the whole discipline, one commit per finding; kills strike mid-fix-round too. The lead re-verifies and closes the loop on the review channel (finding → resolution), keeping the PR/change description current where the host supports it — an intended lesson, stated host-agnostically. Evidence: one agent completed an entire fix round and died to a session limit with all of it uncommitted. (SKILL "not one-shot", §7, §9)
4. **Takeover recipe for uncommitted work** — review the whole diff against the claimed findings, run the gates, commit under an honest message; trivial mechanical CI failures (a formatter diff) are the lead's to fix in place. (§7)
5. **Sibling worktrees double as flake controls** — the same failure appearing in a sibling whose diff can't touch that path points at infra; plus the wave-scoped (not per-PR) heavy-gate economy, framed as an explicit lead decision with its trade named. (§6)

Deliberately kept OUT (project-specific, lives in project memory/STATE): engine binary paths, exact test/CI commands, this repo's per-wave e2e dispatch rule as policy, model-choice preferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
