### PR TITLE
feat(panda-editor): numeric hand-tune forms + debug palette (#441)

### DIFF
--- a/examples/platformer/panda-adventure/scenes/editor.tscn
+++ b/examples/platformer/panda-adventure/scenes/editor.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=3]
 
 [ext_resource type="Script" path="res://src/editor/editor_controller.gd" id="1_pgkmy"]
+[ext_resource type="Script" path="res://src/editor/debug_palette.gd" id="2_dbgpl"]
 
 [node name="Editor" type="Node2D" unique_id=1236236346]
 script = ExtResource("1_pgkmy")
@@ -11,12 +12,15 @@ zoom = Vector2(0.55, 0.55)
 
 [node name="PlayHost" type="Node" parent="." unique_id=2004750590]
 
+[node name="DebugPalette" type="Node" parent="." unique_id=1490022711]
+script = ExtResource("2_dbgpl")
+
 [node name="Overlay" type="CanvasLayer" parent="." unique_id=71628236]
 
 [node name="Help" type="Label" parent="Overlay" unique_id=1972067865]
 offset_left = 16.0
 offset_top = 12.0
-text = "Tab: play/edit    S: save+derive    click: select    drag: move    corner: resize    arrows: nudge    Backdrop: color    Esc: deselect"
+text = "Tab: play/edit    S: save+derive    click: select    drag: move    corner: resize    arrows: nudge    Backdrop: color    Esc: deselect    Forms: numeric hand-tune (edit)    Palette: god/wave/spawn (play)"
 
 [node name="Status" type="Label" parent="Overlay" unique_id=1336018156]
 offset_left = 16.0
@@ -29,3 +33,15 @@ offset_top = 68.0
 offset_right = 140.0
 offset_bottom = 96.0
 text = "Backdrop "
+
+[node name="Forms" type="VBoxContainer" parent="Overlay" unique_id=1490022712]
+offset_left = 900.0
+offset_top = 12.0
+offset_right = 1264.0
+offset_bottom = 700.0
+
+[node name="Palette" type="VBoxContainer" parent="Overlay" unique_id=1490022713]
+offset_left = 16.0
+offset_top = 108.0
+offset_right = 300.0
+offset_bottom = 300.0

--- a/examples/platformer/panda-adventure/src/controllers/player_controller.gd
+++ b/examples/platformer/panda-adventure/src/controllers/player_controller.gd
@@ -65,6 +65,13 @@ var _facing := 1.0
 # of scope for Phase 1).
 var _last_hit_time := -INF
 var _dead := false
+# Debug god-mode (#476 review): when set — only by the Editor's debug palette, a
+# dev-machine tool — take_hit skips the whole hit so the Player cannot die while a
+# playtest finding is reproduced. A DEBUG SEAM, not a gameplay-logic change: the
+# editor scene that drives it is export-stripped (gADR-0012), and take_hit gates
+# the effect on NOT a template (exported) build, so a shipped build ignores it
+# even if the flag were somehow set.
+var _debug_invulnerable := false
 # The time scale a Time Dilation Field imposes (S8, gADR-0009): 1.0 = full
 # speed. Set by the field via the time_dilatable contract each overlap frame,
 # reset to 1.0 the frame the Player leaves (or the field expires).
@@ -226,8 +233,20 @@ func set_time_dilation(factor: float) -> void:
 ## chain hits. On death: log player_died once and emit the `died` edge — the
 ## LevelController owns the consequences (S9, gADR-0010: game_lost, the World
 ## freeze, the End screen, Retry).
+## Debug god-mode toggle (#476 review): the Editor's debug palette drives this to
+## make the Player invulnerable while reproducing a finding. Dev-machine only — the
+## effect is gated in take_hit on NOT a template build, so it is a debug seam.
+func set_debug_invulnerable(on: bool) -> void:
+	_debug_invulnerable = on
+
+
 func take_hit(attacker: StatsConfigScript) -> void:
 	if _stats == null or _dead:
+		return
+	# Debug god-mode: skip the whole hit (no damage, no i-frame, no death latch) so
+	# the Player never dies. Gated on NOT a template build — a shipped build always
+	# takes hits; only a dev-machine editor run can enable it (#476 review).
+	if _debug_invulnerable and not OS.has_feature("template"):
 		return
 	var now := _now()
 	if CombatSystemScript.is_invulnerable(_last_hit_time, now, _combat.iframe_duration):

--- a/examples/platformer/panda-adventure/src/editor/debug_palette.gd
+++ b/examples/platformer/panda-adventure/src/editor/debug_palette.gd
@@ -35,10 +35,6 @@ const EnemyScene := preload("res://scenes/enemy.tscn")
 # The per-kind derived EnemyConfig path (matches LevelController's convention) —
 # structural wiring, not a config number.
 const ENEMY_KIND_TRES := "res://data/generated/enemy_%s.tres"
-# Spawn-on-demand's default drop point: the S2/S5 shooting-lane position, a spot
-# on the Rampart in view of the resting Player. A structural default, overridable
-# via `gda game set … --property spawn_position` (or the overlay).
-const DEFAULT_SPAWN_POS := Vector2(640.0, 452.0)
 
 # The owning EditorController (untyped: no global class cache — the EnemyWarpDriver
 # precedent). Set by the controller in its _ready. The palette reads its play
@@ -78,9 +74,15 @@ var jump_to_wave := 0:
 ## first wave's first kind. Plain data (no side effect until `spawn` pulses).
 var spawn_kind := ""
 
-## Where spawn-on-demand drops the enemy. Plain data; defaults to the shooting lane
-## in _ready.
-var spawn_position := DEFAULT_SPAWN_POS
+## Where spawn-on-demand drops the enemy. When the caller has NOT set it, the drop
+## point is DERIVED from the Wave schedule's first spawn coord at spawn time
+## (gADR-0000: no hardcoded level coordinate). Setting it — via `gda game set …
+## --property spawn_position` or the overlay — marks it overridden so the explicit
+## value wins.
+var spawn_position := Vector2.ZERO:
+	set(value):
+		spawn_position = value
+		_spawn_position_overridden = true
 
 ## A spawn trigger: setting it TRUE spawns one enemy on demand. It latches the
 ## set value rather than self-resetting — the gda harness's live-set write-verify
@@ -101,10 +103,9 @@ var last_action := "idle"
 # Monotonic suffix so successive on-demand spawns get unique, addressable names
 # (the schedule's uniqueness contract, gADR-0005).
 var _spawn_seq := 0
-
-
-func _ready() -> void:
-	spawn_position = DEFAULT_SPAWN_POS
+# Whether the caller pinned spawn_position; false lets the drop point derive from
+# the Wave schedule (gADR-0000: derive the default, don't hardcode it).
+var _spawn_position_overridden := false
 
 
 ## Sync god-mode onto the live Player each frame while playing: drive its
@@ -144,10 +145,11 @@ func _do_wave_jump(wave_one_based: int) -> void:
 	GameLogScript.emit("info", "debug_wave_jump", {"wave": index + 1, "total": count})
 
 
-## Spawn one enemy of `spawn_kind` (or the schedule's first kind) at `spawn_position`
-## on the running level. Reuses enemy.tscn + setup() — the spawner contract every
-## wave enemy is built with (gADR-0003) — so a debug spawn behaves like a real one;
-## it is a free-standing target (no wave-fold / reward wiring), addressable by a
+## Spawn one enemy of `spawn_kind` (or the schedule's first kind) at the drop point
+## (an explicit `spawn_position`, else derived from the Wave schedule) on the
+## running level. Reuses enemy.tscn + setup() — the spawner contract every wave
+## enemy is built with (gADR-0003) — so a debug spawn behaves like a real one; it
+## is a free-standing target (no wave-fold / reward wiring), addressable by a
 ## unique DebugSpawn<n> name for a live-op assert.
 func _do_spawn() -> void:
 	var level := _play_root()
@@ -166,18 +168,19 @@ func _do_spawn() -> void:
 		GameLogScript.emit("error", "debug_spawn_failed", {"kind": kind_id})
 		push_error("DebugPalette: unknown enemy kind '%s' for spawn-on-demand." % kind_id)
 		return
+	var pos := spawn_position if _spawn_position_overridden else _default_spawn_position(level)
 	var enemy := EnemyScene.instantiate()
 	enemy.setup(kind)
 	enemy.name = "DebugSpawn%d" % _spawn_seq
 	_spawn_seq += 1
-	enemy.position = spawn_position
+	enemy.position = pos
 	level.add_child(enemy)
 	last_action = "spawn:%s" % kind_id
 	GameLogScript.emit("info", "debug_spawn", {
 		"kind": kind_id,
 		"name": enemy.name,
-		"x": spawn_position.x,
-		"y": spawn_position.y,
+		"x": pos.x,
+		"y": pos.y,
 	})
 
 
@@ -221,3 +224,21 @@ func _default_kind(level: Node) -> String:
 	if spawns.is_empty():
 		return ""
 	return String(spawns[0]["kind"])
+
+
+## Spawn-on-demand's default drop point (#476 review): the Wave schedule's first
+## spawn coord — DERIVED from data, not a hardcoded literal (gADR-0000). The
+## derived WaveScheduleConfig stores each spawn `position` as a Vector2. Falls back
+## to the live Player's position, then the origin, if the schedule has no spawn.
+func _default_spawn_position(level: Node) -> Vector2:
+	var schedule: Variant = level.get("_schedule")
+	if schedule != null:
+		var waves: Array = schedule.waves
+		if not waves.is_empty():
+			var spawns: Array = waves[0]["spawns"]
+			if not spawns.is_empty():
+				return spawns[0]["position"]
+	var player := _find_player()
+	if player != null:
+		return player.position
+	return Vector2.ZERO

