### PR TITLE
perf(gda-balancing): reduce full-suite latency

### DIFF
--- a/libs/gda-balancing/README.md
+++ b/libs/gda-balancing/README.md
@@ -77,8 +77,8 @@ The suite is fast and needs no game engine — the toolkit is engine- and game-a
 an isolation gate in the suite enforces that. Its e2e tier drives the installed console
 script as a real subprocess, which is why the test commands above run through `--project`:
 that is what puts `gda-balancing` on `PATH`.
-The admitted-authority fixture boundary, logical inventory gate, CI shards, and latency
-measurement protocol are documented in
+The admitted-authority fixture boundary, logical inventory gate, CI shards, and full-suite
+latency guidance are documented in
 [`docs/agents/testing.md`](docs/agents/testing.md).
 
 Design decisions live in [`docs/badr/`](docs/badr) (balancing ADRs) and the domain glossary

--- a/libs/gda-balancing/docs/agents/testing.md
+++ b/libs/gda-balancing/docs/agents/testing.md
@@ -93,8 +93,8 @@ real-subprocess and end-to-end job. The other six shards feed the stable
 
 | Shard | Main ownership | Local median test time |
 | --- | --- | ---: |
-| `fast` | policy, lifecycle, resources, migration, and small suites | 41.170 s |
-| `authority` | authority CLI and authority bootstrap | 132.534 s |
+| `fast` | policy, lifecycle, authority bootstrap, resources, migration, and small suites | 80.444 s |
+| `authority` | authority CLI | 93.359 s |
 | `language` | language bootstrap and formula CLI | 85.316 s |
 | `model` | model CLI and independent lowerer | 86.394 s |
 | `experiment` | experiment CLI | 113.766 s |
@@ -104,7 +104,10 @@ real-subprocess and end-to-end job. The other six shards feed the stable
 The figures are medians calculated from the same three post-change full-suite
 JUnit reports used below. Shard membership is deliberately static and
 reviewable; the existing partition test proves that files neither overlap nor
-fall outside the matrix.
+fall outside the matrix. The combined authority job reached 310 seconds in the
+362-second CI sample. Moving the independently selectable bootstrap file to
+`fast` changes the three-report local medians to 80.444 and 93.359 seconds
+without adding a shard; exact-head CI revalidates the resulting critical path.
 
 ## Local evidence
 

