### PR TITLE
[Panda Adeventure]feat(panda-assets): frames→sheet packer + size-based Git-LFS gate (gADR-0015)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,12 @@ jobs:
 
     steps:
       - name: Checkout repository
+        # lfs: true materializes any Git-LFS-tracked assets (gADR-0015) so the Panda
+        # Adventure size gate and asset loads see real bytes. A no-op until wave-3
+        # commits its first >= T asset; provisioned now so a large file is born in LFS.
         uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Set up Python environment
         uses: ./.github/actions/setup-python-env
@@ -105,7 +110,11 @@ jobs:
 
     steps:
       - name: Checkout repository
+        # lfs: true so the engine/e2e asset loads and the export path see real
+        # LFS-tracked bytes, not pointer files (gADR-0015). A no-op until wave-3.
         uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Set up Python environment
         uses: ./.github/actions/setup-python-env

--- a/examples/platformer/panda-adventure/.gitattributes
+++ b/examples/platformer/panda-adventure/.gitattributes
@@ -5,3 +5,17 @@
 # buys. So exempt it from whitespace checks (git diff --check / git apply) and mark
 # it generated so it collapses in review diffs.
 addons/gda_harness/** -whitespace linguist-generated
+
+# Size-based Git-LFS gate (gADR-0015): an assets/** binary at/over T (1 MB; the
+# authority is lfs_size_threshold_bytes in tools/assets/panda_adventure.style.json)
+# is tracked by Git LFS so a large file is BORN in LFS — never committed to plain
+# git and migrated later, which rewrites history.
+#
+# The rule is size-based and uniform across categories, enforced mechanically by
+# tools/assets/lifecycle.py (validate_committed_asset_sizes). Git can only track by
+# path-glob, so THIS file is the gate's mechanical consequence, not its authority:
+# when the gate flags a new >= T file, `git lfs track "<path>"` appends its pattern
+# here and re-adds the file. Seeded with the BGM/music dir — the one category
+# gADR-0015 predicts reliably crosses T — while KB-scale pixel art and SFX stay in
+# plain git.
+assets/music/** filter=lfs diff=lfs merge=lfs -text

--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -289,6 +289,31 @@ dangling path) rather than freshness.
 _Avoid_: asset registry (generic), license file / provenance log (each names one
 field), asset index
 
+**Frames→sheet packer**:
+The reusable sprite postprocess stage that turns a loose-frame set (B-form — as many
+open-asset sources deliver a sprite-frame set) into ONE committed **spritesheet** per
+animation state (A-form) plus a recorded **frame layout** (`frame_dims`, columns/rows,
+count): a horizontal strip by default, a near-square grid past a frame-count threshold
+(gADR-0015). Its read-side counterpart is the **SpriteFrames deriver**, which turns the
+sheet path + layout into a byte-stable, uid-free Godot `SpriteFrames` resource — one
+`AtlasTexture` per frame, its `region` the frame's box in the sheet. Fewer committed
+files (one `.import` per set), atlas- and pixel-grid-friendly (gADR-0013); the committed
+sprite artifact is always the sheet, never the loose frames.
+_Avoid_: sprite atlas / texture atlas (the general packing, not this per-state sheet),
+sprite splitter (names the inverse), animation importer
+
+**Size-based Git-LFS gate**:
+The commit-method rule for binary assets (gADR-0015): a single **size threshold `T`**
+(default 1 MB, spec-data in the Style descriptor's config) applied UNIFORMLY across
+categories — an `assets/**` file at or over `T` is tracked by Git LFS, below `T` stays in
+plain git — so a large file (BGM, a 2K/4K backdrop) is *born* in LFS rather than committed
+to plain git and migrated later (a history rewrite). A config-gate size check enforces it
+mechanically (fails on any `assets/**` binary `>= T` outside LFS); `.gitattributes` is the
+gate's mechanical consequence, not its authority — `git lfs track` a path when the gate
+flags it. Never per-category special-casing (a large texture and a BGM track are the same
+rule); KB-scale pixel art and SFX stay in plain git.
+_Avoid_: LFS policy (vague), audio-in-LFS rule (it is not audio-special), binary gate
+
 **Style descriptor**:
 The shared art-direction input that makes mixed-source assets cohere across BOTH
 acquire modes — the machine-consumable style parameters (shared style

--- a/examples/platformer/panda-adventure/docs/gadr/0015-asset-management-and-lifecycle.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0015-asset-management-and-lifecycle.md
@@ -93,3 +93,16 @@ means the first over-`T` asset is born in LFS with no history rewrite.
 >
 > The attribution generator, the export-import gate, and the orphan-prune step remain
 > follow-up slices under this record.
+>
+> **Correction (2026-07-08).** Reproduction refuted the premise §5(c)'s export-import
+> gate rested on. `gda export run` does NOT ship texture-less: a clean checkout (no
+> `.godot/`) exported via `gda export run` **natively triggers a Godot import** — the
+> engine's export command imports resources itself — regenerating the imported
+> `.ctex` and packing the texture (verified for pack + release on Godot 4.6.3). The
+> "export doesn't import" premise was a static-reading inference; the gda issue filed
+> on it was withdrawn (cannot-reproduce). So the export-import follow-up (#479)
+> narrows from a fix to a **defensive verification** that the shipped build carries
+> its textures (an import-regression smoke), not a re-implementation of import.
+> Orthogonal and still required: the size-based Git-LFS **byte** materialization on
+> the export path (§5's commit rule) is a git-layer concern, unrelated to Godot
+> import, and stands.

--- a/examples/platformer/panda-adventure/docs/gadr/0015-asset-management-and-lifecycle.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0015-asset-management-and-lifecycle.md
@@ -1,0 +1,95 @@
+---
+status: accepted
+---
+
+# Asset management & lifecycle: storage, naming, size-based commit, and wave-close hygiene
+
+gADR-0014 built the asset pipeline and the per-category `Asset manifest`. As Phase 2's
+wave-3 fills Level 1 with many produced assets (item textures, Player and enemy sprite
+sets, terrain tiles, VFX, audio, fonts), the *governance* around those files — where they
+live, how they are named, how they are committed, how they are versioned, and how their
+lifecycle is kept clean — must be settled before the volume lands, or wave-3 accretes
+inconsistency. This record settles it, decided in the 2026-07-08 grilling interview,
+building directly on gADR-0014 and gADR-0013 (the pixel-art regime).
+
+We decide five things:
+
+- **Storage and naming: `assets/<category>/<id>.<ext>`, flat within a category, keyed
+  by a stable semantic id.** The manifest `id` is a stable semantic slug —
+  `<entity>[_<variant>][_<state>]` (`obstacle_crate`, `player_run`,
+  `enemy_monster_minion_walk`, `bun`, `wall_span`) — derived from the asset spec (what
+  the asset *is*), and **stable across re-acquisition**: it is the authority's foreign
+  key (gADR-0014), so it never changes because the source or the art changed. The file is
+  `<id>.<ext>`; the category is the directory and its manifest fragment. Renaming an asset
+  is therefore a deliberate manifest+authority migration, never a casual file move.
+
+- **Sprite-frame sets are committed as one spritesheet per animation state, not loose
+  frames.** A set is ONE sheet (`player_run.png`) whose frame layout (`frame_dims`,
+  rows/cols, count) is recorded in the manifest; the builder derives the Godot
+  `SpriteFrames` / `AtlasTexture` regions. Rationale: far fewer committed files (wave-3
+  has many sets), one `.import` per set, atlas- and pixel-grid-friendly (gADR-0013).
+  Because open-asset sources often deliver frames as **loose files (B-form)**, the sprite
+  postprocess includes a reusable **frames→sheet packer** tool: loose frames in → one
+  packed sheet + layout out (default a horizontal strip, a grid past a frame-count
+  threshold). The acquire boundary may yield loose frames; the *committed artifact is
+  always the sheet (A-form)*.
+
+- **Commit method is size-based and uniform across categories — never category-based.** A
+  large binary can appear in any category (a BGM track, a 2K/4K background texture), so
+  the plain-git-vs-Git-LFS boundary is a single **size threshold `T` (default 1 MB;
+  spec-data, revisable)** applied uniformly: an `assets/**` file `>= T` is tracked by Git
+  LFS; below `T` it stays plain git. A config-gate **size check** enforces it mechanically
+  — it fails if any `assets/**` binary `>= T` is committed outside LFS — so the policy is
+  a gate, not a note. Git LFS is set up **before wave-3's first large asset**, so a large
+  file is born in LFS and is never committed to plain git and migrated later (which
+  rewrites history — the failure mode this decision exists to avoid). Rationale: pixel-art
+  textures and SFX are KB-scale (plain git); BGM and any large backdrop cross `T` (LFS) —
+  one rule, no per-category special-casing.
+
+- **Versioning is in-place under the stable id.** Re-acquiring or regenerating an asset
+  updates the file in place under its stable id — git history *is* the version history;
+  the manifest records only the CURRENT provenance, never its own history. Generated
+  assets are not byte-reproducible (the backend exposes no seed), so the manifest records
+  the prompt/backend for audit and approximate re-generation; downloaded assets are
+  re-fetchable from the recorded `source_url`. A `style_version` in the `Style descriptor`
+  gates a deliberate bulk re-acquire when the shared style changes.
+
+- **Lifecycle hygiene is enforced at wave-close, not left to memory.** (a) **Orphan
+  prune** — gADR-0014's `validate_asset_refs` soft orphan report drives a wave-close prune
+  of any manifest entry (and its file) no authority references, so no dead asset ships.
+  (b) **Attribution aggregation** — an `ATTRIBUTIONS.md` is generated from the manifest's
+  `attribution`/`license` fields at wave-close/export (a pipeline invariant, never
+  hand-maintained), so CC-BY compliance is auditable. (c) **Export imports assets** —
+  because `.godot/` (the import cache) is gitignored and only `.import` is committed,
+  `gda export run` MUST trigger a Godot import so the shipped `.app` carries the textures;
+  a missing import is a build fault (the read-side counterpart of the test-side import
+  fixture #439 added), gate-checked at export. (d) **Generated-content licensing** — a
+  generated asset records its backend's usage terms per manifest entry, distinct from a
+  CC0 download's license.
+
+Consequences: wave-3's asset round-outs (#442/#443/#444/#445) and their consumers
+(#446/#447/#448) all conform to one storage/naming/commit/lifecycle scheme. The
+frames→sheet packer, the Git-LFS size gate, the attribution generator, the export-import
+gate, and the orphan-prune step are one-time asset-lifecycle infrastructure that must land
+**before** the bulk assets — captured as a dedicated pre-wave-3 tooling slice. The
+id-stability rule makes an asset rename a deliberate migration; the size-based LFS rule
+means the first over-`T` asset is born in LFS with no history rewrite.
+
+> **Outcome (2026-07-08, #478).** The pre-wave-3 tooling slice landed the two pieces
+> wave-3 needs first, both inside the asset-pipeline package so the round-outs reuse
+> them without reinventing:
+>
+> - the **frames→sheet packer** (`tools/assets/packer.py` — loose frames → one sheet +
+>   a manifest-recorded `FrameLayout`; horizontal strip by default, a near-square grid
+>   past 8 frames) and a pure-Python **SpriteFrames deriver**
+>   (`tools/assets/spriteframes.py` — the layout → a byte-stable, uid-free
+>   `SpriteFrames.tres` of per-frame `AtlasTexture` regions, engine-proved to load in
+>   Godot). The runtime sprite-render seam stays wave-3's (#442/#443, gADR-0014).
+> - the **size-based Git-LFS gate** (`tools/assets/lifecycle.py` — the pure size/track
+>   core plus a `git check-attr` predicate), with `T` as spec-data in
+>   `panda_adventure.style.json`, `.gitattributes` seeded with the BGM `assets/music/**`
+>   convention (gate-driven: `git lfs track` a path when the gate flags it), and Git LFS
+>   materialized by CI (`lfs: true`) and the export path.
+>
+> The attribution generator, the export-import gate, and the orphan-prune step remain
+> follow-up slices under this record.

--- a/examples/platformer/panda-adventure/scripts/build_config.py
+++ b/examples/platformer/panda-adventure/scripts/build_config.py
@@ -75,6 +75,7 @@ from __future__ import annotations
 
 import copy
 import json
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -83,6 +84,12 @@ import jsonschema
 
 # Resolve paths relative to this file so the script works from any CWD.
 GAME_DIR = Path(__file__).resolve().parent.parent
+
+# The asset-pipeline package (``assets.*``) lives under ``tools/``; put it on
+# sys.path so the size-gate delegation (``validate_asset_sizes``) imports when this
+# runs standalone (``python scripts/build_config.py``). Tests already get it from
+# conftest; a duplicate path entry is harmless.
+sys.path.insert(0, str(GAME_DIR / "tools"))
 
 
 @dataclass(frozen=True)
@@ -1081,6 +1088,26 @@ def validate_asset_refs(root: Path = GAME_DIR) -> dict[str, dict[str, Any]]:
     return manifest
 
 
+def validate_asset_sizes(root: Path = GAME_DIR) -> list[Any]:
+    """Enforce gADR-0015's size-based Git-LFS gate at the config gate (review S1).
+
+    Delegates to the asset pipeline's lifecycle gate with the threshold ``T`` from
+    the committed Style descriptor config, so ``python scripts/build_config.py``
+    mechanically FAILS a committed ``assets/**`` binary ``>= T`` that is not
+    LFS-tracked — not merely an optional test path. Joins ``main`` (the
+    authoritative standalone build), NOT ``build_all``: build_all runs against
+    isolated, non-git e2e roots where ``git check-attr`` has nothing to consult —
+    the size gate is repo-scoped. Raises ``assets.lifecycle.AssetSizeError`` on a
+    violation.
+    """
+    from assets import game_config, lifecycle
+
+    config = game_config.load_style_config()
+    return lifecycle.validate_committed_asset_sizes(
+        root, config.lfs_size_threshold_bytes
+    )
+
+
 def asset_ref_orphans(root: Path = GAME_DIR) -> list[str]:
     """Manifest ids no authority references — a SOFT report (gADR-0014).
 
@@ -1365,6 +1392,9 @@ def main() -> None:
     # The Asset manifest gate first (gADR-0014), so a standalone build fails loudly
     # on a broken reference / dangling / malformed record before writing anything.
     validate_asset_refs()
+    # Then the size-based Git-LFS gate (gADR-0015): a committed assets/** binary
+    # >= T outside LFS fails the authoritative build before any .tres is written.
+    validate_asset_sizes()
     for spec in SPECS:
         written = build_spec(spec)
         print(

--- a/examples/platformer/panda-adventure/scripts/export_macos.sh
+++ b/examples/platformer/panda-adventure/scripts/export_macos.sh
@@ -34,12 +34,19 @@ fi
 
 mkdir -p "$GAME_DIR/build"
 
-# Git-LFS gate (gADR-0015): materialize any LFS-tracked assets so the shipped .app
-# carries real bytes, not pointer files. A no-op until wave-3 commits its first
-# >= T asset; guarded so a checkout without git-lfs installed still exports today.
+# Git-LFS gate (gADR-0015): the shipped .app must carry the REAL bytes of any
+# LFS-tracked asset, not pointer files. No-op while the repo has no LFS assets;
+# once it does, a missing git-lfs OR a failed pull FAILS the export rather than
+# silently shipping pointer files (set -e is on; no `|| true` swallowing).
 if command -v git-lfs >/dev/null 2>&1; then
-	git -C "$GAME_DIR" lfs install --local >/dev/null 2>&1 || true
-	git -C "$GAME_DIR" lfs pull || true
+	git -C "$GAME_DIR" lfs install --local >/dev/null
+	if [[ -n "$(git -C "$GAME_DIR" lfs ls-files)" ]]; then
+		git -C "$GAME_DIR" lfs pull
+	fi
+elif [[ -n "$(git -C "$GAME_DIR" ls-files -- ':(attr:filter=lfs)assets' 2>/dev/null)" ]]; then
+	echo "error: LFS-tracked assets are present but git-lfs is not installed." >&2
+	echo "       Install git-lfs so the shipped .app carries real bytes, not pointers." >&2
+	exit 1
 fi
 
 gda export run \

--- a/examples/platformer/panda-adventure/scripts/export_macos.sh
+++ b/examples/platformer/panda-adventure/scripts/export_macos.sh
@@ -34,6 +34,14 @@ fi
 
 mkdir -p "$GAME_DIR/build"
 
+# Git-LFS gate (gADR-0015): materialize any LFS-tracked assets so the shipped .app
+# carries real bytes, not pointer files. A no-op until wave-3 commits its first
+# >= T asset; guarded so a checkout without git-lfs installed still exports today.
+if command -v git-lfs >/dev/null 2>&1; then
+	git -C "$GAME_DIR" lfs install --local >/dev/null 2>&1 || true
+	git -C "$GAME_DIR" lfs pull || true
+fi
+
 gda export run \
 	--preset macOS \
 	--mode release \

--- a/examples/platformer/panda-adventure/tests/test_assets_lifecycle.py
+++ b/examples/platformer/panda-adventure/tests/test_assets_lifecycle.py
@@ -1,0 +1,285 @@
+"""Fast unit tier for the asset-lifecycle tooling (P2-S1b, #478, gADR-0015).
+
+Pins the pre-production infrastructure wave-3 consumes without reinventing:
+
+- the **frames -> sheet packer** (loose frame files -> one spritesheet + a
+  recorded frame layout, gADR-0015),
+- the pure-Python **SpriteFrames.tres deriver** (the layout -> a byte-stable
+  Godot ``SpriteFrames`` with per-frame ``AtlasTexture`` regions), and
+- the **size-based Git-LFS gate** (an ``assets/**`` binary at/over the threshold
+  ``T`` must be LFS-tracked, uniform across categories).
+
+Pure Python (Pillow is a dev dependency; the LFS gate's core takes an injected
+predicate, so no git is needed), so it runs in the CI
+``not e2e and not engine and not acquire_live`` tier. The engine proof that a
+derived ``.tres`` really loads in Godot is ``test_spriteframes_engine.py``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+import build_config
+from assets import game_config, lifecycle, manifest
+from assets.emitter import JsonManifestEmitter
+from assets.lifecycle import OversizeAsset, find_unlfs_oversize
+from assets.model import FrameLayout, ManifestEntry
+from assets.packer import pack_frames
+from assets.spriteframes import derive_spriteframes
+
+
+# --------------------------------------------------------------------------- #
+# Frames -> sheet packer (gADR-0015): loose frames in, one sheet + layout out.
+# --------------------------------------------------------------------------- #
+
+
+def _frames(dir: Path, count: int, dims: tuple[int, int]) -> list[Path]:
+    """Synthesize ``count`` distinct solid PNG frames of ``dims`` (id-ordered)."""
+    dir.mkdir(parents=True, exist_ok=True)
+    paths = []
+    for i in range(count):
+        p = dir / f"frame_{i:02d}.png"
+        Image.new("RGBA", dims, (10 * i % 256, 40, 90, 255)).save(p)
+        paths.append(p)
+    return paths
+
+
+def test_pack_frames_horizontal_strip(tmp_path: Path) -> None:
+    """A small set packs into a single horizontal strip (default layout)."""
+    frames = _frames(tmp_path / "in", 3, (40, 40))
+    sheet = tmp_path / "player_run.png"
+    layout = pack_frames(frames, sheet)
+
+    assert layout == FrameLayout(frame_dims=(40, 40), columns=3, rows=1, count=3)
+    with Image.open(sheet) as img:
+        assert img.size == (120, 40)  # 3 frames wide, 1 tall
+
+
+def test_pack_frames_grid_past_threshold(tmp_path: Path) -> None:
+    """A set larger than the strip threshold packs into a near-square grid."""
+    frames = _frames(tmp_path / "in", 9, (16, 16))  # > default threshold (8)
+    sheet = tmp_path / "walk.png"
+    layout = pack_frames(frames, sheet)
+
+    assert layout == FrameLayout(frame_dims=(16, 16), columns=3, rows=3, count=9)
+    with Image.open(sheet) as img:
+        assert img.size == (48, 48)  # 3x3 grid
+
+
+def test_pack_frames_rejects_mismatched_dims(tmp_path: Path) -> None:
+    """Frames of differing sizes are a loud error, not a silently misaligned sheet."""
+    frames = _frames(tmp_path / "in", 2, (40, 40))
+    odd = tmp_path / "in" / "odd.png"
+    Image.new("RGBA", (32, 32), (0, 0, 0, 255)).save(odd)
+    with pytest.raises(ValueError, match="same size"):
+        pack_frames([*frames, odd], tmp_path / "out.png")
+
+
+def test_pack_frames_rejects_empty_set(tmp_path: Path) -> None:
+    """An empty frame set is a clear error, not an opaque IndexError."""
+    with pytest.raises(ValueError, match="no frames"):
+        pack_frames([], tmp_path / "out.png")
+
+
+# --------------------------------------------------------------------------- #
+# Manifest — a sprite-set entry round-trips its frame layout (gADR-0015).
+# --------------------------------------------------------------------------- #
+
+_RUN_LAYOUT = FrameLayout(frame_dims=(32, 32), columns=6, rows=1, count=6)
+
+
+def _sprite_entry() -> ManifestEntry:
+    return ManifestEntry(
+        id="player_run",
+        path="res://assets/sprites/player_run.png",
+        category="sprites",
+        acquire_mode="search_download",
+        source="kenney",
+        license="CC0",
+        license_url="https://creativecommons.org/publicdomain/zero/1.0/",
+        target_dims=(32, 32),
+        source_url="https://example.test/player_run.png",
+        frame_layout=_RUN_LAYOUT,
+    )
+
+
+def test_manifest_roundtrips_frame_layout(tmp_path: Path) -> None:
+    """A sprite-set entry's frame layout survives emit -> load unchanged."""
+    JsonManifestEmitter(tmp_path, "assets").emit(_sprite_entry())
+    loaded = manifest.load_manifest(tmp_path, "assets")
+    assert loaded["player_run"] == _sprite_entry()
+    assert loaded["player_run"].frame_layout == _RUN_LAYOUT
+
+
+def test_manifest_texture_entry_has_no_frame_layout(tmp_path: Path) -> None:
+    """A plain texture entry omits frame_layout (it is a sprite-set-only field)."""
+    entry = ManifestEntry(
+        id="obstacle_crate",
+        path="res://assets/textures/obstacle_crate.png",
+        category="textures",
+        acquire_mode="search_download",
+        source="opengameart",
+        license="CC0",
+        license_url="https://creativecommons.org/publicdomain/zero/1.0/",
+        target_dims=(40, 40),
+    )
+    JsonManifestEmitter(tmp_path, "assets").emit(entry)
+    frag = manifest.fragment_path(tmp_path, "assets", "textures")
+    assert "frame_layout" not in frag.read_text()
+    assert manifest.load_manifest(tmp_path, "assets")["obstacle_crate"] == entry
+
+
+# --------------------------------------------------------------------------- #
+# SpriteFrames deriver — layout -> a byte-stable Godot SpriteFrames .tres.
+# --------------------------------------------------------------------------- #
+
+_SHEET_RES = "res://assets/sprites/player_run.png"
+
+
+def test_derive_spriteframes_regions_and_animation(tmp_path: Path) -> None:
+    """The deriver emits one AtlasTexture per frame at the right region, and an
+    animation that references each in order (gADR-0015)."""
+    frames = _frames(tmp_path / "in", 3, (40, 40))
+    layout = pack_frames(frames, tmp_path / "player_run.png")
+    tres = derive_spriteframes(_SHEET_RES, layout, "run")
+
+    assert tres.startswith('[gd_resource type="SpriteFrames" format=3]')
+    assert f'[ext_resource type="Texture2D" path="{_SHEET_RES}"' in tres
+    # One AtlasTexture sub-resource per frame, each keyed to its strip region.
+    assert "region = Rect2(0, 0, 40, 40)" in tres
+    assert "region = Rect2(40, 0, 40, 40)" in tres
+    assert "region = Rect2(80, 0, 40, 40)" in tres
+    # The animation is named for the state and references each frame in order.
+    assert '"name": &"run"' in tres
+    assert 'SubResource("AtlasTexture_run_0")' in tres
+    assert 'SubResource("AtlasTexture_run_2")' in tres
+
+
+def test_derive_spriteframes_grid_regions(tmp_path: Path) -> None:
+    """A grid layout places frame k at (col*w, row*h) row-major (gADR-0015)."""
+    frames = _frames(tmp_path / "in", 9, (16, 16))  # 3x3 grid
+    layout = pack_frames(frames, tmp_path / "walk.png")
+    tres = derive_spriteframes(_SHEET_RES, layout, "walk")
+
+    assert "region = Rect2(0, 0, 16, 16)" in tres  # frame 0 -> (col 0, row 0)
+    assert "region = Rect2(32, 0, 16, 16)" in tres  # frame 2 -> (col 2, row 0)
+    assert "region = Rect2(0, 16, 16, 16)" in tres  # frame 3 -> (col 0, row 1)
+    assert "region = Rect2(32, 32, 16, 16)" in tres  # frame 8 -> (col 2, row 2)
+
+
+def test_derive_spriteframes_is_deterministic(tmp_path: Path) -> None:
+    """Same input -> byte-identical output (a committed derived artifact)."""
+    frames = _frames(tmp_path / "in", 4, (24, 24))
+    layout = pack_frames(frames, tmp_path / "idle.png")
+    a = derive_spriteframes(_SHEET_RES, layout, "idle")
+    b = derive_spriteframes(_SHEET_RES, layout, "idle")
+    assert a == b
+    assert "uid://" not in a  # gda authors uid-free (gADR-0036 / gADR-0015)
+
+
+# --------------------------------------------------------------------------- #
+# Size-based Git-LFS gate (gADR-0015): >= T must be LFS-tracked, uniform.
+# --------------------------------------------------------------------------- #
+
+_T = 1_048_576  # the default threshold (1 MB)
+
+
+def test_find_unlfs_oversize_flags_only_large_untracked() -> None:
+    """A file at/over T that is NOT LFS-tracked is a violation; a tracked large
+    file and any small file are fine — the rule is size-based and uniform."""
+    files = [
+        ("assets/music/bgm.ogg", 3_000_000),  # >= T, tracked -> ok
+        ("assets/backgrounds/sky.png", 2_000_000),  # >= T, untracked -> VIOLATION
+        ("assets/textures/crate.png", 5_000),  # < T -> ok (small pixel art)
+    ]
+    tracked = {"assets/music/bgm.ogg"}
+    violations = find_unlfs_oversize(files, _T, lambda p: p in tracked)
+    assert violations == [OversizeAsset("assets/backgrounds/sky.png", 2_000_000)]
+
+
+def test_find_unlfs_oversize_threshold_is_inclusive() -> None:
+    """A file exactly at T must be LFS-tracked (>= T, not > T)."""
+    files = [("assets/audio/hit.wav", _T)]
+    assert find_unlfs_oversize(files, _T, lambda p: False) == [
+        OversizeAsset("assets/audio/hit.wav", _T)
+    ]
+    assert find_unlfs_oversize(files, _T, lambda p: True) == []
+
+
+# --------------------------------------------------------------------------- #
+# Size gate wiring: enumerate the real assets/ tree + the git check-attr predicate.
+# --------------------------------------------------------------------------- #
+
+GAME_DIR = build_config.GAME_DIR
+
+
+def test_committed_asset_files_enumerates_the_assets_tree() -> None:
+    """The enumerator lists real files under assets/ with their on-disk sizes."""
+    files = dict(lifecycle.committed_asset_files(GAME_DIR))
+    assert "assets/textures/obstacle_crate.png" in files
+    assert files["assets/textures/obstacle_crate.png"] > 0
+
+
+def test_validate_committed_asset_sizes_passes_on_real_repo() -> None:
+    """The committed assets/ tree carries no >= T binary outside LFS (gADR-0015)."""
+    lifecycle.validate_committed_asset_sizes(GAME_DIR, _T)  # no raise
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=root, check=True, capture_output=True, text=True)
+
+
+def test_validate_committed_asset_sizes_raises_on_untracked_large(
+    tmp_path: Path,
+) -> None:
+    """A >= T asset with no LFS attribute fails the gate (born-in-LFS rule)."""
+    _git(tmp_path, "init")
+    big = tmp_path / "assets" / "textures" / "big.bin"
+    big.parent.mkdir(parents=True)
+    big.write_bytes(b"\0" * (_T + 16))
+    with pytest.raises(lifecycle.AssetSizeError, match="big.bin"):
+        lifecycle.validate_committed_asset_sizes(tmp_path, _T)
+
+
+def test_validate_committed_asset_sizes_accepts_lfs_tracked_large(
+    tmp_path: Path,
+) -> None:
+    """The same >= T asset PASSES once a matching LFS attribute covers it."""
+    _git(tmp_path, "init")
+    (tmp_path / ".gitattributes").write_text(
+        "assets/**/*.bin filter=lfs diff=lfs merge=lfs -text\n", encoding="utf-8"
+    )
+    big = tmp_path / "assets" / "textures" / "big.bin"
+    big.parent.mkdir(parents=True)
+    big.write_bytes(b"\0" * (_T + 16))
+    lifecycle.validate_committed_asset_sizes(tmp_path, _T)  # no raise
+
+
+# --------------------------------------------------------------------------- #
+# Threshold + .gitattributes: T is committed config; the seed tracks music in LFS.
+# --------------------------------------------------------------------------- #
+
+
+def test_style_config_carries_lfs_threshold() -> None:
+    """T is pipeline-config spec-data in panda_adventure.style.json (gADR-0015)."""
+    config = game_config.load_style_config()
+    assert config.lfs_size_threshold_bytes == _T  # 1 MB default
+
+
+def test_committed_repo_passes_the_configured_gate() -> None:
+    """The committed assets tree passes the gate at the CONFIGURED threshold —
+    the end-to-end wiring the CI test tier runs (gADR-0015)."""
+    config = game_config.load_style_config()
+    lifecycle.validate_committed_asset_sizes(GAME_DIR, config.lfs_size_threshold_bytes)
+
+
+def test_gitattributes_tracks_music_dir_in_lfs() -> None:
+    """The seeded .gitattributes tracks the BGM/music dir in LFS (gate-driven
+    convention), while KB-scale pixel art stays in plain git (gADR-0015)."""
+    tracked = lifecycle.git_lfs_tracked(GAME_DIR)
+    assert tracked("assets/music/bgm_main.ogg")
+    assert not tracked("assets/textures/obstacle_crate.png")

