### PR TITLE
chore: lift the non-releasing title discipline for gda-balancing (#528)

### DIFF
--- a/.github/workflows/release-scope-guard.yml
+++ b/.github/workflows/release-scope-guard.yml
@@ -31,15 +31,18 @@ jobs:
       contents: read
       pull-requests: read
 
-    # NOTE: a guard only blocks a merge once it is a REQUIRED status check. Add
-    # "Member releasing-PR scope guard" to the branch protection rules for
-    # `main` — a repo-settings action a maintainer must take, which no workflow
-    # can do for itself. Until then this reports but does not enforce.
+    # LOAD-BEARING (#528): "Member releasing-PR scope guard" is a REQUIRED
+    # status check on `main`, and gda-balancing PRs now carry truthful
+    # releasing types (`feat`/`fix`/...) — so this job is what actually stops a
+    # releasing-typed PR that spans `libs/gda-balancing/**` AND anything
+    # outside it from merging into both release histories (ADR-0037's flip
+    # note, ADR-0038).
     #
-    # Currently belt-and-braces regardless: member PRs are still held to
-    # non-releasing types by discipline. It becomes truly load-bearing when #528
-    # flips that discipline and member PRs start carrying truthful feat/fix
-    # titles.
+    # The required-check configuration is part of the guarantee, not a
+    # convenience: a guard only blocks a merge while it is required, and no
+    # workflow can grant itself that status. If the rule is ever removed from
+    # the ruleset, this job silently degrades to advisory and the flipped title
+    # discipline loses its enforcement — keep it required.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,9 +197,9 @@ jobs:
       # Idempotent via skip-existing: PyPI files are immutable, so a re-run from
       # the same tagged commit skips whatever already landed and uploads the rest,
       # mirroring the --clobber idempotency of the gh release upload downstream.
-      # Configuring the PyPI pending publisher is the one-time human step on #207;
-      # until then this step fails the release — intended, it gates tag creation on
-      # a working publisher.
+      # The trusted publisher for `gda` is configured (#207); this step failing
+      # is therefore a real publish failure, and it gates tag creation on a
+      # working publisher — no tag is minted unless PyPI accepted the upload.
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/docs/adr/0037-workspace-members-join-the-single-authority-release-model.md
+++ b/docs/adr/0037-workspace-members-join-the-single-authority-release-model.md
@@ -59,7 +59,9 @@ separate release trains, and no hand-edited version anywhere.**
   `libs/gda-balancing/**` keep non-bumping conventional-commit types
   (`chore`/`docs`/`refactor`/...) until a member release is deliberately
   wanted. Registration governs the version line; it does not open the release
-  train.
+  train. *(Historical — superseded by the dated **Flip** note in Consequences:
+  the member's path is excluded and the discipline is lifted for it. Still
+  current for every un-excluded path, e.g. `examples/**`.)*
 - **Publishing gda-balancing is deferred.** No PyPI publish tail, no trusted
   publisher, no artifact upload. Known dormant consequence, accepted: if a
   member Release PR were merged today, the cut job would leave a tag-less
@@ -67,6 +69,9 @@ separate release trains, and no hand-edited version anywhere.**
   maintenance tag gate (#79/#82) only guards the root package's tag. The
   member's first-release issue must wire its publish tail, extend the tag
   gate to its component, and only then may member PRs adopt releasing types.
+  *(Historical — all three preconditions were met by #528/#529; see the dated
+  **Flip** note in Consequences. Publishing is wired but no member release has
+  been cut yet.)*
 
 ## Consequences
 
@@ -136,7 +141,10 @@ separate release trains, and no hand-edited version anywhere.**
   at PR time.)*
 - The member's changelog will accumulate at `libs/gda-balancing/CHANGELOG.md`
   once its first releasing commit lands; until then release-please proposes
-  nothing for it (its history is non-releasing by discipline).
+  nothing for it (its history is non-releasing by discipline). *(The
+  parenthetical is historical — the discipline is lifted per the **Flip** note;
+  the changelog still starts empty because the pre-flip history is `chore`,
+  which is why the first release's notes are hand-authored.)*
 
 ## Considered options
 

--- a/docs/adr/0037-workspace-members-join-the-single-authority-release-model.md
+++ b/docs/adr/0037-workspace-members-join-the-single-authority-release-model.md
@@ -100,8 +100,25 @@ separate release trains, and no hand-edited version anywhere.**
 >   never-released marker (release-please's first bump cannot produce it), and
 >   requiring a tag that cannot exist yet would deadlock both trains.
 >
-> Remaining before member PRs may adopt releasing types: the title-discipline
-> flip itself, tracked on #528. Until then the discipline stays in force.
+> **Flip (2026-07-20, #528):** every precondition this record set is now met —
+> publish tail wired, tag gate extended, and the `Member releasing-PR scope
+> guard` made a **required** status check — so the non-releasing title
+> discipline is **lifted for `libs/gda-balancing`**: its PRs use truthful
+> `feat`/`fix` types and release on their own train.
+>
+> Two limits the flip does **not** touch, both still in force:
+> - **It is scoped to the excluded path only.** `examples/**` (panda) and every
+>   other un-excluded path is still absorbed by the root package, so work there
+>   keeps a non-releasing type or it bumps `gda`. The flip follows the
+>   exclusion, not the "is it gda?" intuition.
+> - **A PR spanning the member and anything outside it is still absorbed.** The
+>   scope guard refuses such a PR when its title is releasing-typed; split it.
+>
+> **First-release changelog:** the member's foundation (#502, #504) landed under
+> `chore` titles by the very constraint this issue retires, so those commits are
+> invisible to release-please's changelog. The first member release therefore
+> gets **hand-authored release notes** describing the schema core as a one-time
+> cost of the old discipline; every release after it is fully generated.
 
 
 - One ledger now spans both packages; neither `pyproject.toml`, the manifest,

--- a/docs/adr/0037-workspace-members-join-the-single-authority-release-model.md
+++ b/docs/adr/0037-workspace-members-join-the-single-authority-release-model.md
@@ -60,8 +60,11 @@ separate release trains, and no hand-edited version anywhere.**
   (`chore`/`docs`/`refactor`/...) until a member release is deliberately
   wanted. Registration governs the version line; it does not open the release
   train. *(Historical — superseded by the dated **Flip** note in Consequences:
-  the member's path is excluded and the discipline is lifted for it. Still
-  current for every un-excluded path, e.g. `examples/**`.)*
+  the member's path is excluded and the discipline is lifted for it. The
+  underlying rule still holds for un-excluded paths — a title there must be
+  truthful about its effect on `gda`, which means a non-releasing type for
+  non-`gda` work such as `examples/**`, and a truthful releasing type for a
+  genuine `gda` change.)*
 - **Publishing gda-balancing is deferred.** No PyPI publish tail, no trusted
   publisher, no artifact upload. Known dormant consequence, accepted: if a
   member Release PR were merged today, the cut job would leave a tag-less
@@ -112,10 +115,14 @@ separate release trains, and no hand-edited version anywhere.**
 > `feat`/`fix` types and release on their own train.
 >
 > Two limits the flip does **not** touch, both still in force:
-> - **It is scoped to the excluded path only.** `examples/**` (panda) and every
->   other un-excluded path is still absorbed by the root package, so work there
->   keeps a non-releasing type or it bumps `gda`. The flip follows the
->   exclusion, not the "is it gda?" intuition.
+> - **It is scoped to the excluded path only.** Every un-excluded path is still
+>   attributed to the root package, so a title there must honestly describe the
+>   change's effect on `gda`: a genuine `gda` feature or fix keeps its truthful
+>   releasing type and bumps `gda` — that is the normal release flow
+>   (ADR-0007/ADR-0034) — while work that merely *lives* in an un-excluded path
+>   without being a `gda` change (`examples/**`, panda) takes a non-releasing
+>   type so it does not bump `gda` falsely. The flip changes which paths are
+>   attributed to the root, not the rule that the type must be truthful.
 > - **A PR spanning the member and anything outside it is still absorbed.** The
 >   scope guard refuses such a PR when its title is releasing-typed; split it.
 >

--- a/docs/adr/0038-gda-balancing-leaves-the-uv-workspace.md
+++ b/docs/adr/0038-gda-balancing-leaves-the-uv-workspace.md
@@ -119,6 +119,13 @@ uv project inside the repo, with its own lock under its own directory.**
   The guard is belt-and-braces while the non-releasing title discipline is
   still in force, and becomes load-bearing when #528 flips it.
 
+  > **Outcome (2026-07-20, #528):** the flip has happened and the guard is a
+  > **required** status check, so it is load-bearing now: a releasing-typed PR
+  > spanning `libs/gda-balancing` and anything outside it cannot merge. The
+  > discipline is lifted for that path only — every un-excluded path
+  > (`examples/**`, root) still needs a non-releasing type (ADR-0037's flip
+  > note).
+
 - **Tag identity has one implementation.** Three places need to know a
   package's tag — the root release build's validation, the member release
   build's validation, and the release-PR tag gate — and each composing its own

--- a/docs/adr/0038-gda-balancing-leaves-the-uv-workspace.md
+++ b/docs/adr/0038-gda-balancing-leaves-the-uv-workspace.md
@@ -122,9 +122,13 @@ uv project inside the repo, with its own lock under its own directory.**
   > **Outcome (2026-07-20, #528):** the flip has happened and the guard is a
   > **required** status check, so it is load-bearing now: a releasing-typed PR
   > spanning `libs/gda-balancing` and anything outside it cannot merge. The
-  > discipline is lifted for that path only — every un-excluded path
-  > (`examples/**`, root) still needs a non-releasing type (ADR-0037's flip
-  > note).
+  > discipline is lifted for that path only. Every un-excluded path stays
+  > attributed to the **root release train**, so its title type must honestly
+  > describe the change's effect on `gda`: a genuine `gda` feature or fix keeps
+  > its truthful releasing type and bumps `gda` (ADR-0007/ADR-0034), while work
+  > that lands in an un-excluded path without being a `gda` change —
+  > `examples/**` is the standing case — takes a non-releasing type so it does
+  > not bump `gda` falsely (ADR-0037's flip note).
 
 - **Tag identity has one implementation.** Three places need to know a
   package's tag — the root release build's validation, the member release

--- a/libs/gda-balancing/AGENTS.md
+++ b/libs/gda-balancing/AGENTS.md
@@ -63,3 +63,13 @@ detail — on any divergence, it wins.
   gate (landing with #502) at the hardened (recursive, AST-level) standard.
 - **Schema is the single authority** — the Standard Schema is the sole spec and authority
   source for numeric design; games consume the toolkit's Standard Schema output (PRD #501).
+- **Own project, own release train** (ADR-0038) — this package is an independent uv project,
+  not a workspace member: it locks separately, so every command run from the repo root needs
+  `--project libs/gda-balancing` (see this package's README). Its PRs therefore use
+  **truthful conventional-commit types** (`feat`/`fix`/…) and release under
+  `gda-balancing-vX.Y.Z` tags — the non-releasing-title discipline that applied before #528
+  is lifted **for this directory only**.
+  - A PR that touches this directory **and anything outside it** is still attributed to the
+    root `gda` package. The `Member releasing-PR scope guard` required check refuses such a
+    PR when its title is releasing-typed — **split it** rather than downgrading the type,
+    because a dependency change that warrants a release should not be recorded as a chore.


### PR DESCRIPTION
Part of #528 — step 3's convention flip. The live proof (this issue's remaining AC) arrives with the first genuinely-releasing member PR; see "What happens next".

## What

Every precondition ADR-0037 set for the flip is now met — publish tail wired, tag gate extended to all manifest packages (PR #529), and **`Member releasing-PR scope guard` made a required status check** (repo settings, done). So the discipline is lifted: **gda-balancing PRs now use truthful `feat`/`fix` types** and release on their own train.

Records updated: ADR-0037 (dated flip note in its existing Outcome block), ADR-0038 (the guard is load-bearing now, not belt-and-braces), and `libs/gda-balancing/AGENTS.md` — the last of these matters most in practice, since that is what an agent working in the package actually reads; the ADRs are the decision record.

## Two limits the flip deliberately does NOT touch

- **It follows the exclusion, not the "is it gda?" intuition.** `examples/**` (panda) and every other un-excluded path is still absorbed by the root package, so work there keeps a non-releasing type or it bumps `gda`. Flipping those too would be the easy over-generalization.
- **A PR spanning the member and anything outside it is still absorbed.** The guard refuses it when releasing-typed, and the documented answer is to **split** — not to downgrade the type, because a member dependency change that warrants a release must not be recorded as a chore (the reasoning that killed the earlier chore-discipline proposal).

**This PR demonstrates its own rule:** it touches root ADRs *and* the member's AGENTS.md, so it is mixed-path and correctly titled `chore`. Verified against the shipped guard — the same file set under `feat(gda-balancing): …` is blocked.

## First-release changelog

Recorded in ADR-0037: the member's foundation (#502, #504) landed under `chore` titles by the very constraint this issue retires, so those commits are invisible to release-please's changelog. The first member release gets **hand-authored release notes** describing the schema core — a one-time cost of the old discipline; every release after it is fully generated.

## What happens next

The next member-only PR carrying a real `feat`/`fix` will make release-please propose a `gda-balancing` Release PR (0.0.0 → 0.1.0). Merging that Release PR publishes to PyPI through the tail wired in #529 — so whether to cut the first release, and when, stays a deliberate decision rather than a side effect. That merge is also what produces this issue's live evidence (no `gda` bump, no spurious root Release PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)