### PR TITLE
docs(gda-balancing): record CLI interface contract (bADR-0007..0011)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,1 @@
 @AGENTS.md
-
-## Subagent model tier configuration (including built-in Explore/Plan/General subagents and workflow fan-out subagents)
-
-Concretizes RULES.md's model-selection principle, which this
-table implements — pass `model:` explicitly on every dispatch; never silently inherit
-the session model.
-
-- Reconnaissance, exploration, summarization, and retrieval: **Sonnet** by default;
-  escalate to **Opus** only when the digest's precision directly gates downstream
-  design quality (e.g. ADR/issue digests feeding a design gate).
-- Large fan-out stages (N-vote adversarial panels, bulk refutation voters, bulk
-  search/fetch): **Sonnet** per voter/fetcher; the single synthesis, judge, or
-  high-stakes verifier stays **Opus**.
-- Design reviews, single-point adversarial validation, consistency checks, and
-  routine tasks: **Opus**.
-- **Fable** is used only for main-loop coordination, orchestration, final judgment,
-  or the design and implementation of the most complex tasks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,18 @@
 @AGENTS.md
+
+## Subagent model tier configuration (including built-in Explore/Plan/General subagents and workflow fan-out subagents)
+
+Concretizes RULES.md's model-selection principle, which this
+table implements — pass `model:` explicitly on every dispatch; never silently inherit
+the session model.
+
+- Reconnaissance, exploration, summarization, and retrieval: **Sonnet** by default;
+  escalate to **Opus** only when the digest's precision directly gates downstream
+  design quality (e.g. ADR/issue digests feeding a design gate).
+- Large fan-out stages (N-vote adversarial panels, bulk refutation voters, bulk
+  search/fetch): **Sonnet** per voter/fetcher; the single synthesis, judge, or
+  high-stakes verifier stays **Opus**.
+- Design reviews, single-point adversarial validation, consistency checks, and
+  routine tasks: **Opus**.
+- **Fable** is used only for main-loop coordination, orchestration, final judgment,
+  or the design and implementation of the most complex tasks.

--- a/libs/gda-balancing/BALANCING-CONTEXT.md
+++ b/libs/gda-balancing/BALANCING-CONTEXT.md
@@ -148,10 +148,11 @@ _Avoid_: command spec, command config, registry entry
 
 **Error envelope**:
 The single top-level-`error` JSON object a failed invocation emits — category `refusal`
