### PR TITLE
ci(gda-balancing): parallelize exact full-suite validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,6 @@ on:
         required: false
         default: false
         type: boolean
-      run-balancing-unfiltered:
-        description: "Run the complete unfiltered gda-balancing suite"
-        required: false
-        default: false
-        type: boolean
   schedule:
     # Nightly (03:24 UTC) — the automatic, dependable trigger for the godot-e2e job
     # (workflow_dispatch with run-e2e is the on-demand extra). Daily so a regression in
@@ -261,6 +256,9 @@ jobs:
       - name: Run complete shard with hard duration bound
         run: |
           mkdir -p test-results
+          uv run --no-project --python 3.13 python \
+            libs/gda-balancing/tools/ci.py start-timer \
+            --report "test-results/${{ matrix.shard }}-started.json"
           set -o pipefail
           process_timeout="$(uv run --no-project --python 3.13 python \
             libs/gda-balancing/tools/ci.py process-timeout required)"
@@ -276,6 +274,15 @@ jobs:
         if: ${{ always() }}
         run: |
           mkdir -p test-results
+          if [ -f "test-results/${{ matrix.shard }}-started.json" ]; then
+            uv run --no-project --python 3.13 python \
+              libs/gda-balancing/tools/ci.py finish-timer \
+              --started "test-results/${{ matrix.shard }}-started.json" \
+              --report "test-results/wall-${{ matrix.shard }}.json"
+          else
+            printf '{"error":"shard timer did not start"}\n' \
+              > "test-results/wall-${{ matrix.shard }}.json"
+          fi
           if [ -f "test-results/junit-${{ matrix.shard }}.xml" ]; then
             uv run --no-project --python 3.13 python \
               libs/gda-balancing/tools/ci.py summarize-junit \
@@ -322,6 +329,9 @@ jobs:
       - name: Run subprocess tests and build with one hard duration bound
         run: |
           mkdir -p test-results
+          uv run --no-project --python 3.13 python \
+            libs/gda-balancing/tools/ci.py start-timer \
+            --report test-results/smoke-started.json
           process_timeout="$(uv run --no-project --python 3.13 python \
             libs/gda-balancing/tools/ci.py process-timeout required)"
           uv run --no-project --python 3.13 python \
@@ -341,6 +351,15 @@ jobs:
         if: ${{ always() }}
         run: |
           mkdir -p test-results
+          if [ -f test-results/smoke-started.json ]; then
+            uv run --no-project --python 3.13 python \
+              libs/gda-balancing/tools/ci.py finish-timer \
+              --started test-results/smoke-started.json \
+              --report test-results/wall-smoke.json
+          else
+            printf '{"error":"smoke timer did not start"}\n' \
+              > test-results/wall-smoke.json
+          fi
           if [ -f test-results/junit-smoke.xml ]; then
             uv run --no-project --python 3.13 python \
               libs/gda-balancing/tools/ci.py summarize-junit \
@@ -395,6 +414,7 @@ jobs:
 
       - name: Download every shard result
         if: ${{ needs.balancing-scope.outputs.required == 'true' }}
+        continue-on-error: true
         uses: actions/download-artifact@v8.0.1
         with:
           pattern: gda-balancing-*-diagnostics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,9 @@ jobs:
           uv run --frozen --project libs/gda-balancing \
             python libs/gda-balancing/tools/ci.py verify-inventory \
             --report test-results/inventory.json
+          uv run --frozen --project libs/gda-balancing \
+            python libs/gda-balancing/tools/ci.py verify-claims \
+            --report test-results/coverage-claims.json
 
       - name: Export required shard matrix
         id: test_matrix
@@ -226,7 +229,7 @@ jobs:
         uses: actions/upload-artifact@v7.0.1
         with:
           name: gda-balancing-inventory
-          path: test-results/inventory.json
+          path: test-results/
           if-no-files-found: error
 
   balancing-tests:
