### PR TITLE
feat(mcp): advertise a public cache hint on tools/list

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ The server resolves two pieces of context — which Godot **project** to drive a
 
 For clients on the MCP 2026-07-28 revision, `gda-mcp` marks its `tools/list` response cacheable
 (1-hour TTL, public scope) — the generated tool surface is fixed for a server's lifetime, so
-upgraded clients skip re-fetching it; pre-2026 clients see identical traffic.
+upgraded clients can skip re-fetching it; pre-2026 clients see identical traffic.
 
 
 #### Register with Coding Agents

--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ The server resolves two pieces of context — which Godot **project** to drive a
   roots to advertise). See [Configuration](#configuration) for the full CLI-vs-MCP resolution order.
 - **Engine** — set `GDA_GODOT` to your Godot binary, e.g. `"GDA_GODOT": "/path/to/Godot"`.
 
+For clients on the MCP 2026-07-28 revision, `gda-mcp` marks its `tools/list` response cacheable
+(1-hour TTL, public scope) — the generated tool surface is fixed for a server's lifetime, so
+upgraded clients skip re-fetching it; pre-2026 clients see identical traffic.
+
 
 #### Register with Coding Agents
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=3a595c5ac14763cd6aa8236c34d543ecaa719371040f852645327be2d78af73f -->
+<!-- gda-readme-i18n: source=README.md sha256=0da6852ffc73cbf5aa589b50c5ba5c3dcf07ea1d64cf228fe784db4ca591d542 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -227,6 +227,11 @@ ejecutar (MCP no puede pasar flags por llamada):
   protocolo sin estado no tiene roots que anunciar). Consulta
   [Configuración](#configuration) para conocer el orden completo de resolución CLI vs MCP.
 - **Motor** — define `GDA_GODOT` con tu binario de Godot, p. ej. `"GDA_GODOT": "/path/to/Godot"`.
+
+Para clientes de la revisión MCP 2026-07-28, `gda-mcp` marca su respuesta de `tools/list` como
+cacheable (TTL de 1 hora, ámbito public) — la superficie de herramientas generada es fija durante
+la vida del servidor, así que los clientes actualizados evitan volver a pedirla; los clientes
+anteriores a 2026 ven tráfico idéntico.
 
 
 #### Registrar con agentes de programación

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=0da6852ffc73cbf5aa589b50c5ba5c3dcf07ea1d64cf228fe784db4ca591d542 -->
+<!-- gda-readme-i18n: source=README.md sha256=5b0ecafe46c7228d7f155d1f36bd89885d8337cf434c5079cc69ebecb673ee0e -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -230,8 +230,8 @@ ejecutar (MCP no puede pasar flags por llamada):
 
 Para clientes de la revisión MCP 2026-07-28, `gda-mcp` marca su respuesta de `tools/list` como
 cacheable (TTL de 1 hora, ámbito public) — la superficie de herramientas generada es fija durante
-la vida del servidor, así que los clientes actualizados evitan volver a pedirla; los clientes
-anteriores a 2026 ven tráfico idéntico.
+la vida del servidor, así que los clientes actualizados pueden evitar volver a pedirla; los
+clientes anteriores a 2026 ven tráfico idéntico.
 
 
 #### Registrar con agentes de programación

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=3a595c5ac14763cd6aa8236c34d543ecaa719371040f852645327be2d78af73f -->
+<!-- gda-readme-i18n: source=README.md sha256=0da6852ffc73cbf5aa589b50c5ba5c3dcf07ea1d64cf228fe784db4ca591d542 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -231,6 +231,11 @@ uvx --from "gda[mcp]" gda-mcp
   有効な設定です(新しいステートレスプロトコルのクライアントには提示する roots がありません)。
   CLI と MCP の完全な解決順序については [設定](#configuration) を参照してください。
 - **エンジン** — `GDA_GODOT` に Godot バイナリを設定します。例: `"GDA_GODOT": "/path/to/Godot"`。
+
+MCP 2026-07-28 改訂版のクライアントに対しては、`gda-mcp` は `tools/list` 応答をキャッシュ可能
+(TTL 1 時間、public スコープ)としてマークします — 生成されるツール群はサーバーの生存期間中
+不変なので、アップグレード済みクライアントは再取得を省けます。2026 年以前のクライアントの
+トラフィックは変わりません。
 
 
 #### コーディングエージェントへの登録

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=0da6852ffc73cbf5aa589b50c5ba5c3dcf07ea1d64cf228fe784db4ca591d542 -->
+<!-- gda-readme-i18n: source=README.md sha256=5b0ecafe46c7228d7f155d1f36bd89885d8337cf434c5079cc69ebecb673ee0e -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=0da6852ffc73cbf5aa589b50c5ba5c3dcf07ea1d64cf228fe784db4ca591d542 -->
+<!-- gda-readme-i18n: source=README.md sha256=5b0ecafe46c7228d7f155d1f36bd89885d8337cf434c5079cc69ebecb673ee0e -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -223,7 +223,7 @@ uvx --from "gda[mcp]" gda-mcp
 
 对走 MCP 2026-07-28 修订版协议的客户端，`gda-mcp` 会把 `tools/list` 响应标记为可缓存
 （1 小时 TTL、public 范围）——生成的工具面在服务器生命周期内固定不变，升级后的客户端
-因此无需反复拉取；2026 前的客户端流量完全不变。
+因此可以不再反复拉取；2026 前的客户端流量完全不变。
 
 
 #### 在编程 agent 中注册

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=3a595c5ac14763cd6aa8236c34d543ecaa719371040f852645327be2d78af73f -->
+<!-- gda-readme-i18n: source=README.md sha256=0da6852ffc73cbf5aa589b50c5ba5c3dcf07ea1d64cf228fe784db4ca591d542 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -220,6 +220,10 @@ uvx --from "gda[mcp]" gda-mcp
   现在的客户端行为不变，但固定 `GDA_PROJECT` 才是面向未来的配置（走新无状态协议的客户端没有
   roots 可公布）。完整的 CLI 与 MCP 解析顺序参见[配置](#configuration)。
 - **引擎** — 把 `GDA_GODOT` 设为你的 Godot 二进制文件，例如 `"GDA_GODOT": "/path/to/Godot"`。
+
+对走 MCP 2026-07-28 修订版协议的客户端，`gda-mcp` 会把 `tools/list` 响应标记为可缓存
+（1 小时 TTL、public 范围）——生成的工具面在服务器生命周期内固定不变，升级后的客户端
+因此无需反复拉取；2026 前的客户端流量完全不变。
 
 
 #### 在编程 agent 中注册

--- a/docs/adr/0039-gda-mcp-sdk-v2-dual-era-stdio-server.md
+++ b/docs/adr/0039-gda-mcp-sdk-v2-dual-era-stdio-server.md
@@ -120,5 +120,7 @@ Concretely:
   tool definition wasn't cached), so canned test results must conform to the real
   output schemas — a test-tier tightening, not a behavior change.
 - Cache hints on `tools/list` (`ttlMs`/`cacheScope`, new in the revision) are a
-  natural follow-up for the process-immutable generated surface; they only reach
-  2026-07-28 clients and are tracked separately (#602).
+  natural fit for the process-immutable generated surface and shipped as the
+  follow-up slice (#602): `CacheHint(ttl_ms=3_600_000, scope="public")`. The hint
+  only reaches 2026-07-28 clients, and caching remains the client's choice —
+  pre-2026 clients see identical un-hinted traffic.

--- a/src/gda/mcp/server.py
+++ b/src/gda/mcp/server.py
@@ -48,7 +48,7 @@ from urllib.parse import unquote, urlparse
 
 import mcp.server.stdio
 import mcp.types as types
-from mcp.server import Server, ServerRequestContext
+from mcp.server import CacheHint, Server, ServerRequestContext
 from mcp.shared.exceptions import MCPDeprecationWarning
 
 from gda.mcp.project_context import resolve_project_dir
@@ -348,6 +348,13 @@ def build_server(runner: GdaRunner) -> Server:
             on_list_tools=_list_tools,
             on_call_tool=_call_tool,
             on_roots_list_changed=_on_roots_list_changed,
+            # The tool surface is immutable for the process's lifetime (built
+            # once from the startup dump, ADR-0012) and depends on no user,
+            # auth, or project (ADR-0014 keeps the project out of the surface)
+            # — so tools/list is safely cacheable for a long TTL at public
+            # scope. Forward-compat only: the hint reaches 2026-07-28 clients;
+            # pre-2026 clients see identical uncached traffic (#602).
+            cache_hints={"tools/list": CacheHint(ttl_ms=3_600_000, scope="public")},
         )
     return server
 

--- a/tests/test_mcp_registration.py
+++ b/tests/test_mcp_registration.py
@@ -105,3 +105,21 @@ def test_startup_introspects_the_dump_through_the_seam_once():
     # The startup introspection call carries no project (the schema meta command
     # is projectless); per-tool dispatch is what injects the resolved project.
     assert runner.calls == [(["schema"], None, None)]
+
+
+def test_tools_list_advertises_cache_hint_to_modern_clients_only():
+    # #602: the tool surface is immutable for the process's lifetime (one
+    # startup dump, ADR-0012) and depends on no user or project (ADR-0014), so
+    # tools/list carries a long public cache hint. The hint is a 2026-07-28
+    # protocol feature: a modern client observes it, a legacy client sees
+    # identical un-hinted traffic (the SDK-side defaults), so today's agents
+    # are unaffected — forward-compat, not a latency claim.
+    server = _server()
+
+    modern = list_tools(server, mode="2026-07-28")
+    assert modern.ttl_ms == 3_600_000
+    assert modern.cache_scope == "public"
+
+    legacy = list_tools(server, mode="legacy")
+    assert legacy.ttl_ms == 0
+    assert legacy.cache_scope == "private"


### PR DESCRIPTION
## Summary

S2 of the MCP SDK v2 migration (follow-up to #603 / ADR-0039): `tools/list` now carries `CacheHint(ttl_ms=3_600_000, scope="public")` — the 2026-07-28 revision's cacheable-list-responses feature.

Why this shape: the generated tool surface is **immutable for a server process's lifetime** (built once from the startup `gda schema` dump, ADR-0012) and depends on **no user, auth, or project** (ADR-0014 keeps the project out of the surface), so a long public-scope TTL is safe by construction.

Honest framing (also in the README one-liner): this is **forward-compat, not a latency claim** — a 2026-07-28 client observes the hint and can stop re-fetching the ~67-tool schema payload; pre-2026 clients (all real agents today) see identical un-hinted traffic.

Changes: one `cache_hints` argument on the `Server` constructor; a dual-era test asserting the modern client sees `ttl_ms=3_600_000` / `cache_scope="public"` while the legacy client sees the untransmitted SDK defaults; README one-liner (+ the three translations, re-stamped).

## Verification

- New test probes both eras against the in-memory client (acceptance is the observed hint, not a latency measurement)
- Fast tier: **1190 passed**; i18n sync test green; `ruff check` / `ruff format --check` / `pyright` clean

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)