### PR TITLE
chore(gda-balancing): bootstrap package skeleton and domain docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,4 +18,7 @@ Five canonical triage roles, default label names. See `docs/agents/triage-labels
 
 ### Domain docs
 
-Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+One `CONTEXT.md` + `docs/adr/` at the repo root — the `gda` domain. Two subtrees carry
+their own local domain contexts (overrides declared in their own `AGENTS.md`):
+`examples/platformer/panda-adventure/` (game domain) and `libs/gda-balancing/`
+(balancing-toolkit domain). See `docs/agents/domain.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Five canonical triage roles, default label names. See `docs/agents/triage-labels
 
 ### Domain docs
 
-One `CONTEXT.md` + `docs/adr/` at the repo root — the `gda` domain. Two subtrees carry
-their own local domain contexts (overrides declared in their own `AGENTS.md`):
-`examples/platformer/panda-adventure/` (game domain) and `libs/gda-balancing/`
-(balancing-toolkit domain). See `docs/agents/domain.md`.
+Multi-context: `CONTEXT-MAP.md` at the repo root is the routing authority — one entry per
+domain context. The root's own context is the `gda` domain (`CONTEXT.md` + `docs/adr/`);
+each non-root domain declares its layout and override rules in its own `AGENTS.md`. See
+`docs/agents/domain.md`.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,8 @@
+# Context Map
+
+One `CONTEXT.md` per domain context in this repo (see `docs/agents/domain.md`). Each
+non-root domain's layout and override rules are declared in its own `AGENTS.md`.
+
+- [gda](CONTEXT.md) — the agent-facing Godot toolchain: `gda`, `gda-mcp`, `gda-daemon`.
+- [Panda Adventure](examples/platformer/panda-adventure/GAME-CONTEXT.md) — the 2D-platformer game demo.
+- [gda-balancing](libs/gda-balancing/BALANCING-CONTEXT.md) — the standalone numeric design & balancing toolkit.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,7 +1,8 @@
 # Context Map
 
-One `CONTEXT.md` per domain context in this repo (see `docs/agents/domain.md`). Each
-non-root domain's layout and override rules are declared in its own `AGENTS.md`.
+One context glossary per domain context in this repo — the root's is `CONTEXT.md`; a local
+domain names its own (see `docs/agents/domain.md`). Each non-root domain's layout and
+override rules are declared in its own `AGENTS.md`.
 
 - [gda](CONTEXT.md) — the agent-facing Godot toolchain: `gda`, `gda-mcp`, `gda-daemon`.
 - [Panda Adventure](examples/platformer/panda-adventure/GAME-CONTEXT.md) — the 2D-platformer game demo.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -5,7 +5,7 @@ How the engineering skills should consume this repo's domain documentation when 
 ## Before exploring, read these
 
 - **`CONTEXT.md`** at the repo root, or
-- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one context glossary per context (`CONTEXT.md` or a local equivalent). Read each one relevant to the topic.
 - **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
 
 If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -12,10 +12,11 @@ If any of these files don't exist, **proceed silently**. Don't flag their absenc
 
 ## File structure
 
-The repo root is a single context — the `gda` domain:
+The repo root's own context is the `gda` domain:
 
 ```
 /
+├── CONTEXT-MAP.md
 ├── CONTEXT.md
 ├── docs/adr/
 │   ├── 0000-architecture-design.md
@@ -23,13 +24,10 @@ The repo root is a single context — the `gda` domain:
 └── src/
 ```
 
-## Local domain overrides
-
-Two subtrees override this convention with their own local domain context. Inside them,
-follow the local `AGENTS.md` / `docs/agents/domain.md` instead of this file:
-
-- `examples/platformer/panda-adventure/` — the game domain (`GAME-CONTEXT.md`, `docs/gadr/`).
-- `libs/gda-balancing/` — the balancing-toolkit domain (`BALANCING-CONTEXT.md`, `docs/badr/`).
+This repo is **multi-context**: `CONTEXT-MAP.md` at the repo root is the single routing
+authority for which domain contexts exist and where. A non-root domain's layout and
+override rules live in that subtree's own `AGENTS.md` / `docs/agents/domain.md` — inside
+such a subtree, follow the local convention instead of this file.
 
 ## Use the glossary's vocabulary
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -12,7 +12,7 @@ If any of these files don't exist, **proceed silently**. Don't flag their absenc
 
 ## File structure
 
-This is a single-context repo:
+The repo root is a single context — the `gda` domain:
 
 ```
 /
