### PR TITLE
docs(skills): add STE prose standard to artifact review

### DIFF
--- a/.agents/skills/artifact-review/SKILL.md
+++ b/.agents/skills/artifact-review/SKILL.md
@@ -110,9 +110,9 @@ artifact.
   accurately, and define it at first use.
 - When a local convention broadens an established term, state the convention and its
   practical effects.
-- Technical prose should conform to ASD-STE100 Simplified Technical English unless
-  the project specifies otherwise. Preserve established project and domain terms as
-  technical nouns or technical verbs.
+- Use ASD-STE100 Simplified Technical English as the default reference for technical
+  prose unless the project specifies otherwise. Preserve established project and
+  domain terms as technical nouns or technical verbs.
 - Prefer plain, concrete prose. Remove formulaic wording, abstract noun chains,
   slogans, empty bullets, and legal or procurement language.
 - Check that sentences express causal, dependency, scope, and ordering relationships

--- a/.agents/skills/artifact-review/SKILL.md
+++ b/.agents/skills/artifact-review/SKILL.md
@@ -110,6 +110,9 @@ artifact.
   accurately, and define it at first use.
 - When a local convention broadens an established term, state the convention and its
   practical effects.
+- Technical prose should conform to ASD-STE100 Simplified Technical English unless
+  the project specifies otherwise. Preserve established project and domain terms as
+  technical nouns or technical verbs.
 - Prefer plain, concrete prose. Remove formulaic wording, abstract noun chains,
   slogans, empty bullets, and legal or procurement language.
 - Check that sentences express causal, dependency, scope, and ordering relationships


### PR DESCRIPTION
## Summary

- use ASD-STE100 Simplified Technical English as the default writing reference for technical prose unless the project specifies otherwise
- preserve established project and domain terms as technical nouns or technical verbs
- keep the standard-selection rule independent from the existing plain-prose review signals

## Validation

- `quick_validate.py .agents/skills/artifact-review`
- YAML assertions for skill name and disabled implicit invocation
- `git diff --check`