--- a/libs/gda-balancing/docs/agents/testing.md
+++ b/libs/gda-balancing/docs/agents/testing.md
@@ -150,10 +150,11 @@ median. Three successful six-shard runs produced these results:
 | [Attempt 4](https://github.com/aigengame/godot-agent/actions/runs/30927209932/attempts/4) | 229 s |
 
 The median was 268 s, a 44.5% improvement, with a 277 s maximum. These runs
-establish the accepted six-shard partition. The final review-fix head still
-needs ordinary CI before merge; no four-shard remeasurement is required. #597
-uses this fixed three-run comparison; the rolling 20-run p95 protocol from the
-superseded implementation is not a standing gate for this refactor.
+establish the accepted six-shard partition. Review-fix heads require ordinary
+CI before merge, but unchanged shard membership does not require another
+three-run performance sample. #597 uses this fixed comparison; the rolling
+20-run p95 protocol from the superseded implementation is not a standing gate
+for this refactor.
 
 Nightly and release flows are not restructured by this member change. Any
 future workflow change must be justified independently by measured CI evidence

--- a/libs/gda-balancing/docs/agents/testing.md
+++ b/libs/gda-balancing/docs/agents/testing.md
@@ -46,8 +46,8 @@ cached by the actual canonical schema and Kernel profile bytes.
 Tests preserve those boundaries:
 
 - `pristine_authority_context` supplies the immutable packaged baseline;
-- `authority_candidate` and `mutable_authorities()` return independently owned
-  deep mutable copies;
+- `mutable_authorities()` is the shared deep-copy helper, and the
+  `authority_candidate` fixture builds its candidate from that helper;
 - loader, failure-publication, cache, and cold-command tests continue to use
   the dedicated loading and lifecycle seams; and
 - Consumer B remains an independent interpreter and does not call production
@@ -63,13 +63,20 @@ uv run --frozen --project libs/gda-balancing python \
   --report /tmp/gda-balancing-inventory.json
 ```
 
+`schema2-test-inventory-v1.json` remains the source for baseline test and
+vector identities and allowed skips. `schema2-bootstrap-migration-map.json`
+remains the mapping for the earlier bootstrap test split. Pytest collection
+rejects `xfail(strict=False)` before execution.
+
 CI also runs the existing outcome check on each JUnit file; undeclared skips
 and xfails fail the job. Balancing-affecting or unknown paths run inventory,
 all six required shards, the separate smoke shard, and the stable
 `gda-balancing required` result. Each test process retains the existing
 eight-minute bound and fifteen-minute job timeout. Scheduled and release flows
-retain their complete unfiltered-suite checks and existing fifteen-minute
-process bound; this member change does not alter those workflows.
+retain their complete unfiltered-suite checks, existing fifteen-minute process
+bound, outcome verification, and diagnostic uploads. Member release PRs remain
+restricted to `libs/gda-balancing/**`; this change does not alter those
+workflows or their ownership boundary.
 
 ## Optimizations
 
@@ -91,23 +98,25 @@ The complete suite is partitioned by file. The `smoke` shard remains a separate
 real-subprocess and end-to-end job. The other six shards feed the stable
 `gda-balancing required` check.
 
-| Shard | Main ownership | Local median test time |
-| --- | --- | ---: |
-| `fast` | policy, lifecycle, authority bootstrap, resources, migration, and small suites | 80.444 s |
-| `authority` | authority CLI | 93.359 s |
-| `language` | language bootstrap and formula CLI | 85.316 s |
-| `model` | model CLI and independent lowerer | 86.394 s |
-| `experiment` | experiment CLI | 113.766 s |
-| `composition` | CLI conformance, composition bootstrap, and templates | 82.880 s |
-| `smoke` | end-to-end CLI paths | 96.557 s |
+| Shard | Main ownership |
+| --- | --- |
+| `fast` | policy, lifecycle, authority bootstrap, resources, migration, and small suites |
+| `authority` | authority CLI |
+| `language` | language bootstrap and formula CLI |
+| `model` | model CLI and independent lowerer |
+| `experiment` | experiment CLI |
+| `composition` | CLI conformance, composition bootstrap, and templates |
+| `smoke` | end-to-end CLI paths |
 
-The figures are medians calculated from the same three post-change full-suite
-JUnit reports used below. Shard membership is deliberately static and
-reviewable; the existing partition test proves that files neither overlap nor
-fall outside the matrix. The combined authority job reached 310 seconds in the
-362-second CI sample. Moving the independently selectable bootstrap file to
-`fast` changes the three-report local medians to 80.444 and 93.359 seconds
-without adding a shard; exact-head CI revalidates the resulting critical path.
+Shard membership is deliberately static and reviewable; the existing partition
+test proves that files neither overlap nor fall outside the matrix. The `model`
+and `experiment` files are measured indivisible hotspots. Giving each a matrix
+entry keeps the largest local required shard near 114 seconds instead of
+combining files into partitions near 172 and 197 seconds. The workflow already
+derives its matrix from `REQUIRED_TEST_SHARDS`, so the split costs two additional
+standard matrix executions but adds no custom runner or new aggregator, timer,
+inventory, or artifact protocol. Moving the two independently selectable
+bootstrap files to `fast` separates them from the authority CLI hotspot.
 
 ## Local evidence
 
@@ -124,17 +133,27 @@ time comes from JUnit; wall time comes from `/usr/bin/time -p`.
 All three optimized runs collected 1,409 tests and finished with 1,382 passed
 and 27 skipped. Their wall times were 636.840 s, 643.920 s, and 632.840 s.
 
-The remaining largest file medians are experiment CLI (113.766 s), end-to-end
-CLI (96.557 s), authority CLI (93.359 s), and language bootstrap (79.369 s).
+The remaining largest file medians are experiment CLI (about 114 s), end-to-end
+CLI (about 97 s), authority CLI (about 93 s), and language bootstrap (about 79 s).
 These values explain the shard split; they are not new test policy.
 
 ## CI acceptance
 
 Before #597, three required-CI runs at the clean base took 483 s, 496 s, and
 483 s from the scope job start to the stable required check, for a 483 s
-median. Record the three exact-head post-change runs and their URLs in the PR.
-Acceptance requires a median improvement of at least 25% and no run above six
-minutes.
+median. Three successful six-shard runs produced these results:
+
+| Run | Elapsed |
+| --- | ---: |
+| [Attempt 1](https://github.com/aigengame/godot-agent/actions/runs/30927209932/attempts/1) | 277 s |
+| [Attempt 3](https://github.com/aigengame/godot-agent/actions/runs/30927209932/attempts/3) | 268 s |
+| [Attempt 4](https://github.com/aigengame/godot-agent/actions/runs/30927209932/attempts/4) | 229 s |
+
+The median was 268 s, a 44.5% improvement, with a 277 s maximum. These runs
+establish the accepted six-shard partition. The final review-fix head still
+needs ordinary CI before merge; no four-shard remeasurement is required. #597
+uses this fixed three-run comparison; the rolling 20-run p95 protocol from the
+superseded implementation is not a standing gate for this refactor.
 
 Nightly and release flows are not restructured by this member change. Any
 future workflow change must be justified independently by measured CI evidence

--- a/libs/gda-balancing/docs/agents/testing.md
+++ b/libs/gda-balancing/docs/agents/testing.md
@@ -34,6 +34,43 @@ manifest, or aggregate JUnit protocol. Test preservation is checked by
 comparing the complete collection before and after the change. The repository's
 pre-existing inventory and outcome checks continue unchanged.
 
+## Existing verification contract
+
+Production publishes one process-scoped, deeply immutable
+`AdmittedAuthorityContext` only after the complete packaged Kernel and sealed
+Language Definition Bundle graph has loaded, admitted, indexed, and frozen. A
+failed admission publishes no partial context. Explicitly injected candidates
+are admitted into independently owned contexts, and schema meta-validation is
+cached by the actual canonical schema and Kernel profile bytes.
+
+Tests preserve those boundaries:
+
+- `pristine_authority_context` supplies the immutable packaged baseline;
+- `authority_candidate` and `mutable_authorities()` return independently owned
+  deep mutable copies;
+- loader, failure-publication, cache, and cold-command tests continue to use
+  the dedicated loading and lifecycle seams; and
+- Consumer B remains an independent interpreter and does not call production
+  admission or schema-cache implementations.
+
+The pre-existing inventory check proves that baseline tests and vectors have
+not disappeared and that every current test belongs to exactly one shard. Run
+it from the repository root with:
+
+```bash
+uv run --frozen --project libs/gda-balancing python \
+  libs/gda-balancing/tools/ci.py verify-inventory \
+  --report /tmp/gda-balancing-inventory.json
+```
+
+CI also runs the existing outcome check on each JUnit file; undeclared skips
+and xfails fail the job. Balancing-affecting or unknown paths run inventory,
+all six required shards, the separate smoke shard, and the stable
+`gda-balancing required` result. Each test process retains the existing
+eight-minute bound and fifteen-minute job timeout. Scheduled and release flows
+retain their complete unfiltered-suite checks and existing fifteen-minute
+process bound; this member change does not alter those workflows.
+
 ## Optimizations
 
 Two repeated setup costs were removed without weakening the tested contracts:

--- a/libs/gda-balancing/docs/agents/testing.md
+++ b/libs/gda-balancing/docs/agents/testing.md
@@ -153,8 +153,8 @@ The median was 268 s, a 44.5% improvement, with a 277 s maximum. These runs
 establish the accepted six-shard partition. Review-fix heads require ordinary
 CI before merge, but unchanged shard membership does not require another
 three-run performance sample. #597 uses this fixed comparison; the rolling
-20-run p95 protocol from the superseded implementation is not a standing gate
-for this refactor.
+20-run p95 protocol introduced with #587 is not a standing gate for this
+refactor.
 
 Nightly and release flows are not restructured by this member change. Any
 future workflow change must be justified independently by measured CI evidence

--- a/libs/gda-balancing/docs/agents/testing.md
+++ b/libs/gda-balancing/docs/agents/testing.md
@@ -1,201 +1,101 @@
-# Schema 2.0 authority and feedback-latency verification
+# Testing and full-suite latency
 
-This document is the operational contract for issue
-[#597](https://github.com/aigengame/godot-agent/issues/597). It explains what is
-shared, what must remain independent, how required CI selects and partitions
-tests, and how latency evidence is measured. It does not change Schema 2.0
-semantics.
+This page records how to run the gda-balancing test suite and the measured
+latency work tracked by
+[#597](https://github.com/aigengame/godot-agent/issues/597). It is an
+operational guide, not a second test specification.
 
-## Admitted authority lifecycle
+## Commands
 
-Production has one process-scoped `AdmittedAuthorityContext`. Its lifecycle
-module loads the exact packaged Kernel and sealed LDB graph, admits the complete
-trust boundary, derives the language index, deeply freezes all reachable
-objects, and only then publishes the context. Concurrent first use is
-single-flight. A failed packaged admission publishes one deterministic refusal,
-never a partial context.
-
-All authority-dependent commands and model, migration, experiment, template,
-projection, lowering, and Resolved-Model paths borrow this exact context.
-Injected providers are separate lifecycles: a supplied Kernel/LDB pair is
-admitted into an independently owned context and cannot update the packaged
-cache.
-
-Production JSON-Schema meta-validation has one cache domain. Its key is the
-tuple of actual canonical schema bytes and actual canonical Kernel
-schema-profile bytes. Claimed content identities are not cache keys.
-
-## Test ownership and Consumer B
-
-Read-only tests use the session-scoped `pristine_authority_context` fixture.
-Mutation tests use `authority_candidate` or the bootstrap suite's equivalent
-helper, which makes one deep mutable copy for the test's isolation boundary.
-No mutation helper reloads or re-admits the packaged graph.
-
-Consumer B remains an independent interpreter. It does not call the production
-admission or schema-cache implementation. Its optional schema
-meta-validation cache is separately implemented and separately keyed by
-Consumer B's own canonical bytes. Tests compare both consumers on all positive,
-negative, mutation, ordering, and resource-boundary vectors.
-
-The former `test_schema2_bootstrap_conformance.py` is split by semantic
-ownership:
-
-- `test_schema2_bootstrap_authority.py`: graph, binding, identity, and package
-  authority;
-- `test_schema2_bootstrap_language.py`: language definitions, rules, reasons,
-  diagnostics, and Wire Schemas;
-- `test_schema2_bootstrap_composition.py`: Model, Operation, Runtime, and
-  Template composition;
-- `test_schema2_bootstrap_resources.py`: resource and adversarial boundaries.
-
-Shared Consumer B implementation remains single-source in
-`schema2_bootstrap_conformance_support.py`, which imports no production
-admission or authority-cache module. Consumer A and mutable-fixture adapters
-live separately in `schema2_bootstrap_production_support.py`.
-
-## Inventory closure
-
-`schema2-test-inventory-v1.json` records the 1,030 logical tests and 92 packaged
-conformance vectors present before the final #597 root-CI cutover. Its current
-allowlist contains 96 structurally inapplicable skip outcomes; implementing a
-formerly missing conformance row removes that row from the allowlist. Logical
-identifiers preserve classes and parameter/vector cases.
-`schema2-bootstrap-migration-map.json` maps every bootstrap test moved to one
-of the four semantic files; normalization applies only to those declared moves.
-
-Run the closure check from the repository root:
+Run the complete member suite from the repository root:
 
 ```bash
-uv run --frozen --project libs/gda-balancing \
-  python libs/gda-balancing/tools/ci.py verify-inventory \
-  --report /tmp/gda-balancing-inventory.json
+uv run --frozen --project libs/gda-balancing pytest \
+  libs/gda-balancing/tests -q
 ```
 
-The check fails if a baseline test or vector disappears, two shards overlap, a
-current test is uncovered, or a shard selects a test outside the unfiltered
-collection. New regression tests are allowed and increase the current count.
-After execution, `verify-outcomes` reads each JUnit result and fails if a test
-outside the recorded set is skipped or if any test is xfailed. Member pytest
-also uses strict xfail behavior, and its collection hook rejects an explicit
-`xfail(strict=False)` override, so an XPASS cannot conceal a newly introduced
-xfail marker.
+From this package directory, the equivalent command is:
 
-## Required, nightly, and release policy
+```bash
+uv run --frozen pytest tests -q
+```
 
-`tools/ci.py` is the reviewed path and shard authority.
-`libs/gda-balancing/**`, its lock, the shared Python setup action, CI/release
-workflows, the root balancing-CI wiring regression, and shared
-release/tag/scope tooling run the complete matrix. Only explicitly enumerated
-root-product and documentation paths are unrelated. Every unknown path fails
-closed to the complete matrix.
-
-The shared Python setup action owns one exact uv version for every CI and
-Release consumer; individual jobs do not restate or override that version.
-The stdlib-only scope classifier is the exception to using uv: it pins Python
-3.13 directly with `actions/setup-python` so an unrelated PR does not install a
-package manager merely to classify paths.
-
-An affecting PR runs:
-
-1. inventory closure;
-2. four pairwise-disjoint test shards: `fast`, `authority`, `language`, and
-   `composition`;
-3. a separate wheel and real-subprocess smoke shard;
-4. the stable `gda-balancing required` aggregator.
-
-Each executable shard has a hard eight-minute process bound and a fifteen-minute
-job timeout. JUnit, raw logs, per-file totals, the 50 slowest tests, and the
-outcome-closure report are uploaded even after a test failure. A known
-unrelated PR runs only scope classification and the successful stable
-aggregator. The one-minute unrelated target is measured from scope-job start to
-aggregator completion; it is not the aggregator's job timeout.
-
-Nightly and release validation run the complete unfiltered suite under a
-separate fifteen-minute process bound. The nightly job has a twenty-minute job
-timeout; the release build job has thirty minutes for inventory, tests, tag
-validation, and build. Release also checks inventory closure and uploads the
-inventory, JUnit, duration, outcome, and raw-log evidence. Maintainers can run
-the exact nightly path against a PR head with **Run workflow** and
-`run-balancing-unfiltered=true`; scheduled and manual evidence runs use unique,
-non-cancelling concurrency groups, so a later `main` push cannot discard them.
-
-Member release PRs may contain only `libs/gda-balancing/**`, so the member-owned
-policy, inventory, and tests land separately from the root-owned workflow
-wiring. That wiring must be reviewed as a non-releasing root change stacked
-after the member change; it must not be folded into a releasing member PR.
-The required-check cutover is complete: repository protection requires
-`gda-balancing required`, and the duplicate serial member test/build path was
-removed only after that protection was active.
-
-To reproduce a shard:
+`tools/ci.py` remains the existing authority for CI scope classification,
+static shard membership, and inventory closure. Reproduce one shard with:
 
 ```bash
 uv run --no-project --python 3.13 python \
   libs/gda-balancing/tools/ci.py shard-paths authority |
-  xargs uv run --frozen --project libs/gda-balancing pytest -q --durations=50
+  xargs uv run --frozen --project libs/gda-balancing pytest -q
 ```
 
-## Baseline and current evidence
+This optimization adds no local runner, coverage ledger, accepted-test
+manifest, or aggregate JUnit protocol. Test preservation is checked by
+comparing the complete collection before and after the change. The repository's
+pre-existing inventory and outcome checks continue unchanged.
 
-The accepted pre-change exact head was `84e3212`. GitHub CI collected 1,030
-tests and reported 940 passed, 90 skipped in 2,697.07 seconds. The critical
-path was:
+## Optimizations
 
-| File | Pre-change duration |
-| --- | ---: |
-| bootstrap conformance | 20:21 |
-| model CLI | 5:48 |
-| experiment CLI | 4:34 |
-| authority CLI | 4:21 |
-| template CLI | 4:11 |
-| CLI conformance | 2:41 |
-| independent model lowerer | 2:03 |
+Two repeated setup costs were removed without weakening the tested contracts:
 
-A cold `model check` process performed six full packaged-authority admissions
-and 190 JSON-Schema meta-validations. The lifecycle regression suite now proves
-one full packaged admission for every authority-dependent public command and
-one meta-validation per unique canonical schema/profile key in the production
-cache domain.
+- Tests that need mutable Kernel and Language Definition Bundle inputs now
+  copy the already admitted packaged authority. Cold-load and lifecycle tests
+  continue to use their dedicated loaders.
+- The built-wheel authority test still checks the archive bytes, runs the real
+  wheel module, and compares every source and wheel result. Its repeated
+  `package get` commands now share one wheel process instead of starting one
+  process per child.
 
-Local command latency was measured with dependencies already installed, one new
-OS process per command, and `/usr/bin/time -p`:
+No test, parameter case, assertion, or packaged vector was removed.
 
-| Command | `84e3212` | #597 worktree |
-| --- | ---: | ---: |
-| `version` | 1.34 s | 0.75 s |
-| `model check examples/schema2/rpg-combat-cast/model-source.json` | 2.56 s | 0.83 s |
-| `template list` | 2.33 s | 0.73 s |
+## Static CI shards
 
-The post-review PR #598 verification collects 1,085 tests and retains the same
-92 packaged vectors. The four semantic matrix shards contain 990 passing tests
-and the same 90 accepted skips; the separate required smoke shard contains five
-passing tests. Across required execution, 995 tests pass, and outcome closure
-reports zero new skips and zero xfails.
-Exact-head manual-unfiltered evidence and individual-run wall clocks are kept
-with the PR rather than frozen here. Command timings and individual-run timings
-are diagnostic evidence; the rolling CI service-level measurement below is the
-operational gate.
+The complete suite is partitioned by file. The `smoke` shard remains a separate
+real-subprocess and end-to-end job. The other six shards feed the stable
+`gda-balancing required` check.
 
-## CI latency measurement protocol
+| Shard | Main ownership | Local median test time |
+| --- | --- | ---: |
+| `fast` | policy, lifecycle, resources, migration, and small suites | 41.170 s |
+| `authority` | authority CLI and authority bootstrap | 132.534 s |
+| `language` | language bootstrap and formula CLI | 85.316 s |
+| `model` | model CLI and independent lowerer | 86.394 s |
+| `experiment` | experiment CLI | 113.766 s |
+| `composition` | CLI conformance, composition bootstrap, and templates | 82.880 s |
+| `smoke` | end-to-end CLI paths | 96.557 s |
 
-Measure from the earliest required balancing job's GitHub `startedAt` to the
-stable aggregator's `completedAt`. This includes setup, collection, execution,
-summary generation, and artifact upload. Exclude runner queue time and
-cancelled superseded runs.
+The figures are medians calculated from the same three post-change full-suite
+JUnit reports used below. Shard membership is deliberately static and
+reviewable; the existing partition test proves that files neither overlap nor
+fall outside the matrix.
 
-For balancing-affecting runs on the same runner class:
+## Local evidence
 
-1. retain a rolling window of at least the latest 20 successful runs;
-2. publish every raw GitHub run URL and elapsed value;
-3. sort elapsed values ascending and select rank `ceil(0.95 * n)` (nearest-rank
-   p95);
-4. require p95 at or below ten minutes and target five minutes;
-5. enforce the eight-minute shard bound on every run, independent of sample
-   size.
+The accepted clean base is commit `2b81e2e`. Each measurement used an already
+installed frozen environment and a fresh pytest process. Pytest cumulative
+time comes from JUnit; wall time comes from `/usr/bin/time -p`.
 
-Until 20 post-change samples exist, report every available sample and their
-maximum; do not label that provisional maximum as p95. For explicitly
-unrelated changes, measure the scope job `startedAt` through aggregator
-`completedAt` and require less than one minute. Queue time is excluded in both
-cases.
+| Measurement | Clean base median | Optimized median | Change |
+| --- | ---: | ---: | ---: |
+| Collected tests | 1,409 | 1,409 | unchanged |
+| Pytest cumulative time | 1,292.539 s | 634.676 s | -50.9% |
+| Full-suite wall time | 1,297.274 s | 636.840 s | -50.9% |
+
+All three optimized runs collected 1,409 tests and finished with 1,382 passed
+and 27 skipped. Their wall times were 636.840 s, 643.920 s, and 632.840 s.
+
+The remaining largest file medians are experiment CLI (113.766 s), end-to-end
+CLI (96.557 s), authority CLI (93.359 s), and language bootstrap (79.369 s).
+These values explain the shard split; they are not new test policy.
+
+## CI acceptance
+
+Before #597, three required-CI runs at the clean base took 483 s, 496 s, and
+483 s from the scope job start to the stable required check, for a 483 s
+median. Record the three exact-head post-change runs and their URLs in the PR.
+Acceptance requires a median improvement of at least 25% and no run above six
+minutes.
+
+Nightly and release flows are not restructured by this member change. Any
+future workflow change must be justified independently by measured CI evidence
+and must live in a root-owned, non-releasing PR.

--- a/libs/gda-balancing/tests/conftest.py
+++ b/libs/gda-balancing/tests/conftest.py
@@ -37,6 +37,7 @@ from gda_balancing.schema2.authority import (
     AdmittedAuthorityContext,
     packaged_authority_context,
 )
+from schema2_authority_support import mutable_authorities
 
 RunResult = tuple[int, str, str]
 
@@ -69,7 +70,7 @@ def authority_candidate(
     pristine_authority_context: AdmittedAuthorityContext,
 ) -> dict[str, object]:
     """One independently owned mutable authority candidate for a test boundary."""
-    kernel, language_bundle = pristine_authority_context.mutable_pair()
+    kernel, language_bundle = mutable_authorities()
     admission = pristine_authority_context.admission
     return {
         "kernel": kernel,

--- a/libs/gda-balancing/tests/schema2_authority_support.py
+++ b/libs/gda-balancing/tests/schema2_authority_support.py
@@ -1,4 +1,4 @@
-"""Fast authority candidates for tests that do not exercise loading."""
+"""Shared authority inputs for tests that do not exercise loading."""
 
 from typing import Any
 

--- a/libs/gda-balancing/tests/schema2_test_authority.py
+++ b/libs/gda-balancing/tests/schema2_test_authority.py
@@ -1,0 +1,11 @@
+"""Fast authority candidates for tests that do not exercise loading."""
+
+from typing import Any
+
+from gda_balancing.schema2.authority import packaged_authority_context
+from gda_balancing.schema2.authority_graph import LanguageBundleIndex
+
+
+def mutable_authorities() -> tuple[dict[str, Any], LanguageBundleIndex]:
+    """Return an owned mutable copy of the admitted packaged authorities."""
+    return packaged_authority_context().mutable_pair()

--- a/libs/gda-balancing/tests/test_ci_policy.py
+++ b/libs/gda-balancing/tests/test_ci_policy.py
@@ -74,6 +74,8 @@ def test_shards_pairwise_partition_every_balancing_test_file():
         "fast",
         "authority",
         "language",
+        "model",
+        "experiment",
         "composition",
     )
     assert ci.PROCESS_TIMEOUT_SECONDS == {

--- a/libs/gda-balancing/tests/test_schema2_authority_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_authority_cli.py
@@ -1027,9 +1027,11 @@ def test_built_wheel_ships_only_the_declared_authority_graph_and_runs_it(
         cwd=tmp_path,
         environment=environment,
     )
-    for source, from_wheel in zip(source_gets, wheel_gets, strict=True):
-        assert (from_wheel[0], from_wheel[2]) == (0, "")
-        assert from_wheel[1] == source[1]
+    for source, (returncode, stdout, stderr) in zip(
+        source_gets, wheel_gets, strict=True
+    ):
+        assert (returncode, stderr) == (0, "")
+        assert stdout == source[1]
 
 
 def test_kernel_closes_the_root_descriptor_index_and_graph_limits(run_cli):

--- a/libs/gda-balancing/tests/test_schema2_authority_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_authority_cli.py
@@ -64,6 +64,38 @@ from gda_balancing.schema2.diagnostics import (
 from gda_balancing.schema2.surface import schema2_error_envelope_schema
 
 
+_WHEEL_DISPATCH_BATCH = """
+import io
+import json
+import sys
+
+from gda_balancing.dispatch import dispatch
+
+results = []
+for command in json.load(sys.stdin):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    returncode = dispatch(command, stdout, stderr, stdin=io.StringIO())
+    results.append([returncode, stdout.getvalue(), stderr.getvalue()])
+json.dump(results, sys.stdout)
+"""
+
+
+def _run_wheel_dispatch_batch(
+    commands: list[list[str]], *, cwd: Path, environment: dict[str, str]
+) -> list[list[Any]]:
+    completed = subprocess.run(
+        [sys.executable, "-c", _WHEEL_DISPATCH_BATCH],
+        cwd=cwd,
+        env=environment,
+        input=json.dumps(commands),
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    return cast(list[list[Any]], json.loads(completed.stdout))
+
+
 def _reidentify_graph(kernel, ldb):
     root = deepcopy(ldb.root)
     releases = deepcopy(ldb.package_releases)
@@ -972,22 +1004,27 @@ def test_built_wheel_ships_only_the_declared_authority_graph_and_runs_it(
     assert (installed_list.returncode, installed_list.stderr) == (0, "")
     assert installed_list.stdout == source_list[1]
 
-    for descriptor in source_root["package_descriptors"]:
-        for member in ("release", "conformance-vectors"):
-            arguments = (
-                "package",
-                "get",
-                "--id",
-                descriptor["id"],
-                "--version",
-                descriptor["version"],
-                "--member",
-                member,
-            )
-            source = run_cli(list(arguments))
-            from_wheel = installed(*arguments)
-            assert (from_wheel.returncode, from_wheel.stderr) == (0, "")
-            assert from_wheel.stdout == source[1]
+    get_commands = [
+        [
+            "package",
+            "get",
+            "--id",
+            descriptor["id"],
+            "--version",
+            descriptor["version"],
+            "--member",
+            member,
+        ]
+        for descriptor in source_root["package_descriptors"]
+        for member in ("release", "conformance-vectors")
+    ]
+    source_gets = [run_cli(command) for command in get_commands]
+    wheel_gets = _run_wheel_dispatch_batch(
+        get_commands,
+        cwd=tmp_path,
+        environment=environment,
+    )
+    assert wheel_gets == [list(result) for result in source_gets]
 
 
 def test_kernel_closes_the_root_descriptor_index_and_graph_limits(run_cli):

--- a/libs/gda-balancing/tests/test_schema2_authority_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_authority_cli.py
@@ -92,7 +92,10 @@ def _run_wheel_dispatch_batch(
         capture_output=True,
         text=True,
     )
-    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert (completed.returncode, completed.stderr) == (
+        0,
+        "",
+    ), completed.stdout + completed.stderr
     return cast(list[list[Any]], json.loads(completed.stdout))
 
 
@@ -1024,7 +1027,9 @@ def test_built_wheel_ships_only_the_declared_authority_graph_and_runs_it(
         cwd=tmp_path,
         environment=environment,
     )
-    assert wheel_gets == [list(result) for result in source_gets]
+    for source, from_wheel in zip(source_gets, wheel_gets, strict=True):
+        assert (from_wheel[0], from_wheel[2]) == (0, "")
+        assert from_wheel[1] == source[1]
 
 
 def test_kernel_closes_the_root_descriptor_index_and_graph_limits(run_cli):

--- a/libs/gda-balancing/tests/test_schema2_authority_lifecycle.py
+++ b/libs/gda-balancing/tests/test_schema2_authority_lifecycle.py
@@ -45,6 +45,13 @@ _AUTHORITY_COMMANDS = tuple(
 )
 
 
+@pytest.fixture(autouse=True)
+def _reset_packaged_authority_context_after_test():
+    """Keep deliberate lifecycle mutations inside this module."""
+    yield
+    authority_module.reset_packaged_authority_context_for_tests()
+
+
 def test_packaged_context_initialization_is_single_flight(monkeypatch):
     authority_module.reset_packaged_authority_context_for_tests()
     original = authority_module._load_packaged_authority_context_uncached

--- a/libs/gda-balancing/tests/test_schema2_experiment_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_experiment_cli.py
@@ -28,7 +28,7 @@ from schema2_scheduler_production_support import (
     require_complete_scheduler_detector_bindings,
     scheduler_detector_inventory,
 )
-from schema2_test_authority import mutable_authorities
+from schema2_authority_support import mutable_authorities
 
 _EXAMPLE_DIR = Path(__file__).parents[1] / "examples" / "schema2" / "rpg-combat-cast"
 _PERIODIC_EXAMPLE_DIR = (

--- a/libs/gda-balancing/tests/test_schema2_experiment_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_experiment_cli.py
@@ -28,6 +28,7 @@ from schema2_scheduler_production_support import (
     require_complete_scheduler_detector_bindings,
     scheduler_detector_inventory,
 )
+from schema2_test_authority import mutable_authorities
 
 _EXAMPLE_DIR = Path(__file__).parents[1] / "examples" / "schema2" / "rpg-combat-cast"
 _PERIODIC_EXAMPLE_DIR = (
@@ -67,7 +68,7 @@ def test_tutorial_tuning_values_are_not_package_conformance_configuration():
         row["target"]["name"]: row["value"]
         for row in specification["scenarios"][0]["assignments"]
     }
-    _kernel, language_bundle = authority_module.load_authorities()
+    _kernel, language_bundle = mutable_authorities()
     combat_vectors = next(
         row
         for row in language_bundle.package_conformance_vector_sets
@@ -2049,7 +2050,7 @@ def test_snapshots_bind_the_complete_runtime_continuation(tmp_path, run_cli):
 
 
 def test_kernel_closes_runtime_configuration_transition_and_public_step():
-    kernel, _language_bundle = authority_module.load_authorities()
+    kernel, _language_bundle = mutable_authorities()
     runtime_program = kernel["meta_format"]["runtime_program"]
 
     assert runtime_program["runtime_configuration"] == {
@@ -2132,7 +2133,7 @@ def test_kernel_closes_runtime_configuration_transition_and_public_step():
 
 
 def test_runtime_profile_bounds_are_ldb_owned_under_the_kernel_shape():
-    kernel, language_bundle = authority_module.load_authorities()
+    kernel, language_bundle = mutable_authorities()
     profile_contract = kernel["meta_format"]["runtime_profile_definition"]
     assert profile_contract["active_runtime"]["resource_bounds"] == {
         "members": [
@@ -3574,7 +3575,7 @@ def test_public_experiment_admits_external_input_before_transition_until_queue_d
     assert events[0]["operation"] is None
     assert events[0]["outcome"] == {"id": "input-admitted", "kind": "success"}
     reproduction = _member(receipt, "reproduction-receipt")
-    kernel, _language_bundle = authority_module.load_authorities()
+    kernel, _language_bundle = mutable_authorities()
     input_contract = kernel["meta_format"]["runtime_program"]["scheduler"][
         "external_input_identity"
     ]
@@ -5384,7 +5385,7 @@ def test_kernel_runtime_contract_vectors_and_rng_execute_in_reference_evaluator(
 
 
 def test_package_runtime_scenario_vectors_execute_in_independent_reference_evaluator():
-    kernel, ldb = authority_module.load_authorities()
+    kernel, ldb = mutable_authorities()
     operations = {row["id"]: row for row in ldb["language"]["operations"]}
     vectors = [
         vector
@@ -5457,7 +5458,7 @@ def test_package_runtime_scenario_vectors_execute_in_independent_reference_evalu
 
 
 def test_package_scheduler_vectors_execute_in_two_consumers_and_detect_mutations():
-    kernel, ldb = authority_module.load_authorities()
+    kernel, ldb = mutable_authorities()
     vectors = {
         vector["id"]: vector
         for vector in next(
@@ -5535,7 +5536,7 @@ def test_package_scheduler_vectors_execute_in_two_consumers_and_detect_mutations
 
 
 def test_runtime_scheduler_seam_orders_events_from_the_kernel_contract():
-    kernel, _ldb = authority_module.load_authorities()
+    kernel, _ldb = mutable_authorities()
     events = [
         {
             "id": "observation",
@@ -5578,7 +5579,7 @@ def test_runtime_scheduler_seam_orders_events_from_the_kernel_contract():
 
 
 def test_runtime_scheduler_seam_refuses_backward_scheduling():
-    kernel, ldb = authority_module.load_authorities()
+    kernel, ldb = mutable_authorities()
     vector = next(
         vector
         for vector_set in ldb.package_conformance_vector_sets
@@ -5596,7 +5597,7 @@ def test_runtime_scheduler_seam_refuses_backward_scheduling():
 
 
 def test_runtime_scheduler_seam_refuses_completed_cancellation():
-    kernel, ldb = authority_module.load_authorities()
+    kernel, ldb = mutable_authorities()
     vector = next(
         vector
         for vector_set in ldb.package_conformance_vector_sets
@@ -5613,7 +5614,7 @@ def test_runtime_scheduler_seam_refuses_completed_cancellation():
 
 
 def test_scheduler_conformance_harness_refuses_missing_detector_implementations():
-    kernel, _ldb = authority_module.load_authorities()
+    kernel, _ldb = mutable_authorities()
 
     with pytest.raises(ValueError, match="missing detector implementations"):
         require_complete_scheduler_detector_bindings(
@@ -5624,7 +5625,7 @@ def test_scheduler_conformance_harness_refuses_missing_detector_implementations(
 
 
 def test_scheduler_conformance_harness_refuses_unexpected_detector_implementations():
-    kernel, _ldb = authority_module.load_authorities()
+    kernel, _ldb = mutable_authorities()
     declared = {
         detector: object()
         for detector in next(
@@ -5655,7 +5656,7 @@ def test_scheduler_conformance_harness_refuses_unexpected_detector_implementatio
     ids=["not-list", "empty", "unsorted", "duplicate", "empty-name", "non-string"],
 )
 def test_scheduler_detector_inventory_refuses_a_nonclosed_declaration(detectors):
-    kernel, _ldb = authority_module.load_authorities()
+    kernel, _ldb = mutable_authorities()
     altered_kernel = deepcopy(kernel)
     vector_contract = next(
         kind
@@ -5669,7 +5670,7 @@ def test_scheduler_detector_inventory_refuses_a_nonclosed_declaration(detectors)
 
 
 def test_reference_scheduler_consumer_refuses_an_unimplemented_kernel_detector():
-    kernel, ldb = authority_module.load_authorities()
+    kernel, ldb = mutable_authorities()
     altered_kernel = deepcopy(kernel)
     vector_contract = next(
         kind
@@ -5692,7 +5693,7 @@ def test_reference_scheduler_consumer_refuses_an_unimplemented_kernel_detector()
 
 
 def test_production_scheduler_consumer_refuses_an_unimplemented_kernel_detector():
-    kernel, ldb = authority_module.load_authorities()
+    kernel, ldb = mutable_authorities()
     altered_kernel = deepcopy(kernel)
     vector_contract = next(
         kind
@@ -5720,7 +5721,7 @@ def test_production_scheduler_consumer_refuses_an_unimplemented_kernel_detector(
     ids=["production", "reference"],
 )
 def test_scheduler_consumers_refuse_unknown_requested_mutations(consumer):
-    kernel, ldb = authority_module.load_authorities()
+    kernel, ldb = mutable_authorities()
     vector = next(
         vector
         for vector_set in ldb.package_conformance_vector_sets
@@ -5734,7 +5735,7 @@ def test_scheduler_consumers_refuse_unknown_requested_mutations(consumer):
 
 
 def test_package_value_program_vectors_execute_in_two_consumers():
-    _kernel, ldb = authority_module.load_authorities()
+    _kernel, ldb = mutable_authorities()
     vectors = [
         vector
         for vector in next(
@@ -5760,7 +5761,7 @@ def test_package_value_program_vectors_execute_in_two_consumers():
 
 
 def test_package_observation_lifecycle_vectors_execute_in_two_consumers():
-    _kernel, ldb = authority_module.load_authorities()
+    _kernel, ldb = mutable_authorities()
     vectors = [
         vector
         for vector in next(
@@ -6357,7 +6358,7 @@ def test_numeric_overflow_rolls_back_the_entire_current_event(tmp_path, run_cli)
         {"name": "target_health", "value": 100},
     ]
     assert audit["rollback"]["state_after"] == audit["rollback"]["state_before"]
-    kernel, ldb = authority_module.load_authorities()
+    kernel, ldb = mutable_authorities()
     operations = {row["id"]: row for row in ldb["language"]["operations"]}
     rir = _member(build_receipt, "rir-semantic-payload")
     resolved_entrypoint = next(

--- a/libs/gda-balancing/tests/test_schema2_model_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_model_cli.py
@@ -35,7 +35,7 @@ from gda_balancing.schema2.authority_graph import (
 )
 from gda_balancing.schema2.surface import descriptor_identity
 from gda_balancing.schema2.package_semantics import package_runtime_semantic_closure
-from schema2_test_authority import mutable_authorities
+from schema2_authority_support import mutable_authorities
 
 
 def _inject_authority_context(monkeypatch, kernel, language_bundle):
@@ -2236,7 +2236,7 @@ def test_model_check_refuses_conflicting_transitive_dependency_versions(
 
 
 def test_in_memory_model_check_reuses_only_a_matching_authority_admission():
-    kernel, language_bundle = mutable_authorities()
+    kernel, language_bundle = authority_module.load_authorities()
     admission = admit_authorities(kernel, language_bundle)
 
     checked = model_module.check_model_source_value(
@@ -3067,7 +3067,7 @@ def test_model_build_rejects_invocation_key_reuse_after_exact_authority_changes(
     artifact_dir = _artifact_directory(json.loads(first[1]))
     before = {path.name: path.read_bytes() for path in artifact_dir.iterdir()}
 
-    kernel, language_bundle = mutable_authorities()
+    kernel, language_bundle = authority_module.load_authorities()
     candidate_ldb = deepcopy(language_bundle)
     candidate_ldb["resources"]["max_diagnostics"] -= 1
     _reidentify_language_bundle(candidate_ldb)
@@ -6316,8 +6316,9 @@ def test_non_rpg_package_reaches_evaluator_without_kernel_or_host_extension(
     )
     _reidentify_language_bundle(candidate_ldb)
     assert admit_authorities(kernel, candidate_ldb).admitted is True
-    assert kernel == mutable_authorities()[0]
-    assert baseline_ldb == mutable_authorities()[1]
+    pristine_kernel, pristine_ldb = mutable_authorities()
+    assert kernel == pristine_kernel
+    assert baseline_ldb == pristine_ldb
 
     source_document = _model_source()
     source_document["package_requirements"] = [

--- a/libs/gda-balancing/tests/test_schema2_model_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_model_cli.py
@@ -35,6 +35,7 @@ from gda_balancing.schema2.authority_graph import (
 )
 from gda_balancing.schema2.surface import descriptor_identity
 from gda_balancing.schema2.package_semantics import package_runtime_semantic_closure
+from schema2_test_authority import mutable_authorities
 
 
 def _inject_authority_context(monkeypatch, kernel, language_bundle):
@@ -450,7 +451,7 @@ def test_formula_parameter_sugar_normalizes_to_same_formula_and_rir_through_conv
 
 
 def test_formula_policy_uses_authority_values_without_host_spelling_or_limit_pins():
-    _kernel, language_bundle = authority_module.load_authorities()
+    _kernel, language_bundle = mutable_authorities()
     candidate = deepcopy(language_bundle)
     profile = next(
         row
@@ -1724,7 +1725,7 @@ def test_formula_slot_value_axes_have_stable_authority_diagnostics(
     diagnostic_row = json.loads(stdout)["error"]["diagnostics"][0]
     assert diagnostic_row["code"] == diagnostic
     assert diagnostic_row["primary"]["pointer"] == "/formula_bindings/0/formula"
-    _, language_bundle = authority_module.load_authorities()
+    _, language_bundle = mutable_authorities()
     assert (
         model_module.reason_by_id(language_bundle, reason_id)["diagnostic"]
         == diagnostic
@@ -2167,7 +2168,7 @@ def test_model_check_rejects_an_invalid_value_policy_on_an_unused_symbol(
 def test_model_check_refuses_conflicting_transitive_dependency_versions(
     tmp_path, monkeypatch
 ):
-    kernel, baseline_ldb = authority_module.load_authorities()
+    kernel, baseline_ldb = mutable_authorities()
     candidate_ldb = deepcopy(baseline_ldb)
     language = candidate_ldb["language"]
     seed = next(
@@ -2235,7 +2236,7 @@ def test_model_check_refuses_conflicting_transitive_dependency_versions(
 
 
 def test_in_memory_model_check_reuses_only_a_matching_authority_admission():
-    kernel, language_bundle = authority_module.load_authorities()
+    kernel, language_bundle = mutable_authorities()
     admission = admit_authorities(kernel, language_bundle)
 
     checked = model_module.check_model_source_value(
@@ -2326,7 +2327,7 @@ def test_model_check_applies_the_ldb_diagnostic_cap_and_marks_truncation(
         symbol["kind"] = "unknown-kind"
     source = tmp_path / "model-source.json"
     source.write_text(json.dumps(source_document), encoding="utf-8")
-    kernel, language_bundle = authority_module.load_authorities()
+    kernel, language_bundle = mutable_authorities()
     candidate_ldb = deepcopy(language_bundle)
     candidate_ldb["resources"]["max_diagnostics"] = 2
     _reidentify_language_bundle(candidate_ldb)
@@ -3066,7 +3067,7 @@ def test_model_build_rejects_invocation_key_reuse_after_exact_authority_changes(
     artifact_dir = _artifact_directory(json.loads(first[1]))
     before = {path.name: path.read_bytes() for path in artifact_dir.iterdir()}
 
-    kernel, language_bundle = authority_module.load_authorities()
+    kernel, language_bundle = mutable_authorities()
     candidate_ldb = deepcopy(language_bundle)
     candidate_ldb["resources"]["max_diagnostics"] -= 1
     _reidentify_language_bundle(candidate_ldb)
@@ -3616,7 +3617,7 @@ def test_publication_index_anchor_rejects_a_coherently_reidentified_rewrite(
 
 
 def test_receipt_content_identity_excludes_transport_locators():
-    _, language_bundle = authority_module.load_authorities()
+    _, language_bundle = mutable_authorities()
     common = {
         "descriptor_identity": "sha256:" + "1" * 64,
         "invocation_key": "2" * 64,
@@ -3854,7 +3855,7 @@ def _package_vector_set(
 
 def _reidentify_language_bundle(language_bundle: dict[str, Any]) -> None:
     assert isinstance(language_bundle, LanguageBundleIndex)
-    kernel, _ = authority_module.load_authorities()
+    kernel, _ = mutable_authorities()
     projections = kernel["meta_format"]["package_release"]["semantic_closure"][
         "projections"
     ]
@@ -4168,7 +4169,7 @@ def test_resolved_model_admission_requires_the_kernel_boolean_conditional_contra
     artifacts = _published_semantic_artifacts(_artifact_directory(json.loads(built[1])))
     assert model_module.admit_resolved_model(artifacts).admitted is True
 
-    kernel, language_bundle = authority_module.load_authorities()
+    kernel, language_bundle = mutable_authorities()
     policy = model_module._formula_policy(language_bundle)
     actual_operand_domain = kernel["meta_format"]["runtime_program"][
         "invocation_contract"
@@ -4658,7 +4659,7 @@ def test_literal_profile_reidentity_changes_rir_semantics(tmp_path, monkeypatch)
     assert isinstance(original_checked, model_module.CheckedModel)
     original = model_module.lower_checked_model(original_checked)
 
-    kernel, candidate_ldb = deepcopy(authority_module.load_authorities())
+    kernel, candidate_ldb = mutable_authorities()
     profile = candidate_ldb["language"]["literal_typing_profiles"][0]
     old_id = profile["id"]
     profile["id"] = "quantity.dimensionless-int64-reidentified"
@@ -6162,7 +6163,7 @@ def test_unreachable_runtime_operation_does_not_change_rir_semantics(tmp_path):
 def test_non_rpg_package_reaches_evaluator_without_kernel_or_host_extension(
     tmp_path, monkeypatch
 ):
-    kernel, baseline_ldb = authority_module.load_authorities()
+    kernel, baseline_ldb = mutable_authorities()
     candidate_ldb = deepcopy(baseline_ldb)
     language = candidate_ldb["language"]
     package = deepcopy(
@@ -6315,8 +6316,8 @@ def test_non_rpg_package_reaches_evaluator_without_kernel_or_host_extension(
     )
     _reidentify_language_bundle(candidate_ldb)
     assert admit_authorities(kernel, candidate_ldb).admitted is True
-    assert kernel == authority_module.load_authorities()[0]
-    assert baseline_ldb == authority_module.load_authorities()[1]
+    assert kernel == mutable_authorities()[0]
+    assert baseline_ldb == mutable_authorities()[1]
 
     source_document = _model_source()
     source_document["package_requirements"] = [
@@ -6549,7 +6550,7 @@ def test_resolution_step_exhaustion_is_a_typed_static_refusal(
 ):
     source = tmp_path / "model-source.json"
     source.write_text(json.dumps(_model_source()), encoding="utf-8")
-    kernel, candidate_ldb = deepcopy(authority_module.load_authorities())
+    kernel, candidate_ldb = mutable_authorities()
     candidate_ldb["resources"]["max_rule_match_steps"] = 1
     boundary = next(
         vector
@@ -6583,7 +6584,7 @@ def test_runtime_projection_step_exhaustion_is_a_typed_static_refusal(
 ):
     source = tmp_path / "model-source.json"
     source.write_text(json.dumps(_model_source()), encoding="utf-8")
-    kernel, candidate_ldb = deepcopy(authority_module.load_authorities())
+    kernel, candidate_ldb = mutable_authorities()
     candidate_ldb["resources"]["max_runtime_projection_steps"] = 1
     boundary = next(
         vector

--- a/libs/gda-balancing/tests/test_schema2_model_lowerer_conformance.py
+++ b/libs/gda-balancing/tests/test_schema2_model_lowerer_conformance.py
@@ -29,7 +29,7 @@ from gda_balancing.schema2.model import (
     check_model_source,
     lower_checked_model,
 )
-from schema2_test_authority import mutable_authorities
+from schema2_authority_support import mutable_authorities
 
 
 def _inject_authority_context(monkeypatch, kernel, language_bundle):

--- a/libs/gda-balancing/tests/test_schema2_model_lowerer_conformance.py
+++ b/libs/gda-balancing/tests/test_schema2_model_lowerer_conformance.py
@@ -12,7 +12,6 @@ import jsonschema
 from gda_balancing.schema2.authority import (
     AdmittedAuthorityContext,
     admit_authority_context,
-    load_authorities,
 )
 from gda_balancing.schema2.authority_graph import (
     LanguageBundleIndex,
@@ -30,6 +29,7 @@ from gda_balancing.schema2.model import (
     check_model_source,
     lower_checked_model,
 )
+from schema2_test_authority import mutable_authorities
 
 
 def _inject_authority_context(monkeypatch, kernel, language_bundle):
@@ -255,7 +255,7 @@ def _exact_path(root: Any, dotted: str) -> Any:
 
 def _reidentify_language_bundle(language_bundle: dict[str, Any]) -> None:
     assert isinstance(language_bundle, LanguageBundleIndex)
-    kernel, _ = load_authorities()
+    kernel, _ = mutable_authorities()
     projections = kernel["meta_format"]["package_release"]["semantic_closure"][
         "projections"
     ]
@@ -809,7 +809,7 @@ def _reference_check_source(
 def _renamed_reason_authorities(
     reason_id: str, diagnostic: str
 ) -> tuple[dict[str, Any], dict[str, Any], str]:
-    kernel, candidate_ldb = deepcopy(load_authorities())
+    kernel, candidate_ldb = mutable_authorities()
     language = candidate_ldb["language"]
     renamed_reason = f"{reason_id}.renamed"
     renamed_diagnostic = f"{diagnostic}.renamed"
@@ -3752,7 +3752,7 @@ def _lock_oracle(lock: dict[str, Any]) -> dict[str, Any]:
 
 
 def test_permanent_model_program_vectors_close_both_compiler_pipelines(tmp_path):
-    kernel, language_bundle = load_authorities()
+    kernel, language_bundle = mutable_authorities()
     vectors = [item for item in language_bundle["vectors"] if "source_fixture" in item]
     vector_ids = {item["id"] for item in vectors}
     assert {
@@ -3981,7 +3981,7 @@ def test_independent_lowerers_mutually_consume_byte_identical_rir(tmp_path):
     path = tmp_path / "source.json"
     source = _source([_symbol(role, role) for role in roles])
     _write_source(path, source)
-    kernel, language_bundle = load_authorities()
+    kernel, language_bundle = mutable_authorities()
     checked = check_model_source(str(path))
     reference_checked = _reference_check_source(source, kernel, language_bundle)
     assert isinstance(checked, CheckedModel)
@@ -4020,7 +4020,7 @@ def test_independent_lowerers_close_the_rpg_entrypoint_and_nested_call_graph():
         dict[str, Any],
         json.loads(path.read_text(encoding="utf-8")),
     )
-    kernel, language_bundle = load_authorities()
+    kernel, language_bundle = mutable_authorities()
     checked = check_model_source(str(path))
     reference_checked = _reference_check_source(source, kernel, language_bundle)
     assert isinstance(checked, CheckedModel)
@@ -4061,7 +4061,7 @@ def test_independent_lowerers_treat_empty_collection_exclusion_as_noop(monkeypat
         dict[str, Any],
         json.loads(path.read_text(encoding="utf-8")),
     )
-    kernel, candidate_ldb = deepcopy(load_authorities())
+    kernel, candidate_ldb = mutable_authorities()
     contract = next(
         row
         for row in candidate_ldb["language"]["artifact_contracts"]
@@ -4108,7 +4108,7 @@ def test_nested_integer_literal_is_identical_across_lowerers(
         dict[str, Any],
         json.loads(path.read_text(encoding="utf-8")),
     )
-    kernel, candidate_ldb = deepcopy(load_authorities())
+    kernel, candidate_ldb = mutable_authorities()
     cast_operation = next(
         operation
         for operation in candidate_ldb["language"]["operations"]
@@ -4192,7 +4192,7 @@ def test_resolution_stage_order_is_authoritative_across_independent_consumers(
     source["modules"][0]["imports"].append(deepcopy(source["modules"][0]["imports"][0]))
     path = tmp_path / "source.json"
     _write_source(path, source)
-    kernel, language_bundle = load_authorities()
+    kernel, language_bundle = mutable_authorities()
 
     production = check_model_source(str(path))
     reference = _reference_check_source(source, kernel, language_bundle)
@@ -4211,7 +4211,7 @@ def test_resolution_stage_order_is_authoritative_across_independent_consumers(
 
 def test_resolution_step_budget_drives_both_independent_consumers():
     source = _source([_symbol("health", "state")])
-    kernel, language_bundle = deepcopy(load_authorities())
+    kernel, language_bundle = mutable_authorities()
     language_bundle["resources"]["max_rule_match_steps"] = 1
     vectors = {
         vector["id"]: vector
@@ -4246,7 +4246,7 @@ def test_runtime_projection_budget_drives_both_independent_consumers(
     source = _source([_symbol("health", "state")])
     path = tmp_path / "source.json"
     _write_source(path, source)
-    kernel, language_bundle = deepcopy(load_authorities())
+    kernel, language_bundle = mutable_authorities()
     language_bundle["resources"]["max_runtime_projection_steps"] = 1
     vectors = {
         vector["id"]: vector
@@ -4280,7 +4280,7 @@ def test_resolution_law_fields_drive_both_independent_interpreters(tmp_path):
     source["modules"][0]["imports"].append(second_import)
     path = tmp_path / "source.json"
     _write_source(path, source)
-    kernel, language_bundle = deepcopy(load_authorities())
+    kernel, language_bundle = mutable_authorities()
     operation = next(
         item
         for item in kernel["meta_format"]["resolution_judgment"]["operations"]
@@ -4315,7 +4315,7 @@ def test_resolution_relation_recipes_drive_both_independent_interpreters(tmp_pat
     source["modules"][0]["imports"].append(second_import)
     path = tmp_path / "source.json"
     _write_source(path, source)
-    kernel, language_bundle = deepcopy(load_authorities())
+    kernel, language_bundle = mutable_authorities()
     profile = language_bundle["language"]["resolution_profiles"][0]
     imports_recipe = next(
         item for item in profile["relation_recipes"] if item["id"] == "imports"
@@ -4436,7 +4436,7 @@ def test_model_source_routing_follows_the_selected_ldb_profile_without_host_toke
     path = tmp_path / "profile-routed-source.json"
     source = renamed_source(_source([_symbol("health", "state")]))
     _write_source(path, source)
-    kernel, candidate_ldb = deepcopy(load_authorities())
+    kernel, candidate_ldb = mutable_authorities()
     language = candidate_ldb["language"]
     profile = language["resolution_profiles"][0]
     old_profile_id = profile["id"]
@@ -4656,7 +4656,7 @@ def test_rir_output_member_follows_the_ldb_lowering_and_wire_schema(tmp_path):
     path = tmp_path / "renamed-rir-output.json"
     source = _source([_symbol("health", "state")])
     _write_source(path, source)
-    kernel, candidate_ldb = deepcopy(load_authorities())
+    kernel, candidate_ldb = mutable_authorities()
     language = candidate_ldb["language"]
     lowering = _reference_lowering(language)
     lowering["output_member"] = "items"
@@ -4702,7 +4702,7 @@ def test_schema_error_mapping_uses_the_complete_ldb_selector_path():
     error = next(
         jsonschema.Draft202012Validator(schema).iter_errors({"metadata": {"unit": 7}})
     )
-    _, language_bundle = load_authorities()
+    _, language_bundle = mutable_authorities()
 
     code = model_module._schema_error_code(error, language_bundle)
 

--- a/libs/gda-balancing/tests/test_version_command.py
+++ b/libs/gda-balancing/tests/test_version_command.py
@@ -10,7 +10,7 @@ from dataclasses import replace
 from importlib.metadata import version as package_version
 
 from gda_balancing.commands.version import VERSION, version_handler
-from schema2_test_authority import mutable_authorities
+from schema2_authority_support import mutable_authorities
 
 SUPPORTED_SCHEMA_LINE = "2.0"
 

--- a/libs/gda-balancing/tests/test_version_command.py
+++ b/libs/gda-balancing/tests/test_version_command.py
@@ -6,12 +6,11 @@ line, now `"2.0"`).
 """
 
 import json
-from copy import deepcopy
 from dataclasses import replace
 from importlib.metadata import version as package_version
 
 from gda_balancing.commands.version import VERSION, version_handler
-from gda_balancing.schema2.authority import load_authorities
+from schema2_test_authority import mutable_authorities
 
 SUPPORTED_SCHEMA_LINE = "2.0"
 
@@ -48,7 +47,7 @@ def test_supported_schema_line_is_a_required_string_not_nullable(run_cli):
 
 
 def test_version_refuses_an_unadmitted_language_bundle(run_cli):
-    kernel, language_bundle = deepcopy(load_authorities())
+    kernel, language_bundle = mutable_authorities()
     language_bundle["language"]["model_source_schema_versions"] = ["9.0.0"]
     descriptor = replace(
         VERSION,

--- a/libs/gda-balancing/tools/ci.py
+++ b/libs/gda-balancing/tools/ci.py
@@ -29,6 +29,7 @@ SHARDS: Final[dict[str, tuple[str, ...]]] = {
         "test_formula_seam.py",
         "test_isolation.py",
         "test_schema2_authority_lifecycle.py",
+        "test_schema2_bootstrap_resources.py",
         "test_schema2_canonical.py",
         "test_schema2_migration_cli.py",
         "test_schema_command.py",
@@ -40,18 +41,19 @@ SHARDS: Final[dict[str, tuple[str, ...]]] = {
     "authority": (
         "test_schema2_authority_cli.py",
         "test_schema2_bootstrap_authority.py",
-        "test_schema2_bootstrap_resources.py",
     ),
     "language": (
         "test_schema2_bootstrap_language.py",
         "test_schema2_formula_cli.py",
-        "test_schema2_model_cli.py",
     ),
+    "model": (
+        "test_schema2_model_cli.py",
+        "test_schema2_model_lowerer_conformance.py",
+    ),
+    "experiment": ("test_schema2_experiment_cli.py",),
     "composition": (
         "test_cli_conformance.py",
         "test_schema2_bootstrap_composition.py",
-        "test_schema2_experiment_cli.py",
-        "test_schema2_model_lowerer_conformance.py",
         "test_schema2_template_cli.py",
     ),
     "smoke": ("test_e2e_cli.py",),

--- a/libs/gda-balancing/tools/ci.py
+++ b/libs/gda-balancing/tools/ci.py
@@ -29,6 +29,7 @@ SHARDS: Final[dict[str, tuple[str, ...]]] = {
         "test_formula_seam.py",
         "test_isolation.py",
         "test_schema2_authority_lifecycle.py",
+        "test_schema2_bootstrap_authority.py",
         "test_schema2_bootstrap_resources.py",
         "test_schema2_canonical.py",
         "test_schema2_migration_cli.py",
@@ -38,10 +39,7 @@ SHARDS: Final[dict[str, tuple[str, ...]]] = {
         "test_version_bundle.py",
         "test_version_command.py",
     ),
-    "authority": (
-        "test_schema2_authority_cli.py",
-        "test_schema2_bootstrap_authority.py",
-    ),
+    "authority": ("test_schema2_authority_cli.py",),
     "language": (
         "test_schema2_bootstrap_language.py",
         "test_schema2_formula_cli.py",


### PR DESCRIPTION
## Summary

- reuse the already admitted packaged authority when tests need isolated mutable inputs
- batch repeated built-wheel `package get` checks through one real wheel process while preserving archive and source-vs-wheel assertions
- rebalance the existing static CI matrix from measured file durations
- replace the obsolete latency contract with concise commands, scope, and evidence

## Scope

This refactor deliberately adds no claim ledger, accepted-test manifest, custom local runner, aggregate JUnit protocol, or release-workflow architecture. Existing inventory and outcome checks remain unchanged.

Project-local skill changes were split from this member PR into #617; this branch is again confined to `libs/gda-balancing/**`.

Nightly and release workflows remain unchanged after measurement. Required CI already meets the feedback target; the scheduled unfiltered job retains a distinct single-process check, and the optimized 636.840 s serial median retains 263.160 s of the existing 900 s release process bound. A root-owned workflow refactor is therefore not justified by this change.

## Local evidence

Clean base: `2b81e2e`

| Measurement | Before (3-run median) | After (3-run median) | Change |
| --- | ---: | ---: | ---: |
| Collected tests | 1,409 | 1,409 | unchanged |
| Pytest cumulative time | 1,292.539 s | 634.676 s | -50.9% |
| Full-suite wall time | 1,297.274 s | 636.840 s | -50.9% |

Every optimized run completed with 1,382 passed and 27 skipped. Wall times: 636.840 s, 643.920 s, and 632.840 s.

Focused verification:

- `pytest tests/test_ci_policy.py -q`: 11 passed
- `tools/ci.py verify-inventory`: 1,409 current tests, 194 vectors, no missing/overlapping/uncovered/unexpected entries
- full collection: 1,409 tests
- Ruff check and format check: passed

## CI acceptance

Accepted performance head: `61b08f219ce22975424370b2ef4f014f5770f538`

Current implementation head: `59b9b635cc79f848a6d11062365d15e89308e8a8`

The clean-base required-CI baseline is 483 s, 496 s, and 483 s (median 483 s). Three successful exact-head attempts measured from the scope job start through the stable required check:

| Attempt | Elapsed |
| --- | ---: |
| [1](https://github.com/aigengame/godot-agent/actions/runs/30927209932/attempts/1) | 277 s |
| [3](https://github.com/aigengame/godot-agent/actions/runs/30927209932/attempts/3) | 268 s |
| [4](https://github.com/aigengame/godot-agent/actions/runs/30927209932/attempts/4) | 229 s |

Median: 268 s, 44.5% below baseline. Provisional maximum: 277 s, below the six-minute bound.

[Attempt 2](https://github.com/aigengame/godot-agent/actions/runs/30927209932/attempts/2) was cancelled and excluded after one runner remained in the shared environment setup step for about nine minutes; the experiment tests never started. The infrastructure exception is retained here rather than presented as test latency.

The final review-fix head passed ordinary exact-head CI in [run 30969668201](https://github.com/aigengame/godot-agent/actions/runs/30969668201): all six required shards, smoke, inventory, outcome gates, lint, typing, build, co-install, release-scope guard, and the stable required result passed. Scope start through required completion was 260 s. Because shard membership is unchanged, this validates the review fixes without replacing the accepted three-run performance sample.

## Independent review

The delegated reviewers independently confirmed identical before/after sets of 1,409 `(classname, name)` test IDs, deep-copy isolation, real-wheel execution, complete shard partitioning, and evidence consistency. The initial assertion and documentation findings were fixed. The later three-axis review was re-evaluated rather than accepted mechanically: the measured six-shard partition was retained, lifecycle cache mutation was isolated to its test module, fresh loading was restored only for admission/cache coverage, and single-use result wrapping was removed. An entropy-focused re-review found one minor runner-cost wording issue; it was fixed and rechecked. No actionable findings remain.

Closes #597
