### PR TITLE
docs(gda-balancing): define Standard Schema 2.0 architecture

### DIFF
--- a/libs/gda-balancing/AGENTS.md
+++ b/libs/gda-balancing/AGENTS.md
@@ -54,15 +54,16 @@ detail — on any divergence, it wins.
 
 - **CLI interface style follows `gda`** (adjudicated 2026-07-15, recorded on PRD #501):
   the family's interface conventions and `gda`'s accumulated CLI spec experience are the
-  reference. The binding contract (command taxonomy, result/error envelopes, exit-code
-  semantics, self-description) will be designed under issue #518 and recorded as bADRs —
-  once landed, those bADRs are the single authority; read the parent CLI-contract ADRs as
-  *reference input* only.
+  reference. bADR-0007…0011 are the binding transitional 1.x CLI contract; bADR-0015 and
+  bADR-0021 are the binding Standard Schema 2.x outcome and command-taxonomy contract. Read the
+  parent CLI-contract ADRs as *reference input* only.
 - **Engine- and game-agnostic core** — the toolkit names no game identity and imports no
   game or engine code (nor `gda`); agnosticism is enforced by packaging plus an isolation
   gate (landing with #502) at the hardened (recursive, AST-level) standard.
-- **Schema is the single authority** — the Standard Schema is the sole spec and authority
-  source for numeric design; games consume the toolkit's Standard Schema output (PRD #501).
+- **Standard Schema is the sole specification family** — inside 2.x, authority is scoped:
+  the Language Definition Bundle owns machine language semantics, while Model Source Packages,
+  Experiment Specifications, and Approval Records own their authored domains (bADR-0012). Games
+  consume resolved Standard Schema output; no parallel game-config authority is adapted (PRD #501).
 - **Own project, own release train** (ADR-0038) — this package is an independent uv project,
   not a workspace member: it locks separately, so every command run from the repo root needs
   `--project libs/gda-balancing` (see this package's README). Its PRs therefore use

--- a/libs/gda-balancing/BALANCING-CONTEXT.md
+++ b/libs/gda-balancing/BALANCING-CONTEXT.md
@@ -12,38 +12,267 @@ it, with structured output suitable for programmatic consumption. (Requirements:
 The toolkit itself. The `gda-` prefix is the **product-family brand** — this is a sibling
 product of `gda`, not a `gda` component (contrast `gda-mcp` / `gda-daemon`, which are gda's
 own components). It neither depends on nor extends `gda`; its CLI *interface style* follows
-gda's conventions (PRD #501 addendum) — the binding CLI contract is bADR-0007…0011.
+gda's conventions (PRD #501 addendum). bADR-0007…0011 describe the transitional 1.x surface;
+bADR-0015/0021 are the forward Standard Schema 2.x invocation and taxonomy contract.
 _Avoid_: gda balancing module, balancing plugin
 
 **Standard Schema**:
-The machine-readable schema for game numeric systems (character attributes, combat, builds,
-encounters, growth, economy) that is the toolkit's **sole spec and single authority source**.
-The pipeline designs and configures numbers before game development; a game is then developed
-consuming the pipeline's Standard Schema output. Non-standard game configs are not adapted or
-imported.
+The versioned language, runtime, artifact, and evidence specification for game numeric systems
+(character attributes, combat, builds, encounters, growth, economy). In Standard Schema 2.x,
+authority is deliberately scoped: the `Language Definition Bundle` is the sole machine authority
+for language semantics, while authored model, experiment, and approval facts belong to separate
+`Authority domains` (bADR-0012). The pipeline designs and configures numbers before game
+development; a game is then developed consuming its resolved output. Non-standard game configs
+are not adapted or imported.
 _Avoid_: config format, data model, descriptor
 
+**Authority domain**:
+A boundary inside which exactly one artifact owns a class of authored facts. Standard Schema 2.x
+has three authored domains: the `Model Source Package` owns model definitions, the `Experiment
+Specification` owns scenario/evaluation intent, and the `Approval Record` owns the governance
+decision. “Single authority” is always stated with its domain; none of the three artifacts is the
+global authority for the others (bADR-0012).
+_Avoid_: global source of truth, authority layer
+
+**Language Definition Bundle**:
+The sole machine-readable authority for Standard Schema 2.x language semantics: grammar, type
+constructors and rules, operation specifications, diagnostic codes, package manifests, and
+version/capability compatibility. It also carries the bootstrap Semantic kernel, structured static
+and lowering rules, Runtime/Numeric profiles, and normative vectors. Structural schemas, semantic
+catalogs, registries, evaluator tables, documentation projections, and CLI self-description are
+generated from it or guarded by conformance tests against it; no hand-maintained peer authority is
+allowed (bADR-0012/0022).
+_Avoid_: schema registry, implementation registry, language manifest (partial)
+
+**Semantic kernel**:
+The closed bootstrap operation set whose structured rules give Standard Schema 2.x its irreducible
+meaning: literals, reads, calls, conditionals, local bindings, bounded aggregation, lookup,
+sampling, and transition/event primitives. Domain operations are defined as kernel compositions
+where possible; an irreducible addition is a Schema-major change with formal rules, reference
+implementation, and normative vectors (bADR-0022).
+_Avoid_: standard library, evaluator built-ins, host functions
+
+**Language rule**:
+A stable-id, machine-readable rule in the Language Definition Bundle, represented as structured
+premises, conclusion, phase, and refusal diagnostics. Rules define name resolution, typing/effects,
+evaluation, and HIR-to-RIR lowering; prose explains them but cannot override their structured
+meaning (bADR-0022).
+_Avoid_: validator rule (implementation), prose requirement, compiler special case
+
+**Typed effect set**:
+The statically inferred or checked set attached to an expression/operation judgment, including
+state read/write, signal emission, event schedule/cancel, and Named-random-stream sampling.
+Effect-free expressions are pure; effectful operations are legal only in contexts whose Operation
+specification declares and bounds the same effects (bADR-0016/0022).
+_Avoid_: Effect specification (gameplay concept), side-effect flag, purity hint
+
+**Resolved symbol identity**:
+The exact package-version, module, and declaration identity produced by explicit name resolution.
+Source uses explicit imports/aliases and no wildcard imports or shadowing; Typed HIR/RIR carry the
+resolved identity rather than source spelling or lookup order (bADR-0022).
+_Avoid_: string reference, qualified name (before resolution), registry key
+
+**Model Source Package**:
+The sole editable authority for one game's numeric model definitions in Standard Schema 2.x. It
+contains an authored manifest and model modules, including dependency requirements, but not an
+authored resolution result. It may be compiled into a `Resolved Model`; experiment or approval
+facts never become hidden model definitions (bADR-0012).
+_Avoid_: Source Package (unqualified), design bundle, model config
+
+**Experiment Specification**:
+The authored authority for scenarios, Metric definitions, targets, sampling/replication design,
+observation and discrepancy models, calibration policy, train/holdout partition, acceptance rule,
+and drift policy. It references an exact `Resolved Model` identity or a declared compatibility
+contract and may bind inputs, but it cannot redefine the model. It is versioned and hashed
+independently so evidence identifies both model and experiment (bADR-0012/0018).
+_Avoid_: experiment config, model overrides, scenario package
+
+**Approval Record**:
+The immutable governance authority for an approval decision. It identifies the exact model,
+experiment, Metric datasets, Evaluation runs, Calibration reports, Evidence assertions, evaluator,
+and applicable policy by content identity and carries the human or organizational attestation; it
+does not copy or mutate those artifacts. A boolean flag without that evidence chain is not an
+Approval Record (bADR-0012/0018).
+_Avoid_: approval flag, approved model, sign-off note
+
+**Resolved Model (RIR)**:
+The immutable, canonical, content-addressed public intermediate representation produced by
+resolving and compiling a `Model Source Package` under one `Language Definition Bundle` and one
+generated `Package Lock`. It contains no unresolved name or authoring sugar and is the normative
+cross-evaluator semantic boundary and execution authority for the exact build it represents. It is
+never an authored authority or an editable interchange format (bADR-0012/0013).
+_Avoid_: compiled config, authored IR, normalized source, evaluator plan
+
+**Package Lock**:
+The generated, content-addressed record of exact package versions, capabilities, and dependency
+resolution used to build a `Resolved Model`. It projects the Model Source Package's requirements
+through the Language Definition Bundle's compatibility rules; it is reproducibility evidence, not
+an independently authored authority. One package id resolves to one exact version; incompatible
+majors require distinct namespaces or an explicit adapter package (bADR-0012/0016).
+_Avoid_: dependency config, package manifest, lock authority
+
 **Genre template**:
-A genre's numeric design baseline — default values plus formulas-as-data — shipped as an
-*instance of the Standard Schema*, never as code paths. First families: RPG (CRPG/JRPG/ARPG)
-and Roguelike (metroidvania-like, survivors-like, deckbuilder-like).
+A versioned template release for a genre's numeric design baseline, never an evaluator code path.
+In Standard Schema 2.x it distributes an instantiable starter Model Source Package, companion
+Experiment Specifications, and a `Genre coverage matrix` while preserving their separate authority
+domains. Instantiation creates a new model identity with template provenance; later template
+releases never mutate an instantiated game silently. First families: RPG (CRPG/JRPG/ARPG) and
+Roguelike (metroidvania-like, survivors-like, deckbuilder-like) (bADR-0017).
 _Avoid_: preset, profile
 
 **Reference fixture**:
-A paper-game config per supported genre, living in the test suite as an executable consumer
-and golden example — exercising template superset paths no live game exercises yet.
-_Avoid_: sample project, demo config
+A paper-game source/experiment pair for a supported genre, living in the conformance suite as an
+executable consumer. In 2.x each fixture participates in one or more `Golden scenarios` and traces
+back to rows in the Genre coverage matrix, including paths no live game exercises yet
+(bADR-0017).
+_Avoid_: sample project, demo config, template itself
+
+**Genre coverage matrix**:
+The normative proof behind an RPG or Roguelike support claim. Each requirement row identifies its
+owning package capabilities and operations, cross-package boundary, positive Golden scenario,
+negative vector, and observable metric/evidence. A package list or prose example without a closed
+matrix is not representational-adequacy evidence (bADR-0017).
+_Avoid_: feature checklist, roadmap, package inventory
+
+**Golden scenario**:
+A canonical Model Source Package plus Experiment Specification and expected compiled/runtime/
+evidence observations that exercises one or more coverage-matrix requirements end to end. Golden
+scenarios test package composition and public artifacts, not private evaluator functions
+(bADR-0017).
+_Avoid_: unit fixture, demo battle, snapshot test (too narrow)
 
 ### Standard Schema design
 
-**Design document**:
-The single root JSON document holding one game's complete numeric design — an instance of
-the Standard Schema, declaring the `schema_version` it targets. Subsystems are sections
-within it; there is no multi-file document set (bADR-0001). The document names its game;
+**Core type constructor**:
+One of the closed Standard Schema 2.x language-level constructors: `Bool`, `Int`, `Fixed`,
+`Decimal`, `Float`, `Enum`, `Record`, `Vector`, `List`, `Set`, `Map`, `EntityRef`, `Quantity`, or
+`Distribution`. Domain packages instantiate and compose these constructors but cannot add grammar
+or primitive representation semantics; changing this set requires a Schema major decision
+(bADR-0016).
+_Avoid_: package type, attribute type, custom primitive
+
+**Quantity**:
+A typed numeric value whose concerns are explicit and orthogonal: numeric representation, nominal
+kind, unit/dimension, support/domain, and Numeric profile policy. Nominal kind prevents accidental
+mixing of numerically similar concepts such as health and mana; unit conversion and cross-kind
+conversion require explicit registered operations (bADR-0016).
+_Avoid_: number with metadata, stat value, unit scalar
+
+**Symbol role**:
+The declared use of a typed symbol or component field — including `constant`, `parameter`, `input`,
+`state`, `derived`, `output`, and `random`, with domain roles such as `current`, `capacity`, `cost`,
+or `rate` composed separately. A role constrains ownership and lifecycle; it never creates another
+numeric type (bADR-0016).
+_Avoid_: attribute type, variable kind (ambiguous), numeric subtype
+
+**Domain package**:
+A versioned, namespaced Standard Schema extension that composes core types into nominal types,
+records/components, operations, capabilities, diagnostics, conversions, and declared runtime
+effects. Its manifest declares dependencies and compatibility; it cannot mutate another package's
+types, add implicit syntax, or bypass the Language Definition Bundle (bADR-0016).
+_Avoid_: plugin (implies host code), schema fragment, profile
+
+**Capability**:
+A versioned, namespaced contract a Domain package provides or requires. Dependency resolution binds
+required capabilities and explicitly selected optional ones, then records the exact set in Package
+Lock and Resolved Model. Missing or incompatible capability is a `resolution` refusal; capability
+presence never enables undeclared fallback behavior (bADR-0016).
+_Avoid_: feature flag, optional behavior, duck-typed extension
+
+**Operation specification**:
+The Language Definition Bundle entry that gives a versioned operation its complete static and
+runtime contract: type signature, unit rules, purity, resource bounds, Numeric profiles, and
+declared reads, writes, emitted signals, scheduled events, and Named random streams. An evaluator
+implements this contract; its host-language function is not the authority (bADR-0012/0016).
+_Avoid_: function registration, evaluator hook, opcode documentation
+
+**Conversion operation**:
+A versioned operation explicitly converting representation, Quantity kind, or unit under declared
+legality and loss behavior. Source must request it and Typed HIR records it; no implicit coercion
+survives name/type resolution (bADR-0016).
+_Avoid_: automatic cast, unit normalization (when implicit), compatibility shim
+
+**Capability manifest**:
+The generated inventory of exact packages, operations, types, conversions, Numeric profiles, and
+runtime capabilities available in one Resolved Model. It is projected from the Language Definition
+Bundle and Package Lock for negotiation and evidence, not authored independently (bADR-0016).
+_Avoid_: feature list, plugin registry, package manifest
+
+**Reference-standard mapping**:
+An explicit record of one mechanism adopted from an external standard, the Standard Schema concept
+it maps to, what is deliberately not adopted, and the conformance evidence required. The external
+standard supplies design provenance; the Language Definition Bundle restates the binding local
+contract and remains the sole authority (bADR-0020).
+_Avoid_: standards compliance (unless fully implemented), inspiration, compatible with (unscoped)
+
+**Physical unit code**:
+A UCUM 2.2 case-sensitive unit expression used for a physical Quantity's unit/dimension semantics,
+including semantic equality and commensurability rather than literal-string comparison. Game-only
+health, mana, currency, and similar nominal kinds use package namespaces outside UCUM and never use
+UCUM annotations as semantic extensions (bADR-0016/0020).
+_Avoid_: display unit, arbitrary UCUM annotation, game stat code
+
+**Equation package**:
+The reserved `math.equation` Domain-package identity for a future restricted declarative
+algebraic/ODE subset. It is not admitted by the initial 2.0 Language Definition Bundle. A later
+decision must fix integrator/version, tolerances, continuous state snapshots, zero-crossing and
+event coupling, determinism scope, and normative vectors before equations can lower to RIR. It is
+not the full Modelica language or a general DAE solver contract (bADR-0020).
+_Avoid_: Modelica support, equation script, symbolic escape hatch
+
+**Design document (Standard Schema 1.x)**:
+The legacy single root JSON document holding one game's complete numeric design — an instance of
+Standard Schema 1.x declaring the `schema_version` it targets. Subsystems are sections within it;
+there is no multi-file document set (bADR-0001). Standard Schema 2.x supersedes this authoring
+granularity with the `Model Source Package`. Because no 1.x artifact was published, migration is a
+best-effort source conversion only: semantics-preserving constructs migrate and unsupported ones
+are explicitly deprecated and must be re-authored (bADR-0012/0019). The document names its game;
 the toolkit stays game-agnostic.
 _Avoid_: config file, numbers file, design config
 
-**Attribute facet**:
+**Migration report**:
+The deterministic result of attempting the limited Standard Schema 1.x source conversion. It binds
+the original Design-document identity, converter/Language Definition Bundle identity, every
+successfully mapped construct, and every explicitly deprecated construct. A report with any
+deprecated construct has no 2.x Model Source Package output; partial or lossy migration is never
+presented as success (bADR-0019).
+_Avoid_: upgrade log, compatibility report, converted file
+
+**Deprecated 1.x construct**:
+A Standard Schema 1.x source concept with no semantics-preserving 2.x mapping. The converter emits
+a `migration` refusal and records it in the Migration report; the construct must be re-authored or
+removed. There is no runtime compatibility adapter or best-effort reinterpretation (bADR-0019).
+_Avoid_: legacy fallback, unsupported warning, lossy migration
+
+**Wire representation**:
+The serialization accepted at the Standard Schema 2.x ingress boundary — JSON first — whose
+grammar, resource limits, and source-location mapping are defined by the `Language Definition
+Bundle`. It carries source text/data into parsing; serialization details do not create language
+semantics independent of the parsed `Authoring AST` (bADR-0013).
+_Avoid_: canonical model, source semantics, JSON schema (the structural projection)
+
+**Authoring AST**:
+The parsed source representation of a `Model Source Package`, preserving modules, source spans,
+unresolved names, and permitted authoring sugar so diagnostics can point back to authored input.
+It is not executable and is not the cross-implementation semantic boundary (bADR-0013).
+_Avoid_: runtime AST, resolved tree, executable model
+
+**Typed HIR**:
+The high-level intermediate representation after complete name resolution, type checking, unit
+checking, and static legality checks. It retains source-level structure and provenance useful for
+diagnostics, but every semantically relevant reference and operation is explicit. Its lowering to
+the `Resolved Model (RIR)` must preserve the specified observable behavior (bADR-0013).
+_Avoid_: typed AST (when resolution is incomplete), runtime model, execution plan
+
+**Execution IR (EIR)**:
+An evaluator-specific lowering of one `Resolved Model (RIR)` into layouts, schedules, kernels, or
+other execution details. EIR is neither a stable Standard Schema interchange contract nor a
+language authority; an evaluator proves its behavior against RIR through the reference evaluator,
+normative vectors, and differential tests. Persisted EIR is only a versioned evaluator cache
+(bADR-0013).
+_Avoid_: Resolved Model, portable bytecode, Standard Schema artifact
+
+**Attribute facet (Standard Schema 1.x)**:
 One of the orthogonal properties an attribute declaration composes: `domain`
 (number / percentage / probability), `base` (direct vs formula — the single scalar
 authority), `accepts` (contribution channels: allocation, effects), `bounds` (mandatory
@@ -52,14 +281,14 @@ to the cross-facet validity rules enforced at the boundary funnel; no *named tie
 composition* is ever mandatory (bADR-0002).
 _Avoid_: attribute type, tier (different concept)
 
-**Attribute tier**:
+**Attribute tier (Standard Schema 1.x template vocabulary)**:
 A genre template's **named facet composition** — the vocabulary a template groups its
 attributes by (e.g. an RPG template's primary/derived/tertiary layers; a survivors-like's
 single flat layer). Template data, not schema law: the Standard Schema requires no tier
 taxonomy to exist (bADR-0002).
 _Avoid_: stat level, attribute class, schema-enforced tier
 
-**Effect**:
+**Effect (Standard Schema 1.x)**:
 A first-class, time-scoped carrier of numeric influence — the numerical core of a
 buff/debuff, status effect, or over-time effect: a list of modifiers, a duration
 (instant / timed / infinite), a tick period (its legality governed by the modifier mix),
@@ -68,7 +297,7 @@ plus its own re-application `lifetime` (independent / refresh) (bADR-0006). Buil
 numbers.
 _Avoid_: buff (as the generic term), status (alone), proc
 
-**Modifier**:
+**Modifier (Standard Schema 1.x)**:
 One numeric operation inside an `Effect`: a target attribute, an operation
 (add / multiply / override), an application kind — continuous (contributes to the value
 pipeline while active) or one_shot/periodic (a delta to the simulated current value) —
@@ -76,26 +305,52 @@ and a formula-capable magnitude (per-tick amount when periodic). Not an attribut
 and not a bounded correction coefficient (bADR-0006).
 _Avoid_: modifier tier, correction coefficient, stat bonus (vague)
 
-**Stacking policy**:
+**Stacking policy (Standard Schema 1.x)**:
 How same-type effect magnitudes combine — `aggregation` (stack / keep_best), declared
 **once per stacking type** in the document's stacking-type catalog, the single authority
 no individual effect can override. Orthogonal to an effect's re-application `lifetime`.
 Declared data, never formula logic (bADR-0006).
 _Avoid_: stacking rule (as a per-effect property), stack behavior
 
-**Named form**:
+**Effect specification (Standard Schema 2.x)**:
+A composition of independently typed contracts for application requirements, value capture,
+continuous contributions, state transitions, scheduling, stacking identity/reducer, reapplication,
+removal/expiry/dispel, and immunity. Action, combat, resource, and runtime packages consume these
+contracts through declared operations; no single Effect object owns every mechanic
+(bADR-0016/0017).
+_Avoid_: modifier list, buff object, monolithic status schema
+
+**Target query**:
+A deterministic, typed selection expression over a dynamic entity set, with filters, ordering,
+cardinality, tie-breaking, and empty-result behavior. Action and effect operations receive its
+resolved targets; they do not implement private target-selection rules (bADR-0017).
+_Avoid_: target list (when dynamically selected), selector callback, implicit area target
+
+**Run scope**:
+The lifecycle boundary for state created for one Roguelike run and cleared by an explicit run-reset
+transition. It is orthogonal to `Meta scope`, which survives that reset; every state declaration
+names its scope so reset cannot depend on naming conventions (bADR-0017).
+_Avoid_: session data, temporary state, run flag
+
+**Meta scope**:
+The lifecycle boundary for progression intentionally retained across Roguelike run resets. Transfer
+between Run and Meta scopes requires declared operations and appears in the event/evidence trace
+(bADR-0017).
+_Avoid_: permanent state (ambiguous), account state, global progression
+
+**Named form (Standard Schema 1.x)**:
 A parameterized formula shape — a form id plus named parameters (e.g. linear, piecewise
 linear, lookup table). The preferred formula representation: its parameters are explicit,
 named tuning knobs for Phase-2 sensitivity analysis and search (bADR-0003).
 _Avoid_: formula preset, curve type (as a term of art)
 
-**Expression tree**:
+**Expression tree (Standard Schema 1.x)**:
 The JSON-structured formula AST over a closed operator set — the general fallback when no
 named form fits a per-game formula. Operator closure and reference integrity are validated
 at the boundary funnel; infix strings are never authoritative (bADR-0003).
 _Avoid_: formula script, expression DSL, infix formula
 
-**Reserved section**:
+**Reserved section (Standard Schema 1.x)**:
 A top-level Design-document section whose name is fixed but whose shape is not yet designed
 (`combat`, `encounters`, `builds`, `growth`, `economy`, `targets`). A document using one is
 refused until the owning issue lands its shape as a minor schema bump — never
@@ -104,99 +359,265 @@ _Avoid_: placeholder section, stub, TODO section
 
 ### Validation & self-description
 
-**Boundary funnel**:
-The single validation boundary every Design document crosses before any use — three
-phases, each gating the next: preflight (ingress caps + version dispatch), structural
-(against the structural schema), semantic (the rules the semantic rule catalog indexes).
-Validity is a property of a document *state*: any mutation re-enters the funnel before
-evaluation or emission. Downstream code never re-validates input; the one sanctioned
-downstream class is the non-finite `Evaluation refusal` (bADR-0004).
+**Boundary funnel (Standard Schema 1.x)**:
+The single validation boundary every 1.x Design document crosses before any use — three phases,
+each gating the next: preflight (ingress caps + version dispatch), structural (against the
+structural schema), semantic (the rules the semantic rule catalog indexes). Validity is a property
+of a document *state*: any mutation re-enters the funnel before evaluation or emission. Standard
+Schema 2.x replaces this three-phase limit with compiler and artifact `Refusal stages` while
+retaining gated execution, ingress caps, report-all diagnostics, and typed refusal (bADR-0004/0015).
 _Avoid_: input guard, validation pass (as something repeatable downstream)
 
 **Typed refusal**:
-The element-level rejection of invalid input: a stable refusal code, a JSON Pointer to the
-offending element, and human-readable detail; validation reports **all** violations
-(bounded), not fail-fast. A refusal rejects invalid *input*; a verdict judges a *valid*
-design against balance targets — the two are never conflated (bADR-0004). One downstream
-class exists beyond the funnel: the non-finite `Evaluation refusal` (bADR-0003). The CLI
-carrier of refusals is the `Error envelope` (bADR-0008).
-_Avoid_: validation error (vague), warning, exception
+An expected, machine-actionable inability to accept or complete the requested domain operation.
+In 1.x it rejects invalid input through bounded JSON-Pointer entries (bADR-0004). In 2.x it may
+stop ingress, parsing, static analysis, resolution, runtime, evaluation, migration, or approval and
+carries bounded, stably ordered `Diagnostic` entries in the `Error envelope` (bADR-0015). It never
+represents a negative but successfully computed `Verdict`, a malformed invocation, or an internal
+exception.
+_Avoid_: validation error (too narrow), failed verdict, exception
+
+**Refusal stage**:
+The one pipeline boundary at which a Standard Schema 2.x typed refusal stopped an invocation:
+`ingress`, `parse`, `static`, `resolution`, `runtime`, `evaluation`, `migration`, or `approval`.
+Stages gate later work and are stable machine vocabulary; they classify diagnostics without
+creating new exit codes (bADR-0015).
+_Avoid_: error type, compiler pass (implementation-specific), exit code
+
+**Diagnostic**:
+One machine-actionable reason inside a 2.x typed-refusal envelope: stable code, human message,
+tagged primary location, and optional related locations. A location identifies an invocation,
+source span, artifact pointer, symbol, or runtime event/snapshot; it is not forced into a JSON
+Pointer when the failure is not a JSON element. Codes and location identities are normative;
+message prose is explanatory (bADR-0015).
+_Avoid_: log message, exception, validation warning
 
 **Structural schema**:
-The published JSON Schema 2020-12 artifact whose instances are Design documents, `$id`
-versioned with the Standard Schema. Passing it means structurally well-formed — not valid;
-the semantic layer closes the gap (bADR-0005). Ecosystem validators can run it without the
-toolkit installed.
+The published JSON Schema 2020-12 projection for a Standard Schema wire artifact, `$id` versioned
+with that artifact contract. Passing it means structurally well-formed — not valid; the semantic
+layer closes the gap. In 1.x it accompanies the required validator (bADR-0005); in 2.x it is
+generated from or conformance-checked against the `Language Definition Bundle` and cannot define
+language semantics independently (bADR-0012). Ecosystem validators can run it without the toolkit
+installed.
 _Avoid_: meta-schema (JSON Schema term of art for schemas-of-schemas), the JSON file
 
 **Semantic rule catalog**:
-The machine-readable **index** of semantic-phase rules — rule id (identical to the
-refusal code), scope, description, since-version. Together with the structural schema it
-answers "what is structurally well-formed and which semantic rules exist"; full validity
-additionally requires the versioned validator, the third required artifact. Derived from
-the validator or guarded by conformance tests, never hand-maintained twice (bADR-0005).
+The machine-readable **index** of semantic-phase rules — rule id (identical to the refusal code),
+scope, description, since-version. Together with the structural schema it answers “what is
+structurally well-formed and which semantic rules exist”; full validity additionally requires a
+conforming compiler/validator. In 1.x it is derived from the validator or conformance-guarded
+(bADR-0005). In 2.x both are projections or implementations of the `Language Definition Bundle`;
+the catalog is never a peer semantic authority (bADR-0012).
 _Avoid_: rules doc, validation spec (as a prose document)
 
 ### Command surface
 
 **Command descriptor**:
-The single per-command registration object naming everything the surface needs to
-run, describe, and conformance-test a command: tree position (group + command), a
-human description, typed input/output models (with the descriptor-designated
-positional argument), the typed handler (the execution binding), execution markings
-(today exactly one: stochastic), and the command's conformance fixtures. The only
-path into the command surface; dispatch, `--schema`, the future `manifest`, and the
-conformance harness are all projections of it (bADR-0011).
+The single per-command registration object naming everything the surface needs to run, describe,
+and conformance-test a command: tree position, description, typed input and success-result models,
+applicable verdict and refusal schemas/stages, argument presentation, typed handler, execution
+markings, and conformance fixtures. The only path into the command surface; dispatch, schema and
+manifest projection, structured-params binding, artifact receipts, and the conformance harness all
+derive from it (bADR-0011/0015/0021).
 _Avoid_: command spec, command config, registry entry
 
+**Surface manifest**:
+The aggregate machine-readable projection of every registered 2.x Command descriptor: command
+identity/description, input, success, optional verdict, error schemas, execution markings, and
+artifact behavior. The ungrouped `manifest` command emits it from the live descriptor registry; it
+is not maintained as another command list (bADR-0021).
+_Avoid_: command catalog, CLI docs, schema manifest (ambiguous)
+
+**Structured params input**:
+The `--params-json <json | ->` adapter that binds one command's published input model directly,
+with `-` reading stdin. It is mutually exclusive with individual argv fields and cannot introduce
+parameters absent from the Command descriptor; `--schema` takes precedence without executing the
+command (bADR-0021).
+_Avoid_: config file, JSON flags, alternate command API
+
 **Error envelope**:
-The single top-level-`error` JSON object a failed invocation emits — category `refusal`
-(stdout, exit 2; carrying typed refusals verbatim — the funnel's families plus the
-downstream `Evaluation refusal` family — report-all) or `usage` / `internal` (stderr,
-exits 3 / 4; a single envelope-level code). It carries the refusal codes without
-minting any; the CLI-usage family plus the fixed `internal_error` code are all the CLI
-contract owns (bADR-0008).
+The single closed top-level-`error` JSON object a failed invocation emits. Categories remain
+`refusal` (stdout, exit 2), `usage` (stderr, exit 3), and `internal` (stderr, exit 4). A 2.x refusal
+variant carries one `Refusal stage`, non-empty bounded `Diagnostic` entries, a truncation marker,
+and optional reproduction or terminal-evidence receipts; usage/internal variants carry their own
+single codes and never masquerade as domain diagnostics (bADR-0008/0015).
 _Avoid_: error blob, failure JSON, exception dump
 
 **Verdict**:
-The Phase-2 pass/fail judgment of a **valid** design against balance targets — never
-conflated with a refusal, which rejects invalid *input* (bADR-0004). Its CLI channel
-is reserved now: exit 1, verdict report on stdout (bADR-0008); its report shape is
-owned by the Phase-2 design gate.
+The negative answer from a successfully completed domain judgment — for example valid evidence
+showing balance targets were not met, or governance declining approval. It is never conflated with
+a refusal, which means the judgment could not be completed. A negative verdict emits its typed
+report on stdout with exit 1; a positive judgment is a success result on stdout with exit 0
+(bADR-0008/0015).
 _Avoid_: validation result, balance error, failure (vague)
 
 **Usage error**:
-An invocation-surface failure — everything that goes wrong **before** the document's
-bytes reach the `Boundary funnel`: a bare invocation naming no command, unknown
-command or flag, argument conflicts, an unreadable input path. Exit 3, envelope on
-stderr, own stable code family (bADR-0008);
-unparseable JSON and everything after ingress are typed refusals (the funnel's, or the
-downstream `Evaluation refusal`), never usage errors.
-_Avoid_: refusal (the funnel's word), invalid input (ambiguous)
+An invocation-surface failure before a command can admit its artifact input: missing/unknown
+command or argument, argument conflicts, invalid scalar argument syntax, or unreadable/unwritable
+paths. It emits its own stable code on stderr with exit 3. Once bytes or referenced artifacts enter
+the command's ingress stage, every expected domain failure is a typed refusal, never a usage error
+(bADR-0008/0015).
+_Avoid_: refusal (the domain word), invalid input (ambiguous)
 
 **Effective seed**:
 The seed that actually drove a stochastic run — supplied via `--seed` (unsigned
 32-bit) or drawn fresh — always echoed in the structured result together with the
 toolkit version, and carried by any failure envelope once drawn, so every stochastic
-outcome keeps its own reproduction key (bADR-0008/0010).
+outcome keeps its own reproduction key (bADR-0008/0010). For Standard Schema 2.x it is
+the root of named streams and is reproducible only together with the exact Resolved Model,
+Experiment Specification, evaluator, RNG algorithm/derivation, and Numeric profile identities
+(bADR-0014); the current CLI encoding remains in force until the 2.x CLI contract supersedes it.
 _Avoid_: random seed (ambiguous), default seed
+
+### Runtime
+
+**Runtime lifecycle**:
+The explicit state machine for one RIR execution instance: `instantiated`, `initializing`, `event`,
+`step`, `terminated`, and reset to a new instance. The states adapt FMI's lifecycle discipline to
+Standard Schema artifacts and the atomic-event runtime without adopting FMU, C API, or
+co-simulation compatibility (bADR-0014/0020).
+_Avoid_: FMI runtime, process lifecycle, implicit evaluator state
+
+**Runtime profile**:
+The immutable declaration of every execution choice that can affect replay: Language Definition
+Bundle, scheduler semantics, evaluator build, platform/runtime scope, `Numeric profile`, RNG
+algorithm and stream-derivation version, and deterministic resource budgets. Two runs make an
+identity claim only when their Runtime profiles and input artifact identities match (bADR-0014).
+_Avoid_: environment, runtime config (too broad), execution mode
+
+**Numeric profile**:
+The named, versioned arithmetic contract selected by a Runtime profile: supported numeric
+representations and operations, rounding, overflow and non-finite behavior, comparison tolerance,
+and portability scope. A portable exact profile may promise cross-platform bit identity; a profile
+admitting native floating operations is scoped to its declared evaluator/runtime/platform and ULP
+contract (bADR-0014).
+_Avoid_: precision setting, float mode, tolerance flag
+
+**Runtime event**:
+An immutable, uniquely identified queued transaction carrying logical time, phase, priority, enqueue
+sequence, operation, and typed payload. The scheduler orders events by logical time ascending,
+fixed `input → transition → observation` phase order, priority descending, then enqueue sequence
+ascending. Input admits ordered external facts, transition owns model mutation, and observation is
+read-only evidence collection (bADR-0014).
+_Avoid_: callback, message (unqualified), async task
+
+**Signal**:
+An ephemeral typed fact emitted during one Event transaction to subscribers declared statically in
+the Model Source Package and compiled into the Resolved Model's static subscription table. The
+Language Definition Bundle owns signal types plus validation, effect, ordering, and execution laws,
+not game-specific topology. Subscribers read the same committed pre-event snapshot and run in stable
+Resolved-symbol order; their bounded writes and child events join the transaction buffers. The
+signal and subscriber observations enter the trace only if the event commits. A signal is never
+persistent state, a queued Runtime event, or a hidden callback (bADR-0012/0014/0016).
+_Avoid_: scheduled signal, event alias, broadcast callback
+
+**Event transaction**:
+The atomic execution of one Runtime event. It reads the latest committed snapshot, buffers its one
+final write per state slot plus child events and cancellations, and commits all effects together.
+Multiple contributors must use an explicit reducer/composition operation; an event may not depend
+on hidden write order (bADR-0014).
+_Avoid_: event handler (implementation term), tick mutation, transaction batch
+
+**Snapshot boundary**:
+The semantic state boundary before the first event and after every committed Event transaction.
+The full state exists conceptually at each boundary; traces may store a canonical state hash and
+materialize full state only at declared checkpoints without changing semantics (bADR-0014).
+_Avoid_: save point, frame snapshot, periodic dump
+
+**Runtime refusal**:
+The deterministic terminal result when execution cannot legally continue after successful static
+validation — for example an event targets a past phase, an event budget is exhausted, or a runtime
+operation violates its declared domain. The current Event transaction is rolled back, its children
+are discarded, prior commits remain in terminal evidence, and the run stops (bADR-0014). It is a
+`runtime`-stage typed refusal: exit 2 on stdout, with an optional receipt for terminal evidence
+(bADR-0015).
+_Avoid_: crash, validation refusal, skipped event
+
+**Named random stream**:
+A stable logical random source derived from the effective root seed and a declared stream identity
+under the Runtime profile's versioned RNG contract. Sampling never consumes an ambient global RNG;
+reordering an unrelated stream cannot perturb this stream (bADR-0014).
+_Avoid_: global RNG, random state, implicit seed
 
 ### Simulation
 
-**Evaluation method**:
+**Metric definition**:
+An Experiment-Specification declaration giving one metric its stable identity, Quantity type/unit,
+dimensions, observation window, aggregation, missing/censoring behavior, and replication semantics.
+The same definition governs simulated and observed samples; source kind cannot change its meaning
+(bADR-0018).
+_Avoid_: report field, telemetry name, evaluator counter
+
+**Metric sample**:
+One typed observation under a Metric definition: value, logical time/window, declared dimensions
+(such as entity, encounter, or run), replication identity, source kind, and provenance. Missing and
+censored observations are explicit states, never sentinel numeric values (bADR-0018).
+_Avoid_: result number, measurement row (without schema identity), aggregate report
+
+**Metric dataset**:
+An immutable, content-addressed collection of Metric samples with exact Metric-definition,
+experiment, source/build, partition, and data-version provenance. `simulated` and `observed` are
+source kinds in this one schema, not separate result formats (bADR-0018).
+_Avoid_: simulation report, telemetry dump, CSV result
+
+**Evaluation run**:
+The immutable evidence artifact binding exact Resolved Model, Experiment Specification, Runtime
+profile, evaluator, external inputs, effective seed/streams, ordered trace, and produced Metric
+dataset. It records what ran and what was observed; it does not itself decide acceptance
+(bADR-0018).
+_Avoid_: simulation result, run log, benchmark
+
+**Observation model**:
+The Experiment-Specification contract mapping latent model metrics to observed playtest data,
+including measurement noise, censoring/missing assumptions, replication unit, correlation
+structure, and model discrepancy. Calibration cannot infer these choices from a dataset after the
+fact (bADR-0018).
+_Avoid_: telemetry adapter, error bars, noise setting
+
+**Calibration report**:
+The immutable result of applying a declared estimator and policy to exact model, experiment,
+training datasets, and Evaluation runs. It records parameter identifiability, constraints/priors,
+observation noise, model discrepancy, correlation handling, uncertainty, sensitivity, objectives,
+and candidate selection without erasing unsuccessful or inconclusive results. Holdout verification
+is a separate post-calibration evidence step (bADR-0018).
+_Avoid_: tuned config, best parameters, optimizer output
+
+**Evidence assertion**:
+A small immutable, content-addressed claim that a specific artifact set passed one declared gate,
+such as `well_typed`, `resolved`, `evaluable`, `reproducible`, `calibrated`, or
+`holdout_verified`. Each assertion references its prerequisites and policy; progress is an evidence
+graph, never a mutable status field (bADR-0018).
+_Avoid_: workflow status, passed flag, maturity level
+
+**Holdout verification**:
+Evaluation of a calibrated candidate against an immutable partition frozen before calibration and
+excluded from fitting or model selection. New data versions or a drift assessment beyond policy do
+not mutate historical evidence, but make that verification ineligible for a later approval
+(bADR-0018).
+_Avoid_: final test (ambiguous), validation set (often used during tuning), post-hoc sample
+
+**Drift assessment**:
+An `Evidence assertion` subtype that applies one predeclared drift policy to exact baseline and new
+Metric-dataset identities. It records compared measures, windows, statistical results, decision,
+and eligibility effect. It never edits a Calibration report or Holdout-verification assertion;
+beyond-policy drift blocks those assertions from satisfying a later approval (bADR-0018).
+_Avoid_: stale flag, mutable data status, automatic recalibration
+
+**Evaluation method (legacy planning term)**:
 A method that *estimates* balance metrics from a config — Monte-Carlo encounter estimation
 and system-dynamics (first-order nonlinear ODE) long-horizon prediction. Distinct from a
 `Tuning method`; Monte-Carlo is an estimation method, never an "exact algorithm".
 _Avoid_: exact algorithm, precise algorithm
 
-**Tuning method**:
+**Tuning method (legacy planning term)**:
 A method that *searches* config space toward balance targets — parameter sensitivity
 analysis first, then simple (greedy) search; stronger optimizers later. Delivery ordering is
 simple-to-hard.
 _Avoid_: approximation algorithm, auto-balancer
 
 **Metrics schema**:
-The one shape shared by simulated results and (future) observed playtest results, so the
-playtest feedback loop can be wired later without schema rework — round-trip capable by
-design; ingestion wiring is deferred until playtests produce real feedback.
+The one round-trip shape shared by simulated and observed playtest Metric samples/datasets. It
+preserves typed values, dimensions, replication identity, provenance, missing/censoring state, and
+partition without source-specific reinterpretation. Live ingestion wiring is deferred, but future
+observed data must enter this same contract (bADR-0018).
 _Avoid_: report format (as a separate shape)

--- a/libs/gda-balancing/docs/badr/0012-language-and-artifact-authority-domains.md
+++ b/libs/gda-balancing/docs/badr/0012-language-and-artifact-authority-domains.md
@@ -1,0 +1,112 @@
+---
+status: accepted
+---
+
+# Scope Standard Schema 2.0 authority by language, model, experiment, and approval domains
+
+Standard Schema 1.x deliberately made one root Design document the authored authority and
+required a versioned validator beside structural and semantic self-description artifacts
+(bADR-0001, bADR-0005). That topology kept a small data schema coherent, but it does not close the
+authority chain for Standard Schema 2.0's proposed language, package, compiler, runtime, and
+evidence system. Grammar, type rules, operation definitions, schemas, rule catalogs, registries,
+evaluator behavior, dependency resolution, scenarios, and approvals could otherwise become peer
+sources that disagree while each still appears authoritative.
+
+At the other extreme, calling a Model Source Package the sole authority for everything would be
+false. A scenario author, an evaluator, and a governance approver own facts that are not model
+definitions. Reproducibility needs those facts independently identifiable without allowing any of
+them to redefine another domain. PRD #534 makes closing this chain the first human decision gate.
+
+## Decision
+
+- **The Language Definition Bundle is the sole machine authority for Standard Schema 2.x language
+  semantics.** One immutable, versioned bundle defines:
+  - grammar and wire-shape definitions;
+  - type constructors, name-resolution and typing rules;
+  - versioned operation specifications and their semantic contracts;
+  - stable diagnostic-code definitions;
+  - package manifests, capabilities, dependencies, and compatibility rules.
+  bADR-0022 fixes the canonical bundle, structured-rule meta-format, Semantic kernel, and
+  conformance boundary; field-level wire projections remain generated implementation artifacts,
+  not another authority.
+
+- **Every other language-description surface is a projection or a conforming implementation.**
+  Structural schemas, semantic rule catalogs, registries, evaluator tables, documentation
+  projections, and CLI self-description are generated from the Language Definition Bundle where
+  practical. Where direct generation would distort the target representation, a conformance test
+  proves agreement with the bundle. A hand-maintained peer definition is prohibited. An evaluator
+  implements the bundle; its source code is not an alternative language specification.
+
+- **Authored facts are divided into three non-overlapping authority domains:**
+  1. The **Model Source Package** is the sole editable authority for a game's model definitions and
+     declared dependency requirements. It contains an authored manifest and model modules.
+  2. The **Experiment Specification** is the authority for scenarios, model inputs, metrics,
+     targets, observation/calibration policy, and other evaluation intent. It references an exact
+     resolved-model identity or an explicit compatibility contract and cannot redefine the model.
+  3. The **Approval Record** is the immutable governance authority for one approval decision. It
+     binds the exact model, experiment, evidence, evaluator, policy, and attestation identities and
+     cannot mutate or copy their owned facts.
+  “Sole authority” is always qualified by one of these domains; there is no honest global authored
+  source of truth.
+
+- **Generated build artifacts have execution authority, not authoring authority.** A **Package
+  Lock** is the generated result of resolving the Model Source Package's requirements under the
+  Language Definition Bundle's compatibility rules. A **Resolved Model** is the immutable,
+  content-addressed result of compiling that source with that lock and language bundle. The
+  Resolved Model is the execution authority for the exact build it represents, but neither it nor
+  the lock may be edited as a substitute for source.
+
+- **References cross domains by identity, never by copied mutable data.** Package locks, resolved
+  models, experiments, evidence, and approvals carry content identities for every upstream
+  artifact needed to reproduce or audit them. If compatibility-based binding is allowed instead
+  of an exact identity, the compatibility contract and the final bound identity are both recorded.
+  Downstream artifacts may cache projections for transport, but identity and conflict checks make
+  the owning upstream artifact decisive.
+
+- **Schema and product versions remain independent.** “Standard Schema 2.0” identifies the
+  language/specification major. It does not imply a `gda-balancing` 2.0.0 release; product version
+  changes continue to follow the repository release policy.
+
+- **This decision supersedes only the conflicting 2.x authority portions of earlier bADRs.** For
+  Standard Schema 2.x, it supersedes bADR-0001's one-root Design document as the authored model
+  authority and bADR-0005's validator-centered semantic-authority topology. Their 1.x contracts
+  remain normative for 1.x inputs and migration. bADR-0005's anti-drift principle, structural vs
+  semantic honesty, stable rule identifiers, and canonical artifact discipline are retained and
+  generalized. Other accepted bADRs remain in force until an explicit 2.x decision supersedes
+  them.
+
+## Considered options
+
+- **One language bundle plus scoped authored authority domains** (chosen) — closes machine
+  semantic drift while keeping model, experiment, and governance ownership honest and separately
+  auditable.
+- **Model Source Package as the global sole authority** (rejected) — would either make scenarios
+  and approvals hidden model fields or falsely claim that independently authored facts are derived.
+- **Validator implementation as the language authority** (rejected for 2.x) — makes semantics an
+  implementation detail and prevents independent compilers/runtimes from proving conformance.
+- **Peer schemas, registries, operation tables, and evaluator definitions** (rejected) — creates no
+  deterministic answer when two descriptions disagree.
+- **Resolved Model as editable canonical source** (rejected) — collapses authoring and lowering,
+  loses provenance, and makes dependency resolution irreproducible.
+- **One combined model-and-experiment package** (rejected) — permits scenario-specific values and
+  targets to become accidental model authority, preventing reuse and independent evidence.
+
+## Consequences
+
+- bADR-0022 defines the Language Definition Bundle's machine-readable rule/kernel contract;
+  language registries or schemas must now be generated from it or reverse-conformance checked.
+- The compiler boundary becomes explicit: Model Source Package plus Language Definition Bundle
+  resolves dependencies, emits a Package Lock, and builds an immutable Resolved Model.
+- Experiment, evidence, calibration, and approval artifacts must identify exact upstream content;
+  mutation produces a new identity rather than changing prior evidence in place.
+- bADR-0019 limits Standard Schema 1.x migration to semantics-preserving source conversion and
+  explicit deprecation; it creates no rollout/compatibility runtime.
+- bADR-0013…0022 close the formal-semantics, package, CLI, runtime, evidence, migration, external-
+  mapping, and command-surface decisions gated by #534.
+
+## References
+
+- PRD #501 — balancing toolkit product requirements.
+- PRD #534 — Standard Schema 2.0 language, runtime, and evidence architecture.
+- bADR-0001 — Standard Schema 1.x Design document structure and versioning.
+- bADR-0005 — Standard Schema 1.x self-description and anti-drift contract.

--- a/libs/gda-balancing/docs/badr/0013-compiler-stages-and-semantic-equivalence-boundary.md
+++ b/libs/gda-balancing/docs/badr/0013-compiler-stages-and-semantic-equivalence-boundary.md
@@ -1,0 +1,114 @@
+---
+status: accepted
+---
+
+# Make RIR the public semantic boundary and EIR an evaluator-specific lowering
+
+Standard Schema 1.x validates and evaluates JSON-shaped formula data close to its authored form.
+Standard Schema 2.x adds modules, packages, types, units, scoped names, domain operations, state,
+events, and multiple evaluator implementations. Treating one tree as source syntax, linked model,
+and execution plan would make source convenience features observable, force every evaluator to
+repeat resolution, and leave no stable point at which two implementations can be compared.
+
+Conversely, standardizing backend layouts and optimized kernels would expose evaluator internals
+as language law and prevent safe optimization. PRD #534 therefore requires a staged compiler and
+an explicit boundary for lowering equivalence.
+
+## Decision
+
+- **The Standard Schema 2.x compilation and execution pipeline is:**
+
+  `Wire representation → Authoring AST → Typed HIR → Resolved Model IR (RIR) → Execution IR (EIR) → Runtime`
+
+  The arrows are one-way transformations. An implementation may fuse stages internally for
+  performance, but it must expose the same diagnostics and conform at the RIR boundary as though
+  the stages were distinct.
+
+- **Wire representation owns serialization, not independent semantics.** JSON is the first wire
+  representation. The Language Definition Bundle defines its grammar, ingress limits, structural
+  projection, and source-location mapping. A future serialization is conforming only when it
+  produces the same Authoring AST meaning; wire-specific defaults or coercions cannot silently
+  create a second language.
+
+- **Authoring AST owns source fidelity.** It preserves module boundaries, source spans, unresolved
+  names, and permitted authoring sugar. Parse diagnostics terminate before Typed HIR construction.
+  The AST is not executable, content authority, or a stable interchange contract.
+
+- **Typed HIR owns static semantics.** Construction completes name resolution, type inference or
+  checking, unit checking, operation selection, and all other static legality rules. Every
+  semantically relevant reference, conversion, and versioned operation is explicit. HIR may retain
+  source-level structure and provenance for diagnostics, but no unresolved name or implicit
+  semantic coercion survives it.
+
+- **RIR is the canonical public semantic boundary.** Lowering removes authoring sugar, closes the
+  dependency graph, normalizes declarations and operations, and emits an immutable canonical
+  representation. A serialized RIR plus its Language Definition Bundle, Package Lock, and compiler
+  identity is content-addressed as the Resolved Model. Independent conforming evaluators accept
+  RIR rather than reinterpreting authored source.
+
+- **HIR-to-RIR lowering must preserve specified observable behavior.** For any well-typed model,
+  the RIR preserves its exported typed values and units; initialization; readable state;
+  transitions; emitted signals and events; event-ordering inputs; named random-stream identity;
+  terminal outputs; and declared runtime refusals. Source spans, module layout, comments, aliases,
+  and eliminated sugar are non-semantic except where retained as explicit provenance metadata.
+  bADR-0022 makes these observations and the lowering relation structured Language rules in the
+  Language Definition Bundle.
+
+- **EIR is evaluator-specific and non-normative.** An evaluator may lower RIR into specialized
+  layouts, schedules, kernels, bytecode, or other plans. EIR is not a stable Standard Schema
+  interchange format and cannot add language operations or observable behavior. If persisted, it
+  is an evaluator-versioned cache keyed by the exact RIR, evaluator build, target, and numeric
+  profile; evidence remains anchored to the RIR and evaluator identities rather than EIR encoding.
+
+- **Conformance, not a universal proof obligation, guards RIR-to-EIR lowering.** The specification
+  provides a reference evaluator for RIR plus normative positive, negative, limit, replay, and
+  migration vectors. Optimizing evaluators run differential tests against the reference behavior
+  under the same runtime/numeric profile. A backend may additionally provide formal proofs, but
+  Standard Schema conformance does not require proof of every optimization.
+
+- **The proof boundary is stated honestly.** Parsing and static semantics are judged by normative
+  rules and diagnostics; HIR-to-RIR is governed by a semantics-preservation contract; RIR-to-EIR is
+  governed by reference and differential conformance. Claims such as progress or preservation are
+  made only for the formally specified subset and never used as labels for unproved behavior.
+
+- **This decision supersedes direct authored-tree execution for Standard Schema 2.x.** It replaces
+  the 2.x applicability of bADR-0003's expression tree as the form directly consumed for
+  evaluation, while retaining its closed-operator, pure data, no-infix-authority, and explicit
+  parameter principles. Standard Schema 1.x behavior remains governed by its accepted bADRs and
+  enters this pipeline only through a separately decided migration.
+
+## Considered options
+
+- **Typed HIR plus public RIR plus private EIR** (chosen) — gives language tooling a rich static
+  form, implementations a stable comparison point, and evaluators freedom to optimize.
+- **Evaluate the Authoring AST directly** (rejected) — repeats resolution in every consumer, makes
+  sugar observable, and provides no canonical cross-implementation contract.
+- **Make HIR the public execution artifact** (rejected) — exposes source organization and retains
+  information execution does not need, weakening canonical identity.
+- **Standardize EIR as portable bytecode** (rejected) — binds the language to current evaluator
+  architecture and makes every optimization a Schema compatibility concern.
+- **Require a formal proof for every lowering** (rejected as the baseline) — valuable where
+  feasible but would block practical independent evaluators; a precise reference semantics plus
+  normative and differential conformance is the enforceable minimum.
+- **Allow evaluator-defined source extensions** (rejected) — bypasses the Language Definition
+  Bundle and prevents a source package from having one meaning across evaluators.
+
+## Consequences
+
+- The bADR-0022 Language Definition Bundle carries parsing, name resolution, typing/effects, units,
+  diagnostics, observable runtime behavior, and HIR-to-RIR lowering rules; a compiler must conform
+  to all of them before claiming 2.x conformance.
+- RIR needs a canonical encoding, content-identity law, compatibility contract, and normative
+  vectors. These are public Standard Schema surfaces.
+- EIR may evolve with an evaluator without a Schema version bump, provided its behavior remains
+  conforming and its cache identity prevents stale reuse.
+- CLI and evidence artifacts report the Resolved Model identity and evaluator/numeric profile; they
+  do not promise EIR portability.
+- bADR-0014 defines event ordering, snapshots, conflicts, rollback, cancellation, external inputs,
+  RNG derivation, and Numeric-profile boundaries that make RIR's observable behavior testable.
+
+## References
+
+- PRD #534 — Standard Schema 2.0 language, runtime, and evidence architecture.
+- bADR-0003 — Standard Schema 1.x formula-as-data representation.
+- bADR-0012 — language and artifact authority domains.

--- a/libs/gda-balancing/docs/badr/0014-deterministic-atomic-event-runtime.md
+++ b/libs/gda-balancing/docs/badr/0014-deterministic-atomic-event-runtime.md
@@ -1,0 +1,159 @@
+---
+status: accepted
+---
+
+# Execute deterministic atomic event transactions under an explicit runtime profile
+
+RIR is the public semantic boundary (bADR-0013), but a model is not reproducible until execution
+defines ordering, state visibility, conflicts, cancellation, rollback, external inputs, random
+streams, and resource exhaustion. A tuple such as `(time, phase, priority, sequence)` is
+insufficient unless direction, snapshot boundaries, and scheduling legality are normative. A seed
+alone is likewise insufficient when numeric behavior, evaluator code, RNG algorithms, or event
+policies can differ.
+
+Standard Schema 2.x needs one deterministic state-transition model that is implementable by a
+simple reference evaluator and optimizable by other evaluators without giving them observable
+scheduling freedom. PRD #534 makes that runtime contract a human decision gate.
+
+## Decision
+
+- **The runtime is a sequential scheduler of atomic Event transactions.** It maintains immutable
+  committed state at Snapshot boundaries and a totally ordered event queue. Exactly one event is
+  dispatched at a time by the normative scheduler. Parallel evaluators may speculate internally,
+  but their commits and observable trace must match the sequential semantics.
+
+- **Runtime events carry a complete stable ordering key.** Events are ordered by:
+  1. logical time, ascending;
+  2. phase according to the versioned fixed order `input`, `transition`, `observation`;
+  3. signed priority, descending — a larger value runs first;
+  4. enqueue sequence, ascending — FIFO for otherwise equal keys.
+  The enqueue sequence is assigned monotonically by the runtime when an event is admitted. Models
+  and packages cannot supply it or reorder/extend the phase table.
+
+- **The three phases have non-overlapping ownership.** `input` admits the externally supplied,
+  source-sequenced facts for that logical time and cannot be scheduled by model operations.
+  `transition` executes model actions, effects, resource changes, combat, generation, and other
+  stateful events; domain packages express finer ordering through typed events and priority rather
+  than new core phases. `observation` reads the final committed state after the transition queue for
+  that time is drained and emits metrics/evidence only; it cannot mutate model state, consume model
+  resources, or schedule another event at the same logical time. A later Domain package therefore
+  cannot acquire a hidden scheduler slot.
+
+- **Each event is one atomic transaction over the latest committed state.** Dispatch reads the
+  snapshot produced by the previous successful event, including events at the same logical time.
+  State writes, emitted Signals, child events, and cancellations are buffered. A successful handler
+  commits them together and creates the next Snapshot boundary. An event cannot observe its own
+  buffered writes unless an operation explicitly defines a local accumulator.
+
+- **Signals are intra-transaction facts, not Runtime events.** An emitted Signal has a nominal
+  type and payload. The Model Source Package authors game-specific subscriptions; static
+  resolution validates each subscriber against Language Definition Bundle signal/effect laws and
+  lowers the topology into the Resolved Model. Subscribers execute in ascending Resolved-symbol
+  identity order against the same committed pre-event snapshot. Their declared, bounded writes and
+  child events contribute to the active transaction buffers under the normal one-final-write rule.
+  Signal emission and subscriber observations enter the ordered trace only when the transaction
+  commits. A Signal is never queued, persisted, scheduled, or delivered through evaluator callbacks.
+
+- **Every state slot has at most one final write per event.** Independent contributions to one slot
+  must flow through a declared reducer or composition operation with specified ordering/algebraic
+  properties. Multiple hidden assignments are a compile-time refusal where statically knowable and
+  otherwise a Runtime refusal. Sequential event order resolves writes between different events;
+  there is no implicit last-writer-wins merge inside one event.
+
+- **Runtime refusal rolls back only the current event and terminates the run.** Its buffered writes,
+  child events, and cancellations are discarded. Earlier committed snapshots remain valid and the
+  terminal evidence identifies the last commit, refusing event, diagnostic, and Runtime profile.
+  No package may convert a Runtime refusal into a skipped event or continue under partial state.
+  Domain-level failures intended as gameplay branches must be modeled as typed outcomes, not
+  refusals.
+
+- **Scheduling cannot travel backward.** A transaction may schedule later logical time, a later
+  phase at the same time, or a zero-time `transition` child whose complete ordering key is strictly
+  after the active event's key. For the same time and phase, a child priority greater than the
+  active priority is therefore refused; equal priority remains after the active event through the
+  later runtime-assigned enqueue sequence. Only the runtime admits `input` events; `observation` is
+  read-only and cannot schedule. A transaction may never enqueue into an already completed time,
+  phase, or queue position. Illegal scheduling is a Runtime refusal. Deterministic caps on zero-time
+  derivation depth, total events, and queue size bound cycles and denial-of-service behavior.
+
+- **Cancellation is prospective and identity-based.** Every admitted event has a stable `event_id`.
+  Cancellation may target only an event that has not begun dispatch; canceling an absent, completed,
+  or active event follows the operation's declared typed outcome and never rewinds committed state.
+  Undo is represented by an explicit compensating event or a higher-level rollback model, not by
+  scheduler time travel.
+
+- **External input enters only at declared boundaries.** Each input carries a stable source identity
+  and monotonically increasing source sequence. At an input boundary, the runtime admits inputs in
+  `(source identity, source sequence)` order into the fixed input phase. Duplicate, missing when the
+  contract requires continuity, or decreasing sequence numbers are refusals. Wall-clock arrival
+  order and thread scheduling are never semantic inputs.
+
+- **A Snapshot boundary exists initially and after every successful event.** The semantic snapshot
+  includes all persistent state and scheduler state required to resume deterministically. Evidence
+  may record a canonical hash at every boundary and materialize full snapshots only at declared
+  checkpoints; storage optimization cannot change the conceptual boundary or replay trace.
+
+- **Fairness is explicit and bounded.** FIFO holds within equal time, phase, and priority. There is
+  no promise that a lower priority event preempts a finite higher priority chain. Deterministic
+  zero-time and total-event budgets prevent an unbounded chain from silently starving the queue;
+  exhaustion is a Runtime refusal with the last committed snapshot preserved.
+
+- **Randomness is stream-scoped.** Stochastic operations read only a Named random stream derived
+  from the effective root seed and stable stream identity under the Runtime profile's versioned RNG
+  algorithm and derivation contract. There is no ambient global RNG. An unrelated stream's
+  insertion or consumption cannot perturb another stream. Exact algorithms and sampling mappings
+  belong to the Language Definition Bundle/runtime-profile specification and normative vectors.
+
+- **Determinism is Runtime-profile scoped.** The profile identifies the Language Definition Bundle,
+  scheduler contract, evaluator build, platform/runtime scope, Numeric profile, RNG algorithm and
+  derivation version, and deterministic budgets. Together with exact Resolved Model, Experiment
+  Specification, external input, and effective seed identities, it forms the reproduction key.
+
+- **Numeric promises are profile-specific.** A portable exact profile can promise cross-platform
+  bit identity only for standardized exact/fixed operations and sampling mappings. A profile that
+  admits platform-native floating operations promises replay only within its declared evaluator,
+  runtime, platform, and ULP contract. Standard Schema 2.x makes no unconditional cross-platform
+  byte-equality claim.
+
+- **This decision supersedes bADR-0010's 2.x reproduction scope, not its current CLI convention.**
+  Explicit stochastic seeds, fresh entropy when omitted, and unconditional effective-seed echo are
+  retained. For 2.x, `(seed, input, toolkit version)` is no longer a sufficient reproduction key;
+  the artifact and Runtime-profile identities above are required. bADR-0010's unsigned-32-bit CLI
+  encoding and current envelopes remain binding until the 2.x CLI decision explicitly replaces
+  them. Standard Schema 1.x continues under bADR-0010.
+
+## Considered options
+
+- **Sequential atomic events with a total order** (chosen) — gives one simple reference semantics,
+  deterministic state visibility, and a comparison target for parallel evaluators.
+- **Batch all simultaneous events against one snapshot** (rejected) — requires a universal merge
+  algebra for arbitrary writes and makes order-sensitive game mechanics unnatural or implicit.
+- **Implementation/thread order** (rejected) — cannot be replayed or compared across evaluators.
+- **Implicit last-writer-wins inside one event** (rejected) — hides conflicts and makes declaration
+  reordering semantic.
+- **Continue after runtime failure** (rejected) — permits partial transactions and divergent traces;
+  expected gameplay failure must be an explicit modeled outcome.
+- **Ambient global RNG** (rejected) — unrelated changes perturb every downstream sample and destroy
+  orthogonality.
+- **Blanket cross-platform bit identity** (rejected) — contradicts native floating behavior and the
+  existing numeric contract; portability must be an explicit Numeric profile property.
+
+## Consequences
+
+- The Language Definition Bundle must encode the fixed phase order and scheduling edges, runtime
+  diagnostics, RNG algorithms/derivation, Numeric profiles, and canonical snapshot/hash rules.
+- RIR operations and package extensions must declare state read/write sets, emitted event types,
+  cancellation behavior, and reducers sufficiently for static and runtime enforcement.
+- The reference evaluator and every optimizing evaluator must emit the same ordered trace under an
+  identical Runtime profile, subject only to the profile's declared numeric tolerance.
+- Experiment and evidence artifacts must bind external-input identity, effective seed, Runtime
+  profile, terminal snapshot, and refusal details.
+- The 2.x invocation-result decision must assign Runtime refusal an envelope, output channel, and
+  exit status without overloading validation refusal or balance verdict.
+
+## References
+
+- PRD #534 — Standard Schema 2.0 language, runtime, and evidence architecture.
+- bADR-0010 — Standard Schema 1.x seed surfacing and determinism scope.
+- bADR-0012 — language and artifact authority domains.
+- bADR-0013 — compiler stages and RIR semantic boundary.

--- a/libs/gda-balancing/docs/badr/0015-invocation-outcomes-and-diagnostic-locations.md
+++ b/libs/gda-balancing/docs/badr/0015-invocation-outcomes-and-diagnostic-locations.md
@@ -1,0 +1,145 @@
+---
+status: accepted
+---
+
+# Preserve the exit algebra while generalizing refusals by stage and diagnostic location
+
+bADR-0008 gives the current CLI a useful five-way outcome algebra: success, negative verdict,
+typed refusal, usage error, and internal error. Standard Schema 2.x introduces failures that the
+1.x envelope cannot represent honestly. A dependency conflict is not a JSON element, a runtime
+budget refusal belongs to an event and snapshot, an evaluation may be impossible without making
+the model invalid, and an approval may either be a valid negative decision or be impossible because
+its evidence is malformed.
+
+Adding an exit code for every compiler/runtime stage would make automation brittle. Forcing every
+location into a JSON Pointer would lose the source, symbol, artifact, and runtime identity agents
+need to remediate it. PRD #534 therefore preserves the small outcome algebra while making the
+refusal payload stage-aware and artifact-aware.
+
+## Decision
+
+- **The exit-code and output-channel algebra remains stable:**
+
+  | Exit | Meaning | Payload | Channel |
+  |---|---|---|---|
+  | `0` | requested operation completed with a positive or non-judgment result | typed result | stdout |
+  | `1` | requested judgment completed with a negative Verdict | typed verdict report | stdout |
+  | `2` | expected domain condition refused completion | refusal Error envelope | stdout |
+  | `3` | invocation surface is malformed or inaccessible | usage Error envelope | stderr |
+  | `4` | toolkit implementation failed unexpectedly | internal Error envelope | stderr |
+
+  Exits 0–2 are machine-readable products of a correctly invoked command. Exits 3–4 mean the
+  command did not perform its domain job. Every channel contains exactly one JSON document and
+  stdout is empty for exits 3–4.
+
+- **A negative judgment is a Verdict, not a refusal.** Failing a balance target or declining a
+  governance approval after valid evidence is evaluated returns exit 1 with the command's typed
+  verdict report. Missing evidence, invalid signatures, an unevaluable metric, or any condition
+  preventing the judgment is a typed refusal at the applicable stage. A positive judgment returns
+  the command's exit-0 result.
+
+- **Standard Schema 2.x defines eight stable Refusal stages:** `ingress`, `parse`, `static`,
+  `resolution`, `runtime`, `evaluation`, `migration`, and `approval`.
+  - `ingress` owns byte/resource caps, artifact identity/version dispatch, and safe admission.
+  - `parse` owns wire grammar and source construction.
+  - `static` owns structural, name, type, unit, and other compile-time semantic rules.
+  - `resolution` owns package dependency/capability binding and HIR-to-RIR lowering preconditions.
+  - `runtime` owns legal execution under bADR-0014.
+  - `evaluation` owns metric computability and statistical evaluation preconditions.
+  - `migration` owns source/artifact conversion preconditions and loss classification.
+  - `approval` owns evidence, attestation, and governance-policy preconditions.
+  A refusal envelope names the earliest stage that cannot complete; later stages do not run.
+
+- **The 2.x refusal envelope carries Diagnostics rather than 1.x JSON-Pointer-only entries.** The
+  closed refusal variant contains `category: refusal`, one `stage`, a non-empty `diagnostics` array,
+  and `truncated`. It may additionally carry `reproduction` after stochastic identity exists and a
+  `terminal_evidence` receipt after runtime has committed evidence. It has no envelope-level
+  diagnostic code: stable codes belong to individual entries.
+
+- **Every Diagnostic has one stable code, explanatory message, tagged primary location, and zero
+  or more related locations.** Primary and related locations use a closed tagged union:
+  - `invocation` for a whole admitted request or dependency-resolution context;
+  - `source` for package/module identity plus a source span;
+  - `artifact` for content identity plus an artifact-native pointer;
+  - `symbol` for a canonical symbol identity, optionally with its declaration source;
+  - `runtime` for run, event, and Snapshot-boundary identities.
+  No implementation may fabricate a JSON Pointer for a non-JSON location. Diagnostic codes and
+  location identities are normative; message wording is not an automation key.
+
+- **Report-all behavior is stage-bounded.** Parse and static stages report all safely discoverable
+  diagnostics up to the deterministic cap. Resolution reports the complete bounded conflict set.
+  Runtime, evaluation, migration, and approval may produce one terminal diagnostic plus related
+  locations, or a bounded set when the operation can establish independence. Diagnostics sort by
+  the location-kind order above, canonical location key, then code; duplicates are removed by
+  `(code, primary location, related locations)`. `truncated` records cap exhaustion.
+
+- **Terminal evidence is referenced, not embedded as accidental success.** A runtime refusal may
+  attach a receipt identifying the ordered trace, last committed snapshot, refusing event, and
+  Runtime profile. The envelope remains category `refusal` and exit 2. Consumers can inspect or
+  replay the evidence without mistaking partial execution for a completed result.
+
+- **Usage and internal variants remain separate and closed.** They carry one envelope-level code
+  and no domain-diagnostic array. Usage covers only command/argument/path failures before artifact
+  admission. Internal uses `internal_error`; under explicit debug mode its sanitized envelope may
+  add a `debug` string. Typed domain conditions must never be caught and relabeled `internal`, and
+  unexpected exceptions must never be exposed as typed refusals.
+
+- **The Language Definition Bundle owns typed-refusal diagnostic codes and stage membership.**
+  Core and extension packages declare versioned, namespaced codes through the bundle authority.
+  The CLI usage family and fixed internal code remain command-surface concerns. A code cannot move
+  stages or change meaning within a compatible Schema line.
+
+- **The Command descriptor remains the sole surface authority.** In 2.x it names the command's
+  input and success-result models; optional verdict model; applicable refusal stages and projected
+  refusal schema; handler; argument presentation; execution markings; and fixtures for every
+  applicable outcome. Dispatch, help/schema/manifest projections, and the conformance harness walk
+  that one registration seam.
+
+- **The conformance harness expands without creating a second registry.** It asserts channel,
+  exit, closed-envelope shape, diagnostic code/stage membership, stable location encoding,
+  truncation/order/deduplication, terminal-evidence receipts, reproduction identity, and
+  result/verdict schemas for every registered command.
+
+- **This decision supersedes only the conflicting 2.x portions of bADR-0004, bADR-0008, and
+  bADR-0011.** It replaces the three-phase-only refusal boundary, JSON-Pointer-only refusal entry,
+  and 1.x closed envelope for 2.x. It retains gated validation, preflight caps, typed/report-all
+  refusal, the 0–4 exit/channel meanings, single JSON payload, sanitized internal failures, one
+  Command descriptor seam, and registry-walking conformance. Their existing contracts remain
+  normative for Standard Schema 1.x and the current CLI until 2.x commands ship.
+
+## Considered options
+
+- **Keep five outcomes and add refusal stage/location** (chosen) — preserves automation behavior
+  while making new compiler, runtime, evidence, and governance failures actionable.
+- **One exit code per pipeline stage** (rejected) — couples shell automation to pipeline growth and
+  confuses failure origin with outcome meaning.
+- **Map runtime/evaluation failure to internal error** (rejected) — these are expected domain
+  conditions with stable remediation, not toolkit defects.
+- **Return runtime refusal as success with a partial-result flag** (rejected) — makes incomplete
+  execution indistinguishable from a requested terminal result.
+- **Treat a negative approval as approval refusal** (rejected) — the judgment completed; its answer
+  is negative, exactly the Verdict distinction.
+- **Keep JSON Pointer as the only location** (rejected) — multi-file source, symbols, dependency
+  graphs, events, and snapshots do not have honest JSON Pointer coordinates.
+- **Wrap success, verdict, and errors in one universal envelope** (rejected) — adds ceremony without
+  improving discrimination; descriptor-projected schemas already define successful payloads.
+
+## Consequences
+
+- The 2.x wire specification needs closed schemas for all location variants, refusal envelopes,
+  terminal-evidence receipts, and verdict reports.
+- Existing refusal codes need an explicit 1.x-to-2.x mapping and stage assignment during migration.
+- Runtime, evaluation, migration, and approval implementations gain typed failure paths and may not
+  signal expected conditions with exceptions.
+- CLI taxonomy may change only through a separate decision that updates command descriptors and
+  their projections; this bADR fixes outcome behavior, not command names.
+- Issue #534's capability mismatch, `not_evaluable`, Runtime refusal, migration, and approval gates
+  now have one carrier and stable automation contract.
+
+## References
+
+- PRD #534 — Standard Schema 2.0 language, runtime, and evidence architecture.
+- bADR-0004 — Standard Schema 1.x boundary-funnel validation semantics.
+- bADR-0008 — current invocation result contract.
+- bADR-0011 — command registration seam and conformance harness.
+- bADR-0014 — deterministic atomic event runtime.

--- a/libs/gda-balancing/docs/badr/0016-closed-type-core-and-versioned-package-extensions.md
+++ b/libs/gda-balancing/docs/badr/0016-closed-type-core-and-versioned-package-extensions.md
@@ -1,0 +1,156 @@
+---
+status: accepted
+---
+
+# Keep the type core closed and extend game domains through versioned packages
+
+Standard Schema 1.x made attributes, float parameters, formula references, effects, and reserved
+sections the central schema vocabulary. The RPG template review showed that extending those shapes
+field by field would make every game concept compete for a place in the root schema. It would also
+conflate unrelated concerns: numeric representation, game meaning, units, legal domains, lifecycle,
+and tuning role.
+
+Standard Schema 2.x needs to represent RPG and Roguelike systems without turning their current
+mechanics into universal primitives. At the same time, an “open extension map” or evaluator plugin
+would sacrifice static typing, deterministic execution, and cross-implementation meaning. PRD #534
+therefore requires a small closed type language and a constrained package extension contract.
+
+## Decision
+
+- **The core type-constructor set is closed:** `Bool`, `Int`, `Fixed`, `Decimal`, `Float`, `Enum`,
+  `Record`, `Vector`, `List`, `Set`, `Map`, `EntityRef`, `Quantity`, and `Distribution`.
+  Domain packages compose and instantiate these constructors. They cannot add primitive wire
+  syntax, host-language objects, or new representation semantics. Adding or changing a constructor
+  is a Standard Schema major decision in the Language Definition Bundle.
+
+- **Quantity separates five orthogonal concerns:**
+  1. numeric representation (`Int`, `Fixed`, `Decimal`, or `Float`);
+  2. nominal kind — package-defined semantic identity such as health, mana, damage, or currency;
+  3. unit and dimension;
+  4. support/domain — intervals, discreteness, allowed exceptional values, and other value-set law;
+  5. Numeric-profile policy — rounding, overflow, non-finite, tolerance, and portability behavior.
+  Equal representation or dimension does not erase nominal kind. Packages may define kind
+  relationships only through explicit operation/conversion contracts.
+
+- **Lifecycle and domain uses are Symbol roles, not numeric types.** Core symbol roles include
+  `constant`, `parameter`, `input`, `state`, `derived`, `output`, and `random`. Domain roles such as
+  `current`, `capacity`, `cost`, and `rate` compose separately on typed symbols or component fields.
+  Roles constrain who may initialize, tune, read, write, sample, or export a value; they do not
+  create `CurrentNumber`, `CostNumber`, or other redundant type constructors.
+
+- **`attribute` is not a 2.x language primitive.** A domain package may call a Quantity-typed symbol
+  or component field an attribute in its own vocabulary, but the compiler sees the same typed
+  declaration machinery used by resources, cooldowns, currencies, positions, counters, and rates.
+  New attributes therefore require data declarations, not changes to the root schema or evaluator.
+
+- **Entities compose through typed records/components and EntityRef.** A package defines nominal
+  component contracts using core constructors. Entity references state the required nominal entity
+  or capability contract; they are not untyped ids. A package cannot reopen another package's
+  record or attach undeclared fields. Additional behavior composes as a separate component and
+  explicit operations over imported contracts.
+
+- **Every Domain package has one versioned, namespaced manifest in the Language Definition Bundle.**
+  It declares exact package identity; semantic version; required and optional dependency ranges;
+  provided and required capabilities; exported types, components, operations, conversions, and
+  diagnostics; supported Numeric profiles; and normative-vector inventory. Package contents cannot
+  exist in an evaluator registry without appearing in this authority.
+
+- **Dependency resolution is deterministic and single-version per package id.** A Resolved Model
+  binds one exact version for every package identity. Incompatible majors coexist only under
+  distinct namespaces or through an explicit adapter package; the resolver never selects two
+  ambiguous versions of one id. The generated Package Lock records the exact graph, capabilities,
+  and resolver contract. Empty, conflicting, or cyclic invalid solutions are `resolution` refusals
+  with the bounded conflict set.
+
+- **Optional dependencies are explicit capability branches, not ambient behavior.** Source may use
+  an optional package only inside a construct that declares the corresponding capability
+  requirement. Resolution either binds that capability and makes the chosen branch explicit in RIR
+  or refuses the construct. Absence cannot silently select evaluator-specific fallback semantics.
+
+- **Unknown language elements fail closed.** An unknown package, capability, type, field,
+  operation, conversion, diagnostic, or attribute is a typed refusal at `static` or `resolution`
+  according to whether name lookup or version/capability binding failed. No wire field is preserved
+  as an opaque extension for a later evaluator to reinterpret.
+
+- **Operation specifications close the extension's semantic surface.** Every operation declares a
+  complete type signature, unit/kind rules, purity, deterministic resource bounds, permitted
+  Numeric profiles, and runtime effects: state reads/writes, emitted signals, scheduled/canceled
+  events, and Named random streams. Its formal/reference semantics and diagnostic codes belong to
+  the Language Definition Bundle. Host evaluator code is a conforming implementation only.
+
+- **Signal types belong to packages; subscription topology belongs to authored models.** A Domain
+  package exports a nominal signal payload and the effects/capabilities a subscriber may declare.
+  A Model Source Package declares game-specific subscriptions using resolved handler identities.
+  Static resolution rejects incompatible, cyclic-unbounded, or undeclared effects and lowers the
+  closed subscriber table into RIR. An evaluator registry cannot add subscribers.
+
+- **Conversions are explicit operations.** Cross-kind, cross-unit, and representation conversions
+  exist only as versioned Conversion operations with declared legality, exact/lossy status,
+  rounding, domain mapping, and refusal behavior. Source requests the conversion; Typed HIR records
+  the selected operation explicitly. Contextual literal typing may choose a literal's initial type,
+  but no implicit coercion remains in HIR or RIR.
+
+- **Package compatibility follows strict semantic versioning.** Minor versions may add optional
+  types, operations, capabilities, or fields whose absence preserves every existing program's
+  meaning. Changing/removing existing structure, diagnostics, operation behavior, defaults,
+  effects, or numeric results requires a major version. Patch versions may correct prose,
+  projection, or implementation defects only when observable semantics and valid-program sets are
+  unchanged. Exact versions remain locked for replay even when a change is compatible.
+
+- **Cross-package identity is nominal and exact.** Type and operation identity includes package
+  namespace, compatible major line, and exported symbol; Package Lock supplies the exact version.
+  Structural similarity does not make records or Quantity kinds interchangeable. Adapter packages
+  and Conversion operations make interoperability reviewable.
+
+- **Every package ships executable conformance evidence.** Positive, negative, boundary,
+  compatibility, deterministic replay, and declared-effect vectors are required before a package
+  enters the Language Definition Bundle. The resolver and reference evaluator discover vectors
+  through the manifest, not a parallel test registry.
+
+- **This decision supersedes the conflicting 2.x portions of bADR-0001, bADR-0002, and
+  bADR-0003.** It replaces the fixed root/reserved-section extension model, attribute-specific core
+  facets, float-only parameter surface, and untyped reference assumptions for 2.x. It retains the
+  principles of closed input, orthogonal composition, explicit named tuning controls, closed
+  operations, bounded formulas, and hard refusal. Their 1.x contracts remain normative for 1.x and
+  migration. Effect-domain semantics in bADR-0006 require a separate 2.x package decision.
+
+## Considered options
+
+- **Closed type constructors plus constrained packages** (chosen) — permits new game concepts
+  without allowing extensions to fork grammar, typing, or runtime semantics.
+- **Add every RPG concept to the root schema** (rejected) — creates a non-orthogonal taxonomy that
+  cannot represent new genres without core changes.
+- **Open attribute/property maps** (rejected) — make unknown content silently valid and move typing
+  into individual evaluators.
+- **Host-language plugins** (rejected) — bypass deterministic semantics, capability negotiation,
+  resource bounds, and cross-implementation conformance.
+- **Structural/duck typing across packages** (rejected) — permits accidental compatibility when two
+  records or numeric kinds happen to share a shape.
+- **Multiple versions of one package id in one model** (rejected) — makes type and operation
+  identity ambiguous; explicit namespaces/adapters expose the compatibility boundary.
+- **Implicit numeric and unit coercions** (rejected) — hide loss, make overload resolution unstable,
+  and prevent HIR/RIR from being semantically explicit.
+
+## Consequences
+
+- The Language Definition Bundle owns each core constructor, type relation, literal rule, role
+  constraint, manifest field, resolver algorithm, compatibility rule, and conversion law through
+  bADR-0022's structured Language rules.
+- Package authors gain an additive route for new attributes, resources, actions, economies, and
+  game-specific components without root-schema changes.
+- The RIR serializer and Capability manifest expose exact package/type/operation identities; every
+  evidence artifact binds them through the Resolved Model hash.
+- RPG/Roguelike completeness must now be demonstrated as package operations and golden scenarios,
+  not as a long list of special root fields.
+- bADR-0017 establishes the coverage matrix and splits effect, combat, build, progression, economy,
+  generation, and reset behavior across orthogonal packages.
+
+## References
+
+- PRD #534 — Standard Schema 2.0 language, runtime, and evidence architecture.
+- bADR-0001 — Standard Schema 1.x document and reserved sections.
+- bADR-0002 — Standard Schema 1.x orthogonal attribute facets.
+- bADR-0003 — Standard Schema 1.x formula and parameter representation.
+- bADR-0012 — language and artifact authority domains.
+- bADR-0013 — compiler stages and RIR semantic boundary.
+- bADR-0014 — deterministic atomic event runtime.

--- a/libs/gda-balancing/docs/badr/0017-genre-templates-and-coverage-contract.md
+++ b/libs/gda-balancing/docs/badr/0017-genre-templates-and-coverage-contract.md
@@ -1,0 +1,166 @@
+---
+status: accepted
+---
+
+# Prove RPG and Roguelike support through template releases and executable coverage
+
+The closed package system in bADR-0016 makes extension possible, but a list of package names does
+not prove that Standard Schema 2.x can represent a production RPG or Roguelike. The rejected RPG
+template PR attempted to encode one genre baseline directly in the 1.x shape; review found missing
+target selection, dynamic entities, damage stages, immunity, interruption, build conflicts, loot
+constraints, and run/meta reset semantics. Adding fields would neither close those gaps nor show
+that independently designed packages compose into one executable model.
+
+A template also cannot become a fourth authority domain. Its model starter, experiments, and
+support evidence have different owners under bADR-0012. PRD #534 therefore needs a template
+distribution contract and a falsifiable definition of genre completeness.
+
+## Decision
+
+- **A Genre template is a versioned template release, not a Standard Schema instance or runtime
+  profile.** A release contains:
+  - an instantiable starter Model Source Package with default declarations and formulas;
+  - companion Experiment Specifications with scenarios, metrics, and targets;
+  - a Genre coverage matrix and its Golden scenarios/negative vectors;
+  - a manifest binding template version, compatible Language Definition Bundle/package ranges, and
+    the content identities of those members.
+  The release is a distribution container, not a semantic authority: each member retains its
+  bADR-0012 authority domain.
+
+- **Instantiation creates a new authored model identity.** It copies/materializes the starter under
+  a new package identity and records template id/version/content provenance. The game owns all
+  subsequent edits. Installing a later template cannot mutate, rebase, or reinterpret an existing
+  Model Source Package. Initial 2.0 defines no template-upgrade converter: adopt later content only
+  by re-instantiating or making explicit authored changes. A future 2.x upgrade decision may add a
+  separately versioned migration/report contract without retroactively changing existing models.
+
+- **Templates contain no evaluator code and define no alternate language.** Defaults, formulas,
+  package requirements, and example experiments are Standard Schema source. Genre-specific
+  behavior exists only through Language Definition Bundle operations and Domain packages. The term
+  `profile` remains reserved away from Genre template because Runtime/Numeric profiles have
+  different authority and compatibility semantics.
+
+- **The initial game-domain package boundaries are:**
+
+  | Package | Owns | Does not own |
+  |---|---|---|
+  | `game.entity` | entity identity, components, faction/team/relationship, dynamic entity sets | targeting or action lifecycle |
+  | `game.resource` | current/capacity, cost, regeneration, reservation and transfer | action timing or damage stages |
+  | `game.query` | typed target filters, ordering, cardinality, tie-break and empty behavior | target-side effects |
+  | `game.check` | threshold/opposed checks, hit resolution, dice/pools, advantage and success degree | damage application |
+  | `game.action` | requirements, resource commitment, wind-up/channel, cooldown, completion and interruption | target enumeration or damage math |
+  | `game.effect` | application/capture, contributions, transitions, schedule, stacking/reapply/remove and immunity contracts | action lifecycle or combat pipeline |
+  | `game.combat` | typed damage/healing stages, criticals, mitigation/resistance, shields and defeat state | generic effect lifetime or inventory |
+  | `game.build` | equipment/skill/perk selection, prerequisites, exclusivity, slots and synergy declarations | item ownership or reward sampling |
+  | `game.progression` | XP, levels, growth, unlocks and progression gates | currency exchange or run reset |
+  | `game.economy` | currency, inventory, sources/sinks, transfer, exchange and pricing | stochastic reward selection |
+  | `game.generation` | seeded weighted/constrained pools, rarity and guarantee rules | inventory transfer or meta retention |
+  | `game.encounter` | party/enemy composition, spawn/wave schedule, objectives and terminal conditions | entity internals or scheduler law |
+  | `game.run` | Run/Meta scope declarations, start/end/reset and explicit retained transfers | progression formulas themselves |
+  | `game.turn` | optional rounds, initiative, action economy and turn windows | core logical-time scheduler |
+  | `game.spatial` | optional positions, ranges, shapes, movement and spatial queries | generic target-query semantics |
+
+  Package names are stable conceptual namespaces; final operation/type inventories live only in the
+  Language Definition Bundle.
+
+- **Target selection is its own typed contract.** A Target query operates over a dynamic entity set
+  and declares filters, stable ordering, cardinality, tie-breaking, empty-result behavior, and any
+  spatial capability required. Action, combat, and effect packages consume the resolved targets;
+  none may hide target selection inside evaluator code.
+
+- **Effects decompose instead of growing a universal object.** `game.effect` composes distinct
+  contracts for application requirements, capture timing (including snapshot/live reads),
+  continuous contributions, state transitions, scheduling, stacking identity/reducer/cap,
+  reapplication lifetime, removal/expiry/dispel, and immunity. Action owns interruption; combat owns
+  damage/healing stages; resource owns current/capacity transfer. Cross-package operations declare
+  their reads, writes, events, and refusal outcomes under bADR-0016.
+
+- **Loot is a composition, not another monolith.** `game.generation` selects a reward under seeded
+  weights and constraints; `game.economy` owns item/currency inventory transfer; `game.build` owns
+  whether the result can be equipped or selected. A Golden scenario spans all three so no package
+  silently owns the handoff.
+
+- **Run and Meta scopes are explicit state lifecycle contracts.** Every relevant state declaration
+  names its scope. A run-end transaction clears Run-scoped state and performs only declared
+  transfers to Meta-scoped state. Build state, encounter state, transient effects, and run currency
+  cannot survive by naming convention or evaluator accident. Replay observes the reset and retained
+  transfers as ordinary ordered events.
+
+- **Every support claim is backed by a Genre coverage matrix.** Each normative row records:
+  requirement id and statement; owning capability/operation identities; involved package boundary;
+  positive Golden scenario; at least one negative/refusal vector; and the metric/evidence field that
+  makes the behavior observable. A row is incomplete if any column is absent. Package inventory,
+  prose examples, or unit tests alone do not establish representational adequacy.
+
+- **The RPG minimum coverage includes:** typed base/parameter/derived-stat composition across
+  progression, build, and effect contributions; dynamic target selection; resource
+  reservation/payment/regeneration plus action cooldown; action admission/resolution/completion/
+  interruption; threshold/opposed hit checks; critical and staged typed damage and healing;
+  mitigation, resistance, shields, defeat, and revival policy; immunity; snapshot/live capture;
+  stacking, reapplication, contribution, transition, expiration, and dispel; model-authored
+  passive/reactive Signal subscriptions; build prerequisite/exclusion/synergy; progression and
+  unlock; generated loot plus inventory/economy transfer; and final Metrics/evidence emission.
+  CRPG/JRPG/ARPG variants may select `game.turn` and/or `game.spatial` capabilities without changing
+  core logical-time or language semantics; those optional capabilities are not inherited by every
+  RPG/Roguelike support claim.
+
+- **The Roguelike minimum coverage adds:** seeded constrained reward generation; rarity/guarantee
+  behavior; build conflict and synergy; dynamic encounter/wave composition; Run-scope teardown;
+  explicit Meta-scope retention; and replay equality under identical model, experiment, Runtime
+  profile, external input, and seed identities. Metroidvania-like, survivors-like, and deckbuilder-
+  like templates may specialize package selection while satisfying the shared lifecycle rows.
+
+- **The first implementation tracer is vertical.** It compiles one RPG starter source to RIR,
+  resolves a dynamic target, commits an action cost, executes hit/critical/staged damage, applies an
+  interruptible stacking effect with immunity behavior, terminates the encounter, and emits the
+  shared Metrics/evidence artifact through the public CLI contract. Supporting Golden scenarios
+  isolate negative and boundary cases; implementation does not build every package horizontally
+  before this path runs.
+
+- **This decision supersedes conflicting 2.x template/effect portions of bADR-0001, bADR-0002, and
+  bADR-0006.** It replaces “template as one Design-document instance”, root reserved genre sections,
+  fixed template attribute-tier assumptions, and the monolithic Effect/Modifier shape for 2.x. It
+  retains data-defined genre baselines, orthogonal attribute composition, formula-capable values,
+  explicit duration/stacking/reapplication concepts, and hard refusal. Their complete 1.x behavior
+  remains normative for 1.x and migration.
+
+## Considered options
+
+- **Template release plus executable coverage matrix** (chosen) — preserves authority boundaries
+  and makes genre-support claims independently testable.
+- **One large RPG/Roguelike root schema** (rejected) — couples unrelated mechanics and forces every
+  genre extension into core.
+- **Package list as the support definition** (rejected) — says where concepts might live but not
+  whether their operations compose or cover production cases.
+- **Genre-specific evaluator profiles** (rejected) — forks semantics in runtime code and conflicts
+  with Runtime/Numeric profile terminology.
+- **Template dependency that updates instantiated games automatically** (rejected) — makes template
+  releases hidden model authority and invalidates evidence without an authored change.
+- **Monolithic Effect and Loot objects** (rejected) — combine selection, lifecycle, math, inventory,
+  and build policy into shapes that cannot evolve orthogonally.
+- **One enormous golden battle only** (rejected) — demonstrates a happy path but cannot localize
+  negative, limit, or cross-package boundary failures; the matrix requires both integrated and
+  focused vectors.
+
+## Consequences
+
+- RPG/Roguelike package work begins from the matrix and tracer, not from serializing defaults into
+  the 1.x Design-document shape.
+- Adding a new attribute is normally a Quantity-typed model declaration; adding a reusable mechanic
+  is a package operation/capability with conformance vectors, not a root-schema edit.
+- Template releases, instantiated models, Experiment Specifications, and approval/evidence records
+  retain separate identities and migration histories.
+- Metrics/evidence semantics must be decided before the tracer can close every required row.
+- The old RPG/Roguelike template implementation issues require re-triage against #534 and this
+  coverage contract before work resumes.
+
+## References
+
+- PRD #501 — balancing toolkit product requirements.
+- PRD #534 — Standard Schema 2.0 language, runtime, and evidence architecture.
+- `docs/standard-schema-2.0/genre-coverage.md` — normative RPG/Roguelike rows, scenarios,
+  negative vectors, and tracer gate.
+- bADR-0001/0002/0006 — Standard Schema 1.x document, attribute, and effect contracts.
+- bADR-0012 — authored authority domains.
+- bADR-0014 — deterministic atomic event runtime.
+- bADR-0016 — closed type core and versioned package extensions.

--- a/libs/gda-balancing/docs/badr/0018-unified-metrics-calibration-and-evidence-chain.md
+++ b/libs/gda-balancing/docs/badr/0018-unified-metrics-calibration-and-evidence-chain.md
@@ -1,0 +1,145 @@
+---
+status: accepted
+---
+
+# Use one Metrics schema and immutable evidence for evaluation, calibration, and approval
+
+The balancing toolkit must compare predicted behavior with future playtest observations without
+inventing two meanings for the same metric. A simulation-only report shape would force adapters,
+weaken calibration provenance, and violate the product requirement that simulated and observed
+results round-trip through one Metrics schema.
+
+Calibration also needs more than an optimizer and confidence interval. Without a declared
+observation model, parameter identifiability, model discrepancy, replication unit, correlation
+structure, frozen holdout, multi-objective policy, and data-drift handling, two evaluators can call
+different results “calibrated.” Finally, a mutable lifecycle status cannot prove which exact model,
+data, runtime, and policy passed each gate. PRD #534 therefore fixes one metric contract and an
+append-only evidence graph.
+
+## Decision
+
+- **One Metrics schema represents both simulated and observed samples.** Every Metric definition
+  declares stable identity; Quantity type and unit; dimensions; observation window; aggregation;
+  replication semantics; and missing/censoring behavior. Every Metric sample carries that
+  definition identity, typed value or explicit missing/censored state, logical time/window,
+  dimension values, replication identity, source kind, and provenance. `simulated` and `observed`
+  are source-kind values only; they cannot alter type, unit, dimension, or aggregation semantics.
+
+- **Metric datasets are immutable and content-addressed.** A dataset binds exact Metric-definition
+  and Experiment-Specification identities, source/build provenance, data version, partition,
+  samples, ordering/canonicalization law, and any ingestion transformation identity. A corrected or
+  extended dataset receives a new identity. Sentinel values cannot stand for missingness,
+  censoring, refusal, or infinity.
+
+- **The Experiment Specification owns evaluation and statistical intent.** It declares scenarios,
+  model inputs, Metric definitions, sampling plan, replication unit, correlation clusters,
+  Observation model, model-discrepancy treatment, parameter space and constraints, objectives,
+  acceptance rule, estimator policy, train/holdout partition, and drift policy. The Resolved Model
+  exports typed state/events/outputs; it does not own targets or post-hoc acceptance criteria.
+
+- **An Evaluation run records execution facts without deciding success.** It binds the exact
+  Resolved Model, Experiment Specification, Runtime profile, evaluator build, effective seed and
+  Named random streams, external-input identity, ordered trace/snapshots, terminal status, and
+  produced Metric dataset. A runtime refusal may still produce a terminal-evidence receipt, but it
+  cannot produce a completed Evaluation-run success artifact.
+
+- **Calibration requires an explicit Observation model.** The model specifies how latent simulated
+  metrics map to observed data, including measurement error/noise, missing and censoring mechanism,
+  replication unit, within/between-cluster correlation, and model discrepancy. These choices are
+  fixed before fitting and identified in every Calibration report; an evaluator cannot infer a
+  favorable model silently from the observed dataset.
+
+- **A Calibration report is complete even when the conclusion is negative or inconclusive.** It
+  records exact model, experiment, training data, Evaluation runs, estimator and version,
+  parameter constraints/priors, identifiability analysis, discrepancy/noise assumptions,
+  correlation handling, convergence diagnostics, parameter uncertainty, sensitivity, objective
+  values, and candidate identities. Failure to meet predeclared statistical acceptance is a
+  negative Verdict, not missing output.
+
+- **Identifiability and replication are first-class gates.** A policy states acceptable structural
+  or practical identifiability, effective sample size, convergence, and uncertainty thresholds.
+  Samples sharing a declared player, session, encounter seed, run, or other replication cluster are
+  not treated as independent. If required information is absent or computation is undefined, the
+  command returns an `evaluation` refusal; if analysis completes but evidence is inadequate, it
+  returns an exit-1 Verdict.
+
+- **Multi-objective acceptance is predeclared and deterministic.** The Experiment Specification
+  chooses conjunctive thresholds, a versioned scalarization, or a versioned Pareto acceptance rule,
+  including direction, weights/tolerances, uncertainty treatment, and tie-breaks. Objectives cannot
+  be selected, dropped, or reweighted after seeing candidate or holdout results without producing a
+  new Experiment Specification identity.
+
+- **Holdout partitions are frozen before calibration.** Partition membership is content-addressed
+  and cannot participate in fitting, hyperparameter selection, stopping, or objective choice.
+  Holdout verification references the chosen candidate and reports every declared objective under
+  the same Observation model. Passing produces a `holdout_verified` Evidence assertion; failing or
+  inconclusive verification is a Verdict and produces no positive assertion.
+
+- **Data drift affects eligibility through a typed Evidence assertion, never mutation.** A Drift
+  assessment is an Evidence-assertion subtype whose policy declares
+  compared distributions/metrics, windows, tests, multiplicity/tolerance, and action threshold. A
+  new data version or beyond-policy Drift assessment does not rewrite a historical Calibration
+  report or Holdout-verification assertion; it makes that assertion ineligible as a prerequisite
+  for a later approval and requires recalibration/reverification under new identities.
+
+- **Progress is an immutable evidence graph, not a mutable state field.** Claims such as
+  `well_typed`, `resolved`, `evaluable`, `reproducible`, `calibrated`, and `holdout_verified` are
+  separate Evidence assertions. Each names the exact subject artifacts, policy, tool/evaluator, and
+  prerequisite assertions. A later assertion can depend on earlier ones but cannot upgrade them in
+  place. `approved` exists only as an Approval Record in its governance authority domain.
+
+- **Approval binds exact evidence.** An Approval Record references the precise Resolved Model,
+  Experiment Specification, Runtime profile/evaluator, Metric datasets, Evaluation runs,
+  Calibration report, Holdout-verification and Drift-assessment assertions, approval policy, and
+  attestation.
+  A naked `approved: true`, branch label, or mutable dashboard state is not approval evidence.
+
+- **Outcome classification follows bADR-0015.** Missing required metrics, incompatible dimensions,
+  invalid dataset shape, undefined observation mapping, or non-computable evaluation is an
+  `evaluation` refusal. A completed evaluation that misses targets, lacks sufficient evidence, is
+  non-identifiable under policy, or fails holdout is an exit-1 Verdict. Evidence assertions are
+  emitted only for positive gates.
+
+- **Live telemetry ingestion is deferred, not forked.** This decision fixes the observed-data
+  artifact and statistical contract. Transport, consent/privacy, collection SDKs, and live
+  ingestion operations are outside this design slice. When ingestion lands, its canonical output
+  must be the same Metric dataset shape and carry transformation provenance.
+
+## Considered options
+
+- **One typed Metrics schema plus source provenance** (chosen) — comparisons and calibration operate
+  on identical metric meaning without adapters.
+- **Separate simulation and telemetry reports** (rejected) — duplicates type/aggregation semantics
+  and moves reconciliation into unversioned ingestion glue.
+- **Mutable calibration/approval status on the model** (rejected) — loses exact evidence and lets a
+  data or policy change rewrite history.
+- **Optimizer output as Calibration report** (rejected) — omits observation noise, identifiability,
+  discrepancy, correlation, uncertainty, holdout, and acceptance semantics.
+- **Random holdout selected after fitting** (rejected) — leaks model-selection information and
+  cannot be audited independently.
+- **Treat inadequate evidence as refusal** (rejected when analysis completed) — the judgment is a
+  valid negative/inconclusive answer; refusal is reserved for inability to perform it.
+- **Treat historical evidence as deleted by drift** (rejected) — destroys audit history; eligibility
+  changes through a new linked assessment instead.
+
+## Consequences
+
+- Metric definitions, datasets, Evaluation runs, Calibration reports, Drift assessments, Evidence
+  assertions, and Approval Records need canonical schemas and content-identity laws.
+- The RPG/Roguelike tracer can close its final coverage rows by emitting an Evaluation run and the
+  same Metric dataset shape future observed playtests will use.
+- Calibration implementations must expose statistical assumptions and diagnostics rather than
+  returning only tuned parameters.
+- Approval tooling becomes graph validation over immutable artifacts and current policy, not a flag
+  update.
+- Migration must state whether and how 1.x reports or future legacy telemetry become 2.x datasets;
+  unproven provenance cannot be invented.
+
+## References
+
+- PRD #501 — shared simulated/observed Metrics schema requirement.
+- PRD #534 — Standard Schema 2.0 language, runtime, and evidence architecture.
+- bADR-0012 — authored authority domains and Approval Record.
+- bADR-0014 — Runtime profile and deterministic execution identity.
+- bADR-0015 — invocation outcomes, refusals, and Verdicts.
+- bADR-0017 — genre coverage and Golden scenarios.

--- a/libs/gda-balancing/docs/badr/0019-schema-2.0-clean-break-and-limited-source-migration.md
+++ b/libs/gda-balancing/docs/badr/0019-schema-2.0-clean-break-and-limited-source-migration.md
@@ -1,0 +1,101 @@
+---
+status: accepted
+---
+
+# Make Schema 2.0 the clean baseline and limit migration to safe source conversion
+
+The initial migration proposal covered saves, active effects, scheduled events, replays, old
+rulesets, shadow execution, cohorts, rollback, and reverse migration. Those mechanisms are justified
+when published artifacts or live games depend on the old contract. The maintainer confirmed that
+gda-balancing has published no Standard Schema product artifacts and carries little historical
+compatibility burden. Designing a production compatibility subsystem now would spend complexity on
+states that do not exist and would constrain the 2.0 model before its tracer is implemented.
+
+Standard Schema 1.x remains useful design history and current implementation input, but it is not a
+released compatibility line. PRD #534 therefore adopts 2.0 as the sole forward standard and keeps
+only a narrow, semantics-preserving source-conversion opportunity.
+
+## Decision
+
+- **Standard Schema 2.0 is a clean forward baseline.** New templates, models, experiments,
+  evaluators, metrics, evidence, and approvals target 2.x. There is no promise that a 2.x compiler
+  or runtime accepts a 1.x Design document, report, save, event log, or ruleset. This Schema-major
+  decision remains independent from the `gda-balancing` package version.
+
+- **Compatibility work is limited to authored 1.x Design-document source.** A deterministic,
+  one-shot converter may map declarations whose 2.x meaning is demonstrably equivalent into a new
+  Model Source Package. Repository fixtures and unfinished template sources may use the same path.
+  The converter is a convenience for pre-release work, not an acceptance prerequisite for 2.0.
+
+- **A source construct has only two outcomes: migrated or deprecated.** `migrated` requires a
+  semantics-preserving mapping with explicit destination identities. Anything ambiguous, lossy,
+  dependent on removed defaults, or lacking an equivalent type/operation is a Deprecated 1.x
+  construct. There is no automatic lossy tier, interactive patching inside the converter, or
+  “mostly migrated” success.
+
+- **Unsupported conversion is a typed `migration` refusal.** The converter emits a Migration report
+  that binds input identity, converter and Language Definition Bundle identities, successful
+  mappings, deprecated constructs, stable diagnostics, and remediation text. If any construct is
+  deprecated, it emits no authoritative 2.x Model Source Package. The user re-authors/removes the
+  construct and runs normal 2.x validation.
+
+- **Migration never mutates input or invents provenance.** A successful conversion emits a new
+  Model Source Package identity plus its Migration report. Original source remains byte-identical.
+  Missing authorship, units, kinds, roles, package dependencies, or operation semantics cannot be
+  inferred from evaluator behavior and recorded as fact.
+
+- **Runtime compatibility artifacts are explicitly out of scope.** No 1.x save-state migration,
+  active-effect mapping, scheduled-event conversion, replay/event-log conversion, old-ruleset
+  runtime adapter, dual authoritative state, shadow/gray rollout machinery, reverse migration, or
+  rollback protocol is designed. No such published artifact exists to preserve. If a real consumer
+  appears before 2.0 implementation, that new evidence requires a separate decision rather than
+  speculative hooks in this design.
+
+- **1.x evidence cannot satisfy 2.x gates.** Existing test output or unpublished reports may be
+  retained as historical provenance, but they cannot become a 2.x Metric dataset, Evaluation run,
+  Calibration report, Evidence assertion, or Approval Record without re-execution under exact 2.x
+  artifacts and contracts.
+
+- **The implementation transition is replace-then-remove, not dual-stack compatibility.** The first
+  2.x RPG tracer lands end to end alongside only the minimum current code needed to compare and
+  replace it. Once the tracer covers the public path, superseded 1.x implementation and fixtures are
+  removed or rewritten rather than maintained as a permanent compatibility runtime.
+
+- **Historical bADRs remain provenance, not competing forward requirements.** New 2.x bADRs state
+  exactly which 1.x decisions they retain or supersede. The old records remain readable so the
+  design evolution is auditable, but implementation issues must target the 2.x decisions and may
+  not invoke 1.x compatibility as an unstated acceptance criterion.
+
+## Considered options
+
+- **Clean break plus best-effort source conversion** (chosen) — preserves cheaply recoverable
+  authored work without imposing runtime compatibility for artifacts that were never published.
+- **Full source/save/replay/ruleset migration** (rejected) — solves a nonexistent deployed-state
+  problem and hardens premature runtime interfaces.
+- **No converter at all** (rejected as a blanket rule) — some simple declarations can be mapped
+  deterministically at low cost; allowing that convenience does not create a compatibility promise.
+- **Lossy conversion with warnings** (rejected) — produces a valid-looking 2.x model whose behavior
+  may have changed and transfers an unreviewable burden to later evidence.
+- **Permanent 1.x/2.x dual runtime** (rejected) — doubles authority and conformance surfaces before
+  the product has external consumers.
+- **Schema 2.0 implies package 2.0.0** (rejected) — Schema and product release versions remain
+  independent under bADR-0001/0012 and repository release policy.
+
+## Consequences
+
+- The 2.0 specification can choose coherent type, package, runtime, and evidence contracts without
+  reserving compatibility holes for unpublished 1.x runtime artifacts.
+- Migration acceptance tests cover exact source mappings and explicit deprecation/refusal only.
+- Save, effect-instance, replay, gray-rollout, and reverse-migration tests are not required by #534.
+- Existing template/simulation implementation issues must be re-triaged against the 2.x tracer and
+  may be closed or rewritten rather than adapted mechanically.
+- A future compatibility demand requires evidence of a real published consumer and a new bADR; it
+  is not smuggled into Domain packages or evaluators as an optional fallback.
+
+## References
+
+- PRD #534 — Standard Schema 2.0 language, runtime, and evidence architecture.
+- bADR-0012 — Model Source Package authority and artifact identities.
+- bADR-0015 — `migration` refusal stage and diagnostics.
+- bADR-0017 — template instantiation and explicit future template upgrades.
+- bADR-0018 — 2.x evidence-chain identity requirements.

--- a/libs/gda-balancing/docs/badr/0020-explicit-mappings-to-external-modeling-standards.md
+++ b/libs/gda-balancing/docs/badr/0020-explicit-mappings-to-external-modeling-standards.md
@@ -1,0 +1,140 @@
+---
+status: accepted
+---
+
+# Adopt explicit mechanisms from modeling standards without importing their runtimes or formats
+
+Standard Schema 2.0 draws on UCUM, MLIR, SBML, FMI, Modelica, and ONNX. Naming those systems without
+a mapping would be decorative borrowing: it would not tell an implementer which semantics are
+binding, which features are excluded, or how conformance is tested. Directly adopting all six
+formats/runtimes would instead create multiple authorities and a scope far beyond game balancing.
+
+PRD #534 therefore requires every external influence to be recorded as a Reference-standard
+mapping: adopted mechanism, local owner, rejected surface, and evidence. With one exception—pinned
+UCUM physical-unit semantics—the external documents remain provenance rather than runtime
+dependencies or alternative specifications.
+
+## Decision
+
+- **The Language Definition Bundle remains the sole local authority.** Every adopted mechanism is
+  restated as Standard Schema types, operations, lifecycle rules, verifier laws, lowering rules, and
+  normative vectors. A newer external-standard release never changes an existing Schema bundle
+  automatically. Adoption or upgrade requires an explicit bundle/package version and, where the
+  contract changes, a new bADR.
+
+- **UCUM 2.2 is the pinned physical-unit code and semantic substrate.** A physical Quantity uses a
+  case-sensitive UCUM 2.2 expression. Full conformance is required for parsing, canonical semantic
+  equality, commensurability, dimension, and conversion magnitude; literal-only “limited
+  conformance” is insufficient. UCUM annotations carry no semantics and cannot encode game kinds.
+  Health, mana, currencies, damage channels, and other game-only concepts remain namespaced nominal
+  kinds/units in Domain packages. Cross-kind conversion still requires an explicit bADR-0016
+  Conversion operation.
+
+- **MLIR contributes the operation/dialect/interface/conversion architecture only.** The local
+  mapping is:
+  - Domain package → dialect-like namespace;
+  - Operation specification → declarative operation definition;
+  - capability/effect contract → interface/trait-like contract;
+  - static legality → verifier;
+  - HIR-to-RIR lowering → conversion target plus explicit legal/illegal operations and typed
+    conversions.
+  Standard Schema 2.0 does not depend on MLIR libraries or TableGen, expose MLIR textual/bytecode
+  syntax, accept dynamic evaluator dialects, or make EIR portable. The local Operation
+  specification has game/runtime fields MLIR does not supply and remains authoritative.
+
+- **SBML Level 3 contributes modular core/package declarations and semantics-preserving
+  composition.** Standard Schema adopts explicit package use, required capability disclosure,
+  orthogonality, and deterministic flattening of composed source into a closed RIR. Unlike an SBML
+  tool that may preserve unsupported package content, this system fails closed on every unknown or
+  unsupported package/capability (bADR-0016). No SBML XML/RNG import/export, biological reaction
+  semantics, or claim of SBML conformance is included. Composition conformance is proved by
+  source-to-RIR identity/provenance plus golden and differential vectors.
+
+- **FMI 3.0.2 contributes lifecycle-state discipline, not FMU interoperability.** One execution
+  instance follows the local Runtime lifecycle:
+  - `instantiated`: exact RIR, Experiment Specification, Runtime profile, evaluator, inputs, and seed
+    are bound; no mutable state exists;
+  - `initializing`: initialization operations create and validate the first Snapshot boundary;
+  - `event`: the bADR-0014 scheduler executes atomic events at the current logical time;
+  - `step`: the scheduler advances to the next declared observation/logical boundary;
+  - `terminated`: terminal trace, snapshot, metrics, and evidence identities are sealed;
+  - reset: the runtime instance is discarded and a new initialization begins from the same immutable
+    artifacts, never by mutating RIR.
+  FMU archives, XML model descriptions, C ABI, Model Exchange, Co-Simulation, Scheduled Execution,
+  clocks, callbacks, and binary/source FMUs are not adopted.
+
+- **Modelica 3.6 contributes a reserved equation-modeling pattern, not an initial 2.0 package.**
+  `math.equation` is reserved but absent from the initial Language Definition Bundle and first
+  tracer. A later bADR and package admission must fix integrator and version, tolerance policy,
+  continuous-state Snapshot boundaries, zero-crossing/event coupling, deterministic resource
+  bounds, runtime-profile scope, and positive/negative/differential vectors before typed algebraic
+  equations or first-order ODEs may lower into RIR. Until then, source requesting the package is a
+  `resolution` refusal. The object-oriented class language, `connect` ecosystem, unrestricted
+  algorithms/functions, general high-index DAE solving, complete synchronous language, and
+  Modelica file compatibility remain excluded.
+
+- **ONNX contributes separation of model/IR/operator-set versions and namespaced operator domains.**
+  Standard Schema already separates Schema/LDB, artifact, package/opset, evaluator, and product
+  versions; Package Lock binds exact `(domain, operation-set version)`-like identities. Initial 2.0
+  has no ONNX model import, graph execution, tensor runtime, or inference dependency. Any future
+  learned-model Domain package requires its own decision and must bind exact model content, operator
+  domains/versions, runtime/evaluator, Numeric profile, determinism, resource bounds, and declared
+  effects before it can enter RIR.
+
+- **A mapping is admitted or claimed only with executable evidence.** The initial Language
+  Definition Bundle must carry UCUM vectors for parsing, equality, commensurability, conversion,
+  special/non-ratio behavior, and rejection of semantic annotations. MLIR/SBML-derived patterns
+  require verifier, package-resolution, conversion-legality, flattening, and cross-evaluator
+  vectors. FMI-derived lifecycle rules require legal/illegal transition vectors. The reserved
+  Modelica mapping initially requires a negative package-admission vector proving `math.equation`
+  cannot enter RIR; a later admission must add solvable, under/overdetermined, event, unit, numeric,
+  and resource-limit vectors. ONNX-derived version separation requires package/opset compatibility
+  vectors even before learned-model execution can be admitted. Until #534 supplies and validates
+  these vectors, this bADR records required mappings but makes no implementation/conformance claim.
+
+- **External names do not appear as unsupported marketing claims.** Documentation may say a
+  mechanism is “adopted from” the named version and link this bADR. It may not say Standard Schema is
+  FMI-, SBML-, Modelica-, MLIR-, UCUM-, or ONNX-compatible unless the full corresponding conformance
+  surface is later implemented and separately decided.
+
+## Considered options
+
+- **Explicit mechanism-by-mechanism mappings** (chosen) — captures mature design lessons while
+  preserving one local authority and testable scope.
+- **Treat all standards as informal inspiration** (rejected) — makes references unfalsifiable and
+  leaves reviewers unable to distinguish real adoption from terminology.
+- **Adopt each external format/runtime directly** (rejected) — creates incompatible authorities,
+  dependencies, and far more surface than RPG/Roguelike balancing needs.
+- **Use MLIR as the public RIR implementation** (rejected) — leaks compiler framework ABI into the
+  Standard Schema contract and conflicts with evaluator-specific EIR freedom.
+- **Use UCUM annotations for health/mana/currency** (rejected) — UCUM defines annotations as
+  semantically meaningless; package nominal kinds are the honest authority.
+- **Promise generic Modelica/SBML import** (rejected) — their full semantics exceed the restricted,
+  deterministic, resource-bounded core and would make refusal behavior ambiguous.
+- **Embed ONNX now for future ML balance models** (rejected) — no initial user story requires it;
+  versioning is useful now, inference is a separately justified package later.
+
+## Consequences
+
+- UCUM 2.2 becomes a normative dependency for physical-unit vectors and must be represented in the
+  Language Definition Bundle/version identity.
+- The compiler architecture can use generated operation definitions, interfaces, verifiers, and
+  legality-checked lowering without introducing an MLIR dependency.
+- Package composition and runtime lifecycle gain explicit conformance targets instead of framework
+  analogies.
+- The Equation package remains a named future extension rather than an underspecified runtime
+  bridge in the initial 2.0 bundle.
+- External-version updates are deliberate Schema/package evolution, never ambient dependency drift.
+
+## References
+
+- UCUM 2.2 specification (2024-06-17): https://unitsofmeasure.org/ucum
+- MLIR dialect, operation, interface, and conversion documentation:
+  https://mlir.llvm.org/docs/DefiningDialects/ and
+  https://mlir.llvm.org/docs/DialectConversion/
+- SBML Level 3 Version 2 Core Release 2 and package catalog:
+  https://sbml.org/documents/specifications/
+- FMI 3.0.2 specification: https://fmi-standard.org/docs/3.0.2/
+- Modelica Language Specification 3.6: https://specification.modelica.org/maint/3.6/
+- ONNX versioning and operator-set domains: https://onnx.ai/onnx/repo-docs/Versioning.html
+- PRD #534 and bADR-0012/0013/0014/0016 — local authority, IR, runtime, and package contracts.

--- a/libs/gda-balancing/docs/badr/0021-schema-2.0-cli-taxonomy-and-structured-surface.md
+++ b/libs/gda-balancing/docs/badr/0021-schema-2.0-cli-taxonomy-and-structured-surface.md
@@ -1,0 +1,145 @@
+---
+status: accepted
+---
+
+# Align the Schema 2.0 CLI with model, experiment, and evidence artifacts
+
+bADR-0007 organized the 1.x surface around a single Design document and reserved generic
+`evaluation` and `tuning` groups. Standard Schema 2.0 instead has Model Source Packages, package
+resolution, RIR builds, Experiment Specifications, Evaluation runs, Metric datasets, and evidence
+graphs. Retaining `design validate` or adding independent runtime flags would hide the new authority
+domains and allow command-line arguments to redefine an experiment.
+
+The descriptor, structured-output, atomic-write, and noun-group principles remain valuable. PRD
+#534 therefore replaces the 1.x nouns while making the previously deferred aggregate manifest and
+structured-params adapter part of the first vertical tracer.
+
+## Decision
+
+- **The binary remains `gda-balancing` with noun-group commands.** Registered domain commands use
+  `gda-balancing <group> <command>`. Tokens are kebab-case; delivery phase never appears in the
+  tree. `version`, `manifest`, and human-facing `help` remain ungrouped meta commands.
+
+- **The Standard Schema 2.x command taxonomy is:**
+
+  | Group | Commands | Authority/artifact boundary |
+  |---|---|---|
+  | `schema` | `get language-bundle`, `get wire-schema`, `get diagnostic-catalog` | emit the Language Definition Bundle or a named generated projection |
+  | `package` | `list`, `get` | enumerate or retrieve package definitions from one exact language bundle |
+  | `model` | `check`, `build`, `inspect`, `diff`, `migrate` | validate/resolve source, build or compare RIR artifacts, or attempt limited 1.x source conversion |
+  | `template` | `list`, `get`, `instantiate` | enumerate template releases or create a new Model Source Package identity |
+  | `experiment` | `check`, `run`, `replay`, `compare` | validate Experiment Specifications or produce/compare deterministic Evaluation runs and Metric datasets |
+  | `evidence` | `inspect`, `verify` | inspect or verify the immutable evidence graph and content identities |
+
+  `calibration` and `approval` are reserved noun groups. They are absent until their first vertical
+  commands have complete descriptors, bADR-0018 statistical/governance contracts, and conformance
+  fixtures. Invoking a reserved-but-undelivered group is an unknown-command usage error.
+
+- **There is no standalone `runtime` group.** Runtime execution requires an exact Resolved Model,
+  Experiment Specification, Runtime profile, evaluator, external inputs, and seed identity. Public
+  execution therefore enters through `experiment run` or `experiment replay`; free-form runtime
+  flags cannot become a fourth experiment authority.
+
+- **There is no standalone `metrics` group in the initial surface.** Metric definitions belong to
+  Experiment Specifications; Metric datasets are produced by experiment commands and verified as
+  evidence. A future independently justified transformation/ingestion workflow may add a noun group
+  through a new decision, but storage format alone is not a group.
+
+- **`model build` is the public compiler boundary.** It admits a Model Source Package and exact
+  Language Definition Bundle/resolution inputs, then returns identities/receipts for the generated
+  Package Lock, Resolved Model (RIR), Capability manifest, and compiler provenance.
+  `model check` performs the same gated front end without claiming or emitting a build artifact.
+
+- **`experiment run` is the public execution/evaluation boundary.** It admits artifact identities
+  rather than redefining source values in flags and returns the completed Evaluation run, Metric
+  dataset, trace/evidence identities, and verdict when applicable. `experiment replay` requires the
+  exact prior reproduction identities; it is replay of 2.x evidence, not 1.x migration.
+
+- **`manifest` ships with the first 2.x tracer.** It emits the Surface manifest by walking the live
+  Command-descriptor registry. Each registered entry carries command name/description, input,
+  success, optional verdict, and error schemas; execution markings; and artifact behavior. Help and
+  reserved/undelivered groups are excluded because they have no dispatchable descriptor.
+
+- **Every registered command ships `--schema`.** Its closed result contains `input`, `success`,
+  optional `verdict`, and `error`. `verdict` is present only for commands that can return exit 1;
+  `error` includes the applicable bADR-0015 usage/internal and stage-aware refusal variants. The
+  exact same models feed argv/structured binding, dispatch validation, manifest emission, and the
+  conformance harness.
+
+- **Structured params input ships with the first 2.x tracer.** `--params-json <json | ->` binds the
+  descriptor's typed input model, with `-` reading stdin. It is mutually exclusive with individual
+  argv fields; conflict is a usage error. Bare `--schema` takes precedence over all other arguments
+  and emits without reading artifacts or executing the handler. Structured input cannot express
+  fields the descriptor does not own.
+
+- **The Command descriptor remains the only registration seam.** In addition to bADR-0015 fields,
+  it owns artifact input/output roles and receipts, structured-params eligibility, and fixtures for
+  success, verdict, every applicable refusal stage, usage, internal fault injection, schema,
+  manifest, and stochastic reproduction. Parallel argument maps, command lists, error schemas, or
+  manifest rows are prohibited.
+
+- **Artifact output retains the safe bADR-0009 law.** Results always remain on stdout. `--out`
+  writes the descriptor-declared primary artifact atomically and adds its path/size/content identity
+  receipt to the success result; generated companion-artifact identities remain in the typed result.
+  Input artifacts are never mutated, direct/symlink aliasing of input and output is a usage error,
+  and failed invocations leave no partial authoritative output.
+
+- **Verb meanings are closed.** `get` retrieves one definition/artifact, `list` enumerates,
+  `instantiate` creates a new model authority from a template, `check` performs gated analysis,
+  `build` emits a resolved artifact, `run` executes a new experiment, `replay` repeats exact
+  reproduction identities, `compare` evaluates declared comparable artifacts, `inspect` returns
+  structured internal facts, `diff` returns semantic model differences, `verify` validates evidence
+  claims, and `migrate` attempts bADR-0019's limited conversion. `read`, `show`, `validate`, `format`,
+  `simulate`, `tune`, and other synonyms cannot enter the 2.x tree without amending this record.
+
+- **`version` reports distinct identities.** It returns the toolkit package version, supported
+  Standard Schema lines, Language Definition Bundle versions, and command-surface version without
+  conflating them. Schema 2.0 still does not imply product version 2.0.0.
+
+- **This decision supersedes bADR-0007 for the 2.x surface and the conflicting 2.x portions of
+  bADR-0009/0011.** It replaces the `design` group and reserved `evaluation`/`tuning` nouns, delivers
+  rather than defers `manifest`/`--params-json`, expands per-command schema outcomes, and extends the
+  descriptor/harness. It retains one binary, noun groups, explicit help, JSON channel discipline,
+  schema projection, safe output, input immutability, one descriptor registry, and exhaustive
+  conformance. The current 1.x CLI remains only until the clean-break tracer replaces it
+  (bADR-0019).
+
+## Considered options
+
+- **Artifact-oriented groups with experiment-owned runtime** (chosen) — mirrors authority domains
+  and prevents command flags from becoming hidden model/experiment definitions.
+- **Keep `design/evaluation/tuning`** (rejected) — encodes the 1.x single-document worldview and
+  obscures compiled/evidence artifacts.
+- **Expose `runtime run` with free flags** (rejected) — duplicates Experiment Specification authority
+  and makes reproduction inputs invisible.
+- **Expose every artifact type as a top-level group** (rejected) — storage nouns such as metrics,
+  locks, and traces do not each justify independent workflows.
+- **Continue deferring manifest and structured params** (rejected) — the 2.x surface is large and
+  agent-driven; the first tracer is the real consumer that justifies the adapters.
+- **Hand-maintain a CLI manifest** (rejected) — recreates command-surface drift beside the descriptor
+  authority.
+- **One generic `artifact` group** (rejected) — erases the domain actions and authority boundaries
+  agents need to choose a safe operation.
+
+## Consequences
+
+- The first 2.x tracer must register schema/model/template/experiment/evidence commands only as they
+  become executable; the manifest exposes exactly the delivered subset.
+- CLI schema and conformance fixtures cover success, optional Verdict, all applicable Refusal
+  stages, usage/internal failures, structured input, artifacts, and reproduction.
+- Existing 1.x command implementation/issues must be rewritten around the new descriptors rather
+  than aliased indefinitely.
+- Calibration and approval delivery require vertical command decisions but their noun ownership is
+  protected now.
+- Issue/README/help surfaces must use the same nouns and may not advertise reserved commands as
+  available.
+
+## References
+
+- PRD #534 — Standard Schema 2.0 language, runtime, and evidence architecture.
+- bADR-0007/0009/0011 — 1.x taxonomy, structured I/O, and descriptor contracts superseded for the
+  2.x surface only.
+- bADR-0012 — authored authority domains.
+- bADR-0015 — invocation outcomes and diagnostic locations.
+- bADR-0018 — metrics/evidence ownership.
+- bADR-0019 — clean break and limited migration.

--- a/libs/gda-balancing/docs/badr/0022-machine-readable-language-rules-and-formal-semantics.md
+++ b/libs/gda-balancing/docs/badr/0022-machine-readable-language-rules-and-formal-semantics.md
@@ -1,0 +1,166 @@
+---
+status: accepted
+---
+
+# Make structured language rules and a small semantic kernel the executable specification
+
+bADR-0012 makes the Language Definition Bundle the sole machine authority, and bADR-0013 fixes the
+AST/HIR/RIR/EIR pipeline. Those boundaries are incomplete unless the bundle can state name
+resolution, typing, effects, evaluation, and lowering without delegating meaning to one compiler's
+source code. A JSON shape plus prose Operation descriptions would recreate the validator/catalog
+split that 2.x was intended to close.
+
+At the same time, making the rule language self-host every primitive produces an infinite regress,
+and requiring a full theorem prover would block a practical reference implementation. PRD #534
+therefore chooses a small bootstrapped meta-format, structured formal judgments, and an honest
+proof/conformance boundary.
+
+## Decision
+
+- **The Language Definition Bundle is a canonical, content-addressed artifact.** Its manifest binds
+  the exact Schema line, bundle format, Semantic-kernel version, grammar/AST definitions, core type
+  constructors, Language rules, Operation specifications, Domain-package manifests, diagnostics,
+  Runtime/Numeric profiles, lowering rules, external-standard mappings, and normative vectors.
+  Canonical emission and hashing cover every normative member; changing normative content produces
+  a new bundle identity and compatible or breaking version as applicable.
+
+- **Language rules use one machine-readable meta-format.** Each rule has a stable id, phase,
+  structured premises, structured conclusion, bound metavariables, applicability/priority where
+  needed, and typed Diagnostic templates. The closed judgment families are:
+  - module/import and name-resolution judgments;
+  - type and Typed-effect-set judgments;
+  - pure-expression evaluation and explicit sampling judgments;
+  - event-runtime transition judgments;
+  - HIR-to-RIR legality and lowering judgments.
+  Human prose, generated docs, JSON Schemas, and reference code explain/project these records but
+  cannot add exceptions or override their result.
+
+- **The meta-format has a non-self-hosted bootstrap definition.** Its structural grammar,
+  metavariable binding/substitution, premise satisfaction, deterministic rule selection, and
+  diagnostic construction are fixed by the Schema-major bundle-format specification and normative
+  vectors. Implementations may compile rules for speed, but the bootstrap interpreter's observable
+  behavior is the conformance reference. Adding a judgment construct changes the bundle-format
+  major rather than entering as an evaluator special case.
+
+- **The Semantic kernel is intentionally small and closed.** It contains literals, typed reads,
+  versioned calls, conditionals, non-shadowing local bindings, statically bounded aggregates,
+  lookup, named-stream sampling, and the transition/event primitives required by bADR-0014.
+  Recursion, user-defined loops, unbounded collection traversal, reflection, dynamic operation
+  lookup, host callbacks, and ambient state are not kernel features.
+
+- **Domain operations are machine-defined compositions whenever possible.** An Operation
+  specification may give semantics as a typed kernel AST plus declared effects/resource bounds.
+  An operation that cannot be reduced to existing kernel composition is an irreducible kernel
+  operation: it requires a formal rule in the bundle, reference implementation, positive/negative/
+  boundary vectors, Runtime/Numeric-profile law, and a Schema-major review. Merely registering a
+  host-language function is never enough.
+
+- **Name resolution is explicit and deterministic.** Packages contain named modules. Imports are
+  selective or explicitly aliased; wildcard imports are forbidden. A declaration or local binding
+  cannot shadow another visible binding. Duplicate declarations, unresolved names, and ambiguous
+  aliases are `static` refusals. Successful resolution replaces every source reference with a
+  Resolved symbol identity containing exact Package-Lock version, module, and declaration identity;
+  HIR/RIR never repeat lookup heuristics.
+
+- **Public type contracts are annotated; inference is deliberately local.** Exported declarations,
+  state, parameters, inputs, outputs, random symbols, component fields, and Operation inputs/results
+  require explicit types and roles. Inference is limited to local bindings and contextually typed
+  literals. Records and Quantity kinds are nominal; generic containers are invariant; there is no
+  implicit subtyping, unit conversion, kind conversion, or numeric coercion. Every accepted
+  conversion is an explicit selected operation in Typed HIR.
+
+- **Typing includes effects.** The central static form is conceptually
+  `Γ ⊢ expression : type ! effects`, where effects include state reads/writes, signal emission,
+  event schedule/cancel, and named-stream sampling. An empty set denotes a pure expression. Calls
+  compose declared effects; effectful operations are legal only in event/experiment contexts whose
+  Operation specifications declare compatible, statically bounded effects. Hidden evaluator I/O is
+  non-conforming.
+
+- **Pure expressions use deterministic big-step semantics.** Given typed values and no effects,
+  evaluation returns exactly one typed value or a declared Runtime/evaluation refusal under the
+  selected Numeric profile. Sampling is not mislabeled pure: its separate judgment consumes and
+  returns one Named-random-stream state/value under the Runtime profile. Aggregate evaluation order
+  and bounds are explicit rules, never host-container order.
+
+- **Runtime behavior uses small-step transition semantics.** The runtime configuration contains the
+  committed snapshot, ordered event queue, named RNG-stream states, Runtime profile, budgets, and
+  trace. One step dispatches exactly one atomic Event transaction under bADR-0014, then commits a
+  uniquely determined next configuration or terminal refusal. Lifecycle transitions in bADR-0020
+  gate when initialization, event, step, termination, and reset judgments are legal.
+
+- **HIR-to-RIR lowering is a terminating rule relation to a canonical normal form.** Rules declare
+  legal source operation/type patterns, required capabilities, replacement RIR patterns, and
+  preservation obligations. A deterministic ordering and decreasing measure prevent rewrite loops.
+  The normal form has no unresolved name, implicit conversion, authoring sugar, or unbound optional
+  capability. The compiler emits rule/provenance ids so a build can explain its lowering.
+
+- **Observable preservation is tested and claimed narrowly.** For the kernel subset with written
+  rules, the specification may state progress/preservation propositions and maintain their proof or
+  mechanically checked argument. It does not label unproved Domain operations or optimizing
+  backends “formally verified.” HIR-to-RIR is guarded by rule-level preservation vectors; RIR-to-EIR
+  remains reference/differential conformance under bADR-0013.
+
+- **All secondary language surfaces are projections or reverse-conformance targets.** Structural
+  wire schemas, semantic Diagnostic catalogs, package/operation registries, evaluator dispatch
+  tables, generated documentation, CLI `--schema`/manifest entries, and reference tables derive from
+  the bundle where representable. If a target cannot be generated directly, a test enumerates it
+  back against the bundle and fails on missing, extra, or changed meaning.
+
+- **Resource safety is part of the rules.** Grammar depth/bytes, module/import graph, symbols,
+  rule-match steps, type-instantiation depth, aggregate bounds, lowering rewrites, diagnostics, and
+  generated artifact sizes have deterministic caps in the bundle/Runtime profile. Exhaustion is a
+  stage-appropriate typed refusal, never partial RIR or an implementation timeout presented as
+  semantics.
+
+- **This decision supersedes bADR-0005's rejection of executable semantic-rule representation for
+  2.x and bADR-0003's reference-evaluator authority.** In 1.x, a rule DSL would have duplicated a
+  small validator. In 2.x, the language rules are the sole authority from which validators and
+  evaluators are derived or checked. bADR-0005's anti-drift, honest structural/semantic split,
+  canonical emission, and stable diagnostic identity are retained. Existing 1.x contracts remain
+  historical under the clean break in bADR-0019.
+
+## Considered options
+
+- **Structured rules plus a closed bootstrap kernel** (chosen) — makes semantics machine-readable
+  without making one compiler implementation normative.
+- **Prose specification plus reference interpreter** (rejected) — leaves ambiguity when prose and
+  code disagree and cannot generate or exhaustively check projections.
+- **Reference implementation source as authority** (rejected) — prevents independent evaluator
+  conformance and hides semantic changes in ordinary refactors.
+- **Self-host every rule including the rule meta-language** (rejected) — creates an unnecessary
+  bootstrap regress and makes bundle admission impossible to validate independently.
+- **General-purpose executable rule scripts** (rejected) — reintroduce unbounded execution, host
+  effects, and evaluator-specific meaning.
+- **Global type inference, structural records, or implicit coercions** (rejected) — make public
+  contracts unstable under extension and obscure HIR/RIR semantics.
+- **Require machine-checked proofs for every package operation** (rejected as the baseline) — the
+  enforceable contract is structured semantics plus vectors/differential conformance; stronger
+  proofs remain allowed and accurately scoped.
+
+## Consequences
+
+- The first tracer must implement the bundle bootstrap parser/interpreter, not a parallel set of
+  handwritten registries.
+- `docs/standard-schema-2.0/` records the open Genre coverage contract and executable-specification
+  gates. It deliberately contains no placeholder bundle: #534 remains open until a closed bootstrap
+  schema, exhaustive rules, artifact shapes, profiles, and executable vectors are supplied together.
+- A minimal bundle can start with only the kernel and RPG-tracer packages, then add packages through
+  versioned manifests and conformance vectors without changing the core grammar.
+- Compiler diagnostics can identify the exact Language rule and source/artifact locations that
+  caused a refusal or lowering.
+- Formal-spec work now has bounded deliverables: resolution rules, type/effect rules, pure/sample
+  evaluation, atomic runtime steps, lowering rules, and their declared proof/conformance boundary.
+- Global consistency review must verify that every 2.x glossary term and bADR uses this authority
+  chain and does not introduce a hand-maintained semantic peer.
+
+## References
+
+- PRD #534 — Standard Schema 2.0 language, runtime, and evidence architecture.
+- `docs/standard-schema-2.0/` — open specification gates and Genre coverage matrix.
+- bADR-0003/0005 — 1.x evaluator/self-description authority choices superseded for 2.x only.
+- bADR-0012 — Language Definition Bundle authority.
+- bADR-0013 — compiler stages and semantic equivalence boundary.
+- bADR-0014 — atomic event runtime.
+- bADR-0016 — type and Operation/package contracts.
+- bADR-0020 — explicit external-standard mappings.
+- bADR-0021 — CLI projection and Command-descriptor surface.

--- a/libs/gda-balancing/docs/standard-schema-2.0/README.md
+++ b/libs/gda-balancing/docs/standard-schema-2.0/README.md
@@ -1,0 +1,25 @@
+# Standard Schema 2.0 specification work
+
+This directory holds acceptance artifacts for the Standard Schema 2.0 specification tracked by
+PRD #534. The architecture and authority decisions are bADR-0012…0022. They do not make the 2.0
+language, runtime, CLI, or genre templates implemented.
+
+The current artifact is [`genre-coverage.md`](genre-coverage.md): the open RPG/Roguelike
+requirements-to-operations matrix used to judge the future Language Definition Bundle and vertical
+tracer. Every row is open. It is a completeness contract, not evidence that the package operations,
+Golden scenarios, or vectors already exist.
+
+PRD #534 remains open until a later implementation/specification PR supplies and validates:
+
+1. the closed Language Definition Bundle bootstrap schema and canonical bundle;
+2. exhaustive machine rules for grammar, resolution, types/effects, evaluation, runtime steps, and
+   HIR-to-RIR lowering;
+3. closed AST, Typed HIR, RIR, package-manifest, profile, experiment, Metrics, Evaluation-run, and
+   evidence artifact schemas;
+4. exact Numeric-profile and RNG/stream/sampling laws;
+5. executable fixture inputs with canonical outputs/refusals for every required vector; and
+6. public-CLI closure of every `Tracer` row before broader RPG/Roguelike support claims.
+
+Free-text operation descriptions, lists of node names, or vectors containing only expected prose do
+not satisfy those gates. They must not be presented as an executable or content-addressed bundle.
+`math.equation` is reserved and refused until its separate continuous-runtime contract is accepted.

--- a/libs/gda-balancing/docs/standard-schema-2.0/genre-coverage.md
+++ b/libs/gda-balancing/docs/standard-schema-2.0/genre-coverage.md
@@ -1,0 +1,93 @@
+# RPG and Roguelike Genre coverage matrix
+
+This matrix is the open representational-adequacy contract required by bADR-0017. It defines what a
+future support claim must prove; it is not evidence that Standard Schema 2.0 or a genre template is
+implemented. Every row is currently `open`. A support claim becomes valid only when every inherited
+row has an admitted operation, executable Golden scenario, executable negative/boundary vector, and
+observable evidence field.
+
+The ids below reserve the intended operation and fixture boundaries for review, but do not enter the
+machine authority merely by appearing here. The Language Definition Bundle must admit or explicitly
+revise them, provide their closed types and semantics, and carry executable fixture inputs plus
+canonical expected artifacts/outcomes. Prose expectations do not close a row.
+
+`Tracer` rows are the first vertical implementation gate. `RPG` rows must close before a general
+RPG template-release claim. `Roguelike` rows add to all `Tracer` and `RPG` rows before a Roguelike
+template-release claim. `Variant` rows close only when a release selects their optional capability;
+they are not inherited by every genre. CRPG/JRPG/ARPG and metroidvania-like/survivors-like/
+deckbuilder-like releases may add rows but cannot waive inherited baseline rows.
+
+## Matrix
+
+| Gate / requirement | Normative requirement | Capability and operation ids | Package boundary exercised | Golden scenario | Negative or boundary vector | Required observable |
+|---|---|---|---|---|---|---|
+| Tracer `RPG-STAT-01` | Compose explicitly typed base/parameter/state symbols into derived combat values through progression, build and effect contributions with declared kind, unit, rounding and cap laws. | `core.typed-symbols-v1`; `core.expression.derive@1`; `game.build.contribution@1`; `game.progression.contribution@1`; `game.effect.contribute@1` | core owns nominal typing/formula evaluation; packages own independently composable contribution sources | `rpg.stat.composition-v1` | `rpg.stat.dependency-cycle-refused-v1`; `rpg.stat.kind-unit-mismatch-refused-v1`; `rpg.stat.round-cap-boundary-v1` | resolved dependency graph, contribution provenance, Numeric profile and final typed Quantity |
+| Tracer `RPG-TARGET-01` | Resolve targets from the current dynamic entity set with declared filtering, cardinality, stable order, tie and empty behavior. | `game.entity.dynamic-sets-v1`; `game.query.dynamic-targets-v1`; `game.query.select@1` | entity owns membership; query owns selection; action consumes resolved refs | `rpg.combat.cast-v1` | `rpg.target.empty-refused-v1` | target ids/order and `target_count` Metric sample |
+| Tracer `RPG-COST-01` | Reserve an action cost, commit it exactly once, and make insufficient funds an explicit typed outcome. | `game.resource.atomic-cost-v1`; `game.resource.reserve@1`; `game.resource.commit@1`; `game.action.begin@1` | resource owns quantity/reservation; action owns lifecycle | `rpg.combat.cast-v1` | `rpg.resource.insufficient-refused-v1` | reservation/commit trace, before/after resource Quantity |
+| RPG `RPG-RESOURCE-02` | Regenerate a typed resource by a declared rate/domain while action cooldown state gates reuse independently. | `game.resource.regeneration-v1`; `game.resource.regenerate@1`; `game.action.cooldown-v1`; `game.action.set-cooldown@1` | resource owns current/capacity/rate; action owns cooldown lifecycle | `rpg.resource.regeneration-cooldown-v1` | `rpg.resource.capacity-boundary-v1`; `rpg.action.cooldown-active-outcome-v1` | applied/clamped regeneration, cooldown deadline and next legal action time |
+| Tracer `RPG-CHECK-01` | Resolve threshold or opposed hit checks with named randomness, explicit tie policy, and success degree. | `game.check.typed-resolution-v1`; `game.check.resolve@1` | check owns resolution; combat consumes the typed outcome | `rpg.combat.cast-v1` | `rpg.check.tie-policy-missing-v1` | stream identity/draw index and `hit_degree` Metric sample |
+| Tracer `RPG-DAMAGE-01` | Apply critical and typed damage through declared stages. | `game.combat.staged-damage-v1`; `game.combat.resolve-damage@1` | check produces outcome; combat owns stages; resource owns health-like current value | `rpg.combat.cast-v1` | `rpg.combat.kind-mismatch-v1` | per-stage trace and final typed Quantity |
+| RPG `RPG-HEAL-01` | Apply typed healing, amplification/reduction, caps and revival policy without treating healing as negative damage. | `game.combat.staged-healing-v1`; `game.combat.resolve-healing@1` | combat owns healing stages; resource owns current/capacity; entity owns defeat/revival state | `rpg.combat.healing-v1` | `rpg.combat.revival-not-allowed-outcome-v1` | per-stage healing, cap/clamp result and defeat/revival transition |
+| Tracer `RPG-DEFENSE-01` | Apply mitigation, resistance, shields, health and defeat in one stable order. | `game.combat.staged-damage-v1`; `game.combat.resolve-damage@1` | combat owns defense stages; entity owns target identity | `rpg.combat.cast-v1` | `rpg.combat.defeat-order-boundary-v1` | stage contributions, shield/health deltas and defeat transition |
+| Tracer `RPG-EFFECT-01` | Apply an effect with immunity, stack identity/cap, and explicit reapplication policy. | `game.effect.lifecycle-v1`; `game.effect.apply@1` | effect owns lifecycle; combat/action only consume effect outcomes | `rpg.effect.stack-immunity-v1` | `rpg.effect.immunity-outcome-v1`; `rpg.effect.stack-cap-boundary-v1` | effect instance ids, stack count, immunity/reapply outcome |
+| Tracer `RPG-EFFECT-02` | Capture declared fields at snapshot time and read declared live fields without hidden evaluator reads. | `game.effect.lifecycle-v1`; `game.effect.apply@1` | effect declares capture/read effects; entity/resource own fields | `rpg.effect.stack-immunity-v1` | `rpg.effect.live-read-undeclared-v1` | capture source/version and value in effect trace |
+| Tracer `RPG-ACTION-01` | Interrupt an active action, cancel its resolution event, and apply declared refund policy. | `game.action.lifecycle-v1`; `game.action.begin@1`; `game.action.interrupt@1` | action owns interruption; resource owns refund/commit; runtime owns cancellation | `rpg.combat.cast-v1` | `rpg.action.interrupt-after-complete-v1` | action state, canceled event id and refund outcome |
+| Tracer `RPG-ACTION-02` | Resolve and complete an admitted action exactly once, committing its reservation and scheduling cooldown/declared child effects atomically. | `game.action.lifecycle-v1`; `game.action.resolve@1`; `game.action.complete@1`; `game.resource.commit@1` | action owns resolution/completion; resource owns cost commit; runtime owns atomic event commit | `rpg.combat.cast-v1` | `rpg.action.duplicate-completion-refused-v1` | action-state transitions, one cost commit, child-event ids and cooldown state |
+| Tracer `RPG-REACTIVE-01` | Let a Model Source Package declare a passive/reactive subscription to a typed Signal, then execute all resolved subscribers in stable order inside the emitting Event transaction. | `core.signal-subscription-v1`; `game.combat.damage-resolved-signal-v1`; `game.effect.react@1`; `game.action.react@1` | packages own signal/handler contracts; model owns topology; RIR owns resolved table; runtime owns same-snapshot atomic delivery | `rpg.reactive.passive-v1` | `rpg.reactive.illegal-subscription-refused-v1`; `rpg.reactive.unbounded-cycle-refused-v1`; `rpg.reactive.order-boundary-v1` | authored/resolved subscriber ids, stable dispatch order, shared pre-event snapshot and commit/rollback trace |
+| Tracer `RPG-EVIDENCE-01` | Finish the encounter and emit shared typed Metrics and evidence from the final committed snapshot. | `game.encounter.dynamic-waves-v1`; `game.encounter.advance@1`; `experiment.balance.metrics-v1`; `experiment.balance.observe@1` | encounter owns terminal condition; experiment owns Metric definition | `rpg.combat.cast-v1` | `rpg.metrics.missing-dimension-refused-v1` | Evaluation-run id, terminal snapshot, Metric dataset and assertion prerequisites |
+| RPG `RPG-EFFECT-03` | Expire, remove, and dispel effects under declared legality and cleanup rules. | `game.effect.lifecycle-v1`; `game.effect.remove@1` | effect owns removal; runtime owns scheduled expiry/cancel | `rpg.effect.stack-immunity-v1` | `rpg.effect.illegal-dispel-outcome-v1` | removal cause, expiry event/cancel identity and remaining stacks |
+| RPG `RPG-EFFECT-04` | Compute declared continuous/discrete contributions and transition effect state without hidden write ordering. | `game.effect.contribution-v1`; `game.effect.contribute@1`; `game.effect.transition@1` | effect owns contribution/transition law; receiving package owns reduced target slot; runtime owns one-final-write/reducer rule | `rpg.effect.contribution-transition-v1` | `rpg.effect.missing-reducer-refused-v1` | contributor order/identity, reducer result, old/new effect state and scheduled transition |
+| RPG `RPG-BUILD-01` | Enforce build prerequisites, exclusions, slots and explicit synergy declarations. | `game.build.constraints-v1`; `game.build.select@1` | build owns selection; economy owns item possession | `rpg.build-progression-loot-v1` | `rpg.build.exclusion-outcome-v1` | accepted/rejected choice, prerequisite path and active synergies |
+| RPG `RPG-PROGRESSION-01` | Award typed progression and emit all crossed unlocks in stable threshold order. | `game.progression.unlocks-v1`; `game.progression.award@1` | progression owns thresholds/unlocks; build may consume unlocks | `rpg.build-progression-loot-v1` | `rpg.progression.unlock-order-boundary-v1` | progression before/after and ordered unlock ids |
+| RPG `RPG-LOOT-01` | Generate constrained loot, transfer it through inventory/economy, then validate build eligibility. | `game.generation.constrained-reward-v1`; `game.generation.draw@1`; `game.economy.transfer-v1`; `game.economy.transfer@1`; `game.build.select@1` | generation chooses; economy transfers; build equips/selects | `rpg.build-progression-loot-v1` | `rpg.loot.inventory-capacity-outcome-v1` | stream/draw, generated asset, transfer result and build result |
+| Variant `RPG-TURN-SPATIAL-01` | When selected, optional turn/spatial packages compose without changing core logical-time phases or target-query rules. | `game.turn.windows-v1`; `game.turn.advance@1`; `game.spatial.queries-v1`; `game.spatial.query@1`; `game.query.select@1` | turn owns windows; spatial owns geometry; query owns final selection; runtime owns phases | `rpg.turn-spatial-target-v1` | `rpg.turn.hidden-phase-refused-v1` | phase key, turn/window id, spatial candidates and final target order |
+| Roguelike `ROGUE-REWARD-01` | Draw seeded constrained rewards with rarity and guarantee behavior. | `game.generation.constrained-reward-v1`; `game.generation.draw@1` | generation owns draw/guarantee; build/economy consume result | `roguelike.reward-build-v1` | `roguelike.reward.guarantee-exhaustion-refused-v1` | stream/draw indexes, eligible pool, rarity and guarantee state |
+| Roguelike `ROGUE-BUILD-01` | Apply run-time build conflicts and synergies to generated rewards. | `game.build.constraints-v1`; `game.build.select@1`; `game.generation.draw@1` | generation proposes; build admits/rejects; economy transfers admitted result | `roguelike.reward-build-v1` | `roguelike.build.conflict-outcome-v1` | conflict ids, synergy changes and disposition of rejected reward |
+| Roguelike `ROGUE-ENCOUNTER-01` | Compose dynamic encounter/wave state with bounded deterministic spawning and terminal objectives. | `game.encounter.dynamic-waves-v1`; `game.encounter.advance@1`; `game.entity.spawn@1` | encounter owns schedule/objectives; entity owns spawned instances | `roguelike.encounter-waves-v1` | `roguelike.encounter.spawn-cap-refused-v1` | wave/objective trace, spawn order and terminal state |
+| Roguelike `ROGUE-RESET-01` | Clear all Run-scoped state and retain only declared typed transfers into Meta scope. | `game.run.scope-reset-v1`; `game.run.reset@1` | packages declare slot scope; run owns teardown/retention transaction | `roguelike.run-reset-v1` | `roguelike.run.implicit-retention-refused-v1` | cleared Run-slot inventory, retained transfer list and post-reset snapshot |
+| Roguelike `ROGUE-REPLAY-01` | Reproduce the same RIR outcomes, trace, Metrics and evidence under identical reproduction identities. | core replay contract; all operations exercised by the scenario | bundle/RIR/runtime/experiment identities jointly define replay | `roguelike.replay-v1` | `roguelike.replay.identity-mismatch-refused-v1` | reproduction key, ordered trace/Snapshot hashes, Metric/evidence identities |
+
+## Golden scenario contracts
+
+- `rpg.stat.composition-v1`: base and tunable typed symbols combine progression, equipment and
+  effect contributions into a derived combat Quantity with explicit rounding/cap behavior.
+- `rpg.combat.cast-v1`: a dynamic caster targets one enemy, reserves mana, resolves a named-stream
+  hit/critical check, applies staged typed damage and an effect, exercises interruption, terminates
+  the encounter, and emits Metrics/evidence through `experiment run`.
+- `rpg.effect.stack-immunity-v1`: snapshot/live capture, immune target, stack cap, reapplication,
+  expiry, dispel, and trace atomicity are exercised without action/combat owning effect lifecycle.
+- `rpg.effect.contribution-transition-v1`: multiple typed contributions use a declared reducer and
+  one effect-state transition schedules its next legal boundary without hidden write order.
+- `rpg.resource.regeneration-cooldown-v1`: regeneration reaches a typed capacity boundary while an
+  independent action cooldown blocks and later admits reuse.
+- `rpg.combat.healing-v1`: staged typed healing exercises caps, reduction/amplification and explicit
+  no-revival/revival policy.
+- `rpg.reactive.passive-v1`: a model-authored passive subscribes to a typed combat Signal; multiple
+  resolved subscribers prove stable order, same-snapshot visibility and atomic rollback behavior.
+- `rpg.build-progression-loot-v1`: progression unlocks a build choice; constrained generation
+  yields loot; economy transfers it; build validates prerequisites/exclusions/synergies.
+- `rpg.turn-spatial-target-v1`: optional turn windows and spatial candidates feed the unchanged
+  typed target-query operation while the scheduler retains the three core phases.
+- `roguelike.reward-build-v1`: seeded rarity/guarantee generation composes with run-local build
+  conflicts, synergies, and inventory transfer.
+- `roguelike.encounter-waves-v1`: objectives advance bounded waves and dynamic spawns to a terminal
+  encounter.
+- `roguelike.run-reset-v1`: terminal run state is torn down and only declared typed rewards enter
+  Meta scope.
+- `roguelike.replay-v1`: the reward, encounter, and reset path runs twice under one reproduction
+  key and produces byte-identical canonical observations.
+
+## Closure rules
+
+A row is `closed` only when all referenced package/operation ids exist in the admitted bundle, the
+Golden and negative/boundary vector ids are in its vector inventory, and the public CLI artifacts
+contain every required observable. A typed gameplay outcome may satisfy a negative vector when the
+model explicitly declares that branch; invalid language/runtime conditions must use the bADR-0015
+refusal path. A test that reaches private evaluator state or uses an unregistered helper does not
+close the row.
+
+Adding an ordinary game-specific attribute adds a nominal Quantity declaration or component field;
+it changes neither the core type constructor set nor this matrix. A row changes only when a genre
+support requirement or reusable mechanism changes. Adding that reusable mechanic requires a
+versioned package capability/operation, rule semantics, diagnostics and vectors, then updates every
+affected row. This is the extension test for consistency, orthogonality, and coverage.


### PR DESCRIPTION
## Summary

- define Standard Schema 2.0 authority domains, compiler/IR boundaries, deterministic atomic-event runtime, typed outcomes, package/type extension model, evidence chain, CLI taxonomy, and formal-language requirements;
- adopt a clean forward baseline with best-effort semantics-preserving 1.x source conversion only; unsupported constructs are deprecated/refused, with no unpublished save/effect/replay/ruleset compatibility layer;
- update the balancing glossary and package-local agent guidance to distinguish transitional 1.x contracts from 2.x decisions;
- add an explicitly open RPG/Roguelike requirements-to-operations coverage matrix, including typed stat composition, reactive Signal subscriptions, and optional variant gates.

## Scope boundary

This architecture PR does not close #534 and does not claim that an executable Language Definition Bundle, compiler/runtime, CLI, normative fixtures, or genre template already exists. The specification gates and every Genre coverage row remain open until a later implementation/specification PR supplies closed machine rules, artifact/profile schemas, Numeric/RNG laws, executable inputs, and canonical outcomes.

The RPG-template failure is traced to Standard Schema 1.x language/package/runtime boundaries rather than missing template defaults. PR #533 was closed instead of extending the wrong abstraction.

## Validation

- 366 tests passed, 17 skipped
- Pyright: 0 errors, 0 warnings, 0 informations
- source distribution and wheel built successfully
- git diff whitespace check passed
- independent review subagent: PASS after Standards/Spec rechecks and four design-axis checks

Tracks #534.