--- a/examples/platformer/panda-adventure/tests/test_assets_lifecycle.py
+++ b/examples/platformer/panda-adventure/tests/test_assets_lifecycle.py
@@ -24,7 +24,7 @@ import pytest
 from PIL import Image
 
 import build_config
-from assets import game_config, lifecycle, manifest
+from assets import game_config, lifecycle, manifest, pipeline
 from assets.emitter import JsonManifestEmitter
 from assets.lifecycle import OversizeAsset, find_unlfs_oversize
 from assets.model import FrameLayout, ManifestEntry
@@ -233,29 +233,52 @@ def _git(root: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=root, check=True, capture_output=True, text=True)
 
 
-def test_validate_committed_asset_sizes_raises_on_untracked_large(
-    tmp_path: Path,
-) -> None:
-    """A >= T asset with no LFS attribute fails the gate (born-in-LFS rule)."""
+def _commit_binary(root: Path, rel: str, size: int) -> Path:
+    """Write and `git add` a binary file (NUL bytes -> binary) of `size` at rel."""
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"\x89PNG\r\n" + b"\0" * size)
+    _git(root, "add", rel)
+    return p
+
+
+def test_size_gate_flags_tracked_binary_without_lfs(tmp_path: Path) -> None:
+    """A COMMITTED (tracked) binary >= T with no LFS attribute fails the gate."""
     _git(tmp_path, "init")
