### PR TITLE
chore(gda-balancing): mark CLI-contract bADRs accepted

### DIFF
--- a/libs/gda-balancing/docs/badr/0007-cli-command-taxonomy.md
+++ b/libs/gda-balancing/docs/badr/0007-cli-command-taxonomy.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # CLI command taxonomy: domain-object groups under one agent-facing binary

--- a/libs/gda-balancing/docs/badr/0008-invocation-result-contract.md
+++ b/libs/gda-balancing/docs/badr/0008-invocation-result-contract.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # Invocation result contract: one JSON result, refusal-carrying error envelope, layered exit codes

--- a/libs/gda-balancing/docs/badr/0009-surface-self-description-and-structured-io.md
+++ b/libs/gda-balancing/docs/badr/0009-surface-self-description-and-structured-io.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # Surface self-description, structured input, and config/logic separation

--- a/libs/gda-balancing/docs/badr/0010-determinism-and-seed-surfacing.md
+++ b/libs/gda-balancing/docs/badr/0010-determinism-and-seed-surfacing.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # Determinism and seed surfacing: explicit seeds, echoed effective seed, version-scoped reproducibility

--- a/libs/gda-balancing/docs/badr/0011-command-registration-seam-and-conformance.md
+++ b/libs/gda-balancing/docs/badr/0011-command-registration-seam-and-conformance.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # One command descriptor seam: registration, projections, and the conformance harness


### PR DESCRIPTION
Mechanical companion to #523 (same pattern as #522 for the Standard Schema set): flips bADR-0007…0011 `status: proposed` → `accepted`, following the maintainer approval recorded on #518 (the merge of #523 is the approval). No content changes — the diff is exactly five frontmatter lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)