@@ -266,21 +269,21 @@ jobs:
             xargs timeout --signal=TERM --kill-after=30s "${process_timeout}s" \
               uv run --frozen --project libs/gda-balancing pytest \
               -q --durations=50 \
-              --junitxml="test-results/${{ matrix.shard }}-junit.xml" \
+              --junitxml="test-results/junit-${{ matrix.shard }}.xml" \
             2>&1 | tee "test-results/${{ matrix.shard }}.log"
 
       - name: Summarize durations and verify test outcomes
         if: ${{ always() }}
         run: |
           mkdir -p test-results
-          if [ -f "test-results/${{ matrix.shard }}-junit.xml" ]; then
+          if [ -f "test-results/junit-${{ matrix.shard }}.xml" ]; then
             uv run --no-project --python 3.13 python \
               libs/gda-balancing/tools/ci.py summarize-junit \
-              --junit "test-results/${{ matrix.shard }}-junit.xml" \
+              --junit "test-results/junit-${{ matrix.shard }}.xml" \
               --report "test-results/${{ matrix.shard }}-durations.json"
             uv run --no-project --python 3.13 python \
               libs/gda-balancing/tools/ci.py verify-outcomes \
-              --junit "test-results/${{ matrix.shard }}-junit.xml" \
+              --junit "test-results/junit-${{ matrix.shard }}.xml" \
               --report "test-results/${{ matrix.shard }}-outcomes.json"
           else
             printf '{"error":"shard timed out before JUnit was finalized"}\n' \
@@ -328,7 +331,7 @@ jobs:
             bash -euo pipefail -c '
               xargs uv run --frozen --project libs/gda-balancing pytest \
                 -q --durations=50 \
-                --junitxml=test-results/smoke-junit.xml \
+                --junitxml=test-results/junit-smoke.xml \
                 < test-results/smoke-paths.txt \
                 2>&1 | tee test-results/smoke.log
               uv build --project libs/gda-balancing --out-dir dist-gda-balancing
@@ -338,14 +341,14 @@ jobs:
         if: ${{ always() }}
         run: |
           mkdir -p test-results
-          if [ -f test-results/smoke-junit.xml ]; then
+          if [ -f test-results/junit-smoke.xml ]; then
             uv run --no-project --python 3.13 python \
               libs/gda-balancing/tools/ci.py summarize-junit \
-              --junit test-results/smoke-junit.xml \
+              --junit test-results/junit-smoke.xml \
               --report test-results/smoke-durations.json
             uv run --no-project --python 3.13 python \
               libs/gda-balancing/tools/ci.py verify-outcomes \
-              --junit test-results/smoke-junit.xml \
+              --junit test-results/junit-smoke.xml \
               --report test-results/smoke-outcomes.json
           else
             printf '{"error":"smoke timed out before JUnit was finalized"}\n' \
@@ -376,9 +379,44 @@ jobs:
     # The one-minute unrelated-path target is a measured service level, not a
     # job timeout. Leave enough room for runner/startup jitter while the step
     # itself remains a constant-time shell assertion.
-    timeout-minutes: 5
+    timeout-minutes: 15
 
     steps:
+      - name: Checkout repository
+        if: ${{ needs.balancing-scope.outputs.required == 'true' }}
+        uses: actions/checkout@v6
+
+      - name: Set up gda-balancing environment
+        if: ${{ needs.balancing-scope.outputs.required == 'true' }}
+        uses: ./.github/actions/setup-python-env
+        with:
+          sync: member
+          save-cache: false
+
+      - name: Download every shard result
+        if: ${{ needs.balancing-scope.outputs.required == 'true' }}
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: gda-balancing-*-diagnostics
+          path: test-results
+          merge-multiple: true
+
+      - name: Prove aggregate execution closure
+        if: ${{ needs.balancing-scope.outputs.required == 'true' }}
+        run: |
+          uv run --frozen --project libs/gda-balancing \
+            python libs/gda-balancing/tools/ci.py aggregate-junit \
+            --junit-dir test-results \
+            --report test-results/aggregate.json
+
+      - name: Upload aggregate duration and verdict report
+        if: ${{ always() && needs.balancing-scope.outputs.required == 'true' }}
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: gda-balancing-aggregate
+          path: test-results/aggregate.json
+          if-no-files-found: error
+
       - name: Aggregate stable required result
         env:
           SCOPE_RESULT: ${{ needs.balancing-scope.result }}
