### PR TITLE
fix(game): report live set verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,11 @@ a missing file still use the normal Error envelope.
 | `game set` | Set a runtime node property, or an explicitly named attached-script variable, on the running game. |
 
 Live `game set --property position` follows the same `Control` policy as
-`node set`; `game rect` remains a read-only rendered-geometry query.
+`node set`; `game rect` remains a read-only rendered-geometry query. `game set`
+success results include `verified`: `true` when the observed read-back value
+matches the coerced requested value, and `false` when the set completed but the
+observed value differs, such as getter-only/no-op script variables or
+edge-triggered controls.
 
 **`diag`** — runtime diagnostics
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=982e7a5aa9ff2150490487576a0d22ee2a3348988af1e56d1adc0a3d00f54264 -->
+<!-- gda-readme-i18n: source=README.md sha256=d0624578d2e00805a61ea7e983ce98c850dcafa07848468c961c82d4acec270e -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -496,7 +496,10 @@ normal.
 
 `game set --property position` en vivo sigue la misma política de `Control` que
 `node set`; `game rect` sigue siendo una consulta de geometría renderizada de solo
-lectura.
+lectura. Los resultados exitosos de `game set` incluyen `verified`: `true` cuando
+el valor observado al leer de vuelta coincide con el valor coercionado solicitado,
+y `false` cuando el set se completó pero el valor observado difiere, como en
+variables de script getter-only/no-op o controles edge-triggered.
 
 **`diag`** — diagnósticos de runtime
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=982e7a5aa9ff2150490487576a0d22ee2a3348988af1e56d1adc0a3d00f54264 -->
+<!-- gda-readme-i18n: source=README.md sha256=d0624578d2e00805a61ea7e983ce98c850dcafa07848468c961c82d4acec270e -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -501,6 +501,9 @@ offset プロパティを明示的に設定してください。
 
 Live の `game set --property position` は `node set` と同じ `Control` ポリシーに
 従います。`game rect` は引き続き読み取り専用のレンダリングジオメトリ問い合わせです。
+`game set` の成功結果には `verified` が含まれます。観測された読み戻し値が
+要求された変換済み値と一致する場合は `true`、set は完了したが観測値が異なる場合
+（getter-only/no-op のスクリプト変数やエッジトリガー制御など）は `false` です。
 
 **`diag`** — ランタイム診断
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=982e7a5aa9ff2150490487576a0d22ee2a3348988af1e56d1adc0a3d00f54264 -->
+<!-- gda-readme-i18n: source=README.md sha256=d0624578d2e00805a61ea7e983ce98c850dcafa07848468c961c82d4acec270e -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -481,7 +481,10 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 | `game set` | 在正在运行的游戏上设置运行时节点属性，或显式命名的附加脚本变量。 |
 
 Live `game set --property position` 遵循与 `node set` 相同的 `Control` 策略；
-`game rect` 仍然是只读的渲染几何查询。
+`game rect` 仍然是只读的渲染几何查询。`game set` 的成功结果包含
+`verified`：当观测到的读回值匹配本次请求的已转换值时为 `true`；当 set
+已完成但观测值不同（例如 getter-only/no-op 脚本变量或边沿触发控制）时为
+`false`。
 
 **`diag`** — 运行时诊断
 

--- a/docs/adr/0020-live-state-consistency.md
+++ b/docs/adr/0020-live-state-consistency.md
@@ -28,6 +28,14 @@ and writes guarantee".
 > a window exactly as it holds for a single-frame op; the window only sequences N such
 > coherent snapshots.
 
+> **Outcome (2026-07-08, #473) — `game set` exposes read-after-write verification
+> as structured data.** A completed live `game set` returns the observed read-back
+> `value` plus `verified`, true only when that value equals the coerced requested
+> value. A mismatch is no longer guessed as failure by the harness: getter-only/no-op
+> script variables and edge-triggered/self-consuming controls both return success with
+> `verified:false`, leaving interpretation to the caller and preserving same-session
+> follow-up reads for domain-specific side effects.
+
 ## Decision
 
 `state consistency` is the property [gda-daemon](../../CONTEXT.md) provides over one

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -245,9 +245,13 @@ as `node set` round-trips through `node get`; here `unknown_property` names a pr
 **running** node's runtime property (the gda harness carries a verbatim copy of the coercion helpers,
 kept in sync by a drift test). When a `game get` / `game set` property name is explicit, the harness
 checks storage properties first, then attached-script variables; unfiltered `game get` keeps the