--- a/examples/platformer/panda-adventure/src/editor/debug_palette.gd
+++ b/examples/platformer/panda-adventure/src/editor/debug_palette.gd
@@ -1,0 +1,220 @@
+extends Node
+
+## The Panda Adventure Editor's DEBUG PALETTE (gADR-0012, #441): the minimal set
+## of live debug affordances for reproducing playtest findings in the editor's
+## play mode — wave jump, god-mode, spawn-on-demand — plus the edit<->play toggle.
+##
+## DOGFOODS gda live ops (gADR-0012): the palette's whole control surface is
+## drivable runtime state — settable script properties an agent (or the e2e gate)
+## reaches with `gda game set <DebugPalette> --property <op> --value <v>` and reads
+## back with `gda game get`. The editor overlay's HITL buttons write the SAME
+## properties, so a human click and a `gda game set` converge on one path. The
+## palette manipulates the running game exactly as gda's live layer does — via the
+## runtime node tree, not a private back-channel — so nothing new is reinvented:
+##
+##   - play_active (bool)   -> enter/exit play mode (the edit<->play switch)
+##   - god_mode (bool)      -> keep the Player topped up each frame while on
+##   - jump_to_wave (int)   -> clear live enemies + (re)start that 1-based wave
+##   - spawn (bool, pulse)  -> spawn one `spawn_kind` at `spawn_position` on demand
+##   - last_action (String) -> read-back proof an op landed (via `gda game get`)
+##
+## The palette node lives in the EDITOR scene, so the export exclude_filter
+## (`scenes/editor.tscn, src/editor/*`) strips it from player builds with the rest
+## of the editor (gADR-0012). It acts on the play instance the EditorController
+## hosts (main.tscn under PlayHost) — a debug tool's tight coupling to runtime
+## internals, confined to the dev-machine editor. Every op no-ops (with a log)
+## when not playing, so a stray set in edit mode is inert, not a crash.
+##
+## preload() over class_name (the project-wide convention): no global class cache
+## exists, so bare type names would not resolve in the headless daemon session.
+
+const GameLogScript := preload("res://src/util/game_log.gd")
+const EnemyControllerScript := preload("res://src/controllers/enemy_controller.gd")
+const EnemyScene := preload("res://scenes/enemy.tscn")
+
+# The per-kind derived EnemyConfig path (matches LevelController's convention) —
+# structural wiring, not a config number.
+const ENEMY_KIND_TRES := "res://data/generated/enemy_%s.tres"
+# Spawn-on-demand's default drop point: the S2/S5 shooting-lane position, a spot
+# on the Rampart in view of the resting Player. A structural default, overridable
+# via `gda game set … --property spawn_position` (or the overlay).
+const DEFAULT_SPAWN_POS := Vector2(640.0, 452.0)
+
+# The owning EditorController (untyped: no global class cache — the EnemyWarpDriver
+# precedent). Set by the controller in its _ready. The palette reads its play
+# state and play instance through it.
+var _editor
+
+# --- The drivable op surface (gda game set / get; the overlay writes these too) ---
+
+## Enter (true) / exit (false) play mode — the edit<->play switch, delegated to
+## the controller (which owns the save+derive-before-play guard).
+var play_active := false:
+	set(value):
+		play_active = value
+		if _editor != null:
+			_editor.request_play(value)
+		last_action = "play" if value else "edit"
+
+## While on, the Player is kept at full HP each frame (a debug tool's invulnerable
+## — hits still register and flash, but never kill), so a finding can be probed
+## without dying. Logged on the toggle edge only.
+var god_mode := false:
+	set(value):
+		god_mode = value
+		last_action = "god_mode:%s" % value
+		GameLogScript.emit("info", "debug_god_mode", {"on": value})
+
+## The 1-based wave to jump to: clears the live enemies, then (re)starts that wave
+## through the game's OWN wave director (no re-implemented spawn logic) — so the
+## jumped-to wave behaves and advances exactly as a real one.
+var jump_to_wave := 0:
+	set(value):
+		jump_to_wave = value
+		_do_wave_jump(value)
+
+## The Enemy Kind id spawn-on-demand instances; empty falls back to the schedule's
+## first wave's first kind. Plain data (no side effect until `spawn` pulses).
+var spawn_kind := ""
+
+## Where spawn-on-demand drops the enemy. Plain data; defaults to the shooting lane
+## in _ready.
+var spawn_position := DEFAULT_SPAWN_POS
+
+## A momentary trigger: setting it true spawns one enemy and self-resets to false,
+## so a `gda game set … spawn true` (or a button) is a single pulse, not a latch.
+var spawn := false:
+	set(value):
+		if value:
+			_do_spawn()
+		spawn = false
+
+## The last op the palette performed — a read-back surface (`gda game get … --property
+## last_action`) proving an op landed, alongside the structured gda_log records.
+var last_action := "idle"
+
+# Monotonic suffix so successive on-demand spawns get unique, addressable names
+# (the schedule's uniqueness contract, gADR-0005).
+var _spawn_seq := 0
+
+
+func _ready() -> void:
+	spawn_position = DEFAULT_SPAWN_POS
+
+
+## God-mode's only per-frame work: while playing and on, restore the Player to full
+## HP so no incoming hit can drop it to 0. Reaches the Player through the runtime
+## group lookup (the game's own "find the player" idiom), not a cached reference.
+func _process(_delta: float) -> void:
+	if not god_mode or not _is_playing():
+		return
+	var player := _find_player()
+	if player == null:
+		return
+	var stats: Variant = player.get("_stats")
+	var stats_config: Variant = player.get("_stats_config")
+	if stats != null and stats_config != null:
+		stats.hp = stats_config.max_hp
+
+
+# --- Ops -----------------------------------------------------------------------
+
+## Jump to a 1-based wave: clamp to the schedule, clear the live enemies, then hand
+## off to the LevelController's own `_start_wave` (0-based) — the SAME director the
+## boot path drives, so the jumped wave spawns, counts, and advances identically.
+func _do_wave_jump(wave_one_based: int) -> void:
+	var level := _play_root()
+	if level == null:
+		last_action = "wave_jump_skipped"
+		GameLogScript.emit("info", "debug_wave_jump_skipped", {"reason": "not_playing"})
+		return
+	var schedule: Variant = level.get("_schedule")
+	if schedule == null:
+		last_action = "wave_jump_skipped"
+		GameLogScript.emit("info", "debug_wave_jump_skipped", {"reason": "no_schedule"})
+		return
+	var count: int = (schedule.waves as Array).size()
+	var index := clampi(wave_one_based - 1, 0, count - 1)
+	_clear_enemies(level)
+	level._start_wave(index)
+	last_action = "wave_jump:%d" % (index + 1)
+	GameLogScript.emit("info", "debug_wave_jump", {"wave": index + 1, "total": count})
+
+
+## Spawn one enemy of `spawn_kind` (or the schedule's first kind) at `spawn_position`
+## on the running level. Reuses enemy.tscn + setup() — the spawner contract every
+## wave enemy is built with (gADR-0003) — so a debug spawn behaves like a real one;
+## it is a free-standing target (no wave-fold / reward wiring), addressable by a
+## unique DebugSpawn<n> name for a live-op assert.
+func _do_spawn() -> void:
+	var level := _play_root()
+	if level == null:
+		last_action = "spawn_skipped"
+		GameLogScript.emit("info", "debug_spawn_skipped", {"reason": "not_playing"})
+		return
+	var kind_id := spawn_kind if spawn_kind != "" else _default_kind(level)
+	if kind_id == "":
+		last_action = "spawn_skipped"
+		GameLogScript.emit("info", "debug_spawn_skipped", {"reason": "no_kind"})
+		return
+	var kind: Resource = load(ENEMY_KIND_TRES % kind_id)
+	if kind == null:
+		last_action = "spawn_failed"
+		GameLogScript.emit("error", "debug_spawn_failed", {"kind": kind_id})
+		push_error("DebugPalette: unknown enemy kind '%s' for spawn-on-demand." % kind_id)
+		return
+	var enemy := EnemyScene.instantiate()
+	enemy.setup(kind)
+	enemy.name = "DebugSpawn%d" % _spawn_seq
+	_spawn_seq += 1
+	enemy.position = spawn_position
+	level.add_child(enemy)
+	last_action = "spawn:%s" % kind_id
+	GameLogScript.emit("info", "debug_spawn", {
+		"kind": kind_id,
+		"name": enemy.name,
+		"x": spawn_position.x,
+		"y": spawn_position.y,
+	})
+
+
+# --- Runtime access helpers ----------------------------------------------------
+
+func _is_playing() -> bool:
+	return _editor != null and bool(_editor.is_playing)
+
+
+## The running level root (main.tscn's LevelController) the controller hosts, or
+## null when not playing.
+func _play_root() -> Node:
+	if not _is_playing():
+		return null
+	return _editor.get_play_instance()
+
+
+func _find_player() -> Node:
+	return get_tree().get_first_node_in_group("player")
+
+
+## Free every live Enemy under the level (identified by the EnemyController script,
+## not a group the game does not define). queue_free() emits no `died`, so clearing
+## has no reward/wave-fold side effect — a clean slate for the jumped-to wave.
+func _clear_enemies(level: Node) -> void:
+	for child in level.get_children():
+		if child.get_script() == EnemyControllerScript:
+			child.queue_free()
+
+
+## The schedule's first wave's first kind — spawn-on-demand's fallback when no
+## `spawn_kind` was set. Empty when the schedule is unreadable (guarded by caller).
+func _default_kind(level: Node) -> String:
+	var schedule: Variant = level.get("_schedule")
+	if schedule == null:
+		return ""
+	var waves: Array = schedule.waves
+	if waves.is_empty():
+		return ""
+	var spawns: Array = waves[0]["spawns"]
+	if spawns.is_empty():
+		return ""
+	return String(spawns[0]["kind"])

--- a/examples/platformer/panda-adventure/src/editor/debug_palette.gd
+++ b/examples/platformer/panda-adventure/src/editor/debug_palette.gd
@@ -56,9 +56,10 @@ var play_active := false:
 			_editor.request_play(value)
 		last_action = "play" if value else "edit"
 
-## While on, the Player is kept at full HP each frame (a debug tool's invulnerable
-## — hits still register and flash, but never kill), so a finding can be probed
-## without dying. Logged on the toggle edge only.
+## While on, the Player is invulnerable (its take_hit skips the whole hit, so no
+## death latch ever fires), so a finding can be probed without dying. Driven onto
+## the Player through its set_debug_invulnerable API each frame (below). Logged on
+## the toggle edge only.
 var god_mode := false:
 	set(value):
 		god_mode = value
@@ -106,19 +107,17 @@ func _ready() -> void:
 	spawn_position = DEFAULT_SPAWN_POS
 
 
-## God-mode's only per-frame work: while playing and on, restore the Player to full
-## HP so no incoming hit can drop it to 0. Reaches the Player through the runtime
-## group lookup (the game's own "find the player" idiom), not a cached reference.
+## Sync god-mode onto the live Player each frame while playing: drive its
+## set_debug_invulnerable API so a lethal hit is refused at the SOURCE (take_hit),
+## not patched up after the death latch already fired. Per-frame (not just on the
+## toggle) so a Player replaced by a Retry reload re-inherits the current god-mode.
+## Reaches the Player through the runtime group lookup (the game's own idiom).
 func _process(_delta: float) -> void:
-	if not god_mode or not _is_playing():
+	if not _is_playing():
 		return
 	var player := _find_player()
-	if player == null:
-		return
-	var stats: Variant = player.get("_stats")
-	var stats_config: Variant = player.get("_stats_config")
-	if stats != null and stats_config != null:
-		stats.hp = stats_config.max_hp
+	if player != null and player.has_method("set_debug_invulnerable"):
+		player.set_debug_invulnerable(god_mode)
 
 
 # --- Ops -----------------------------------------------------------------------

--- a/examples/platformer/panda-adventure/src/editor/debug_palette.gd
+++ b/examples/platformer/panda-adventure/src/editor/debug_palette.gd
@@ -81,13 +81,17 @@ var spawn_kind := ""
 ## in _ready.
 var spawn_position := DEFAULT_SPAWN_POS
 
-## A momentary trigger: setting it true spawns one enemy and self-resets to false,
-## so a `gda game set … spawn true` (or a button) is a single pulse, not a latch.
+## A spawn trigger: setting it TRUE spawns one enemy on demand. It latches the
+## set value rather than self-resetting — the gda harness's live-set write-verify
+## rejects a script variable that reads back unchanged, so a self-reset-to-false
+## would look like a failed set. The setter runs on every assignment (Godot fires
+## setters even when the value is unchanged), so a repeated `gda game set … spawn
+## true` (or button click) spawns again; set it false to disarm.
 var spawn := false:
 	set(value):
+		spawn = value
 		if value:
 			_do_spawn()
-		spawn = false
 
 ## The last op the palette performed — a read-back surface (`gda game get … --property
 ## last_action`) proving an op landed, alongside the structured gda_log records.

--- a/examples/platformer/panda-adventure/src/editor/editor_controller.gd
+++ b/examples/platformer/panda-adventure/src/editor/editor_controller.gd
@@ -18,7 +18,14 @@ extends Node2D
 ## Direct manipulation: left-drag a segment body to move it, its yellow corner
 ## handle to resize (snapped to the tile grid so the Scale-spec semantic gate
 ## stays satisfied), an Arena line to move that bound, a spawn marker to reposition
-## that spawn. Numeric forms and the debug palette are a later slice (#441).
+## that spawn.
+##
+## Numeric hand-tune forms + debug palette (#441): the overlay's schema-driven
+## SpinBox forms (EditorForms) edit scalar feel/level numbers into the JSON
+## authority — saved through the SAME S = save+derive path as a drag, never
+## free-text JSON — and the DebugPalette node exposes the play-mode debug ops
+## (wave jump, god-mode, spawn-on-demand) as runtime-drivable state the overlay's
+## HITL buttons AND `gda game set` both write (dogfooding gda live ops, gADR-0012).
 ##
 ## preload() over the global class_name registry: this project ships no
 ## editor-generated global_script_class_cache, so a bare type name would not
@@ -26,6 +33,7 @@ extends Node2D
 
 const EditorLevelModelScript := preload("res://src/editor/editor_level_model.gd")
 const EditorBuilderScript := preload("res://src/editor/editor_builder.gd")
+const EditorFormsScript := preload("res://src/editor/editor_forms.gd")
 const GameLogScript := preload("res://src/util/game_log.gd")
 const GeneratedConfigScript := preload("res://src/util/generated_config.gd")
 const ScaleSpecConfigScript := preload("res://src/resources/scale_spec_config.gd")
@@ -79,12 +87,20 @@ var _active := {"kind": HIT_NONE, "a": -1, "b": -1}
 var _dragging := false
 var _drag_offset := Vector2.ZERO
 var _play_instance: Node = null
+# The numeric hand-tune forms (#441): schema-driven SpinBox rows over the JSON
+# authority, built into the overlay in _ready (EditorForms).
+var _forms: EditorFormsScript
 
 @onready var _editor_camera: Camera2D = $EditorCamera
 @onready var _play_host: Node = $PlayHost
 @onready var _overlay_status: Label = $Overlay/Status
 @onready var _overlay_help: Label = $Overlay/Help
 @onready var _backdrop_button: ColorPickerButton = $Overlay/BackdropColor
+# The numeric forms panel (edit-mode) and the debug palette panel (play-mode);
+# the DebugPalette node carries the play-mode debug ops the overlay + gda drive.
+@onready var _forms_container: VBoxContainer = $Overlay/Forms
+@onready var _palette_container: VBoxContainer = $Overlay/Palette
+@onready var _palette: Node = $DebugPalette
 
 
 func _ready() -> void:
@@ -115,6 +131,11 @@ func _ready() -> void:
 	# same model/save path as every spatial edit. Numeric forms remain #441.
 	_backdrop_button.color = _model.get_background_color()
 	_backdrop_button.color_changed.connect(_on_backdrop_color_changed)
+	_build_forms()
+	_wire_palette()
+	# Edit mode boots showing the forms; the play-mode debug palette stays hidden
+	# until Tab (the forms/palette are the two modes' overlays).
+	_palette_container.visible = false
 	_set_status()
 	queue_redraw()
 	GameLogScript.emit("info", "editor_ready", {
@@ -122,6 +143,7 @@ func _ready() -> void:
 		"waves": _model.wave_count(),
 		"arena_min_x": _model.get_arena_min_x(),
 		"arena_max_x": _model.get_arena_max_x(),
+		"form_fields": _forms.field_count(),
 	})
 
 
@@ -222,6 +244,86 @@ func _on_backdrop_color_changed(color: Color) -> void:
 	RenderingServer.set_default_clear_color(color)
 	last_action = "edit:backdrop"
 	_set_status()