@@ -408,67 +446,6 @@ jobs:
               exit 1
             fi
           done
-
-  balancing-nightly:
-    name: gda-balancing nightly unfiltered suite
-    if: >-
-      ${{
-        github.event_name == 'schedule' ||
-        (github.event_name == 'workflow_dispatch' &&
-          inputs['run-balancing-unfiltered'])
-      }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Set up gda-balancing environment
-        uses: ./.github/actions/setup-python-env
-        with:
-          sync: member
-          save-cache: false
-
-      - name: Run the complete unfiltered suite
-        run: |
-          mkdir -p test-results
-          set -o pipefail
-          process_timeout="$(uv run --no-project --python 3.13 python \
-            libs/gda-balancing/tools/ci.py process-timeout unfiltered)"
-          timeout --signal=TERM --kill-after=30s "${process_timeout}s" \
-            uv run --frozen --project libs/gda-balancing pytest \
-              libs/gda-balancing/tests -q --durations=50 \
-              --junitxml=test-results/nightly-junit.xml \
-            2>&1 | tee test-results/nightly.log
-
-      - name: Summarize durations and verify nightly outcomes
-        if: ${{ always() }}
-        run: |
-          mkdir -p test-results
-          if [ -f test-results/nightly-junit.xml ]; then
-            uv run --no-project --python 3.13 python \
-              libs/gda-balancing/tools/ci.py summarize-junit \
-              --junit test-results/nightly-junit.xml \
-              --report test-results/nightly-durations.json
-            uv run --no-project --python 3.13 python \
-              libs/gda-balancing/tools/ci.py verify-outcomes \
-              --junit test-results/nightly-junit.xml \
-              --report test-results/nightly-outcomes.json
-          else
-            printf '{"error":"nightly timed out before JUnit was finalized"}\n' \
-              > test-results/nightly-durations.json
-            printf '{"error":"nightly timed out before JUnit was finalized"}\n' \
-              > test-results/nightly-outcomes.json
-          fi
-
-      - name: Upload nightly diagnostics
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: gda-balancing-nightly-diagnostics
-          path: test-results/
-          if-no-files-found: error
 
   coinstall-smoke:
     name: Both products co-install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,6 +350,9 @@ jobs:
       - name: Run complete release shard with hard duration bound
         run: |
           mkdir -p test-results
+          uv run --no-project --python 3.13 python \
+            libs/gda-balancing/tools/ci.py start-timer \
+            --report "test-results/${{ matrix.shard }}-started.json"
           set -o pipefail
           process_timeout="$(uv run --no-project --python 3.13 python \
             libs/gda-balancing/tools/ci.py process-timeout required)"
@@ -365,6 +368,15 @@ jobs:
         if: ${{ always() }}
         run: |
           mkdir -p test-results
+          if [ -f "test-results/${{ matrix.shard }}-started.json" ]; then
+            uv run --no-project --python 3.13 python \
+              libs/gda-balancing/tools/ci.py finish-timer \
+              --started "test-results/${{ matrix.shard }}-started.json" \
+              --report "test-results/wall-${{ matrix.shard }}.json"
+          else
+            printf '{"error":"release shard timer did not start"}\n' \
+              > "test-results/wall-${{ matrix.shard }}.json"
+          fi
           if [ -f "test-results/junit-${{ matrix.shard }}.xml" ]; then
             uv run --no-project --python 3.13 python \
               libs/gda-balancing/tools/ci.py summarize-junit \
@@ -398,7 +410,7 @@ jobs:
       - prepare-release-gda-balancing
       - test-release-gda-balancing
     if: >-
-      !failure() && !cancelled() &&
+      always() &&
       needs.cut-release.outputs.balancing_release_created == 'true'
     permissions:
       contents: read
@@ -416,6 +428,7 @@ jobs:
           save-cache: false
 
       - name: Download every release shard result
+        continue-on-error: true
         uses: actions/download-artifact@v8.0.1
         with:
           pattern: gda-balancing-release-*-diagnostics
@@ -430,6 +443,7 @@ jobs:
             --report test-results/aggregate.json
 
       - name: Upload release aggregate verdict and duration report
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7.0.1
         with:
           name: gda-balancing-release-validation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,22 +266,18 @@ jobs:
   # independent uv project, NOT a uv workspace member (ADR-0038), which is why
   # these jobs sync and build only its own project.
 
-  build-release-gda-balancing:
-    name: Build and verify gda-balancing release artifacts
+  prepare-release-gda-balancing:
+    name: Prepare exact gda-balancing release inventory
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     needs: cut-release
     if: >-
       !failure() && !cancelled() &&
       needs.cut-release.outputs.balancing_release_created == 'true'
-    # Deliberately NO id-token, exactly as in build-release: the job that runs
-    # project, test, and build-backend code never holds publishing authority
-    # (ADR-0016).
     permissions:
       contents: read
-
-    env:
-      RELEASE_TAG: ${{ needs.cut-release.outputs.balancing_tag_name }}
+    outputs:
+      test_matrix: ${{ steps.test_matrix.outputs.value }}
 
     steps:
       - name: Checkout release commit
@@ -297,54 +293,175 @@ jobs:
           # depend on anything from the root gda project.
           sync: member
 
-      # The member is engine- and game-agnostic by construction (its isolation
-      # gate is part of this suite), so there is no e2e tier to install Godot for.
-      - name: Verify gda-balancing test and vector inventory
+      - name: Verify gda-balancing test, vector, and behavior-claim inventory
         run: |
           mkdir -p test-results
           uv run --frozen --project libs/gda-balancing \
             python libs/gda-balancing/tools/ci.py verify-inventory \
             --report test-results/inventory.json
+          uv run --frozen --project libs/gda-balancing \
+            python libs/gda-balancing/tools/ci.py verify-claims \
+            --report test-results/coverage-claims.json
 
-      - name: Run gda-balancing tests
+      - name: Export exact release shard matrix
+        id: test_matrix
         run: |
-          set -o pipefail
-          process_timeout="$(uv run --no-project --python 3.13 python \
-            libs/gda-balancing/tools/ci.py process-timeout unfiltered)"
-          timeout --signal=TERM --kill-after=30s "${process_timeout}s" \
-            uv run --frozen --project libs/gda-balancing pytest \
-              libs/gda-balancing/tests -q --durations=50 \
-              --junitxml=test-results/release-junit.xml \
-            2>&1 | tee test-results/release.log
+          value="$(uv run --no-project --python 3.13 python \
+            libs/gda-balancing/tools/ci.py all-test-shards)"
+          echo "value=${value}" >> "$GITHUB_OUTPUT"
 
-      - name: Summarize durations and verify release outcomes
-        if: ${{ always() }}
-        run: |
-          mkdir -p test-results
-          if [ -f test-results/release-junit.xml ]; then
-            uv run --no-project --python 3.13 python \
-              libs/gda-balancing/tools/ci.py summarize-junit \
-              --junit test-results/release-junit.xml \
-              --report test-results/release-durations.json
-            uv run --no-project --python 3.13 python \
-              libs/gda-balancing/tools/ci.py verify-outcomes \
-              --junit test-results/release-junit.xml \
-              --report test-results/release-outcomes.json
-          else
-            printf '{"error":"release suite timed out before JUnit was finalized"}\n' \
-              > test-results/release-durations.json
-            printf '{"error":"release suite timed out before JUnit was finalized"}\n' \
-              > test-results/release-outcomes.json
-          fi
-
-      - name: Upload release validation inventory
-        if: ${{ always() }}
+      - name: Upload release inventory
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: gda-balancing-release-validation
+          name: gda-balancing-release-inventory
           path: test-results/
           if-no-files-found: error
           overwrite: true
+
+  test-release-gda-balancing:
+    name: Test gda-balancing release (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - cut-release
+      - prepare-release-gda-balancing
+    if: >-
+      !failure() && !cancelled() &&
+      needs.cut-release.outputs.balancing_release_created == 'true'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.prepare-release-gda-balancing.outputs.test_matrix || '["__invalid__"]') }}
+
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.cut-release.outputs.balancing_sha }}
+
+      - name: Set up Python environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          sync: member
+          save-cache: false
+
+      - name: Run complete release shard with hard duration bound
+        run: |
+          mkdir -p test-results
+          set -o pipefail
+          process_timeout="$(uv run --no-project --python 3.13 python \
+            libs/gda-balancing/tools/ci.py process-timeout required)"
+          uv run --no-project --python 3.13 python \
+            libs/gda-balancing/tools/ci.py shard-paths "${{ matrix.shard }}" |
+            xargs timeout --signal=TERM --kill-after=30s "${process_timeout}s" \
+              uv run --frozen --project libs/gda-balancing pytest \
+              -q --durations=50 \
+              --junitxml="test-results/junit-${{ matrix.shard }}.xml" \
+            2>&1 | tee "test-results/${{ matrix.shard }}.log"
+
+      - name: Summarize durations and verify release shard outcomes
+        if: ${{ always() }}
+        run: |
+          mkdir -p test-results
+          if [ -f "test-results/junit-${{ matrix.shard }}.xml" ]; then
+            uv run --no-project --python 3.13 python \
+              libs/gda-balancing/tools/ci.py summarize-junit \
+              --junit "test-results/junit-${{ matrix.shard }}.xml" \
+              --report "test-results/${{ matrix.shard }}-durations.json"
+            uv run --no-project --python 3.13 python \
+              libs/gda-balancing/tools/ci.py verify-outcomes \
+              --junit "test-results/junit-${{ matrix.shard }}.xml" \
+              --report "test-results/${{ matrix.shard }}-outcomes.json"
+          else
+            printf '{"error":"release shard timed out before JUnit was finalized"}\n' \
+              > "test-results/${{ matrix.shard }}-durations.json"
+            printf '{"error":"release shard timed out before JUnit was finalized"}\n' \
+              > "test-results/${{ matrix.shard }}-outcomes.json"
+          fi
+
+      - name: Upload release shard diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: gda-balancing-release-${{ matrix.shard }}-diagnostics
+          path: test-results/
+          if-no-files-found: error
+
+  aggregate-release-gda-balancing:
+    name: Aggregate exact gda-balancing release tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - cut-release
+      - prepare-release-gda-balancing
+      - test-release-gda-balancing
+    if: >-
+      !failure() && !cancelled() &&
+      needs.cut-release.outputs.balancing_release_created == 'true'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.cut-release.outputs.balancing_sha }}
+
+      - name: Set up Python environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          sync: member
+          save-cache: false
+
+      - name: Download every release shard result
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: gda-balancing-release-*-diagnostics
+          path: test-results
+          merge-multiple: true
+
+      - name: Prove exact release aggregate closure
+        run: |
+          uv run --frozen --project libs/gda-balancing \
+            python libs/gda-balancing/tools/ci.py aggregate-junit \
+            --junit-dir test-results \
+            --report test-results/aggregate.json
+
+      - name: Upload release aggregate verdict and duration report
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: gda-balancing-release-validation
+          path: test-results/aggregate.json
+          if-no-files-found: error
+          overwrite: true
+
+  build-release-gda-balancing:
+    name: Build verified gda-balancing release artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - cut-release
+      - aggregate-release-gda-balancing
+    if: >-
+      !failure() && !cancelled() &&
+      needs.cut-release.outputs.balancing_release_created == 'true'
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ needs.cut-release.outputs.balancing_tag_name }}
+
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.cut-release.outputs.balancing_sha }}
+
+      - name: Set up Python environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          sync: member
 
       # Same derivation as the root build job — scripts/release_tags.py is the
       # one authority. The tag prefix is NOT restated here: it follows from the

