### PR TITLE
docs(skills): address review findings

### DIFF
--- a/.agents/skills/git-conventional-commits/SKILL.md
+++ b/.agents/skills/git-conventional-commits/SKILL.md
@@ -47,10 +47,11 @@ Use this Conventional Commits grammar:
 [optional footer(s)]
 ```
 
-- **type** identifies the kind of change. `feat` introduces a feature, and `fix` corrects a bug.
-  The standard permits other types. Use the repository's type vocabulary when it defines one.
-- **scope** is an optional phrase that identifies a section of the codebase. Use the repository's
-  scope vocabulary when it defines one.
+- **type** is a noun that identifies the kind of change. `feat` introduces a feature, and `fix`
+  corrects a bug. The standard permits other types. Use the repository's type vocabulary when it
+  defines one.
+- **scope** is an optional noun in parentheses that identifies a section of the codebase. Use the
+  repository's scope vocabulary when it defines one.
 - **description** is a short summary of the staged change.
 - **body** provides optional context about the change.
 - **footer** records optional metadata. Format footer tokens as specified by Conventional Commits

--- a/.agents/skills/git-conventional-commits/SKILL.md
+++ b/.agents/skills/git-conventional-commits/SKILL.md
@@ -1,84 +1,115 @@
 ---
 name: git-conventional-commits
-description: Formulate precise, standard-compliant Git commit messages based on the conventional commits specification. Use when you are ready to execute `git commit`.
+description: Formulate precise Git commit messages that conform to Conventional Commits 1.0.0 and the target repository's documented conventions. Use when changes are staged and you are ready to execute `git commit`.
 ---
 
-This skill enables the code agent to formulate precise, standard-compliant Git commit messages and branch names based on the Conventional Commits 1.0.0 specification. Adhering to this standard allows automated tools to parse commit histories, bump semantic versions (Major/Minor/Patch) accurately, and generate clean changelogs.
+# Git Conventional Commits
 
-## Requirements & Triggers
-- **Trigger**: Whenever the agent completes a task, implements a feature, fixes an issue, or refactors code and is ready to execute `git commit`.
-- **Pre-requisite**: Understand the scope of changes and know the associated GitHub Issue number (if any).
+## Goal
 
-## Guidelines & Rules
+Formulate a commit message that describes the staged change accurately. Follow
+[Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) and any applicable
+conventions in the target repository. Keep repository-specific rules separate from requirements
+of the standard.
 
-### 1. Commit Message Structure
-Every commit message must strictly follow this structural pattern:
+## Workflow
+
+### 1. Inspect the Staged Change
+
+- Run `git status --short` and inspect `git diff --cached`.
+- Stop if no change is staged.
+- Confirm that the staged change represents one atomic intent.
+- If the staged change contains unrelated intents, stop and split it before formulating the
+  message.
+
+### 2. Find Repository Conventions
+
+Check the target repository for commit-message rules, validator configuration, and release or
+merge policy. These sources can define:
+
+- An allowed or preferred type set.
+- Scope conventions.
+- Description style, capitalization, punctuation, or line length.
+- Required issue references or footer syntax.
+- How commit messages affect releases and version numbers.
+
+Apply these rules when they exist. Do not present them as requirements of Conventional Commits.
+
+### 3. Formulate the Message
+
+Use this Conventional Commits grammar:
+
 ```text
-<type>(<scope>): <subject>
+<type>[optional scope][optional !]: <description>
 
-<body>
+[optional body]
 
-<footer>
+[optional footer(s)]
 ```
 
--	<type> (Required): Must be one of the structural keywords defining the change intent.
--	<scope> (Optional): A noun describing the affected section of the codebase enclosed in parentheses (e.g., auth, api, parser).
--	<subject> (Required): A succinct description of the change. Use imperative mood ("add" not "added"). No period . at the end.
--	<body> (Optional): Detailed explanatory text, providing the motivation for the change and contrasting it with previous behavior.
--	<footer> (Optional): Used to reference tracking issues (e.g., Fixes: #123) or denote breaking changes.
+- **type** identifies the kind of change. `feat` introduces a feature, and `fix` corrects a bug.
+  The standard permits other types. Use the repository's type vocabulary when it defines one.
+- **scope** is an optional phrase that identifies a section of the codebase. Use the repository's
+  scope vocabulary when it defines one.
+- **description** is a short summary of the staged change.
+- **body** provides optional context about the change.
+- **footer** records optional metadata. Format footer tokens as specified by Conventional Commits
+  and any applicable repository or hosting policy.
 
+Indicate a breaking change in either of these ways:
 
-### 2. Allowed Commit Types ( <type> )
-| Type | Definition | SemVer Impact |
-| :--- | :--- | :--- |
-| `feat` | A new feature implemented in the codebase | **Minor** |
-| `fix` | A bug fix implemented in the codebase | **Patch** |
-| `docs` | Documentation only changes (e.g., markdown files) | None |
-| `style` | Changes that do not affect the meaning of the code (white-space, formatting, etc.) | None |
-| `refactor` | A code change that neither fixes a bug nor adds a feature | None |
-| `perf` | A code change that improves performance | None |
-| `test` | Adding missing tests or correcting existing tests | None |
-| `build` | Changes that affect the build system or external dependencies | None |
-| `ci` | Changes to CI configuration files and scripts | None |
-| `chore` | Other changes that don't modify src or test files (e.g., .gitignore) | None |
+- Add `!` immediately before the colon.
+- Add a `BREAKING CHANGE: <description>` footer.
 
-### 3. Handling Breaking Changes
-A breaking change must be indicated by an exclamation mark ! immediately after the type/scope, or by including BREAKING CHANGE: at the beginning of the footer. This triggers a Major version bump.
+In Conventional Commits, `fix` corresponds to a patch change, `feat` corresponds to a minor
+change, and a breaking change corresponds to a major change under Semantic Versioning. Before
+predicting an actual release or version number, check the target repository's release policy.
+Other types have no implicit effect on Semantic Versioning unless they indicate a breaking
+change.
 
-### 4. Issue Correlation Rule
-When resolving a **tracked** issue, the agent MUST reference the issue number in the footer using specific keywords (Fixes: #<id>, Closes: #<id>) to trigger GitHub's automated issue-closure workflows.
+Add issue-closing or issue-reference footers only when the repository and hosting platform define
+their meaning. Check the merge policy before assuming that a footer in an individual commit will
+reach the default branch or close an issue.
 
+### 4. Validate the Message
+
+Before committing, confirm that:
+
+- The message matches the staged change and does not describe unstaged work.
+- The message follows the Conventional Commits grammar.
+- The type, scope, description, and footers follow applicable repository conventions.
+- A breaking marker is present when the staged change breaks a public contract.
+- Any claimed issue or release effect is supported by the target repository's policy.
+
+If authorized to commit, use the validated message without changing its meaning.
 
 ## Examples
-### Example 1: Standard Feature with Scope
-```text
-feat(auth): add JWT token expiration validation
 
-Introduce an automated expiry verification check on the middleware layer 
-to automatically reject tokens older than 15 minutes.
+### Feature with a Scope
+
+```text
+feat(auth): reject expired access tokens
+
+Check the expiration time before accepting an access token.
 ```