+
+
+# --- Numeric hand-tune forms + debug palette (#441) ----------------------------
+
+## Build the schema-driven numeric forms (EditorForms) into the overlay: the
+## Player feel numbers and the Level authority's scalars, each field + its range
+## read from `data/schema/*.json` (never a hand-forked registry). A form edit
+## marks the model dirty and re-uses the SAME S = save+derive path as a drag.
+func _build_forms() -> void:
+	_forms = EditorFormsScript.new(_model)
+	_forms.field_edited.connect(_on_form_edited)
+	_forms.build(_forms_container, [
+		{
+			"authority": EditorLevelModelScript.AUTHORITY_PLAYER,
+			"schema_path": "res://data/schema/player_config.schema.json",
+			"title": "Player (feel)",
+		},
+		{
+			"authority": EditorLevelModelScript.AUTHORITY_LEVEL,
+			"schema_path": "res://data/schema/level_config.schema.json",
+			"title": "Level",
+		},
+	])
+
+
+## One numeric form field changed: mark the edit (the model already dirtied) and
+## refresh — a queue_redraw so a changed Arena bound re-draws its line (the form
+## and the drag write the same `arena_min_x`/`arena_max_x`).
+func _on_form_edited() -> void:
+	last_action = "edit:form"
+	queue_redraw()
+	_set_status()
+
+
+## Wire the DebugPalette node to this controller and build its HITL buttons. The
+## palette's ops are runtime-drivable state (dogfooding gda live ops); these
+## buttons write the SAME properties `gda game set` does.
+func _wire_palette() -> void:
+	_palette._editor = self
+	_build_palette_controls()
+
+
+func _build_palette_controls() -> void:
+	var god := CheckButton.new()
+	god.text = "God Mode"
+	god.toggled.connect(func(on: bool) -> void: _palette.god_mode = on)
+	_palette_container.add_child(god)
+
+	var wave_row := HBoxContainer.new()
+	var wave_spin := SpinBox.new()
+	wave_spin.min_value = 1
+	wave_spin.max_value = maxi(_model.wave_count(), 1)
+	wave_spin.value = 1
+	wave_row.add_child(wave_spin)
+	var jump := Button.new()
+	jump.text = "Jump to Wave"
+	jump.pressed.connect(func() -> void: _palette.jump_to_wave = int(wave_spin.value))
+	wave_row.add_child(jump)
+	_palette_container.add_child(wave_row)
+
+	var spawn := Button.new()
+	spawn.text = "Spawn Enemy"
+	spawn.pressed.connect(func() -> void: _palette.spawn = true)
+	_palette_container.add_child(spawn)
+
+
+## The running play instance (main.tscn's LevelController) the palette acts on, or
+## null in edit mode. Read by DebugPalette through its `_editor` reference.
+func get_play_instance() -> Node:
+	return _play_instance
+
+
+## Enter (true) / exit (false) play mode to a target state — the drivable
+## edit<->play switch behind the palette's `play_active` (and a `gda game set`).
+## Idempotent: a request matching the current mode is a no-op.
+func request_play(active: bool) -> void:
+	if active and not is_playing:
+		_enter_play()
+	elif not active and is_playing:
+		_exit_play()
 
 
 func _arrow_delta(keycode: int) -> Vector2:
@@ -340,6 +442,9 @@ func _enter_play() -> void:
 	is_playing = true
 	_overlay_help.visible = false
 	_backdrop_button.visible = false
+	# Swap the edit-mode forms for the play-mode debug palette.
+	_forms_container.visible = false
+	_palette_container.visible = true
 	queue_redraw()
 	_set_status()
 	GameLogScript.emit("info", "editor_play_entered", {})
@@ -352,6 +457,9 @@ func _exit_play() -> void:
 	is_playing = false
 	_overlay_help.visible = true
 	_backdrop_button.visible = true
+	# Restore the edit-mode forms, hide the play-mode debug palette.
+	_forms_container.visible = true
+	_palette_container.visible = false
 	# The play instance freed its Player Camera2D; restore the editor framing and
 	# the backdrop the game's LevelController overwrote.
 	_editor_camera.make_current()

--- a/examples/platformer/panda-adventure/src/editor/editor_controller.gd
+++ b/examples/platformer/panda-adventure/src/editor/editor_controller.gd
@@ -227,6 +227,9 @@ func _update_drag(world: Vector2) -> void:
 		HIT_ARENA_MAX:
 			_model.set_arena_max_x(maxf(roundf(world.x), _model.get_arena_min_x() + _tile))
 	last_action = "edit:" + _kind_name(_active["kind"])
+	# Keep the numeric forms in sync: a dragged Arena bound is also a form field, so
+	# re-seed the SpinBoxes from the model (#476 review) — no stale row, no clobber.
+	_forms.refresh()
 	queue_redraw()
 	_set_status()
 
@@ -362,6 +365,8 @@ func _nudge(delta: Vector2) -> void:
 		HIT_ARENA_MAX:
 			_model.set_arena_max_x(maxf(_model.get_arena_max_x() + delta.x, _model.get_arena_min_x() + _tile))
 	last_action = "nudge:" + _kind_name(_sel["kind"])
+	# A nudged Arena bound is a form field too — re-seed the SpinBoxes (#476 review).
+	_forms.refresh()
 	queue_redraw()
 	_set_status()
 

--- a/examples/platformer/panda-adventure/src/editor/editor_controller.gd
+++ b/examples/platformer/panda-adventure/src/editor/editor_controller.gd
@@ -398,7 +398,16 @@ func _hit_test(world: Vector2) -> Dictionary:
 ## the ONE Python builder. Returns true only when BOTH steps succeeded — the
 ## edit->play switch keys on this, because playing after a failed save/derive
 ## would run STALE derived .tres (the review-round correctness finding).
+##
+## Integrity on a FAILED derive (#476 review): the JSON authority is ROLLED BACK
+## to its last-derived-good content and the edits stay dirty (pending). So a build
+## failure never leaves invalid JSON on disk (out of sync with the derived .tres)
+## nor silently clears the unsaved-edits marker — the save->JSON->builder->reload
+## contract holds even when the builder rejects the edit.
 func _save_and_derive() -> bool:
+	# Capture the on-disk last-good content of the authorities about to be written,
+	# so a derive failure can restore them.
+	var snapshot := _model.snapshot_dirty()
 	if not _model.save():
 		last_action = "save_failed"
 		GameLogScript.emit("error", "editor_save_failed", {})
@@ -417,14 +426,18 @@ func _save_and_derive() -> bool:
 		})
 		_set_status()
 		return true
+	# Derive failed: undo the just-written JSON (back to last-good) and keep the
+	# edits pending, so the authority never persists in an un-derivable state.
+	_model.rollback(snapshot)
 	last_action = "derive_failed"
 	GameLogScript.emit("error", "editor_derive_failed", {
 		"exit_code": result["exit_code"],
 		"python": result["python"],
 	})
 	push_error(
-		("EditorController: build_config.py failed (exit %d via %s). A Python " +
-		"toolchain must be on PATH (gADR-0012). Output: %s")
+		("EditorController: build_config.py failed (exit %d via %s); JSON authority " +
+		"rolled back, edits kept pending. A Python toolchain must be on PATH " +
+		"(gADR-0012). Output: %s")
 		% [result["exit_code"], result["python"], result["output"]]
 	)
 	_set_status()

--- a/examples/platformer/panda-adventure/src/editor/editor_controller.gd
+++ b/examples/platformer/panda-adventure/src/editor/editor_controller.gd
@@ -255,18 +255,32 @@ func _on_backdrop_color_changed(color: Color) -> void:
 func _build_forms() -> void:
 	_forms = EditorFormsScript.new(_model)
 	_forms.field_edited.connect(_on_form_edited)
+	# Every tuning config gets a section (#476 review): the schema-driven extractor
+	# maps each config's scalar numbers to SpinBox rows, so the hand-tune surface
+	# spans the whole tuning space, not just player + level. A section whose schema
+	# declares no scalar numbers builds nothing (EditorForms skips it).
 	_forms.build(_forms_container, [
-		{
-			"authority": EditorLevelModelScript.AUTHORITY_PLAYER,
-			"schema_path": "res://data/schema/player_config.schema.json",
-			"title": "Player (feel)",
-		},
-		{
-			"authority": EditorLevelModelScript.AUTHORITY_LEVEL,
-			"schema_path": "res://data/schema/level_config.schema.json",
-			"title": "Level",
-		},
+		_section(EditorLevelModelScript.AUTHORITY_PLAYER, "player_config", "Player (feel)"),
+		_section(EditorLevelModelScript.AUTHORITY_LEVEL, "level_config", "Level"),
+		_section(EditorLevelModelScript.AUTHORITY_COMBAT, "combat_config", "Combat"),
+		_section(EditorLevelModelScript.AUTHORITY_GRAVITY, "gravity_config", "Gravity"),
+		_section(EditorLevelModelScript.AUTHORITY_ITEMS, "items_config", "Items"),
+		_section(EditorLevelModelScript.AUTHORITY_PROGRESSION, "progression_config", "Progression"),
+		_section(EditorLevelModelScript.AUTHORITY_SCALE, "scale_spec", "Scale spec"),
+		_section(EditorLevelModelScript.AUTHORITY_ENEMIES, "enemies_config", "Enemies"),
+		_section(EditorLevelModelScript.AUTHORITY_HUD, "hud_config", "HUD"),
 	])
+
+
+## One form-section descriptor: an authority id + the schema that declares its
+## numeric fields + a heading. The schema path follows the config naming
+## convention (data/schema/<name>.schema.json).
+func _section(authority: String, schema_name: String, title: String) -> Dictionary:
+	return {
+		"authority": authority,
+		"schema_path": "res://data/schema/%s.schema.json" % schema_name,
+		"title": title,
+	}
 
 
 ## One numeric form field changed: mark the edit (the model already dirtied) and

--- a/examples/platformer/panda-adventure/src/editor/editor_form_spec.gd
+++ b/examples/platformer/panda-adventure/src/editor/editor_form_spec.gd
@@ -25,13 +25,15 @@ extends RefCounted
 ## The numeric scalar fields of a parsed JSON-Schema document, in schema order
 ## (Godot Dictionaries preserve JSON key order). Each field spec is:
 ##   {
-##     "key": String,        # the JSON property name (the authority key)
-##     "label": String,      # a humanized label for the SpinBox row
-##     "min": float,         # lower bound (or -INF when the schema sets none)
-##     "max": float,         # upper bound (or INF when the schema sets none)
-##     "has_min": bool,      # whether the schema bounded it below
-##     "has_max": bool,      # whether the schema bounded it above
-##     "step": float,        # a sensible SpinBox increment for the field's range
+##     "key": String,          # the JSON property name (the authority key)
+##     "label": String,        # a humanized label for the SpinBox row
+##     "min": float,           # lower bound (or -INF when the schema sets none)
+##     "max": float,           # upper bound (or INF when the schema sets none)
+##     "has_min": bool,        # whether the schema bounded it below
+##     "has_max": bool,        # whether the schema bounded it above
+##     "exclusive_min": bool,  # the lower bound is EXCLUSIVE (unselectable)
+##     "exclusive_max": bool,  # the upper bound is EXCLUSIVE (unselectable)
+##     "step": float,          # a sensible SpinBox increment for the field's range
 ##   }
 ## A non-object schema, or one without `properties`, yields an empty Array.
 static func numeric_fields(schema: Dictionary) -> Array[Dictionary]:
@@ -53,13 +55,16 @@ static func numeric_fields(schema: Dictionary) -> Array[Dictionary]:
 
 ## Build one field spec from a property schema — folding the four JSON-Schema
 ## bound keywords (minimum / maximum and their exclusive siblings) into a single
-## numeric floor/ceiling the SpinBox can enforce. An exclusive bound is treated
-## as the SpinBox limit (the offline builder's jsonschema pass stays the hard
-## gate that rejects the exact-boundary value on derive — the form only needs a
-## humane range, not a re-implementation of schema validation).
+## numeric floor/ceiling the SpinBox enforces, PLUS whether each bound is
+## exclusive so EditorForms can make the invalid boundary value unselectable
+## (#476 review). The offline builder's jsonschema pass stays the hard gate for
+## cross-field rules the SpinBox cannot express; the form enforces the single-field
+## range strictly so a lone bad number is never even entered.
 static func _field_spec(key: String, prop: Dictionary) -> Dictionary:
-	var has_min := prop.has("minimum") or prop.has("exclusiveMinimum")
-	var has_max := prop.has("maximum") or prop.has("exclusiveMaximum")
+	var exclusive_min := prop.has("exclusiveMinimum")
+	var exclusive_max := prop.has("exclusiveMaximum")
+	var has_min := prop.has("minimum") or exclusive_min
+	var has_max := prop.has("maximum") or exclusive_max
 	var lo := float(prop.get("minimum", prop.get("exclusiveMinimum", -INF)))
 	var hi := float(prop.get("maximum", prop.get("exclusiveMaximum", INF)))
 	return {
@@ -69,6 +74,8 @@ static func _field_spec(key: String, prop: Dictionary) -> Dictionary:
 		"max": hi,
 		"has_min": has_min,
 		"has_max": has_max,
+		"exclusive_min": exclusive_min,
+		"exclusive_max": exclusive_max,
 		"step": _step_for(has_max, hi),
 	}
 