--- a/tests/test_balancing_ci_wiring.py
+++ b/tests/test_balancing_ci_wiring.py
@@ -130,6 +130,10 @@ def test_workflow_derives_shards_budgets_and_smoke_paths_from_policy():
     assert "shard-paths smoke" in workflow
     assert "verify-claims" in workflow
     assert "aggregate-junit" in workflow
+    assert "start-timer" in workflow
+    assert "finish-timer" in workflow
+    assert "wall-${{ matrix.shard }}.json" in workflow
+    assert "run-balancing-unfiltered" not in workflow
     assert "libs/gda-balancing/tests/test_e2e_cli.py" not in workflow
     assert "python3 libs/gda-balancing/tools/ci.py" not in workflow
     assert "\n    timeout-minutes: 1\n" not in workflow
@@ -157,6 +161,8 @@ def test_workflow_derives_shards_budgets_and_smoke_paths_from_policy():
     assert "process-timeout required" in release
     assert "verify-outcomes" in release
     assert "aggregate-junit" in release
+    assert "start-timer" in release
+    assert "finish-timer" in release
 
 
 def test_release_matrix_and_build_are_pinned_to_the_exact_member_release_sha():
@@ -173,5 +179,12 @@ def test_release_matrix_and_build_are_pinned_to_the_exact_member_release_sha():
 
     build = _workflow_job(release, "build-release-gda-balancing")
     assert "aggregate-release-gda-balancing" in build