@@ -22,6 +22,14 @@ This is a single-context repo:
 │   └── ...
 └── src/
 ```
+
+## Local domain overrides
+
+Two subtrees override this convention with their own local domain context. Inside them,
+follow the local `AGENTS.md` / `docs/agents/domain.md` instead of this file:
+
+- `examples/platformer/panda-adventure/` — the game domain (`GAME-CONTEXT.md`, `docs/gadr/`).
+- `libs/gda-balancing/` — the balancing-toolkit domain (`BALANCING-CONTEXT.md`, `docs/badr/`).
 
 ## Use the glossary's vocabulary
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -6,7 +6,7 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 | -------------------------- | -------------------- | ---------------------------------------- |
 | `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
 | `needs-info`               | `needs-info`         | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified for an AFK agent; start only once its Blocked-by list is clear |
 | `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
 | `wontfix`                  | `wontfix`            | Will not be actioned                     |
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -6,7 +6,7 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 | -------------------------- | -------------------- | ---------------------------------------- |
 | `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
 | `needs-info`               | `needs-info`         | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready-for-agent`    | Fully specified for an AFK agent; start only once its Blocked-by list is clear |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
 | `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
 | `wontfix`                  | `wontfix`            | Will not be actioned                     |
 

--- a/examples/platformer/panda-adventure/AGENTS.md
+++ b/examples/platformer/panda-adventure/AGENTS.md
@@ -19,9 +19,10 @@ Align with the repo-root `AGENTS.md` for everything **except domain docs**:
 
 ### Domain docs (local override)
 
