### PR TITLE
docs(skills): four-dimension audit hardening for subagent-worktree-parallel

### DIFF
--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -100,7 +100,8 @@ You are implementing <slice> in an ISOLATED git worktree.
 - Commit early and often, even WIP — a truncated/killed run only loses UNcommitted work.
 - Definition of Done: the INTEGRATION-tier test passes (the tier that actually exercises
   the integration boundary — integration / e2e / compile / a parse `--check-only`), not
-  just the fast tier that stubs it. Do not satisfy DoD with `-m "not <integration>"`.
+  just the fast tier that stubs it. Do not satisfy DoD by deselecting the integration
+  tier (e.g. a pytest-style `-m "not <integration>"` filter — or your runner's equivalent).
 - Also part of DoD — beyond the test tiers, mirror the repo's NON-TEST PR-CI gates: read
   the gate list off the CI workflow itself (do not recite it from memory) and run each
   gate exactly as CI invokes it (same commands/flags) — typically the formatter CHECK,
@@ -200,7 +201,8 @@ After the replay, update the PR metadata before merging:
 - retarget the PR to the real base branch if the host did not already do it
 - remove stale "stacked on PR-A" text
 - change `Refs #N` to `Closes #N` only if B now fully satisfies the issue
-- update the validation section to the commands run on the post-rebase head
+- refresh any verification evidence recorded in the PR description to the commands
+  actually run on the post-rebase head
 - wait for CI on the new head; old green checks belonged to the stacked base
 
 ## 5. The two silent merge hazards (no conflict marker; fast tests still pass)

--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -34,7 +34,7 @@ expect a conflict-heavy serial merge, or fix it structurally first (§8).
 **Assign each hotspot exactly one owner slice per wave.** When two slices *could*
 legitimately touch the same shared file (one refactors a module, another instances it),
 name the owner in both dispatch prompts: the owner edits; every other slice must **flag
-the needed change in its report instead of editing** (the orchestrator then serializes
+the needed change in its report instead of editing** (the orchestrator — the "lead" — then serializes
 or folds it into the owner's slice). This converts a probable merge conflict into an
 explicit coordination point — one real wave ran a view-layer refactor in parallel with a
 consumer of those same files at zero conflicts this way. Ownership **routes** a
@@ -295,9 +295,9 @@ the grep heuristic might miss in another language.
 - **A review/fix round is a re-dispatch — restate the whole discipline.** Prefer
   resuming the ORIGINAL implementer (its context is intact), but do not assume it
   remembers the rules it followed last round: restate worktree pinning, commit-early,
-  and the CI-mirror DoD in the fix brief, and require **one commit per finding**. Kills
-  strike mid-fix-round too (session/usage limits, not just truncation) — one real agent
-  finished an entire fix round and died with all of it uncommitted.
+  and the §3 DoD gates in the fix brief, and require **one commit per finding**. Kills
+  strike mid-round too (session/usage limits, not just truncation) — one real agent
+  finished an entire review/fix round and died with all of it uncommitted.
 - **Takeover recipe for uncommitted work:** review the whole uncommitted diff yourself
   against the findings it claims to fix, run the same gates the dispatch DoD requires
   (§3: the integration tier plus the PR-CI gate list read off the CI workflow), then

--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -35,12 +35,12 @@ expect a conflict-heavy serial merge, or fix it structurally first (§8).
 legitimately touch the same shared file (one refactors a module, another instances it),
 name the owner in both dispatch prompts: the owner edits; every other slice must **flag
 the needed change in its report instead of editing** (the orchestrator — the "lead" — then serializes
-or folds it into the owner's slice). This converts a probable merge conflict into an
-explicit coordination point — one real wave ran a view-layer refactor in parallel with a
-consumer of those same files at zero conflicts this way. Ownership **routes** a
-legitimate shared-file edit through one slice; it never suppresses the edit (the
-disjointness guardrail below still holds) — a non-owner's needed change lands via the
-owner, a lead-reassigned ownership, or a serialized follow-up.
+or folds it into the owner's slice). Ownership converts a probable merge conflict into
+an explicit coordination point: it **routes** a legitimate shared-file edit through one
+slice — never suppresses it (the disjointness guardrail below still holds) — so a
+non-owner's needed change lands via the owner, a lead-reassigned ownership, or a
+serialized follow-up. One real wave ran a view-layer refactor in parallel with a
+consumer of those same files at zero conflicts this way.
 
 **Guardrail: disjointness is a merge-cost heuristic, not an architecture goal.** When
 slicing for disjointness would suppress or distort a sound design decision, the design

--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -297,7 +297,7 @@ the grep heuristic might miss in another language.
 - **A review/fix round is a re-dispatch — restate the whole discipline.** Prefer
   resuming the ORIGINAL implementer (its context is intact), but do not assume it
   remembers the rules it followed last round: restate worktree pinning, commit-early,
-  and the §3 DoD gates in the fix brief, and require **one commit per finding**. Kills
+  and the §3 DoD gates in the round's dispatch brief, and require **one commit per finding**. Kills
   strike mid-round too (session/usage limits, not just truncation) — one real agent
   finished an entire review/fix round and died with all of it uncommitted.
 - **Takeover recipe for uncommitted work:** review the whole uncommitted diff yourself

--- a/.agents/skills/subagent-worktree-parallel/SKILL.md
+++ b/.agents/skills/subagent-worktree-parallel/SKILL.md
@@ -74,7 +74,7 @@ the cost/benefit table).
 ## Workflow
 
 ```
-decompose + dependency analysis → plan waves → fan out (implement) → merge serially (dependency order) → verify
+decompose + dependency analysis → plan waves → fan out (implement) → verify + open PRs (per slice) → merge serially (dependency order)
 ```
 
 1. **Decompose + analyze dependencies.** Split the work into vertical slices. Mark which
@@ -89,18 +89,18 @@ decompose + dependency analysis → plan waves → fan out (implement) → merge
    with a dispatch prompt that pins it to its worktree, tells it to commit early and push its
    branch but not open the PR (the orchestrator does), and bakes the integration-tier test
    into its DoD. (REFERENCE §3)
-4. **Merge serially in dependency order.** Tracer first → rebase followers onto the new
-   base → independent groups can merge in any order. Re-poll mergeability after each
-   merge. For stacked PRs, retarget followers after the base lands and update any stale
-   `Refs`/`Closes` or validation text before merging. Watch for the two marker-free
-   conflict traps. (REFERENCE §4, §5)
-5. **Verify, open PRs, take over.** Re-run the integration tier yourself (a *clean* rebase
-   still needs it); run shared-global-resource tests serially; audit any public docs/agent
-   docs surface; treat any "completed but no commit/push" report as needs-takeover, not
-   success. **You** (not the subagent) open each PR, choosing `Closes #N` only when the
-   slice fully satisfies its issue (else `Refs #N`). Address actionable review comments
-   with code/tests and reply or resolve them according to the repo's PR convention.
-   (REFERENCE §6, §7)
+4. **Verify, open PRs, take over.** As each implementer finishes — and before anything
+   merges — re-run the integration tier yourself; run shared-global-resource tests
+   serially; audit any public docs/agent docs surface; treat any "completed but no
+   commit/push" report as needs-takeover, not success. **You** (not the subagent) open
+   each PR, choosing `Closes #N` only when the slice fully satisfies its issue (else
+   `Refs #N`). Address actionable review comments with code/tests and reply or resolve
+   them according to the repo's PR convention. (REFERENCE §6, §7)
+5. **Merge serially in dependency order.** Tracer first → rebase followers onto the new
+   base → independent groups can merge in any order; a *clean* rebase still gets the
+   integration gate. Re-poll mergeability after each merge. For stacked PRs, retarget
+   followers after the base lands and update any stale `Refs`/`Closes` or validation
+   text before merging. Watch for the two marker-free conflict traps. (REFERENCE §4, §5)
 
 This path is **not one-shot**: independent review sends merged-ready slices back, and
 remediation reshapes the plan. A review/fix round is a **re-dispatch** — resume the

--- a/.agents/skills/subagent-worktree-parallel/SKILL.md
+++ b/.agents/skills/subagent-worktree-parallel/SKILL.md
@@ -38,7 +38,7 @@ the cost/benefit table).
   from memory: typically the formatter *check*, linter, typecheck, and build/packaging —
   invoked exactly as CI invokes them. A green test run with a red format check still
   bounces the PR (every slice of one real wave tripped this). (REFERENCE §3, §6)
-- **The orchestrator independently re-verifies before merging.** Subagent implements and
+- **The orchestrator (the "lead") independently re-verifies before merging.** Subagent implements and
   **commits** (its own branch, in its worktree); the lead re-runs tests and spot-checks the
   diff. "Done but no artifact" = needs takeover.
 - **PR creation and its body are the orchestrator's, not the subagent's.** A PR is a
@@ -105,7 +105,8 @@ decompose + dependency analysis → plan waves → fan out (implement) → verif
 This path is **not one-shot**: independent review sends merged-ready slices back, and
 remediation reshapes the plan. A review/fix round is a **re-dispatch** — resume the
 original implementer with its context where possible, restate the full dispatch
-discipline (worktree pinning, commit-early, the CI-mirror DoD), and require **one commit
+discipline (worktree pinning, commit-early, the full DoD gates — integration tier plus
+the PR-CI gate list), and require **one commit
 per finding** so a mid-round kill is cheap to take over. The lead then re-verifies and
 closes the loop on the review channel — e.g. a reply mapping each finding → resolution —
 keeping the PR/change description current where the host supports it.

--- a/.agents/skills/subagent-worktree-parallel/SKILL.md
+++ b/.agents/skills/subagent-worktree-parallel/SKILL.md
@@ -94,8 +94,7 @@ decompose + dependency analysis → plan waves → fan out (implement) → verif
    serially; audit any public docs/agent docs surface; treat any "completed but no
    commit/push" report as needs-takeover, not success. **You** (not the subagent) open
    each PR, choosing `Closes #N` only when the slice fully satisfies its issue (else
-   `Refs #N`). Address actionable review comments with code/tests and reply or resolve
-   them according to the repo's PR convention. (REFERENCE §6, §7)
+   `Refs #N`). (REFERENCE §6, §7)
 5. **Merge serially in dependency order.** Tracer first → rebase followers onto the new
    base → independent groups can merge in any order; a *clean* rebase still gets the
    integration gate. Re-poll mergeability after each merge. For stacked PRs, retarget

--- a/.agents/skills/subagent-worktree-parallel/SKILL.md
+++ b/.agents/skills/subagent-worktree-parallel/SKILL.md
@@ -98,8 +98,9 @@ decompose + dependency analysis → plan waves → fan out (implement) → verif
 5. **Merge serially in dependency order.** Tracer first → rebase followers onto the new
    base → independent groups can merge in any order; a *clean* rebase still gets the
    integration gate. Re-poll mergeability after each merge. For stacked PRs, retarget
-   followers after the base lands and update any stale `Refs`/`Closes` or validation
-   text before merging. Watch for the two marker-free conflict traps. (REFERENCE §4, §5)
+   followers after the base lands and update any stale `Refs`/`Closes` or recorded
+   verification text before merging. Watch for the two marker-free conflict traps.
+   (REFERENCE §4, §5)
 
 This path is **not one-shot**: independent review sends merged-ready slices back, and
 remediation reshapes the plan. A review/fix round is a **re-dispatch** — resume the


### PR DESCRIPTION
## Background

Two parallel-development lesson sets landed on this skill in quick succession — #470 (from the #461/#462/#464 stacked-PR run) and #469 (from the Panda Adventure wave-1 fan-out, plus its own review round and a P1-residual follow-up). Each was verified in isolation, but accreting two authors' lessons plus review-driven rewording is exactly the kind of change that drifts a document: a rename can orphan its old shorthand, workflow steps accumulate content that contradicts the diagram, and the same rule ends up phrased three ways. So the skill got a full four-dimension audit of its post-merge state; this PR fixes what the audit found. Docs only — one commit per dimension.

## Audit dimensions

1. **Soundness of principles & workflow** — do the non-negotiables cohere, and does the workflow's order match them?
2. **Internal consistency & terminology** — stable terms, no orphaned shorthands, accurate cross-references, no drift.
3. **Redundancy & compressibility** — the deliberate principle→recipe→checklist layering stays; same-layer duplication goes.
4. **Generality** — no coupling to a specific project, tool, or host workflow beyond the skill's own domain (git worktrees, PRs).

## Findings → fixes

| # | Dim | Finding | Fix |
|---|-----|---------|-----|
| F1 | 1 | Arrow diagram + step order said fan out → **merge** → verify, contradicting the "orchestrator re-verifies BEFORE merging" principle (and PRs open before they merge) | Steps 4/5 swapped: per-slice verify + PR-open precedes the serial merge; diagram updated; clean-rebase-still-gets-the-gate clause moved into the merge step (`1d3d0b5`) |
| F2 | 2 | "CI-mirror DoD" orphaned by #469-P1's rename — used twice, defined nowhere | Both uses spell the concept out (integration tier + PR-CI gate list / the §3 DoD gates) (`0d7d5fb`) |
| F3 | 2 | *orchestrator* and *lead* used interchangeably, equivalence never declared | First occurrence in each file binds them: "the orchestrator (the "lead")" (`0d7d5fb`) |
| F4 | 2 | Four review-round name variants (review/fix round, fix round, remediation, fix brief) | Converged on "review/fix round"; bare "fix round" dropped (`0d7d5fb`) |
| F5 | 3 | SKILL step 4's trailing review-comment sentence duplicated the "not one-shot" paragraph directly below | Dropped; the paragraph is the single home (`6682017`) |
| F6 | 3 | §1 ownership paragraph carried two partially-overlapping rationale sentences | Merged into one; wave evidence closes the paragraph (`6682017`) |
| F7 | 4 | `-m "not <integration>"` — the only concrete tool syntax left — read as prescriptive pytest | Reframed as a pytest-style *example* with "your runner's equivalent" (`9d7cae0`) |
| F8 | 4 | "update the validation section" presumed a specific PR-body convention | "refresh any verification evidence recorded in the PR description" (+ the SKILL twin phrase) (`9d7cae0`) |

Explicitly **kept**: the principle→recipe→checklist triple-statement of each rule (deliberate — three consumption moments: pre-dispatch, mid-execution, pre-launch); the git/worktree/PR vocabulary (the skill's own domain); the anonymized wave evidence.

## Validation

- `git diff --check` clean on the branch (no stray markers).
- Post-fix sweeps: no `CI-mirror` occurrences remain; no bare `fix round`; the only concrete tool syntax is the marked pytest-style example; cross-references (§ numbers, "previous line") re-verified after the reorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
