### PR TITLE
chore: record subagent model tier policy in root CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,18 @@
 @AGENTS.md
+
+## Subagent model tier configuration (including built-in Explore/Plan/General subagents and workflow fan-out subagents)
+
+Model-selection principle: choose the subagent model tier heuristically by task
+complexity, weighing quality against token cost. This table implements it — pass
+`model:` explicitly on every dispatch; never silently inherit the session model.
+
+- Reconnaissance, exploration, summarization, and retrieval: **Sonnet** by default;
+  escalate to **Opus** only when the digest's precision directly gates downstream
+  design quality (e.g. ADR/issue digests feeding a design gate).
+- Large fan-out stages (N-vote adversarial panels, bulk refutation voters, bulk
+  search/fetch): **Sonnet** per voter/fetcher; the single synthesis, judge, or
+  high-stakes verifier stays **Opus**.
+- Design reviews, single-point adversarial validation, consistency checks, and
+  routine tasks: **Opus**.
+- **Fable** is used only for main-loop coordination, orchestration, final judgment,
+  or the design and implementation of the most complex tasks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 ## Subagent model tier configuration (including built-in Explore/Plan/General subagents and workflow fan-out subagents)
 
-Model-selection principle: choose the subagent model tier heuristically by task
-complexity, weighing quality against token cost. This table implements it — pass
-`model:` explicitly on every dispatch; never silently inherit the session model.
+Concretizes the model-selection principle of RULES.md (if exists), which this
+table implements — pass `model:` explicitly on every dispatch; never silently inherit
+the session model.
 
 - Reconnaissance, exploration, summarization, and retrieval: **Sonnet** by default;
   escalate to **Opus** only when the digest's precision directly gates downstream


### PR DESCRIPTION
Split out of #523 per its review round 1 (findings Std-5 / Spec-7 / Q-9: unrelated to the #518 acceptance criteria).

The tier table concretizes the model-selection principle of `RULES.md` **(if exists)** — the same qualifier `AGENTS.md` uses for that file, since it may be absent from a checkout (maintainer direction, 2026-07-18: the table must visibly implement the RULES principle rather than restate it).

Policy content as adjudicated by the maintainer on 2026-07-18: Sonnet by default for reconnaissance/retrieval and bulk fan-out voters; Opus for design reviews, single-point adversarial validation, consistency checks, and routine tasks; the session model only for orchestration, final judgment, and the most complex work. Haiku and fork-type subagents are currently out of use per the same adjudication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)