--- a/examples/platformer/panda-adventure/src/editor/editor_form_spec.gd
+++ b/examples/platformer/panda-adventure/src/editor/editor_form_spec.gd
@@ -1,0 +1,93 @@
+extends RefCounted
+
+## Derives the Panda Adventure Editor's numeric hand-tune FORM fields straight
+## from a config's JSON Schema (gADR-0012, #441).
+##
+## The forms MAP FROM the existing `data/schema/*.json` — the authoritative place
+## the config's numeric types and ranges are already encoded — instead of a
+## hand-forked field registry that could drift from the schema the builder
+## validates against. This keeps ONE source for "which numbers exist and what
+## bounds they carry": the schema. Each derived field becomes one SpinBox
+## (EditorForms), bound to the JSON authority value, so a Save writes the number
+## back to JSON and re-derives through the ONE Python builder (the forms half of
+## the gADR-0012 round-trip: forms -> JSON -> builder -> reload).
+##
+## PURE and node-free (the logic-seam shape the game's systems use): a parsed
+## schema Dictionary in, a field-spec Array out — so the extraction is exercised
+## headless (the editor round-trip seam) without a Control tree.
+##
+## Scope: SCALAR numbers only (JSON Schema `type: "number"`). Array-valued numeric
+## properties (RGBA colors, [x, y] positions/sizes, [w, h] extents) are the
+## direct-manipulation / color-picker channel (#438), never a free-text or
+## per-component form — so they are deliberately skipped here.
+
+
+## The numeric scalar fields of a parsed JSON-Schema document, in schema order
+## (Godot Dictionaries preserve JSON key order). Each field spec is:
+##   {
+##     "key": String,        # the JSON property name (the authority key)
+##     "label": String,      # a humanized label for the SpinBox row
+##     "min": float,         # lower bound (or -INF when the schema sets none)
+##     "max": float,         # upper bound (or INF when the schema sets none)
+##     "has_min": bool,      # whether the schema bounded it below
+##     "has_max": bool,      # whether the schema bounded it above
+##     "step": float,        # a sensible SpinBox increment for the field's range
+##   }
+## A non-object schema, or one without `properties`, yields an empty Array.
+static func numeric_fields(schema: Dictionary) -> Array[Dictionary]:
+	var fields: Array[Dictionary] = []
+	var properties: Variant = schema.get("properties", {})
+	if typeof(properties) != TYPE_DICTIONARY:
+		return fields
+	for key: String in (properties as Dictionary):
+		var prop: Variant = properties[key]
+		if typeof(prop) != TYPE_DICTIONARY:
+			continue
+		# Scalar numbers only: `type: "number"` (an array-of-number property is a
+		# color/position/size — the direct-manipulation channel, never a form).
+		if String((prop as Dictionary).get("type", "")) != "number":
+			continue
+		fields.append(_field_spec(key, prop))
+	return fields
+
+
+## Build one field spec from a property schema — folding the four JSON-Schema
+## bound keywords (minimum / maximum and their exclusive siblings) into a single
+## numeric floor/ceiling the SpinBox can enforce. An exclusive bound is treated
+## as the SpinBox limit (the offline builder's jsonschema pass stays the hard
+## gate that rejects the exact-boundary value on derive — the form only needs a
+## humane range, not a re-implementation of schema validation).
+static func _field_spec(key: String, prop: Dictionary) -> Dictionary:
+	var has_min := prop.has("minimum") or prop.has("exclusiveMinimum")
+	var has_max := prop.has("maximum") or prop.has("exclusiveMaximum")
+	var lo := float(prop.get("minimum", prop.get("exclusiveMinimum", -INF)))
+	var hi := float(prop.get("maximum", prop.get("exclusiveMaximum", INF)))
+	return {
+		"key": key,
+		"label": _humanize(key),
+		"min": lo,
+		"max": hi,
+		"has_min": has_min,
+		"has_max": has_max,
+		"step": _step_for(has_max, hi),
+	}
+
+
+## A readable SpinBox increment: tight (0.01 / 0.05) for the small unit ranges a
+## 0..1 or seconds-scale field carries, 1.0 for the wide px / px·s⁻¹ feel numbers.
+## The user can always type an exact value; this only sizes the arrow nudge.
+static func _step_for(has_max: bool, hi: float) -> float:
+	if has_max and hi <= 1.0:
+		return 0.01
+	if has_max and hi <= 4.0:
+		return 0.05
+	return 1.0
+
+
+## "move_speed" -> "Move Speed": a per-word Title-Case of the snake_case key, for
+## the SpinBox row label (the key stays the authority reference).
+static func _humanize(key: String) -> String:
+	var words := PackedStringArray()
+	for word in key.split("_", false):
+		words.append(word.substr(0, 1).to_upper() + word.substr(1))
+	return " ".join(words)

--- a/examples/platformer/panda-adventure/src/editor/editor_forms.gd
+++ b/examples/platformer/panda-adventure/src/editor/editor_forms.gd
@@ -27,6 +27,9 @@ var _model
 # Total SpinBox rows built across all sections — the editor_ready log's proof the
 # schema-driven forms materialized (and a headless seam's assertable count).
 var _field_count := 0
+# Each built row: {authority, key, spin}. Kept so refresh() can re-seed every
+# SpinBox from the model after direct manipulation touches a form-backed key.
+var _rows: Array = []
 
 
 func _init(model) -> void:
@@ -97,6 +100,7 @@ func _build_row(authority: String, field: Dictionary) -> HBoxContainer:
 	# — no per-field method, one handler).
 	spin.value_changed.connect(_on_value_changed.bind(authority, String(field["key"])))
 	row.add_child(spin)
+	_rows.append({"authority": authority, "key": String(field["key"]), "spin": spin})
 	_field_count += 1
 	return row
 
@@ -104,6 +108,17 @@ func _build_row(authority: String, field: Dictionary) -> HBoxContainer:
 func _on_value_changed(value: float, authority: String, key: String) -> void:
 	_model.set_number(authority, key, value)
 	field_edited.emit()
+
+
+## Re-seed every SpinBox from the model — called after DIRECT MANIPULATION mutates
+## a JSON key a form also exposes (arena_min_x/arena_max_x are drag targets AND
+## form fields), so a drag and its form row never drift and a later form edit
+## never overwrites the drag with stale data (#476 review). Uses set_value_no_signal
+## so the refresh does not re-fire value_changed — no dirty loop, no clobber.
+func refresh() -> void:
+	for row: Dictionary in _rows:
+		var spin: SpinBox = row["spin"]
+		spin.set_value_no_signal(_model.get_number(String(row["authority"]), String(row["key"])))
 
 
 ## A humane SpinBox step: never coarser than the schema hint, but fine enough that

--- a/examples/platformer/panda-adventure/src/editor/editor_forms.gd
+++ b/examples/platformer/panda-adventure/src/editor/editor_forms.gd
@@ -1,0 +1,113 @@
+extends RefCounted
+
+## The Panda Adventure Editor's numeric hand-tune FORMS (gADR-0012, #441): a
+## structured SpinBox per schema-derived scalar number, NEVER free-text JSON.
+##
+## Builds one labeled SpinBox row per field EditorFormSpec derives from a config's
+## JSON Schema (so the field set and its ranges come from `data/schema/*.json`,
+## the same contract the builder validates against — no hand-forked registry).
+## Each row is two-way bound to the EditorLevelModel: it seeds from the JSON
+## authority's current value and, on edit, writes back through `set_number`
+## (marking that authority dirty). A Save then writes ONLY the JSON authority and
+## re-derives through the ONE Python builder (gADR-0012's forms round-trip:
+## forms -> JSON -> builder -> reload) — the forms never touch a `.tres`.
+##
+## Thin over Godot's own SpinBox (numeric field with min/max/step, keyboard entry,
+## arrow nudge). Held by the EditorController; the built rows live under a Control
+## the controller supplies. Emits `field_edited` so the controller can refresh the
+## unsaved-edits marker exactly as a drag does.
+
+const FormSpecScript := preload("res://src/editor/editor_form_spec.gd")
+
+## One numeric field was edited (the authority dirtied) — the controller refreshes
+## its status line / save-state marker, the drag path's `_set_status` sibling.
+signal field_edited
+
+var _model
+# Total SpinBox rows built across all sections — the editor_ready log's proof the
+# schema-driven forms materialized (and a headless seam's assertable count).
+var _field_count := 0
+
+
+func _init(model) -> void:
+	_model = model
+
+
+func field_count() -> int:
+	return _field_count
+
+
+## Build every section's rows under `container` (a VBoxContainer). `sections` is an
+## ordered Array of {authority, schema_path, title}: for each, a heading Label
+## then one SpinBox row per numeric scalar the schema declares. Idempotent per
+## call is not required (the controller builds once in _ready).
+func build(container: VBoxContainer, sections: Array) -> void:
+	for section: Dictionary in sections:
+		_build_section(container, section)
+
+
+func _build_section(container: VBoxContainer, section: Dictionary) -> void:
+	var authority := String(section["authority"])
+	var schema: Dictionary = _model.read_schema(String(section["schema_path"]))
+	var fields := FormSpecScript.numeric_fields(schema)
+	if fields.is_empty():
+		return
+	var heading := Label.new()
+	heading.text = String(section["title"])
+	container.add_child(heading)
+	for field: Dictionary in fields:
+		container.add_child(_build_row(authority, field))
+
+
+## One "<label>  [SpinBox]" row bound to `authority[field.key]`. The SpinBox range
+## comes from the schema (an unbounded side allows lesser/greater so the field is
+## not silently clamped); the display step is refined from the seed value so a
+## seconds-scale number keeps its decimals while a wide feel number nudges by 1.
+func _build_row(authority: String, field: Dictionary) -> HBoxContainer:
+	var row := HBoxContainer.new()
+	var label := Label.new()
+	label.text = String(field["label"])
+	label.custom_minimum_size = Vector2(220.0, 0.0)
+	row.add_child(label)
+
+	var value: float = _model.get_number(authority, String(field["key"]))
+	var spin := SpinBox.new()
+	spin.allow_lesser = not bool(field["has_min"])
+	spin.allow_greater = not bool(field["has_max"])
+	if bool(field["has_min"]):
+		spin.min_value = float(field["min"])
+	else:
+		spin.min_value = -1_000_000.0
+	if bool(field["has_max"]):
+		spin.max_value = float(field["max"])
+	else:
+		spin.max_value = 1_000_000.0
+	spin.step = _display_step(float(field["step"]), value)
+	spin.value = value
+	spin.custom_minimum_size = Vector2(160.0, 0.0)
+	# bind(authority, key): the SpinBox reports only the new value; the binding
+	# routes it to the right authority key (the LevelController group-lookup idiom
+	# — no per-field method, one handler).
+	spin.value_changed.connect(_on_value_changed.bind(authority, String(field["key"])))
+	row.add_child(spin)
+	_field_count += 1
+	return row
+
+
+func _on_value_changed(value: float, authority: String, key: String) -> void:
+	_model.set_number(authority, key, value)
+	field_edited.emit()
+
+
+## A humane SpinBox step: never coarser than the schema hint, but fine enough that
+## the seed value keeps its own precision (a 0.15s duration must not display/snap
+## as an integer just because its field carries no upper bound). Value-scale wins
+## for small magnitudes; wide feel numbers keep the schema's 1.0 nudge.
+static func _display_step(schema_step: float, value: float) -> float:
+	var magnitude := absf(value)
+	var value_step := 1.0
+	if magnitude > 0.0 and magnitude < 4.0:
+		value_step = 0.01
+	elif magnitude < 50.0:
+		value_step = 0.1
+	return minf(schema_step, value_step)

--- a/examples/platformer/panda-adventure/src/editor/editor_forms.gd
+++ b/examples/platformer/panda-adventure/src/editor/editor_forms.gd
@@ -72,17 +72,24 @@ func _build_row(authority: String, field: Dictionary) -> HBoxContainer:
 
 	var value: float = _model.get_number(authority, String(field["key"]))
 	var spin := SpinBox.new()
+	var step := _display_step(float(field["step"]), value)
+	spin.step = step
 	spin.allow_lesser = not bool(field["has_min"])
 	spin.allow_greater = not bool(field["has_max"])
+	# Exclusive schema bounds are made UNSELECTABLE (#476 review): offset the
+	# SpinBox limit one step inside the boundary so the invalid exact-boundary value
+	# cannot be entered. Clamp the limit so the current (valid) seed value stays
+	# selectable — seeding must never move the authored number.
 	if bool(field["has_min"]):
-		spin.min_value = float(field["min"])
+		var lo := float(field["min"])
+		spin.min_value = minf(lo + step if bool(field["exclusive_min"]) else lo, value)
 	else:
 		spin.min_value = -1_000_000.0
 	if bool(field["has_max"]):
-		spin.max_value = float(field["max"])
+		var hi := float(field["max"])
+		spin.max_value = maxf(hi - step if bool(field["exclusive_max"]) else hi, value)
 	else:
 		spin.max_value = 1_000_000.0
-	spin.step = _display_step(float(field["step"]), value)
 	spin.value = value
 	spin.custom_minimum_size = Vector2(160.0, 0.0)
 	# bind(authority, key): the SpinBox reports only the new value; the binding

--- a/examples/platformer/panda-adventure/src/editor/editor_level_model.gd
+++ b/examples/platformer/panda-adventure/src/editor/editor_level_model.gd
@@ -258,6 +258,46 @@ func save() -> bool:
 	return true
 
 
+## Snapshot the CURRENT on-disk text of every dirty authority — its last-derived-
+## GOOD content — so a subsequent derive failure can restore it (#476 review:
+## integrity — the JSON authority on disk is never left in a written-but-failed-to-
+## derive state). Read BEFORE save() overwrites. Returns [{id, path, text}].
+func snapshot_dirty() -> Array:
+	var snaps: Array = []
+	for id: String in _docs:
+		if _dirty_ids.get(id, false):
+			snaps.append({
+				"id": id,
+				"path": AUTHORITY_PATHS[id],
+				"text": _read_text(AUTHORITY_PATHS[id]),
+			})
+	return snaps
+
+
+## Restore each snapshot's on-disk text and RE-MARK those authorities dirty — used
+## when a derive fails after save, so the JSON authority returns to its last-good
+## content while the in-memory edits stay PENDING (unsaved) for a retry. The
+## in-memory _docs keep the edits; only the files revert.
+func rollback(snapshots: Array) -> void:
+	for snap: Dictionary in snapshots:
+		var text: Variant = snap.get("text")
+		if typeof(text) == TYPE_STRING:
+			var file := FileAccess.open(String(snap["path"]), FileAccess.WRITE)
+			if file != null:
+				file.store_string(text)
+				file.close()
+		_mark(String(snap["id"]))
+
+
+func _read_text(path: String) -> Variant:
+	var file := FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return null
+	var text := file.get_as_text()
+	file.close()
+	return text
+
+
 func _write_json(path: String, document: Dictionary) -> bool:
 	var file := FileAccess.open(path, FileAccess.WRITE)
 	if file == null:

--- a/examples/platformer/panda-adventure/src/editor/editor_level_model.gd
+++ b/examples/platformer/panda-adventure/src/editor/editor_level_model.gd
@@ -2,12 +2,16 @@ extends RefCounted
 
 ## The Panda Adventure Editor's in-memory authority model (gADR-0012).
 ##
-## Loads Level 1's JSON authorities FOR EDITING — the level authority
+## Loads Level 1's JSON authorities FOR EDITING and holds them in a single
+## authority registry (id -> parsed document). The level authority
 ## (`level_config.json`: platform segments, the Arena interval, the backdrop) and
 ## the enemies authority (`enemies_config.json`: the Wave schedule's Spawn Roster
-## positions) — and exposes their editable SPATIAL content as typed accessors over
-## the raw documents. A `save()` writes ONLY the JSON authority back (gADR-0000:
-## JSON is the single source of truth; the derived `.tres` are never hand-written).
+## positions) expose their editable SPATIAL content as typed accessors; EVERY
+## tuning config (player, combat, gravity, items, hud, progression, scale, and the
+## two above) additionally exposes its scalar NUMBERS through the generic
+## get_number/set_number pair the schema-driven forms drive (#476 review). A
+## `save()` writes ONLY the changed JSON authorities back (gADR-0000: JSON is the
+## single source of truth; the derived `.tres` are never hand-written).
 ## Re-derivation is NOT done here — it belongs to the one Python builder, invoked
 ## through `editor_builder.gd` (gADR-0012 rejects a second, GDScript derivation
 ## path).
@@ -18,52 +22,73 @@ extends RefCounted
 ## untouched. The PLAY side keeps consuming the derived Resources through the
 ## existing chain (GeneratedConfig); this model never loads a `.tres`.
 
-const LEVEL_JSON_PATH := "res://data/json/level_config.json"
-const ENEMIES_JSON_PATH := "res://data/json/enemies_config.json"
-# The Player traversal authority (#441): the hand-tune NUMERIC forms edit its
-# scalar feel numbers (move_speed, jump_velocity, gravity, …) alongside the level
-# authority's own scalars — the "playtest-driven numeric feel [as] ordinary JSON
-# diffs" gADR-0012 routes through this same JSON->builder->reload path. Its
-# spatial fields (player_start, colors) stay out of the numeric forms (arrays are
-# the direct-manipulation / picker channel).
-const PLAYER_JSON_PATH := "res://data/json/player_config.json"
-
 # The authority identifiers the generic numeric accessors key on — the Editor's
 # own vocabulary for "which JSON document a form field writes", not a config
-# number. Structural (the WEAPON_* / kind-id pattern used across the game).
+# number. Structural (the WEAPON_* / kind-id pattern used across the game). Every
+# tuning config is registered so the schema-driven forms span the whole tuning
+# surface, not just player + level (#476 review, gADR-0012's "tune numbers").
 const AUTHORITY_LEVEL := "level"
+const AUTHORITY_ENEMIES := "enemies"
 const AUTHORITY_PLAYER := "player"
+const AUTHORITY_COMBAT := "combat"
+const AUTHORITY_GRAVITY := "gravity"
+const AUTHORITY_ITEMS := "items"
+const AUTHORITY_HUD := "hud"
+const AUTHORITY_PROGRESSION := "progression"
+const AUTHORITY_SCALE := "scale"
 
-# The whole parsed authority documents. Kept intact so unedited fields survive a
-# save byte-for-value; the editable spatial slices are mutated in place.
+# authority id -> its JSON authority path. The single registry every operation
+# iterates (load / save / dirty / snapshot / rollback), so adding a tuning config
+# is one entry, never a new field + branch in five methods.
+const AUTHORITY_PATHS := {
+	AUTHORITY_LEVEL: "res://data/json/level_config.json",
+	AUTHORITY_ENEMIES: "res://data/json/enemies_config.json",
+	AUTHORITY_PLAYER: "res://data/json/player_config.json",
+	AUTHORITY_COMBAT: "res://data/json/combat_config.json",
+	AUTHORITY_GRAVITY: "res://data/json/gravity_config.json",
+	AUTHORITY_ITEMS: "res://data/json/items_config.json",
+	AUTHORITY_HUD: "res://data/json/hud_config.json",
+	AUTHORITY_PROGRESSION: "res://data/json/progression_config.json",
+	AUTHORITY_SCALE: "res://data/json/scale_spec.json",
+}
+
+# id -> the whole parsed authority Dictionary. Kept intact so unedited fields
+# survive a save byte-for-value; the editable slices are mutated in place.
+var _docs: Dictionary = {}
+# id -> bool: which authorities carry unsaved edits, so a save reserializes ONLY
+# the files that changed (a minimal JSON diff; untouched authorities never churn).
+var _dirty_ids: Dictionary = {}
+# The OR of _dirty_ids — the "unsaved edits" marker and the save-before-play guard.
+var dirty := false
+# Convenience aliases into _docs for the SPATIAL accessors below (platforms /
+# arena / backdrop read `_level`; wave spawns read `_enemies`). Godot Dictionaries
+# are reference types, so these alias the SAME objects the registry holds — a
+# spatial edit and a numeric-form edit mutate one document.
 var _level: Dictionary = {}
 var _enemies: Dictionary = {}
-var _player: Dictionary = {}
-# Set on any mutation, cleared on load/save — drives the "unsaved edits" marker
-# and the save-before-play guard. Backed by per-authority flags so a save writes
-# ONLY the file that actually changed (a minimal JSON diff; the untouched
-# authority is never reserialized).
-var dirty := false
-var _level_dirty := false
-var _enemies_dirty := false
-var _player_dirty := false
 
 
-## Load both JSON authorities from `res://data/json`. Returns false (after a loud
-## push_error) if either file is missing or malformed, so the controller can show
-## a fault rather than crash. res:// is writable here because the Editor is a
-## dev-machine tool run from source (gADR-0012), never a shipped/exported build.
+## Load every registered JSON authority from `res://data/json`. Returns false
+## (after a loud push_error inside _read_json) when the documents the editor's own
+## editing needs are missing/malformed, so the controller shows a fault rather than
+## crash. res:// is writable here because the Editor is a dev-machine tool run from
+## source (gADR-0012), never a shipped/exported build.
 func load_authorities() -> bool:
-	_level = _read_json(LEVEL_JSON_PATH)
-	_enemies = _read_json(ENEMIES_JSON_PATH)
-	_player = _read_json(PLAYER_JSON_PATH)
+	_docs.clear()
+	_dirty_ids.clear()
 	dirty = false
-	_level_dirty = false
-	_enemies_dirty = false
-	_player_dirty = false
-	if _level.is_empty() or _enemies.is_empty() or _player.is_empty():
+	for id: String in AUTHORITY_PATHS:
+		_docs[id] = _read_json(AUTHORITY_PATHS[id])
+		_dirty_ids[id] = false
+	_level = _docs[AUTHORITY_LEVEL]
+	_enemies = _docs[AUTHORITY_ENEMIES]
+	var player: Dictionary = _docs[AUTHORITY_PLAYER]
+	# Guard the shape the editor DIRECTLY manipulates (platforms, waves) + the
+	# player feel forms; the other tuning configs are form-only, guarded by their
+	# own empty-form fallback rather than a hard load failure.
+	if _level.is_empty() or _enemies.is_empty() or player.is_empty():
 		return false
-	return _level.has("platforms") and _enemies.has("waves") and _player.has("move_speed")
+	return _level.has("platforms") and _enemies.has("waves") and player.has("move_speed")
 
 
 func _read_json(path: String) -> Dictionary:
@@ -80,56 +105,43 @@ func _read_json(path: String) -> Dictionary:
 	return parsed
 
 
+# The three spatial-edit paths (backdrop/platforms/arena live in the level
+# authority; wave spawns in the enemies authority) mark through the registry.
 func _mark_level() -> void:
-	_level_dirty = true
-	dirty = true
+	_mark(AUTHORITY_LEVEL)
 
 
 func _mark_enemies() -> void:
-	_enemies_dirty = true
-	dirty = true
+	_mark(AUTHORITY_ENEMIES)
 
 
-func _mark_player() -> void:
-	_player_dirty = true
+## Mark one authority dirty (edits pending) and refresh the OR marker.
+func _mark(id: String) -> void:
+	_dirty_ids[id] = true
 	dirty = true
 
 
 # --- Numeric hand-tune scalars (schema-driven forms, #441) ---------------------
 # One generic scalar get/set pair keyed on an authority id + a JSON key, driving
-# the schema-derived SpinBox rows (EditorFormSpec + EditorForms). The forms edit
-# scalar NUMBERS only; spatial arrays stay the direct-manipulation channel. The
-# level authority's arena_min_x/arena_max_x also carry dedicated setters above
-# (the drag/nudge path) — both write the SAME `_level[key]`, so a numeric form
-# and a drag are one edit.
-
-## The parsed document backing an authority id, or an empty Dictionary for an
-## unknown id (the caller only ever passes the two AUTHORITY_* constants).
-func _authority_doc(authority: String) -> Dictionary:
-	match authority:
-		AUTHORITY_LEVEL:
-			return _level
-		AUTHORITY_PLAYER:
-			return _player
-		_:
-			return {}
-
+# the schema-derived SpinBox rows (EditorFormSpec + EditorForms) across EVERY
+# tuning config. The forms edit scalar NUMBERS only; spatial arrays stay the
+# direct-manipulation channel. The level authority's arena_min_x/arena_max_x also
+# carry dedicated setters above (the drag/nudge path) — both write the SAME
+# `_level[key]`, so a numeric form and a drag are one edit.
 
 func get_number(authority: String, key: String) -> float:
-	return float(_authority_doc(authority).get(key, 0.0))
+	return float((_docs.get(authority, {}) as Dictionary).get(key, 0.0))
 
 
 ## Write one scalar number into its authority document and mark that authority
 ## dirty (so save() reserializes only it). Coerced to float — JSON numbers are
-## floats, and the derived Resources' fields are floats (gADR-0000).
+## floats, and the derived Resources' fields are floats (gADR-0000). An unknown
+## authority is a no-op (the forms only ever pass a registered id).
 func set_number(authority: String, key: String, value: float) -> void:
-	match authority:
-		AUTHORITY_LEVEL:
-			_level[key] = value
-			_mark_level()
-		AUTHORITY_PLAYER:
-			_player[key] = value
-			_mark_player()
+	if not _docs.has(authority):
+		return
+	(_docs[authority] as Dictionary)[key] = value
+	_mark(authority)
 
 
 ## Read a JSON-Schema document (res://data/schema/…) for the forms to derive
@@ -237,16 +249,12 @@ func get_spawn_label(wave: int, spawn: int) -> String:
 ## differ; every unedited field keeps its value. Returns false after a loud
 ## push_error on any write failure; clears the dirty flags on success.
 func save() -> bool:
-	if _level_dirty and not _write_json(LEVEL_JSON_PATH, _level):
-		return false
-	if _enemies_dirty and not _write_json(ENEMIES_JSON_PATH, _enemies):
-		return false
-	if _player_dirty and not _write_json(PLAYER_JSON_PATH, _player):
-		return false
+	for id: String in _docs:
+		if _dirty_ids.get(id, false) and not _write_json(AUTHORITY_PATHS[id], _docs[id]):
+			return false
 	dirty = false
-	_level_dirty = false
-	_enemies_dirty = false
-	_player_dirty = false
+	for id: String in _dirty_ids:
+		_dirty_ids[id] = false
 	return true
 
 

--- a/examples/platformer/panda-adventure/src/editor/editor_level_model.gd
+++ b/examples/platformer/panda-adventure/src/editor/editor_level_model.gd
@@ -20,11 +20,25 @@ extends RefCounted
 
 const LEVEL_JSON_PATH := "res://data/json/level_config.json"
 const ENEMIES_JSON_PATH := "res://data/json/enemies_config.json"
+# The Player traversal authority (#441): the hand-tune NUMERIC forms edit its
+# scalar feel numbers (move_speed, jump_velocity, gravity, …) alongside the level
+# authority's own scalars — the "playtest-driven numeric feel [as] ordinary JSON
+# diffs" gADR-0012 routes through this same JSON->builder->reload path. Its
+# spatial fields (player_start, colors) stay out of the numeric forms (arrays are
+# the direct-manipulation / picker channel).
+const PLAYER_JSON_PATH := "res://data/json/player_config.json"
+
+# The authority identifiers the generic numeric accessors key on — the Editor's
+# own vocabulary for "which JSON document a form field writes", not a config
+# number. Structural (the WEAPON_* / kind-id pattern used across the game).
+const AUTHORITY_LEVEL := "level"
+const AUTHORITY_PLAYER := "player"
 
 # The whole parsed authority documents. Kept intact so unedited fields survive a
 # save byte-for-value; the editable spatial slices are mutated in place.
 var _level: Dictionary = {}
 var _enemies: Dictionary = {}
+var _player: Dictionary = {}
 # Set on any mutation, cleared on load/save — drives the "unsaved edits" marker
 # and the save-before-play guard. Backed by per-authority flags so a save writes
 # ONLY the file that actually changed (a minimal JSON diff; the untouched
@@ -32,6 +46,7 @@ var _enemies: Dictionary = {}
 var dirty := false
 var _level_dirty := false
 var _enemies_dirty := false