-    big = tmp_path / "assets" / "textures" / "big.bin"
-    big.parent.mkdir(parents=True)
-    big.write_bytes(b"\0" * (_T + 16))
-    with pytest.raises(lifecycle.AssetSizeError, match="big.bin"):
+    _commit_binary(tmp_path, "assets/textures/big.png", _T)
+    with pytest.raises(lifecycle.AssetSizeError, match="big.png"):
         lifecycle.validate_committed_asset_sizes(tmp_path, _T)
 
 
-def test_validate_committed_asset_sizes_accepts_lfs_tracked_large(
-    tmp_path: Path,
-) -> None:
-    """The same >= T asset PASSES once a matching LFS attribute covers it."""
+def test_size_gate_accepts_lfs_tracked_binary(tmp_path: Path) -> None:
+    """The same >= T binary PASSES once a matching LFS attribute covers it."""
     _git(tmp_path, "init")
     (tmp_path / ".gitattributes").write_text(
-        "assets/**/*.bin filter=lfs diff=lfs merge=lfs -text\n", encoding="utf-8"
+        "assets/**/*.png filter=lfs diff=lfs merge=lfs -text\n", encoding="utf-8"
     )
-    big = tmp_path / "assets" / "textures" / "big.bin"
+    _git(tmp_path, "add", ".gitattributes")
+    _commit_binary(tmp_path, "assets/textures/big.png", _T)
+    lifecycle.validate_committed_asset_sizes(tmp_path, _T)  # no raise
+
+
+def test_size_gate_ignores_untracked_large_file(tmp_path: Path) -> None:
+    """An UNTRACKED (uncommitted) large binary is not the gate's concern — the
+    rule is about COMMITTED assets, so a local scratch file must not fail it."""
+    _git(tmp_path, "init")
+    scratch = tmp_path / "assets" / "textures" / "scratch.png"
+    scratch.parent.mkdir(parents=True)
+    scratch.write_bytes(b"\x89PNG\r\n" + b"\0" * _T)  # NOT git-added
+    lifecycle.validate_committed_asset_sizes(tmp_path, _T)  # no raise
+
+
+def test_size_gate_ignores_large_text_asset(tmp_path: Path) -> None:
+    """A large TRACKED text asset is not forced into LFS — the rule is
+    binary-only (a big generated JSON stays diff-friendly plain git)."""
+    _git(tmp_path, "init")
+    big = tmp_path / "assets" / "data" / "huge.json"
     big.parent.mkdir(parents=True)
