### PR TITLE
feat(mcp): migrate gda-mcp to MCP SDK v2 dual-era stdio server

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,10 @@ The server resolves two pieces of context — which Godot **project** to drive a
 
 - **Project** — set `GDA_PROJECT` when your client can't advertise workspace **roots**; otherwise
   `gda-mcp` auto-detects the project from the roots the client sends (the folder you have open). A
-  *set-but-invalid* `GDA_PROJECT` is a reported error, not a silent fallback. See
-  [Configuration](#configuration) for the full CLI-vs-MCP resolution order.
+  *set-but-invalid* `GDA_PROJECT` is a reported error, not a silent fallback. Note the MCP
+  2026-07-28 spec revision deprecates the roots capability: today's clients keep working unchanged,
+  but pinning `GDA_PROJECT` is the future-proof setup (a client on the new stateless protocol has no
+  roots to advertise). See [Configuration](#configuration) for the full CLI-vs-MCP resolution order.
 - **Engine** — set `GDA_GODOT` to your Godot binary, e.g. `"GDA_GODOT": "/path/to/Godot"`.
 
 
@@ -563,7 +565,7 @@ A named directory must be a project, or `gda` reports it as an error. When none 
 | Context | Project resolution order |
 | --- | --- |
 | **CLI** | `--project` → `GDA_PROJECT` (both strict — invalid is reported) → cwd if it holds `project.godot`, else projectless |
-| **MCP** (`gda-mcp`) | `GDA_PROJECT` (strict — set-but-invalid is reported, not skipped) → a *valid* client workspace `root` → a *valid* server cwd, else projectless |
+| **MCP** (`gda-mcp`) | `GDA_PROJECT` (strict — set-but-invalid is reported, not skipped) → a *valid* client workspace `root` (clients on the pre-2026 MCP protocol; the 2026-07-28 revision has no roots, so those clients skip straight on) → a *valid* server cwd, else projectless |
 
 <details>
 <summary>Project code execution — what runs when you point at a project</summary>

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=d0624578d2e00805a61ea7e983ce98c850dcafa07848468c961c82d4acec270e -->
+<!-- gda-readme-i18n: source=README.md sha256=3a595c5ac14763cd6aa8236c34d543ecaa719371040f852645327be2d78af73f -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -221,7 +221,10 @@ ejecutar (MCP no puede pasar flags por llamada):
 
 - **Proyecto** — define `GDA_PROJECT` cuando tu cliente no pueda anunciar **roots** de workspace; de lo contrario,
   `gda-mcp` detecta automáticamente el proyecto a partir de los roots que envía el cliente (la carpeta que tienes abierta). Un
-  `GDA_PROJECT` *definido pero inválido* es un error reportado, no una alternativa silenciosa. Consulta
+  `GDA_PROJECT` *definido pero inválido* es un error reportado, no una alternativa silenciosa. Ten en cuenta que la
+  revisión 2026-07-28 de la especificación MCP marca la capacidad de roots como obsoleta: los clientes actuales siguen
+  funcionando sin cambios, pero fijar `GDA_PROJECT` es la configuración a prueba de futuro (un cliente del nuevo
+  protocolo sin estado no tiene roots que anunciar). Consulta
   [Configuración](#configuration) para conocer el orden completo de resolución CLI vs MCP.
 - **Motor** — define `GDA_GODOT` con tu binario de Godot, p. ej. `"GDA_GODOT": "/path/to/Godot"`.
 
@@ -575,7 +578,7 @@ relativas al cwd), no `res://`. El **servidor MCP** no tiene flags, así que res
 | Contexto | Orden de resolución del proyecto |
 | --- | --- |
 | **CLI** | `--project` → `GDA_PROJECT` (ambos estrictos — lo inválido se reporta) → cwd si contiene `project.godot`, si no, sin proyecto |
-| **MCP** (`gda-mcp`) | `GDA_PROJECT` (estricto — definido pero inválido se reporta, no se omite) → un `root` de workspace del cliente *válido* → un cwd del servidor *válido*, si no, sin proyecto |
+| **MCP** (`gda-mcp`) | `GDA_PROJECT` (estricto — definido pero inválido se reporta, no se omite) → un `root` de workspace del cliente *válido* (clientes del protocolo MCP anterior a 2026; la revisión 2026-07-28 no tiene roots, así que esos clientes pasan directamente al siguiente nivel) → un cwd del servidor *válido*, si no, sin proyecto |
 
 <details>
 <summary>Ejecución del código del proyecto — qué se ejecuta cuando apuntas a un proyecto</summary>

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=d0624578d2e00805a61ea7e983ce98c850dcafa07848468c961c82d4acec270e -->
+<!-- gda-readme-i18n: source=README.md sha256=3a595c5ac14763cd6aa8236c34d543ecaa719371040f852645327be2d78af73f -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -226,8 +226,10 @@ uvx --from "gda[mcp]" gda-mcp
 - **プロジェクト** — クライアントがワークスペースの **roots** を提示できない場合は `GDA_PROJECT` を
   設定します。そうでなければ、`gda-mcp` はクライアントが送る roots(あなたが開いているフォルダ)から
   プロジェクトを自動検出します。*設定されているが無効な* `GDA_PROJECT` は、静かにフォールバックする
-  のではなくエラーとして報告されます。CLI と MCP の完全な解決順序については
-  [設定](#configuration) を参照してください。
+  のではなくエラーとして報告されます。なお、MCP の 2026-07-28 仕様改訂は roots 機能を非推奨に
+  しました。現在のクライアントはそのまま動作しますが、`GDA_PROJECT` を固定するのが将来にわたって
+  有効な設定です(新しいステートレスプロトコルのクライアントには提示する roots がありません)。
+  CLI と MCP の完全な解決順序については [設定](#configuration) を参照してください。
 - **エンジン** — `GDA_GODOT` に Godot バイナリを設定します。例: `"GDA_GODOT": "/path/to/Godot"`。
 
 
@@ -578,7 +580,7 @@ Godot は daemon セッション内で `get_mouse_position()` /
 | コンテキスト | プロジェクトの解決順序 |
 | --- | --- |
 | **CLI** | `--project` → `GDA_PROJECT`(どちらも厳格 — 無効ならエラー報告)→ `project.godot` を持つなら cwd、なければ projectless |
-| **MCP**(`gda-mcp`) | `GDA_PROJECT`(厳格 — 設定済みだが無効ならスキップせずエラー報告)→ *有効な* クライアントワークスペースの `root` → *有効な* サーバーの cwd、なければ projectless |
+| **MCP**(`gda-mcp`) | `GDA_PROJECT`(厳格 — 設定済みだが無効ならスキップせずエラー報告)→ *有効な* クライアントワークスペースの `root`(2026 年以前の MCP プロトコルのクライアント。2026-07-28 改訂版には roots がないため、そのクライアントは次へ進む)→ *有効な* サーバーの cwd、なければ projectless |
 
 <details>
 <summary>プロジェクトコードの実行 — プロジェクトを指定したときに何が実行されるか</summary>

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=d0624578d2e00805a61ea7e983ce98c850dcafa07848468c961c82d4acec270e -->
+<!-- gda-readme-i18n: source=README.md sha256=3a595c5ac14763cd6aa8236c34d543ecaa719371040f852645327be2d78af73f -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -216,7 +216,9 @@ uvx --from "gda[mcp]" gda-mcp
 
 - **项目** — 当你的客户端无法公布工作区 **roots** 时，设置 `GDA_PROJECT`；否则 `gda-mcp`
   会从客户端发来的 roots（你打开的那个文件夹）自动检测项目。*已设置但无效*的 `GDA_PROJECT`
-  会被当作一个上报的错误，而不是悄悄兜底。完整的 CLI 与 MCP 解析顺序参见[配置](#configuration)。
+  会被当作一个上报的错误，而不是悄悄兜底。注意 MCP 2026-07-28 规范修订版弃用了 roots 能力：
+  现在的客户端行为不变，但固定 `GDA_PROJECT` 才是面向未来的配置（走新无状态协议的客户端没有
+  roots 可公布）。完整的 CLI 与 MCP 解析顺序参见[配置](#configuration)。
 - **引擎** — 把 `GDA_GODOT` 设为你的 Godot 二进制文件，例如 `"GDA_GODOT": "/path/to/Godot"`。
 
 
@@ -557,7 +559,7 @@ Live `game set --property position` 遵循与 `node set` 相同的 `Control` 策
 | 上下文 | 项目解析顺序 |
 | --- | --- |
 | **CLI** | `--project` → `GDA_PROJECT`（两者都严格——无效即上报）→ 含有 `project.godot` 的 cwd，否则无项目 |
-| **MCP**（`gda-mcp`） | `GDA_PROJECT`（严格——已设置但无效会被上报，而非跳过）→ 一个*有效的*客户端工作区 `root` → 一个*有效的*服务器 cwd，否则无项目 |
+| **MCP**（`gda-mcp`） | `GDA_PROJECT`（严格——已设置但无效会被上报，而非跳过）→ 一个*有效的*客户端工作区 `root`（走 2026 前 MCP 协议的客户端；2026-07-28 修订版没有 roots，这类客户端直接跳到下一级）→ 一个*有效的*服务器 cwd，否则无项目 |
 
 <details>
 <summary>项目代码执行——当你指向一个项目时会运行什么</summary>

--- a/docs/adr/0011-gda-mcp-integration-mechanism.md
+++ b/docs/adr/0011-gda-mcp-integration-mechanism.md
@@ -108,3 +108,11 @@ Phase 2 automatically" literally true:
 - This ADR owns the integration mechanism **and its error mapping**. gda-mcp's
   packaging, tool-generation strategy, and transport are downstream and decided
   separately (ADR-0013, ADR-0012, and the PRD respectively).
+
+> **Outcome (2026-07-31, ADR-0039/#601):** the exit-code-keyed, lossless error
+> mapping survived the MCP SDK v2 migration unchanged. What moved: SDK v2 no
+> longer auto-wraps a success dict, so gda-mcp now constructs the result itself
+> (the dict as `structured_content` plus the v1-identical indented-JSON text
+> block); and the SDK's output-schema validation — which an `is_error=True`
+> result without `structured_content` bypasses (spike-verified) — still never
+> touches the verbatim `GdaError` envelope relay.

--- a/docs/adr/0012-gda-mcp-tool-surface-generation.md
+++ b/docs/adr/0012-gda-mcp-tool-surface-generation.md
@@ -103,3 +103,10 @@ does not decide for them.
   the dump, then register).
 - gda-mcp carries no per-command knowledge: it is a pure schema→tool transformation,
   so it stays correct as the `gda` surface grows without edits to gda-mcp.
+
+> **Outcome (2026-07-31, ADR-0039/#601):** the transform survived the MCP SDK v2
+> migration unchanged — still one startup dump, one generic dispatcher, zero
+> per-command knowledge. Only the SDK-side spelling of the mirrored fields
+> changed (`inputSchema`/`outputSchema` → `input_schema`/`output_schema` on the
+> v2 wire models); this ADR's prose keeps the v1 names as its point-in-time
+> record.

--- a/docs/adr/0014-gda-mcp-project-context-resolution.md
+++ b/docs/adr/0014-gda-mcp-project-context-resolution.md
@@ -91,3 +91,16 @@ error, relayed unchanged.
 > above against the now-active roots; a pinned `GDA_PROJECT` still wins (env is read
 > first). The project stays out of the tool surface — no per-call parameter — so
 > ADR-0012 and ADR-0006 are untouched.
+
+> **Outcome (2026-07-31, ADR-0039/#601):** the 2026-07-28 spec revision
+> deprecated the roots capability outright (SEP-2577), so precedence level 2's
+> *acquisition* became connection-dependent under MCP SDK v2: gda-mcp asks for
+> roots iff the connection has a back-channel (`can_send_request`) and the
+> client advertises the capability — every pre-2026 agent keeps this behavior
+> unchanged — while a 2026-07-28 stateless connection has no roots signal at
+> all and degrades silently to `GDA_PROJECT` → cwd. `GDA_PROJECT` is thereby
+> promoted to the durable anchor of this precedence; a per-call `project` tool
+> argument (the spec's suggested roots replacement) remains rejected, and the
+> `roots/list_changed` re-resolution (#209) lives on as a legacy-connection
+> behavior. The MRTR-based roots acquisition is deferred with a written trigger
+> in ADR-0039.

--- a/docs/adr/0039-gda-mcp-sdk-v2-dual-era-stdio-server.md
+++ b/docs/adr/0039-gda-mcp-sdk-v2-dual-era-stdio-server.md
@@ -27,9 +27,14 @@ stateless.
 **gda-mcp adopts MCP SDK v2 (`mcp>=2,<3`) and serves both protocol eras from the one
 low-level stdio `Server`.** Pre-2026 clients complete the legacy `initialize`
 handshake and keep today's behavior bit-for-bit; 2026-07-28 clients are served the
-stateless path by the same binary. Both eras are a permanent automated gate (the
-real console script driven under `mode="legacy"` **and** `mode="auto"`), not a
-compatibility claim. Concretely:
+stateless path by the same binary. Both eras are a permanent automated gate, not a
+compatibility claim: the real console script is driven over real stdio under
+`mode="legacy"` **and** `mode="2026-07-28"`, asserting the negotiated
+`protocol_version` per era — the modern era is pinned, never `mode="auto"`, because
+auto falls back to the legacy handshake on a server that lost modern support and
+would go green without proving it. The engine-free half (handshake + generated
+surface) runs in the PR-CI fast tier; the e2e half adds real tool dispatch.
+Concretely:
 
 - **Stay on the low-level `Server`.** The ADR-0012 rationale is unchanged by v2:
   our schemas come *from* gda, tools are discovered at runtime and served by one

--- a/docs/adr/0039-gda-mcp-sdk-v2-dual-era-stdio-server.md
+++ b/docs/adr/0039-gda-mcp-sdk-v2-dual-era-stdio-server.md
@@ -1,0 +1,115 @@
+---
+status: accepted
+---
+
+# gda-mcp on MCP SDK v2: one low-level stdio server serving both protocol eras
+
+The MCP spec revision **2026-07-28** turns the protocol from bidirectional-stateful
+into request/response-stateless: the `initialize` handshake is retired in favor of
+`server/discover`, each request self-describes in `_meta`, and the server→client
+back-channels — **roots**, sampling, logging — are deprecated (SEP-2577, 12-month
+window) in favor of multi round-trip requests (MRTR: a tool returns
+`InputRequiredResult{input_requests, request_state}` and the client retries with
+`input_responses`). The Python SDK's v2.0.0 implements the revision with a breaking
+API: constructor-callback handler registration, snake_case wire-model fields, the
+in-memory test client (`mcp.Client`), and no automatic wrapping of tool results.
+
+gda-mcp (ADR-0011/0012/0013/0014) was pinned to `mcp>=1.12,<2` and used two things
+the revision deprecates: the `roots/list` back-channel (ADR-0014 precedence level 2)
+and its `roots/list_changed` invalidation (#209). Staying pinned means riding a
+deprecated protocol generation to its removal; migrating naively means breaking one
+era or the other — every surveyed agent (Claude Code, Codex, Cursor, Claude Desktop)
+still speaks the pre-2026 protocol over stdio, while new clients will arrive
+stateless.
+
+## Decision
+
+**gda-mcp adopts MCP SDK v2 (`mcp>=2,<3`) and serves both protocol eras from the one
+low-level stdio `Server`.** Pre-2026 clients complete the legacy `initialize`
+handshake and keep today's behavior bit-for-bit; 2026-07-28 clients are served the
+stateless path by the same binary. Both eras are a permanent automated gate (the
+real console script driven under `mode="legacy"` **and** `mode="auto"`), not a
+compatibility claim. Concretely:
+
+- **Stay on the low-level `Server`.** The ADR-0012 rationale is unchanged by v2:
+  our schemas come *from* gda, tools are discovered at runtime and served by one
+  generic dispatcher, and the result/error channels need direct control — v2 keeps
+  the low-level API first-class (constructor callbacks), so the generated-surface
+  design ports mechanically.
+- **Roots is acquired by capability, not by era.** ADR-0014's precedence is
+  untouched (`GDA_PROJECT` strict → client roots → cwd); only level 2's acquisition
+  becomes connection-dependent: gda-mcp calls the deprecated-but-working
+  `list_roots()` **iff** `session.can_send_request` and the client advertises the
+  roots capability. A 2026-07-28 connection has no back-channel (`can_send_request`
+  is `False`), so the roots level is skipped silently — no `NoBackChannelError`, no
+  failed round trip — landing on env → cwd, exactly the setup every registration
+  recipe already pins. `GDA_PROJECT` is thereby promoted from "recommended" to
+  **the durable anchor**: it is the one resolution input that survives the roots
+  deprecation clock. The `roots/list_changed` invalidation (#209) stays registered
+  and is legacy-only by nature (modern connections never deliver it).
+- **The SDK's deprecation warnings are suppressed at exactly two sites** — the
+  `Server(...)` construction (registering `on_roots_list_changed` warns) and the
+  `list_roots()` call — because stderr is the agent-visible log channel of a stdio
+  server, and a per-session warning would read as noise in every agent's MCP log.
+  The suppression is commented with SEP-2577 and the 12-month window; when the SDK
+  actually removes the APIs, the fallback is already the code's other branch.
+- **The v1 success wrap is reproduced in-house.** v2 no longer auto-wraps a
+  handler's return: gda-mcp constructs `CallToolResult` itself — the success dict
+  as `structured_content` **plus** the indented-JSON `TextContent` block v1 used to
+  emit (clients that render `content` rather than `structured_content` would
+  otherwise silently lose every result). The SDK still validates
+  `structured_content` against the tool's `output_schema` on success, and — spike-
+  verified — an `is_error=True` result without `structured_content` bypasses that
+  validation entirely, so ADR-0011's verbatim-envelope error relay is untouched.
+
+## Considered and rejected
+
+- **Drop roots now (env → cwd only).** Where the deprecation clock ends anyway, but
+  doing it inside the migration turns a dependency bump into a user-visible
+  regression for the one agent whose recipe ships an empty `env` and relies on
+  roots auto-detection. Behavior preservation is the point of the migration slice;
+  roots retirement happens by attrition when the SDK removes `list_roots()`.
+- **MRTR `ListRootsRequest` now.** The revision's sanctioned roots replacement —
+  but it turns the first tool call of a modern session into an `input_required`
+  interstitial that *fails* on clients without a roots callback (today's silent
+  fall-through is strictly better), it models "fetch ambient workspace config" as
+  a user-facing prompt, and no real agent can exercise it yet, so it would ship
+  verified only against the SDK's own client. **Deferred with a trigger**: revisit
+  when a real agent ships a 2026-07-28 client whose users cannot pin
+  `GDA_PROJECT`. If it lands, gate it on the client advertising roots and cap it at
+  one MRTR round per connection (an unanswerable retry marks roots permanently
+  unavailable and falls to cwd).
+- **Per-request MRTR, no caching.** Doubles round trips on every call and discards
+  ADR-0014's snapshot-then-cache contract for zero gain.
+- **A `project` tool argument.** The spec's own suggested replacement for roots —
+  and still rejected: ADR-0014 keeps the project out of the tool surface so it
+  stays a faithful `--schema` mirror (ADR-0012).
+- **A `gda_use_project` meta-tool.** Real multi-project support without touching
+  any mirrored tool's schema — but it hand-writes a tool into a deliberately
+  generated surface and is *stateful*, precisely what the 2026-07-28 revision moves
+  away from (it cannot work behind a load balancer).
+- **Streamable-HTTP transport.** The revision makes stateless HTTP trivially
+  load-balanceable, but for gda-mcp an HTTP listener is a **trust-boundary
+  change**, not a transport flag: nearly every gda command executes target-project
+  code (ADR-0009), so anyone who can reach the socket gets code execution on the
+  host, and ADR-0013 fixes the launch contract as a stdio console script. If ever
+  wanted it needs its own PRD and an ADR extending ADR-0009 / amending ADR-0013
+  (auth story, loopback-only default bind, per-connection project resolution).
+
+## Consequences
+
+- The `mcp` pin moves to `>=2,<3` everywhere it appears (the `[mcp]` extra, the
+  `dev` group, and the `assets-live` group — one `uv.lock`), which also migrates
+  the second in-repo SDK consumer, panda-adventure's asset-gen MCP channel
+  (`FastMCP` → `MCPServer`, `ClientSession` → `Client`, `McpError` → `MCPError`,
+  `timedelta` timeout → float seconds).
+- The fast tier drives the server through `mcp.Client` in-memory
+  (`raise_exceptions=True`, so server crashes surface instead of the SDK's
+  sanitized internal-error reply); the stdio e2e gate is parameterized over both
+  eras; a degrade test pins "stateless connection + no pin → projectless success".
+- SDK v2 validates structured content on **every** call (v1 skipped it when the
+  tool definition wasn't cached), so canned test results must conform to the real
+  output schemas — a test-tier tightening, not a behavior change.
+- Cache hints on `tools/list` (`ttlMs`/`cacheScope`, new in the revision) are a
+  natural follow-up for the process-immutable generated surface; they only reach
+  2026-07-28 clients and are tracked separately (#602).

--- a/docs/adr/0039-gda-mcp-sdk-v2-dual-era-stdio-server.md
+++ b/docs/adr/0039-gda-mcp-sdk-v2-dual-era-stdio-server.md
@@ -57,12 +57,16 @@ compatibility claim. Concretely:
   handler's return: gda-mcp constructs `CallToolResult` itself — the success dict
   as `structured_content` **plus** the indented-JSON `TextContent` block v1 used to
   emit (clients that render `content` rather than `structured_content` would
-  otherwise silently lose every result). The SDK still validates
-  `structured_content` against the tool's `output_schema` on success, and — spike-
-  verified — an `is_error=True` result without `structured_content` bypasses that
-  validation entirely, so ADR-0011's verbatim-envelope error relay is untouched.
+  otherwise silently lose every result). Output-schema validation **moved sides**
+  in v2 — v1 validated on the server (downgrading a non-conforming success to a
+  structured error result); v2 validates on the SDK *client* only, so a non-SDK
+  client sees results unvalidated. Accepted: gda-mcp's conformance is by
+  construction (result and `output_schema` share one Pydantic model), so the
+  check was redundant on this server. Spike-verified either way: an
+  `is_error=True` result without `structured_content` bypasses the validation
+  entirely, so ADR-0011's verbatim-envelope error relay is untouched.
 
-## Considered and rejected
+## Considered options
 
 - **Drop roots now (env → cwd only).** Where the deprecation clock ends anyway, but
   doing it inside the migration turns a dependency bump into a user-visible

--- a/docs/gda-mcp-registration.md
+++ b/docs/gda-mcp-registration.md
@@ -50,6 +50,11 @@ it is not a valid project, `gda` reports a typed error rather than silently fall
 or cwd. **Recommended: register at project scope, or pin `GDA_PROJECT`.** Each recipe below shows the
 right way to pin the project for that agent.
 
+Heads-up: the MCP **2026-07-28** spec revision deprecates the roots capability. Clients on the
+pre-2026 protocol (all of the agents below today) keep the `roots/list` auto-detection unchanged;
+a client on the new stateless protocol advertises no roots and resolves by `GDA_PROJECT` → cwd —
+one more reason a pinned `GDA_PROJECT` is the durable setup.
+
 ## Two cross-cutting constraints
 
 ### Minimal PATH on GUI-launched agents

--- a/docs/gda-mcp-registration.md
+++ b/docs/gda-mcp-registration.md
@@ -50,10 +50,10 @@ it is not a valid project, `gda` reports a typed error rather than silently fall
 or cwd. **Recommended: register at project scope, or pin `GDA_PROJECT`.** Each recipe below shows the
 right way to pin the project for that agent.
 
-Heads-up: the MCP **2026-07-28** spec revision deprecates the roots capability. Clients on the
-pre-2026 protocol (all of the agents below today) keep the `roots/list` auto-detection unchanged;
-a client on the new stateless protocol advertises no roots and resolves by `GDA_PROJECT` → cwd —
-one more reason a pinned `GDA_PROJECT` is the durable setup.
+Heads-up: the MCP **2026-07-28** spec revision deprecates the roots capability (ADR-0014). Clients
+on the pre-2026 protocol (all of the agents below today) keep the `roots/list` auto-detection
+unchanged; a client on the new stateless protocol advertises no roots and resolves by
+`GDA_PROJECT` → cwd — one more reason a pinned `GDA_PROJECT` is the durable setup.
 
 ## Two cross-cutting constraints
 

--- a/examples/platformer/panda-adventure/scripts/mcp/gemini_img_gen.py
+++ b/examples/platformer/panda-adventure/scripts/mcp/gemini_img_gen.py
@@ -20,10 +20,10 @@ from typing import Annotated
 
 from google import genai
 from google.genai import types
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 from pydantic import Field
 
-mcp = FastMCP("gemini-nano-banana")
+mcp = MCPServer("gemini-nano-banana")
 
 _client: genai.Client | None = None
 

--- a/examples/platformer/panda-adventure/tests/_mcp_hang_server.py
+++ b/examples/platformer/panda-adventure/tests/_mcp_hang_server.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 import time
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
-mcp = FastMCP("hang")
+mcp = MCPServer("hang")
 
 
 @mcp.tool()

--- a/examples/platformer/panda-adventure/tools/assets/backends.py
+++ b/examples/platformer/panda-adventure/tools/assets/backends.py
@@ -143,7 +143,10 @@ class McpBackend:
         # ExceptionGroup instead of our clear error.
         result = None
         error: MCPError | None = None
-        async with Client(stdio_client(params)) as client:
+        # mode="legacy" keeps the pre-migration handshake (the v1 client spoke
+        # `initialize`) and skips the default auto-mode discover probe — one
+        # fewer round trip per acquire, identical behavior for any channel server.
+        async with Client(stdio_client(params), mode="legacy") as client:
             try:
                 result = await client.call_tool(
                     self._tool,

--- a/examples/platformer/panda-adventure/tools/assets/backends.py
+++ b/examples/platformer/panda-adventure/tools/assets/backends.py
@@ -122,11 +122,9 @@ class McpBackend:
     async def _call(self, prompt: str, out_path: Path) -> str:
         # Lazy import: the live-only group carries `mcp`; CI never installs it, so
         # importing this module must not need it.
-        from datetime import timedelta
-
-        from mcp import ClientSession, StdioServerParameters
+        from mcp import Client, StdioServerParameters
         from mcp.client.stdio import stdio_client
-        from mcp.shared.exceptions import McpError
+        from mcp.shared.exceptions import MCPError
 
         params = StdioServerParameters(
             command=self._command[0],
@@ -140,22 +138,20 @@ class McpBackend:
         }
         # Bound the call with mcp's native per-request read timeout, so a hung
         # image-gen call cannot hang an on-demand acquire forever. Capture the
-        # McpError and raise AFTER the contexts exit cleanly — raising THROUGH the
+        # MCPError and raise AFTER the context exits cleanly — raising THROUGH the
         # anyio-backed `async with` teardown would surface a task-group
         # ExceptionGroup instead of our clear error.
         result = None
-        error: McpError | None = None
-        async with stdio_client(params) as (read, write):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                try:
-                    result = await session.call_tool(
-                        self._tool,
-                        arguments,
-                        read_timeout_seconds=timedelta(seconds=self._timeout),
-                    )
-                except McpError as exc:
-                    error = exc
+        error: MCPError | None = None
+        async with Client(stdio_client(params)) as client:
+            try:
+                result = await client.call_tool(
+                    self._tool,
+                    arguments,
+                    read_timeout_seconds=self._timeout,
+                )
+            except MCPError as exc:
+                error = exc
         if error is not None:
             raise GenerationError(
                 f"MCP channel {self._channel!r} call to {self._tool!r} failed or "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,11 @@ Changelog = "https://github.com/aigengame/godot-agent/blob/main/CHANGELOG.md"
 [project.optional-dependencies]
 # The MCP adapter (gda-mcp) ships inside this one distribution, gated behind an
 # optional extra so a plain `gda` install stays lean — only `gda[mcp]` pulls the
-# MCP SDK (ADR-0013). Pinned to the v1 low-level Server API (decorator handlers,
-# camelCase Tool/CallToolResult fields) that gda-mcp targets; <2 fences off the
-# different v2 constructor API.
+# MCP SDK (ADR-0013). Pinned to the v2 low-level Server API (constructor-callback
+# handlers, snake_case Tool/CallToolResult fields, 2026-07-28 dual-era protocol)
+# that gda-mcp targets (ADR-0039); <3 fences off the next major's API break.
 mcp = [
-    "mcp>=1.12,<2",
+    "mcp>=2,<3",
 ]
 
 [project.scripts]
@@ -56,7 +56,7 @@ dev = [
     "pytest>=9.0.3",
     # The MCP SDK is also a dev dependency (not just the `[mcp]` extra) so
     # `uv run pytest` has it for the gda-mcp fast/e2e tiers (ADR-0013).
-    "mcp>=1.12,<2",
+    "mcp>=2,<3",
     # The example game's asset pipeline postprocess stage (gADR-0014, panda-
     # adventure): Pillow conforms acquired images to the pixel-art regime and the
     # Scale spec size. A dev dependency (not a live-only one) because those
@@ -77,7 +77,7 @@ dev = [
 # and the acquire tests that need it carry the `acquire_live` marker. The backend
 # modules lazy-import these, so CI collection stays green without the group.
 assets-live = [
-    "mcp>=1.12,<2",
+    "mcp>=2,<3",
     "google-genai>=1.0",
 ]
 

--- a/src/gda/mcp/runner.py
+++ b/src/gda/mcp/runner.py
@@ -118,7 +118,7 @@ class SubprocessGdaRunner:
             # override pointing at a missing / non-executable path. Mirror gda's
             # own runner (gda.runner.launch): never let the OSError escape;
             # synthesize a non-zero raw result so the layer above turns it into a
-            # structured ``isError`` (ADR-0011's "can't-run" edge, synthesized by
+            # structured ``is_error`` (ADR-0011's "can't-run" edge, synthesized by
             # gda-mcp) rather than a traceback crossing the MCP boundary.
             return GdaResult(
                 stdout="",

--- a/src/gda/mcp/server.py
+++ b/src/gda/mcp/server.py
@@ -12,10 +12,12 @@ stdin; ADR-0015), and maps the result mechanically off gda's exit code
 - **exit 0** → the ``--json`` result dict, wrapped by :func:`_success_result`
   into ``structured_content`` plus a JSON ``TextContent`` block (SDK v2 removed
   v1's auto-wrap, so gda-mcp reproduces it — clients that render ``content``
-  keep seeing output). The SDK still validates ``structured_content`` against
-  the tool's ``output_schema`` (Design decision 5 — gda-mcp does NOT
-  re-validate: gda's result and its ``output_schema`` share one Pydantic model,
-  so conformance is by construction);
+  keep seeing output). SDK v2 validates ``structured_content`` against the
+  tool's ``output_schema`` on the **client** side only (v1's server-side check
+  is gone; a non-SDK client sees the result unvalidated — ADR-0039). gda-mcp
+  does NOT re-validate either way (Design decision 5): gda's result and its
+  ``output_schema`` share one Pydantic model, so conformance is by
+  construction;
 - **exit ≠ 0** → ``CallToolResult(is_error=True)`` carrying the full ``GdaError``
   envelope *verbatim* as JSON content — lossless, never flattened to prose, and
   kept out of ``structured_content`` / ``output_schema`` (an error result
@@ -158,8 +160,9 @@ def dispatch(
 
     Returns the full :class:`~mcp.types.CallToolResult` for success and failure
     alike (SDK v2 has no auto-wrap to lean on). Never raises for a gda failure:
-    the SDK flattens an exception to a prose ``is_error`` string, which would
-    lose the structured envelope, so failures are *returned* instead.
+    an exception escaping the handler becomes a JSON-RPC protocol error on the
+    client (``MCPError``, not a tool result at all), which would lose the
+    structured envelope entirely, so failures are *returned* instead.
     """
     params_json = json.dumps(arguments)
     # Verbatim passthrough (ADR-0015): the input object goes to gda on stdin via
@@ -220,10 +223,15 @@ async def _session_root_dirs(session) -> list[str]:
     try:
         # Deprecated as of 2026-07-28 (SEP-2577, 12-month window) but the only
         # roots channel legacy clients have; suppressed because stderr is the
-        # agent-visible log stream for a stdio server (ADR-0039).
+        # agent-visible log stream for a stdio server (ADR-0039). The deprecated
+        # wrapper warns synchronously at call time, so the filter block closes
+        # BEFORE the await: warnings filters are process-global state, and a
+        # block spanning a suspension could interleave with a concurrent
+        # request's save/restore and leak the filter.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", MCPDeprecationWarning)
-            result = await session.list_roots()
+            pending = session.list_roots()
+        result = await pending
     except Exception:
         return []
     # A Root.uri is a file:// URI; recover the local path (percent-decoded).

--- a/src/gda/mcp/server.py
+++ b/src/gda/mcp/server.py
@@ -1,26 +1,36 @@
-"""The gda-mcp low-level stdio Server (ADR-0011/0012/0013, issue #193).
+"""The gda-mcp low-level stdio Server (ADR-0011/0012/0013/0039, issue #193).
 
 A *generated* server: at startup it introspects gda's aggregate schema dump
 (``gda schema``) and registers one MCP tool per command — name
-``<group>_<command>``, ``description`` ← the command's help, ``inputSchema`` /
-``outputSchema`` ← the command's input/output schemas (ADR-0012's faithful
+``<group>_<command>``, ``description`` ← the command's help, ``input_schema`` /
+``output_schema`` ← the command's input/output schemas (ADR-0012's faithful
 mirror). On a tool call it shells out to the installed gda, forwarding the tool
 input *verbatim* via ``gda <group> <command> --params-json -`` (the object on
 stdin; ADR-0015), and maps the result mechanically off gda's exit code
 (ADR-0011):
 
-- **exit 0** → the ``--json`` result dict; the SDK validates it against the
-  tool's ``outputSchema`` and wraps it as ``structuredContent`` (Design
-  decision 5 — gda-mcp does NOT re-validate: gda's result and its ``outputSchema``
-  share one Pydantic model, so conformance is by construction);
-- **exit ≠ 0** → ``CallToolResult(isError=True)`` carrying the full ``GdaError``
+- **exit 0** → the ``--json`` result dict, wrapped by :func:`_success_result`
+  into ``structured_content`` plus a JSON ``TextContent`` block (SDK v2 removed
+  v1's auto-wrap, so gda-mcp reproduces it — clients that render ``content``
+  keep seeing output). The SDK still validates ``structured_content`` against
+  the tool's ``output_schema`` (Design decision 5 — gda-mcp does NOT
+  re-validate: gda's result and its ``output_schema`` share one Pydantic model,
+  so conformance is by construction);
+- **exit ≠ 0** → ``CallToolResult(is_error=True)`` carrying the full ``GdaError``
   envelope *verbatim* as JSON content — lossless, never flattened to prose, and
-  kept out of ``structuredContent`` / ``outputSchema``.
+  kept out of ``structured_content`` / ``output_schema`` (an error result
+  without ``structured_content`` bypasses the SDK's output validation).
 
-Why the low-level ``Server`` and not FastMCP: our schemas come *from* gda (not
-from Python signatures), tools are discovered at runtime and served by one
-generic dispatcher, and we need direct control of the result/error channels —
-the inverse of FastMCP's "one tool = one decorated Python function" assumption.
+One server serves **both protocol eras** (ADR-0039): pre-2026 clients complete
+the legacy ``initialize`` handshake and keep the roots back-channel; 2026-07-28
+clients get the stateless request/response path, where project resolution
+degrades to env → cwd (see :func:`_session_root_dirs`).
+
+Why the low-level ``Server`` and not MCPServer (né FastMCP): our schemas come
+*from* gda (not from Python signatures), tools are discovered at runtime and
+served by one generic dispatcher, and we need direct control of the
+result/error channels — the inverse of MCPServer's "one tool = one decorated
+Python function" assumption.
 
 gda-mcp consumes only gda's public CLI ABI (``--json`` / exit code / ``GdaError``
 envelope); it never imports a gda internal symbol.
@@ -28,6 +38,7 @@ envelope); it never imports a gda internal symbol.
 
 import json
 import os
+import warnings
 from importlib.metadata import version
 from pathlib import Path
 from typing import Any, Optional
@@ -35,8 +46,8 @@ from urllib.parse import unquote, urlparse
 
 import mcp.server.stdio
 import mcp.types as types
-from mcp.server.lowlevel import NotificationOptions, Server
-from mcp.server.models import InitializationOptions
+from mcp.server import Server, ServerRequestContext
+from mcp.shared.exceptions import MCPDeprecationWarning
 
 from gda.mcp.project_context import resolve_project_dir
 from gda.mcp.runner import GdaResult, GdaRunner, SubprocessGdaRunner
@@ -98,8 +109,24 @@ def _parse_error_envelope(stdout: str) -> Optional[dict[str, Any]]:
     return payload
 
 
+def _success_result(payload: dict[str, Any]) -> types.CallToolResult:
+    """Wrap gda's success dict the way SDK v1 used to (ADR-0011, ADR-0039).
+
+    v1's ``call_tool`` decorator auto-wrapped a returned dict into
+    ``structuredContent`` plus an indented-JSON ``TextContent`` block; v2 removed
+    the auto-wrap, so gda-mcp reproduces it verbatim (``indent=2`` included) —
+    dropping the ``content`` block would silently blank the result in every
+    client that renders ``content`` rather than ``structured_content``.
+    """
+    return types.CallToolResult(
+        content=[types.TextContent(type="text", text=json.dumps(payload, indent=2))],
+        structured_content=payload,
+        is_error=False,
+    )
+
+
 def _synthesized_error(message: str, result: GdaResult) -> types.CallToolResult:
-    """gda-mcp's own ``isError`` result when gda produced no usable envelope.
+    """gda-mcp's own ``is_error`` result when gda produced no usable envelope.
 
     The edge of ADR-0011: gda failed to even run (e.g. ``-m gda`` import failure)
     or emitted non-envelope output. gda-mcp synthesizes a structured error in the
@@ -117,7 +144,7 @@ def _synthesized_error(message: str, result: GdaResult) -> types.CallToolResult:
     }
     return types.CallToolResult(
         content=[types.TextContent(type="text", text=json.dumps(body))],
-        isError=True,
+        is_error=True,
     )
 
 
@@ -126,15 +153,13 @@ def dispatch(
     argv: list[str],
     arguments: dict[str, Any],
     project: Optional[Path] = None,
-) -> dict[str, Any] | types.CallToolResult:
+) -> types.CallToolResult:
     """Forward one MCP tool call to gda and map the outcome (ADR-0011/0015).
 
-    Returns the success result *dict* (the SDK validates it against the tool's
-    ``outputSchema`` and wraps it as ``structuredContent``) or a
-    :class:`~mcp.types.CallToolResult` for a failure. Never raises for a gda
-    failure: the low-level SDK flattens an exception to a prose ``isError``
-    string, which would lose the structured envelope, so failures are *returned*
-    as a ``CallToolResult`` instead.
+    Returns the full :class:`~mcp.types.CallToolResult` for success and failure
+    alike (SDK v2 has no auto-wrap to lean on). Never raises for a gda failure:
+    the SDK flattens an exception to a prose ``is_error`` string, which would
+    lose the structured envelope, so failures are *returned* instead.
     """
     params_json = json.dumps(arguments)
     # Verbatim passthrough (ADR-0015): the input object goes to gda on stdin via
@@ -147,7 +172,7 @@ def dispatch(
 
     if result.returncode == 0:
         try:
-            return json.loads(result.stdout)
+            return _success_result(json.loads(result.stdout))
         except json.JSONDecodeError:
             # exit 0 but non-JSON stdout: gda could not have honored ``--json``.
             # Treat as the can't-run / non-envelope edge rather than crash.
@@ -165,28 +190,40 @@ def dispatch(
         )
     # Relay gda's envelope verbatim and losslessly (ADR-0011): the exact JSON gda
     # emitted, carrying {category, code, message, diagnostics}, kept out of
-    # structuredContent / outputSchema.
+    # structured_content / output_schema.
     return types.CallToolResult(
         content=[types.TextContent(type="text", text=result.stdout.strip())],
-        isError=True,
+        is_error=True,
     )
 
 
 async def _session_root_dirs(session) -> list[str]:
     """The client's advertised roots as local dir paths (ADR-0014 precedence 2).
 
-    A server->client ``roots/list`` request, so it needs a live session and is
-    issued lazily (see :class:`_ProjectResolver`). Best-effort: skip clients that
-    do not declare the roots capability, and degrade any failure to *no roots*
-    (gda's own cwd resolution then applies) rather than breaking dispatch — roots
-    is one optional precedence level, never a hard dependency.
+    A server->client ``roots/list`` back-channel request, so it needs a
+    connection that *has* a back-channel: the ``can_send_request`` guard skips
+    2026-07-28 stateless connections outright (SEP-2577 retired the roots
+    capability there; without the guard the call would raise
+    ``NoBackChannelError`` on every first tool call). Legacy connections — every
+    surveyed agent today — keep exactly the pre-migration behavior. Best-effort
+    beyond that: skip clients that do not declare the roots capability, and
+    degrade any failure to *no roots* (gda's own cwd resolution then applies)
+    rather than breaking dispatch — roots is one optional precedence level,
+    never a hard dependency.
     """
+    if not session.can_send_request:
+        return []
     if not session.check_client_capability(
         types.ClientCapabilities(roots=types.RootsCapability())
     ):
         return []
     try:
-        result = await session.list_roots()
+        # Deprecated as of 2026-07-28 (SEP-2577, 12-month window) but the only
+        # roots channel legacy clients have; suppressed because stderr is the
+        # agent-visible log stream for a stdio server (ADR-0039).
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", MCPDeprecationWarning)
+            result = await session.list_roots()
     except Exception:
         return []
     # A Root.uri is a file:// URI; recover the local path (percent-decoded).
@@ -241,8 +278,8 @@ def build_server(runner: GdaRunner) -> Server:
         types.Tool(
             name=tool_name(entry["name"]),
             description=entry["description"],
-            inputSchema=entry["input"],
-            outputSchema=entry["output"],
+            input_schema=entry["input"],
+            output_schema=entry["output"],
         )
         for entry in commands
     ]
@@ -254,43 +291,56 @@ def build_server(runner: GdaRunner) -> Server:
         tool_name(entry["name"]): entry["name"].split(" ") for entry in commands
     }
 
-    server: Server = Server(SERVER_NAME)
+    async def _list_tools(
+        ctx: ServerRequestContext, params: Optional[types.PaginatedRequestParams]
+    ) -> types.ListToolsResult:
+        return types.ListToolsResult(tools=tools)
 
-    # A client roots/list_changed means the active project may have moved (#209):
-    # invalidate the cache so the next tool call re-runs the ADR-0014 precedence
-    # against the now-current roots. We only invalidate here, never resolve — a
-    # notification handler runs outside any request context, so there is no live
-    # request_context/session for the roots/list back-request; lazy re-resolution
-    # in call_tool keeps resolve_project_dir the single source of precedence
-    # (so a pinned GDA_PROJECT, read first there, still wins).
-    async def _on_roots_list_changed(_n: types.RootsListChangedNotification) -> None:
-        resolver.invalidate()
-
-    server.notification_handlers[types.RootsListChangedNotification] = (
-        _on_roots_list_changed
-    )
-
-    @server.list_tools()
-    async def list_tools() -> list[types.Tool]:
-        return tools
-
-    # validate_input=False: gda owns input validation (ADR-0015 — gda-mcp forwards
+    # No input validation happens SDK-side (v2 dropped v1's opt-out jsonschema
+    # check entirely): gda owns input validation (ADR-0015 — gda-mcp forwards
     # verbatim and gda's params model validates), so invalid params surface as
-    # gda's structured ``invalid_params`` envelope, not the SDK's prose error.
-    @server.call_tool(validate_input=False)
-    async def call_tool(name: str, arguments: dict[str, Any]):
-        argv = argv_by_tool.get(name)
+    # gda's structured ``invalid_params`` envelope, not an SDK prose error.
+    async def _call_tool(
+        ctx: ServerRequestContext, params: types.CallToolRequestParams
+    ) -> types.CallToolResult:
+        argv = argv_by_tool.get(params.name)
         if argv is None:
             # The SDK only routes registered tool names here; this is defensive.
             return types.CallToolResult(
                 content=[
-                    types.TextContent(type="text", text=f"unknown tool: {name!r}")
+                    types.TextContent(
+                        type="text", text=f"unknown tool: {params.name!r}"
+                    )
                 ],
-                isError=True,
+                is_error=True,
             )
-        project = await resolver.resolve(server.request_context.session)
-        return dispatch(runner, argv, arguments or {}, project)
+        project = await resolver.resolve(ctx.session)
+        return dispatch(runner, argv, params.arguments or {}, project)
 
+    # A client roots/list_changed means the active project may have moved (#209):
+    # invalidate the cache so the next tool call re-runs the ADR-0014 precedence
+    # against the now-current roots. We only invalidate here, never resolve —
+    # lazy re-resolution in _call_tool keeps resolve_project_dir the single
+    # source of precedence (so a pinned GDA_PROJECT, read first there, still
+    # wins) and cannot race an in-flight call. Legacy-only by nature: 2026-07-28
+    # connections never deliver the notification (SEP-2577).
+    async def _on_roots_list_changed(
+        ctx: ServerRequestContext, params: Optional[types.NotificationParams]
+    ) -> None:
+        resolver.invalidate()
+
+    # Registering on_roots_list_changed warns at construction time (the roots
+    # capability is deprecated, SEP-2577); suppressed for the same stderr-is-log
+    # reason as the list_roots call above (ADR-0039).
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", MCPDeprecationWarning)
+        server = Server(
+            SERVER_NAME,
+            version=version("gda"),
+            on_list_tools=_list_tools,
+            on_call_tool=_call_tool,
+            on_roots_list_changed=_on_roots_list_changed,
+        )
     return server
 
 
@@ -300,7 +350,8 @@ def run_stdio() -> None:
     Builds the server once (introspecting the dump — ADR-0012's single startup
     ``gda`` subprocess) and serves it over the stdio transport every surveyed
     agent registers (``command`` + ``args``). gda and gda-mcp share one version
-    (ADR-0008), so the advertised ``server_version`` is gda's.
+    (ADR-0008), so the ``version`` advertised at construction is gda's; one run
+    loop serves both protocol eras (ADR-0039).
     """
     import anyio
 
@@ -311,14 +362,7 @@ def run_stdio() -> None:
             await server.run(
                 read_stream,
                 write_stream,
-                InitializationOptions(
-                    server_name=SERVER_NAME,
-                    server_version=version("gda"),
-                    capabilities=server.get_capabilities(
-                        notification_options=NotificationOptions(),
-                        experimental_capabilities={},
-                    ),
-                ),
+                server.create_initialization_options(),
             )
 
     anyio.run(_serve)

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -157,11 +157,11 @@ class CommandSchema(BaseModel):
     failure-envelope schema, identical for every command, produced from the one
     shared :class:`GdaErrorEnvelope` model — zero per-command maintenance (#43).
 
-    ``gda-mcp`` later maps ``input`` → ``inputSchema`` and ``output`` →
-    ``outputSchema`` (success / structuredContent) mechanically. The ``error``
-    half is kept OUT of ``output``: a non-zero-exit failure maps to MCP's
-    separate ``isError`` channel, so the future adapter must not fold ``error``
-    into ``outputSchema``.
+    ``gda-mcp`` later maps ``input`` → ``input_schema`` and ``output`` →
+    ``output_schema`` (success / ``structured_content``) mechanically. The
+    ``error`` half is kept OUT of ``output``: a non-zero-exit failure maps to
+    MCP's separate ``is_error`` channel, so the adapter must not fold ``error``
+    into ``output_schema``.
 
     ``kind`` carries the command's static execution channel as the typed
     :class:`~gda.execution.ExecutionKind` (serialized as the lowercase value

--- a/tests/mcp_support.py
+++ b/tests/mcp_support.py
@@ -14,11 +14,13 @@ The fast tiers drive the surface from the **real** aggregate dump
 true mirror of the live ``gda`` surface, not a hand-stubbed subset.
 """
 
+import warnings
 from pathlib import Path
 from typing import Callable, Optional
 
 import anyio
 from mcp.client.session import ListRootsFnT
+from mcp.shared.exceptions import MCPDeprecationWarning
 from mcp.types import CallToolResult, TextContent
 from pydantic import FileUrl
 
@@ -100,25 +102,37 @@ def tool_text(result: CallToolResult, index: int = 0) -> str:
     return block.text
 
 
-def list_tools(server):
-    """Open an in-memory MCP session and return the server's ``list_tools`` result."""
-    from mcp.shared.memory import create_connected_server_and_client_session as connect
+def list_tools(server, *, mode: str = "legacy"):
+    """Open an in-memory MCP connection and return the server's ``list_tools`` result."""
+    from mcp import Client
 
     async def _inner():
-        async with connect(server) as session:
-            return await session.list_tools()
+        async with Client(server, mode=mode, raise_exceptions=True) as client:
+            return await client.list_tools()
 
     return anyio.run(_inner)
 
 
-def call_tool(server, name: str, arguments: dict, *, roots: Optional[list[str]] = None):
-    """Open an in-memory MCP session, call one tool, return its ``CallToolResult``.
+def call_tool(
+    server,
+    name: str,
+    arguments: dict,
+    *,
+    roots: Optional[list[str]] = None,
+    mode: str = "legacy",
+):
+    """Open an in-memory MCP connection, call one tool, return its ``CallToolResult``.
 
     When ``roots`` is given the in-memory client advertises them (as ``file://``
     URIs) and answers the server's ``roots/list`` request with them, so the
     server's project-context resolution (ADR-0014 precedence 2) can be exercised.
+    ``mode`` pins the protocol era: ``"legacy"`` (the default — the pre-2026
+    handshake every surveyed agent speaks today, with a roots back-channel) or
+    ``"auto"`` (the 2026-07-28 stateless path, no back-channel — ADR-0039's
+    degrade tier). ``raise_exceptions=True`` surfaces unexpected server crashes
+    in the fast tier instead of the SDK's sanitized internal-error reply.
     """
-    from mcp.shared.memory import create_connected_server_and_client_session as connect
+    from mcp import Client
 
     list_roots_callback: ListRootsFnT | None = None
     if roots is not None:
@@ -133,8 +147,13 @@ def call_tool(server, name: str, arguments: dict, *, roots: Optional[list[str]] 
         list_roots_callback = _list_roots
 
     async def _inner():
-        async with connect(server, list_roots_callback=list_roots_callback) as session:
-            return await session.call_tool(name, arguments)
+        async with Client(
+            server,
+            mode=mode,
+            list_roots_callback=list_roots_callback,
+            raise_exceptions=True,
+        ) as client:
+            return await client.call_tool(name, arguments)
 
     return anyio.run(_inner)
 
@@ -154,9 +173,12 @@ def roots_changed_call(
     mutable holder, so the server's first resolve sees ``roots_before`` and the
     post-notification re-resolve sees ``roots_after`` — exercising dynamic
     re-resolution that the single-shot :func:`call_tool` (roots fixed at connect,
-    one call) structurally cannot.
+    one call) structurally cannot. Legacy-era by construction: the notification
+    only exists on back-channel connections (SEP-2577), so the client-side send
+    is deprecated too — suppressed here for the same reason the server suppresses
+    its ``list_roots`` warning.
     """
-    from mcp.shared.memory import create_connected_server_and_client_session as connect
+    from mcp import Client
     from mcp.types import ListRootsResult, Root
 
     holder = {"roots": roots_before}
@@ -170,11 +192,18 @@ def roots_changed_call(
     list_roots_callback: ListRootsFnT = _list_roots
 
     async def _inner():
-        async with connect(server, list_roots_callback=list_roots_callback) as session:
-            r1 = await session.call_tool(name, arguments)
+        async with Client(
+            server,
+            mode="legacy",
+            list_roots_callback=list_roots_callback,
+            raise_exceptions=True,
+        ) as client:
+            r1 = await client.call_tool(name, arguments)
             holder["roots"] = roots_after
-            await session.send_roots_list_changed()
-            r2 = await session.call_tool(name, arguments)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", MCPDeprecationWarning)
+                await client.send_roots_list_changed()
+            r2 = await client.call_tool(name, arguments)
             return r1, r2
 
     return anyio.run(_inner)

--- a/tests/test_e2e_mcp_live.py
+++ b/tests/test_e2e_mcp_live.py
@@ -6,18 +6,18 @@ gda-mcp ``Server`` → the real ``gda`` subprocess seam → ``gda-daemon`` → a
 ``SceneTree``. It proves a live command auto-exposes and *routes* as a tool with
 NO live-specific code in gda-mcp (ADR-0011): the same generic ``--params-json``
 dispatch + exit-code map that serves a headless tool carries the live one, so on
-success the SDK validates and wraps gda's result as ``structuredContent`` and on
-failure gda's full ``GdaError`` envelope crosses verbatim as ``isError`` content.
+success the SDK validates and wraps gda's result as ``structured_content`` and on
+failure gda's full ``GdaError`` envelope crosses verbatim as ``is_error`` content.
 
 Two routings:
 
 - **success** — ``daemon_start`` then ``game_tree`` over one MCP session: the
   daemon launches the session on demand, the live op returns the runtime tree,
-  and ``structuredContent.root.name == "Main"`` (the same proof as
+  and ``structured_content.root.name == "Main"`` (the same proof as
   ``test_e2e_daemon``, now driven through gda-mcp instead of the console script).
 - **failure** — ``game_tree`` with no daemon: gda's typed
   ``daemon_not_running`` / category ``live`` envelope reaches the client
-  losslessly as ``isError`` content, with ``structuredContent is None`` (the
+  losslessly as ``is_error`` content, with ``structured_content is None`` (the
   envelope is kept out of the success channel — ADR-0011).
 
 Godot is resolved by gda's OWN precedence (gda-mcp never hardcodes it); the
@@ -32,7 +32,7 @@ import os
 
 import anyio
 import pytest
-from mcp.shared.memory import create_connected_server_and_client_session as connect
+from mcp import Client
 
 from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
 from gda.mcp.project_context import GDA_PROJECT_ENV
@@ -78,13 +78,13 @@ def test_mcp_live_game_tree_routes_through_daemon_to_a_real_tree(
 ):
     # Success routing: the live `game tree` tool, dispatched by the SAME generic
     # gda-mcp path as a headless tool, returns the RUNNING game's runtime tree as
-    # validated structuredContent.
+    # validated structured_content.
     _scaffold_project(tmp_path)
     _pin_env(monkeypatch, tmp_path)
     server = build_server(SubprocessGdaRunner.default())
 
     async def _drive():
-        async with connect(server) as session:
+        async with Client(server, mode="legacy") as session:
             # Start the daemon over MCP; it installs the harness and stands ready
             # to launch an engine session on demand.
             started = await session.call_tool("daemon_start", {})
@@ -95,16 +95,16 @@ def test_mcp_live_game_tree_routes_through_daemon_to_a_real_tree(
         started, tree = anyio.run(_drive)
 
         # daemon_start succeeded through the generic dispatcher (exit 0 → result
-        # dict wrapped as structuredContent by the SDK).
-        assert started.isError is False, started.content
-        assert started.structuredContent is not None
-        assert started.structuredContent["installed_harness"] is True
+        # dict wrapped as structured_content by the SDK).
+        assert started.is_error is False, started.content
+        assert started.structured_content is not None
+        assert started.structured_content["installed_harness"] is True
 
         # The live op routed CLI → daemon → engine session and returned the live
         # runtime tree — exactly what a headless tool's success looks like.
-        assert tree.isError is False, tree.content
-        assert tree.structuredContent is not None
-        root = tree.structuredContent["root"]
+        assert tree.is_error is False, tree.content
+        assert tree.structured_content is not None
+        root = tree.structured_content["root"]
         assert root["name"] == "Main"
         assert root["type"] == "Node2D"
     finally:
@@ -116,24 +116,24 @@ def test_mcp_live_game_tree_relays_daemon_not_running_verbatim(
     tmp_path, daemon_runtime_dir, monkeypatch
 ):
     # Failure routing: with no daemon, gda's typed `daemon_not_running` / category
-    # `live` GdaError reaches the MCP client losslessly as isError content, and is
-    # kept OUT of structuredContent (ADR-0011) — the same error channel a headless
+    # `live` GdaError reaches the MCP client losslessly as is_error content, and is
+    # kept OUT of structured_content (ADR-0011) — the same error channel a headless
     # tool failure uses, carrying a live-category code.
     _scaffold_project(tmp_path)
     _pin_env(monkeypatch, tmp_path)
     server = build_server(SubprocessGdaRunner.default())
 
     async def _drive():
-        async with connect(server) as session:
+        async with Client(server, mode="legacy") as session:
             return await session.call_tool("game_tree", {})
 
     try:
         result = anyio.run(_drive)
 
-        assert result.isError is True, result.content
+        assert result.is_error is True, result.content
         # The success channel is empty: gda-mcp never puts a failure envelope into
-        # structuredContent / outputSchema.
-        assert result.structuredContent is None
+        # structured_content / output_schema.
+        assert result.structured_content is None
         # The full GdaError envelope crossed verbatim as text content.
         assert result.content, "expected the GdaError envelope as text content"
         payload = json.loads(tool_text(result))
@@ -159,7 +159,7 @@ async def _stop_daemon(server):
     # left running so e2e runs stay isolated. Tolerant of "no daemon" (the failure
     # test never starts one).
     try:
-        async with connect(server) as session:
+        async with Client(server, mode="legacy") as session:
             await session.call_tool("daemon_stop", {})
     except Exception:
         pass

--- a/tests/test_e2e_mcp_project_context.py
+++ b/tests/test_e2e_mcp_project_context.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import anyio
 import pytest
 from mcp.client.session import ListRootsFnT
-from mcp.shared.memory import create_connected_server_and_client_session as connect
+from mcp import Client
 from mcp.types import ListRootsResult, Root
 from pydantic import FileUrl
 
@@ -40,7 +40,9 @@ def _call_tool(server, name, arguments, *, roots=None):
         list_roots_callback = _list_roots
 
     async def _drive():
-        async with connect(server, list_roots_callback=list_roots_callback) as session:
+        async with Client(
+            server, mode="legacy", list_roots_callback=list_roots_callback
+        ) as session:
             return await session.call_tool(name, arguments)
 
     return anyio.run(_drive)
@@ -64,7 +66,7 @@ def test_roots_resolution_drives_real_tool_against_resolved_project(
         roots=[str(godot_project)],
     )
 
-    assert result.isError is False, result.content
+    assert result.is_error is False, result.content
     assert (godot_project / "from_roots.tscn").exists()
 
 
@@ -80,7 +82,7 @@ def test_gda_project_scoped_resolution_drives_real_tool(godot_project, monkeypat
         server, "scene_create", {"path": "res://pinned.tscn", "root_type": "Node2D"}
     )
 
-    assert result.isError is False, result.content
+    assert result.is_error is False, result.content
     assert (godot_project / "pinned.tscn").exists()
 
 
@@ -96,6 +98,6 @@ def test_meta_command_tolerates_a_pinned_project(godot_project, monkeypatch):
 
     result = _call_tool(server, "info", {}, roots=[str(godot_project)])
 
-    assert result.isError is False, result.content
-    assert result.structuredContent is not None
-    assert result.structuredContent["major"] == 4
+    assert result.is_error is False, result.content
+    assert result.structured_content is not None
+    assert result.structured_content["major"] == 4

--- a/tests/test_e2e_mcp_stdio.py
+++ b/tests/test_e2e_mcp_stdio.py
@@ -49,18 +49,23 @@ def _server_params() -> StdioServerParameters:
     return StdioServerParameters(command=str(gda_mcp), args=[], env=env)
 
 
-def _call(tool: str, arguments: dict, *, mode: str = "legacy"):
+def _call(tool: str, arguments: dict, *, mode: str, expected_protocol: str):
     """Spawn the real gda-mcp over stdio, call one tool, return its result.
 
     ``mode`` pins the protocol era (ADR-0039's dual-era gate): ``"legacy"`` is
     the pre-2026 ``initialize`` handshake every surveyed agent speaks today;
-    ``"auto"`` probes ``server/discover`` first — the 2026-07-28 stateless path.
-    Deliberately NOT ``raise_exceptions`` (a client-side flag): this gate must
-    see exactly what a real agent sees on the wire.
+    ``"2026-07-28"`` pins the stateless era outright — deliberately NOT
+    ``"auto"``, which falls back to the legacy handshake on a server that lost
+    modern support, so an auto-mode run could go green without ever proving the
+    modern path. The negotiated ``expected_protocol`` is asserted for the same
+    reason: era coverage must be able to FAIL, not just happen. Deliberately
+    NOT ``raise_exceptions`` (a client-side flag): this gate must see exactly
+    what a real agent sees on the wire.
     """
 
     async def _drive():
         async with Client(stdio_client(_server_params()), mode=mode) as client:
+            assert client.protocol_version == expected_protocol
             return await client.call_tool(tool, arguments)
 
     return anyio.run(_drive)
@@ -68,11 +73,16 @@ def _call(tool: str, arguments: dict, *, mode: str = "legacy"):
 
 # Both protocol eras run the SAME assertions: backward compat ("no agent alive
 # today breaks") and forward compat (a 2026-07-28 client is served by the same
-# binary) are one gate, not a claim (ADR-0039).
+# binary) are one gate, not a claim (ADR-0039). The engine-free half of the
+# gate (handshake + surface) also runs on every PR in the fast tier
+# (test_mcp_stdio_handshake.py); this e2e half adds real tool dispatch.
+_ERAS = [("legacy", "2025-11-25"), ("2026-07-28", "2026-07-28")]
+
+
 @pytest.mark.e2e
-@pytest.mark.parametrize("mode", ["legacy", "auto"])
-def test_info_over_stdio_reports_engine_version(mode):
-    result = _call("info", {}, mode=mode)
+@pytest.mark.parametrize(("mode", "expected_protocol"), _ERAS)
+def test_info_over_stdio_reports_engine_version(mode, expected_protocol):
+    result = _call("info", {}, mode=mode, expected_protocol=expected_protocol)
 
     assert result.is_error is False, result.content
     assert result.structured_content is not None
@@ -84,12 +94,17 @@ def test_info_over_stdio_reports_engine_version(mode):
 
 
 @pytest.mark.e2e
-@pytest.mark.parametrize("mode", ["legacy", "auto"])
-def test_scene_create_over_stdio_creates_a_scene_file(tmp_path, mode):
+@pytest.mark.parametrize(("mode", "expected_protocol"), _ERAS)
+def test_scene_create_over_stdio_creates_a_scene_file(
+    tmp_path, mode, expected_protocol
+):
     scene = tmp_path / "main.tscn"
 
     result = _call(
-        "scene_create", {"path": str(scene), "root_type": "Node2D"}, mode=mode
+        "scene_create",
+        {"path": str(scene), "root_type": "Node2D"},
+        mode=mode,
+        expected_protocol=expected_protocol,
     )
 
     assert result.is_error is False, result.content

--- a/tests/test_e2e_mcp_stdio.py
+++ b/tests/test_e2e_mcp_stdio.py
@@ -19,8 +19,7 @@ import sysconfig
 
 import anyio
 import pytest
-from mcp import StdioServerParameters
-from mcp.client.session import ClientSession
+from mcp import Client, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
@@ -50,42 +49,54 @@ def _server_params() -> StdioServerParameters:
     return StdioServerParameters(command=str(gda_mcp), args=[], env=env)
 
 
-def _call(tool: str, arguments: dict):
-    """Spawn the real gda-mcp over stdio, call one tool, return its result."""
+def _call(tool: str, arguments: dict, *, mode: str = "legacy"):
+    """Spawn the real gda-mcp over stdio, call one tool, return its result.
+
+    ``mode`` pins the protocol era (ADR-0039's dual-era gate): ``"legacy"`` is
+    the pre-2026 ``initialize`` handshake every surveyed agent speaks today;
+    ``"auto"`` probes ``server/discover`` first — the 2026-07-28 stateless path.
+    Deliberately NOT ``raise_exceptions`` (a client-side flag): this gate must
+    see exactly what a real agent sees on the wire.
+    """
 
     async def _drive():
-        async with stdio_client(_server_params()) as (read, write):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                return await session.call_tool(tool, arguments)
+        async with Client(stdio_client(_server_params()), mode=mode) as client:
+            return await client.call_tool(tool, arguments)
 
     return anyio.run(_drive)
 
 
+# Both protocol eras run the SAME assertions: backward compat ("no agent alive
+# today breaks") and forward compat (a 2026-07-28 client is served by the same
+# binary) are one gate, not a claim (ADR-0039).
 @pytest.mark.e2e
-def test_info_over_stdio_reports_engine_version():
-    result = _call("info", {})
+@pytest.mark.parametrize("mode", ["legacy", "auto"])
+def test_info_over_stdio_reports_engine_version(mode):
+    result = _call("info", {}, mode=mode)
 
-    assert result.isError is False, result.content
-    assert result.structuredContent is not None
-    assert result.structuredContent["major"] == 4
-    assert (result.structuredContent["major"], result.structuredContent["minor"]) >= (
+    assert result.is_error is False, result.content
+    assert result.structured_content is not None
+    assert result.structured_content["major"] == 4
+    assert (result.structured_content["major"], result.structured_content["minor"]) >= (
         4,
         4,
     )
 
 
 @pytest.mark.e2e
-def test_scene_create_over_stdio_creates_a_scene_file(tmp_path):
+@pytest.mark.parametrize("mode", ["legacy", "auto"])
+def test_scene_create_over_stdio_creates_a_scene_file(tmp_path, mode):
     scene = tmp_path / "main.tscn"
 
-    result = _call("scene_create", {"path": str(scene), "root_type": "Node2D"})
+    result = _call(
+        "scene_create", {"path": str(scene), "root_type": "Node2D"}, mode=mode
+    )
 
-    assert result.isError is False, result.content
-    assert result.structuredContent is not None
+    assert result.is_error is False, result.content
+    assert result.structured_content is not None
     # The verbatim --params-json dispatch produced gda's typed result…
-    assert result.structuredContent["root_type"] == "Node2D"
+    assert result.structured_content["root_type"] == "Node2D"
     # root_name derived model-side from the filename, same as the argv path.
-    assert result.structuredContent["root_name"] == "main"
+    assert result.structured_content["root_name"] == "main"
     # …and the .tscn really landed on disk (the real outcome, not a fake).
     assert scene.exists()

--- a/tests/test_e2e_mcp_tracer.py
+++ b/tests/test_e2e_mcp_tracer.py
@@ -10,7 +10,7 @@ reuses the shared ``_require_godot_engine`` gate.
 
 import anyio
 import pytest
-from mcp.shared.memory import create_connected_server_and_client_session as connect
+from mcp import Client
 
 from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
 from gda.mcp.runner import SubprocessGdaRunner
@@ -29,7 +29,7 @@ def test_info_tracer_real_chain(monkeypatch):
     server = build_server(SubprocessGdaRunner.default())
 
     async def _drive():
-        async with connect(server) as session:
+        async with Client(server, mode="legacy") as session:
             tools = await session.list_tools()
             result = await session.call_tool("info", {})
             return tools, result
@@ -39,9 +39,9 @@ def test_info_tracer_real_chain(monkeypatch):
     # Startup registered the real surface, including the info tracer tool.
     assert "info" in {t.name for t in tools.tools}
     # The call succeeded and the engine version came back as validated
-    # structuredContent (the SDK checked it against info's outputSchema).
-    assert result.isError is False, result.content
-    version = result.structuredContent
+    # structured_content (the SDK checked it against info's output_schema).
+    assert result.is_error is False, result.content
+    version = result.structured_content
     assert version is not None
     assert version["major"] == 4
     assert (version["major"], version["minor"]) >= (4, 4)  # ADR-0003 minimum

--- a/tests/test_mcp_dispatch.py
+++ b/tests/test_mcp_dispatch.py
@@ -2,8 +2,8 @@
 
 A tool call forwards its input object *verbatim* to gda via
 ``gda <group> <command> --params-json -`` (object on stdin) and relays the
-success: gda's ``--json`` dict becomes the tool's ``structuredContent``, which
-the SDK validates against the tool's ``outputSchema`` (Design decision 5). These
+success: gda's ``--json`` dict becomes the tool's ``structured_content``, which
+the SDK validates against the tool's ``output_schema`` (Design decision 5). These
 drive the real surface through a fake seam (no gda subprocess, no Godot) over an
 in-memory MCP client, asserting both the seam invocation and the relayed result.
 """
@@ -17,7 +17,7 @@ from tests.support import SCENE_CREATE_RESULT, VERSION_INFO
 
 def test_scene_create_input_object_builds_params_json_dispatch():
     # The canonical S5 case: scene_create's input object → the exact gda argv +
-    # the object on stdin; the canned --json result relays as structuredContent.
+    # the object on stdin; the canned --json result relays as structured_content.
     runner = FakeGdaRunner(
         schema_then(lambda args, stdin: gda_result(json.dumps(SCENE_CREATE_RESULT)))
     )
@@ -26,9 +26,9 @@ def test_scene_create_input_object_builds_params_json_dispatch():
 
     result = call_tool(server, "scene_create", arguments)
 
-    # Success relayed as structuredContent, validated against the real outputSchema.
-    assert result.isError is False
-    assert result.structuredContent == SCENE_CREATE_RESULT
+    # Success relayed as structured_content, validated against the real output_schema.
+    assert result.is_error is False
+    assert result.structured_content == SCENE_CREATE_RESULT
     # The seam was driven with the gda command argv + verbatim object on stdin.
     dispatch_args, dispatch_stdin, _ = runner.calls[-1]
     assert dispatch_stdin is not None
@@ -40,9 +40,12 @@ def test_multiword_command_name_maps_back_to_the_right_argv():
     # The MCP tool name `scene_get_exports` must dispatch to `scene get-exports`
     # (hyphen restored), proving the argv comes from the dump's own name — not a
     # lossy reverse of the underscored tool name.
+    # The canned result must conform to the command's real output schema: SDK v2
+    # validates structured content on every call (v1 skipped it when the tool
+    # definition wasn't cached yet, so a shapeless stub used to slip through).
     runner = FakeGdaRunner(
         schema_then(
-            lambda args, stdin: gda_result(json.dumps({"path": "x", "exports": []}))
+            lambda args, stdin: gda_result(json.dumps({"path": "x", "nodes": []}))
         )
     )
     server = build_server(runner)
@@ -63,10 +66,33 @@ def test_no_param_tool_dispatches_an_empty_params_object():
 
     result = call_tool(server, "info", {})
 
-    assert result.isError is False
-    assert result.structuredContent is not None
-    assert result.structuredContent["string"] == VERSION_INFO["string"]
+    assert result.is_error is False
+    assert result.structured_content is not None
+    assert result.structured_content["string"] == VERSION_INFO["string"]
     dispatch_args, dispatch_stdin, _ = runner.calls[-1]
     assert dispatch_stdin is not None
     assert dispatch_args == ["info", "--params-json", "-", "--json"]
     assert json.loads(dispatch_stdin) == {}
+
+
+def test_success_result_carries_content_block_alongside_structured_content():
+    # ADR-0039: SDK v2 removed v1's auto-wrap, so gda-mcp constructs the success
+    # result itself. Pin BOTH halves of the v1-identical shape: the structured
+    # payload AND the indented-JSON TextContent block — many clients render
+    # `content`, not `structured_content`, so dropping the block would silently
+    # blank every result for them. No other test guards the hand-rolled wrap.
+    runner = FakeGdaRunner(
+        schema_then(lambda args, stdin: gda_result(json.dumps(SCENE_CREATE_RESULT)))
+    )
+    server = build_server(runner)
+
+    result = call_tool(
+        server, "scene_create", {"path": "/tmp/proj/main.tscn", "root_type": "Node2D"}
+    )
+
+    assert result.is_error is False
+    assert result.structured_content == SCENE_CREATE_RESULT
+    assert len(result.content) == 1
+    block = result.content[0]
+    assert block.type == "text"
+    assert block.text == json.dumps(SCENE_CREATE_RESULT, indent=2)

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -1,9 +1,9 @@
 """S3 (fast): gda-mcp error channel + the can't-run / non-envelope edge (issue #193).
 
-A failing gda call (non-zero exit) maps to ``CallToolResult(isError=True)``
+A failing gda call (non-zero exit) maps to ``CallToolResult(is_error=True)``
 carrying gda's ``GdaError`` envelope **verbatim and losslessly** as JSON content
-(never flattened to prose, never folded into ``structuredContent`` /
-``outputSchema``) — ADR-0011. The stable ``code`` survives for every non-zero
+(never flattened to prose, never folded into ``structured_content`` /
+``output_schema``) — ADR-0011. The stable ``code`` survives for every non-zero
 category: environment / version / operation / parse, including the launch codes
 (``binary_not_found`` / ``launch_timeout``) and the parse-category
 ``contract_violation``. The edge — gda could not even run, or emitted
@@ -69,9 +69,9 @@ def test_each_category_relays_losslessly_as_is_error(code):
         _failing_server(code), "scene_create", {"path": "x", "root_type": "Node2D"}
     )
 
-    # The failure channel: isError, and the error stays OUT of structuredContent.
-    assert result.isError is True
-    assert result.structuredContent is None
+    # The failure channel: is_error, and the error stays OUT of structured_content.
+    assert result.is_error is True
+    assert result.structured_content is None
     # Lossless: the single content block parses back to gda's exact envelope —
     # all four fields, and crucially the stable code, preserved verbatim.
     assert len(result.content) == 1
@@ -92,7 +92,7 @@ def test_relayed_content_is_not_flattened_to_prose():
 
 def test_cannot_run_edge_is_synthesized_by_gda_mcp():
     # gda could not even run (e.g. `-m gda` import failure): no stdout, a traceback
-    # on stderr, non-zero exit. gda-mcp synthesizes its OWN structured isError,
+    # on stderr, non-zero exit. gda-mcp synthesizes its OWN structured is_error,
     # preserving gda's stderr as diagnostics rather than crashing or going silent.
     runner = FakeGdaRunner(
         schema_then(
@@ -105,8 +105,8 @@ def test_cannot_run_edge_is_synthesized_by_gda_mcp():
     )
     result = call_tool(build_server(runner), "info", {})
 
-    assert result.isError is True
-    assert result.structuredContent is None
+    assert result.is_error is True
+    assert result.structured_content is None
     body = json.loads(tool_text(result))
     assert body["error"]["category"] == "adapter"  # gda-mcp's own, not a gda category
     assert "ModuleNotFoundError" in body["error"]["diagnostics"]
@@ -122,7 +122,7 @@ def test_non_envelope_output_edge_is_synthesized():
     )
     result = call_tool(build_server(runner), "info", {})
 
-    assert result.isError is True
+    assert result.is_error is True
     assert json.loads(tool_text(result))["error"]["category"] == "adapter"
 
 
@@ -136,5 +136,5 @@ def test_exit_zero_but_non_json_stdout_edge_is_synthesized():
     )
     result = call_tool(build_server(runner), "info", {})
 
-    assert result.isError is True
+    assert result.is_error is True
     assert json.loads(tool_text(result))["error"]["category"] == "adapter"

--- a/tests/test_mcp_project_injection.py
+++ b/tests/test_mcp_project_injection.py
@@ -37,11 +37,11 @@ def _project(dir_path: Path) -> Path:
 def test_no_tool_inputschema_carries_a_project_field():
     # ADR-0014/0012: the project is server context, never a tool parameter — the
     # tool surface stays a faithful mirror of --schema, so gda-mcp synthesizes no
-    # `project` field into any tool's inputSchema.
+    # `project` field into any tool's input_schema.
     runner = FakeGdaRunner(schema_then(lambda _args, _stdin: gda_result("{}")))
     server = build_server(runner)
     for tool in list_tools(server).tools:
-        properties = (tool.inputSchema or {}).get("properties", {})
+        properties = (tool.input_schema or {}).get("properties", {})
         assert "project" not in properties, tool.name
 
 
@@ -247,6 +247,52 @@ def test_no_roots_capability_degrades_to_no_project_without_error(
         server, "scene_create", {"path": "x.tscn", "root_type": "Node2D"}
     )
 
-    assert result.isError is False
+    assert result.is_error is False
     _args, _stdin, project = runner.calls[-1]
     assert project is None
+
+
+def test_stateless_connection_degrades_to_no_project_without_error(
+    tmp_path, monkeypatch
+):
+    # ADR-0039: a 2026-07-28 connection has no back-channel (can_send_request is
+    # False), so the roots precedence level is skipped outright — even a client
+    # WITH a roots callback wired can never be asked. The call must succeed
+    # projectless (no NoBackChannelError escapes the server), landing on the
+    # env→cwd tail of the ADR-0014 precedence.
+    monkeypatch.delenv("GDA_PROJECT", raising=False)
+    unreachable = _project(tmp_path / "game")
+    runner = _scene_create_runner()
+    server = build_server(runner)
+
+    result = call_tool(
+        server,
+        "scene_create",
+        {"path": "x.tscn", "root_type": "Node2D"},
+        roots=[str(unreachable)],
+        mode="auto",
+    )
+
+    assert result.is_error is False
+    _args, _stdin, project = runner.calls[-1]
+    assert project is None
+
+
+def test_gda_project_env_resolves_on_stateless_connection(tmp_path, monkeypatch):
+    # ADR-0039 promotes GDA_PROJECT to the durable anchor: on a 2026-07-28
+    # connection (no roots signal at all) the env pin must keep resolving exactly
+    # as it does for legacy clients.
+    proj = _project(tmp_path)
+    monkeypatch.setenv("GDA_PROJECT", str(proj))
+    runner = _scene_create_runner()
+    server = build_server(runner)
+
+    call_tool(
+        server,
+        "scene_create",
+        {"path": "main.tscn", "root_type": "Node2D"},
+        mode="auto",
+    )
+
+    _args, _stdin, project = runner.calls[-1]
+    assert project == proj

--- a/tests/test_mcp_registration.py
+++ b/tests/test_mcp_registration.py
@@ -54,21 +54,21 @@ def test_tool_names_are_group_command_with_separators_underscored():
 
 
 def test_each_tool_mirrors_its_commands_description_and_schemas():
-    # description ← command help; inputSchema ← input; outputSchema ← output —
+    # description ← command help; input_schema ← input; output_schema ← output —
     # passed through verbatim from the dump (ADR-0012's per-field fidelity).
     by_name = {tool_name(e["name"]): e for e in _manifest_entries()}
     for tool in list_tools(_server()).tools:
         entry = by_name[tool.name]
         assert tool.description == entry["description"]
-        assert tool.inputSchema == entry["input"]
-        assert tool.outputSchema == entry["output"]
+        assert tool.input_schema == entry["input"]
+        assert tool.output_schema == entry["output"]
 
 
 def test_known_tool_has_a_nonempty_output_schema():
-    # info's outputSchema is the EngineVersion contract — present so the SDK can
-    # validate a successful call's structuredContent against it (Design dec. 5).
+    # info's output_schema is the EngineVersion contract — present so the SDK can
+    # validate a successful call's structured_content against it (Design dec. 5).
     info = next(t for t in list_tools(_server()).tools if t.name == "info")
-    assert info.outputSchema and info.outputSchema.get("type") == "object"
+    assert info.output_schema and info.output_schema.get("type") == "object"
 
 
 def test_non_dispatchable_meta_commands_are_not_registered():
@@ -93,8 +93,8 @@ def test_live_command_game_tree_appears_as_a_tool_mirroring_the_dump():
     tool = tools["game_tree"]
     entry = by_name["game_tree"]
     assert tool.description == entry["description"]
-    assert tool.inputSchema == entry["input"]
-    assert tool.outputSchema == entry["output"]
+    assert tool.input_schema == entry["input"]
+    assert tool.output_schema == entry["output"]
 
 
 def test_startup_introspects_the_dump_through_the_seam_once():

--- a/tests/test_mcp_runner.py
+++ b/tests/test_mcp_runner.py
@@ -3,7 +3,7 @@
 Reviewer-requested regression (PR #203): a gda command that cannot be launched —
 e.g. a bad ``$GDA_BIN`` override pointing nowhere — must surface as a structured
 non-zero :class:`~gda.mcp.runner.GdaResult` that :func:`~gda.mcp.server.dispatch`
-turns into an ``isError`` ``CallToolResult``, NOT an ``OSError`` escaping across
+turns into an ``is_error`` ``CallToolResult``, NOT an ``OSError`` escaping across
 the MCP boundary (ADR-0011's "can't-run" edge, synthesized by gda-mcp). These are
 fast: the bad binary fails to exec immediately, no Godot involved.
 """
@@ -34,14 +34,14 @@ def test_unlaunchable_command_returns_a_failure_result_not_an_exception():
 
 def test_dispatch_synthesizes_is_error_for_a_launch_failure():
     # End to end through the real seam: an unlaunchable gda becomes gda-mcp's own
-    # structured isError (the can't-run edge), with the launch diagnostics
+    # structured is_error (the can't-run edge), with the launch diagnostics
     # preserved — not a traceback.
     outcome = dispatch(_UNLAUNCHABLE, ["info"], {})
 
     # A CallToolResult (failure channel), not a raised exception or a result dict.
     assert isinstance(outcome, CallToolResult)
-    assert outcome.isError is True
-    assert outcome.structuredContent is None
+    assert outcome.is_error is True
+    assert outcome.structured_content is None
     body = json.loads(tool_text(outcome))
     assert body["error"]["category"] == "adapter"  # gda-mcp's own synthesized error
     assert "/does/not/exist/gda" in body["error"]["diagnostics"]

--- a/tests/test_mcp_stdio_handshake.py
+++ b/tests/test_mcp_stdio_handshake.py
@@ -1,0 +1,48 @@
+"""Fast dual-era stdio handshake gate (#601, ADR-0039).
+
+The engine-free half of ADR-0039's dual-era gate, running on every PR: the real
+``gda-mcp`` **console script** over **real stdio**, once per protocol era. Era
+negotiation needs no Godot — startup introspection (``gda schema``) spawns no
+engine (ADR-0012) — so this tier proves the handshake and the generated surface
+where CI actually looks, while the e2e twin (``test_e2e_mcp_stdio.py``) adds
+real tool dispatch against a real engine on the nightly tier.
+
+Two deliberate choices keep the gate falsifiable (the whole point — era coverage
+must be able to FAIL): the modern era is pinned as ``mode="2026-07-28"``, never
+``"auto"`` (auto falls back to the legacy handshake on a server that lost modern
+support, so it can go green without proving anything), and the negotiated
+``protocol_version`` is asserted per era.
+"""
+
+import shutil
+import sysconfig
+
+import anyio
+import pytest
+from mcp import Client, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+def _server_params() -> StdioServerParameters:
+    # The real console script, resolved deterministically from this
+    # interpreter's scripts dir — same rationale as the e2e twin (ADR-0013;
+    # never an unbounded PATH lookup).
+    scripts_dir = sysconfig.get_path("scripts")
+    gda_mcp = shutil.which("gda-mcp", path=scripts_dir)
+    assert gda_mcp, f"`gda-mcp` console script not found in {scripts_dir}"
+    return StdioServerParameters(command=str(gda_mcp), args=[])
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_protocol"),
+    [("legacy", "2025-11-25"), ("2026-07-28", "2026-07-28")],
+)
+def test_console_script_serves_both_protocol_eras(mode, expected_protocol):
+    async def _drive():
+        async with Client(stdio_client(_server_params()), mode=mode) as client:
+            assert client.protocol_version == expected_protocol
+            tools = await client.list_tools()
+            # The generated surface registered over this era's handshake.
+            assert "info" in {t.name for t in tools.tools}
+
+    anyio.run(_drive)

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -47,7 +47,7 @@ def test_info_error_schema_is_the_uniform_failure_envelope():
     # issue #43 / ADR-0004: --schema now carries a third key, `error`, holding the uniform
     # failure-envelope schema shared by every command (GdaErrorEnvelope). It is
     # the same for all commands and kept OUT of `output` so gda-mcp can map
-    # `output` → outputSchema (success) and `error` → the isError channel.
+    # `output` → output_schema (success) and `error` → the is_error channel.
     result = CliRunner().invoke(app, ["info", "--schema"])
 
     doc = json.loads(result.stdout)

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.12,<2" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2,<3" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "typer", specifier = ">=0.26.7" },
 ]
@@ -268,11 +268,11 @@ provides-extras = ["mcp"]
 [package.metadata.requires-dev]
 assets-live = [
     { name = "google-genai", specifier = ">=1.0" },
-    { name = "mcp", specifier = ">=1.12,<2" },
+    { name = "mcp", specifier = ">=2,<3" },
 ]
 dev = [
     { name = "jsonschema", specifier = ">=4.26.0" },
-    { name = "mcp", specifier = ">=1.12,<2" },
+    { name = "mcp", specifier = ">=2,<3" },
     { name = "pillow", specifier = ">=11.0" },
     { name = "pyright", specifier = ">=1.1.411,<1.2" },
     { name = "pytest", specifier = ">=9.0.3" },
@@ -341,6 +341,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -356,12 +369,18 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -423,15 +442,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -441,9 +460,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/ee/94c6c50ffc5b5cf4737052275d11b57367f32d1a8516e31dcd60591b3916/mcp-1.28.0.tar.gz", hash = "sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2", size = 636040, upload-time = "2026-06-16T21:37:17.996Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/e1/4c1dc1fbb688641a712d34650c3d58bbbdcb314ddb75bc5817bbf33515a4/mcp-1.28.0-py3-none-any.whl", hash = "sha256:9c1e7cf3a9125557e418ecd4fed8e9adddce81b0dfdae4d6601d700f5beb71a4", size = 221959, upload-time = "2026-06-16T21:37:16.579Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -462,6 +494,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -646,20 +690,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -709,15 +739,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -956,6 +977,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Migrates gda-mcp from MCP Python SDK v1 (`>=1.12,<2`) to **v2.0.0**, which implements the **2026-07-28 stateless spec revision** — behavior-preserving for every agent alive today. One low-level stdio `Server` now serves **both protocol eras**: pre-2026 clients (Claude Code, Codex, Cursor, Claude Desktop) complete the legacy `initialize` handshake and keep today's behavior bit-for-bit; 2026-07-28 clients get the stateless path from the same binary. Decisions recorded in new **ADR-0039**, with dated Outcome notes on ADR-0011 and ADR-0014.

Design highlights (spike findings on #600 were the authority on ambiguous SDK behaviors):

- **Roots by capability, not era**: ADR-0014 precedence unchanged (`GDA_PROJECT` strict → client roots → cwd); `list_roots()` is attempted iff `session.can_send_request` and the client advertises the roots capability. Stateless connections skip silently to env→cwd (no `NoBackChannelError`, no failed round trip); `GDA_PROJECT` is promoted to the durable anchor. The #209 `roots/list_changed` re-resolution lives on for legacy connections.
- **v1 success wrap reproduced in-house** (v2 removed the auto-wrap): success dict as `structured_content` **plus** the v1-identical indented-JSON text block — clients that render `content` keep seeing output. The verbatim `GdaError` envelope relay is byte-identical; spike-verified that `is_error=True` results without `structured_content` bypass the SDK's output validation.
- **MRTR `ListRootsRequest` deferred** with a written trigger condition; **streamable-HTTP rejected** as a trust-boundary change needing its own PRD/ADR (both in ADR-0039's considered-and-rejected record).
- **Panda-adventure's MCP channel migrated in the same slice** (second SDK consumer in the one `uv.lock`; its unmarked timeout test runs in the required CI fast tier, so a lone pin bump would land red).

## Verification

- `ruff check` + `ruff format --check`: clean; `pyright`: 0 errors; `uv build`: OK
- gda fast tier: **1189 passed** (new tests: stateless degrade, `GDA_PROJECT`-on-stateless, success-result shape, and a real-stdio dual-era **handshake gate** that runs on every PR — no Godot needed)
- Panda Adventure pure-Python CI tier: **475 passed** (incl. the MCP-backend timeout gate against the real hang server)
- MCP e2e vs real Godot 4.6.3 (serial): **10 passed** — incl. the dual-era gate: the real `gda-mcp` console script driven over real stdio under `Client(mode="legacy")` **and** `Client(mode="2026-07-28")` (modern era pinned — `auto` would fall back to the legacy handshake — with the negotiated `protocol_version` asserted per era)
- Manual smoke vs **real Claude Code** (v2.1.220, project-scoped `.mcp.json`, no `GDA_PROJECT`): server connects and lists the surface, `info` returns the engine version, `scene_create` lands `scenes/main.tscn` inside the workspace project (roots-resolved), and a failing `scene_get` relays the verbatim `{"error":{category,code,message,diagnostics}}` envelope

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)