+var _player_dirty := false
 
 
 ## Load both JSON authorities from `res://data/json`. Returns false (after a loud
@@ -41,12 +56,14 @@ var _enemies_dirty := false
 func load_authorities() -> bool:
 	_level = _read_json(LEVEL_JSON_PATH)
 	_enemies = _read_json(ENEMIES_JSON_PATH)
+	_player = _read_json(PLAYER_JSON_PATH)
 	dirty = false
 	_level_dirty = false
 	_enemies_dirty = false
-	if _level.is_empty() or _enemies.is_empty():
+	_player_dirty = false
+	if _level.is_empty() or _enemies.is_empty() or _player.is_empty():
 		return false
-	return _level.has("platforms") and _enemies.has("waves")
+	return _level.has("platforms") and _enemies.has("waves") and _player.has("move_speed")
 
 
 func _read_json(path: String) -> Dictionary:
@@ -71,6 +88,56 @@ func _mark_level() -> void:
 func _mark_enemies() -> void:
 	_enemies_dirty = true
 	dirty = true
+
+
+func _mark_player() -> void:
+	_player_dirty = true
+	dirty = true
+
+
+# --- Numeric hand-tune scalars (schema-driven forms, #441) ---------------------
+# One generic scalar get/set pair keyed on an authority id + a JSON key, driving
+# the schema-derived SpinBox rows (EditorFormSpec + EditorForms). The forms edit
+# scalar NUMBERS only; spatial arrays stay the direct-manipulation channel. The
+# level authority's arena_min_x/arena_max_x also carry dedicated setters above
+# (the drag/nudge path) — both write the SAME `_level[key]`, so a numeric form
+# and a drag are one edit.
+
+## The parsed document backing an authority id, or an empty Dictionary for an
+## unknown id (the caller only ever passes the two AUTHORITY_* constants).
+func _authority_doc(authority: String) -> Dictionary:
+	match authority:
+		AUTHORITY_LEVEL:
+			return _level
+		AUTHORITY_PLAYER:
+			return _player
+		_:
+			return {}
+
+
+func get_number(authority: String, key: String) -> float:
+	return float(_authority_doc(authority).get(key, 0.0))
+
+
+## Write one scalar number into its authority document and mark that authority
+## dirty (so save() reserializes only it). Coerced to float — JSON numbers are
+## floats, and the derived Resources' fields are floats (gADR-0000).
+func set_number(authority: String, key: String, value: float) -> void:
+	match authority:
+		AUTHORITY_LEVEL:
+			_level[key] = value
+			_mark_level()
+		AUTHORITY_PLAYER:
+			_player[key] = value
+			_mark_player()
+
+
+## Read a JSON-Schema document (res://data/schema/…) for the forms to derive
+## their fields from. Read-only — the Editor never writes a schema (gADR-0000:
+## schemas are the config contract, owned by the pipeline). Returns {} on any
+## read/parse failure, so a missing schema yields an empty form, not a crash.
+func read_schema(path: String) -> Dictionary:
+	return _read_json(path)
 
 
 # --- Backdrop + segment color (level authority) --------------------------------
@@ -174,9 +241,12 @@ func save() -> bool:
 		return false
 	if _enemies_dirty and not _write_json(ENEMIES_JSON_PATH, _enemies):
 		return false
+	if _player_dirty and not _write_json(PLAYER_JSON_PATH, _player):
+		return false
 	dirty = false
 	_level_dirty = false
 	_enemies_dirty = false
+	_player_dirty = false
 	return true
 
 

--- a/examples/platformer/panda-adventure/tests/gdscript/test_editor_form_refresh.gd
+++ b/examples/platformer/panda-adventure/tests/gdscript/test_editor_form_refresh.gd
@@ -1,0 +1,71 @@
+extends SceneTree
+
+## Regression for the #476 review's forms-drift finding: a form row and a direct-
+## manipulation edit share JSON keys (arena_min_x / arena_max_x are BOTH SpinBox
+## fields and drag targets), so a drag must re-seed the row or the SpinBox shows
+## stale data and a later form edit clobbers the drag.
+##
+## Builds the real EditorForms over a loaded model, mutates a shared key through
+## the DRAG-path setter (set_arena_min_x), and proves: before refresh the SpinBox
+## is stale; after forms.refresh() it re-seeds from the model. Read-only.
+##
+## Run via gda (ADR-0031):
+##   gda script run res://tests/gdscript/test_editor_form_refresh.gd
+## Prints "FORM_REFRESH: PASS" + quit(0) on success, else push_error + quit(1).
+
+const ModelScript := preload("res://src/editor/editor_level_model.gd")
+const FormsScript := preload("res://src/editor/editor_forms.gd")
+
+
+func _fail(msg: String) -> void:
+	push_error("FORM_REFRESH: " + msg)
+	quit(1)
+
+
+func _init() -> void:
+	var model := ModelScript.new()
+	if not model.load_authorities():
+		_fail("could not load Level 1 JSON authorities")
+		return
+	var forms := FormsScript.new(model)
+	var box := VBoxContainer.new()
+	root.add_child(box)
+	forms.build(box, [
+		{
+			"authority": ModelScript.AUTHORITY_LEVEL,
+			"schema_path": "res://data/schema/level_config.schema.json",
+			"title": "Level",
+		},
+	])
+
+	var spin: SpinBox = _find_spin(forms, ModelScript.AUTHORITY_LEVEL, "arena_min_x")
+	if spin == null:
+		_fail("arena_min_x form row was not built")
+		return
+	var original: float = model.get_number(ModelScript.AUTHORITY_LEVEL, "arena_min_x")
+	if spin.value != original:
+		_fail("SpinBox was not seeded from the model: %s != %s" % [spin.value, original])
+		return
+
+	# Simulate a DRAG mutating the shared key through the direct-manipulation setter.
+	var dragged := original - 32.0
+	model.set_arena_min_x(dragged)
+	# Before refresh the SpinBox is STALE (the drift the finding names).
+	if spin.value != original:
+		_fail("SpinBox unexpectedly changed without a refresh")
+		return
+	# refresh() re-seeds it from the model (the fix) without re-firing value_changed.
+	forms.refresh()
+	if spin.value != dragged:
+		_fail("refresh did not re-seed the SpinBox: %s != %s" % [spin.value, dragged])
+		return
+
+	print("FORM_REFRESH: PASS")
+	quit(0)
+
+
+func _find_spin(forms, authority: String, key: String) -> SpinBox:
+	for row in forms._rows:
+		if row["authority"] == authority and row["key"] == key:
+			return row["spin"] as SpinBox
+	return null

--- a/examples/platformer/panda-adventure/tests/gdscript/test_editor_god_mode.gd
+++ b/examples/platformer/panda-adventure/tests/gdscript/test_editor_god_mode.gd
@@ -1,0 +1,71 @@
+extends SceneTree
+
+## Regression for the #476 review's god-mode correctness finding: the debug
+## palette's god-mode must PREVENT death, not paper over it after the fact.
+##
+## Boots the real game (main.tscn), then drives the Player's set_debug_invulnerable
+## API — the exact seam the palette's _process drives — and proves a LETHAL hit is
+## refused at the source (take_hit), so the death latch never fires:
+##
+##   god-mode ON  -> a hit with attack far above the Player's HP does NO damage and
+##                   does NOT kill (the run cannot end via game_lost).
+##   god-mode OFF -> the SAME lethal hit now kills, proving god-mode did the work.
+##
+## Run via gda (ADR-0031):
+##   gda script run res://tests/gdscript/test_editor_god_mode.gd
+## Read-only (no save/derive). Prints "GOD_MODE: PASS" + quit(0) on success, else
+## push_error + quit(1). Runs from source (not a template build), so the take_hit
+## debug gate is active — exactly the dev-machine editor context god-mode targets.
+
+const MainScene := preload("res://scenes/main.tscn")
+const StatsConfigScript := preload("res://src/resources/stats_config.gd")
+
+
+func _fail(msg: String) -> void:
+	push_error("GOD_MODE: " + msg)
+	quit(1)
+
+
+func _init() -> void:
+	var main := MainScene.instantiate()
+	root.add_child(main)
+	# Two frames: the level + Player _ready run and the Player's stats initialize.
+	await process_frame
+	await process_frame
+
+	var player := get_first_node_in_group("player")
+	if player == null:
+		_fail("player not found in the running game")
+		return
+	if player._dead:
+		_fail("player already dead at boot")
+		return
+
+	# A lethal attacker: attack far above the Player's HP, so the mitigated damage
+	# (attack * scale - defense * scale) exceeds max_hp in one hit.
+	var attacker := StatsConfigScript.new()
+	attacker.max_hp = 1.0
+	attacker.max_mp = 0.0
+	attacker.attack = 1_000_000.0
+	attacker.defense = 0.0
+
+	# --- god-mode ON: the lethal hit is refused; the Player survives untouched.
+	player.set_debug_invulnerable(true)
+	var hp_before: float = player._stats.hp
+	player.take_hit(attacker)
+	if player._dead:
+		_fail("player died despite god-mode")
+		return
+	if player._stats.hp != hp_before:
+		_fail("god-mode still applied damage: %s -> %s" % [hp_before, player._stats.hp])
+		return
+
+	# --- god-mode OFF: the SAME lethal hit now kills — god-mode was the difference.
+	player.set_debug_invulnerable(false)
+	player.take_hit(attacker)
+	if not player._dead:
+		_fail("lethal hit did not kill with god-mode off")
+		return
+
+	print("GOD_MODE: PASS")
+	quit(0)

--- a/examples/platformer/panda-adventure/tests/gdscript/test_editor_play_abort.gd
+++ b/examples/platformer/panda-adventure/tests/gdscript/test_editor_play_abort.gd
@@ -65,6 +65,11 @@ func _init() -> void:
 	if not String(editor.status_line).contains("derive_failed"):
 		_fail("status line must surface the failure, got %s" % editor.status_line)
 		return
+	# Integrity (#476 review): a failed derive keeps the edits PENDING (dirty) — the
+	# JSON authority was rolled back, so the edit lives only in memory, unsaved.
+	if not editor._model.dirty:
+		_fail("edits must stay pending (dirty) after a failed derive")
+		return
 
 	print("PLAY_ABORT: PASS")
 	quit(0)

--- a/examples/platformer/panda-adventure/tests/gdscript/test_editor_roundtrip.gd
+++ b/examples/platformer/panda-adventure/tests/gdscript/test_editor_roundtrip.gd
@@ -66,6 +66,13 @@ func _init() -> void:
 		return
 	var new_move_speed := 320.0  # was 300.0
 	model.set_number(ModelScript.AUTHORITY_PLAYER, "move_speed", new_move_speed)
+	# Multi-config coverage (#476 review): hand-tune a Combat and a Gravity number
+	# too, proving the numeric round-trip spans EVERY tuning config, not just
+	# player/level. 0.5 / 8.0 are exact in float32 + JSON.
+	var new_iframe := 0.5  # combat.iframe_duration, was 0.6
+	var new_mp_cost := 8.0  # gravity.mp_cost, was 10.0
+	model.set_number(ModelScript.AUTHORITY_COMBAT, "iframe_duration", new_iframe)
+	model.set_number(ModelScript.AUTHORITY_GRAVITY, "mp_cost", new_mp_cost)
 
 	if not model.dirty:
 		_fail("model must be dirty after edits")
@@ -106,6 +113,12 @@ func _init() -> void:
 	if reloaded.get_number(ModelScript.AUTHORITY_PLAYER, "move_speed") != new_move_speed:
 		_fail("JSON move_speed not persisted: %s" % [reloaded.get_number(ModelScript.AUTHORITY_PLAYER, "move_speed")])
 		return
+	if reloaded.get_number(ModelScript.AUTHORITY_COMBAT, "iframe_duration") != new_iframe:
+		_fail("JSON combat iframe_duration not persisted")
+		return
+	if reloaded.get_number(ModelScript.AUTHORITY_GRAVITY, "mp_cost") != new_mp_cost:
+		_fail("JSON gravity mp_cost not persisted")
+		return
 
 	# --- the DERIVED Resources carry the edit (proof the builder actually ran).
 	var level: Resource = load(LEVEL_TRES)
@@ -139,6 +152,14 @@ func _init() -> void:
 		return
 	if player.move_speed != new_move_speed:
 		_fail("derived .tres move_speed stale: %s" % [player.move_speed])
+		return
+	var combat: Resource = load("res://data/generated/combat_config.tres")
+	if combat == null or combat.iframe_duration != new_iframe:
+		_fail("derived combat_config.tres iframe_duration stale")
+		return
+	var gravity: Resource = load("res://data/generated/gravity_config.tres")
+	if gravity == null or gravity.mp_cost != new_mp_cost:
+		_fail("derived gravity_config.tres mp_cost stale")
 		return
 
 	print("EDITOR_ROUNDTRIP: PASS")

--- a/examples/platformer/panda-adventure/tests/gdscript/test_editor_roundtrip.gd
+++ b/examples/platformer/panda-adventure/tests/gdscript/test_editor_roundtrip.gd
@@ -20,9 +20,12 @@ extends SceneTree
 
 const ModelScript := preload("res://src/editor/editor_level_model.gd")
 const BuilderScript := preload("res://src/editor/editor_builder.gd")
+const FormSpecScript := preload("res://src/editor/editor_form_spec.gd")
 
 const LEVEL_TRES := "res://data/generated/level_config.tres"
 const SCHEDULE_TRES := "res://data/generated/wave_schedule.tres"
+const PLAYER_TRES := "res://data/generated/player_config.tres"
+const PLAYER_SCHEMA := "res://data/schema/player_config.schema.json"
 
 
 func _fail(msg: String) -> void:
@@ -52,6 +55,18 @@ func _init() -> void:
 	model.set_arena_min_x(arena_min)
 	model.set_spawn_position(0, 0, spawn_pos)
 	model.set_background_color(backdrop)
+
+	# --- form edit (#441): a schema-driven NUMERIC hand-tune of a Player feel
+	# number. The field set comes from the SCHEMA (EditorFormSpec), proving the
+	# form maps from data/schema, and the write goes through the model's generic
+	# set_number exactly as a SpinBox row does. 320.0 is exact in float32 + JSON.
+	var fields := FormSpecScript.numeric_fields(model.read_schema(PLAYER_SCHEMA))
+	if not _has_field(fields, "move_speed"):
+		_fail("schema-derived numeric fields missing move_speed")
+		return
+	var new_move_speed := 320.0  # was 300.0
+	model.set_number(ModelScript.AUTHORITY_PLAYER, "move_speed", new_move_speed)
+
 	if not model.dirty:
 		_fail("model must be dirty after edits")
 		return
@@ -88,6 +103,9 @@ func _init() -> void:
 	if reloaded.get_background_color() != backdrop:
 		_fail("JSON backdrop color not persisted: %s" % [reloaded.get_background_color()])
 		return
+	if reloaded.get_number(ModelScript.AUTHORITY_PLAYER, "move_speed") != new_move_speed:
+		_fail("JSON move_speed not persisted: %s" % [reloaded.get_number(ModelScript.AUTHORITY_PLAYER, "move_speed")])
+		return
 
 	# --- the DERIVED Resources carry the edit (proof the builder actually ran).
 	var level: Resource = load(LEVEL_TRES)
@@ -113,6 +131,23 @@ func _init() -> void:
 	if schedule.waves[0]["spawns"][0]["position"] != spawn_pos:
 		_fail("derived .tres spawn position stale: %s" % [schedule.waves[0]["spawns"][0]["position"]])
 		return
+	# The form edit propagated through the builder into the derived PlayerConfig
+	# (#441): forms -> JSON -> builder -> reload closed the numeric loop.
+	var player: Resource = load(PLAYER_TRES)
+	if player == null:
+		_fail("derived player_config.tres missing")
+		return
+	if player.move_speed != new_move_speed:
+		_fail("derived .tres move_speed stale: %s" % [player.move_speed])
+		return
 
 	print("EDITOR_ROUNDTRIP: PASS")
 	quit(0)
+
+
+## Whether a schema-derived field list carries `key` — the forms map from schema.
+func _has_field(fields: Array, key: String) -> bool:
+	for field: Dictionary in fields:
+		if String(field["key"]) == key:
+			return true
+	return false

--- a/examples/platformer/panda-adventure/tests/test_editor_god_mode_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_editor_god_mode_seam.py
@@ -39,7 +39,15 @@ def test_god_mode_prevents_death(tmp_path) -> None:
     shutil.copytree(GAME_DIR, project, ignore=_COPY_IGNORE)
 
     result = subprocess.run(
-        [*GDA_CMD, "script", "run", _GOD_MODE_SCRIPT, "--project", str(project), "--json"],
+        [
+            *GDA_CMD,
+            "script",
+            "run",
+            _GOD_MODE_SCRIPT,
+            "--project",
+            str(project),
+            "--json",
+        ],
         capture_output=True,
         text=True,
     )

--- a/examples/platformer/panda-adventure/tests/test_editor_god_mode_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_editor_god_mode_seam.py
@@ -1,0 +1,49 @@
+"""God-mode regression seam for the Panda Adventure Editor (#476 review).
+
+Drives the debug palette's god-mode correctness through ``gda script run``
+(ADR-0031): the review found that refilling HP next-frame does NOT stop the
+synchronous death latch in ``PlayerController.take_hit``. The fix routes god-mode
+through a Player invulnerability API the palette drives, so a lethal hit is
+refused at the source. This seam boots the real game, enables god-mode, lands a
+lethal hit, and asserts the Player survives; then disables god-mode and lands the
+same hit to prove it kills (god-mode was the difference).
+
+Engine tier (fast, no daemon): a one-shot headless call against a THROWAWAY COPY
+(kept read-only, but copied for isolation like the round-trip seam).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+import build_config
+
+GDA_CMD = [sys.executable, "-m", "gda"]
+GAME_DIR = build_config.GAME_DIR
+_GOD_MODE_SCRIPT = "res://tests/gdscript/test_editor_god_mode.gd"
+
+# Keep tests/ (the seam script) and data/generated (main.tscn loads the derived
+# .tres). Drop only the editor cache, the build artifact, and pycache.
+_COPY_IGNORE = shutil.ignore_patterns(".godot", "build", "__pycache__")
+
+
+@pytest.mark.engine
+def test_god_mode_prevents_death(tmp_path) -> None:
+    """A lethal hit under god-mode does NOT end the run; without it, it kills."""
+    project = tmp_path / "panda_copy"
+    shutil.copytree(GAME_DIR, project, ignore=_COPY_IGNORE)
+
+    result = subprocess.run(
+        [*GDA_CMD, "script", "run", _GOD_MODE_SCRIPT, "--project", str(project), "--json"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    doc = json.loads(result.stdout)
+    assert doc["exit_status"] == 0, doc["stdout"] + doc["stderr"]
+    assert "GOD_MODE: PASS" in doc["stdout"], doc["stdout"] + doc["stderr"]

--- a/examples/platformer/panda-adventure/tests/test_editor_palette_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_editor_palette_e2e.py
@@ -1,0 +1,224 @@
+"""Integration seam (e2e) for the Panda Adventure Editor's DEBUG PALETTE (#441).
+
+The palette's play-mode debug ops driven END TO END through gda live ops against
+a running Engine session — proving the palette DOGFOODS gda's live layer
+(gADR-0012): its whole control surface is runtime-drivable state an agent (here,
+the test) reaches with the exact same commands a human's overlay buttons write.
+
+The daemon boots the EDITOR entry scene (the copy's ``run/main_scene`` is
+reconfigured to ``scenes/editor.tscn``; the editor is stripped from player builds,
+not from a dev-machine daemon run), then every step is one gda live command:
+
+- ``gda game set /root/Editor/DebugPalette --property play_active --value true``
+  enters play mode (main.tscn instanced under PlayHost) — Wave 1 boots.
+- ``gda game set … --property jump_to_wave --value 3`` clears the live enemies and
+  (re)starts Wave 3 through the game's OWN wave director — asserted from the
+  monotonic ``gda logger tail`` records (the #406 lesson: records, not position
+  polls) AND the ``gda game tree`` (Wave 3's named spawn present, Wave 1's gone).
+- ``gda game set … --property spawn --value true`` spawns one enemy on demand —
+  the addressable ``DebugSpawn0`` appears in ``gda game tree`` + a ``debug_spawn``
+  record.
+- ``gda game set … --property god_mode --value true`` toggles god-mode, read back
+  with ``gda game get … --property last_action`` (dogfooding the live READ too).
+
+Isolation matches the other daemon e2e (a throwaway COPY; ``gda daemon start``
+mutates ``project.godot``). posix-only (the live stack uses ``AF_UNIX``, ADR-0021)
+and HEADLESS (no windowed/display gate — the palette ops are observed through the
+tree/logger, not a screenshot).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+import build_config
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+GDA_CMD = [sys.executable, "-m", "gda"]
+GODOT = resolve_godot_binary()
+GAME_DIR = build_config.GAME_DIR
+
+# The editor scene starts in EDIT mode; the palette node hangs off its root.
+_PALETTE = "/root/Editor/DebugPalette"
+
+_COPY_IGNORE = shutil.ignore_patterns(
+    "tests", ".godot", "build", "generated", "__pycache__"
+)
+
+
+def _make_editor_project(dst: Path) -> Path:
+    """Copy the game, build its config, and boot the EDITOR scene by default.
+
+    The editor is the daemon's ``run/main_scene`` here (a dev-machine tool run,
+    gADR-0012) so the palette node is in the session's tree for gda live ops. The
+    reconfig is a one-line text swap on the throwaway copy — the same
+    reconfigure-the-copy pattern the waves e2e uses for its enemies config.
+    """
+    shutil.copytree(GAME_DIR, dst, ignore=_COPY_IGNORE)
+    build_config.build_all(root=dst)
+    project_godot = dst / "project.godot"
+    text = project_godot.read_text(encoding="utf-8")
+    assert 'run/main_scene="res://scenes/main.tscn"' in text, "unexpected main_scene"
+    project_godot.write_text(
+        text.replace(
+            'run/main_scene="res://scenes/main.tscn"',
+            'run/main_scene="res://scenes/editor.tscn"',
+        ),
+        encoding="utf-8",
+    )
+    return dst
+
+
+def _find_node(node: dict, name: str) -> dict | None:
+    """Depth-first search a ``game tree`` subtree for a node by name."""
+    if node.get("name") == name:
+        return node
+    for child in node.get("children", []):
+        found = _find_node(child, name)
+        if found is not None:
+            return found
+    return None
+
+
+class _Session:
+    """A tiny per-scenario harness over the gda CLI (the waves e2e idioms)."""
+
+    def __init__(self, project: Path):
+        self.project = project
+        self.env = {**os.environ}
+
+    def run(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(self.project),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            env=self.env,
+            timeout=90,
+        )
+
+    def records(self, message: str) -> list[dict]:
+        proc = self.run("logger", "tail")
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        return [
+            r
+            for r in json.loads(proc.stdout)["records"]
+            if r["message"] == message and r["origin"] == "gda_log"
+        ]
+
+    def poll(self, predicate, timeout: float = 20.0, interval: float = 0.5):
+        deadline = time.monotonic() + timeout
+        result = predicate()
+        while not result and time.monotonic() < deadline:
+            time.sleep(interval)
+            result = predicate()
+        return result
+
+    def tree_root(self) -> dict:
+        tree = self.run("game", "tree")
+        assert tree.returncode == 0, tree.stdout + tree.stderr
+        return json.loads(tree.stdout)["root"]
+
+    def node_in_tree(self, name: str) -> dict | None:
+        return _find_node(self.tree_root(), name)
+
+    def set_palette(self, prop: str, value: str) -> None:
+        """One ``gda game set`` on a palette property — the drivable op surface."""
+        proc = self.run("game", "set", _PALETTE, "--property", prop, "--value", value)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    def get_palette(self, prop: str):
+        """One ``gda game get`` on a palette property (the live READ dogfood)."""
+        proc = self.run("game", "get", _PALETTE, "--property", prop)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        for p in json.loads(proc.stdout)["properties"]:
+            if p["name"] == prop:
+                return p["value"]
+        raise AssertionError(f"palette property {prop} not returned")
+
+
+@pytest.mark.e2e
+def test_palette_ops_drive_the_running_game(tmp_path, daemon_runtime_dir):
+    """Every palette op functions when driven through the gda daemon (gADR-0012)."""
+    project = _make_editor_project(tmp_path / "game")
+    enemies = build_config.load_composed("data/json/enemies_config.json")
+    waves = enemies["waves"]
+    wave_one_name = waves[0]["spawns"][0]["name"]  # "Enemy"
+    wave_three_name = waves[2]["spawns"][0]["name"]  # "SwarmMeleeA"
+    total_waves = len(waves)
+    s = _Session(project)
+
+    try:
+        started = s.run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        # The first live op launches the session: the editor boots in EDIT mode
+        # (no play instance, so no game tree under PlayHost yet).
+        assert s.poll(lambda: bool(s.records("editor_ready"))), "editor never booted"
+
+        # --- edit<->play switch: play_active drives main.tscn under PlayHost.
+        s.set_palette("play_active", "true")
+        first = s.poll(lambda: bool(s.records("wave_started")))
+        assert first, "entering play did not boot the wave schedule"
+        assert s.records("wave_started")[0]["fields"]["wave"] == 1
+        assert s.poll(lambda: s.node_in_tree(wave_one_name) is not None), (
+            "Wave 1's spawn never entered the running tree"
+        )
+
+        # --- WAVE JUMP: clear the live enemies + (re)start Wave 3 via the game's
+        # own director. Assert from the monotonic records AND the runtime tree.
+        s.set_palette("jump_to_wave", "3")
+        assert s.poll(
+            lambda: any(
+                r["fields"]["wave"] == 3 for r in s.records("debug_wave_jump")
+            )
+        ), "no debug_wave_jump record for wave 3"
+        jump = s.records("debug_wave_jump")[-1]["fields"]
+        assert jump == {"wave": 3, "total": total_waves}
+        assert s.records("wave_started")[-1]["fields"]["wave"] == 3, (
+            "the game director did not (re)start Wave 3"
+        )
+        assert s.poll(lambda: s.node_in_tree(wave_three_name) is not None), (
+            "Wave 3's named spawn never materialized after the jump"
+        )
+        assert s.poll(lambda: s.node_in_tree(wave_one_name) is None), (
+            "the jump did not clear Wave 1's live enemy"
+        )
+
+        # --- SPAWN ON DEMAND: one addressable enemy at the default lane.
+        s.set_palette("spawn", "true")
+        assert s.poll(lambda: bool(s.records("debug_spawn"))), "no debug_spawn record"
+        assert s.node_in_tree("DebugSpawn0") is not None, (
+            "the on-demand spawn never entered the runtime tree"
+        )
+        assert s.records("debug_spawn")[0]["fields"]["name"] == "DebugSpawn0"
+
+        # --- GOD MODE: toggle, then read the op back through gda's live READ.
+        s.set_palette("god_mode", "true")
+        god = s.poll(lambda: bool(s.records("debug_god_mode")))
+        assert god and s.records("debug_god_mode")[-1]["fields"]["on"] is True, (
+            "god-mode toggle produced no debug_god_mode record"
+        )
+        assert s.get_palette("last_action") == "god_mode:true", (
+            "gda game get did not read the palette's op back"
+        )
+    finally:
+        s.run("daemon", "stop")