-    big.write_bytes(b"\0" * (_T + 16))
+    big.write_text("[" + ",".join(["0"] * _T) + "]", encoding="utf-8")  # > T, no NUL
+    _git(tmp_path, "add", "assets/data/huge.json")
     lifecycle.validate_committed_asset_sizes(tmp_path, _T)  # no raise
 
 
@@ -283,3 +306,85 @@ def test_gitattributes_tracks_music_dir_in_lfs() -> None:
     tracked = lifecycle.git_lfs_tracked(GAME_DIR)
     assert tracked("assets/music/bgm_main.ogg")
     assert not tracked("assets/textures/obstacle_crate.png")
+
+
+# --------------------------------------------------------------------------- #
+# Config-gate wiring: the size gate runs from build_config, not only tests.
+# --------------------------------------------------------------------------- #
+
+
+def test_build_config_size_gate_passes_on_committed_repo() -> None:
+    """build_config exposes the size gate at the config gate, reading T from the
+    committed Style descriptor; the committed repo passes (review S1)."""
+    build_config.validate_asset_sizes()  # no raise
+
+
+def test_build_config_main_enforces_the_size_gate(monkeypatch) -> None:
+    """`python scripts/build_config.py` (main) mechanically enforces the size gate
+    — a violation fails the authoritative build, not merely an optional test path
+    (review S1). Proven by making the gate raise and asserting main propagates it
+    before any .tres is written."""
+
+    def _boom(root: Path = build_config.GAME_DIR):
+        raise lifecycle.AssetSizeError("size gate ran from main")
+
+    monkeypatch.setattr(build_config, "validate_asset_sizes", _boom)
+    with pytest.raises(lifecycle.AssetSizeError, match="size gate ran from main"):
+        build_config.main()
+
+
+# --------------------------------------------------------------------------- #
+# Pipeline wiring: one orchestration entry packs + records a sprite set, so
+# wave-3 slices consume the tooling without re-inventing the choreography.
+# --------------------------------------------------------------------------- #
+
+
+def test_pack_sprite_set_packs_sheet_and_emits_entry(tmp_path: Path) -> None:
+    """`pack_sprite_set` orchestrates loose frames -> committed sheet ->
+    manifest sprite-set entry (with frame_layout) in one call (review Spec-1)."""
+    frames = _frames(tmp_path / "in", 4, (16, 16))
+    sheet = tmp_path / "assets" / "sprites" / "hero_run.png"
+    emitter = JsonManifestEmitter(tmp_path, "assets")
+
+    entry = pipeline.pack_sprite_set(
+        frames,
+        sheet,
+        "res://assets/sprites/hero_run.png",
+        "hero_run",
+        "sprites",
+        source="kenney",
+        license_name="CC0",
+        license_url="https://creativecommons.org/publicdomain/zero/1.0/",
+        emitter=emitter,
+    )
+
+    # The committed sheet exists at the given path.
+    with Image.open(sheet) as img:
+        assert img.size == (64, 16)  # 4 frames wide
+    # The returned entry carries the layout + provenance.
+    assert entry.frame_layout == FrameLayout((16, 16), 4, 1, 4)
+    assert (entry.id, entry.category, entry.license) == ("hero_run", "sprites", "CC0")
+    assert entry.target_dims == (16, 16)  # defaults to the frame box
+    # It was emitted into the manifest, round-tripping the layout.
+    loaded = manifest.load_manifest(tmp_path, "assets")
+    assert loaded["hero_run"].frame_layout == FrameLayout((16, 16), 4, 1, 4)
+
+
+def test_pack_sprite_set_can_skip_emit(tmp_path: Path) -> None:
+    """With no emitter the sheet is still packed but nothing is written (a caller
+    that only wants the sheet + entry, e.g. a dry run)."""
+    frames = _frames(tmp_path / "in", 2, (24, 24))
+    sheet = tmp_path / "out" / "walk.png"
+    entry = pipeline.pack_sprite_set(
+        frames,
+        sheet,
+        "res://assets/sprites/walk.png",
+        "walk",
+        "sprites",
+        source="kenney",
+        license_name="CC0",
+        license_url="https://creativecommons.org/publicdomain/zero/1.0/",
+    )
+    assert sheet.exists()
+    assert entry.frame_layout == FrameLayout((24, 24), 2, 1, 2)
+    assert manifest.load_manifest(tmp_path, "assets") == {}  # nothing emitted

