### PR TITLE
docs(panda): gADR-0017 Player mount points — equipment & weapon attachment

### DIFF
--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -243,6 +243,36 @@ Warp driver / Game-flow director).
 _Avoid_: renderer, sprite factory, blockout (that names the fallback the seam builds, not
 the seam)
 
+**Mount point**:
+A named `Marker2D` socket placed on the Player where a swappable part attaches — a weapon
+or an equipment overlay hangs beneath its mount point, so the part's sprite can be swapped
+without touching the base look. The Player's on-screen figure is just its base sprite (the
+Model-S `SpriteFrames`, gADR-0016) plus the mount points on it; nothing wraps them under
+an umbrella node or name. The mount points are reserved ahead of the art that fills them so
+the swappable parts have somewhere to attach.
+_Avoid_: pivot (Godot's Node2D/Control transform origin — a different concept), bone/attach
+socket (that is skeletal; the design chose `Marker2D`, not `Skeleton2D`)
+
+**Weapon mount**:
+The Mount point where the Current weapon's sprite attaches — the Laser Gun or the Gravity
+Gun, swapped by the `switch_weapon` action. The one mount with a live gameplay driver
+today (Current weapon is already tracked state).
+_Avoid_: gun slot, holster
+
+**Equipment mount**:
+The Mount point where a swappable Equipment overlay (the Spacesuit) attaches. Forward-looking:
+the Spacesuit is worn from spawn and persistent today (gADR-0008), so this mount is reserved
+for future swappable Equipment, not a current in-game swap.
+_Avoid_: armor slot, gear socket
+
+**Paperdoll**:
+The conventional 2D layered-character technique the modular-art round uses to fill the mount
+points: a base body sprite plus equipment-overlay sprite(s) sharing the same animation-state
+names and playing in sync (driven by the same view-integration hooks, gADR-0016), so the
+equipment reads as worn over the body. Distinct from a Weapon mount, which hangs a whole
+sprite at a `Marker2D` rather than layering over the body.
+_Avoid_: dress-up, layered-sprite hack
+
 ### Pipelines
 
 **Tool Script**:

--- a/examples/platformer/panda-adventure/docs/gadr/0017-player-mount-points-equipment-and-weapon-attachment.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0017-player-mount-points-equipment-and-weapon-attachment.md
@@ -5,9 +5,10 @@ status: accepted
 # Player mount points — equipment & weapon attachment
 
 gADR-0016's Model S renders the Player as ONE `SpriteFrames` — the spacesuit-panda, its
-suit and implicit weapon baked into the frames. P2-S3 (#442) then found the **Spacesuit**
-and **Gravity Gun** textures have no data-only slot: a monolithic sprite cannot reflect a
-swappable Equipment overlay or the switchable Current weapon. The root cause is not a
+suit and implicit weapon baked into the frames. P2-S3 (#442) then found that several of its listed items have no data-only texture slot: the
+**Spacesuit** and the **Laser Gun / Gravity Gun** *held weapons* — as opposed to the Laser
+Gun's Projectile bolt, which #442 *did* wire. A monolithic sprite cannot reflect a modular
+Equipment overlay or a held weapon that swaps with the Current weapon. The root cause is not a
 missing texture reference — it is that the Player's on-screen figure reserves nowhere for a
 swapped or held part to attach. Today the Player's **weapons switch in play** (the Current
 weapon toggles between the Laser Gun and the Gravity Gun); the **Spacesuit is persistent** —

--- a/examples/platformer/panda-adventure/docs/gadr/0017-player-mount-points-equipment-and-weapon-attachment.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0017-player-mount-points-equipment-and-weapon-attachment.md
@@ -1,0 +1,78 @@
+---
+status: accepted
+---
+
+# Player mount points — equipment & weapon attachment
+
+gADR-0016's Model S renders the Player as ONE `SpriteFrames` — the spacesuit-panda, its
+suit and implicit weapon baked into the frames. P2-S3 (#442) then found the **Spacesuit**
+and **Gravity Gun** textures have no data-only slot: a monolithic sprite cannot reflect a
+swappable Equipment overlay or the switchable Current weapon. The root cause is not a
+missing texture reference — it is that the Player's on-screen figure reserves nowhere for a
+swapped part to attach. The Player's Equipment (Spacesuit) and weapons (Laser Gun / Gravity
+Gun) are swappable by design, so the body must plan attachment points.
+
+Scope here is **phase A: reserve the attachment architecture now**; the modular art that
+fills it is **phase B** (a follow-up). This record settles the reservation decisions so
+phase B is purely additive. Built on gADR-0000 (Resource/Controller/CanvasItem layering),
+gADR-0016 (Model S + view-integration hooks), gADR-0013 (Scale spec presentation authority),
+and gADR-0008 (the Spacesuit as persistent Equipment).
+
+We decide:
+
+1. **A Mount point is a named `Marker2D` socket on the Player node, positioned from config
+   at `_ready` — not a skeleton, not baked scene coordinates.** The Player's on-screen figure
+   is its base sprite (the Model-S `SpriteFrames`, gADR-0016) plus empty `Marker2D` mount
+   points authored as children of the Player node in `main.tscn`; nothing wraps them under an
+   umbrella node or name. Positions are set in `_ready` from config — mirroring how
+   `player_size` is applied via `ViewBuilder.apply_box` — never baked into the scene, so the
+   offset stays data-driven (gADR-0000). The **View seam stays generic and stateless** (its
+   glossary contract): it builds the base sprite into `Visual`; the mounts are Player-specific
+   structure alongside it, not something the shared seam knows about. `Marker2D` was chosen
+   over `Skeleton2D`/`Bone2D`: the pixel-art regime (gADR-0013) and the existing
+   `AnimatedSprite2D` composition do not warrant skeletal rigging — a fixed socket per state
+   suffices; skeletal attachment (per-frame bone tracking) is rejected as overkill (rigged art,
+   heavier runtime) for this fidelity.
+
+2. **Mount-offset authority is `scale_spec.json`'s new `player_mounts` section** (gADR-0013).
+   Offsets — relative to the `player_size` box — live beside `player_size`, `hud_margin`, and
+   `pickup_spacing`; scale_spec already carries positional/spacing values, and gADR-0013 is the
+   single authority for the Player's presentation geometry. They compose into the derived
+   `player_config` and apply at `_ready`, one authored home. Splitting mount offsets into
+   `player_config` was rejected: it would put the Player's presentation geometry under two
+   authorities.
+
+3. **Both mounts are reserved now; each names its phase-B driver contract — but phase A adds
+   no signals and no art.**
+   - **Weapon mount** — where the Current weapon's sprite attaches. It has a live gameplay
+     driver today (`switch_weapon` toggles the Current weapon). Phase B adds a
+     **`weapon_switched(weapon)` controller SIGNAL**, promoting today's log-only "weapon
+     switched" moment to a proper gADR-0016 view-integration hook (a sibling of `fired(weapon)`),
+     which a weapon-mount presenter consumes to swap the mounted sprite.
+   - **Equipment mount** — where a swappable Equipment overlay attaches. Forward-looking: the
+     Spacesuit is worn from spawn and persistent (gADR-0008), so there is no live driver; a
+     future `equipment_changed`-style hook lands when swappable Equipment is actually designed.
+   Phase A materializes only the two reserved `Marker2D` nodes and the offset authority.
+
+4. **Model S is untouched in phase A; phase B evolves it via Paperdoll + mounted sprites.**
+   Phase A keeps the Player as one baked Model-S `SpriteFrames` (#443 ships as-is). Phase B is
+   the modular-art round: a suit-agnostic base body, a **Spacesuit overlay `SpriteFrames`**
+   (Paperdoll — shares the animation-state names, played in sync via the same hooks) at the
+   Equipment mount, and per-weapon sprites hung at the Weapon mount. Those overlay/weapon assets
+   become additional referenced assets — the per-state / layered manifest model gADR-0016
+   anticipated ("may be revisited toward per-state entries"); that manifest model is phase B's
+   decision, not settled here.
+
+Consequences:
+
+- **Supersedes #442's Spacesuit/Gravity-Gun deferral.** The Spacesuit is not a data-only
+  pickup texture — it becomes the phase-B Equipment overlay at the Equipment mount. The Gravity
+  Gun has no player-body texture at all: its on-screen presence is the Gravity Field VFX
+  (#447/#448); only *held-weapon* sprites, if any, hang at the Weapon mount in phase B.
+- Phase A is a small slice — the two `Marker2D` nodes in `main.tscn`, the scale_spec
+  `player_mounts` section, `_ready` positioning, and tests — that does **not** touch #443's art,
+  `player.tres`, or `src/systems`. Phase B (Paperdoll overlay + weapon sprites + the
+  `weapon_switched` hook) is a separate follow-up, blocked on phase A.
+- The reserved mounts are inert until phase B fills them: an empty `Marker2D` renders nothing
+  and adds no runtime cost. The reservation's value is deciding the offsets and authority now,
+  so phase B is purely additive rather than a view re-architecture.

--- a/examples/platformer/panda-adventure/docs/gadr/0017-player-mount-points-equipment-and-weapon-attachment.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0017-player-mount-points-equipment-and-weapon-attachment.md
@@ -9,8 +9,12 @@ suit and implicit weapon baked into the frames. P2-S3 (#442) then found the **Sp
 and **Gravity Gun** textures have no data-only slot: a monolithic sprite cannot reflect a
 swappable Equipment overlay or the switchable Current weapon. The root cause is not a
 missing texture reference — it is that the Player's on-screen figure reserves nowhere for a
-swapped part to attach. The Player's Equipment (Spacesuit) and weapons (Laser Gun / Gravity
-Gun) are swappable by design, so the body must plan attachment points.
+swapped or held part to attach. Today the Player's **weapons switch in play** (the Current
+weapon toggles between the Laser Gun and the Gravity Gun); the **Spacesuit is persistent** —
+worn from spawn (gADR-0008) — but its look is a distinct layer over the body. So the body
+must plan attachment points: a held-weapon sprite that swaps with the Current weapon, and an
+equipment overlay. (General *Equipment swapping* beyond the Spacesuit is architectural
+readiness, not current game design.)
 
 Scope here is **phase A: reserve the attachment architecture now**; the modular art that
 fills it is **phase B** (a follow-up). This record settles the reservation decisions so
@@ -30,9 +34,12 @@ We decide:
    glossary contract): it builds the base sprite into `Visual`; the mounts are Player-specific
    structure alongside it, not something the shared seam knows about. `Marker2D` was chosen
    over `Skeleton2D`/`Bone2D`: the pixel-art regime (gADR-0013) and the existing
-   `AnimatedSprite2D` composition do not warrant skeletal rigging — a fixed socket per state
-   suffices; skeletal attachment (per-frame bone tracking) is rejected as overkill (rigged art,
-   heavier runtime) for this fidelity.
+   `AnimatedSprite2D` composition do not warrant skeletal rigging. Phase A reserves **one fixed
+   Player-local offset per mount**, applied once at `_ready`. Whether phase B needs per-state or
+   per-frame offsets — a held weapon tracking the hand as the base animates — is a **phase-B
+   decision**, not settled here; the reserved socket is the anchor either refinement builds on.
+   Skeletal attachment (per-frame bone tracking) is rejected as overkill (rigged art, heavier
+   runtime) for this fidelity.
 
 2. **Mount-offset authority is `scale_spec.json`'s new `player_mounts` section** (gADR-0013).
    Offsets — relative to the `player_size` box — live beside `player_size`, `hud_margin`, and
@@ -44,11 +51,14 @@ We decide:
 
 3. **Both mounts are reserved now; each names its phase-B driver contract — but phase A adds
    no signals and no art.**
-   - **Weapon mount** — where the Current weapon's sprite attaches. It has a live gameplay
-     driver today (`switch_weapon` toggles the Current weapon). Phase B adds a
-     **`weapon_switched(weapon)` controller SIGNAL**, promoting today's log-only "weapon
-     switched" moment to a proper gADR-0016 view-integration hook (a sibling of `fired(weapon)`),
-     which a weapon-mount presenter consumes to swap the mounted sprite.
+   - **Weapon mount** — where the equipped weapon's **held sprite** attaches: **both** the Laser
+     Gun and the Gravity Gun have one, swapped with the Current weapon. (The held gun is distinct
+     from what it *fires* — the Laser Gun's Projectile/bolt, already wired by #442, and the
+     Gravity Field the Gravity Gun creates — neither of which is the held sprite.) It has a live
+     gameplay driver today (`switch_weapon` toggles the Current weapon). Phase B adds a
+     **`weapon_switched(weapon)` controller SIGNAL**, promoting today's log-only "weapon switched"
+     moment to a proper gADR-0016 view-integration hook (a sibling of `fired(weapon)`), which a
+     weapon-mount presenter consumes to swap the held sprite.
    - **Equipment mount** — where a swappable Equipment overlay attaches. Forward-looking: the
      Spacesuit is worn from spawn and persistent (gADR-0008), so there is no live driver; a
      future `equipment_changed`-style hook lands when swappable Equipment is actually designed.
@@ -65,14 +75,20 @@ We decide:
 
 Consequences:
 
-- **Supersedes #442's Spacesuit/Gravity-Gun deferral.** The Spacesuit is not a data-only
-  pickup texture — it becomes the phase-B Equipment overlay at the Equipment mount. The Gravity
-  Gun has no player-body texture at all: its on-screen presence is the Gravity Field VFX
-  (#447/#448); only *held-weapon* sprites, if any, hang at the Weapon mount in phase B.
+- **Supersedes #442's Spacesuit + weapon-sprite deferral.** #442 wired the *data-only* textures
+  (pickups, the Laser Gun's Projectile bolt, the Obstacle). Three of its listed items are not
+  data-only and move to phase B (#492): the **Spacesuit** → the Equipment overlay at the Equipment
+  mount; the **Laser Gun** and **Gravity Gun** *held-weapon sprites* → the Weapon mount (distinct
+  from the already-wired Laser bolt Projectile). The **Gravity Field** the Gravity Gun fires is a
+  separate effect — today the blockout translucent circle (`ViewBuilder.apply_circle`); giving it
+  a textured skin is its own future concern with **no owner assigned here**, and is explicitly
+  **not** folded into #447 (enemy Faction sprites) or #448 (hit/explosion/pickup/level-up/Warp
+  VFX).
 - Phase A is a small slice — the two `Marker2D` nodes in `main.tscn`, the scale_spec
   `player_mounts` section, `_ready` positioning, and tests — that does **not** touch #443's art,
   `player.tres`, or `src/systems`. Phase B (Paperdoll overlay + weapon sprites + the
   `weapon_switched` hook) is a separate follow-up, blocked on phase A.
-- The reserved mounts are inert until phase B fills them: an empty `Marker2D` renders nothing
-  and adds no runtime cost. The reservation's value is deciding the offsets and authority now,
-  so phase B is purely additive rather than a view re-architecture.
+- The reserved mounts are inert until phase B fills them: an empty `Marker2D` still exists in the
+  scene tree but renders nothing and has negligible runtime overhead (no rendering or gameplay
+  behavior). The reservation's value is deciding the offsets and authority now, so phase B is
+  purely additive rather than a view re-architecture.


### PR DESCRIPTION
## gADR-0017: Player mount points — equipment & weapon attachment (+ glossary)

Design record from a design-alignment session: **reserve** equipment/weapon attachment points on the Player body (phase A) so the modular Spacesuit and the held weapons have somewhere to attach. **Doc-only** — a gADR + GAME-CONTEXT glossary terms, no code.

### What it decides (phase A = reserve now; phase B = modular art later)
- **Mount point** = a named `Marker2D` socket on the Player node, positioned from config at `_ready` (not `Skeleton2D`, not baked scene coords). The View seam stays generic/stateless; mounts are Player-specific structure. Phase A reserves one fixed Player-local offset per mount; per-state/per-frame refinement is a phase-B decision.
- **Authority** = `scale_spec.json` `player_mounts` offsets (gADR-0013), composed into `player_config`.
- **Both** Weapon + Equipment mounts reserved; each names its phase-B driver contract — a `weapon_switched(weapon)` signal (promotes today's log-only moment to a gADR-0016 hook) for the weapon mount; a forward-looking `equipment_changed` for the equipment mount. **Phase A adds no signals and no art.**
- **The Weapon mount holds each gun's *held sprite*** — both the Laser Gun and the Gravity Gun, swapped with the Current weapon; distinct from what a gun *fires* (the Laser Gun's Projectile bolt — already wired by #442 — and the Gravity Field).
- **Model S (gADR-0016) untouched**; phase B evolves it via **Paperdoll** overlay + mounted sprites.

### Scope transfer (supersedes #442's deferral)
Three of #442's listed items are not data-only and move to **phase-B #492**: the **Spacesuit** → the Equipment overlay at the Equipment mount (the Spacesuit is *persistent*, worn from spawn — gADR-0008 — but its art becomes a modular overlay), and the **Laser Gun + Gravity Gun held-weapon sprites** → the Weapon mount. The **Gravity Field** the Gravity Gun fires is a separate effect (today the blockout translucent circle via `ViewBuilder.apply_circle`); a textured Gravity-Field skin is a separate, currently-unowned concern — explicitly **not** #447 (enemy Faction sprites) or #448 (its listed VFX set).

### Glossary
Adds **Mount point / Weapon mount / Equipment mount / Paperdoll** to `GAME-CONTEXT.md`.

### Implementation
Tracked by two follow-up issues: **#491** (phase A — reserve the mounts, ready) and **#492** (phase B — the modular Paperdoll art, backlog, blocked on #491).

### Merge ordering
References **gADR-0016** (landed via #443/#487) — already on main. Mergeable onto the current main; docs-only, no code overlap with the other wave-3 slices.

Refs #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)