-**This section supersedes the repo-root "Domain docs" convention** (`Single-context: one
-CONTEXT.md + docs/adr/ at the repo root`) for all **game-domain** knowledge. The game's
-domain context is confined to this directory and must **not** pollute the parent's docs.
+**This section is the game domain's local convention** — the repo root routes domain
+contexts via `CONTEXT-MAP.md` and delegates each non-root domain's layout and override
+rules to its own `AGENTS.md`, i.e. here. The game's domain context is confined to this
+directory and must **not** pollute the parent's docs.
 
 Local layout (analogue of the parent's):
 

--- a/libs/gda-balancing/AGENTS.md
+++ b/libs/gda-balancing/AGENTS.md
@@ -1,5 +1,5 @@
 This directory is **gda-balancing** — a standalone, engine- and game-agnostic numeric
-design & balancing toolkit: standard-Schema numeric design (attributes, builds, growth,
+design & balancing toolkit: Standard Schema numeric design (attributes, builds, growth,
 economy, encounters), simulation-backed balance validation and tuning, structured JSON
 output. It is a **sibling product** of `gda` in the same family — it neither depends on
 nor extends `gda`; the `gda-` prefix is the product-family brand, not component
@@ -47,17 +47,19 @@ directory. You **may read** the parent `gda` docs when the work concerns
 CLI-interface-style alignment (see below) or family conventions — just don't treat them as
 this toolkit's domain authority.
 
-See `./docs/agents/domain.md` for the authoritative detail.
+This section is the loaded summary; `./docs/agents/domain.md` is the authoritative
+detail — on any divergence, it wins.
 
 ## Development conventions
 
 - **CLI interface style follows `gda`** (adjudicated 2026-07-15, recorded on PRD #501):
   the family's interface conventions and `gda`'s accumulated CLI spec experience are the
   reference. The binding contract (command taxonomy, result/error envelopes, exit-code
-  semantics, self-description) is designed under issue #518 and recorded as bADRs — that
-  is the single authority; read the parent CLI-contract ADRs as *reference input* only.
+  semantics, self-description) will be designed under issue #518 and recorded as bADRs —
+  once landed, those bADRs are the single authority; read the parent CLI-contract ADRs as
+  *reference input* only.
 - **Engine- and game-agnostic core** — the toolkit names no game identity and imports no
-  game or engine code (nor `gda`); agnosticism is enforced by packaging plus isolation
-  gates at the hardened (recursive, AST-level) standard.
+  game or engine code (nor `gda`); agnosticism is enforced by packaging plus an isolation
+  gate (landing with #502) at the hardened (recursive, AST-level) standard.
 - **Schema is the single authority** — the standard Schema is the sole spec and authority
-  source for numeric design; games consume the toolkit's Schema-standard output (PRD #501).
+  source for numeric design; games consume the toolkit's Standard Schema output (PRD #501).

--- a/libs/gda-balancing/AGENTS.md
+++ b/libs/gda-balancing/AGENTS.md
@@ -1,0 +1,63 @@
+This directory is **gda-balancing** — a standalone, engine- and game-agnostic numeric
+design & balancing toolkit: standard-Schema numeric design (attributes, builds, growth,
+economy, encounters), simulation-backed balance validation and tuning, structured JSON
+output. It is a **sibling product** of `gda` in the same family — it neither depends on
+nor extends `gda`; the `gda-` prefix is the product-family brand, not component
+ownership. Requirements record: PRD #501; milestones #8 (Phase 1) / #9 (Phase 2).
+
+## Inherited from the repo root
+
+Align with the repo-root `AGENTS.md` for everything **except domain docs**:
+
+- `RULES.md` — communication & collaboration conventions.
+- Issue tracker — toolkit issues go to the same `aigengame/godot-agent` tracker, with titles
+  prefixed **`[gda-balancing]`** to distinguish them from `gda`-tool issues (unprefixed).
+  See `../../docs/agents/issue-tracker.md` (inherited, not duplicated here).
+- Triage labels. See `../../docs/agents/triage-labels.md`.
+
+## Agent skills
+
+### Domain docs (local override)
+
+**This section supersedes the repo-root "Domain docs" convention** (`Single-context: one
+CONTEXT.md + docs/adr/ at the repo root`) for all **toolkit-domain** knowledge. The
+toolkit's domain context is confined to this directory and must **not** pollute the
+parent's docs.
+
+Local layout (analogue of the parent's):
+
+| Parent (gda domain) | Here (balancing domain) | Holds |
+|---|---|---|
+| `CONTEXT.md` | `BALANCING-CONTEXT.md` | the toolkit's shared language / glossary |
+| `docs/adr/NNNN-*.md` | `docs/badr/NNNN-*.md` | balancing decision records (bADR), same numbering |
+
+**Skill remap.** The domain skills hardcode `CONTEXT.md` / `docs/adr/` as literals. When you
+run one **inside this package**, restate and apply this remap before acting:
+
+- any skill's `CONTEXT.md` → `BALANCING-CONTEXT.md`
+- any skill's `docs/adr/` → `docs/badr/`
+- `CONTEXT-MAP.md` → not applicable (single local context — ignore)
+
+Applies to `grill-with-docs`, `improve-codebase-architecture`, and `reconcile`. `to-prd` /
+`to-issues` already defer abstractly to "the project's domain glossary" — point them here.
+
+**Isolation boundary.** Never **write** toolkit terms or decisions into the parent root
+`CONTEXT.md` or `docs/adr/` — balancing-domain language and decisions live only under this
+directory. You **may read** the parent `gda` docs when the work concerns
+CLI-interface-style alignment (see below) or family conventions — just don't treat them as
+this toolkit's domain authority.
+
+See `./docs/agents/domain.md` for the authoritative detail.
+
+## Development conventions
+
+- **CLI interface style follows `gda`** (adjudicated 2026-07-15, recorded on PRD #501):
+  the family's interface conventions and `gda`'s accumulated CLI spec experience are the
+  reference. The binding contract (command taxonomy, result/error envelopes, exit-code
+  semantics, self-description) is designed under issue #518 and recorded as bADRs — that
+  is the single authority; read the parent CLI-contract ADRs as *reference input* only.
+- **Engine- and game-agnostic core** — the toolkit names no game identity and imports no
+  game or engine code (nor `gda`); agnosticism is enforced by packaging plus isolation
+  gates at the hardened (recursive, AST-level) standard.
+- **Schema is the single authority** — the standard Schema is the sole spec and authority
+  source for numeric design; games consume the toolkit's Schema-standard output (PRD #501).

--- a/libs/gda-balancing/AGENTS.md
+++ b/libs/gda-balancing/AGENTS.md
@@ -19,10 +19,10 @@ Align with the repo-root `AGENTS.md` for everything **except domain docs**:
 
 ### Domain docs (local override)
 
-**This section supersedes the repo-root "Domain docs" convention** (`Single-context: one
-CONTEXT.md + docs/adr/ at the repo root`) for all **toolkit-domain** knowledge. The
-toolkit's domain context is confined to this directory and must **not** pollute the
-parent's docs.
+**This section is the toolkit domain's local convention** — the repo root routes domain
+contexts via `CONTEXT-MAP.md` and delegates each non-root domain's layout and override
+rules to its own `AGENTS.md`, i.e. here. The toolkit's domain context is confined to this
+directory and must **not** pollute the parent's docs.
 
 Local layout (analogue of the parent's):
 
@@ -61,5 +61,5 @@ detail — on any divergence, it wins.
 - **Engine- and game-agnostic core** — the toolkit names no game identity and imports no
   game or engine code (nor `gda`); agnosticism is enforced by packaging plus an isolation
   gate (landing with #502) at the hardened (recursive, AST-level) standard.
-- **Schema is the single authority** — the standard Schema is the sole spec and authority
+- **Schema is the single authority** — the Standard Schema is the sole spec and authority
   source for numeric design; games consume the toolkit's Standard Schema output (PRD #501).

--- a/libs/gda-balancing/BALANCING-CONTEXT.md
+++ b/libs/gda-balancing/BALANCING-CONTEXT.md
@@ -19,7 +19,7 @@ _Avoid_: gda balancing module, balancing plugin
 The machine-readable schema for game numeric systems (character attributes, combat, builds,
 encounters, growth, economy) that is the toolkit's **sole spec and single authority source**.
 The pipeline designs and configures numbers before game development; a game is then developed
-consuming the pipeline's Schema-standard output. Non-standard game configs are not adapted or
+consuming the pipeline's Standard Schema output. Non-standard game configs are not adapted or
 imported.
 _Avoid_: config format, data model, descriptor
 

--- a/libs/gda-balancing/BALANCING-CONTEXT.md
+++ b/libs/gda-balancing/BALANCING-CONTEXT.md
@@ -1,0 +1,55 @@
+# gda-balancing
+
+The shared language of gda-balancing: a standalone, engine- and game-agnostic toolkit for
+designing a game's numerics before development and validating balance quantitatively during
+it, with structured output suitable for programmatic consumption. (Requirements: PRD #501.)
+
+## Language
+
+### Product
+
+**gda-balancing**:
+The toolkit itself. The `gda-` prefix is the **product-family brand** — this is a sibling
+product of `gda`, not a `gda` component (contrast `gda-mcp` / `gda-daemon`, which are gda's
+own components). It neither depends on nor extends `gda`; its CLI *interface style* follows
+gda's conventions (PRD #501 addendum).
+_Avoid_: gda balancing module, balancing plugin
+
+**Standard Schema**:
+The machine-readable schema for game numeric systems (character attributes, combat, builds,
+encounters, growth, economy) that is the toolkit's **sole spec and single authority source**.
+The pipeline designs and configures numbers before game development; a game is then developed
+consuming the pipeline's Schema-standard output. Non-standard game configs are not adapted or
+imported.
+_Avoid_: config format, data model, descriptor
+
+**Genre template**:
+A genre's numeric design baseline — default values plus formulas-as-data — shipped as an
+*instance of the Standard Schema*, never as code paths. First families: RPG (CRPG/JRPG/ARPG)
+and Roguelike (metroidvania-like, survivors-like, deckbuilder-like).
+_Avoid_: preset, profile
+
+**Reference fixture**:
+A paper-game config per supported genre, living in the test suite as an executable consumer
+and golden example — exercising template superset paths no live game exercises yet.
+_Avoid_: sample project, demo config
+
+### Simulation
+
+**Evaluation method**:
+A method that *estimates* balance metrics from a config — Monte-Carlo encounter estimation
+and system-dynamics (first-order nonlinear ODE) long-horizon prediction. Distinct from a
+`Tuning method`; Monte-Carlo is an estimation method, never an "exact algorithm".
+_Avoid_: exact algorithm, precise algorithm
+
+**Tuning method**:
+A method that *searches* config space toward balance targets — parameter sensitivity
+analysis first, then simple (greedy) search; stronger optimizers later. Delivery ordering is
+simple-to-hard.
+_Avoid_: approximation algorithm, auto-balancer
+
+**Metrics schema**:
+The one shape shared by simulated results and (future) observed playtest results, so the
+playtest feedback loop can be wired later without schema rework — round-trip capable by
+design; ingestion wiring is deferred until playtests produce real feedback.
+_Avoid_: report format (as a separate shape)

--- a/libs/gda-balancing/CLAUDE.md
+++ b/libs/gda-balancing/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/libs/gda-balancing/README.md
+++ b/libs/gda-balancing/README.md
@@ -1,10 +1,10 @@
 # gda-balancing
 
 Game numeric design & balancing toolkit — design a game's numbers before development
-(standard-Schema attribute/build/growth/economy templates for the RPG and Roguelike
+(Standard Schema attribute/build/growth/economy templates for the RPG and Roguelike
 families), validate and tune balance quantitatively during it (Monte-Carlo + system-dynamics
 simulation, metrics and weighted scoring), and emit the result as structured,
-Schema-standard JSON.
+Standard Schema JSON.
 
 A standalone, engine- and game-agnostic sibling product of `gda` — it neither depends on nor
 extends `gda`; its CLI follows the family's interface conventions.

--- a/libs/gda-balancing/README.md
+++ b/libs/gda-balancing/README.md
@@ -1,0 +1,15 @@
+# gda-balancing
+
+Game numeric design & balancing toolkit — design a game's numbers before development
+(standard-Schema attribute/build/growth/economy templates for the RPG and Roguelike
+families), validate and tune balance quantitatively during it (Monte-Carlo + system-dynamics
+simulation, metrics and weighted scoring), and emit the result as structured,
+Schema-standard JSON.
+
+A standalone, engine- and game-agnostic sibling product of `gda` — it neither depends on nor
+extends `gda`; its CLI follows the family's interface conventions.
+
+- Requirements: [PRD #501](https://github.com/aigengame/godot-agent/issues/501)
+- Milestones: [Phase 1 — numeric design & config templates](https://github.com/aigengame/godot-agent/milestone/8) ·
+  [Phase 2 — balance simulation](https://github.com/aigengame/godot-agent/milestone/9)
+- Status: pre-development skeleton.

--- a/libs/gda-balancing/docs/agents/domain.md
+++ b/libs/gda-balancing/docs/agents/domain.md
@@ -1,0 +1,65 @@
+# Domain Docs — gda-balancing (local override)
+
+How the engineering skills should consume **this package's** domain documentation. This is
+the authoritative copy of the local convention; `../../AGENTS.md` carries the short pointer.
+
+It **overrides** the repo-root domain-doc convention (`/CONTEXT.md` + `/docs/adr/`) for all
+balancing-domain knowledge. The toolkit's context is confined to this directory.
+
+## Before exploring, read these
+
+- **`BALANCING-CONTEXT.md`** at this package's root — the toolkit's glossary / shared language.
+- **`docs/badr/`** — balancing decision records (bADR); read the ones touching the area
+  you'll work in.
+
+If any of these don't exist yet, **proceed silently**. Don't flag their absence; don't
+suggest creating them upfront. They are created lazily when a term or decision actually gets
+resolved.
+
+## File structure
+
+This is a single local context, scoped to this subdirectory:
+
+```
+libs/gda-balancing/
+├── BALANCING-CONTEXT.md     # toolkit glossary  (analogue of the repo-root CONTEXT.md)
+└── docs/
+    └── badr/                # balancing decision records (analogue of docs/adr/)
+```
+
+## Skill remap
+
+The domain skills hardcode `CONTEXT.md` / `docs/adr/` as string literals — they have no way
+to discover this layout on their own. When running one **inside this package**, restate and
+apply this remap before acting:
+
+| In the skill body | Use here |
+|---|---|
+| `CONTEXT.md` | `BALANCING-CONTEXT.md` |
+| `docs/adr/` | `docs/badr/` |
+| `CONTEXT-MAP.md` | not applicable — single local context, ignore |
+
+Applies to `grill-with-docs`, `improve-codebase-architecture`, and `reconcile`. `to-prd` and
+`to-issues` defer abstractly to "the project's domain glossary" — point them at
+`BALANCING-CONTEXT.md`.
+
+**Isolation boundary.** Never **write** toolkit terms or decisions into the parent root
+`CONTEXT.md` or `docs/adr/`; balancing-domain language and decisions live only here. You
+**may read** the parent `gda` docs when the work concerns CLI-interface-style alignment or
+family conventions — just don't treat them as this toolkit's domain authority.
+
+## Use the glossary's vocabulary
+
+When your output names a toolkit concept (an issue title, a refactor proposal, a test name),
+use the term as defined in `BALANCING-CONTEXT.md`. Don't drift to synonyms the glossary avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing
+language the toolkit doesn't use (reconsider) or there's a real gap (note it for
+`grill-with-docs`, remapped to `BALANCING-CONTEXT.md`).
+
+## Flag bADR conflicts
+
+If your output contradicts an existing bADR, surface it explicitly rather than silently
+overriding:
+
+> _Contradicts bADR-0000 (…) — but worth reopening because…_

--- a/libs/gda-balancing/pyproject.toml
+++ b/libs/gda-balancing/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gda-balancing"
-version = "0.1.0"
-description = "Game numeric design & balancing toolkit — standard-Schema numeric design (RPG & Roguelike templates), simulation-backed balance validation and tuning, structured JSON output."
+version = "0.0.0"
+description = "Game numeric design & balancing toolkit — Standard Schema numeric design (RPG & Roguelike templates), simulation-backed balance validation and tuning, structured JSON output."
 requires-python = ">=3.13"
 dependencies = []
 

--- a/libs/gda-balancing/pyproject.toml
+++ b/libs/gda-balancing/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "gda-balancing"
+version = "0.1.0"
+description = "Game numeric design & balancing toolkit — standard-Schema numeric design (RPG & Roguelike templates), simulation-backed balance validation and tuning, structured JSON output."
+requires-python = ">=3.13"
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/aigengame/godot-agent"
+Repository = "https://github.com/aigengame/godot-agent"
+Issues = "https://github.com/aigengame/godot-agent/issues"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gda_balancing"]

--- a/libs/gda-balancing/src/gda_balancing/__init__.py
+++ b/libs/gda-balancing/src/gda_balancing/__init__.py
@@ -1,0 +1,5 @@
+"""gda-balancing: game numeric design & balancing toolkit.
+
+Pre-development skeleton — requirements live in PRD aigengame/godot-agent#501;
+the shared language lives in BALANCING-CONTEXT.md at the package root.
+"""


### PR DESCRIPTION
## What

Bootstrap the `gda-balancing` standalone toolkit's home at `libs/gda-balancing/` (PRD #501):

- `pyproject.toml` + `src/gda_balancing/` — the minimal package shell.
- Domain docs: `AGENTS.md`, `BALANCING-CONTEXT.md` (glossary seed), and `docs/agents/domain.md` — the skill remap (`CONTEXT.md` → `BALANCING-CONTEXT.md`, `docs/adr/` → `docs/badr/`) and the isolation boundary, modeled on the panda demo's local-override convention.
- Placeholders: `tests/`, `docs/badr/`.

## Why

Adjudicated on PRD #501 (and its addendum): the toolkit is a standalone, engine- and game-agnostic **sibling product** of `gda` — the `gda-` prefix is family brand, not component ownership. The skeleton gives the Phase 1 slices a home and pins the domain-doc boundary (no game content, no parent-doc pollution) before implementation starts.

Typed `chore`, not `feat`: release-please parses commit types repo-wide (`packages: {"."}`), and this PR changes no `gda` code — chore keeps it out of gda's version bump and changelog.

## Not in this PR

uv-workspace wiring, CI, and the isolation gate — deferred to #502 (whose CLI tracer is blocked by the #518 CLI interface contract).

Refs #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)