### PR TITLE
docs: clarify script validate valid=false verdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,11 @@ offset properties explicitly instead.
 | `script attach` | Attach a `.gd` script to a node (by node path) in a scene. |
 | `script validate` | Syntax/compile-check a `.gd` script. |
 
+For `script validate --json`, read the result object's `valid` field. A script that
+does not compile is still a successful operation: exit `0`, no top-level `error`,
+and `valid: false` with `error_string` / `diagnostics`. Operation problems such as
+a missing file still use the normal Error envelope.
+
 **`project`** — the project as a whole (settings, autoloads, static analysis)
 
 | Command | What it does |

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=06067154e90ca388c08772e7be322327d9d2241f6f23aa1056dd57c0d356da3d -->
+<!-- gda-readme-i18n: source=README.md sha256=982e7a5aa9ff2150490487576a0d22ee2a3348988af1e56d1adc0a3d00f54264 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -418,6 +418,12 @@ layout, así que define esas propiedades offset explícitamente.
 | `script delete` | Elimina un archivo de script e informa qué se eliminó. |
 | `script attach` | Adjunta un script `.gd` a un nodo (por ruta de nodo) en una escena. |
 | `script validate` | Comprueba la sintaxis/compilación de un script `.gd`. |
+
+Para `script validate --json`, lee el campo `valid` del objeto de resultado. Un
+script que no compila sigue siendo una operación exitosa: salida `0`, sin `error`
+de nivel superior, y `valid: false` con `error_string` / `diagnostics`. Los
+problemas de operación, como un archivo inexistente, siguen usando el Error envelope
+normal.
 
 **`project`** — el proyecto en su conjunto (ajustes, autoloads, análisis estático)
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=06067154e90ca388c08772e7be322327d9d2241f6f23aa1056dd57c0d356da3d -->
+<!-- gda-readme-i18n: source=README.md sha256=982e7a5aa9ff2150490487576a0d22ee2a3348988af1e56d1adc0a3d00f54264 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -424,6 +424,11 @@ offset プロパティを明示的に設定してください。
 | `script delete` | スクリプトファイルを削除し、削除された内容を報告します。 |
 | `script attach` | シーン内のノードに(ノードパスで指定して)`.gd` スクリプトをアタッチします。 |
 | `script validate` | `.gd` スクリプトの構文/コンパイルチェックを行います。 |
+
+`script validate --json` では、結果オブジェクトの `valid` フィールドを読んでください。
+コンパイルできないスクリプトも成功した操作として扱われます。終了コードは `0`、トップレベルの
+`error` はなく、`valid: false` と `error_string` / `diagnostics` が返ります。存在しない
+ファイルなどの操作上の問題は、通常どおり Error envelope を使います。
 
 **`project`** — プロジェクト全体(設定、オートロード、静的解析)
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=06067154e90ca388c08772e7be322327d9d2241f6f23aa1056dd57c0d356da3d -->
+<!-- gda-readme-i18n: source=README.md sha256=982e7a5aa9ff2150490487576a0d22ee2a3348988af1e56d1adc0a3d00f54264 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -406,6 +406,10 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 | `script delete` | 删除一个脚本文件并报告删除了什么。 |
 | `script attach` | 按节点路径把一个 `.gd` 脚本附加到场景里的某个节点上。 |
 | `script validate` | 对一个 `.gd` 脚本做语法 / 编译检查。 |
+
+对 `script validate --json`，要读取结果对象里的 `valid` 字段。脚本无法编译仍然是一个成功操作：
+退出码为 `0`，没有顶层 `error`，并以 `valid: false` 携带 `error_string` / `diagnostics`。
+缺失文件等操作层问题仍然使用正常的 Error envelope。
 
 **`project`** — 作为整体的项目（设置、autoload、静态分析）
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -2788,7 +2788,7 @@ def validate_script(
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Syntax/compile-check a .gd script; an invalid script is a successful op."""
+    """Syntax/compile-check a .gd script; invalid exits 0 with valid=false."""
     _dispatch(
         SCRIPT_VALIDATE_COMMAND,
         ScriptValidateParams(path=path),

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -48,6 +48,12 @@ Branch on the stable `category`/`code` and the **exit code**, never on prose:
 | `5`   | could not parse the engine's output |
 | `6`   | live operation failed (e.g. `daemon_not_running`) |
 
+Some commands carry a verdict inside a successful result. For
+`gda script validate --json`, read the result's `valid` field: a script that does
+not compile exits `0` with no top-level `error`, and reports `valid=false` plus
+`error_string` / `diagnostics`. Do not treat exit `0` or the absence of an Error
+envelope as a pass for this command.
+
 ## Discovery
 
 - `gda --help` — every group.

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -507,6 +507,13 @@ def test_script_validate_valid_script_reports_valid_true_no_diagnostics(monkeypa
     assert fake.calls == [("script-validate", {"path": "/tmp/proj/ok.gd"})]
 
 
+def test_script_validate_help_mentions_valid_false_success_result():
+    result = CliRunner().invoke(app, ["script", "validate", "--help"])
+
+    assert result.exit_code == 0
+    assert "invalid exits 0 with valid=false" in result.stdout
+
+
 def test_script_validate_invalid_script_is_success_with_parsed_diagnostics(monkeypatch):
     # Validating an INVALID script is a SUCCESSFUL op (exit 0): the sentinel says
     # valid=false, and the per-command classifier parses the line/message

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -81,6 +81,14 @@ def test_skill_documents_json_container_number_preservation():
     assert "json float" in lower
 
 
+def test_skill_documents_script_validate_valid_verdict():
+    # #463: `script validate` reports a compile failure as a success-shaped
+    # result, so the agent-facing Skill must teach agents to inspect `valid`.
+    assert "gda script validate --json" in BUNDLED
+    assert "valid=false" in BUNDLED
+    assert "top-level `error`" in BUNDLED
+
+
 def test_skill_description_is_within_the_skill_frontmatter_limit():
     # An Agent Skill `description` is the one thing an agent sees when deciding to
     # load the Skill; the SKILL.md spec caps it at 1024 chars.


### PR DESCRIPTION
## Summary

- Clarify that `gda script validate --json` reports compile failures through the success result's `valid` field.
- Add the warning to README, translated READMEs, bundled `gda skill`, and CLI help.
- Add regression tests for the CLI help and bundled Skill guidance.

## Tests

- `env UV_CACHE_DIR=/tmp/caw-uv-cache uv run pytest tests/test_script_commands.py::test_script_validate_help_mentions_valid_false_success_result tests/test_script_commands.py::test_script_validate_invalid_script_is_success_with_parsed_diagnostics tests/test_skill_command.py::test_skill_documents_script_validate_valid_verdict tests/test_skill_command.py::test_skill_json_emits_name_version_content tests/test_readme_i18n_sync.py tests/test_skill_surface_sync.py`
- `env UV_CACHE_DIR=/tmp/caw-uv-cache uv run ruff format --check src/gda/cli.py tests/test_script_commands.py tests/test_skill_command.py`
- `env UV_CACHE_DIR=/tmp/caw-uv-cache uv run ruff check src/gda/cli.py tests/test_script_commands.py tests/test_skill_command.py`
- `env UV_CACHE_DIR=/tmp/caw-uv-cache uv run pytest tests/test_schema_command.py::test_script_validate_schema_emits_model_derived_contract_without_other_args`
- `env UV_CACHE_DIR=/tmp/caw-uv-cache uv run gda script validate --help`
- `git diff --check`

Fixes #463
