### PR TITLE
feat(gda-balancing)!: publish Schema 2.0 Kernel and LDB authority

### DIFF
--- a/libs/gda-balancing/README.md
+++ b/libs/gda-balancing/README.md
@@ -10,27 +10,31 @@ A standalone, engine- and game-agnostic sibling product of `gda` — it neither 
 extends `gda`; its CLI follows the family's interface conventions.
 
 - Requirements: [PRD #501](https://github.com/aigengame/godot-agent/issues/501)
-- Milestones: [Phase 1 — numeric design & config templates](https://github.com/aigengame/godot-agent/milestone/8) ·
-  [Phase 2 — balance simulation](https://github.com/aigengame/godot-agent/milestone/9)
-- Status: Phase 1 in progress. The Standard Schema core ships — a Design document validates
-  through the boundary funnel, round-trips as canonical JSON, and the schema describes
-  itself. Genre templates, evaluation, and tuning are still ahead; the package is **not
-  published to PyPI yet**.
+- Milestones: [Phase 1 — Schema 2.0 language & model foundation](https://github.com/aigengame/godot-agent/milestone/8) ·
+  [Phase 2 — runtime, evidence & genre closure](https://github.com/aigengame/godot-agent/milestone/9)
+- Status: Phase 1 in progress. The first permanent Schema 2.0 Kernel/LDB authority and command
+  discovery slice ships alongside the transitional 1.x Design commands. Model compilation,
+  runtime, evidence, and Genre/template closure are still ahead; the package is **not published
+  to PyPI yet**.
 
 ## Commands
 
 ```bash
 gda-balancing design validate <document>   # validate through the boundary funnel
 gda-balancing design format <document>     # emit the validated document, canonically
-gda-balancing schema get structural        # the JSON Schema 2020-12 artifact
-gda-balancing schema get catalog           # the semantic rule catalog
+gda-balancing schema get language-bundle   # admitted Kernel/LDB authority pair
+gda-balancing schema get wire-schema       # exact generated wire-schema projection
+gda-balancing schema get diagnostic-catalog # exact generated Diagnostic projection
+gda-balancing manifest                     # delivered Schema 2.0 command surface
 gda-balancing version                      # package version + supported Schema line
 ```
 
 Every command emits one JSON document: the typed result on stdout at exit 0, or an error
 envelope — `refusal` (exit 2, on stdout), `usage` (exit 3) or `internal` (exit 4). Add
-`--schema` to any command for its input/output/error contract, or `--out <path>` to an
-artifact-emitting command to write the artifact to a file and get a receipt on stdout.
+`--schema` to any command for its closed input/result/error contract, or `--out <path>` to an
+artifact-emitting command to write the artifact to a file and get a receipt on stdout. Every
+Schema 2.0 command also accepts `--params-json <json | ->`; `-` reads the same descriptor-owned
+input object from stdin, and structured input is mutually exclusive with individual argv fields.
 
 ## Development
 

--- a/libs/gda-balancing/docs/ARCHITECTURE.md
+++ b/libs/gda-balancing/docs/ARCHITECTURE.md
@@ -35,9 +35,12 @@ module, or prototype may become an accidental second specification.
 | Conformance vectors | Executable proof obligations derived from Kernel and LDB authority | New semantic decisions |
 | Prototype code | Disposable evidence used to challenge the design | Architecture, language, or product authority |
 
-The Kernel Specification and LDB are future machine-readable artifacts. Until they exist and pass
-independent conformance, this document and the accepted bADRs state the design but cannot prove that
-two implementations will interpret it identically.
+The first permanent, machine-readable Kernel Specification and LDB are published under
+`src/gda_balancing/schema2/authorities/` and independently admitted for #538's bounded Quantity
+foundation. They prove the bootstrap, identity, closed meta-format, two selected rules, Diagnostic
+reason closure, generated projections, and command discovery of that admitted slice only. They do
+not yet prove the complete language, Model build, Runtime, Experiment, Evidence, or Genre contracts;
+the remaining gates below grow the same authorities vertically.
 
 When this document and an accepted bADR appear to conflict, neither silently overrides the other.
 The conflict must be reconciled in the same change: the bADR records the detailed decision and this
@@ -839,6 +842,13 @@ package resolution, identity, audit/publication, CLI, comparison, and Evidence p
 that slice. This is not a horizontal implementation of every rule or package. Gate 3 grows the same
 suite source-to-evidence; later gates add general resolver, cross-LDB identity, broader publication,
 and Evidence cases as their vertical scenarios require them.
+
+Issue #538 delivers the first bounded sub-slice of this gate: packaged content-addressed Kernel/LDB
+authority, independent bootstrap/rule/reason conformance, one typed-Quantity source schema, exact
+wire/Diagnostic projections, and descriptor-derived `schema get`/`manifest` discovery. Numeric/RNG,
+selected package resolution, publication, comparison, and Evidence obligations named above remain
+open until the vertical tracer that first exercises each contract lands; #538 makes no success claim
+for those absent artifact domains.
 
 Gate 2 follows bADR-0012's dependency order: permanent Kernel/LDB and encoding/identity/schema
 authorities → bounded artifact/graph/terminal-audit validation → authenticated eligible independent

--- a/libs/gda-balancing/docs/standard-schema-2.0/README.md
+++ b/libs/gda-balancing/docs/standard-schema-2.0/README.md
@@ -23,13 +23,17 @@ Quantity slice:
   fact/term/rule/reason formats, unique rule selection, binding/substitution, Diagnostic closure,
   and deterministic resource bounds.
 - `src/gda_balancing/schema2/authorities/language-bundle.json` binds that exact Kernel and owns the
-  seven Quantity symbol roles, selected representation/kind/unit/domain/Numeric policy, one complete
-  package release, two executable Quantity rules, post-admission Diagnostic reasons, one Model
-  Source wire schema, and their normative vectors.
+  seven Quantity symbol roles, selected representation/kind/unit/domain/Numeric policy, one closed
+  content-addressed `core.quantity` package release, two executable Quantity rules,
+  post-admission Diagnostic reasons, the admitted Model Source schema-version inventory, one Model
+  Source wire schema bound to that inventory, and their normative vectors.
 - The production bootstrap consumer and a separately implemented conformance consumer agree on
   exact identities, law/rule/reason inventories, generated projection identities, positive vectors,
   and old-identity/reidentified deletion/behavior/token mutations. Neither contains a Quantity host
   dispatch fallback.
+- This bounded authority admits the closed Quantity constructor and Model Source wire-schema
+  envelope. Components, Conversions, Operations, and Runtime Profiles remain explicitly empty;
+  admission refuses those definitions until their declarative Kernel contracts are delivered.
 - `schema get language-bundle|wire-schema|diagnostic-catalog`, `manifest`, per-command `--schema`,
   and `--params-json <json|->` expose the admitted slice through the descriptor-owned 2.x surface.
   Admission failures use bounded, ordered, deduplicated, stage-aware Diagnostics.

--- a/libs/gda-balancing/docs/standard-schema-2.0/README.md
+++ b/libs/gda-balancing/docs/standard-schema-2.0/README.md
@@ -3,13 +3,41 @@
 This directory holds acceptance artifacts for the Standard Schema 2.0 specification tracked by
 PRD #534. [`../ARCHITECTURE.md`](../ARCHITECTURE.md) is the human-readable macro architecture
 authority; bADR-0012…0022 own the binding detailed decisions; and PRD #534 owns requirements,
-acceptance criteria, and live completion status. These documents do not make the 2.0 language,
-runtime, CLI, or genre templates implemented.
+acceptance criteria, and live completion status. These documents do not by themselves make the 2.0
+language, runtime, CLI, or genre templates implemented. Issue #538 now supplies the first permanent
+machine authority and public discovery slice described below; all broader delivery claims remain
+bounded by PRD #534 and the coverage matrix.
 
 The current artifact is [`genre-coverage.md`](genre-coverage.md): the open RPG/Roguelike
 requirements-to-operations matrix used to judge the future Language Definition Bundle and vertical
 tracer. Every row is open. It is a completeness contract, not evidence that the package operations,
 Golden scenarios, or vectors already exist.
+
+## Permanent authority foundation (#538)
+
+The first production foundation replaces the disposable authority mechanism for one admitted
+Quantity slice:
+
+- `src/gda_balancing/schema2/authorities/kernel.json` is the versioned, content-addressed,
+  non-self-hosted Kernel Specification for canonical encoding, identity, admission, closed
+  fact/term/rule/reason formats, unique rule selection, binding/substitution, Diagnostic closure,
+  and deterministic resource bounds.
+- `src/gda_balancing/schema2/authorities/language-bundle.json` binds that exact Kernel and owns the
+  seven Quantity symbol roles, selected representation/kind/unit/domain/Numeric policy, one complete
+  package release, two executable Quantity rules, post-admission Diagnostic reasons, one Model
+  Source wire schema, and their normative vectors.
+- The production bootstrap consumer and a separately implemented conformance consumer agree on
+  exact identities, law/rule/reason inventories, generated projection identities, positive vectors,
+  and old-identity/reidentified deletion/behavior/token mutations. Neither contains a Quantity host
+  dispatch fallback.
+- `schema get language-bundle|wire-schema|diagnostic-catalog`, `manifest`, per-command `--schema`,
+  and `--params-json <json|->` expose the admitted slice through the descriptor-owned 2.x surface.
+  Admission failures use bounded, ordered, deduplicated, stage-aware Diagnostics.
+
+This foundation proves only its admitted authority and command loop. It publishes no Model, Package
+Lock, RIR, Resolved Model, Runtime profile, Experiment, Metric, Replay, Evidence, template, or Genre
+success artifact, and it closes no Genre row. Issue #539 is the first consumer that may extend the
+same permanent authority into a Model-build vertical slice.
 
 ## Prototype evidence
 
@@ -95,13 +123,13 @@ decision introduces a new semantic root, open host extension, or cross-artifact 
 
 ## Next validation gates
 
-1. The bounded executable Kernel/LDB authority mechanism gate is complete. Its contracts must now
-   be replaced by permanent versioned Kernel/LDB artifacts and normative conformance vectors;
-   disposable code remains non-authoritative and closes no acceptance criterion.
-2. Build the permanent conformance foundation from the authority gate and the completed
-   Orthogonality/extensibility mechanism probe: versioned Kernel/LDB artifacts, authoritative
-   vectors, and the required identity, package, Operation, Experiment, audit, descriptor, and
-   publication contracts.
+1. The bounded disposable authority mechanism has been replaced for #538's admitted Quantity
+   foundation by permanent versioned Kernel/LDB artifacts and normative bootstrap/rule/reason
+   vectors. Disposable code remains non-authoritative and closes no acceptance criterion.
+2. Issue #539 must consume that exact foundation to build one Model Source through selected Lock,
+   canonical RIR, Resolved Model, independent lowerers, and atomic public artifact publication.
+   Later tracers extend the same authorities with Operation, Experiment, audit, comparison, and
+   Evidence contracts only when their vertical paths exercise them.
 3. A production RPG tracer must then close its required
    vertical coverage rows and public artifact path.
 4. A Roguelike cross-genre tracer follows only after those gates pass; it must reuse the same kernel,

--- a/libs/gda-balancing/src/gda_balancing/cli.py
+++ b/libs/gda-balancing/src/gda_balancing/cli.py
@@ -11,4 +11,4 @@ from gda_balancing.dispatch import dispatch
 
 
 def main() -> None:
-    sys.exit(dispatch(sys.argv[1:], sys.stdout, sys.stderr))
+    sys.exit(dispatch(sys.argv[1:], sys.stdout, sys.stderr, stdin=sys.stdin))

--- a/libs/gda-balancing/src/gda_balancing/commands/__init__.py
+++ b/libs/gda-balancing/src/gda_balancing/commands/__init__.py
@@ -7,10 +7,11 @@ the tuple.
 """
 
 from gda_balancing.commands.design import DESIGN_FORMAT, DESIGN_VALIDATE
+from gda_balancing.commands.manifest import MANIFEST
 from gda_balancing.commands.schema import SCHEMA_GET
 from gda_balancing.commands.version import VERSION
 from gda_balancing.descriptors import CommandDescriptor, build_registry
 
 REGISTRY: tuple[CommandDescriptor, ...] = build_registry(
-    VERSION, DESIGN_VALIDATE, DESIGN_FORMAT, SCHEMA_GET
+    VERSION, DESIGN_VALIDATE, DESIGN_FORMAT, SCHEMA_GET, MANIFEST
 )

--- a/libs/gda-balancing/src/gda_balancing/commands/manifest.py
+++ b/libs/gda-balancing/src/gda_balancing/commands/manifest.py
@@ -37,5 +37,6 @@ MANIFEST = CommandDescriptor(
     fixtures=ConformanceFixtures(),
     schema_major=2,
     structured_params=True,
+    usage_codes=("argument_conflict", "invalid_argument", "unknown_argument"),
     success_schema=surface_manifest_success_schema,
 )

--- a/libs/gda-balancing/src/gda_balancing/commands/manifest.py
+++ b/libs/gda-balancing/src/gda_balancing/commands/manifest.py
@@ -1,0 +1,41 @@
+"""The descriptor-derived Standard Schema 2.0 Surface manifest command."""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, RootModel
+
+from gda_balancing.descriptors import CommandDescriptor, ConformanceFixtures
+from gda_balancing.schema2.surface import (
+    surface_manifest,
+    surface_manifest_success_schema,
+)
+
+
+class ManifestInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class ManifestOutput(RootModel[dict[str, Any]]):
+    pass
+
+
+def run_manifest(_inp: ManifestInput) -> ManifestOutput:
+    # Runtime import avoids a second registry and the commands-package import
+    # cycle: the live assembled registry is the sole projection source.
+    from gda_balancing.commands import REGISTRY
+
+    return ManifestOutput(root=surface_manifest(REGISTRY))
+
+
+MANIFEST = CommandDescriptor(
+    group=None,
+    command="manifest",
+    description="Emit the delivered Standard Schema 2.0 command surface.",
+    input_model=ManifestInput,
+    output_model=ManifestOutput,
+    handler=run_manifest,
+    fixtures=ConformanceFixtures(),
+    schema_major=2,
+    structured_params=True,
+    success_schema=surface_manifest_success_schema,
+)

--- a/libs/gda-balancing/src/gda_balancing/commands/schema.py
+++ b/libs/gda-balancing/src/gda_balancing/commands/schema.py
@@ -1,70 +1,118 @@
-"""The `schema` command group — Standard Schema self-description (bADR-0005).
+"""Standard Schema 2.0 authority retrieval (bADR-0012/0021/0022).
 
-``schema get <artifact>`` emits one of the two published self-description
-artifacts verbatim, each generated from a single authority so it can never drift
-from the validator (:mod:`gda_balancing.schema.artifacts`):
-
-* ``structural`` — the JSON Schema 2020-12 document whose instances are Design
-  documents (generated from the pydantic model);
-* ``catalog`` — the semantic rule catalog, an index of the semantic phase's
-  rules projected from the one rule registry (bADR-0005).
-
-Each artifact document *is* the bare result — there is no wrapper (bADR-0008's
-no-wrapper law) — so the output model is a ``RootModel`` that dumps the raw
-object. An unknown artifact value binds into the input model and fails
-validation → the usage `invalid_argument` boundary / exit 3, automatically
-(bADR-0008).
+``schema get`` exposes the admitted Kernel/LDB pair and the exact wire-schema
+and Diagnostic-catalog projections generated from it. The packaged JSON
+resources are language authority; this command admits them before emitting
+anything and returns a stage-aware refusal if their identity, binding, closed
+shape, executable vectors, or resource contract fails.
 """
 
-from typing import Any, Literal
+from collections.abc import Callable
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, RootModel
 
-from gda_balancing.descriptors import (
-    ArtifactReceipt,
-    CommandDescriptor,
-    ConformanceFixtures,
+from gda_balancing.descriptors import CommandDescriptor, ConformanceFixtures
+from gda_balancing.schema2.authority import load_authorities
+from gda_balancing.schema2.bootstrap import admit_authorities
+from gda_balancing.schema2.canonical import JsonValue
+from gda_balancing.schema2.diagnostics import Schema2RefusalReport, bootstrap_refusal
+from gda_balancing.schema2.projections import (
+    diagnostic_catalog_projection,
+    wire_schema_projection,
 )
-from gda_balancing.schema.bundle import current_bundle
 
 
 class SchemaGetInput(BaseModel):
-    """`schema get` takes exactly the artifact name (``structural``/``catalog``)."""
+    """Select one delivered Standard Schema 2.0 authority projection."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    artifact: Literal["structural", "catalog"]
+    artifact: Literal[
+        "language-bundle",
+        "wire-schema",
+        "diagnostic-catalog",
+    ]
 
 
-class SchemaArtifact(RootModel[dict[str, Any] | ArtifactReceipt]):
-    """A self-description artifact — the bare schema object, no wrapper
-    (bADR-0008) — or, when ``--out`` was given, the :class:`ArtifactReceipt` the
-    dispatch tail substitutes (bADR-0009). The union is the artifact-sink
-    output-model contract; the body arm is the raw JSON object the ``RootModel``
-    root dumps directly."""
+class SchemaArtifact(RootModel[dict[str, Any]]):
+    """One stdout-only authority/projection result; descriptor schema is exact."""
 
 
-def run_schema_get(inp: SchemaGetInput) -> SchemaArtifact:
-    """Emit the requested artifact for the current (newest) schema line. Never
-    refuses — a self-description artifact is always available for a bound (hence
-    valid) artifact name. Self-description is line-agnostic, so it reads the
-    newest bundle (:func:`~gda_balancing.schema.bundle.current_bundle`)."""
-    bundle = current_bundle()
-    if inp.artifact == "catalog":
-        return SchemaArtifact(root=bundle.catalog())
-    return SchemaArtifact(root=bundle.structural_schema())
+AuthorityProvider = Callable[[], tuple[dict[str, Any], dict[str, Any]]]
+
+
+def schema_get_handler(
+    provider: AuthorityProvider,
+) -> Callable[[SchemaGetInput], SchemaArtifact | Schema2RefusalReport]:
+    """Build the retrieval handler around an injectable authority source.
+
+    Production uses packaged resources; the conformance harness injects
+    mutations through the same dispatch/descriptor boundary.
+    """
+
+    def _run(inp: SchemaGetInput) -> SchemaArtifact | Schema2RefusalReport:
+        kernel, ldb = provider()
+        admission = admit_authorities(kernel, ldb)
+        if not admission.admitted:
+            return bootstrap_refusal(admission)
+        authorities: dict[str, JsonValue] = {
+            "kernel": cast(JsonValue, kernel),
+            "language_bundle": cast(JsonValue, ldb),
+            "admission": {
+                "admitted": True,
+                "kernel_identity": admission.kernel_identity,
+                "language_bundle_identity": admission.language_bundle_identity,
+            },
+        }
+        if inp.artifact == "language-bundle":
+            return SchemaArtifact(root=cast(dict[str, Any], authorities))
+        if inp.artifact == "wire-schema":
+            return SchemaArtifact(root=wire_schema_projection(authorities))
+        return SchemaArtifact(root=diagnostic_catalog_projection(authorities))
+
+    return _run
+
+
+run_schema_get = schema_get_handler(load_authorities)
+
+
+def schema_get_success_schema() -> dict[str, object]:
+    """Exact closed success union for the three immutable retrieval results."""
+    kernel, ldb = load_authorities()
+    admission = admit_authorities(kernel, ldb)
+    if not admission.admitted:
+        raise RuntimeError("cannot project success schemas from refused authorities")
+    authorities: dict[str, JsonValue] = {
+        "kernel": cast(JsonValue, kernel),
+        "language_bundle": cast(JsonValue, ldb),
+        "admission": {
+            "admitted": True,
+            "kernel_identity": admission.kernel_identity,
+            "language_bundle_identity": admission.language_bundle_identity,
+        },
+    }
+    return {
+        "oneOf": [
+            {"const": authorities},
+            {"const": wire_schema_projection(authorities)},
+            {"const": diagnostic_catalog_projection(authorities)},
+        ]
+    }
 
 
 SCHEMA_GET = CommandDescriptor(
     group="schema",
     command="get",
-    description="Emit a Standard Schema self-description artifact (bADR-0005).",
+    description="Emit a Standard Schema 2.0 language authority or projection.",
     input_model=SchemaGetInput,
     output_model=SchemaArtifact,
     handler=run_schema_get,
     positional_field="artifact",
-    # The self-description artifacts are artifacts too (bADR-0009): `--out`
-    # redirects the emitted schema to the sink under the same artifact law.
-    artifact_sink=True,
-    fixtures=ConformanceFixtures(valid_args=("structural",)),
+    artifact_sink=False,
+    fixtures=ConformanceFixtures(valid_args=("language-bundle",)),
+    schema_major=2,
+    structured_params=True,
+    refusal_stages=("ingress", "static"),
+    success_schema=schema_get_success_schema,
 )

--- a/libs/gda-balancing/src/gda_balancing/commands/schema.py
+++ b/libs/gda-balancing/src/gda_balancing/commands/schema.py
@@ -13,10 +13,18 @@ from typing import Any, Literal, cast
 from pydantic import BaseModel, ConfigDict, RootModel
 
 from gda_balancing.descriptors import CommandDescriptor, ConformanceFixtures
-from gda_balancing.schema2.authority import load_authorities
-from gda_balancing.schema2.bootstrap import admit_authorities
+from gda_balancing.schema2.authority import AuthorityLoadError, load_authorities
+from gda_balancing.schema2.bootstrap import (
+    BOOTSTRAP_REFUSAL_CATALOG,
+    SCHEMA2_REFUSAL_STAGES,
+    admit_authorities,
+)
 from gda_balancing.schema2.canonical import JsonValue
-from gda_balancing.schema2.diagnostics import Schema2RefusalReport, bootstrap_refusal
+from gda_balancing.schema2.diagnostics import (
+    Schema2RefusalReport,
+    bootstrap_refusal,
+    ingress_refusal,
+)
 from gda_balancing.schema2.projections import (
     diagnostic_catalog_projection,
     wire_schema_projection,
@@ -52,7 +60,10 @@ def schema_get_handler(
     """
 
     def _run(inp: SchemaGetInput) -> SchemaArtifact | Schema2RefusalReport:
-        kernel, ldb = provider()
+        try:
+            kernel, ldb = provider()
+        except AuthorityLoadError as err:
+            return ingress_refusal(err.code, err.subject, err.message)
         admission = admit_authorities(kernel, ldb)
         if not admission.admitted:
             return bootstrap_refusal(admission)
@@ -77,28 +88,99 @@ def schema_get_handler(
 run_schema_get = schema_get_handler(load_authorities)
 
 
+def schema_get_refusal_catalog() -> tuple[tuple[str, str], ...]:
+    """Return the non-self-hosted Kernel bootstrap refusal vocabulary."""
+    return BOOTSTRAP_REFUSAL_CATALOG
+
+
 def schema_get_success_schema() -> dict[str, object]:
-    """Exact closed success union for the three immutable retrieval results."""
-    kernel, ldb = load_authorities()
-    admission = admit_authorities(kernel, ldb)
-    if not admission.admitted:
-        raise RuntimeError("cannot project success schemas from refused authorities")
-    authorities: dict[str, JsonValue] = {
-        "kernel": cast(JsonValue, kernel),
-        "language_bundle": cast(JsonValue, ldb),
-        "admission": {
-            "admitted": True,
-            "kernel_identity": admission.kernel_identity,
-            "language_bundle_identity": admission.language_bundle_identity,
+    """Static closed result shapes; introspection never reads authority bytes."""
+    identity = {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+    admission = {
+        "type": "object",
+        "properties": {
+            "admitted": {"const": True},
+            "kernel_identity": identity,
+            "language_bundle_identity": identity,
         },
+        "required": [
+            "admitted",
+            "kernel_identity",
+            "language_bundle_identity",
+        ],
+        "unevaluatedProperties": False,
     }
-    return {
-        "oneOf": [
-            {"const": authorities},
-            {"const": wire_schema_projection(authorities)},
-            {"const": diagnostic_catalog_projection(authorities)},
-        ]
+    authority_result = {
+        "type": "object",
+        "properties": {
+            "kernel": {},
+            "language_bundle": {},
+            "admission": admission,
+        },
+        "required": ["kernel", "language_bundle", "admission"],
+        "unevaluatedProperties": False,
     }
+    projection_base = {
+        "kernel_identity": identity,
+        "language_bundle_identity": identity,
+        "content_identity": identity,
+    }
+    wire_projection = {
+        "type": "object",
+        "properties": {
+            "artifact_kind": {"const": "wire-schema-projection"},
+            **projection_base,
+            "schemas": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "artifact_kind": {"type": "string", "minLength": 1},
+                        "schema": {},
+                    },
+                    "required": ["artifact_kind", "schema"],
+                    "unevaluatedProperties": False,
+                },
+            },
+        },
+        "required": [
+            "artifact_kind",
+            "kernel_identity",
+            "language_bundle_identity",
+            "schemas",
+            "content_identity",
+        ],
+        "unevaluatedProperties": False,
+    }
+    diagnostic_projection = {
+        "type": "object",
+        "properties": {
+            "artifact_kind": {"const": "diagnostic-catalog-projection"},
+            **projection_base,
+            "entries": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "authority": {"enum": ["kernel", "language-bundle"]},
+                        "code": {"type": "string", "minLength": 1},
+                        "stage": {"enum": list(SCHEMA2_REFUSAL_STAGES)},
+                    },
+                    "required": ["authority", "code", "stage"],
+                    "unevaluatedProperties": False,
+                },
+            },
+        },
+        "required": [
+            "artifact_kind",
+            "kernel_identity",
+            "language_bundle_identity",
+            "entries",
+            "content_identity",
+        ],
+        "unevaluatedProperties": False,
+    }
+    return {"oneOf": [authority_result, wire_projection, diagnostic_projection]}
 
 
 SCHEMA_GET = CommandDescriptor(
@@ -113,6 +195,7 @@ SCHEMA_GET = CommandDescriptor(
     fixtures=ConformanceFixtures(valid_args=("language-bundle",)),
     schema_major=2,
     structured_params=True,
-    refusal_stages=("ingress", "static"),
+    refusal_catalog=schema_get_refusal_catalog(),
+    usage_codes=("argument_conflict", "invalid_argument", "unknown_argument"),
     success_schema=schema_get_success_schema,
 )

--- a/libs/gda-balancing/src/gda_balancing/descriptors.py
+++ b/libs/gda-balancing/src/gda_balancing/descriptors.py
@@ -18,11 +18,12 @@ from dataclasses import dataclass, field
 from pydantic import BaseModel, ConfigDict
 
 from gda_balancing.envelope import RefusalReport
+from gda_balancing.schema2.diagnostics import Schema2RefusalReport
 
 # Reserved by bADR-0007 for Phase 2; the conformance harness asserts no
 # registered command occupies them, and dispatch resolves them as unknown.
 RESERVED_GROUPS = frozenset({"evaluation", "tuning"})
-RESERVED_META = frozenset({"manifest"})
+RESERVED_META: frozenset[str] = frozenset()
 
 
 class ArtifactSpec(BaseModel):
@@ -87,7 +88,7 @@ class CommandDescriptor:
     # exits, never sees a usage error. An unexpected exception here is the
     # sole path to `internal` / exit 4. Typed `...` because each command's
     # handler takes its own concrete input model (contravariance).
-    handler: Callable[..., BaseModel | RefusalReport]
+    handler: Callable[..., BaseModel | RefusalReport | Schema2RefusalReport]
     fixtures: ConformanceFixtures
     positional_field: str | None = None
     # Execution markings (bADR-0010/0011); the harness's per-marking rows key
@@ -101,12 +102,28 @@ class CommandDescriptor:
     # `RootModel[<Body> | ArtifactReceipt]`, so the dispatch tail can construct
     # the receipt as the declared output type.
     artifact_sink: bool = field(default=False)
+    # The current registry temporarily contains historical 1.x commands while
+    # Schema 2.0 lands in vertical slices.  Only descriptors marked ``2`` are
+    # projected into the 2.x Surface manifest.
+    schema_major: int = field(default=1)
+    structured_params: bool = field(default=False)
+    refusal_stages: tuple[str, ...] = field(default=())
+    # A 2.x descriptor may own a closed schema that is more precise than a
+    # dynamic RootModel. Dispatch validates its result against this same
+    # callable used by --schema and manifest.
+    success_schema: Callable[[], dict[str, object]] | None = field(default=None)
 
     def __post_init__(self) -> None:
         if self.group in RESERVED_GROUPS or (
             self.group is None and self.command in RESERVED_GROUPS | RESERVED_META
         ):
             raise ValueError(f"reserved name: {self.group or self.command!r}")
+        if self.schema_major not in (1, 2):
+            raise ValueError(
+                f"unsupported descriptor schema major: {self.schema_major}"
+            )
+        if self.structured_params and self.schema_major != 2:
+            raise ValueError("structured params are a Schema 2.x descriptor contract")
         if (
             self.positional_field is not None
             and self.positional_field not in self.input_model.model_fields

--- a/libs/gda-balancing/src/gda_balancing/descriptors.py
+++ b/libs/gda-balancing/src/gda_balancing/descriptors.py
@@ -17,13 +17,15 @@ from dataclasses import dataclass, field
 
 from pydantic import BaseModel, ConfigDict
 
-from gda_balancing.envelope import RefusalReport
+from gda_balancing.envelope import USAGE_CODES, RefusalReport
+from gda_balancing.schema2.bootstrap import SCHEMA2_REFUSAL_STAGES
 from gda_balancing.schema2.diagnostics import Schema2RefusalReport
 
 # Reserved by bADR-0007 for Phase 2; the conformance harness asserts no
 # registered command occupies them, and dispatch resolves them as unknown.
 RESERVED_GROUPS = frozenset({"evaluation", "tuning"})
 RESERVED_META: frozenset[str] = frozenset()
+_SCHEMA2_REFUSAL_STAGES = frozenset(SCHEMA2_REFUSAL_STAGES)
 
 
 class ArtifactSpec(BaseModel):
@@ -107,7 +109,11 @@ class CommandDescriptor:
     # projected into the 2.x Surface manifest.
     schema_major: int = field(default=1)
     structured_params: bool = field(default=False)
-    refusal_stages: tuple[str, ...] = field(default=())
+    # Exact per-command error authority for Schema 2.x.  The catalog is a
+    # reverse-conformance projection of Kernel/LDB Diagnostics; dispatch and
+    # --schema both consume it, so an undeclared stage/code cannot leak.
+    refusal_catalog: tuple[tuple[str, str], ...] = field(default=())
+    usage_codes: tuple[str, ...] = field(default=())
     # A 2.x descriptor may own a closed schema that is more precise than a
     # dynamic RootModel. Dispatch validates its result against this same
     # callable used by --schema and manifest.
@@ -124,6 +130,17 @@ class CommandDescriptor:
             )
         if self.structured_params and self.schema_major != 2:
             raise ValueError("structured params are a Schema 2.x descriptor contract")
+        if self.schema_major != 2 and (self.refusal_catalog or self.usage_codes):
+            raise ValueError("Schema 2.x error contracts require schema_major=2")
+        if len(self.refusal_catalog) != len(set(self.refusal_catalog)):
+            raise ValueError("duplicate Schema 2.x refusal catalog entry")
+        if any(
+            not code or stage not in _SCHEMA2_REFUSAL_STAGES
+            for code, stage in self.refusal_catalog
+        ):
+            raise ValueError("invalid Schema 2.x refusal catalog entry")
+        if not set(self.usage_codes) <= USAGE_CODES:
+            raise ValueError("unknown Schema 2.x usage code")
         if (
             self.positional_field is not None
             and self.positional_field not in self.input_model.model_fields
@@ -132,6 +149,10 @@ class CommandDescriptor:
                 f"positional designation {self.positional_field!r} names no "
                 f"{self.input_model.__name__} field"
             )
+
+    @property
+    def refusal_stages(self) -> tuple[str, ...]:
+        return tuple(sorted({stage for _, stage in self.refusal_catalog}))
 
 
 def build_registry(*descriptors: CommandDescriptor) -> tuple[CommandDescriptor, ...]:

--- a/libs/gda-balancing/src/gda_balancing/dispatch.py
+++ b/libs/gda-balancing/src/gda_balancing/dispatch.py
@@ -12,12 +12,14 @@ bare traceback is never any invocation's output; ``--debug`` routes it into
 ``diagnostics``.
 """
 
+import json
 import os
 import tempfile
 import traceback
 from collections.abc import Sequence
 from typing import Any, TextIO
 
+import jsonschema
 from pydantic import BaseModel, ValidationError
 
 from gda_balancing.commands import REGISTRY
@@ -39,6 +41,10 @@ from gda_balancing.envelope import (
     internal_envelope,
     refusal_envelope,
     usage_envelope,
+)
+from gda_balancing.schema2.diagnostics import (
+    Schema2RefusalReport,
+    refusal_envelope as schema2_refusal_envelope,
 )
 
 _SCHEMA_FLAG = "--schema"
@@ -66,6 +72,7 @@ def dispatch(
     stderr: TextIO,
     *,
     registry: tuple[CommandDescriptor, ...] = REGISTRY,
+    stdin: TextIO | None = None,
 ) -> int:
     """Run one invocation; returns the exit code, never raises or exits.
 
@@ -74,7 +81,7 @@ def dispatch(
     (bADR-0011's fault-injection seam — production has no fault path).
     """
     try:
-        return _dispatch(list(argv), stdout, registry)
+        return _dispatch(list(argv), stdout, registry, stdin)
     except _UsageError as err:
         stderr.write(canonical_json(usage_envelope(err.code, err.message)))
         return EXIT_USAGE
@@ -91,7 +98,10 @@ def dispatch(
 
 
 def _dispatch(
-    argv: list[str], stdout: TextIO, registry: tuple[CommandDescriptor, ...]
+    argv: list[str],
+    stdout: TextIO,
+    registry: tuple[CommandDescriptor, ...],
+    stdin: TextIO | None,
 ) -> int:
     if not argv:
         raise _UsageError(
@@ -126,13 +136,18 @@ def _dispatch(
 
     # Bare `--schema` wins over any other argument (bADR-0009).
     if _SCHEMA_FLAG in tail:
-        stdout.write(canonical_json(_schema_projection(descriptor)))
+        if descriptor.schema_major == 2:
+            from gda_balancing.schema2.surface import command_schema_projection
+
+            stdout.write(canonical_json(command_schema_projection(descriptor)))
+        else:
+            stdout.write(canonical_json(_schema_projection(descriptor)))
         return EXIT_SUCCESS
     if _HELP_FLAG in tail:
         stdout.write(_render_command_help(descriptor))
         return EXIT_SUCCESS
 
-    values, out = _bind(descriptor, tail)
+    values, out = _bind(descriptor, tail, stdin)
     try:
         input_obj = descriptor.input_model(**values)
     except ValidationError as err:
@@ -141,6 +156,9 @@ def _dispatch(
     outcome = descriptor.handler(input_obj)
     if isinstance(outcome, RefusalReport):
         stdout.write(canonical_json(refusal_envelope(outcome)))
+        return EXIT_REFUSAL
+    if isinstance(outcome, Schema2RefusalReport):
+        stdout.write(canonical_json(schema2_refusal_envelope(outcome)))
         return EXIT_REFUSAL
     if type(outcome) is not descriptor.output_model:
         # The declared output model is authoritative at runtime, not merely
@@ -154,7 +172,10 @@ def _dispatch(
             f"handler returned {type(outcome).__name__}, not the declared "
             f"output model {descriptor.output_model.__name__}"
         )
-    body = canonical_json(model_payload(outcome))
+    payload = model_payload(outcome)
+    if descriptor.schema_major == 2 and descriptor.success_schema is not None:
+        jsonschema.validate(payload, descriptor.success_schema())
+    body = canonical_json(payload)
     if descriptor.artifact_sink and out is not None:
         # The BODY arm goes to the sink; stdout carries the receipt (bADR-0009).
         # The sink is written BEFORE stdout, and an unwritable sink raises
@@ -168,8 +189,8 @@ def _dispatch(
 
 
 def _bind(
-    descriptor: CommandDescriptor, tail: list[str]
-) -> tuple[dict[str, str], str | None]:
+    descriptor: CommandDescriptor, tail: list[str], stdin: TextIO | None
+) -> tuple[dict[str, Any], str | None]:
     """Apply the binding law to the command tail (bADR-0011); return the bound
     model values and the ``--out`` sink path (``None`` when absent).
 
@@ -179,8 +200,12 @@ def _bind(
     here, never bound as model fields. ``--out`` is accepted only for an
     ``artifact_sink`` command; anywhere else it is an unknown argument.
     """
+    structured = _structured_params(descriptor, tail, stdin)
+    if structured is not None:
+        return structured, None
+
     options = option_bindings(descriptor)
-    values: dict[str, str] = {}
+    values: dict[str, Any] = {}
     positionals: list[str] = []
     out: str | None = None
     i = 0
@@ -237,6 +262,63 @@ def _bind(
     if out is not None and descriptor.positional_field is not None:
         _reject_input_aliasing(out, values.get(descriptor.positional_field))
     return values, out
+
+
+def _structured_params(
+    descriptor: CommandDescriptor, tail: list[str], stdin: TextIO | None
+) -> dict[str, Any] | None:
+    """Decode the descriptor input object from ``--params-json`` when used.
+
+    The flag is one alternate presentation of the same input model, never a
+    second parameter authority.  It is therefore mutually exclusive with
+    positional and individual options; ``--schema`` has already returned
+    before this function can read stdin.
+    """
+    flag = "--params-json"
+    indices = [
+        index
+        for index, token in enumerate(tail)
+        if token == flag or token.startswith(flag + "=")
+    ]
+    if not indices:
+        return None
+    if not descriptor.structured_params:
+        raise _UsageError("unknown_argument", f"unknown argument: {flag}")
+    if len(indices) > 1:
+        raise _UsageError("argument_conflict", f"argument named more than once: {flag}")
+
+    index = indices[0]
+    token = tail[index]
+    consumed = 1
+    if token.startswith(flag + "="):
+        source = token.partition("=")[2]
+    else:
+        if index + 1 >= len(tail):
+            raise _UsageError("invalid_argument", f"missing value for {flag}")
+        source = tail[index + 1]
+        consumed = 2
+    remaining = [
+        item
+        for offset, item in enumerate(tail)
+        if not index <= offset < index + consumed and item != _DEBUG_FLAG
+    ]
+    if remaining:
+        raise _UsageError(
+            "argument_conflict",
+            "--params-json is mutually exclusive with individual arguments",
+        )
+    text = stdin.read() if source == "-" and stdin is not None else source
+    if source == "-" and stdin is None:
+        text = ""
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as err:
+        raise _UsageError(
+            "invalid_argument", "--params-json is not valid JSON"
+        ) from err
+    if not isinstance(value, dict):
+        raise _UsageError("invalid_argument", "--params-json must contain an object")
+    return value
 
 
 def _reject_input_aliasing(out: str, input_path: str | None) -> None:

--- a/libs/gda-balancing/src/gda_balancing/dispatch.py
+++ b/libs/gda-balancing/src/gda_balancing/dispatch.py
@@ -9,7 +9,7 @@ stdout / exit 2 (#504 lands the first producer); usage error → one `usage`
 envelope on stderr / exit 3 with stdout empty; an unexpected exception → one
 sanitized `internal` envelope on stderr / exit 4 (the sole internal path). A
 bare traceback is never any invocation's output; ``--debug`` routes it into
-``diagnostics``.
+the versioned internal-envelope debug member.
 """
 
 import json
@@ -56,8 +56,7 @@ _OUT_FLAG = "--out"
 class _UsageError(Exception):
     """Dispatch-internal control flow for the invocation surface.
 
-    Raised only before the handler runs (handlers never see usage errors);
-    the dispatch tail maps it to the `usage` envelope / exit 3.
+    The dispatch tail maps it to the `usage` envelope / exit 3.
     """
 
     def __init__(self, code: str, message: str) -> None:
@@ -93,8 +92,37 @@ def dispatch(
     except Exception as exc:
         diagnostics = traceback.format_exc() if _DEBUG_FLAG in argv else None
         message = f"the toolkit failed unexpectedly ({type(exc).__name__})"
-        stderr.write(canonical_json(internal_envelope(message, diagnostics)))
+        envelope = internal_envelope(message, diagnostics)
+        descriptor = _descriptor_for_invocation(argv, registry)
+        if descriptor is not None and descriptor.schema_major == 2 and diagnostics:
+            envelope["error"]["debug"] = envelope["error"].pop("diagnostics")
+        stderr.write(canonical_json(envelope))
         return EXIT_INTERNAL
+
+
+def _descriptor_for_invocation(
+    argv: Sequence[str], registry: tuple[CommandDescriptor, ...]
+) -> CommandDescriptor | None:
+    """Resolve only descriptor identity for versioned internal serialization."""
+    if not argv:
+        return None
+    head = argv[0]
+    groups = {item.group for item in registry if item.group is not None}
+    if head in groups:
+        if len(argv) < 2:
+            return None
+        return next(
+            (
+                item
+                for item in registry
+                if item.group == head and item.command == argv[1]
+            ),
+            None,
+        )
+    return next(
+        (item for item in registry if item.group is None and item.command == head),
+        None,
+    )
 
 
 def _dispatch(
@@ -147,8 +175,34 @@ def _dispatch(
         stdout.write(_render_command_help(descriptor))
         return EXIT_SUCCESS
 
-    values, out = _bind(descriptor, tail, stdin)
     try:
+        return _invoke_descriptor(descriptor, tail, stdout, stdin)
+    except _UsageError as err:
+        if descriptor.schema_major == 2 and err.code not in descriptor.usage_codes:
+            raise TypeError(
+                "dispatch produced a Schema 2.x usage outcome absent from its descriptor"
+            ) from err
+        raise
+    except UnreadableInputError as err:
+        if (
+            descriptor.schema_major == 2
+            and "unreadable_input" not in descriptor.usage_codes
+        ):
+            raise TypeError(
+                "dispatch produced a Schema 2.x usage outcome absent from its descriptor"
+            ) from err
+        raise
+
+
+def _invoke_descriptor(
+    descriptor: CommandDescriptor,
+    tail: list[str],
+    stdout: TextIO,
+    stdin: TextIO | None,
+) -> int:
+    """Invoke a resolved descriptor inside its declared usage boundary."""
+    try:
+        values, out = _bind(descriptor, tail, stdin)
         input_obj = descriptor.input_model(**values)
     except ValidationError as err:
         raise _UsageError("invalid_argument", _summarize(err)) from err
@@ -158,6 +212,11 @@ def _dispatch(
         stdout.write(canonical_json(refusal_envelope(outcome)))
         return EXIT_REFUSAL
     if isinstance(outcome, Schema2RefusalReport):
+        observed = {(item.code, outcome.stage) for item in outcome.diagnostics}
+        if not observed <= set(descriptor.refusal_catalog):
+            raise TypeError(
+                "handler returned a Schema 2.x refusal absent from its descriptor"
+            )
         stdout.write(canonical_json(schema2_refusal_envelope(outcome)))
         return EXIT_REFUSAL
     if type(outcome) is not descriptor.output_model:
@@ -329,7 +388,7 @@ def _reject_input_aliasing(out: str, input_path: str | None) -> None:
     The guard treats the positional as an *input path* only when it names an
     existing filesystem entry: a command whose positional is a read document
     (``design format``) always has one, while a command whose positional is an
-    enum name (``schema get``'s ``structural``/``catalog``) has no input file to
+    enum name (such as ``schema get``'s artifact selector) has no input file to
     alias, so it is exempt. ``realpath`` resolves symlinks on both sides, so the
     check catches an aliased sink as well as a directly-named one.
     """

--- a/libs/gda-balancing/src/gda_balancing/schema2/__init__.py
+++ b/libs/gda-balancing/src/gda_balancing/schema2/__init__.py
@@ -1,0 +1,1 @@
+"""Permanent Standard Schema 2.0 bootstrap authority and projections."""

--- a/libs/gda-balancing/src/gda_balancing/schema2/authorities/__init__.py
+++ b/libs/gda-balancing/src/gda_balancing/schema2/authorities/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged Standard Schema 2.0 machine authorities (data, not host code)."""

--- a/libs/gda-balancing/src/gda_balancing/schema2/authorities/kernel.json
+++ b/libs/gda-balancing/src/gda_balancing/schema2/authorities/kernel.json
@@ -2,29 +2,98 @@
   "admission": {
     "closed": true,
     "laws": [
-      {"id": "kernel.identity.verify", "identity_member": "content_identity", "operation": "verify-content-identity"},
-      {"id": "kernel.binding.exact", "left": "language_bundle.kernel_identity", "operation": "require-equal", "right": "kernel.content_identity"},
-      {"id": "kernel.members.closed", "members_from": "admission.required_ldb_members", "operation": "require-exact-members"},
-      {"id": "kernel.identifiers.unique", "operation": "require-unique-identifiers"},
-      {"id": "kernel.operations.closed", "operation": "require-known-operations"},
-      {"id": "kernel.vectors.closed", "operation": "require-vector-closure"},
-      {"id": "kernel.diagnostics.closed", "operation": "require-diagnostic-closure"},
-      {"id": "kernel.resources.bound", "operation": "enforce-resource-limits"}
+      {
+        "arguments": {"targets": [{"artifact": "kernel", "domain": "schema-major-kernel-v2", "identity_member": "content_identity"}, {"artifact": "language-bundle", "domain": "language-definition-bundle-v2", "identity_member": "content_identity"}, {"collection": "language_bundle.language.packages", "domain": "domain-package-release-v2", "identity_member": "content_identity"}]},
+        "effects": [], "id": "kernel.identity.verify", "input": {"fact_kind": "authority-pair"},
+        "operation": "verify-content-identity", "refusals": ["kernel.identity_mismatch"],
+        "resources": ["max_authority_bytes", "max_nesting_depth"], "result": {"fact_kind": "admission-verdict"}
+      },
+      {
+        "arguments": {"left": "language_bundle.kernel_identity", "right": "kernel.content_identity"},
+        "effects": [], "id": "kernel.binding.exact", "input": {"fact_kind": "authority-pair"},
+        "operation": "require-equal", "refusals": ["kernel.binding_mismatch"], "resources": [],
+        "result": {"fact_kind": "admission-verdict"}
+      },
+      {
+        "arguments": {"artifact": "language_bundle", "expected_members": "kernel.admission.required_ldb_members"},
+        "effects": [], "id": "kernel.members.closed", "input": {"fact_kind": "authority-pair"},
+        "operation": "require-exact-members", "refusals": ["kernel.member_set_mismatch"],
+        "resources": ["max_members"], "result": {"fact_kind": "admission-verdict"}
+      },
+      {
+        "arguments": {"collections": [{"keys": ["id"], "path": "kernel.admission.laws", "subject": "kernel.admission.laws"}, {"keys": ["code"], "path": "kernel.diagnostics", "subject": "kernel.diagnostics"}, {"keys": ["id"], "path": "kernel.vectors", "subject": "kernel.vectors"}, {"keys": ["id"], "path": "language_bundle.language.capabilities", "subject": "language.capabilities"}, {"keys": ["id"], "path": "language_bundle.language.components", "subject": "language.components"}, {"keys": ["id"], "path": "language_bundle.language.constructors", "subject": "language.constructors"}, {"keys": ["id"], "path": "language_bundle.language.conversions", "subject": "language.conversions"}, {"keys": ["id"], "path": "language_bundle.language.operations", "subject": "language.operations"}, {"keys": ["id", "version"], "path": "language_bundle.language.packages", "subject": "language.packages"}, {"keys": ["id"], "path": "language_bundle.language.quantity.numeric_policies", "subject": "language.quantity.numeric_policies"}, {"keys": ["id"], "path": "language_bundle.language.reasons", "subject": "language.reasons"}, {"keys": ["id"], "path": "language_bundle.language.rules", "subject": "language.rules"}, {"keys": ["id"], "path": "language_bundle.language.runtime_profiles", "subject": "language.runtime_profiles"}, {"keys": ["artifact_kind"], "path": "language_bundle.language.wire_schemas", "subject": "language.wire_schemas"}, {"keys": ["code"], "path": "language_bundle.diagnostics", "subject": "language-bundle.diagnostics"}, {"keys": ["id"], "path": "language_bundle.vectors", "subject": "language-bundle.vectors"}]},
+        "effects": [], "id": "kernel.identifiers.unique", "input": {"fact_kind": "authority-pair"},
+        "operation": "require-unique-identifiers", "refusals": ["kernel.duplicate_identifier"],
+        "resources": ["max_members"], "result": {"fact_kind": "admission-verdict"}
+      },
+      {
+        "arguments": {"admission_operations": ["verify-content-identity", "require-equal", "require-exact-members", "require-unique-identifiers", "require-known-operations", "require-vector-closure", "require-diagnostic-closure", "enforce-resource-limits"], "reason_operations": ["not-member", "has-duplicate", "greater-than"]},
+        "effects": [], "id": "kernel.operations.closed", "input": {"fact_kind": "authority-pair"},
+        "operation": "require-known-operations", "refusals": ["kernel.unknown_operation"],
+        "resources": ["max_members"], "result": {"fact_kind": "admission-verdict"}
+      },
+      {
+        "arguments": {"closures": [{"inventory": "kernel.admission.laws", "reference": "law", "vectors": "kernel.vectors"}, {"inventory": "language_bundle.language.rules", "reference": "rule", "vectors": "language_bundle.vectors"}, {"inventory": "language_bundle.language.reasons", "reference": "reason", "vectors": "language_bundle.vectors"}], "equalities": [{"left": "language_bundle.language.model_source_schema_versions", "mode": "set", "right": "language_bundle.language.wire_schemas.schema.properties.schema_version.const"}, {"left": "language_bundle.language.quantity.kinds", "mode": "set", "right": "language_bundle.language.wire_schemas.schema.properties.symbols.items.properties.kind.const"}, {"left": "language_bundle.language.quantity.numeric_policies.id", "mode": "set", "right": "language_bundle.language.wire_schemas.schema.properties.symbols.items.properties.numeric_policy.const"}, {"left": "language_bundle.language.quantity.representations", "mode": "set", "right": "language_bundle.language.wire_schemas.schema.properties.symbols.items.properties.representation.const"}, {"left": "language_bundle.language.quantity.symbol_roles", "mode": "set", "right": "language_bundle.language.wire_schemas.schema.properties.symbols.items.properties.role.enum"}, {"left": "language_bundle.language.quantity.units.id", "mode": "set", "right": "language_bundle.language.wire_schemas.schema.properties.symbols.items.properties.unit.const"}], "references": [{"owners": "language_bundle.language.capabilities", "targets": {"rule": "language_bundle.language.rules.id"}}, {"owners": "language_bundle.language.packages", "targets": {"capabilities.provided": "language_bundle.language.capabilities.id", "capabilities.required": "language_bundle.language.capabilities.id", "dependencies.optional": "language_bundle.language.packages.id", "dependencies.required": "language_bundle.language.packages.id", "exports.components": "language_bundle.language.components.id", "exports.conversions": "language_bundle.language.conversions.id", "exports.diagnostics": "language_bundle.diagnostics.code", "exports.language_rules": "language_bundle.language.rules.id", "exports.operations": "language_bundle.language.operations.id", "exports.types.constructor": "language_bundle.language.constructors.id", "profiles.numeric": "language_bundle.language.quantity.numeric_policies.id", "profiles.runtime": "language_bundle.language.runtime_profiles.id", "vectors": "language_bundle.vectors.id"}}]},
+        "effects": [], "id": "kernel.vectors.closed", "input": {"fact_kind": "authority-pair"},
+        "operation": "require-vector-closure", "refusals": ["kernel.vector_mismatch"],
+        "resources": ["max_members"], "result": {"fact_kind": "admission-verdict"}
+      },
+      {
+        "arguments": {"catalogs": [{"diagnostics": "kernel.diagnostics", "vectors": "kernel.vectors"}, {"diagnostics": "language_bundle.diagnostics", "vectors": "language_bundle.vectors"}]},
+        "effects": [], "id": "kernel.diagnostics.closed", "input": {"fact_kind": "authority-pair"},
+        "operation": "require-diagnostic-closure", "refusals": ["kernel.diagnostic_closure"],
+        "resources": ["max_diagnostics", "max_members"], "result": {"fact_kind": "admission-verdict"}
+      },
+      {
+        "arguments": {"limits": "kernel.resources", "targets": ["kernel", "language_bundle"]},
+        "effects": [], "id": "kernel.resources.bound", "input": {"fact_kind": "authority-pair"},
+        "operation": "enforce-resource-limits", "refusals": ["kernel.resource_exhausted"],
+        "resources": ["max_authority_bytes", "max_diagnostics", "max_members", "max_nesting_depth"],
+        "result": {"fact_kind": "admission-verdict"}
+      }
     ],
-    "required_ldb_members": ["artifact_kind", "artifact_version", "schema_major", "kernel_identity", "content_identity", "language", "diagnostics", "resources", "vectors"]
+    "refusal_stages": ["ingress", "parse", "static", "resolution", "runtime", "evaluation", "migration", "approval"],
+    "required_ldb_members": ["artifact_kind", "artifact_version", "schema_major", "kernel_identity", "content_identity", "language", "diagnostics", "resources", "vectors"],
+    "required_language_members": ["capabilities", "components", "constructors", "conversions", "model_source_schema_versions", "operations", "packages", "quantity", "reasons", "rules", "runtime_profiles", "wire_schemas"]
   },
   "artifact_kind": "schema-major-kernel",
   "artifact_version": "2.0.0",
   "canonical_encoding": {
+    "array_order": "preserve",
     "character_encoding": "UTF-8",
-    "identity_algorithm": "domain-separated-sha256",
+    "digest_hex_case": "lowercase",
+    "document_terminator": "LF",
+    "duplicate_object_keys": "refuse-at-decoding",
+    "escape_solidus": false,
+    "identity_algorithm": "sha256",
+    "identity_domain_prefix": "gda-balancing:",
+    "identity_domain_suffix": ":",
+    "identity_excluded_members": ["content_identity"],
+    "identity_output_prefix": "sha256:",
     "integer_domain": "signed-int64",
+    "item_separator": ",",
+    "key_separator": ":",
+    "lone_surrogate": "refuse",
+    "non_ascii_strings": "literal-utf8",
+    "number_kinds": ["signed-int64"],
     "object_order": "UTF-8-key-byte-order",
     "optional_members": "omit",
+    "printable_ascii_escaping": "only-quotation-mark-and-reverse-solidus",
     "profile": "gda-canonical-json-v1",
-    "unicode_normalization": "preserve"
+    "control_character_escaping": {"backspace": "\\b", "form-feed": "\\f", "line-feed": "\\n", "other-u0000-u001f": "lowercase-u00xx", "carriage-return": "\\r", "tab": "\\t"},
+    "delete_character_escaping": "literal-byte-7f",
+    "unicode_normalization": "preserve",
+    "vectors": [
+      {"canonical_utf8_hex": "5b2d393232333337323033363835343737353830382c393232333337323033363835343737353830375d0a", "domain": "canonical-vector-v1", "id": "canonical.boundary-integers", "identity": "sha256:730e16b6945138a4f955c95bd573942514ee746350e9dd99547593cba77d7f56", "value": [-9223372036854775808, 9223372036854775807]},
+      {"canonical_utf8_hex": "5b225c7530303030222c225c7530303031222c225c7530303032222c225c7530303033222c225c7530303034222c225c7530303035222c225c7530303036222c225c7530303037222c225c62222c225c74222c225c6e222c225c7530303062222c225c66222c225c72222c225c7530303065222c225c7530303066222c225c7530303130222c225c7530303131222c225c7530303132222c225c7530303133222c225c7530303134222c225c7530303135222c225c7530303136222c225c7530303137222c225c7530303138222c225c7530303139222c225c7530303161222c225c7530303162222c225c7530303163222c225c7530303164222c225c7530303165222c225c7530303166222c227f225d0a", "domain": "canonical-vector-v1", "id": "canonical.control-character-escaping", "identity": "sha256:712d2750b3feeb2cd91f0b0e4819c8c1e1e8aa9d7af0d5073743e0bf4e0b64c9", "value": ["\u0000", "\u0001", "\u0002", "\u0003", "\u0004", "\u0005", "\u0006", "\u0007", "\b", "\t", "\n", "\u000b", "\f", "\r", "\u000e", "\u000f", "\u0010", "\u0011", "\u0012", "\u0013", "\u0014", "\u0015", "\u0016", "\u0017", "\u0018", "\u0019", "\u001a", "\u001b", "\u001c", "\u001d", "\u001e", "\u001f", "\u007f"]},
+      {"canonical_utf8_hex": "7b2261223a5b332c322c315d2c2271756f7465223a225c225c6e5c5c222c22c3a9223a22e99baa227d0a", "domain": "canonical-vector-v1", "id": "canonical.order-array-unicode-escaping", "identity": "sha256:72118703be25b8eddcc7341c974f732f4dffa1c8ab04ae050718737fb7f89b62", "value": {"a": [3, 2, 1], "quote": "\"\n\\", "é": "雪"}},
+      {"id": "canonical.reject-duplicate-key", "input_lexeme": "{\"a\":1,\"a\":2}", "refusal": "duplicate-object-key"},
+      {"id": "canonical.reject-float", "input_lexeme": "1.5", "refusal": "unsupported-number-kind"},
+      {"id": "canonical.reject-lone-surrogate", "input_lexeme": "\"\\ud800\"", "refusal": "non-unicode-scalar"}
+    ],
+    "whitespace": "none"
   },
-  "content_identity": "sha256:67ca30bf675611a8cf68f4fc0cdaf2f0a7a16e5aa4fd5be270e9ddc1ecb066a5",
+  "content_identity": "sha256:cdac2365950e7d7f42c5c763055861e61eb6e9628852f7428ca879e569fc270e",
   "diagnostics": [
     {"code": "kernel.identity_mismatch", "stage": "ingress"},
     {"code": "kernel.binding_mismatch", "stage": "ingress"},
@@ -36,29 +105,65 @@
     {"code": "kernel.resource_exhausted", "stage": "ingress"}
   ],
   "meta_format": {
-    "fact": {"closed": true, "field_names": "non-empty-strings", "required_members": ["kind", "fields"]},
+    "fact": {"closed": true, "field_contracts": {"quantity-symbol": {"domain": {"type": "closed-int64-interval"}, "kind": {"path": "language.quantity.kinds", "type": "inventory-member"}, "numeric_policy": {"path": "language.quantity.numeric_policies.id", "type": "inventory-member"}, "representation": {"path": "language.quantity.representations", "type": "inventory-member"}, "role": {"path": "language.quantity.symbol_roles", "type": "inventory-member"}, "symbol": {"type": "non-empty-string"}, "unit": {"path": "language.quantity.units.id", "type": "inventory-member"}}}, "field_names": "non-empty-strings", "required_members": ["kind", "fields"], "schemas": [{"field_contract": "quantity-symbol", "kind": "quantity-source"}, {"field_contract": "quantity-symbol", "kind": "typed-quantity-symbol"}, {"field_contract": "quantity-symbol", "kind": "rir-quantity-declaration"}]},
     "term": {
       "closed": true,
       "constructors": [
-        {"required_members": ["tag", "value"], "tag": "literal"},
-        {"required_members": ["tag", "name"], "tag": "variable"}
+        {"member_types": {"tag": {"const": "literal"}, "value": {"type": "canonical-value"}}, "required_members": ["tag", "value"], "tag": "literal"},
+        {"member_types": {"name": {"type": "non-empty-string"}, "tag": {"const": "variable"}}, "required_members": ["tag", "name"], "tag": "variable"}
       ]
     },
-    "rule": {"closed": true, "required_members": ["id", "judgment", "premises", "conclusion"]},
+    "rule": {"closed": true, "conclusion_required_members": ["fact_kind", "fields"], "phases": ["type", "lower"], "premise_required_members": ["bind", "fact_kind"], "required_members": ["id", "phase", "judgment", "premises", "conclusion"]},
     "rule_selection": {
       "candidate_order": "rule-id-utf8-byte-order",
       "cardinality": "exactly-one",
-      "match": ["judgment-equality", "premise-fact-kind-equality"]
+      "match": ["phase-equality", "judgment-equality", "premise-fact-kind-equality"]
     },
     "binding_substitution": {
       "binding": "premise-bind maps variable names to source fact field names",
+      "conflicting_duplicate_binding": "kernel.vector_mismatch",
+      "duplicate_binding": "require-equal",
       "substitution": "evaluate every conclusion field term in the complete binding",
       "unbound_variable": "kernel.vector_mismatch"
     },
     "diagnostic_reason": {
       "closed": true,
+      "member_types": {"diagnostic": {"type": "non-empty-string"}, "id": {"type": "non-empty-string"}, "stage": {"enum": ["static"]}},
       "predicate_operations": ["not-member", "has-duplicate", "greater-than"],
-      "required_members": ["id", "diagnostic", "stage", "predicate"]
+      "predicate_schemas": [{"input_member_types": {"value": {"type": "canonical-scalar"}}, "input_members": ["value"], "member_types": {"inventory_path": {"type": "inventory-list-path"}, "member_field": {"type": "non-empty-string"}, "operation": {"const": "not-member"}}, "operation": "not-member", "optional_members": ["member_field"], "required_members": ["operation", "inventory_path"]}, {"input_member_types": {"values": {"type": "scalar-list"}}, "input_members": ["values"], "member_types": {"operation": {"const": "has-duplicate"}}, "operation": "has-duplicate", "optional_members": [], "required_members": ["operation"]}, {"input_member_types": {"value": {"type": "signed-int64"}}, "input_members": ["value"], "member_types": {"limit_path": {"type": "signed-int64-path"}, "operation": {"const": "greater-than"}}, "operation": "greater-than", "optional_members": [], "required_members": ["operation", "limit_path"]}],
+      "required_members": ["id", "diagnostic", "stage", "predicate"],
+      "scalar_equality": "type-and-canonical-value",
+      "vector_coverage": {"greater-than": "limit-and-successor", "has-duplicate": "both-outcomes", "not-member": "every-inventory-member-and-one-non-member"},
+      "vector_member_types": {"diagnostic": {"type": "non-empty-string"}, "id": {"type": "non-empty-string"}, "matched": {"type": "boolean"}, "reason": {"type": "non-empty-string"}, "stage": {"enum": ["static"]}},
+      "vector_required_members": ["id", "reason", "diagnostic", "stage", "input", "matched"]
+    },
+    "language_bundle": {
+      "closed": true,
+      "diagnostic": {"field_types": {"code": {"type": "non-empty-string"}, "stage": {"type": "refusal-stage"}}, "required_members": ["code", "stage"]},
+      "member_types": {"artifact_kind": {"const": "language-definition-bundle"}, "artifact_version": {"const": "2.0.0"}, "content_identity": {"type": "non-empty-string"}, "diagnostics": {"type": "list"}, "kernel_identity": {"type": "non-empty-string"}, "language": {"type": "object"}, "resources": {"type": "object"}, "schema_major": {"const": 2}, "vectors": {"type": "list"}},
+      "required_members": ["artifact_kind", "artifact_version", "schema_major", "kernel_identity", "content_identity", "language", "diagnostics", "resources", "vectors"],
+      "resources": {"field_types": {"max_diagnostics": {"type": "positive-signed-int64"}, "max_rule_match_steps": {"type": "positive-signed-int64"}, "max_source_bytes": {"type": "positive-signed-int64"}, "max_symbols": {"type": "positive-signed-int64"}}, "required_members": ["max_diagnostics", "max_rule_match_steps", "max_source_bytes", "max_symbols"]}
+    },
+    "language_definitions": {
+      "collections": {
+        "capabilities": {"field_types": {"id": {"type": "non-empty-string"}, "rule": {"type": "non-empty-string"}}, "required_members": ["id", "rule"]},
+        "components": {"max_items": 0},
+        "constructors": {"field_types": {"id": {"type": "non-empty-string"}, "parameters": {"type": "string-list"}}, "required_members": ["id", "parameters"]},
+        "conversions": {"max_items": 0},
+        "model_source_schema_versions": {"item_type": "non-empty-string"},
+        "operations": {"max_items": 0},
+        "runtime_profiles": {"max_items": 0},
+        "wire_schemas": {"field_types": {"artifact_kind": {"const": "model-source-package"}, "schema": {"allowed_keywords": ["$schema", "const", "enum", "items", "minLength", "properties", "required", "type", "unevaluatedProperties"], "dialect": "https://json-schema.org/draft/2020-12/schema", "keyword_type_requirements": {"items": ["array"], "minLength": ["string"], "properties": ["object"], "required": ["object"], "unevaluatedProperties": ["object"]}, "object_closure_keyword": "unevaluatedProperties", "object_closure_value": false, "references": "forbidden", "type": "closed-json-schema", "type_form": "single-string"}}, "required_members": ["artifact_kind", "schema"]}
+      },
+      "quantity": {"collections": {"domains": {"item_type": "non-empty-string"}, "kinds": {"item_type": "non-empty-string"}, "numeric_policies": {"field_types": {"id": {"type": "non-empty-string"}, "overflow": {"const": "refuse"}, "rounding": {"const": "none"}}, "required_members": ["id", "overflow", "rounding"]}, "representations": {"item_type": "non-empty-string"}, "symbol_roles": {"item_type": "non-empty-string"}, "units": {"field_types": {"dimension": {"type": "non-empty-string"}, "id": {"type": "non-empty-string"}}, "required_members": ["dimension", "id"]}}, "required_members": ["domains", "kinds", "numeric_policies", "representations", "symbol_roles", "units"]}
+    },
+    "package_release": {
+      "closed": true,
+      "field_types": {"artifact_kind": {"const": "domain-package-release"}, "content_identity": {"type": "non-empty-string"}, "id": {"type": "non-empty-string"}, "vectors": {"type": "string-list"}, "version": {"type": "non-empty-string"}},
+      "nested_field_types": {"capabilities": {"provided": {"type": "string-list"}, "required": {"type": "string-list"}}, "dependencies": {"optional": {"type": "string-list"}, "required": {"type": "string-list"}}, "exports": {"components": {"type": "string-list"}, "conversions": {"type": "string-list"}, "diagnostics": {"type": "string-list"}, "language_rules": {"type": "string-list"}, "operations": {"type": "string-list"}, "types": {"type": "list"}}, "profiles": {"numeric": {"type": "string-list"}, "runtime": {"type": "string-list"}}},
+      "nested_members": {"capabilities": ["provided", "required"], "dependencies": ["optional", "required"], "exports": ["components", "conversions", "diagnostics", "language_rules", "operations", "types"], "profiles": ["numeric", "runtime"]},
+      "required_members": ["artifact_kind", "capabilities", "content_identity", "dependencies", "exports", "id", "profiles", "vectors", "version"],
+      "type_export": {"field_types": {"constructor": {"type": "non-empty-string"}, "id": {"type": "non-empty-string"}}, "required_members": ["constructor", "id"]}
     }
   },
   "resources": {"max_authority_bytes": 262144, "max_diagnostics": 128, "max_members": 256, "max_nesting_depth": 32},

--- a/libs/gda-balancing/src/gda_balancing/schema2/authorities/kernel.json
+++ b/libs/gda-balancing/src/gda_balancing/schema2/authorities/kernel.json
@@ -1,0 +1,77 @@
+{
+  "admission": {
+    "closed": true,
+    "laws": [
+      {"id": "kernel.identity.verify", "identity_member": "content_identity", "operation": "verify-content-identity"},
+      {"id": "kernel.binding.exact", "left": "language_bundle.kernel_identity", "operation": "require-equal", "right": "kernel.content_identity"},
+      {"id": "kernel.members.closed", "members_from": "admission.required_ldb_members", "operation": "require-exact-members"},
+      {"id": "kernel.identifiers.unique", "operation": "require-unique-identifiers"},
+      {"id": "kernel.operations.closed", "operation": "require-known-operations"},
+      {"id": "kernel.vectors.closed", "operation": "require-vector-closure"},
+      {"id": "kernel.diagnostics.closed", "operation": "require-diagnostic-closure"},
+      {"id": "kernel.resources.bound", "operation": "enforce-resource-limits"}
+    ],
+    "required_ldb_members": ["artifact_kind", "artifact_version", "schema_major", "kernel_identity", "content_identity", "language", "diagnostics", "resources", "vectors"]
+  },
+  "artifact_kind": "schema-major-kernel",
+  "artifact_version": "2.0.0",
+  "canonical_encoding": {
+    "character_encoding": "UTF-8",
+    "identity_algorithm": "domain-separated-sha256",
+    "integer_domain": "signed-int64",
+    "object_order": "UTF-8-key-byte-order",
+    "optional_members": "omit",
+    "profile": "gda-canonical-json-v1",
+    "unicode_normalization": "preserve"
+  },
+  "content_identity": "sha256:67ca30bf675611a8cf68f4fc0cdaf2f0a7a16e5aa4fd5be270e9ddc1ecb066a5",
+  "diagnostics": [
+    {"code": "kernel.identity_mismatch", "stage": "ingress"},
+    {"code": "kernel.binding_mismatch", "stage": "ingress"},
+    {"code": "kernel.member_set_mismatch", "stage": "ingress"},
+    {"code": "kernel.duplicate_identifier", "stage": "static"},
+    {"code": "kernel.unknown_operation", "stage": "static"},
+    {"code": "kernel.vector_mismatch", "stage": "static"},
+    {"code": "kernel.diagnostic_closure", "stage": "static"},
+    {"code": "kernel.resource_exhausted", "stage": "ingress"}
+  ],
+  "meta_format": {
+    "fact": {"closed": true, "field_names": "non-empty-strings", "required_members": ["kind", "fields"]},
+    "term": {
+      "closed": true,
+      "constructors": [
+        {"required_members": ["tag", "value"], "tag": "literal"},
+        {"required_members": ["tag", "name"], "tag": "variable"}
+      ]
+    },
+    "rule": {"closed": true, "required_members": ["id", "judgment", "premises", "conclusion"]},
+    "rule_selection": {
+      "candidate_order": "rule-id-utf8-byte-order",
+      "cardinality": "exactly-one",
+      "match": ["judgment-equality", "premise-fact-kind-equality"]
+    },
+    "binding_substitution": {
+      "binding": "premise-bind maps variable names to source fact field names",
+      "substitution": "evaluate every conclusion field term in the complete binding",
+      "unbound_variable": "kernel.vector_mismatch"
+    },
+    "diagnostic_reason": {
+      "closed": true,
+      "predicate_operations": ["not-member", "has-duplicate", "greater-than"],
+      "required_members": ["id", "diagnostic", "stage", "predicate"]
+    }
+  },
+  "resources": {"max_authority_bytes": 262144, "max_diagnostics": 128, "max_members": 256, "max_nesting_depth": 32},
+  "schema_major": 2,
+  "vectors": [
+    {"expect": "admitted", "id": "kernel.accept.identity", "law": "kernel.identity.verify"},
+    {"diagnostic": "kernel.identity_mismatch", "id": "kernel.refuse.identity", "law": "kernel.identity.verify", "stage": "ingress"},
+    {"diagnostic": "kernel.binding_mismatch", "id": "kernel.refuse.binding", "law": "kernel.binding.exact", "stage": "ingress"},
+    {"diagnostic": "kernel.member_set_mismatch", "id": "kernel.refuse.members", "law": "kernel.members.closed", "stage": "ingress"},
+    {"diagnostic": "kernel.duplicate_identifier", "id": "kernel.refuse.duplicate", "law": "kernel.identifiers.unique", "stage": "static"},
+    {"diagnostic": "kernel.unknown_operation", "id": "kernel.refuse.operation", "law": "kernel.operations.closed", "stage": "static"},
+    {"diagnostic": "kernel.vector_mismatch", "id": "kernel.refuse.vector", "law": "kernel.vectors.closed", "stage": "static"},
+    {"diagnostic": "kernel.diagnostic_closure", "id": "kernel.refuse.diagnostic-closure", "law": "kernel.diagnostics.closed", "stage": "static"},
+    {"diagnostic": "kernel.resource_exhausted", "id": "kernel.refuse.resources", "law": "kernel.resources.bound", "stage": "ingress"}
+  ]
+}

--- a/libs/gda-balancing/src/gda_balancing/schema2/authorities/language-bundle.json
+++ b/libs/gda-balancing/src/gda_balancing/schema2/authorities/language-bundle.json
@@ -1,33 +1,58 @@
 {
   "artifact_kind": "language-definition-bundle",
   "artifact_version": "2.0.0",
-  "content_identity": "sha256:8b1cfdaf4f3604d18a43c7967258ee23f7e5ad3dc113a58c7e9347e534622cab",
+  "content_identity": "sha256:9198ebaac2bbcd208d61e7dbff79f8f0f388eae2522edf91b2a718011f7eae30",
   "diagnostics": [
     {"code": "language.unknown_kind", "stage": "static"},
     {"code": "language.unknown_unit", "stage": "static"},
-    {"code": "language.duplicate_symbol", "stage": "resolution"},
+    {"code": "language.duplicate_symbol", "stage": "static"},
     {"code": "language.resource_exhausted", "stage": "static"}
   ],
-  "kernel_identity": "sha256:67ca30bf675611a8cf68f4fc0cdaf2f0a7a16e5aa4fd5be270e9ddc1ecb066a5",
+  "kernel_identity": "sha256:cdac2365950e7d7f42c5c763055861e61eb6e9628852f7428ca879e569fc270e",
   "language": {
+    "capabilities": [
+      {"id": "quantity.declare", "rule": "quantity.declare"},
+      {"id": "quantity.lower", "rule": "quantity.lower"}
+    ],
+    "components": [],
     "constructors": [
       {"id": "core.quantity", "parameters": ["kind", "unit", "domain", "representation", "numeric_policy", "role"]}
     ],
+    "conversions": [],
+    "model_source_schema_versions": ["2.0.0"],
+    "operations": [],
     "packages": [
-      {"capabilities": ["quantity.declare", "quantity.lower"], "id": "core.quantity", "operations": [], "types": ["Quantity"], "version": "2.0.0"}
+      {
+        "artifact_kind": "domain-package-release",
+        "capabilities": {"provided": ["quantity.declare", "quantity.lower"], "required": []},
+        "content_identity": "sha256:2f50589e4a148753b569bda88d256fbb0a5283513e9b474fe4651a0038f79182",
+        "dependencies": {"optional": [], "required": []},
+        "exports": {
+          "components": [],
+          "conversions": [],
+          "diagnostics": ["language.duplicate_symbol", "language.resource_exhausted", "language.unknown_kind", "language.unknown_unit"],
+          "language_rules": ["quantity.declare", "quantity.lower"],
+          "operations": [],
+          "types": [{"constructor": "core.quantity", "id": "Quantity"}]
+        },
+        "id": "core.quantity",
+        "profiles": {"numeric": ["exact-int64"], "runtime": []},
+        "vectors": ["quantity.accept.kind", "quantity.accept.resources-boundary", "quantity.accept.unique", "quantity.accept.unit", "quantity.declare.valid", "quantity.lower.valid", "quantity.refuse.duplicate", "quantity.refuse.kind", "quantity.refuse.resources", "quantity.refuse.unit"],
+        "version": "2.0.0"
+      }
     ],
     "quantity": {
       "domains": ["closed-interval"],
       "kinds": ["scalar"],
       "numeric_policies": [{"id": "exact-int64", "overflow": "refuse", "rounding": "none"}],
-      "representations": ["signed-int64"],
-      "symbol_roles": ["constant", "parameter", "input", "state", "derived", "output", "random-variable"],
+      "representations": ["Int"],
+      "symbol_roles": ["constant", "parameter", "input", "state", "derived", "output", "random"],
       "units": [{"dimension": "dimensionless", "id": "1"}]
     },
     "reasons": [
       {"diagnostic": "language.unknown_kind", "id": "quantity.reason.unknown-kind", "predicate": {"inventory_path": "language.quantity.kinds", "operation": "not-member"}, "stage": "static"},
       {"diagnostic": "language.unknown_unit", "id": "quantity.reason.unknown-unit", "predicate": {"inventory_path": "language.quantity.units", "member_field": "id", "operation": "not-member"}, "stage": "static"},
-      {"diagnostic": "language.duplicate_symbol", "id": "quantity.reason.duplicate-symbol", "predicate": {"operation": "has-duplicate"}, "stage": "resolution"},
+      {"diagnostic": "language.duplicate_symbol", "id": "quantity.reason.duplicate-symbol", "predicate": {"operation": "has-duplicate"}, "stage": "static"},
       {"diagnostic": "language.resource_exhausted", "id": "quantity.reason.resource-exhausted", "predicate": {"limit_path": "resources.max_symbols", "operation": "greater-than"}, "stage": "static"}
     ],
     "rules": [
@@ -46,6 +71,7 @@
         },
         "id": "quantity.declare",
         "judgment": "declare-quantity",
+        "phase": "type",
         "premises": [{
           "bind": {
             "domain": "domain", "kind": "kind", "numeric_policy": "numeric_policy",
@@ -69,6 +95,7 @@
         },
         "id": "quantity.lower",
         "judgment": "lower-quantity",
+        "phase": "lower",
         "premises": [{
           "bind": {
             "domain": "domain", "kind": "kind", "numeric_policy": "numeric_policy",
@@ -78,6 +105,7 @@
         }]
       }
     ],
+    "runtime_profiles": [],
     "wire_schemas": [{
       "artifact_kind": "model-source-package",
       "schema": {
@@ -91,8 +119,8 @@
               "type": "object",
               "properties": {
                 "symbol": {"type": "string", "minLength": 1},
-                "role": {"enum": ["constant", "parameter", "input", "state", "derived", "output", "random-variable"]},
-                "representation": {"const": "signed-int64"},
+                "role": {"enum": ["constant", "parameter", "input", "state", "derived", "output", "random"]},
+                "representation": {"const": "Int"},
                 "kind": {"const": "scalar"},
                 "unit": {"const": "1"},
                 "domain": {
@@ -117,20 +145,24 @@
   "schema_major": 2,
   "vectors": [
     {
-      "expect": {"kind": "typed-quantity-symbol", "fields": {"domain": {"maximum": 100, "minimum": 0}, "kind": "scalar", "numeric_policy": "exact-int64", "representation": "signed-int64", "role": "state", "symbol": "health", "unit": "1"}},
+      "expect": {"kind": "typed-quantity-symbol", "fields": {"domain": {"maximum": 100, "minimum": 0}, "kind": "scalar", "numeric_policy": "exact-int64", "representation": "Int", "role": "state", "symbol": "health", "unit": "1"}},
       "id": "quantity.declare.valid",
-      "input": {"facts": [{"kind": "quantity-source", "fields": {"domain": {"maximum": 100, "minimum": 0}, "kind": "scalar", "numeric_policy": "exact-int64", "representation": "signed-int64", "role": "state", "symbol": "health", "unit": "1"}}], "judgment": "declare-quantity"},
+      "input": {"facts": [{"kind": "quantity-source", "fields": {"domain": {"maximum": 100, "minimum": 0}, "kind": "scalar", "numeric_policy": "exact-int64", "representation": "Int", "role": "state", "symbol": "health", "unit": "1"}}], "judgment": "declare-quantity", "phase": "type"},
       "rule": "quantity.declare"
     },
     {
-      "expect": {"kind": "rir-quantity-declaration", "fields": {"domain": {"maximum": 100, "minimum": 0}, "kind": "scalar", "numeric_policy": "exact-int64", "representation": "signed-int64", "role": "state", "symbol": "health", "unit": "1"}},
+      "expect": {"kind": "rir-quantity-declaration", "fields": {"domain": {"maximum": 100, "minimum": 0}, "kind": "scalar", "numeric_policy": "exact-int64", "representation": "Int", "role": "state", "symbol": "health", "unit": "1"}},
       "id": "quantity.lower.valid",
-      "input": {"facts": [{"kind": "typed-quantity-symbol", "fields": {"domain": {"maximum": 100, "minimum": 0}, "kind": "scalar", "numeric_policy": "exact-int64", "representation": "signed-int64", "role": "state", "symbol": "health", "unit": "1"}}], "judgment": "lower-quantity"},
+      "input": {"facts": [{"kind": "typed-quantity-symbol", "fields": {"domain": {"maximum": 100, "minimum": 0}, "kind": "scalar", "numeric_policy": "exact-int64", "representation": "Int", "role": "state", "symbol": "health", "unit": "1"}}], "judgment": "lower-quantity", "phase": "lower"},
       "rule": "quantity.lower"
     },
-    {"diagnostic": "language.unknown_kind", "id": "quantity.refuse.kind", "input": {"value": "missing-kind"}, "reason": "quantity.reason.unknown-kind", "stage": "static"},
-    {"diagnostic": "language.unknown_unit", "id": "quantity.refuse.unit", "input": {"value": "missing-unit"}, "reason": "quantity.reason.unknown-unit", "stage": "static"},
-    {"diagnostic": "language.duplicate_symbol", "id": "quantity.refuse.duplicate", "input": {"values": ["health", "health"]}, "reason": "quantity.reason.duplicate-symbol", "stage": "resolution"},
-    {"diagnostic": "language.resource_exhausted", "id": "quantity.refuse.resources", "input": {"value": 4097}, "reason": "quantity.reason.resource-exhausted", "stage": "static"}
+    {"diagnostic": "language.unknown_kind", "id": "quantity.refuse.kind", "input": {"value": "missing-kind"}, "matched": true, "reason": "quantity.reason.unknown-kind", "stage": "static"},
+    {"diagnostic": "language.unknown_kind", "id": "quantity.accept.kind", "input": {"value": "scalar"}, "matched": false, "reason": "quantity.reason.unknown-kind", "stage": "static"},
+    {"diagnostic": "language.unknown_unit", "id": "quantity.refuse.unit", "input": {"value": "missing-unit"}, "matched": true, "reason": "quantity.reason.unknown-unit", "stage": "static"},
+    {"diagnostic": "language.unknown_unit", "id": "quantity.accept.unit", "input": {"value": "1"}, "matched": false, "reason": "quantity.reason.unknown-unit", "stage": "static"},
+    {"diagnostic": "language.duplicate_symbol", "id": "quantity.refuse.duplicate", "input": {"values": ["health", "health"]}, "matched": true, "reason": "quantity.reason.duplicate-symbol", "stage": "static"},
+    {"diagnostic": "language.duplicate_symbol", "id": "quantity.accept.unique", "input": {"values": ["health", "mana"]}, "matched": false, "reason": "quantity.reason.duplicate-symbol", "stage": "static"},
+    {"diagnostic": "language.resource_exhausted", "id": "quantity.refuse.resources", "input": {"value": 4097}, "matched": true, "reason": "quantity.reason.resource-exhausted", "stage": "static"},
+    {"diagnostic": "language.resource_exhausted", "id": "quantity.accept.resources-boundary", "input": {"value": 4096}, "matched": false, "reason": "quantity.reason.resource-exhausted", "stage": "static"}
   ]
 }

--- a/libs/gda-balancing/src/gda_balancing/schema2/authorities/language-bundle.json
+++ b/libs/gda-balancing/src/gda_balancing/schema2/authorities/language-bundle.json
@@ -1,0 +1,136 @@
+{
+  "artifact_kind": "language-definition-bundle",
+  "artifact_version": "2.0.0",
+  "content_identity": "sha256:8b1cfdaf4f3604d18a43c7967258ee23f7e5ad3dc113a58c7e9347e534622cab",
+  "diagnostics": [
+    {"code": "language.unknown_kind", "stage": "static"},
+    {"code": "language.unknown_unit", "stage": "static"},
+    {"code": "language.duplicate_symbol", "stage": "resolution"},
+    {"code": "language.resource_exhausted", "stage": "static"}
+  ],
+  "kernel_identity": "sha256:67ca30bf675611a8cf68f4fc0cdaf2f0a7a16e5aa4fd5be270e9ddc1ecb066a5",
+  "language": {
+    "constructors": [
+      {"id": "core.quantity", "parameters": ["kind", "unit", "domain", "representation", "numeric_policy", "role"]}
+    ],
+    "packages": [
+      {"capabilities": ["quantity.declare", "quantity.lower"], "id": "core.quantity", "operations": [], "types": ["Quantity"], "version": "2.0.0"}
+    ],
+    "quantity": {
+      "domains": ["closed-interval"],
+      "kinds": ["scalar"],
+      "numeric_policies": [{"id": "exact-int64", "overflow": "refuse", "rounding": "none"}],
+      "representations": ["signed-int64"],
+      "symbol_roles": ["constant", "parameter", "input", "state", "derived", "output", "random-variable"],
+      "units": [{"dimension": "dimensionless", "id": "1"}]
+    },
+    "reasons": [
+      {"diagnostic": "language.unknown_kind", "id": "quantity.reason.unknown-kind", "predicate": {"inventory_path": "language.quantity.kinds", "operation": "not-member"}, "stage": "static"},
+      {"diagnostic": "language.unknown_unit", "id": "quantity.reason.unknown-unit", "predicate": {"inventory_path": "language.quantity.units", "member_field": "id", "operation": "not-member"}, "stage": "static"},
+      {"diagnostic": "language.duplicate_symbol", "id": "quantity.reason.duplicate-symbol", "predicate": {"operation": "has-duplicate"}, "stage": "resolution"},
+      {"diagnostic": "language.resource_exhausted", "id": "quantity.reason.resource-exhausted", "predicate": {"limit_path": "resources.max_symbols", "operation": "greater-than"}, "stage": "static"}
+    ],
+    "rules": [
+      {
+        "conclusion": {
+          "fact_kind": "typed-quantity-symbol",
+          "fields": {
+            "domain": {"name": "domain", "tag": "variable"},
+            "kind": {"name": "kind", "tag": "variable"},
+            "numeric_policy": {"name": "numeric_policy", "tag": "variable"},
+            "representation": {"name": "representation", "tag": "variable"},
+            "role": {"name": "role", "tag": "variable"},
+            "symbol": {"name": "symbol", "tag": "variable"},
+            "unit": {"name": "unit", "tag": "variable"}
+          }
+        },
+        "id": "quantity.declare",
+        "judgment": "declare-quantity",
+        "premises": [{
+          "bind": {
+            "domain": "domain", "kind": "kind", "numeric_policy": "numeric_policy",
+            "representation": "representation", "role": "role", "symbol": "symbol", "unit": "unit"
+          },
+          "fact_kind": "quantity-source"
+        }]
+      },
+      {
+        "conclusion": {
+          "fact_kind": "rir-quantity-declaration",
+          "fields": {
+            "domain": {"name": "domain", "tag": "variable"},
+            "kind": {"name": "kind", "tag": "variable"},
+            "numeric_policy": {"name": "numeric_policy", "tag": "variable"},
+            "representation": {"name": "representation", "tag": "variable"},
+            "role": {"name": "role", "tag": "variable"},
+            "symbol": {"name": "symbol", "tag": "variable"},
+            "unit": {"name": "unit", "tag": "variable"}
+          }
+        },
+        "id": "quantity.lower",
+        "judgment": "lower-quantity",
+        "premises": [{
+          "bind": {
+            "domain": "domain", "kind": "kind", "numeric_policy": "numeric_policy",
+            "representation": "representation", "role": "role", "symbol": "symbol", "unit": "unit"
+          },
+          "fact_kind": "typed-quantity-symbol"
+        }]
+      }
+    ],
+    "wire_schemas": [{
+      "artifact_kind": "model-source-package",
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "schema_version": {"const": "2.0.0"},
+          "symbols": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "symbol": {"type": "string", "minLength": 1},
+                "role": {"enum": ["constant", "parameter", "input", "state", "derived", "output", "random-variable"]},
+                "representation": {"const": "signed-int64"},
+                "kind": {"const": "scalar"},
+                "unit": {"const": "1"},
+                "domain": {
+                  "type": "object",
+                  "properties": {"minimum": {"type": "integer"}, "maximum": {"type": "integer"}},
+                  "required": ["minimum", "maximum"],
+                  "unevaluatedProperties": false
+                },
+                "numeric_policy": {"const": "exact-int64"}
+              },
+              "required": ["symbol", "role", "representation", "kind", "unit", "domain", "numeric_policy"],
+              "unevaluatedProperties": false
+            }
+          }
+        },
+        "required": ["schema_version", "symbols"],
+        "unevaluatedProperties": false
+      }
+    }]
+  },
+  "resources": {"max_diagnostics": 1000, "max_rule_match_steps": 65536, "max_source_bytes": 1048576, "max_symbols": 4096},
+  "schema_major": 2,
+  "vectors": [
+    {
+      "expect": {"kind": "typed-quantity-symbol", "fields": {"domain": {"maximum": 100, "minimum": 0}, "kind": "scalar", "numeric_policy": "exact-int64", "representation": "signed-int64", "role": "state", "symbol": "health", "unit": "1"}},
+      "id": "quantity.declare.valid",
+      "input": {"facts": [{"kind": "quantity-source", "fields": {"domain": {"maximum": 100, "minimum": 0}, "kind": "scalar", "numeric_policy": "exact-int64", "representation": "signed-int64", "role": "state", "symbol": "health", "unit": "1"}}], "judgment": "declare-quantity"},
+      "rule": "quantity.declare"
+    },
+    {
+      "expect": {"kind": "rir-quantity-declaration", "fields": {"domain": {"maximum": 100, "minimum": 0}, "kind": "scalar", "numeric_policy": "exact-int64", "representation": "signed-int64", "role": "state", "symbol": "health", "unit": "1"}},
+      "id": "quantity.lower.valid",
+      "input": {"facts": [{"kind": "typed-quantity-symbol", "fields": {"domain": {"maximum": 100, "minimum": 0}, "kind": "scalar", "numeric_policy": "exact-int64", "representation": "signed-int64", "role": "state", "symbol": "health", "unit": "1"}}], "judgment": "lower-quantity"},
+      "rule": "quantity.lower"
+    },
+    {"diagnostic": "language.unknown_kind", "id": "quantity.refuse.kind", "input": {"value": "missing-kind"}, "reason": "quantity.reason.unknown-kind", "stage": "static"},
+    {"diagnostic": "language.unknown_unit", "id": "quantity.refuse.unit", "input": {"value": "missing-unit"}, "reason": "quantity.reason.unknown-unit", "stage": "static"},
+    {"diagnostic": "language.duplicate_symbol", "id": "quantity.refuse.duplicate", "input": {"values": ["health", "health"]}, "reason": "quantity.reason.duplicate-symbol", "stage": "resolution"},
+    {"diagnostic": "language.resource_exhausted", "id": "quantity.refuse.resources", "input": {"value": 4097}, "reason": "quantity.reason.resource-exhausted", "stage": "static"}
+  ]
+}

--- a/libs/gda-balancing/src/gda_balancing/schema2/authority.py
+++ b/libs/gda-balancing/src/gda_balancing/schema2/authority.py
@@ -13,14 +13,102 @@ from typing import Any
 from gda_balancing.schema2.bootstrap import admit_authorities
 
 _AUTHORITY_PACKAGE = "gda_balancing.schema2.authorities"
+_BOOTSTRAP_MAX_AUTHORITY_BYTES = 262144
+_BOOTSTRAP_MAX_NESTING_DEPTH = 32
+
+
+class AuthorityLoadError(Exception):
+    """A candidate authority failed the non-self-hosted ingress preflight."""
+
+    stage = "ingress"
+
+    def __init__(self, *, code: str, subject: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.subject = subject
+        self.message = message
+
+
+def _raw_nesting_depth(data: bytes) -> int:
+    depth = 0
+    maximum = 0
+    in_string = False
+    escaped = False
+    for byte in data:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif byte == 0x5C:
+                escaped = True
+            elif byte == 0x22:
+                in_string = False
+            continue
+        if byte == 0x22:
+            in_string = True
+        elif byte in (0x7B, 0x5B):
+            depth += 1
+            maximum = max(maximum, depth)
+        elif byte in (0x7D, 0x5D):
+            depth -= 1
+    return maximum
+
+
+def _decode_authority(text: str, name: str, subject: str) -> dict[str, Any]:
+    def reject_number(_value: str) -> Any:
+        raise ValueError("non-integer number")
+
+    def closed_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        value: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError(f"duplicate object key: {key}")
+            value[key] = item
+        return value
+
+    try:
+        value = json.loads(
+            text,
+            object_pairs_hook=closed_object,
+            parse_float=reject_number,
+            parse_constant=reject_number,
+        )
+    except (json.JSONDecodeError, RecursionError, ValueError) as err:
+        raise AuthorityLoadError(
+            code="kernel.member_set_mismatch",
+            subject=subject,
+            message=f"packaged authority {name} is not canonical JSON: {err}",
+        ) from err
+    if not isinstance(value, dict):
+        raise AuthorityLoadError(
+            code="kernel.member_set_mismatch",
+            subject=subject,
+            message=f"packaged authority {name} is not an object",
+        )
+    return value
 
 
 def _load(name: str) -> dict[str, Any]:
     resource = files(_AUTHORITY_PACKAGE).joinpath(name)
-    value = json.loads(resource.read_text(encoding="utf-8"))
-    if not isinstance(value, dict):
-        raise RuntimeError(f"packaged authority {name} is not an object")
-    return value
+    data = resource.read_bytes()
+    subject = "kernel" if name == "kernel.json" else "language-bundle"
+    if (
+        len(data) > _BOOTSTRAP_MAX_AUTHORITY_BYTES
+        or _raw_nesting_depth(data) > _BOOTSTRAP_MAX_NESTING_DEPTH
+    ):
+        raise AuthorityLoadError(
+            code="kernel.resource_exhausted",
+            subject=subject,
+            message=f"packaged authority {name} exceeds the raw ingress bound",
+        )
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as err:
+        raise AuthorityLoadError(
+            code="kernel.member_set_mismatch",
+            subject=subject,
+            message=f"packaged authority {name} is not UTF-8",
+        ) from err
+    return _decode_authority(text, name, subject)
 
 
 def load_authorities() -> tuple[dict[str, Any], dict[str, Any]]:

--- a/libs/gda-balancing/src/gda_balancing/schema2/authority.py
+++ b/libs/gda-balancing/src/gda_balancing/schema2/authority.py
@@ -1,0 +1,43 @@
+"""Loader for the permanent, packaged Kernel/LDB authority artifacts.
+
+The JSON resources are the language authority.  This host module only reads,
+independently admits, and defensively copies them; changing Python dispatch
+cannot silently add a law, rule, diagnostic, or package to the language.
+"""
+
+import json
+from copy import deepcopy
+from importlib.resources import files
+from typing import Any
+
+from gda_balancing.schema2.bootstrap import admit_authorities
+
+_AUTHORITY_PACKAGE = "gda_balancing.schema2.authorities"
+
+
+def _load(name: str) -> dict[str, Any]:
+    resource = files(_AUTHORITY_PACKAGE).joinpath(name)
+    value = json.loads(resource.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise RuntimeError(f"packaged authority {name} is not an object")
+    return value
+
+
+def load_authorities() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Load fresh copies of both packaged authority artifacts."""
+    return _load("kernel.json"), _load("language-bundle.json")
+
+
+def authority_set() -> dict[str, Any]:
+    """Return a defensive copy of the independently admitted authority pair."""
+    kernel, ldb = load_authorities()
+    admission = admit_authorities(kernel, ldb)
+    return {
+        "kernel": deepcopy(kernel),
+        "language_bundle": deepcopy(ldb),
+        "admission": {
+            "admitted": admission.admitted,
+            "kernel_identity": admission.kernel_identity,
+            "language_bundle_identity": admission.language_bundle_identity,
+        },
+    }

--- a/libs/gda-balancing/src/gda_balancing/schema2/bootstrap.py
+++ b/libs/gda-balancing/src/gda_balancing/schema2/bootstrap.py
@@ -5,13 +5,73 @@ does not contain Quantity rule dispatch: LDB rules are checked through their
 declared generic inputs/result and normative vectors.
 """
 
+import json
 from dataclasses import dataclass
 from typing import Any, cast
+
+import jsonschema
 
 from gda_balancing.schema2.canonical import JsonValue, canonical_bytes, content_identity
 
 _KERNEL_DOMAIN = "schema-major-kernel-v2"
 _LDB_DOMAIN = "language-definition-bundle-v2"
+SCHEMA2_REFUSAL_STAGES = (
+    "ingress",
+    "parse",
+    "static",
+    "resolution",
+    "runtime",
+    "evaluation",
+    "migration",
+    "approval",
+)
+BOOTSTRAP_REFUSAL_CATALOG = (
+    ("kernel.binding_mismatch", "ingress"),
+    ("kernel.diagnostic_closure", "static"),
+    ("kernel.duplicate_identifier", "static"),
+    ("kernel.identity_mismatch", "ingress"),
+    ("kernel.member_set_mismatch", "ingress"),
+    ("kernel.resource_exhausted", "ingress"),
+    ("kernel.unknown_operation", "static"),
+    ("kernel.vector_mismatch", "static"),
+)
+_SUPPORTED_KERNEL_IDENTITY = (
+    "sha256:cdac2365950e7d7f42c5c763055861e61eb6e9628852f7428ca879e569fc270e"
+)
+_SUPPORTED_CANONICAL_PROFILE: dict[str, Any] = {
+    "array_order": "preserve",
+    "character_encoding": "UTF-8",
+    "control_character_escaping": {
+        "backspace": "\\b",
+        "carriage-return": "\\r",
+        "form-feed": "\\f",
+        "line-feed": "\\n",
+        "other-u0000-u001f": "lowercase-u00xx",
+        "tab": "\\t",
+    },
+    "delete_character_escaping": "literal-byte-7f",
+    "digest_hex_case": "lowercase",
+    "document_terminator": "LF",
+    "duplicate_object_keys": "refuse-at-decoding",
+    "escape_solidus": False,
+    "identity_algorithm": "sha256",
+    "identity_domain_prefix": "gda-balancing:",
+    "identity_domain_suffix": ":",
+    "identity_excluded_members": ["content_identity"],
+    "identity_output_prefix": "sha256:",
+    "integer_domain": "signed-int64",
+    "item_separator": ",",
+    "key_separator": ":",
+    "lone_surrogate": "refuse",
+    "non_ascii_strings": "literal-utf8",
+    "number_kinds": ["signed-int64"],
+    "object_order": "UTF-8-key-byte-order",
+    "optional_members": "omit",
+    "printable_ascii_escaping": "only-quotation-mark-and-reverse-solidus",
+    "profile": "gda-canonical-json-v1",
+    "unicode_normalization": "preserve",
+    "whitespace": "none",
+}
 _KERNEL_MEMBERS = frozenset(
     {
         "admission",
@@ -66,6 +126,98 @@ def _artifact_identity(domain: str, artifact: dict[str, Any]) -> str:
     return content_identity(domain, cast(JsonValue, body))
 
 
+def _strict_json_value(text: str) -> JsonValue:
+    def reject_number(_value: str) -> Any:
+        raise ValueError("non-integer number is outside canonical JSON")
+
+    def closed_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError("duplicate object key is outside canonical JSON")
+            result[key] = value
+        return result
+
+    return cast(
+        JsonValue,
+        json.loads(
+            text,
+            object_pairs_hook=closed_object,
+            parse_float=reject_number,
+            parse_constant=reject_number,
+        ),
+    )
+
+
+def _canonical_contract_is_supported(canonical_encoding: Any) -> bool:
+    if not isinstance(canonical_encoding, dict):
+        return False
+    vectors = canonical_encoding.get("vectors")
+    profile = {
+        key: value for key, value in canonical_encoding.items() if key != "vectors"
+    }
+    if profile != _SUPPORTED_CANONICAL_PROFILE or not isinstance(vectors, list):
+        return False
+    expected_ids = {
+        "canonical.boundary-integers",
+        "canonical.control-character-escaping",
+        "canonical.order-array-unicode-escaping",
+        "canonical.reject-duplicate-key",
+        "canonical.reject-float",
+        "canonical.reject-lone-surrogate",
+    }
+    if {item.get("id") for item in vectors if isinstance(item, dict)} != expected_ids:
+        return False
+    for vector in vectors:
+        if not isinstance(vector, dict):
+            return False
+        if "value" in vector:
+            if set(vector) != {
+                "canonical_utf8_hex",
+                "domain",
+                "id",
+                "identity",
+                "value",
+            }:
+                return False
+            value = cast(JsonValue, vector["value"])
+            domain = vector.get("domain")
+            if (
+                not isinstance(domain, str)
+                or canonical_bytes(value).hex() != vector.get("canonical_utf8_hex")
+                or content_identity(domain, value) != vector.get("identity")
+            ):
+                return False
+        else:
+            if set(vector) != {"id", "input_lexeme", "refusal"} or not isinstance(
+                vector.get("input_lexeme"), str
+            ):
+                return False
+            try:
+                canonical_bytes(_strict_json_value(vector["input_lexeme"]))
+            except (TypeError, ValueError, UnicodeEncodeError):
+                continue
+            return False
+    return True
+
+
+def _safe_artifact_identity(
+    domain: str,
+    artifact: dict[str, Any],
+    canonical_encoding: Any,
+) -> str | None:
+    try:
+        supported = _canonical_contract_is_supported(canonical_encoding)
+    except (TypeError, ValueError, UnicodeEncodeError):
+        supported = False
+    if not supported:
+        return None
+    try:
+        return _artifact_identity(domain, artifact)
+    except (TypeError, ValueError):
+        return None
+
+
 def _resource_shape(value: Any) -> tuple[int, int]:
     """Return maximum nesting depth and largest single collection iteratively."""
     maximum_depth = 0
@@ -83,6 +235,780 @@ def _resource_shape(value: Any) -> tuple[int, int]:
     return maximum_depth, maximum_members
 
 
+def _package_is_closed(
+    package: dict[str, Any], contract: Any, language_bundle: dict[str, Any]
+) -> bool:
+    if not isinstance(contract, dict) or contract.get("closed") is not True:
+        return False
+    required = contract.get("required_members")
+    field_types = contract.get("field_types")
+    nested_members = contract.get("nested_members")
+    nested_types = contract.get("nested_field_types")
+    type_export = contract.get("type_export")
+    if (
+        not isinstance(required, list)
+        or set(package) != set(required)
+        or not isinstance(field_types, dict)
+        or not isinstance(nested_members, dict)
+        or not isinstance(nested_types, dict)
+        or set(nested_members) != set(nested_types)
+        or set(field_types) | set(nested_members) != set(required)
+        or set(field_types) & set(nested_members)
+        or not all(
+            _value_matches_contract(package[name], field_types[name], language_bundle)
+            for name in field_types
+        )
+    ):
+        return False
+    for name, members in nested_members.items():
+        value = package.get(name)
+        member_types = nested_types.get(name)
+        if (
+            not isinstance(value, dict)
+            or not isinstance(members, list)
+            or set(value) != set(members)
+            or not isinstance(member_types, dict)
+            or set(member_types) != set(members)
+            or not all(
+                _value_matches_contract(
+                    value[member], member_types[member], language_bundle
+                )
+                for member in members
+            )
+        ):
+            return False
+    exports = package.get("exports")
+    exported_types = exports.get("types") if isinstance(exports, dict) else None
+    if not isinstance(exported_types, list) or not isinstance(type_export, dict):
+        return False
+    export_members = type_export.get("required_members")
+    export_field_types = type_export.get("field_types")
+    return (
+        isinstance(export_members, list)
+        and isinstance(export_field_types, dict)
+        and set(export_field_types) == set(export_members)
+        and all(
+            isinstance(item, dict)
+            and set(item) == set(export_members)
+            and all(
+                _value_matches_contract(
+                    item[member], export_field_types[member], language_bundle
+                )
+                for member in export_members
+            )
+            for item in exported_types
+        )
+    )
+
+
+def _language_bundle_is_closed(
+    language_bundle: dict[str, Any], contract: Any, refusal_stages: Any
+) -> bool:
+    if not isinstance(contract, dict) or contract.get("closed") is not True:
+        return False
+    required = contract.get("required_members")
+    member_types = contract.get("member_types")
+    diagnostics_contract = contract.get("diagnostic")
+    resources_contract = contract.get("resources")
+    if (
+        not isinstance(required, list)
+        or set(language_bundle) != set(required)
+        or not isinstance(member_types, dict)
+        or set(member_types) != set(required)
+        or not isinstance(refusal_stages, list)
+        or tuple(refusal_stages) != SCHEMA2_REFUSAL_STAGES
+    ):
+        return False
+    for name, value_contract in member_types.items():
+        if name == "diagnostics":
+            if not isinstance(language_bundle[name], list):
+                return False
+        elif not _value_matches_contract(
+            language_bundle[name], value_contract, language_bundle
+        ):
+            return False
+    if not isinstance(diagnostics_contract, dict):
+        return False
+    diagnostic_members = diagnostics_contract.get("required_members")
+    diagnostic_types = diagnostics_contract.get("field_types")
+    diagnostics = language_bundle["diagnostics"]
+    if (
+        not isinstance(diagnostic_members, list)
+        or not isinstance(diagnostic_types, dict)
+        or set(diagnostic_types) != set(diagnostic_members)
+        or not all(
+            isinstance(item, dict)
+            and set(item) == set(diagnostic_members)
+            and isinstance(item.get("code"), str)
+            and bool(item["code"])
+            and item.get("stage") in refusal_stages
+            for item in diagnostics
+        )
+    ):
+        return False
+    if not isinstance(resources_contract, dict):
+        return False
+    resource_members = resources_contract.get("required_members")
+    resource_types = resources_contract.get("field_types")
+    resources = language_bundle["resources"]
+    return (
+        isinstance(resources, dict)
+        and isinstance(resource_members, list)
+        and set(resources) == set(resource_members)
+        and isinstance(resource_types, dict)
+        and set(resource_types) == set(resource_members)
+        and all(
+            _value_matches_contract(
+                resources[name], resource_types[name], language_bundle
+            )
+            for name in resource_members
+        )
+    )
+
+
+def _path_values(root: Any, dotted: Any) -> list[Any]:
+    """Project a closed dotted path, flattening collection members."""
+    if not isinstance(dotted, str) or not dotted:
+        return []
+    values = [root]
+    for part in dotted.split("."):
+        projected: list[Any] = []
+        for value in values:
+            if not isinstance(value, dict) or part not in value:
+                return []
+            child = value[part]
+            if isinstance(child, list):
+                projected.extend(child)
+            else:
+                projected.append(child)
+        values = projected
+    return values
+
+
+def _path_is_declared(root: Any, dotted: Any) -> bool:
+    if not isinstance(dotted, str) or not dotted:
+        return False
+
+    def walk(value: Any, parts: list[str]) -> bool:
+        if not parts:
+            return True
+        if not isinstance(value, dict) or parts[0] not in value:
+            return False
+        child = value[parts[0]]
+        if isinstance(child, list):
+            return all(walk(item, parts[1:]) for item in child)
+        return walk(child, parts[1:])
+
+    return walk(root, dotted.split("."))
+
+
+def _exact_path_value(root: Any, dotted: Any) -> tuple[bool, Any]:
+    """Resolve a path whose intermediate values are mappings, without flattening."""
+    if not isinstance(dotted, str) or not dotted:
+        return False, None
+    value = root
+    for part in dotted.split("."):
+        if not isinstance(value, dict) or part not in value:
+            return False, None
+        value = value[part]
+    return True, value
+
+
+def _closed_json_schema(value: Any, contract: dict[str, Any]) -> bool:
+    allowed = contract.get("allowed_keywords")
+    dialect = contract.get("dialect")
+    closure_keyword = contract.get("object_closure_keyword")
+    closure_value = contract.get("object_closure_value")
+    keyword_type_requirements = contract.get("keyword_type_requirements")
+    if (
+        not isinstance(value, dict)
+        or not isinstance(allowed, list)
+        or not all(isinstance(item, str) for item in allowed)
+        or not isinstance(dialect, str)
+        or not isinstance(keyword_type_requirements, dict)
+        or not all(
+            isinstance(keyword, str)
+            and isinstance(types, list)
+            and types
+            and all(isinstance(item, str) for item in types)
+            for keyword, types in keyword_type_requirements.items()
+        )
+        or closure_keyword != "unevaluatedProperties"
+        or closure_value is not False
+        or contract.get("references") != "forbidden"
+        or contract.get("type_form") != "single-string"
+        or value.get("$schema") != dialect
+    ):
+        return False
+    try:
+        jsonschema.Draft202012Validator.check_schema(value)
+    except jsonschema.SchemaError:
+        return False
+    allowed_set = set(allowed)
+
+    def walk(schema: Any) -> bool:
+        if not isinstance(schema, dict) or not set(schema) <= allowed_set:
+            return False
+        schema_type = schema.get("type")
+        if schema_type is not None and (
+            not isinstance(schema_type, str)
+            or schema_type
+            not in {
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string",
+            }
+        ):
+            return False
+        if schema_type == "object" and schema.get(closure_keyword) is not False:
+            return False
+        if any(
+            keyword in schema and schema_type not in required_types
+            for keyword, required_types in keyword_type_requirements.items()
+        ):
+            return False
+        if "$ref" in schema:
+            return False
+        required = schema.get("required")
+        if required is not None and (
+            not isinstance(required, list)
+            or not all(isinstance(item, str) and item for item in required)
+            or len(required) != len(set(required))
+        ):
+            return False
+        for keyword in ("$defs", "properties"):
+            children = schema.get(keyword)
+            if children is not None and (
+                not isinstance(children, dict)
+                or not all(
+                    isinstance(name, str) and name and walk(child)
+                    for name, child in children.items()
+                )
+            ):
+                return False
+        items = schema.get("items")
+        if items is not None and not walk(items):
+            return False
+        for keyword in ("anyOf", "oneOf"):
+            children = schema.get(keyword)
+            if children is not None and (
+                not isinstance(children, list)
+                or not children
+                or not all(walk(child) for child in children)
+            ):
+                return False
+        for keyword in ("const", "default", "enum"):
+            if keyword in schema:
+                try:
+                    canonical_bytes(cast(JsonValue, schema[keyword]))
+                except (TypeError, ValueError):
+                    return False
+        return True
+
+    return walk(value)
+
+
+def _reference_contracts_close(
+    kernel: dict[str, Any], language_bundle: dict[str, Any]
+) -> bool:
+    laws = kernel.get("admission", {}).get("laws", [])
+    vector_law = next(
+        (
+            law
+            for law in laws
+            if isinstance(law, dict) and law.get("id") == "kernel.vectors.closed"
+        ),
+        None,
+    )
+    if not isinstance(vector_law, dict):
+        return False
+    references = vector_law.get("arguments", {}).get("references")
+    equalities = vector_law.get("arguments", {}).get("equalities")
+    if not isinstance(references, list) or not isinstance(equalities, list):
+        return False
+    authorities = {"kernel": kernel, "language_bundle": language_bundle}
+    for contract in equalities:
+        if (
+            not isinstance(contract, dict)
+            or set(contract) != {"left", "mode", "right"}
+            or contract.get("mode") != "set"
+            or not _path_is_declared(authorities, contract.get("left"))
+            or not _path_is_declared(authorities, contract.get("right"))
+        ):
+            return False
+        try:
+            if set(_path_values(authorities, contract["left"])) != set(
+                _path_values(authorities, contract["right"])
+            ):
+                return False
+        except TypeError:
+            return False
+    for contract in references:
+        if not isinstance(contract, dict):
+            return False
+        owners = _path_values(authorities, contract.get("owners"))
+        targets = contract.get("targets")
+        if (
+            not _path_is_declared(authorities, contract.get("owners"))
+            or not owners
+            or not isinstance(targets, dict)
+        ):
+            return False
+        for owner in owners:
+            if not isinstance(owner, dict):
+                return False
+            for source_path, target_path in targets.items():
+                if not _path_is_declared(owner, source_path) or not _path_is_declared(
+                    authorities, target_path
+                ):
+                    return False
+                source_values = _path_values(owner, source_path)
+                target_values = _path_values(authorities, target_path)
+                if any(value not in target_values for value in source_values):
+                    return False
+    return True
+
+
+def _duplicate_identifier_subjects(
+    kernel: dict[str, Any], language_bundle: dict[str, Any]
+) -> set[str]:
+    laws = kernel.get("admission", {}).get("laws", [])
+    uniqueness_law = next(
+        (
+            law
+            for law in laws
+            if isinstance(law, dict) and law.get("id") == "kernel.identifiers.unique"
+        ),
+        None,
+    )
+    if not isinstance(uniqueness_law, dict):
+        return {"kernel.admission.laws"}
+    collections = uniqueness_law.get("arguments", {}).get("collections")
+    if not isinstance(collections, list):
+        return {"kernel.admission.laws"}
+    authorities = {"kernel": kernel, "language_bundle": language_bundle}
+    duplicates: set[str] = set()
+    for contract in collections:
+        if not isinstance(contract, dict):
+            duplicates.add("kernel.admission.laws")
+            continue
+        keys = contract.get("keys")
+        path = contract.get("path")
+        subject = contract.get("subject")
+        items = _path_values(authorities, path)
+        if (
+            not isinstance(keys, list)
+            or not keys
+            or not all(isinstance(key, str) and key for key in keys)
+            or not isinstance(subject, str)
+            or not subject
+        ):
+            duplicates.add(str(subject or path or "kernel.admission.laws"))
+            continue
+        identities: list[tuple[Any, ...]] = []
+        for item in items:
+            if not isinstance(item, dict) or any(key not in item for key in keys):
+                duplicates.add(subject)
+                break
+            identities.append(tuple(item[key] for key in keys))
+        try:
+            if len(identities) != len(set(identities)):
+                duplicates.add(subject)
+        except TypeError:
+            duplicates.add(subject)
+    return duplicates
+
+
+def _value_matches_contract(
+    value: Any,
+    contract: Any,
+    language_bundle: dict[str, Any],
+) -> bool:
+    if not isinstance(contract, dict):
+        return False
+    if "const" in contract:
+        return value == contract["const"] and type(value) is type(contract["const"])
+    if "enum" in contract:
+        return isinstance(contract["enum"], list) and value in contract["enum"]
+    value_type = contract.get("type")
+    if value_type == "non-empty-string":
+        return isinstance(value, str) and bool(value)
+    if value_type == "boolean":
+        return isinstance(value, bool)
+    if value_type == "list":
+        return isinstance(value, list)
+    if value_type == "object":
+        return isinstance(value, dict)
+    if value_type == "positive-signed-int64":
+        return (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and 1 <= value <= 2**63 - 1
+        )
+    if value_type == "signed-int64":
+        return (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and -(2**63) <= value <= 2**63 - 1
+        )
+    if value_type == "canonical-scalar":
+        return (
+            value is None
+            or isinstance(value, (bool, str))
+            or (
+                isinstance(value, int)
+                and not isinstance(value, bool)
+                and -(2**63) <= value <= 2**63 - 1
+            )
+        )
+    if value_type == "scalar-list":
+        return isinstance(value, list) and all(
+            _value_matches_contract(item, {"type": "canonical-scalar"}, language_bundle)
+            for item in value
+        )
+    if value_type == "string-list":
+        return (
+            isinstance(value, list)
+            and all(isinstance(item, str) and item for item in value)
+            and len(value) == len(set(value))
+        )
+    if value_type == "canonical-value":
+        try:
+            canonical_bytes(cast(JsonValue, value))
+        except (TypeError, ValueError):
+            return False
+        return True
+    if value_type == "inventory-member":
+        path = contract.get("path")
+        return _path_is_declared(language_bundle, path) and value in _path_values(
+            language_bundle, path
+        )
+    if value_type == "inventory-list-path":
+        declared, target = _exact_path_value(language_bundle, value)
+        return declared and isinstance(target, list) and bool(target)
+    if value_type == "signed-int64-path":
+        declared, target = _exact_path_value(language_bundle, value)
+        return declared and _value_matches_contract(
+            target, {"type": "signed-int64"}, language_bundle
+        )
+    if value_type == "closed-json-schema":
+        return _closed_json_schema(value, contract)
+    if value_type == "closed-int64-interval":
+        if not isinstance(value, dict) or set(value) != {"minimum", "maximum"}:
+            return False
+        minimum = value["minimum"]
+        maximum = value["maximum"]
+        return (
+            isinstance(minimum, int)
+            and not isinstance(minimum, bool)
+            and isinstance(maximum, int)
+            and not isinstance(maximum, bool)
+            and -(2**63) <= minimum <= maximum <= 2**63 - 1
+        )
+    return False
+
+
+def _definition_is_closed(
+    value: Any,
+    contract: Any,
+    language_bundle: dict[str, Any],
+) -> bool:
+    if not isinstance(value, dict) or not isinstance(contract, dict):
+        return False
+    required = contract.get("required_members")
+    field_types = contract.get("field_types")
+    return (
+        isinstance(required, list)
+        and isinstance(field_types, dict)
+        and set(value) == set(required)
+        and set(field_types) == set(required)
+        and all(
+            _value_matches_contract(value[name], field_types[name], language_bundle)
+            for name in required
+        )
+    )
+
+
+def _language_definitions_are_closed(
+    language_bundle: dict[str, Any], meta_format: dict[str, Any]
+) -> bool:
+    language = language_bundle.get("language")
+    authority = meta_format.get("language_definitions")
+    if not isinstance(language, dict) or not isinstance(authority, dict):
+        return False
+    collections = authority.get("collections")
+    if not isinstance(collections, dict):
+        return False
+    for name, contract in collections.items():
+        values = language.get(name)
+        if not isinstance(values, list) or not isinstance(contract, dict):
+            return False
+        max_items = contract.get("max_items")
+        if max_items is not None:
+            if not isinstance(max_items, int) or len(values) > max_items:
+                return False
+            continue
+        item_type = contract.get("item_type")
+        if item_type is not None:
+            item_contract = {"type": item_type}
+            if not all(
+                _value_matches_contract(value, item_contract, language_bundle)
+                for value in values
+            ):
+                return False
+            continue
+        if not all(
+            _definition_is_closed(value, contract, language_bundle) for value in values
+        ):
+            return False
+    quantity = language.get("quantity")
+    quantity_contract = authority.get("quantity")
+    if not isinstance(quantity, dict) or not isinstance(quantity_contract, dict):
+        return False
+    required = quantity_contract.get("required_members")
+    quantity_collections = quantity_contract.get("collections")
+    if (
+        not isinstance(required, list)
+        or set(quantity) != set(required)
+        or not isinstance(quantity_collections, dict)
+        or set(quantity_collections) != set(required)
+    ):
+        return False
+    for name, contract in quantity_collections.items():
+        values = quantity.get(name)
+        if not isinstance(values, list) or not isinstance(contract, dict):
+            return False
+        item_type = contract.get("item_type")
+        if item_type is not None:
+            item_contract = {"type": item_type}
+            if not all(
+                _value_matches_contract(value, item_contract, language_bundle)
+                for value in values
+            ):
+                return False
+        elif not all(
+            _definition_is_closed(value, contract, language_bundle) for value in values
+        ):
+            return False
+    return True
+
+
+def _fact_schemas(
+    meta_format: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    fact_contract = meta_format.get("fact")
+    if not isinstance(fact_contract, dict):
+        return {}
+    schemas = fact_contract.get("schemas")
+    field_contracts = fact_contract.get("field_contracts")
+    if not isinstance(schemas, list) or not isinstance(field_contracts, dict):
+        return {}
+    result: dict[str, dict[str, Any]] = {}
+    for schema in schemas:
+        if not isinstance(schema, dict):
+            return {}
+        kind = schema.get("kind")
+        contract_name = schema.get("field_contract")
+        fields = field_contracts.get(contract_name)
+        if (
+            not isinstance(kind, str)
+            or not kind
+            or not isinstance(contract_name, str)
+            or not isinstance(fields, dict)
+            or not all(isinstance(field, str) and field for field in fields)
+            or kind in result
+        ):
+            return {}
+        result[kind] = fields
+    return result
+
+
+def _fact_is_closed(
+    fact: Any,
+    meta_format: dict[str, Any],
+    language_bundle: dict[str, Any],
+) -> bool:
+    fact_contract = meta_format.get("fact")
+    schemas = _fact_schemas(meta_format)
+    if not isinstance(fact_contract, dict) or not schemas or not isinstance(fact, dict):
+        return False
+    required = fact_contract.get("required_members")
+    kind = fact.get("kind")
+    fields = fact.get("fields")
+    return (
+        fact_contract.get("closed") is True
+        and isinstance(required, list)
+        and set(fact) == set(required)
+        and isinstance(kind, str)
+        and kind in schemas
+        and isinstance(fields, dict)
+        and set(fields) == set(schemas[kind])
+        and all(isinstance(name, str) and name for name in fields)
+        and all(
+            _value_matches_contract(fields[name], schemas[kind][name], language_bundle)
+            for name in fields
+        )
+    )
+
+
+def _reason_is_closed(
+    reason: Any,
+    meta_format: dict[str, Any],
+    language_bundle: dict[str, Any],
+) -> bool:
+    contract = meta_format.get("diagnostic_reason")
+    if not isinstance(contract, dict) or not isinstance(reason, dict):
+        return False
+    required = contract.get("required_members")
+    member_types = contract.get("member_types")
+    schemas = contract.get("predicate_schemas")
+    predicate = reason.get("predicate")
+    if (
+        contract.get("closed") is not True
+        or contract.get("scalar_equality") != "type-and-canonical-value"
+        or not isinstance(required, list)
+        or set(reason) != set(required)
+        or not isinstance(member_types, dict)
+        or set(member_types) != set(required) - {"predicate"}
+        or not all(
+            _value_matches_contract(reason[name], member_types[name], language_bundle)
+            for name in member_types
+        )
+        or not isinstance(predicate, dict)
+        or not isinstance(schemas, list)
+    ):
+        return False
+    operation = predicate.get("operation")
+    schema = next(
+        (
+            item
+            for item in schemas
+            if isinstance(item, dict) and item.get("operation") == operation
+        ),
+        None,
+    )
+    if not isinstance(schema, dict):
+        return False
+    predicate_required = schema.get("required_members")
+    optional = schema.get("optional_members")
+    predicate_types = schema.get("member_types")
+    input_members = schema.get("input_members")
+    input_types = schema.get("input_member_types")
+    return (
+        isinstance(predicate_required, list)
+        and isinstance(optional, list)
+        and isinstance(predicate_types, dict)
+        and isinstance(input_members, list)
+        and isinstance(input_types, dict)
+        and set(input_types) == set(input_members)
+        and set(predicate_required) <= set(predicate)
+        and set(predicate) <= set(predicate_required) | set(optional)
+        and set(predicate_types) == set(predicate_required) | set(optional)
+        and all(
+            _value_matches_contract(
+                predicate[name], predicate_types[name], language_bundle
+            )
+            for name in predicate
+        )
+        and _reason_operands_are_closed(predicate, language_bundle)
+    )
+
+
+def _reason_operands_are_closed(
+    predicate: dict[str, Any], language_bundle: dict[str, Any]
+) -> bool:
+    operation = predicate.get("operation")
+    if operation == "not-member":
+        declared, inventory = _exact_path_value(
+            language_bundle, predicate.get("inventory_path")
+        )
+        if not declared or not isinstance(inventory, list) or not inventory:
+            return False
+        member_field = predicate.get("member_field")
+        if member_field is None:
+            values = inventory
+        elif isinstance(member_field, str) and member_field:
+            if not all(
+                isinstance(item, dict) and member_field in item for item in inventory
+            ):
+                return False
+            values = [item[member_field] for item in inventory]
+        else:
+            return False
+        return all(
+            _value_matches_contract(
+                value, {"type": "canonical-scalar"}, language_bundle
+            )
+            for value in values
+        )
+    if operation == "greater-than":
+        declared, limit = _exact_path_value(
+            language_bundle, predicate.get("limit_path")
+        )
+        return declared and _value_matches_contract(
+            limit, {"type": "signed-int64"}, language_bundle
+        )
+    return operation == "has-duplicate"
+
+
+def _vector_header_is_closed(
+    vector: Any,
+    meta_format: dict[str, Any],
+    language_bundle: dict[str, Any],
+) -> bool:
+    if not isinstance(vector, dict):
+        return False
+    if "rule" in vector:
+        invocation = vector.get("input")
+        rule_contract = meta_format.get("rule")
+        phases = (
+            rule_contract.get("phases") if isinstance(rule_contract, dict) else None
+        )
+        return (
+            set(vector) == {"expect", "id", "input", "rule"}
+            and isinstance(vector.get("id"), str)
+            and bool(vector["id"])
+            and isinstance(vector.get("rule"), str)
+            and bool(vector["rule"])
+            and isinstance(invocation, dict)
+            and set(invocation) == {"facts", "judgment", "phase"}
+            and isinstance(invocation.get("judgment"), str)
+            and bool(invocation["judgment"])
+            and isinstance(phases, list)
+            and invocation.get("phase") in phases
+            and isinstance(invocation.get("facts"), list)
+            and all(
+                _fact_is_closed(fact, meta_format, language_bundle)
+                for fact in invocation["facts"]
+            )
+            and _fact_is_closed(vector.get("expect"), meta_format, language_bundle)
+        )
+    if "diagnostic" in vector:
+        contract = meta_format.get("diagnostic_reason")
+        if not isinstance(contract, dict):
+            return False
+        required = contract.get("vector_required_members")
+        member_types = contract.get("vector_member_types")
+        return (
+            isinstance(required, list)
+            and set(vector) == set(required)
+            and isinstance(member_types, dict)
+            and set(member_types) == set(required) - {"input"}
+            and all(
+                _value_matches_contract(
+                    vector[name], member_types[name], language_bundle
+                )
+                for name in member_types
+            )
+            and isinstance(vector.get("input"), dict)
+        )
+    return False
+
+
 def admit_authorities(
     kernel: dict[str, Any], language_bundle: dict[str, Any]
 ) -> BootstrapAdmission:
@@ -94,13 +1020,20 @@ def admit_authorities(
 
     kernel_identity = kernel.get("content_identity")
     ldb_identity = language_bundle.get("content_identity")
-    if not isinstance(kernel_identity, str) or kernel_identity != _artifact_identity(
-        _KERNEL_DOMAIN, kernel
+    canonical_encoding = kernel.get("canonical_encoding")
+    computed_kernel_identity = _safe_artifact_identity(
+        _KERNEL_DOMAIN, kernel, canonical_encoding
+    )
+    computed_ldb_identity = _safe_artifact_identity(
+        _LDB_DOMAIN, language_bundle, canonical_encoding
+    )
+    if (
+        not isinstance(kernel_identity, str)
+        or kernel_identity != computed_kernel_identity
+        or kernel_identity != _SUPPORTED_KERNEL_IDENTITY
     ):
         refuse("kernel.identity_mismatch", "ingress", "kernel")
-    if not isinstance(ldb_identity, str) or ldb_identity != _artifact_identity(
-        _LDB_DOMAIN, language_bundle
-    ):
+    if not isinstance(ldb_identity, str) or ldb_identity != computed_ldb_identity:
         refuse("kernel.identity_mismatch", "ingress", "language-bundle")
     if language_bundle.get("kernel_identity") != kernel_identity:
         refuse(
@@ -110,10 +1043,46 @@ def admit_authorities(
         )
     if set(kernel) != _KERNEL_MEMBERS:
         refuse("kernel.member_set_mismatch", "ingress", "kernel")
+    if any(item.subject == "kernel" for item in found):
+        return _result(
+            found,
+            128,
+            kernel_identity if isinstance(kernel_identity, str) else None,
+            ldb_identity if isinstance(ldb_identity, str) else None,
+            (),
+            (),
+            (),
+            (),
+            (),
+        )
 
     admission = cast(dict[str, Any], kernel.get("admission", {}))
     expected_members = set(cast(list[str], admission.get("required_ldb_members", [])))
     if set(language_bundle) != expected_members:
+        refuse("kernel.member_set_mismatch", "ingress", "language-bundle")
+    raw_language = language_bundle.get("language")
+    expected_language_members = set(
+        cast(list[str], admission.get("required_language_members", []))
+    )
+    if (
+        not isinstance(raw_language, dict)
+        or set(raw_language) != expected_language_members
+    ):
+        refuse(
+            "kernel.member_set_mismatch",
+            "ingress",
+            "language-bundle.language",
+        )
+    raw_meta_format = kernel.get("meta_format")
+    refusal_stages = admission.get("refusal_stages")
+    language_bundle_contract = (
+        raw_meta_format.get("language_bundle")
+        if isinstance(raw_meta_format, dict)
+        else None
+    )
+    if not _language_bundle_is_closed(
+        language_bundle, language_bundle_contract, refusal_stages
+    ):
         refuse("kernel.member_set_mismatch", "ingress", "language-bundle")
 
     resources = cast(dict[str, Any], kernel.get("resources", {}))
@@ -140,6 +1109,29 @@ def admit_authorities(
         if size > max_bytes:
             refuse("kernel.resource_exhausted", "ingress", subject)
 
+    packages = raw_language.get("packages") if isinstance(raw_language, dict) else None
+    package_contract = (
+        raw_meta_format.get("package_release")
+        if isinstance(raw_meta_format, dict)
+        else None
+    )
+    if not isinstance(packages, list):
+        refuse(
+            "kernel.member_set_mismatch", "ingress", "language-bundle.language.packages"
+        )
+    else:
+        for index, package in enumerate(packages):
+            subject = f"language-bundle.language.packages.{index}"
+            if not isinstance(package, dict) or not _package_is_closed(
+                package, package_contract, language_bundle
+            ):
+                refuse("kernel.member_set_mismatch", "ingress", subject)
+                continue
+            if package.get("content_identity") != _safe_artifact_identity(
+                "domain-package-release-v2", package, canonical_encoding
+            ):
+                refuse("kernel.identity_mismatch", "ingress", subject)
+
     cap = resources.get("max_diagnostics", 128)
     if not isinstance(cap, int) or cap < 1:
         cap = 128
@@ -157,11 +1149,24 @@ def admit_authorities(
         )
 
     laws = cast(list[dict[str, Any]], admission.get("laws", []))
+    for subject in _duplicate_identifier_subjects(kernel, language_bundle):
+        refuse("kernel.duplicate_identifier", "static", subject)
     law_ids = [str(law.get("id", "")) for law in laws]
     if len(law_ids) != len(set(law_ids)):
         refuse("kernel.duplicate_identifier", "static", "kernel.admission.laws")
+    operation_law = next(
+        (law for law in laws if law.get("id") == "kernel.operations.closed"), None
+    )
+    operation_arguments = (
+        operation_law.get("arguments", {}) if isinstance(operation_law, dict) else {}
+    )
+    allowed_operations = operation_arguments.get("admission_operations")
+    if not isinstance(allowed_operations, list) or set(allowed_operations) != set(
+        _KNOWN_OPERATIONS
+    ):
+        refuse("kernel.unknown_operation", "static", "kernel.operations.closed")
     for law in laws:
-        if law.get("operation") not in _KNOWN_OPERATIONS:
+        if law.get("operation") not in set(allowed_operations or []):
             refuse("kernel.unknown_operation", "static", str(law.get("id", "")))
     law_projections = tuple(
         sorted(
@@ -174,6 +1179,9 @@ def admit_authorities(
     )
 
     kernel_vectors = cast(list[dict[str, Any]], kernel.get("vectors", []))
+    kernel_vector_ids = [str(vector.get("id", "")) for vector in kernel_vectors]
+    if len(kernel_vector_ids) != len(set(kernel_vector_ids)):
+        refuse("kernel.duplicate_identifier", "static", "kernel.vectors")
     referenced_laws = {str(vector.get("law", "")) for vector in kernel_vectors}
     if set(law_ids) != referenced_laws:
         refuse("kernel.vector_mismatch", "static", "kernel.vectors")
@@ -185,6 +1193,8 @@ def admit_authorities(
         (str(item.get("code", "")), str(item.get("stage", "")))
         for item in kernel_diagnostics
     }
+    if kernel_catalog != set(BOOTSTRAP_REFUSAL_CATALOG):
+        refuse("kernel.diagnostic_closure", "static", "kernel.diagnostics")
     kernel_vector_catalog = {
         (str(item["diagnostic"]), str(item.get("stage", "")))
         for item in kernel_vectors
@@ -194,19 +1204,65 @@ def admit_authorities(
         refuse("kernel.diagnostic_closure", "static", "kernel.diagnostics")
 
     language = cast(dict[str, Any], language_bundle.get("language", {}))
-    rules = cast(list[dict[str, Any]], language.get("rules", []))
+    meta_format = cast(dict[str, Any], kernel.get("meta_format", {}))
+    if not _language_definitions_are_closed(language_bundle, meta_format):
+        refuse("kernel.vector_mismatch", "static", "language.definitions")
+    raw_ldb_vectors = language_bundle.get("vectors")
+    ldb_vectors: list[dict[str, Any]] = []
+    if not isinstance(raw_ldb_vectors, list):
+        refuse("kernel.vector_mismatch", "static", "language-bundle.vectors")
+    else:
+        for vector in raw_ldb_vectors:
+            if _vector_header_is_closed(vector, meta_format, language_bundle):
+                ldb_vectors.append(vector)
+            else:
+                subject = str(vector.get("id", "")) if isinstance(vector, dict) else ""
+                refuse("kernel.vector_mismatch", "static", subject)
+    raw_rules = language.get("rules")
+    rules: list[dict[str, Any]] = []
+    if not isinstance(raw_rules, list) or not all(
+        _rule_is_closed(rule, meta_format, language_bundle) for rule in raw_rules
+    ):
+        refuse("kernel.vector_mismatch", "static", "language.rules")
+    else:
+        rules = cast(list[dict[str, Any]], raw_rules)
+    raw_reasons = language.get("reasons")
+    reasons: list[dict[str, Any]] = []
+    if not isinstance(raw_reasons, list) or not all(
+        _reason_is_closed(reason, meta_format, language_bundle)
+        for reason in raw_reasons
+    ):
+        refuse("kernel.vector_mismatch", "static", "language.reasons")
+    else:
+        reasons = cast(list[dict[str, Any]], raw_reasons)
+    if found:
+        return _result(
+            found,
+            cap,
+            kernel_identity if isinstance(kernel_identity, str) else None,
+            ldb_identity if isinstance(ldb_identity, str) else None,
+            tuple(sorted(law_ids)),
+            law_projections,
+            (),
+            (),
+            (),
+        )
     rule_ids = [str(rule.get("id", "")) for rule in rules]
     if len(rule_ids) != len(set(rule_ids)):
         refuse("kernel.duplicate_identifier", "static", "language.rules")
-    if not all(_rule_is_closed(rule) for rule in rules):
-        refuse("kernel.vector_mismatch", "static", "language.rules")
-    ldb_vectors = cast(list[dict[str, Any]], language_bundle.get("vectors", []))
+    ldb_vector_ids = [str(item.get("id", "")) for item in ldb_vectors]
+    if len(ldb_vector_ids) != len(set(ldb_vector_ids)):
+        refuse(
+            "kernel.duplicate_identifier",
+            "static",
+            "language-bundle.vectors",
+        )
     rule_vectors = [item for item in ldb_vectors if "rule" in item]
     if set(rule_ids) != {str(item["rule"]) for item in rule_vectors}:
         refuse("kernel.vector_mismatch", "static", "language-bundle.vectors")
     rule_projections: list[tuple[str, str]] = []
     for vector in rule_vectors:
-        output = _execute_rule_vector(rules, vector)
+        output = _execute_rule_vector(rules, vector, meta_format, language_bundle)
         if output is None or output != vector.get("expect"):
             refuse("kernel.vector_mismatch", "static", str(vector.get("id", "")))
             continue
@@ -233,7 +1289,6 @@ def admit_authorities(
     if ldb_catalog != ldb_vector_catalog:
         refuse("kernel.diagnostic_closure", "static", "language-bundle.diagnostics")
 
-    reasons = cast(list[dict[str, Any]], language.get("reasons", []))
     reason_ids = [str(item.get("id", "")) for item in reasons]
     if len(reason_ids) != len(set(reason_ids)):
         refuse("kernel.duplicate_identifier", "static", "language.reasons")
@@ -244,9 +1299,10 @@ def admit_authorities(
     diagnostic_projections: list[tuple[str, str, str]] = []
     for vector in reason_vectors:
         reason = by_reason.get(str(vector.get("reason", "")))
-        output = _execute_reason_vector(language_bundle, reason, vector)
+        output = _execute_reason_vector(language_bundle, reason, vector, meta_format)
         expected = {
             "code": vector.get("diagnostic"),
+            "matched": vector.get("matched"),
             "stage": vector.get("stage"),
         }
         if output != expected:
@@ -261,6 +1317,59 @@ def admit_authorities(
                 ),
             )
         )
+    for reason_id, reason in by_reason.items():
+        vectors = [
+            vector for vector in reason_vectors if vector.get("reason") == reason_id
+        ]
+        if not _reason_vectors_cover_operands(
+            language_bundle, reason, vectors, meta_format
+        ):
+            refuse("kernel.vector_mismatch", "static", reason_id)
+
+    if isinstance(packages, list):
+        package_coordinates = [
+            (str(package.get("id", "")), str(package.get("version", "")))
+            for package in packages
+            if isinstance(package, dict)
+        ]
+        if len(package_coordinates) != len(set(package_coordinates)):
+            refuse("kernel.duplicate_identifier", "static", "language.packages")
+        vector_ids = {str(item.get("id", "")) for item in ldb_vectors}
+        constructor_ids = {
+            str(item.get("id", ""))
+            for item in cast(list[dict[str, Any]], language.get("constructors", []))
+        }
+        numeric_profiles = {
+            str(item.get("id", ""))
+            for item in cast(dict[str, Any], language.get("quantity", {})).get(
+                "numeric_policies", []
+            )
+            if isinstance(item, dict)
+        }
+        for package in packages:
+            if not isinstance(package, dict):
+                continue
+            exports = cast(dict[str, Any], package.get("exports", {}))
+            profiles = cast(dict[str, Any], package.get("profiles", {}))
+            references_close = (
+                set(map(str, package.get("vectors", []))) <= vector_ids
+                and set(map(str, exports.get("language_rules", []))) <= set(rule_ids)
+                and set(map(str, exports.get("diagnostics", []))) <= set(ldb_codes)
+                and set(map(str, profiles.get("numeric", []))) <= numeric_profiles
+                and all(
+                    str(item.get("constructor", "")) in constructor_ids
+                    for item in exports.get("types", [])
+                    if isinstance(item, dict)
+                )
+            )
+            if not references_close:
+                refuse(
+                    "kernel.vector_mismatch",
+                    "static",
+                    f"language.packages.{package.get('id', '')}",
+                )
+        if not _reference_contracts_close(kernel, language_bundle):
+            refuse("kernel.vector_mismatch", "static", "language.packages")
 
     return _result(
         found,
@@ -276,21 +1385,42 @@ def admit_authorities(
 
 
 def _execute_rule_vector(
-    rules: list[dict[str, Any]], vector: dict[str, Any]
+    rules: list[dict[str, Any]],
+    vector: dict[str, Any],
+    meta_format: dict[str, Any],
+    language_bundle: dict[str, Any],
 ) -> dict[str, Any] | None:
     """Execute the Kernel's closed fact/select/bind/substitute meta-format."""
+    if set(vector) != {"expect", "id", "input", "rule"}:
+        return None
     invocation = vector.get("input")
-    if not isinstance(invocation, dict):
+    if not isinstance(invocation, dict) or set(invocation) != {
+        "facts",
+        "judgment",
+        "phase",
+    }:
         return None
     judgment = invocation.get("judgment")
+    phase = invocation.get("phase")
     facts = invocation.get("facts")
-    if not isinstance(judgment, str) or not isinstance(facts, list):
+    if (
+        not isinstance(judgment, str)
+        or not isinstance(phase, str)
+        or not isinstance(facts, list)
+        or not all(
+            _fact_is_closed(fact, meta_format, language_bundle) for fact in facts
+        )
+    ):
         return None
 
     candidates: list[dict[str, Any]] = []
     for rule in sorted(rules, key=lambda item: str(item.get("id", ""))):
         premises = rule.get("premises")
-        if rule.get("judgment") != judgment or not isinstance(premises, list):
+        if (
+            rule.get("phase") != phase
+            or rule.get("judgment") != judgment
+            or not isinstance(premises, list)
+        ):
             continue
         if len(premises) != len(facts):
             continue
@@ -332,52 +1462,170 @@ def _execute_rule_vector(
             output_fields[name] = term["value"]
         elif term.get("tag") == "variable" and set(term) == {"tag", "name"}:
             variable = term["name"]
-            if variable not in bindings:
+            if not isinstance(variable, str) or variable not in bindings:
                 return None
             output_fields[name] = bindings[variable]
         else:
             return None
-    return {"kind": conclusion.get("fact_kind"), "fields": output_fields}
+    output = {"kind": conclusion.get("fact_kind"), "fields": output_fields}
+    return output if _fact_is_closed(output, meta_format, language_bundle) else None
 
 
-def _rule_is_closed(rule: dict[str, Any]) -> bool:
-    if set(rule) != {"id", "judgment", "premises", "conclusion"}:
+def _rule_is_closed(
+    rule: Any,
+    meta_format: dict[str, Any],
+    language_bundle: dict[str, Any],
+) -> bool:
+    contract = meta_format.get("rule")
+    term_contract = meta_format.get("term")
+    fact_schemas = _fact_schemas(meta_format)
+    if (
+        not isinstance(contract, dict)
+        or not isinstance(rule, dict)
+        or contract.get("closed") is not True
+        or not isinstance(contract.get("required_members"), list)
+        or set(rule) != set(contract["required_members"])
+        or rule.get("phase") not in contract.get("phases", [])
+        or not isinstance(rule.get("id"), str)
+        or not rule.get("id")
+        or not isinstance(rule.get("judgment"), str)
+        or not rule.get("judgment")
+        or not fact_schemas
+    ):
         return False
     premises = rule.get("premises")
     conclusion = rule.get("conclusion")
-    if not isinstance(premises, list) or not all(
-        isinstance(item, dict) and set(item) == {"bind", "fact_kind"}
-        for item in premises
+    premise_members = contract.get("premise_required_members")
+    conclusion_members = contract.get("conclusion_required_members")
+    if not isinstance(premises, list) or not isinstance(premise_members, list):
+        return False
+    for item in premises:
+        if not isinstance(item, dict):
+            return False
+        fact_kind = item.get("fact_kind")
+        bindings = item.get("bind")
+        if (
+            set(item) != set(premise_members)
+            or not isinstance(fact_kind, str)
+            or fact_kind not in fact_schemas
+            or not isinstance(bindings, dict)
+            or not all(
+                isinstance(variable, str)
+                and variable
+                and isinstance(field, str)
+                and field in fact_schemas[fact_kind]
+                for variable, field in bindings.items()
+            )
+        ):
+            return False
+    conclusion_kind = (
+        conclusion.get("fact_kind") if isinstance(conclusion, dict) else None
+    )
+    if (
+        not isinstance(conclusion, dict)
+        or not isinstance(conclusion_members, list)
+        or set(conclusion) != set(conclusion_members)
+        or not isinstance(conclusion_kind, str)
+        or conclusion_kind not in fact_schemas
     ):
         return False
-    if not isinstance(conclusion, dict) or set(conclusion) != {"fact_kind", "fields"}:
-        return False
     fields = conclusion.get("fields")
-    if not isinstance(fields, dict):
+    if (
+        not isinstance(fields, dict)
+        or set(fields) != set(fact_schemas[conclusion_kind])
+        or not isinstance(term_contract, dict)
+        or not isinstance(term_contract.get("constructors"), list)
+    ):
         return False
-    return all(
-        isinstance(term, dict)
-        and (
-            (term.get("tag") == "literal" and set(term) == {"tag", "value"})
-            or (term.get("tag") == "variable" and set(term) == {"tag", "name"})
-        )
-        for term in fields.values()
-    )
+    constructors = {
+        str(item.get("tag")): item
+        for item in term_contract["constructors"]
+        if isinstance(item, dict)
+    }
+    for term in fields.values():
+        if not isinstance(term, dict):
+            return False
+        tag = term.get("tag")
+        constructor = constructors.get(tag) if isinstance(tag, str) else None
+        if not isinstance(constructor, dict):
+            return False
+        required_members = constructor.get("required_members")
+        member_types = constructor.get("member_types")
+        if (
+            not isinstance(required_members, list)
+            or set(term) != set(required_members)
+            or not isinstance(member_types, dict)
+            or set(member_types) != set(required_members)
+            or not all(
+                _value_matches_contract(term[name], member_types[name], language_bundle)
+                for name in term
+            )
+        ):
+            return False
+    return True
 
 
 def _execute_reason_vector(
     language_bundle: dict[str, Any],
     reason: dict[str, Any] | None,
     vector: dict[str, Any],
+    meta_format: dict[str, Any],
 ) -> dict[str, Any] | None:
     """Execute one closed post-admission reason predicate from LDB data."""
-    if reason is None or not isinstance(vector.get("input"), dict):
+    reason_contract = meta_format.get("diagnostic_reason")
+    if not isinstance(reason_contract, dict):
+        return None
+    required = reason_contract.get("vector_required_members")
+    member_types = reason_contract.get("vector_member_types")
+    if (
+        not isinstance(required, list)
+        or set(vector) != set(required)
+        or not isinstance(member_types, dict)
+        or set(member_types) != set(required) - {"input"}
+        or not all(
+            _value_matches_contract(vector[name], member_types[name], language_bundle)
+            for name in member_types
+        )
+        or not _reason_is_closed(reason, meta_format, language_bundle)
+        or not isinstance(vector.get("input"), dict)
+    ):
+        return None
+    assert reason is not None
+    if (
+        vector["reason"] != reason.get("id")
+        or vector["diagnostic"] != reason.get("diagnostic")
+        or vector["stage"] != reason.get("stage")
+    ):
         return None
     predicate = reason.get("predicate")
     if not isinstance(predicate, dict):
         return None
     operation = predicate.get("operation")
     inp = cast(dict[str, Any], vector["input"])
+    predicate_schema = next(
+        (
+            item
+            for item in cast(list[dict[str, Any]], reason_contract["predicate_schemas"])
+            if item.get("operation") == operation
+        ),
+        None,
+    )
+    input_types = (
+        predicate_schema.get("input_member_types")
+        if isinstance(predicate_schema, dict)
+        else None
+    )
+    if (
+        not isinstance(predicate_schema, dict)
+        or set(inp) != set(cast(list[str], predicate_schema.get("input_members", [])))
+        or not isinstance(input_types, dict)
+        or set(inp) != set(input_types)
+        or not all(
+            _value_matches_contract(inp[name], input_types[name], language_bundle)
+            for name in inp
+        )
+    ):
+        return None
     matched = False
     if operation == "not-member":
         inventory = _resolve_path(language_bundle, predicate.get("inventory_path"))
@@ -390,21 +1638,137 @@ def _execute_reason_vector(
             else item
             for item in inventory
         ]
-        matched = inp.get("value") not in values
+        matched = _canonical_scalar_key(inp.get("value")) not in {
+            _canonical_scalar_key(item) for item in values
+        }
     elif operation == "has-duplicate":
         values = inp.get("values")
         if not isinstance(values, list):
             return None
-        matched = len(values) != len({repr(item) for item in values})
+        keys = [_canonical_scalar_key(item) for item in values]
+        matched = len(keys) != len(set(keys))
     elif operation == "greater-than":
         limit = _resolve_path(language_bundle, predicate.get("limit_path"))
         value = inp.get("value")
         if not isinstance(limit, int) or not isinstance(value, int):
             return None
         matched = value > limit
-    if not matched:
-        return None
-    return {"code": reason.get("diagnostic"), "stage": reason.get("stage")}
+    return {
+        "code": reason.get("diagnostic"),
+        "matched": matched,
+        "stage": reason.get("stage"),
+    }
+
+
+def _canonical_scalar_key(value: Any) -> tuple[str, Any]:
+    return (
+        "null"
+        if value is None
+        else "boolean"
+        if isinstance(value, bool)
+        else "integer"
+        if isinstance(value, int)
+        else "string",
+        value,
+    )
+
+
+def _reason_vectors_cover_operands(
+    language_bundle: dict[str, Any],
+    reason: dict[str, Any],
+    vectors: list[dict[str, Any]],
+    meta_format: dict[str, Any],
+) -> bool:
+    contract = meta_format.get("diagnostic_reason")
+    predicate = reason.get("predicate")
+    if not isinstance(contract, dict) or not isinstance(predicate, dict):
+        return False
+    coverage = contract.get("vector_coverage")
+    operation = predicate.get("operation")
+    if not isinstance(coverage, dict) or not isinstance(operation, str):
+        return False
+    if not vectors or any(
+        not isinstance(vector, dict)
+        or not isinstance(vector.get("matched"), bool)
+        or not isinstance(vector.get("input"), dict)
+        for vector in vectors
+    ):
+        return False
+    outcomes = {vector.get("matched") for vector in vectors}
+    if outcomes != {False, True}:
+        return False
+    if operation == "not-member":
+        if coverage.get(operation) != "every-inventory-member-and-one-non-member":
+            return False
+        inventory = _resolve_path(language_bundle, predicate.get("inventory_path"))
+        if not isinstance(inventory, list):
+            return False
+        member_field = predicate.get("member_field")
+        if member_field is None:
+            values = inventory
+        elif (
+            isinstance(member_field, str)
+            and member_field
+            and all(
+                isinstance(item, dict) and member_field in item for item in inventory
+            )
+        ):
+            values = [item[member_field] for item in inventory]
+        else:
+            return False
+        if not all(
+            _value_matches_contract(
+                value, {"type": "canonical-scalar"}, language_bundle
+            )
+            for value in values
+        ):
+            return False
+        if not all(
+            _value_matches_contract(
+                cast(dict[str, Any], vector["input"]).get("value"),
+                {"type": "canonical-scalar"},
+                language_bundle,
+            )
+            for vector in vectors
+        ):
+            return False
+        nonmatches = {
+            _canonical_scalar_key(vector.get("input", {}).get("value"))
+            for vector in vectors
+            if vector.get("matched") is False and isinstance(vector.get("input"), dict)
+        }
+        return {_canonical_scalar_key(value) for value in values} <= nonmatches
+    if operation == "has-duplicate":
+        return coverage.get(operation) == "both-outcomes" and all(
+            _value_matches_contract(
+                cast(dict[str, Any], vector["input"]).get("values"),
+                {"type": "scalar-list"},
+                language_bundle,
+            )
+            for vector in vectors
+        )
+    if operation == "greater-than":
+        if coverage.get(operation) != "limit-and-successor":
+            return False
+        limit = _resolve_path(language_bundle, predicate.get("limit_path"))
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit >= 2**63 - 1:
+            return False
+        if not all(
+            _value_matches_contract(
+                cast(dict[str, Any], vector["input"]).get("value"),
+                {"type": "signed-int64"},
+                language_bundle,
+            )
+            for vector in vectors
+        ):
+            return False
+        witnesses = {
+            (vector.get("input", {}).get("value"), vector.get("matched"))
+            for vector in vectors
+            if isinstance(vector.get("input"), dict)
+        }
+        return {(limit, False), (limit + 1, True)} <= witnesses
+    return False
 
 
 def _resolve_path(root: dict[str, Any], dotted: Any) -> Any:

--- a/libs/gda-balancing/src/gda_balancing/schema2/bootstrap.py
+++ b/libs/gda-balancing/src/gda_balancing/schema2/bootstrap.py
@@ -1,0 +1,446 @@
+"""One production bootstrap consumer for the Schema 2.0 Kernel/LDB pair.
+
+The consumer implements the Kernel's small, closed meta-operation set.  It
+does not contain Quantity rule dispatch: LDB rules are checked through their
+declared generic inputs/result and normative vectors.
+"""
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+from gda_balancing.schema2.canonical import JsonValue, canonical_bytes, content_identity
+
+_KERNEL_DOMAIN = "schema-major-kernel-v2"
+_LDB_DOMAIN = "language-definition-bundle-v2"
+_KERNEL_MEMBERS = frozenset(
+    {
+        "admission",
+        "artifact_kind",
+        "artifact_version",
+        "canonical_encoding",
+        "content_identity",
+        "diagnostics",
+        "meta_format",
+        "resources",
+        "schema_major",
+        "vectors",
+    }
+)
+_KNOWN_OPERATIONS = frozenset(
+    {
+        "verify-content-identity",
+        "require-equal",
+        "require-exact-members",
+        "require-unique-identifiers",
+        "require-known-operations",
+        "require-vector-closure",
+        "require-diagnostic-closure",
+        "enforce-resource-limits",
+    }
+)
+
+
+@dataclass(frozen=True)
+class AdmissionDiagnostic:
+    code: str
+    stage: str
+    subject: str
+
+
+@dataclass(frozen=True)
+class BootstrapAdmission:
+    admitted: bool
+    kernel_identity: str | None
+    language_bundle_identity: str | None
+    law_ids: tuple[str, ...]
+    law_projections: tuple[tuple[str, str], ...]
+    rule_ids: tuple[str, ...]
+    rule_projections: tuple[tuple[str, str], ...]
+    diagnostic_projections: tuple[tuple[str, str, str], ...]
+    diagnostics: tuple[AdmissionDiagnostic, ...]
+    truncated: bool
+
+
+def _artifact_identity(domain: str, artifact: dict[str, Any]) -> str:
+    body = {key: value for key, value in artifact.items() if key != "content_identity"}
+    return content_identity(domain, cast(JsonValue, body))
+
+
+def _resource_shape(value: Any) -> tuple[int, int]:
+    """Return maximum nesting depth and largest single collection iteratively."""
+    maximum_depth = 0
+    maximum_members = 0
+    stack: list[tuple[Any, int]] = [(value, 0)]
+    while stack:
+        current, depth = stack.pop()
+        maximum_depth = max(maximum_depth, depth)
+        if isinstance(current, dict):
+            maximum_members = max(maximum_members, len(current))
+            stack.extend((item, depth + 1) for item in current.values())
+        elif isinstance(current, list):
+            maximum_members = max(maximum_members, len(current))
+            stack.extend((item, depth + 1) for item in current)
+    return maximum_depth, maximum_members
+
+
+def admit_authorities(
+    kernel: dict[str, Any], language_bundle: dict[str, Any]
+) -> BootstrapAdmission:
+    """Admit an authority pair or return all deterministic bootstrap diagnostics."""
+    found: set[AdmissionDiagnostic] = set()
+
+    def refuse(code: str, stage: str, subject: str) -> None:
+        found.add(AdmissionDiagnostic(code=code, stage=stage, subject=subject))
+
+    kernel_identity = kernel.get("content_identity")
+    ldb_identity = language_bundle.get("content_identity")
+    if not isinstance(kernel_identity, str) or kernel_identity != _artifact_identity(
+        _KERNEL_DOMAIN, kernel
+    ):
+        refuse("kernel.identity_mismatch", "ingress", "kernel")
+    if not isinstance(ldb_identity, str) or ldb_identity != _artifact_identity(
+        _LDB_DOMAIN, language_bundle
+    ):
+        refuse("kernel.identity_mismatch", "ingress", "language-bundle")
+    if language_bundle.get("kernel_identity") != kernel_identity:
+        refuse(
+            "kernel.binding_mismatch",
+            "ingress",
+            "language-bundle.kernel_identity",
+        )
+    if set(kernel) != _KERNEL_MEMBERS:
+        refuse("kernel.member_set_mismatch", "ingress", "kernel")
+
+    admission = cast(dict[str, Any], kernel.get("admission", {}))
+    expected_members = set(cast(list[str], admission.get("required_ldb_members", [])))
+    if set(language_bundle) != expected_members:
+        refuse("kernel.member_set_mismatch", "ingress", "language-bundle")
+
+    resources = cast(dict[str, Any], kernel.get("resources", {}))
+    max_bytes = resources.get("max_authority_bytes", 262144)
+    if not isinstance(max_bytes, int) or max_bytes < 1:
+        max_bytes = 262144
+        refuse("kernel.resource_exhausted", "ingress", "kernel.resources")
+    max_depth = resources.get("max_nesting_depth", 32)
+    max_members = resources.get("max_members", 256)
+    if not isinstance(max_depth, int) or max_depth < 1:
+        max_depth = 32
+        refuse("kernel.resource_exhausted", "ingress", "kernel.resources")
+    if not isinstance(max_members, int) or max_members < 1:
+        max_members = 256
+        refuse("kernel.resource_exhausted", "ingress", "kernel.resources")
+    for subject, artifact in (("kernel", kernel), ("language-bundle", language_bundle)):
+        depth, largest_collection = _resource_shape(artifact)
+        if depth > max_depth or largest_collection > max_members:
+            refuse("kernel.resource_exhausted", "ingress", subject)
+        try:
+            size = len(canonical_bytes(cast(JsonValue, artifact)))
+        except (TypeError, ValueError):
+            size = max_bytes + 1
+        if size > max_bytes:
+            refuse("kernel.resource_exhausted", "ingress", subject)
+
+    cap = resources.get("max_diagnostics", 128)
+    if not isinstance(cap, int) or cap < 1:
+        cap = 128
+    if found:
+        return _result(
+            found,
+            cap,
+            kernel_identity if isinstance(kernel_identity, str) else None,
+            ldb_identity if isinstance(ldb_identity, str) else None,
+            (),
+            (),
+            (),
+            (),
+            (),
+        )
+
+    laws = cast(list[dict[str, Any]], admission.get("laws", []))
+    law_ids = [str(law.get("id", "")) for law in laws]
+    if len(law_ids) != len(set(law_ids)):
+        refuse("kernel.duplicate_identifier", "static", "kernel.admission.laws")
+    for law in laws:
+        if law.get("operation") not in _KNOWN_OPERATIONS:
+            refuse("kernel.unknown_operation", "static", str(law.get("id", "")))
+    law_projections = tuple(
+        sorted(
+            (
+                str(law.get("id", "")),
+                content_identity("kernel-law-projection-v2", cast(JsonValue, law)),
+            )
+            for law in laws
+        )
+    )
+
+    kernel_vectors = cast(list[dict[str, Any]], kernel.get("vectors", []))
+    referenced_laws = {str(vector.get("law", "")) for vector in kernel_vectors}
+    if set(law_ids) != referenced_laws:
+        refuse("kernel.vector_mismatch", "static", "kernel.vectors")
+    kernel_diagnostics = cast(list[dict[str, Any]], kernel.get("diagnostics", []))
+    kernel_codes = [str(item.get("code", "")) for item in kernel_diagnostics]
+    if len(kernel_codes) != len(set(kernel_codes)):
+        refuse("kernel.duplicate_identifier", "static", "kernel.diagnostics")
+    kernel_catalog = {
+        (str(item.get("code", "")), str(item.get("stage", "")))
+        for item in kernel_diagnostics
+    }
+    kernel_vector_catalog = {
+        (str(item["diagnostic"]), str(item.get("stage", "")))
+        for item in kernel_vectors
+        if "diagnostic" in item
+    }
+    if kernel_catalog != kernel_vector_catalog:
+        refuse("kernel.diagnostic_closure", "static", "kernel.diagnostics")
+
+    language = cast(dict[str, Any], language_bundle.get("language", {}))
+    rules = cast(list[dict[str, Any]], language.get("rules", []))
+    rule_ids = [str(rule.get("id", "")) for rule in rules]
+    if len(rule_ids) != len(set(rule_ids)):
+        refuse("kernel.duplicate_identifier", "static", "language.rules")
+    if not all(_rule_is_closed(rule) for rule in rules):
+        refuse("kernel.vector_mismatch", "static", "language.rules")
+    ldb_vectors = cast(list[dict[str, Any]], language_bundle.get("vectors", []))
+    rule_vectors = [item for item in ldb_vectors if "rule" in item]
+    if set(rule_ids) != {str(item["rule"]) for item in rule_vectors}:
+        refuse("kernel.vector_mismatch", "static", "language-bundle.vectors")
+    rule_projections: list[tuple[str, str]] = []
+    for vector in rule_vectors:
+        output = _execute_rule_vector(rules, vector)
+        if output is None or output != vector.get("expect"):
+            refuse("kernel.vector_mismatch", "static", str(vector.get("id", "")))
+            continue
+        rule_projections.append(
+            (
+                str(vector.get("id", "")),
+                content_identity("rule-vector-projection-v2", cast(JsonValue, output)),
+            )
+        )
+
+    ldb_diagnostics = cast(list[dict[str, Any]], language_bundle.get("diagnostics", []))
+    ldb_codes = [str(item.get("code", "")) for item in ldb_diagnostics]
+    if len(ldb_codes) != len(set(ldb_codes)):
+        refuse("kernel.duplicate_identifier", "static", "language-bundle.diagnostics")
+    ldb_catalog = {
+        (str(item.get("code", "")), str(item.get("stage", "")))
+        for item in ldb_diagnostics
+    }
+    ldb_vector_catalog = {
+        (str(item["diagnostic"]), str(item.get("stage", "")))
+        for item in ldb_vectors
+        if "diagnostic" in item
+    }
+    if ldb_catalog != ldb_vector_catalog:
+        refuse("kernel.diagnostic_closure", "static", "language-bundle.diagnostics")
+
+    reasons = cast(list[dict[str, Any]], language.get("reasons", []))
+    reason_ids = [str(item.get("id", "")) for item in reasons]
+    if len(reason_ids) != len(set(reason_ids)):
+        refuse("kernel.duplicate_identifier", "static", "language.reasons")
+    reason_vectors = [item for item in ldb_vectors if "diagnostic" in item]
+    if set(reason_ids) != {str(item.get("reason", "")) for item in reason_vectors}:
+        refuse("kernel.vector_mismatch", "static", "language-bundle.reasons")
+    by_reason = {str(item.get("id", "")): item for item in reasons}
+    diagnostic_projections: list[tuple[str, str, str]] = []
+    for vector in reason_vectors:
+        reason = by_reason.get(str(vector.get("reason", "")))
+        output = _execute_reason_vector(language_bundle, reason, vector)
+        expected = {
+            "code": vector.get("diagnostic"),
+            "stage": vector.get("stage"),
+        }
+        if output != expected:
+            refuse("kernel.vector_mismatch", "static", str(vector.get("id", "")))
+            continue
+        diagnostic_projections.append(
+            (
+                str(vector.get("id", "")),
+                str(vector.get("diagnostic", "")),
+                content_identity(
+                    "diagnostic-vector-projection-v2", cast(JsonValue, output)
+                ),
+            )
+        )
+
+    return _result(
+        found,
+        cap,
+        kernel_identity if isinstance(kernel_identity, str) else None,
+        ldb_identity if isinstance(ldb_identity, str) else None,
+        tuple(sorted(law_ids)),
+        law_projections,
+        tuple(sorted(rule_ids)),
+        tuple(sorted(rule_projections)),
+        tuple(sorted(diagnostic_projections)),
+    )
+
+
+def _execute_rule_vector(
+    rules: list[dict[str, Any]], vector: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Execute the Kernel's closed fact/select/bind/substitute meta-format."""
+    invocation = vector.get("input")
+    if not isinstance(invocation, dict):
+        return None
+    judgment = invocation.get("judgment")
+    facts = invocation.get("facts")
+    if not isinstance(judgment, str) or not isinstance(facts, list):
+        return None
+
+    candidates: list[dict[str, Any]] = []
+    for rule in sorted(rules, key=lambda item: str(item.get("id", ""))):
+        premises = rule.get("premises")
+        if rule.get("judgment") != judgment or not isinstance(premises, list):
+            continue
+        if len(premises) != len(facts):
+            continue
+        if all(
+            isinstance(premise, dict)
+            and isinstance(fact, dict)
+            and premise.get("fact_kind") == fact.get("kind")
+            for premise, fact in zip(premises, facts, strict=True)
+        ):
+            candidates.append(rule)
+    if len(candidates) != 1 or candidates[0].get("id") != vector.get("rule"):
+        return None
+
+    selected = candidates[0]
+    bindings: dict[str, Any] = {}
+    for premise, fact in zip(selected["premises"], facts, strict=True):
+        fields = fact.get("fields")
+        bind = premise.get("bind")
+        if not isinstance(fields, dict) or not isinstance(bind, dict):
+            return None
+        for variable, field_name in bind.items():
+            if not isinstance(variable, str) or field_name not in fields:
+                return None
+            value = fields[field_name]
+            if variable in bindings and bindings[variable] != value:
+                return None
+            bindings[variable] = value
+
+    conclusion = selected.get("conclusion")
+    if not isinstance(conclusion, dict) or not isinstance(
+        conclusion.get("fields"), dict
+    ):
+        return None
+    output_fields: dict[str, Any] = {}
+    for name, term in conclusion["fields"].items():
+        if not isinstance(name, str) or not isinstance(term, dict):
+            return None
+        if term.get("tag") == "literal" and set(term) == {"tag", "value"}:
+            output_fields[name] = term["value"]
+        elif term.get("tag") == "variable" and set(term) == {"tag", "name"}:
+            variable = term["name"]
+            if variable not in bindings:
+                return None
+            output_fields[name] = bindings[variable]
+        else:
+            return None
+    return {"kind": conclusion.get("fact_kind"), "fields": output_fields}
+
+
+def _rule_is_closed(rule: dict[str, Any]) -> bool:
+    if set(rule) != {"id", "judgment", "premises", "conclusion"}:
+        return False
+    premises = rule.get("premises")
+    conclusion = rule.get("conclusion")
+    if not isinstance(premises, list) or not all(
+        isinstance(item, dict) and set(item) == {"bind", "fact_kind"}
+        for item in premises
+    ):
+        return False
+    if not isinstance(conclusion, dict) or set(conclusion) != {"fact_kind", "fields"}:
+        return False
+    fields = conclusion.get("fields")
+    if not isinstance(fields, dict):
+        return False
+    return all(
+        isinstance(term, dict)
+        and (
+            (term.get("tag") == "literal" and set(term) == {"tag", "value"})
+            or (term.get("tag") == "variable" and set(term) == {"tag", "name"})
+        )
+        for term in fields.values()
+    )
+
+
+def _execute_reason_vector(
+    language_bundle: dict[str, Any],
+    reason: dict[str, Any] | None,
+    vector: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Execute one closed post-admission reason predicate from LDB data."""
+    if reason is None or not isinstance(vector.get("input"), dict):
+        return None
+    predicate = reason.get("predicate")
+    if not isinstance(predicate, dict):
+        return None
+    operation = predicate.get("operation")
+    inp = cast(dict[str, Any], vector["input"])
+    matched = False
+    if operation == "not-member":
+        inventory = _resolve_path(language_bundle, predicate.get("inventory_path"))
+        if not isinstance(inventory, list):
+            return None
+        member_field = predicate.get("member_field")
+        values = [
+            item.get(member_field)
+            if isinstance(member_field, str) and isinstance(item, dict)
+            else item
+            for item in inventory
+        ]
+        matched = inp.get("value") not in values
+    elif operation == "has-duplicate":
+        values = inp.get("values")
+        if not isinstance(values, list):
+            return None
+        matched = len(values) != len({repr(item) for item in values})
+    elif operation == "greater-than":
+        limit = _resolve_path(language_bundle, predicate.get("limit_path"))
+        value = inp.get("value")
+        if not isinstance(limit, int) or not isinstance(value, int):
+            return None
+        matched = value > limit
+    if not matched:
+        return None
+    return {"code": reason.get("diagnostic"), "stage": reason.get("stage")}
+
+
+def _resolve_path(root: dict[str, Any], dotted: Any) -> Any:
+    if not isinstance(dotted, str):
+        return None
+    value: Any = root
+    for part in dotted.split("."):
+        if not isinstance(value, dict) or part not in value:
+            return None
+        value = value[part]
+    return value
+
+
+def _result(
+    found: set[AdmissionDiagnostic],
+    cap: int,
+    kernel_identity: str | None,
+    ldb_identity: str | None,
+    law_ids: tuple[str, ...],
+    law_projections: tuple[tuple[str, str], ...],
+    rule_ids: tuple[str, ...],
+    rule_projections: tuple[tuple[str, str], ...],
+    diagnostic_projections: tuple[tuple[str, str, str], ...],
+) -> BootstrapAdmission:
+    ordered = sorted(found, key=lambda item: (item.stage, item.subject, item.code))
+    truncated = len(ordered) > cap
+    emitted = tuple(ordered[:cap])
+    return BootstrapAdmission(
+        admitted=not found,
+        kernel_identity=kernel_identity,
+        language_bundle_identity=ldb_identity,
+        law_ids=law_ids,
+        law_projections=law_projections,
+        rule_ids=rule_ids,
+        rule_projections=rule_projections,
+        diagnostic_projections=diagnostic_projections,
+        diagnostics=emitted,
+        truncated=truncated,
+    )

--- a/libs/gda-balancing/src/gda_balancing/schema2/canonical.py
+++ b/libs/gda-balancing/src/gda_balancing/schema2/canonical.py
@@ -1,0 +1,68 @@
+"""Canonical bytes and content identities fixed by the Schema 2.0 Kernel.
+
+The profile intentionally admits a small JSON subset.  It is sufficient for
+the bootstrap authorities and removes host-dependent float, Unicode
+normalisation, and object-order behaviour from their identity.
+"""
+
+import hashlib
+import json
+from typing import TypeAlias
+
+JsonScalar: TypeAlias = str | int | bool | None
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+
+_INT64_MIN = -(2**63)
+_INT64_MAX = 2**63 - 1
+
+
+def canonical_bytes(value: JsonValue) -> bytes:
+    """Encode one value under ``gda-canonical-json-v1``.
+
+    Objects are sorted by their UTF-8 key bytes, whitespace is absent, strings
+    are emitted as UTF-8 without normalisation, and integers are signed Int64.
+    Floats and lone surrogate code points are outside the profile.
+    """
+    _validate(value)
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def content_identity(domain: str, value: JsonValue) -> str:
+    """Return the domain-separated SHA-256 identity of ``value``."""
+    prefix = f"gda-balancing:{domain}:".encode()
+    return "sha256:" + hashlib.sha256(prefix + canonical_bytes(value)).hexdigest()
+
+
+def _validate(value: JsonValue) -> None:
+    if value is None or isinstance(value, (str, bool)):
+        if isinstance(value, str):
+            try:
+                value.encode("utf-8")
+            except UnicodeEncodeError as exc:
+                raise ValueError("lone surrogate is outside canonical JSON") from exc
+        return
+    if isinstance(value, int):
+        if not _INT64_MIN <= value <= _INT64_MAX:
+            raise ValueError("integer is outside signed Int64")
+        return
+    if isinstance(value, list):
+        for item in value:
+            _validate(item)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("canonical JSON object keys must be strings")
+            _validate(key)
+            _validate(item)
+        return
+    raise TypeError(f"value of type {type(value).__name__} is outside canonical JSON")

--- a/libs/gda-balancing/src/gda_balancing/schema2/diagnostics.py
+++ b/libs/gda-balancing/src/gda_balancing/schema2/diagnostics.py
@@ -1,0 +1,96 @@
+"""Stage-aware Schema 2.0 diagnostics and refusal envelopes."""
+
+from typing import Literal, cast
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from gda_balancing.schema2.bootstrap import BootstrapAdmission
+
+RefusalStage = Literal[
+    "ingress",
+    "parse",
+    "static",
+    "resolution",
+    "runtime",
+    "evaluation",
+    "migration",
+    "approval",
+]
+
+
+class ArtifactLocation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: Literal["artifact"] = "artifact"
+    content_identity: str
+    pointer: str
+
+
+class Schema2Diagnostic(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    code: str
+    message: str
+    primary: ArtifactLocation
+    related: tuple[ArtifactLocation, ...] = ()
+
+
+class Schema2RefusalReport(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    stage: RefusalStage
+    diagnostics: tuple[Schema2Diagnostic, ...] = Field(min_length=1)
+    truncated: bool
+
+
+def bootstrap_refusal(admission: BootstrapAdmission) -> Schema2RefusalReport:
+    """Translate a refused bootstrap result without minting new code/stage facts."""
+    if admission.admitted or not admission.diagnostics:
+        raise ValueError("an admitted bootstrap result is not a refusal")
+    stage = admission.diagnostics[0].stage
+    diagnostics: list[Schema2Diagnostic] = []
+    for item in admission.diagnostics:
+        if item.stage != stage:
+            continue
+        is_kernel = item.subject == "kernel" or item.subject.startswith("kernel.")
+        identity = (
+            admission.kernel_identity
+            if is_kernel
+            else admission.language_bundle_identity
+        )
+        diagnostics.append(
+            Schema2Diagnostic(
+                code=item.code,
+                message=f"Schema 2.0 authority admission failed at {item.subject}",
+                primary=ArtifactLocation(
+                    content_identity=identity or "unidentified",
+                    pointer="/" + item.subject.replace(".", "/"),
+                ),
+            )
+        )
+    diagnostics.sort(
+        key=lambda item: (
+            item.primary.pointer,
+            item.code,
+            item.primary.content_identity,
+        )
+    )
+    return Schema2RefusalReport(
+        stage=cast(RefusalStage, stage),
+        diagnostics=tuple(diagnostics),
+        truncated=admission.truncated,
+    )
+
+
+def refusal_envelope(report: Schema2RefusalReport) -> dict[str, object]:
+    """Build the closed Schema 2.0 refusal Error envelope."""
+    return {
+        "error": {
+            "category": "refusal",
+            "stage": report.stage,
+            "diagnostics": [
+                item.model_dump(mode="json") for item in report.diagnostics
+            ],
+            "truncated": report.truncated,
+        }
+    }

--- a/libs/gda-balancing/src/gda_balancing/schema2/diagnostics.py
+++ b/libs/gda-balancing/src/gda_balancing/schema2/diagnostics.py
@@ -82,6 +82,24 @@ def bootstrap_refusal(admission: BootstrapAdmission) -> Schema2RefusalReport:
     )
 
 
+def ingress_refusal(code: str, subject: str, message: str) -> Schema2RefusalReport:
+    """Represent a raw authority preflight/decode failure before admission."""
+    return Schema2RefusalReport(
+        stage="ingress",
+        diagnostics=(
+            Schema2Diagnostic(
+                code=code,
+                message=message,
+                primary=ArtifactLocation(
+                    content_identity="unidentified",
+                    pointer="/" + subject.replace(".", "/"),
+                ),
+            ),
+        ),
+        truncated=False,
+    )
+
+
 def refusal_envelope(report: Schema2RefusalReport) -> dict[str, object]:
     """Build the closed Schema 2.0 refusal Error envelope."""
     return {

--- a/libs/gda-balancing/src/gda_balancing/schema2/projections.py
+++ b/libs/gda-balancing/src/gda_balancing/schema2/projections.py
@@ -1,0 +1,111 @@
+"""Generated, content-addressed projections of the admitted Schema 2.0 authority."""
+
+from typing import cast
+
+from gda_balancing.schema2.authority import authority_set
+from gda_balancing.schema2.canonical import JsonValue, content_identity
+
+_DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
+
+
+def _identified(domain: str, body: dict[str, JsonValue]) -> dict[str, JsonValue]:
+    return {**body, "content_identity": content_identity(domain, cast(JsonValue, body))}
+
+
+def _closed_authority_schema(
+    artifact_kind: str, artifact: dict[str, JsonValue]
+) -> dict[str, JsonValue]:
+    body: dict[str, JsonValue] = {
+        "$schema": _DRAFT_2020_12,
+        "title": f"Exact admitted {artifact_kind}",
+        "type": "object",
+        "properties": {name: {} for name in artifact},
+        "required": list(artifact),
+        "const": artifact,
+        "unevaluatedProperties": False,
+    }
+    digest = content_identity(f"{artifact_kind}-wire-schema-v2", cast(JsonValue, body))
+    return {
+        "$id": f"urn:gda-balancing:schema2:wire:{digest.removeprefix('sha256:')}",
+        **body,
+    }
+
+
+def _identified_ldb_schema(
+    artifact_kind: str, schema: dict[str, JsonValue]
+) -> dict[str, JsonValue]:
+    body = {key: value for key, value in schema.items() if key != "$id"}
+    digest = content_identity(f"{artifact_kind}-wire-schema-v2", cast(JsonValue, body))
+    return {
+        "$id": f"urn:gda-balancing:schema2:wire:{digest.removeprefix('sha256:')}",
+        **body,
+    }
+
+
+def wire_schema_projection(
+    authorities: dict[str, JsonValue] | None = None,
+) -> dict[str, JsonValue]:
+    """Project the exact admitted Kernel and LDB into closed wire schemas."""
+    authorities = authority_set() if authorities is None else authorities
+    kernel = cast(dict[str, JsonValue], authorities["kernel"])
+    ldb = cast(dict[str, JsonValue], authorities["language_bundle"])
+    schemas: list[JsonValue] = [
+        {
+            "artifact_kind": "schema-major-kernel",
+            "schema": _closed_authority_schema("schema-major-kernel", kernel),
+        },
+        {
+            "artifact_kind": "language-definition-bundle",
+            "schema": _closed_authority_schema("language-definition-bundle", ldb),
+        },
+    ]
+    language = cast(dict[str, JsonValue], ldb["language"])
+    for raw in cast(list[JsonValue], language.get("wire_schemas", [])):
+        item = cast(dict[str, JsonValue], raw)
+        artifact_kind = cast(str, item["artifact_kind"])
+        schema = cast(dict[str, JsonValue], item["schema"])
+        schemas.append(
+            {
+                "artifact_kind": artifact_kind,
+                "schema": _identified_ldb_schema(artifact_kind, schema),
+            }
+        )
+    schemas.sort(
+        key=lambda raw: cast(str, cast(dict[str, JsonValue], raw)["artifact_kind"])
+    )
+    body: dict[str, JsonValue] = {
+        "artifact_kind": "wire-schema-projection",
+        "kernel_identity": cast(str, kernel["content_identity"]),
+        "language_bundle_identity": cast(str, ldb["content_identity"]),
+        "schemas": schemas,
+    }
+    return _identified("wire-schema-projection-v2", body)
+
+
+def diagnostic_catalog_projection(
+    authorities: dict[str, JsonValue] | None = None,
+) -> dict[str, JsonValue]:
+    """Project the exact Kernel/LDB diagnostic inventories in stable order."""
+    authorities = authority_set() if authorities is None else authorities
+    kernel = cast(dict[str, JsonValue], authorities["kernel"])
+    ldb = cast(dict[str, JsonValue], authorities["language_bundle"])
+    entries: list[dict[str, JsonValue]] = []
+    for owner, artifact in (("kernel", kernel), ("language-bundle", ldb)):
+        diagnostics = cast(list[JsonValue], artifact["diagnostics"])
+        for raw_entry in diagnostics:
+            entry = cast(dict[str, JsonValue], raw_entry)
+            entries.append(
+                {
+                    "authority": owner,
+                    "code": cast(str, entry["code"]),
+                    "stage": cast(str, entry["stage"]),
+                }
+            )
+    entries.sort(key=lambda item: (item["stage"], item["code"], item["authority"]))
+    body: dict[str, JsonValue] = {
+        "artifact_kind": "diagnostic-catalog-projection",
+        "kernel_identity": cast(str, kernel["content_identity"]),
+        "language_bundle_identity": cast(str, ldb["content_identity"]),
+        "entries": cast(JsonValue, entries),
+    }
+    return _identified("diagnostic-catalog-projection-v2", body)

--- a/libs/gda-balancing/src/gda_balancing/schema2/surface.py
+++ b/libs/gda-balancing/src/gda_balancing/schema2/surface.py
@@ -1,0 +1,332 @@
+"""Descriptor-derived Schema 2.0 command schemas and Surface manifest."""
+
+from typing import Any, cast
+
+from gda_balancing.descriptors import CommandDescriptor
+from copy import deepcopy
+
+from gda_balancing.envelope import ERROR_ENVELOPE_SCHEMA
+from gda_balancing.schema2.canonical import JsonValue, content_identity
+
+_DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
+_ADMITTED_KEYWORDS = (
+    "$defs",
+    "$id",
+    "$ref",
+    "$schema",
+    "additionalProperties",
+    "anyOf",
+    "const",
+    "default",
+    "description",
+    "enum",
+    "exclusiveMaximum",
+    "items",
+    "maxItems",
+    "maxLength",
+    "maximum",
+    "minItems",
+    "minLength",
+    "minimum",
+    "oneOf",
+    "pattern",
+    "properties",
+    "required",
+    "title",
+    "type",
+    "unevaluatedProperties",
+)
+
+_PROFILE_BODY: dict[str, JsonValue] = {
+    "artifact_kind": "command-schema-profile",
+    "artifact_version": "2.0.0",
+    "json_schema_dialect": _DRAFT_2020_12,
+    "object_closure_keyword": "unevaluatedProperties",
+    "object_closure_value": False,
+    "reference_policy": "local-defs-and-exact-content-only",
+    "remote_resolution": "forbidden",
+    "defaults": "descriptor-owned-binding; JSON-Schema-default-is-annotation",
+    "admitted_keywords": list(_ADMITTED_KEYWORDS),
+    "admitted_formats": [],
+}
+
+
+def command_schema_profile() -> dict[str, JsonValue]:
+    """Return the immutable cross-command JSON Schema profile."""
+    return {
+        **_PROFILE_BODY,
+        "content_identity": content_identity(
+            "command-schema-profile-v2", cast(JsonValue, _PROFILE_BODY)
+        ),
+    }
+
+
+def schema2_error_envelope_schema() -> dict[str, Any]:
+    """Return the shared closed 2.x usage/internal/refusal Error contract."""
+    location = {
+        "type": "object",
+        "properties": {
+            "kind": {"const": "artifact"},
+            "content_identity": {"type": "string"},
+            "pointer": {"type": "string", "pattern": "^/"},
+        },
+        "required": ["kind", "content_identity", "pointer"],
+        "unevaluatedProperties": False,
+    }
+    diagnostic = {
+        "type": "object",
+        "properties": {
+            "code": {"type": "string"},
+            "message": {"type": "string"},
+            "primary": location,
+            "related": {"type": "array", "items": location},
+        },
+        "required": ["code", "message", "primary", "related"],
+        "unevaluatedProperties": False,
+    }
+    refusal = {
+        "type": "object",
+        "properties": {
+            "category": {"const": "refusal"},
+            "stage": {
+                "enum": [
+                    "ingress",
+                    "parse",
+                    "static",
+                    "resolution",
+                    "runtime",
+                    "evaluation",
+                    "migration",
+                    "approval",
+                ]
+            },
+            "diagnostics": {
+                "type": "array",
+                "minItems": 1,
+                "items": diagnostic,
+            },
+            "truncated": {"type": "boolean"},
+        },
+        "required": ["category", "stage", "diagnostics", "truncated"],
+        "unevaluatedProperties": False,
+    }
+    legacy_variants = deepcopy(ERROR_ENVELOPE_SCHEMA["properties"]["error"]["oneOf"])
+    return _close_schema_objects(
+        {
+            "$schema": _DRAFT_2020_12,
+            "type": "object",
+            "properties": {"error": {"oneOf": [refusal, *legacy_variants[1:]]}},
+            "required": ["error"],
+            "unevaluatedProperties": False,
+        }
+    )
+
+
+def _close_schema_objects(value: Any) -> Any:
+    """Apply the profile's one object-closure form recursively."""
+    if isinstance(value, list):
+        return [_close_schema_objects(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    closed = {key: _close_schema_objects(item) for key, item in value.items()}
+    if closed.get("type") == "object":
+        additional = closed.pop("additionalProperties", None)
+        if additional not in (None, False):
+            raise ValueError("open object schema is outside the Command schema profile")
+        closed["unevaluatedProperties"] = False
+    return closed
+
+
+def _schema_document(name: str, raw: dict[str, Any]) -> dict[str, JsonValue]:
+    body = cast(dict[str, JsonValue], _close_schema_objects(raw))
+    body["$schema"] = _DRAFT_2020_12
+    digest = content_identity(f"command-wire-schema:{name}", cast(JsonValue, body))
+    return {
+        "$id": f"urn:gda-balancing:command-schema:{digest.removeprefix('sha256:')}",
+        **body,
+    }
+
+
+def _descriptor_body(descriptor: CommandDescriptor) -> dict[str, JsonValue]:
+    profile = command_schema_profile()
+    success_schema = (
+        descriptor.success_schema()
+        if descriptor.success_schema is not None
+        else descriptor.output_model.model_json_schema()
+    )
+    return {
+        "group": descriptor.group,
+        "command": descriptor.command,
+        "description": descriptor.description,
+        "schema_major": descriptor.schema_major,
+        "profile_identity": cast(str, profile["content_identity"]),
+        "input": _schema_document(
+            f"{descriptor.group or 'meta'}.{descriptor.command}.input",
+            descriptor.input_model.model_json_schema(),
+        ),
+        "success": _schema_document(
+            f"{descriptor.group or 'meta'}.{descriptor.command}.success",
+            success_schema,
+        ),
+        "execution": {
+            "stochastic": descriptor.stochastic,
+            "structured_params": descriptor.structured_params,
+            "refusal_stages": list(descriptor.refusal_stages),
+        },
+        "artifact_behavior": "atomic-artifact-set"
+        if descriptor.artifact_sink
+        else "stdout-only",
+    }
+
+
+def descriptor_identity(descriptor: CommandDescriptor) -> str:
+    return content_identity(
+        "command-descriptor-v2", cast(JsonValue, _descriptor_body(descriptor))
+    )
+
+
+def command_schema_projection(descriptor: CommandDescriptor) -> dict[str, JsonValue]:
+    """Return the exact per-command schema object used by manifest and CLI."""
+    body = _descriptor_body(descriptor)
+    identity = descriptor_identity(descriptor)
+    schema_body: dict[str, JsonValue] = {
+        "artifact_kind": "command-schema",
+        "profile_identity": cast(str, body["profile_identity"]),
+        "descriptor_identity": identity,
+        "input": body["input"],
+        "success": body["success"],
+        "error": cast(JsonValue, schema2_error_envelope_schema()),
+    }
+    return {
+        **schema_body,
+        "content_identity": content_identity(
+            "command-schema-v2", cast(JsonValue, schema_body)
+        ),
+    }
+
+
+def surface_manifest_success_schema() -> dict[str, object]:
+    """Closed structural contract for the self-referential Surface manifest."""
+    identity = {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+    schema_document = {
+        "type": "object",
+        "properties": {keyword: {} for keyword in _ADMITTED_KEYWORDS},
+        "unevaluatedProperties": False,
+    }
+    command_schema = {
+        "type": "object",
+        "properties": {
+            "artifact_kind": {"const": "command-schema"},
+            "content_identity": identity,
+            "descriptor_identity": identity,
+            "profile_identity": identity,
+            "input": schema_document,
+            "success": schema_document,
+            "error": schema_document,
+        },
+        "required": [
+            "artifact_kind",
+            "content_identity",
+            "descriptor_identity",
+            "profile_identity",
+            "input",
+            "success",
+            "error",
+        ],
+        "unevaluatedProperties": False,
+    }
+    execution = {
+        "type": "object",
+        "properties": {
+            "stochastic": {"type": "boolean"},
+            "structured_params": {"type": "boolean"},
+            "refusal_stages": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["stochastic", "structured_params", "refusal_stages"],
+        "unevaluatedProperties": False,
+    }
+    row = {
+        "type": "object",
+        "properties": {
+            "group": {"type": ["string", "null"]},
+            "command": {"type": "string"},
+            "description": {"type": "string"},
+            "descriptor_identity": identity,
+            "schema": command_schema,
+            "execution": execution,
+            "artifact_behavior": {"enum": ["stdout-only", "atomic-artifact-set"]},
+        },
+        "required": [
+            "group",
+            "command",
+            "description",
+            "descriptor_identity",
+            "schema",
+            "execution",
+            "artifact_behavior",
+        ],
+        "unevaluatedProperties": False,
+    }
+    return {
+        "type": "object",
+        "properties": {
+            "artifact_kind": {"const": "surface-manifest"},
+            "surface_version": {"const": "2.0.0"},
+            "command_schema_profile": {"const": command_schema_profile()},
+            "commands": {"type": "array", "items": row},
+            "content_identity": identity,
+        },
+        "required": [
+            "artifact_kind",
+            "surface_version",
+            "command_schema_profile",
+            "commands",
+            "content_identity",
+        ],
+        "unevaluatedProperties": False,
+    }
+
+
+def surface_manifest(
+    registry: tuple[CommandDescriptor, ...],
+) -> dict[str, JsonValue]:
+    """Enumerate the delivered 2.x subset from the live descriptor registry."""
+    rows: list[JsonValue] = []
+    for descriptor in registry:
+        if descriptor.schema_major != 2:
+            continue
+        rows.append(
+            {
+                "group": descriptor.group,
+                "command": descriptor.command,
+                "description": descriptor.description,
+                "descriptor_identity": descriptor_identity(descriptor),
+                "schema": command_schema_projection(descriptor),
+                "execution": {
+                    "stochastic": descriptor.stochastic,
+                    "structured_params": descriptor.structured_params,
+                    "refusal_stages": list(descriptor.refusal_stages),
+                },
+                "artifact_behavior": (
+                    "atomic-artifact-set" if descriptor.artifact_sink else "stdout-only"
+                ),
+            }
+        )
+    rows.sort(
+        key=lambda raw: (
+            cast(dict[str, JsonValue], raw)["group"] or "",
+            cast(dict[str, JsonValue], raw)["command"],
+        )
+    )
+    body: dict[str, JsonValue] = {
+        "artifact_kind": "surface-manifest",
+        "surface_version": "2.0.0",
+        "command_schema_profile": command_schema_profile(),
+        "commands": rows,
+    }
+    return {
+        **body,
+        "content_identity": content_identity(
+            "surface-manifest-v2", cast(JsonValue, body)
+        ),
+    }

--- a/libs/gda-balancing/src/gda_balancing/schema2/surface.py
+++ b/libs/gda-balancing/src/gda_balancing/schema2/surface.py
@@ -61,8 +61,8 @@ def command_schema_profile() -> dict[str, JsonValue]:
     }
 
 
-def schema2_error_envelope_schema() -> dict[str, Any]:
-    """Return the shared closed 2.x usage/internal/refusal Error contract."""
+def schema2_error_envelope_schema(descriptor: CommandDescriptor) -> dict[str, Any]:
+    """Return the descriptor's exact closed 2.x Error contract."""
     location = {
         "type": "object",
         "properties": {
@@ -84,38 +84,70 @@ def schema2_error_envelope_schema() -> dict[str, Any]:
         "required": ["code", "message", "primary", "related"],
         "unevaluatedProperties": False,
     }
-    refusal = {
-        "type": "object",
-        "properties": {
-            "category": {"const": "refusal"},
-            "stage": {
-                "enum": [
-                    "ingress",
-                    "parse",
-                    "static",
-                    "resolution",
-                    "runtime",
-                    "evaluation",
-                    "migration",
-                    "approval",
-                ]
-            },
-            "diagnostics": {
-                "type": "array",
-                "minItems": 1,
-                "items": diagnostic,
-            },
-            "truncated": {"type": "boolean"},
-        },
-        "required": ["category", "stage", "diagnostics", "truncated"],
-        "unevaluatedProperties": False,
-    }
     legacy_variants = deepcopy(ERROR_ENVELOPE_SCHEMA["properties"]["error"]["oneOf"])
+    usage = legacy_variants[1]
+    usage["properties"]["code"] = {"enum": sorted(descriptor.usage_codes)}
+    variants: list[dict[str, Any]] = []
+    for stage in descriptor.refusal_stages:
+        codes = sorted(
+            code
+            for code, declared_stage in descriptor.refusal_catalog
+            if declared_stage == stage
+        )
+        stage_diagnostic = deepcopy(diagnostic)
+        stage_diagnostic["properties"]["code"] = {"enum": codes}
+        variants.append(
+            {
+                "type": "object",
+                "properties": {
+                    "category": {"const": "refusal"},
+                    "stage": {"const": stage},
+                    "diagnostics": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": stage_diagnostic,
+                    },
+                    "truncated": {"type": "boolean"},
+                },
+                "required": ["category", "stage", "diagnostics", "truncated"],
+                "unevaluatedProperties": False,
+            }
+        )
+    if descriptor.usage_codes:
+        variants.append(usage)
+    internal_properties: dict[str, Any] = {
+        "category": {"const": "internal"},
+        "code": {"const": "internal_error"},
+        "message": {"type": "string"},
+        "debug": {"type": "string"},
+    }
+    if descriptor.stochastic:
+        internal_properties["reproduction"] = {
+            "type": "object",
+            "properties": {
+                "seed": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMaximum": 2**32,
+                },
+                "toolkit_version": {"type": "string"},
+            },
+            "required": ["seed", "toolkit_version"],
+            "unevaluatedProperties": False,
+        }
+    variants.append(
+        {
+            "type": "object",
+            "properties": internal_properties,
+            "required": ["category", "code", "message"],
+            "unevaluatedProperties": False,
+        }
+    )
     return _close_schema_objects(
         {
             "$schema": _DRAFT_2020_12,
             "type": "object",
-            "properties": {"error": {"oneOf": [refusal, *legacy_variants[1:]]}},
+            "properties": {"error": {"oneOf": variants}},
             "required": ["error"],
             "unevaluatedProperties": False,
         }
@@ -123,12 +155,27 @@ def schema2_error_envelope_schema() -> dict[str, Any]:
 
 
 def _close_schema_objects(value: Any) -> Any:
-    """Apply the profile's one object-closure form recursively."""
-    if isinstance(value, list):
-        return [_close_schema_objects(item) for item in value]
+    """Apply object closure only at JSON Schema positions.
+
+    Literal data carried by ``const``, ``enum``, or ``default`` may itself
+    contain mappings that look like schemas.  Those values are data and must
+    remain byte-for-byte exact.
+    """
     if not isinstance(value, dict):
-        return value
-    closed = {key: _close_schema_objects(item) for key, item in value.items()}
+        return deepcopy(value)
+    closed = deepcopy(value)
+    for keyword in ("$defs", "properties"):
+        children = value.get(keyword)
+        if isinstance(children, dict):
+            closed[keyword] = {
+                name: _close_schema_objects(schema) for name, schema in children.items()
+            }
+    for keyword in ("anyOf", "oneOf"):
+        children = value.get(keyword)
+        if isinstance(children, list):
+            closed[keyword] = [_close_schema_objects(schema) for schema in children]
+    if isinstance(value.get("items"), dict):
+        closed["items"] = _close_schema_objects(value["items"])
     if closed.get("type") == "object":
         additional = closed.pop("additionalProperties", None)
         if additional not in (None, False):
@@ -172,6 +219,11 @@ def _descriptor_body(descriptor: CommandDescriptor) -> dict[str, JsonValue]:
             "stochastic": descriptor.stochastic,
             "structured_params": descriptor.structured_params,
             "refusal_stages": list(descriptor.refusal_stages),
+            "refusal_catalog": [
+                {"code": code, "stage": stage}
+                for code, stage in descriptor.refusal_catalog
+            ],
+            "usage_codes": list(descriptor.usage_codes),
         },
         "artifact_behavior": "atomic-artifact-set"
         if descriptor.artifact_sink
@@ -195,7 +247,7 @@ def command_schema_projection(descriptor: CommandDescriptor) -> dict[str, JsonVa
         "descriptor_identity": identity,
         "input": body["input"],
         "success": body["success"],
-        "error": cast(JsonValue, schema2_error_envelope_schema()),
+        "error": cast(JsonValue, schema2_error_envelope_schema(descriptor)),
     }
     return {
         **schema_body,
@@ -241,8 +293,27 @@ def surface_manifest_success_schema() -> dict[str, object]:
             "stochastic": {"type": "boolean"},
             "structured_params": {"type": "boolean"},
             "refusal_stages": {"type": "array", "items": {"type": "string"}},
+            "refusal_catalog": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "code": {"type": "string"},
+                        "stage": {"type": "string"},
+                    },
+                    "required": ["code", "stage"],
+                    "unevaluatedProperties": False,
+                },
+            },
+            "usage_codes": {"type": "array", "items": {"type": "string"}},
         },
-        "required": ["stochastic", "structured_params", "refusal_stages"],
+        "required": [
+            "stochastic",
+            "structured_params",
+            "refusal_stages",
+            "refusal_catalog",
+            "usage_codes",
+        ],
         "unevaluatedProperties": False,
     }
     row = {
@@ -306,6 +377,11 @@ def surface_manifest(
                     "stochastic": descriptor.stochastic,
                     "structured_params": descriptor.structured_params,
                     "refusal_stages": list(descriptor.refusal_stages),
+                    "refusal_catalog": [
+                        {"code": code, "stage": stage}
+                        for code, stage in descriptor.refusal_catalog
+                    ],
+                    "usage_codes": list(descriptor.usage_codes),
                 },
                 "artifact_behavior": (
                     "atomic-artifact-set" if descriptor.artifact_sink else "stdout-only"

--- a/libs/gda-balancing/tests/conftest.py
+++ b/libs/gda-balancing/tests/conftest.py
@@ -45,13 +45,18 @@ def minimal_design_path() -> Path:
 
 
 def _run(
-    argv: list[str], registry: tuple[CommandDescriptor, ...] | None = None
+    argv: list[str],
+    registry: tuple[CommandDescriptor, ...] | None = None,
+    *,
+    stdin: str = "",
 ) -> RunResult:
-    stdout, stderr = io.StringIO(), io.StringIO()
+    stdout, stderr, input_stream = io.StringIO(), io.StringIO(), io.StringIO(stdin)
     if registry is None:
-        exit_code = dispatch(argv, stdout, stderr)
+        exit_code = dispatch(argv, stdout, stderr, stdin=input_stream)
     else:
-        exit_code = dispatch(argv, stdout, stderr, registry=registry)
+        exit_code = dispatch(
+            argv, stdout, stderr, registry=registry, stdin=input_stream
+        )
     return exit_code, stdout.getvalue(), stderr.getvalue()
 
 

--- a/libs/gda-balancing/tests/test_cli_conformance.py
+++ b/libs/gda-balancing/tests/test_cli_conformance.py
@@ -29,6 +29,7 @@ from gda_balancing.envelope import (
     RefusalReport,
 )
 from gda_balancing.schema.funnel import refusal_code_namespace
+from gda_balancing.schema2.surface import schema2_error_envelope_schema
 
 
 def _command_path(descriptor: CommandDescriptor) -> list[str]:
@@ -153,7 +154,18 @@ class TestPerDescriptorRows:
         exit_code, stdout, stderr = run_cli(argv)
         assert (exit_code, stderr) == (0, "")
         payload = json.loads(stdout)
-        assert sorted(payload) == ["error", "input", "output"]
+        if descriptor.schema_major == 2:
+            assert sorted(payload) == [
+                "artifact_kind",
+                "content_identity",
+                "descriptor_identity",
+                "error",
+                "input",
+                "profile_identity",
+                "success",
+            ]
+        else:
+            assert sorted(payload) == ["error", "input", "output"]
 
     def test_schema_wins_over_any_other_argument(self, descriptor, run_cli):
         argv = [*_command_path(descriptor), "--no-such-argument", "--schema"]
@@ -235,13 +247,17 @@ class TestPerDescriptorRows:
 
 
 class TestSurfaceLaws:
-    def test_error_schema_byte_identical_across_the_walk(self, run_cli):
-        renderings = set()
+    def test_error_schema_byte_identical_within_each_schema_line(self, run_cli):
+        renderings: dict[int, set[str]] = {}
         for descriptor in REGISTRY:
             _, stdout, _ = run_cli([*_command_path(descriptor), "--schema"])
-            renderings.add(canonical_json(json.loads(stdout)["error"]))
-        assert len(renderings) == 1
-        assert renderings == {canonical_json(ERROR_ENVELOPE_SCHEMA)}
+            renderings.setdefault(descriptor.schema_major, set()).add(
+                canonical_json(json.loads(stdout)["error"])
+            )
+        assert renderings == {
+            1: {canonical_json(ERROR_ENVELOPE_SCHEMA)},
+            2: {canonical_json(schema2_error_envelope_schema())},
+        }
 
     def test_reserved_names_unoccupied(self):
         for descriptor in REGISTRY:

--- a/libs/gda-balancing/tests/test_cli_conformance.py
+++ b/libs/gda-balancing/tests/test_cli_conformance.py
@@ -27,6 +27,7 @@ from gda_balancing.envelope import (
     USAGE_CODES,
     Refusal,
     RefusalReport,
+    UnreadableInputError,
 )
 from gda_balancing.schema.funnel import refusal_code_namespace
 from gda_balancing.schema2.surface import schema2_error_envelope_schema
@@ -72,6 +73,11 @@ class TestPerDescriptorRows:
         error = _assert_envelope(stderr, "internal")
         assert error["code"] == "internal_error"
         assert "diagnostics" not in error  # only under --debug
+        assert "debug" not in error
+        if descriptor.schema_major == 2:
+            jsonschema.validate(
+                json.loads(stderr), schema2_error_envelope_schema(descriptor)
+            )
         assert "Traceback" not in stderr  # sanitized by default
 
     def test_internal_row_debug_diagnostics(
@@ -80,8 +86,16 @@ class TestPerDescriptorRows:
         argv = [*invocation(descriptor), "--debug"]
         exit_code, stdout, stderr = run_cli(argv, fault_registry)
         assert (exit_code, stdout) == (4, "")
-        error = _assert_envelope(stderr, "internal")
-        assert "injected fault" in error["diagnostics"]
+        if descriptor.schema_major == 2:
+            payload = json.loads(stderr)
+            jsonschema.validate(payload, schema2_error_envelope_schema(descriptor))
+            error = payload["error"]
+            assert error["category"] == "internal"
+            assert "diagnostics" not in error
+            assert "injected fault" in error["debug"]
+        else:
+            error = _assert_envelope(stderr, "internal")
+            assert "injected fault" in error["diagnostics"]
 
     def test_wrong_success_model_row(self, descriptor, run_cli, invocation):
         # The declared output model is authoritative at runtime: a handler
@@ -247,17 +261,71 @@ class TestPerDescriptorRows:
 
 
 class TestSurfaceLaws:
-    def test_error_schema_byte_identical_within_each_schema_line(self, run_cli):
-        renderings: dict[int, set[str]] = {}
+    def test_error_schema_is_line_or_descriptor_owned(self, run_cli):
+        legacy_renderings: set[str] = set()
         for descriptor in REGISTRY:
             _, stdout, _ = run_cli([*_command_path(descriptor), "--schema"])
-            renderings.setdefault(descriptor.schema_major, set()).add(
-                canonical_json(json.loads(stdout)["error"])
-            )
-        assert renderings == {
-            1: {canonical_json(ERROR_ENVELOPE_SCHEMA)},
-            2: {canonical_json(schema2_error_envelope_schema())},
-        }
+            actual = canonical_json(json.loads(stdout)["error"])
+            if descriptor.schema_major == 1:
+                legacy_renderings.add(actual)
+            else:
+                assert actual == canonical_json(
+                    schema2_error_envelope_schema(descriptor)
+                )
+        assert legacy_renderings == {canonical_json(ERROR_ENVELOPE_SCHEMA)}
+
+    def test_schema2_runtime_rejects_usage_outside_descriptor_catalog(self, run_cli):
+        descriptor = next(item for item in REGISTRY if item.schema_major == 2)
+        registry = tuple(
+            dataclasses.replace(item, usage_codes=()) if item is descriptor else item
+            for item in REGISTRY
+        )
+
+        exit_code, stdout, stderr = run_cli(
+            [*_command_path(descriptor), "--no-such-argument"], registry
+        )
+
+        assert (exit_code, stdout) == (4, "")
+        assert _assert_envelope(stderr, "internal")["code"] == "internal_error"
+
+    def test_schema2_runtime_rejects_handler_usage_outside_descriptor_catalog(
+        self, run_cli, invocation
+    ):
+        descriptor = next(item for item in REGISTRY if item.schema_major == 2)
+
+        def unreadable(_input):
+            raise UnreadableInputError("injected unreadable input")
+
+        registry = tuple(
+            dataclasses.replace(item, usage_codes=(), handler=unreadable)
+            if item is descriptor
+            else item
+            for item in REGISTRY
+        )
+
+        exit_code, stdout, stderr = run_cli(invocation(descriptor), registry)
+
+        assert (exit_code, stdout) == (4, "")
+        assert _assert_envelope(stderr, "internal")["code"] == "internal_error"
+
+    def test_schema2_runtime_rejects_sink_usage_outside_descriptor_catalog(
+        self, run_cli, invocation
+    ):
+        descriptor = next(item for item in REGISTRY if item.schema_major == 2)
+        registry = tuple(
+            dataclasses.replace(item, usage_codes=(), artifact_sink=True)
+            if item is descriptor
+            else item
+            for item in REGISTRY
+        )
+
+        exit_code, stdout, stderr = run_cli(
+            [*invocation(descriptor), "--out", "/nonexistent-dir/result.json"],
+            registry,
+        )
+
+        assert (exit_code, stdout) == (4, "")
+        assert _assert_envelope(stderr, "internal")["code"] == "internal_error"
 
     def test_reserved_names_unoccupied(self):
         for descriptor in REGISTRY:

--- a/libs/gda-balancing/tests/test_e2e_cli.py
+++ b/libs/gda-balancing/tests/test_e2e_cli.py
@@ -100,7 +100,11 @@ class TestKeyUserPath:
         assert receipt["bytes"] == sink.stat().st_size
 
     def test_schema_get_key_path(self):
-        result = _run("schema", "get", "structural")
+        result = _run("schema", "get", "language-bundle")
         assert (result.returncode, result.stderr) == (0, "")
         artifact = json.loads(result.stdout)
-        assert artifact["$id"].endswith("1.0.0")
+        assert artifact["admission"]["admitted"] is True
+        assert (
+            artifact["language_bundle"]["kernel_identity"]
+            == artifact["kernel"]["content_identity"]
+        )

--- a/libs/gda-balancing/tests/test_engine_parity.py
+++ b/libs/gda-balancing/tests/test_engine_parity.py
@@ -10,8 +10,8 @@ phase and then crash model construction (exit 4) instead of being refused (exit
 2). These tests pin that the guards hold — a near-miss id in either position, and
 unknown/miscased keys, all land in ``{0, 2}``, never the internal path.
 
-They also pin the published artifact itself: ``schema get structural`` must
-reproduce the committed golden byte-for-byte, and the golden must stay portable
+They also pin the historical 1.x structural projection itself against the
+committed golden byte-for-byte, and the golden must stay portable
 (ECMA-262 patterns only) and hardened (every ``patternProperties`` node closed).
 """
 
@@ -23,6 +23,8 @@ import pytest
 from pydantic import ValidationError
 
 from gda_balancing.envelope import ERROR_ENVELOPE_SCHEMA
+from gda_balancing.emit import canonical_json
+from gda_balancing.schema.bundle import current_bundle
 from gda_balancing.schema.funnel.structural import structural
 from gda_balancing.schema.model.document import DesignDocument
 
@@ -206,13 +208,12 @@ def test_reshaped_schema_verdict_matches_model_construction(formula):
 # --- The published artifact: golden snapshot + portability/hardening ---------
 
 
-def test_schema_get_structural_matches_golden(run_cli):
+def test_historical_structural_projection_matches_golden():
     # Byte-for-byte against the committed golden. To regenerate after a reviewed
     # model change, overwrite it deliberately and review the diff:
-    #   uv run gda-balancing schema get structural \
-    #     > libs/gda-balancing/tests/goldens/structural_schema.json
-    exit_code, stdout, stderr = run_cli(["schema", "get", "structural"])
-    assert (exit_code, stderr) == (0, "")
+    # This remains an internal 1.x regression fixture after the 2.0 public
+    # `schema get` surface replaces the historical structural/catalog tokens.
+    stdout = canonical_json(current_bundle().structural_schema())
     assert stdout.encode("utf-8") == _GOLDEN.read_bytes()
 
 

--- a/libs/gda-balancing/tests/test_isolation.py
+++ b/libs/gda-balancing/tests/test_isolation.py
@@ -123,9 +123,17 @@ def test_toolkit_speaks_no_game_identity_vocabulary() -> None:
 
 
 def test_toolkit_carries_no_per_game_config() -> None:
+    # Schema-major Kernel/LDB resources are product-wide language authority,
+    # not per-game configuration. Keep the allowlist exact so a third JSON
+    # file cannot enter src unnoticed.
+    machine_authorities = {
+        "src/gda_balancing/schema2/authorities/kernel.json",
+        "src/gda_balancing/schema2/authorities/language-bundle.json",
+    }
     stray = [
         str(path.relative_to(_PACKAGE_ROOT))
         for path in sorted(_SRC_DIR.rglob("*.json"))
+        if str(path.relative_to(_PACKAGE_ROOT)) not in machine_authorities
     ]
     assert not stray, "per-game config files inside the toolkit:\n" + "\n".join(stray)
 

--- a/libs/gda-balancing/tests/test_schema2_authority_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_authority_cli.py
@@ -1,0 +1,279 @@
+"""Public bootstrap surface for the permanent Standard Schema 2.0 authority.
+
+These tests deliberately enter through dispatch: the first permanent language
+authority is useful only if a consumer can retrieve and identify it without
+importing implementation-private registries.
+"""
+
+import json
+from dataclasses import replace
+from copy import deepcopy
+
+import jsonschema
+
+from gda_balancing.commands.schema import SCHEMA_GET, schema_get_handler
+from gda_balancing.schema2.canonical import content_identity
+from gda_balancing.schema2.surface import schema2_error_envelope_schema
+
+
+def test_language_bundle_returns_the_admitted_kernel_and_ldb(run_cli):
+    exit_code, stdout, stderr = run_cli(["schema", "get", "language-bundle"])
+
+    assert (exit_code, stderr) == (0, "")
+    authority = json.loads(stdout)
+    assert set(authority) == {"kernel", "language_bundle", "admission"}
+    assert authority["kernel"]["artifact_kind"] == "schema-major-kernel"
+    assert authority["language_bundle"]["artifact_kind"] == "language-definition-bundle"
+    assert (
+        authority["language_bundle"]["kernel_identity"]
+        == authority["kernel"]["content_identity"]
+    )
+    assert authority["admission"] == {
+        "admitted": True,
+        "kernel_identity": authority["kernel"]["content_identity"],
+        "language_bundle_identity": authority["language_bundle"]["content_identity"],
+    }
+
+
+def test_wire_schema_is_an_exact_projection_of_the_admitted_authorities(run_cli):
+    _, authority_stdout, _ = run_cli(["schema", "get", "language-bundle"])
+    exit_code, stdout, stderr = run_cli(["schema", "get", "wire-schema"])
+
+    assert (exit_code, stderr) == (0, "")
+    authority = json.loads(authority_stdout)
+    projection = json.loads(stdout)
+    assert set(projection) == {
+        "artifact_kind",
+        "content_identity",
+        "kernel_identity",
+        "language_bundle_identity",
+        "schemas",
+    }
+    assert projection["artifact_kind"] == "wire-schema-projection"
+    assert projection["kernel_identity"] == authority["kernel"]["content_identity"]
+    assert (
+        projection["language_bundle_identity"]
+        == authority["language_bundle"]["content_identity"]
+    )
+    schemas = {item["artifact_kind"]: item["schema"] for item in projection["schemas"]}
+    assert set(schemas) == {
+        "schema-major-kernel",
+        "language-definition-bundle",
+        "model-source-package",
+    }
+    jsonschema.validate(authority["kernel"], schemas["schema-major-kernel"])
+    jsonschema.validate(
+        authority["language_bundle"], schemas["language-definition-bundle"]
+    )
+    for role in (
+        "constant",
+        "parameter",
+        "input",
+        "state",
+        "derived",
+        "output",
+        "random-variable",
+    ):
+        jsonschema.validate(
+            {
+                "schema_version": "2.0.0",
+                "symbols": [
+                    {
+                        "symbol": role,
+                        "role": role,
+                        "representation": "signed-int64",
+                        "kind": "scalar",
+                        "unit": "1",
+                        "domain": {"minimum": 0, "maximum": 100},
+                        "numeric_policy": "exact-int64",
+                    }
+                ],
+            },
+            schemas["model-source-package"],
+        )
+
+
+def test_diagnostic_catalog_is_reverse_closed_over_kernel_and_ldb(run_cli):
+    _, authority_stdout, _ = run_cli(["schema", "get", "language-bundle"])
+    exit_code, stdout, stderr = run_cli(["schema", "get", "diagnostic-catalog"])
+
+    assert (exit_code, stderr) == (0, "")
+    authority = json.loads(authority_stdout)
+    catalog = json.loads(stdout)
+    expected = sorted(
+        [
+            {"authority": owner, "code": entry["code"], "stage": entry["stage"]}
+            for owner, artifact in (
+                ("kernel", authority["kernel"]),
+                ("language-bundle", authority["language_bundle"]),
+            )
+            for entry in artifact["diagnostics"]
+        ],
+        key=lambda entry: (entry["stage"], entry["code"], entry["authority"]),
+    )
+    assert catalog["entries"] == expected
+    assert len({entry["code"] for entry in catalog["entries"]}) == len(expected)
+
+
+def test_manifest_and_per_command_schema_are_one_descriptor_projection(run_cli):
+    exit_code, stdout, stderr = run_cli(["manifest"])
+
+    assert (exit_code, stderr) == (0, "")
+    manifest = json.loads(stdout)
+    assert manifest["artifact_kind"] == "surface-manifest"
+    assert manifest["surface_version"] == "2.0.0"
+    assert manifest["command_schema_profile"]["artifact_kind"] == (
+        "command-schema-profile"
+    )
+    commands = {
+        " ".join(filter(None, (row["group"], row["command"]))): row
+        for row in manifest["commands"]
+    }
+    assert set(commands) == {"schema get", "manifest"}
+
+    for path, row in commands.items():
+        schema_exit, schema_stdout, schema_stderr = run_cli([*path.split(), "--schema"])
+        assert (schema_exit, schema_stderr) == (0, "")
+        assert json.loads(schema_stdout) == row["schema"]
+        assert row["descriptor_identity"].startswith("sha256:")
+        assert set(row["schema"]) == {
+            "artifact_kind",
+            "content_identity",
+            "descriptor_identity",
+            "error",
+            "input",
+            "profile_identity",
+            "success",
+        }
+        invocation = (
+            ["schema", "get", "language-bundle"]
+            if path == "schema get"
+            else ["manifest"]
+        )
+        result_exit, result_stdout, result_stderr = run_cli(invocation)
+        assert (result_exit, result_stderr) == (0, "")
+        jsonschema.validate(json.loads(result_stdout), row["schema"]["success"])
+
+
+def test_structured_params_share_binding_and_conflict_with_argv_fields(run_cli):
+    direct = run_cli(["schema", "get", "language-bundle"])
+    inline = run_cli(["schema", "get", '--params-json={"artifact":"language-bundle"}'])
+    piped = run_cli(
+        ["schema", "get", "--params-json", "-"],
+        stdin='{"artifact":"language-bundle"}',
+    )
+
+    assert inline == direct == piped
+
+    exit_code, stdout, stderr = run_cli(
+        [
+            "schema",
+            "get",
+            "language-bundle",
+            "--params-json",
+            '{"artifact":"wire-schema"}',
+        ]
+    )
+    assert (exit_code, stdout) == (3, "")
+    assert json.loads(stderr)["error"]["code"] == "argument_conflict"
+
+    # Bare --schema wins without parsing or reading structured input.
+    exit_code, stdout, stderr = run_cli(
+        ["schema", "get", "--params-json", "-", "--schema"], stdin="not JSON"
+    )
+    assert (exit_code, stderr) == (0, "")
+    assert json.loads(stdout)["artifact_kind"] == "command-schema"
+
+
+def test_bootstrap_refusal_reports_sorted_bounded_diagnostics_at_cli(run_cli):
+    authority = json.loads(run_cli(["schema", "get", "language-bundle"])[1])
+    kernel = deepcopy(authority["kernel"])
+    ldb = deepcopy(authority["language_bundle"])
+    kernel["resources"]["max_diagnostics"] = 3
+    for index in range(8):
+        kernel["admission"]["laws"].append(
+            {"id": f"mutant.{index}", "operation": f"unknown.{index}"}
+        )
+
+    # Reidentify the mutated pair independently so the failure reaches the
+    # static operation/vector gates instead of stopping at ingress identity.
+    kernel_body = {
+        key: value for key, value in kernel.items() if key != "content_identity"
+    }
+    kernel["content_identity"] = content_identity("schema-major-kernel-v2", kernel_body)
+    ldb["kernel_identity"] = kernel["content_identity"]
+    ldb_body = {key: value for key, value in ldb.items() if key != "content_identity"}
+    ldb["content_identity"] = content_identity(
+        "language-definition-bundle-v2", ldb_body
+    )
+
+    descriptor = replace(
+        SCHEMA_GET,
+        handler=schema_get_handler(lambda: (kernel, ldb)),
+    )
+    exit_code, stdout, stderr = run_cli(
+        ["schema", "get", "language-bundle"], registry=(descriptor,)
+    )
+
+    assert (exit_code, stderr) == (2, "")
+    payload = json.loads(stdout)
+    jsonschema.validate(payload, schema2_error_envelope_schema())
+    error = payload["error"]
+    assert error["stage"] == "static"
+    assert error["truncated"] is True
+    assert len(error["diagnostics"]) == 3
+    keys = [(item["primary"]["pointer"], item["code"]) for item in error["diagnostics"]]
+    assert keys == sorted(set(keys))
+
+
+def test_bootstrap_nesting_cap_refuses_before_static_rule_execution(run_cli):
+    authority = json.loads(run_cli(["schema", "get", "language-bundle"])[1])
+    kernel = authority["kernel"]
+    ldb = authority["language_bundle"]
+    nested: object = "leaf"
+    for _ in range(kernel["resources"]["max_nesting_depth"] + 1):
+        nested = [nested]
+    ldb["vectors"][0]["unused_host_payload"] = nested
+    ldb_body = {key: value for key, value in ldb.items() if key != "content_identity"}
+    ldb["content_identity"] = content_identity(
+        "language-definition-bundle-v2", ldb_body
+    )
+    descriptor = replace(SCHEMA_GET, handler=schema_get_handler(lambda: (kernel, ldb)))
+
+    exit_code, stdout, stderr = run_cli(
+        ["schema", "get", "language-bundle"], registry=(descriptor,)
+    )
+
+    assert (exit_code, stderr) == (2, "")
+    error = json.loads(stdout)["error"]
+    assert error["stage"] == "ingress"
+    assert {item["code"] for item in error["diagnostics"]} == {
+        "kernel.resource_exhausted"
+    }
+
+
+def test_command_schema_profile_closes_objects_and_exhausts_used_keywords(run_cli):
+    manifest = json.loads(run_cli(["manifest"])[1])
+    admitted = set(manifest["command_schema_profile"]["admitted_keywords"])
+    used: set[str] = set()
+
+    def walk(schema):
+        assert isinstance(schema, dict)
+        used.update(schema)
+        if schema.get("type") == "object":
+            assert schema.get("unevaluatedProperties") is False
+        for keyword in ("properties", "$defs"):
+            for child in schema.get(keyword, {}).values():
+                walk(child)
+        items = schema.get("items")
+        if isinstance(items, dict):
+            walk(items)
+        for keyword in ("oneOf", "anyOf"):
+            for child in schema.get(keyword, []):
+                walk(child)
+
+    for command in manifest["commands"]:
+        for outcome in ("input", "success", "error"):
+            walk(command["schema"][outcome])
+
+    assert used <= admitted

--- a/libs/gda-balancing/tests/test_schema2_authority_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_authority_cli.py
@@ -8,12 +8,105 @@ importing implementation-private registries.
 import json
 from dataclasses import replace
 from copy import deepcopy
+from typing import get_args
 
 import jsonschema
+import pytest
 
+import gda_balancing.schema2.authority as authority_module
+import gda_balancing.schema2.bootstrap as bootstrap_module
+import gda_balancing.commands.schema as schema_command_module
+from gda_balancing.commands.manifest import MANIFEST
 from gda_balancing.commands.schema import SCHEMA_GET, schema_get_handler
 from gda_balancing.schema2.canonical import content_identity
+from gda_balancing.schema2.diagnostics import (
+    ArtifactLocation,
+    RefusalStage,
+    Schema2Diagnostic,
+    Schema2RefusalReport,
+)
 from gda_balancing.schema2.surface import schema2_error_envelope_schema
+
+
+def test_packaged_authority_loader_refuses_duplicate_object_keys(monkeypatch, run_cli):
+    class DuplicateKeyResource:
+        def joinpath(self, _name):
+            return self
+
+        def read_text(self, *, encoding):
+            assert encoding == "utf-8"
+            return '{"schema_major":999,"schema_major":2}'
+
+        def read_bytes(self):
+            return b'{"schema_major":999,"schema_major":2}'
+
+    monkeypatch.setattr(
+        authority_module, "files", lambda _package: DuplicateKeyResource()
+    )
+
+    with pytest.raises(authority_module.AuthorityLoadError) as caught:
+        authority_module.load_authorities()
+    assert caught.value.code == "kernel.member_set_mismatch"
+    assert caught.value.stage == "ingress"
+
+    exit_code, stdout, stderr = run_cli(["schema", "get", "language-bundle"])
+    assert (exit_code, stderr) == (2, "")
+    assert json.loads(stdout)["error"]["stage"] == "ingress"
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"{" + b" " * 262144 + b"}",
+        b"[" * 33 + b"0" + b"]" * 33,
+    ],
+)
+def test_authority_raw_resource_bounds_precede_json_decode(monkeypatch, data):
+    class BoundedResource:
+        def joinpath(self, _name):
+            return self
+
+        def read_bytes(self):
+            return data
+
+    monkeypatch.setattr(authority_module, "files", lambda _package: BoundedResource())
+
+    with pytest.raises(authority_module.AuthorityLoadError) as caught:
+        authority_module.load_authorities()
+    assert caught.value.code == "kernel.resource_exhausted"
+
+
+def test_authority_decode_failure_is_a_typed_ingress_refusal(run_cli):
+    def failed_provider():
+        raise authority_module.AuthorityLoadError(
+            code="kernel.member_set_mismatch",
+            subject="language-bundle",
+            message="duplicate object key",
+        )
+
+    descriptor = replace(SCHEMA_GET, handler=schema_get_handler(failed_provider))
+    exit_code, stdout, stderr = run_cli(
+        ["schema", "get", "language-bundle"], registry=(descriptor,)
+    )
+
+    assert (exit_code, stderr) == (2, "")
+    error = json.loads(stdout)["error"]
+    assert error["stage"] == "ingress"
+    assert {item["code"] for item in error["diagnostics"]} == {
+        "kernel.member_set_mismatch"
+    }
+
+
+def test_schema_introspection_does_not_read_runtime_authorities(monkeypatch, run_cli):
+    def fail_if_loaded():
+        raise AssertionError("introspection read runtime authority")
+
+    monkeypatch.setattr(schema_command_module, "load_authorities", fail_if_loaded)
+
+    for argv in (["schema", "get", "--schema"], ["manifest"]):
+        exit_code, stdout, stderr = run_cli(argv)
+        assert (exit_code, stderr) == (0, "")
+        assert json.loads(stdout)
 
 
 def test_language_bundle_returns_the_admitted_kernel_and_ldb(run_cli):
@@ -72,7 +165,7 @@ def test_wire_schema_is_an_exact_projection_of_the_admitted_authorities(run_cli)
         "state",
         "derived",
         "output",
-        "random-variable",
+        "random",
     ):
         jsonschema.validate(
             {
@@ -81,7 +174,7 @@ def test_wire_schema_is_an_exact_projection_of_the_admitted_authorities(run_cli)
                     {
                         "symbol": role,
                         "role": role,
-                        "representation": "signed-int64",
+                        "representation": "Int",
                         "kind": "scalar",
                         "unit": "1",
                         "domain": {"minimum": 0, "maximum": 100},
@@ -155,6 +248,97 @@ def test_manifest_and_per_command_schema_are_one_descriptor_projection(run_cli):
         jsonschema.validate(json.loads(result_stdout), row["schema"]["success"])
 
 
+def test_per_command_error_schema_rejects_undeclared_refusal_stages_and_codes(run_cli):
+    manifest_schema = json.loads(run_cli(["manifest", "--schema"])[1])["error"]
+    schema_get_schema = json.loads(run_cli(["schema", "get", "--schema"])[1])["error"]
+    invented_refusal = {
+        "error": {
+            "category": "refusal",
+            "stage": "runtime",
+            "diagnostics": [
+                {
+                    "code": "host.invented",
+                    "message": "not authoritative",
+                    "primary": {
+                        "kind": "artifact",
+                        "content_identity": "unidentified",
+                        "pointer": "/",
+                    },
+                    "related": [],
+                }
+            ],
+            "truncated": False,
+        }
+    }
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(invented_refusal, manifest_schema)
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(invented_refusal, schema_get_schema)
+
+
+def test_schema2_internal_schema_matches_deterministic_debug_contract():
+    schema = schema2_error_envelope_schema(SCHEMA_GET)
+    base = {
+        "error": {
+            "category": "internal",
+            "code": "internal_error",
+            "message": "sanitized",
+        }
+    }
+    jsonschema.validate(base, schema)
+    with_debug = deepcopy(base)
+    with_debug["error"]["debug"] = "trace"
+    jsonschema.validate(with_debug, schema)
+
+    for forbidden in ("diagnostics", "reproduction"):
+        mutant = deepcopy(base)
+        mutant["error"][forbidden] = "not reachable"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(mutant, schema)
+
+
+def test_kernel_stage_vocabulary_is_the_runtime_discriminant(run_cli):
+    authority = json.loads(run_cli(["schema", "get", "language-bundle"])[1])
+    declared = tuple(authority["kernel"]["admission"]["refusal_stages"])
+
+    assert declared == (
+        "ingress",
+        "parse",
+        "static",
+        "resolution",
+        "runtime",
+        "evaluation",
+        "migration",
+        "approval",
+    )
+    assert set(declared) == set(get_args(RefusalStage))
+    assert set(declared) == set(bootstrap_module.SCHEMA2_REFUSAL_STAGES)
+    assert {
+        (item["code"], item["stage"]) for item in authority["kernel"]["diagnostics"]
+    } == set(bootstrap_module.BOOTSTRAP_REFUSAL_CATALOG)
+
+
+def test_dispatch_rejects_a_refusal_absent_from_the_descriptor_catalog(run_cli):
+    invented = Schema2RefusalReport(
+        stage="runtime",
+        diagnostics=(
+            Schema2Diagnostic(
+                code="host.invented",
+                message="not authoritative",
+                primary=ArtifactLocation(content_identity="unidentified", pointer="/"),
+            ),
+        ),
+        truncated=False,
+    )
+    descriptor = replace(MANIFEST, handler=lambda _inp: invented)
+
+    exit_code, stdout, stderr = run_cli(["manifest"], registry=(descriptor,))
+
+    assert (exit_code, stdout) == (4, "")
+    assert json.loads(stderr)["error"]["code"] == "internal_error"
+
+
 def test_structured_params_share_binding_and_conflict_with_argv_fields(run_cli):
     direct = run_cli(["schema", "get", "language-bundle"])
     inline = run_cli(["schema", "get", '--params-json={"artifact":"language-bundle"}'])
@@ -189,19 +373,18 @@ def test_bootstrap_refusal_reports_sorted_bounded_diagnostics_at_cli(run_cli):
     authority = json.loads(run_cli(["schema", "get", "language-bundle"])[1])
     kernel = deepcopy(authority["kernel"])
     ldb = deepcopy(authority["language_bundle"])
-    kernel["resources"]["max_diagnostics"] = 3
-    for index in range(8):
-        kernel["admission"]["laws"].append(
-            {"id": f"mutant.{index}", "operation": f"unknown.{index}"}
+    diagnostic_cap = kernel["resources"]["max_diagnostics"]
+    for index in range(diagnostic_cap + 2):
+        ldb["vectors"].append(
+            {
+                "expect": {},
+                "id": f"mutant.{index}",
+                "input": {"facts": [], "judgment": "missing"},
+                "rule": "quantity.declare",
+            }
         )
 
-    # Reidentify the mutated pair independently so the failure reaches the
-    # static operation/vector gates instead of stopping at ingress identity.
-    kernel_body = {
-        key: value for key, value in kernel.items() if key != "content_identity"
-    }
-    kernel["content_identity"] = content_identity("schema-major-kernel-v2", kernel_body)
-    ldb["kernel_identity"] = kernel["content_identity"]
+    # Reidentify only the mutable LDB; the Schema-major Kernel stays exact.
     ldb_body = {key: value for key, value in ldb.items() if key != "content_identity"}
     ldb["content_identity"] = content_identity(
         "language-definition-bundle-v2", ldb_body
@@ -217,11 +400,11 @@ def test_bootstrap_refusal_reports_sorted_bounded_diagnostics_at_cli(run_cli):
 
     assert (exit_code, stderr) == (2, "")
     payload = json.loads(stdout)
-    jsonschema.validate(payload, schema2_error_envelope_schema())
+    jsonschema.validate(payload, schema2_error_envelope_schema(descriptor))
     error = payload["error"]
     assert error["stage"] == "static"
     assert error["truncated"] is True
-    assert len(error["diagnostics"]) == 3
+    assert len(error["diagnostics"]) == diagnostic_cap
     keys = [(item["primary"]["pointer"], item["code"]) for item in error["diagnostics"]]
     assert keys == sorted(set(keys))
 
@@ -249,6 +432,27 @@ def test_bootstrap_nesting_cap_refuses_before_static_rule_execution(run_cli):
     assert error["stage"] == "ingress"
     assert {item["code"] for item in error["diagnostics"]} == {
         "kernel.resource_exhausted"
+    }
+
+
+def test_noncanonical_authority_value_is_a_typed_ingress_refusal(run_cli):
+    authority = json.loads(run_cli(["schema", "get", "language-bundle"])[1])
+    kernel = authority["kernel"]
+    ldb = authority["language_bundle"]
+    ldb["resources"]["max_source_bytes"] = 2**63
+    descriptor = replace(SCHEMA_GET, handler=schema_get_handler(lambda: (kernel, ldb)))
+
+    exit_code, stdout, stderr = run_cli(
+        ["schema", "get", "language-bundle"], registry=(descriptor,)
+    )
+
+    assert (exit_code, stderr) == (2, "")
+    error = json.loads(stdout)["error"]
+    assert error["stage"] == "ingress"
+    assert {item["code"] for item in error["diagnostics"]} == {
+        "kernel.identity_mismatch",
+        "kernel.member_set_mismatch",
+        "kernel.resource_exhausted",
     }
 
 

--- a/libs/gda-balancing/tests/test_schema2_bootstrap_conformance.py
+++ b/libs/gda-balancing/tests/test_schema2_bootstrap_conformance.py
@@ -1,0 +1,615 @@
+"""Independent bootstrap and mutation conformance for the permanent authority.
+
+Consumer B below intentionally imports no production bootstrap or canonical
+code.  Agreement is over public artifact bytes and observable inventories,
+not shared helper behavior.
+"""
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any
+
+from gda_balancing.schema2.authority import authority_set
+from gda_balancing.schema2.bootstrap import admit_authorities
+
+
+def _identity(domain: str, artifact: dict[str, Any]) -> str:
+    body = {key: value for key, value in artifact.items() if key != "content_identity"}
+    encoded = _encoded(body)
+    return (
+        "sha256:"
+        + hashlib.sha256(f"gda-balancing:{domain}:".encode() + encoded).hexdigest()
+    )
+
+
+def _encoded(value: Any) -> bytes:
+    return (
+        json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        + "\n"
+    ).encode()
+
+
+def _shape(value: Any) -> tuple[int, int]:
+    depth = 0
+    members = 0
+    stack = [(value, 0)]
+    while stack:
+        current, current_depth = stack.pop()
+        depth = max(depth, current_depth)
+        if isinstance(current, dict):
+            members = max(members, len(current))
+            stack.extend((item, current_depth + 1) for item in current.values())
+        elif isinstance(current, list):
+            members = max(members, len(current))
+            stack.extend((item, current_depth + 1) for item in current)
+    return depth, members
+
+
+def _consumer_b(kernel: dict[str, Any], ldb: dict[str, Any]) -> dict[str, Any]:
+    """A separate, deliberately compact Kernel interpreter for cross-checking."""
+    diagnostics: set[tuple[str, str, str]] = set()
+    cap = kernel.get("resources", {}).get("max_diagnostics", 128)
+    if not isinstance(cap, int) or cap < 1:
+        cap = 128
+
+    def refuse(code: str, stage: str, subject: str) -> None:
+        diagnostics.add((stage, code, subject))
+
+    if kernel.get("content_identity") != _identity("schema-major-kernel-v2", kernel):
+        refuse("kernel.identity_mismatch", "ingress", "kernel")
+    if ldb.get("content_identity") != _identity("language-definition-bundle-v2", ldb):
+        refuse("kernel.identity_mismatch", "ingress", "language-bundle")
+    if ldb.get("kernel_identity") != kernel.get("content_identity"):
+        refuse("kernel.binding_mismatch", "ingress", "language-bundle.kernel_identity")
+
+    kernel_members = {
+        "admission",
+        "artifact_kind",
+        "artifact_version",
+        "canonical_encoding",
+        "content_identity",
+        "diagnostics",
+        "meta_format",
+        "resources",
+        "schema_major",
+        "vectors",
+    }
+    if set(kernel) != kernel_members:
+        refuse("kernel.member_set_mismatch", "ingress", "kernel")
+
+    expected_members = set(kernel["admission"]["required_ldb_members"])
+    if set(ldb) != expected_members:
+        refuse("kernel.member_set_mismatch", "ingress", "language-bundle")
+
+    limits = kernel["resources"]
+    for subject, artifact in (("kernel", kernel), ("language-bundle", ldb)):
+        depth, members = _shape(artifact)
+        if (
+            depth > limits["max_nesting_depth"]
+            or members > limits["max_members"]
+            or len(_encoded(artifact)) > limits["max_authority_bytes"]
+        ):
+            refuse("kernel.resource_exhausted", "ingress", subject)
+
+    if diagnostics:
+        ordered = sorted(diagnostics, key=lambda item: (item[0], item[2], item[1]))
+        truncated = len(ordered) > cap
+        return {
+            "admitted": False,
+            "kernel_identity": kernel.get("content_identity"),
+            "language_bundle_identity": ldb.get("content_identity"),
+            "law_ids": [],
+            "law_projections": [],
+            "rule_ids": [],
+            "rule_projections": [],
+            "diagnostic_projections": [],
+            "diagnostics": ordered[:cap],
+            "truncated": truncated,
+        }
+
+    laws = kernel["admission"]["laws"]
+    allowed_operations = {
+        "verify-content-identity",
+        "require-equal",
+        "require-exact-members",
+        "require-unique-identifiers",
+        "require-known-operations",
+        "require-vector-closure",
+        "require-diagnostic-closure",
+        "enforce-resource-limits",
+    }
+    law_ids = [law["id"] for law in laws]
+    if len(law_ids) != len(set(law_ids)):
+        refuse("kernel.duplicate_identifier", "static", "kernel.admission.laws")
+    for law in laws:
+        if law["operation"] not in allowed_operations:
+            refuse("kernel.unknown_operation", "static", law["id"])
+    law_projections = sorted(
+        (law["id"], _identity("kernel-law-projection-v2", law)) for law in laws
+    )
+
+    kernel_vectors = kernel["vectors"]
+    referenced_laws = {vector["law"] for vector in kernel_vectors}
+    if set(law_ids) != referenced_laws:
+        refuse("kernel.vector_mismatch", "static", "kernel.vectors")
+    kernel_codes = [item["code"] for item in kernel["diagnostics"]]
+    if len(kernel_codes) != len(set(kernel_codes)):
+        refuse("kernel.duplicate_identifier", "static", "kernel.diagnostics")
+    kernel_catalog = {(item["code"], item["stage"]) for item in kernel["diagnostics"]}
+    kernel_vector_catalog = {
+        (item["diagnostic"], item["stage"])
+        for item in kernel_vectors
+        if "diagnostic" in item
+    }
+    if kernel_catalog != kernel_vector_catalog:
+        refuse("kernel.diagnostic_closure", "static", "kernel.diagnostics")
+
+    rules = ldb["language"]["rules"]
+    rule_ids = [rule["id"] for rule in rules]
+    if len(rule_ids) != len(set(rule_ids)):
+        refuse("kernel.duplicate_identifier", "static", "language.rules")
+    closed_rules = all(
+        set(rule) == {"id", "judgment", "premises", "conclusion"}
+        and all(set(item) == {"bind", "fact_kind"} for item in rule["premises"])
+        and set(rule["conclusion"]) == {"fact_kind", "fields"}
+        and all(
+            (term.get("tag") == "literal" and set(term) == {"tag", "value"})
+            or (term.get("tag") == "variable" and set(term) == {"tag", "name"})
+            for term in rule["conclusion"]["fields"].values()
+        )
+        for rule in rules
+    )
+    if not closed_rules:
+        refuse("kernel.vector_mismatch", "static", "language.rules")
+    rule_vectors = [item for item in ldb["vectors"] if "rule" in item]
+    if set(rule_ids) != {item["rule"] for item in rule_vectors}:
+        refuse("kernel.vector_mismatch", "static", "language-bundle.vectors")
+    projections = []
+    for vector in rule_vectors:
+        invocation = vector["input"]
+        facts = invocation["facts"]
+        candidates = [
+            rule
+            for rule in sorted(rules, key=lambda item: item["id"])
+            if rule["judgment"] == invocation["judgment"]
+            and len(rule["premises"]) == len(facts)
+            and all(
+                premise["fact_kind"] == fact["kind"]
+                for premise, fact in zip(rule["premises"], facts, strict=True)
+            )
+        ]
+        output = None
+        if len(candidates) == 1 and candidates[0]["id"] == vector["rule"]:
+            selected = candidates[0]
+            bindings = {}
+            valid = True
+            for premise, fact in zip(selected["premises"], facts, strict=True):
+                for variable, field_name in premise["bind"].items():
+                    if field_name not in fact["fields"]:
+                        valid = False
+                        break
+                    bindings[variable] = fact["fields"][field_name]
+            fields = {}
+            for name, term in selected["conclusion"]["fields"].items():
+                if term["tag"] == "literal" and set(term) == {"tag", "value"}:
+                    fields[name] = term["value"]
+                elif term["tag"] == "variable" and term.get("name") in bindings:
+                    fields[name] = bindings[term["name"]]
+                else:
+                    valid = False
+            if valid:
+                output = {"kind": selected["conclusion"]["fact_kind"], "fields": fields}
+        if output != vector["expect"]:
+            refuse("kernel.vector_mismatch", "static", vector["id"])
+        else:
+            assert isinstance(output, dict)
+            projections.append(
+                (vector["id"], _identity("rule-vector-projection-v2", output))
+            )
+
+    ldb_codes = [item["code"] for item in ldb["diagnostics"]]
+    if len(ldb_codes) != len(set(ldb_codes)):
+        refuse("kernel.duplicate_identifier", "static", "language-bundle.diagnostics")
+    ldb_catalog = {(item["code"], item["stage"]) for item in ldb["diagnostics"]}
+    ldb_vector_catalog = {
+        (item["diagnostic"], item["stage"])
+        for item in ldb["vectors"]
+        if "diagnostic" in item
+    }
+    if ldb_catalog != ldb_vector_catalog:
+        refuse("kernel.diagnostic_closure", "static", "language-bundle.diagnostics")
+
+    def resolve(path: str) -> Any:
+        value: Any = ldb
+        for part in path.split("."):
+            value = value[part]
+        return value
+
+    reasons = {item["id"]: item for item in ldb["language"]["reasons"]}
+    diagnostic_projections = []
+    diagnostic_vectors = [item for item in ldb["vectors"] if "diagnostic" in item]
+    if set(reasons) != {item["reason"] for item in diagnostic_vectors}:
+        refuse("kernel.vector_mismatch", "static", "language-bundle.reasons")
+    for vector in diagnostic_vectors:
+        reason = reasons.get(vector["reason"])
+        matched = False
+        if reason is not None:
+            predicate = reason["predicate"]
+            operation = predicate["operation"]
+            if operation == "not-member":
+                inventory = resolve(predicate["inventory_path"])
+                if "member_field" in predicate:
+                    inventory = [item[predicate["member_field"]] for item in inventory]
+                matched = vector["input"]["value"] not in inventory
+            elif operation == "has-duplicate":
+                values = vector["input"]["values"]
+                matched = len(values) != len(set(values))
+            elif operation == "greater-than":
+                matched = vector["input"]["value"] > resolve(predicate["limit_path"])
+        output = (
+            {"code": reason["diagnostic"], "stage": reason["stage"]}
+            if matched and reason is not None
+            else None
+        )
+        expected = {"code": vector["diagnostic"], "stage": vector["stage"]}
+        if output != expected:
+            refuse("kernel.vector_mismatch", "static", vector["id"])
+        else:
+            assert isinstance(output, dict)
+            diagnostic_projections.append(
+                (
+                    vector["id"],
+                    vector["diagnostic"],
+                    _identity("diagnostic-vector-projection-v2", output),
+                )
+            )
+
+    ordered = sorted(diagnostics, key=lambda item: (item[0], item[2], item[1]))
+    truncated = len(ordered) > cap
+    return {
+        "admitted": not ordered,
+        "kernel_identity": kernel.get("content_identity"),
+        "language_bundle_identity": ldb.get("content_identity"),
+        "law_ids": sorted(law_ids),
+        "law_projections": law_projections,
+        "rule_ids": sorted(rule_ids),
+        "rule_projections": sorted(projections),
+        "diagnostic_projections": sorted(diagnostic_projections),
+        "diagnostics": ordered[:cap],
+        "truncated": truncated,
+    }
+
+
+def _consumer_a(kernel: dict[str, Any], ldb: dict[str, Any]) -> dict[str, Any]:
+    result = admit_authorities(kernel, ldb)
+    return {
+        "admitted": result.admitted,
+        "kernel_identity": result.kernel_identity,
+        "language_bundle_identity": result.language_bundle_identity,
+        "law_ids": list(result.law_ids),
+        "law_projections": list(result.law_projections),
+        "rule_ids": list(result.rule_ids),
+        "rule_projections": list(result.rule_projections),
+        "diagnostic_projections": list(result.diagnostic_projections),
+        "diagnostics": [
+            (item.stage, item.code, item.subject) for item in result.diagnostics
+        ],
+        "truncated": result.truncated,
+    }
+
+
+def _reidentify(kernel: dict[str, Any], ldb: dict[str, Any]) -> None:
+    kernel["content_identity"] = _identity("schema-major-kernel-v2", kernel)
+    ldb["kernel_identity"] = kernel["content_identity"]
+    ldb["content_identity"] = _identity("language-definition-bundle-v2", ldb)
+
+
+def test_two_independent_consumers_admit_the_exact_authority_and_inventories():
+    authority = authority_set()
+    kernel = authority["kernel"]
+    ldb = authority["language_bundle"]
+
+    first = _consumer_a(kernel, ldb)
+    second = _consumer_b(kernel, ldb)
+
+    assert first == second
+    assert first["admitted"] is True
+    assert first["law_ids"]
+    assert first["rule_ids"] == ["quantity.declare", "quantity.lower"]
+
+
+def test_kernel_meta_format_and_ldb_rules_are_structured_for_independent_execution():
+    authority = authority_set()
+    meta_format = authority["kernel"]["meta_format"]
+
+    assert set(meta_format) == {
+        "fact",
+        "term",
+        "rule",
+        "rule_selection",
+        "binding_substitution",
+        "diagnostic_reason",
+    }
+    assert {item["tag"] for item in meta_format["term"]["constructors"]} == {
+        "literal",
+        "variable",
+    }
+    for rule in authority["language_bundle"]["language"]["rules"]:
+        assert set(rule) == {"id", "judgment", "premises", "conclusion"}
+        assert rule["premises"]
+        assert set(rule["conclusion"]) == {"fact_kind", "fields"}
+
+
+def test_bootstrap_executes_every_rule_vector_into_a_stable_projection():
+    authority = authority_set()
+    admission = admit_authorities(authority["kernel"], authority["language_bundle"])
+
+    assert admission.admitted is True
+    assert dict(admission.rule_projections).keys() == {
+        "quantity.declare.valid",
+        "quantity.lower.valid",
+    }
+    assert all(
+        identity.startswith("sha256:") for _, identity in admission.rule_projections
+    )
+
+
+def test_bootstrap_projects_every_kernel_law_without_a_host_fallback_table():
+    authority = authority_set()
+    admission = admit_authorities(authority["kernel"], authority["language_bundle"])
+
+    law_ids = {item["id"] for item in authority["kernel"]["admission"]["laws"]}
+    assert {law_id for law_id, _ in admission.law_projections} == law_ids
+    assert all(
+        identity.startswith("sha256:") for _, identity in admission.law_projections
+    )
+
+
+def test_bootstrap_behavior_covers_every_ldb_diagnostic_reason():
+    authority = authority_set()
+    admission = admit_authorities(authority["kernel"], authority["language_bundle"])
+
+    catalog_codes = {
+        item["code"] for item in authority["language_bundle"]["diagnostics"]
+    }
+    projection_codes = {code for _, code, _ in admission.diagnostic_projections}
+    assert admission.admitted is True
+    assert projection_codes == catalog_codes
+    assert all(
+        identity.startswith("sha256:")
+        for _, _, identity in admission.diagnostic_projections
+    )
+
+
+def test_reidentified_deletion_of_every_law_and_rule_is_refused_by_both_consumers():
+    baseline = authority_set()
+    kernel_laws = baseline["kernel"]["admission"]["laws"]
+    ldb_rules = baseline["language_bundle"]["language"]["rules"]
+
+    for index in range(len(kernel_laws)):
+        authority = deepcopy(baseline)
+        del authority["kernel"]["admission"]["laws"][index]
+        _reidentify(authority["kernel"], authority["language_bundle"])
+        first = _consumer_a(authority["kernel"], authority["language_bundle"])
+        second = _consumer_b(authority["kernel"], authority["language_bundle"])
+        assert first == second
+        assert first["admitted"] is False
+        assert any(
+            code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"]
+        )
+
+    for index in range(len(ldb_rules)):
+        authority = deepcopy(baseline)
+        del authority["language_bundle"]["language"]["rules"][index]
+        authority["language_bundle"]["content_identity"] = _identity(
+            "language-definition-bundle-v2", authority["language_bundle"]
+        )
+        first = _consumer_a(authority["kernel"], authority["language_bundle"])
+        second = _consumer_b(authority["kernel"], authority["language_bundle"])
+        assert first == second
+        assert first["admitted"] is False
+        assert any(
+            code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"]
+        )
+
+
+def test_reidentified_duplicate_diagnostic_is_not_hidden_by_set_projection():
+    authority = authority_set()
+    authority["language_bundle"]["diagnostics"].append(
+        deepcopy(authority["language_bundle"]["diagnostics"][0])
+    )
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert (
+        "static",
+        "kernel.duplicate_identifier",
+        "language-bundle.diagnostics",
+    ) in first["diagnostics"]
+
+
+def test_old_identity_tamper_and_reidentified_behavior_or_token_mutations_refuse():
+    baseline = authority_set()
+
+    old_identity = deepcopy(baseline)
+    old_identity["language_bundle"]["language"]["rules"][0]["conclusion"][
+        "fact_kind"
+    ] = "changed"
+    first = _consumer_a(old_identity["kernel"], old_identity["language_bundle"])
+    second = _consumer_b(old_identity["kernel"], old_identity["language_bundle"])
+    assert first == second
+    assert any(
+        code == "kernel.identity_mismatch" for _, code, _ in first["diagnostics"]
+    )
+
+    for index in range(len(baseline["kernel"]["admission"]["laws"])):
+        authority = deepcopy(baseline)
+        authority["kernel"]["admission"]["laws"][index]["operation"] += ".renamed"
+        _reidentify(authority["kernel"], authority["language_bundle"])
+        first = _consumer_a(authority["kernel"], authority["language_bundle"])
+        second = _consumer_b(authority["kernel"], authority["language_bundle"])
+        assert first == second
+        assert any(
+            code == "kernel.unknown_operation" for _, code, _ in first["diagnostics"]
+        )
+
+    for index in range(len(baseline["language_bundle"]["language"]["rules"])):
+        authority = deepcopy(baseline)
+        authority["language_bundle"]["language"]["rules"][index]["conclusion"][
+            "fact_kind"
+        ] += ".changed"
+        authority["language_bundle"]["content_identity"] = _identity(
+            "language-definition-bundle-v2", authority["language_bundle"]
+        )
+        first = _consumer_a(authority["kernel"], authority["language_bundle"])
+        second = _consumer_b(authority["kernel"], authority["language_bundle"])
+        assert first == second
+        assert any(
+            code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"]
+        )
+
+    for owner, path in (
+        ("kernel", ("admission", "laws")),
+        ("language_bundle", ("language", "rules")),
+    ):
+        authority = deepcopy(baseline)
+        collection = authority[owner]
+        for part in path:
+            collection = collection[part]
+        collection[0]["id"] += ".renamed"
+        _reidentify(authority["kernel"], authority["language_bundle"])
+        first = _consumer_a(authority["kernel"], authority["language_bundle"])
+        second = _consumer_b(authority["kernel"], authority["language_bundle"])
+        assert first == second
+        assert any(
+            code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"]
+        )
+
+
+def test_diagnostic_catalog_missing_extra_and_stage_drift_are_refused():
+    baseline = authority_set()
+    mutations = []
+
+    missing = deepcopy(baseline)
+    missing["language_bundle"]["diagnostics"].pop()
+    mutations.append(missing)
+
+    extra = deepcopy(baseline)
+    extra["language_bundle"]["diagnostics"].append(
+        {"code": "language.unreachable", "stage": "static"}
+    )
+    mutations.append(extra)
+
+    drift = deepcopy(baseline)
+    drift["language_bundle"]["diagnostics"][0]["stage"] = "resolution"
+    mutations.append(drift)
+
+    for authority in mutations:
+        authority["language_bundle"]["content_identity"] = _identity(
+            "language-definition-bundle-v2", authority["language_bundle"]
+        )
+        first = _consumer_a(authority["kernel"], authority["language_bundle"])
+        second = _consumer_b(authority["kernel"], authority["language_bundle"])
+        assert first == second
+        assert (
+            "static",
+            "kernel.diagnostic_closure",
+            "language-bundle.diagnostics",
+        ) in first["diagnostics"]
+
+
+def test_reidentified_deletion_and_behavior_mutation_of_every_reason_refuse():
+    baseline = authority_set()
+    reasons = baseline["language_bundle"]["language"]["reasons"]
+
+    for index in range(len(reasons)):
+        for mutation in ("delete", "operation"):
+            authority = deepcopy(baseline)
+            target = authority["language_bundle"]["language"]["reasons"]
+            if mutation == "delete":
+                del target[index]
+            else:
+                target[index]["predicate"]["operation"] += ".changed"
+            authority["language_bundle"]["content_identity"] = _identity(
+                "language-definition-bundle-v2", authority["language_bundle"]
+            )
+            first = _consumer_a(authority["kernel"], authority["language_bundle"])
+            second = _consumer_b(authority["kernel"], authority["language_bundle"])
+            assert first == second
+            assert first["admitted"] is False
+            assert any(
+                code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"]
+            )
+
+
+def test_reidentified_extra_members_cannot_extend_kernel_ldb_or_rule_shapes():
+    baseline = authority_set()
+    mutations = []
+
+    kernel_extra = deepcopy(baseline)
+    kernel_extra["kernel"]["host_extension"] = True
+    _reidentify(kernel_extra["kernel"], kernel_extra["language_bundle"])
+    mutations.append(kernel_extra)
+
+    ldb_extra = deepcopy(baseline)
+    ldb_extra["language_bundle"]["host_extension"] = True
+    ldb_extra["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", ldb_extra["language_bundle"]
+    )
+    mutations.append(ldb_extra)
+
+    rule_extra = deepcopy(baseline)
+    rule_extra["language_bundle"]["language"]["rules"][0]["host_hook"] = "run"
+    rule_extra["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", rule_extra["language_bundle"]
+    )
+    mutations.append(rule_extra)
+
+    for authority in mutations:
+        first = _consumer_a(authority["kernel"], authority["language_bundle"])
+        second = _consumer_b(authority["kernel"], authority["language_bundle"])
+        assert first == second
+        assert first["admitted"] is False
+
+
+def test_two_consumers_agree_on_report_all_cap_and_truncation():
+    authority = authority_set()
+    authority["kernel"]["resources"]["max_diagnostics"] = 3
+    for index in range(8):
+        authority["kernel"]["admission"]["laws"].append(
+            {"id": f"mutant.{index}", "operation": f"unknown.{index}"}
+        )
+    _reidentify(authority["kernel"], authority["language_bundle"])
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["truncated"] is True
+    assert len(first["diagnostics"]) == 3
+
+
+def test_two_consumers_refuse_the_same_nesting_resource_exhaustion():
+    authority = authority_set()
+    nested: object = "leaf"
+    for _ in range(authority["kernel"]["resources"]["max_nesting_depth"] + 1):
+        nested = [nested]
+    authority["language_bundle"]["vectors"][0]["unused_host_payload"] = nested
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["diagnostics"] == [
+        ("ingress", "kernel.resource_exhausted", "language-bundle")
+    ]

--- a/libs/gda-balancing/tests/test_schema2_bootstrap_conformance.py
+++ b/libs/gda-balancing/tests/test_schema2_bootstrap_conformance.py
@@ -10,8 +10,15 @@ import json
 from copy import deepcopy
 from typing import Any
 
+import jsonschema
+import pytest
+
 from gda_balancing.schema2.authority import authority_set
 from gda_balancing.schema2.bootstrap import admit_authorities
+
+_SUPPORTED_KERNEL_IDENTITY = (
+    "sha256:cdac2365950e7d7f42c5c763055861e61eb6e9628852f7428ca879e569fc270e"
+)
 
 
 def _identity(domain: str, artifact: dict[str, Any]) -> str:
@@ -23,11 +30,168 @@ def _identity(domain: str, artifact: dict[str, Any]) -> str:
     )
 
 
+def _safe_identity(domain: str, artifact: dict[str, Any]) -> str | None:
+    try:
+        return _identity(domain, artifact)
+    except (TypeError, ValueError, UnicodeEncodeError):
+        return None
+
+
+def _identity_from_kernel(
+    kernel: dict[str, Any], domain: str, artifact: dict[str, Any]
+) -> str | None:
+    recipe = kernel.get("canonical_encoding")
+    try:
+        supported = _consumer_b_canonical_contract_supported(recipe)
+    except (TypeError, ValueError, UnicodeEncodeError):
+        return None
+    if not supported:
+        return None
+    assert isinstance(recipe, dict)
+    expected = {
+        "array_order": "preserve",
+        "character_encoding": "UTF-8",
+        "control_character_escaping": {
+            "backspace": "\\b",
+            "carriage-return": "\\r",
+            "form-feed": "\\f",
+            "line-feed": "\\n",
+            "other-u0000-u001f": "lowercase-u00xx",
+            "tab": "\\t",
+        },
+        "delete_character_escaping": "literal-byte-7f",
+        "digest_hex_case": "lowercase",
+        "document_terminator": "LF",
+        "duplicate_object_keys": "refuse-at-decoding",
+        "escape_solidus": False,
+        "identity_algorithm": "sha256",
+        "identity_domain_prefix": "gda-balancing:",
+        "identity_domain_suffix": ":",
+        "identity_excluded_members": ["content_identity"],
+        "identity_output_prefix": "sha256:",
+        "integer_domain": "signed-int64",
+        "item_separator": ",",
+        "key_separator": ":",
+        "lone_surrogate": "refuse",
+        "non_ascii_strings": "literal-utf8",
+        "number_kinds": ["signed-int64"],
+        "object_order": "UTF-8-key-byte-order",
+        "optional_members": "omit",
+        "printable_ascii_escaping": "only-quotation-mark-and-reverse-solidus",
+        "profile": "gda-canonical-json-v1",
+        "unicode_normalization": "preserve",
+        "whitespace": "none",
+    }
+    if {key: value for key, value in recipe.items() if key != "vectors"} != expected:
+        return None
+    excluded = set(recipe["identity_excluded_members"])
+    body = {key: value for key, value in artifact.items() if key not in excluded}
+    try:
+        encoded = _encoded(body)
+    except (TypeError, ValueError, UnicodeEncodeError):
+        return None
+    prefix = (
+        recipe["identity_domain_prefix"] + domain + recipe["identity_domain_suffix"]
+    ).encode(recipe["character_encoding"])
+    digest = hashlib.new(recipe["identity_algorithm"], prefix + encoded).hexdigest()
+    if recipe["digest_hex_case"] == "lowercase":
+        digest = digest.lower()
+    return recipe["identity_output_prefix"] + digest
+
+
 def _encoded(value: Any) -> bytes:
+    _validate_canonical(value)
     return (
         json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
         + "\n"
     ).encode()
+
+
+def _validate_canonical(value: Any) -> None:
+    if value is None or isinstance(value, bool):
+        return
+    if isinstance(value, str):
+        value.encode("utf-8")
+        return
+    if isinstance(value, int):
+        if not -(2**63) <= value <= 2**63 - 1:
+            raise ValueError("integer is outside signed Int64")
+        return
+    if isinstance(value, list):
+        for item in value:
+            _validate_canonical(item)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("canonical object key is not a string")
+            _validate_canonical(key)
+            _validate_canonical(item)
+        return
+    raise TypeError("value is outside canonical JSON")
+
+
+def _consumer_b_canonical_contract_supported(recipe: Any) -> bool:
+    if not isinstance(recipe, dict) or not isinstance(recipe.get("vectors"), list):
+        return False
+
+    def reject_number(_value: str) -> Any:
+        raise ValueError("non-integer number")
+
+    def closed_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        value: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError("duplicate key")
+            value[key] = item
+        return value
+
+    expected_ids = {
+        "canonical.boundary-integers",
+        "canonical.control-character-escaping",
+        "canonical.order-array-unicode-escaping",
+        "canonical.reject-duplicate-key",
+        "canonical.reject-float",
+        "canonical.reject-lone-surrogate",
+    }
+    vectors = recipe["vectors"]
+    if {item.get("id") for item in vectors if isinstance(item, dict)} != expected_ids:
+        return False
+    for vector in vectors:
+        if not isinstance(vector, dict):
+            return False
+        if "value" in vector:
+            value = vector["value"]
+            domain = vector.get("domain")
+            if not isinstance(domain, str):
+                return False
+            encoded = _encoded(value)
+            identity = (
+                "sha256:"
+                + hashlib.sha256(
+                    f"gda-balancing:{domain}:".encode() + encoded
+                ).hexdigest()
+            )
+            if encoded.hex() != vector.get(
+                "canonical_utf8_hex"
+            ) or identity != vector.get("identity"):
+                return False
+        else:
+            lexeme = vector.get("input_lexeme")
+            if not isinstance(lexeme, str):
+                return False
+            try:
+                value = json.loads(
+                    lexeme,
+                    object_pairs_hook=closed_object,
+                    parse_float=reject_number,
+                    parse_constant=reject_number,
+                )
+                _encoded(value)
+            except (TypeError, ValueError, UnicodeEncodeError):
+                continue
+            return False
+    return True
 
 
 def _shape(value: Any) -> tuple[int, int]:
@@ -46,6 +210,848 @@ def _shape(value: Any) -> tuple[int, int]:
     return depth, members
 
 
+def _consumer_b_package_is_closed(
+    package: dict[str, Any], contract: Any, ldb: dict[str, Any]
+) -> bool:
+    if not isinstance(contract, dict) or contract.get("closed") is not True:
+        return False
+    required = contract.get("required_members")
+    field_types = contract.get("field_types")
+    nested_members = contract.get("nested_members")
+    nested_types = contract.get("nested_field_types")
+    type_export = contract.get("type_export")
+    if (
+        not isinstance(required, list)
+        or set(package) != set(required)
+        or not isinstance(field_types, dict)
+        or not isinstance(nested_members, dict)
+        or not isinstance(nested_types, dict)
+        or set(nested_members) != set(nested_types)
+        or set(field_types) | set(nested_members) != set(required)
+        or set(field_types) & set(nested_members)
+        or not all(
+            _consumer_b_value_matches(package[name], field_types[name], ldb)
+            for name in field_types
+        )
+    ):
+        return False
+    for name, members in nested_members.items():
+        value = package.get(name)
+        member_types = nested_types.get(name)
+        if (
+            not isinstance(value, dict)
+            or not isinstance(members, list)
+            or set(value) != set(members)
+            or not isinstance(member_types, dict)
+            or set(member_types) != set(members)
+            or not all(
+                _consumer_b_value_matches(value[member], member_types[member], ldb)
+                for member in members
+            )
+        ):
+            return False
+    exports = package.get("exports")
+    exported_types = exports.get("types") if isinstance(exports, dict) else None
+    if not isinstance(exported_types, list) or not isinstance(type_export, dict):
+        return False
+    export_members = type_export.get("required_members")
+    export_field_types = type_export.get("field_types")
+    return (
+        isinstance(export_members, list)
+        and isinstance(export_field_types, dict)
+        and set(export_field_types) == set(export_members)
+        and all(
+            isinstance(item, dict)
+            and set(item) == set(export_members)
+            and all(
+                _consumer_b_value_matches(item[name], export_field_types[name], ldb)
+                for name in export_members
+            )
+            for item in exported_types
+        )
+    )
+
+
+def _consumer_b_ldb_is_closed(
+    ldb: dict[str, Any], contract: Any, refusal_stages: Any
+) -> bool:
+    if not isinstance(contract, dict) or contract.get("closed") is not True:
+        return False
+    required = contract.get("required_members")
+    member_types = contract.get("member_types")
+    diagnostic_contract = contract.get("diagnostic")
+    resources_contract = contract.get("resources")
+    if (
+        not isinstance(required, list)
+        or set(ldb) != set(required)
+        or not isinstance(member_types, dict)
+        or set(member_types) != set(required)
+        or not isinstance(refusal_stages, list)
+        or refusal_stages
+        != [
+            "ingress",
+            "parse",
+            "static",
+            "resolution",
+            "runtime",
+            "evaluation",
+            "migration",
+            "approval",
+        ]
+    ):
+        return False
+    if not all(
+        _consumer_b_value_matches(ldb[name], value_contract, ldb)
+        for name, value_contract in member_types.items()
+    ):
+        return False
+    if not isinstance(diagnostic_contract, dict):
+        return False
+    diagnostic_members = diagnostic_contract.get("required_members")
+    diagnostic_types = diagnostic_contract.get("field_types")
+    diagnostics = ldb.get("diagnostics")
+    if (
+        not isinstance(diagnostics, list)
+        or not isinstance(diagnostic_members, list)
+        or not isinstance(diagnostic_types, dict)
+        or set(diagnostic_types) != set(diagnostic_members)
+        or not all(
+            isinstance(item, dict)
+            and set(item) == set(diagnostic_members)
+            and isinstance(item.get("code"), str)
+            and bool(item["code"])
+            and item.get("stage") in refusal_stages
+            for item in diagnostics
+        )
+    ):
+        return False
+    if not isinstance(resources_contract, dict):
+        return False
+    resource_members = resources_contract.get("required_members")
+    resource_types = resources_contract.get("field_types")
+    resources = ldb.get("resources")
+    return (
+        isinstance(resources, dict)
+        and isinstance(resource_members, list)
+        and set(resources) == set(resource_members)
+        and isinstance(resource_types, dict)
+        and set(resource_types) == set(resource_members)
+        and all(
+            _consumer_b_value_matches(resources[name], resource_types[name], ldb)
+            for name in resource_members
+        )
+    )
+
+
+def _project(root: Any, dotted: Any) -> list[Any]:
+    if not isinstance(dotted, str) or not dotted:
+        return []
+    values = [root]
+    for part in dotted.split("."):
+        projected: list[Any] = []
+        for value in values:
+            if not isinstance(value, dict) or part not in value:
+                return []
+            child = value[part]
+            projected.extend(child if isinstance(child, list) else [child])
+        values = projected
+    return values
+
+
+def _consumer_b_path_is_declared(root: Any, dotted: Any) -> bool:
+    if not isinstance(dotted, str) or not dotted:
+        return False
+
+    def walk(value: Any, parts: list[str]) -> bool:
+        if not parts:
+            return True
+        if not isinstance(value, dict) or parts[0] not in value:
+            return False
+        child = value[parts[0]]
+        if isinstance(child, list):
+            return all(walk(item, parts[1:]) for item in child)
+        return walk(child, parts[1:])
+
+    return walk(root, dotted.split("."))
+
+
+def _consumer_b_exact_path(root: Any, dotted: Any) -> tuple[bool, Any]:
+    if not isinstance(dotted, str) or not dotted:
+        return False, None
+    value = root
+    for part in dotted.split("."):
+        if not isinstance(value, dict) or part not in value:
+            return False, None
+        value = value[part]
+    return True, value
+
+
+def _consumer_b_closed_json_schema(value: Any, contract: dict[str, Any]) -> bool:
+    allowed = contract.get("allowed_keywords")
+    closure_keyword = contract.get("object_closure_keyword")
+    keyword_type_requirements = contract.get("keyword_type_requirements")
+    if (
+        not isinstance(value, dict)
+        or not isinstance(allowed, list)
+        or not all(isinstance(item, str) for item in allowed)
+        or not isinstance(keyword_type_requirements, dict)
+        or not all(
+            isinstance(keyword, str)
+            and isinstance(types, list)
+            and types
+            and all(isinstance(item, str) for item in types)
+            for keyword, types in keyword_type_requirements.items()
+        )
+        or value.get("$schema") != contract.get("dialect")
+        or closure_keyword != "unevaluatedProperties"
+        or contract.get("object_closure_value") is not False
+        or contract.get("references") != "forbidden"
+        or contract.get("type_form") != "single-string"
+    ):
+        return False
+    try:
+        jsonschema.Draft202012Validator.check_schema(value)
+    except jsonschema.SchemaError:
+        return False
+    allowed_set = set(allowed)
+
+    def walk(schema: Any) -> bool:
+        if not isinstance(schema, dict) or not set(schema) <= allowed_set:
+            return False
+        schema_type = schema.get("type")
+        if schema_type is not None and (
+            not isinstance(schema_type, str)
+            or schema_type
+            not in {
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string",
+            }
+        ):
+            return False
+        if schema_type == "object" and schema.get(closure_keyword) is not False:
+            return False
+        if any(
+            keyword in schema and schema_type not in required_types
+            for keyword, required_types in keyword_type_requirements.items()
+        ):
+            return False
+        if "$ref" in schema:
+            return False
+        required = schema.get("required")
+        if required is not None and (
+            not isinstance(required, list)
+            or not all(isinstance(item, str) and item for item in required)
+            or len(required) != len(set(required))
+        ):
+            return False
+        for keyword in ("$defs", "properties"):
+            children = schema.get(keyword)
+            if children is not None and (
+                not isinstance(children, dict)
+                or not all(
+                    isinstance(name, str) and name and walk(child)
+                    for name, child in children.items()
+                )
+            ):
+                return False
+        if "items" in schema and not walk(schema["items"]):
+            return False
+        for keyword in ("anyOf", "oneOf"):
+            children = schema.get(keyword)
+            if children is not None and (
+                not isinstance(children, list)
+                or not children
+                or not all(walk(child) for child in children)
+            ):
+                return False
+        for keyword in ("const", "default", "enum"):
+            if keyword in schema:
+                try:
+                    _encoded(schema[keyword])
+                except (TypeError, ValueError, UnicodeEncodeError):
+                    return False
+        return True
+
+    return walk(value)
+
+
+def _consumer_b_value_matches(value: Any, contract: Any, ldb: dict[str, Any]) -> bool:
+    if not isinstance(contract, dict):
+        return False
+    if "const" in contract:
+        return value == contract["const"] and type(value) is type(contract["const"])
+    if "enum" in contract:
+        return isinstance(contract["enum"], list) and value in contract["enum"]
+    kind = contract.get("type")
+    if kind == "non-empty-string":
+        return isinstance(value, str) and bool(value)
+    if kind == "boolean":
+        return isinstance(value, bool)
+    if kind == "list":
+        return isinstance(value, list)
+    if kind == "object":
+        return isinstance(value, dict)
+    if kind == "positive-signed-int64":
+        return (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and 1 <= value <= 2**63 - 1
+        )
+    if kind == "signed-int64":
+        return (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and -(2**63) <= value <= 2**63 - 1
+        )
+    if kind == "canonical-scalar":
+        return (
+            value is None
+            or isinstance(value, (bool, str))
+            or (
+                isinstance(value, int)
+                and not isinstance(value, bool)
+                and -(2**63) <= value <= 2**63 - 1
+            )
+        )
+    if kind == "scalar-list":
+        return isinstance(value, list) and all(
+            _consumer_b_value_matches(item, {"type": "canonical-scalar"}, ldb)
+            for item in value
+        )
+    if kind == "string-list":
+        return (
+            isinstance(value, list)
+            and all(isinstance(item, str) and item for item in value)
+            and len(value) == len(set(value))
+        )
+    if kind == "canonical-value":
+        try:
+            _encoded(value)
+        except (TypeError, ValueError, UnicodeEncodeError):
+            return False
+        return True
+    if kind == "inventory-member":
+        path = contract.get("path")
+        return _consumer_b_path_is_declared(ldb, path) and value in _project(ldb, path)
+    if kind == "inventory-list-path":
+        declared, target = _consumer_b_exact_path(ldb, value)
+        return declared and isinstance(target, list) and bool(target)
+    if kind == "signed-int64-path":
+        declared, target = _consumer_b_exact_path(ldb, value)
+        return declared and _consumer_b_value_matches(
+            target, {"type": "signed-int64"}, ldb
+        )
+    if kind == "closed-json-schema":
+        return _consumer_b_closed_json_schema(value, contract)
+    if kind == "closed-int64-interval":
+        if not isinstance(value, dict) or set(value) != {"minimum", "maximum"}:
+            return False
+        minimum = value["minimum"]
+        maximum = value["maximum"]
+        return (
+            isinstance(minimum, int)
+            and not isinstance(minimum, bool)
+            and isinstance(maximum, int)
+            and not isinstance(maximum, bool)
+            and -(2**63) <= minimum <= maximum <= 2**63 - 1
+        )
+    return False
+
+
+def _consumer_b_definition_is_closed(
+    value: Any, contract: Any, ldb: dict[str, Any]
+) -> bool:
+    if not isinstance(value, dict) or not isinstance(contract, dict):
+        return False
+    required = contract.get("required_members")
+    field_types = contract.get("field_types")
+    return (
+        isinstance(required, list)
+        and isinstance(field_types, dict)
+        and set(value) == set(required)
+        and set(field_types) == set(required)
+        and all(
+            _consumer_b_value_matches(value[name], field_types[name], ldb)
+            for name in required
+        )
+    )
+
+
+def _consumer_b_language_definitions_are_closed(
+    ldb: dict[str, Any], meta: dict[str, Any]
+) -> bool:
+    language = ldb.get("language")
+    authority = meta.get("language_definitions")
+    if not isinstance(language, dict) or not isinstance(authority, dict):
+        return False
+    collections = authority.get("collections")
+    if not isinstance(collections, dict):
+        return False
+    for name, contract in collections.items():
+        values = language.get(name)
+        if not isinstance(values, list) or not isinstance(contract, dict):
+            return False
+        if "max_items" in contract:
+            max_items = contract["max_items"]
+            if not isinstance(max_items, int) or len(values) > max_items:
+                return False
+            continue
+        if "item_type" in contract:
+            if not all(
+                _consumer_b_value_matches(value, {"type": contract["item_type"]}, ldb)
+                for value in values
+            ):
+                return False
+            continue
+        if not all(
+            _consumer_b_definition_is_closed(value, contract, ldb) for value in values
+        ):
+            return False
+    quantity = language.get("quantity")
+    quantity_contract = authority.get("quantity")
+    if not isinstance(quantity, dict) or not isinstance(quantity_contract, dict):
+        return False
+    required = quantity_contract.get("required_members")
+    quantity_collections = quantity_contract.get("collections")
+    if (
+        not isinstance(required, list)
+        or set(quantity) != set(required)
+        or not isinstance(quantity_collections, dict)
+        or set(quantity_collections) != set(required)
+    ):
+        return False
+    for name, contract in quantity_collections.items():
+        values = quantity.get(name)
+        if not isinstance(values, list) or not isinstance(contract, dict):
+            return False
+        if "item_type" in contract:
+            if not all(
+                _consumer_b_value_matches(value, {"type": contract["item_type"]}, ldb)
+                for value in values
+            ):
+                return False
+        elif not all(
+            _consumer_b_definition_is_closed(value, contract, ldb) for value in values
+        ):
+            return False
+    return True
+
+
+def _consumer_b_fact_schemas(
+    meta: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    schemas = meta.get("fact", {}).get("schemas")
+    field_contracts = meta.get("fact", {}).get("field_contracts")
+    if not isinstance(schemas, list) or not isinstance(field_contracts, dict):
+        return {}
+    result: dict[str, dict[str, Any]] = {}
+    for item in schemas:
+        if not isinstance(item, dict):
+            return {}
+        kind = item.get("kind")
+        contract_name = item.get("field_contract")
+        fields = field_contracts.get(contract_name)
+        if (
+            not isinstance(kind, str)
+            or not isinstance(contract_name, str)
+            or not isinstance(fields, dict)
+            or not all(isinstance(field, str) and field for field in fields)
+            or kind in result
+        ):
+            return {}
+        result[kind] = fields
+    return result
+
+
+def _consumer_b_fact_is_closed(
+    fact: Any, meta: dict[str, Any], ldb: dict[str, Any]
+) -> bool:
+    contract = meta.get("fact")
+    schemas = _consumer_b_fact_schemas(meta)
+    if not isinstance(contract, dict) or not isinstance(fact, dict):
+        return False
+    kind = fact.get("kind")
+    fields = fact.get("fields")
+    return (
+        contract.get("closed") is True
+        and isinstance(contract.get("required_members"), list)
+        and set(fact) == set(contract["required_members"])
+        and isinstance(kind, str)
+        and kind in schemas
+        and isinstance(fields, dict)
+        and set(fields) == set(schemas[kind])
+        and all(isinstance(field, str) and field for field in fields)
+        and all(
+            _consumer_b_value_matches(fields[name], schemas[kind][name], ldb)
+            for name in fields
+        )
+    )
+
+
+def _consumer_b_reason_is_closed(
+    reason: Any, meta: dict[str, Any], ldb: dict[str, Any]
+) -> bool:
+    contract = meta.get("diagnostic_reason")
+    if not isinstance(contract, dict) or not isinstance(reason, dict):
+        return False
+    predicate = reason.get("predicate")
+    if (
+        contract.get("closed") is not True
+        or contract.get("scalar_equality") != "type-and-canonical-value"
+        or not isinstance(contract.get("required_members"), list)
+        or set(reason) != set(contract["required_members"])
+        or not isinstance(contract.get("member_types"), dict)
+        or set(contract["member_types"])
+        != set(contract["required_members"]) - {"predicate"}
+        or not all(
+            _consumer_b_value_matches(reason[name], contract["member_types"][name], ldb)
+            for name in contract["member_types"]
+        )
+        or not isinstance(predicate, dict)
+        or not isinstance(contract.get("predicate_schemas"), list)
+    ):
+        return False
+    schema = next(
+        (
+            item
+            for item in contract["predicate_schemas"]
+            if isinstance(item, dict)
+            and item.get("operation") == predicate.get("operation")
+        ),
+        None,
+    )
+    if not isinstance(schema, dict):
+        return False
+    required = schema.get("required_members")
+    optional = schema.get("optional_members")
+    member_types = schema.get("member_types")
+    input_members = schema.get("input_members")
+    input_types = schema.get("input_member_types")
+    return (
+        isinstance(required, list)
+        and isinstance(optional, list)
+        and isinstance(member_types, dict)
+        and isinstance(input_members, list)
+        and isinstance(input_types, dict)
+        and set(input_types) == set(input_members)
+        and set(required) <= set(predicate)
+        and set(predicate) <= set(required) | set(optional)
+        and set(member_types) == set(required) | set(optional)
+        and all(
+            _consumer_b_value_matches(predicate[name], member_types[name], ldb)
+            for name in predicate
+        )
+        and _consumer_b_reason_operands_close(predicate, ldb)
+    )
+
+
+def _consumer_b_reason_operands_close(
+    predicate: dict[str, Any], ldb: dict[str, Any]
+) -> bool:
+    operation = predicate.get("operation")
+    if operation == "not-member":
+        declared, inventory = _consumer_b_exact_path(
+            ldb, predicate.get("inventory_path")
+        )
+        if not declared or not isinstance(inventory, list) or not inventory:
+            return False
+        member_field = predicate.get("member_field")
+        if member_field is None:
+            values = inventory
+        elif isinstance(member_field, str) and member_field:
+            if not all(
+                isinstance(item, dict) and member_field in item for item in inventory
+            ):
+                return False
+            values = [item[member_field] for item in inventory]
+        else:
+            return False
+        return all(
+            _consumer_b_value_matches(value, {"type": "canonical-scalar"}, ldb)
+            for value in values
+        )
+    if operation == "greater-than":
+        declared, limit = _consumer_b_exact_path(ldb, predicate.get("limit_path"))
+        return declared and _consumer_b_value_matches(
+            limit, {"type": "signed-int64"}, ldb
+        )
+    return operation == "has-duplicate"
+
+
+def _consumer_b_scalar_key(value: Any) -> tuple[str, Any]:
+    return (
+        "null"
+        if value is None
+        else "boolean"
+        if isinstance(value, bool)
+        else "integer"
+        if isinstance(value, int)
+        else "string",
+        value,
+    )
+
+
+def _consumer_b_reason_vectors_cover(
+    ldb: dict[str, Any],
+    reason: dict[str, Any],
+    vectors: list[dict[str, Any]],
+    meta: dict[str, Any],
+) -> bool:
+    contract = meta.get("diagnostic_reason")
+    predicate = reason.get("predicate")
+    if not isinstance(contract, dict) or not isinstance(predicate, dict):
+        return False
+    coverage = contract.get("vector_coverage")
+    operation = predicate.get("operation")
+    if not isinstance(coverage, dict) or not isinstance(operation, str):
+        return False
+    if not vectors or any(
+        not isinstance(vector, dict)
+        or not isinstance(vector.get("matched"), bool)
+        or not isinstance(vector.get("input"), dict)
+        for vector in vectors
+    ):
+        return False
+    if {vector.get("matched") for vector in vectors} != {False, True}:
+        return False
+    if operation == "not-member":
+        if coverage.get(operation) != "every-inventory-member-and-one-non-member":
+            return False
+        declared, inventory = _consumer_b_exact_path(
+            ldb, predicate.get("inventory_path")
+        )
+        if not declared or not isinstance(inventory, list):
+            return False
+        member_field = predicate.get("member_field")
+        if member_field is None:
+            values = inventory
+        elif (
+            isinstance(member_field, str)
+            and member_field
+            and all(
+                isinstance(item, dict) and member_field in item for item in inventory
+            )
+        ):
+            values = [item[member_field] for item in inventory]
+        else:
+            return False
+        if not all(
+            _consumer_b_value_matches(value, {"type": "canonical-scalar"}, ldb)
+            for value in values
+        ):
+            return False
+        if not all(
+            _consumer_b_value_matches(
+                vector["input"].get("value"), {"type": "canonical-scalar"}, ldb
+            )
+            for vector in vectors
+        ):
+            return False
+        nonmatches = {
+            _consumer_b_scalar_key(vector.get("input", {}).get("value"))
+            for vector in vectors
+            if vector.get("matched") is False and isinstance(vector.get("input"), dict)
+        }
+        return {_consumer_b_scalar_key(value) for value in values} <= nonmatches
+    if operation == "has-duplicate":
+        return coverage.get(operation) == "both-outcomes" and all(
+            _consumer_b_value_matches(
+                vector["input"].get("values"), {"type": "scalar-list"}, ldb
+            )
+            for vector in vectors
+        )
+    if operation == "greater-than":
+        if coverage.get(operation) != "limit-and-successor":
+            return False
+        declared, limit = _consumer_b_exact_path(ldb, predicate.get("limit_path"))
+        if (
+            not declared
+            or not isinstance(limit, int)
+            or isinstance(limit, bool)
+            or limit >= 2**63 - 1
+        ):
+            return False
+        if not all(
+            _consumer_b_value_matches(
+                vector["input"].get("value"), {"type": "signed-int64"}, ldb
+            )
+            for vector in vectors
+        ):
+            return False
+        witnesses = {
+            (vector.get("input", {}).get("value"), vector.get("matched"))
+            for vector in vectors
+            if isinstance(vector.get("input"), dict)
+        }
+        return {(limit, False), (limit + 1, True)} <= witnesses
+    return False
+
+
+def _consumer_b_rule_is_closed(
+    rule: Any, meta: dict[str, Any], ldb: dict[str, Any]
+) -> bool:
+    contract = meta.get("rule")
+    term_contract = meta.get("term")
+    schemas = _consumer_b_fact_schemas(meta)
+    if (
+        not isinstance(contract, dict)
+        or not isinstance(term_contract, dict)
+        or not isinstance(rule, dict)
+        or contract.get("closed") is not True
+        or not isinstance(contract.get("required_members"), list)
+        or set(rule) != set(contract["required_members"])
+        or rule.get("phase") not in contract.get("phases", [])
+        or not isinstance(rule.get("id"), str)
+        or not rule.get("id")
+        or not isinstance(rule.get("judgment"), str)
+        or not rule.get("judgment")
+        or not schemas
+    ):
+        return False
+    premises = rule.get("premises")
+    premise_members = contract.get("premise_required_members")
+    conclusion = rule.get("conclusion")
+    conclusion_members = contract.get("conclusion_required_members")
+    if not isinstance(premises, list) or not isinstance(premise_members, list):
+        return False
+    for item in premises:
+        if not isinstance(item, dict):
+            return False
+        fact_kind = item.get("fact_kind")
+        bindings = item.get("bind")
+        if (
+            set(item) != set(premise_members)
+            or not isinstance(fact_kind, str)
+            or fact_kind not in schemas
+            or not isinstance(bindings, dict)
+            or not all(
+                isinstance(variable, str)
+                and variable
+                and isinstance(field, str)
+                and field in schemas[fact_kind]
+                for variable, field in bindings.items()
+            )
+        ):
+            return False
+    conclusion_kind = (
+        conclusion.get("fact_kind") if isinstance(conclusion, dict) else None
+    )
+    if (
+        not isinstance(conclusion, dict)
+        or not isinstance(conclusion_members, list)
+        or set(conclusion) != set(conclusion_members)
+        or not isinstance(conclusion_kind, str)
+        or conclusion_kind not in schemas
+        or not isinstance(conclusion.get("fields"), dict)
+        or set(conclusion["fields"]) != set(schemas[conclusion_kind])
+        or not isinstance(term_contract.get("constructors"), list)
+    ):
+        return False
+    constructors = {
+        str(item.get("tag")): item
+        for item in term_contract["constructors"]
+        if isinstance(item, dict)
+    }
+    for term in conclusion["fields"].values():
+        if not isinstance(term, dict):
+            return False
+        tag = term.get("tag")
+        constructor = constructors.get(tag) if isinstance(tag, str) else None
+        if not isinstance(constructor, dict):
+            return False
+        required_members = constructor.get("required_members")
+        member_types = constructor.get("member_types")
+        if (
+            not isinstance(required_members, list)
+            or set(term) != set(required_members)
+            or not isinstance(member_types, dict)
+            or set(member_types) != set(required_members)
+            or not all(
+                _consumer_b_value_matches(term[name], member_types[name], ldb)
+                for name in term
+            )
+        ):
+            return False
+    return True
+
+
+def _consumer_b_duplicate_subjects(
+    kernel: dict[str, Any], ldb: dict[str, Any]
+) -> set[str]:
+    law = next(
+        item
+        for item in kernel["admission"]["laws"]
+        if item["id"] == "kernel.identifiers.unique"
+    )
+    authorities = {"kernel": kernel, "language_bundle": ldb}
+    duplicates: set[str] = set()
+    for contract in law["arguments"]["collections"]:
+        keys = contract["keys"]
+        subject = contract["subject"]
+        identities: list[tuple[Any, ...]] = []
+        for item in _project(authorities, contract["path"]):
+            if not isinstance(item, dict) or any(key not in item for key in keys):
+                duplicates.add(subject)
+                break
+            identities.append(tuple(item[key] for key in keys))
+        try:
+            if len(identities) != len(set(identities)):
+                duplicates.add(subject)
+        except TypeError:
+            duplicates.add(subject)
+    return duplicates
+
+
+def _consumer_b_vector_header_is_closed(
+    vector: Any, meta: dict[str, Any], ldb: dict[str, Any]
+) -> bool:
+    if not isinstance(vector, dict):
+        return False
+    if "rule" in vector:
+        invocation = vector.get("input")
+        return (
+            set(vector) == {"expect", "id", "input", "rule"}
+            and isinstance(vector.get("id"), str)
+            and bool(vector["id"])
+            and isinstance(vector.get("rule"), str)
+            and bool(vector["rule"])
+            and isinstance(invocation, dict)
+            and set(invocation) == {"facts", "judgment", "phase"}
+            and isinstance(invocation.get("judgment"), str)
+            and bool(invocation["judgment"])
+            and invocation.get("phase") in meta.get("rule", {}).get("phases", [])
+            and isinstance(invocation.get("facts"), list)
+            and all(
+                _consumer_b_fact_is_closed(fact, meta, ldb)
+                for fact in invocation["facts"]
+            )
+            and _consumer_b_fact_is_closed(vector.get("expect"), meta, ldb)
+        )
+    if "diagnostic" in vector:
+        contract = meta.get("diagnostic_reason")
+        if not isinstance(contract, dict):
+            return False
+        required = contract.get("vector_required_members")
+        member_types = contract.get("vector_member_types")
+        return (
+            isinstance(required, list)
+            and set(vector) == set(required)
+            and isinstance(member_types, dict)
+            and set(member_types) == set(required) - {"input"}
+            and all(
+                _consumer_b_value_matches(vector[name], member_types[name], ldb)
+                for name in member_types
+            )
+            and isinstance(vector.get("input"), dict)
+        )
+    return False
+
+
 def _consumer_b(kernel: dict[str, Any], ldb: dict[str, Any]) -> dict[str, Any]:
     """A separate, deliberately compact Kernel interpreter for cross-checking."""
     diagnostics: set[tuple[str, str, str]] = set()
@@ -56,9 +1062,15 @@ def _consumer_b(kernel: dict[str, Any], ldb: dict[str, Any]) -> dict[str, Any]:
     def refuse(code: str, stage: str, subject: str) -> None:
         diagnostics.add((stage, code, subject))
 
-    if kernel.get("content_identity") != _identity("schema-major-kernel-v2", kernel):
+    if (
+        kernel.get("content_identity")
+        != _identity_from_kernel(kernel, "schema-major-kernel-v2", kernel)
+        or kernel.get("content_identity") != _SUPPORTED_KERNEL_IDENTITY
+    ):
         refuse("kernel.identity_mismatch", "ingress", "kernel")
-    if ldb.get("content_identity") != _identity("language-definition-bundle-v2", ldb):
+    if ldb.get("content_identity") != _identity_from_kernel(
+        kernel, "language-definition-bundle-v2", ldb
+    ):
         refuse("kernel.identity_mismatch", "ingress", "language-bundle")
     if ldb.get("kernel_identity") != kernel.get("content_identity"):
         refuse("kernel.binding_mismatch", "ingress", "language-bundle.kernel_identity")
@@ -78,19 +1090,80 @@ def _consumer_b(kernel: dict[str, Any], ldb: dict[str, Any]) -> dict[str, Any]:
     if set(kernel) != kernel_members:
         refuse("kernel.member_set_mismatch", "ingress", "kernel")
 
+    if any(subject == "kernel" for _, _, subject in diagnostics):
+        ordered = sorted(diagnostics, key=lambda item: (item[0], item[2], item[1]))
+        return {
+            "admitted": False,
+            "kernel_identity": kernel.get("content_identity"),
+            "language_bundle_identity": ldb.get("content_identity"),
+            "law_ids": [],
+            "law_projections": [],
+            "rule_ids": [],
+            "rule_projections": [],
+            "diagnostic_projections": [],
+            "diagnostics": ordered[:cap],
+            "truncated": len(ordered) > cap,
+        }
+
     expected_members = set(kernel["admission"]["required_ldb_members"])
     if set(ldb) != expected_members:
+        refuse("kernel.member_set_mismatch", "ingress", "language-bundle")
+    expected_language_members = set(kernel["admission"]["required_language_members"])
+    if (
+        not isinstance(ldb.get("language"), dict)
+        or set(ldb["language"]) != expected_language_members
+    ):
+        refuse(
+            "kernel.member_set_mismatch",
+            "ingress",
+            "language-bundle.language",
+        )
+    meta = kernel.get("meta_format")
+    ldb_contract = meta.get("language_bundle") if isinstance(meta, dict) else None
+    if not _consumer_b_ldb_is_closed(
+        ldb, ldb_contract, kernel["admission"].get("refusal_stages")
+    ):
         refuse("kernel.member_set_mismatch", "ingress", "language-bundle")
 
     limits = kernel["resources"]
     for subject, artifact in (("kernel", kernel), ("language-bundle", ldb)):
         depth, members = _shape(artifact)
+        try:
+            encoded_size = len(_encoded(artifact))
+        except (TypeError, ValueError, UnicodeEncodeError):
+            encoded_size = limits["max_authority_bytes"] + 1
         if (
             depth > limits["max_nesting_depth"]
             or members > limits["max_members"]
-            or len(_encoded(artifact)) > limits["max_authority_bytes"]
+            or encoded_size > limits["max_authority_bytes"]
         ):
             refuse("kernel.resource_exhausted", "ingress", subject)
+
+    raw_language = ldb.get("language")
+    raw_packages = (
+        raw_language.get("packages") if isinstance(raw_language, dict) else None
+    )
+    packages: list[dict[str, Any]] = []
+    package_contract = meta.get("package_release") if isinstance(meta, dict) else None
+    if not isinstance(raw_packages, list):
+        refuse(
+            "kernel.member_set_mismatch",
+            "ingress",
+            "language-bundle.language.packages",
+        )
+    else:
+        for index, package in enumerate(raw_packages):
+            subject = f"language-bundle.language.packages.{index}"
+            if not isinstance(package, dict) or not _consumer_b_package_is_closed(
+                package, package_contract, ldb
+            ):
+                refuse("kernel.member_set_mismatch", "ingress", subject)
+                continue
+            packages.append(package)
+            if package.get("content_identity") != _identity_from_kernel(
+                kernel, "domain-package-release-v2", package
+            ):
+                refuse("kernel.identity_mismatch", "ingress", subject)
 
     if diagnostics:
         ordered = sorted(diagnostics, key=lambda item: (item[0], item[2], item[1]))
@@ -109,16 +1182,10 @@ def _consumer_b(kernel: dict[str, Any], ldb: dict[str, Any]) -> dict[str, Any]:
         }
 
     laws = kernel["admission"]["laws"]
-    allowed_operations = {
-        "verify-content-identity",
-        "require-equal",
-        "require-exact-members",
-        "require-unique-identifiers",
-        "require-known-operations",
-        "require-vector-closure",
-        "require-diagnostic-closure",
-        "enforce-resource-limits",
-    }
+    for subject in _consumer_b_duplicate_subjects(kernel, ldb):
+        refuse("kernel.duplicate_identifier", "static", subject)
+    operation_law = next(law for law in laws if law["id"] == "kernel.operations.closed")
+    allowed_operations = set(operation_law["arguments"]["admission_operations"])
     law_ids = [law["id"] for law in laws]
     if len(law_ids) != len(set(law_ids)):
         refuse("kernel.duplicate_identifier", "static", "kernel.admission.laws")
@@ -130,6 +1197,9 @@ def _consumer_b(kernel: dict[str, Any], ldb: dict[str, Any]) -> dict[str, Any]:
     )
 
     kernel_vectors = kernel["vectors"]
+    kernel_vector_ids = [vector["id"] for vector in kernel_vectors]
+    if len(kernel_vector_ids) != len(set(kernel_vector_ids)):
+        refuse("kernel.duplicate_identifier", "static", "kernel.vectors")
     referenced_laws = {vector["law"] for vector in kernel_vectors}
     if set(law_ids) != referenced_laws:
         refuse("kernel.vector_mismatch", "static", "kernel.vectors")
@@ -145,34 +1215,84 @@ def _consumer_b(kernel: dict[str, Any], ldb: dict[str, Any]) -> dict[str, Any]:
     if kernel_catalog != kernel_vector_catalog:
         refuse("kernel.diagnostic_closure", "static", "kernel.diagnostics")
 
-    rules = ldb["language"]["rules"]
+    meta = kernel["meta_format"]
+    if not _consumer_b_language_definitions_are_closed(ldb, meta):
+        refuse("kernel.vector_mismatch", "static", "language.definitions")
+    raw_vectors = ldb.get("vectors")
+    valid_vectors: list[dict[str, Any]] = []
+    if not isinstance(raw_vectors, list):
+        refuse("kernel.vector_mismatch", "static", "language-bundle.vectors")
+    else:
+        for vector in raw_vectors:
+            if _consumer_b_vector_header_is_closed(vector, meta, ldb):
+                valid_vectors.append(vector)
+            else:
+                subject = str(vector.get("id", "")) if isinstance(vector, dict) else ""
+                refuse("kernel.vector_mismatch", "static", subject)
+    raw_rules = ldb.get("language", {}).get("rules")
+    rules: list[dict[str, Any]] = []
+    if not isinstance(raw_rules, list) or not all(
+        _consumer_b_rule_is_closed(rule, meta, ldb) for rule in raw_rules
+    ):
+        refuse("kernel.vector_mismatch", "static", "language.rules")
+    else:
+        rules = raw_rules
+    raw_reasons = ldb.get("language", {}).get("reasons")
+    reasons_list: list[dict[str, Any]] = []
+    if not isinstance(raw_reasons, list) or not all(
+        _consumer_b_reason_is_closed(reason, meta, ldb) for reason in raw_reasons
+    ):
+        refuse("kernel.vector_mismatch", "static", "language.reasons")
+    else:
+        reasons_list = raw_reasons
+    if diagnostics:
+        ordered = sorted(diagnostics, key=lambda item: (item[0], item[2], item[1]))
+        return {
+            "admitted": False,
+            "kernel_identity": kernel.get("content_identity"),
+            "language_bundle_identity": ldb.get("content_identity"),
+            "law_ids": sorted(law_ids),
+            "law_projections": law_projections,
+            "rule_ids": [],
+            "rule_projections": [],
+            "diagnostic_projections": [],
+            "diagnostics": ordered[:cap],
+            "truncated": len(ordered) > cap,
+        }
     rule_ids = [rule["id"] for rule in rules]
     if len(rule_ids) != len(set(rule_ids)):
         refuse("kernel.duplicate_identifier", "static", "language.rules")
-    closed_rules = all(
-        set(rule) == {"id", "judgment", "premises", "conclusion"}
-        and all(set(item) == {"bind", "fact_kind"} for item in rule["premises"])
-        and set(rule["conclusion"]) == {"fact_kind", "fields"}
-        and all(
-            (term.get("tag") == "literal" and set(term) == {"tag", "value"})
-            or (term.get("tag") == "variable" and set(term) == {"tag", "name"})
-            for term in rule["conclusion"]["fields"].values()
+    ldb_vector_ids = [item["id"] for item in valid_vectors]
+    if len(ldb_vector_ids) != len(set(ldb_vector_ids)):
+        refuse(
+            "kernel.duplicate_identifier",
+            "static",
+            "language-bundle.vectors",
         )
-        for rule in rules
-    )
-    if not closed_rules:
-        refuse("kernel.vector_mismatch", "static", "language.rules")
-    rule_vectors = [item for item in ldb["vectors"] if "rule" in item]
+    rule_vectors = [item for item in valid_vectors if "rule" in item]
     if set(rule_ids) != {item["rule"] for item in rule_vectors}:
         refuse("kernel.vector_mismatch", "static", "language-bundle.vectors")
     projections = []
     for vector in rule_vectors:
-        invocation = vector["input"]
+        invocation = vector.get("input")
+        if (
+            set(vector) != {"expect", "id", "input", "rule"}
+            or not isinstance(invocation, dict)
+            or set(invocation) != {"facts", "judgment", "phase"}
+            or not isinstance(invocation.get("facts"), list)
+            or not all(
+                _consumer_b_fact_is_closed(fact, meta, ldb)
+                for fact in invocation.get("facts", [])
+            )
+        ):
+            refuse("kernel.vector_mismatch", "static", str(vector.get("id", "")))
+            continue
         facts = invocation["facts"]
         candidates = [
             rule
             for rule in sorted(rules, key=lambda item: item["id"])
-            if rule["judgment"] == invocation["judgment"]
+            if rule["phase"] == invocation["phase"]
+            and rule["judgment"] == invocation["judgment"]
             and len(rule["premises"]) == len(facts)
             and all(
                 premise["fact_kind"] == fact["kind"]
@@ -189,17 +1309,27 @@ def _consumer_b(kernel: dict[str, Any], ldb: dict[str, Any]) -> dict[str, Any]:
                     if field_name not in fact["fields"]:
                         valid = False
                         break
-                    bindings[variable] = fact["fields"][field_name]
+                    value = fact["fields"][field_name]
+                    if variable in bindings and bindings[variable] != value:
+                        valid = False
+                        break
+                    bindings[variable] = value
             fields = {}
             for name, term in selected["conclusion"]["fields"].items():
                 if term["tag"] == "literal" and set(term) == {"tag", "value"}:
                     fields[name] = term["value"]
-                elif term["tag"] == "variable" and term.get("name") in bindings:
+                elif (
+                    term["tag"] == "variable"
+                    and isinstance(term.get("name"), str)
+                    and term["name"] in bindings
+                ):
                     fields[name] = bindings[term["name"]]
                 else:
                     valid = False
             if valid:
                 output = {"kind": selected["conclusion"]["fact_kind"], "fields": fields}
+                if not _consumer_b_fact_is_closed(output, meta, ldb):
+                    output = None
         if output != vector["expect"]:
             refuse("kernel.vector_mismatch", "static", vector["id"])
         else:
@@ -214,7 +1344,7 @@ def _consumer_b(kernel: dict[str, Any], ldb: dict[str, Any]) -> dict[str, Any]:
     ldb_catalog = {(item["code"], item["stage"]) for item in ldb["diagnostics"]}
     ldb_vector_catalog = {
         (item["diagnostic"], item["stage"])
-        for item in ldb["vectors"]
+        for item in valid_vectors
         if "diagnostic" in item
     }
     if ldb_catalog != ldb_vector_catalog:
@@ -226,33 +1356,99 @@ def _consumer_b(kernel: dict[str, Any], ldb: dict[str, Any]) -> dict[str, Any]:
             value = value[part]
         return value
 
-    reasons = {item["id"]: item for item in ldb["language"]["reasons"]}
+    reasons = {item["id"]: item for item in reasons_list}
     diagnostic_projections = []
-    diagnostic_vectors = [item for item in ldb["vectors"] if "diagnostic" in item]
-    if set(reasons) != {item["reason"] for item in diagnostic_vectors}:
+    diagnostic_vectors = [item for item in valid_vectors if "diagnostic" in item]
+    if set(reasons) != {item.get("reason") for item in diagnostic_vectors}:
         refuse("kernel.vector_mismatch", "static", "language-bundle.reasons")
+    reason_contract = meta.get("diagnostic_reason")
+    vector_required = (
+        reason_contract.get("vector_required_members")
+        if isinstance(reason_contract, dict)
+        else None
+    )
+    vector_types = (
+        reason_contract.get("vector_member_types")
+        if isinstance(reason_contract, dict)
+        else None
+    )
     for vector in diagnostic_vectors:
-        reason = reasons.get(vector["reason"])
+        reason = reasons.get(vector.get("reason"))
         matched = False
+        if (
+            not isinstance(vector_required, list)
+            or set(vector) != set(vector_required)
+            or not isinstance(vector_types, dict)
+            or set(vector_types) != set(vector_required) - {"input"}
+            or not all(
+                _consumer_b_value_matches(vector[name], vector_types[name], ldb)
+                for name in vector_types
+            )
+            or not _consumer_b_reason_is_closed(reason, meta, ldb)
+            or not isinstance(vector.get("input"), dict)
+        ):
+            refuse("kernel.vector_mismatch", "static", str(vector.get("id", "")))
+            continue
         if reason is not None:
+            if (
+                vector["reason"] != reason["id"]
+                or vector["diagnostic"] != reason["diagnostic"]
+                or vector["stage"] != reason["stage"]
+            ):
+                refuse("kernel.vector_mismatch", "static", vector["id"])
+                continue
             predicate = reason["predicate"]
             operation = predicate["operation"]
+            predicate_schema = next(
+                item
+                for item in meta["diagnostic_reason"]["predicate_schemas"]
+                if item["operation"] == operation
+            )
+            input_types = predicate_schema.get("input_member_types")
+            if (
+                set(vector["input"]) != set(predicate_schema["input_members"])
+                or not isinstance(input_types, dict)
+                or set(vector["input"]) != set(input_types)
+                or not all(
+                    _consumer_b_value_matches(
+                        vector["input"][name], input_types[name], ldb
+                    )
+                    for name in vector["input"]
+                )
+            ):
+                refuse(
+                    "kernel.vector_mismatch",
+                    "static",
+                    str(vector.get("id", "")),
+                )
+                continue
             if operation == "not-member":
                 inventory = resolve(predicate["inventory_path"])
                 if "member_field" in predicate:
                     inventory = [item[predicate["member_field"]] for item in inventory]
-                matched = vector["input"]["value"] not in inventory
+                matched = _consumer_b_scalar_key(vector["input"]["value"]) not in {
+                    _consumer_b_scalar_key(item) for item in inventory
+                }
             elif operation == "has-duplicate":
                 values = vector["input"]["values"]
-                matched = len(values) != len(set(values))
+                keys = [_consumer_b_scalar_key(item) for item in values]
+                matched = len(keys) != len(set(keys))
             elif operation == "greater-than":
                 matched = vector["input"]["value"] > resolve(predicate["limit_path"])
         output = (
-            {"code": reason["diagnostic"], "stage": reason["stage"]}
-            if matched and reason is not None
+            {
+                "code": reason["diagnostic"],
+                "matched": matched,
+                "stage": reason["stage"],
+            }
+            if reason is not None
             else None
         )
-        expected = {"code": vector["diagnostic"], "stage": vector["stage"]}
+        expected = {
+            "code": vector["diagnostic"],
+            "matched": vector["matched"],
+            "stage": vector["stage"],
+        }
         if output != expected:
             refuse("kernel.vector_mismatch", "static", vector["id"])
         else:
@@ -264,6 +1460,83 @@ def _consumer_b(kernel: dict[str, Any], ldb: dict[str, Any]) -> dict[str, Any]:
                     _identity("diagnostic-vector-projection-v2", output),
                 )
             )
+    for reason_id, reason in reasons.items():
+        vectors = [
+            vector for vector in diagnostic_vectors if vector.get("reason") == reason_id
+        ]
+        if not _consumer_b_reason_vectors_cover(ldb, reason, vectors, meta):
+            refuse("kernel.vector_mismatch", "static", reason_id)
+
+    package_coordinates = [(item["id"], item["version"]) for item in packages]
+    if len(package_coordinates) != len(set(package_coordinates)):
+        refuse("kernel.duplicate_identifier", "static", "language.packages")
+    vector_ids = {item["id"] for item in valid_vectors}
+    constructor_ids = {item["id"] for item in ldb["language"]["constructors"]}
+    numeric_profiles = {
+        item["id"] for item in ldb["language"]["quantity"]["numeric_policies"]
+    }
+    for package in packages:
+        exports = package["exports"]
+        profiles = package["profiles"]
+        references_close = (
+            set(package["vectors"]) <= vector_ids
+            and set(exports["language_rules"]) <= set(rule_ids)
+            and set(exports["diagnostics"]) <= set(ldb_codes)
+            and set(profiles["numeric"]) <= numeric_profiles
+            and all(item["constructor"] in constructor_ids for item in exports["types"])
+        )
+        if not references_close:
+            refuse(
+                "kernel.vector_mismatch",
+                "static",
+                f"language.packages.{package['id']}",
+            )
+
+    vector_law = next(law for law in laws if law["id"] == "kernel.vectors.closed")
+    authorities = {"kernel": kernel, "language_bundle": ldb}
+    reference_contracts_close = True
+    for contract in vector_law["arguments"]["equalities"]:
+        if (
+            set(contract) != {"left", "mode", "right"}
+            or contract["mode"] != "set"
+            or not _consumer_b_path_is_declared(authorities, contract["left"])
+            or not _consumer_b_path_is_declared(authorities, contract["right"])
+        ):
+            reference_contracts_close = False
+            break
+        try:
+            if set(_project(authorities, contract["left"])) != set(
+                _project(authorities, contract["right"])
+            ):
+                reference_contracts_close = False
+                break
+        except TypeError:
+            reference_contracts_close = False
+            break
+    for contract in vector_law["arguments"]["references"]:
+        owners = _project(authorities, contract["owners"])
+        if (
+            not _consumer_b_path_is_declared(authorities, contract["owners"])
+            or not owners
+        ):
+            reference_contracts_close = False
+            break
+        for owner in owners:
+            if not isinstance(owner, dict):
+                reference_contracts_close = False
+                break
+            for source, target in contract["targets"].items():
+                if not _consumer_b_path_is_declared(
+                    owner, source
+                ) or not _consumer_b_path_is_declared(authorities, target):
+                    reference_contracts_close = False
+                    break
+                target_values = _project(authorities, target)
+                if any(value not in target_values for value in _project(owner, source)):
+                    reference_contracts_close = False
+                    break
+    if not reference_contracts_close:
+        refuse("kernel.vector_mismatch", "static", "language.packages")
 
     ordered = sorted(diagnostics, key=lambda item: (item[0], item[2], item[1]))
     truncated = len(ordered) > cap
@@ -317,6 +1590,7 @@ def test_two_independent_consumers_admit_the_exact_authority_and_inventories():
     assert first["admitted"] is True
     assert first["law_ids"]
     assert first["rule_ids"] == ["quantity.declare", "quantity.lower"]
+    assert ldb["language"]["model_source_schema_versions"] == ["2.0.0"]
 
 
 def test_kernel_meta_format_and_ldb_rules_are_structured_for_independent_execution():
@@ -330,15 +1604,192 @@ def test_kernel_meta_format_and_ldb_rules_are_structured_for_independent_executi
         "rule_selection",
         "binding_substitution",
         "diagnostic_reason",
+        "language_bundle",
+        "language_definitions",
+        "package_release",
     }
     assert {item["tag"] for item in meta_format["term"]["constructors"]} == {
         "literal",
         "variable",
     }
     for rule in authority["language_bundle"]["language"]["rules"]:
-        assert set(rule) == {"id", "judgment", "premises", "conclusion"}
+        assert set(rule) == {"id", "phase", "judgment", "premises", "conclusion"}
+        assert rule["phase"] in meta_format["rule"]["phases"]
         assert rule["premises"]
         assert set(rule["conclusion"]) == {"fact_kind", "fields"}
+
+
+def test_kernel_publishes_the_complete_canonical_identity_recipe():
+    encoding = authority_set()["kernel"]["canonical_encoding"]
+
+    assert encoding["identity_algorithm"] == "sha256"
+    assert encoding["identity_domain_prefix"] == "gda-balancing:"
+    assert encoding["identity_domain_suffix"] == ":"
+    assert encoding["identity_excluded_members"] == ["content_identity"]
+    assert encoding["identity_output_prefix"] == "sha256:"
+    assert encoding["digest_hex_case"] == "lowercase"
+    assert encoding["document_terminator"] == "LF"
+    assert encoding["array_order"] == "preserve"
+    assert encoding["whitespace"] == "none"
+    assert encoding["item_separator"] == ","
+    assert encoding["key_separator"] == ":"
+    assert encoding["non_ascii_strings"] == "literal-utf8"
+    assert encoding["escape_solidus"] is False
+    assert encoding["printable_ascii_escaping"] == (
+        "only-quotation-mark-and-reverse-solidus"
+    )
+    assert encoding["control_character_escaping"] == {
+        "backspace": "\\b",
+        "form-feed": "\\f",
+        "line-feed": "\\n",
+        "other-u0000-u001f": "lowercase-u00xx",
+        "carriage-return": "\\r",
+        "tab": "\\t",
+    }
+    assert encoding["delete_character_escaping"] == "literal-byte-7f"
+    assert encoding["lone_surrogate"] == "refuse"
+    assert encoding["number_kinds"] == ["signed-int64"]
+    assert encoding["duplicate_object_keys"] == "refuse-at-decoding"
+    assert {item["id"] for item in encoding["vectors"]} == {
+        "canonical.boundary-integers",
+        "canonical.control-character-escaping",
+        "canonical.order-array-unicode-escaping",
+        "canonical.reject-duplicate-key",
+        "canonical.reject-float",
+        "canonical.reject-lone-surrogate",
+    }
+
+
+def test_every_kernel_law_publishes_a_complete_machine_contract():
+    kernel = authority_set()["kernel"]
+
+    for law in kernel["admission"]["laws"]:
+        assert set(law) == {
+            "arguments",
+            "effects",
+            "id",
+            "input",
+            "operation",
+            "refusals",
+            "resources",
+            "result",
+        }
+        assert isinstance(law["arguments"], dict)
+        assert law["input"] == {"fact_kind": "authority-pair"}
+        assert law["result"] == {"fact_kind": "admission-verdict"}
+        assert law["effects"] == []
+        assert law["refusals"]
+        assert isinstance(law["resources"], list)
+
+
+def test_quantity_package_is_complete_content_addressed_and_uses_canonical_terms():
+    ldb = authority_set()["language_bundle"]
+    package = ldb["language"]["packages"][0]
+
+    assert set(package) == {
+        "artifact_kind",
+        "capabilities",
+        "content_identity",
+        "dependencies",
+        "exports",
+        "id",
+        "profiles",
+        "vectors",
+        "version",
+    }
+    assert package["artifact_kind"] == "domain-package-release"
+    assert package["content_identity"] == _identity(
+        "domain-package-release-v2", package
+    )
+    assert package["dependencies"] == {"optional": [], "required": []}
+    assert package["capabilities"]["required"] == []
+    assert package["exports"]["operations"] == []
+    assert package["exports"]["types"]
+    assert package["vectors"]
+    assert ldb["language"]["quantity"]["representations"] == ["Int"]
+    assert "random" in ldb["language"]["quantity"]["symbol_roles"]
+    assert "random-variable" not in ldb["language"]["quantity"]["symbol_roles"]
+    duplicate = next(
+        item
+        for item in ldb["diagnostics"]
+        if item["code"] == "language.duplicate_symbol"
+    )
+    assert duplicate["stage"] == "static"
+
+
+def test_reidentified_ldb_cannot_hide_a_tampered_package_release():
+    authority = authority_set()
+    package = authority["language_bundle"]["language"]["packages"][0]
+    package["version"] = "2.0.1"
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(
+        code == "kernel.identity_mismatch" for _, code, _ in first["diagnostics"]
+    )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "ldb-artifact-kind",
+        "ldb-schema-major",
+        "diagnostic-extra-member",
+        "package-id-type",
+        "package-version-type",
+        "package-exported-type-empty-id",
+    ],
+)
+def test_reidentified_ldb_and_package_shapes_remain_closed(mutation):
+    authority = authority_set()
+    ldb = authority["language_bundle"]
+    package = ldb["language"]["packages"][0]
+
+    if mutation == "ldb-artifact-kind":
+        ldb["artifact_kind"] = "not-a-bundle"
+    elif mutation == "ldb-schema-major":
+        ldb["schema_major"] = 3
+    elif mutation == "diagnostic-extra-member":
+        ldb["diagnostics"][0]["host_semantics"] = True
+    elif mutation == "package-id-type":
+        package["id"] = 7
+    elif mutation == "package-version-type":
+        package["version"] = False
+    else:
+        package["exports"]["types"][0]["id"] = ""
+
+    if mutation.startswith("package-"):
+        package["content_identity"] = _identity("domain-package-release-v2", package)
+    ldb["content_identity"] = _identity("language-definition-bundle-v2", ldb)
+
+    first = _consumer_a(authority["kernel"], ldb)
+    second = _consumer_b(authority["kernel"], ldb)
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+def test_reidentified_package_cannot_reference_an_unowned_vector():
+    authority = authority_set()
+    package = authority["language_bundle"]["language"]["packages"][0]
+    package["vectors"][0] = "host.missing"
+    package["content_identity"] = _identity("domain-package-release-v2", package)
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
 
 
 def test_bootstrap_executes_every_rule_vector_into_a_stable_projection():
@@ -396,7 +1847,7 @@ def test_reidentified_deletion_of_every_law_and_rule_is_refused_by_both_consumer
         assert first == second
         assert first["admitted"] is False
         assert any(
-            code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"]
+            code == "kernel.identity_mismatch" for _, code, _ in first["diagnostics"]
         )
 
     for index in range(len(ldb_rules)):
@@ -435,6 +1886,654 @@ def test_reidentified_duplicate_diagnostic_is_not_hidden_by_set_projection():
     ) in first["diagnostics"]
 
 
+def test_reidentified_duplicate_vector_id_is_refused_by_both_consumers():
+    authority = authority_set()
+    duplicate = deepcopy(authority["language_bundle"]["vectors"][0])
+    duplicate["rule"] = "quantity.lower"
+    authority["language_bundle"]["vectors"].append(duplicate)
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert (
+        "static",
+        "kernel.duplicate_identifier",
+        "language-bundle.vectors",
+    ) in first["diagnostics"]
+
+
+def test_reidentified_open_fact_shape_is_refused_by_both_consumers():
+    authority = authority_set()
+    authority["language_bundle"]["vectors"][0]["input"]["facts"][0][
+        "host_semantics"
+    ] = "invented"
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
+
+
+def test_reidentified_open_reason_shape_is_refused_by_both_consumers():
+    authority = authority_set()
+    authority["language_bundle"]["language"]["reasons"][0]["host_predicate"] = (
+        "invented"
+    )
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
+
+
+@pytest.mark.parametrize(
+    ("path", "replacement"),
+    [
+        (("exports", "operations"), ["host.invented"]),
+        (("exports", "components"), ["host.invented"]),
+        (("exports", "conversions"), ["host.invented"]),
+        (("profiles", "runtime"), ["host.invented"]),
+        (("capabilities", "provided"), ["host.invented"]),
+        (("capabilities", "required"), ["host.invented"]),
+        (("dependencies", "required"), ["host.invented"]),
+        (("dependencies", "optional"), ["host.invented"]),
+    ],
+)
+def test_reidentified_package_cannot_hide_an_unowned_reference(path, replacement):
+    authority = authority_set()
+    package = authority["language_bundle"]["language"]["packages"][0]
+    target = package
+    for member in path[:-1]:
+        target = target[member]
+    target[path[-1]] = replacement
+    package["content_identity"] = _identity("domain-package-release-v2", package)
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
+
+
+def test_reidentified_rule_phase_mutation_is_refused_by_both_consumers():
+    authority = authority_set()
+    authority["language_bundle"]["language"]["rules"][0]["phase"] = "host"
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
+
+
+def test_reidentified_capability_definition_cannot_omit_its_rule_reference():
+    authority = authority_set()
+    del authority["language_bundle"]["language"]["capabilities"][0]["rule"]
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
+
+
+def test_reidentified_package_cannot_export_an_open_host_operation_definition():
+    authority = authority_set()
+    authority["language_bundle"]["language"]["operations"].append(
+        {"host_semantics": "invented", "id": "host.op"}
+    )
+    package = authority["language_bundle"]["language"]["packages"][0]
+    package["exports"]["operations"].append("host.op")
+    package["content_identity"] = _identity("domain-package-release-v2", package)
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
+
+
+def test_malformed_quantity_inventory_returns_a_typed_refusal_from_both_consumers():
+    authority = authority_set()
+    authority["language_bundle"]["language"]["quantity"] = []
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert first["diagnostics"]
+
+
+def test_reidentified_fact_enum_drift_is_refused_by_both_consumers():
+    authority = authority_set()
+    input_fact = authority["language_bundle"]["vectors"][0]["input"]["facts"][0]
+    expected_fact = authority["language_bundle"]["vectors"][0]["expect"]
+    input_fact["fields"]["role"] = "host-role"
+    expected_fact["fields"]["role"] = "host-role"
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
+
+
+def test_reidentified_non_string_variable_term_returns_a_typed_refusal():
+    authority = authority_set()
+    authority["language_bundle"]["language"]["rules"][0]["conclusion"]["fields"][
+        "role"
+    ]["name"] = {"host": "role"}
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
+
+
+def test_reidentified_reason_operand_type_drift_is_refused_by_both_consumers():
+    authority = authority_set()
+    authority["language_bundle"]["language"]["reasons"][1]["predicate"][
+        "member_field"
+    ] = 42
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
+
+
+def test_reidentified_reason_cannot_change_its_inventory_semantics():
+    authority = authority_set()
+    authority["language_bundle"]["language"]["reasons"][0]["predicate"][
+        "inventory_path"
+    ] = "language.quantity.symbol_roles"
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
+
+
+def test_reidentified_reason_cannot_change_its_limit_semantics():
+    authority = authority_set()
+    authority["language_bundle"]["language"]["reasons"][3]["predicate"][
+        "limit_path"
+    ] = "resources.max_diagnostics"
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
+
+
+def test_reidentified_reason_vector_with_non_boolean_outcome_is_a_total_refusal():
+    authority = authority_set()
+    reason_vector = next(
+        item for item in authority["language_bundle"]["vectors"] if "reason" in item
+    )
+    reason_vector["matched"] = {"host": True}
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
+
+
+@pytest.mark.parametrize(
+    ("member", "replacement"),
+    [("reason", []), ("diagnostic", {}), ("stage", ["static"])],
+)
+def test_reidentified_reason_vector_header_type_drift_is_a_total_refusal(
+    member, replacement
+):
+    authority = authority_set()
+    reason_vector = next(
+        item for item in authority["language_bundle"]["vectors"] if "reason" in item
+    )
+    reason_vector[member] = replacement
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+@pytest.mark.parametrize(
+    ("member", "replacement"),
+    [("rule", []), ("rule", {}), ("id", None), ("id", False), ("id", 42)],
+)
+def test_reidentified_rule_vector_header_type_drift_is_a_total_refusal(
+    member, replacement
+):
+    authority = authority_set()
+    rule_vector = next(
+        item for item in authority["language_bundle"]["vectors"] if "rule" in item
+    )
+    rule_vector[member] = replacement
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "rule-id-none",
+        "premises-none",
+        "bind-list",
+        "conclusion-none",
+        "conclusion-fields-false",
+        "reason-id-none",
+        "conclusion-fact-kind-list",
+        "premise-fact-kind-list",
+        "premise-fact-kind-object",
+        "conclusion-term-tag-list",
+        "conclusion-term-tag-object",
+    ],
+)
+def test_reidentified_rule_and_reason_shape_drift_is_a_total_refusal(mutation):
+    authority = authority_set()
+    ldb = authority["language_bundle"]
+    rule = ldb["language"]["rules"][0]
+    if mutation == "rule-id-none":
+        rule["id"] = None
+    elif mutation == "premises-none":
+        rule["premises"] = None
+    elif mutation == "bind-list":
+        rule["premises"][0]["bind"] = []
+    elif mutation == "conclusion-none":
+        rule["conclusion"] = None
+    elif mutation == "conclusion-fields-false":
+        rule["conclusion"]["fields"] = False
+    elif mutation == "reason-id-none":
+        ldb["language"]["reasons"][0]["id"] = None
+    elif mutation == "conclusion-fact-kind-list":
+        rule["conclusion"]["fact_kind"] = []
+    elif mutation == "premise-fact-kind-list":
+        rule["premises"][0]["fact_kind"] = []
+    elif mutation == "premise-fact-kind-object":
+        rule["premises"][0]["fact_kind"] = {}
+    elif mutation == "conclusion-term-tag-list":
+        next(iter(rule["conclusion"]["fields"].values()))["tag"] = []
+    else:
+        next(iter(rule["conclusion"]["fields"].values()))["tag"] = {}
+    ldb["content_identity"] = _identity("language-definition-bundle-v2", ldb)
+
+    first = _consumer_a(authority["kernel"], ldb)
+    second = _consumer_b(authority["kernel"], ldb)
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+@pytest.mark.parametrize("replacement", [None, False, 0, "language", []])
+def test_reidentified_non_object_language_is_a_total_refusal(replacement):
+    authority = authority_set()
+    ldb = authority["language_bundle"]
+    ldb["language"] = replacement
+    ldb["content_identity"] = _identity("language-definition-bundle-v2", ldb)
+
+    first = _consumer_a(authority["kernel"], ldb)
+    second = _consumer_b(authority["kernel"], ldb)
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+def test_reidentified_wire_schema_token_drift_is_refused_by_both_consumers():
+    authority = authority_set()
+    authority["language_bundle"]["language"]["quantity"]["symbol_roles"][-1] = (
+        "host-random"
+    )
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
+
+
+@pytest.mark.parametrize("replacement", [None, False, 0, [], {}])
+def test_reidentified_model_source_schema_version_drift_is_refused(replacement):
+    authority = authority_set()
+    ldb = authority["language_bundle"]
+    ldb["language"]["wire_schemas"][0]["schema"]["properties"]["schema_version"][
+        "const"
+    ] = replacement
+    ldb["content_identity"] = _identity("language-definition-bundle-v2", ldb)
+
+    first = _consumer_a(authority["kernel"], ldb)
+    second = _consumer_b(authority["kernel"], ldb)
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+@pytest.mark.parametrize(
+    ("reason_index", "member", "replacement"),
+    [
+        (0, "inventory_path", "artifact_kind"),
+        (1, "member_field", "host"),
+        (3, "limit_path", "artifact_kind"),
+    ],
+)
+def test_reidentified_reason_path_shape_drift_is_a_total_refusal(
+    reason_index, member, replacement
+):
+    authority = authority_set()
+    authority["language_bundle"]["language"]["reasons"][reason_index]["predicate"][
+        member
+    ] = replacement
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"])
+
+
+@pytest.mark.parametrize("collection", ["constructors", "wire_schemas"])
+def test_reidentified_language_definition_envelopes_are_closed(collection):
+    authority = authority_set()
+    authority["language_bundle"]["language"][collection][0]["host_semantics"] = (
+        "invented"
+    )
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+def test_reidentified_wire_schema_cannot_carry_an_unknown_host_keyword():
+    authority = authority_set()
+    wire_schema = authority["language_bundle"]["language"]["wire_schemas"][0]
+    wire_schema["schema"]["host_semantics"] = "invented"
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+def test_reidentified_wire_schema_must_be_valid_under_its_declared_dialect():
+    authority = authority_set()
+    symbol_schema = authority["language_bundle"]["language"]["wire_schemas"][0][
+        "schema"
+    ]["properties"]["symbols"]["items"]
+    symbol_schema["type"] = 42
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+def test_reidentified_wire_schema_cannot_bypass_object_closure_with_type_array():
+    authority = authority_set()
+    domain_schema = authority["language_bundle"]["language"]["wire_schemas"][0][
+        "schema"
+    ]["properties"]["symbols"]["items"]["properties"]["domain"]
+    domain_schema["type"] = ["object"]
+    del domain_schema["unevaluatedProperties"]
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+def test_reidentified_wire_schema_object_keywords_require_explicit_closed_type():
+    authority = authority_set()
+    domain_schema = authority["language_bundle"]["language"]["wire_schemas"][0][
+        "schema"
+    ]["properties"]["symbols"]["items"]["properties"]["domain"]
+    del domain_schema["type"]
+    del domain_schema["unevaluatedProperties"]
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+def test_reidentified_wire_schema_cannot_add_an_open_combinator_branch():
+    authority = authority_set()
+    domain_schema = authority["language_bundle"]["language"]["wire_schemas"][0][
+        "schema"
+    ]["properties"]["symbols"]["items"]["properties"]["domain"]
+    replacement = {"anyOf": [deepcopy(domain_schema), {}]}
+    authority["language_bundle"]["language"]["wire_schemas"][0]["schema"]["properties"][
+        "symbols"
+    ]["items"]["properties"]["domain"] = replacement
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+def test_reidentified_wire_schema_cannot_reference_a_missing_local_definition():
+    authority = authority_set()
+    authority["language_bundle"]["language"]["wire_schemas"][0]["schema"]["$ref"] = (
+        "#/$defs/missing"
+    )
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+def test_reidentified_wire_schema_cannot_collide_with_reserved_projection_kind():
+    authority = authority_set()
+    authority["language_bundle"]["language"]["wire_schemas"][0]["artifact_kind"] = (
+        "schema-major-kernel"
+    )
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+def test_reidentified_numeric_policy_cannot_invent_overflow_semantics():
+    authority = authority_set()
+    policy = authority["language_bundle"]["language"]["quantity"]["numeric_policies"][0]
+    policy["overflow"] = "wrap"
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+def test_current_slice_refuses_not_yet_delivered_operation_definitions():
+    authority = authority_set()
+    authority["language_bundle"]["language"]["operations"].append(
+        {
+            "body": {},
+            "effects": [],
+            "id": "host.op",
+            "inputs": {},
+            "numeric_profiles": [],
+            "refusals": [],
+            "resource_bounds": {},
+            "result": {},
+            "runtime_profiles": [],
+            "vectors": [],
+        }
+    )
+    package = authority["language_bundle"]["language"]["packages"][0]
+    package["exports"]["operations"].append("host.op")
+    package["content_identity"] = _identity("domain-package-release-v2", package)
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+def test_reidentified_conflicting_duplicate_binding_refuses_in_both_consumers():
+    authority = authority_set()
+    rule = authority["language_bundle"]["language"]["rules"][0]
+    rule["premises"].append(deepcopy(rule["premises"][0]))
+    vector = authority["language_bundle"]["vectors"][0]
+    conflicting_fact = deepcopy(vector["input"]["facts"][0])
+    conflicting_fact["fields"]["role"] = "input"
+    vector["input"]["facts"].append(conflicting_fact)
+    vector["expect"]["fields"]["role"] = "input"
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+
+
+def test_reidentified_duplicate_reason_uses_type_sensitive_scalar_equality():
+    authority = authority_set()
+    duplicate_vector = next(
+        item
+        for item in authority["language_bundle"]["vectors"]
+        if item["id"] == "quantity.refuse.duplicate"
+    )
+    duplicate_vector["input"]["values"] = [False, 0]
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+
+
 def test_old_identity_tamper_and_reidentified_behavior_or_token_mutations_refuse():
     baseline = authority_set()
 
@@ -457,7 +2556,7 @@ def test_old_identity_tamper_and_reidentified_behavior_or_token_mutations_refuse
         second = _consumer_b(authority["kernel"], authority["language_bundle"])
         assert first == second
         assert any(
-            code == "kernel.unknown_operation" for _, code, _ in first["diagnostics"]
+            code == "kernel.identity_mismatch" for _, code, _ in first["diagnostics"]
         )
 
     for index in range(len(baseline["language_bundle"]["language"]["rules"])):
@@ -488,9 +2587,32 @@ def test_old_identity_tamper_and_reidentified_behavior_or_token_mutations_refuse
         first = _consumer_a(authority["kernel"], authority["language_bundle"])
         second = _consumer_b(authority["kernel"], authority["language_bundle"])
         assert first == second
-        assert any(
-            code == "kernel.vector_mismatch" for _, code, _ in first["diagnostics"]
+        expected_code = (
+            "kernel.identity_mismatch"
+            if owner == "kernel"
+            else "kernel.vector_mismatch"
         )
+        assert any(code == expected_code for _, code, _ in first["diagnostics"])
+
+
+def test_reidentified_kernel_law_operand_mutation_is_refused_by_both_consumers():
+    authority = authority_set()
+    binding_law = next(
+        law
+        for law in authority["kernel"]["admission"]["laws"]
+        if law["id"] == "kernel.binding.exact"
+    )
+    binding_law["arguments"]["left"] = "language_bundle.host_invented_binding"
+    _reidentify(authority["kernel"], authority["language_bundle"])
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert any(
+        code == "kernel.identity_mismatch" for _, code, _ in first["diagnostics"]
+    )
 
 
 def test_diagnostic_catalog_missing_extra_and_stage_drift_are_refused():
@@ -581,19 +2703,26 @@ def test_reidentified_extra_members_cannot_extend_kernel_ldb_or_rule_shapes():
 
 def test_two_consumers_agree_on_report_all_cap_and_truncation():
     authority = authority_set()
-    authority["kernel"]["resources"]["max_diagnostics"] = 3
-    for index in range(8):
-        authority["kernel"]["admission"]["laws"].append(
-            {"id": f"mutant.{index}", "operation": f"unknown.{index}"}
+    diagnostic_cap = authority["kernel"]["resources"]["max_diagnostics"]
+    for index in range(diagnostic_cap + 2):
+        authority["language_bundle"]["vectors"].append(
+            {
+                "expect": {},
+                "id": f"mutant.{index}",
+                "input": {"facts": [], "judgment": "missing"},
+                "rule": "quantity.declare",
+            }
         )
-    _reidentify(authority["kernel"], authority["language_bundle"])
+    authority["language_bundle"]["content_identity"] = _identity(
+        "language-definition-bundle-v2", authority["language_bundle"]
+    )
 
     first = _consumer_a(authority["kernel"], authority["language_bundle"])
     second = _consumer_b(authority["kernel"], authority["language_bundle"])
 
     assert first == second
     assert first["truncated"] is True
-    assert len(first["diagnostics"]) == 3
+    assert len(first["diagnostics"]) == diagnostic_cap
 
 
 def test_two_consumers_refuse_the_same_nesting_resource_exhaustion():
@@ -613,3 +2742,19 @@ def test_two_consumers_refuse_the_same_nesting_resource_exhaustion():
     assert first["diagnostics"] == [
         ("ingress", "kernel.resource_exhausted", "language-bundle")
     ]
+
+
+def test_two_consumers_refuse_the_same_noncanonical_integer():
+    authority = authority_set()
+    authority["language_bundle"]["resources"]["max_source_bytes"] = 2**63
+
+    first = _consumer_a(authority["kernel"], authority["language_bundle"])
+    second = _consumer_b(authority["kernel"], authority["language_bundle"])
+
+    assert first == second
+    assert first["admitted"] is False
+    assert {code for _, code, _ in first["diagnostics"]} == {
+        "kernel.identity_mismatch",
+        "kernel.member_set_mismatch",
+        "kernel.resource_exhausted",
+    }

--- a/libs/gda-balancing/tests/test_schema2_canonical.py
+++ b/libs/gda-balancing/tests/test_schema2_canonical.py
@@ -1,0 +1,18 @@
+"""The Kernel's canonical JSON/identity profile at its host boundary."""
+
+from typing import Any, cast
+
+import pytest
+
+from gda_balancing.schema2.canonical import canonical_bytes, content_identity
+
+
+def test_profile_preserves_unicode_and_sorts_by_utf8_key_order():
+    assert canonical_bytes({"é": "é", "a": 1}) == '{"a":1,"é":"é"}\n'.encode()
+    assert content_identity("probe", "é") != content_identity("probe", "e\u0301")
+
+
+@pytest.mark.parametrize("outside_profile", [1.5, 2**63, "\ud800"])
+def test_profile_rejects_host_numeric_and_unicode_extensions(outside_profile: Any):
+    with pytest.raises((TypeError, ValueError)):
+        canonical_bytes(cast(Any, outside_profile))

--- a/libs/gda-balancing/tests/test_schema_command.py
+++ b/libs/gda-balancing/tests/test_schema_command.py
@@ -7,8 +7,6 @@ validation at the usage boundary, so `schema get bogus` is a usage
 """
 
 import json
-import os
-
 import jsonschema
 
 from gda_balancing.envelope import ERROR_ENVELOPE_SCHEMA
@@ -23,16 +21,11 @@ def test_unknown_artifact_is_a_usage_error(run_cli):
     assert payload["error"]["code"] == "invalid_argument"
 
 
-def test_schema_get_is_an_artifact_sink(run_cli, tmp_path):
-    # The self-description artifacts are artifacts too (bADR-0009): `--out`
-    # redirects the schema to the sink and stdout carries the receipt.
-    _, body, _ = run_cli(["schema", "get", "structural"])
-    sink = tmp_path / "structural.json"
+def test_schema_get_is_stdout_only(run_cli):
+    # bADR-0021: retrieval commands can remain stdout-only and therefore do
+    # not advertise or accept an artifact publication sink.
     exit_code, stdout, stderr = run_cli(
-        ["schema", "get", "structural", "--out", str(sink)]
+        ["schema", "get", "language-bundle", "--out", "authority.json"]
     )
-    assert (exit_code, stderr) == (0, "")
-    assert sink.read_bytes() == body.encode("utf-8")
-    assert json.loads(stdout) == {
-        "artifact": {"path": os.path.realpath(str(sink)), "bytes": sink.stat().st_size}
-    }
+    assert (exit_code, stdout) == (3, "")
+    assert json.loads(stderr)["error"]["code"] == "unknown_argument"

--- a/libs/gda-balancing/tests/test_semantic_catalog.py
+++ b/libs/gda-balancing/tests/test_semantic_catalog.py
@@ -21,15 +21,16 @@ Two conformance surfaces:
   structural validation is linear, a depth-33 tree clears preflight and the
   structural phase and is refused by ``expression_tree_too_deep`` itself (see
   ``test_deep_expression_tree_is_refused`` in test_validate_vectors.py).
-* **Catalog↔registry identity** — the published ``schema get catalog`` artifact's
-  rule ids equal the sorted registry codes, each entry carries the full metadata,
-  and the bytes match a committed golden.
+* **Catalog↔registry identity** — the historical 1.x catalog projection's rule
+  ids equal the sorted registry codes, each entry carries the full metadata, and
+  the bytes match a committed golden.
 """
 
 import json
 from pathlib import Path
 
 from gda_balancing.emit import canonical_json
+from gda_balancing.schema.bundle import current_bundle
 from gda_balancing.schema.funnel import semantic
 from gda_balancing.schema.funnel.semantic import SEMANTIC_RULES
 from gda_balancing.schema.model.document import DesignDocument
@@ -111,23 +112,21 @@ def test_registry_codes_are_unique() -> None:
     assert len(codes) == len(set(codes))
 
 
-# --- Catalog artifact ↔ registry identity (via the CLI) --------------------
+# --- Historical 1.x catalog projection ↔ registry identity ----------------
 
 
-def _catalog(run_cli) -> dict:
-    exit_code, stdout, stderr = run_cli(["schema", "get", "catalog"])
-    assert (exit_code, stderr) == (0, "")
-    return json.loads(stdout)
+def _catalog() -> dict:
+    return current_bundle().catalog()
 
 
-def test_catalog_ids_match_the_registry(run_cli) -> None:
-    catalog = _catalog(run_cli)
+def test_catalog_ids_match_the_registry() -> None:
+    catalog = _catalog()
     ids = [entry["id"] for entry in catalog["rules"]]
     assert ids == sorted(rule.code for rule in SEMANTIC_RULES)
 
 
-def test_catalog_entries_carry_full_metadata(run_cli) -> None:
-    catalog = _catalog(run_cli)
+def test_catalog_entries_carry_full_metadata() -> None:
+    catalog = _catalog()
     by_id = {entry["id"]: entry for entry in catalog["rules"]}
     for rule in SEMANTIC_RULES:
         entry = by_id[rule.code]
@@ -142,19 +141,16 @@ def test_catalog_entries_carry_full_metadata(run_cli) -> None:
         assert sorted(entry) == ["description", "id", "scope", "since_version"]
 
 
-def test_catalog_declares_the_schema_version(run_cli) -> None:
+def test_catalog_declares_the_schema_version() -> None:
     from gda_balancing.schema.version import SCHEMA_VERSION
 
-    assert _catalog(run_cli)["schema_version"] == SCHEMA_VERSION
+    assert _catalog()["schema_version"] == SCHEMA_VERSION
 
 
-def test_schema_get_catalog_matches_golden(run_cli) -> None:
+def test_historical_catalog_projection_matches_golden() -> None:
     # Byte-for-byte against the committed golden. To regenerate after a reviewed
     # rule change, overwrite it deliberately and review the diff:
-    #   uv run gda-balancing schema get catalog \
-    #     > libs/gda-balancing/tests/goldens/semantic_catalog.json
-    exit_code, stdout, stderr = run_cli(["schema", "get", "catalog"])
-    assert (exit_code, stderr) == (0, "")
+    stdout = canonical_json(_catalog())
     assert stdout.encode("utf-8") == _GOLDEN.read_bytes()
     # The golden is canonical (sorted keys, single trailing LF).
     assert stdout == canonical_json(json.loads(stdout))


### PR DESCRIPTION
## Summary

- publish a content-addressed Schema 2.0 Kernel and exact Language Definition Bundle for the bounded Quantity foundation
- independently admit and mutation-test every Kernel law, LDB rule, and diagnostic reason without host-side semantic fallback
- bind the admitted Model Source schema-version inventory to the projected wire schema and totalize malformed/reidentified authority refusal
- expose descriptor-derived Schema 2.0 `schema get`, `manifest`, `--schema`, structured parameters, and stage-aware refusals
- update the authority status and delivery-scope documentation

## Scope boundary

This PR proves only the admitted Kernel/LDB and command-discovery slice. It publishes no Model, Package Lock, RIR, Resolved Model, Runtime, Experiment, Metric, Replay, Evidence, template, or Genre success artifact.

## Validation

- `cd libs/gda-balancing && env UV_CACHE_DIR=/tmp/gda-balancing-uv-cache uv run --frozen pytest -q` — 491 passed, 26 skipped
- `cd libs/gda-balancing && env UV_CACHE_DIR=/tmp/gda-balancing-uv-cache uv run --frozen pyright` — 0 errors, 0 warnings
- `env UV_CACHE_DIR=/tmp/godot-agent-uv-cache uv run --frozen ruff check libs/gda-balancing`
- `env UV_CACHE_DIR=/tmp/godot-agent-uv-cache uv run --frozen ruff format --check libs/gda-balancing` — 57 files already formatted
- built a fresh wheel, installed it into an isolated virtual environment, admitted the packaged Kernel/LDB as `cdac236…` / `9198eba…`, and exercised `schema get --schema` plus `manifest` from `/tmp`
- an independent final sweep reidentified 2,050 single-node canonical-type LDB mutations with no consumer exception or admission disagreement; the 12 admitted mutations preserved their observable reason behavior

Closes #538