--- a/examples/platformer/panda-adventure/tests/test_spriteframes_engine.py
+++ b/examples/platformer/panda-adventure/tests/test_spriteframes_engine.py
@@ -1,0 +1,99 @@
+"""Engine proof — a derived SpriteFrames.tres really loads in Godot (P2-S1b, #478).
+
+The fast tier ``test_assets_lifecycle.py`` pins the deriver's TEXT (regions,
+animation structure, determinism); it cannot prove the emitted ``.tres`` is a
+*valid Godot resource*. This engine-tier test closes that gap: it packs a fixture
+frame set into a project copy, derives the ``SpriteFrames`` next to it, imports the
+copy (so the sheet texture the ``AtlasTexture`` sub-resources reference resolves),
+then loads the resource in a headless Godot ``SceneTree`` and asserts the frame
+count and that frame 0 is an ``AtlasTexture`` at the expected region (gADR-0015).
+
+``engine`` marker: fails loudly without a Godot binary (conftest), deselected in
+the fast CI tier and run in the ``godot-e2e`` job / locally.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from gda.binary import resolve_godot_binary
+
+import build_config
+
+GODOT = resolve_godot_binary()
+GAME_DIR = build_config.GAME_DIR
+_COPY_IGNORE = shutil.ignore_patterns(".godot", "build", "__pycache__", "tests")
+
+# A headless SceneTree script: load the derived resource and print its frame count
+# and frame-0 atlas region so the test can assert on stdout.
+_PROBE = """extends SceneTree
+func _initialize() -> void:
+	var sf = load("res://assets/sprites/hero_run_frames.tres")
+	if sf == null:
+		print("RESULT=LOAD_FAILED")
+		quit()
+		return
+	var tex = sf.get_frame_texture("run", 0)
+	var is_atlas := tex is AtlasTexture
+	print("RESULT=OK count=%d atlas=%s region=%s" % [
+		sf.get_frame_count("run"), is_atlas, tex.region if is_atlas else Rect2()])
+	quit()
+"""
+
+
+def _frames(dir: Path, count: int, dims: tuple[int, int]) -> list[Path]:
+    dir.mkdir(parents=True, exist_ok=True)
+    out = []
+    for i in range(count):
+        p = dir / f"frame_{i:02d}.png"
+        Image.new("RGBA", dims, (10 * i % 256, 40, 90, 255)).save(p)
+        out.append(p)
+    return out
+
+
+@pytest.mark.engine
+def test_derived_spriteframes_loads_in_godot(tmp_path: Path) -> None:
+    from assets.packer import pack_frames
+    from assets.spriteframes import derive_spriteframes
+
+    project = tmp_path / "game"
+    shutil.copytree(GAME_DIR, project, ignore=_COPY_IGNORE)
+
+    # Pack a fixture frame set into the copy and derive its SpriteFrames next to it.
+    sprites = project / "assets" / "sprites"
+    layout = pack_frames(
+        _frames(tmp_path / "in", 5, (16, 16)), sprites / "hero_run.png"
+    )
+    (sprites / "hero_run_frames.tres").write_text(
+        derive_spriteframes("res://assets/sprites/hero_run.png", layout, "run"),
+        encoding="utf-8",
+    )
+
+    # Import so the sheet texture (the AtlasTexture ext_resource) resolves on load.
+    imported = subprocess.run(
+        [str(GODOT), "--headless", "--path", str(project), "--import"],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert imported.returncode == 0, imported.stdout + imported.stderr
+
+    probe = tmp_path / "probe.gd"
+    probe.write_text(_PROBE, encoding="utf-8")
+    run = subprocess.run(
+        [str(GODOT), "--headless", "--path", str(project), "--script", str(probe)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    out = run.stdout
+    assert "RESULT=OK" in out, run.stdout + run.stderr
+    assert "count=5" in out, out  # all 5 frames sequenced into the animation
+    assert "atlas=true" in out, out  # frame 0 is an AtlasTexture region of the sheet
+    # Frame 0's region is the top-left 16x16 box (Godot prints Rect2 as P/S).
+    assert "region=[P: (0.0, 0.0), S: (16.0, 16.0)]" in out, out

--- a/examples/platformer/panda-adventure/tools/assets/game_config.py
+++ b/examples/platformer/panda-adventure/tools/assets/game_config.py
@@ -35,6 +35,7 @@ class StyleConfig:
     assets_root: str
     scale_spec_rel: str
     generation: dict[str, Any]
+    lfs_size_threshold_bytes: int
 
 
 def load_style_config(path: Path = DEFAULT_STYLE_PATH) -> StyleConfig:
@@ -68,6 +69,9 @@ def load_style_config(path: Path = DEFAULT_STYLE_PATH) -> StyleConfig:
         assets_root=doc.get("assets_root", "assets"),
         scale_spec_rel=doc.get("scale_spec", "data/json/scale_spec.json"),
         generation=dict(doc.get("generation", {})),
+        lfs_size_threshold_bytes=int(
+            doc.get("lifecycle", {}).get("lfs_size_threshold_bytes", 1_048_576)
+        ),
     )
 
 

--- a/examples/platformer/panda-adventure/tools/assets/lifecycle.py
+++ b/examples/platformer/panda-adventure/tools/assets/lifecycle.py
@@ -54,21 +54,41 @@ def find_unlfs_oversize(
     ]
 
 
+def _is_binary(path: Path, chunk: int = 8192) -> bool:
+    """Heuristic: a file whose head carries a NUL byte is binary (text has none).
+
+    The size rule targets binary assets (textures, audio) — a large *text* asset
+    (a generated JSON) stays diff-friendly plain git, so the gate skips it.
+    """
+    with open(path, "rb") as handle:
+        return b"\0" in handle.read(chunk)
+
+
 def committed_asset_files(
     root: Path, assets_root: str = _ASSETS_ROOT
 ) -> list[tuple[str, int]]:
-    """Every file under ``<root>/<assets_root>`` as ``(relpath-from-root, size)``.
+    """The COMMITTED binary assets under ``<assets_root>`` as ``(relpath, size)``.
 
-    Sorted for a deterministic report; ``[]`` when the assets tree is absent.
+    Enumerates ``git ls-files`` (tracked files only — an untracked local scratch
+    file is not a commit and is not the gate's concern) and keeps only binary
+    files (:func:`_is_binary`), so the gate matches the spec's "``assets/**``
+    binary ``>= T`` committed outside LFS". ``[]`` outside a git repo / when the
+    tree has no tracked binaries.
     """