-(stdout, exit 2; carrying the funnel's typed refusals verbatim, report-all) or
-`usage` / `internal` (stderr, exits 3 / 4; a single envelope-level code). It carries
-the funnel's refusal codes without minting any; the CLI-usage family is the one code
-family the CLI contract owns (bADR-0008).
+(stdout, exit 2; carrying typed refusals verbatim — the funnel's families plus the
+downstream `Evaluation refusal` family — report-all) or `usage` / `internal` (stderr,
+exits 3 / 4; a single envelope-level code). It carries the refusal codes without
+minting any; the CLI-usage family plus the fixed `internal_error` code are all the CLI
+contract owns (bADR-0008).
 _Avoid_: error blob, failure JSON, exception dump
 
 **Verdict**:
@@ -165,7 +166,8 @@ _Avoid_: validation result, balance error, failure (vague)
 An invocation-surface failure — everything that goes wrong **before** the document's
 bytes reach the `Boundary funnel`: unknown command or flag, argument conflicts, an
 unreadable input path. Exit 3, envelope on stderr, own stable code family (bADR-0008);
-unparseable JSON and everything after ingress belong to the funnel, not here.
+unparseable JSON and everything after ingress are typed refusals (the funnel's, or the
+downstream `Evaluation refusal`), never usage errors.
 _Avoid_: refusal (the funnel's word), invalid input (ambiguous)
 
 **Effective seed**:

--- a/libs/gda-balancing/BALANCING-CONTEXT.md
+++ b/libs/gda-balancing/BALANCING-CONTEXT.md
@@ -171,9 +171,10 @@ downstream `Evaluation refusal`), never usage errors.
 _Avoid_: refusal (the funnel's word), invalid input (ambiguous)
 
 **Effective seed**:
-The seed that actually drove a stochastic run — supplied via `--seed` or drawn fresh —
-always echoed in the structured result together with the toolkit version, so every
-stochastic result carries its own reproduction key (bADR-0010).
+The seed that actually drove a stochastic run — supplied via `--seed` (unsigned
+32-bit) or drawn fresh — always echoed in the structured result together with the
+toolkit version, and carried by any failure envelope once drawn, so every stochastic
+outcome keeps its own reproduction key (bADR-0008/0010).
 _Avoid_: random seed (ambiguous), default seed
 
 ### Simulation

--- a/libs/gda-balancing/BALANCING-CONTEXT.md
+++ b/libs/gda-balancing/BALANCING-CONTEXT.md
@@ -140,10 +140,13 @@ _Avoid_: rules doc, validation spec (as a prose document)
 ### Command surface
 
 **Command descriptor**:
-The single per-command registration object naming a command's tree position (group +
-command), its typed input and output models, and its execution markings (today exactly
-one: stochastic). The only path into the command surface; dispatch, `--schema`, the
-future `manifest`, and the conformance harness are all projections of it (bADR-0011).
+The single per-command registration object naming everything the surface needs to
+run, describe, and conformance-test a command: tree position (group + command), a
+human description, typed input/output models (with the descriptor-designated
+positional argument), the typed handler (the execution binding), execution markings
+(today exactly one: stochastic), and the command's conformance fixtures. The only
+path into the command surface; dispatch, `--schema`, the future `manifest`, and the
+conformance harness are all projections of it (bADR-0011).
 _Avoid_: command spec, command config, registry entry
 
 **Error envelope**:
@@ -164,8 +167,9 @@ _Avoid_: validation result, balance error, failure (vague)
 
 **Usage error**:
 An invocation-surface failure — everything that goes wrong **before** the document's
-bytes reach the `Boundary funnel`: unknown command or flag, argument conflicts, an
-unreadable input path. Exit 3, envelope on stderr, own stable code family (bADR-0008);
+bytes reach the `Boundary funnel`: a bare invocation naming no command, unknown
+command or flag, argument conflicts, an unreadable input path. Exit 3, envelope on
+stderr, own stable code family (bADR-0008);
 unparseable JSON and everything after ingress are typed refusals (the funnel's, or the
 downstream `Evaluation refusal`), never usage errors.
 _Avoid_: refusal (the funnel's word), invalid input (ambiguous)

--- a/libs/gda-balancing/BALANCING-CONTEXT.md
+++ b/libs/gda-balancing/BALANCING-CONTEXT.md
@@ -12,7 +12,7 @@ it, with structured output suitable for programmatic consumption. (Requirements:
 The toolkit itself. The `gda-` prefix is the **product-family brand** — this is a sibling
 product of `gda`, not a `gda` component (contrast `gda-mcp` / `gda-daemon`, which are gda's
 own components). It neither depends on nor extends `gda`; its CLI *interface style* follows
-gda's conventions (PRD #501 addendum).
+gda's conventions (PRD #501 addendum) — the binding CLI contract is bADR-0007…0011.
 _Avoid_: gda balancing module, balancing plugin
 
 **Standard Schema**:
@@ -119,7 +119,7 @@ offending element, and human-readable detail; validation reports **all** violati
 (bounded), not fail-fast. A refusal rejects invalid *input*; a verdict judges a *valid*
 design against balance targets — the two are never conflated (bADR-0004). One downstream
 class exists beyond the funnel: the non-finite `Evaluation refusal` (bADR-0003). The CLI
-envelope carrying refusals is #518's contract.
+carrier of refusals is the `Error envelope` (bADR-0008).
 _Avoid_: validation error (vague), warning, exception
 
 **Structural schema**:
@@ -136,6 +136,43 @@ answers "what is structurally well-formed and which semantic rules exist"; full 
 additionally requires the versioned validator, the third required artifact. Derived from
 the validator or guarded by conformance tests, never hand-maintained twice (bADR-0005).
 _Avoid_: rules doc, validation spec (as a prose document)
+
+### Command surface
+
+**Command descriptor**:
+The single per-command registration object naming a command's tree position (group +
+command), its typed input and output models, and its execution markings (today exactly
+one: stochastic). The only path into the command surface; dispatch, `--schema`, the
+future `manifest`, and the conformance harness are all projections of it (bADR-0011).
+_Avoid_: command spec, command config, registry entry
+
+**Error envelope**:
+The single top-level-`error` JSON object a failed invocation emits — category `refusal`
+(stdout, exit 2; carrying the funnel's typed refusals verbatim, report-all) or
+`usage` / `internal` (stderr, exits 3 / 4; a single envelope-level code). It carries
+the funnel's refusal codes without minting any; the CLI-usage family is the one code
+family the CLI contract owns (bADR-0008).
+_Avoid_: error blob, failure JSON, exception dump
+
+**Verdict**:
+The Phase-2 pass/fail judgment of a **valid** design against balance targets — never
+conflated with a refusal, which rejects invalid *input* (bADR-0004). Its CLI channel
+is reserved now: exit 1, verdict report on stdout (bADR-0008); its report shape is
+owned by the Phase-2 design gate.
+_Avoid_: validation result, balance error, failure (vague)
+
+**Usage error**:
+An invocation-surface failure — everything that goes wrong **before** the document's
+bytes reach the `Boundary funnel`: unknown command or flag, argument conflicts, an
+unreadable input path. Exit 3, envelope on stderr, own stable code family (bADR-0008);
+unparseable JSON and everything after ingress belong to the funnel, not here.
+_Avoid_: refusal (the funnel's word), invalid input (ambiguous)
+
+**Effective seed**:
+The seed that actually drove a stochastic run — supplied via `--seed` or drawn fresh —
+always echoed in the structured result together with the toolkit version, so every
+stochastic result carries its own reproduction key (bADR-0010).
+_Avoid_: random seed (ambiguous), default seed
 
 ### Simulation
 

--- a/libs/gda-balancing/docs/badr/0007-cli-command-taxonomy.md
+++ b/libs/gda-balancing/docs/badr/0007-cli-command-taxonomy.md
@@ -57,9 +57,13 @@ semantics of individual commands stay with their owning issues (#504, #505/#506,
   exemption**: it emits framework help text on stdout at exit 0, is not
   descriptor-registered, and is excluded from `--schema` and the future `manifest`
   (bADR-0009/0011) — the JSON result contract governs every *registered* command,
-  and this exemption is decided here rather than left to framework accident. A
-  third meta name is **reserved**: `manifest`, the deferred aggregate surface
-  manifest (bADR-0009) — reserved on the same terms as the Phase-2 groups above.
+  and this exemption is decided here rather than left to framework accident.
+  **Help is reached only by asking**: a bare `gda-balancing`, or a group named
+  with no command, is a malformed invocation in automation and fails loudly — a
+  usage error (exit 3, `missing_command`, bADR-0008), never an exit-0 help dump
+  that would mask a broken agent script. A third meta name is **reserved**:
+  `manifest`, the deferred aggregate surface manifest (bADR-0009) — reserved on
+  the same terms as the Phase-2 groups above.
 
 - **Verb vocabulary adopted verbatim** *(adopted-from-gda: ADR-0005)*: `create`/
   `delete` for standalone entities vs `add`/`remove` for sub-entities in a container;

--- a/libs/gda-balancing/docs/badr/0007-cli-command-taxonomy.md
+++ b/libs/gda-balancing/docs/badr/0007-cli-command-taxonomy.md
@@ -1,0 +1,83 @@
+---
+status: proposed
+---
+
+# CLI command taxonomy: domain-object groups under one agent-facing binary
+
+PRD #501 US19 requires a CLI agents can drive in automation, and the PRD addendum
+(2026-07-15) adjudicates that the CLI's interface style follows `gda`. This bADR fixes
+the command taxonomy — the tree shape and its naming law — for design gate #518. The
+semantics of individual commands stay with their owning issues (#504, #505/#506,
+#509/#510); no command may be named outside this tree.
+
+## Decision
+
+- **One binary, full family name: `gda-balancing`** *(new ground)*. The console script
+  is `gda-balancing`; `python -m gda_balancing` is its equivalent module invocation
+  (#502 registers both). No abbreviation: the `gda-` prefix is the product-family
+  brand (BALANCING-CONTEXT), agents do not economize keystrokes, and an abbreviated
+  second name would be a second identity to keep consistent.
+
+- **Grouped invocation `gda-balancing <group> <command>`; groups are domain objects**
+  *(adopted-from-gda: ADR-0005)*. Every group names a noun from the toolkit's shared
+  language, all tokens kebab-case. Delivery phase never appears in the tree
+  *(adopted-from-gda: ADR-0005/0019 — a command's phase is metadata, not position)*.
+
+- **v1 groups:**
+  - **`design`** — operations on a `Design document`: `design validate`,
+    `design format` (canonical round-trip emission, bADR-0005). Owned by #504.
+  - **`template`** — operations on `Genre template`s: `template list`, `template get`.
+    The instantiation command's shape is owned by #505/#506 within this tree and the
+    verb law below.
+  - **`schema`** — the Standard Schema's self-description artifacts (bADR-0009).
+    **Recorded deviation from gda**: in `gda`, `schema` names the aggregate
+    command-surface manifest (ADR-0012); here the word belongs to the toolkit's
+    central domain object — the `Standard Schema` — and the surface manifest takes the
+    reserved name `manifest` instead (bADR-0009). One word, one owner.
+
+- **Reserved Phase-2 groups: `evaluation` and `tuning`** *(new ground, mirroring
+  bADR-0001's reserved sections)*. Noun groups after the glossary's `Evaluation
+  method` / `Tuning method` — not verb names (`simulate`, `tune`), which would break
+  the groups-are-nouns law. Reserved means: the names are fixed now so no later
+  surface squats on them, they are **absent** from the v1 surface (invoking one is an
+  unknown-command usage refusal, bADR-0008), and #509/#510 fill them at delivery.
+
+- **Meta commands stay ungrouped: `version`, `help`** *(adopted-from-gda: ADR-0005)*.
+  `version` reports the toolkit package version and the supported Standard Schema
+  line as **distinct fields** — the two versions are independent authorities and are
+  never conflated (bADR-0001).
+
+- **Verb vocabulary adopted verbatim** *(adopted-from-gda: ADR-0005)*: `create`/
+  `delete` for standalone entities vs `add`/`remove` for sub-entities in a container;
+  `get` (one entity), `list` (enumerate), `set` (mutate a property); constant meaning
+  across groups, no synonyms (`read`, `edit`, `update` are banned). Domain verbs
+  (`validate`, `format`) are sanctioned where the family precedent sanctions them.
+
+## Considered options
+
+- **Domain-object groups + reserved Phase-2 nouns** (chosen) — the family's law,
+  extensible across phases without renames.
+- **Flat command list** (rejected) — the surface spans four functional areas plus
+  Phase-2 growth; a flat namespace forces prefix-encoding the group into command
+  names, which is the tree again but unenforced.
+- **Verb-named Phase-2 groups (`simulate`, `tune`)** (rejected) — groups are nouns;
+  a verb group collapses the group/command distinction and drifts from ADR-0005's
+  discipline the family adjudication points at.
+- **Abbreviated binary (e.g. `gdab`)** (rejected) — a second identity with no agent
+  benefit; search and docs anchor on the product name.
+
+## Consequences
+
+- #502 registers the console script + module entry and the first meta command
+  (`version`); every subsequent CLI-surface issue names its commands inside this tree.
+- The `schema`-vs-`manifest` naming deviation is load-bearing for bADR-0009; changing
+  it later renames a public surface (breaking), so it is decided here, once.
+- Reserved group names are enforceable by the conformance harness (bADR-0011): the
+  registry must not contain `evaluation`/`tuning` commands until their owning issues
+  land.
+
+## References
+
+- gda ADR-0005 (taxonomy), ADR-0019 (placement by domain object) — reference input
+  per the PRD #501 addendum; this bADR is the binding authority for this toolkit.
+- Research provenance (non-normative): issue #518 comment (2026-07-18).

--- a/libs/gda-balancing/docs/badr/0007-cli-command-taxonomy.md
+++ b/libs/gda-balancing/docs/badr/0007-cli-command-taxonomy.md
@@ -35,19 +35,31 @@ semantics of individual commands stay with their owning issues (#504, #505/#506,
     central domain object — the `Standard Schema` — and the surface manifest takes the
     reserved name `manifest` instead (bADR-0009). One word, one owner.
 
-- **Reserved Phase-2 groups: `evaluation` and `tuning`** *(new ground, mirroring
-  bADR-0001's reserved sections)*. Noun groups after the glossary's `Evaluation
-  method` / `Tuning method` — not verb names (`simulate`, `tune`), which would break
-  the groups-are-nouns law. Reserved means: the names are fixed now so no later
-  surface squats on them, they are **absent** from the v1 surface (invoking one is an
-  unknown-command usage error, bADR-0008), and #509/#510 fill them at delivery.
+- **Reserved Phase-2 groups: `evaluation` and `tuning`** *(recorded deviation from
+  gda ADR-0005, which enumerates no future surface up front; the reservation
+  pattern mirrors bADR-0001's reserved sections)*. Noun groups after the glossary's
+  `Evaluation method` / `Tuning method` — not verb names (`simulate`, `tune`),
+  which would break the groups-are-nouns law. Reserved means: the names are fixed
+  now so no later surface squats on them, they are **absent** from the v1 surface
+  (invoking one is an unknown-command usage error, bADR-0008), and #509/#510 fill
+  them at delivery. Why deviate: this surface has already had one name contention
+  (`schema` vs `manifest`, above) and the Phase-2 surfaces are certain per PRD
+  #501 — only their shapes are open. Reserving the two nouns costs nothing
+  publicly (a reserved name has no surface to break, and can still be renamed by
+  amending this record before delivery), while an accidental squat *would* force a
+  breaking rename later.
 
 - **Meta commands stay ungrouped: `version`, `help`** *(adopted-from-gda: ADR-0005)*.
   `version` reports the toolkit package version and the supported Standard Schema
   line as **distinct fields** — the two versions are independent authorities and are
-  never conflated (bADR-0001). A third meta name is **reserved**: `manifest`, the
-  deferred aggregate surface manifest (bADR-0009) — reserved on the same terms as the
-  Phase-2 groups above.
+  never conflated (bADR-0001); it is a registered, `--schema`-bearing command like
+  any other (bADR-0011). **`help` (and `--help`) is the surface's one human-facing
+  exemption**: it emits framework help text on stdout at exit 0, is not
+  descriptor-registered, and is excluded from `--schema` and the future `manifest`
+  (bADR-0009/0011) — the JSON result contract governs every *registered* command,
+  and this exemption is decided here rather than left to framework accident. A
+  third meta name is **reserved**: `manifest`, the deferred aggregate surface
+  manifest (bADR-0009) — reserved on the same terms as the Phase-2 groups above.
 
 - **Verb vocabulary adopted verbatim** *(adopted-from-gda: ADR-0005)*: `create`/
   `delete` for standalone entities vs `add`/`remove` for sub-entities in a container;

--- a/libs/gda-balancing/docs/badr/0007-cli-command-taxonomy.md
+++ b/libs/gda-balancing/docs/badr/0007-cli-command-taxonomy.md
@@ -40,12 +40,14 @@ semantics of individual commands stay with their owning issues (#504, #505/#506,
   method` / `Tuning method` — not verb names (`simulate`, `tune`), which would break
   the groups-are-nouns law. Reserved means: the names are fixed now so no later
   surface squats on them, they are **absent** from the v1 surface (invoking one is an
-  unknown-command usage refusal, bADR-0008), and #509/#510 fill them at delivery.
+  unknown-command usage error, bADR-0008), and #509/#510 fill them at delivery.
 
 - **Meta commands stay ungrouped: `version`, `help`** *(adopted-from-gda: ADR-0005)*.
   `version` reports the toolkit package version and the supported Standard Schema
   line as **distinct fields** — the two versions are independent authorities and are
-  never conflated (bADR-0001).
+  never conflated (bADR-0001). A third meta name is **reserved**: `manifest`, the
+  deferred aggregate surface manifest (bADR-0009) — reserved on the same terms as the
+  Phase-2 groups above.
 
 - **Verb vocabulary adopted verbatim** *(adopted-from-gda: ADR-0005)*: `create`/
   `delete` for standalone entities vs `add`/`remove` for sub-entities in a container;

--- a/libs/gda-balancing/docs/badr/0008-invocation-result-contract.md
+++ b/libs/gda-balancing/docs/badr/0008-invocation-result-contract.md
@@ -8,8 +8,9 @@ PRD #501 US19 requires structured JSON output and typed machine-readable refusal
 distinct from pass/fail verdicts; bADR-0004 fixes the refusal semantics and hands their
 CLI surface — envelope shape and exit codes — to this gate (#518). This bADR fixes what
 one `gda-balancing` invocation returns: the output channels, the success and failure
-payloads, and the exit-code layering. It carries the funnel's refusal codes; it mints
-exactly one new code family (CLI usage) and no refusal codes.
+payloads, and the exit-code layering. It carries the funnel's refusal codes; it mints exactly one
+new code family (CLI usage) plus the single fixed `internal_error` code, and no
+refusal codes.
 
 ## Decision
 
@@ -49,23 +50,28 @@ exactly one new code family (CLI usage) and no refusal codes.
 
   - `category` ∈ `refusal` | `usage` | `internal` — the discriminator agents branch
     on. (A verdict is not an error and never appears here; see the exit table.)
-  - `refusal` envelopes carry the funnel's report verbatim: each entry is bADR-0004's
-    typed refusal — stable `code`, `path` (RFC 6901 JSON Pointer), human `detail` —
-    with bADR-0004's report-all list semantics (deduplicated, path-then-code order,
-    ≤ 1000 entries, explicit `truncated` marker). Envelope-level `code` is absent for
-    refusals: the codes live in the entries, and **this contract mints no refusal
-    codes** — the namespace is the funnel's (preflight + structural families, the
-    semantic rule catalog, and the Evaluation refusal family; bADR-0003/0004).
+  - `refusal` envelopes carry the refusal report verbatim: each entry is bADR-0004's
+    typed refusal — stable `code`, `path` (bADR-0004's instance path, an RFC 6901
+    JSON Pointer), human `detail` — with bADR-0004's report-all list semantics
+    (deduplicated, path-then-code order, ≤ 1000 entries, explicit `truncated`
+    marker). Envelope-level `code` is absent for refusals: the codes live in the
+    entries, and **this contract mints no refusal codes** — the carried namespace is
+    the funnel's families (preflight + structural + the semantic rule catalog,
+    bADR-0004) plus the one downstream class, the non-finite Evaluation refusal
+    family (bADR-0003).
   - `usage` and `internal` envelopes carry a single envelope-level `code` and no
-    `refusals` list.
+    `refusals` list. Internal errors use the single fixed code `internal_error`,
+    registered in the same registry as the CLI-usage family (bADR-0011).
 
-- **The CLI-usage code family — the one family this contract mints.** Its boundary is
-  the funnel's ingress: **everything that fails before the document's bytes reach the
-  funnel is a usage error** (unknown command or flag, mutually-exclusive arguments,
-  an unreadable input path); **everything after is the funnel's** (unparseable JSON,
-  caps, version dispatch, structure, semantics — all typed refusals, bADR-0004). The
-  family's codes live in the single registry the conformance harness walks
-  (bADR-0011); the seam keeps the two namespaces from ever overlapping.
+- **The CLI-usage code family — the one family this contract mints** *(new ground)*.
+  Its boundary is the funnel's ingress: **everything that fails before the document's
+  bytes reach the funnel is a usage error** (unknown command or flag,
+  mutually-exclusive arguments, an unreadable input path); **everything after is a
+  typed refusal** — the funnel's phases (unparseable JSON, caps, version dispatch,
+  structure, semantics; bADR-0004) and, past an accepting funnel, the one downstream
+  class, the non-finite Evaluation refusal (bADR-0003). The family's codes live in
+  the single registry the conformance harness walks (bADR-0011); the seam keeps the
+  two namespaces from ever overlapping.
 
 - **Exit-code layering** *(new ground — no dominant industry precedent; this layout is
   the toolkit's own assembly of individually verified precedents, recorded per the
@@ -75,7 +81,7 @@ exactly one new code family (CLI usage) and no refusal codes.
   |---|---|---|---|---|
   | `0` | success (incl. validate-passed; later verdict-pass) | result object | stdout | v1 |
   | `1` | **verdict-fail** — a *valid* design judged failing its balance targets | verdict report (shape owned by Phase-2 design) | stdout | reserved |
-  | `2` | **input refusal** — the funnel refused the document | `refusal` envelope | stdout | v1 |
+  | `2` | **refusal** — typed refusals rejected the document (funnel phases, or the downstream Evaluation refusal) | `refusal` envelope | stdout | v1 |
   | `3` | **usage error** — the invocation itself is malformed | `usage` envelope | stderr | v1 |
   | `4` | **internal error** — the toolkit itself failed | `internal` envelope | stderr | v1 |
 
@@ -124,11 +130,9 @@ exactly one new code family (CLI usage) and no refusal codes.
 - **Refusal report on stderr** (rejected) — the refusal report is the primary product
   of a validation run and the batch-fix input for agents (bADR-0004's report-all
   rationale); hiding the product on the diagnostics channel serves no one.
-
-## Considered options — result shape
-
-- **Bare typed result object, envelope only on failure** (chosen) — one top-level
-  `error` key is the in-band discriminator; exit code is the out-of-band one.
+- **Bare typed result object on success, envelope only on failure** (chosen) — one
+  top-level `error` key is the in-band discriminator; exit code is the out-of-band
+  one.
 - **Uniform wrapper around success results too** (rejected) — a second envelope with
   no discriminating job; the success schema is already per-command via `--schema`
   (bADR-0009).

--- a/libs/gda-balancing/docs/badr/0008-invocation-result-contract.md
+++ b/libs/gda-balancing/docs/badr/0008-invocation-result-contract.md
@@ -81,8 +81,9 @@ refusal codes.
   typed refusal** — the funnel's phases (unparseable JSON, caps, version dispatch,
   structure, semantics; bADR-0004) and, past an accepting funnel, the one downstream
   class, the non-finite Evaluation refusal (bADR-0003). The **v1 normative code
-  set**: `unknown_command`, `unknown_argument`, `argument_conflict`,
-  `invalid_argument`, `unreadable_input`, `unwritable_output`. The family's codes
+  set**: `missing_command`, `unknown_command`, `unknown_argument`,
+  `argument_conflict`, `invalid_argument`, `unreadable_input`,
+  `unwritable_output`. The family's codes
   live in the single registry the conformance harness walks (bADR-0011); additions
   are additive registry entries, never renames, and the seam keeps the two
   namespaces from ever overlapping.

--- a/libs/gda-balancing/docs/badr/0008-invocation-result-contract.md
+++ b/libs/gda-balancing/docs/badr/0008-invocation-result-contract.md
@@ -1,0 +1,154 @@
+---
+status: proposed
+---
+
+# Invocation result contract: one JSON result, refusal-carrying error envelope, layered exit codes
+
+PRD #501 US19 requires structured JSON output and typed machine-readable refusals
+distinct from pass/fail verdicts; bADR-0004 fixes the refusal semantics and hands their
+CLI surface — envelope shape and exit codes — to this gate (#518). This bADR fixes what
+one `gda-balancing` invocation returns: the output channels, the success and failure
+payloads, and the exit-code layering. It carries the funnel's refusal codes; it mints
+exactly one new code family (CLI usage) and no refusal codes.
+
+## Decision
+
+- **One structured JSON payload per invocation** *(adopted-from-gda principle:
+  ADR-0002; JSON-first per bADR-0005)*. A successful command emits its typed result
+  object — canonically emitted per bADR-0005 — as the only content on stdout. Human
+  diagnostics and progress go to stderr; stderr is never parsed for outcome
+  *(adopted-from-gda: ADR-0002's channel discipline)*.
+
+- **JSON by default; no human renderer in v1.** *(Recorded deviation from gda's
+  human-default + `--json` flag.)* This toolkit is agent-first with no human-terminal
+  install base: every Phase-1 consumer is an agent, CI, or a test, and bADR-0005
+  already makes JSON the authoritative serialization for toolkit reports. Defaulting
+  to JSON removes the forgot-`--json` failure class entirely. Precedent exists on both
+  sides (AWS CLI v2 is JSON-by-default; gh/Terraform render human-first) — this is a
+  recorded adjudication (maintainer-approved, 2026-07-18), not drift. A human render
+  may arrive later behind an explicit additive flag (e.g. `--format human`) without
+  contract change.
+
+- **No sentinel wrapping.** *(Recorded deviation from gda ADR-0002.)* gda's sentinels
+  exist because it parses an engine subprocess's stdout, where engine noise
+  interleaves with the payload. This toolkit spawns no subprocess and owns its stdout
+  end to end, so that risk class is structurally absent; the payload is a plain JSON
+  document. (Research: cargo documents plain JSON-per-line on stdout and its
+  `starts with {` sniffing caveat exists precisely for *foreign* output interleaving —
+  the precondition this toolkit does not have.)
+
+- **The error envelope.** Any failed invocation emits exactly one envelope object,
+  recognizable by its single top-level `error` key *(adopted-from-gda: ADR-0002's
+  envelope pattern; field set is balancing-local)*:
+
+  ```json
+  {"error": {"category": "...", "code": "...", "message": "...",
+             "refusals": [{"code": "...", "path": "...", "detail": "..."}],
+             "truncated": false}}
+  ```
+
+  - `category` ∈ `refusal` | `usage` | `internal` — the discriminator agents branch
+    on. (A verdict is not an error and never appears here; see the exit table.)
+  - `refusal` envelopes carry the funnel's report verbatim: each entry is bADR-0004's
+    typed refusal — stable `code`, `path` (RFC 6901 JSON Pointer), human `detail` —
+    with bADR-0004's report-all list semantics (deduplicated, path-then-code order,
+    ≤ 1000 entries, explicit `truncated` marker). Envelope-level `code` is absent for
+    refusals: the codes live in the entries, and **this contract mints no refusal
+    codes** — the namespace is the funnel's (preflight + structural families, the
+    semantic rule catalog, and the Evaluation refusal family; bADR-0003/0004).
+  - `usage` and `internal` envelopes carry a single envelope-level `code` and no
+    `refusals` list.
+
+- **The CLI-usage code family — the one family this contract mints.** Its boundary is
+  the funnel's ingress: **everything that fails before the document's bytes reach the
+  funnel is a usage error** (unknown command or flag, mutually-exclusive arguments,
+  an unreadable input path); **everything after is the funnel's** (unparseable JSON,
+  caps, version dispatch, structure, semantics — all typed refusals, bADR-0004). The
+  family's codes live in the single registry the conformance harness walks
+  (bADR-0011); the seam keeps the two namespaces from ever overlapping.
+
+- **Exit-code layering** *(new ground — no dominant industry precedent; this layout is
+  the toolkit's own assembly of individually verified precedents, recorded per the
+  #518 research)*:
+
+  | Exit | Meaning | Payload | Channel | Status |
+  |---|---|---|---|---|
+  | `0` | success (incl. validate-passed; later verdict-pass) | result object | stdout | v1 |
+  | `1` | **verdict-fail** — a *valid* design judged failing its balance targets | verdict report (shape owned by Phase-2 design) | stdout | reserved |
+  | `2` | **input refusal** — the funnel refused the document | `refusal` envelope | stdout | v1 |
+  | `3` | **usage error** — the invocation itself is malformed | `usage` envelope | stderr | v1 |
+  | `4` | **internal error** — the toolkit itself failed | `internal` envelope | stderr | v1 |
+
+  - Channel follows meaning: exits 0–2 are the command *doing its job* (a refusal
+    report **is** `design validate`'s product on an invalid document), so their
+    payload is stdout content; exits 3–4 mean no job was done, so stdout stays empty
+    and the machine-readable envelope goes to stderr (precedent: rustc's JSON
+    diagnostics on stderr; clig.dev's messaging-to-stderr; #502's tracer acceptance).
+  - Verdict-fail sits adjacent to success (grep/diff/pytest's 40-year form: exit 1 is
+    a negative *answer*, not a malfunction); usage and internal stay separate rather
+    than collapsed linter-style, because the conformance harness must distinguish
+    "you called it wrong" from "the tool broke" *(pytest's four-way layering is the
+    closest live precedent; ESLint/Ruff's three-bucket collapse is the recorded
+    counter-practice)*.
+  - An unsupported or malformed `schema_version` is a **preflight refusal (exit 2)**,
+    not a usage error — version dispatch is the funnel's (bADR-0001/0004).
+  - All codes stay far below the shell-reserved band (126/127/128+N).
+  - *(Recorded deviation from gda's exit codes: gda's 3 version / 4 operation /
+    5 parse / 6 live / 124 / 127 classify engine-wrapper failure sources — binary
+    resolution, launch, engine crash, live channel — none of which exist here. The
+    refusal/verdict split gda has no analogue for is bADR-0004's mandate.)*
+  - `1` is reserved **now** so Phase-2 (#509) inherits it as fixed contract; nothing
+    may repurpose it meanwhile, and the internal-error exit does not shift when the
+    verdict channel is delivered.
+
+- **Internal errors still emit the envelope.** An unexpected exception produces the
+  `internal` envelope on stderr (a traceback may follow it as plain stderr text) —
+  a bare traceback is never the only output of any invocation.
+
+## Considered options
+
+- **Layered small integers, envelope by category** (chosen).
+- **Human-default output with `--json`** (rejected) — see the recorded deviation
+  above; it optimizes for a consumer this product does not have.
+- **Sentinel-delimited payload** (rejected) — solves an interleaving risk this
+  toolkit structurally lacks; pure ceremony here.
+- **sysexits integers (`EX_USAGE=64`, `EX_DATAERR=65`)** (rejected) — the only
+  written usage-vs-data standard, but unadopted by the canonical small-integer tools
+  (grep/diff/git, verified), and alien to the family's small-integer style; adopting
+  the *distinction* does not require adopting the integers.
+- **Linter-style collapse (usage + internal in one code)** (rejected) — erases a
+  distinction the conformance harness and agents both branch on.
+- **Everything on stdout** (rejected) — a malformed invocation would still "produce a
+  result", muddying stdout-as-product; contradicts the channel-meaning precedent and
+  #502's recorded tracer expectation.
+- **Refusal report on stderr** (rejected) — the refusal report is the primary product
+  of a validation run and the batch-fix input for agents (bADR-0004's report-all
+  rationale); hiding the product on the diagnostics channel serves no one.
+
+## Considered options — result shape
+
+- **Bare typed result object, envelope only on failure** (chosen) — one top-level
+  `error` key is the in-band discriminator; exit code is the out-of-band one.
+- **Uniform wrapper around success results too** (rejected) — a second envelope with
+  no discriminating job; the success schema is already per-command via `--schema`
+  (bADR-0009).
+
+## Consequences
+
+- #502's version tracer implements exits 0/3 and the `usage` envelope; #504
+  implements exit 2 and the `refusal` envelope end to end.
+- The conformance harness (bADR-0011) asserts, per registered command, every
+  applicable row of the exit table and both envelope channels.
+- The `refusal` envelope is the single CLI carrier of bADR-0004 refusals; any future
+  command that can receive a document inherits it unchanged.
+- Exit `1` and the verdict-report shape are the fixed inheritance of the Phase-2
+  design gate (#509) — reserved, never redesigned there.
+
+## References
+
+- gda ADR-0002 (structured output contract) — reference input; deviations recorded
+  above. bADR-0003/0004 own every refusal code this envelope carries.
+- Research provenance (non-normative): issue #518 comment (2026-07-18) — exit-code
+  precedents (sysexits, pytest, grep/diff, ESLint/Ruff, Bash reserved band), output
+  conventions (cargo, rustc, AWS/gh/Terraform, RFC 9457 congruence with the refusal
+  triple).

--- a/libs/gda-balancing/docs/badr/0008-invocation-result-contract.md
+++ b/libs/gda-balancing/docs/badr/0008-invocation-result-contract.md
@@ -18,7 +18,10 @@ refusal codes.
   ADR-0002; JSON-first per bADR-0005)*. A successful command emits its typed result
   object — canonically emitted per bADR-0005 — as the only content on stdout. Human
   diagnostics and progress go to stderr; stderr is never parsed for outcome
-  *(adopted-from-gda: ADR-0002's channel discipline)*.
+  *(adopted-from-gda: ADR-0002's channel discipline)*. The invariant is
+  channel-invariant: with `--out` (bADR-0009) the artifact body moves to the sink
+  while stdout still carries the typed result as the receipt — `--out` never forks
+  the result contract.
 
 - **JSON by default; no human renderer in v1.** *(Recorded deviation from gda's
   human-default + `--json` flag.)* This toolkit is agent-first with no human-terminal
@@ -62,6 +65,14 @@ refusal codes.
   - `usage` and `internal` envelopes carry a single envelope-level `code` and no
     `refusals` list. Internal errors use the single fixed code `internal_error`,
     registered in the same registry as the CLI-usage family (bADR-0011).
+  - **Field law (normative).** `category` and `message` are required in every
+    envelope. For `refusal`: `refusals` (non-empty) and `truncated` are required,
+    envelope-level `code` is forbidden. For `usage`/`internal`: `code` is
+    required, `refusals`/`truncated` are forbidden. Two optional members exist:
+    `diagnostics` (string, `internal` only, populated only under `--debug` — see
+    below) and `reproduction` (below). No other member is permitted — the envelope
+    schema is closed, and it is exactly the uniform `error` schema `--schema`
+    publishes (bADR-0009).
 
 - **The CLI-usage code family — the one family this contract mints** *(new ground)*.
   Its boundary is the funnel's ingress: **everything that fails before the document's
@@ -69,9 +80,12 @@ refusal codes.
   mutually-exclusive arguments, an unreadable input path); **everything after is a
   typed refusal** — the funnel's phases (unparseable JSON, caps, version dispatch,
   structure, semantics; bADR-0004) and, past an accepting funnel, the one downstream
-  class, the non-finite Evaluation refusal (bADR-0003). The family's codes live in
-  the single registry the conformance harness walks (bADR-0011); the seam keeps the
-  two namespaces from ever overlapping.
+  class, the non-finite Evaluation refusal (bADR-0003). The **v1 normative code
+  set**: `unknown_command`, `unknown_argument`, `argument_conflict`,
+  `invalid_argument`, `unreadable_input`, `unwritable_output`. The family's codes
+  live in the single registry the conformance harness walks (bADR-0011); additions
+  are additive registry entries, never renames, and the seam keeps the two
+  namespaces from ever overlapping.
 
 - **Exit-code layering** *(new ground — no dominant industry precedent; this layout is
   the toolkit's own assembly of individually verified precedents, recorded per the
@@ -107,9 +121,20 @@ refusal codes.
     may repurpose it meanwhile, and the internal-error exit does not shift when the
     verdict channel is delivered.
 
-- **Internal errors still emit the envelope.** An unexpected exception produces the
-  `internal` envelope on stderr (a traceback may follow it as plain stderr text) —
-  a bare traceback is never the only output of any invocation.
+- **Failure stderr is exactly one sanitized JSON document.** For exits 3 and 4,
+  stdout is empty and stderr carries the envelope and nothing else — no banner, no
+  trailing traceback — so the failure channel is machine-parseable whole, never by
+  line-sniffing. An unexpected exception's detail (traceback, paths) appears only
+  inside the envelope's `diagnostics` field and only under an explicit `--debug`
+  flag; the default `internal` envelope carries the stable code and a sanitized
+  message. A bare traceback is never any invocation's output.
+
+- **Failures after stochastic execution starts carry the reproduction key.** Once a
+  stochastic command (bADR-0010) has drawn its effective seed, any failure envelope
+  it emits — e.g. a Monte-Carlo run hitting the non-finite Evaluation refusal —
+  includes `reproduction: {seed, toolkit_version}`, so the replay key is never lost
+  to the failure path. Deterministic commands never carry the member. (No v1
+  command is stochastic; #510 inherits this with bADR-0010.)
 
 ## Considered options
 

--- a/libs/gda-balancing/docs/badr/0009-surface-self-description-and-structured-io.md
+++ b/libs/gda-balancing/docs/badr/0009-surface-self-description-and-structured-io.md
@@ -48,17 +48,22 @@ input enters, and the config/logic separation every command obeys (design gate #
   file-path argument — configuration is data handed to the tool, never encoded in
   flags *(family convention; PRD #501 US19)*. The typed result always stays on
   stdout (bADR-0008); where an artifact file is wanted, an explicit `--out <path>`
-  receives the **artifact body** while stdout carries the result as a receipt
-  naming the sink — `--out` moves the artifact, never the result. Artifact writes
-  are safe by law: an existing destination is overwritten; the write is atomic
-  (write-then-rename), so a failed invocation leaves no partial file; an
-  unwritable sink is a usage error (`unwritable_output`, bADR-0008). **No command
-  ever writes to its input path** *(new ground, grounded in bADR-0004)*: validity
-  is a property of a document state, and any mutated state must visibly re-enter
-  the funnel — an in-place write would silently alias an unvalidated state over
-  the input authority. `--out` resolving to the input path, directly or through a
-  symlink alias, is therefore a usage error. Derived documents (a `design format`
-  emission, a Phase-2 tuning result) are always a new stream or path.
+  receives the **artifact body** while stdout carries the result as a receipt —
+  `--out` moves the artifact, never the result. The receipt is one normative
+  member: **`artifact: {path, bytes}`** (resolved sink path, bytes written),
+  present in the result object exactly when `--out` was used and forbidden
+  otherwise; the rest of the result stays the command's own output model.
+  Artifact writes are safe by law: an existing destination is overwritten; the
+  write is atomic (write-then-rename), so a failed invocation leaves no partial
+  file; an unwritable sink is a usage error (`unwritable_output`, bADR-0008).
+  **No command ever writes to its input path** *(new ground, grounded in
+  bADR-0004)*: validity is a property of a document state, and any mutated state
+  must visibly re-enter the funnel — an in-place write would silently alias an
+  unvalidated state over the input authority. `--out` resolving to the input
+  path, directly or through a symlink alias, is therefore a usage error with the
+  stable code **`argument_conflict`** (the two arguments' *values* collide).
+  Derived documents (a `design format` emission, a Phase-2 tuning result) are
+  always a new stream or path.
 
 - **Structured params input: adopted in principle, deferred in delivery.**
   *(adopted-from-gda: ADR-0015 — semantics reserved verbatim; delivery deferred.)*
@@ -91,7 +96,8 @@ input enters, and the config/logic separation every command obeys (design gate #
   second guarded surface; every workflow it serves is covered by redirecting the
   emission.
 - **Both channels** (rejected) — two authorities for one artifact with no consumer
-  demanding the second; violates the single-authority rule (RULES).
+  demanding the second; two independently served copies of one artifact is the
+  drift-by-design bADR-0005's anti-drift rule exists to prevent.
 - **`--params-json` delivered in v1** (rejected) — all carrying cost, no consumer;
   gda grew it *for* gda-mcp, which has no analogue here yet.
 - **No reservation of the deferred surfaces** (rejected) — retrofit risk: without the

--- a/libs/gda-balancing/docs/badr/0009-surface-self-description-and-structured-io.md
+++ b/libs/gda-balancing/docs/badr/0009-surface-self-description-and-structured-io.md
@@ -1,0 +1,103 @@
+---
+status: proposed
+---
+
+# Surface self-description, structured input, and config/logic separation
+
+bADR-0005 defined the Standard Schema's two self-description artifacts and left their
+delivery channel to this gate; gda's surface conventions (`--schema`, structured params
+input) are the family reference. This bADR fixes how the *toolkit's command surface*
+describes itself, how the self-description artifacts are delivered, how structured
+input enters, and the config/logic separation every command obeys (design gate #518).
+
+## Decision
+
+- **Per-command `--schema`, emit-only** *(adopted-from-gda: ADR-0004)*. Every domain
+  command supports `--schema`, which emits a JSON object with keys `input` (the
+  command's parameter schema), `output` (its success-result schema), and `error` (the
+  bADR-0008 envelope schema — **byte-identical across every command**). The flag only
+  emits, never accepts; bare `--schema` wins over any other argument *(adopted:
+  ADR-0015's precedence rule)*.
+
+- **Model-driven, single source** *(adopted-from-gda: ADR-0004; anti-drift as in
+  bADR-0005)*. Each command's typed input and output models are the one authority:
+  argv parsing, result serialization, and both `--schema` keys derive from them.
+  A hand-maintained schema copy is prohibited.
+
+- **The `schema` group is the sole public delivery channel for the Standard Schema's
+  self-description artifacts** *(completes bADR-0005's deferral; maintainer-adjudicated
+  2026-07-18)*. `schema get structural` and `schema get catalog` emit the structural
+  schema and the semantic rule catalog (bADR-0005), canonically emitted, to stdout.
+  Packaged data files may exist but are an implementation detail — **no installed
+  file path is a public contract** (a site-packages path is a brittle interface
+  agents cannot reliably locate, and a second authority surface to guard).
+  bADR-0005's "runnable by off-the-shelf validators" is a property of the artifact's
+  *content*; redirecting the emission to a file serves that workflow. Free-standing
+  publication (a hosted URL) is an explicit extension point for a future bADR.
+
+- **Config/logic separation.** Commands take the `Design document` as an explicit
+  file-path argument — configuration is data handed to the tool, never encoded in
+  flags *(family convention; PRD #501 US19)*. Command output goes to stdout, or to an
+  explicit `--out <path>` where a file is wanted. **No command ever writes to its
+  input path** *(new ground, grounded in bADR-0004)*: validity is a property of a
+  document state, and any mutated state must visibly re-enter the funnel — an
+  in-place write would silently alias an unvalidated state over the input authority.
+  Derived documents (a `design format` emission, a Phase-2 tuning result) are always
+  a new stream or path.
+
+- **Structured params input: adopted in principle, deferred in delivery.**
+  *(adopted-from-gda: ADR-0015 — semantics reserved verbatim; delivery deferred.)*
+  The enabling architecture is mandatory from the first command: typed input models
+  with argv as a thin adapter, so a structured-params channel is purely additive.
+  The flag `--params-json <json | ->` (with `-` reading stdin), its mutual exclusion
+  with individual arguments (a usage refusal, bADR-0008), and its `--schema`
+  precedence rule are reserved exactly as gda ADR-0015 defines them, and are
+  delivered when an adapter consumer (an MCP or similar protocol adapter) exists.
+  Until then the input models are already published through `--schema`'s `input` key,
+  so the ABI is visible before the channel ships.
+
+- **The aggregate surface manifest is named `manifest` and deferred** *(shape
+  adopted-from-gda: ADR-0012; name is the bADR-0007 deviation; delivery deferred)*.
+  When an adapter consumer exists, a meta command `manifest` emits the whole-surface
+  document — one entry per dispatchable command with `name`, `description`, `input`,
+  `output`, `error`; non-dispatchable meta commands excluded at the source — walking
+  the same registry the conformance harness walks (bADR-0011). Deferred on the same
+  no-consumer ground as `--params-json`; the name is fixed now so nothing squats.
+
+- **`version` self-describes both authorities** *(bADR-0007 meta command; bADR-0001)*:
+  the toolkit package version and the supported Standard Schema line, as distinct
+  fields in one result object — never a single conflated version string.
+
+## Considered options
+
+- **CLI emission as the sole artifact channel** (chosen) — one public seam,
+  version-locked to the installed toolkit, canonical by construction.
+- **Installed file path as a public contract** (rejected) — brittle discovery, a
+  second guarded surface; every workflow it serves is covered by redirecting the
+  emission.
+- **Both channels** (rejected) — two authorities for one artifact with no consumer
+  demanding the second; violates the single-authority rule (RULES).
+- **`--params-json` delivered in v1** (rejected) — all carrying cost, no consumer;
+  gda grew it *for* gda-mcp, which has no analogue here yet.
+- **No reservation of the deferred surfaces** (rejected) — retrofit risk: without the
+  reserved names and semantics, later delivery would be a fresh design liable to
+  drift from the family ABI.
+
+## Consequences
+
+- #504 implements `schema get structural` / `schema get catalog` and per-command
+  `--schema`; the conformance harness (bADR-0011) asserts `--schema` presence and
+  validity for every registered command, and that the emitted `error` schema is the
+  one bADR-0008 envelope.
+- Delivering `--params-json` or `manifest` later is an additive slice: reserved
+  semantics + already-typed input models mean no existing surface changes.
+- The never-mutate-the-input rule is testable per command (input bytes before ==
+  after) and belongs to the conformance harness.
+
+## References
+
+- gda ADR-0004 (`--schema`), ADR-0012 (aggregate manifest), ADR-0015 (structured
+  params input) — reference input; adoption and deviations recorded above.
+- bADR-0005 — the artifacts this surface delivers; bADR-0008 — the envelope its
+  `error` key publishes.
+- Research provenance (non-normative): issue #518 comment (2026-07-18).

--- a/libs/gda-balancing/docs/badr/0009-surface-self-description-and-structured-io.md
+++ b/libs/gda-balancing/docs/badr/0009-surface-self-description-and-structured-io.md
@@ -12,12 +12,15 @@ input enters, and the config/logic separation every command obeys (design gate #
 
 ## Decision
 
-- **Per-command `--schema`, emit-only** *(adopted-from-gda: ADR-0004)*. Every domain
-  command supports `--schema`, which emits a JSON object with keys `input` (the
-  command's parameter schema), `output` (its success-result schema), and `error` (the
-  bADR-0008 envelope schema — **byte-identical across every command**). The flag only
-  emits, never accepts; bare `--schema` wins over any other argument *(adopted:
-  ADR-0015's precedence rule)*.
+- **Per-command `--schema`, emit-only** *(adopted-from-gda: ADR-0004)*. Every
+  **registered** command — domain commands and the registered meta command
+  `version` alike (bADR-0011's meta rule) — supports `--schema`, which emits a JSON
+  object with keys `input` (the command's parameter schema), `output` (its
+  success-result schema), and `error` (the bADR-0008 envelope schema —
+  **byte-identical across every command**). The flag only emits, never accepts;
+  bare `--schema` wins over any other argument *(adopted: ADR-0015's precedence
+  rule)*. `help` is the one exempt human-facing surface and carries no `--schema`
+  (bADR-0007/0011).
 
 - **Model-driven, single source** *(adopted-from-gda: ADR-0004; anti-drift as in
   bADR-0005)*. Each command's typed input and output models are the one authority:
@@ -43,13 +46,19 @@ input enters, and the config/logic separation every command obeys (design gate #
 
 - **Config/logic separation.** Commands take the `Design document` as an explicit
   file-path argument — configuration is data handed to the tool, never encoded in
-  flags *(family convention; PRD #501 US19)*. Command output goes to stdout, or to an
-  explicit `--out <path>` where a file is wanted. **No command ever writes to its
-  input path** *(new ground, grounded in bADR-0004)*: validity is a property of a
-  document state, and any mutated state must visibly re-enter the funnel — an
-  in-place write would silently alias an unvalidated state over the input authority.
-  Derived documents (a `design format` emission, a Phase-2 tuning result) are always
-  a new stream or path.
+  flags *(family convention; PRD #501 US19)*. The typed result always stays on
+  stdout (bADR-0008); where an artifact file is wanted, an explicit `--out <path>`
+  receives the **artifact body** while stdout carries the result as a receipt
+  naming the sink — `--out` moves the artifact, never the result. Artifact writes
+  are safe by law: an existing destination is overwritten; the write is atomic
+  (write-then-rename), so a failed invocation leaves no partial file; an
+  unwritable sink is a usage error (`unwritable_output`, bADR-0008). **No command
+  ever writes to its input path** *(new ground, grounded in bADR-0004)*: validity
+  is a property of a document state, and any mutated state must visibly re-enter
+  the funnel — an in-place write would silently alias an unvalidated state over
+  the input authority. `--out` resolving to the input path, directly or through a
+  symlink alias, is therefore a usage error. Derived documents (a `design format`
+  emission, a Phase-2 tuning result) are always a new stream or path.
 
 - **Structured params input: adopted in principle, deferred in delivery.**
   *(adopted-from-gda: ADR-0015 — semantics reserved verbatim; delivery deferred.)*

--- a/libs/gda-balancing/docs/badr/0009-surface-self-description-and-structured-io.md
+++ b/libs/gda-balancing/docs/badr/0009-surface-self-description-and-structured-io.md
@@ -22,10 +22,15 @@ input enters, and the config/logic separation every command obeys (design gate #
   rule)*. `help` is the one exempt human-facing surface and carries no `--schema`
   (bADR-0007/0011).
 
-- **Model-driven, single source** *(adopted-from-gda: ADR-0004; anti-drift as in
-  bADR-0005)*. Each command's typed input and output models are the one authority:
-  argv parsing, result serialization, and both `--schema` keys derive from them.
-  A hand-maintained schema copy is prohibited.
+- **Model-driven, with one deliberate division of authority** *(adopted-from-gda:
+  ADR-0004; anti-drift as in bADR-0005)*. Each command's typed input and output
+  models own **field names, types, validation, defaults, result serialization, and
+  both `--schema` keys** — a hand-maintained schema copy is prohibited. **Argv
+  presentation belongs to the Command descriptor** (bADR-0011): the binding law
+  derives each option mechanically from a model field, and the descriptor's
+  positional designation is binding metadata the model deliberately does not carry
+  (an input schema cannot express positional-vs-option, gda ADR-0015). Two
+  authorities, disjoint territories, both inside the single registration.
 
 - **The `schema` group is the sole public delivery channel for the Standard Schema's
   self-description artifacts** *(completes bADR-0005's deferral; maintainer-adjudicated

--- a/libs/gda-balancing/docs/badr/0009-surface-self-description-and-structured-io.md
+++ b/libs/gda-balancing/docs/badr/0009-surface-self-description-and-structured-io.md
@@ -32,8 +32,14 @@ input enters, and the config/logic separation every command obeys (design gate #
   file path is a public contract** (a site-packages path is a brittle interface
   agents cannot reliably locate, and a second authority surface to guard).
   bADR-0005's "runnable by off-the-shelf validators" is a property of the artifact's
-  *content*; redirecting the emission to a file serves that workflow. Free-standing
-  publication (a hosted URL) is an explicit extension point for a future bADR.
+  *content*; redirecting the emission to a file serves that workflow — any emitted
+  copy is the artifact, so validating "without installing the toolkit" needs only a
+  copy someone emitted, not an installation of one's own. Free-standing publication
+  (a hosted URL) is an explicit extension point for a future bADR; until it exists,
+  the structural schema's `$id` is an *identifier*, not a dereferenceable location
+  (JSON Schema's own treatment of `$id`), and the editor ambient validation
+  bADR-0001/0005 describe via `$schema` requires pointing the editor at an emitted
+  copy.
 
 - **Config/logic separation.** Commands take the `Design document` as an explicit
   file-path argument — configuration is data handed to the tool, never encoded in
@@ -50,7 +56,7 @@ input enters, and the config/logic separation every command obeys (design gate #
   The enabling architecture is mandatory from the first command: typed input models
   with argv as a thin adapter, so a structured-params channel is purely additive.
   The flag `--params-json <json | ->` (with `-` reading stdin), its mutual exclusion
-  with individual arguments (a usage refusal, bADR-0008), and its `--schema`
+  with individual arguments (a usage error, bADR-0008), and its `--schema`
   precedence rule are reserved exactly as gda ADR-0015 defines them, and are
   delivered when an adapter consumer (an MCP or similar protocol adapter) exists.
   Until then the input models are already published through `--schema`'s `input` key,

--- a/libs/gda-balancing/docs/badr/0010-determinism-and-seed-surfacing.md
+++ b/libs/gda-balancing/docs/badr/0010-determinism-and-seed-surfacing.md
@@ -18,7 +18,7 @@ is this toolkit's own, assembled from verified external precedent.)*
 - **Stochastic commands take an explicit `--seed <int>`; deterministic commands never
   do.** A command's descriptor (bADR-0011) declares whether it is stochastic; the
   flag exists exactly on the stochastic ones. Passing `--seed` to a deterministic
-  command is a usage refusal (bADR-0008) — the flag's presence is itself surface
+  command is a usage error (bADR-0008) — the flag's presence is itself surface
   truth about the command's nature, and the conformance harness asserts it both ways.
 
 - **An omitted seed is drawn fresh, and the result always echoes the effective
@@ -35,8 +35,9 @@ is this toolkit's own, assembled from verified external precedent.)*
 
 - **The reproducibility contract is version-scoped:** same seed + same input + same
   toolkit version → identical output, within bADR-0003's two-tier determinism
-  boundary (bit-exact arithmetic core; pow-family results ULP-loose with the
-  versioned evaluator as reference). **Cross-version seed replay is explicitly
+  boundary (bit-exact arithmetic core, including bounded integer exponents;
+  non-integer/large exponents and `exponential` ULP-loose, with the versioned
+  evaluator as reference). **Cross-version seed replay is explicitly
   unsupported** (QuickCheck: "saving a seed from one version … is not supported";
   Hypothesis's reproduction blob is "not intended to be stable across versions").
 

--- a/libs/gda-balancing/docs/badr/0010-determinism-and-seed-surfacing.md
+++ b/libs/gda-balancing/docs/badr/0010-determinism-and-seed-surfacing.md
@@ -1,0 +1,78 @@
+---
+status: proposed
+---
+
+# Determinism and seed surfacing: explicit seeds, echoed effective seed, version-scoped reproducibility
+
+No randomness exists in the v1 surface — Monte-Carlo estimation is Phase-2 territory
+(#509/#510) — but the seed convention already has consumers: #518 places "how seeds
+surface on the CLI" in this gate, and #504's acceptance requires seeded, deterministic
+tests. This bADR reserves the surface convention so Phase-2 issues inherit one rule
+instead of inventing per-command conventions. It designs no simulation.
+
+## Decision
+
+*(New ground for the family — gda has no determinism/seed decision; every point below
+is this toolkit's own, assembled from verified external precedent.)*
+
+- **Stochastic commands take an explicit `--seed <int>`; deterministic commands never
+  do.** A command's descriptor (bADR-0011) declares whether it is stochastic; the
+  flag exists exactly on the stochastic ones. Passing `--seed` to a deterministic
+  command is a usage refusal (bADR-0008) — the flag's presence is itself surface
+  truth about the command's nature, and the conformance harness asserts it both ways.
+
+- **An omitted seed is drawn fresh, and the result always echoes the effective
+  seed.** When `--seed` is absent, the toolkit draws fresh entropy; either way the
+  structured result reports the seed that actually drove the run, alongside the
+  toolkit version, so the reproduction key `(seed, input, toolkit version)` is
+  self-contained in every stochastic result. (Precedent: pytest-randomly's
+  unconditional `Using --randomly-seed=<int>` header; NumPy's documented
+  `SeedSequence` best practice — default `None` in, read `.entropy` back out.)
+  **Recorded deviation from SUMO's fixed-default-seed model**: a fixed default makes
+  nominally independent runs silently share one random stream — a statistics hazard
+  for Monte-Carlo estimation. Determinism-on-demand comes from passing `--seed`;
+  reproducibility-always comes from the echo.
+
+- **The reproducibility contract is version-scoped:** same seed + same input + same
+  toolkit version → identical output, within bADR-0003's two-tier determinism
+  boundary (bit-exact arithmetic core; pow-family results ULP-loose with the
+  versioned evaluator as reference). **Cross-version seed replay is explicitly
+  unsupported** (QuickCheck: "saving a seed from one version … is not supported";
+  Hypothesis's reproduction blob is "not intended to be stable across versions").
+
+- **Silent degradation is named, not denied.** When generation logic evolves in a new
+  toolkit version, an old seed produces a valid but *different* run with no error
+  raised (proptest's documented strategy-drift behavior). Consumers must treat the
+  echoed `(seed, toolkit version)` pair — not the seed alone — as the reproduction
+  key; the contract never claims "seed present ⇒ reproducible forever".
+
+## Considered options
+
+- **Fresh-entropy default + mandatory echo** (chosen).
+- **Fixed default seed (SUMO's model)** (rejected) — deterministic-by-default reads
+  attractive, but correlates independent Monte-Carlo runs by default; the recorded
+  deviation above.
+- **Seeding via environment variable** (rejected) — hidden global state; violates
+  config/logic separation (bADR-0009) and makes the effective seed's provenance
+  invisible to the invocation record.
+- **Defer the convention entirely to Phase 2** (rejected) — #504's seeded tests
+  consume the convention now, and deferral invites divergent per-issue conventions
+  that would each be a public ABI by the time Phase 2 consolidates.
+
+## Consequences
+
+- #509/#510 deliver the first stochastic commands under this convention and may not
+  redesign it; their design gate treats this bADR as fixed contract.
+- The command descriptor (bADR-0011) carries the stochastic marking from v1, even
+  though no v1 command sets it; the conformance harness's seed assertions activate
+  with the first stochastic command.
+- Test suites (from #504 on) pass explicit seeds and assert on the echoed seed field,
+  satisfying the "seeded and deterministic" acceptance mechanically.
+
+## References
+
+- bADR-0003 (two-tier evaluation determinism) — the boundary this contract is scoped
+  within.
+- Research provenance (non-normative): issue #518 comment (2026-07-18) —
+  pytest-randomly, NumPy SeedSequence, SUMO, QuickCheck/proptest/Hypothesis, all
+  primary-source verified.

--- a/libs/gda-balancing/docs/badr/0010-determinism-and-seed-surfacing.md
+++ b/libs/gda-balancing/docs/badr/0010-determinism-and-seed-surfacing.md
@@ -5,10 +5,12 @@ status: proposed
 # Determinism and seed surfacing: explicit seeds, echoed effective seed, version-scoped reproducibility
 
 No randomness exists in the v1 surface — Monte-Carlo estimation is Phase-2 territory
-(#509/#510) — but the seed convention already has consumers: #518 places "how seeds
-surface on the CLI" in this gate, and #504's acceptance requires seeded, deterministic
-tests. This bADR reserves the surface convention so Phase-2 issues inherit one rule
-instead of inventing per-command conventions. It designs no simulation.
+(#509/#510) — but the convention cannot wait for Phase 2: #518 places "how seeds
+surface on the CLI" in this gate, and #504's acceptance phrase "seeded and
+deterministic" needs the contract-level reading this record fixes (v1 is
+deterministic by construction; the seed surface activates at #510). This bADR
+reserves the surface convention so Phase-2 issues inherit one rule instead of
+inventing per-command conventions. It designs no simulation.
 
 ## Decision
 
@@ -67,9 +69,10 @@ is this toolkit's own, assembled from verified external precedent.)*
 - **Seeding via environment variable** (rejected) — hidden global state; violates
   config/logic separation (bADR-0009) and makes the effective seed's provenance
   invisible to the invocation record.
-- **Defer the convention entirely to Phase 2** (rejected) — #504's seeded tests
-  consume the convention now, and deferral invites divergent per-issue conventions
-  that would each be a public ABI by the time Phase 2 consolidates.
+- **Defer the convention entirely to Phase 2** (rejected) — #504's acceptance
+  wording already needs the contract-level reading only this record can fix, and
+  deferral invites divergent per-issue conventions that would each be a public ABI
+  by the time Phase 2 consolidates.
 
 ## Consequences
 

--- a/libs/gda-balancing/docs/badr/0010-determinism-and-seed-surfacing.md
+++ b/libs/gda-balancing/docs/badr/0010-determinism-and-seed-surfacing.md
@@ -16,16 +16,25 @@ instead of inventing per-command conventions. It designs no simulation.
 is this toolkit's own, assembled from verified external precedent.)*
 
 - **Stochastic commands take an explicit `--seed <int>`; deterministic commands never
-  do.** A command's descriptor (bADR-0011) declares whether it is stochastic; the
-  flag exists exactly on the stochastic ones. Passing `--seed` to a deterministic
-  command is a usage error (bADR-0008) — the flag's presence is itself surface
+  do.** The seed's domain is pinned: an **unsigned 32-bit integer** (0 ≤ seed <
+  2³²), rendered as a JSON number wherever echoed — chosen to stay inside JSON's
+  exact-integer interoperability band under bADR-0005's shortest-round-trip
+  rendering (a 64-bit seed would cross 2⁵³ and corrupt silently in JSON
+  consumers); out-of-domain values are a usage error (`invalid_argument`,
+  bADR-0008). A command's descriptor (bADR-0011) declares whether it is stochastic;
+  the flag exists exactly on the stochastic ones. Passing `--seed` to a
+  deterministic command is a usage error (bADR-0008) — the flag's presence is
+  itself surface
   truth about the command's nature, and the conformance harness asserts it both ways.
 
 - **An omitted seed is drawn fresh, and the result always echoes the effective
   seed.** When `--seed` is absent, the toolkit draws fresh entropy; either way the
   structured result reports the seed that actually drove the run, alongside the
   toolkit version, so the reproduction key `(seed, input, toolkit version)` is
-  self-contained in every stochastic result. (Precedent: pytest-randomly's
+  self-contained in every stochastic result. The key survives failure: once the
+  seed is drawn, any failure envelope the run emits carries
+  `reproduction: {seed, toolkit_version}` (bADR-0008), so a refused or crashed
+  stochastic run stays replayable. (Precedent: pytest-randomly's
   unconditional `Using --randomly-seed=<int>` header; NumPy's documented
   `SeedSequence` best practice — default `None` in, read `.entropy` back out.)
   **Recorded deviation from SUMO's fixed-default-seed model**: a fixed default makes
@@ -33,11 +42,13 @@ is this toolkit's own, assembled from verified external precedent.)*
   for Monte-Carlo estimation. Determinism-on-demand comes from passing `--seed`;
   reproducibility-always comes from the echo.
 
-- **The reproducibility contract is version-scoped:** same seed + same input + same
-  toolkit version → identical output, within bADR-0003's two-tier determinism
-  boundary (bit-exact arithmetic core, including bounded integer exponents;
-  non-integer/large exponents and `exponential` ULP-loose, with the versioned
-  evaluator as reference). **Cross-version seed replay is explicitly
+- **The reproducibility contract is version- and platform-scoped:** same seed +
+  same input + same toolkit version → identical output **on the same platform and
+  runtime**. Across platforms the promise narrows to exactly bADR-0003's numeric
+  contract — bit-identical on the exact tier (the arithmetic core, including
+  bounded integer exponents), final-ULP variation permitted on the loose tier
+  (non-integer/large exponents, `exponential`) — never a blanket cross-platform
+  byte-equality claim. **Cross-version seed replay is explicitly
   unsupported** (QuickCheck: "saving a seed from one version … is not supported";
   Hypothesis's reproduction blob is "not intended to be stable across versions").
 
@@ -67,8 +78,11 @@ is this toolkit's own, assembled from verified external precedent.)*
 - The command descriptor (bADR-0011) carries the stochastic marking from v1, even
   though no v1 command sets it; the conformance harness's seed assertions activate
   with the first stochastic command.
-- Test suites (from #504 on) pass explicit seeds and assert on the echoed seed field,
-  satisfying the "seeded and deterministic" acceptance mechanically.
+- v1 satisfies "seeded and deterministic" (#504) **by construction**: no v1 command
+  draws randomness, so every run is deterministic and there is no seed to pass or
+  echo — the CLI seed rules above activate with the first stochastic command
+  (#510). Randomness a *test suite* uses internally (e.g. property-based
+  generation) is test-infrastructure state outside this contract.
 
 ## References
 

--- a/libs/gda-balancing/docs/badr/0011-command-registration-seam-and-conformance.md
+++ b/libs/gda-balancing/docs/badr/0011-command-registration-seam-and-conformance.md
@@ -1,0 +1,96 @@
+---
+status: proposed
+---
+
+# One command descriptor seam: registration, projections, and the conformance harness
+
+#518 requires the CLI contract to be structurally self-enforcing: a single seam every
+command plugs into, plus a conformance test that walks the registered surface asserting
+envelope and exit-code behavior — enforcement by architecture and tests, never by
+per-issue prose. The family precedent is gda ADR-0023 (the descriptor whose render,
+dispatch, and schema are projections). This bADR fixes the seam and the harness; the
+CLI framework choice is #502's implementation territory and is deliberately not fixed
+here.
+
+## Decision
+
+- **Every command registers exactly one frozen Command descriptor** *(pattern
+  adopted-from-gda: ADR-0023; field set is balancing-local)*. The descriptor names
+  everything the surface needs to run and describe one command: its tree position
+  (group, command — bADR-0007), its typed input and output models (bADR-0009), and
+  its execution markings — today exactly one, **stochastic** (bADR-0010). Registering
+  the descriptor is the *only* way a command enters the surface; a command without
+  one cannot be wired in.
+  *(Recorded deviation from gda's field set: `render` — no human renderer exists,
+  bADR-0008; `recipe`/`kind`/`projectless` — engine, daemon, and project channels
+  have no analogue here. Fields are added when a real second channel exists, not
+  speculatively.)*
+
+- **All surface behavior is a projection of the descriptor.** Argv wiring, dispatch,
+  `--schema` emission (bADR-0009), the future `manifest` aggregation, and the
+  conformance harness's enumeration all read the one registry. Parallel registries —
+  a render map here, a command list there — are prohibited *(adopted-from-gda:
+  ADR-0023's single-registration consequence)*.
+
+- **The registered surface is enumerable without side effects.** This is the
+  harness's precondition, stated framework-agnostically: whatever CLI framework #502
+  picks must expose, or be wrapped to expose, a walk of every registered descriptor
+  (gda walks its live Typer tree; the mechanism is free, the walkability is law).
+
+- **The conformance harness ships with the surface, from the first command.** It
+  walks every registered descriptor and asserts, per command, every applicable row
+  of the bADR-0008 contract:
+  - success → exit 0, stdout is exactly one JSON document validating against the
+    descriptor's output schema, canonically emitted (bADR-0005);
+  - input refusal (document-taking commands) → exit 2, a `refusal` envelope on
+    stdout whose entry codes all resolve against the funnel's namespace — the
+    semantic rule catalog plus the preflight/structural/Evaluation families
+    (bADR-0004/0005) — so the CLI can never grow a second refusal-code registry;
+  - usage → exit 3, a `usage` envelope on stderr with a code from the CLI-usage
+    registry; internal (fault injected) → exit 4, an `internal` envelope on stderr;
+  - `--schema` → emits `input`/`output`/`error`, with `error` byte-identical across
+    the walk (bADR-0009);
+  - seed law → stochastic commands accept `--seed` and echo the effective seed;
+    deterministic commands refuse it (bADR-0010);
+  - input immutability → a command's input file is byte-identical before and after
+    (bADR-0009);
+  - reserved names → no command occupies `evaluation`/`tuning` before their owning
+    issues land (bADR-0007).
+
+- **The CLI-usage code family lives in one registry** (bADR-0008), read by dispatch
+  and by the harness, drift-tested the way the funnel's catalog is (bADR-0005's
+  anti-drift rule; family precedent: gda's authoritative `error_codes` registry and
+  its ADR-mirror drift test).
+
+## Considered options
+
+- **One descriptor + registry-walking harness** (chosen) — a conforming surface is
+  the only easy path; coverage of every command is by construction, not by sampling.
+- **Per-command hand-wiring plus review discipline** (rejected) — prose-enforced
+  contracts drift; this gate exists to make that impossible.
+- **The framework's native introspection as the contract** (rejected) — binds the
+  public contract to #502's framework choice; the descriptor keeps the contract
+  framework-agnostic and the framework swappable.
+- **Golden end-to-end samples instead of a registry walk** (rejected) — samples prove
+  the commands sampled; the walk proves the law holds for every registered command,
+  including tomorrow's.
+
+## Consequences
+
+- #502 lands the descriptor, the registry, and the harness skeleton with `version`
+  as the first registered command; #504 extends both with the `design` and `schema`
+  groups.
+- Adding a command without a descriptor is structurally impossible; adding one with a
+  descriptor drags it under every harness assertion automatically. The harness is
+  the executable form of bADR-0008/0009/0010.
+- The descriptor gains fields only when a decided surface needs them (a `--format
+  human` render seam, a `manifest` description field) — each addition rides its
+  owning decision, keeping the seam honest about what exists.
+
+## References
+
+- gda ADR-0023 (descriptor single-registration) and its registration-invariant test
+  suite — reference input; deviations recorded above.
+- bADR-0004/0005 (refusal-code namespace and anti-drift), bADR-0007–0010 (the
+  contract rows the harness executes).
+- Research provenance (non-normative): issue #518 comment (2026-07-18).

--- a/libs/gda-balancing/docs/badr/0011-command-registration-seam-and-conformance.md
+++ b/libs/gda-balancing/docs/badr/0011-command-registration-seam-and-conformance.md
@@ -20,15 +20,23 @@ here.
   - its **tree position** (group, command — bADR-0007) and a human **description**
     — the one-line summary shared by `--schema`, the future `manifest`, and help
     surfaces;
-  - its typed **input and output models** (bADR-0009). Argv binding is *derived*
-    from the input model's fields by one mechanical rule — the model is the single
-    source and the CLI layer a thin adapter (gda ADR-0015's discipline); no
-    per-command hand-wired argument maps exist;
-  - its **handler** — the execution binding, a callable from validated input model
-    to output model. Dispatch is: bind argv into the input model, invoke the
-    handler, emit per bADR-0008. This field is what makes the descriptor
-    *sufficient* to dispatch — without it the single-seam claim would be unearned
-    (gda ADR-0023 carries the same fact as its `operation` + runner selection);
+  - its typed **input and output models** (bADR-0009), with the binding law
+    stated: **every input-model field binds as a kebab-case option
+    `--<field-name>`; the descriptor may designate at most one field as the
+    positional argument** (in practice the `Design document` path, bADR-0009).
+    An input schema alone cannot distinguish positional from option — the family
+    recorded exactly this in gda ADR-0015 — so the positional designation lives
+    *in the descriptor*: single registration, still no hand-wired argument maps;
+  - its **handler** — the execution binding, a callable whose outcome is typed:
+    it **returns the output model** (success) **or the funnel's refusal report**
+    (bADR-0004); it never prints, never exits, and never sees a usage error
+    (those are resolved at binding, before invocation). The **dispatch tail owns
+    emission**: it maps the outcome onto bADR-0008 — result on stdout / exit 0,
+    `refusal` envelope / exit 2 — and converts any unexpected handler exception
+    into the `internal` envelope / exit 4. The field plus this outcome law are
+    what make the descriptor *sufficient* to dispatch — without them the
+    single-seam claim would be unearned (gda ADR-0023 carries the same fact as
+    its `operation` + runner selection);
   - its execution markings — today exactly one, **stochastic** (bADR-0010);
   - its **conformance fixtures**: a valid invocation case and, for document-taking
     commands, a refusing-input case — the harness's per-command fuel, registered
@@ -116,9 +124,9 @@ here.
 - Adding a command without a descriptor is structurally impossible; adding one with a
   descriptor drags it under every harness assertion automatically. The harness is
   the executable form of bADR-0008/0009/0010.
-- The descriptor gains fields only when a decided surface needs them (a `--format
-  human` render seam, a `manifest` description field) — each addition rides its
-  owning decision, keeping the seam honest about what exists.
+- The descriptor gains fields only when a decided surface needs them (e.g. a
+  `--format human` render seam, should that flag ever be adopted) — each addition
+  rides its owning decision, keeping the seam honest about what exists.
 
 ## References
 

--- a/libs/gda-balancing/docs/badr/0011-command-registration-seam-and-conformance.md
+++ b/libs/gda-balancing/docs/badr/0011-command-registration-seam-and-conformance.md
@@ -16,15 +16,41 @@ here.
 
 - **Every command registers exactly one frozen Command descriptor** *(pattern
   adopted-from-gda: ADR-0023; field set is balancing-local)*. The descriptor names
-  everything the surface needs to run and describe one command: its tree position
-  (group, command — bADR-0007), its typed input and output models (bADR-0009), and
-  its execution markings — today exactly one, **stochastic** (bADR-0010). Registering
-  the descriptor is the *only* way a command enters the surface; a command without
-  one cannot be wired in.
+  everything the surface needs to run, describe, and conformance-test one command:
+  - its **tree position** (group, command — bADR-0007) and a human **description**
+    — the one-line summary shared by `--schema`, the future `manifest`, and help
+    surfaces;
+  - its typed **input and output models** (bADR-0009). Argv binding is *derived*
+    from the input model's fields by one mechanical rule — the model is the single
+    source and the CLI layer a thin adapter (gda ADR-0015's discipline); no
+    per-command hand-wired argument maps exist;
+  - its **handler** — the execution binding, a callable from validated input model
+    to output model. Dispatch is: bind argv into the input model, invoke the
+    handler, emit per bADR-0008. This field is what makes the descriptor
+    *sufficient* to dispatch — without it the single-seam claim would be unearned
+    (gda ADR-0023 carries the same fact as its `operation` + runner selection);
+  - its execution markings — today exactly one, **stochastic** (bADR-0010);
+  - its **conformance fixtures**: a valid invocation case and, for document-taking
+    commands, a refusing-input case — the harness's per-command fuel, registered
+    with the command so test coverage structurally cannot lag the surface.
+  Registering the descriptor is the *only* way a command enters the surface; a
+  command without one cannot be wired in.
   *(Recorded deviation from gda's field set: `render` — no human renderer exists,
   bADR-0008; `recipe`/`kind`/`projectless` — engine, daemon, and project channels
   have no analogue here. Fields are added when a real second channel exists, not
   speculatively.)*
+
+- **Meta commands follow one rule: registered iff they emit a typed JSON result.**
+  `version` is a registered descriptor like any domain command (typed result,
+  `--schema`, harness rows). `help` / `--help` is the surface's **one exempt
+  human-facing channel** (bADR-0007): framework help text, exit 0, no descriptor,
+  excluded from `--schema` and the future `manifest` exactly as gda excludes
+  non-dispatchable meta commands at the source (ADR-0012). The exemption is a
+  recorded decision, not a framework accident.
+
+- **Fault injection is a harness seam, not a production path.** The registry is
+  data the harness owns in test: it substitutes a command's handler with a failing
+  one to drive the internal-error row (exit 4) without any production fault path.
 
 - **All surface behavior is a projection of the descriptor.** Argv wiring, dispatch,
   `--schema` emission (bADR-0009), the future `manifest` aggregation, and the
@@ -38,21 +64,26 @@ here.
   (gda walks its live Typer tree; the mechanism is free, the walkability is law).
 
 - **The conformance harness ships with the surface, from the first command.** It
-  walks every registered descriptor and asserts, per command, every applicable row
-  of the bADR-0008 contract:
-  - success → exit 0, stdout is exactly one JSON document validating against the
-    descriptor's output schema, canonically emitted (bADR-0005);
-  - refusal (document-taking commands) → exit 2, a `refusal` envelope on stdout
-    whose entry codes all resolve against the typed-refusal namespace — the funnel's
-    preflight/structural families and semantic rule catalog, plus the downstream
-    Evaluation refusal family (bADR-0003/0004/0005) — so the CLI can never grow a
-    second refusal-code registry;
-  - usage → exit 3, a `usage` envelope on stderr with a code from the CLI-usage
-    registry; internal (fault injected) → exit 4, an `internal` envelope on stderr;
+  walks every registered descriptor, drives it with its registered fixtures, and
+  asserts, per command, every applicable row of the bADR-0008 contract:
+  - success (valid fixture) → exit 0, stdout is exactly one JSON document
+    validating against the descriptor's output schema, canonically emitted
+    (bADR-0005);
+  - refusal (refusing fixture, document-taking commands) → exit 2, a `refusal`
+    envelope on stdout whose entry codes all resolve against the typed-refusal
+    namespace — the funnel's preflight/structural families and semantic rule
+    catalog, plus the downstream Evaluation refusal family (bADR-0003/0004/0005) —
+    so the CLI can never grow a second refusal-code registry;
+  - usage → exit 3; internal (via the fault-injection seam) → exit 4; for both:
+    **stdout is empty and stderr parses as exactly one schema-valid envelope**
+    (bADR-0008's field law), with the code resolving against the CLI registry;
   - `--schema` → emits `input`/`output`/`error`, with `error` byte-identical across
     the walk (bADR-0009);
   - seed law → stochastic commands accept `--seed` and echo the effective seed;
     deterministic commands refuse it (bADR-0010);
+  - artifact-sink law → with `--out`, stdout still carries the receipt result
+    naming the sink, the write is atomic, and `--out` aliasing the input path
+    refuses (bADR-0009);
   - input immutability → a command's input file is byte-identical before and after
     (bADR-0009);
   - reserved names → no command occupies `evaluation`/`tuning` before their owning

--- a/libs/gda-balancing/docs/badr/0011-command-registration-seam-and-conformance.md
+++ b/libs/gda-balancing/docs/badr/0011-command-registration-seam-and-conformance.md
@@ -42,10 +42,11 @@ here.
   of the bADR-0008 contract:
   - success → exit 0, stdout is exactly one JSON document validating against the
     descriptor's output schema, canonically emitted (bADR-0005);
-  - input refusal (document-taking commands) → exit 2, a `refusal` envelope on
-    stdout whose entry codes all resolve against the funnel's namespace — the
-    semantic rule catalog plus the preflight/structural/Evaluation families
-    (bADR-0004/0005) — so the CLI can never grow a second refusal-code registry;
+  - refusal (document-taking commands) → exit 2, a `refusal` envelope on stdout
+    whose entry codes all resolve against the typed-refusal namespace — the funnel's
+    preflight/structural families and semantic rule catalog, plus the downstream
+    Evaluation refusal family (bADR-0003/0004/0005) — so the CLI can never grow a
+    second refusal-code registry;
   - usage → exit 3, a `usage` envelope on stderr with a code from the CLI-usage
     registry; internal (fault injected) → exit 4, an `internal` envelope on stderr;
   - `--schema` → emits `input`/`output`/`error`, with `error` byte-identical across
@@ -57,7 +58,8 @@ here.
   - reserved names → no command occupies `evaluation`/`tuning` before their owning
     issues land (bADR-0007).
 
-- **The CLI-usage code family lives in one registry** (bADR-0008), read by dispatch
+- **The CLI-usage code family and the fixed `internal_error` code live in one
+  registry** (bADR-0008), read by dispatch
   and by the harness, drift-tested the way the funnel's catalog is (bADR-0005's
   anti-drift rule; family precedent: gda's authoritative `error_codes` registry and
   its ADR-mirror drift test).

--- a/libs/gda-balancing/docs/badr/0011-command-registration-seam-and-conformance.md
+++ b/libs/gda-balancing/docs/badr/0011-command-registration-seam-and-conformance.md
@@ -22,21 +22,27 @@ here.
     surfaces;
   - its typed **input and output models** (bADR-0009), with the binding law
     stated: **every input-model field binds as a kebab-case option
-    `--<field-name>`; the descriptor may designate at most one field as the
-    positional argument** (in practice the `Design document` path, bADR-0009).
-    An input schema alone cannot distinguish positional from option — the family
-    recorded exactly this in gda ADR-0015 — so the positional designation lives
-    *in the descriptor*: single registration, still no hand-wired argument maps;
+    `--<field-name>`, except that the descriptor may designate at most one field
+    as the positional argument — the designation *replaces* that field's option
+    binding** (the field is positional-only, never also `--<field-name>`; in
+    practice the `Design document` path, bADR-0009). An input schema alone cannot
+    distinguish positional from option — the family recorded exactly this in gda
+    ADR-0015 — so the positional designation lives *in the descriptor*: the model
+    owns the fields, the descriptor owns argv presentation (bADR-0009's division
+    of authority), single registration, still no hand-wired argument maps;
   - its **handler** — the execution binding, a callable whose outcome is typed:
-    it **returns the output model** (success) **or the funnel's refusal report**
-    (bADR-0004); it never prints, never exits, and never sees a usage error
-    (those are resolved at binding, before invocation). The **dispatch tail owns
-    emission**: it maps the outcome onto bADR-0008 — result on stdout / exit 0,
-    `refusal` envelope / exit 2 — and converts any unexpected handler exception
-    into the `internal` envelope / exit 4. The field plus this outcome law are
-    what make the descriptor *sufficient* to dispatch — without them the
-    single-seam claim would be unearned (gda ADR-0023 carries the same fact as
-    its `operation` + runner selection);
+    it **returns the output model** (success) **or a typed-refusal report** —
+    the funnel's families (bADR-0004) *or*, for evaluating commands, the
+    downstream non-finite Evaluation refusal family (bADR-0003) — so a Phase-2
+    evaluation handler has a declared path for its one sanctioned refusal; it
+    never prints, never exits, and never sees a usage error (those are resolved
+    at binding, before invocation). The **dispatch tail owns emission**: it maps
+    the outcome onto bADR-0008 — result on stdout / exit 0, `refusal` envelope /
+    exit 2 — and **unexpected exceptions remain the sole path to `internal` /
+    exit 4**. The field plus this outcome law are what make the descriptor
+    *sufficient* to dispatch — without them the single-seam claim would be
+    unearned (gda ADR-0023 carries the same fact as its `operation` + runner
+    selection);
   - its execution markings — today exactly one, **stochastic** (bADR-0010);
   - its **conformance fixtures**: a valid invocation case and, for document-taking
     commands, a refusing-input case — the harness's per-command fuel, registered


### PR DESCRIPTION
Closes #518

## What this records

The gda-balancing CLI interface contract as five bADRs (`status: proposed`; the flip to `accepted` follows in a mechanical companion PR after merge), plus the glossary's new **Command surface** section (`Command descriptor`, `Error envelope`, `Verdict`, `Usage error`, `Effective seed`).

| bADR | Decision |
|---|---|
| 0007 | Command taxonomy: `gda-balancing <group> <command>`; v1 groups `design` / `template` / `schema`; reserved Phase-2 noun groups `evaluation` / `tuning`; meta `version` / `help` + reserved `manifest`; gda's verb law adopted verbatim |
| 0008 | Invocation result contract: one canonical JSON payload per invocation, JSON-by-default (recorded deviation from gda's human-default), no sentinels (recorded deviation — no subprocess boundary), the `error`-keyed envelope carrying the funnel's refusal codes verbatim, exit layering `0` pass / `1` verdict-fail (reserved) / `2` refusal / `3` usage / `4` internal |
| 0009 | Per-command `--schema` (input/output/error, uniform error schema); `schema get structural` / `schema get catalog` as the sole public delivery channel for bADR-0005's artifacts; config/logic separation incl. never-mutate-the-input; `--params-json` adopted-in-principle, deferred-in-delivery; `manifest` reserved |
| 0010 | Seeds: explicit `--seed` on stochastic commands only; omitted → fresh entropy; result always echoes the effective seed + toolkit version; reproducibility is version-scoped (recorded deviation from SUMO's fixed-default model) |
| 0011 | Single frozen Command descriptor as the only registration path; all surface behavior is a projection; conformance harness walks the registry asserting every envelope/exit/seed/immutability rule; framework choice stays #502's |

Every convention is marked **adopted-from-gda** or a **recorded deviation with rationale**; refusal codes stay funnel-owned per bADR-0004 (the CLI mints only the usage family + `internal_error`).

## Adjudications encoded (maintainer, 2026-07-18)

Exit-code integer layout · JSON-by-default · CLI-only artifact delivery · group/verb naming (incl. `schema`-vs-`manifest`) · `--params-json` deferral · `--seed` reservation — settled in a grill session against the domain docs before drafting.

## Provenance & internal review

- Research provenance (non-normative): [#518 comment](https://github.com/aigengame/godot-agent/issues/518#issuecomment-5011089008) — 20 primary sources, 43 claims, 17 load-bearing claims adversarially verified (17 confirmed / 0 refuted).
- Internal pass before this PR: an adversarial consistency review (vs bADR-0001…0006 + the cited gda ADRs; 0 blockers, findings F1–F8 resolved in the second commit) and a spec-coverage review (all #518 acceptance items and #502/#504 consumer expectations mapped; verdict READY / 0 blockers).

## Review gate

Per #518's acceptance criteria, maintainer review gates implementation: merge is the approval, recorded on #518 afterwards. #502 and #504 stay blocked until then. No implementation in this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