+    aggregate = _workflow_job(release, "aggregate-release-gda-balancing")
+    assert "always() &&" in aggregate
+    assert "continue-on-error: true" in aggregate
+    assert (
+        "Upload release aggregate verdict and duration report\n        if: ${{ always() }}"
+        in aggregate
+    )
     publish = _workflow_job(release, "publish-pypi-gda-balancing")
     assert "build-release-gda-balancing" in publish

--- a/tests/test_balancing_ci_wiring.py
+++ b/tests/test_balancing_ci_wiring.py
@@ -127,8 +127,9 @@ def test_workflow_derives_shards_budgets_and_smoke_paths_from_policy():
 
     assert "required-test-shards" in workflow
     assert "process-timeout required" in workflow
-    assert "process-timeout unfiltered" in workflow
     assert "shard-paths smoke" in workflow
+    assert "verify-claims" in workflow
+    assert "aggregate-junit" in workflow
     assert "libs/gda-balancing/tests/test_e2e_cli.py" not in workflow
     assert "python3 libs/gda-balancing/tools/ci.py" not in workflow
     assert "\n    timeout-minutes: 1\n" not in workflow
@@ -136,7 +137,7 @@ def test_workflow_derives_shards_budgets_and_smoke_paths_from_policy():
     assert "uv-version:" not in action
     assert "uv-version:" not in workflow
     assert "uv-version:" not in release