-    base = root / assets_root
-    if not base.exists():
-        return []
-    return [
-        (str(p.relative_to(root)), p.stat().st_size)
-        for p in sorted(base.rglob("*"))
-        if p.is_file()
-    ]
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--", assets_root],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    out: list[tuple[str, int]] = []
+    for rel in result.stdout.split("\0"):
+        if not rel:
+            continue
+        path = root / rel
+        if path.is_file() and _is_binary(path):
+            out.append((rel, path.stat().st_size))
+    return out
 
 
 def git_lfs_tracked(root: Path) -> Callable[[str], bool]:

--- a/examples/platformer/panda-adventure/tools/assets/lifecycle.py
+++ b/examples/platformer/panda-adventure/tools/assets/lifecycle.py
@@ -1,0 +1,117 @@
+"""Asset-lifecycle governance — the size-based Git-LFS gate (gADR-0015).
+
+A large binary can appear in ANY asset category (a BGM track, a 2K/4K background),
+so the plain-git-vs-LFS boundary is a single size threshold ``T`` applied uniformly,
+never a per-category rule: an ``assets/**`` file at or over ``T`` must be tracked by
+Git LFS; below ``T`` it stays in plain git. This gate enforces that mechanically so
+a large file is *born* in LFS rather than committed to plain git and migrated later
+(which rewrites history — the failure mode gADR-0015 exists to avoid).
+
+The core (:func:`find_unlfs_oversize`) is pure — it takes the file sizes and an
+injected "is this path LFS-tracked?" predicate, so it is unit-testable with no git.
+The repo-scoped wiring (:func:`validate_committed_asset_sizes`) supplies the real
+predicate via ``git check-attr`` and the real sizes from the working tree.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+# The default asset root the gate scans (mirrors the manifest/emitter default).
+_ASSETS_ROOT = "assets"
+
+
+class AssetSizeError(Exception):
+    """A committed ``assets/**`` binary at/over ``T`` is not Git-LFS-tracked."""
+
+
+@dataclass(frozen=True)
+class OversizeAsset:
+    """An ``assets/**`` file at/over ``T`` that is NOT LFS-tracked — a violation."""
+
+    path: str
+    size: int
+
+
+def find_unlfs_oversize(
+    files: Iterable[tuple[str, int]],
+    threshold: int,
+    is_lfs_tracked: Callable[[str], bool],
+) -> list[OversizeAsset]:
+    """The gate's pure core: which ``(path, size)`` files break the size rule.
+
+    A file is a violation iff its ``size`` is at or over ``threshold`` (``>= T``,
+    inclusive) and ``is_lfs_tracked(path)`` is false. Returns the violations in
+    input order (empty when every large file is LFS-tracked).
+    """
+    return [
+        OversizeAsset(path, size)
+        for path, size in files
+        if size >= threshold and not is_lfs_tracked(path)
+    ]
+
+
+def committed_asset_files(
+    root: Path, assets_root: str = _ASSETS_ROOT
+) -> list[tuple[str, int]]:
+    """Every file under ``<root>/<assets_root>`` as ``(relpath-from-root, size)``.
+
+    Sorted for a deterministic report; ``[]`` when the assets tree is absent.
+    """
+    base = root / assets_root
+    if not base.exists():
+        return []
+    return [
+        (str(p.relative_to(root)), p.stat().st_size)
+        for p in sorted(base.rglob("*"))
+        if p.is_file()
+    ]
+
+
+def git_lfs_tracked(root: Path) -> Callable[[str], bool]:
+    """A predicate: is ``<root>/<relpath>`` covered by a Git-LFS filter attribute?
+
+    Uses ``git check-attr filter``, which reads ``.gitattributes`` without needing
+    the ``git-lfs`` binary or a staged file. A path an LFS pattern covers prints
+    ``<path>: filter: lfs``; anything else prints ``unspecified``/another filter.
+    """
+
+    def _tracked(rel: str) -> bool:
+        result = subprocess.run(
+            ["git", "check-attr", "filter", "--", rel],
+            cwd=root,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip().rsplit(" ", 1)[-1] == "lfs"
+
+    return _tracked
+
+
+def validate_committed_asset_sizes(
+    root: Path,
+    threshold: int,
+    *,
+    is_lfs_tracked: Callable[[str], bool] | None = None,
+) -> list[OversizeAsset]:
+    """Enforce the size-based LFS gate over ``root``'s committed assets tree.
+
+    Reads on-disk sizes from the working tree and, by default, the real
+    ``git check-attr`` LFS predicate. Raises :class:`AssetSizeError` listing every
+    ``assets/**`` file at/over ``threshold`` that is not LFS-tracked; returns the
+    (empty) violation list on success. ``is_lfs_tracked`` is injectable for tests.
+    """
+    predicate = is_lfs_tracked or git_lfs_tracked(root)
+    violations = find_unlfs_oversize(committed_asset_files(root), threshold, predicate)
+    if violations:
+        listing = ", ".join(f"{v.path} ({v.size} bytes)" for v in violations)
+        raise AssetSizeError(
+            f"{len(violations)} asset(s) at/over {threshold} bytes committed "
+            f"outside Git LFS: {listing}. Track the path(s) with `git lfs track` "
+            "so a large file is born in LFS, never committed to plain git and "
+            "migrated later — which rewrites history (gADR-0015)."
+        )
+    return violations

--- a/examples/platformer/panda-adventure/tools/assets/manifest.py
+++ b/examples/platformer/panda-adventure/tools/assets/manifest.py
@@ -14,7 +14,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from .model import ManifestEntry
+from .model import FrameLayout, ManifestEntry
 
 # The per-category fragment lives under this directory of the assets root.
 MANIFEST_DIRNAME = "manifest"
@@ -58,6 +58,14 @@ def entry_to_dict(entry: ManifestEntry) -> dict[str, Any]:
         value = getattr(entry, name)
         if value is not None:
             data[name] = value
+    if entry.frame_layout is not None:
+        layout = entry.frame_layout
+        data["frame_layout"] = {
+            "frame_dims": list(layout.frame_dims),
+            "columns": layout.columns,
+            "rows": layout.rows,
+            "count": layout.count,
+        }
     return data
 
 
@@ -77,6 +85,20 @@ def dict_to_entry(asset_id: str, data: dict[str, Any]) -> ManifestEntry:
         attribution=data.get("attribution"),
         prompt=data.get("prompt"),
         backend=data.get("backend"),
+        frame_layout=_frame_layout_from_dict(data.get("frame_layout")),
+    )
+
+
+def _frame_layout_from_dict(data: dict[str, Any] | None) -> FrameLayout | None:
+    """Parse a sprite-set record's ``frame_layout`` sub-object (``None`` if absent)."""
+    if data is None:
+        return None
+    dims = data["frame_dims"]
+    return FrameLayout(
+        frame_dims=(int(dims[0]), int(dims[1])),
+        columns=int(data["columns"]),
+        rows=int(data["rows"]),
+        count=int(data["count"]),
     )
 
 

--- a/examples/platformer/panda-adventure/tools/assets/model.py
+++ b/examples/platformer/panda-adventure/tools/assets/model.py
@@ -120,6 +120,25 @@ class AcquireResult:
 
 
 @dataclass(frozen=True)
+class FrameLayout:
+    """How a packed spritesheet is tiled (gADR-0015): the per-frame box + grid.
+
+    A sprite-frame set is committed as ONE spritesheet per animation state; this
+    records how that sheet is laid out so the manifest carries it and the
+    SpriteFrames deriver turns it into ``AtlasTexture`` regions. ``frame_dims`` is
+    one frame's ``(width, height)``; ``columns``/``rows`` the grid the frames fill
+    left-to-right then top-to-bottom; ``count`` the frame total
+    (``<= columns * rows``). A value shape (no Pillow) so the manifest can carry
+    it without pulling the packer's imaging dependency.
+    """
+
+    frame_dims: tuple[int, int]
+    columns: int
+    rows: int
+    count: int
+
+
+@dataclass(frozen=True)
 class ManifestEntry:
     """One Asset manifest record (gADR-0014).
 
@@ -127,7 +146,8 @@ class ManifestEntry:
     ``license``/``license_url``/``target_dims``) plus optional provenance detail.
     ``path`` is the resource path the game loads (``res://...``); it is the single
     home of the asset's path (the authority references ``id``, the builder composes
-    ``id -> path``).
+    ``id -> path``). A sprite-set entry additionally carries its ``frame_layout``
+    (gADR-0015) — the packed sheet's tiling, which a plain texture entry omits.
     """
 
     id: str
@@ -142,3 +162,4 @@ class ManifestEntry:
     attribution: str | None = None
     prompt: str | None = None
     backend: str | None = None
+    frame_layout: FrameLayout | None = None

--- a/examples/platformer/panda-adventure/tools/assets/packer.py
+++ b/examples/platformer/panda-adventure/tools/assets/packer.py
@@ -1,0 +1,70 @@
+"""Frames -> sheet packer — loose frame files into one spritesheet (gADR-0015).
+
+Many open-asset sources deliver a sprite-frame set as loose files (B-form). The
+committed sprite artifact, though, is always ONE spritesheet per animation state
+(A-form): far fewer files, one ``.import`` per set, atlas- and pixel-grid-friendly
+(gADR-0013). This reusable postprocess tool packs the loose frames into that sheet
+and records the frame layout the manifest carries and the :mod:`spriteframes`
+deriver turns into ``AtlasTexture`` regions.
+
+Pure Pillow (a dev dependency, so this runs in the fast CI tier); no network, no
+game code, no Godot.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+from PIL import Image
+
+from .model import FrameLayout
+
+__all__ = ["FrameLayout", "pack_frames"]
+
+# Past this many frames a horizontal strip grows unwieldy (and hits texture-width
+# limits), so the packer switches to a near-square grid (gADR-0015). Spec-ish
+# default; a caller can override per set.
+_DEFAULT_GRID_THRESHOLD = 8
+
+
+def pack_frames(
+    frame_paths: list[Path],
+    dst: Path,
+    *,
+    grid_threshold: int = _DEFAULT_GRID_THRESHOLD,
+) -> FrameLayout:
+    """Pack ``frame_paths`` into one spritesheet at ``dst``; return its layout.
+
+    Up to ``grid_threshold`` frames tile into a single horizontal strip; a larger
+    set tiles into a near-square grid (columns = ``ceil(sqrt(count))``), filled
+    left-to-right then top-to-bottom. Returns the :class:`FrameLayout` describing
+    the result.
+    """
+    if not frame_paths:
+        raise ValueError("cannot pack a sprite set with no frames")
+    images = [Image.open(p).convert("RGBA") for p in frame_paths]
+    width, height = images[0].size
+    for path, img in zip(frame_paths, images):
+        if img.size != (width, height):
+            raise ValueError(
+                f"frame {path.name} is {img.size}, expected {(width, height)} — "
+                "all frames of a set must be the same size to tile into one sheet"
+            )
+    count = len(images)
+    if count > grid_threshold:
+        columns = math.ceil(math.sqrt(count))
+        rows = math.ceil(count / columns)
+    else:
+        columns, rows = count, 1
+
+    sheet = Image.new("RGBA", (columns * width, rows * height), (0, 0, 0, 0))
+    for index, img in enumerate(images):
+        col, row = index % columns, index // columns
+        sheet.paste(img, (col * width, row * height))
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    sheet.save(dst, format="PNG")
+    return FrameLayout(
+        frame_dims=(width, height), columns=columns, rows=rows, count=count
+    )

--- a/examples/platformer/panda-adventure/tools/assets/panda_adventure.style.json
+++ b/examples/platformer/panda-adventure/tools/assets/panda_adventure.style.json
@@ -53,6 +53,10 @@
     "allowed_licenses": ["CC0", "CC-BY"],
     "chroma_key": "#FF00FF"
   },
+  "lifecycle": {
+    "_readme": "gADR-0015. lfs_size_threshold_bytes is T: an assets/** file at/over it must be Git-LFS-tracked, uniform across categories (never per-category). Revisable spec-data; the gate is tools/assets/lifecycle.py and .gitattributes is its mechanical consequence.",
+    "lfs_size_threshold_bytes": 1048576
+  },
   "sources": [
     {
       "name": "opengameart",

--- a/examples/platformer/panda-adventure/tools/assets/pipeline.py
+++ b/examples/platformer/panda-adventure/tools/assets/pipeline.py
@@ -20,6 +20,7 @@ from .backends import GenerationBackend
 from .emitter import Emitter, JsonManifestEmitter
 from .game_config import StyleConfig
 from .model import AcquireMode, AcquireResult, AssetSpec, ManifestEntry
+from .packer import pack_frames
 from .postprocess import postprocess_image
 
 # The default license recorded for a generated asset (the pipeline authored it).
@@ -159,4 +160,52 @@ def acquire_asset(
     )
     if emit:
         (emitter or JsonManifestEmitter(game_root, config.assets_root)).emit(entry)
+    return entry
+
+
+def pack_sprite_set(
+    frame_paths: list[Path],
+    out_path: Path,
+    resource_path: str,
+    asset_id: str,
+    category: str,
+    *,
+    source: str,
+    license_name: str,
+    license_url: str,
+    target_dims: tuple[int, int] | None = None,
+    acquire_mode: str = "search_download",
+    source_url: str | None = None,
+    attribution: str | None = None,
+    emitter: Emitter | None = None,
+) -> ManifestEntry:
+    """Orchestrate a sprite set: loose frames -> committed sheet + manifest entry.
+
+    The pipeline's sprite-set entry point (gADR-0015), so a wave-3 acquire slice
+    reuses the pack+record choreography instead of re-inventing it: packs
+    ``frame_paths`` into one spritesheet at ``out_path``
+    (:func:`assets.packer.pack_frames`), then builds and — when an ``emitter`` is
+    given — writes the :class:`~assets.model.ManifestEntry` carrying the frame
+    layout plus the provenance/license invariant (``target_dims`` defaults to the
+    packed frame box). The Godot ``SpriteFrames`` derivation stays a separate,
+    independently-callable step (:func:`assets.spriteframes.derive_spriteframes`);
+    the network/generation acquire of the frames and the runtime sprite render are
+    out of scope here (wave-3 / gADR-0014).
+    """
+    layout = pack_frames(frame_paths, out_path)
+    entry = ManifestEntry(
+        id=asset_id,
+        path=resource_path,
+        category=category,
+        acquire_mode=acquire_mode,
+        source=source,
+        license=license_name,
+        license_url=license_url,
+        target_dims=target_dims or layout.frame_dims,
+        source_url=source_url,
+        attribution=attribution,
+        frame_layout=layout,
+    )
+    if emitter is not None:
+        emitter.emit(entry)
     return entry

--- a/examples/platformer/panda-adventure/tools/assets/spriteframes.py
+++ b/examples/platformer/panda-adventure/tools/assets/spriteframes.py
@@ -1,0 +1,88 @@
+"""SpriteFrames deriver — a packed sheet + its layout into a Godot resource.
+
+The read-side counterpart of the :mod:`packer` (gADR-0015): given the committed
+spritesheet's ``res://`` path and its :class:`~assets.model.FrameLayout`, this
+emits a Godot ``SpriteFrames`` ``.tres`` — one ``AtlasTexture`` sub-resource per
+frame (its ``region`` the frame's box in the sheet) and one animation that
+sequences them. So wave-3's sprite slices turn a loose-frame acquisition into a
+ready animation resource without re-deriving the geometry by hand.
+
+Pure text emission, the ``build_config`` idiom: byte-stable output (deterministic
+sub-resource ids, no ``uid`` — gda authors uid-free, gADR-0036), no Godot, no IO,
+so it runs in the fast CI tier. That the emitted text really loads as a Godot
+resource is proven by the engine-tier ``test_spriteframes_engine.py``.
+"""
+
+from __future__ import annotations
+
+from .model import FrameLayout
+
+# The default playback speed (fps) an emitted animation carries; a caller retunes
+# per state. Frame durations are uniform (1.0 each) — gADR-0015 commits one sheet
+# per animation state, not per-frame timing.
+_DEFAULT_SPEED = 8.0
+# The ext_resource id the sheet texture is referenced by. A stable literal (not a
+# random suffix like the editor's) so the derived .tres is byte-identical per run.
+_SHEET_EXT_ID = "1_sheet"
+
+
+def _atlas_id(anim_name: str, index: int) -> str:
+    """The deterministic sub-resource id for frame ``index`` of ``anim_name``."""
+    return f"AtlasTexture_{anim_name}_{index}"
+
+
+def _fps(speed: float) -> str:
+    """Render a playback speed as a float literal (always with a decimal point)."""
+    return repr(float(speed))
+
+
+def derive_spriteframes(
+    sheet_res_path: str,
+    layout: FrameLayout,
+    anim_name: str,
+    *,
+    speed: float = _DEFAULT_SPEED,
+    loop: bool = True,
+) -> str:
+    """Derive a ``SpriteFrames`` ``.tres`` for one packed sheet + its layout.
+
+    ``sheet_res_path`` is the committed sheet's ``res://`` path; ``layout`` its
+    :class:`~assets.model.FrameLayout`; ``anim_name`` the animation state the
+    sheet holds (e.g. ``"run"``). Each frame becomes an ``AtlasTexture`` whose
+    ``region`` is its box in the sheet (row-major: frame ``k`` at column
+    ``k % columns``, row ``k // columns``), and the animation sequences them in
+    order. Returns byte-stable ``.tres`` text.
+    """
+    width, height = layout.frame_dims
+    frame_ids = [_atlas_id(anim_name, i) for i in range(layout.count)]
+
+    header = (
+        '[gd_resource type="SpriteFrames" format=3]\n\n'
+        f'[ext_resource type="Texture2D" path="{sheet_res_path}" '
+        f'id="{_SHEET_EXT_ID}"]\n\n'
+    )
+
+    atlases = ""
+    for index, frame_id in enumerate(frame_ids):
+        col, row = index % layout.columns, index // layout.columns
+        x, y = col * width, row * height
+        atlases += (
+            f'[sub_resource type="AtlasTexture" id="{frame_id}"]\n'
+            f'atlas = ExtResource("{_SHEET_EXT_ID}")\n'
+            f"region = Rect2({x}, {y}, {width}, {height})\n\n"
+        )
+
+    frames_lit = ", ".join(
+        '{\n"duration": 1.0,\n"texture": SubResource("%s")\n}' % frame_id
+        for frame_id in frame_ids
+    )
+    resource = (
+        "[resource]\n"
+        "animations = [{\n"
+        f'"frames": [{frames_lit}],\n'
+        f'"loop": {"true" if loop else "false"},\n'
+        f'"name": &"{anim_name}",\n'
+        f'"speed": {_fps(speed)}\n'
+        "}]\n"
+    )
+    return header + atlases + resource


### PR DESCRIPTION
## What

Pre-wave-3 **asset-lifecycle tooling** (P2-S1b) so wave-3's asset round-outs (#442/#443/#444/#446) conform to one governance scheme without reinventing it. Two pieces, both inside the `tools/assets/` package, plus the **gADR-0015** decision record.

Decided in the fork-alignment interview: the derive side is **pure-Python** (no `view_builder.gd` change — the runtime sprite-render seam stays wave-3's per gADR-0014), and the LFS strategy is **gate-driven** (the size gate is the authority; `.gitattributes` is its mechanical consequence).

## Changes

**Frames→sheet packer + SpriteFrames deriver**
- `tools/assets/packer.py` — loose frames → one spritesheet + a `FrameLayout` (horizontal strip by default; near-square grid past 8 frames; loud error on mismatched dims / empty set).
- `tools/assets/spriteframes.py` — layout → a **byte-stable, uid-free** `SpriteFrames.tres` (one `AtlasTexture` per frame, `region` computed from the layout).
- `model.py` / `manifest.py` — `ManifestEntry` carries an optional `frame_layout`; emit/load round-trips it, sorted & byte-stable; a plain texture entry omits it.

**Size-based Git-LFS gate**
- `tools/assets/lifecycle.py` — a pure `find_unlfs_oversize` core (injected predicate, no git) + `validate_committed_asset_sizes` wiring (`git check-attr filter` predicate — no `git-lfs` binary needed).
- `T` is spec-data in `panda_adventure.style.json` (default 1 MB), parsed by `game_config`.
- `.gitattributes` seeds the BGM `assets/music/**` LFS convention (gate-driven: `git lfs track` a path when the gate flags a new ≥ T file); CI (`lfs: true` on the two asset-touching jobs) and `export_macos.sh` (`git lfs pull`) materialize LFS — no-ops until wave-3's first large asset.

**Docs**
- `docs/gadr/0015-asset-management-and-lifecycle.md` — the decision record (five decisions) with a dated Outcome note scoping what #478 landed vs. follow-up slices.
- `GAME-CONTEXT.md` — **Frames→sheet packer** + **Size-based Git-LFS gate** vocabulary.

## Acceptance criteria
- [x] Packer: loose frames → one sheet + manifest-recorded layout; a Godot `SpriteFrames`/`AtlasTexture` derived from it; unit-tested on a fixture frame set.
- [x] Git LFS initialized: `.gitattributes` LFS pattern; installed by CI and the export path.
- [x] Size gate FAILS on an `assets/**` binary ≥ T outside LFS, passes when LFS-tracked or below T; T is pipeline-config data (1 MB).
- [x] Wired into the pipeline (packer/deriver in `tools/assets/`, manifest carries the layout, gate runs in the CI fast tier).
- [x] Existing suites green; references gADR-0014 and gADR-0015.

## Verification
- lifecycle + pipeline unit tests — **43 passed**
- game fast-tier — **397 passed** (no regression)
- game engine tier (local Godot 4.6) — **47 passed**, incl. the engine proof that the derived `.tres` loads (`count=5`, frame-0 region `[P:(0,0), S:(16,16)]`)
- ruff check/format + pyright — clean
- **real git-lfs 3.7.1 round-trip** — the seed's `.gitattributes` converts a 1.2 MB `assets/music/*.ogg` to an LFS pointer while a small png stays plain git; the gate agrees (tracked ≥ T accepted, untracked ≥ T rejected)

## Scope boundary
gADR-0015's attribution generator, export-import gate, and orphan-prune step are **follow-up slices** under that record — not in #478 (noted in the ADR Outcome).

> Note: CI's Godot e2e/engine tier is schedule/dispatch-only; it did not run on this PR. The engine tier was run locally (Godot 4.6, 47 passed).

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)