### PR TITLE
docs(gda-balancing): mark Standard Schema bADRs accepted

### DIFF
--- a/libs/gda-balancing/docs/badr/0001-design-document-structure-and-versioning.md
+++ b/libs/gda-balancing/docs/badr/0001-design-document-structure-and-versioning.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # One root Design document per game, semver-versioned, with a closed section envelope

--- a/libs/gda-balancing/docs/badr/0002-orthogonal-attribute-facets.md
+++ b/libs/gda-balancing/docs/badr/0002-orthogonal-attribute-facets.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # Orthogonal attribute facets; tiers are template compositions, not schema law

--- a/libs/gda-balancing/docs/badr/0003-formula-as-data-representation.md
+++ b/libs/gda-balancing/docs/badr/0003-formula-as-data-representation.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # Formulas as data: named forms first, a closed-operator expression tree as fallback

--- a/libs/gda-balancing/docs/badr/0004-boundary-funnel-validation-semantics.md
+++ b/libs/gda-balancing/docs/badr/0004-boundary-funnel-validation-semantics.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # Validation at one boundary funnel: phased, element-level typed refusals, report-all

--- a/libs/gda-balancing/docs/badr/0005-two-layer-self-description-and-emission.md
+++ b/libs/gda-balancing/docs/badr/0005-two-layer-self-description-and-emission.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # Two-layer self-description: JSON Schema artifact plus semantic rule catalog

--- a/libs/gda-balancing/docs/badr/0006-effect-numeric-core.md
+++ b/libs/gda-balancing/docs/badr/0006-effect-numeric-core.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # Effects are first-class: the numeric core of buffs, debuffs, and over-time influence


### PR DESCRIPTION
Mechanical follow-through of the #503 design-gate approval ([recorded on the issue](https://github.com/aigengame/godot-agent/issues/503#issuecomment-5010983967)): the six bADRs landed in #521 as `status: proposed` pending maintainer approval; the merge was that approval, so this PR flips them to `status: accepted`. Status-line-only diff, no content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)