### PR TITLE
[Panda Adventure] refactor(panda-balancing): framework/plug-in split (gADR-0018)

### DIFF
--- a/examples/platformer/panda-adventure/GAME-CONTEXT.md
+++ b/examples/platformer/panda-adventure/GAME-CONTEXT.md
@@ -349,8 +349,10 @@ The shared art-direction input that makes mixed-source assets cohere across BOTH
 acquire modes — the machine-consumable style parameters (shared style
 keywords/prompt fragment, the bounded pixel-art palette, per-category style hints)
 plus the format/licensing constraints (gADR-0014). A pipeline-only per-game
-configuration living inside the asset pipeline package (mirroring the Balancing
-pipeline's `panda_adventure.targets.json`), NOT in the JSON authority and never
+configuration living inside the asset pipeline package (the layout the Balancing
+pipeline used before gADR-0018 moved its per-game half out to
+`tools/panda_balancing/targets.json`; migrating the asset pipeline likewise is an
+open follow-up), NOT in the JSON authority and never
 derived to a Resource — the game reads assets, not their style. The preprocess stage
 composes it with the Scale spec's target dimensions into the per-asset `asset spec`,
 which renders either as a search query (search-download) or a generation prompt
@@ -427,7 +429,10 @@ Monte-Carlo encounter simulation validates encounter-level numbers; a
 system-dynamics model (first-order nonlinear ODEs over the growth/economy stocks
 and flows) predicts long-term balance trajectories. Deliberately isolated from the
 game's GDScript (reusable across games): it reads and writes the same JSON
-authority the game derives from, and never imports game code.
+authority the game derives from, and never imports game code. The framework
+(`tools/balancing/`) is strictly game-agnostic; everything Panda Adventure
+contributes — the JSON-authority adapter and `targets.json` — lives in the
+`tools/panda_balancing/` plug-in, wired in through config alone (gADR-0018).
 _Avoid_: balance patch, number tweaking; balancing sim (that names only the
 Monte-Carlo half)
 

--- a/examples/platformer/panda-adventure/docs/gadr/0014-asset-pipeline-architecture.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0014-asset-pipeline-architecture.md
@@ -12,6 +12,14 @@ stand on, decided in the 2026-07-07 P2-S1 grilling interview (HITL). It is the a
 analogue of gADR-0011 (the Balancing pipeline) and reuses gADR-0013's authority
 patterns.
 
+> **Outcome note (2026-07-14).** The Balancing-pipeline layout this record cites
+> as its mirror ("`tools/balancing/`'s core + `game_config` +
+> `panda_adventure.targets.json`") has since changed: gADR-0018 moved balancing's
+> per-game half out to the sibling plug-in `tools/panda_balancing/` (adapter +
+> targets). The two-layer *pattern* decided here is unchanged; the asset
+> pipeline still keeps its plug-in in-package, and migrating it to the
+> gADR-0018 split is an open follow-up.
+
 We decide six things:
 
 - **A standalone `tools/assets/` package, mirroring the Balancing pipeline's

--- a/examples/platformer/panda-adventure/docs/gadr/0018-balancing-framework-plugin-split.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0018-balancing-framework-plugin-split.md
@@ -21,7 +21,13 @@ We decide four things:
   schema, CLI). It never imports game code, names no game vocabulary (items,
   actors, docs, engine), and carries no per-game config file. That isolation is
   pinned by a fast test gate (`tests/test_balancing_isolation.py`) — imports,
-  vocabulary, and stray config are all regressions, not style.
+  vocabulary, and stray config are all regressions, not style. *Mechanic*
+  vocabulary is a different category: waves, archetypes, the warp/blink kit,
+  and slow fields are the reference combat model's own feature names —
+  data-driven and presence-gated, usable or ignorable by any game — i.e. the
+  framework's genre scope, not a game identity leak. This game's GAME-CONTEXT
+  binding Warp to its Boss does not make the mechanic panda-specific, so the
+  vocabulary gate deliberately checks identity terms, not mechanic terms.
 - **Everything Panda Adventure contributes lives in the sibling plug-in
   `tools/panda_balancing/`**: `adapter.py` (the JSON-authority → generic-model
   mapping, ex-`game_config.py`) and `targets.json` (ex-

--- a/examples/platformer/panda-adventure/docs/gadr/0018-balancing-framework-plugin-split.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0018-balancing-framework-plugin-split.md
@@ -1,0 +1,56 @@
+---
+status: accepted
+---
+
+# Balancing framework/plug-in split: the per-game half moves out of the package
+
+gADR-0011 positioned the Balancing pipeline as a first-class reusable asset —
+"input-driven core, per-game configuration" — but the realized layout kept the
+per-game half *inside* the framework package: `tools/balancing/` carried
+`game_config.py` (this game's JSON mapping), `panda_adventure.targets.json`
+(this game's design intent), a CLI whose defaults hardcoded this game's targets
+file and `data/` tree, and — deeper — the SD model's state vector named this
+game's items (`BUN`/`WINE` stocks, `bun_hp_restore`, `boss_is_peak`). A 2026-07
+architecture review judged that coupling incompatible with the module's stated
+positioning: the package was game-agnostic in name, per-game in content.
+
+We decide four things:
+
+- **The framework package contains no game.** `tools/balancing/` keeps only the
+  generic pipeline (model, rules, both engines, statistics, reports, targets
+  schema, CLI). It never imports game code, names no game vocabulary (items,
+  actors, docs, engine), and carries no per-game config file. That isolation is
+  pinned by a fast test gate (`tests/test_balancing_isolation.py`) — imports,
+  vocabulary, and stray config are all regressions, not style.
+- **Everything Panda Adventure contributes lives in the sibling plug-in
+  `tools/panda_balancing/`**: `adapter.py` (the JSON-authority → generic-model
+  mapping, ex-`game_config.py`) and `targets.json` (ex-
+  `panda_adventure.targets.json`). The parity fixtures/tests that pin the rules
+  against the shipped GDScript seams stay in `tests/` (gADR-0011 unchanged).
+- **The wiring is config-only, through a deep-module surface.** The CLI takes a
+  required `--targets` file; that file names the game's `config_dir`, the
+  `adapter` (a Python file exporting `load_inputs(config_dir) -> GameInputs`,
+  resolved relative to the targets file), and the protected `no_write_roots`
+  (this game: the whole `data/` chain — the guard policy moves from code to
+  config). The old code's heuristic that auto-protected a `--config-dir`
+  override's parent when it was *named* `data` is deliberately dropped:
+  protection is declared config, never a path-name heuristic — the override
+  dir itself stays protected, and a copied project gets full-tree protection
+  by carrying its own targets file. The adapter consumes only the framework's
+  public `model` types; a game plugs in without touching package internals,
+  and a bad input is a structured exit-2 refusal, not a traceback.
+- **The SD economy goes generic.** Stocks are `Q`/`HP`/`EXP`/`CURRENCY` plus
+  one stock per tracked drop item; the adapter binds `currency_item` ("gold"),
+  `heal_item` ("bun") and its restore amount. Wine is just a tracked
+  inflow-only stock; `boss_is_peak` becomes `final_wave_is_peak` (what the
+  check actually tests). Report JSON follows (`final_currency`, `final_items`,
+  `items_end`).
+
+Consequences: reusing the pipeline for another game = one targets file + one
+adapter file, no framework edits. The targets schema changed
+(`adapter`/`no_write_roots` added; paths now resolve relative to the targets
+file; `heal_consume_rate`, `final_wave_is_peak` renamed) — its single schema
+home is `balancing/config.py`. The asset pipeline still keeps its per-game
+plug-in in-package (gADR-0014's "exactly like `tools/balancing/`" now describes
+the *old* layout); migrating it to this split is a follow-up decision, not made
+here.

--- a/examples/platformer/panda-adventure/tests/test_balancing_dynamics.py
+++ b/examples/platformer/panda-adventure/tests/test_balancing_dynamics.py
@@ -11,6 +11,10 @@ Covers, deterministically (no RNG, no engine, no game code):
   win) — the nonlinearities that make this a first-order NONLINEAR ODE system.
 - **From the JSON authority alone** — the per-Wave projection produces sane
   aggregates and a Boss-peaked difficulty ramp (AC1), importing no game code.
+
+The framework tracks this game's Bun/Wine as generic item stocks (gADR-0018:
+the heal-item and drop bindings come from the adapter), so these tests address
+them through ``dynamics.item_index`` / the ``items_*`` outcome maps.
 """
 
 from __future__ import annotations
@@ -18,7 +22,7 @@ from __future__ import annotations
 import math
 
 import build_config
-from balancing import dynamics, game_config
+from balancing import dynamics
 from balancing.dynamics import (
     SdParams,
     WaveDynamics,
@@ -26,7 +30,8 @@ from balancing.dynamics import (
     run_scenario,
     run_wave_overlap,
 )
-from balancing.model import GrowthEconomy
+from balancing.model import GrowthEconomy, TierReward, build_player_model
+from panda_balancing import adapter
 
 CONFIG_DIR = build_config.GAME_DIR / "data" / "json"
 
@@ -37,15 +42,23 @@ _PLAYER_MODEL_PARAMS = {
     "engagement_distance": 60.0,
 }
 
+# A phantom tier whose drop table tracks Wine, so hand-built economies carry
+# this game's inflow-only stock without reading the authority.
+_WINE_TIER = {
+    "t": TierReward(
+        tier="t", exp_reward=0.0, currency_reward=0.0, expected_drops={"wine": 1.0}
+    )
+}
+
 
 def _econ(**over) -> GrowthEconomy:
     base = dict(
         level_curve=(10.0, 50.0, 150.0, 280.0),
         tier_rewards={},
-        bun_hp_restore=25.0,
-        wine_mp_restore=15.0,
         player_max_hp=100.0,
-        player_max_mp=50.0,
+        currency_item="gold",
+        heal_item="bun",
+        heal_item_restore=25.0,
     )
     base.update(over)
     return GrowthEconomy(**base)  # type: ignore[arg-type]
@@ -58,9 +71,8 @@ def _wd(**over) -> WaveDynamics:
         player_dps=50.0,
         enemy_dps=0.0,
         exp_reward=25.0,
-        gold_reward=10.0,
-        bun_drops=0.0,
-        wine_drops=0.0,
+        currency_reward=10.0,
+        item_drops={},
     )
     base.update(over)
     return WaveDynamics(**base)  # type: ignore[arg-type]
@@ -72,16 +84,26 @@ def _params(**over) -> SdParams:
         max_wave_time=200.0,
         growth_gain=0.0,
         heal_threshold_frac=0.5,
-        bun_consume_rate=0.0,
+        heal_consume_rate=0.0,
     )
     base.update(over)
     return SdParams(**base)  # type: ignore[arg-type]
 
 
+def _y0(econ: GrowthEconomy, q: float, hp: float, **items: float):
+    """A hand-built state vector: Q/HP plus named item stocks (rest zero)."""
+    y = [0.0] * dynamics.state_size(econ)
+    y[dynamics.Q] = q
+    y[dynamics.HP] = hp
+    for item, count in items.items():
+        y[dynamics.item_index(econ, item)] = count
+    return tuple(y)
+
+
 def _authority():
-    game = game_config.load_game_data(CONFIG_DIR)
-    econ = game_config.load_growth_economy(CONFIG_DIR)
-    player = game_config.build_player_model(game, _PLAYER_MODEL_PARAMS)
+    game = adapter.load_game_data(CONFIG_DIR)
+    econ = adapter.load_growth_economy(CONFIG_DIR)
+    player = build_player_model(game, _PLAYER_MODEL_PARAMS)
     return game, econ, player, build_wave_dynamics(game, econ, player)
 
 
@@ -92,13 +114,13 @@ def test_reward_conservation_on_clear() -> None:
     """Clearing a Wave accrues EXACTLY its EXP/Gold/Wine reward — the kill flow's
     coflow integrates to the design total, and the clear time is the analytic
     wave_hp / player_dps."""
-    econ = _econ()
-    wd = _wd(exp_reward=25.0, gold_reward=10.0, wine_drops=3.0)
+    econ = _econ(tier_rewards=_WINE_TIER)
+    wd = _wd(exp_reward=25.0, currency_reward=10.0, item_drops={"wine": 3.0})
     outcome = run_wave_overlap(wd, _params(), econ)
     assert outcome.cleared and not outcome.died
     assert math.isclose(outcome.exp_gained, 25.0, abs_tol=1e-9)
-    assert math.isclose(outcome.gold_end, 10.0, abs_tol=1e-9)
-    assert math.isclose(outcome.wine_end, 3.0, abs_tol=1e-9)
+    assert math.isclose(outcome.currency_end, 10.0, abs_tol=1e-9)
+    assert math.isclose(outcome.items_end["wine"], 3.0, abs_tol=1e-9)
     assert outcome.clear_time is not None
     assert math.isclose(outcome.clear_time, wd.wave_hp / wd.player_dps, abs_tol=2e-3)
 
@@ -116,7 +138,7 @@ def test_reward_conservation_across_the_run() -> None:
     """Chaining the real Wave schedule, the cumulative EXP after each cleared Wave
     is the running sum of the per-Wave rewards (no drift, no double count)."""
     _game, econ, _player, wds = _authority()
-    run = run_scenario(wds, _params(bun_consume_rate=2.0), econ)
+    run = run_scenario(wds, _params(heal_consume_rate=2.0), econ)
     running = 0.0
     for outcome, wd in zip(run.waves, wds):
         if not outcome.cleared:
@@ -132,10 +154,10 @@ def test_heal_never_overfills_hp() -> None:
     """The Bun heal saturates at max HP — with the heal threshold at full HP and
     Buns in hand, a long, damage-free Wave recovers HP to the cap and NO further
     (the cap is a ``min`` saturation, enforced even across a discrete RK4 step)."""
-    econ = _econ(player_max_hp=100.0, bun_hp_restore=25.0)
+    econ = _econ(player_max_hp=100.0, heal_item_restore=25.0)
     wd = _wd(wave_hp=2000.0, player_dps=10.0, enemy_dps=0.0)
-    params = _params(heal_threshold_frac=1.0, bun_consume_rate=2.0)  # heal to full
-    y0 = (wd.wave_hp, 50.0, 0.0, 0.0, 20.0, 0.0)  # start at 50 HP, 20 Buns
+    params = _params(heal_threshold_frac=1.0, heal_consume_rate=2.0)  # heal to full
+    y0 = _y0(econ, q=wd.wave_hp, hp=50.0, bun=20.0)  # start at 50 HP, 20 Buns
     outcome, _ = dynamics._run_one_wave(wd, params, econ, y0)
     assert outcome.hp_end <= econ.player_max_hp + 1e-9  # never above the cap
     assert math.isclose(outcome.hp_end, econ.player_max_hp, abs_tol=1e-6)
@@ -144,17 +166,17 @@ def test_heal_never_overfills_hp() -> None:
 def test_healing_is_supply_limited_within_a_step() -> None:
     """A sliver of Bun buys only a sliver of healing — consumption is capped by
     the Bun on hand within an RK4 step, so it can never fund more HP than the
-    inventory pays for (``bun × bun_hp_restore``). A tiny 0.001 Bun heals at most
-    ~0.025 HP, not a full unclamped step's ~0.2."""
-    econ = _econ(player_max_hp=100.0, bun_hp_restore=25.0)
+    inventory pays for (``bun × heal_item_restore``). A tiny 0.001 Bun heals at
+    most ~0.025 HP, not a full unclamped step's ~0.2."""
+    econ = _econ(player_max_hp=100.0, heal_item_restore=25.0)
     wd = _wd(wave_hp=1000.0, player_dps=1.0, enemy_dps=0.0)
-    params = _params(heal_threshold_frac=1.0, bun_consume_rate=1.0)
+    params = _params(heal_threshold_frac=1.0, heal_consume_rate=1.0)
     bun0 = 0.001
-    y0 = (wd.wave_hp, 50.0, 0.0, 0.0, bun0, 0.0)  # 50 HP, a sliver of Bun
+    y0 = _y0(econ, q=wd.wave_hp, hp=50.0, bun=bun0)  # 50 HP, a sliver of Bun
     outcome, end = dynamics._run_one_wave(wd, params, econ, y0)
-    max_fundable = bun0 * econ.bun_hp_restore
+    max_fundable = bun0 * econ.heal_item_restore
     assert outcome.hp_end - 50.0 <= max_fundable + 1e-9
-    assert end[dynamics.BUN] >= 0.0
+    assert end[dynamics.item_index(econ, "bun")] >= 0.0
 
 
 def test_hp_and_bun_stay_in_bounds() -> None:
@@ -162,33 +184,34 @@ def test_hp_and_bun_stay_in_bounds() -> None:
     consumption drains the last Bun under fire."""
     econ = _econ()
     wd = _wd(wave_hp=2000.0, player_dps=8.0, enemy_dps=6.0)
-    params = _params(heal_threshold_frac=0.9, bun_consume_rate=3.0)
-    y0 = (wd.wave_hp, 60.0, 0.0, 0.0, 1.0, 0.0)  # one Bun, then empty
+    params = _params(heal_threshold_frac=0.9, heal_consume_rate=3.0)
+    y0 = _y0(econ, q=wd.wave_hp, hp=60.0, bun=1.0)  # one Bun, then empty
     outcome, end = dynamics._run_one_wave(wd, params, econ, y0)
     assert 0.0 <= outcome.hp_min
     assert outcome.hp_end <= econ.player_max_hp + 1e-9
-    assert end[dynamics.BUN] >= 0.0
+    assert end[dynamics.item_index(econ, "bun")] >= 0.0
 
 
 def test_gold_inflow_includes_pickup_drops() -> None:
     """Gold accrues the guaranteed Kill reward AND the expected gold Pickup drops
-    (gADR-0006). On the committed schedule that is 212 (kill 5+20+15+100 = 140
-    plus gold drops 3+10+9+50 = 72), not the kill-only 140."""
+    (gADR-0006, the adapter's ``currency_item`` binding). On the committed
+    schedule that is 212 (kill 5+20+15+100 = 140 plus gold drops 3+10+9+50 = 72),
+    not the kill-only 140."""
     _game, econ, _player, wds = _authority()
-    run = run_scenario(wds, _params(bun_consume_rate=2.0), econ)
+    run = run_scenario(wds, _params(heal_consume_rate=2.0), econ)
     assert run.cleared_schedule
-    assert math.isclose(run.final_gold, 212.0, abs_tol=1e-9)
+    assert math.isclose(run.final_currency, 212.0, abs_tol=1e-9)
     # Each Wave's gold coflow exceeds its kill reward by exactly the gold drops.
-    per_wave_gold = [wd.gold_reward for wd in wds]
+    per_wave_gold = [wd.currency_reward for wd in wds]
     assert per_wave_gold == [8.0, 30.0, 24.0, 150.0]
 
 
 def test_reward_stocks_are_monotonic() -> None:
     """EXP and Gold are inflow-only — they never decrease across the run."""
     _game, econ, _player, wds = _authority()
-    run = run_scenario(wds, _params(bun_consume_rate=2.0), econ)
+    run = run_scenario(wds, _params(heal_consume_rate=2.0), econ)
     exps = [o.exp_end for o in run.waves]
-    golds = [o.gold_end for o in run.waves]
+    golds = [o.currency_end for o in run.waves]
     assert exps == sorted(exps)
     assert golds == sorted(golds)
 
@@ -200,7 +223,7 @@ def test_deterministic_no_rng() -> None:
     """The SD model has no randomness — two runs of the same inputs are identical
     (the determinism the pipeline needs)."""
     _game, econ, _player, wds = _authority()
-    params = _params(bun_consume_rate=2.0)
+    params = _params(heal_consume_rate=2.0)
     a = run_scenario(wds, params, econ)
     b = run_scenario(wds, params, econ)
     assert a == b
@@ -213,8 +236,8 @@ def test_growth_feedback_speeds_clears() -> None:
     """The reinforcing growth loop: with ``growth_gain`` > 0 a higher Level feeds
     back into the kill rate, so the Boss clears strictly faster than at gain 0."""
     _game, econ, _player, wds = _authority()
-    base = run_scenario(wds, _params(bun_consume_rate=2.0, growth_gain=0.0), econ)
-    fast = run_scenario(wds, _params(bun_consume_rate=2.0, growth_gain=0.5), econ)
+    base = run_scenario(wds, _params(heal_consume_rate=2.0, growth_gain=0.0), econ)
+    fast = run_scenario(wds, _params(heal_consume_rate=2.0, growth_gain=0.5), econ)
     assert base.waves[-1].clear_time is not None
     assert fast.waves[-1].clear_time is not None
     assert fast.waves[-1].clear_time < base.waves[-1].clear_time
@@ -225,8 +248,8 @@ def test_consumable_loop_turns_a_boss_loss_into_a_win() -> None:
     laser-brawl kills the Player at the Boss; turning it ON lets the designed Bun
     economy clear the schedule — the macro prediction MC cannot make."""
     _game, econ, _player, wds = _authority()
-    no_heal = run_scenario(wds, _params(bun_consume_rate=0.0), econ)
-    with_heal = run_scenario(wds, _params(bun_consume_rate=2.0), econ)
+    no_heal = run_scenario(wds, _params(heal_consume_rate=0.0), econ)
+    with_heal = run_scenario(wds, _params(heal_consume_rate=2.0), econ)
     assert no_heal.died_at_wave == wds[-1].index  # bare brawl loses the Boss
     assert with_heal.cleared_schedule  # the consumable economy saves the run
 
@@ -249,13 +272,14 @@ def test_build_wave_dynamics_from_authority() -> None:
     """The per-Wave projection reads only already-parsed authority data and
     produces one sane coefficient set per Wave (positive HP/DPS/reward)."""
     game, econ, _player, wds = _authority()
+    assert econ.item_keys == ("bun", "wine")  # this game's tracked stocks
     assert len(wds) == len(game.waves)
     for wd in wds:
         assert wd.wave_hp > 0.0
         assert wd.player_dps > 0.0
         assert wd.enemy_dps > 0.0
         assert wd.exp_reward > 0.0
-        assert wd.gold_reward > 0.0
+        assert wd.currency_reward > 0.0
 
 
 def test_difficulty_ramp_peaks_at_the_boss() -> None:

--- a/examples/platformer/panda-adventure/tests/test_balancing_isolation.py
+++ b/examples/platformer/panda-adventure/tests/test_balancing_isolation.py
@@ -1,0 +1,72 @@
+"""The framework/plug-in isolation gate for the Balancing pipeline (gADR-0018).
+
+gADR-0011 positions the pipeline as a reusable, game-agnostic asset;
+gADR-0018 splits everything Panda Adventure contributes into the
+``tools/panda_balancing/`` plug-in and pins the framework package clean. These
+tests are that pin: the framework must not import game code, must not speak
+this game's vocabulary (no panda terms, no gADR/doc references, no engine
+names), and must carry no per-game config file — a regression here means a
+coupling leaked back in. Fast tier, no engine.
+"""
+
+from __future__ import annotations
+
+import re
+
+import build_config
+
+FRAMEWORK_DIR = build_config.GAME_DIR / "tools" / "balancing"
+
+# Imports that would couple the framework to this game or its engine.
+_FORBIDDEN_IMPORTS = (
+    "import gda",
+    "from gda",
+    "import godot",
+    "import build_config",
+    "from build_config",
+    "import panda_balancing",
+    "from panda_balancing",
+)
+
+# Game/domain vocabulary the framework must describe generically instead
+# (word-boundary, case-insensitive): this game's name, its docs/decision
+# records, its engine, and its items/actors. "wave"/"warp"/"currency" etc. are
+# the framework's own model vocabulary and stay allowed.
+_FORBIDDEN_WORDS = re.compile(
+    r"\b(panda|gadr|game-context|godot|gdscript|spacesuit|laser|bun|wine|boss"
+    r"|gravity)\b",
+    re.IGNORECASE,
+)
+
+
+def _framework_sources() -> list:
+    files = sorted(FRAMEWORK_DIR.glob("*.py"))
+    assert files, f"no framework sources found under {FRAMEWORK_DIR}"
+    return files
+
+
+def test_framework_imports_no_game_code() -> None:
+    """The framework is pure-Python and game-agnostic: no Godot binding, no gda,
+    no game builder, no per-game plug-in — only stdlib and sibling modules."""
+    for path in _framework_sources():
+        source = path.read_text(encoding="utf-8")
+        for needle in _FORBIDDEN_IMPORTS:
+            assert needle not in source, f"{path.name} imports game code: {needle!r}"
+
+
+def test_framework_speaks_no_game_vocabulary() -> None:
+    """The framework's code and docs stay in its own model vocabulary — every
+    per-game term lives in the plug-in (adapter + targets), not the package."""
+    for path in _framework_sources():
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            hit = _FORBIDDEN_WORDS.search(line)
+            assert hit is None, (
+                f"{path.name}:{i} uses game vocabulary {hit.group(0)!r}: {line.strip()}"
+            )
+
+
+def test_framework_carries_no_per_game_config() -> None:
+    """No per-game configuration file lives inside the framework package — the
+    targets file is the plug-in's (``tools/panda_balancing/targets.json``)."""
+    strays = [p.name for p in FRAMEWORK_DIR.iterdir() if p.suffix == ".json"]
+    assert strays == [], f"per-game config inside the framework package: {strays}"

--- a/examples/platformer/panda-adventure/tests/test_balancing_predict.py
+++ b/examples/platformer/panda-adventure/tests/test_balancing_predict.py
@@ -209,6 +209,23 @@ def test_cli_predict_out_relative_traversal_is_refused(capsys, monkeypatch) -> N
     assert _tree_hash(DATA_DIR) == before
 
 
+def test_cli_predict_null_sd_model_is_structured_refusal(capsys, tmp_path) -> None:
+    """A ``sd_model: null`` targets document refuses as ``targets_invalid``
+    when predict reads its block — never a TypeError traceback (PR #493
+    re-review; config_dir/adapter point at the real ones so the parse is the
+    first failure)."""
+    doc = json.loads(TARGETS.read_text(encoding="utf-8"))
+    doc["sd_model"] = None
+    doc["config_dir"] = str(CONFIG_DIR)
+    doc["adapter"] = str(GAME_DIR / "tools" / "panda_balancing" / "adapter.py")
+    doc["no_write_roots"] = []
+    bad = tmp_path / "targets.json"
+    bad.write_text(json.dumps(doc), encoding="utf-8")
+    code = cli_main(["predict", "--targets", str(bad), "--json"])
+    assert code == EXIT_REFUSED
+    assert json.loads(capsys.readouterr().err)["error"] == "targets_invalid"
+
+
 def test_cli_predict_out_outside_authority_works(tmp_path) -> None:
     """A normal ``--out`` (tmp dir) is unaffected by the guard."""
     out = tmp_path / "prediction.json"

--- a/examples/platformer/panda-adventure/tests/test_balancing_predict.py
+++ b/examples/platformer/panda-adventure/tests/test_balancing_predict.py
@@ -19,15 +19,21 @@ from pathlib import Path
 import pytest
 
 import build_config
-from balancing import game_config, prediction, report
+from balancing import config, prediction
 from balancing.cli import EXIT_REFUSED, main as cli_main
+from balancing.model import build_player_model
+from panda_balancing import adapter
 
 GAME_DIR = build_config.GAME_DIR
 CONFIG_DIR = GAME_DIR / "data" / "json"
 GENERATED_DIR = GAME_DIR / "data" / "generated"
 DATA_DIR = GAME_DIR / "data"
-TARGETS = GAME_DIR / "tools" / "balancing" / "panda_adventure.targets.json"
-SD_SOURCE_DIR = GAME_DIR / "tools" / "balancing"
+TARGETS = GAME_DIR / "tools" / "panda_balancing" / "targets.json"
+
+
+def _cli(*args: str) -> list[str]:
+    """A CLI argv against the committed per-game targets file."""
+    return [args[0], "--targets", str(TARGETS), *args[1:]]
 
 
 def _tree_hash(*dirs: Path) -> str:
@@ -41,12 +47,14 @@ def _tree_hash(*dirs: Path) -> str:
 
 
 def _prediction():
-    cfg = report.load_pipeline_config(TARGETS)
-    sd = prediction.load_sd_config(TARGETS)
-    game = game_config.load_game_data(CONFIG_DIR)
-    econ = game_config.load_growth_economy(CONFIG_DIR)
-    player = game_config.build_player_model(game, cfg.player_model_params)
-    return prediction.run_prediction(game, econ, player, cfg.sim, sd), sd
+    cfg = config.load_pipeline_config(TARGETS)
+    sd = config.load_sd_config(TARGETS)
+    inputs = adapter.load_inputs(CONFIG_DIR)
+    player = build_player_model(inputs.game, cfg.player_model_params)
+    return (
+        prediction.run_prediction(inputs.game, inputs.economy, player, cfg.sim, sd),
+        sd,
+    )
 
 
 # --- Cross-validation vs MC (AC3) -------------------------------------------- #
@@ -100,7 +108,7 @@ def test_report_shape_and_design_targets() -> None:
     stocks, and the committed config MEETS its design targets (a green baseline
     for the predict gate)."""
     result, _ = _prediction()
-    game = game_config.load_game_data(CONFIG_DIR)
+    game = adapter.load_game_data(CONFIG_DIR)
     assert len(result.waves) == len(game.waves)
     assert result.design_targets_ok
     assert result.cleared_schedule  # the designed kit clears the schedule
@@ -115,13 +123,12 @@ def test_monotonic_ramp_target_gates_the_verdict() -> None:
     red — with ``expect_monotonic_ramp=True`` but the committed ramp dipping at
     the swarm Wave, ``design_targets_ok`` and ``ok`` are False (finding 4: the
     ramp target must gate the verdict, not merely be reported)."""
-    cfg = report.load_pipeline_config(TARGETS)
-    sd = prediction.load_sd_config(TARGETS)
+    cfg = config.load_pipeline_config(TARGETS)
+    sd = config.load_sd_config(TARGETS)
     sd = replace(sd, targets=replace(sd.targets, expect_monotonic_ramp=True))
-    game = game_config.load_game_data(CONFIG_DIR)
-    econ = game_config.load_growth_economy(CONFIG_DIR)
-    player = game_config.build_player_model(game, cfg.player_model_params)
-    result = prediction.run_prediction(game, econ, player, cfg.sim, sd)
+    inputs = adapter.load_inputs(CONFIG_DIR)
+    player = build_player_model(inputs.game, cfg.player_model_params)
+    result = prediction.run_prediction(inputs.game, inputs.economy, player, cfg.sim, sd)
     assert result.monotonic_ramp_actual is False  # the swarm Wave dips
     assert result.monotonic_ramp_ok is False  # expected True, actual False
     assert not result.design_targets_ok
@@ -150,7 +157,7 @@ def test_predict_writes_nothing() -> None:
 
 def test_cli_predict_default_verdict_is_green() -> None:
     """The default ``predict`` (committed targets) exits 0."""
-    assert cli_main(["predict", "--json"]) == 0
+    assert cli_main(_cli("predict", "--json")) == 0
 
 
 def test_cli_predict_json_writes_nothing(tmp_path) -> None:
@@ -158,7 +165,7 @@ def test_cli_predict_json_writes_nothing(tmp_path) -> None:
     path and writes nothing to the authority."""
     before = _tree_hash(CONFIG_DIR, GENERATED_DIR)
     out = tmp_path / "prediction.json"
-    code = cli_main(["predict", "--json", "--runs", "16", "--out", str(out)])
+    code = cli_main(_cli("predict", "--json", "--runs", "16", "--out", str(out)))
     assert code in (0, 1)  # a verdict, not a crash
     assert _tree_hash(CONFIG_DIR, GENERATED_DIR) == before
     doc = json.loads(out.read_text(encoding="utf-8"))
@@ -181,7 +188,7 @@ def test_cli_predict_out_into_authority_is_refused(capsys, forbidden: Path) -> N
     runs: structured error, ``EXIT_REFUSED``, authority byte-identical."""
     before = _tree_hash(DATA_DIR)
     existed_before = forbidden.exists()
-    code = cli_main(["predict", "--json", "--runs", "1", "--out", str(forbidden)])
+    code = cli_main(_cli("predict", "--json", "--runs", "1", "--out", str(forbidden)))
     assert code == EXIT_REFUSED
     err = json.loads(capsys.readouterr().err)
     assert err["error"] == "out_path_in_authority"
@@ -195,7 +202,7 @@ def test_cli_predict_out_relative_traversal_is_refused(capsys, monkeypatch) -> N
     monkeypatch.chdir(GAME_DIR / "tools")
     before = _tree_hash(DATA_DIR)
     code = cli_main(
-        ["predict", "--json", "--runs", "1", "--out", "../data/json/sneaky.json"]
+        _cli("predict", "--json", "--runs", "1", "--out", "../data/json/sneaky.json")
     )
     assert code == EXIT_REFUSED
     assert json.loads(capsys.readouterr().err)["error"] == "out_path_in_authority"
@@ -205,20 +212,10 @@ def test_cli_predict_out_relative_traversal_is_refused(capsys, monkeypatch) -> N
 def test_cli_predict_out_outside_authority_works(tmp_path) -> None:
     """A normal ``--out`` (tmp dir) is unaffected by the guard."""
     out = tmp_path / "prediction.json"
-    code = cli_main(["predict", "--json", "--runs", "1", "--out", str(out)])
+    code = cli_main(_cli("predict", "--json", "--runs", "1", "--out", str(out)))
     assert code in (0, 1)
     assert "cross_validation" in json.loads(out.read_text(encoding="utf-8"))
 
 
-# --- Game-agnostic: no game-code imports (AC6) ------------------------------- #
-
-
-def test_sd_modules_import_no_game_code() -> None:
-    """The SD modules are pure-Python and game-agnostic (gADR-0011): they import
-    no Godot binding, no gda, and no game builder — only stdlib and sibling
-    balancing modules."""
-    forbidden = ("import gda", "import godot", "import build_config", "from gda")
-    for name in ("integrate.py", "dynamics.py", "prediction.py"):
-        source = (SD_SOURCE_DIR / name).read_text(encoding="utf-8")
-        for needle in forbidden:
-            assert needle not in source, f"{name} imports game code: {needle!r}"
+# The game-agnostic guarantee (AC6) is pinned package-wide — imports AND
+# vocabulary — in ``test_balancing_isolation.py`` (gADR-0018).

--- a/examples/platformer/panda-adventure/tests/test_balancing_sim.py
+++ b/examples/platformer/panda-adventure/tests/test_balancing_sim.py
@@ -16,7 +16,6 @@ import math
 from random import Random
 
 import build_config
-from balancing import game_config
 from balancing.encounter import TimeField, run_wave, simulate_encounter
 from balancing.model import (
     CombatParams,
@@ -25,7 +24,9 @@ from balancing.model import (
     Spawn,
     StatBlock,
     Wave,
+    build_player_model,
 )
+from panda_balancing import adapter
 
 CONFIG_DIR = build_config.GAME_DIR / "data" / "json"
 
@@ -174,10 +175,10 @@ def test_spacesuit_defender_composition_from_json() -> None:
     config's base defense PLUS the items config's ``spacesuit_defense`` —
     composed exactly like ``ItemSystem.effective_defender`` (other stats copied,
     the attacker side stays the BASE block)."""
-    game = game_config.load_game_data(CONFIG_DIR)
+    game = adapter.load_game_data(CONFIG_DIR)
     combat_doc = json.loads((CONFIG_DIR / "combat_config.json").read_text())
     items_doc = json.loads((CONFIG_DIR / "items_config.json").read_text())
-    player = game_config.build_player_model(game, _PLAYER_MODEL_PARAMS)
+    player = build_player_model(game, _PLAYER_MODEL_PARAMS)
     base_defense = combat_doc["player_stats"]["defense"]
     bonus = items_doc["spacesuit_defense"]
     assert player.defender is not None
@@ -479,9 +480,9 @@ def test_determinism_same_seed() -> None:
 def test_reads_from_json_authority() -> None:
     """The sim runs from the game's real JSON authority alone (no game code):
     every wave produces finite, non-empty samples."""
-    game = game_config.load_game_data(CONFIG_DIR)
+    game = adapter.load_game_data(CONFIG_DIR)
     assert len(game.waves) == 4  # the demo's default schedule
-    player = game_config.build_player_model(game, _PLAYER_MODEL_PARAMS)
+    player = build_player_model(game, _PLAYER_MODEL_PARAMS)
     for wave in game.waves:
         samples = run_wave(
             player,

--- a/examples/platformer/panda-adventure/tests/test_balancing_validate.py
+++ b/examples/platformer/panda-adventure/tests/test_balancing_validate.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -152,6 +154,72 @@ def test_cli_out_outside_authority_still_works(tmp_path) -> None:
     code = cli_main(_cli("validate", "--json", "--runs", "1", "--out", str(out)))
     assert code in (0, 1)  # the verdict, never the refusal
     assert json.loads(out.read_text(encoding="utf-8"))["runs"] == 1
+
+
+@pytest.mark.parametrize(
+    "artifact", ["targets.json", "adapter.py"], ids=["targets", "adapter"]
+)
+def test_cli_out_onto_own_input_artifact_is_refused(capsys, artifact: str) -> None:
+    """An ``--out`` aimed at the run's own input artifacts (the targets file or
+    the adapter) is REFUSED automatically — no declared root needed — and the
+    artifact stays byte-identical (the self-clobber guard, PR #493 review)."""
+    target = GAME_DIR / "tools" / "panda_balancing" / artifact
+    before = target.read_bytes()
+    code = cli_main(_cli("validate", "--json", "--runs", "1", "--out", str(target)))
+    assert code == EXIT_REFUSED
+    assert json.loads(capsys.readouterr().err)["error"] == "out_path_in_authority"
+    assert target.read_bytes() == before
+
+
+def test_cli_non_object_targets_is_structured_refusal(capsys, tmp_path) -> None:
+    """A syntactically valid targets document whose root is not a JSON object
+    is a structured exit-2 refusal, never an AttributeError traceback."""
+    bad = tmp_path / "targets.json"
+    bad.write_text("[]", encoding="utf-8")
+    code = cli_main(["validate", "--targets", str(bad), "--json"])
+    assert code == EXIT_REFUSED
+    assert json.loads(capsys.readouterr().err)["error"] == "targets_invalid"
+
+
+def test_cli_adapter_import_failure_is_structured_refusal(capsys, tmp_path) -> None:
+    """An adapter that raises while importing is a structured exit-2 refusal
+    (``adapter_invalid``), never a traceback."""
+    doc = json.loads(TARGETS.read_text(encoding="utf-8"))
+    doc["config_dir"] = str(CONFIG_DIR)
+    doc["adapter"] = "boom.py"
+    doc["no_write_roots"] = []
+    (tmp_path / "boom.py").write_text("raise RuntimeError('broken adapter')\n")
+    bad = tmp_path / "targets.json"
+    bad.write_text(json.dumps(doc), encoding="utf-8")
+    code = cli_main(["validate", "--targets", str(bad), "--json"])
+    assert code == EXIT_REFUSED
+    err = json.loads(capsys.readouterr().err)
+    assert err["error"] == "adapter_invalid"
+    assert "broken adapter" in err["detail"]
+
+
+def test_documented_run_command_works() -> None:
+    """The plug-in's documented invocation — ``python -m balancing validate
+    --targets panda_balancing/targets.json`` from the ``tools/`` directory —
+    actually runs (a verdict, not a usage error)."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "balancing",
+            "validate",
+            "--targets",
+            "panda_balancing/targets.json",
+            "--json",
+            "--runs",
+            "1",
+        ],
+        cwd=GAME_DIR / "tools",
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode in (0, 1), proc.stderr
+    assert json.loads(proc.stdout)["runs"] == 1
 
 
 def test_cli_incomplete_player_model_is_structured_refusal(capsys, tmp_path) -> None:

--- a/examples/platformer/panda-adventure/tests/test_balancing_validate.py
+++ b/examples/platformer/panda-adventure/tests/test_balancing_validate.py
@@ -222,6 +222,44 @@ def test_documented_run_command_works() -> None:
     assert json.loads(proc.stdout)["runs"] == 1
 
 
+@pytest.mark.parametrize(
+    "field", ["player_model", "simulation", "waves"], ids=lambda f: f"{f}-null"
+)
+def test_cli_null_targets_block_is_structured_refusal(
+    capsys, tmp_path, field: str
+) -> None:
+    """A targets document whose nested block holds the wrong SHAPE (null where
+    an object/array belongs) is a structured exit-2 refusal, never a
+    TypeError traceback (PR #493 recheck)."""
+    doc = json.loads(TARGETS.read_text(encoding="utf-8"))
+    doc[field] = None
+    bad = tmp_path / "targets.json"
+    bad.write_text(json.dumps(doc), encoding="utf-8")
+    code = cli_main(["validate", "--targets", str(bad), "--json"])
+    assert code == EXIT_REFUSED
+    assert json.loads(capsys.readouterr().err)["error"] == "targets_invalid"
+
+
+def test_cli_adapter_returning_none_is_structured_refusal(capsys, tmp_path) -> None:
+    """An adapter whose ``load_inputs`` returns something other than
+    ``model.GameInputs`` (e.g. None) is a structured exit-2 refusal
+    (``adapter_invalid``), never an AttributeError traceback (PR #493 recheck)."""
+    doc = json.loads(TARGETS.read_text(encoding="utf-8"))
+    doc["config_dir"] = str(CONFIG_DIR)
+    doc["adapter"] = "none_adapter.py"
+    doc["no_write_roots"] = []
+    (tmp_path / "none_adapter.py").write_text(
+        "def load_inputs(config_dir):\n    return None\n"
+    )
+    bad = tmp_path / "targets.json"
+    bad.write_text(json.dumps(doc), encoding="utf-8")
+    code = cli_main(["validate", "--targets", str(bad), "--json"])
+    assert code == EXIT_REFUSED
+    err = json.loads(capsys.readouterr().err)
+    assert err["error"] == "adapter_invalid"
+    assert "GameInputs" in err["detail"]
+
+
 def test_cli_incomplete_player_model_is_structured_refusal(capsys, tmp_path) -> None:
     """A targets file missing a player-model assumption is a structured exit-2
     refusal (``targets_invalid``), never a KeyError traceback (gADR-0018)."""

--- a/examples/platformer/panda-adventure/tests/test_balancing_validate.py
+++ b/examples/platformer/panda-adventure/tests/test_balancing_validate.py
@@ -17,14 +17,21 @@ from pathlib import Path
 import pytest
 
 import build_config
-from balancing import game_config, report
+from balancing import config, report
 from balancing.cli import EXIT_REFUSED, main as cli_main
+from balancing.model import build_player_model
+from panda_balancing import adapter
 
 GAME_DIR = build_config.GAME_DIR
 CONFIG_DIR = GAME_DIR / "data" / "json"
 GENERATED_DIR = GAME_DIR / "data" / "generated"
 DATA_DIR = GAME_DIR / "data"
-TARGETS = GAME_DIR / "tools" / "balancing" / "panda_adventure.targets.json"
+TARGETS = GAME_DIR / "tools" / "panda_balancing" / "targets.json"
+
+
+def _cli(*args: str) -> list[str]:
+    """A CLI argv against the committed per-game targets file."""
+    return [args[0], "--targets", str(TARGETS), *args[1:]]
 
 
 def _tree_hash(*dirs: Path) -> str:
@@ -39,9 +46,9 @@ def _tree_hash(*dirs: Path) -> str:
 
 
 def _small_config() -> tuple:
-    cfg = report.load_pipeline_config(TARGETS)
-    game = game_config.load_game_data(CONFIG_DIR)
-    player = game_config.build_player_model(game, cfg.player_model_params)
+    cfg = config.load_pipeline_config(TARGETS)
+    game = adapter.load_game_data(CONFIG_DIR)
+    player = build_player_model(game, cfg.player_model_params)
     fast = type(cfg.sim)(dt=cfg.sim.dt, max_time=cfg.sim.max_time, runs=8, seed=1)
     return game, player, fast, cfg.targets
 
@@ -74,9 +81,9 @@ def test_validate_writes_nothing() -> None:
 def test_committed_targets_are_within_tolerance() -> None:
     """The committed design targets pass at the committed seed/run count — the
     demo's initial tune meets intent (a green baseline for the validate gate)."""
-    cfg = report.load_pipeline_config(TARGETS)
-    game = game_config.load_game_data(CONFIG_DIR)
-    player = game_config.build_player_model(game, cfg.player_model_params)
+    cfg = config.load_pipeline_config(TARGETS)
+    game = adapter.load_game_data(CONFIG_DIR)
+    player = build_player_model(game, cfg.player_model_params)
     result = report.run_validation(game, player, cfg.sim, cfg.targets)
     assert result.all_within_tolerance, report.format_text(result)
 
@@ -86,7 +93,7 @@ def test_cli_validate_json_writes_nothing(capsys, tmp_path) -> None:
     writes nothing to config; ``--out`` targets a non-config path only."""
     before = _tree_hash(CONFIG_DIR, GENERATED_DIR)
     out = tmp_path / "report.json"
-    code = cli_main(["validate", "--json", "--runs", "8", "--out", str(out)])
+    code = cli_main(_cli("validate", "--json", "--runs", "8", "--out", str(out)))
     assert code in (0, 1)  # a verdict, not a crash
     assert _tree_hash(CONFIG_DIR, GENERATED_DIR) == before
     doc = json.loads(out.read_text(encoding="utf-8"))
@@ -97,7 +104,7 @@ def test_cli_validate_json_writes_nothing(capsys, tmp_path) -> None:
 
 def test_cli_validate_default_verdict_is_green() -> None:
     """The default ``validate`` (committed targets, seed, runs) exits 0."""
-    assert cli_main(["validate", "--json"]) == 0
+    assert cli_main(_cli("validate", "--json")) == 0
 
 
 @pytest.mark.parametrize(
@@ -117,7 +124,7 @@ def test_cli_out_into_authority_is_refused(capsys, forbidden: Path) -> None:
     tolerance verdict), no file created, authority tree byte-identical."""
     before = _tree_hash(DATA_DIR)
     existed_before = forbidden.exists()
-    code = cli_main(["validate", "--json", "--runs", "1", "--out", str(forbidden)])
+    code = cli_main(_cli("validate", "--json", "--runs", "1", "--out", str(forbidden)))
     assert code == EXIT_REFUSED
     err = json.loads(capsys.readouterr().err)
     assert err["error"] == "out_path_in_authority"
@@ -131,7 +138,7 @@ def test_cli_out_relative_traversal_is_refused(capsys, monkeypatch) -> None:
     monkeypatch.chdir(GAME_DIR / "tools")
     before = _tree_hash(DATA_DIR)
     code = cli_main(
-        ["validate", "--json", "--runs", "1", "--out", "../data/json/sneaky.json"]
+        _cli("validate", "--json", "--runs", "1", "--out", "../data/json/sneaky.json")
     )
     assert code == EXIT_REFUSED
     assert json.loads(capsys.readouterr().err)["error"] == "out_path_in_authority"
@@ -142,6 +149,30 @@ def test_cli_out_outside_authority_still_works(tmp_path) -> None:
     """A normal ``--out`` (tmp dir) is unaffected by the guard and produces the
     report file."""
     out = tmp_path / "report.json"
-    code = cli_main(["validate", "--json", "--runs", "1", "--out", str(out)])
+    code = cli_main(_cli("validate", "--json", "--runs", "1", "--out", str(out)))
     assert code in (0, 1)  # the verdict, never the refusal
     assert json.loads(out.read_text(encoding="utf-8"))["runs"] == 1
+
+
+def test_cli_incomplete_player_model_is_structured_refusal(capsys, tmp_path) -> None:
+    """A targets file missing a player-model assumption is a structured exit-2
+    refusal (``targets_invalid``), never a KeyError traceback (gADR-0018)."""
+    doc = json.loads(TARGETS.read_text(encoding="utf-8"))
+    del doc["player_model"]["accuracy"]
+    bad = tmp_path / "targets.json"
+    bad.write_text(json.dumps(doc), encoding="utf-8")
+    code = cli_main(["validate", "--targets", str(bad), "--json"])
+    assert code == EXIT_REFUSED
+    err = json.loads(capsys.readouterr().err)
+    assert err["error"] == "targets_invalid"
+    assert "accuracy" in err["detail"]
+
+
+def test_cli_unloadable_config_dir_is_structured_refusal(capsys, tmp_path) -> None:
+    """A config dir the adapter cannot load from (missing files) is a structured
+    exit-2 refusal (``game_config_invalid``), never a traceback (gADR-0018)."""
+    code = cli_main(
+        _cli("validate", "--json", "--config-dir", str(tmp_path / "nowhere"))
+    )
+    assert code == EXIT_REFUSED
+    assert json.loads(capsys.readouterr().err)["error"] == "game_config_invalid"

--- a/examples/platformer/panda-adventure/tests/test_balancing_validate.py
+++ b/examples/platformer/panda-adventure/tests/test_balancing_validate.py
@@ -223,14 +223,25 @@ def test_documented_run_command_works() -> None:
 
 
 @pytest.mark.parametrize(
-    "field", ["player_model", "simulation", "waves"], ids=lambda f: f"{f}-null"
+    "field",
+    [
+        "player_model",
+        "simulation",
+        "waves",
+        "config_dir",
+        "adapter",
+        "tolerance",
+        "no_write_roots",
+    ],
+    ids=lambda f: f"{f}-null",
 )
-def test_cli_null_targets_block_is_structured_refusal(
+def test_cli_null_targets_field_is_structured_refusal(
     capsys, tmp_path, field: str
 ) -> None:
-    """A targets document whose nested block holds the wrong SHAPE (null where
-    an object/array belongs) is a structured exit-2 refusal, never a
-    TypeError traceback (PR #493 recheck)."""
+    """A targets document where ANY consumed field holds the wrong SHAPE (null
+    where an object/array/string/number belongs) is a structured exit-2
+    refusal at the schema boundary, never a TypeError traceback — including
+    the path-valued fields resolved later (PR #493 re-review)."""
     doc = json.loads(TARGETS.read_text(encoding="utf-8"))
     doc[field] = None
     bad = tmp_path / "targets.json"
@@ -238,6 +249,14 @@ def test_cli_null_targets_block_is_structured_refusal(
     code = cli_main(["validate", "--targets", str(bad), "--json"])
     assert code == EXIT_REFUSED
     assert json.loads(capsys.readouterr().err)["error"] == "targets_invalid"
+
+
+def test_cli_nonpositive_runs_is_structured_refusal(capsys) -> None:
+    """A non-positive simulation control (here ``--runs 0``, the CLI-override
+    path) refuses as ``sim_invalid`` instead of crashing inside the sim."""
+    code = cli_main(_cli("validate", "--json", "--runs", "0"))
+    assert code == EXIT_REFUSED
+    assert json.loads(capsys.readouterr().err)["error"] == "sim_invalid"
 
 
 def test_cli_adapter_returning_none_is_structured_refusal(capsys, tmp_path) -> None:

--- a/examples/platformer/panda-adventure/tests/test_balancing_validate.py
+++ b/examples/platformer/panda-adventure/tests/test_balancing_validate.py
@@ -251,6 +251,32 @@ def test_cli_null_targets_field_is_structured_refusal(
     assert json.loads(capsys.readouterr().err)["error"] == "targets_invalid"
 
 
+@pytest.mark.parametrize(
+    "field", ["config_dir", "adapter", "no_write_roots"], ids=lambda f: f"{f}-nul"
+)
+def test_cli_nul_path_string_is_structured_refusal(capsys, tmp_path, field) -> None:
+    """A syntactically valid JSON string the OS cannot treat as a path (an
+    embedded NUL) refuses as ``targets_invalid`` — never a ValueError
+    traceback from ``Path.resolve()`` (PR #493 re-review). Covers every
+    path-valued targets field, which all funnel through ``resolve_against``."""
+    doc = json.loads(TARGETS.read_text(encoding="utf-8"))
+    doc[field] = ["bad\x00path"] if field == "no_write_roots" else "bad\x00path"
+    bad = tmp_path / "targets.json"
+    bad.write_text(json.dumps(doc), encoding="utf-8")
+    code = cli_main(["validate", "--targets", str(bad), "--json"])
+    assert code == EXIT_REFUSED
+    assert json.loads(capsys.readouterr().err)["error"] == "targets_invalid"
+
+
+@pytest.mark.parametrize("flag", ["--config-dir", "--out"])
+def test_cli_nul_path_argument_is_structured_refusal(capsys, flag: str) -> None:
+    """The CLI's own path arguments share the invalid-OS-path class: an
+    embedded-NUL value refuses as ``path_invalid``, never a traceback."""
+    code = cli_main(_cli("validate", "--json", "--runs", "1", flag, "bad\x00path"))
+    assert code == EXIT_REFUSED
+    assert json.loads(capsys.readouterr().err)["error"] == "path_invalid"
+
+
 def test_cli_nonpositive_runs_is_structured_refusal(capsys) -> None:
     """A non-positive simulation control (here ``--runs 0``, the CLI-override
     path) refuses as ``sim_invalid`` instead of crashing inside the sim."""

--- a/examples/platformer/panda-adventure/tools/assets/__init__.py
+++ b/examples/platformer/panda-adventure/tools/assets/__init__.py
@@ -2,10 +2,13 @@
 
 A ``Tool Script`` (GAME-CONTEXT.md) that acquires and conforms the game's textures
 (and, in later slices, sprites/audio/fonts), WITHOUT importing any game code —
-game-agnostic core plus a per-game plug-in, exactly like ``tools/balancing/``
-(gADR-0014). The core is the deep module the wave-3 asset round-outs
-(#442/#443/#444/#445) reuse; there is deliberately NO shared ``tools/_core`` (the
-two pipelines share the two-layer *pattern*, not code).
+game-agnostic core plus a per-game plug-in, the two-layer pattern it shares with
+the Balancing pipeline (gADR-0014). The core is the deep module the wave-3 asset
+round-outs (#442/#443/#444/#445) reuse; there is deliberately NO shared
+``tools/_core`` (the two pipelines share the two-layer *pattern*, not code).
+Since gADR-0018 the Balancing pipeline keeps its per-game half in a SIBLING
+plug-in package (``tools/panda_balancing/``); this pipeline still keeps its
+plug-in in-package — migrating it likewise is an open follow-up.
 
 Two layers:
 

--- a/examples/platformer/panda-adventure/tools/assets/game_config.py
+++ b/examples/platformer/panda-adventure/tools/assets/game_config.py
@@ -1,7 +1,7 @@
 """Panda Adventure plug-in: load the Style descriptor + per-asset acquire recipes.
 
 The ONE per-game module of the asset pipeline (gADR-0014's per-game configuration,
-the analogue of ``balancing/game_config.py``). It knows this game's on-disk shape —
+the analogue of ``panda_balancing/adapter.py``). It knows this game's on-disk shape —
 ``panda_adventure.style.json`` (the Style descriptor, the CC0/CC-BY sources, the
 generation channels, and the per-asset acquire recipes) and ``scale_spec.json`` (the
 single size authority, gADR-0013) — and maps them into the game-agnostic core's
@@ -19,7 +19,8 @@ from typing import Any
 from .backends import BuiltinBackend, GenerationBackend, McpBackend
 from .model import Source, StyleDescriptor
 
-# The committed per-game config, next to this module (the balancing targets idiom).
+# The committed per-game config, next to this module (the pre-gADR-0018 layout;
+# the balancing pipeline's per-game config now lives in its own plug-in package).
 DEFAULT_STYLE_PATH = Path(__file__).resolve().parent / "panda_adventure.style.json"
 # tools/assets/ -> tools/ -> <game root>.
 GAME_ROOT = Path(__file__).resolve().parents[2]

--- a/examples/platformer/panda-adventure/tools/balancing/__init__.py
+++ b/examples/platformer/panda-adventure/tools/balancing/__init__.py
@@ -1,49 +1,57 @@
-"""Balancing pipeline — the twin Monte-Carlo + system-dynamics engines (gADR-0011).
+"""Balancing pipeline — twin Monte-Carlo + system-dynamics engines, game-agnostic.
 
-A `Tool Script` (GAME-CONTEXT.md) that tunes the game's numbers against design
-intent, WITHOUT importing any game code. Per gADR-0011 the pipeline is
-deliberately isolated from the game's GDScript: it reads the same authoritative
-JSON configs the game derives its Resources from, reimplements the combat/AI
-rules in Python, and pins that reimplementation against the shipped GDScript
-logic seams with golden parity fixtures (so a rule change on either side goes
-red). It writes nothing back to config (both modes are pure reads).
+A reusable numeric-design tool that tunes a game's numbers against design
+intent WITHOUT importing any game code. It reads the game's authoritative
+config through a per-game adapter, reimplements nothing game-specific, and
+writes nothing back (both modes are pure reads).
 
 Two engines share the framework:
 
-- **Monte-Carlo encounter simulation** (`validate`, #437) — micro fidelity: one
-  encounter at a time, stochastic, aggregated to per-Wave TTK/TTD distributions.
-- **System-dynamics model** (`predict`, #440) — macro fidelity: a first-order
-  nonlinear ODE over the whole run's growth/economy stocks and flows, integrated
-  by a hand-rolled RK4, cross-validated against MC on their overlapping domain.
+- **Monte-Carlo encounter simulation** (``validate``) — micro fidelity: one
+  encounter at a time, stochastic, aggregated to per-wave TTK/TTD
+  distributions and checked against design targets.
+- **System-dynamics model** (``predict``) — macro fidelity: a first-order
+  nonlinear ODE over the whole run's growth/economy stocks and flows,
+  integrated by a hand-rolled RK4, cross-validated against MC on their
+  overlapping domain.
 
-Two layers:
+The public surface is deliberately small — everything else is internals:
 
-- **Game-agnostic core** — the reusable pipeline structure, decoupled from any
-  one game's engine or code:
-  - `model` — plain dataclasses both engines run on (stat blocks, enemy kinds,
-    waves, the player model, sim config, design targets, the growth/economy
-    reward + Leveling data).
-  - `encounter` — the time-stepped Monte-Carlo encounter simulation; a fixed
-    seed makes it deterministic.
-  - `statistics` — the deterministic aggregation stages (distributions:
-    mean/median/percentiles) over the per-run TTK/TTD samples.
-  - `report` — validate mode: per-wave measured TTK/TTD vs targets, within a
-    configurable tolerance. Pure read; emits a report object, never config.
-  - `integrate` — the hand-rolled fixed-step RK4 integrator (stdlib-only).
-  - `dynamics` — the system-dynamics state model: the run's growth/economy
-    stocks + flows as a first-order nonlinear ODE system.
-  - `prediction` — predict mode: the long-term SD trajectory vs difficulty/growth
-    design targets, plus the MC cross-validation. Pure read; emits a report object.
-  - `cli` — the `python -m balancing {validate,predict} ...` entry point.
+- the **CLI**: ``python -m balancing {validate,predict} --targets <file>``
+  (see ``cli`` for flags and the 0/1/2 exit contract);
+- the **targets file**: one JSON document holding the whole per-game
+  configuration — config location, adapter, protected write roots, player-model
+  assumptions, sim controls, and design targets (schema in ``config``);
+- the **adapter contract**: a game-side Python file, named by the targets
+  file, exporting ``load_inputs(config_dir) -> model.GameInputs`` — it maps the
+  game's on-disk config into the generic ``model`` dataclasses and is the only
+  code a game contributes. The framework never imports a game; the adapter
+  consumes only the public ``model`` types.
 
-- **Per-game plug-ins** (Panda Adventure's instantiation) — no game *code*, only
-  Python reimplementation and JSON reading:
-  - `rules` — the pure Python reimplementation of the `CombatSystem`/`EnemyAI`
-    logic seams (GAME-CONTEXT.md), the functions the parity fixtures pin.
-  - `game_config` — the adapter that maps this game's JSON authority
-    (`data/json/*.json`) into the generic `model`. Reads JSON only; imports no
-    game code.
-  - `panda_adventure.targets.json` — the design targets, tolerances, player-model
-    assumptions, simulation controls, and the SD model params/levers (per-game
-    configuration).
+Internal layout (consumed through the surface above):
+
+- ``model``      — the plain dataclasses both engines run on.
+- ``rules``      — the reference ruleset: pure, deterministic decision
+  functions (damage, gates, steering, warp kit, leveling). A host game is
+  expected to pin its own engine-side implementation against these with golden
+  parity fixtures, generated from the game side (that gate lives with the
+  game, not here).
+- ``encounter``  — the time-stepped Monte-Carlo encounter simulation; a fixed
+  seed makes it deterministic.
+- ``statistics`` — deterministic aggregation (mean/median/percentiles) over
+  per-run TTK/TTD samples.
+- ``report``     — validate mode: per-wave measured TTK/TTD vs targets.
+- ``integrate``  — the hand-rolled fixed-step RK4 integrator (stdlib-only).
+- ``dynamics``   — the system-dynamics stocks/flows model (generic currency +
+  item stocks, a configurable heal-item loop).
+- ``prediction`` — predict mode: the long-term SD trajectory vs design
+  targets, plus the MC cross-validation.
+- ``config``     — the targets-file schema, the adapter loader, and the
+  protected-root resolution.
+- ``cli``        — the entry point.
+
+Guarantees: pure stdlib (no dependencies), deterministic under a fixed seed,
+never writes into a protected config tree (refused before anything runs), and
+no game imports or game vocabulary inside the package — the host project's
+test suite is expected to pin that isolation.
 """

--- a/examples/platformer/panda-adventure/tools/balancing/cli.py
+++ b/examples/platformer/panda-adventure/tools/balancing/cli.py
@@ -15,9 +15,11 @@ The per-game wiring is entirely config-driven: the required ``--targets`` file
 names the game's config dir, the adapter that maps it into the generic model,
 and the protected write roots. Emission goes to stdout (text or ``--json``) or
 an ``--out`` path. Every refused or invalid input — an ``--out`` inside a
-protected root, an unreadable targets file, a broken adapter, or game config
-the adapter cannot map — is a structured error on stderr with exit 2, distinct
-from the 0/1 verdict, and is raised BEFORE anything runs.
+protected root (including the targets/adapter files themselves), an unreadable
+targets file, a broken adapter, or game config the adapter cannot map — is a
+structured error on stderr with exit 2, distinct from the 0/1 verdict, and is
+raised BEFORE anything runs (an ``--out`` that turns out unwritable is the one
+write-time case, refused with the same envelope).
 """
 
 from __future__ import annotations
@@ -58,9 +60,15 @@ def _check_out(out: Path | None, roots: list[Path]) -> None:
 
 
 def _emit(doc: dict, text: str, out: Path | None, as_json: bool) -> None:
-    """Emit a report: to ``--out`` as JSON, else JSON or text to stdout."""
+    """Emit a report: to ``--out`` as JSON, else JSON or text to stdout. An
+    unwritable ``--out`` is a structured refusal like every other bad input."""
     if out is not None:
-        out.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+        try:
+            out.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+        except OSError as exc:
+            raise config.ConfigError(
+                "out_unwritable", f"cannot write the report to --out {out}: {exc}"
+            )
     elif as_json:
         print(json.dumps(doc, indent=2))
     else:
@@ -138,9 +146,12 @@ def _load_inputs(
     adapter = config.load_adapter(cfg, args.targets)
     try:
         inputs: model.GameInputs = adapter.load_inputs(config_dir)
-    except (OSError, KeyError, ValueError) as exc:
-        # The bad-input family (missing dir/file, missing key, bad JSON) becomes
-        # a structured refusal; genuine adapter bugs still trace.
+    except config.ConfigError:
+        raise  # an adapter may speak the structured contract itself
+    except Exception as exc:
+        # Any adapter failure is a bad per-game input to THIS tool: a
+        # structured refusal, never a traceback (process interrupts stay
+        # BaseException and pass through).
         raise config.ConfigError(
             "game_config_invalid",
             f"the adapter failed to load the game config from {config_dir}: {exc!r}",

--- a/examples/platformer/panda-adventure/tools/balancing/cli.py
+++ b/examples/platformer/panda-adventure/tools/balancing/cli.py
@@ -48,7 +48,12 @@ def _check_out(out: Path | None, roots: list[Path]) -> None:
     ``../`` cannot sneak in."""
     if out is None:
         return
-    resolved = out.resolve()
+    try:
+        resolved = out.resolve()
+    except (ValueError, OSError) as exc:
+        raise config.ConfigError(
+            "path_invalid", f"--out {str(out)!r} is not a valid path: {exc}"
+        )
     for root in roots:
         if resolved == root or resolved.is_relative_to(root):
             raise config.ConfigError(

--- a/examples/platformer/panda-adventure/tools/balancing/cli.py
+++ b/examples/platformer/panda-adventure/tools/balancing/cli.py
@@ -168,6 +168,14 @@ def _load_inputs(
             f"carrying a model.GameData, got {type(inputs).__name__}",
         )
     sim = _sim_with_overrides(cfg.sim, args.seed, args.runs)
+    if sim.dt <= 0 or sim.max_time <= 0 or sim.runs <= 0:
+        # Guards the file values AND the CLI overrides in one place: a
+        # non-positive control would only crash later inside the sim.
+        raise config.ConfigError(
+            "sim_invalid",
+            "simulation controls must be positive "
+            f"(dt={sim.dt}, max_time={sim.max_time}, runs={sim.runs})",
+        )
     return cfg, inputs, sim
 
 

--- a/examples/platformer/panda-adventure/tools/balancing/cli.py
+++ b/examples/platformer/panda-adventure/tools/balancing/cli.py
@@ -156,6 +156,17 @@ def _load_inputs(
             "game_config_invalid",
             f"the adapter failed to load the game config from {config_dir}: {exc!r}",
         )
+    if not isinstance(inputs, model.GameInputs) or not isinstance(
+        inputs.game, model.GameData
+    ):
+        # The return-shape half of the adapter contract (the callable half is
+        # checked at load time): anything but a GameInputs with a GameData
+        # inside is a broken adapter, refused with the same envelope.
+        raise config.ConfigError(
+            "adapter_invalid",
+            "adapter load_inputs(config_dir) must return model.GameInputs "
+            f"carrying a model.GameData, got {type(inputs).__name__}",
+        )
     sim = _sim_with_overrides(cfg.sim, args.seed, args.runs)
     return cfg, inputs, sim
 

--- a/examples/platformer/panda-adventure/tools/balancing/cli.py
+++ b/examples/platformer/panda-adventure/tools/balancing/cli.py
@@ -1,20 +1,23 @@
-"""The balancing pipeline CLI: ``python -m balancing {validate,predict} ...``.
+"""The balancing pipeline CLI: ``python -m balancing {validate,predict} --targets <file>``.
 
-Two modes over the SAME JSON authority + targets file, both a PURE READ that
-writes NOTHING to config (gADR-0011):
+Two modes over the SAME per-game targets file (see ``config`` for the schema),
+both a PURE READ that writes NOTHING to the game's config:
 
-- **validate** (#437) — runs the Monte-Carlo encounter simulation and emits a
-  per-Wave TTK/TTD-vs-targets report. Exit 0 when every targeted Wave is within
+- **validate** — runs the Monte-Carlo encounter simulation and emits a per-wave
+  TTK/TTD-vs-targets report. Exit 0 when every targeted wave is within
   tolerance, 1 when any is out of tolerance.
-- **predict** (#440) — integrates the long-term system-dynamics growth/economy
+- **predict** — integrates the long-term system-dynamics growth/economy
   trajectory and emits it against the difficulty/growth design targets, plus the
   MC cross-validation. Exit 0 when the prediction meets its design targets AND
-  every overlapping Wave cross-validates within tolerance, 1 otherwise.
+  every overlapping wave cross-validates within tolerance, 1 otherwise.
 
-Emission goes to stdout (text or ``--json``) or an ``--out`` path. An ``--out``
-inside the game's ``data/`` tree (the whole authority chain — authored JSON,
-schemas, derived Resources) or inside the configured authority dir is REFUSED
-with a structured error before anything runs (exit 2, distinct from the verdict).
+The per-game wiring is entirely config-driven: the required ``--targets`` file
+names the game's config dir, the adapter that maps it into the generic model,
+and the protected write roots. Emission goes to stdout (text or ``--json``) or
+an ``--out`` path. Every refused or invalid input — an ``--out`` inside a
+protected root, an unreadable targets file, a broken adapter, or game config
+the adapter cannot map — is a structured error on stderr with exit 2, distinct
+from the 0/1 verdict, and is raised BEFORE anything runs.
 """
 
 from __future__ import annotations
@@ -22,65 +25,36 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from dataclasses import replace
 from pathlib import Path
 
-from . import game_config, prediction, report
-
-# Default targets file (this game's per-game configuration), next to this module.
-_DEFAULT_TARGETS = Path(__file__).resolve().parent / "panda_adventure.targets.json"
-# The game root is tools/balancing/ -> tools/ -> <game>. config_dir is resolved
-# against it when the targets file gives a relative path.
-_GAME_ROOT = Path(__file__).resolve().parents[2]
+from . import config, model, prediction, report
 
 # The usage/refusal exit code — distinct from the tolerance verdict (0/1).
 EXIT_REFUSED = 2
 
 
-def forbidden_out_roots(config_dir: Path) -> list[Path]:
-    """The directory trees a report must never land in (gADR-0011: this slice
-    writes nothing to config).
-
-    The game's whole ``data/`` tree is forbidden — not just ``data/json``: it
-    is the config authority CHAIN (authored JSON + the schemas that validate it
-    + the derived ``data/generated`` Resources), and no report legitimately
-    belongs anywhere in it. The resolved authority dir itself (and its parent
-    ``data/`` tree, for a copied project root) is forbidden too, so a
-    ``--config-dir`` pointing at an e2e copy is equally protected.
-    """
-    roots = [(_GAME_ROOT / "data").resolve(), config_dir.resolve()]
-    if config_dir.resolve().parent.name == "data":
-        roots.append(config_dir.resolve().parent)
-    return roots
-
-
-def _refuse_authority_out(out: Path, config_dir: Path) -> str | None:
-    """The reason ``--out`` is refused (a path inside an authority tree), or
-    None when it is safe. Resolves the path first so ``../`` cannot sneak in."""
-    resolved = out.resolve()
-    for root in forbidden_out_roots(config_dir):
-        if resolved == root or resolved.is_relative_to(root):
-            return (
-                f"--out {out} resolves into the config authority tree {root}; "
-                "the Balancing pipeline writes nothing to config "
-                "(gADR-0011) — choose a path outside data/"
-            )
-    return None
-
-
-def _guard_out(out: Path | None, config_dir: Path) -> int | None:
-    """The shared no-write guard both modes run BEFORE the sim: if ``out`` lands
-    in an authority tree, print the structured error and return ``EXIT_REFUSED``;
-    otherwise None (safe to proceed)."""
-    if out is None:
-        return None
-    reason = _refuse_authority_out(out, config_dir)
-    if reason is None:
-        return None
-    print(
-        json.dumps({"error": "out_path_in_authority", "detail": reason}),
-        file=sys.stderr,
-    )
+def _fail(code: str, detail: str) -> int:
+    """Print a structured refusal to stderr and return ``EXIT_REFUSED``."""
+    print(json.dumps({"error": code, "detail": detail}), file=sys.stderr)
     return EXIT_REFUSED
+
+
+def _check_out(out: Path | None, roots: list[Path]) -> None:
+    """The shared no-write guard both modes run BEFORE the sim: an ``--out``
+    inside a protected root raises the refusal. Resolves the path first so
+    ``../`` cannot sneak in."""
+    if out is None:
+        return
+    resolved = out.resolve()
+    for root in roots:
+        if resolved == root or resolved.is_relative_to(root):
+            raise config.ConfigError(
+                "out_path_in_authority",
+                f"--out {out} resolves into the protected config tree {root}; "
+                "the balancing pipeline writes nothing to config — choose a "
+                "path outside it",
+            )
 
 
 def _emit(doc: dict, text: str, out: Path | None, as_json: bool) -> None:
@@ -93,36 +67,20 @@ def _emit(doc: dict, text: str, out: Path | None, as_json: bool) -> None:
         print(text)
 
 
-def _resolve_config_dir(config_dir: str, targets_path: Path) -> Path:
-    """Resolve the targets file's ``config_dir`` to an absolute path.
-
-    Absolute paths pass through; a relative path resolves against the game root
-    (so the committed ``data/json`` default works from any CWD), then falls back
-    to the targets file's own directory.
-    """
-    p = Path(config_dir)
-    if p.is_absolute():
-        return p
-    from_root = _GAME_ROOT / p
-    if from_root.exists():
-        return from_root
-    return (targets_path.parent / p).resolve()
-
-
 def _add_common_args(p: argparse.ArgumentParser) -> None:
-    """The args every mode shares (both read the same authority + targets file and
-    emit the same way, writing nothing to config)."""
+    """The args every mode shares (both read the same targets file and emit the
+    same way, writing nothing to config)."""
     p.add_argument(
         "--targets",
         type=Path,
-        default=_DEFAULT_TARGETS,
-        help="targets file (default: the committed panda_adventure targets)",
+        required=True,
+        help="the per-game targets file (config dir, adapter, design targets)",
     )
     p.add_argument(
         "--config-dir",
         type=Path,
         default=None,
-        help="override the JSON authority dir (default: the targets file's config_dir)",
+        help="override the game's config-authority dir (default: the targets file's config_dir)",
     )
     p.add_argument(
         "--out",
@@ -156,32 +114,46 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _sim_with_overrides(sim, seed: int | None, runs: int | None):
+def _sim_with_overrides(
+    sim: model.SimConfig, seed: int | None, runs: int | None
+) -> model.SimConfig:
     """Apply the ``--seed`` / ``--runs`` CLI overrides to a ``SimConfig``."""
     if seed is not None:
-        sim = type(sim)(dt=sim.dt, max_time=sim.max_time, runs=sim.runs, seed=seed)
+        sim = replace(sim, seed=seed)
     if runs is not None:
-        sim = type(sim)(dt=sim.dt, max_time=sim.max_time, runs=runs, seed=sim.seed)
+        sim = replace(sim, runs=runs)
     return sim
 
 
-def _run_validate(args: argparse.Namespace) -> int:
-    cfg = report.load_pipeline_config(args.targets)
-    config_dir = (
-        args.config_dir
-        if args.config_dir is not None
-        else _resolve_config_dir(cfg.config_dir, args.targets)
-    )
-    # The no-write guard runs BEFORE the sim: a forbidden --out is refused with
-    # a structured error and EXIT_REFUSED — never the tolerance verdict.
-    refused = _guard_out(args.out, config_dir)
-    if refused is not None:
-        return refused
-    game = game_config.load_game_data(config_dir)
-    player = game_config.build_player_model(game, cfg.player_model_params)
+def _load_inputs(
+    args: argparse.Namespace,
+) -> tuple[config.PipelineConfig, model.GameInputs, model.SimConfig]:
+    """The shared per-game front door both modes run, entirely from the targets
+    file: parse it, resolve the config dir, run the no-write guard BEFORE the
+    sim, then let the configured adapter map the game's config into the model.
+    Every refusal raises a ``ConfigError`` (the structured exit-2 path)."""
+    cfg = config.load_pipeline_config(args.targets)
+    config_dir = config.resolve_config_dir(cfg, args.targets, args.config_dir)
+    _check_out(args.out, config.forbidden_out_roots(cfg, args.targets, config_dir))
+    adapter = config.load_adapter(cfg, args.targets)
+    try:
+        inputs: model.GameInputs = adapter.load_inputs(config_dir)
+    except (OSError, KeyError, ValueError) as exc:
+        # The bad-input family (missing dir/file, missing key, bad JSON) becomes
+        # a structured refusal; genuine adapter bugs still trace.
+        raise config.ConfigError(
+            "game_config_invalid",
+            f"the adapter failed to load the game config from {config_dir}: {exc!r}",
+        )
     sim = _sim_with_overrides(cfg.sim, args.seed, args.runs)
+    return cfg, inputs, sim
 
-    result = report.run_validation(game, player, sim, cfg.targets)
+
+def _run_validate(args: argparse.Namespace) -> int:
+    cfg, inputs, sim = _load_inputs(args)
+    player = model.build_player_model(inputs.game, cfg.player_model_params)
+
+    result = report.run_validation(inputs.game, player, sim, cfg.targets)
     _emit(
         report.report_to_dict(result), report.format_text(result), args.out, args.json
     )
@@ -189,23 +161,19 @@ def _run_validate(args: argparse.Namespace) -> int:
 
 
 def _run_predict(args: argparse.Namespace) -> int:
-    cfg = report.load_pipeline_config(args.targets)
-    sd_config = prediction.load_sd_config(args.targets)
-    config_dir = (
-        args.config_dir
-        if args.config_dir is not None
-        else _resolve_config_dir(cfg.config_dir, args.targets)
-    )
-    # The same no-write guard as validate, BEFORE anything runs (gADR-0011).
-    refused = _guard_out(args.out, config_dir)
-    if refused is not None:
-        return refused
-    game = game_config.load_game_data(config_dir)
-    econ = game_config.load_growth_economy(config_dir)
-    player = game_config.build_player_model(game, cfg.player_model_params)
-    sim = _sim_with_overrides(cfg.sim, args.seed, args.runs)
+    cfg, inputs, sim = _load_inputs(args)
+    if inputs.economy is None:
+        return _fail(
+            "economy_missing",
+            "predict needs growth/economy inputs, but the adapter returned "
+            "GameInputs.economy = None (validate-only adapter)",
+        )
+    sd_config = config.load_sd_config(args.targets)
+    player = model.build_player_model(inputs.game, cfg.player_model_params)
 
-    result = prediction.run_prediction(game, econ, player, sim, sd_config)
+    result = prediction.run_prediction(
+        inputs.game, inputs.economy, player, sim, sd_config
+    )
     _emit(
         prediction.report_to_dict(result),
         prediction.format_text(result),
@@ -217,11 +185,14 @@ def _run_predict(args: argparse.Namespace) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
-    if args.command == "validate":
-        return _run_validate(args)
-    if args.command == "predict":
-        return _run_predict(args)
-    return 2  # unreachable: subparser is required
+    try:
+        if args.command == "validate":
+            return _run_validate(args)
+        if args.command == "predict":
+            return _run_predict(args)
+    except config.ConfigError as exc:
+        return _fail(exc.code, exc.detail)
+    return EXIT_REFUSED  # unreachable: subparser is required
 
 
 if __name__ == "__main__":

--- a/examples/platformer/panda-adventure/tools/balancing/config.py
+++ b/examples/platformer/panda-adventure/tools/balancing/config.py
@@ -1,0 +1,250 @@
+"""The targets file and the adapter contract — the pipeline's whole per-game surface.
+
+One JSON document (the **targets file**) wires a game into the pipeline without
+touching the package. Its schema (every path is resolved relative to the targets
+file's own directory, so a targets file is relocatable with its game):
+
+- ``config_dir``   — the game's config-authority directory, handed verbatim to
+  the adapter.
+- ``adapter``      — the per-game adapter: a Python file exporting
+  ``load_inputs(config_dir: Path) -> model.GameInputs`` that maps the game's
+  on-disk config shape into the generic model. It consumes the pipeline's
+  public ``model`` types and lives OUTSIDE this package.
+- ``no_write_roots`` — optional: directory trees a report ``--out`` must never
+  land in (the game's config-authority chain). The effective config dir itself
+  is always protected — even under a ``--config-dir`` override — but the
+  override's SURROUNDING tree is not: tree-level protection comes only from
+  these declared roots, so to run against a copied project with full
+  protection, use a targets file living with the copy.
+- ``player_model`` — the design player-model assumptions (``fire_interval``,
+  ``accuracy``, ``dodge_chance``, ``engagement_distance``).
+- ``simulation``   — the Monte-Carlo controls (``dt``, ``max_time``, ``runs``,
+  ``seed``).
+- ``tolerance`` / ``waves`` — the validate-mode design targets: the relative
+  tolerance and the per-wave TTK/TTD intents.
+- ``sd_model``     — the predict-mode block: ``params`` (``dt``,
+  ``max_wave_time``, ``growth_gain``, ``heal_threshold_frac``,
+  ``heal_consume_rate``), ``cross_validation.tolerance``, and ``targets``
+  (``growth`` checkpoints/final level, ``difficulty`` ramp expectations).
+
+Any free-form documentation keys (model assumptions, notes) are the game's own;
+the pipeline ignores what it does not know.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from .dynamics import SdParams
+from .model import SimConfig, Targets, WaveTarget
+
+
+class ConfigError(Exception):
+    """A refused or invalid per-game input (targets file or adapter), carrying
+    a stable machine-readable ``code`` alongside the human ``detail``."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.code = code
+        self.detail = detail
+
+
+# The design player-model assumptions every targets file must supply — the
+# inputs ``model.build_player_model`` consumes. Validated here (the schema
+# home) so a missing key is a structured refusal, not a KeyError traceback.
+PLAYER_MODEL_KEYS = ("fire_interval", "accuracy", "dodge_chance", "engagement_distance")
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    """One targets file parsed: where the game's config lives, which adapter
+    maps it, the protected write roots, the player-model assumptions, the sim
+    controls, and the validate design targets."""
+
+    config_dir: str
+    adapter: str
+    no_write_roots: tuple[str, ...]
+    player_model_params: dict[str, Any]
+    sim: SimConfig
+    targets: Targets
+
+
+def _read_targets_doc(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ConfigError(
+            "targets_unreadable", f"cannot read targets file {path}: {exc}"
+        )
+    except ValueError as exc:
+        raise ConfigError(
+            "targets_invalid", f"targets file {path} is not valid JSON: {exc}"
+        )
+
+
+def load_pipeline_config(path: Path) -> PipelineConfig:
+    """Parse a targets file (the per-game configuration) into a PipelineConfig."""
+    doc = _read_targets_doc(path)
+    player_model = dict(doc.get("player_model", {}))
+    missing = [k for k in PLAYER_MODEL_KEYS if k not in player_model]
+    if missing:
+        raise ConfigError(
+            "targets_invalid",
+            f"targets file {path} player_model is missing {missing}",
+        )
+    try:
+        sim = doc["simulation"]
+        return PipelineConfig(
+            config_dir=doc["config_dir"],
+            adapter=doc["adapter"],
+            no_write_roots=tuple(doc.get("no_write_roots", ())),
+            player_model_params=player_model,
+            sim=SimConfig(
+                dt=sim["dt"],
+                max_time=sim["max_time"],
+                runs=sim["runs"],
+                seed=sim["seed"],
+            ),
+            targets=Targets(
+                waves=tuple(
+                    WaveTarget(wave=w["wave"], ttk=w["ttk"], ttd=w["ttd"])
+                    for w in doc["waves"]
+                ),
+                tolerance=doc["tolerance"],
+            ),
+        )
+    except KeyError as exc:
+        raise ConfigError(
+            "targets_invalid", f"targets file {path} is missing the {exc} key"
+        )
+
+
+# --- The sd_model block (predict mode) ---------------------------------------- #
+
+
+@dataclass(frozen=True)
+class LevelCheckpoint:
+    """A growth design checkpoint: the minimum level the player should have
+    reached after clearing a given wave."""
+
+    after_wave: int
+    min_level: int
+
+
+@dataclass(frozen=True)
+class SdDesignTargets:
+    """The growth/difficulty design intent the prediction is checked against.
+    ``final_wave_is_peak`` states whether the schedule's LAST wave should be
+    the difficulty peak; ``expect_monotonic_ramp`` whether the ramp should
+    never dip."""
+
+    min_final_level: int
+    level_checkpoints: tuple[LevelCheckpoint, ...]
+    final_wave_is_peak: bool
+    expect_monotonic_ramp: bool
+
+
+@dataclass(frozen=True)
+class SdConfig:
+    """The ``sd_model`` block of a targets file: the model params/levers, the
+    cross-validation tolerance, and the design targets."""
+
+    params: SdParams
+    cross_validation_tolerance: float
+    targets: SdDesignTargets
+
+
+def load_sd_config(path: Path) -> SdConfig:
+    """Parse the ``sd_model`` block of a targets file into an :class:`SdConfig`."""
+    doc = _read_targets_doc(path)
+    try:
+        sd = doc["sd_model"]
+        p = sd["params"]
+        t = sd["targets"]
+        growth = t["growth"]
+        return SdConfig(
+            params=SdParams(
+                dt=p["dt"],
+                max_wave_time=p["max_wave_time"],
+                growth_gain=p["growth_gain"],
+                heal_threshold_frac=p["heal_threshold_frac"],
+                heal_consume_rate=p["heal_consume_rate"],
+            ),
+            cross_validation_tolerance=sd["cross_validation"]["tolerance"],
+            targets=SdDesignTargets(
+                min_final_level=growth["min_final_level"],
+                level_checkpoints=tuple(
+                    LevelCheckpoint(
+                        after_wave=c["after_wave"], min_level=c["min_level"]
+                    )
+                    for c in growth["checkpoints"]
+                ),
+                final_wave_is_peak=t["difficulty"]["final_wave_is_peak"],
+                expect_monotonic_ramp=t["difficulty"]["expect_monotonic_ramp"],
+            ),
+        )
+    except KeyError as exc:
+        raise ConfigError(
+            "targets_invalid", f"targets file {path} is missing the {exc} key"
+        )
+
+
+# --- Path resolution + the adapter plug-in ------------------------------------ #
+
+
+def resolve_against(base_dir: Path, value: str) -> Path:
+    """Resolve a targets-file path value: absolute passes through, relative
+    resolves against the targets file's own directory."""
+    p = Path(value)
+    return p.resolve() if p.is_absolute() else (base_dir / p).resolve()
+
+
+def resolve_config_dir(
+    cfg: PipelineConfig, targets_path: Path, override: Path | None
+) -> Path:
+    """The effective config-authority dir: the ``--config-dir`` override wins,
+    else the targets file's ``config_dir`` resolved against the file."""
+    if override is not None:
+        return override.resolve()
+    return resolve_against(targets_path.parent, cfg.config_dir)
+
+
+def forbidden_out_roots(
+    cfg: PipelineConfig, targets_path: Path, config_dir: Path
+) -> list[Path]:
+    """The directory trees a report must never land in: every configured
+    ``no_write_roots`` entry (resolved against the targets file) plus the
+    effective config dir itself — so a ``--config-dir`` override dir is
+    protected too, though its surrounding tree is not (tree protection is
+    declared config, never a code heuristic)."""
+    roots = [resolve_against(targets_path.parent, r) for r in cfg.no_write_roots]
+    roots.append(config_dir.resolve())
+    return roots
+
+
+def load_adapter(cfg: PipelineConfig, targets_path: Path) -> ModuleType:
+    """Import the per-game adapter named by the targets file and check its
+    contract (a callable ``load_inputs``). The adapter is game-side code
+    consuming the pipeline's public ``model`` types — never the other way
+    around."""
+    path = resolve_against(targets_path.parent, cfg.adapter)
+    if not path.is_file():
+        raise ConfigError("adapter_not_found", f"adapter file {path} does not exist")
+    spec = importlib.util.spec_from_file_location(
+        f"_balancing_adapter_{path.stem}", path
+    )
+    if spec is None or spec.loader is None:
+        raise ConfigError("adapter_invalid", f"cannot import adapter {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    if not callable(getattr(module, "load_inputs", None)):
+        raise ConfigError(
+            "adapter_invalid",
+            f"adapter {path} does not export a callable load_inputs(config_dir)",
+        )
+    return module

--- a/examples/platformer/panda-adventure/tools/balancing/config.py
+++ b/examples/platformer/panda-adventure/tools/balancing/config.py
@@ -98,7 +98,13 @@ def _read_targets_doc(path: Path) -> dict[str, Any]:
 def load_pipeline_config(path: Path) -> PipelineConfig:
     """Parse a targets file (the per-game configuration) into a PipelineConfig."""
     doc = _read_targets_doc(path)
-    player_model = dict(doc.get("player_model", {}))
+    player_model = doc.get("player_model")
+    if not isinstance(player_model, dict):
+        raise ConfigError(
+            "targets_invalid",
+            f"targets file {path} player_model must be a JSON object, "
+            f"got {type(player_model).__name__}",
+        )
     missing = [k for k in PLAYER_MODEL_KEYS if k not in player_model]
     if missing:
         raise ConfigError(
@@ -129,6 +135,12 @@ def load_pipeline_config(path: Path) -> PipelineConfig:
     except KeyError as exc:
         raise ConfigError(
             "targets_invalid", f"targets file {path} is missing the {exc} key"
+        )
+    except (TypeError, ValueError, AttributeError) as exc:
+        # A present key holding the wrong shape (null, list, scalar where an
+        # object belongs) is the same bad input as a missing key.
+        raise ConfigError(
+            "targets_invalid", f"targets file {path} has an invalid shape: {exc!r}"
         )
 
 
@@ -199,6 +211,10 @@ def load_sd_config(path: Path) -> SdConfig:
     except KeyError as exc:
         raise ConfigError(
             "targets_invalid", f"targets file {path} is missing the {exc} key"
+        )
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise ConfigError(
+            "targets_invalid", f"targets file {path} has an invalid shape: {exc!r}"
         )
 
 

--- a/examples/platformer/panda-adventure/tools/balancing/config.py
+++ b/examples/platformer/panda-adventure/tools/balancing/config.py
@@ -15,7 +15,8 @@ file's own directory, so a targets file is relocatable with its game):
   is always protected — even under a ``--config-dir`` override — but the
   override's SURROUNDING tree is not: tree-level protection comes only from
   these declared roots, so to run against a copied project with full
-  protection, use a targets file living with the copy.
+  protection, use a targets file living with the copy. The run's own input
+  artifacts — the targets file and the adapter file — are always protected.
 - ``player_model`` — the design player-model assumptions (``fire_interval``,
   ``accuracy``, ``dodge_chance``, ``engagement_distance``).
 - ``simulation``   — the Monte-Carlo controls (``dt``, ``max_time``, ``runs``,
@@ -76,7 +77,7 @@ class PipelineConfig:
 
 def _read_targets_doc(path: Path) -> dict[str, Any]:
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        doc = json.loads(path.read_text(encoding="utf-8"))
     except OSError as exc:
         raise ConfigError(
             "targets_unreadable", f"cannot read targets file {path}: {exc}"
@@ -85,6 +86,13 @@ def _read_targets_doc(path: Path) -> dict[str, Any]:
         raise ConfigError(
             "targets_invalid", f"targets file {path} is not valid JSON: {exc}"
         )
+    if not isinstance(doc, dict):
+        raise ConfigError(
+            "targets_invalid",
+            f"targets file {path} must be a JSON object at the root, "
+            f"got {type(doc).__name__}",
+        )
+    return doc
 
 
 def load_pipeline_config(path: Path) -> PipelineConfig:
@@ -217,13 +225,17 @@ def resolve_config_dir(
 def forbidden_out_roots(
     cfg: PipelineConfig, targets_path: Path, config_dir: Path
 ) -> list[Path]:
-    """The directory trees a report must never land in: every configured
-    ``no_write_roots`` entry (resolved against the targets file) plus the
-    effective config dir itself — so a ``--config-dir`` override dir is
-    protected too, though its surrounding tree is not (tree protection is
-    declared config, never a code heuristic)."""
+    """The paths a report must never land on: every configured
+    ``no_write_roots`` tree (resolved against the targets file), the effective
+    config dir itself — so a ``--config-dir`` override dir is protected too,
+    though its surrounding tree is not (tree protection is declared config,
+    never a code heuristic) — and the run's OWN input artifacts, the targets
+    file and the adapter file, which are always protected against an ``--out``
+    self-clobber regardless of declared roots."""
     roots = [resolve_against(targets_path.parent, r) for r in cfg.no_write_roots]
     roots.append(config_dir.resolve())
+    roots.append(targets_path.resolve())
+    roots.append(resolve_against(targets_path.parent, cfg.adapter))
     return roots
 
 
@@ -241,7 +253,14 @@ def load_adapter(cfg: PipelineConfig, targets_path: Path) -> ModuleType:
     if spec is None or spec.loader is None:
         raise ConfigError("adapter_invalid", f"cannot import adapter {path}")
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:
+        # A broken adapter is a bad per-game input: a structured refusal, not
+        # a traceback (process interrupts stay BaseException and pass through).
+        raise ConfigError(
+            "adapter_invalid", f"adapter {path} failed to import: {exc!r}"
+        )
     if not callable(getattr(module, "load_inputs", None)):
         raise ConfigError(
             "adapter_invalid",

--- a/examples/platformer/panda-adventure/tools/balancing/config.py
+++ b/examples/platformer/panda-adventure/tools/balancing/config.py
@@ -284,9 +284,15 @@ def load_sd_config(path: Path) -> SdConfig:
 
 def resolve_against(base_dir: Path, value: str) -> Path:
     """Resolve a targets-file path value: absolute passes through, relative
-    resolves against the targets file's own directory."""
-    p = Path(value)
-    return p.resolve() if p.is_absolute() else (base_dir / p).resolve()
+    resolves against the targets file's own directory. A string the OS cannot
+    treat as a path (an embedded NUL, an overlong component) is the same bad
+    input as a wrong-typed field — every targets path value funnels through
+    here, so the whole class refuses structured."""
+    try:
+        p = Path(value)
+        return p.resolve() if p.is_absolute() else (base_dir / p).resolve()
+    except (ValueError, OSError) as exc:
+        raise ConfigError("targets_invalid", f"invalid path value {value!r}: {exc}")
 
 
 def resolve_config_dir(
@@ -295,7 +301,13 @@ def resolve_config_dir(
     """The effective config-authority dir: the ``--config-dir`` override wins,
     else the targets file's ``config_dir`` resolved against the file."""
     if override is not None:
-        return override.resolve()
+        try:
+            return override.resolve()
+        except (ValueError, OSError) as exc:
+            raise ConfigError(
+                "path_invalid",
+                f"--config-dir {str(override)!r} is not a valid path: {exc}",
+            )
     return resolve_against(targets_path.parent, cfg.config_dir)
 
 

--- a/examples/platformer/panda-adventure/tools/balancing/config.py
+++ b/examples/platformer/panda-adventure/tools/balancing/config.py
@@ -60,6 +60,49 @@ class ConfigError(Exception):
 # home) so a missing key is a structured refusal, not a KeyError traceback.
 PLAYER_MODEL_KEYS = ("fire_interval", "accuracy", "dodge_chance", "engagement_distance")
 
+# The message names of the typed accessor's JSON kinds. ``float`` means "any
+# number" (bool excluded), matching JSON's single number type.
+_KIND_NAMES = {
+    str: "a string",
+    int: "an integer",
+    float: "a number",
+    bool: "a boolean",
+    list: "an array",
+    dict: "an object",
+}
+
+
+def _invalid(path: Path, detail: str) -> ConfigError:
+    return ConfigError("targets_invalid", f"targets file {path}: {detail}")
+
+
+def _is_kind(value: Any, kind: type) -> bool:
+    if kind is float:  # any JSON number; bool is not a number
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if kind is int:
+        return isinstance(value, int) and not isinstance(value, bool)
+    if kind is bool:
+        return isinstance(value, bool)
+    return isinstance(value, kind)
+
+
+def _typed(
+    path: Path, mapping: dict[str, Any], key: str, kind: type, where: str = ""
+) -> Any:
+    """The schema boundary's typed accessor: a missing key or a wrong-typed
+    value (null included) refuses with ``targets_invalid`` at LOAD time —
+    never a TypeError later during path resolution or the simulation."""
+    label = f"{where}{key}"
+    if key not in mapping:
+        raise _invalid(path, f"missing the '{label}' key")
+    value = mapping[key]
+    if not _is_kind(value, kind):
+        raise _invalid(
+            path,
+            f"'{label}' must be {_KIND_NAMES[kind]}, got {type(value).__name__}",
+        )
+    return value
+
 
 @dataclass(frozen=True)
 class PipelineConfig:
@@ -96,52 +139,50 @@ def _read_targets_doc(path: Path) -> dict[str, Any]:
 
 
 def load_pipeline_config(path: Path) -> PipelineConfig:
-    """Parse a targets file (the per-game configuration) into a PipelineConfig."""
+    """Parse a targets file (the per-game configuration) into a PipelineConfig.
+
+    Every field is read through the typed accessor, so ANY malformed field —
+    missing, null, or the wrong JSON type, at the root or nested — is a
+    ``targets_invalid`` refusal here at the schema boundary.
+    """
     doc = _read_targets_doc(path)
-    player_model = doc.get("player_model")
-    if not isinstance(player_model, dict):
-        raise ConfigError(
-            "targets_invalid",
-            f"targets file {path} player_model must be a JSON object, "
-            f"got {type(player_model).__name__}",
+    player_model = _typed(path, doc, "player_model", dict)
+    for key in PLAYER_MODEL_KEYS:
+        _typed(path, player_model, key, float, "player_model.")
+    sim = _typed(path, doc, "simulation", dict)
+    waves: list[WaveTarget] = []
+    for i, wave in enumerate(_typed(path, doc, "waves", list)):
+        if not isinstance(wave, dict):
+            raise _invalid(
+                path, f"'waves[{i}]' must be an object, got {type(wave).__name__}"
+            )
+        where = f"waves[{i}]."
+        waves.append(
+            WaveTarget(
+                wave=_typed(path, wave, "wave", int, where),
+                ttk=_typed(path, wave, "ttk", float, where),
+                ttd=_typed(path, wave, "ttd", float, where),
+            )
         )
-    missing = [k for k in PLAYER_MODEL_KEYS if k not in player_model]
-    if missing:
-        raise ConfigError(
-            "targets_invalid",
-            f"targets file {path} player_model is missing {missing}",
-        )
-    try:
-        sim = doc["simulation"]
-        return PipelineConfig(
-            config_dir=doc["config_dir"],
-            adapter=doc["adapter"],
-            no_write_roots=tuple(doc.get("no_write_roots", ())),
-            player_model_params=player_model,
-            sim=SimConfig(
-                dt=sim["dt"],
-                max_time=sim["max_time"],
-                runs=sim["runs"],
-                seed=sim["seed"],
-            ),
-            targets=Targets(
-                waves=tuple(
-                    WaveTarget(wave=w["wave"], ttk=w["ttk"], ttd=w["ttd"])
-                    for w in doc["waves"]
-                ),
-                tolerance=doc["tolerance"],
-            ),
-        )
-    except KeyError as exc:
-        raise ConfigError(
-            "targets_invalid", f"targets file {path} is missing the {exc} key"
-        )
-    except (TypeError, ValueError, AttributeError) as exc:
-        # A present key holding the wrong shape (null, list, scalar where an
-        # object belongs) is the same bad input as a missing key.
-        raise ConfigError(
-            "targets_invalid", f"targets file {path} has an invalid shape: {exc!r}"
-        )
+    roots = doc.get("no_write_roots", [])
+    if not isinstance(roots, list) or any(not isinstance(r, str) for r in roots):
+        raise _invalid(path, "'no_write_roots' must be an array of strings")
+    return PipelineConfig(
+        config_dir=_typed(path, doc, "config_dir", str),
+        adapter=_typed(path, doc, "adapter", str),
+        no_write_roots=tuple(roots),
+        player_model_params=dict(player_model),
+        sim=SimConfig(
+            dt=_typed(path, sim, "dt", float, "simulation."),
+            max_time=_typed(path, sim, "max_time", float, "simulation."),
+            runs=_typed(path, sim, "runs", int, "simulation."),
+            seed=_typed(path, sim, "seed", int, "simulation."),
+        ),
+        targets=Targets(
+            waves=tuple(waves),
+            tolerance=_typed(path, doc, "tolerance", float),
+        ),
+    )
 
 
 # --- The sd_model block (predict mode) ---------------------------------------- #
@@ -180,42 +221,62 @@ class SdConfig:
 
 
 def load_sd_config(path: Path) -> SdConfig:
-    """Parse the ``sd_model`` block of a targets file into an :class:`SdConfig`."""
+    """Parse the ``sd_model`` block of a targets file into an :class:`SdConfig`
+    (typed like :func:`load_pipeline_config` — any malformed field refuses at
+    the schema boundary)."""
     doc = _read_targets_doc(path)
-    try:
-        sd = doc["sd_model"]
-        p = sd["params"]
-        t = sd["targets"]
-        growth = t["growth"]
-        return SdConfig(
-            params=SdParams(
-                dt=p["dt"],
-                max_wave_time=p["max_wave_time"],
-                growth_gain=p["growth_gain"],
-                heal_threshold_frac=p["heal_threshold_frac"],
-                heal_consume_rate=p["heal_consume_rate"],
+    sd = _typed(path, doc, "sd_model", dict)
+    p = _typed(path, sd, "params", dict, "sd_model.")
+    cross = _typed(path, sd, "cross_validation", dict, "sd_model.")
+    t = _typed(path, sd, "targets", dict, "sd_model.")
+    growth = _typed(path, t, "growth", dict, "sd_model.targets.")
+    difficulty = _typed(path, t, "difficulty", dict, "sd_model.targets.")
+    checkpoints: list[LevelCheckpoint] = []
+    for i, c in enumerate(
+        _typed(path, growth, "checkpoints", list, "sd_model.targets.growth.")
+    ):
+        where = f"sd_model.targets.growth.checkpoints[{i}]"
+        if not isinstance(c, dict):
+            raise _invalid(path, f"'{where}' must be an object, got {type(c).__name__}")
+        checkpoints.append(
+            LevelCheckpoint(
+                after_wave=_typed(path, c, "after_wave", int, f"{where}."),
+                min_level=_typed(path, c, "min_level", int, f"{where}."),
+            )
+        )
+    pw = "sd_model.params."
+    return SdConfig(
+        params=SdParams(
+            dt=_typed(path, p, "dt", float, pw),
+            max_wave_time=_typed(path, p, "max_wave_time", float, pw),
+            growth_gain=_typed(path, p, "growth_gain", float, pw),
+            heal_threshold_frac=_typed(path, p, "heal_threshold_frac", float, pw),
+            heal_consume_rate=_typed(path, p, "heal_consume_rate", float, pw),
+        ),
+        cross_validation_tolerance=_typed(
+            path, cross, "tolerance", float, "sd_model.cross_validation."
+        ),
+        targets=SdDesignTargets(
+            min_final_level=_typed(
+                path, growth, "min_final_level", int, "sd_model.targets.growth."
             ),
-            cross_validation_tolerance=sd["cross_validation"]["tolerance"],
-            targets=SdDesignTargets(
-                min_final_level=growth["min_final_level"],
-                level_checkpoints=tuple(
-                    LevelCheckpoint(
-                        after_wave=c["after_wave"], min_level=c["min_level"]
-                    )
-                    for c in growth["checkpoints"]
-                ),
-                final_wave_is_peak=t["difficulty"]["final_wave_is_peak"],
-                expect_monotonic_ramp=t["difficulty"]["expect_monotonic_ramp"],
+            level_checkpoints=tuple(checkpoints),
+            final_wave_is_peak=_typed(
+                path,
+                difficulty,
+                "final_wave_is_peak",
+                bool,
+                "sd_model.targets.difficulty.",
             ),
-        )
-    except KeyError as exc:
-        raise ConfigError(
-            "targets_invalid", f"targets file {path} is missing the {exc} key"
-        )
-    except (TypeError, ValueError, AttributeError) as exc:
-        raise ConfigError(
-            "targets_invalid", f"targets file {path} has an invalid shape: {exc!r}"
-        )
+            expect_monotonic_ramp=_typed(
+                path,
+                difficulty,
+                "expect_monotonic_ramp",
+                bool,
+                "sd_model.targets.difficulty.",
+            ),
+        ),
+    )
 
 
 # --- Path resolution + the adapter plug-in ------------------------------------ #

--- a/examples/platformer/panda-adventure/tools/balancing/dynamics.py
+++ b/examples/platformer/panda-adventure/tools/balancing/dynamics.py
@@ -1,77 +1,75 @@
-"""The system-dynamics state model of the run's growth/economy (gADR-0011, #440).
+"""The system-dynamics state model of a run's growth/economy — the macro engine.
 
-The macro half of the Balancing pipeline: a first-order nonlinear ODE system
-over the run's **stocks** (accumulating state) and **flows** (their rates),
-integrated by the hand-rolled RK4 (``integrate``) across the Wave schedule to
-predict the long-term growth/economy trajectory. Where the Monte-Carlo engine
-(``encounter``) simulates ONE encounter at micro fidelity, this model is the
-mean-field aggregate of the whole run — deterministic, no RNG.
+A first-order nonlinear ODE system over the run's **stocks** (accumulating
+state) and **flows** (their rates), integrated by the hand-rolled RK4
+(``integrate``) across the wave schedule to predict the long-term growth/economy
+trajectory. Where the Monte-Carlo engine (``encounter``) simulates ONE encounter
+at micro fidelity, this model is the mean-field aggregate of the whole run —
+deterministic, no RNG.
 
-Stocks (the state vector, in order):
+Stocks (the state vector): four fixed stocks, then one stock per tracked drop
+item (``GrowthEconomy.item_keys``, deterministic sorted order):
 
-- ``Q``    — the current Wave's remaining aggregate enemy HP (depletes to clear).
-- ``HP``   — the Player's health, bounded ``[0, player_max_hp]`` (the survival
-  stock; carried across Waves in the chained run, like the game).
-- ``EXP``  — cumulative EXP (the growth stock; Level is its readout via the
-  Leveling curve, gADR-0006).
-- ``GOLD`` — cumulative Gold (economy inflow = the guaranteed Kill reward PLUS
-  the expected gold Pickup drops; no sink in this demo — no shop — so it is an
-  accumulator, documented).
-- ``BUN``  — Bun Consumable count (economy in AND out: drops in, HP-restore use
-  out — the balancing loop).
-- ``WINE`` — Wine Consumable count. This slice models Wine as INFLOW-ONLY (drops)
-  and deliberately does NOT model Wine/MP outflow: the only MP sink is the Gravity
-  Gun, whose MP-use cadence is not a modeled design input — contrast Bun, whose
-  consumption is driven by the modeled HP loss, so its outflow has a rate the
-  model can read. MP outflow is therefore out of scope here (same honest scoping
-  the targets file makes for the Gravity Gun), NOT an oversight.
+- ``Q``        — the current wave's remaining aggregate enemy HP (depletes to clear).
+- ``HP``       — the player's health, bounded ``[0, max]`` (the survival stock;
+  carried across waves in the chained run, like a real playthrough).
+- ``EXP``      — cumulative EXP (the growth stock; level is its readout via the
+  leveling curve).
+- ``CURRENCY`` — cumulative currency inflow: the guaranteed kill reward PLUS the
+  expected drops of the economy's ``currency_item``. Inflow-only unless the game
+  models a sink, so it is an accumulator.
+- one stock per tracked item — economy in via expected drops; the configured
+  ``heal_item`` also flows OUT via HP-restore use (the balancing loop), every
+  other item is inflow-only (a game-side sink outside this model's scope is a
+  scoping note for the targets file, not a modeling error).
 
-Flows (the ODE right-hand side), per Wave ``w`` with coefficients projected from
-the JSON authority (``build_wave_dynamics``):
+Flows (the ODE right-hand side), per wave ``w`` with coefficients projected from
+the adapter-mapped model data (``build_wave_dynamics``):
 
-- ``dQ/dt   = -P``                      — the Player's effective damage rate
-  ``P = player_dps_w * growth(EXP)`` drains the Wave's enemy HP.
-- ``dHP/dt  = -enemy_dps_w + heal``     — incoming aggregate enemy DPS, offset by
-  Bun healing (``heal``).
-- ``dEXP/dt  = (exp_reward_w  / wave_hp_w) * P``   — reward accrues in proportion
-- ``dGOLD/dt = (gold_reward_w / wave_hp_w) * P``     to the fraction of the
-- ``dBUN/dt  = (bun_drops_w   / wave_hp_w) * P - consume``  Wave's HP destroyed,
-- ``dWINE/dt = (wine_drops_w  / wave_hp_w) * P``     so integrating a fully
-  cleared Wave yields EXACTLY its total reward (the conservation the unit tests
-  pin) — the continuous mean-field of the game's discrete per-kill rewards.
+- ``dQ/dt        = -P``                    — the player's effective damage rate
+  ``P = player_dps_w * growth(EXP)`` drains the wave's enemy HP.
+- ``dHP/dt       = -enemy_dps_w + heal``   — incoming aggregate enemy DPS,
+  offset by heal-item use (``heal``).
+- ``dEXP/dt      = (exp_reward_w      / wave_hp_w) * P``  — reward accrues in
+- ``dCURRENCY/dt = (currency_reward_w / wave_hp_w) * P``    proportion to the
+- ``dITEM_k/dt   = (item_drops_w[k]   / wave_hp_w) * P``    fraction of the
+  (minus consumption for the heal item)                     wave's HP destroyed,
+  so integrating a fully cleared wave yields EXACTLY its total reward (the
+  conservation the unit tests pin) — the continuous mean-field of the game's
+  discrete per-kill rewards.
 
 The nonlinearities that make this a genuine first-order NONLINEAR ODE system —
 the two coupled system-dynamics feedback loops plus the difficulty driver:
 
-- **Reinforcing growth loop** — ``growth(EXP) = 1 + growth_gain * (Level(EXP) - 1)``
-  feeds the growth stock back into the kill rate through the piecewise Leveling
-  curve (more kills → more EXP → higher Level → faster kills). ``growth_gain``
-  defaults to 0.0 (Phase-1 fidelity: level-up is readout-only today, gADR-0006),
-  so it is an explicit, documented design lever; setting it > 0 predicts the
-  INTENDED growth curve.
-- **Balancing consumable loop** — Bun healing is a state-switched, supply-limited,
-  saturating term: it engages only while ``HP < heal_threshold_frac * max`` AND
-  ``BUN > 0``, restores toward ``player_max_hp`` (the cap — a ``min`` saturation),
-  and drains the Bun stock. The threshold switch, the supply gate, and the cap
-  are all nonlinear in the state.
-- **Difficulty ramp** — the exogenous forcing: each Wave's ``enemy_dps_w`` /
+- **Reinforcing growth loop** — ``growth(EXP) = 1 + growth_gain * (level(EXP) - 1)``
+  feeds the growth stock back into the kill rate through the piecewise leveling
+  curve (more kills → more EXP → higher level → faster kills). ``growth_gain``
+  defaults to 0.0 (a readout-only level system), so it is an explicit,
+  documented design lever; setting it > 0 predicts the INTENDED growth curve.
+- **Balancing consumable loop** — heal-item use is a state-switched,
+  supply-limited, saturating term: it engages only while ``HP <
+  heal_threshold_frac * max`` AND the heal stock is positive, restores toward
+  ``player_max_hp`` (the cap — a ``min`` saturation), and drains the heal stock.
+  The threshold switch, the supply gate, and the cap are all nonlinear in the
+  state.
+- **Difficulty ramp** — the exogenous forcing: each wave's ``enemy_dps_w`` /
   ``wave_hp_w`` step up across the schedule (the driving function the loops
   respond to).
 
 Cross-validation overlap with the MC engine (``prediction``): in the reduced
-"bare laser-brawl" scenario — ``growth_gain = 0`` and Bun healing off — the
-system collapses to the same constant-coefficient combat attrition the MC sim
-runs, so per-Wave clear time ↔ MC median TTK and Player-death time ↔ MC median
-TTD agree within the documented tolerance. The consumable economy and the growth
-feedback are this model's extensions BEYOND MC's domain (validated by the
+"bare brawl" scenario — ``growth_gain = 0`` and healing off — the system
+collapses to the same constant-coefficient combat attrition the MC sim runs, so
+per-wave clear time ↔ MC median TTK and player-death time ↔ MC median TTD agree
+within the documented tolerance. The consumable economy and the growth feedback
+are this model's extensions BEYOND MC's domain (validated by the
 conservation/boundary unit tests, not by MC).
 
-Reuse (gADR-0011): the damage arithmetic is the parity-pinned ``rules`` seam
-(``compute_damage``), the data comes from the ``game_config`` adapter as generic
-``model`` dataclasses — no game-code import, no second rule copy, no second JSON
-parser. The 1D mean-field aggregation (approach/travel latency, discrete kill
-ordering, per-shot accuracy/dodge variance, and the Boss Warp micro-timing are
-all averaged out) is why the cross-validation band is coarser than the MC-level
+Reuse: the damage arithmetic is the shared ``rules`` ruleset
+(``compute_damage``), the data comes from the per-game adapter as generic
+``model`` dataclasses — no game-code import, no second rule copy, no second
+config parser. The 1D mean-field aggregation (approach/travel latency, discrete
+kill ordering, per-shot accuracy/dodge variance, and warp micro-timing are all
+averaged out) is why the cross-validation band is coarser than the MC-level
 validate tolerance.
 """
 
@@ -83,72 +81,90 @@ from . import rules
 from .integrate import State, rk4_step
 from .model import CombatParams, EnemyKind, GameData, GrowthEconomy, PlayerModel
 
-# The state-vector layout (see the module docstring). Bare indices keep the
-# vector a plain float tuple for the generic RK4 integrator.
-Q, HP, EXP, GOLD, BUN, WINE = range(6)
-_N = 6
+# The fixed head of the state vector (see the module docstring); the tracked
+# item stocks follow, one per ``GrowthEconomy.item_keys`` entry, in that order.
+# Bare indices keep the vector a plain float tuple for the generic integrator.
+Q, HP, EXP, CUR = range(4)
+_FIXED = 4
+
+
+def state_size(econ: GrowthEconomy) -> int:
+    """The state vector's length for this economy."""
+    return _FIXED + len(econ.item_keys)
+
+
+def item_index(econ: GrowthEconomy, item: str) -> int:
+    """The state-vector index of ``item``'s stock (raises if untracked)."""
+    return _FIXED + econ.item_keys.index(item)
+
+
+def initial_state(econ: GrowthEconomy, hp: float | None = None) -> State:
+    """A fresh run's stocks: zero everywhere except HP (full by default)."""
+    hp0 = econ.player_max_hp if hp is None else hp
+    return (0.0, hp0, 0.0, 0.0) + (0.0,) * len(econ.item_keys)
 
 
 @dataclass(frozen=True)
 class SdParams:
     """The SD model's controls and design levers (per-game configuration).
 
-    ``growth_gain`` is the reinforcing-growth lever (0.0 = Phase-1 readout-only
-    fidelity). ``heal_threshold_frac`` and ``bun_consume_rate`` shape the
-    balancing consumable loop (the fraction of max HP below which the Player eats
-    a Bun, and how fast — Buns/sec — while healing; 0.0 disables the loop, the
-    cross-validation overlap setting). ``dt`` / ``max_wave_time`` are the fixed
-    RK4 step and the per-Wave time cap.
+    ``growth_gain`` is the reinforcing-growth lever (0.0 = readout-only
+    fidelity). ``heal_threshold_frac`` and ``heal_consume_rate`` shape the
+    balancing consumable loop (the fraction of max HP below which the player
+    uses the heal item, and how fast — items/sec — while healing; 0.0 disables
+    the loop, the cross-validation overlap setting). ``dt`` / ``max_wave_time``
+    are the fixed RK4 step and the per-wave time cap.
     """
 
     dt: float
     max_wave_time: float
     growth_gain: float = 0.0
     heal_threshold_frac: float = 0.5
-    bun_consume_rate: float = 0.0
+    heal_consume_rate: float = 0.0
 
     def overlap(self) -> SdParams:
         """The reduced params for the MC cross-validation overlap: growth
-        feedback OFF and the consumable loop OFF — the bare laser-brawl the MC
-        engine also models."""
-        return replace(self, growth_gain=0.0, bun_consume_rate=0.0)
+        feedback OFF and the consumable loop OFF — the bare brawl the MC engine
+        also models."""
+        return replace(self, growth_gain=0.0, heal_consume_rate=0.0)
 
 
 @dataclass(frozen=True)
 class WaveDynamics:
-    """One Wave's SD coefficients, projected from the JSON authority once (a thin
+    """One wave's SD coefficients, projected from the model data once (a thin
     SD-specific data shape over ``GameData`` + ``GrowthEconomy``, not a second
-    parse). ``player_dps`` is the base (Level-1) effective damage rate; the
-    growth lever scales it at run time. ``difficulty`` is the per-Wave HP-cost
-    index — the fraction of full HP the bare brawl costs to clear (> 1.0 = lethal
-    without counterplay), the exogenous ramp the report charts."""
+    parse). ``player_dps`` is the base (level-1) effective damage rate; the
+    growth lever scales it at run time. ``item_drops`` is the wave's expected
+    per-item drop inflow, keyed like ``GrowthEconomy.item_keys``.
+    ``difficulty`` is the per-wave HP-cost index — the fraction of full HP the
+    bare brawl costs to clear (> 1.0 = lethal without counterplay), the
+    exogenous ramp the report charts."""
 
     index: int
     wave_hp: float
     player_dps: float
     enemy_dps: float
     exp_reward: float
-    gold_reward: float
-    bun_drops: float
-    wine_drops: float
+    currency_reward: float
+    item_drops: dict[str, float]
 
     @property
     def base_clear_time(self) -> float:
-        """Base (Level-1) time to clear this Wave's HP at full player DPS."""
+        """Base (level-1) time to clear this wave's HP at full player DPS."""
         return self.wave_hp / self.player_dps if self.player_dps > 0 else float("inf")
 
     def difficulty(self, player_max_hp: float) -> float:
         """The HP-cost difficulty index: the fraction of full HP the bare brawl
-        costs to clear this Wave (ignoring survival) — the ramp scalar."""
+        costs to clear this wave (ignoring survival) — the ramp scalar."""
         return self.enemy_dps * self.base_clear_time / player_max_hp
 
 
 def _player_dps(
     player: PlayerModel, combat: CombatParams, enemy_defense: float
 ) -> float:
-    """The Player's steady effective DPS against one enemy defense: the
-    parity-pinned damage per shot (``rules.compute_damage``) times the effective
-    hit rate (fire cadence discounted by aim)."""
+    """The player's steady effective DPS against one enemy defense: the shared
+    damage rule per shot (``rules.compute_damage``) times the effective hit
+    rate (fire cadence discounted by aim)."""
     hit_rate = player.accuracy / player.fire_interval
     per_shot = rules.compute_damage(
         player.stats.attack,
@@ -163,7 +179,7 @@ def _player_dps(
 def _wave_enemy_dps(
     player: PlayerModel, combat: CombatParams, kinds: list[EnemyKind]
 ) -> float:
-    """The Wave's aggregate incoming DPS on the Player (mean-field): every
+    """The wave's aggregate incoming DPS on the player (mean-field): every
     enemy's per-attack damage (``rules.compute_damage`` against the composed
     defender) over its cooldown, i-frame-capped (at most the largest single hit
     per i-frame window) and discounted by the dodge rate."""
@@ -187,16 +203,16 @@ def _wave_enemy_dps(
 def build_wave_dynamics(
     game: GameData, econ: GrowthEconomy, player: PlayerModel
 ) -> tuple[WaveDynamics, ...]:
-    """Project each Wave into its SD coefficients (reward/HP/DPS aggregates).
+    """Project each wave into its SD coefficients (reward/HP/DPS aggregates).
 
-    A thin, per-Wave reduction over the generic ``model`` data: the Player's
+    A thin, per-wave reduction over the generic ``model`` data: the player's
     sequential clear effort (Σ per-enemy HP / per-enemy DPS) gives the effective
-    ``player_dps``; the Tier reward table gives the EXP/Gold/Drop inflows; the
-    aggregate incoming DPS gives ``enemy_dps``. Gold inflow is the guaranteed Kill
-    reward PLUS the expected gold Pickup drops (gADR-0006 — both accrue to the
-    Player's Gold), the same both-sources sum a kill yields in-game. Reads only
-    already-parsed ``GameData`` / ``GrowthEconomy`` — no JSON, no game code
-    (gADR-0011).
+    ``player_dps``; the tier reward table gives the EXP/currency/drop inflows;
+    the aggregate incoming DPS gives ``enemy_dps``. Currency inflow is the
+    guaranteed kill reward PLUS the expected drops of the economy's
+    ``currency_item`` — both accrue to the player, the same both-sources sum a
+    kill yields in-game. Reads only already-parsed ``GameData`` /
+    ``GrowthEconomy`` — no config files, no game code.
     """
     out: list[WaveDynamics] = []
     for wave in game.waves:
@@ -207,6 +223,11 @@ def build_wave_dynamics(
             for k in kinds
         )
         rewards = [econ.tier_rewards[k.tier] for k in kinds]
+        currency_drops = (
+            sum(r.expected_drop(econ.currency_item) for r in rewards)
+            if econ.currency_item is not None
+            else 0.0
+        )
         out.append(
             WaveDynamics(
                 index=wave.index,
@@ -214,64 +235,76 @@ def build_wave_dynamics(
                 player_dps=wave_hp / effort if effort > 0 else 0.0,
                 enemy_dps=_wave_enemy_dps(player, game.combat, kinds),
                 exp_reward=sum(r.exp_reward for r in rewards),
-                gold_reward=sum(
-                    r.gold_reward + r.expected_drop("gold") for r in rewards
-                ),
-                bun_drops=sum(r.expected_drop("bun") for r in rewards),
-                wine_drops=sum(r.expected_drop("wine") for r in rewards),
+                currency_reward=sum(r.currency_reward for r in rewards)
+                + currency_drops,
+                item_drops={
+                    item: sum(r.expected_drop(item) for r in rewards)
+                    for item in econ.item_keys
+                },
             )
         )
     return tuple(out)
 
 
 def _deriv(wd: WaveDynamics, params: SdParams, econ: GrowthEconomy):
-    """Build the RHS closure ``f(t, y) -> dy`` for one Wave (the flows above)."""
+    """Build the RHS closure ``f(t, y) -> dy`` for one wave (the flows above)."""
     inv_hp = 1.0 / wd.wave_hp if wd.wave_hp > 0 else 0.0
-    heal_per_bun = econ.bun_hp_restore
+    # The closure is the hot path (4 evaluations per RK4 step): precompute the
+    # per-item drop rates and the heal stock's position once per wave.
+    drop_rates = tuple(wd.item_drops.get(item, 0.0) * inv_hp for item in econ.item_keys)
+    heal_index = item_index(econ, econ.heal_item) if econ.heal_item else -1
+    heal_pos = heal_index - _FIXED
+    heal_per_item = econ.heal_item_restore
     threshold = params.heal_threshold_frac * econ.player_max_hp
 
     def f(_t: float, y: State) -> tuple[float, ...]:
-        q, hp, exp, _gold, bun, _wine = y
+        q, hp = y[Q], y[HP]
         combat = 1.0 if (q > 0.0 and hp > 0.0) else 0.0
-        level = econ.level_for(exp)
+        level = econ.level_for(y[EXP])
         growth = 1.0 + params.growth_gain * (level - 1)
         p = wd.player_dps * growth * combat  # effective kill rate
         # Balancing consumable loop: state-switched, saturating, and supply-LIMITED
-        # within the step. Capping the consume rate at bun/dt bounds one step's
-        # Bun spend to the Bun on hand, so a sliver of inventory buys only a sliver
+        # within the step. Capping the consume rate at stock/dt bounds one step's
+        # spend to the items on hand, so a sliver of inventory buys only a sliver
         # of healing (never a full step of it) — the boundary conservation the
         # unit tests pin. dt is params.dt (the step is never larger), so the cap
         # is conservative on the shorter final step.
-        if hp > 0.0 and hp < threshold and bun > 0.0:
+        if heal_index >= 0 and hp > 0.0 and hp < threshold and y[heal_index] > 0.0:
             max_consume = (
-                bun / params.dt if params.dt > 0.0 else params.bun_consume_rate
+                y[heal_index] / params.dt
+                if params.dt > 0.0
+                else params.heal_consume_rate
             )
-            healing = min(params.bun_consume_rate, max_consume)
+            healing = min(params.heal_consume_rate, max_consume)
         else:
             healing = 0.0
-        heal_flow = healing * heal_per_bun
+        heal_flow = healing * heal_per_item
         d_hp = -wd.enemy_dps * combat + heal_flow
         if hp >= econ.player_max_hp and d_hp > 0.0:
             d_hp = 0.0  # cap saturation: no overfill past max HP
+        d_items = tuple(
+            rate * p - (healing if i == heal_pos else 0.0)
+            for i, rate in enumerate(drop_rates)
+        )
         return (
             -p,
             d_hp,
             wd.exp_reward * inv_hp * p,
-            wd.gold_reward * inv_hp * p,
-            wd.bun_drops * inv_hp * p - healing,
-            wd.wine_drops * inv_hp * p,
-        )
+            wd.currency_reward * inv_hp * p,
+        ) + d_items
 
     return f
 
 
 def _clamp_bounds(y: State, econ: GrowthEconomy) -> State:
     """Project the bounded stocks back into range after a step: HP into
-    ``[0, max]`` (the survival stock's saturation) and BUN into ``[0, ∞)`` (a
-    count never goes negative). EXP/Gold/Wine are inflow-only and unclamped."""
+    ``[0, max]`` (the survival stock's saturation) and every item stock into
+    ``[0, ∞)`` (a count never goes negative). EXP/currency are inflow-only and
+    unclamped."""
     v = list(y)
     v[HP] = min(max(v[HP], 0.0), econ.player_max_hp)
-    v[BUN] = max(v[BUN], 0.0)
+    for i in range(_FIXED, len(v)):
+        v[i] = max(v[i], 0.0)
     return tuple(v)
 
 
@@ -283,8 +316,9 @@ def _lerp(a: State, b: State, f: float) -> State:
 
 @dataclass(frozen=True)
 class WaveOutcome:
-    """One Wave's SD result: whether/when it cleared or the Player died, the HP
-    trajectory bounds, the accrued stocks, and the difficulty index."""
+    """One wave's SD result: whether/when it cleared or the player died, the HP
+    trajectory bounds, the accrued stocks (items keyed like
+    ``GrowthEconomy.item_keys``), and the difficulty index."""
 
     index: int
     cleared: bool
@@ -297,10 +331,9 @@ class WaveOutcome:
     exp_start: float
     exp_end: float
     level_end: int
-    gold_end: float
-    bun_start: float
-    bun_end: float
-    wine_end: float
+    currency_end: float
+    items_start: dict[str, float]
+    items_end: dict[str, float]
     wave_hp: float
     player_dps: float
     enemy_dps: float
@@ -321,16 +354,19 @@ def _run_one_wave(
     econ: GrowthEconomy,
     y0: State,
 ) -> tuple[WaveOutcome, State]:
-    """Integrate ONE Wave from initial stocks ``y0`` (with ``y0[Q]`` reset to the
-    Wave's HP) to a clear (Q→0), a Player death (HP→0), or the per-Wave time cap,
-    with a linear crossing refinement so a cleared Wave's reward integrates to its
+    """Integrate ONE wave from initial stocks ``y0`` (with ``y0[Q]`` reset to the
+    wave's HP) to a clear (Q→0), a player death (HP→0), or the per-wave time cap,
+    with a linear crossing refinement so a cleared wave's reward integrates to its
     exact total (conservation). Returns the outcome and the carry-out stocks."""
     f = _deriv(wd, params, econ)
-    y = tuple(y0)
-    y = tuple(wd.wave_hp if i == Q else y[i] for i in range(_N))
+    items = econ.item_keys
+    size = _FIXED + len(items)
+    index = {item: _FIXED + i for i, item in enumerate(items)}
+    y = tuple(wd.wave_hp if i == Q else y0[i] for i in range(size))
     t = 0.0
-    hp_start, exp_start, bun_start = y[HP], y[EXP], y[BUN]
-    gold_start, wine_start = y[GOLD], y[WINE]
+    hp_start, exp_start = y[HP], y[EXP]
+    currency_start = y[CUR]
+    items_start = {item: y[index[item]] for item in items}
     hp_min = y[HP]
     cleared = died = False
     clear_time = death_time = None
@@ -342,7 +378,7 @@ def _run_one_wave(
             frac = y[HP] / (y[HP] - y_next[HP])
             death_time = t + frac * step
             y = _lerp(y, y_next, frac)
-            y = tuple(0.0 if i == HP else y[i] for i in range(_N))
+            y = tuple(0.0 if i == HP else y[i] for i in range(size))
             died = True
             hp_min = 0.0
             break
@@ -351,28 +387,31 @@ def _run_one_wave(
             frac = y[Q] / (y[Q] - y_next[Q])
             clear_time = t + frac * step
             y = _lerp(y, y_next, frac)
-            y = tuple(0.0 if i == Q else y[i] for i in range(_N))
+            y = tuple(0.0 if i == Q else y[i] for i in range(size))
             cleared = True
             hp_min = min(hp_min, y[HP])
             break
         y = y_next
         t += step
         hp_min = min(hp_min, y[HP])
-    # Coflow snap: EXP/Gold/Wine are pure coflows of the kill flow — their exact
-    # first integral is total_reward × killed_fraction (killed_fraction = 1 on a
-    # clear). Snapping to it at the Wave boundary removes the RK4 drift that would
-    # otherwise flip a Level read at an exact threshold; the analytic integral is
-    # known, so this is exact accounting, not a fudge. (Bun keeps its integrated
-    # value — its HP-driven consumption is genuinely path-dependent, not a coflow.)
+    # Coflow snap: EXP, currency, and every inflow-only item are pure coflows of
+    # the kill flow — their exact first integral is total_reward × killed_fraction
+    # (killed_fraction = 1 on a clear). Snapping to it at the wave boundary
+    # removes the RK4 drift that would otherwise flip a level read at an exact
+    # threshold; the analytic integral is known, so this is exact accounting, not
+    # a fudge. (The heal item keeps its integrated value — its HP-driven
+    # consumption is genuinely path-dependent, not a coflow.)
     killed_fraction = (wd.wave_hp - max(y[Q], 0.0)) / wd.wave_hp if wd.wave_hp else 0.0
-    y = tuple(
-        {
-            EXP: exp_start + wd.exp_reward * killed_fraction,
-            GOLD: gold_start + wd.gold_reward * killed_fraction,
-            WINE: wine_start + wd.wine_drops * killed_fraction,
-        }.get(i, y[i])
-        for i in range(_N)
-    )
+    snapped = {
+        EXP: exp_start + wd.exp_reward * killed_fraction,
+        CUR: currency_start + wd.currency_reward * killed_fraction,
+    }
+    for item in items:
+        if item != econ.heal_item:
+            snapped[index[item]] = (
+                items_start[item] + wd.item_drops.get(item, 0.0) * killed_fraction
+            )
+    y = tuple(snapped.get(i, y[i]) for i in range(size))
     outcome = WaveOutcome(
         index=wd.index,
         cleared=cleared,
@@ -385,10 +424,9 @@ def _run_one_wave(
         exp_start=exp_start,
         exp_end=y[EXP],
         level_end=econ.level_for(y[EXP]),
-        gold_end=y[GOLD],
-        bun_start=bun_start,
-        bun_end=y[BUN],
-        wine_end=y[WINE],
+        currency_end=y[CUR],
+        items_start=items_start,
+        items_end={item: y[index[item]] for item in items},
         wave_hp=wd.wave_hp,
         player_dps=wd.player_dps,
         enemy_dps=wd.enemy_dps,
@@ -399,8 +437,8 @@ def _run_one_wave(
 
 @dataclass(frozen=True)
 class RunOutcome:
-    """The whole-run SD trajectory: per-Wave outcomes plus the run-level verdict
-    (did the Player clear the schedule, or die at which Wave) and end stocks."""
+    """The whole-run SD trajectory: per-wave outcomes plus the run-level verdict
+    (did the player clear the schedule, or die at which wave) and end stocks."""
 
     waves: tuple[WaveOutcome, ...]
     cleared_schedule: bool
@@ -408,9 +446,8 @@ class RunOutcome:
     final_hp: float
     final_exp: float
     final_level: int
-    final_gold: float
-    final_bun: float
-    final_wine: float
+    final_currency: float
+    final_items: dict[str, float]
 
 
 def run_scenario(
@@ -419,13 +456,13 @@ def run_scenario(
     econ: GrowthEconomy,
     start_hp: float | None = None,
 ) -> RunOutcome:
-    """Integrate the whole Wave schedule as one chained run (the long-term
-    prediction): HP and the economy stocks CARRY across Waves (persistent, like
-    the game — only Consumables restore HP), each Wave resets ``Q`` to its enemy
-    HP, and the run stops at the first Player death. Start at full HP by default.
+    """Integrate the whole wave schedule as one chained run (the long-term
+    prediction): HP and the economy stocks CARRY across waves (persistent, like
+    a real playthrough — only the heal item restores HP), each wave resets ``Q``
+    to its enemy HP, and the run stops at the first player death. Start at full
+    HP by default.
     """
-    hp0 = econ.player_max_hp if start_hp is None else start_hp
-    y: State = (0.0, hp0, 0.0, 0.0, 0.0, 0.0)
+    y: State = initial_state(econ, start_hp)
     outcomes: list[WaveOutcome] = []
     died_at: int | None = None
     for wd in dynamics:
@@ -442,20 +479,17 @@ def run_scenario(
         final_hp=y[HP],
         final_exp=y[EXP],
         final_level=econ.level_for(y[EXP]),
-        final_gold=y[GOLD],
-        final_bun=y[BUN],
-        final_wine=y[WINE],
+        final_currency=y[CUR],
+        final_items={item: y[item_index(econ, item)] for item in econ.item_keys},
     )
 
 
 def run_wave_overlap(
     wd: WaveDynamics, params: SdParams, econ: GrowthEconomy
 ) -> WaveOutcome:
-    """Integrate ONE Wave from FULL HP with the overlap params (growth + healing
-    off) — the bare laser-brawl the MC engine also simulates, for cross-validation
-    (each MC Wave is an independent full-HP encounter, so this matches its shape).
+    """Integrate ONE wave from FULL HP with the overlap params (growth + healing
+    off) — the bare brawl the MC engine also simulates, for cross-validation
+    (each MC wave is an independent full-HP encounter, so this matches its shape).
     """
-    overlap = params.overlap()
-    y0: State = (wd.wave_hp, econ.player_max_hp, 0.0, 0.0, 0.0, 0.0)
-    outcome, _ = _run_one_wave(wd, overlap, econ, y0)
+    outcome, _ = _run_one_wave(wd, params.overlap(), econ, initial_state(econ))
     return outcome

--- a/examples/platformer/panda-adventure/tools/balancing/encounter.py
+++ b/examples/platformer/panda-adventure/tools/balancing/encounter.py
@@ -1,41 +1,38 @@
-"""The Monte-Carlo encounter simulation (game-agnostic structure, gADR-0011).
+"""The Monte-Carlo encounter simulation — the pipeline's micro engine.
 
-One encounter pits the modeled Player against one Wave and runs a fixed-timestep
-simulation to an outcome — per-enemy Time-To-Kill, whether/when the Player died
-(Time-To-Die), and whether the Wave was cleared. The gameplay rules are the
-parity-pinned pure functions in ``rules`` (the ``CombatSystem``/``EnemyAI``/
-``WarpSystem``/``ItemSystem`` seams); this module owns only the orchestration a
-controller would own in-engine (the clock, movement/projectile integration, the
-Warp phase machine, RNG, mutation) — never a second copy of a rule.
+One encounter pits the modeled player against one wave and runs a fixed-timestep
+simulation to an outcome — per-enemy Time-To-Kill, whether/when the player died
+(Time-To-Die), and whether the wave was cleared. The gameplay rules are the pure
+functions in ``rules``; this module owns only the orchestration a game controller
+would own in-engine (the clock, movement/projectile integration, the warp phase
+machine, RNG, mutation) — never a second copy of a rule.
 
-Delivery follows the shipped controllers at first-order fidelity:
+Attack delivery, at first-order fidelity:
 
-- **Contact** (melee, and tank since gADR-0009): an ``EnemyAI.can_attack``-gated
-  immediate strike through the Player's i-frame gate, mitigated by the
-  Spacesuit-composed defender (gADR-0008).
-- **Ranged bolts** (gADR-0003): an attack spawns a traveling bolt (per-kind
-  speed/lifetime/spawn offset from the JSON authority); damage lands on ARRIVAL
-  (swept 1D contact against the target's box), and an expired bolt despawns
-  harmless. The Player's Laser bolts travel the same way — a shot's damage is
-  delayed by ``distance / projectile_speed``.
-- **The Boss Warp kit** (gADR-0009): the ``WarpSystem.should_warp`` gate opens
-  the tell (steering and attack suspended), the blink relocates to the pure
-  far-side landing clamped to the Arena (inset by the body's half-width) and
-  drops the Time Dilation Field there, then a no-attack recovery precedes normal
-  AI. While the Player is inside an active field, the Player's movement and the
-  Player's bolts inside it are slowed by the config factor; fire cadence stays
-  full speed (input registers — slowed, not stunned).
+- **Contact**: a ``rules.can_attack``-gated immediate strike through the
+  player's i-frame gate, mitigated by the equipment-composed defender.
+- **Ranged bolts**: an attack spawns a traveling bolt (per-kind speed/lifetime/
+  spawn offset); damage lands on ARRIVAL (swept 1D contact against the target's
+  box), and an expired bolt despawns harmless. The player's bolts travel the
+  same way — a shot's damage is delayed by ``distance / projectile_speed``.
+- **The warp kit**: the ``rules.should_warp`` gate opens the tell (steering and
+  attack suspended), the blink relocates to the pure far-side landing clamped to
+  the arena (inset by the body's half-width) and drops a slow field there, then
+  a no-attack recovery precedes normal AI. While the player is inside an active
+  field, the player's movement and the player's bolts inside it are slowed by
+  the field's factor; fire cadence stays full speed (input registers — slowed,
+  not stunned).
 
-Spatial model (deliberately 1D): actors live on a single horizontal ground line,
-matching the grounded-platformer steering, which is horizontal. Verticality is a
-platformer detail irrelevant to encounter pacing, so ``y`` is pinned to 0: the
-seam's full-2D distance reduces to the horizontal gap, and the y components of
-spawn offsets, ``warp_offset``, and the field sphere project onto the line (the
-``spatial`` named assumption in the targets file).
+Spatial model (deliberately 1D): actors live on a single horizontal ground line —
+the model targets games whose encounter steering is horizontal. Verticality is
+irrelevant to encounter pacing, so ``y`` is pinned to 0: the rules' full-2D
+distance reduces to the horizontal gap, and the y components of spawn offsets,
+``warp_offset``, and the field sphere project onto the line (a documented model
+assumption a targets file should restate for its game).
 
-The Monte-Carlo variability is the modeled human: the Player's shots land with
+The Monte-Carlo variability is the modeled human: the player's shots land with
 probability ``accuracy`` (rolled at fire time — a missed shot spawns no damaging
-bolt) and the Player evades an otherwise-landing enemy attack — contact or bolt
+bolt) and the player evades an otherwise-landing enemy attack — contact or bolt
 arrival — with probability ``dodge_chance``. Everything else is deterministic,
 so a fixed RNG seed yields an identical outcome (the determinism the pipeline
 needs).
@@ -54,9 +51,9 @@ _INF = float("inf")
 
 @dataclass(frozen=True)
 class TimeField:
-    """One active Time Dilation Field (gADR-0009): the static slow zone the
-    Warp Blink drops at its landing. Injectable as an initial condition for
-    deterministic tests; normally spawned by a Warp kind's blink."""
+    """One active slow field: the static zone a warp kind's blink drops at its
+    landing. Injectable as an initial condition for deterministic tests;
+    normally spawned by a warp kind's blink."""
 
     center_x: float
     radius: float
@@ -86,9 +83,9 @@ class _EnemyState:
     hp: float
     last_attack_time: float = rules.NEVER
     ttk: float | None = None  # when it died (None while alive)
-    # The Warp rotation (gADR-0009): "" (none) / "tell" / "recovery", when the
-    # in-flight phase ends, and the cooldown stamp (NEVER = the first warp is
-    # gated by distance alone — the shipped sentinel).
+    # The warp rotation: "" (none) / "tell" / "recovery", when the in-flight
+    # phase ends, and the cooldown stamp (NEVER = the first warp is gated by
+    # distance alone).
     warp_phase: str = ""
     warp_phase_until: float = 0.0
     last_warp_time: float = rules.NEVER
@@ -130,9 +127,9 @@ def _nearest(player_x: float, living: list[_EnemyState]) -> _EnemyState:
 
 
 def _player_time_factor(fields: list[TimeField], x: float, t: float) -> float:
-    """The Player's current time-dilation factor: the factor of an active field
-    containing the Player, else 1.0. The config gate (``time_field_duration``
-    strictly below ``warp_cooldown``) guarantees at most one active field."""
+    """The player's current slow factor: the factor of an active field
+    containing the player, else 1.0. Keeping ``time_field_duration`` strictly
+    below ``warp_cooldown`` guarantees at most one active field."""
     for f in fields:
         if f.expires_at > t and rules.is_inside_field(
             x, 0.0, f.center_x, 0.0, f.radius
@@ -165,11 +162,11 @@ def simulate_encounter(
 ) -> EncounterOutcome:
     """Run one encounter to its outcome (see :class:`EncounterOutcome`).
 
-    Each tick, in order: the Player moves (time-dilated inside an active field)
-    and fires on cadence; the Player's bolts advance (slowed inside a field) and
-    resolve arrivals; each enemy runs its Warp rotation or steers/attacks by the
-    pure seams; enemy bolts advance and resolve arrivals through the i-frame and
-    dodge gates against the Spacesuit-composed defender.
+    Each tick, in order: the player moves (slowed inside an active field) and
+    fires on cadence; the player's bolts advance (slowed inside a field) and
+    resolve arrivals; each enemy runs its warp rotation or steers/attacks by the
+    pure rules; enemy bolts advance and resolve arrivals through the i-frame and
+    dodge gates against the equipment-composed defender.
     """
     enemies = [
         _EnemyState(
@@ -227,8 +224,8 @@ def simulate_encounter(
         fields = [f for f in fields if f.expires_at > t]
         player_factor = _player_time_factor(fields, ps.x, t)
 
-        # --- Player: close to the engagement distance (time-dilated), then
-        # fire on cadence (input registers at full speed, gADR-0009) ---
+        # --- Player: close to the engagement distance (slowed inside a
+        # field), then fire on cadence (input registers at full speed) ---
         target = _nearest(ps.x, living)
         gap = target.x - ps.x
         advance = abs(gap) - player.engagement_distance
@@ -242,7 +239,7 @@ def simulate_encounter(
                 shot_target = _nearest(ps.x, in_range)
                 ps.last_fire_time = t
                 # Accuracy is rolled at fire time: a missed shot spawns no
-                # damaging bolt (the named assumption in the targets file).
+                # damaging bolt (the documented player-model assumption).
                 if rng.random() < player.accuracy:
                     facing = 1.0 if shot_target.x >= ps.x else -1.0
                     player_bolts.append(
@@ -257,7 +254,7 @@ def simulate_encounter(
                     )
 
         # --- Player bolts: advance (slowed inside an active field — the
-        # despawn timer stays on the real clock, gADR-0009), resolve arrivals ---
+        # despawn timer stays on the real clock), resolve arrivals ---
         surviving_player_bolts: list[_Bolt] = []
         for bolt in player_bolts:
             if t >= bolt.expires_at:
@@ -279,16 +276,16 @@ def simulate_encounter(
             surviving_player_bolts.append(bolt)
         player_bolts = surviving_player_bolts
 
-        # --- Enemies: the Warp rotation, then steering + attack delivery ---
+        # --- Enemies: the warp rotation, then steering + attack delivery ---
         for e in living:
             if rules.is_dead(e.hp):  # killed by this tick's bolt arrivals
                 continue
-            # An in-flight Warp phase suspends steering and attack (gADR-0009).
+            # An in-flight warp phase suspends steering and attack.
             if e.warp_phase:
                 if t < e.warp_phase_until:
                     continue
                 if e.warp_phase == "tell":
-                    # The blink: the pure far-side landing clamped to the Arena
+                    # The blink: the pure far-side landing clamped to the arena
                     # inset by the body's half-width, the field dropped at the
                     # SAME instant (the zone is the warp's wake), then recovery.
                     landing_x, _ = rules.warp_landing(
@@ -315,7 +312,7 @@ def simulate_encounter(
                 else:
                     e.warp_phase = ""
                 continue
-            if rules.should_warp(
+            if rules.should_warp(  # the blink-engage gate
                 e.x,
                 0.0,
                 ps.x,
@@ -327,7 +324,7 @@ def simulate_encounter(
                 t,
             ):
                 # The tell begins: the cooldown is stamped at the DECISION
-                # moment (it spans the whole rotation, the shipped contract).
+                # moment (it spans the whole rotation).
                 e.last_warp_time = t
                 e.warp_phase = "tell"
                 e.warp_phase_until = t + e.kind.warp_tell_duration
@@ -355,9 +352,9 @@ def simulate_encounter(
             ):
                 e.last_attack_time = t
                 if e.kind.archetype == "ranged":
-                    # Bolt delivery (gADR-0003): aim at the Player at fire time;
-                    # a Player exactly overhead (dx == 0) fires nothing (the
-                    # shipped zero-aim guard) though the cooldown is stamped.
+                    # Bolt delivery: aim at the player at fire time; a player
+                    # exactly overhead (dx == 0) fires nothing (the zero-aim
+                    # guard) though the cooldown is stamped.
                     aim = ps.x - e.x
                     if aim != 0.0:
                         direction = 1.0 if aim > 0.0 else -1.0
@@ -372,11 +369,11 @@ def simulate_encounter(
                             )
                         )
                 else:
-                    # Contact delivery (melee; tank since gADR-0009).
+                    # Contact delivery (every non-ranged archetype).
                     damage_player(e.kind.stats.attack, t)
 
-        # --- Enemy bolts: advance (never time-dilated — only the Player's
-        # side slows, gADR-0009), resolve arrivals at the Player ---
+        # --- Enemy bolts: advance (never slowed — only the player's side
+        # slows), resolve arrivals at the player ---
         surviving_enemy_bolts: list[_Bolt] = []
         for bolt in enemy_bolts:
             if t >= bolt.expires_at:

--- a/examples/platformer/panda-adventure/tools/balancing/integrate.py
+++ b/examples/platformer/panda-adventure/tools/balancing/integrate.py
@@ -1,10 +1,10 @@
-"""A hand-rolled fixed-step RK4 integrator (game-agnostic, stdlib-only, #440).
+"""A hand-rolled fixed-step RK4 integrator (game-agnostic, stdlib-only).
 
-The system-dynamics half of the Balancing pipeline integrates a first-order
+The system-dynamics half of the balancing pipeline integrates a first-order
 nonlinear ODE system (``dynamics``) with the classical 4th-order Runge-Kutta
-method. gADR-0011 keeps the whole pipeline pure-Python with NO new dependency
-(no numpy/scipy), so the integrator is hand-rolled here: a few lines of the
-textbook RK4 tableau over a bare ``tuple[float, ...]`` state vector.
+method. The pipeline stays pure-Python with NO dependency (no numpy/scipy), so
+the integrator is hand-rolled here: a few lines of the textbook RK4 tableau
+over a bare ``tuple[float, ...]`` state vector.
 
 The integrator is deliberately generic — it knows nothing about stocks, flows,
 or the game. A derivative function ``f(t, y) -> dy`` and a step size are all it

--- a/examples/platformer/panda-adventure/tools/balancing/model.py
+++ b/examples/platformer/panda-adventure/tools/balancing/model.py
@@ -27,6 +27,20 @@ class StatBlock:
     defense: float
 
 
+def compose_defender(base: StatBlock, defense_bonus: float) -> StatBlock:
+    """The worn-equipment defender composition every adapter needs: a fresh
+    block copying ``base`` with ``defense`` raised by the equipment's bonus —
+    the formula's mitigation term changes, the other stats copy unchanged.
+    Public so adapters build ``GameData.player_defender`` without reaching
+    into the ruleset internals."""
+    return StatBlock(
+        max_hp=base.max_hp,
+        max_mp=base.max_mp,
+        attack=base.attack,
+        defense=rules.effective_defense(base.defense, defense_bonus),
+    )
+
+
 @dataclass(frozen=True)
 class CombatParams:
     """The damage-formula and i-frame params, plus the player's ranged-weapon

--- a/examples/platformer/panda-adventure/tools/balancing/model.py
+++ b/examples/platformer/panda-adventure/tools/balancing/model.py
@@ -1,15 +1,17 @@
-"""The plain dataclasses the balancing pipeline runs on (game-agnostic).
+"""The plain dataclasses the balancing pipeline runs on.
 
-These carry the numbers the encounter simulation and validate report need,
-decoupled from any game's on-disk shape: the per-game adapter (``game_config``)
-maps a game's JSON authority into these, and the generic core (``encounter``,
-``statistics``, ``report``) consumes only these — never the raw JSON. Every
-field is a bare scalar so the model imports nothing but ``dataclasses``.
+These carry the numbers the two engines need, decoupled from any game's
+on-disk config shape: a per-game adapter (see the package docstring) maps the
+game's config authority into these, and the pipeline (``encounter``,
+``dynamics``, ``statistics``, ``report``, ``prediction``) consumes only these —
+never the raw config files. Every field is a bare scalar or a plain mapping,
+so the model imports nothing but ``dataclasses``.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from . import rules
 
@@ -17,7 +19,7 @@ from . import rules
 @dataclass(frozen=True)
 class StatBlock:
     """One actor's combat stat block — the symmetric attacker/defender contract
-    of the damage formula (the game's ``StatsConfig``)."""
+    of the damage formula."""
 
     max_hp: float
     max_mp: float
@@ -27,10 +29,9 @@ class StatBlock:
 
 @dataclass(frozen=True)
 class CombatParams:
-    """The damage-formula and i-frame params, plus the player's Laser Gun bolt
-    (speed, lifetime, spawn offset, half-width — the bolt is a traveling body,
-    so damage lands on ARRIVAL, not at fire time) — from the combat config
-    authority plus the Scale spec's ``player_projectile_size``."""
+    """The damage-formula and i-frame params, plus the player's ranged-weapon
+    bolt (speed, lifetime, spawn offset, half-width — the bolt is a traveling
+    body, so damage lands on ARRIVAL, not at fire time)."""
 
     attack_scale: float
     defense_scale: float
@@ -49,13 +50,15 @@ class CombatParams:
 
 @dataclass(frozen=True)
 class EnemyKind:
-    """One Enemy Kind's sim-relevant numbers: its stat block, the Archetype-AI
-    gating params (Aggro Range, attack range/cooldown, Steering Band), its box
-    half-width (bolt contact + the arena landing inset), the Ranged bolt block
-    (gADR-0003 — present iff the kind is ranged), and the presence-gated Warp
-    kit (gADR-0009 — ``warp_cooldown`` 0.0 means no kit, the ``WarpSystem``
-    has-Warp predicate). Cosmetic and juice fields are irrelevant to TTK/TTD
-    and omitted."""
+    """One enemy kind's sim-relevant numbers: its stat block, the archetype-AI
+    gating params (aggro range, attack range/cooldown, steering band), its box
+    half-width (bolt contact + the arena landing inset), the ranged bolt block,
+    and the presence-gated warp kit (``warp_cooldown`` 0.0 means no kit — the
+    has-warp predicate). ``archetype`` is the framework's delivery taxonomy,
+    not a free-form label: the literal value ``"ranged"`` selects traveling-bolt
+    delivery (and requires the bolt block), any other value delivers by contact
+    — an adapter must map its game's own kind taxonomy onto it. Cosmetic fields
+    are irrelevant to TTK/TTD and omitted."""
 
     name: str
     tier: str
@@ -68,12 +71,12 @@ class EnemyKind:
     keep_range_min: float
     keep_range_max: float
     half_width: float = 0.0
-    # Ranged bolt delivery (gADR-0003): the enemy bolt's motion + contact box.
+    # Ranged bolt delivery: the enemy bolt's motion + contact box.
     projectile_speed: float = 0.0
     projectile_lifetime: float = 0.0
     projectile_spawn_offset_x: float = 0.0
     projectile_half_width: float = 0.0
-    # The Boss Warp kit (gADR-0009), presence-gated on warp_cooldown > 0.
+    # The warp kit (a blink-engage rotation), presence-gated on warp_cooldown > 0.
     warp_cooldown: float = 0.0
     warp_trigger_range: float = 0.0
     warp_offset_x: float = 0.0
@@ -86,7 +89,7 @@ class EnemyKind:
 
 @dataclass(frozen=True)
 class Spawn:
-    """One Spawn Roster entry: which kind spawns where (its x on the ground)."""
+    """One spawn-roster entry: which kind spawns where (its x on the ground)."""
 
     kind: str
     name: str
@@ -96,7 +99,7 @@ class Spawn:
 
 @dataclass(frozen=True)
 class Wave:
-    """One Wave: an ordered composition of spawns (a Spawn Roster)."""
+    """One wave: an ordered composition of spawns (a spawn roster)."""
 
     index: int
     spawns: tuple[Spawn, ...]
@@ -107,17 +110,18 @@ class PlayerModel:
     """The stochastic player the Monte-Carlo sim runs — the design ASSUMPTIONS
     about how a player fights, not game runtime config.
 
-    The stat block, move speed, spawn position, half-width, and the
-    Spacesuit-composed ``defender`` block come from the game's JSON authority;
+    The stat block, move speed, spawn position, half-width, and the composed
+    ``defender`` block come from the game's config authority (via the adapter);
     the behavioral assumptions (``fire_interval``, ``accuracy``,
-    ``dodge_chance``, ``engagement_distance``) are design inputs that live in the
-    targets file, because the game has no Laser-Gun fire-rate config — firing is
-    per-input-press, so the pipeline must model the human's cadence and aim.
+    ``dodge_chance``, ``engagement_distance``) are design inputs that live in
+    the targets file — a game usually has no fire-rate config for a
+    per-input-press weapon, so the pipeline must model the human's cadence
+    and aim.
 
     ``defender`` is the stat block incoming enemy damage mitigates against —
-    the game's ``ItemSystem.effective_defender`` composition (base defense +
-    the worn Spacesuit's bonus, gADR-0008). ``None`` falls back to ``stats``
-    (an unequipped model)."""
+    the worn-equipment composition the adapter supplies (base defense + the
+    equipment's bonus). ``None`` falls back to ``stats`` (an unequipped
+    model)."""
 
     stats: StatBlock
     move_speed: float
@@ -131,8 +135,7 @@ class PlayerModel:
 
     @property
     def defender_stats(self) -> StatBlock:
-        """The block incoming damage mitigates against (the game's
-        ``_defender_stats`` fallback shape)."""
+        """The block incoming damage mitigates against."""
         return self.defender if self.defender is not None else self.stats
 
 
@@ -149,7 +152,7 @@ class SimConfig:
 
 @dataclass(frozen=True)
 class WaveTarget:
-    """The design intent for one Wave: the intended time to clear it (TTK) and
+    """The design intent for one wave: the intended time to clear it (TTK) and
     the intended player survival time (TTD)."""
 
     wave: int
@@ -171,70 +174,120 @@ class Targets:
 
 @dataclass(frozen=True)
 class GameData:
-    """The game-side inputs the sim needs, mapped out of the JSON authority."""
+    """The game-side inputs the encounter sim needs, mapped out of the game's
+    config authority by its adapter. ``player_defender`` is the pre-composed
+    worn-equipment defender block (``None`` = unequipped)."""
 
     player_stats: StatBlock
     player_move_speed: float
     player_start_x: float
     player_half_width: float
-    spacesuit_defense: float
     combat: CombatParams
     kinds: dict[str, EnemyKind]
     waves: tuple[Wave, ...]
-    # The authored Arena interval (gADR-0010) that clamps the Warp Blink's
-    # landing; an infinite default means "no arena" (unit-test convenience).
+    player_defender: StatBlock | None = None
+    # The authored arena interval that clamps the warp blink's landing; an
+    # infinite default means "no arena" (unit-test convenience).
     arena_min_x: float = float("-inf")
     arena_max_x: float = float("inf")
 
 
-# --- The growth/economy inputs the system-dynamics model runs on (#440) ------ #
+def build_player_model(
+    game: GameData, player_model_params: dict[str, Any]
+) -> PlayerModel:
+    """Combine the game's player numbers with the design player-model assumptions.
+
+    ``player_model_params`` are the design inputs from the targets file (fire
+    cadence, aim, evasion, engagement distance); everything else — including the
+    pre-composed ``defender`` block — comes from the adapter-mapped
+    :class:`GameData`.
+    """
+    return PlayerModel(
+        stats=game.player_stats,
+        move_speed=game.player_move_speed,
+        start_x=game.player_start_x,
+        fire_interval=player_model_params["fire_interval"],
+        accuracy=player_model_params["accuracy"],
+        dodge_chance=player_model_params["dodge_chance"],
+        engagement_distance=player_model_params["engagement_distance"],
+        defender=game.player_defender,
+        half_width=game.player_half_width,
+    )
+
+
+# --- The growth/economy inputs the system-dynamics model runs on ------------- #
 #
 # The SD model needs the reward and progression numbers the encounter sim does
-# NOT — the per-Tier Kill reward + Drop table, the Leveling curve, and the
-# Consumable restore amounts — so these plain dataclasses carry them, mapped out
-# of the same JSON authority by the same per-game adapter (``game_config``), never
-# a second parser (gADR-0011). Every field stays a bare scalar / mapping.
+# NOT — the per-tier kill reward + drop table, the leveling curve, and the
+# heal-item restore amount — so these plain dataclasses carry them, mapped out
+# of the same config authority by the same per-game adapter, never a second
+# parser. Every field stays a bare scalar / mapping.
 
 
 @dataclass(frozen=True)
 class TierReward:
-    """One Tier's Kill reward and expected Drop yield (the enemies config's
-    per-Tier reward table, gADR-0004/0006): the guaranteed EXP/Gold plus the
-    per-item EXPECTED drop count (``Σ amount × chance`` over that item's Drop
-    table entries — the mean-field inflow the SD economy integrates, not a roll)."""
+    """One tier's kill reward and expected drop yield: the guaranteed
+    EXP/currency plus the per-item EXPECTED drop count (``Σ amount × chance``
+    over that item's drop-table entries — the mean-field inflow the SD economy
+    integrates, not a roll)."""
 
     tier: str
     exp_reward: float
-    gold_reward: float
+    currency_reward: float
     expected_drops: dict[str, float]
 
     def expected_drop(self, item: str) -> float:
-        """The expected count of ``item`` a kill of this Tier yields (0 if none)."""
+        """The expected count of ``item`` a kill of this tier yields (0 if none)."""
         return self.expected_drops.get(item, 0.0)
 
 
 @dataclass(frozen=True)
 class GrowthEconomy:
-    """The growth/economy authority the SD model integrates over — the Leveling
-    curve (EXP→Level), the per-Tier Kill reward + expected Drop yield, and the
-    Consumable restore amounts and player pools. Mapped from ``progression_config``
-    / ``enemies_config`` / ``items_config`` / ``combat_config`` (#440)."""
+    """The growth/economy authority the SD model integrates over — the leveling
+    curve (EXP→level), the per-tier kill reward + expected drop yield, and the
+    item bindings: ``currency_item`` names the drop key whose yield folds into
+    the currency stock (alongside the kill reward), ``heal_item`` names the
+    consumable the balancing heal loop drains (restoring ``heal_item_restore``
+    HP per unit). Every other dropped item is tracked as an inflow-only stock."""
 
     level_curve: tuple[float, ...]
     tier_rewards: dict[str, TierReward]
-    bun_hp_restore: float
-    wine_mp_restore: float
     player_max_hp: float
-    player_max_mp: float
+    currency_item: str | None = None
+    heal_item: str | None = None
+    heal_item_restore: float = 0.0
+
+    @property
+    def item_keys(self) -> tuple[str, ...]:
+        """The tracked item stocks, in deterministic (sorted) order: every drop
+        key except the currency item, plus the heal item (whose stock the heal
+        loop needs even when no tier drops it)."""
+        keys = {
+            item
+            for reward in self.tier_rewards.values()
+            for item in reward.expected_drops
+        }
+        keys.discard(self.currency_item or "")
+        if self.heal_item is not None:
+            keys.add(self.heal_item)
+        return tuple(sorted(keys))
 
     def level_for(self, exp: float) -> int:
-        """The Player's Level at a cumulative EXP total — the parity-pinned
-        ``rules.resolve_level`` (``GrowthSystem.resolve_level``, gADR-0006), so
-        the SD growth loop reads Level through the same mirror the golden fixtures
-        pin against the shipped GDScript, not a private copy."""
+        """The player's level at a cumulative EXP total — resolved through the
+        shared :func:`rules.resolve_level`, so the SD growth loop reads level
+        through the same ruleset the engines run on, not a private copy."""
         return rules.resolve_level(exp, list(self.level_curve))
 
     @property
     def max_level(self) -> int:
-        """The highest reachable Level (the curve's length + 1)."""
+        """The highest reachable level (the curve's length + 1)."""
         return len(self.level_curve) + 1
+
+
+@dataclass(frozen=True)
+class GameInputs:
+    """What an adapter returns: the encounter inputs, plus the growth/economy
+    inputs when the game wants predict mode (``None`` = validate-only)."""
+
+    game: GameData
+    economy: GrowthEconomy | None = None

--- a/examples/platformer/panda-adventure/tools/balancing/prediction.py
+++ b/examples/platformer/panda-adventure/tools/balancing/prediction.py
@@ -3,20 +3,20 @@
 The system-dynamics counterpart of validate mode (``report``): it integrates the
 whole-run growth/economy trajectory (``dynamics``) and renders it against the
 difficulty/growth design targets, then cross-validates the macro model against
-the Monte-Carlo micro engine on their overlapping domain (gADR-0011, #440). Like
-validate, it is a PURE READ of the JSON authority — it builds a report object and
-writes NOTHING back to config (the ``cli`` layer owns emission, and refuses an
-``--out`` inside the authority tree).
+the Monte-Carlo micro engine on their overlapping domain. Like validate, it is a
+PURE READ of the game's config authority — it builds a report object and writes
+NOTHING back to config (the ``cli`` layer owns emission, and refuses an
+``--out`` inside a protected tree).
 
 Three sections:
 
-- **Trajectory** — per-Wave: the SD clear/death time, the HP band, the accrued
-  stocks (EXP/Level, Gold, Consumables in/out), and the difficulty index. Plus
+- **Trajectory** — per wave: the SD clear/death time, the HP band, the accrued
+  stocks (EXP/level, currency, items in/out), and the difficulty index. Plus
   the run verdict (did the designed kit clear the schedule?) and end stocks.
-- **Design targets** — the growth curve (per-Wave Level checkpoints + a minimum
-  final Level) and the difficulty ramp (is the Boss the peak?) checked against the
-  targets file's intent, mirroring validate's tolerance verdict.
-- **Cross-validation** — per overlapping Wave, the SD prediction in the reduced
+- **Design targets** — the growth curve (per-wave level checkpoints + a minimum
+  final level) and the difficulty ramp (is the final wave the peak?) checked
+  against the targets file's intent, mirroring validate's tolerance verdict.
+- **Cross-validation** — per overlapping wave, the SD prediction in the reduced
   bare-brawl scenario (growth + healing off) vs the MC median it must not
   contradict: SD clear time ↔ MC median TTK where both clear, SD death time ↔ MC
   median TTD where both die, within the DOCUMENTED cross-validation tolerance
@@ -24,20 +24,18 @@ Three sections:
   deterministic mean-field aggregate — see ``dynamics``).
 
 Exit contract (in ``cli``): 0 when the prediction meets its design targets AND
-every overlapping Wave cross-validates within tolerance; 1 when either fails; 2
+every overlapping wave cross-validates within tolerance; 1 when either fails; 2
 for a refused/invalid input.
 """
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
 from . import report
+from .config import SdConfig
 from .dynamics import (
-    SdParams,
     WaveOutcome,
     build_wave_dynamics,
     run_scenario,
@@ -45,72 +43,14 @@ from .dynamics import (
 )
 from .model import GameData, GrowthEconomy, PlayerModel, SimConfig, Targets
 
-
-@dataclass(frozen=True)
-class LevelCheckpoint:
-    """A growth design checkpoint: the minimum Level the Player should have
-    reached after clearing a given Wave."""
-
-    after_wave: int
-    min_level: int
-
-
-@dataclass(frozen=True)
-class SdDesignTargets:
-    """The growth/difficulty design intent the prediction is checked against."""
-
-    min_final_level: int
-    level_checkpoints: tuple[LevelCheckpoint, ...]
-    boss_is_peak: bool
-    expect_monotonic_ramp: bool
-
-
-@dataclass(frozen=True)
-class SdConfig:
-    """The ``sd_model`` block of a targets file: the model params/levers, the
-    cross-validation tolerance, and the design targets."""
-
-    params: SdParams
-    cross_validation_tolerance: float
-    targets: SdDesignTargets
-
-
-def load_sd_config(path: Path) -> SdConfig:
-    """Parse the ``sd_model`` block of a targets file into an :class:`SdConfig`."""
-    doc = json.loads(path.read_text(encoding="utf-8"))
-    sd = doc["sd_model"]
-    p = sd["params"]
-    t = sd["targets"]
-    growth = t["growth"]
-    return SdConfig(
-        params=SdParams(
-            dt=p["dt"],
-            max_wave_time=p["max_wave_time"],
-            growth_gain=p["growth_gain"],
-            heal_threshold_frac=p["heal_threshold_frac"],
-            bun_consume_rate=p["bun_consume_rate"],
-        ),
-        cross_validation_tolerance=sd["cross_validation"]["tolerance"],
-        targets=SdDesignTargets(
-            min_final_level=growth["min_final_level"],
-            level_checkpoints=tuple(
-                LevelCheckpoint(after_wave=c["after_wave"], min_level=c["min_level"])
-                for c in growth["checkpoints"]
-            ),
-            boss_is_peak=t["difficulty"]["boss_is_peak"],
-            expect_monotonic_ramp=t["difficulty"]["expect_monotonic_ramp"],
-        ),
-    )
-
-
 # --- Cross-validation against the MC engine ---------------------------------- #
 
 
 @dataclass(frozen=True)
 class CrossCheck:
-    """One Wave's SD↔MC cross-validation on their overlapping quantity.
+    """One wave's SD↔MC cross-validation on their overlapping quantity.
 
-    ``metric`` names which quantity the domains share on this Wave — ``"ttk"``
+    ``metric`` names which quantity the domains share on this wave — ``"ttk"``
     (both clear: SD clear time vs MC median TTK) or ``"ttd"`` (both die: SD death
     time vs MC median TTD). ``clearing_agreement`` is whether the two models agree
     on the outcome (clear vs die) at all; when they disagree, the metric compare
@@ -136,7 +76,7 @@ def _cross_check(
     mc_death_rate: float,
     tolerance: float,
 ) -> CrossCheck:
-    """Compare one Wave's SD overlap prediction to the MC medians.
+    """Compare one wave's SD overlap prediction to the MC medians.
 
     MC's majority outcome (clear_rate ≥ 0.5) is the reference; SD must agree on
     clearing, and match the median of whichever quantity is defined there (TTK if
@@ -179,16 +119,15 @@ class PredictionReport:
     died_at_wave: int | None
     final_level: int
     final_hp: float
-    final_gold: float
-    final_bun: float
-    final_wine: float
+    final_currency: float
+    final_items: dict[str, float]
     # Design-target verdicts.
     min_final_level: int
     final_level_ok: bool
     checkpoint_ok: bool
-    boss_is_peak_expected: bool
-    boss_is_peak_actual: bool
-    boss_peak_ok: bool
+    final_wave_is_peak_expected: bool
+    final_wave_is_peak_actual: bool
+    final_wave_peak_ok: bool
     monotonic_ramp_expected: bool
     monotonic_ramp_actual: bool
     monotonic_ramp_ok: bool
@@ -204,13 +143,13 @@ class PredictionReport:
         return (
             self.final_level_ok
             and self.checkpoint_ok
-            and self.boss_peak_ok
+            and self.final_wave_peak_ok
             and self.monotonic_ramp_ok
         )
 
     @property
     def cross_validation_ok(self) -> bool:
-        """Every overlapping Wave agrees with MC within tolerance."""
+        """Every overlapping wave agrees with MC within tolerance."""
         return all(
             c.clearing_agreement and c.within_tolerance for c in self.cross_checks
         )
@@ -229,7 +168,7 @@ def run_prediction(
     sd: SdConfig,
 ) -> PredictionReport:
     """Integrate the SD trajectory, check the design targets, and cross-validate
-    against the MC engine. Pure read; produces no config (gADR-0011).
+    against the MC engine. Pure read; produces no config.
     """
     dynamics = build_wave_dynamics(game, econ, player)
     run = run_scenario(dynamics, sd.params, econ)
@@ -244,8 +183,8 @@ def run_prediction(
         for c in sd.targets.level_checkpoints
     )
     difficulties = [o.difficulty for o in run.waves]
-    boss_peak_actual = bool(difficulties) and difficulties[-1] == max(difficulties)
-    boss_peak_ok = boss_peak_actual == sd.targets.boss_is_peak
+    peak_actual = bool(difficulties) and difficulties[-1] == max(difficulties)
+    peak_ok = peak_actual == sd.targets.final_wave_is_peak
     monotonic_actual = all(a <= b for a, b in zip(difficulties, difficulties[1:]))
     monotonic_ramp_ok = monotonic_actual == sd.targets.expect_monotonic_ramp
 
@@ -274,15 +213,14 @@ def run_prediction(
         died_at_wave=run.died_at_wave,
         final_level=run.final_level,
         final_hp=run.final_hp,
-        final_gold=run.final_gold,
-        final_bun=run.final_bun,
-        final_wine=run.final_wine,
+        final_currency=run.final_currency,
+        final_items=run.final_items,
         min_final_level=sd.targets.min_final_level,
         final_level_ok=final_level_ok,
         checkpoint_ok=checkpoint_ok,
-        boss_is_peak_expected=sd.targets.boss_is_peak,
-        boss_is_peak_actual=boss_peak_actual,
-        boss_peak_ok=boss_peak_ok,
+        final_wave_is_peak_expected=sd.targets.final_wave_is_peak,
+        final_wave_is_peak_actual=peak_actual,
+        final_wave_peak_ok=peak_ok,
         monotonic_ramp_expected=sd.targets.expect_monotonic_ramp,
         monotonic_ramp_actual=monotonic_actual,
         monotonic_ramp_ok=monotonic_ramp_ok,
@@ -313,10 +251,9 @@ def _wave_dict(o: WaveOutcome) -> dict[str, Any]:
         "exp_end": o.exp_end,
         "exp_gained": o.exp_gained,
         "level_end": o.level_end,
-        "gold_end": o.gold_end,
-        "bun_start": o.bun_start,
-        "bun_end": o.bun_end,
-        "wine_end": o.wine_end,
+        "currency_end": o.currency_end,
+        "items_start": dict(o.items_start),
+        "items_end": dict(o.items_end),
         "difficulty": o.difficulty,
     }
 
@@ -342,16 +279,15 @@ def report_to_dict(report: PredictionReport) -> dict[str, Any]:
         "died_at_wave": report.died_at_wave,
         "final_level": report.final_level,
         "final_hp": report.final_hp,
-        "final_gold": report.final_gold,
-        "final_bun": report.final_bun,
-        "final_wine": report.final_wine,
+        "final_currency": report.final_currency,
+        "final_items": dict(report.final_items),
         "design_targets": {
             "min_final_level": report.min_final_level,
             "final_level_ok": report.final_level_ok,
             "checkpoint_ok": report.checkpoint_ok,
-            "boss_is_peak_expected": report.boss_is_peak_expected,
-            "boss_is_peak_actual": report.boss_is_peak_actual,
-            "boss_peak_ok": report.boss_peak_ok,
+            "final_wave_is_peak_expected": report.final_wave_is_peak_expected,
+            "final_wave_is_peak_actual": report.final_wave_is_peak_actual,
+            "final_wave_peak_ok": report.final_wave_peak_ok,
             "monotonic_ramp_expected": report.monotonic_ramp_expected,
             "monotonic_ramp_actual": report.monotonic_ramp_actual,
             "monotonic_ramp_ok": report.monotonic_ramp_ok,
@@ -376,28 +312,31 @@ def format_text(report: PredictionReport) -> str:
     def opt(v: float | None, fmt: str) -> str:
         return "-" if v is None else format(v, fmt)
 
+    items = sorted(report.final_items)
+    item_headers = "".join(f" {name[:5]:>5}" for name in items)
     lines = [
         "Balancing predict — long-term SD trajectory vs design + MC cross-validation",
         f"{'wave':>4}  {'clear':>7} {'death':>7}  {'HP end':>7} {'HP min':>7}  "
-        f"{'EXP':>6} {'Lv':>3}  {'gold':>6} {'bun':>5} {'wine':>5}  {'diff':>6}",
+        f"{'EXP':>6} {'Lv':>3}  {'cur':>6}{item_headers}  {'diff':>6}",
     ]
     for o in report.waves:
+        item_cells = "".join(f" {o.items_end.get(name, 0.0):>5.2f}" for name in items)
         lines.append(
             f"{o.index:>4}  {opt(o.clear_time, '7.2f')} {opt(o.death_time, '7.2f')}  "
             f"{o.hp_end:>7.1f} {o.hp_min:>7.1f}  {o.exp_end:>6.0f} {o.level_end:>3}  "
-            f"{o.gold_end:>6.0f} {o.bun_end:>5.2f} {o.wine_end:>5.2f}  {o.difficulty:>6.3f}"
+            f"{o.currency_end:>6.0f}{item_cells}  {o.difficulty:>6.3f}"
         )
     verdict = (
-        f"cleared the schedule (final Level {report.final_level})"
+        f"cleared the schedule (final level {report.final_level})"
         if report.cleared_schedule
-        else f"DIED at wave {report.died_at_wave} (final Level {report.final_level})"
+        else f"DIED at wave {report.died_at_wave} (final level {report.final_level})"
     )
     lines.append(f"RUN: {verdict}")
     lines.append(
-        f"DESIGN: final Level {report.final_level} >= {report.min_final_level} "
+        f"DESIGN: final level {report.final_level} >= {report.min_final_level} "
         f"[{mark(report.final_level_ok)}]  checkpoints [{mark(report.checkpoint_ok)}]  "
-        f"boss-is-peak {report.boss_is_peak_actual} "
-        f"(want {report.boss_is_peak_expected}) [{mark(report.boss_peak_ok)}]  "
+        f"final-wave-is-peak {report.final_wave_is_peak_actual} "
+        f"(want {report.final_wave_is_peak_expected}) [{mark(report.final_wave_peak_ok)}]  "
         f"monotonic-ramp {report.monotonic_ramp_actual} "
         f"(want {report.monotonic_ramp_expected}) [{mark(report.monotonic_ramp_ok)}]"
     )

--- a/examples/platformer/panda-adventure/tools/balancing/report.py
+++ b/examples/platformer/panda-adventure/tools/balancing/report.py
@@ -1,65 +1,29 @@
-"""Validate mode: per-wave measured TTK/TTD vs design targets (gADR-0011, #437).
+"""Validate mode: per-wave measured TTK/TTD vs design targets.
 
-Runs the Monte-Carlo encounter simulation over every Wave, summarizes the
-per-run samples, and checks each Wave's median TTK/TTD against its design target
-within a configurable relative tolerance. This is a PURE READ of the JSON
-authority: it produces a report object and writes NOTHING back to config — this
-slice is validate-only. Emitting the report to stdout or an ``--out`` path is
-the caller's job (``cli``); those paths are never a config file.
+Runs the Monte-Carlo encounter simulation over every wave, summarizes the
+per-run samples, and checks each wave's median TTK/TTD against its design target
+within a configurable relative tolerance. This is a PURE READ of the game's
+config authority: it produces a report object and writes NOTHING back to config.
+Emitting the report to stdout or an ``--out`` path is the caller's job
+(``cli``); those paths are never a config file.
 """
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
 from . import statistics
 from .encounter import run_wave
-from .model import GameData, PlayerModel, SimConfig, Targets, WaveTarget
+from .model import GameData, PlayerModel, SimConfig, Targets
 from .statistics import Distribution
 
 
 @dataclass(frozen=True)
-class PipelineConfig:
-    """One targets file parsed: where the config lives, the player-model
-    assumptions, the sim controls, and the design targets."""
-
-    config_dir: str
-    player_model_params: dict[str, Any]
-    sim: SimConfig
-    targets: Targets
-
-
-def load_pipeline_config(path: Path) -> PipelineConfig:
-    """Parse a targets file (the per-game configuration) into a PipelineConfig."""
-    doc = json.loads(path.read_text(encoding="utf-8"))
-    sim = doc["simulation"]
-    return PipelineConfig(
-        config_dir=doc["config_dir"],
-        player_model_params=dict(doc["player_model"]),
-        sim=SimConfig(
-            dt=sim["dt"],
-            max_time=sim["max_time"],
-            runs=sim["runs"],
-            seed=sim["seed"],
-        ),
-        targets=Targets(
-            waves=tuple(
-                WaveTarget(wave=w["wave"], ttk=w["ttk"], ttd=w["ttd"])
-                for w in doc["waves"]
-            ),
-            tolerance=doc["tolerance"],
-        ),
-    )
-
-
-@dataclass(frozen=True)
 class WaveReport:
-    """One Wave's validate result: the measured TTK/TTD distributions and clear/
+    """One wave's validate result: the measured TTK/TTD distributions and clear/
     death rates, its targets, and whether the medians fall within tolerance
-    (None when the Wave has no target — report only)."""
+    (None when the wave has no target — report only)."""
 
     wave: int
     ttk: Distribution
@@ -83,7 +47,7 @@ class ValidationReport:
 
     @property
     def all_within_tolerance(self) -> bool:
-        """True iff every Wave that HAS a target is within tolerance on both
+        """True iff every wave that HAS a target is within tolerance on both
         TTK and TTD. A run with no targets at all is vacuously within."""
         checks = [
             ok
@@ -108,9 +72,9 @@ def run_validation(
     sim: SimConfig,
     targets: Targets,
 ) -> ValidationReport:
-    """Simulate every Wave and compare the median TTK/TTD to its design target.
+    """Simulate every wave and compare the median TTK/TTD to its design target.
 
-    Each Wave draws from its own ``seed + wave.index`` RNG stream, so the whole
+    Each wave draws from its own ``seed + wave.index`` RNG stream, so the whole
     report is reproducible from ``sim.seed`` yet waves stay independent. Reads
     only; produces no config.
     """

--- a/examples/platformer/panda-adventure/tools/balancing/rules.py
+++ b/examples/platformer/panda-adventure/tools/balancing/rules.py
@@ -1,35 +1,29 @@
-"""Pure Python reimplementation of the game's combat/AI logic seams (gADR-0011).
+"""The pipeline's reference ruleset: the pure decision functions both engines run on.
 
-These functions mirror the shipped GDScript statics —
-``src/systems/combat_system.gd`` (``CombatSystem``), ``src/systems/enemy_ai.gd``
-(``EnemyAI``), ``src/systems/warp_system.gd`` (``WarpSystem``, the Boss Warp
-kit's pure decisions, gADR-0009), ``src/systems/item_system.gd``
-(``ItemSystem.effective_defender``'s defense composition, gADR-0008), and
-``src/systems/growth_system.gd`` (``GrowthSystem.resolve_level``, the Leveling
-readout, gADR-0006) — one-for-one. gADR-0011 forbids the balancing pipeline from
-importing the game's GDScript, so the rules are reimplemented here and pinned
-against the GDScript ground truth by golden parity fixtures
-(``tests/fixtures/balancing/seams.json``, generated FROM the seams via
-``gda script run``). A rule change on either side breaks parity until both
-co-evolve — the price gADR-0011 pays for isolation.
+Damage, i-frames, death, steering, attack gating, the warp kit's decisions,
+slow-field membership, equipment defense composition, and level resolution —
+every function is pure, deterministic, and clock-free: time and positions are
+parameters. Positions are passed as bare ``(x, y)`` floats rather than a vector
+type so this module depends on nothing but ``math``.
 
-Every function is pure, deterministic, and clock-free: time and positions are
-parameters, exactly as in the GDScript. Positions are passed as bare ``(x, y)``
-floats rather than a Vector2 so this module depends on nothing but ``math``.
+A game that implements the same rules in its own engine code is expected to pin
+the correspondence with golden parity fixtures generated FROM its engine-side
+implementation (the host project's test suite owns that gate); the pipeline
+itself never imports game code. A rule change on either side then breaks parity
+until both co-evolve — the price the pipeline pays for isolation.
 """
 
 from __future__ import annotations
 
 import math
 
-# The sentinel a never-hit / never-attacked actor uses (mirrors the GDScript's
-# -INF): ``now - (-inf) == inf``, so an i-frame window is never active and an
-# attack cooldown is always ready.
+# The sentinel a never-hit / never-attacked actor uses: ``now - (-inf) == inf``,
+# so an i-frame window is never active and an attack cooldown is always ready.
 NEVER = float("-inf")
 
 
 def _signf(value: float) -> float:
-    """Godot ``signf``: -1.0 / 0.0 / 1.0, with an exact 0.0 for a 0.0 input."""
+    """Sign as -1.0 / 0.0 / 1.0, with an exact 0.0 for a 0.0 input."""
     if value > 0.0:
         return 1.0
     if value < 0.0:
@@ -38,11 +32,11 @@ def _signf(value: float) -> float:
 
 
 def _distance(self_x: float, self_y: float, player_x: float, player_y: float) -> float:
-    """The full 2D Euclidean distance — Godot ``Vector2.distance_to``."""
+    """The full 2D Euclidean distance between the two positions."""
     return math.hypot(player_x - self_x, player_y - self_y)
 
 
-# --- CombatSystem (src/systems/combat_system.gd) ---------------------------- #
+# --- Combat ------------------------------------------------------------------ #
 
 
 def compute_damage(
@@ -54,7 +48,7 @@ def compute_damage(
 ) -> float:
     """The data-driven damage formula: scaled attack minus scaled mitigation,
     floored at ``min_damage``. Symmetric — the same call serves player->enemy
-    and enemy->player with the roles swapped (``CombatSystem.compute_damage``)."""
+    and enemy->player with the roles swapped."""
     return max(
         min_damage,
         attacker_attack * attack_scale - defender_defense * defense_scale,
@@ -62,17 +56,17 @@ def compute_damage(
 
 
 def is_invulnerable(last_hit_time: float, now: float, iframe_duration: float) -> bool:
-    """True while the defender is inside its post-hit i-frame window
-    (``CombatSystem.is_invulnerable``). The ``NEVER`` sentinel is never invuln."""
+    """True while the defender is inside its post-hit i-frame window. The
+    ``NEVER`` sentinel is never invulnerable."""
     return (now - last_hit_time) < iframe_duration
 
 
 def is_dead(hp: float) -> bool:
-    """The death rule: an actor dies at exactly 0 HP (``CombatSystem.is_dead``)."""
+    """The death rule: an actor dies at exactly 0 HP."""
     return hp <= 0.0
 
 
-# --- EnemyAI (src/systems/enemy_ai.gd) -------------------------------------- #
+# --- Enemy AI ----------------------------------------------------------------- #
 
 
 def compute_move_dir(
@@ -84,10 +78,10 @@ def compute_move_dir(
     keep_range_min: float,
     keep_range_max: float,
 ) -> float:
-    """Horizontal steering: -1 / 0 / 1 (``EnemyAI.compute_move_dir``). Dormant
-    beyond the Aggro Range; close in beyond ``keep_range_max``, back off inside
-    ``keep_range_min``, hold within the Steering Band. A Player directly above
-    (dx == 0) yields 0 — nowhere to steer horizontally."""
+    """Horizontal steering: -1 / 0 / 1. Dormant beyond the aggro range; close
+    in beyond ``keep_range_max``, back off inside ``keep_range_min``, hold
+    within the steering band. A player directly above (dx == 0) yields 0 —
+    nowhere to steer horizontally."""
     distance = _distance(self_x, self_y, player_x, player_y)
     if distance > aggro_range:
         return 0.0
@@ -100,8 +94,8 @@ def compute_move_dir(
 
 
 def is_attack_ready(last_attack_time: float, now: float, cooldown: float) -> bool:
-    """The attack-cooldown gate: ready once ``cooldown`` has elapsed
-    (``EnemyAI.is_attack_ready``). The ``NEVER`` sentinel is always ready."""
+    """The attack-cooldown gate: ready once ``cooldown`` has elapsed. The
+    ``NEVER`` sentinel is always ready."""
     return (now - last_attack_time) >= cooldown
 
 
@@ -116,22 +110,21 @@ def can_attack(
     last_attack_time: float,
     now: float,
 ) -> bool:
-    """The full attack decision: the Player must be inside BOTH the Aggro Range
-    and the attack range, and the cooldown must have elapsed
-    (``EnemyAI.can_attack``)."""
+    """The full attack decision: the player must be inside BOTH the aggro range
+    and the attack range, and the cooldown must have elapsed."""
     distance = _distance(self_x, self_y, player_x, player_y)
     if distance > aggro_range or distance > attack_range:
         return False
     return is_attack_ready(last_attack_time, now, attack_cooldown)
 
 
-# --- WarpSystem (src/systems/warp_system.gd), the Boss Warp kit (gADR-0009) -- #
+# --- The warp kit (a blink-engage rotation) ----------------------------------- #
 
 
 def has_warp(warp_cooldown: float) -> bool:
-    """The has-Warp predicate (``WarpSystem.has_warp``): the presence-gated
-    block floors ``warp_cooldown`` strictly above 0 at the data seam, so a kind
-    without the kit reads the type default 0.0."""
+    """The has-warp predicate: the presence-gated kit floors ``warp_cooldown``
+    strictly above 0 at the data seam, so a kind without the kit reads the type
+    default 0.0."""
     return warp_cooldown > 0.0
 
 
@@ -146,11 +139,10 @@ def should_warp(
     last_warp_time: float,
     now: float,
 ) -> bool:
-    """The warp gate (``WarpSystem.should_warp``): cast only when the kind HAS
-    the kit, the Player is inside the Aggro Range but FARTHER than the trigger
-    range (the Blink is an anti-kite engage tool — the Boss never warps inside a
-    brawl), and the cooldown has elapsed. The ``NEVER`` sentinel gates the first
-    warp by distance alone."""
+    """The warp gate: cast only when the kind HAS the kit, the player is inside
+    the aggro range but FARTHER than the trigger range (the blink is an
+    anti-kite engage tool — never cast inside a brawl), and the cooldown has
+    elapsed. The ``NEVER`` sentinel gates the first warp by distance alone."""
     if not has_warp(warp_cooldown):
         return False
     distance = _distance(self_x, self_y, player_x, player_y)
@@ -171,11 +163,10 @@ def warp_landing(
     arena_min_x: float,
     arena_max_x: float,
 ) -> tuple[float, float]:
-    """The deterministic blink landing (``WarpSystem.warp_landing``): x lands
-    the configured offset on the Player's FAR side from the caster (cutting off
-    the retreat), clamped to the arena's x range; y is the Player's y plus the
-    offset's y. A Player exactly overhead (dx == 0) resolves to the +x side —
-    never random."""
+    """The deterministic blink landing: x lands the configured offset on the
+    player's FAR side from the caster (cutting off the retreat), clamped to the
+    arena's x range; y is the player's y plus the offset's y. A player exactly
+    overhead (dx == 0) resolves to the +x side — never random."""
     side = _signf(player_x - self_x)
     if side == 0.0:
         side = 1.0
@@ -190,34 +181,30 @@ def is_inside_field(
     field_center_y: float,
     radius: float,
 ) -> bool:
-    """Time Dilation Field membership (``WarpSystem.is_inside_field``): inside
-    the zone at (or within) its radius."""
+    """Slow-field membership: inside the zone at (or within) its radius."""
     return _distance(pos_x, pos_y, field_center_x, field_center_y) <= radius
 
 
-# --- ItemSystem (src/systems/item_system.gd), Spacesuit mitigation (gADR-0008) #
+# --- Equipment mitigation ------------------------------------------------------ #
 
 
 def effective_defense(base_defense: float, defense_bonus: float) -> float:
-    """The worn-Equipment defense composition (``ItemSystem.effective_defender``,
-    gADR-0008): the defender's defense is the base stat block's defense raised by
-    the Spacesuit's bonus — the formula's mitigation term changes, the formula
-    itself is untouched. (The GDScript composes a fresh full stat block; only the
-    defense differs, which is what this mirrors.)"""
+    """The worn-equipment defense composition: the defender's defense is the
+    base stat block's defense raised by the equipment's bonus — the formula's
+    mitigation term changes, the formula itself is untouched."""
     return base_defense + defense_bonus
 
 
-# --- GrowthSystem (src/systems/growth_system.gd), the Leveling readout ------- #
+# --- Progression: the level readout -------------------------------------------- #
 
 
 def resolve_level(exp_points: float, level_curve: list[float]) -> int:
-    """The Level implied by a cumulative EXP total against the Leveling curve
-    (``GrowthSystem.resolve_level``, gADR-0006): Level 1 at the start, +1 per
-    threshold reached, so the Level is ``1 + the thresholds crossed`` and the max
-    Level is ``len(level_curve) + 1`` (the curve is always a parameter — no
-    hardcoded count). Deriving from the TOTAL makes a multi-threshold reward a
-    multi-level-up and re-resolution idempotent. The SD growth loop's feedback
-    term reads Level through this parity-pinned mirror, not a private copy."""
+    """The level implied by a cumulative EXP total against the leveling curve:
+    level 1 at the start, +1 per threshold reached, so the level is ``1 + the
+    thresholds crossed`` and the max level is ``len(level_curve) + 1`` (the
+    curve is always a parameter — no hardcoded count). Deriving from the TOTAL
+    makes a multi-threshold reward a multi-level-up and re-resolution
+    idempotent."""
     level = 1
     for threshold in level_curve:
         if exp_points >= threshold:

--- a/examples/platformer/panda-adventure/tools/balancing/statistics.py
+++ b/examples/platformer/panda-adventure/tools/balancing/statistics.py
@@ -2,8 +2,8 @@
 
 Pure aggregation over the per-run TTK/TTD samples the Monte-Carlo encounter
 simulation produces: no randomness of its own, so a fixed sample list always
-summarizes to the same distribution. These are the "deterministic statistics
-stages" the pipeline-seam unit tests pin on fixed inputs (#437).
+summarizes to the same distribution — the pipeline's deterministic statistics
+stages, pinnable on fixed inputs.
 
 Percentiles use linear interpolation between the two nearest ranks (the
 "inclusive"/numpy-default method), so p0 is the min and p100 is the max and a

--- a/examples/platformer/panda-adventure/tools/panda_balancing/__init__.py
+++ b/examples/platformer/panda-adventure/tools/panda_balancing/__init__.py
@@ -12,8 +12,13 @@ framework package (gADR-0018):
   (``data/json/*.json``) into the framework's generic ``balancing.model``
   types, wired through the targets file's ``adapter`` key.
 
-Run it: ``python -m balancing {validate,predict} --targets
-tools/panda_balancing/targets.json`` (with ``tools/`` importable, e.g. from the
-``tools/`` directory). Rule parity with the shipped GDScript seams is pinned by
-the golden fixtures in ``tests/`` (gADR-0011), not by anything in the framework.
+Run it from the ``tools/`` directory (which makes ``balancing`` importable)::
+
+    python -m balancing validate --targets panda_balancing/targets.json
+    python -m balancing predict  --targets panda_balancing/targets.json
+
+or from the game root with ``PYTHONPATH=tools`` and
+``--targets tools/panda_balancing/targets.json``. Rule parity with the shipped
+GDScript seams is pinned by the golden fixtures in ``tests/`` (gADR-0011), not
+by anything in the framework.
 """

--- a/examples/platformer/panda-adventure/tools/panda_balancing/__init__.py
+++ b/examples/platformer/panda-adventure/tools/panda_balancing/__init__.py
@@ -1,0 +1,19 @@
+"""Panda Adventure's balancing plug-in — the per-game half of the pipeline.
+
+The Balancing pipeline framework (``tools/balancing/``) is game-agnostic
+(gADR-0011); everything Panda Adventure contributes lives HERE, outside the
+framework package (gADR-0018):
+
+- ``targets.json`` — the per-game configuration: where the JSON authority
+  lives, which adapter maps it, the protected write roots (the whole ``data/``
+  chain), the player-model assumptions, the sim controls, and the design
+  targets (TTK/TTD per Wave, the SD growth/difficulty intent).
+- ``adapter.py`` — the mapping from this game's JSON authority
+  (``data/json/*.json``) into the framework's generic ``balancing.model``
+  types, wired through the targets file's ``adapter`` key.
+
+Run it: ``python -m balancing {validate,predict} --targets
+tools/panda_balancing/targets.json`` (with ``tools/`` importable, e.g. from the
+``tools/`` directory). Rule parity with the shipped GDScript seams is pinned by
+the golden fixtures in ``tests/`` (gADR-0011), not by anything in the framework.
+"""

--- a/examples/platformer/panda-adventure/tools/panda_balancing/adapter.py
+++ b/examples/platformer/panda-adventure/tools/panda_balancing/adapter.py
@@ -13,10 +13,12 @@ game code (no GDScript, no ``build_config``, no Godot), so the pipeline stays
 isolated from the engine (gADR-0011).
 
 The framework calls only :func:`load_inputs` (the adapter contract wired from
-``targets.json``); everything else here is this game's mapping detail. The one
-derived value composed here is the Player's ``defender`` block —
+``targets.json``); everything else here is this game's mapping detail, and it
+consumes ONLY the framework's public ``model`` surface (gADR-0018 — the parity
+suite in ``tests/`` is the one deliberate white-box exception, per gADR-0011).
+The one derived value composed here is the Player's ``defender`` block —
 ``ItemSystem.effective_defender``'s Spacesuit composition (gADR-0008), worn
-from spawn — mirrored via the parity-pinned ``rules.effective_defense``.
+from spawn — via the public ``model.compose_defender``.
 """
 
 from __future__ import annotations
@@ -25,7 +27,6 @@ import json
 from pathlib import Path
 from typing import Any
 
-from balancing import rules
 from balancing.model import (
     CombatParams,
     EnemyKind,
@@ -36,6 +37,7 @@ from balancing.model import (
     StatBlock,
     TierReward,
     Wave,
+    compose_defender,
 )
 
 
@@ -208,25 +210,14 @@ def load_game_data(config_dir: Path) -> GameData:
         combat=combat,
         kinds=load_enemy_kinds(config_dir),
         waves=load_waves(config_dir),
+        # The Spacesuit-composed defender (``ItemSystem.effective_defender``,
+        # gADR-0008), worn from spawn — exactly what ``take_hit`` mitigates
+        # against.
         player_defender=compose_defender(
             player_stats, load_spacesuit_defense(config_dir)
         ),
         arena_min_x=arena_min_x,
         arena_max_x=arena_max_x,
-    )
-
-
-def compose_defender(base: StatBlock, defense_bonus: float) -> StatBlock:
-    """The Spacesuit-composed defender (``ItemSystem.effective_defender``,
-    gADR-0008): a fresh block copying ``base`` with ``defense`` raised by the
-    worn Equipment's bonus — the parity-pinned ``rules.effective_defense`` on
-    the defense term, the other stats copied unchanged. Worn from spawn,
-    exactly what the game's ``take_hit`` mitigates against."""
-    return StatBlock(
-        max_hp=base.max_hp,
-        max_mp=base.max_mp,
-        attack=base.attack,
-        defense=rules.effective_defense(base.defense, defense_bonus),
     )
 
 

--- a/examples/platformer/panda-adventure/tools/panda_balancing/adapter.py
+++ b/examples/platformer/panda-adventure/tools/panda_balancing/adapter.py
@@ -1,18 +1,20 @@
 """Panda Adventure adapter: the JSON authority mapped into the generic model.
 
-The ONE per-game module (gADR-0011's per-game configuration): it knows this
-game's on-disk config shape — ``combat_config.json`` / ``enemies_config.json`` /
-``player_config.json`` / ``items_config.json`` (the Spacesuit's defense bonus,
-gADR-0008) / ``level_config.json`` (the Arena interval that clamps the Warp
-Blink's landing, gADR-0010) / ``scale_spec.json`` (the single size authority:
-the player/enemy/bolt boxes and the Time Dilation Field radius, gADR-0013) —
-and maps it into the game-agnostic ``model`` the sim runs on. It reads JSON
-only — it imports NO game code (no GDScript, no ``build_config``, no Godot),
-so the pipeline stays isolated from the engine (gADR-0011). Sizes are read
-from the Scale spec directly (the same authored home the builder composes
-into each derived Resource), so the sim sees exactly what the game derives.
+The ONE per-game module (gADR-0011's per-game configuration, split out of the
+framework package by gADR-0018): it knows this game's on-disk config shape —
+``combat_config.json`` / ``enemies_config.json`` / ``player_config.json`` /
+``items_config.json`` (the Spacesuit's defense bonus, gADR-0008) /
+``level_config.json`` (the Arena interval that clamps the Warp Blink's landing,
+gADR-0010) / ``progression_config.json`` (the Leveling curve, gADR-0006) /
+``scale_spec.json`` (the single size authority: the player/enemy/bolt boxes and
+the Time Dilation Field radius, gADR-0013) — and maps it into the game-agnostic
+``balancing.model`` the pipeline runs on. It reads JSON only — it imports NO
+game code (no GDScript, no ``build_config``, no Godot), so the pipeline stays
+isolated from the engine (gADR-0011).
 
-The one derived value composed here is the Player's ``defender`` block —
+The framework calls only :func:`load_inputs` (the adapter contract wired from
+``targets.json``); everything else here is this game's mapping detail. The one
+derived value composed here is the Player's ``defender`` block —
 ``ItemSystem.effective_defender``'s Spacesuit composition (gADR-0008), worn
 from spawn — mirrored via the parity-pinned ``rules.effective_defense``.
 """
@@ -23,13 +25,13 @@ import json
 from pathlib import Path
 from typing import Any
 
-from . import rules
-from .model import (
+from balancing import rules
+from balancing.model import (
     CombatParams,
     EnemyKind,
     GameData,
+    GameInputs,
     GrowthEconomy,
-    PlayerModel,
     Spawn,
     StatBlock,
     TierReward,
@@ -133,15 +135,20 @@ def load_enemy_kinds(config_dir: Path) -> dict[str, EnemyKind]:
 
 def load_growth_economy(config_dir: Path) -> GrowthEconomy:
     """Map this game's growth/economy authority into the generic
-    :class:`GrowthEconomy` the SD model integrates over (#440).
+    :class:`GrowthEconomy` the SD model integrates over.
 
     Reads the same JSON authority the game derives from — the Leveling curve
     (``progression_config``), the per-Tier Kill reward + Drop table
-    (``enemies_config``, gADR-0004/0006), the Consumable restore amounts
-    (``items_config``, gADR-0008), and the player pools (``combat_config``) —
+    (``enemies_config``, gADR-0004/0006), the Bun's restore amount
+    (``items_config``, gADR-0008), and the player pool (``combat_config``) —
     through the ONE per-game adapter, so the SD model never opens a second
     parser (gADR-0011). Expected drop counts are ``Σ amount × chance`` per item
-    (the mean-field inflow, not a stochastic roll).
+    (the mean-field inflow, not a stochastic roll). The item bindings name this
+    game's economy: gold drops fold into the currency stock (gADR-0006 — both
+    reward sources accrue to the Player's Gold), the Bun is the heal item the
+    balancing loop consumes. The Wine stays a tracked inflow-only stock — its
+    MP-restore sink is the Gravity Gun, outside the combat model's scope (the
+    scoping note in ``targets.json``).
     """
     prog = _load(config_dir, "progression_config.json")
     enemies = _load(config_dir, "enemies_config.json")
@@ -156,16 +163,16 @@ def load_growth_economy(config_dir: Path) -> GrowthEconomy:
         tier_rewards[tier] = TierReward(
             tier=tier,
             exp_reward=t["exp_reward"],
-            gold_reward=t["gold_reward"],
+            currency_reward=t["gold_reward"],
             expected_drops=expected,
         )
     return GrowthEconomy(
         level_curve=tuple(prog["level_curve"]),
         tier_rewards=tier_rewards,
-        bun_hp_restore=items["bun_hp_restore"],
-        wine_mp_restore=items["wine_mp_restore"],
         player_max_hp=player_stats["max_hp"],
-        player_max_mp=player_stats["max_mp"],
+        currency_item="gold",
+        heal_item="bun",
+        heal_item_restore=items["bun_hp_restore"],
     )
 
 
@@ -198,10 +205,12 @@ def load_game_data(config_dir: Path) -> GameData:
         player_move_speed=player["move_speed"],
         player_start_x=player["player_start"][0],
         player_half_width=scale["player_size"][0] / 2.0,
-        spacesuit_defense=load_spacesuit_defense(config_dir),
         combat=combat,
         kinds=load_enemy_kinds(config_dir),
         waves=load_waves(config_dir),
+        player_defender=compose_defender(
+            player_stats, load_spacesuit_defense(config_dir)
+        ),
         arena_min_x=arena_min_x,
         arena_max_x=arena_max_x,
     )
@@ -211,7 +220,8 @@ def compose_defender(base: StatBlock, defense_bonus: float) -> StatBlock:
     """The Spacesuit-composed defender (``ItemSystem.effective_defender``,
     gADR-0008): a fresh block copying ``base`` with ``defense`` raised by the
     worn Equipment's bonus — the parity-pinned ``rules.effective_defense`` on
-    the defense term, the other stats copied unchanged."""
+    the defense term, the other stats copied unchanged. Worn from spawn,
+    exactly what the game's ``take_hit`` mitigates against."""
     return StatBlock(
         max_hp=base.max_hp,
         max_mp=base.max_mp,
@@ -220,25 +230,11 @@ def compose_defender(base: StatBlock, defense_bonus: float) -> StatBlock:
     )
 
 
-def build_player_model(
-    game: GameData, player_model_params: dict[str, Any]
-) -> PlayerModel:
-    """Combine the game's player numbers with the design player-model assumptions.
-
-    ``player_model_params`` are the design inputs from the targets file
-    (fire cadence, aim, evasion, engagement distance) — the game carries no
-    Laser-Gun fire-rate config, so these model the human at the controls. The
-    ``defender`` block is the Spacesuit composition (worn from spawn,
-    gADR-0008), exactly what the game's ``take_hit`` mitigates against.
-    """
-    return PlayerModel(
-        stats=game.player_stats,
-        move_speed=game.player_move_speed,
-        start_x=game.player_start_x,
-        fire_interval=player_model_params["fire_interval"],
-        accuracy=player_model_params["accuracy"],
-        dodge_chance=player_model_params["dodge_chance"],
-        engagement_distance=player_model_params["engagement_distance"],
-        defender=compose_defender(game.player_stats, game.spacesuit_defense),
-        half_width=game.player_half_width,
+def load_inputs(config_dir: Path) -> GameInputs:
+    """The adapter contract (``balancing.config``): this game's whole authority
+    mapped into the generic model — encounter inputs plus the growth/economy
+    inputs (this game uses predict mode)."""
+    return GameInputs(
+        game=load_game_data(config_dir),
+        economy=load_growth_economy(config_dir),
     )

--- a/examples/platformer/panda-adventure/tools/panda_balancing/targets.json
+++ b/examples/platformer/panda-adventure/tools/panda_balancing/targets.json
@@ -1,5 +1,7 @@
 {
-  "config_dir": "data/json",
+  "config_dir": "../../data/json",
+  "adapter": "adapter.py",
+  "no_write_roots": ["../../data"],
   "player_model": {
     "fire_interval": 0.3,
     "accuracy": 0.8,
@@ -28,9 +30,9 @@
   ],
   "sd_model": {
     "notes": {
-      "stocks": "The system-dynamics state stocks (see tools/balancing/dynamics.py): Q (current Wave's remaining aggregate enemy HP, depletes to clear), HP (Player health, bounded [0, max]; carried across Waves), EXP (cumulative, Level is its readout via the Leveling curve), GOLD (cumulative economy inflow; no sink in this demo), BUN (Consumable count, in via drops AND out via HP-restore use), WINE (Consumable count, in via drops; its MP-restore sink is the Gravity Gun, out of the combat model's scope).",
-      "flows": "dQ/dt = -player_dps*growth(EXP); dHP/dt = -enemy_dps + bun_heal; dEXP/dt = (exp_reward/wave_hp)*player_dps; dGOLD/dt = (gold_reward/wave_hp)*player_dps; dBUN/dt = (bun_drops/wave_hp)*player_dps - consumption; dWINE/dt = (wine_drops/wave_hp)*player_dps. Reward stocks are coflows of the kill flow (snapped to their exact first integral at each Wave boundary). Nonlinearities: the reinforcing growth loop growth(EXP)=1+growth_gain*(Level(EXP)-1) via the piecewise Leveling curve, and the balancing consumable loop (threshold switch + supply gate + HP cap).",
-      "cross_validation_scenarios": "Overlapping domain with the Monte-Carlo engine = the bare laser-brawl: growth_gain=0 and Bun healing off (bun_consume_rate=0), each Wave from full HP independently (matching MC's independent full-HP encounters). Compared quantities: SD per-Wave clear time vs MC median TTK where both clear (Waves 1-3); SD Player-death time vs MC median TTD where both die (Wave 4, the Boss). The consumable economy and growth feedback are the SD model's extensions BEYOND MC's domain and are pinned by the deterministic conservation/boundary unit tests, not by MC.",
+      "stocks": "The generic stock layout and its semantics are owned by tools/balancing/dynamics.py (Q, HP, EXP, CURRENCY, plus one stock per tracked drop item). This game's bindings: CURRENCY = Gold (kill reward plus expected gold drops via the adapter's currency_item binding; no sink in this demo), heal item = Bun (in via drops AND out via HP-restore use), and Wine as a tracked inflow-only stock (its MP-restore sink is the Gravity Gun, out of the combat model's scope).",
+      "flows": "The ODE right-hand side, the coflow snap at Wave boundaries, and the two nonlinear feedback loops (reinforcing growth via the Leveling curve; the balancing consumable loop's threshold switch + supply gate + HP cap) are documented in tools/balancing/dynamics.py — the single authority; this file only binds which items participate (see the stocks note).",
+      "cross_validation_scenarios": "Overlapping domain with the Monte-Carlo engine = the bare laser-brawl: growth_gain=0 and Bun healing off (heal_consume_rate=0), each Wave from full HP independently (matching MC's independent full-HP encounters). Compared quantities: SD per-Wave clear time vs MC median TTK where both clear (Waves 1-3); SD Player-death time vs MC median TTD where both die (Wave 4, the Boss). The consumable economy and growth feedback are the SD model's extensions BEYOND MC's domain and are pinned by the deterministic conservation/boundary unit tests, not by MC.",
       "cross_validation_tolerance": "0.30 (30% relative). Deliberately looser than the 25% MC-level validate tolerance: the SD model is a deterministic mean-field aggregate that averages out approach/travel latency, discrete kill ordering and target-switching, per-shot accuracy/dodge variance (SD uses expected rates vs an MC median), the swarm attrition shape, and the Boss Warp micro-timing. The largest observed deviation on the committed config is ~20% (Wave 1's short brawl); 30% gives honest headroom without being vacuous.",
       "wine_mp_outflow_scope": "This slice models Wine as INFLOW-ONLY (Consumable drops) and deliberately does NOT model Wine/MP outflow. The only MP sink is the Gravity Gun, whose MP-use cadence is not a modeled design input — unlike Bun, whose consumption is driven by the modeled HP loss and so has a rate the model can read. MP outflow is out of scope for the SD model here (consistent with the gravity_gun scoping note above), a scoping decision, not an oversight."
     },
@@ -39,7 +41,7 @@
       "max_wave_time": 120.0,
       "growth_gain": 0.0,
       "heal_threshold_frac": 0.5,
-      "bun_consume_rate": 2.0
+      "heal_consume_rate": 2.0
     },
     "cross_validation": {
       "tolerance": 0.30
@@ -54,7 +56,7 @@
         ]
       },
       "difficulty": {
-        "boss_is_peak": true,
+        "final_wave_is_peak": true,
         "expect_monotonic_ramp": false
       }
     }


### PR DESCRIPTION
## Summary

An architecture review of the balancing pipeline found it game-agnostic in name but per-game in content: `tools/balancing/` carried this game's adapter (`game_config.py`), its design config (`panda_adventure.targets.json`), CLI defaults hardcoding this game's targets file and `data/` tree, and — deeper — the SD model's state vector named this game's items (`BUN`/`WINE` stocks). This PR realigns the packaging with gADR-0011's stated positioning ("input-driven core, per-game configuration"), recorded as **gADR-0018**.

## Changes

- **Framework** (`tools/balancing/`) is now strictly game-agnostic — no game imports, no game vocabulary, no per-game config file, pinned by the new `tests/test_balancing_isolation.py` gate. The SD economy generalizes to `CURRENCY` + dynamic per-item stocks with adapter-bound `currency_item`/`heal_item` (report keys: `final_currency`, `final_items`, `items_end`; `boss_is_peak` → `final_wave_is_peak`; `bun_consume_rate` → `heal_consume_rate`).
- **Plug-in** (`tools/panda_balancing/`) holds everything Panda Adventure contributes: `adapter.py` (ex `game_config.py`, exporting the `load_inputs(config_dir) -> GameInputs` contract) + `targets.json` (ex in-package targets).
- **Config-only wiring, deep-module surface**: the CLI requires `--targets`; that file names `config_dir`, the `adapter`, and the protected `no_write_roots` (this game: the whole `data/` chain — guard policy moves from code to config); paths resolve relative to the targets file; every bad input (unreadable targets, missing player-model key, broken adapter, unloadable game config) is a structured exit-2 refusal, never a traceback. `balancing/config.py` is the targets schema's single home.
- **Docs synced**: gADR-0018 (new), GAME-CONTEXT balancing/style-descriptor entries, a dated outcome note on gADR-0014, asset-pipeline docstring cross-refs.

## Review notes (multi-angle self-review applied before this PR)

- Fixed from review: structured refusals for missing player-model keys and unloadable game config; guard/`SimConfig` override simplification (`ConfigError` + `dataclasses.replace`); SD derivative hot-path precomputation; dead state copy removed; targets-notes DRY'd to reference `dynamics.py`; explicit `archetype` delivery-taxonomy contract in `model.EnemyKind`.
- Deliberate trades (documented in gADR-0018/config.py): the old `--config-dir`-override parent-named-`data` auto-protection heuristic is dropped — tree protection is declared config (`no_write_roots`), the override dir itself stays protected; the single-currency/single-EXP stock shape and the ranged-player model are the framework's documented scope, not hidden panda assumptions.
- Follow-up (not in this PR): migrate `tools/assets/` to the same framework/plug-in split.

## Verification

- 78 balancing tests green, including the engine-tier GDScript rules-parity suite (fixtures unchanged — `balancing.rules` names and math untouched).
- Full game fast suite: 437 passed.
- Real CLI runs against the committed authority: `validate` exit 0 (all waves within 25%), `predict` exit 0 with unchanged baselines (final level 5, currency 212, cross-validation within the documented 30%); no-write guard and structured-error paths exercised manually and by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #494
