### PR TITLE
fix(panda-editor): revert #473 spawn-latch workaround now gda 0.8.0 ships game-set verified

### DIFF
--- a/examples/platformer/panda-adventure/src/editor/debug_palette.gd
+++ b/examples/platformer/panda-adventure/src/editor/debug_palette.gd
@@ -84,17 +84,20 @@ var spawn_position := Vector2.ZERO:
 		spawn_position = value
 		_spawn_position_overridden = true
 
-## A spawn trigger: setting it TRUE spawns one enemy on demand. It latches the
-## set value rather than self-resetting — the gda harness's live-set write-verify
-## rejects a script variable that reads back unchanged, so a self-reset-to-false
-## would look like a failed set. The setter runs on every assignment (Godot fires
-## setters even when the value is unchanged), so a repeated `gda game set … spawn
-## true` (or button click) spawns again; set it false to disarm.
+## A momentary spawn trigger: setting it TRUE spawns one enemy on demand and
+## self-resets to false, so a `gda game set … spawn true` (or the overlay's Spawn
+## Enemy button) is a single pulse, not a latch — `gda game get … spawn` always
+## reads false, honestly reporting that nothing stays armed. The read-back-unchanged
+## is by design: gda's live `game set` reports it as SUCCESS with `verified:false`
+## (v0.8.0 / #473) — the setter's side effect is the point, not a value that sticks
+## (an earlier latch workaround for gda's old write-verify is no longer needed).
+## Setting false is inert. The self-reset never recurses: an inline setter's
+## assignment to its own backing var does not re-invoke the setter.
 var spawn := false:
 	set(value):
-		spawn = value
 		if value:
 			_do_spawn()
+		spawn = false
 
 ## The last op the palette performed — a read-back surface (`gda game get … --property
 ## last_action`) proving an op landed, alongside the structured gda_log records.

--- a/examples/platformer/panda-adventure/tests/test_editor_palette_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_editor_palette_e2e.py
@@ -17,7 +17,9 @@ not from a dev-machine daemon run), then every step is one gda live command:
   polls) AND the ``gda game tree`` (Wave 3's named spawn present, Wave 1's gone).
 - ``gda game set … --property spawn --value true`` spawns one enemy on demand —
   the addressable ``DebugSpawn0`` appears in ``gda game tree`` + a ``debug_spawn``
-  record.
+  record. The momentary trigger self-resets, so the live set reports SUCCESS with
+  ``verified:false`` (gda v0.8.0 / #473), not a failure — while a latched state var
+  like god-mode reports ``verified:true``.
 - ``gda game set … --property god_mode --value true`` toggles god-mode, read back
   with ``gda game get … --property last_action`` (dogfooding the live READ too).
 
@@ -140,10 +142,16 @@ class _Session:
     def node_in_tree(self, name: str) -> dict | None:
         return _find_node(self.tree_root(), name)
 
-    def set_palette(self, prop: str, value: str) -> None:
-        """One ``gda game set`` on a palette property — the drivable op surface."""
+    def set_palette(self, prop: str, value: str) -> dict:
+        """One ``gda game set`` on a palette property — the drivable op surface.
+
+        Returns the parsed ``GameSetResult`` so a caller can assert the live-set
+        ``verified`` signal (gda v0.8.0 / #473): the observed read-back ``value``
+        and whether it equals the coerced request.
+        """
         proc = self.run("game", "set", _PALETTE, "--property", prop, "--value", value)
         assert proc.returncode == 0, proc.stdout + proc.stderr
+        return json.loads(proc.stdout)
 
     def get_palette(self, prop: str):
         """One ``gda game get`` on a palette property (the live READ dogfood)."""
@@ -203,16 +211,32 @@ def test_palette_ops_drive_the_running_game(tmp_path, daemon_runtime_dir):
             "the jump did not clear Wave 1's live enemy"
         )
 