-    assert release.count("uses: ./.github/actions/setup-python-env") == 3
+    assert release.count("uses: ./.github/actions/setup-python-env") == 6
     assert "uses: actions/setup-python@v6" in scope_job
     assert 'python-version: "3.13"' in scope_job
     assert "setup-python-env" not in scope_job
@@ -147,14 +148,30 @@ def test_workflow_derives_shards_budgets_and_smoke_paths_from_policy():
     _assert_job_timeout(workflow, "balancing-inventory", 15)
     _assert_job_timeout(workflow, "balancing-tests", 15)
     _assert_job_timeout(workflow, "balancing-smoke", 15)
-    _assert_job_timeout(workflow, "balancing-required", 5)
-    _assert_job_timeout(workflow, "balancing-nightly", 20)
-    _assert_job_timeout(release, "build-release-gda-balancing", 30)
-    assert "process-timeout unfiltered" in release
+    _assert_job_timeout(workflow, "balancing-required", 15)
+    _assert_job_timeout(release, "prepare-release-gda-balancing", 15)
+    _assert_job_timeout(release, "test-release-gda-balancing", 15)
+    _assert_job_timeout(release, "aggregate-release-gda-balancing", 15)
+    _assert_job_timeout(release, "build-release-gda-balancing", 15)
+    assert "all-test-shards" in release
+    assert "process-timeout required" in release
     assert "verify-outcomes" in release
