### PR TITLE
docs(skills): require terminology and prose review

### DIFF
--- a/.agents/skills/skill-review/SKILL.md
+++ b/.agents/skills/skill-review/SKILL.md
@@ -9,6 +9,9 @@ description: Review skill documents and skill-focused changes for correctness, c
 
 Decide whether a skill can do its declared job with accurate instructions and the smallest sufficient structure. Report only actionable issues supported by the artifact or verifiable evidence. Scale the review to the skill's size, risk, and intended use.
 
+Treat terminology and prose as a required review pass. Do not conclude **Pass**
+until this pass is complete and its result is reported.
+
 ## Workflow
 
 ### 1. Inspect Relevant Materials
@@ -43,10 +46,29 @@ Decide whether a skill can do its declared job with accurate instructions and th
 - Keep the skill self-contained: remove hidden assumptions about sibling skills and unexplained private vocabulary.
 - Extract shared material only when it has the same meaning and the same reason to change in every use site.
 
-#### Terminology and Prose
+#### Terminology and Prose — Required Pass
 
-- Prefer established domain terms. If a local convention deliberately broadens one, label the convention, explain the trade-off, and handle its practical consequences.
+- Review terminology and prose independently of other findings. Inspect all prose in
+  the complete `SKILL.md` and agent metadata. Inspect explanatory prose in companion
+  resources when it is relevant to the skill's behavior or the change under review.
+- Search for established terms, alternate names, undefined terms, and changes in
+  meaning. Do not limit this pass to passages already selected for other findings.
+- Prefer established project and domain terms. Do not introduce a second name for an
+  existing concept.
+- Introduce a new term only when existing language cannot express the concept
+  accurately, and define it at first use.
+- If a local convention broadens an established term, state the convention and its
+  practical effects.
+- Use ASD-STE100 Simplified Technical English as the default reference for technical
+  prose unless the project specifies another writing standard. Preserve established
+  project, domain, and tool terms as technical nouns or technical verbs.
+- Unless the project specifies another writing standard, check word choice and
+  meaning, technical nouns and verbs, and sentence structure against ASD-STE100.
+  Apply its procedural or descriptive writing rules according to the passage. Record
+  the checks performed.
 - Prefer plain, concrete instructions. Remove formulaic or stilted prose, long abstract noun chains, slogans, empty bullets, and legal or procurement language.
+- Check that sentences express causal, dependency, scope, and ordering relationships
+  accurately.
 - Keep concrete domain examples when they teach a non-obvious distinction; remove examples that merely repeat a rule.
 - Describe observable text and behavior. Do not infer who or what produced the prose.
 
@@ -57,19 +79,47 @@ Decide whether a skill can do its declared job with accurate instructions and th
 - For a pull request, verify the exact head, merge base, current base, CI status, naming conventions, and validation claims in the description.
 - Treat a passing validator or green CI as structural evidence, not proof that the workflow is correct.
 - Test scripts or resources whose behavior is required for the skill to work.
+- Record the terminology sources, writing reference, inspected scope, and prose checks
+  used in the review. For technical prose, use ASD-STE100 or the project-specified
+  alternative as the writing reference.
 
 ### 4. Report
 
 Start with one conclusion:
 
-- **Pass**: no substantive issue prevents the skill from fulfilling its declared purpose.
-- **Changes required**: one or more substantive issues must be resolved.
+- **Pass**: no substantive content, terminology, or prose issue prevents the skill
+  from fulfilling its declared purpose, and the required terminology and prose pass
+  is complete and reported.
+- **Changes required**: one or more substantive content, terminology, or prose issues
+  must be resolved.
 
-Then group actionable findings under **Required changes**, **Terminology and prose**, or **Minor** as appropriate. For each finding, give the location, evidence, impact, and the smallest practical alternative that preserves the intent. Keep optional improvements separate and include them only when they materially help.
+Always include a **Terminology and prose assessment**, even when it produces no
+finding. State:
+
+- The project, domain, or tool terminology sources used.
+- The writing reference used. For technical prose, name ASD-STE100 or the
+  project-specified alternative.
+- The scope inspected and prose checks performed.
+- The result and the location of any related findings.
+- Important checks that were not performed.
+
+If no substantive terminology or prose issue was found, say so explicitly. The
+assessment documents review coverage; it does not require a finding.
+
+Group actionable findings under **Required changes** or **Minor** as appropriate.
+Classify them by impact, not by issue type. A terminology or prose problem that
+affects correctness, understanding, selection, or execution belongs under
+**Required changes** rather than being downgraded as wording feedback. For each
+finding, give the location, evidence, impact, and the smallest practical alternative
+that preserves the intent. Keep optional improvements separate and include them only
+when they materially help.
 
 If new context invalidates a proposed fix but not the underlying problem, revise the fix instead of dropping the finding. For example, if a proposed cross-reference conflicts with a self-contained skill, keep the finding that an instruction relies on missing context and propose a self-contained rewrite.
 
-If there are no substantive findings, report **Pass** with the reviewed target and a one- or two-sentence summary of the material checks performed. Mention any important validation that was not performed, then stop.
+If there are no substantive findings, report **Pass** with the reviewed target,
+include the required **Terminology and prose assessment**, and give a one- or
+two-sentence summary of the material checks performed. Mention any important
+validation that was not performed, then stop.
 
 Return the review in the medium the user requested. Edit files, post comments, or perform other remote writes only when the user explicitly authorizes them.
 
@@ -77,6 +127,8 @@ Return the review in the medium the user requested. Edit files, post comments, o
 
 - Pin the previous and current versions.
 - Verify every claimed fix in the artifact and relevant tests; a reply is not evidence by itself.
+- Repeat the terminology and prose pass for changed text and report its assessment,
+  even when previous findings concerned only behavior or structure.
 - Review new scope introduced since the previous review.
 - For an item declined by design, verify that the accepted constraint and necessary mitigations appear in the authoritative material.
 - Report with the same conclusion and finding format as the initial review.


### PR DESCRIPTION
## Summary

- make Terminology and Prose a required `skill-review` pass across the complete skill and relevant companion prose
- use ASD-STE100 as the default technical-prose reference unless the project specifies another writing standard
- require terminology sources, review scope, prose checks, and results in every report, including no-finding reports
- classify language findings by impact and repeat the pass during re-review

## Validation

- Skill Creator quick validator: `Skill is valid!`
- frontmatter and agent metadata assertions
- `git diff --check`
- terminology and writing-rule names checked against official ASD-STE100 Issue 9