-        # --- SPAWN ON DEMAND: one addressable enemy at the default lane.
-        s.set_palette("spawn", "true")
+        # --- SPAWN ON DEMAND: one addressable enemy at the default lane. The
+        # momentary trigger self-resets, so the live set reports SUCCESS with
+        # verified:false (gda v0.8.0 / #473) — the side effect landed even though
+        # the read-back does not stick. This is the exact case gda's old
+        # write-verify false-rejected as `live_uncoercible_value`.
+        spawn_set = s.set_palette("spawn", "true")
+        assert spawn_set["verified"] is False, (
+            "the momentary spawn self-resets; gda v0.8.0 (#473) must report it as "
+            f"success with verified:false, not a failed set: {spawn_set}"
+        )
+        assert spawn_set["value"] is False, (
+            f"spawn reads back at its self-reset default, not the request: {spawn_set}"
+        )
         assert s.poll(lambda: bool(s.records("debug_spawn"))), "no debug_spawn record"
         assert s.node_in_tree("DebugSpawn0") is not None, (
             "the on-demand spawn never entered the runtime tree"
         )
         assert s.records("debug_spawn")[0]["fields"]["name"] == "DebugSpawn0"
 
-        # --- GOD MODE: toggle, then read the op back through gda's live READ.
-        s.set_palette("god_mode", "true")
+        # --- GOD MODE: toggle, then read the op back through gda's live READ. A
+        # latched state var reads back the request, so the live set verifies TRUE —
+        # the other arm of the #473 contract from the momentary spawn above.
+        god_set = s.set_palette("god_mode", "true")
+        assert god_set["verified"] is True, (
+            f"a latched state var's read-back equals the request: {god_set}"
+        )
         god = s.poll(lambda: bool(s.records("debug_god_mode")))
         assert god and s.records("debug_god_mode")[-1]["fields"]["on"] is True, (
             "god-mode toggle produced no debug_god_mode record"


### PR DESCRIPTION
## Summary

Dogfooding follow-up closing the loop on **#473** (fixed by **#474**, shipped in **gda 0.8.0**).

`gda game set` now reports a live set whose read-back does not stick as **success with `verified:false`** (keeping `value` as the observed read-back), rather than the old hard `live_uncoercible_value` error. That removes the reason the palette's momentary `spawn` trigger was reshaped into a latch in `a21d24f`.

- **Revert the workaround.** `DebugPalette.spawn` returns to its natural momentary self-consuming pulse: setting it `true` spawns one enemy and self-resets to `false`, so `gda game get … spawn` honestly reads `false` (nothing stays armed). The overlay's "Spawn Enemy" is a momentary `Button` (no persistent checkbox binds `spawn`'s read-back), so the latch bought no UX — it was purely the old-gda compromise. The self-reset never recurses (an inline setter's assignment to its own backing var does not re-invoke the setter).
- **Pin both arms of the #473 contract** in the palette e2e: the momentary `spawn` set now asserts **`verified:false`** with the side effect still observable (`DebugSpawn0` in the tree + a `debug_spawn` record), while a latched state var (`god_mode`) asserts **`verified:true`**.

## Verification (gda 0.8.0 · Godot 4.6.3-stable, local)

- `gda game set --schema` → `GameSetResult` carries the required `verified: boolean`; `value` documented as the observed read-back.
- `gda script validate src/editor/debug_palette.gd` → `valid: true`
- `uv run --frozen ruff check …/test_editor_palette_e2e.py` → clean
- Palette e2e (the live #473 reproduction) → **1 passed** (`spawn` set: success + `verified:false` + `value:false` + spawn landed; `god_mode` set: `verified:true`)
- `uv run --frozen pytest examples/platformer/panda-adventure/tests -m "not e2e and not engine"` → **381 passed, 1 skipped**

## Notes

No `Closes` — #473 is already closed by #474; this is a game-side cleanup enabled by that fix, referencing it for traceability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