-storage-property listing and does not dump plain script variables. Live set round-trips through
-`game get`; its failures are the LIVE-category `live_unknown_property` / `live_uncoercible_value`
-(the harness reports them in-band, mapped by the live classifier — see
+storage-property listing and does not dump plain script variables. Live set success results keep
+`value` as the observed read-back value and add `verified`: `true` when that read-back equals the
+coerced requested value, `false` when the set completed but the read-back differs. The harness does
+not guess whether `verified:false` is a getter-only/no-op variable or a valid edge-triggered control;
+callers can use a follow-up `game get` for domain-specific side effects. Its failures are the
+LIVE-category `live_unknown_property` / `live_uncoercible_value` (the harness reports them in-band,
+mapped by the live classifier — see
 [Phase 2 — live domain commands](#phase-2--live-domain-commands-served-by-gda-daemon)).
 
 **Structural edits** (established by #56): three commands restructure the node tree within a
@@ -608,11 +612,13 @@ headless is unaffected (4.4+, cross-platform).
 
 - **`game` (the running game's scene graph):** `game tree` reads the runtime scene
   tree (shipped — the Phase-2 bootstrap tracer, #7); runtime node property `game get` /
-  `game set` (shipped, #220, extended by #422) read and mutate a running node's live
+  `game set` (shipped, #220, extended by #422/#473) read and mutate a running node's live
   properties — the live counterparts of headless `node get` / `node set`, applying the
-  **same** value-coercion table and round-tripping `set`→`get`. When a property is
-  explicitly named, storage properties are preferred and plain attached-script variables
-  are addressable as a fallback; unfiltered `game get` keeps the storage-property listing.
+  **same** value-coercion table and returning the observed read-back value plus
+  `verified` to distinguish a matched read-back from a completed set whose value did not
+  stick. When a property is explicitly named, storage properties are preferred and plain
+  attached-script variables are addressable as a fallback; unfiltered `game get` keeps the
+  storage-property listing.
   `game rect` (shipped, #419) reads a running
   `Control`'s rendered viewport-space rectangle via `Control.get_global_rect()`, returning
   `position` and `size` as the existing Vector2 projection. These commands address the

--- a/examples/platformer/panda-adventure/addons/gda_harness/gda_harness.gd
+++ b/examples/platformer/panda-adventure/addons/gda_harness/gda_harness.gd
@@ -1,4 +1,4 @@
-# gda-harness-version: 5
+# gda-harness-version: 6
 extends Node
 
 # The gda harness (ADR-0017, ADR-0018). Installed as a project [autoload] by

--- a/examples/platformer/panda-adventure/addons/gda_harness/gda_harness.gd
+++ b/examples/platformer/panda-adventure/addons/gda_harness/gda_harness.gd
@@ -1,4 +1,4 @@
-# gda-harness-version: 6
+# gda-harness-version: 5
 extends Node
 
 # The gda harness (ADR-0017, ADR-0018). Installed as a project [autoload] by
@@ -475,12 +475,17 @@ func _handle_game_set(params: Dictionary) -> String:
 
 	node.set(prop_name, coerced)
 	var current: Variant = node.get(prop_name)
+	if source == "script variable" and before != coerced and current == before:
+		return _error(LIVE_ERROR_UNCOERCIBLE_VALUE,
+				"cannot set value " + raw_value.c_escape()
+				+ " as " + _type_name(declared_type)
+				+ " for script variable " + prop_name
+				+ " on node " + path)
 	return _ok({
 		"path": path,
 		"property": prop_name,
 		"type": _type_name(declared_type),
 		"value": _jsonify(current),
-		"verified": current == coerced,
 	})
 
 

--- a/examples/platformer/panda-adventure/addons/gda_harness/gda_harness.gd
+++ b/examples/platformer/panda-adventure/addons/gda_harness/gda_harness.gd
@@ -475,17 +475,12 @@ func _handle_game_set(params: Dictionary) -> String:
 
 	node.set(prop_name, coerced)
 	var current: Variant = node.get(prop_name)
-	if source == "script variable" and before != coerced and current == before:
-		return _error(LIVE_ERROR_UNCOERCIBLE_VALUE,
-				"cannot set value " + raw_value.c_escape()
-				+ " as " + _type_name(declared_type)
-				+ " for script variable " + prop_name
-				+ " on node " + path)
 	return _ok({
 		"path": path,
 		"property": prop_name,
 		"type": _type_name(declared_type),
 		"value": _jsonify(current),
+		"verified": current == coerced,
 	})
 
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -991,9 +991,12 @@ def game_set(
     Godot type — the SAME coercion table `node set` uses — and applies it at a frame
     boundary (ADR-0020); the mutation is bound to the session, not persisted to disk.
     A named plain script variable on the node's attached script is settable explicitly
-    after storage properties are checked. With no daemon it reports
-    `daemon_not_running`; an absent node is `live_node_not_found`, an absent
-    property `live_unknown_property`, an uncoercible value `live_uncoercible_value`.
+    after storage properties are checked. The success result includes `verified`:
+    true when the observed read-back value equals the coerced requested value,
+    false when the set completed but the observed value differs (for example a
+    getter-only/no-op variable or an edge-triggered variable). With no daemon it
+    reports `daemon_not_running`; an absent node is `live_node_not_found`, an absent
+    property `live_unknown_property`, an uncoercible input value `live_uncoercible_value`.
     """
     _dispatch(
         GAME_SET_COMMAND,

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -445,7 +445,10 @@ func _handle_game_rect(params: Dictionary) -> String:
 # runtime counterpart of headless node set, using the SAME coercion table. The
 # write runs synchronously on the main thread at the _process frame boundary
 # (frame-coherent, ADR-0020); no extra threading. The coerced value is read back
-# and echoed in the same JSON projection game get reports.
+# and echoed in the same JSON projection game get reports. A completed live set
+# returns whether that observed read-back value matches the coerced requested
+# value; the harness does not guess whether a mismatch is a no-op or an
+# edge-triggered/self-consuming variable.
 func _handle_game_set(params: Dictionary) -> String:
 	var path := _string_param(params, "node")
 	var node := _resolve_runtime_node(path)
@@ -474,6 +477,7 @@ func _handle_game_set(params: Dictionary) -> String:
 			"property": prop_name,
 			"type": _type_name(TYPE_VECTOR2),
 			"value": current_position,
+			"verified": control.position == target_position,
 		})
 
 	var prop_info := _runtime_set_property_info(node, prop_name)
@@ -496,17 +500,12 @@ func _handle_game_set(params: Dictionary) -> String:
 
 	node.set(prop_name, coerced)
 	var current: Variant = node.get(prop_name)
-	if source == "script variable" and before != coerced and current == before:
-		return _error(LIVE_ERROR_UNCOERCIBLE_VALUE,
-				"cannot set value " + raw_value.c_escape()
-				+ " as " + _type_name(declared_type)
-				+ " for script variable " + prop_name
-				+ " on node " + path)
 	return _ok({
 		"path": path,
 		"property": prop_name,
 		"type": _type_name(declared_type),
 		"value": _jsonify(current),
+		"verified": current == coerced,
 	})
 
 

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -41,7 +41,7 @@ HARNESS_RES_PATH = f"res://{HARNESS_RES_DIR}/{HARNESS_FILE}"
 # copy to it (#225). The installed copy declares its version in a leading header
 # (`# gda-harness-version: <N>`); a mismatch re-materializes via the content
 # compare. NOT the package version — the harness changes far less often.
-HARNESS_VERSION = "5"
+HARNESS_VERSION = "6"
 
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -3132,8 +3132,9 @@ class GameSetResult(BaseModel):
 
     The live counterpart of :class:`NodeSetResult` (no ``scene_path``): echoes the
     addressed node's runtime ``path``, the ``property`` set, the declared ``type``
-    the CLI value was coerced to, and the coerced ``value`` as JSON — the
-    projection ``game get`` reports, so a ``set`` round-trips through a ``get``.
+    the CLI value was coerced to, and the observed read-back ``value`` as JSON —
+    the projection ``game get`` reports. ``verified`` reports whether that
+    observed value equals the coerced value requested by this command.
     """
 
     path: str = Field(description="The addressed node's runtime (absolute) path.")
@@ -3143,10 +3144,17 @@ class GameSetResult(BaseModel):
     )
     value: Any = Field(
         description=(
-            "The coerced value as JSON, as the running node now holds it. "
+            "The observed read-back value as JSON, as the running node now holds it. "
             + _SET_ECHO_VALUE_DESC
         ),
         json_schema_extra=_projected_value_schema_extra,
+    )
+    verified: bool = Field(
+        description=(
+            "True when the observed read-back value equals the coerced value requested "
+            "by this command; false when the live set completed but the observed "
+            "read-back value differs."
+        )
     )
 
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -452,6 +452,11 @@ _SET_ECHO_VALUE_DESC = (
     "corresponding get reports (ADR-0035)."
 )
 
+_LIVE_SET_READ_BACK_VALUE_DESC = (
+    "The observed read-back value as JSON, in the same recursive value projection "
+    "that game get reports (ADR-0035)."
+)
+
 # node/resource set additionally have the ADR-0033 Object-typed set path;
 # its echo flows through the same projection, so the assigned resource echoes
 # as the reference projection a subsequent get reads back.
@@ -3145,7 +3150,7 @@ class GameSetResult(BaseModel):
     value: Any = Field(
         description=(
             "The observed read-back value as JSON, as the running node now holds it. "
-            + _SET_ECHO_VALUE_DESC
+            + _LIVE_SET_READ_BACK_VALUE_DESC
         ),
         json_schema_extra=_projected_value_schema_extra,
     )

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -202,7 +202,7 @@ def render_game_set(was_set: "GameSetResult") -> str:
     """Render a set runtime property as ``set <path>.<prop> (<type>) = <value>``."""
     return (
         f"set {was_set.path}.{was_set.property} ({was_set.type}) = "
-        f"{format_value(was_set.value)}"
+        f"{format_value(was_set.value)} verified={format_value(was_set.verified)}"
     )
 
 

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -233,6 +233,11 @@ leading space fails as `expected_resource_path`). The value-typed forms are shar
 assignment is headless-only (`node set` / `resource set`). For live `game get` /
 `game set`, an explicitly named attached-script variable is addressable after storage
 properties are checked; unfiltered `game get` still lists only storage properties.
+Inspect live `game set --json` results' `verified` field: `true` means the observed
+read-back value equals the coerced requested value, while `false` means the set
+completed but the value read back differently. Treat `verified:false` as a diagnostic
+signal for getter-only/no-op variables or edge-triggered/self-consuming controls; use a
+domain-specific follow-up `game get` when the side effect matters.
 
 ## Tips
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -481,6 +481,7 @@ GAME_SET_RESULT = {
     "property": "position",
     "type": "Vector2",
     "value": [10.0, 20.0],
+    "verified": True,
 }
 
 # Sample ``gda game rect`` result — a running Control's rendered viewport-space

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -161,6 +161,7 @@ def test_daemon_serves_game_get_set_round_trip(tmp_path, daemon_runtime_dir):
         assert set_doc["property"] == "position"
         assert set_doc["type"] == "Vector2"
         assert set_doc["value"] == [10.0, 20.0]
+        assert set_doc["verified"] is True
 
         # get: the SAME session observes the preceding write (single writer,
         # frame-coherent — ADR-0020). The session is held across the two ops.
@@ -360,6 +361,16 @@ SCRIPT_VARIABLE_PLAYER_GD = (
 READONLY_SCRIPT_VARIABLE_PLAYER_GD = (
     "extends Node2D\nvar readonly: int:\n\tget:\n\t\treturn 1\n"
 )
+EDGE_TRIGGER_SCRIPT_VARIABLE_PLAYER_GD = (
+    "extends Node2D\n"
+    "var spawn_count: int = 0\n"
+    "var spawn: bool:\n"
+    "\tget:\n"
+    "\t\treturn false\n"
+    "\tset(value):\n"
+    "\t\tif value:\n"
+    "\t\t\tspawn_count += 1\n"
+)
 SCRIPT_VARIABLE_MAIN_TSCN = (
     "[gd_scene load_steps=2 format=3]\n\n"
     '[ext_resource type="Script" path="res://player.gd" id="1"]\n\n'
@@ -465,6 +476,7 @@ def test_daemon_game_set_mutates_explicit_plain_script_dictionary_variable(
             "property": "_items",
             "type": "Dictionary",
             "value": {"wine": 2},
+            "verified": True,
         }
 
         got = run("game", "get", "/root/Main/Player", "--property", "_items")
@@ -488,6 +500,7 @@ def test_daemon_game_set_mutates_explicit_plain_script_dictionary_variable(
             "property": "_tags",
             "type": "Array",
             "value": ["rare", "consumable"],
+            "verified": True,
         }
     finally:
         run("daemon", "stop")
@@ -593,7 +606,7 @@ def test_daemon_game_set_uncoercible_script_variable_reports_target_type(
 
 
 @pytest.mark.e2e
-def test_daemon_game_set_readonly_script_variable_reports_uncoercible_value(
+def test_daemon_game_set_readonly_script_variable_reports_unverified_observed_value(
     tmp_path, daemon_runtime_dir
 ):
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
@@ -622,13 +635,56 @@ def test_daemon_game_set_readonly_script_variable_reports_uncoercible_value(
             "--value",
             "2",
         )
-        assert was_set.returncode == 6, was_set.stdout + was_set.stderr
-        error = json.loads(was_set.stdout)["error"]
-        assert error["code"] == "live_uncoercible_value"
-        assert error["message"] == (
-            "cannot set value 2 as int for script variable readonly "
-            "on node /root/Main/Player"
+        assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+        assert json.loads(was_set.stdout) == {
+            "path": "/root/Main/Player",
+            "property": "readonly",
+            "type": "int",
+            "value": 1,
+            "verified": False,
+        }
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_game_set_edge_trigger_reports_unverified_then_side_effect_is_readable(
+    tmp_path, daemon_runtime_dir
+):
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "player.gd").write_text(
+        EDGE_TRIGGER_SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8"
+    )
+    run = _gda(tmp_path, {**os.environ})
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        was_set = run(
+            "game",
+            "set",
+            "/root/Main/Player",
+            "--property",
+            "spawn",
+            "--value",
+            "true",
         )
+        assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+        assert json.loads(was_set.stdout) == {
+            "path": "/root/Main/Player",
+            "property": "spawn",
+            "type": "bool",
+            "value": False,
+            "verified": False,
+        }
+
+        got = run("game", "get", "/root/Main/Player", "--property", "spawn_count")
+        assert got.returncode == 0, got.stdout + got.stderr
+        assert json.loads(got.stdout)["properties"] == [
+            {"name": "spawn_count", "type": "int", "value": 1}
+        ]
     finally:
         run("daemon", "stop")
 

--- a/tests/test_game_commands.py
+++ b/tests/test_game_commands.py
@@ -506,3 +506,6 @@ def test_game_set_schema_is_self_describing():
     schema = json.loads(result.stdout)
     assert "input" in schema and "output" in schema
     assert schema["kind"] == "live"
+    value_description = schema["output"]["properties"]["value"]["description"]
+    assert "observed read-back value" in value_description
+    assert "coerced value" not in value_description

--- a/tests/test_game_commands.py
+++ b/tests/test_game_commands.py
@@ -367,6 +367,7 @@ def test_game_set_mutates_and_echoes_coerced_value_through_the_live_channel(
     assert data["property"] == "position"
     # The harness echoes the coerced value in the node get projection.
     assert data["value"] == [10.0, 20.0]
+    assert data["verified"] is True
     # The node arg, property and raw value are threaded to the operation params;
     # the harness coerces the string to the declared type.
     assert fake.calls == [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1305,6 +1305,9 @@ def test_game_set_result_round_trips_observed_value_and_verification_signal():
     assert result.verified is False
     assert json.loads(result.model_dump_json()) == payload
     schema = GameSetResult.model_json_schema()
+    value_description = schema["properties"]["value"]["description"]
+    assert "observed read-back value" in value_description
+    assert "coerced value" not in value_description
     assert schema["properties"]["verified"]["type"] == "boolean"
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1290,6 +1290,24 @@ def test_node_property_round_trips_a_reference_projection_value():
     assert json.loads(prop.model_dump_json()) == payload
 
 
+def test_game_set_result_round_trips_observed_value_and_verification_signal():
+    payload = {
+        "path": "/root/Main/Player",
+        "property": "spawn",
+        "type": "bool",
+        "value": False,
+        "verified": False,
+    }
+
+    result = GameSetResult.model_validate(payload)
+
+    assert result.value is False
+    assert result.verified is False
+    assert json.loads(result.model_dump_json()) == payload
+    schema = GameSetResult.model_json_schema()
+    assert schema["properties"]["verified"]["type"] == "boolean"
+
+
 def test_every_projected_value_field_exposes_the_named_projection_defs():
     # ADR-0035 carries the projection ABI into the --schema / model chain
     # (ADR-0004): `value` stays Any (the recorded, bounded exception), so the

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -223,10 +223,11 @@ def test_render_game_set_renders_the_set_runtime_property():
         property="position",
         type="Vector2",
         value=[10.0, 20.0],
+        verified=True,
     )
     assert (
         render_game_set(result)
-        == "set /root/Main/Player.position (Vector2) = [10.0, 20.0]"
+        == "set /root/Main/Player.position (Vector2) = [10.0, 20.0] verified=true"
     )
 
 

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -81,6 +81,15 @@ def test_skill_documents_json_container_number_preservation():
     assert "json float" in lower
 
 
+def test_skill_documents_game_set_verified_signal():
+    # #473: live script-variable controls can be edge-triggered; the Skill must
+    # teach agents to inspect `verified` instead of treating success as sticky state.
+    lower = BUNDLED.lower()
+    assert "verified" in lower
+    assert "edge-triggered" in lower
+    assert "follow-up `game get`" in lower
+
+
 def test_skill_documents_script_validate_valid_verdict():
     # #463: `script validate` reports a compile failure as a success-shaped
     # result, so the agent-facing Skill must teach agents to inspect `valid`.


### PR DESCRIPTION
## Summary

- add `verified` to live `game set` success results while keeping `value` as the observed read-back value
- return success with `verified:false` for script variables whose read-back differs after a completed set, including getter-only/no-op and edge-triggered controls
- document the contract across README, command catalog, ADR-0020, CLI help, and the bundled gda skill
- bump the bundled harness version so installed projects resync to the new live-set behavior

Closes #473

## Verification

- `uv run --frozen pytest -m e2e tests/test_e2e_daemon.py::test_daemon_serves_game_get_set_round_trip tests/test_e2e_daemon.py::test_daemon_game_set_readonly_script_variable_reports_unverified_observed_value tests/test_e2e_daemon.py::test_daemon_game_set_edge_trigger_reports_unverified_then_side_effect_is_readable tests/test_e2e_daemon.py::test_daemon_start_re_syncs_harness_after_a_version_bump -rs`
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen pyright`
- `uv run --frozen pytest tests/test_harness_install.py tests/test_readme_i18n_sync.py tests/test_game_commands.py tests/test_models.py::test_game_set_result_round_trips_observed_value_and_verification_signal tests/test_render.py::test_render_game_set_renders_the_set_runtime_property tests/test_skill_command.py::test_skill_documents_game_set_verified_signal tests/test_schema_command.py::test_game_get_rect_set_schemas_report_kind_live_and_are_model_derived`
- `uv run --frozen pytest -m "not e2e"`
- `uv run --frozen pytest examples/platformer/panda-adventure/tests -m "not e2e and not engine"`
- `uv build`
