### PR TITLE
test(ci): verify unrelated balancing path budget

### DIFF
--- a/docs/agents/gda-balancing-ci-unrelated-probe.md
+++ b/docs/agents/gda-balancing-ci-unrelated-probe.md
@@ -1,0 +1,6 @@
+# Disposable gda-balancing CI probe
+
+This branch-only file verifies that an explicitly unrelated root documentation
+change receives a successful `gda-balancing required` result without starting
+the balancing test matrix. The probe PR must be closed without merging after
+the timing evidence is recorded on issue #597.


### PR DESCRIPTION
## Purpose

Disposable real-PR probe for #597. The only changed path is explicitly unrelated root documentation, so the stable `gda-balancing required` context must succeed without starting inventory, matrix, or smoke jobs.

## Disposition

Record the scope-job-to-aggregator execution time on #597, then close this PR without merging and delete the probe branch.

Refs #597