-### Example 2: Bug Fix Correlated with Issue
-```text
-fix(api): prevent null pointer exception during report export
 
-Ensure that user profile data is properly validated before serialization
-to prevent catastrophic crashes on empty profiles.
+### Fix with an Issue Reference Defined by the Repository
+
+```text
+fix(export): handle profiles without a display name
+
+Use an empty label when the profile has no display name.
 
 Fixes: #142
 ```
 
-### Example 3: Breaking Change (API Refactoring)
+Use the footer in this example only when the repository and hosting platform assign the intended
+meaning to `Fixes: #142`.
+
+### Breaking Change
+
 ```text
-refactor(core)!: drop support for legacy v1 endpoint routes
+refactor(router)!: remove v1 route support
 
-The old v1 gateway endpoints have been deprecated for 6 months and are 
-now completely stripped out of the routing framework.
-
-BREAKING CHANGE: Requests sent to `/api/v1/*` will now return a 404 error.
-```
-
-### Example 4: Branch Naming Pattern
-When creating a branch to work on an issue, use the type and issue number format:
-```bash
-git checkout -b fix/142-null-pointer-export
+BREAKING CHANGE: Requests to `/api/v1/*` now return a 404 response.
 ```

--- a/.agents/skills/handle-review/SKILL.md
+++ b/.agents/skills/handle-review/SKILL.md
@@ -220,7 +220,10 @@ Provide:
 5. **Reviewer reply draft, when requested**: A concise response ready to send.
 
 Report only findings that can change a decision or implementation approach. If no feedback warrants
-a change, say so and stop; do not manufacture modifications.
+a change, still provide the review baseline and a decision for every claim. For each **Do Not
+Adopt** decision, state the evidence, retained behavior, and residual risk. Report that the change
+plan is empty, record the validation and unverified items, and then stop. Do not manufacture
+modifications.
 
 ## Boundaries
 

--- a/.agents/skills/reconcile/REFERENCE.md
+++ b/.agents/skills/reconcile/REFERENCE.md
@@ -1,105 +1,128 @@
-# Reconcile — reference
+# Reconcile reference
 
-Detailed companion to [SKILL.md](SKILL.md): the reference-graph edge taxonomy, how to read each
-source, the full check catalog, and a hook sample. This repo is single-context (`CONTEXT.md` +
-`docs/adr/` at the root) per `docs/agents/domain.md`.
+This companion defines the reference-graph taxonomy, artifact discovery, check catalog, report
+format, and optional reminder contract for [SKILL.md](SKILL.md).
+
+## Discover repository authorities
+
+Start with repository and directory guidance. Use it to locate:
+
+- context routing and ownership rules;
+- the issue or task tracker, if one exists;
+- requirements, specifications, and decision records;
+- the glossary or other terminology authority;
+- schemas for identifiers, statuses, links, and supersession;
+- local validation and editing rules.
+
+A repository may have one context or several. Do not infer a global context from a root glossary or
+one decision-record directory. Follow the repository's routing mechanism. If no routing mechanism
+exists, infer the smallest relevant scope from authoritative links and disclose the assumption.
 
 ## Reference-graph edge taxonomy
 
-| Edge | Source → target | How it appears | Mechanical failure |
+Use repository-native names for concrete artifacts. The generic edge types are:
+
+| Edge | Typical source -> target | Mechanical check | Semantic check |
 | --- | --- | --- | --- |
-| issue → issue | issue body | `## Parent` section, `## Blocked by` section, bare `#NN` | target issue missing/closed unexpectedly |
-| issue → ADR | issue body | `ADR-NNNN` | no `docs/adr/NNNN-*.md` |
-| issue → term | issue title/body | domain noun | term absent from glossary, or an `_Avoid_` synonym |
-| ADR → ADR | ADR body | `ADR-NNNN` (supersedes / contradicts / builds-on) | target ADR file missing |
-| ADR → term | ADR body | domain noun | `_Avoid_` synonym used |
-| ADR → CONTEXT | ADR body | references a glossary concept | concept not in glossary |
-| CONTEXT → ADR | glossary entry | `ADR-NNNN` (e.g. gda-mcp → ADR-0004) | target ADR file missing |
-| CONTEXT → term | `_Avoid_` lines | canonical term ↔ banned synonyms | — (this is the rule source) |
+| tracked work -> tracked work | parent, dependency, or related-work link | target exists | relationship and target state still mean what the source claims |
+| tracked work -> authority artifact | requirement or decision reference | target exists | tracked work agrees with the authority |
+| artifact -> artifact | file, section, identifier, or explicit relationship | target exists; required reciprocal pointer exists | relationship and affected scope remain accurate |
+| artifact -> term | use of an established domain term | explicitly prohibited synonym is absent | term is established, correctly scoped, and used with its defined meaning |
+| terminology authority -> artifact | source or decision behind a term | target exists | definition and cited authority agree |
 
-`status:` front-matter on an ADR (`accepted`, `superseded`, …) is graph metadata: a `superseded`
-ADR should have a `superseded-by: ADR-NNNN` pointer, and the superseding ADR should point back.
+Status fields, reciprocal links, and supersession metadata are graph data only when repository
+guidance defines them. Never assume field names, allowed values, or link directions.
 
-## How to read each source
+## How to read sources
 
-- **Issues** — `gh issue list --state open --json number,title,body,labels --jq '...'` to
-  enumerate; `gh issue view <n> --comments` for one. Conventions in `docs/agents/issue-tracker.md`.
-- **ADRs** — files `docs/adr/NNNN-*.md`; parse `status:` front-matter and inline `ADR-NNNN`.
-- **CONTEXT.md** — glossary terms are `**Term**:` headed; each may list `_Avoid_: a, b` synonyms
-  and inline `ADR-NNNN` refs. These define the canonical vocabulary.
+- **Repository guidance:** identify artifact ownership, context boundaries, editing authority, and
+  validation commands. Apply more specific nested guidance within its scope.
+- **Tracked work:** use the configured tracker and its documented fields. Read linked records when
+  their relationship affects the change. A closed state is not inherently inconsistent.
+- **Decision records and specifications:** use the repository's locations, identifiers, statuses,
+  and relationship schema. Read the normative sections and any stated scope.
+- **Terminology authorities:** use the project's declared glossary or domain documentation. Only an
+  explicit rule, such as a prohibited-synonym list, supports a mechanical terminology finding.
+- **Other artifacts:** include tests, implementation docs, examples, or configuration when the
+  changed fact governs them.
 
 ## Check catalog
 
-### Mechanical (always)
+### Mechanical checks
 
-1. **Dangling ADR ref** — `ADR-NNNN` with no matching `docs/adr/NNNN-*.md`.
-2. **Dangling issue ref** — `#NN` / Parent / Blocked-by pointing at a non-existent issue.
-3. **Dangling file path** — a path mentioned in a doc/issue that does not exist.
-4. **Orphan** — an ADR/issue nothing references and which references nothing (may be intentional;
-   report, don't assume broken).
-5. **Term drift** — an artifact uses a synonym the glossary lists under `_Avoid_` instead of the
-   canonical term. Propose the canonical term.
-6. **Status pointer asymmetry** — a `superseded` ADR missing its `superseded-by`, or a one-way
-   supersede link.
+Run only checks with a deterministic result under the repository's declared syntax and schema:
 
-### Semantic (when a change set exists)
+1. **Missing reference target:** an explicit artifact, tracker, section, or file reference does not
+   resolve.
+2. **Explicit terminology violation:** text uses a synonym that the terminology authority explicitly
+   prohibits.
+3. **Required pointer asymmetry:** one side of a relationship is missing when the repository schema
+   requires reciprocal pointers.
 
-For each change in the set, scan artifacts whose terms/topics overlap and judge staleness:
+Do not treat a closed tracker record, a term absent from a glossary, or an unreferenced artifact as
+a mechanical failure. These cases require context and belong in the semantic candidate set.
 
-1. **Contradicted decision** — a change reverses/refines an ADR `Decision` still marked `accepted`.
-2. **Renamed term** — a term changed in-session but old name still used in issues/ADRs/glossary.
-3. **Moved boundary** — Phase/scope boundary changed; issues or ADRs still describe the old split.
-4. **Superseded behavior** — an open issue describes behavior the change makes obsolete.
+### Semantic checks
 
-Match by domain-term overlap first (cheap), then judge each candidate's staleness with reasoning.
-State the evidence linking the change to each affected artifact; do not flag on keyword overlap
-alone.
+For each change, find overlapping artifacts and judge staleness from their meaning:
+
+1. **Contradicted decision:** a statement conflicts with an accepted authority.
+2. **Renamed or new term:** text uses an old name, or a candidate term may require definition in the
+   terminology authority.
+3. **Moved boundary:** an artifact still describes the old scope, phase, ownership, or dependency.
+4. **Superseded behavior:** tracked work, docs, tests, or examples still require obsolete behavior.
+5. **Supersession mismatch:** a record is marked as fully superseded when part remains valid, or a
+   partial refinement is presented as a complete replacement.
+6. **State mismatch:** a tracker state or relationship conflicts with its repository-defined meaning.
+7. **Unreferenced artifact:** an artifact appears detached from the graph and repository rules make
+   that detachment significant.
+
+Use term and topic overlap to find candidates, then inspect their meaning. Do not report a semantic
+finding from keyword overlap alone.
 
 ### Discount illustrative references
 
-A `#NN` or `ADR-NNNN` token is not always a real edge. Discount tokens that appear as
-*illustrative examples* — e.g. a sentence listing what a dangling reference looks like
-(`(ADR-9999, #999, …)`), or a template/skill doc demonstrating the syntax. Judge from context;
-do not report these as broken links. (This skill's own issue contains such examples.)
+An identifier or path token is not always a graph edge. Exclude syntax examples, templates, and
+other illustrative placeholders unless they claim to point to a real artifact.
+
+## Supersession
+
+First classify the change:
+
+- **Complete supersession:** the new decision replaces the old decision throughout the old scope.
+- **Partial supersession or refinement:** part of the old decision remains valid, or the new decision
+  applies only to a narrower scope.
+
+Then apply the repository-native schema. Update statuses, links, or inline statements only when its
+guidance defines them. For partial supersession, preserve the valid scope and identify the replaced
+scope precisely. If no schema exists, report the relationship and propose a convention separately.
 
 ## Reporting format
 
-One consolidated report, grouped by artifact:
+Group findings by artifact:
 
-```
-### <artifact> (e.g. ADR-0005 / issue #4 / CONTEXT.md)
-- [layer] <finding> — evidence: <file:line or issue + quote>
-  proposed: <unified diff for docs | exact gh command for issues>
-```
-
-Per `domain.md`: if a finding contradicts an accepted ADR, surface it explicitly
-(`> Contradicts ADR-NNNN — but worth reopening because…`) rather than silently overriding.
-
-## Hook sample (propose, never auto-add — HITL)
-
-A Stop hook that reminds to run reconciliation at session end. Review timing/behavior with the
-user before writing to `settings.json`.
-
-For a `Stop` event, exit-0 stdout goes to the **debug log**, not the transcript — a plain
-`echo 'reminder'` fires invisibly. To surface a message to the user, emit JSON with a
-`systemMessage` field (still exit 0, still non-blocking):
-
-```jsonc
-// .claude/settings.json
-{
-  "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          { "type": "command", "command": "echo '{\"systemMessage\": \"Consider running /reconcile if a decision changed this session.\"}'" }
-        ]
-      }
-    ]
-  }
-}
+```text
+### <artifact>
+- [mechanical | semantic] <finding>
+  evidence: <location and relevant text or state>
+  impact: <consistency or execution effect>
+  proposed: <local patch or exact repository-native remote edit>
 ```
 
-(`matcher` is omitted — it has no meaning for `Stop`, which carries no tool context.)
+When a proposal conflicts with an accepted authority, name that authority and state whether the
+proposal should be dropped or the decision should be reopened.
 
-A `git` pre-commit alternative belongs in `.git/hooks/pre-commit` or the repo's hook manager; it
-should likewise only *remind*, since reconcile is HITL and must not block on un-confirmed edits.
+## Optional reminder contract
+
+A reminder may suggest reconciliation after a session or before a version-control operation. It
+must:
+
+- be visible through the host's documented output channel;
+- say that reconciliation is only suggested, not completed;
+- remain non-blocking;
+- avoid editing local or remote artifacts;
+- require approval before its configuration is added or changed.
+
+A reminder is not automatic reconciliation. Describe it as automatic only if the host has a
+documented invocation mechanism, the mechanism has been tested, and the workflow still preserves
+the confirmation gate for mutations.

--- a/.agents/skills/reconcile/SKILL.md
+++ b/.agents/skills/reconcile/SKILL.md
@@ -1,86 +1,106 @@
 ---
 name: reconcile
-description: Check and repair consistency between GitHub issues and domain docs (CONTEXT.md, docs/adr/) after a requirement or technical decision changes — mechanical cross-reference integrity plus conversation-driven semantic staleness. Use when a decision or requirement was changed or discussed in the current session, when issues/docs may have drifted out of sync, when the user says "reconcile" / "sync issues and docs" / "check cross-references", or when invoked as /reconcile.
+description: Check and repair consistency among tracked work, requirements, design records, glossaries, and other authoritative project artifacts after a requirement, decision, scope, or term changes. Use when artifacts may have drifted out of sync, when the user asks to reconcile or check cross-references, or after the current session changes an authoritative fact.
 ---
 
 # Reconcile
 
-Keep the cross-referenced web of **issues + domain docs** (`CONTEXT.md`, `docs/adr/`) correct
-and consistent so the development feedback loop stays trustworthy. A decision discussed in a
-session must not silently drift out of sync with the issues and docs that record it.
+Keep related project artifacts consistent after an authoritative fact changes. Reconcile both
+structural references and statements whose meaning became stale.
 
-**Read first:** `docs/agents/domain.md` (glossary + ADR-conflict rules), `docs/agents/issue-tracker.md`
-(`gh` conventions), `docs/agents/triage-labels.md`. See [REFERENCE.md](REFERENCE.md) for the
-reference-graph edge taxonomy and the full check catalog.
+Do not assume a fixed tracker, document name, directory layout, identifier format, or decision-record
+schema. Read the target repository's guidance first. Use its context routing, artifact ownership,
+terminology sources, and editing rules as the authority. See [REFERENCE.md](REFERENCE.md) for the
+reference-graph taxonomy and check catalog.
 
 ## Triggers
 
-- **Manual**: invoked as `/reconcile`, or when the user asks to sync issues and docs.
-- **Automatic**: a Claude Code Stop hook (and optionally a `git` pre-commit hook) may auto-invoke
-  this skill — see "Hook setup" below. Hook wiring is HITL; never add it without user approval.
+- **Manual invocation:** run when the user asks to reconcile artifacts or check cross-references.
+- **Optional reminder:** a session-end or version-control hook may remind the user to run this skill.
+  A reminder does not run reconciliation. Call a hook automatic only when the host has a documented,
+  verified mechanism that invokes the skill. Do not add or change hook configuration without the
+  user's approval.
 
-## Safety posture (non-negotiable)
+## Safety posture
 
-**Report first, mutate only after confirmation.** Always present findings and proposed patches,
-then wait for the user to confirm before editing any doc file or GitHub issue. Never run a
-mutating `gh issue edit` / `gh issue comment` or write to a doc without explicit approval.
+Report first. Mutate only after confirmation. Present findings and proposed changes before editing
+local artifacts or remote tracker records. Apply only the changes that the user confirms.
 
 ## Workflow
 
+```text
+discover authorities -> gather change set -> build reference graph -> check -> report -> confirm -> apply and propagate
 ```
-gather change set → build reference graph → check (mechanical + semantic) → report → confirm → apply + propagate
-```
 
-### 1. Gather the change set
+### 1. Discover authorities and scope
 
-The semantic layer is driven by the **current conversation context**. Identify the decision /
-requirement changes discussed in-session: which terms were renamed, which decisions reversed or
-refined, which scope/Phase boundaries moved. Write them down as an explicit change list. If the
-session contains no such change, run the mechanical layer only and say so.
+Read the repository guidance that defines artifact locations, context boundaries, terminology,
+tracker conventions, and decision-record rules. Follow nested guidance for the target area.
 
-If the user states a change explicitly, use that verbatim as the change set.
+Determine whether the repository has one context or several. For a scoped change, use the owning
+context and every routed context that consumes the changed fact. For a repository-wide check,
+enumerate all declared contexts. If no routing authority exists, discover the relevant artifacts
+from repository guidance and the artifact links themselves.
 
-### 2. Build the reference graph
+Record which artifact owns each affected fact. Treat other occurrences as references or derived
+statements unless the repository declares shared ownership.
 
-Load the artifacts and extract their cross-references (see [REFERENCE.md](REFERENCE.md) for edge
-types and how to read each source):
+### 2. Gather the change set
 
-- Issues + PRDs — `gh issue list`/`view` (Parent, Blocked by, `ADR-NNNN`, `#NN`, domain terms)
-- ADRs — `docs/adr/*.md` (`ADR-NNNN` cross-refs, `status:` front-matter, domain terms)
-- `CONTEXT.md` glossary — canonical terms and their `_Avoid_` synonyms; `ADR-NNNN` refs
+Use the current conversation and authoritative artifacts to list the requirements, decisions,
+terms, or boundaries that changed. Preserve an explicit user statement exactly when it defines the
+change. If there is no semantic change set, run only the mechanical checks and report that limit.
 
-### 3. Check — two layers
+### 3. Build the reference graph
 
-**Mechanical (always runs):** dangling references (`ADR-9999`, `#999`, missing file paths),
-orphans, and glossary term drift (use of an `_Avoid_` synonym instead of the canonical term).
+Load the artifacts in scope and extract their declared references. Typical nodes include tracked
+work, requirements, decision records, specifications, glossaries, tests, and implementation docs.
+Use repository-native identifiers and relationships. Do not infer an edge from a shared keyword
+alone.
 
-**Semantic (runs when a change set exists):** for each change, find the issues / ADRs /
-`CONTEXT.md` entries it makes stale — a change that contradicts an ADR's `Decision`, a renamed
-term, a moved Phase boundary, an issue describing superseded behavior. Report each with the
-reasoning that links the change to the affected artifact.
+### 4. Check two layers
 
-### 4. Report
+**Mechanical checks always run.** Check facts that can be decided without interpreting intent:
 
-Present a single consolidated report: every finding with its evidence (file/issue + line/quote)
-and a **concrete proposed patch** (a diff for docs, the exact `gh` command for issues). Group by
-artifact. Flag any finding that contradicts an accepted ADR per `domain.md`'s flag rule.
+- a declared reference target exists;
+- an artifact does not use a synonym that the terminology authority explicitly prohibits;
+- a reciprocal pointer exists when the repository schema explicitly requires one.
 
-### 5. Confirm (HITL)
+**Semantic checks run when interpretation is required.** For each change, find statements that may
+now be stale. Check changed decisions, renamed or newly introduced terms, moved scope boundaries,
+partly or fully superseded behavior, tracker state, and unreferenced artifacts. Use evidence to
+explain why each candidate is or is not stale. Do not classify tracker state or glossary coverage
+as a defect without applying the repository's meaning and rules.
 
-Ask the user which proposed patches to apply. Do not proceed on un-confirmed items.
+### 5. Report
 
-### 6. Apply + propagate
+Present one report grouped by artifact. For every finding, provide the location, evidence, impact,
+and a concrete proposed change. Use a patch for local text. For a remote record, describe the exact
+edit using the target repository's tracker and tool conventions. Flag any proposal that conflicts
+with an accepted authority; do not silently override it.
 
-For confirmed fixes, apply them, then propagate consistency across the graph:
+### 6. Confirm
 
-- Edit doc files; for issues use `gh issue edit` / `gh issue comment` per `issue-tracker.md`.
-- When an ADR is superseded, add a `superseded-by` link both ways and update its `status:`.
-- Sync the `CONTEXT.md` glossary when a term changes (definition, `_Avoid_` list, ADR refs).
-- Comment affected issues so the change is traceable in the tracker.
-- Re-run the mechanical check on touched artifacts to confirm no new dangling references.
+Ask which proposed changes to apply. Do not proceed with unconfirmed items.
 
-## Hook setup (optional, HITL)
+### 7. Apply and propagate
 
-To auto-invoke on a trigger, propose (do not silently add) a hook in `settings.json` — a Stop
-hook for session-end reconciliation, or a `git` pre-commit hook. Review timing and behavior with
-the user before writing to `settings.json`. See [REFERENCE.md](REFERENCE.md) for a sample.
+Apply confirmed changes, then update every affected reference or derived statement:
+
+- Use the repository-native tool and editing rules for each artifact.
+- For complete supersession, update the old and new decision records as the repository schema
+  requires.
+- For partial supersession or refinement, keep the still-valid decision active. State the affected
+  scope in both records when the repository requires bidirectional traceability.
+- Do not invent frontmatter fields, statuses, or link directions. If the repository has no
+  supersession convention, propose one separately instead of adding an implicit schema.
+- Update the terminology authority and affected uses when an established term changes.
+- Add tracker traceability only when repository guidance requires it.
+- Re-run the applicable mechanical checks on every touched artifact.
+
+## Reminder setup (optional)
+
+Propose a reminder only when it helps the repository workflow. Review its timing, visibility, and
+host-specific behavior with the user before changing configuration. The reminder must remain
+non-blocking because reconciliation can require confirmation. See [REFERENCE.md](REFERENCE.md) for
+the reminder contract.

--- a/.agents/skills/state/SKILL.md
+++ b/.agents/skills/state/SKILL.md
@@ -26,11 +26,11 @@ This skill is **self-sufficient and orthogonal** to whatever else a project happ
 control, an issue/task tracker, design docs). It assumes such tools *may* exist but depends on no
 particular one — read whatever sources the project has, skip the rest.
 
-**Write sparingly — omit rather than mislead.** Every field in the template is **optional**. Only
-write a line when you have something **accurate** and **useful to the next session**. If a value is
-missing, stale, unverified, or you can't judge whether it helps, **leave it out** — a wrong or
-filler line is worse than a missing one. STATE.md must orient the next worker, never misdirect
-them. (The Backlog inverts this default for *removal* — see the workflow.)
+**Write sparingly — omit rather than mislead.** Every content bullet in the template is optional.
+The updated date is required whenever the file is rewritten. Only write a content line when it is
+accurate and useful to the next session. If a value is missing, stale, unverified, or not clearly
+useful, leave it out. A wrong or filler line is worse than a missing one. The Backlog uses a
+different removal rule; follow step 4.
 
 ## When to run
 
@@ -38,8 +38,8 @@ them. (The Backlog inverts this default for *removal* — see the workflow.)
   session-end hook, or you run it yourself.
 - On demand, invoked as `/state`.
 
-Update STATE.md **once per session, by the primary worker** — not once per parallel sub-task or subagent — so
-the file is written a single time and never double-written.
+The primary worker updates STATE.md once per session. Parallel sub-tasks and subagents do not update
+it. This rule prevents concurrent or duplicate writes.
 
 **No-op guard:** if the session did no material work (e.g. a trivial Q&A turn), leave `STATE.md`
 unchanged — at most refresh the date. Don't churn the file with non-progress.
@@ -55,35 +55,32 @@ unchanged — at most refresh the date. Don't churn the file with non-progress.
    as if current is misdirection.) Use the project's own terms.
 3. **Pick the recommended next work** — the open items a fresh session should start with, in
    execution order. Promote Backlog items here when they are the right next start.
-4. **Reconcile the Backlog** — the unfinished cross-session items that must survive the rewrite:
-   - **Inherit by filtering**: start from the previous STATE.md's Backlog (and any Next up items
-     that never ran). Drop an item **only with evidence** — it is done, obsolete, promoted into
-     "Next up", or newly homed in the project's tracker (its reference is the evidence) — check
-     the conversation, corroborate with the tracker when one exists. When unsure, **keep it**:
-     this is the one section where uncertainty preserves a line instead of deleting it.
-   - **Demote**: unfinished work — typically displaced by inserted tasks — moves here **only when
-     it is not selected for "Next up"**. Interrupted work that should simply resume next session
-     belongs in "Next up" (step 3), not here.
-   - **Park**: a newly discovered or accepted item deliberately deferred to a later session —
-     never started, not selected for "Next up" — also enters here, so it cannot fall between the
-     two lists.
-   - **One home per item**: an item appears in "Next up" *or* the Backlog, never both.
-   - **Stamp, and promote oldest-first**: each item carries the date it entered
-     (`since YYYY-MM-DD`) — the snapshot's only observable age. When the Backlog exceeds its
-     budget, or an item is clearly substantive, move items into the project's tracker
-     **oldest-first**; the filed reference is what lets the entry leave. With no tracker, or no
-     authorization to write it, the budget yields: keep every item (staying visibly over budget
-     is the signal to get them homed) — silent truncation is never allowed.
+4. **Reconcile the Backlog.** Apply this algorithm to unfinished cross-session items:
+   - **Inherit by filtering.** Start with the previous Backlog and any "Next up" items that did not
+     run. Drop an item only when evidence shows that it is done, obsolete, selected for "Next up",
+     or recorded in the project's tracker. A tracker reference is evidence that the item has a new
+     home. Check the conversation and corroborate with the tracker when one exists. Keep the item
+     when its status is uncertain.
+   - **Demote unfinished work.** Move displaced work to the Backlog only when it is not selected for
+     "Next up". Work that should resume next session belongs in "Next up".
+   - **Park deferred work.** Add a newly accepted item when it is deferred beyond the next session
+     and has no other home.
+   - **Give each item one home.** Put it in "Next up" or the Backlog, never both.
+   - **Stamp each Backlog item.** Record its entry date as `since YYYY-MM-DD`.
+   - **Apply the five-item budget.** When the Backlog exceeds five items, or an item is clearly
+     substantive, move items to the project's tracker oldest-first. Remove an item only after the
+     tracker provides a reference. If no tracker exists, keep every item. Also keep every item when
+     no authorized writer can create the tracker record. The visible overflow is the signal that
+     the items still need a durable home.
 5. **Add pitfalls/experience only if it serves "Next up".** Include a note **only when this
    session's work is continuous with or related to the recommended next work**, so the note will
    actually get reused. If the next work is unrelated, **omit it** — experience that doesn't help
    the next task is noise, not a war-story archive.
-6. **Rewrite `STATE.md`** from the template — **overwrite, never append**; ≤15 lines, except
-   when step 4's no-loss fallback leaves the Backlog over its own budget: then the file grows by
-   exactly those Backlog lines — the line budget yields with the item budget, it is never
-   rebalanced by dropping an item. Terse; drop any field you have nothing accurate and useful
-   for (the Backlog re-emits its *filtered inheritance* — a fresh rewrite, not an append).
-   Stamp the date.
+6. **Rewrite `STATE.md` from the template.** Overwrite the file; never append. Keep it to 15 lines
+   or fewer. If the no-loss rule in step 4 leaves more than five Backlog items, allow one extra line
+   for each extra item. Do not drop an item to meet the line limit. Omit content bullets that are
+   not accurate and useful. Re-emit the filtered Backlog as part of the new snapshot. Stamp the
+   updated date.
 7. **Do not auto-commit.** Just leave the rewritten `STATE.md` in the working tree. Whether it is
    tracked or kept as a local-only working aid is the project's choice — this skill never commits it.
 
@@ -105,32 +102,14 @@ _Cross-session daily report (~15 lines, rewritten each session via `/state`). Du
 _Updated: <YYYY-MM-DD>_
 ```
 
-(Every bullet is optional — omit any you have nothing accurate and useful for.)
+(Every content bullet is optional. `_Updated` is required whenever the file is rewritten.)
 
 ## Guardrails
 
-- **≤15 lines** of content; keep it scannable. One exception: when the Backlog's no-loss
-  fallback keeps items past its own budget, the file grows by exactly those lines — a
-  line-budget breach is never resolved by dropping a Backlog item.
-- **Omit rather than mislead** — every field is optional; drop any line that is stale, unverified,
-  or not useful to the next session. Never carry a phase forward just because it was there before.
-- **Backlog drops need evidence** — the inverse of the rule above, so unfinished work cannot
-  silently vanish in a rewrite: carry an item forward unless you can point at its completion,
-  obsolescence, promotion into "Next up", or its new tracker home.
-- **Backlog budget: 5 items, one line each, each stamped `since YYYY-MM-DD`** — overflow is
-  resolved by promoting the OLDEST items into the project's tracker, never by truncation; with
-  no tracker or no authorization to write it, keep the items and stay visibly over budget —
-  losing work is worse than breaking the budget. The Backlog is execution carry-over anchored
-  by reference, never a second plan.
-- **One home per item** — "Next up" (ordered, what to start) or Backlog (parked, must not be
-  lost), never both.
-- **Pitfalls only when they serve "Next up"** — record experience only when this session's work is
-  continuous with / related to the recommended next work; otherwise leave it out.
-- **Overwrite, never append** — STATE.md is a current handoff snapshot, not a session-history log;
-  keep only the latest state. The Backlog is no exception: it is re-emitted each rewrite from its
-  filtered inheritance, not accreted.
-- Record only **this session's delta** — not a running journal. The Backlog is the one field that
-  carries filtered state forward.
-- Keep it **self-contained**: don't duplicate the project's durable decision/architecture docs, and
-  don't hard-depend on any particular tracker or tool.
-- Use the **project's own vocabulary** consistently.
+- Follow step 4 for every Backlog change. Never delete unfinished work to meet a budget.
+- Follow step 6 for rewriting and line limits. STATE.md is a current snapshot, not a history log.
+- Record only this session's delta. The Backlog is the only field that carries filtered state
+  forward.
+- Keep the file self-contained. Do not duplicate durable decisions or depend on a specific tracker
+  or tool.
+- Use the project's established vocabulary.

--- a/.agents/skills/state/SKILL.md
+++ b/.agents/skills/state/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: state
-description: Update STATE.md — the lightweight cross-session "daily report" of project progress. Rewrite (never append) the current milestone/phase, what this session completed or changed, pitfalls worth reusing, the recommended next issues/tasks, and the filtered-and-inherited backlog of unfinished cross-session items. Use at the end of a working session, when wrapping up, or when invoked as /state.
+description: Update STATE.md — the lightweight cross-session "daily report" of project progress. Rewrite (never append) the current milestone/phase, what this session completed or changed, pitfalls worth reusing, the recommended next issues/tasks, and the filtered-and-inherited backlog of unfinished cross-session items. Use at the end of a working session, when wrapping up, or when explicitly invoked.
 ---
 
 # State
@@ -36,7 +36,7 @@ different removal rule; follow step 4.
 
 - At the **end of a working session** / wrap-up — your agent runtime may nudge this via a
   session-end hook, or you run it yourself.
-- On demand, invoked as `/state`.
+- On demand, invoke the `state` skill using the host's explicit skill syntax.
 
 The primary worker updates STATE.md once per session. Parallel sub-tasks and subagents do not update
 it. This rule prevents concurrent or duplicate writes.
@@ -89,7 +89,7 @@ unchanged — at most refresh the date. Don't churn the file with non-progress.
 ```markdown
 # STATE — <project>
 
-_Cross-session daily report (~15 lines, rewritten each session via `/state`). Durable decisions live elsewhere, not here._
+_Cross-session daily report (~15 lines, rewritten each session via the `state` skill). Durable decisions live elsewhere, not here._
 
 - **Phase/milestone:** <current stage, in the project's own terms — omit if you can't confirm the *current* one>
 - **Last session:** <what was completed/changed; one line, e.g. issue #N>

--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -114,8 +114,10 @@ You are implementing <slice> in an ISOLATED git worktree.
 - To name your branch, RENAME the pre-created branch in place: `git branch -m <name>`.
   Do NOT use `git switch -c <name>` (your shell cwd can reset to the shared checkout
   between calls, so `switch -c` may create a stray branch there).
-- If local commits are authorized, commit early and often, even as work in progress. Without
-  commit authority, keep the diff reviewable and report its state at each handoff.
+- If local commits are authorized, follow the repository's commit-history and checkpoint policy.
+  Create reviewable durable checkpoints at safe boundaries; do not introduce work-in-progress or
+  per-finding commits unless the repository or user requires them. Without commit authority, keep
+  the diff reviewable and report its state at each handoff.
 - Definition of Done: run every locally reproducible gate that covers the slice. Include
   the tier that exercises the real integration boundary — integration / e2e / compile /
   a parse `--check-only` — rather than only a fast tier that stubs it. Also run applicable
@@ -184,25 +186,35 @@ squash-merged into the base branch, do **NOT** merge the base branch into B. B c
 A's individual commits via the branch point while the base now has one squash commit, so git sees divergence
 and conflicts on **every file A touched** (even files B never edited).
 
-Before any command that mutates B's index, worktree, history, or remote branch, complete
-this preflight in B's worktree:
+Before any command that mutates B's index, worktree, or history, complete this local
+preflight in B's worktree:
 
 ```bash
 git -C <B-worktree> rev-parse --show-toplevel             # must be <B-worktree>
 git -C <B-worktree> branch --show-current                 # must be <B-branch>
 git -C <B-worktree> status --porcelain=v1                 # must be empty: index + worktree
-git -C <B-worktree> fetch <remote>
 original_tip=$(git -C <B-worktree> rev-parse <B-branch>)
-expected_remote_sha=$(git -C <B-worktree> ls-remote --exit-code <remote> refs/heads/<B-branch> | awk '{print $1}')
 test -n "$original_tip"
-test -n "$expected_remote_sha"
-git -C <B-worktree> merge-base --is-ancestor "$expected_remote_sha" "$original_tip"
 ```
 
-Stop if the root, branch, clean-state, remote lookup, or ancestry check fails. Keep
-`original_tip` as the recovery reference. If another process can touch the worktree or
-remote branch, repeat the branch, clean-state, and remote-SHA checks immediately before
-the rewrite. Never replace the recorded expected SHA with the post-rewrite local SHA.
+Stop if the root, branch, clean-state, or local-tip check fails. Keep `original_tip` as the
+recovery reference. A local-only rebase does not require B to have a remote branch.
+
+When a push is authorized and planned, inspect B's remote state before rewriting history:
+
+```bash
+git -C <B-worktree> fetch <remote>
+remote_result=$(git -C <B-worktree> ls-remote <remote> refs/heads/<B-branch>) || exit 1
+expected_remote_sha=$(printf '%s\n' "$remote_result" | awk '{print $1}')
+if test -n "$expected_remote_sha"; then
+  git -C <B-worktree> merge-base --is-ancestor "$expected_remote_sha" "$original_tip" || exit 1
+fi
+```
+
+An empty `expected_remote_sha` means that B is unpublished; it does not block the local rewrite.
+If another process can touch the worktree, repeat the branch and clean-state checks immediately
+before the rewrite. For a published branch, keep the recorded expected SHA until the push. Never
+replace it with the post-rewrite local SHA.
 
 Replay only B's own commits onto the base branch. If B contains only its own commits after
 A, preserve its commit structure:
@@ -212,10 +224,14 @@ git -C <B-worktree> rebase --onto <remote>/<base-branch> <old-A-tip> <B-branch>
 # resolve only genuine A/B overlap; run applicable locally reproducible gates; then verify:
 git -C <B-worktree> branch --show-current                 # must still be <B-branch>
 git -C <B-worktree> status --porcelain=v1                 # must be empty
-# only with explicit push authority:
-git -C <B-worktree> push \
-  --force-with-lease="refs/heads/<B-branch>:$expected_remote_sha" \
-  <remote> HEAD:refs/heads/<B-branch>
+# only with explicit push authority; force only when the branch was already published:
+if test -n "$expected_remote_sha"; then
+  git -C <B-worktree> push \
+    --force-with-lease="refs/heads/<B-branch>:$expected_remote_sha" \
+    <remote> HEAD:refs/heads/<B-branch>
+else
+  git -C <B-worktree> push <remote> HEAD:refs/heads/<B-branch>
+fi
 ```
 
 If B has messy local history and you want a single merge commit's worth of B content,
@@ -231,10 +247,14 @@ git -C <B-worktree> rebase --onto <remote>/<base-branch> "$base" <B-branch>
 # resolve only genuine A/B overlap; run applicable locally reproducible gates; then verify:
 git -C <B-worktree> branch --show-current                 # must still be <B-branch>
 git -C <B-worktree> status --porcelain=v1                 # must be empty
-# only with explicit push authority:
-git -C <B-worktree> push \
-  --force-with-lease="refs/heads/<B-branch>:$expected_remote_sha" \
-  <remote> HEAD:refs/heads/<B-branch>
+# only with explicit push authority; force only when the branch was already published:
+if test -n "$expected_remote_sha"; then
+  git -C <B-worktree> push \
+    --force-with-lease="refs/heads/<B-branch>:$expected_remote_sha" \
+    <remote> HEAD:refs/heads/<B-branch>
+else
+  git -C <B-worktree> push <remote> HEAD:refs/heads/<B-branch>
+fi
 ```
 
 > The portable rule is: **replay only B's own commits with `git rebase --onto`; never
@@ -353,14 +373,15 @@ the documented environment can be reproduced safely. If it cannot, record the li
 
 ## 7. Resilience & takeover
 
-- **Create durable local artifacts early when authorized.** When commits are allowed,
-  commit early because truncation loses uncommitted work. Without commit authority, keep
-  the diff reviewable and report its state at each handoff.
+- **Create durable local artifacts at safe boundaries when authorized.** Follow the repository's
+  commit-history and checkpoint policy. Without commit authority, keep the diff reviewable and
+  report its state at each handoff.
 - **A review/fix round is a re-dispatch — restate the whole discipline.** Prefer
   resuming the ORIGINAL implementer (its context is intact), but do not assume it
-  remembers the rules it followed last round: restate worktree pinning, commit-early,
-  permissions, and the §3 DoD gates in the round's dispatch brief. When commits are authorized,
-  require **one commit per finding**. Kills
+  remembers the rules it followed last round: restate worktree pinning, checkpoint policy,
+  permissions, and the §3 DoD gates in the round's dispatch brief. Require one commit per finding
+  only when the repository or user explicitly requires that granularity. Otherwise map findings to
+  their resolutions in the handoff. Kills
   strike mid-round too (session/usage limits, not just truncation) — one real agent
   finished an entire review/fix round and died with all of it uncommitted.
 - **Takeover recipe for uncommitted work:** review the whole uncommitted diff yourself
@@ -385,9 +406,10 @@ the documented environment can be reproduced safely. If it cannot, record the li
   still on its branch and clean (`git -C <shared-checkout> branch --show-current`, `git status
   --short`, no stray branches) before relying on it — worktree agents have leaked git
   ops to it (§3).
-- **A history-rewrite push after a rebase requires explicit authority and an explicit lease.**
-  Use the exact expected remote SHA recorded by §4; bare `--force-with-lease` is not enough
-  for this recipe. Never rewrite a shared or protected branch.
+- **A history-rewrite push of a published branch requires explicit authority and an explicit
+  lease.** Use the exact expected remote SHA recorded by §4; bare `--force-with-lease` is not
+  enough for this recipe. An unpublished branch uses a normal initial push. Never rewrite a shared
+  or protected branch.
 
 ## 8. Architectural fix: kill the hotspots
 
@@ -412,7 +434,8 @@ design decision record.
 - [ ] Agents are pinned to their worktrees; local artifacts follow the granted commit authority; "done but no artifact" = takeover.
 - [ ] Merge order decided (foundation slice before dependent follow-up slices); after each resolution, audit for the marker-free traps.
 - [ ] Stacked followers have an explicit retarget/rebase plan for after the base change lands
-      or receives review fixes; original local tip and expected remote SHA are recorded before mutation.
+      or receives review fixes; the original local tip is recorded before mutation, and the expected
+      remote SHA is recorded when a published branch will be rewritten and pushed.
 - [ ] Shared-global-resource tests will run serially across worktrees.
 - [ ] Orchestrator will independently re-verify before each merge.
 - [ ] Any public-surface change has the applicable documentation/schema/help/generated-artifact consistency gates in the orchestrator's verification plan.

--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -193,17 +193,19 @@ preflight in B's worktree:
 git -C <B-worktree> rev-parse --show-toplevel             # must be <B-worktree>
 git -C <B-worktree> branch --show-current                 # must be <B-branch>
 git -C <B-worktree> status --porcelain=v1                 # must be empty: index + worktree
+git -C <B-worktree> fetch <remote>
+git -C <B-worktree> rev-parse --verify <remote>/<base-branch>
 original_tip=$(git -C <B-worktree> rev-parse <B-branch>)
 test -n "$original_tip"
 ```
 
-Stop if the root, branch, clean-state, or local-tip check fails. Keep `original_tip` as the
-recovery reference. A local-only rebase does not require B to have a remote branch.
+Stop if the root, branch, clean-state, base-refresh, or local-tip check fails. Keep `original_tip`
+as the recovery reference. The fetch makes `<remote>/<base-branch>` current for both local-only and
+published-branch rebases. A local-only rebase does not require B to have a remote branch.
 
 When a push is authorized and planned, inspect B's remote state before rewriting history:
 
 ```bash
-git -C <B-worktree> fetch <remote>
 remote_result=$(git -C <B-worktree> ls-remote <remote> refs/heads/<B-branch>) || exit 1
 expected_remote_sha=$(printf '%s\n' "$remote_result" | awk '{print $1}')
 if test -n "$expected_remote_sha"; then

--- a/.agents/skills/subagent-worktree-parallel/REFERENCE.md
+++ b/.agents/skills/subagent-worktree-parallel/REFERENCE.md
@@ -9,13 +9,14 @@ resource" rather than naming any one stack — map them onto your own toolchain.
 
 ## 1. Dependency analysis & decomposition
 
-Split the work into vertical slices, then classify every pair:
+Split the work into end-to-end slices, then classify every pair:
 
 - **Independent (parallel-safe):** slices touching disjoint code/modules. Fan these out.
 - **Coupled (must serialize):** two slices that extend the same component, or a
-  foundational *tracer* plus its *round-out*. Land the tracer and **merge it first**,
-  then fan out the round-outs. Parallel siblings that both scaffold the same thing
-  duplicate it and collide at merge.
+  **foundation slice** plus its **dependent follow-up slices**. A foundation slice
+  establishes the smallest shared contract or scaffold that its follow-ups require.
+  Land it first, then fan out the follow-ups. Parallel follow-ups that each scaffold the
+  same foundation duplicate it and collide at merge.
 
 **Identify the append hotspots up front.** These are the shared files *every* slice
 edits, where all the integration cost concentrates:
@@ -78,12 +79,25 @@ pre-flight verdict is not durable.
 - **≤ ~5 independent slices per wave.** (A run that tried ~9 at once hit two failure
   modes: subagents truncated at run limits, and a merge treadmill.)
 - **Merge the whole wave before starting the next.** Each rebase then lands on a stable
-  base. Skipping this creates the *treadmill*: merge one PR, every other open PR goes
-  `CONFLICTING`, rebase them all, merge the next, they all re-conflict again.
+  base. Skipping this creates the *treadmill*: merge one change request, every other open
+  change becomes conflicting, rebase them all, merge the next, then repeat.
 - Larger waves also raise the chance an agent is cut off mid-task (losing uncommitted
   work — see §7).
 
-## 3. Dispatching an implementer subagent (with a worktree)
+## 3. Planning and dispatching
+
+Record the operating mode and permissions before creating a worktree or dispatching an
+implementer:
+
+- **Planning-only:** produce the dependency map, slice briefs, wave plan, integration order,
+  validation plan, and any permission requests. Do not create worktrees or branches, edit,
+  commit, push, open change requests, merge, reply to reviews, or update remote trackers.
+- **Execution:** list the allowed local mutations. List each allowed remote write separately:
+  push, change-request creation or update, merge, review reply, or tracker update. Permission
+  to implement or commit does not imply any remote-write permission.
+
+For planning-only work, stop after returning the plan. The rest of this section applies only
+to execution mode.
 
 Launch one subagent per slice in its own git worktree. The harness usually pre-creates
 the worktree on an auto-named branch. Dispatch prompt should pin down these points:
@@ -91,22 +105,24 @@ the worktree on an auto-named branch. Dispatch prompt should pin down these poin
 ```
 You are implementing <slice> in an ISOLATED git worktree.
 
+- Local mutation authority: <exact allowed actions and files>.
+- Remote-write authority: <none, or an exact list of allowed actions>. Do not infer an
+  unlisted push, change request, merge, review reply, or tracker update.
 - Operate ONLY inside your own worktree directory. Before any git command, confirm
   `git rev-parse --show-toplevel` is your worktree root — NEVER run git ops against the
-  shared main checkout.
+  shared checkout.
 - To name your branch, RENAME the pre-created branch in place: `git branch -m <name>`.
   Do NOT use `git switch -c <name>` (your shell cwd can reset to the shared checkout
   between calls, so `switch -c` may create a stray branch there).
-- Commit early and often, even WIP — a truncated/killed run only loses UNcommitted work.
-- Definition of Done: the INTEGRATION-tier test passes (the tier that actually exercises
-  the integration boundary — integration / e2e / compile / a parse `--check-only`), not
-  just the fast tier that stubs it. Do not satisfy DoD by deselecting the integration
-  tier (e.g. a pytest-style `-m "not <integration>"` filter — or your runner's equivalent).
-- Also part of DoD — beyond the test tiers, mirror the repo's NON-TEST PR-CI gates: read
-  the gate list off the CI workflow itself (do not recite it from memory) and run each
-  gate exactly as CI invokes it (same commands/flags) — typically the formatter CHECK,
-  linter, typecheck, and build/packaging. A green test run with a red format check still
-  bounces the PR.
+- If local commits are authorized, commit early and often, even as work in progress. Without
+  commit authority, keep the diff reviewable and report its state at each handoff.
+- Definition of Done: run every locally reproducible gate that covers the slice. Include
+  the tier that exercises the real integration boundary — integration / e2e / compile /
+  a parse `--check-only` — rather than only a fast tier that stubs it. Also run applicable
+  non-test checks with the repository's documented commands and flags.
+- Classify a gate as CI-only only when it depends on protected infrastructure, secrets,
+  remote policy, or hardware unavailable locally. If any gate cannot run, report the
+  reason, substitute evidence, and remaining risk. Do not report that gate as passed.
 - If a shared file is OWNED by a sibling slice this wave (the prompt names the owners),
   do NOT edit it — flag the needed change in your report and let the orchestrator route it.
 - Also part of DoD — deep-module reuse: if your change belongs in a shared/deep module (a
@@ -117,93 +133,127 @@ You are implementing <slice> in an ISOLATED git worktree.
   the change there and flag it in your report; when a SIBLING slice owns it, flag it for
   the owner/orchestrator instead of editing (previous line) — the lead reassigns
   ownership or serializes the slice, but the change still lands.
-- When done: **commit and push your branch — do NOT open the PR.** The orchestrator opens
-  every PR so the close-vs-reference keyword and PR conventions are applied in one place.
-  Report the branch name, the commit SHA, the exact test command + its result counts, the
-  linked issue/spec and **whether your slice fully satisfies it or only advances it** (so the
-  lead can choose `Closes #N` vs `Refs #N`), and any deep module you reused or shared file
-  you had to touch.
+- When done, commit only if local commit authority was granted. Do not push or perform any
+  other remote write unless the prompt lists that exact action. Report the branch, local
+  commit or uncommitted diff, exact validation commands and results, CI-only/unavailable
+  gates with residual risk, the source requirement, whether the slice fully satisfies it,
+  and any shared module or file involved.
 ```
 
 Worktree setup / cleanup:
 
 ```bash
-git worktree add -b feat/<slice> ../wt-<slice> origin/main   # worktree on a FRESH branch off main
-# ... agent implements, commits, pushes; the orchestrator opens the PR ...
-git worktree remove ../wt-<slice>                            # ONLY after its PR is merged
+git worktree add -b <slice-branch> <slice-worktree> <remote>/<base-branch>
+# ... agent performs only the authorized local work and remote writes ...
+git worktree remove <slice-worktree>  # only after its local artifacts are retained and integration is complete
 ```
 
-> Create the branch *with* the worktree (`-b`). `git worktree add ../wt origin/main`
+> Create the branch *with* the worktree (`-b`). `git worktree add <worktree> <remote>/<base-branch>`
 > (no `-b`) checks out in **detached HEAD**, so a follow-up `git branch -m` fails with
 > "cannot rename the current branch while not on any". The in-place `git branch -m`
-> above is only for the *harness-pre-created* branch case, where a branch already exists.
+> above is only for the *orchestrator-pre-created* branch case, where a branch already exists.
 
 > **Why `git branch -m`, not `switch -c`:** all worktrees share one `.git`, so refs are
 > global and a branch op meant for the worktree can land on the shared checkout when the
-> cwd has reset. Observed leaking to the parent's `main`/HEAD (even via `git reset
-> --hard`) more than once — see §7 for the verification that catches it.
+> cwd has reset. A leaked operation can move the shared checkout's branch or HEAD, including
+> through a reset. See §7 for the verification that catches it.
 
 ## 4. Merge recipe (serial, dependency order)
 
-Merging is an ordered serial workflow, not a fan-out:
+Merging is an ordered serial workflow, not a fan-out. Run local rebase/squash commands
+only with execution authority, and run pushes or hosted merges only with the corresponding
+remote-write authority.
 
-1. **Tracer first**, then **rebase each follower onto the new base**, then independent
-   groups can merge in any order.
-2. **Re-poll mergeability after every merge** — the host (e.g. GitHub) recomputes it
-   asynchronously, so a `CLEAN` PR can flip to `CONFLICTING` once a sibling merges.
+1. **Foundation slice first**, then **rebase each dependent follow-up slice onto the new
+   base**. Independent groups can integrate in any order.
+2. **Re-poll mergeability after every merge** — a hosting service can recompute it
+   asynchronously, so a previously mergeable change can become conflicting after a sibling merges.
 3. **A clean auto-merge still gets the integration gate** (§6) — the marker-free traps
    in §5 hide precisely in conflict-free rebases.
 
-**Base remediation invalidates dependent PR evidence.** If PR-A is the base for PR-B,
-then every review fix, doc fix, or force-push on A requires a fresh B check. Rebase B
-onto A's updated head, re-run the gates that cover the touched surface, and inspect B's
-user/agent-visible docs before treating it as merge-ready. A dependent PR can be green
-and still be stale because the base changed after its CI run.
+**Base remediation invalidates dependent-change evidence.** If change A is the base for
+change B, then every review fix, documentation fix, or history rewrite on A requires a
+fresh B check. Rebase B onto A's updated head, rerun the gates that cover the touched
+surface, and inspect B's user/agent-visible documentation before treating it as ready.
+A dependent change can retain an old green result after its base has changed.
 
-### Stacked PR after its base was squash-merged
+### Stacked change after its base was squash-merged
 
-If the repo **squash-merges** and PR-B is stacked on PR-A, then once A is squash-merged
-into main, do **NOT** `git merge origin/main` into B: B carries A's *individual* commits
-via the branch point while main now has A as *one* squash commit, so git sees divergence
+If the repository **squash-merges** and change B is stacked on change A, then once A is
+squash-merged into the base branch, do **NOT** merge the base branch into B. B carries
+A's individual commits via the branch point while the base now has one squash commit, so git sees divergence
 and conflicts on **every file A touched** (even files B never edited).
 
-Replay only B's own commits onto main instead. If B is a normal branch with only B's
-commits after A, preserve its commit structure:
+Before any command that mutates B's index, worktree, history, or remote branch, complete
+this preflight in B's worktree:
 
 ```bash
-git -C <B-worktree> fetch origin
-git -C <B-worktree> rebase --onto origin/main <old-A-branch-or-sha> B-branch
-# resolve only genuine A↔B overlap, run fast + integration tiers, then:
-git -C <B-worktree> push --force-with-lease
+git -C <B-worktree> rev-parse --show-toplevel             # must be <B-worktree>
+git -C <B-worktree> branch --show-current                 # must be <B-branch>
+git -C <B-worktree> status --porcelain=v1                 # must be empty: index + worktree
+git -C <B-worktree> fetch <remote>
+original_tip=$(git -C <B-worktree> rev-parse <B-branch>)
+expected_remote_sha=$(git -C <B-worktree> ls-remote --exit-code <remote> refs/heads/<B-branch> | awk '{print $1}')
+test -n "$original_tip"
+test -n "$expected_remote_sha"
+git -C <B-worktree> merge-base --is-ancestor "$expected_remote_sha" "$original_tip"
+```
+
+Stop if the root, branch, clean-state, remote lookup, or ancestry check fails. Keep
+`original_tip` as the recovery reference. If another process can touch the worktree or
+remote branch, repeat the branch, clean-state, and remote-SHA checks immediately before
+the rewrite. Never replace the recorded expected SHA with the post-rewrite local SHA.
+
+Replay only B's own commits onto the base branch. If B contains only its own commits after
+A, preserve its commit structure:
+
+```bash
+git -C <B-worktree> rebase --onto <remote>/<base-branch> <old-A-tip> <B-branch>
+# resolve only genuine A/B overlap; run applicable locally reproducible gates; then verify:
+git -C <B-worktree> branch --show-current                 # must still be <B-branch>
+git -C <B-worktree> status --porcelain=v1                 # must be empty
+# only with explicit push authority:
+git -C <B-worktree> push \
+  --force-with-lease="refs/heads/<B-branch>:$expected_remote_sha" \
+  <remote> HEAD:refs/heads/<B-branch>
 ```
 
 If B has messy local history and you want a single merge commit's worth of B content,
 squash B first, then replay it:
 
 ```bash
-# Scope EVERY mutating git command with `-C <B-worktree>` (per §3/§7 — never let a
-# command run against the shared checkout because cwd reset). Don't chain with `&&`,
-# which hides an unscoped second command.
-base=$(git -C <B-worktree> merge-base B-branch A-branch)        # branch point where B forked off A
-git -C <B-worktree> reset --soft "$base"                        # squash B → 1 commit ...
-git -C <B-worktree> commit -m "<B title>"                       # ... (scoped: lands in B, not main)
-git -C <B-worktree> rebase --onto origin/main "$base" B-branch  # 1 commit → ONE conflict pass
-# resolve only the genuine A↔B overlap, run fast + integration tiers, then:
-git -C <B-worktree> push --force-with-lease
+# Complete the same preflight above first. Scope every mutation with `-C <B-worktree>`.
+base=$(git -C <B-worktree> merge-base "$original_tip" <old-A-tip>)
+git -C <B-worktree> reset --soft "$base"
+git -C <B-worktree> diff --cached --check
+git -C <B-worktree> commit -m "<B title>"
+git -C <B-worktree> rebase --onto <remote>/<base-branch> "$base" <B-branch>
+# resolve only genuine A/B overlap; run applicable locally reproducible gates; then verify:
+git -C <B-worktree> branch --show-current                 # must still be <B-branch>
+git -C <B-worktree> status --porcelain=v1                 # must be empty
+# only with explicit push authority:
+git -C <B-worktree> push \
+  --force-with-lease="refs/heads/<B-branch>:$expected_remote_sha" \
+  <remote> HEAD:refs/heads/<B-branch>
 ```
 
-> The portable lesson is host-agnostic: **replay only B's own commits with `git rebase
-> --onto`; never merge the base in.** The `main` / `origin/main` names are just this
-> example's base branch and remote — substitute your own.
+> The portable rule is: **replay only B's own commits with `git rebase --onto`; never
+> merge the squash-merged base into B.** Preserve the original local tip, bind any history
+> rewrite push to the exact remote SHA observed before the rewrite, and stop on drift.
 
-After the replay, update the PR metadata before merging:
+After the replay, update the hosted change record before merging, but only with authority
+for those remote writes:
 
-- retarget the PR to the real base branch if the host did not already do it
-- remove stale "stacked on PR-A" text
-- change `Refs #N` to `Closes #N` only if B now fully satisfies the issue
-- refresh any verification evidence recorded in the PR description to the commands
+- retarget the change to the real base branch if the host did not already do it
+- remove stale text about its former stacked base
+- mark the source work item complete only if B now fully satisfies it
+- refresh any verification evidence recorded in the change description to the commands
   actually run on the post-rebase head
-- wait for CI on the new head; old green checks belonged to the stacked base
+- wait for required CI-only gates on the new head before a hosted merge; old green checks
+  belonged to the stacked base
+
+If the required remote writes are not authorized, report each pending update and the
+remaining merge risk without performing it.
 
 ## 5. The two silent merge hazards (no conflict marker; fast tests still pass)
 
@@ -237,26 +287,37 @@ the grep heuristic might miss in another language.
 
 ## 6. Verification & Definition of Done
 
-- **Re-run the integration tier yourself before merging.** A `mergeable=CLEAN` rebase is
-  exactly where the §5 marker-free traps hide; do not let CLEAN substitute for the gate.
+Classify every required gate before execution:
+
+- **Locally reproducible:** the required dependencies and environment are available without
+  protected secrets or remote-only infrastructure. Run these gates locally with the authoritative
+  commands and flags before integration.
+- **CI-only:** the gate requires protected infrastructure, secrets, remote policy evaluation, or
+  hardware that is not available locally. Do not simulate a pass. Record why it cannot run locally,
+  the substitute evidence gathered, and the remaining risk. When remote execution is authorized,
+  require its result on the exact candidate head before merge.
+
+An unavailable local dependency does not automatically make a gate CI-only. First determine whether
+the documented environment can be reproduced safely. If it cannot, record the limitation as above.
+
+- **Re-run the locally reproducible integration tier yourself before merging.** A clean rebase is
+  exactly where the §5 marker-free traps hide; do not let mergeability substitute for the gate.
 - **Beware the test-tier blind spot.** A fast tier that stubs the integration boundary
   (fakes/mocks/in-memory doubles) never executes the merged artifact, so it passes on a
   broken merge. After touching an integration point, run the real tier (integration /
   e2e / compile / parse-check).
-- **A green DoD is not spec conformance — re-read each slice against its *originating
-  spec*.** Passing its own tests + CI proves a slice does what its author built, not what
+- **A green DoD is not requirement conformance — re-read each slice against its source
+  requirement.** Passing its own tests and hosted gates shows what the implementation does, not what
   the spec/decision required; the author's tests inherit the author's blind spot. Before
-  merging, the orchestrator adversarially re-reads each slice against the spec that
-  spawned it and hunts the contract gap those tests can't see. This *front-runs* the fixed
-  external per-PR review — it complements that review, never replaces or duplicates it —
-  and how deep to go is the orchestrator's call.
+  merging, the orchestrator re-reads each slice against its source requirement and looks
+  for contract gaps that its tests do not cover. This complements independent review; it
+  does not replace it. The orchestrator selects review depth from the slice's risk.
 - **Public-surface consistency is part of integration.** When a slice changes a public
   shape or user/agent-observable behavior, audit every mirrored surface before merge:
-  CLI/help text, schema/model descriptions, command catalogs, README-style user docs,
-  generated or translated docs and their sync markers, and bundled agent skills or
-  playbooks. Re-run the repo's doc/skill/schema sync tests. Do this again after base
-  review fixes in a stacked PR, because the dependent PR may carry stale help text or
-  regenerated docs even when its code tests pass.
+  command/help text, schema/model descriptions, public documentation, generated or
+  translated artifacts, and bundled agent guidance. Rerun the project's applicable
+  consistency checks. Do this again after base review fixes in a stacked change, because
+  the dependent change can carry stale generated surfaces even when its code tests pass.
 - **Run shared-global-resource tests SERIALLY across worktrees.** If the integration
   tier contends on a global resource — a shared log directory, a fixed port, a fixed
   on-disk fixture/path — concurrent runs across worktrees race and produce spurious
@@ -278,85 +339,85 @@ the grep heuristic might miss in another language.
   whose diff cannot touch that path points at infra, not the change. Adjudicate with:
   re-run the single test standalone, then demand one fully green full run — an
   intermittent display/timing-dependent test that passes both is a flake to note, not a
-  blocker (but say so honestly in the PR).
-- **Scale the heaviest gate to the wave, not the PR (a cost decision the lead sets).**
+  blocker (but record it honestly in the change evidence).
+- **Scale the heaviest gate to the wave, not each change request (a cost decision the lead sets).**
   When the full integration tier is expensive (long CI runs, real engines/devices), a
   workable economy is: per-branch risk covered by the lead's local serial runs (above),
-  PR CI running only the cheap tiers, and ONE full-tier run on the merged trunk after
-  the wave's last merge as the wave gate. The trade is deferred detection on the trunk —
+  per-change hosted validation running only the cheap tiers, and one full-tier run on the
+  integrated base after the wave's last merge. The trade is deferred detection on the integrated base —
   make it deliberately, not by default.
-- **Close the review loop.** For actionable PR review comments, implement the fix,
-  re-run the relevant gates, push, and reply or resolve the thread according to the
-  repo's convention. Review remediation can touch shared docs or other hotspots, so
-  update the overlap map and dependent PR plan after each review fix.
+- **Close the review loop.** For actionable review comments, implement the fix,
+  rerun the relevant gates, then push and reply or resolve only when those remote writes
+  are authorized. Follow the host's convention. Review remediation can touch shared surfaces, so
+  update the overlap map and dependent-change plan after each review fix.
 
 ## 7. Resilience & takeover
 
-- **Commit early.** Truncation/kill only loses *uncommitted* work; an agent cut off
-  before committing can leave a broken, unsaved file in its worktree.
+- **Create durable local artifacts early when authorized.** When commits are allowed,
+  commit early because truncation loses uncommitted work. Without commit authority, keep
+  the diff reviewable and report its state at each handoff.
 - **A review/fix round is a re-dispatch — restate the whole discipline.** Prefer
   resuming the ORIGINAL implementer (its context is intact), but do not assume it
   remembers the rules it followed last round: restate worktree pinning, commit-early,
-  and the §3 DoD gates in the round's dispatch brief, and require **one commit per finding**. Kills
+  permissions, and the §3 DoD gates in the round's dispatch brief. When commits are authorized,
+  require **one commit per finding**. Kills
   strike mid-round too (session/usage limits, not just truncation) — one real agent
   finished an entire review/fix round and died with all of it uncommitted.
 - **Takeover recipe for uncommitted work:** review the whole uncommitted diff yourself
   against the findings it claims to fix, run the same gates the dispatch DoD requires
-  (§3: the integration tier plus the PR-CI gate list read off the CI workflow), then
-  commit and push it under an honest message. Don't re-dispatch what a diff review can
+  (§3: the locally reproducible gates plus the recorded CI-only gates), then commit or
+  push only when each action is authorized. Don't re-dispatch what a diff review can
   verify — and don't commit what you haven't read.
-- **Trivial mechanical CI failures are the lead's to fix in place.** A formatter diff or
+- **Trivial mechanical validation failures are the lead's to fix in place when authorized.** A formatter diff or
   an import sort on an otherwise-verified branch is cheaper to fix, test, and push
   yourself than to re-dispatch an agent for.
 - **"Completed but no artifact" = needs-takeover.** Never trust a completion claim —
   independently verify with `git status` (clean?), `git log` (recent commits?), and
-  remote-tracking (pushed?). Also seen: an agent reports done while its test run is "still
-  settling" (no counts), or committed but never pushed — both are takeover, re-run and
-  finish it yourself.
-- **The orchestrator opens the PR — and decides `Closes #N` vs `Refs #N`.** PR creation is
-  the lead's, not the subagent's (§3). Once a slice's pushed commits verify, open its PR
-  yourself. Use the closing keyword `Closes #N` **only when that PR fully satisfies the
-  linked issue** (all acceptance criteria, verified); for a tracer, round-out, or
-  stacked/multi-wave slice that only *advances* the issue, use a non-closing `Refs #N` so a
-  partial merge does not close it prematurely. Do not delegate the keyword to the subagent
-  and spot-check it after: even when the brief demands it, subagent-authored PRs reliably
-  bury or omit it — owning PR creation removes the failure mode.
-- **Verify the shared checkout after every worktree agent.** Confirm the main checkout is
-  still on its branch and clean (`git -C <main> branch --show-current`, `git status
+  remote-tracking when a push was authorized and expected. An agent report with no
+  completed validation result, or with an expected push absent, needs takeover and verification.
+- **The orchestrator owns hosted integration records when remote writes are authorized.**
+  Once a slice's published commits verify, create or update its change request according
+  to the host's convention. Mark a source work item complete only when that slice satisfies
+  every acceptance criterion. A foundation slice, dependent follow-up slice, or stacked
+  partial change must remain non-closing. Without remote-write authority, report the
+  required record and do not create or update it.
+- **Verify the shared checkout after every worktree agent.** Confirm the shared checkout is
+  still on its branch and clean (`git -C <shared-checkout> branch --show-current`, `git status
   --short`, no stray branches) before relying on it — worktree agents have leaked git
   ops to it (§3).
-- **Force-pushing a *feature* branch after a rebase is normal** (`--force-with-lease`).
-  Distinguish it from touching shared/protected branches; don't let a generic
-  "dangerous git" guardrail block the legitimate rebase → force-push of a PR branch you own.
+- **A history-rewrite push after a rebase requires explicit authority and an explicit lease.**
+  Use the exact expected remote SHA recorded by §4; bare `--force-with-lease` is not enough
+  for this recipe. Never rewrite a shared or protected branch.
 
 ## 8. Architectural fix: kill the hotspots
 
 The durable cure for append conflicts is to stop appending to shared files: **split each
 central registry / dispatch table / map so every module owns its own fragment that is
 auto-collected** (one file per module, discovered/aggregated at build or load). Then
-independent slices stop colliding at all, and per-PR conflict count drops from "many
+independent slices stop colliding at all, and per-change conflict count drops from "many
 files, many regions" toward 1–2. When the conflict tax is high, this is worth a dedicated
-design decision (an ADR) of its own.
+design decision record.
 
 ## 9. Pre-launch checklist
 
 - [ ] Slices in this wave are independent (no shared module/group); coupled ones serialized.
-- [ ] Wave ≤ ~5; will merge before the next wave.
+- [ ] Wave ≤ ~5; the plan integrates it before the next wave when execution is authorized.
+- [ ] Operating mode is explicit: planning-only stops after the plan; execution lists allowed local mutations.
+- [ ] Every push, change-request write, merge, review reply, and tracker update has separate explicit authority or is marked pending.
 - [ ] Every append hotspot has exactly ONE owner slice this wave; sibling prompts say "flag, don't edit" (§1).
-- [ ] Each subagent's DoD includes the integration tier (not just the stubbed fast tier).
-- [ ] Each subagent's DoD covers the PR-CI gate list read off the CI workflow itself — the test tiers plus the non-test gates (formatter check, lint, typecheck, build), invoked as CI invokes them (§3).
+- [ ] Each subagent's DoD includes every applicable locally reproducible gate, including the real integration boundary.
+- [ ] Each CI-only or unavailable gate records the reason, substitute evidence, remaining risk, and exact-head requirement (§3, §6).
 - [ ] Each subagent's DoD includes deep-module reuse — no re-implementing shared logic, and no dodging a legitimate shared-file edit, to fake disjointness (§1).
-- [ ] Review/fix rounds restate the dispatch discipline (resume the original agent; one commit per finding); actionable review comments are closed with code/tests plus a finding→resolution reply or thread resolution on the review channel — by the lead, who re-verifies and keeps the PR/change description current where the host supports it (§6, §7).
-- [ ] Agents pinned to their own worktree; will commit early; "done but no artifact" = takeover.
-- [ ] Merge order decided (tracer first); after each resolution, audit for the marker-free traps.
-- [ ] Stacked followers have an explicit retarget/rebase plan for after the base PR lands
-      or receives review fixes; old base branch/SHA is recorded for `rebase --onto`.
+- [ ] Review/fix rounds restate worktree, permission, and gate requirements; remote review replies occur only when authorized (§6, §7).
+- [ ] Agents are pinned to their worktrees; local artifacts follow the granted commit authority; "done but no artifact" = takeover.
+- [ ] Merge order decided (foundation slice before dependent follow-up slices); after each resolution, audit for the marker-free traps.
+- [ ] Stacked followers have an explicit retarget/rebase plan for after the base change lands
+      or receives review fixes; original local tip and expected remote SHA are recorded before mutation.
 - [ ] Shared-global-resource tests will run serially across worktrees.
 - [ ] Orchestrator will independently re-verify before each merge.
-- [ ] Any public-surface change has a docs/schema/help/agent-skill/i18n sync gate in the
-      orchestrator's verification plan.
-- [ ] PR creation is the orchestrator's: subagents commit + push only; the lead opens each PR and chooses `Closes #N` (only if the slice fully satisfies its issue) vs `Refs #N`.
-- [ ] If append hotspots keep causing conflicts, consider splitting them (ADR).
+- [ ] Any public-surface change has the applicable documentation/schema/help/generated-artifact consistency gates in the orchestrator's verification plan.
+- [ ] Hosted integration records are orchestrator-owned when authorized; partial slices do not close their source work item.
+- [ ] If append hotspots keep causing conflicts, consider splitting them through a design decision.
 
 ## 10. Cost / benefit
 
@@ -364,4 +425,4 @@ design decision (an ADR) of its own.
 |---|---|
 | **Wins** | implementation wall-clock (large); context isolation (each agent's tool output stays out of the orchestrator); independent-perspective quality (adversarial review surfaces hidden issues — one slice even found a latent bug in neighboring code) |
 | **Costs** | merging is serial and can be conflict-heavy; duplicated scaffolding; verification burden on the orchestrator; truncation risk at large batch sizes |
-| **Net** | strongly positive for independent, modest-sized waves **with an integration-tier test gate**; neutral-to-negative for tightly-coupled slices hammering shared files |
+| **Net** | strongly positive for independent, modest-sized waves with applicable locally reproducible and CI-only gates; neutral-to-negative for tightly-coupled slices hammering shared files |

--- a/.agents/skills/subagent-worktree-parallel/SKILL.md
+++ b/.agents/skills/subagent-worktree-parallel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subagent-worktree-parallel
-description: Orchestrates parallel development by fanning out independent feature slices to subagents in isolated git worktrees, then merging them serially under an orchestrating agent — covers dependency decomposition, wave sizing, dispatch prompts, merge-conflict hazards, and the integration-test gate. Use when planning to parallelize implementation across multiple subagents/worktrees, split a task for concurrent agents, fan out feature slices, or merge several feature branches back together; or invoked as /subagent-worktree-parallel.
+description: Plans and, when authorized, orchestrates parallel development by fanning out independent feature slices to subagents in isolated git worktrees, then integrating them serially under an orchestrating agent. Covers permission boundaries, dependency decomposition, wave sizing, dispatch prompts, merge hazards, and validation gates. Use when planning concurrent work, running parallel implementation across worktrees, or integrating dependent feature branches; or invoked as /subagent-worktree-parallel.
 ---
 
 # Subagent + Worktree Parallel Development
@@ -22,42 +22,44 @@ the cost/benefit table).
   the same component, or both append to the same shared file, will collide at merge.
   Coupled work is sequenced, not parallelized.
 
+## Choose the operating mode and permissions
+
+- **Planning-only:** produce the dependency map, slice briefs, wave plan, merge order,
+  validation plan, and permission requests. Do not create worktrees or branches, edit files,
+  commit, push, open change requests, merge, or write to a remote tracker.
+- **Execution:** perform only the local mutations that the user authorized. Worktree creation,
+  file edits, and commits do not imply permission to push, open or update a change request,
+  merge, reply to reviews, or change remote tracker state. Record remote-write permissions
+  separately and stop at a local handoff when they are absent.
+
 ## Core principles (non-negotiable)
 
 - **Group-external parallel, group-internal serial.** Only independent modules run in
-  parallel. Within one module, land the foundational "tracer" first and merge it, then
-  fan out its round-outs — parallel siblings duplicate-scaffold and collide.
+  parallel. Within one module, land the **foundation slice** first, then fan out its
+  **dependent follow-up slices**. A foundation slice establishes the smallest shared
+  contract or scaffold that its follow-ups require; parallel follow-ups before it lands
+  duplicate that foundation and collide.
 - **Small batches (≤ ~5), merge before the next wave.** Each rebase then lands on a
   stable base; large waves create a merge *treadmill* (every merge re-conflicts the
   rest) and raise the odds a subagent is truncated at a run limit.
-- **The integration-tier test is the Definition of Done — and so is the rest of the
-  PR-CI gate list.** A fast tier that stubs the integration boundary passes even on a
-  broken merge: DoD must run the tier that really exercises the boundary (integration /
-  e2e / compile or a parse `--check-only`). Beyond the test tiers, DoD must also mirror
-  the repo's non-test PR-CI gates — read the gate list off the CI workflow itself, not
-  from memory: typically the formatter *check*, linter, typecheck, and build/packaging —
-  invoked exactly as CI invokes them. A green test run with a red format check still
-  bounces the PR (every slice of one real wave tripped this). (REFERENCE §3, §6)
+- **The real integration boundary is part of Definition of Done.** A fast tier that stubs
+  that boundary can pass on a broken merge. Run every locally reproducible gate that covers
+  the change, including the real integration/e2e/compile/parse path and relevant non-test
+  checks. Classify gates that require protected infrastructure, secrets, policy evaluation,
+  or unavailable hardware as **CI-only**. If a gate cannot run, record why, the substitute
+  evidence, and the remaining risk; never report it as passed. (REFERENCE §3, §6)
 - **The orchestrator (the "lead") independently re-verifies before merging.** Subagent implements and
-  **commits** (its own branch, in its worktree); the lead re-runs tests and spot-checks the
-  diff. "Done but no artifact" = needs takeover.
-- **PR creation and its body are the orchestrator's, not the subagent's.** A PR is a
-  *merging* artifact, not a *doing* one: the subagent commits **and pushes** its branch but
-  does **not** open the PR — the lead opens every PR and owns its body, base, labels, and the
-  close-vs-reference keyword. That applies PR conventions in one place and lets the lead
-  re-verify a slice against its spec *before* the PR exists. Subagent-authored PRs reliably
-  omit or misplace the close keyword even when the brief demands it, so owning PR creation
-  closes that gap by construction rather than by a fragile after-the-fact check.
-- **`Closes #N` is a per-PR decision the lead makes after verifying — not a default.** Tag a
-  PR `Closes #N` only when it *fully* satisfies the linked issue (all acceptance criteria,
-  verified). A tracer, a round-out, or a stacked/multi-wave slice that only *advances* an
-  issue must use a non-closing `Refs #N`, or the first partial merge closes the issue
-  prematurely. The subagent reports whether its slice fully satisfies the issue; the lead
-  decides the keyword.
-- **Stacked PRs are live dependencies until merged.** When a base PR receives review fixes
-  or is squash-merged, every dependent PR must be re-evaluated: rebase/retarget it, update
-  stale PR body text and close-vs-reference keywords, then rerun the real gates on the new
-  head. Old green CI on the stacked base is not merge evidence.
+  produces the authorized local artifact in its worktree; the lead re-runs locally
+  reproducible gates and spot-checks the diff. "Done but no artifact" = needs takeover.
+- **Remote writes need explicit authority.** Pushes, change-request creation or edits,
+  merges, review replies, and tracker updates are separate permissions. When authorized,
+  the orchestrator owns the integration record and its completion semantics. Mark a work
+  item complete only when the slice satisfies all of it; a foundation slice, dependent
+  follow-up slice, or other partial slice remains non-closing.
+- **Stacked change requests are live dependencies until merged.** When a base change receives
+  review fixes or is squash-merged, every dependent change must be re-evaluated: rebase or
+  retarget it, update stale descriptions and completion semantics, then rerun the applicable
+  gates on the new head. Old validation on the stacked base is not merge evidence.
 - **Public docs and agent-facing docs are integration surfaces.** If a slice changes a
   user/agent-visible behavior or public shape, verify the whole surface chain for that
   slice and its dependents — CLI/help, schemas, user docs, generated or translated docs,
@@ -74,44 +76,49 @@ the cost/benefit table).
 ## Workflow
 
 ```
-decompose + dependency analysis → plan waves → fan out (implement) → verify + open PRs (per slice) → merge serially (dependency order)
+choose mode/permissions → decompose + dependency analysis → plan waves
+  planning-only → return the plan
+  execution → fan out → verify locally → publish/merge only when separately authorized
 ```
 
-1. **Decompose + analyze dependencies.** Split the work into vertical slices. Mark which
+1. **Choose mode and permissions.** Record planning-only or execution, the allowed local
+   mutations, and each allowed remote write. Do not infer execution from a planning request
+   or remote authority from local implementation authority. (REFERENCE §3)
+2. **Decompose + analyze dependencies.** Split the work into end-to-end slices. Mark which
    are independent (parallel-safe) vs. coupled (must serialize). Up front, identify the
    **append hotspots** — central registries, enums, dispatch tables, render/plugin maps,
    shared test files that *every* slice edits — that is where merge cost concentrates —
    and give each hotspot exactly **one owner slice** for the wave; the others flag needed
    changes instead of editing. (REFERENCE §1)
-2. **Plan waves.** Group independent slices into waves of ≤ ~5; sequence coupled slices
-   tracer-first. Decide the merge order now. (REFERENCE §2)
-3. **Fan out to implement.** Launch one subagent per slice in its own git worktree, each
-   with a dispatch prompt that pins it to its worktree, tells it to commit early and push its
-   branch but not open the PR (the orchestrator does), and bakes the integration-tier test
-   into its DoD. (REFERENCE §3)
-4. **Verify, open PRs, take over.** As each implementer finishes — and before anything
-   merges — re-run the integration tier yourself; run shared-global-resource tests
-   serially; audit any public docs/agent docs surface; treat any "completed but no
-   commit/push" report as needs-takeover, not success. **You** (not the subagent) open
-   each PR, choosing `Closes #N` only when the slice fully satisfies its issue (else
-   `Refs #N`). (REFERENCE §6, §7)
-5. **Merge serially in dependency order.** Tracer first → rebase followers onto the new
+3. **Plan waves.** Group independent slices into waves of ≤ ~5; sequence each foundation
+   slice before its dependent follow-up slices. Decide the integration order now. In
+   planning-only mode, return the plan here. (REFERENCE §2)
+4. **Fan out to implement.** In execution mode, launch one subagent per slice in its own
+   git worktree. Its dispatch prompt pins the worktree, states local and remote permissions,
+   requires early durable local artifacts when authorized, and includes the applicable
+   validation gates. (REFERENCE §3)
+5. **Verify, hand off, or publish.** As each implementer finishes, run locally reproducible
+   gates, serialize shared-global-resource tests, audit affected public surfaces, and record
+   every CI-only or unavailable gate with substitute evidence and remaining risk. If remote
+   writes are not authorized, return the local artifact and stop. If they are authorized,
+   the orchestrator performs only the listed remote actions. (REFERENCE §6, §7)
+6. **Merge serially in dependency order when authorized.** Foundation slice first → rebase followers onto the new
    base → independent groups can merge in any order; a *clean* rebase still gets the
-   integration gate. Re-poll mergeability after each merge. For stacked PRs, retarget
-   followers after the base lands and update any stale `Refs`/`Closes` or recorded
-   verification text before merging. Watch for the two marker-free conflict traps.
+   applicable integration gate. Re-poll mergeability after each merge. For stacked changes,
+   retarget followers after the base lands and update stale descriptions, completion
+   semantics, or verification text before merging. Watch for the two marker-free conflict traps.
    (REFERENCE §4, §5)
 
 This path is **not one-shot**: independent review sends merged-ready slices back, and
 remediation reshapes the plan. A review/fix round is a **re-dispatch** — resume the
 original implementer with its context where possible, restate the full dispatch
-discipline (worktree pinning, commit-early, the full DoD gates — integration tier plus
-the PR-CI gate list), and require **one commit
-per finding** so a mid-round kill is cheap to take over. The lead then re-verifies and
-closes the loop on the review channel — e.g. a reply mapping each finding → resolution —
-keeping the PR/change description current where the host supports it.
+discipline (worktree pinning, permissions, and the applicable local and CI-only gate
+inventory), and require one commit per finding when commits are authorized. The lead then re-verifies and
+closes the loop on the review channel only when that remote write is authorized — e.g. a
+reply mapping each finding → resolution — keeping the change description current where
+the host supports it.
 Re-derive the overlap map and merge order as fixes land, verify each slice against its
-*originating spec* (not just its own green tests), and fix a finding at the altitude of
+source requirement (not just its own green tests), and fix a finding at the altitude of
 its true cause, not where it surfaced. (REFERENCE §1, §6, §7)
 
 When append hotspots keep dominating merge cost, the durable fix is architectural —

--- a/.agents/skills/subagent-worktree-parallel/SKILL.md
+++ b/.agents/skills/subagent-worktree-parallel/SKILL.md
@@ -113,7 +113,9 @@ This path is **not one-shot**: independent review sends merged-ready slices back
 remediation reshapes the plan. A review/fix round is a **re-dispatch** — resume the
 original implementer with its context where possible, restate the full dispatch
 discipline (worktree pinning, permissions, and the applicable local and CI-only gate
-inventory), and require one commit per finding when commits are authorized. The lead then re-verifies and
+inventory). Follow the repository's commit-history policy. Require one commit per finding
+only when the repository or user explicitly requires it; otherwise map each finding to its
+resolution in the handoff. The lead then re-verifies and
 closes the loop on the review channel only when that remote write is authorized — e.g. a
 reply mapping each finding → resolution — keeping the change description current where
 the host supports it.

--- a/.agents/skills/validation-driven-design/EXAMPLES.md
+++ b/.agents/skills/validation-driven-design/EXAMPLES.md
@@ -21,17 +21,18 @@ transitions; event sourcing informs audit boundaries but is not imported wholesa
 
 The team studies a pinned workflow specification, a component-extension system, and an audit-log
 model. For each it records the adopted mechanism, local owner, rejected format/runtime surfaces,
-and vectors. None becomes a peer authority merely because its terminology is reused.
+and evidence. Machine-checkable observable claims get executable conformance cases. None becomes a
+peer authority merely because its terminology is reused.
 
 ### 3. Iterative probes
 
-1. A vertical tracer compiles one policy, runs it, and publishes an audit. It confirms connectivity
+1. An end-to-end slice compiles one policy, runs it, and publishes an audit. It confirms connectivity
    but exposes ambiguous refusal staging and identity.
 2. Two independent runtimes consume each other's canonical artifacts. A mutation test reveals one
    rule was still host-coded, so the rule moves into the versioned language bundle.
 3. An extension probe adds a billing policy and a scheduling policy without rebuilding either
    runtime. Cross-product tests expose an unspecified precedence rule; the extension contract gains
-   canonical ordering and a negative vector.
+   canonical ordering and a negative conformance case.
 4. A structurally different access-control domain reuses the same extension and audit path. If it
    needs a runtime switch, the extensibility gate fails and the architecture reopens.
 
@@ -39,12 +40,12 @@ and vectors. None becomes a peer authority merely because its terminology is reu
 
 | Observation | Disposition | Owner update | Non-claim |
 | --- | --- | --- | --- |
-| one end-to-end run succeeds | confirmed-no-change | architecture topology and tracer scenario | not framework completeness |
-| runtimes disagree on a host-coded rule | refined-adopted | language decision and conformance vector | not fixed by documenting one runtime |
-| extension interaction order is absent | gap-opened | open specification owner and boundary-vector work | packages are not yet orthogonal |
+| one end-to-end run succeeds | confirmed-no-change | architecture topology and end-to-end scenario | not framework completeness |
+| runtimes disagree on a host-coded rule | refined-adopted | language decision and executable conformance case | not fixed by documenting one runtime |
+| extension interaction order is absent | gap-opened | open specification owner and boundary conformance case | packages are not yet orthogonal |
 
-Prototype code stays on fixed evidence commits. Only the corrected decisions, terms, scenarios, and
-vectors enter the authority branch.
+Prototype code stays at immutable evidence revisions. Only the corrected decisions, terms,
+scenarios, and executable conformance cases enter their owning authoritative artifacts and authority map.
 
 ### 5. Design-axis conclusion
 
@@ -69,19 +70,19 @@ decision gate.
 The author does not create theory or external-system matrices, a prototype portfolio, or the full
 delivery plan. If the crash check exposes ambiguous commit state, the owner either opens one focused
 idempotency decision or rejects the design; that evidence need does not silently promote the entire
-engagement to full mode.
+engagement to `full-design` mode.
 
 ## Example: audit an existing event-delivery architecture
 
 The team claims that a fixed document set completely specifies retry order, deduplication, and
-failure recovery. The auditor selects `audit-only`, pins the artifact commit and claimed scope, and
+failure recovery. The auditor selects `audit-only`, pins the artifact revision and claimed scope, and
 makes no edits.
 
 - The authority audit finds retry precedence restated differently in the standard and deployment guide.
-- Two independent readers derive different behavior for equal-time retries, so the finding is
-  `gap-opened`; passing integration tests do not turn it into conformance proof.
+- Two independent readers derive different behavior for equal-time retries, so the affected
+  conformance claim is `open`; passing integration tests do not turn it into conformance proof.
 - Orthogonality and reliability remain open, while unrelated extensibility claims are not re-evaluated.
 
-The report proposes one normative owner and a discriminating boundary vector, then stops. The human
+The report proposes one normative owner and a discriminating boundary conformance case, then stops. The human
 decision owner conditionally accepts the audit, authorizes specification repair, and leaves the
 conformance claim open.

--- a/.agents/skills/validation-driven-design/REFERENCE.md
+++ b/.agents/skills/validation-driven-design/REFERENCE.md
@@ -3,48 +3,52 @@
 Use this file for detailed templates, proof obligations, and delivery gates. `SKILL.md` exclusively
 owns the design workflow; this file does not restate it.
 
-Contents: [modes and authority](#1-engagement-modes-and-authority-model) ·
+Contents: [modes and authority](#1-engagement-modes-and-authority-map) ·
 [claims](#2-claim-and-evidence-ladder) · [theory](#3-theory-support-matrix) ·
 [external research](#4-external-system-research-matrix) · [validation](#5-validation-portfolio) ·
 [quality gates](#6-four-design-axes-and-cross-cutting-qualities) ·
 [defect attribution](#7-defect-attribution-ladder) · [delivery](#8-delivery-gates-and-production-planning) ·
 [completion](#9-completion-audit)
 
-## 1. Engagement modes and authority model
+## 1. Engagement modes and authority map
 
 Choose mode before building the authority map:
 
 | Mode | Use when | Required minimum |
 | --- | --- | --- |
-| Lightweight design | a bounded, reversible decision adds no semantic root, authority domain, or extension boundary | owner, requirement/decision, falsifier, affected axes, one discriminating check, non-claims, and human gate |
-| Full design | a framework/language/runtime or broad, hard-to-reverse claim changes authority, semantics, extension, or production boundaries | the complete workflow, matrices, proof obligations, and delivery gates |
-| Audit-only | fixed existing artifacts and claims must be evaluated without redesign | fixed baseline/scope, authority and claim audit, design-axis and cross-cutting-quality findings, completion gaps, and human disposition; no edits unless requested |
+| `lightweight` | a bounded, reversible decision does not change normative public semantics, add an authoritative source, or introduce or alter an extension contract | owner, requirement/decision, falsifier, affected axes, one discriminating check, non-claims, and human gate |
+| `full-design` | a framework/language/runtime or broad, hard-to-reverse claim changes authority, semantics, extension, or production boundaries | the complete workflow, matrices, proof obligations, and delivery gates |
+| `audit-only` | fixed existing artifacts and claims must be evaluated without redesign | fixed baseline/scope, authority and claim audit, design-axis and cross-cutting-quality findings, completion gaps, and human disposition; no edits unless requested |
 
 Every mode keeps explicit authority, falsifier, non-claims, and human decision ownership. Scale the
 remaining evidence work to claim breadth, reversibility, novelty, and operational risk.
 
-`Lightweight design` is a ceiling as well as a minimum: start with one compact decision record and
+`lightweight` is a ceiling as well as a minimum: start with one compact decision record and
 one discriminating check. Do not create theory/research matrices, a prototype portfolio, the full
 delivery sequence, or a full completion audit unless the falsifier exposes a specific need; state
-why before expanding. `Audit-only` similarly reports only findings inside the pinned claimed scope.
+why before expanding. `audit-only` similarly reports only findings inside the pinned claimed scope.
+
+An **executable conformance case** is a permanent, machine-runnable record bound to one exact
+authoritative claim. Its minimum fields are the authority and version or immutable reference, input
+and preconditions, operation, expected observable result or refusal, and pass/fail oracle.
 
 Choose repository-native names, but preserve these ownership roles:
 
 | Role | Owns | Must not become |
 | --- | --- | --- |
-| Requirements/PRD | user outcomes, scope, acceptance criteria, live completion | detailed architecture or evidence by assertion |
+| Requirements | user outcomes, scope, acceptance criteria, live completion | detailed architecture or evidence by assertion |
 | Architecture narrative | macro topology, responsibilities, cross-cutting invariants, delivery order | duplicate detailed decisions or machine semantics |
 | Decision records | one binding decision, alternatives, consequences, validation | status dashboard or broad narrative |
 | Glossary/context | canonical terms and distinctions | a second architecture specification |
 | Specification/standard | normative semantics, public contracts, conformance requirements, versioning, and designation of normative machine-readable artifacts | architecture rationale, implementation details, evidence, or acceptance state |
-| Executable conformance assets | machine-checkable schemas, scenarios, vectors, validators, and observable oracles that realize or test the specification | an independent semantic authority or proof merely because tests pass |
+| Executable conformance assets | machine-checkable schemas, executable conformance cases, validators, and observable oracles that realize or test the specification | an independent semantic authority or proof merely because tests pass |
 | Evidence record | prototype/research inputs, outputs, provenance, bounded conclusions | semantic authority or acceptance state |
 | Acceptance tracker | current gates and their state | proof without required artifacts |
-| Human decision owner | accept, reject, or condition the architecture and authorize the next gate | an evidence generator, automated check, or self-approving agent |
+| Human decision owner | accept, reject, or condition the architecture and authorize or withhold the next gate | an evidence generator, automated check, or self-approving agent |
 | Prototype | one disposable risk probe | production implementation or permanent authority |
-| PR body/comments | reviewable summary and chronological coordination | sole home of requirements, dogfooding, or decisions |
+| Review/change record | reviewable summary and chronological coordination | sole home of requirements, dogfooding, or decisions |
 
-Build a reference graph such as:
+Build the authority map with a one-way reference graph such as:
 
 `requirement → decision → term → specification/standard → executable conformance asset → implementation owner → evidence → gate`
 
@@ -54,7 +58,7 @@ to the exact specification is verified.
 
 For each fact, mark exactly one authoritative source and every derived copy. Prefer a one-way
 reference over restating a list, algorithm, count, precedence rule, or state machine. Reconcile the
-exact current commit and live tracker state after each design iteration.
+pinned current artifact revision and any live coordination state after each design iteration.
 
 ## 2. Claim and evidence ladder
 
@@ -65,7 +69,7 @@ Use exact, bounded language:
 | `proposed` | a candidate mechanism | rationale only |
 | `theory-supported` | established theory explains why the mechanism should work | explicit theory-to-invariant mapping and proof boundary |
 | `confirmed-narrowly` | a selected executable slice behaved as predicted | reproducible prototype with discriminating cases |
-| `conformance-proven` | independent implementations satisfy permanent authority | normative artifacts, vectors, mutation/refusal tests, mutual consumption where applicable |
+| `conformance-proven` | independent implementations satisfy permanent authority | normative artifacts, executable conformance cases, mutation/refusal tests, mutual consumption where applicable |
 | `production-proven` | deployed behavior meets operational requirements | production telemetry, failure recovery, rollout and SLO evidence |
 | `open` | required evidence is absent or contradictory | an owner and next discriminating gate |
 | `non-claim` | a tempting broader inference is explicitly prohibited | stated scope boundary |
@@ -116,9 +120,10 @@ Use current primary specifications and pin the consulted version or edition.
 Rules:
 
 1. Research mechanisms, failure modes, and lifecycle/identity choices—not names to borrow.
-2. Restate every adopted mechanism in the local authority chain.
+2. Restate every adopted mechanism in the local authority map.
 3. Record exclusions so a partial mapping cannot become an accidental compatibility promise.
-4. Require executable vectors for every claimed adoption.
+4. Require an executable conformance case when the adopted claim is machine-checkable and observable;
+   otherwise record the evidence form that can discriminate the claim.
 5. Treat an external version change as a deliberate local design decision, never ambient drift.
 6. Compare with non-adoption: importing a standard can cost more authority and surface than it saves.
 
@@ -128,7 +133,7 @@ Choose validation form by uncertainty:
 
 | Uncertainty | Validation form |
 | --- | --- |
-| layer connectivity/integration | smallest end-to-end vertical tracer |
+| layer connectivity/integration | smallest end-to-end slice |
 | semantic authority/portability | two independent interpreters or compilers consuming each other's artifacts |
 | state/lifecycle/order | executable state-machine or scheduler harness with boundary permutations |
 | orthogonality | add one independent axis, then exercise cross-products and mutation cases |
@@ -152,12 +157,13 @@ Evidence location and immutable reference:
 Explicit non-claims:
 ```
 
-Use a PR only when collaborative review or integration is needed. Disposable code may live on a
-fixed branch/commit with an evidence index. Do not merge it merely to make it visible.
+Use a shared review/change record only when collaborative review or integration is needed. Disposable
+code can live at an immutable artifact revision with an evidence index. Do not promote it merely to
+make it visible.
 
 ### Dogfooding ledger
 
-| Observation | Disposition | Root layer | Design effect | Owning artifact updated | Permanent proof promoted | Remaining gate |
+| Observation | Disposition | Root layer | Design effect | Owning artifact updated | Permanent evidence promoted | Remaining gate |
 | --- | --- | --- | --- | --- | --- | --- |
 
 Keep chronological experiment details in the evidence record. Put only synthesized implications in
@@ -169,14 +175,14 @@ Use independent review to expose ambiguous prose, hidden authority, contradictio
 cases. Give the reviewer fixed raw requirements, artifacts, and claimed scope—not the desired
 conclusion. Record the baseline, independence boundary, findings, and disposition. Review is design
 evidence, never conformance proof or human acceptance.
-Require it for full design, broad or hard-to-reverse claims, and load-bearing authority ambiguity;
+Require it for `full-design`, broad or hard-to-reverse claims, and load-bearing authority ambiguity;
 otherwise scale it to risk.
 
 ### Stop rule
 
-Run another disposable prototype only when a new semantic root, extension mechanism, cross-artifact
-authority boundary, or comparably high-risk uncertainty appears. Otherwise move to permanent
-conformance vectors and production slices.
+Run another disposable prototype only when the design adds or changes normative public semantics, an
+extension contract, an authority owner or binding, or a comparably high-risk uncertainty. Otherwise
+move to permanent executable conformance cases and end-to-end production slices.
 
 ## 6. Four design axes and cross-cutting qualities
 
@@ -186,13 +192,13 @@ axis; they are not additional peers in the design-axis taxonomy.
 | Axis | Required questions | Strong evidence | Failure signal |
 | --- | --- | --- | --- |
 | Abstraction | What theory supports the model? Which semantics are public? Which implementation details may vary? | explicit semantic boundaries; preservation/refusal contracts; independent implementations | host behavior, serialization, framework, or optimizer becomes hidden authority |
-| Completeness | Do all known stories, failures, variants, interactions, operations, and production concerns map to observable contracts? | requirements-to-mechanism-to-scenario-to-vector-to-observable matrix | vocabulary/package inventory presented as coverage; important paths only appear in prose |
+| Completeness | Do all known stories, failures, variants, interactions, operations, and production concerns map to observable contracts? | requirements-to-mechanism-to-scenario-to-conformance-case-to-observable matrix | vocabulary/package inventory presented as coverage; important paths only appear in prose |
 | Orthogonality | Does each concern have one owner and independent representation? Are cross-products and precedence closed? | mutation tests; pairwise/cross-product scenarios; canonical ordering/reducers | independent axes share hidden state or leave interaction order to the host |
 | Extensibility | What is configuration, extension, framework evolution, or irreducible core? Can an out-of-family case use unchanged core and dispatch? | explicit extension invariance; fixed-build witness; negative capability/refusal cases | each new domain adds core fields, phases, switches, callbacks, or parallel semantics |
 
 Also audit consistency, reliability, and operability:
 
-- **Consistency:** one owner per fact; terminology, issue, decision, specification, and live state agree.
+- **Consistency:** one owner per fact; terminology, requirement, decision, specification, and live state agree.
 - **Reliability:** deterministic scope, atomic boundaries, typed failure, recovery, audit, resource caps.
 - **Operability:** public surface, versioning, diagnostics, observability, deployment and rollback.
 
@@ -220,8 +226,8 @@ This section exclusively owns the detailed default delivery sequence:
 
 1. **Bounded architecture feasibility:** resolve the highest-risk mechanism with disposable evidence.
 2. **Permanent conformance foundation:** replace prototype-local authority with versioned rules,
-   schemas, fixtures, negative/mutation vectors, and reusable harnesses.
-3. **Production vertical slice:** exercise the public API/artifact path end to end.
+   schemas, fixtures, negative/mutation conformance cases, and reusable harnesses.
+3. **Production end-to-end slice:** exercise the public API/artifact path end to end.
 4. **Known-domain breadth:** close the full requirements coverage matrix without parallel semantics.
 5. **Out-of-family witness:** prove the extension promise against a structurally different consumer.
 6. **Production rollout:** validate security, performance, capacity, observability, recovery,
@@ -233,8 +239,8 @@ Do not build speculative compatibility machinery.
 
 ## 9. Completion audit
 
-For full design, prove every item before declaring the design ready for implementation or
-production. For lightweight or audit-only work, apply only the selected mode's minimum and the
+For `full-design`, prove every item before declaring the design ready for implementation or
+production. For `lightweight` or `audit-only`, apply only the selected mode's minimum and the
 checklist items affected by its explicit claims; list the rest as out of scope rather than producing
 ceremonial artifacts.
 
@@ -249,10 +255,10 @@ ceremonial artifacts.
 - [ ] The coverage matrix includes positive, negative, boundary, interaction, and observable paths.
 - [ ] The four design axes and consistency, reliability, and operability each have scoped evidence.
 - [ ] Independent implementations cannot disagree within the claimed contract, or the gap is open.
-- [ ] Normative details are not duplicated across architecture, decisions, glossary, issue, and PR.
-- [ ] Live counts, links, statuses, versions, and commit references were refreshed after the final edit.
+- [ ] Normative details are not duplicated across architecture, decisions, glossary, requirements, and coordination records.
+- [ ] Live counts, links, statuses, versions, and pinned artifact references were refreshed after the final edit.
 - [ ] Remaining risks and non-claims are explicit; prototype evidence is not mislabeled as conformance.
 - [ ] The human decision owner accepted, rejected, or conditioned the architecture and explicitly
       authorized or withheld the next gate; no evidence or agent self-approved it.
-- [ ] The delivery plan names permanent assets, vertical slices, migration policy, operational gates,
+- [ ] The delivery plan names permanent assets, end-to-end slices, migration policy, operational gates,
       and the condition that reopens the architecture.

--- a/.agents/skills/validation-driven-design/REFERENCE.md
+++ b/.agents/skills/validation-driven-design/REFERENCE.md
@@ -16,7 +16,7 @@ Choose mode before building the authority map:
 
 | Mode | Use when | Required minimum |
 | --- | --- | --- |
-| `lightweight` | a bounded, reversible decision does not change normative public semantics, add an authoritative source, or introduce or alter an extension contract | owner, requirement/decision, falsifier, affected axes, one discriminating check, non-claims, and human gate |
+| `lightweight` | a bounded, reversible decision can be owned by one compact decision record and does not change a public contract, extension contract, or production boundary | owner, requirement/decision, falsifier, affected axes, one discriminating check, non-claims, and human gate |
 | `full-design` | a framework/language/runtime or broad, hard-to-reverse claim changes authority, semantics, extension, or production boundaries | the complete workflow, matrices, proof obligations, and delivery gates |
 | `audit-only` | fixed existing artifacts and claims must be evaluated without redesign | fixed baseline/scope, authority and claim audit, design-axis and cross-cutting-quality findings, completion gaps, and human disposition; no edits unless requested |
 
@@ -163,7 +163,7 @@ make it visible.
 
 ### Dogfooding ledger
 
-| Observation | Disposition | Root layer | Design effect | Owning artifact updated | Permanent evidence promoted | Remaining gate |
+| Observation | Disposition | Attributed layer | Design effect | Owning artifact updated | Permanent evidence promoted | Remaining gate |
 | --- | --- | --- | --- | --- | --- | --- |
 
 Keep chronological experiment details in the evidence record. Put only synthesized implications in

--- a/.agents/skills/validation-driven-design/REFERENCE.md
+++ b/.agents/skills/validation-driven-design/REFERENCE.md
@@ -16,9 +16,9 @@ Choose mode before building the authority map:
 
 | Mode | Use when | Required minimum |
 | --- | --- | --- |
-| `lightweight` | a bounded, reversible decision can be owned by one compact decision record and does not change a public contract, extension contract, or production boundary | owner, requirement/decision, falsifier, affected axes, one discriminating check, non-claims, and human gate |
+| `lightweight` | a bounded, reversible decision can be owned by one compact decision record and does not change a public contract, extension contract, or production boundary | owner, requirement/decision, falsifier, affected axes, one discriminating check, non-claims, and human decision gate |
 | `full-design` | a framework/language/runtime or broad, hard-to-reverse claim changes authority, semantics, extension, or production boundaries | the complete workflow, matrices, proof obligations, and delivery gates |
-| `audit-only` | fixed existing artifacts and claims must be evaluated without redesign | fixed baseline/scope, authority and claim audit, design-axis and cross-cutting-quality findings, completion gaps, and human disposition; no edits unless requested |
+| `audit-only` | fixed existing artifacts and claims must be evaluated without redesign | fixed baseline/scope, authority and claim audit, design-axis and cross-cutting-quality findings, completion gaps, and recorded human decision outcome; no edits unless requested |
 
 Every mode keeps explicit authority, falsifier, non-claims, and human decision ownership. Scale the
 remaining evidence work to claim breadth, reversibility, novelty, and operational risk.

--- a/.agents/skills/validation-driven-design/SKILL.md
+++ b/.agents/skills/validation-driven-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validation-driven-design
-description: Designs, audits, and iteratively validates framework, platform, language, protocol, or runtime architectures by combining explicit requirements, mature theory, external-system research, executable prototypes, dogfooding, and cross-artifact reconciliation. Use when creating or redesigning an architecture, writing architecture specifications or ADRs, auditing an existing architecture against abstraction/completeness/orthogonality/extensibility, or planning a design for production implementation.
+description: Designs, audits, and iteratively validates framework, platform, language, protocol, or runtime architectures by combining explicit requirements, mature theory, external-system research, executable prototypes, dogfooding, and cross-artifact reconciliation. Use when creating or redesigning an architecture, writing architecture specifications or decision records, auditing an existing architecture against abstraction/completeness/orthogonality/extensibility, or planning a design for production implementation.
 ---
 
 # Validation-Driven Design
@@ -23,20 +23,23 @@ Scale validation work to the importance of the design decision and a concrete ri
 question. If more validation is not justified, simplify or postpone that part of the design instead
 of weakening its checks. Follow the selected mode's limits in [REFERENCE.md](REFERENCE.md).
 
+[REFERENCE.md §1](REFERENCE.md#1-engagement-modes-and-authority-map) defines an executable
+conformance case and its minimum fields.
+
 ## Quick start
 
-1. Choose lightweight, full, or audit-only mode; name the artifact owners and human decision owner.
+1. Choose `lightweight`, `full-design`, or `audit-only` mode; name the artifact owners and human decision owner.
 2. Write goals, non-goals, invariants, quality attributes, production constraints, and claim status.
 3. Map load-bearing mechanisms to mature theory and external systems; record adoption and proof gaps.
 4. Rank architecture uncertainties and run only the smallest discriminating validation.
-5. Feed dogfooding back into requirements, decisions, terms, specifications, vectors, and gates.
+5. Feed dogfooding back into requirements, decisions, terms, specifications, executable conformance cases, and gates.
 6. Audit the four design axes and cross-cutting qualities; keep non-claims explicit.
 
 See [REFERENCE.md](REFERENCE.md) for templates and proof obligations, and [EXAMPLES.md](EXAMPLES.md).
 
 ## Workflow
 
-The sections below define the full-design route. In `lightweight` mode, execute only the mode minimum
+The sections below define the `full-design` route. In `lightweight` mode, execute only the mode minimum
 and add a step when its falsifier or risk requires it; do not generate full matrices or portfolios by
 default. In `audit-only` mode, pin the baseline, evaluate the claimed scope, report gaps, and stop
 without redesign or edits unless the user requests them.
@@ -45,7 +48,8 @@ without redesign or edits unless the user requests them.
 
 - Read repository guidance and current authoritative artifacts before proposing structure.
 - Turn outcomes into traceable requirements, scope, non-goals, invariants, failures, and qualities.
-- Build an authority map. Give every normative fact one owner; derived documents reference it.
+- Build one authority map, which can include a one-way reference graph. Give every normative fact
+  one owner; derived artifacts reference it.
 - Start a claim ledger: `proposed`, `theory-supported`, `confirmed-narrowly`, `conformance-proven`,
   `production-proven`, `open`, and `non-claim`.
 
@@ -75,8 +79,8 @@ without redesign or edits unless the user requests them.
 ### 5. Validate the highest-risk uncertainty
 
 - Charter one question, falsifier, smallest slice, discriminating cases, time box, and deletion plan.
-- Choose the evidence form from the uncertainty: prototype, permanent vector, or independent review.
-  Architecture semantics usually need executable or independently interpreted artifacts.
+- Choose the evidence form from the uncertainty: prototype, permanent executable conformance case,
+  or independent review. Architecture semantics usually need executable or independently interpreted artifacts.
 - Treat prototype/review results as design evidence, never conformance, production authority, or human acceptance.
 
 ### 6. Synthesize dogfooding and iterate
@@ -86,9 +90,9 @@ without redesign or edits unless the user requests them.
 - Attribute defects to the narrowest honest layer: instance/configuration → template/profile →
   extension module/package → framework/schema → irreducible kernel.
 - Update each owning artifact once; remove duplicated normative restatements. Preserve research at a
-  fixed reference and promote only durable scenarios, vectors, or decisions into authority.
+  fixed reference and promote only durable scenarios, executable conformance cases, or decisions into authority.
 - Stop disposable prototyping when the risk class is resolved. Move remaining proof into permanent
-  conformance assets and production vertical slices.
+  conformance assets and end-to-end production slices.
 
 ### 7. Run design-axis and cross-cutting-quality gates
 
@@ -108,7 +112,7 @@ Do not declare the architecture complete from prose quality, a green build, fram
 passing disposable prototypes. Complete the audit in [REFERENCE.md](REFERENCE.md): trace every
 requirement and decision, verify each quality axis with appropriately scoped evidence, reconcile
 live artifacts, preserve explicit non-claims, and leave production gates executable.
-Apply the full completion checklist only in full-design mode. For other modes, satisfy the selected
+Apply the full completion checklist only in `full-design` mode. For other modes, satisfy the selected
 mode's minimum and record excluded checks as out of scope or non-claims, not as missing deliverables.
-The designated human decision owner must accept, reject, or condition the architecture and authorize
-the next gate; evidence and agents cannot self-approve.
+The designated human decision owner must accept, reject, or condition the architecture and explicitly
+authorize or withhold the next gate; evidence and agents cannot self-approve.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '{\"systemMessage\": \"Session wrap-up: if you completed or changed issue/task work, run /state to refresh STATE.md (progress + next steps).\"}'"
+            "command": "echo '{\"systemMessage\": \"Session wrap-up: if this session did material work, run /state to refresh STATE.md with the session results, next work, and unfinished carry-over.\"}'"
           }
         ]
       },
@@ -13,7 +13,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '{\"systemMessage\": \"Reminder: if a requirement or technical decision changed this session, run /reconcile to sync issues and docs (CONTEXT.md, docs/adr/).\"}'"
+            "command": "echo '{\"systemMessage\": \"Reminder: if a requirement, decision, scope boundary, or established term changed this session, run /reconcile to check affected project artifacts for drift.\"}'"
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,23 @@
+{
+  "description": "Session wrap-up reminders for this workspace.",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '{\"systemMessage\": \"Session wrap-up: if this session did material work, run $state to refresh STATE.md with the session results, next work, and unfinished carry-over.\"}'"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '{\"systemMessage\": \"Reminder: if a requirement, decision, scope boundary, or established term changed this session, run $reconcile to check affected project artifacts for drift.\"}'"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- address accepted review findings across six general-purpose skills
- remove assumptions about a specific repository, tracker, document layout, release policy, or hosting workflow
- close workflow, terminology, prose, and DRY gaps without adding project-specific mechanisms

## Key changes

- make Conventional Commits rules accurate and inspect the staged artifact before formulating a message
- preserve per-claim evidence when review feedback does not require a change
- make reconciliation discover repository authorities and separate mechanical checks from semantic judgment
- give the state backlog algorithm one authoritative workflow and clarify the required update date
- separate planning, local execution, and remote-write authority in worktree orchestration; harden history rewrites and CI-only gate handling
- define validation modes, executable conformance cases, authority-map terminology, and human gate outcomes consistently

## Validation

- all six changed skills pass the Skill Creator quick validator
- `git diff --check` passes
- scans for current-project names, ADR paths, release configuration, and replaced private terminology return no matches

No runtime implementation code changed.