--- a/examples/platformer/panda-adventure/tests/test_editor_palette_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_editor_palette_e2e.py
@@ -189,9 +189,7 @@ def test_palette_ops_drive_the_running_game(tmp_path, daemon_runtime_dir):
         # own director. Assert from the monotonic records AND the runtime tree.
         s.set_palette("jump_to_wave", "3")
         assert s.poll(
-            lambda: any(
-                r["fields"]["wave"] == 3 for r in s.records("debug_wave_jump")
-            )
+            lambda: any(r["fields"]["wave"] == 3 for r in s.records("debug_wave_jump"))
         ), "no debug_wave_jump record for wave 3"
         jump = s.records("debug_wave_jump")[-1]["fields"]
         assert jump == {"wave": 3, "total": total_waves}

--- a/examples/platformer/panda-adventure/tests/test_editor_palette_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_editor_palette_e2e.py
@@ -170,8 +170,10 @@ def test_palette_ops_drive_the_running_game(tmp_path, daemon_runtime_dir):
         started = s.run("daemon", "start")
         assert started.returncode == 0, started.stdout + started.stderr
 
-        # The first live op launches the session: the editor boots in EDIT mode
-        # (no play instance, so no game tree under PlayHost yet).
+        # The FIRST live op launches the session (a `logger tail` read will not —
+        # the waves e2e idiom): `game tree` boots the editor in EDIT mode, so the
+        # editor_ready record is then readable.
+        assert s.tree_root()["name"] == "Editor", "the editor scene did not boot"
         assert s.poll(lambda: bool(s.records("editor_ready"))), "editor never booted"
 
         # --- edit<->play switch: play_active drives main.tscn under PlayHost.

--- a/examples/platformer/panda-adventure/tests/test_editor_roundtrip_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_editor_roundtrip_seam.py
@@ -48,6 +48,8 @@ _EXPECT_ARENA_MIN = -144.0  # was -160
 _EXPECT_SPAWN0_POSITION = [688.0, 436.0]  # was [640, 452]
 _EXPECT_BACKDROP = [0.25, 0.5, 0.75, 1.0]  # was [0.07, 0.06, 0.12, 1.0]
 _EXPECT_MOVE_SPEED = 320.0  # was 300.0 (the schema-driven numeric form edit)
+_EXPECT_IFRAME = 0.5  # combat.iframe_duration, was 0.6 (#476 multi-config forms)
+_EXPECT_MP_COST = 8.0  # gravity.mp_cost, was 10.0
 
 
 @pytest.mark.engine
@@ -97,6 +99,16 @@ def test_editor_roundtrip_json_and_derived(tmp_path) -> None:
         (project / "data/json/player_config.json").read_text(encoding="utf-8")
     )
     assert player["move_speed"] == _EXPECT_MOVE_SPEED
+    # Multi-config forms (#476 review): a Combat + a Gravity number hand-tuned
+    # through the same generic set_number path landed on their own authorities.
+    combat = json.loads(
+        (project / "data/json/combat_config.json").read_text(encoding="utf-8")
+    )
+    assert combat["iframe_duration"] == _EXPECT_IFRAME
+    gravity = json.loads(
+        (project / "data/json/gravity_config.json").read_text(encoding="utf-8")
+    )
+    assert gravity["mp_cost"] == _EXPECT_MP_COST
 
     # And the worktree authority is untouched (the copy took all writes).
     worktree_level = json.loads(

--- a/examples/platformer/panda-adventure/tests/test_editor_roundtrip_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_editor_roundtrip_seam.py
@@ -129,7 +129,15 @@ def test_forms_refresh_after_direct_manipulation(tmp_path) -> None:
     project = tmp_path / "panda_copy"
     shutil.copytree(GAME_DIR, project, ignore=_COPY_IGNORE)
     result = subprocess.run(
-        [*GDA_CMD, "script", "run", _FORM_REFRESH_SCRIPT, "--project", str(project), "--json"],
+        [
+            *GDA_CMD,
+            "script",
+            "run",
+            _FORM_REFRESH_SCRIPT,
+            "--project",
+            str(project),
+            "--json",
+        ],
         capture_output=True,
         text=True,
     )

--- a/examples/platformer/panda-adventure/tests/test_editor_roundtrip_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_editor_roundtrip_seam.py
@@ -38,14 +38,16 @@ _PLAY_ABORT_SCRIPT = "res://tests/gdscript/test_editor_play_abort.gd"
 _COPY_IGNORE = shutil.ignore_patterns(".godot", "build", "__pycache__")
 
 # The edits the GDScript applies to Level 1 (segment 0 up one tile + widened,
-# arena_min nudged in one tile, first spawn moved, backdrop recolored) —
-# asserted here on the JSON. The backdrop uses power-of-two components, exact
-# in float32 and JSON, so plain equality holds.
+# arena_min nudged in one tile, first spawn moved, backdrop recolored, and — the
+# #441 numeric-form channel — a Player feel number hand-tuned) — asserted here on
+# the JSON. The backdrop and move_speed use values exact in float32 and JSON, so
+# plain equality holds.
 _EXPECT_SEG0_POSITION = [560.0, 484.0]  # was [560, 500]
 _EXPECT_SEG0_SIZE = [1792.0, 48.0]  # was [1760, 48]
 _EXPECT_ARENA_MIN = -144.0  # was -160
 _EXPECT_SPAWN0_POSITION = [688.0, 436.0]  # was [640, 452]
 _EXPECT_BACKDROP = [0.25, 0.5, 0.75, 1.0]  # was [0.07, 0.06, 0.12, 1.0]
+_EXPECT_MOVE_SPEED = 320.0  # was 300.0 (the schema-driven numeric form edit)
 
 
 @pytest.mark.engine
@@ -89,6 +91,12 @@ def test_editor_roundtrip_json_and_derived(tmp_path) -> None:
         (project / "data/json/enemies_config.json").read_text(encoding="utf-8")
     )
     assert enemies["waves"][0]["spawns"][0]["position"] == _EXPECT_SPAWN0_POSITION
+    # The numeric-form channel (#441): the schema-driven Player feel edit landed on
+    # the player authority (a THIRD JSON file the model now writes).
+    player = json.loads(
+        (project / "data/json/player_config.json").read_text(encoding="utf-8")
+    )
+    assert player["move_speed"] == _EXPECT_MOVE_SPEED
 
     # And the worktree authority is untouched (the copy took all writes).
     worktree_level = json.loads(

--- a/examples/platformer/panda-adventure/tests/test_editor_roundtrip_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_editor_roundtrip_seam.py
@@ -127,6 +127,11 @@ def test_play_entry_aborts_when_derive_fails(tmp_path) -> None:
     (playing would silently run STALE derived ``.tres``). The derived resources
     in the copy must stay byte-identical to the pre-edit baseline: nothing
     re-derived, nothing refreshed.
+
+    Integrity on the failed derive (#476 review): the JSON authority is ROLLED
+    BACK to its pre-edit content — a failed build never leaves the authority in a
+    written-but-un-derivable state — and the edit lives only in memory (the model
+    stays dirty, asserted GDScript-side).
     """
     project = tmp_path / "panda_copy"
     shutil.copytree(GAME_DIR, project, ignore=_COPY_IGNORE)
@@ -158,12 +163,14 @@ def test_play_entry_aborts_when_derive_fails(tmp_path) -> None:
     assert "editor_play_aborted" in doc["stdout"], doc["stdout"]
     assert "editor_play_entered" not in doc["stdout"], doc["stdout"]
 
-    # The failed builder wrote nothing: the derived .tres is the pre-edit baseline
-    # (the save half DID write the JSON authority — that is the expected split).
+    # The failed builder wrote nothing: the derived .tres is the pre-edit baseline.
     assert (project / "data/generated/level_config.tres").read_text(
         encoding="utf-8"
     ) == baseline_tres
+    # And the JSON authority was ROLLED BACK to its pre-edit value (#476 review):
+    # a failed derive leaves NO invalid authority on disk — it matches the
+    # untouched .tres, and the edit remains only in memory (dirty, GDScript-side).
     saved = json.loads(
         (project / "data/json/level_config.json").read_text(encoding="utf-8")
     )
-    assert saved["arena_min_x"] == -144.0  # the seam's one edit landed on JSON
+    assert saved["arena_min_x"] == -160.0  # rolled back from the seam's -144.0 edit

--- a/examples/platformer/panda-adventure/tests/test_editor_roundtrip_seam.py
+++ b/examples/platformer/panda-adventure/tests/test_editor_roundtrip_seam.py
@@ -31,6 +31,7 @@ GDA_CMD = [sys.executable, "-m", "gda"]
 GAME_DIR = build_config.GAME_DIR
 _ROUNDTRIP_SCRIPT = "res://tests/gdscript/test_editor_roundtrip.gd"
 _PLAY_ABORT_SCRIPT = "res://tests/gdscript/test_editor_play_abort.gd"
+_FORM_REFRESH_SCRIPT = "res://tests/gdscript/test_editor_form_refresh.gd"
 
 # Unlike the daemon e2e copies, KEEP ``tests/`` (the round-trip script runs from
 # ``res://tests``) and ``data/generated`` (the pre-edit baseline the derive
@@ -115,6 +116,27 @@ def test_editor_roundtrip_json_and_derived(tmp_path) -> None:
         (GAME_DIR / "data/json/level_config.json").read_text(encoding="utf-8")
     )
     assert worktree_level["platforms"][0]["position"] == [560.0, 500.0]
+
+
+@pytest.mark.engine
+def test_forms_refresh_after_direct_manipulation(tmp_path) -> None:
+    """A drag that mutates a shared JSON key re-seeds its form row (#476 review).
+
+    arena_min_x is both a SpinBox field and a drag target; the seam mutates it
+    through the drag-path setter and proves the SpinBox is stale until
+    ``forms.refresh()`` re-seeds it (no drift, no clobber). Read-only.
+    """
+    project = tmp_path / "panda_copy"
+    shutil.copytree(GAME_DIR, project, ignore=_COPY_IGNORE)
+    result = subprocess.run(
+        [*GDA_CMD, "script", "run", _FORM_REFRESH_SCRIPT, "--project", str(project), "--json"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    doc = json.loads(result.stdout)
+    assert doc["exit_status"] == 0, doc["stdout"] + doc["stderr"]
+    assert "FORM_REFRESH: PASS" in doc["stdout"], doc["stdout"] + doc["stderr"]
 
 
 @pytest.mark.engine


### PR DESCRIPTION
## Summary

The Panda Adventure Editor's second half (P2-S15, gADR-0012): schema-mapped numeric hand-tune forms + a debug palette (wave jump / god-mode / spawn-on-demand) that dogfoods `gda` live ops. Additive under `src/editor/` + `scenes/editor.tscn`.

## Scope (narrowed in review)

This PR delivers schema-mapped numeric hand-tune forms for the **top-level scalar fields** across the nine tuning configs (~39 fields: player, level, combat, gravity, items, progression, scale, enemies, hud). The **nested** numeric surfaces of the enemies config — per-Enemy-Kind stat blocks (`enemies.kinds.*`) and per-Tier reward tables (`enemies.tiers.*`), which need `$ref`/`$defs` resolution + data-key enumeration — are **explicitly deferred** to follow-up **#481**. `Closes #441` reflects this narrowed scope; #481 carries the nested-table remainder.

> The review round on this PR expanded coverage from player+level to all nine configs and fixed five findings (form coverage, god-mode-prevents-death, exclusive-bound + derive-rollback integrity, stale-form-refresh, wave-derived spawn default). See the review-resolution comment for the per-finding SHAs and re-verification.

## What's in it

- `editor_form_spec.gd` / `editor_forms.gd` — numeric fields mapped from the existing `data/schema/*.json` (never free-text JSON editing); one SpinBox per field, two-way bound to the JSON authority. Save writes only dirty authorities; re-derivation stays the ONE Python builder (`editor_builder.gd` → `scripts/build_config.py`).
- `debug_palette.gd` — play-mode ops driven by both the HITL overlay and `gda game set/get`; wave-jump reuses the game's own `_start_wave` director, spawn-on-demand reuses `enemy.tscn` + `setup`. Lives in the export-stripped editor scene.

## Verification (implementer self-reported)

- `ruff check` / `ruff format --check`: pass · `pyright`: 0 errors
- `pytest -m "not e2e"` (gda): **1087 passed** · game `not e2e and not engine`: **314 passed**
- engine tier `test_editor_roundtrip_seam.py`: **2 passed** (forms→JSON→builder→reload numeric round-trip) · e2e `test_editor_palette_e2e.py`: **1 passed** (palette ops via `gda daemon`/`game set`/`game get`) · Phase-1 engine non-e2e: **44 passed** · `gda script validate` on 6 new/changed `.gd`: all valid.

## Dogfooding → gda #473

The palette `spawn` trigger surfaced a `gda game set` friction: the live write-verify false-rejects an edge-triggered/self-consuming script variable (reads back unchanged). Worked around here by latching the set value (commit `a21d24f`); filed as gda issue #473.

## Orchestrator notes

- File-disjoint from #440 and #439 (verified); no flag-don't-edit file touched.
- Wave-2 merge order: #440 → **#441** → #439. Definitive integration gate is the single post-merge `run-e2e` dispatch on `main`.

Closes #441