-    assert (
-        "Summarize durations and verify release outcomes\n"
-        "        if: ${{ always() }}\n"
-        "        run: |\n"
-        "          mkdir -p test-results"
-    ) in release
+    assert "aggregate-junit" in release
+
+
+def test_release_matrix_and_build_are_pinned_to_the_exact_member_release_sha():
+    release = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    for job_name in (
+        "prepare-release-gda-balancing",
+        "test-release-gda-balancing",
+        "aggregate-release-gda-balancing",
+        "build-release-gda-balancing",
+    ):
+        job = _workflow_job(release, job_name)
+        assert "ref: ${{ needs.cut-release.outputs.balancing_sha }}" in job
+
+    build = _workflow_job(release, "build-release-gda-balancing")
+    assert "aggregate-release-gda-balancing" in build
+    publish = _workflow_job(release, "publish-pypi-gda-balancing")
+    assert "build-release-gda-balancing" in publish


### PR DESCRIPTION
## Summary

- fan out the exact `gda-balancing` inventory across the eight member-owned static shards in PR, nightly, and release validation
- aggregate JUnit, duration, inventory, outcome, timeout, and failure evidence through one fail-closed required verdict
- pin every release validation job to the selected release SHA and block build/publish until the complete aggregate succeeds
- retain failed aggregate evidence and preserve read-only permissions for all test jobs

## Dependency and scope

This is the root-owned workflow half of #597. It is intentionally stacked on `feat/596-periodic-effect` / PR #614 because that member-only branch owns the shard policy, inventory, claim ledger, optimized fixtures, and local runner consumed here.

Review only `feat/596-periodic-effect..feat/597-test-suite-latency`. The diff is confined to:

- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`
- `tests/test_balancing_ci_wiring.py`

After PR #614 merges, this PR will be retargeted to its resulting base before merge.

## Correctness evidence

- root workflow wiring: 4 passed
- member CI policy: 38 passed
- accepted inventory: 1,409 tests / 194 package vectors / 27 accepted skips
- current inventory: 1,537 tests / 194 package vectors, exact pairwise-disjoint shard closure
- coverage claims: 19/19 claims and 333 subjects closed; accepted 15/305 mapping closed
- independent review: APPROVE exact tree `54bbc7650864b58e15fb9cf88af6d81926e6132e`

## Performance evidence

- accepted baseline SHA `2b81e2e7428656137cfc26c884681e8e03666b72`
- optimized SHA `7ed95688ec62511e33d0d52250a8db73f533a7d7`
- local cumulative test seconds: 1292.539s baseline median → 986.854s optimized median (23.6% improvement)
- local wall time: 1297.274s baseline median → 1001.421s optimized median (22.8% improvement)
- required CI path: 483s baseline median → 293s optimized median (39.3% improvement); optimized provisional max 294s
- slowest optimized CI shard: 222s, retaining 53.8% headroom below the 480s hard bound
- all local and CI statistics use three complete same-SHA successful runs; constituent values and run links are posted in the evidence comment

Closes #597
