### PR TITLE
docs(skills): add domain modular architecture skill

### DIFF
--- a/.agents/skills/design-domain-modular-architecture/SKILL.md
+++ b/.agents/skills/design-domain-modular-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-domain-modular-architecture
-description: Design and review technology-neutral, domain-centered modular software architectures with domain models as the basis for boundaries, ownership, dependencies, and evolution. Use for technology-neutral or explicitly domain-centered work when structuring a new system, modularizing an existing codebase, separating domain rules from use-case coordination and external integration, identifying context or module boundaries, reviewing coupling, or planning an incremental architecture change.
+description: Design and review framework-independent, domain-centered modular software architectures with domain models as the basis for boundaries, ownership, dependencies, and evolution. Use when no project- or framework-specific modular topology governs the primary structure, or to reason about domain boundaries within an existing topology while structuring a new system, modularizing a codebase, reviewing coupling, or planning an incremental architecture change.
 ---
 
 # Design Domain Modular Architecture
@@ -16,10 +16,19 @@ and evolution. Do not treat it as a set of patterns that every project must impl
 Introduce a Bounded Context, Aggregate, Repository, Domain Service, or other DDD
 building block only when it solves an observed problem.
 
-Unless the user asks only for analysis or review, recommend one concrete architecture.
-Include a module tree, responsibility placement, dependency and communication rules,
-and incremental implementation steps. Present alternatives only after the
-recommendation, with the conditions that would make an alternative preferable.
+For design work, recommend one concrete architecture. Include a module tree,
+responsibility placement, dependency and communication rules, and incremental
+implementation steps. Present alternatives only after the recommendation, with the
+conditions that would make an alternative preferable.
+
+For analysis or review-only work, describe the observed architecture and report
+verified findings. Recommend a change only when evidence shows that the current design
+does not meet the applicable criteria.
+
+Use the default topology in this skill only when no project- or framework-specific
+modular topology already governs the system. When one exists, preserve its module names
+and dependency rules. Use the DDD guidance here to judge language, ownership, and
+evolution within those boundaries.
 
 ## Respect Existing Project Authority
 
@@ -212,10 +221,12 @@ Use **functional pillar** to mean a module or stable module group that owns one 
 system capability. Do not use the term for a layer, Bounded Context, or directory unless
 that element also owns such a capability.
 
-Use the Ubiquitous Language of the applicable Bounded Context to name modules, types,
-interfaces, events, use cases, tests, and documents. When no Bounded Context is defined,
-use the established project and domain terms. Divide modules by conceptual cohesion and
-reason to change, not by file type, framework component, or organization chart.
+Use the Ubiquitous Language of the applicable Bounded Context. This is the shared,
+precise vocabulary built around the domain model and used in collaboration and in the
+software. Use it to name modules, types, interfaces, events, use cases, tests, and
+documents. When no Bounded Context is defined, use the established project and domain
+terms. Divide modules by conceptual cohesion and reason to change, not by file type,
+framework component, or organization chart.
 
 Give every rule, state, invariant, and public contract one authoritative owner. Let
 other modules consume that authority instead of reproducing it.
@@ -296,12 +307,17 @@ At every project size, keep the Ubiquitous Language, alignment between the domai
 and implementation, rule and state ownership, model scope, and conceptual module
 boundaries visible.
 
-### Apply Strategic Design by Complexity
+### Apply Strategic Design to Current Decisions
 
-Consider a Core Domain, Supporting Subdomains, Generic Subdomains, Bounded Contexts, a
-Context Map, upstream and downstream relationships, an Anti-Corruption Layer, or a
-Shared Kernel only when several models, languages, or ownership boundaries make them
-useful.
+Identify the Core Domain as the cohesive part of the model that expresses the system's
+main domain-specific value. Classify a necessary custom capability that is not the main
+differentiator as a Supporting Subdomain. Classify a common capability that gives no
+domain-specific advantage as a Generic Subdomain. Apply these distinctions when they
+change modeling effort, ownership, or sourcing, even within one Bounded Context.
+
+Consider Bounded Contexts, a Context Map, upstream and downstream relationships, an
+Anti-Corruption Layer, or a Shared Kernel only when several models, languages, or
+ownership boundaries make them useful.
 
 Map only the contexts needed for the current decision. Do not model the complete system
 in advance.
@@ -312,7 +328,7 @@ Use a building block only when its semantics fit:
 
 | Building block | Use it when |
 | --- | --- |
-| Entity | An object has persistent identity and a lifecycle. |
+| Entity | An object is distinguished by identity rather than attributes, and its identity continues through its lifecycle; storage persistence is not required. |
 | Value Object | A concept is defined by values, constraints, and value equality. |
 | Domain Event | An occurred fact has domain meaning. |
 | Domain Service | Domain behavior has no natural Entity or Value Object owner. |
@@ -358,13 +374,15 @@ responsibility, move or reimplement it under the correct owner, and add its test
 3. Confirm the needed domain model and identify the owners of rules, state, invariants,
    use cases, and external effects.
 4. Define the functional pillars, topology, and project-appropriate names.
-5. Recommend one concrete module tree and give representative contents for each area.
+5. For design work, recommend one concrete module tree and give representative contents
+   for each area. For review-only work, record the observed tree and verified findings.
 6. Trace source dependencies and downward, upward, and horizontal communication.
 7. Add only the DDD building blocks and communication mechanisms that solve observed
    problems.
 8. Review completeness, orthogonality, DRY, and extensibility.
-9. Plan reversible migration slices, validation, and reconciliation of affected
-   project artifacts.
+9. For design work or accepted changes, plan reversible migration slices, validation,
+   and reconciliation of affected project artifacts. Otherwise, report validation and
+   stop.
 
 ## Review the Architecture
 
@@ -447,22 +465,22 @@ extension seams only for changes the current evidence supports.
 - For a system with several models, prefer a context-first structure. Translate models
   at context boundaries and assign ownership for each integration contract.
 
-Scale the number of mechanisms, not the meaning of the boundaries.
-
 ## Output
 
 Return only the sections needed for the request, but keep the result concrete. Include:
 
 1. Current constraints, assumptions, and the authority sources consulted.
-2. One recommended architecture profile, module tree, and exact local names.
+2. A recommended architecture profile, module tree, and exact local names for design
+   work, or the observed architecture and verified findings for review-only work.
 3. Responsibility placement, functional pillars, and knowledge owners.
 4. Source dependencies and downward, upward, and horizontal communication.
 5. Important domain terms, model boundaries, and DDD choices.
 6. Findings from the completeness, orthogonality, DRY, and extensibility checks.
-7. Incremental implementation, validation, and affected project artifacts.
+7. Incremental implementation, validation, and affected project artifacts when changes
+   are proposed; otherwise, validation and the retained architecture.
 
-If several solutions remain valid, recommend one first. State the conditions under
-which another solution would become better.
+For design work, if several solutions remain valid, recommend one first. State the
+conditions under which another solution would become better.
 
 ## Avoid Overdesign
 

--- a/.agents/skills/design-domain-modular-architecture/SKILL.md
+++ b/.agents/skills/design-domain-modular-architecture/SKILL.md
@@ -1,0 +1,496 @@
+---
+name: design-domain-modular-architecture
+description: Design and review practical modular software architectures with domain models as the basis for boundaries, ownership, dependencies, and evolution. Use when structuring a new system, modularizing an existing codebase, separating domain rules from use-case coordination and external integration, identifying context or module boundaries, reviewing coupling, or planning an incremental architecture change.
+---
+
+# Design Domain Modular Architecture
+
+## Goal
+
+Design the smallest usable architecture that gives the current system complete and
+distinct responsibilities, one authority for each rule, one-way dependencies, and
+clear extension paths.
+
+Use Domain-Driven Design (DDD) as the theory for judging boundaries and evolution. Do
+not treat it as a set of patterns that every project must implement. Introduce a bounded
+context, aggregate, repository, domain service, or other DDD building block only when
+it solves an observed problem.
+
+Unless the user asks only for analysis or review, recommend one concrete architecture.
+Include a module tree, responsibility placement, dependency and communication rules,
+and incremental implementation steps. Present alternatives only after the
+recommendation, with the conditions that would make an alternative preferable.
+
+## Respect Existing Project Authority
+
+Before defining a domain model or naming modules, inspect the project artifacts that
+already govern language and architecture. These can include:
+
+- Repository and directory instructions.
+- Context maps and context documents.
+- Glossaries and ubiquitous-language documents.
+- Architecture documents and ADRs.
+- Requirements, specifications, and design documents.
+- Module manifests, public interfaces, tests, and code conventions.
+
+Follow the declared priority of these artifacts and any rules scoped to a directory or
+domain context. Preserve established terms, definitions, context boundaries, and
+owners. Do not introduce a second name for an existing concept or silently change a
+term's meaning.
+
+Do not infer a DDD meaning from a filename alone. For example, a file named
+`CONTEXT.md` does not necessarily define a bounded context.
+
+Report conflicts between authoritative artifacts and explain their architecture
+impact. Do not hide a conflict by selecting one source without explanation.
+
+When the project has no relevant artifacts, derive the smallest useful language and
+model from the request, code, tests, and examples. Mark facts that cannot be verified
+as assumptions. Do not require a new glossary, context map, or ADR unless the user asks
+for one or the change needs a durable decision record.
+
+## Frame the System
+
+Establish only the facts that can change the design:
+
+- The system form, such as application, service, library, plugin, or data pipeline.
+- The delivery mechanisms, such as UI, API, CLI, messages, or scheduled work.
+- The databases, frameworks, operating systems, and external services involved.
+- The rules, state, and invariants that carry domain complexity.
+- The scope in which each model and language applies.
+- The capabilities that need independent reuse, testing, deployment, or evolution.
+- The observed variation points, team size, change rate, and maintenance budget.
+
+Ask only questions whose answers would materially change the architecture. Continue
+with explicit, reasonable assumptions for the rest.
+
+## Start with a Usable Default
+
+When there is no evidence of several independent domain models, start with this
+single-context shape:
+
+```text
+foundation/
+domain/
+application/
+adapters/
+  inbound/
+  outbound/
+bootstrap/
+```
+
+Treat these names as responsibility labels, not required directory names. Select names
+that match the project language and system form.
+
+| Responsibility | Common name choices |
+| --- | --- |
+| Domain-neutral technical capabilities | `foundation`, `libs`, `platform`, `infrastructure` |
+| Domain model and rules | `domain`, `model`, `business`, a domain capability name |
+| Use cases and application flow | `application`, `use-cases`, `workflows`, `services` |
+| External interaction boundary | `adapters`, `interfaces`, `ports`, `delivery` |
+| Input adaptation | `inbound`, `ui`, `presentation`, `api`, `cli`, `consumers` |
+| Output adaptation | `outbound`, `infrastructure`, `integrations`, `persistence`, `gateways` |
+| Composition and startup | `bootstrap`, `composition-root`, `startup`, `app` |
+
+State the local meaning when a name is ambiguous. For example, `infrastructure` can
+mean a technical foundation or concrete external integration, `services` can mean use
+cases or domain services, and `model` can mean a domain model or a data-transfer shape.
+Do not use one name for several responsibilities without explicit subdivisions.
+
+Keep an existing physical layout when it already expresses the required boundaries.
+Create only the areas whose responsibilities exist. Do not create empty directories
+for symmetry.
+
+### Foundation
+
+Place domain-neutral technical capabilities here. Examples include:
+
+- General result and identifier types.
+- Time, random-number, diagnostic, and validation abstractions.
+- General collections, algorithms, and base protocol types.
+
+Do not use Foundation as a catch-all. Keep domain rules, use-case flow, and vendor
+integration out of it. If the project calls this area `infrastructure`, distinguish it
+from outer database, network, and vendor adapters.
+
+### Domain
+
+Place language, model, and rules that describe the problem domain here. Examples
+include:
+
+- Entities and value objects.
+- Domain state, transitions, rules, and invariants.
+- Domain events, policies, calculations, and cohesive modules.
+- Creation or persistence contracts when the domain language needs them.
+
+Keep the Domain independent of UI, databases, network protocols, concrete frameworks,
+and vendor SDKs.
+
+### Application
+
+Place behavior that drives the domain model toward a user or system goal here.
+Examples include:
+
+- Use cases, application commands, and workflows.
+- Transaction boundaries, entry-point authorization, and cross-module coordination.
+- The order of external calls and application input and output models.
+- Ports for technical capabilities that a use case requires.
+
+Let Application decide when to invoke domain behavior. Do not repeat domain rules or
+move domain invariants into Application.
+
+### Inbound Adapters
+
+Place code that translates external input into application intent here. Examples
+include:
+
+- UI controllers and presentation adapters.
+- HTTP, RPC, or GraphQL endpoints and CLI commands.
+- Message consumers, scheduled jobs, and batch entry points.
+- Framework lifecycle callbacks.
+
+Call Application entry points. Do not mutate Domain internals directly.
+
+### Outbound Adapters
+
+Place concrete external integrations here. Examples include:
+
+- Databases and file storage.
+- Message publishers and HTTP or RPC clients.
+- Search, cache, and object storage.
+- Email, payment, identity, operating-system, framework, and vendor integrations.
+
+Implement ports owned by Application or Domain. Let the side that needs a capability
+own its contract. Put a port in Domain only when the capability is part of the domain
+language; otherwise, let Application own it.
+
+### Bootstrap
+
+Place construction and startup work here. Examples include:
+
+- Creating module instances.
+- Binding ports, adapters, and configuration.
+- Registering entry points and managing process startup and shutdown.
+
+Allow Bootstrap to know the concrete types that it composes. Keep domain rules and
+use-case flow out of it.
+
+## Split Multiple Domain Contexts When Evidence Requires It
+
+Use a context-first shape when the system contains different languages, models, rule
+owners, or independent evolution boundaries:
+
+```text
+contexts/
+  <context-name>/
+    domain/
+    application/
+    adapters/
+      inbound/
+      outbound/
+foundation/
+bootstrap/
+```
+
+Allow each context to contain its own Domain, Application, and Adapters. Do not add a
+bounded-context layer above an existing layer structure.
+
+Integrate contexts through explicit public contracts. Translate models at the boundary
+when their meanings differ. Add an anti-corruption layer when one model would otherwise
+leak into another. Do not share an internal domain model merely to remove translation.
+
+Allow similar words to have different precise meanings in different contexts. Do not
+force a system-wide model when the language does not support one.
+
+Do not assume that a bounded context is a module, service, directory, deployment unit,
+or team. Introduce multiple contexts only when a real model boundary exists.
+
+## Form a Minimal Orthogonal Basis
+
+Treat the selected responsibility areas and core modules as the architecture's
+functional pillars. Together, they must form a minimal orthogonal basis for the current
+problem space:
+
+- Give each pillar one indispensable responsibility.
+- Give each pillar a distinct concept and reason to change.
+- Do not let two pillars own the same rule, state, or decision.
+- Compose complete behavior through small public contracts.
+- Hide each pillar's internal state and implementation.
+- Remove a pillar when its removal leaves no required capability without an owner.
+- Merge or redraw pillars that remain interchangeable or always implement the same
+  decision together.
+
+Name modules, types, interfaces, events, use cases, tests, and documents with the
+project's ubiquitous language. Divide modules by conceptual cohesion and reason to
+change, not by file type, framework component, or organization chart.
+
+Give every rule, state, invariant, and public contract one authoritative owner. Let
+other modules consume that authority instead of reproducing it.
+
+## Keep Dependencies and Communication Directed
+
+### Source Dependencies
+
+Use this default source-dependency direction:
+
+```text
+Inbound Adapters
+       ↓
+   Application
+       ↓
+     Domain
+       ↓
+   Foundation
+```
+
+Let Outbound Adapters depend on ports and contracts owned by Application or Domain. Do
+not let Application or Domain depend on a concrete Outbound Adapter.
+
+Allow same-area modules to depend on public interfaces in one direction. Keep the
+complete dependency graph acyclic.
+
+### Downward Communication
+
+Use direct calls through public interfaces for stable downward requests:
+
+- Let an Inbound Adapter invoke an Application use case.
+- Let Application invoke Domain behavior.
+- Let Application or Domain invoke a port that it owns.
+- Return the result through the existing call stack.
+
+### Upward Communication
+
+Do not let a lower area import, hold, or invoke a concrete higher-area type. When a
+lower area must initiate an upward notification, use an indirect mechanism:
+
+- Use a callback for a small local response supplied by higher-level code.
+- Use an observer for one-to-many notification in one process.
+- Use a domain or application event for a fact that has already occurred.
+- Use publish/subscribe or a message queue only when participants need time, process,
+  or deployment independence.
+
+Define a callback or observer contract in the lower area or in a neutral boundary. Let
+the higher area register its implementation. Let the module that owns a fact define its
+event, and let subscribers decide how to respond.
+
+Treat a return value as the response to an existing downward call, not as an
+independent upward dependency. Do not use a global event bus to hide unclear ownership
+or control flow.
+
+### Horizontal Communication
+
+Choose one clear direction between peer modules, coordinate them in Application, or
+use an event defined by the owner of a fact. At a context boundary, use an explicit
+integration contract and model translation.
+
+When the direction is unclear, identify who owns the rule, who owns the fact, and who
+coordinates the use case. Do not create reciprocal references.
+
+### Runtime Control Flow
+
+Distinguish source dependency from runtime control flow. Application can call an
+Outbound Adapter through a port at runtime while the adapter still depends on the
+inner-owned port in source code.
+
+Do not use a service locator, shared mutable state, dynamic lookup, or a global message
+hub to bypass the dependency rules.
+
+## Apply DDD Selectively
+
+### Always Apply the Core Ideas
+
+At every project size, keep the ubiquitous language, model-to-code alignment, rule and
+state ownership, model scope, and conceptual module boundaries visible.
+
+### Apply Strategic Design by Complexity
+
+Consider subdomains, core and supporting capabilities, bounded contexts, context maps,
+upstream and downstream relationships, anti-corruption layers, or a shared kernel only
+when several models, languages, or ownership boundaries make them useful.
+
+Map only the contexts needed for the current decision. Do not model the complete system
+in advance.
+
+### Apply Tactical Building Blocks by Problem
+
+Use a building block only when its semantics fit:
+
+| Building block | Use it when |
+| --- | --- |
+| Entity | An object has persistent identity and a lifecycle. |
+| Value Object | A concept is defined by values, constraints, and value equality. |
+| Domain Event | An occurred fact has domain meaning. |
+| Domain Service | Domain behavior has no natural Entity or Value Object owner. |
+| Aggregate | Several objects must enforce one consistency boundary. |
+| Factory | Complex construction must always produce a valid result. |
+| Repository | The Domain needs collection-like access to persisted objects. |
+| Module | A set of concepts shares meaning and a reason to change. |
+
+Do not create `entities/`, `services/`, `repositories/`, or similar directories merely
+to display these patterns.
+
+### Keep the Design Supple
+
+Prefer a design that reveals intent and remains easy to change:
+
+- Use names that express domain meaning.
+- Expose behavior instead of internal data.
+- Make side effects and state changes visible.
+- Keep invariants close to their owner.
+- Make composition predictable.
+- Keep a common change from crossing unrelated modules.
+
+### Let Order Evolve
+
+Establish only the large-scale rules needed now. Change module boundaries when new
+domain knowledge or implementation evidence shows that the current structure no longer
+expresses the model, duplicates ownership, or obstructs common changes.
+
+Do not preserve an obsolete plan only because it was defined early. Do not add a
+speculative extension point to prepare for an unverified future.
+
+## Isolate Experiments When Needed
+
+Use an optional `experiments/`, `sandbox/`, or project-specific area when prototypes
+need looser internal rules. Allow experiments to depend on production modules; never
+let production depend on experiments. Before promotion, classify each accepted
+responsibility, move or reimplement it under the correct owner, and add its tests.
+
+## Workflow
+
+1. Define the current goal, evidence, constraints, success conditions, and excluded
+   scope.
+2. Read the existing context, language, architecture, and decision artifacts.
+3. Confirm the smallest domain language and model needed for the decision.
+4. Identify the owners of rules, state, invariants, use cases, and external effects.
+5. Select indispensable, non-overlapping functional pillars.
+6. Choose a single-context or context-first topology and select project-appropriate
+   names.
+7. Recommend one concrete module tree and give representative contents for each area.
+8. Trace source dependencies and downward, upward, and horizontal communication.
+9. Add only the DDD building blocks and communication mechanisms that solve observed
+   problems.
+10. Check completeness, orthogonality, DRY, and extensibility.
+11. Plan the smallest reversible migration slices and their validation.
+12. Identify the glossary, context, ADR, architecture, test, and configuration artifacts
+    that the change must reconcile.
+
+## Review the Architecture
+
+### Completeness
+
+Treat the selected pillars as the span of the current problem space. Confirm that:
+
+- Every required behavior, state, rule, invariant, and use case has an owner.
+- Every input, output, and external effect has a responsible module.
+- Every use case has a complete valid execution path.
+- Relevant lifecycle, failure, transaction, concurrency, and persistence boundaries are
+  covered.
+- No unnamed `misc`, `common`, or hidden module is required to explain the system.
+- The pillars can compose every required current capability.
+
+An essential capability with no owner proves that the selected basis is incomplete.
+
+### Orthogonality
+
+Treat the selected pillars as a minimal independent basis. Confirm that:
+
+- Each pillar owns an indispensable responsibility.
+- Removing any pillar leaves a required capability without an owner.
+- Each pillar has a distinct concept and reason to change.
+- No pair of pillars overlaps in rule, state, or decision ownership.
+- One change does not require several pillars to repeat the same decision.
+- Pillars compose through contracts rather than shared internals.
+- No pillar exists only to preserve symmetry.
+
+Merge or redraw pillars that are interchangeable, always change together for the same
+reason, or cannot state distinct responsibilities. Remove a pillar whose absence does
+not affect a required capability.
+
+### DRY
+
+Treat DRY as single authority for knowledge and rules, not only as removal of similar
+code. Confirm that:
+
+- Each rule, invariant, state transition, contract, event, and protocol has one
+  authoritative owner.
+- Consumers refer to that authority in one direction instead of copying or redefining
+  it.
+- No pair of modules defines each other's required knowledge through a cycle.
+- Derived text, tests, configuration, and code trace back to the same authority.
+- A required generated copy identifies its source and can be regenerated from it.
+- Similar syntax is not shared when its meaning or reason to change differs.
+
+When the same knowledge has several independently editable copies, select one authority
+and replace the others with one-way references or derived representations.
+
+### Extensibility
+
+Review extension paths against observed variation points. Confirm that:
+
+- A new input mechanism normally adds an Inbound Adapter and composition wiring.
+- A replacement database, external service, or vendor normally replaces an Outbound
+  Adapter.
+- A new use case mainly changes Application and its composition.
+- A new domain capability fits an existing owner or a new orthogonal module.
+- A new context does not require changes to unrelated context internals.
+- Public contracts remain small and stable enough for the expected substitutions.
+- Indirect upward communication can add a subscriber without changing the lower
+  publisher.
+- Extension points correspond to observed variation, not imagined requirements.
+- Extension does not require a growing central switch, global registry, or shared
+  mutable state.
+
+Do not demand an interface, plugin point, or event at every location. Preserve
+extension seams only for changes the current evidence supports.
+
+## Scale the Structure
+
+- For a small or early project, prefer one context and a compact physical structure.
+  Keep ownership and dependency direction clear even when responsibilities share a
+  directory. Do not add ports or events without a real boundary.
+- For a medium system, separate Domain from Application, divide modules by domain
+  capability, and add Adapters for external systems. Add ports at stable boundaries and
+  events where independent evolution requires them.
+- For a system with several models, prefer a context-first structure. Translate models
+  at context boundaries and assign ownership for each integration contract.
+
+Scale the number of mechanisms, not the meaning of the boundaries.
+
+## Output
+
+Return only the sections needed for the request, but keep the result concrete. A full
+design should include:
+
+1. Current constraints and explicit assumptions.
+2. Existing context, terminology, and architecture sources consulted.
+3. One recommended architecture profile and module tree.
+4. The selected names and their exact local meanings.
+5. The responsibility, necessity, and non-overlap boundary of each functional pillar.
+6. The authority for each important rule, state, and contract.
+7. Source dependencies and downward, upward, and horizontal communication.
+8. Important domain terms, models, and context boundaries.
+9. DDD building blocks selected or rejected, with reasons.
+10. Missing responsibilities, overlaps, duplicate knowledge, or cycles found.
+11. Supported extension paths and their change surface.
+12. Incremental implementation steps and proportional validation.
+13. Existing glossaries, context documents, ADRs, architecture documents, tests, or
+    configuration that must change with the design.
+
+If several solutions remain valid, recommend one first. State the conditions under
+which another solution would become better.
+
+## Avoid Overdesign
+
+Do not introduce these mechanisms by default:
+
+- One interface for every implementation or a global event bus.
+- A Repository for every object or an Aggregate for every object group.
+- A service or microservice for every module, or one global domain model.
+- A mixed-responsibility `common` module or directories named only after DDD patterns.
+- A complete context map or extension points before evidence requires them.
+- A target architecture that requires a complete rewrite before validation.
+
+Use the least structure that gives the current system a complete, orthogonal, and
+extensible set of functional pillars, one authority for each rule, and one-way
+references to that authority.

--- a/.agents/skills/design-domain-modular-architecture/SKILL.md
+++ b/.agents/skills/design-domain-modular-architecture/SKILL.md
@@ -1,15 +1,20 @@
 ---
 name: design-domain-modular-architecture
-description: Design and review framework-independent, domain-centered modular software architectures with domain models as the basis for boundaries, ownership, dependencies, and evolution. Use when no project- or framework-specific modular topology governs the primary structure, or to reason about domain boundaries within an existing topology while structuring a new system, modularizing a codebase, reviewing coupling, or planning an incremental architecture change.
+description: >-
+  Design and review domain-centered modular architectures for software systems.
+  Turn the applicable domain model, architecture direction, and project constraints into module boundaries, ownership, dependencies, communication, and evolution paths.
+  Use when structuring or modularizing a system, assigning responsibilities, reviewing coupling,
+  adapting an existing topology, or planning an incremental structural change.
 ---
 
 # Design Domain Modular Architecture
 
 ## Goal
 
-Design the smallest usable architecture that gives the current system complete and
-distinct responsibilities, one authority for each rule, one-way dependencies, and
-clear extension paths.
+Translate the current architecture direction and applicable domain model into the
+smallest usable modular structure. Give the current system complete and distinct
+responsibilities, one authority for each rule, one-way dependencies, and clear
+extension paths.
 
 Use Domain-Driven Design (DDD) as the theoretical basis for judging module boundaries
 and evolution. Do not treat it as a set of patterns that every project must implement.
@@ -25,19 +30,18 @@ For analysis or review-only work, describe the observed architecture and report
 verified findings. Recommend a change only when evidence shows that the current design
 does not meet the applicable criteria.
 
-Use the default topology in this skill only when no project- or framework-specific
-modular topology already governs the system. When one exists, preserve its module names
-and dependency rules. Use the DDD guidance here to judge language, ownership, and
-evolution within those boundaries.
+Apply this method to any modular structure. Treat an existing topology, its module names, dependency rules, and composition mechanisms as current constraints.
+Review them against the current goal and structural criteria. Recommend evidence-supported changes when they no longer fit.
+Use the default topology only when no governing topology exists; do not silently replace an existing topology with it.
 
 ## Respect Existing Project Authority
 
-Before defining a domain model or naming modules, inspect the project artifacts that
+Before assigning module or context boundaries, inspect the project artifacts that
 already govern language and architecture. These can include:
 
 - Repository and directory instructions.
 - Context maps and context documents.
-- Glossaries and ubiquitous-language documents.
+- Glossaries and documents that define the Ubiquitous Language.
 - Architecture documents and ADRs.
 - Requirements, specifications, and design documents.
 - Module manifests, public interfaces, tests, and code conventions.
@@ -57,10 +61,10 @@ Do not infer a DDD meaning from a filename alone. For example, a file named
 Report conflicts between authoritative artifacts and explain their architecture
 impact. Do not hide a conflict by selecting one source without explanation.
 
-When the project has no relevant artifacts, derive the smallest useful language and
-model from the request, code, tests, and examples. Mark facts that cannot be verified
-as assumptions. Do not require a new glossary, context map, or ADR unless the user asks
-for one or the change needs a durable decision record.
+When the applicable domain artifacts are absent or materially inconsistent, report the
+gap and continue only with explicit assumptions agreed with the user. Do not invent
+domain knowledge from directory or code structure. Require a new glossary, context map,
+or ADR only when the user asks for one or the change needs a durable decision record.
 
 ## Frame the System
 
@@ -71,11 +75,14 @@ Establish only the facts that can change the design:
 - The databases, frameworks, operating systems, and external services involved.
 - The rules, state, and invariants that carry domain complexity.
 - The scope in which each model and language applies.
+- The architecture drivers, load-bearing mechanisms, and semantic boundaries.
+- The supplied claims, evidence, assumptions, open questions, and claim evidence states. A claim evidence state classifies evidence strength or an explicit scope boundary, not artifact or decision lifecycle status. Reuse project values and ordering only when the project explicitly classifies them as claim evidence states; never copy lifecycle status into this field.
+  If no such vocabulary exists, record `open`, meaning that the available evidence does not establish the claim at its required scope. Record evidence separately; do not invent or infer a stronger state or ordering.
 - The capabilities that need independent reuse, testing, deployment, or evolution.
 - The observed variation points, team size, change rate, and maintenance budget.
 
-Ask only questions whose answers would materially change the architecture. Continue
-with explicit, reasonable assumptions for the rest.
+Ask only questions whose answers would materially change the architecture. Continue with explicit assumptions for the rest.
+Preserve each structure-sensitive input's source, identifier, artifact or decision lifecycle status, claim evidence state, and evidence.
 
 ## Start with a Usable Default
 
@@ -348,6 +355,8 @@ Establish only the large-scale rules needed now. Change module boundaries when n
 domain knowledge or implementation evidence shows that the current structure no longer
 expresses the model, duplicates ownership, or obstructs common changes.
 
+When new evidence changes an architecture driver, domain meaning, invariant, or claim evidence state, revisit only the affected module boundaries and their dependents. Preserve unaffected owners and contracts.
+
 Do not preserve an obsolete plan only because it was defined early. Do not add a
 speculative extension point to prepare for an unverified future.
 
@@ -358,24 +367,28 @@ need looser internal rules. Allow experiments to depend on production modules; n
 let production depend on experiments. Before promotion, classify each accepted
 responsibility, move or reimplement it under the correct owner, and add its tests.
 
+This section governs only placement, dependency direction, and promotion into the modular
+structure. It does not define the experiment charter, claim evidence state, or acceptance decision.
+
 ## Workflow
 
 1. Define the current goal, evidence, constraints, success conditions, and excluded scope.
-2. Read the existing context, language, architecture, and decision artifacts.
-3. Confirm the needed domain model and identify the owners of rules, state, invariants,
-   use cases, and external effects.
-4. Choose module boundaries, topology, and project-appropriate names.
-5. For design work, recommend one concrete module tree and give representative contents
-   for each area. For review-only work, record the observed tree and verified findings.
-6. Trace source dependencies and downward, upward, and horizontal communication.
-7. Add only the DDD building blocks and communication mechanisms that solve observed
-   problems.
-8. Review completeness, orthogonality, DRY, and extensibility.
-9. For design work or accepted changes, plan reversible migration slices, validation,
-   and reconciliation of affected project artifacts. Otherwise, report validation and
-   stop.
+2. Read the existing domain, language, architecture, and decision artifacts.
+3. Identify the applicable domain model, architecture drivers, invariants, load-bearing mechanisms, assumptions, and open claims.
+4. Map each required capability, rule, state, use case, and external effect to an owner.
+5. Choose module and context boundaries, topology, and project-appropriate names.
+6. For design work, recommend one concrete module tree and give representative contents for each area. For review-only work, record the observed tree and verified findings.
+7. Trace source dependencies and downward, upward, and horizontal communication.
+8. Add only the DDD building blocks and communication mechanisms that solve observed problems.
+9. Review structural completeness, orthogonality, DRY, and extensibility.
+10. Link each load-bearing structural claim to its driver or invariant and module decision. Record its claim evidence state, evidence, disconfirming condition, and unresolved validation need.
+    For iterative work or handoff, use stable repository-native identifiers and report added, changed, and retired identifiers.
+    For design work or accepted changes, also plan reversible migration slices and reconcile affected artifacts; otherwise stop.
 
 ## Review the Architecture
+
+These checks evaluate structural fitness. Preserve the artifact lifecycle status, claim evidence state, and evidence from authoritative inputs.
+Treat an unsupported conclusion as a structural claim that still requires validation; do not advance its claim evidence state.
 
 ### Completeness
 
@@ -462,19 +475,17 @@ extension seams only for changes the current evidence supports.
 
 Return only the sections needed for the request, but keep the result concrete. Include:
 
-1. Current constraints, assumptions, and the authority sources consulted.
-2. A recommended architecture profile, module tree, and exact local names for design
-   work, or the observed architecture and verified findings for review-only work.
-3. Responsibility placement, capability ownership, and authoritative sources for shared
-   rules and knowledge.
+1. Domain and architecture authority sources, constraints, and assumptions. Preserve artifact or decision lifecycle status and claim evidence state.
+2. A recommended architecture profile, module tree, and exact local names for design work, or the observed architecture and verified findings for review-only work.
+3. The mapping from architecture drivers, invariants, and capabilities to responsibility and knowledge owners.
 4. Source dependencies and downward, upward, and horizontal communication.
 5. Important domain terms, model boundaries, and DDD choices.
-6. Findings from the completeness, orthogonality, DRY, and extensibility checks.
-7. For design work or accepted changes, incremental implementation, validation, and
-   affected project artifacts; otherwise, validation and the retained architecture.
+6. Findings from the structural completeness, orthogonality, DRY, and extensibility checks.
+7. Load-bearing structural claims linked to their drivers or invariants and module decisions. For each claim, include its claim evidence state, evidence, disconfirming condition, and open validation questions.
+   Use stable identifiers for iterative work or handoff.
+8. For design work or accepted changes, incremental implementation, validation needs, and affected project artifacts; otherwise, validation needs and the retained architecture.
 
-For design work, if several solutions remain valid, recommend one first. State the
-conditions under which another solution would become better.
+For design work, if several solutions remain valid, recommend one first. State the conditions under which another solution would become better.
 
 ## Avoid Overdesign
 

--- a/.agents/skills/design-domain-modular-architecture/SKILL.md
+++ b/.agents/skills/design-domain-modular-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-domain-modular-architecture
-description: Design and review practical modular software architectures with domain models as the basis for boundaries, ownership, dependencies, and evolution. Use when structuring a new system, modularizing an existing codebase, separating domain rules from use-case coordination and external integration, identifying context or module boundaries, reviewing coupling, or planning an incremental architecture change.
+description: Design and review technology-neutral, domain-centered modular software architectures with domain models as the basis for boundaries, ownership, dependencies, and evolution. Use for technology-neutral or explicitly domain-centered work when structuring a new system, modularizing an existing codebase, separating domain rules from use-case coordination and external integration, identifying context or module boundaries, reviewing coupling, or planning an incremental architecture change.
 ---
 
 # Design Domain Modular Architecture
@@ -11,10 +11,10 @@ Design the smallest usable architecture that gives the current system complete a
 distinct responsibilities, one authority for each rule, one-way dependencies, and
 clear extension paths.
 
-Use Domain-Driven Design (DDD) as the theory for judging boundaries and evolution. Do
-not treat it as a set of patterns that every project must implement. Introduce a bounded
-context, aggregate, repository, domain service, or other DDD building block only when
-it solves an observed problem.
+Use Domain-Driven Design (DDD) as the theoretical basis for judging module boundaries
+and evolution. Do not treat it as a set of patterns that every project must implement.
+Introduce a Bounded Context, Aggregate, Repository, Domain Service, or other DDD
+building block only when it solves an observed problem.
 
 Unless the user asks only for analysis or review, recommend one concrete architecture.
 Include a module tree, responsibility placement, dependency and communication rules,
@@ -39,7 +39,7 @@ owners. Do not introduce a second name for an existing concept or silently chang
 term's meaning.
 
 Do not infer a DDD meaning from a filename alone. For example, a file named
-`CONTEXT.md` does not necessarily define a bounded context.
+`CONTEXT.md` does not necessarily define a Bounded Context.
 
 Report conflicts between authoritative artifacts and explain their architecture
 impact. Do not hide a conflict by selecting one source without explanation.
@@ -87,7 +87,7 @@ that match the project language and system form.
 | Domain-neutral technical capabilities | `foundation`, `libs`, `platform`, `infrastructure` |
 | Domain model and rules | `domain`, `model`, `business`, a domain capability name |
 | Use cases and application flow | `application`, `use-cases`, `workflows`, `services` |
-| External interaction boundary | `adapters`, `interfaces`, `ports`, `delivery` |
+| External interaction boundary | `adapters`, `interfaces`, `delivery` |
 | Input adaptation | `inbound`, `ui`, `presentation`, `api`, `cli`, `consumers` |
 | Output adaptation | `outbound`, `infrastructure`, `integrations`, `persistence`, `gateways` |
 | Composition and startup | `bootstrap`, `composition-root`, `startup`, `app` |
@@ -175,7 +175,7 @@ Place construction and startup work here. Examples include:
 Allow Bootstrap to know the concrete types that it composes. Keep domain rules and
 use-case flow out of it.
 
-## Split Multiple Domain Contexts When Evidence Requires It
+## Split Bounded Contexts When Evidence Requires It
 
 Use a context-first shape when the system contains different languages, models, rule
 owners, or independent evolution boundaries:
@@ -192,37 +192,30 @@ foundation/
 bootstrap/
 ```
 
-Allow each context to contain its own Domain, Application, and Adapters. Do not add a
-bounded-context layer above an existing layer structure.
+Allow each Bounded Context to contain its applicable Domain, Application, and Adapters.
+Do not treat a Bounded Context as another dependency layer. When several models exist,
+organize the applicable layers inside each context.
 
 Integrate contexts through explicit public contracts. Translate models at the boundary
-when their meanings differ. Add an anti-corruption layer when one model would otherwise
+when their meanings differ. Add an Anti-Corruption Layer when one model would otherwise
 leak into another. Do not share an internal domain model merely to remove translation.
 
 Allow similar words to have different precise meanings in different contexts. Do not
 force a system-wide model when the language does not support one.
 
-Do not assume that a bounded context is a module, service, directory, deployment unit,
+Do not assume that a Bounded Context is a module, service, directory, deployment unit,
 or team. Introduce multiple contexts only when a real model boundary exists.
 
-## Form a Minimal Orthogonal Basis
+## Define Functional Pillars
 
-Treat the selected responsibility areas and core modules as the architecture's
-functional pillars. Together, they must form a minimal orthogonal basis for the current
-problem space:
+Use **functional pillar** to mean a module or stable module group that owns one required
+system capability. Do not use the term for a layer, Bounded Context, or directory unless
+that element also owns such a capability.
 
-- Give each pillar one indispensable responsibility.
-- Give each pillar a distinct concept and reason to change.
-- Do not let two pillars own the same rule, state, or decision.
-- Compose complete behavior through small public contracts.
-- Hide each pillar's internal state and implementation.
-- Remove a pillar when its removal leaves no required capability without an owner.
-- Merge or redraw pillars that remain interchangeable or always implement the same
-  decision together.
-
-Name modules, types, interfaces, events, use cases, tests, and documents with the
-project's ubiquitous language. Divide modules by conceptual cohesion and reason to
-change, not by file type, framework component, or organization chart.
+Use the Ubiquitous Language of the applicable Bounded Context to name modules, types,
+interfaces, events, use cases, tests, and documents. When no Bounded Context is defined,
+use the established project and domain terms. Divide modules by conceptual cohesion and
+reason to change, not by file type, framework component, or organization chart.
 
 Give every rule, state, invariant, and public contract one authoritative owner. Let
 other modules consume that authority instead of reproducing it.
@@ -299,14 +292,16 @@ hub to bypass the dependency rules.
 
 ### Always Apply the Core Ideas
 
-At every project size, keep the ubiquitous language, model-to-code alignment, rule and
-state ownership, model scope, and conceptual module boundaries visible.
+At every project size, keep the Ubiquitous Language, alignment between the domain model
+and implementation, rule and state ownership, model scope, and conceptual module
+boundaries visible.
 
 ### Apply Strategic Design by Complexity
 
-Consider subdomains, core and supporting capabilities, bounded contexts, context maps,
-upstream and downstream relationships, anti-corruption layers, or a shared kernel only
-when several models, languages, or ownership boundaries make them useful.
+Consider a Core Domain, Supporting Subdomains, Generic Subdomains, Bounded Contexts, a
+Context Map, upstream and downstream relationships, an Anti-Corruption Layer, or a
+Shared Kernel only when several models, languages, or ownership boundaries make them
+useful.
 
 Map only the contexts needed for the current decision. Do not model the complete system
 in advance.
@@ -321,15 +316,15 @@ Use a building block only when its semantics fit:
 | Value Object | A concept is defined by values, constraints, and value equality. |
 | Domain Event | An occurred fact has domain meaning. |
 | Domain Service | Domain behavior has no natural Entity or Value Object owner. |
-| Aggregate | Several objects must enforce one consistency boundary. |
+| Aggregate | Related Entities and Value Objects need one consistency and transaction boundary, with external access controlled by an Aggregate Root. |
 | Factory | Complex construction must always produce a valid result. |
-| Repository | The Domain needs collection-like access to persisted objects. |
+| Repository | An Aggregate Root needs collection-like access expressed in the Ubiquitous Language. |
 | Module | A set of concepts shares meaning and a reason to change. |
 
 Do not create `entities/`, `services/`, `repositories/`, or similar directories merely
 to display these patterns.
 
-### Keep the Design Supple
+### Apply Supple Design
 
 Prefer a design that reveals intent and remains easy to change:
 
@@ -340,7 +335,7 @@ Prefer a design that reveals intent and remains easy to change:
 - Make composition predictable.
 - Keep a common change from crossing unrelated modules.
 
-### Let Order Evolve
+### Apply Evolving Order
 
 Establish only the large-scale rules needed now. Change module boundaries when new
 domain knowledge or implementation evidence shows that the current structure no longer
@@ -358,28 +353,25 @@ responsibility, move or reimplement it under the correct owner, and add its test
 
 ## Workflow
 
-1. Define the current goal, evidence, constraints, success conditions, and excluded
-   scope.
+1. Define the current goal, evidence, constraints, success conditions, and excluded scope.
 2. Read the existing context, language, architecture, and decision artifacts.
-3. Confirm the smallest domain language and model needed for the decision.
-4. Identify the owners of rules, state, invariants, use cases, and external effects.
-5. Select indispensable, non-overlapping functional pillars.
-6. Choose a single-context or context-first topology and select project-appropriate
-   names.
-7. Recommend one concrete module tree and give representative contents for each area.
-8. Trace source dependencies and downward, upward, and horizontal communication.
-9. Add only the DDD building blocks and communication mechanisms that solve observed
+3. Confirm the needed domain model and identify the owners of rules, state, invariants,
+   use cases, and external effects.
+4. Define the functional pillars, topology, and project-appropriate names.
+5. Recommend one concrete module tree and give representative contents for each area.
+6. Trace source dependencies and downward, upward, and horizontal communication.
+7. Add only the DDD building blocks and communication mechanisms that solve observed
    problems.
-10. Check completeness, orthogonality, DRY, and extensibility.
-11. Plan the smallest reversible migration slices and their validation.
-12. Identify the glossary, context, ADR, architecture, test, and configuration artifacts
-    that the change must reconcile.
+8. Review completeness, orthogonality, DRY, and extensibility.
+9. Plan reversible migration slices, validation, and reconciliation of affected
+   project artifacts.
 
 ## Review the Architecture
 
 ### Completeness
 
-Treat the selected pillars as the span of the current problem space. Confirm that:
+Confirm that the selected responsibilities, modules, and contexts cover the current
+problem space:
 
 - Every required behavior, state, rule, invariant, and use case has an owner.
 - Every input, output, and external effect has a responsible module.
@@ -387,13 +379,13 @@ Treat the selected pillars as the span of the current problem space. Confirm tha
 - Relevant lifecycle, failure, transaction, concurrency, and persistence boundaries are
   covered.
 - No unnamed `misc`, `common`, or hidden module is required to explain the system.
-- The pillars can compose every required current capability.
+- The design can compose every required current capability.
 
-An essential capability with no owner proves that the selected basis is incomplete.
+An essential capability with no owner proves that the design is incomplete.
 
 ### Orthogonality
 
-Treat the selected pillars as a minimal independent basis. Confirm that:
+Treat the defined functional pillars as a minimal orthogonal basis. Confirm that:
 
 - Each pillar owns an indispensable responsibility.
 - Removing any pillar leaves a required capability without an owner.
@@ -459,23 +451,15 @@ Scale the number of mechanisms, not the meaning of the boundaries.
 
 ## Output
 
-Return only the sections needed for the request, but keep the result concrete. A full
-design should include:
+Return only the sections needed for the request, but keep the result concrete. Include:
 
-1. Current constraints and explicit assumptions.
-2. Existing context, terminology, and architecture sources consulted.
-3. One recommended architecture profile and module tree.
-4. The selected names and their exact local meanings.
-5. The responsibility, necessity, and non-overlap boundary of each functional pillar.
-6. The authority for each important rule, state, and contract.
-7. Source dependencies and downward, upward, and horizontal communication.
-8. Important domain terms, models, and context boundaries.
-9. DDD building blocks selected or rejected, with reasons.
-10. Missing responsibilities, overlaps, duplicate knowledge, or cycles found.
-11. Supported extension paths and their change surface.
-12. Incremental implementation steps and proportional validation.
-13. Existing glossaries, context documents, ADRs, architecture documents, tests, or
-    configuration that must change with the design.
+1. Current constraints, assumptions, and the authority sources consulted.
+2. One recommended architecture profile, module tree, and exact local names.
+3. Responsibility placement, functional pillars, and knowledge owners.
+4. Source dependencies and downward, upward, and horizontal communication.
+5. Important domain terms, model boundaries, and DDD choices.
+6. Findings from the completeness, orthogonality, DRY, and extensibility checks.
+7. Incremental implementation, validation, and affected project artifacts.
 
 If several solutions remain valid, recommend one first. State the conditions under
 which another solution would become better.
@@ -490,7 +474,3 @@ Do not introduce these mechanisms by default:
 - A mixed-responsibility `common` module or directories named only after DDD patterns.
 - A complete context map or extension points before evidence requires them.
 - A target architecture that requires a complete rewrite before validation.
-
-Use the least structure that gives the current system a complete, orthogonal, and
-extensible set of functional pillars, one authority for each rule, and one-way
-references to that authority.

--- a/.agents/skills/design-domain-modular-architecture/SKILL.md
+++ b/.agents/skills/design-domain-modular-architecture/SKILL.md
@@ -47,6 +47,10 @@ domain context. Preserve established terms, definitions, context boundaries, and
 owners. Do not introduce a second name for an existing concept or silently change a
 term's meaning.
 
+Use the Ubiquitous Language of the applicable Bounded Context to name modules, types,
+interfaces, events, use cases, tests, and documents. When no Bounded Context is defined,
+use the established project and domain terms.
+
 Do not infer a DDD meaning from a filename alone. For example, a file named
 `CONTEXT.md` does not necessarily define a Bounded Context.
 
@@ -109,6 +113,9 @@ Do not use one name for several responsibilities without explicit subdivisions.
 Keep an existing physical layout when it already expresses the required boundaries.
 Create only the areas whose responsibilities exist. Do not create empty directories
 for symmetry.
+
+Divide modules by conceptual cohesion and reason to change, not by file type, framework
+component, or organization chart.
 
 ### Foundation
 
@@ -214,22 +221,6 @@ force a system-wide model when the language does not support one.
 
 Do not assume that a Bounded Context is a module, service, directory, deployment unit,
 or team. Introduce multiple contexts only when a real model boundary exists.
-
-## Define Functional Pillars
-
-Use **functional pillar** to mean a module or stable module group that owns one required
-system capability. Do not use the term for a layer, Bounded Context, or directory unless
-that element also owns such a capability.
-
-Use the Ubiquitous Language of the applicable Bounded Context. This is the shared,
-precise vocabulary built around the domain model and used in collaboration and in the
-software. Use it to name modules, types, interfaces, events, use cases, tests, and
-documents. When no Bounded Context is defined, use the established project and domain
-terms. Divide modules by conceptual cohesion and reason to change, not by file type,
-framework component, or organization chart.
-
-Give every rule, state, invariant, and public contract one authoritative owner. Let
-other modules consume that authority instead of reproducing it.
 
 ## Keep Dependencies and Communication Directed
 
@@ -373,7 +364,7 @@ responsibility, move or reimplement it under the correct owner, and add its test
 2. Read the existing context, language, architecture, and decision artifacts.
 3. Confirm the needed domain model and identify the owners of rules, state, invariants,
    use cases, and external effects.
-4. Define the functional pillars, topology, and project-appropriate names.
+4. Choose module boundaries, topology, and project-appropriate names.
 5. For design work, recommend one concrete module tree and give representative contents
    for each area. For review-only work, record the observed tree and verified findings.
 6. Trace source dependencies and downward, upward, and horizontal communication.
@@ -403,19 +394,21 @@ An essential capability with no owner proves that the design is incomplete.
 
 ### Orthogonality
 
-Treat the defined functional pillars as a minimal orthogonal basis. Confirm that:
+Use **orthogonal basis** as a system metaphor for the modules or cohesive module groups
+that own the required capabilities. Together, they must cover the current capability
+set, while each owner remains necessary and non-overlapping. Confirm that:
 
-- Each pillar owns an indispensable responsibility.
-- Removing any pillar leaves a required capability without an owner.
-- Each pillar has a distinct concept and reason to change.
-- No pair of pillars overlaps in rule, state, or decision ownership.
-- One change does not require several pillars to repeat the same decision.
-- Pillars compose through contracts rather than shared internals.
-- No pillar exists only to preserve symmetry.
+- Each capability owner has an indispensable responsibility.
+- Removing any owner leaves a required capability without an owner.
+- Each owner has a distinct concept and reason to change.
+- No pair of owners overlaps in rule, state, or decision ownership.
+- One change does not require several owners to repeat the same decision.
+- Owners compose through contracts rather than shared internals.
+- No owner exists only to preserve symmetry.
 
-Merge or redraw pillars that are interchangeable, always change together for the same
-reason, or cannot state distinct responsibilities. Remove a pillar whose absence does
-not affect a required capability.
+Merge or redraw modules or groups that are interchangeable, always change together for
+the same reason, or cannot state distinct responsibilities. Remove one whose absence
+does not affect a required capability.
 
 ### DRY
 
@@ -472,7 +465,8 @@ Return only the sections needed for the request, but keep the result concrete. I
 1. Current constraints, assumptions, and the authority sources consulted.
 2. A recommended architecture profile, module tree, and exact local names for design
    work, or the observed architecture and verified findings for review-only work.
-3. Responsibility placement, functional pillars, and knowledge owners.
+3. Responsibility placement, capability ownership, and authoritative sources for shared
+   rules and knowledge.
 4. Source dependencies and downward, upward, and horizontal communication.
 5. Important domain terms, model boundaries, and DDD choices.
 6. Findings from the completeness, orthogonality, DRY, and extensibility checks.

--- a/.agents/skills/design-domain-modular-architecture/SKILL.md
+++ b/.agents/skills/design-domain-modular-architecture/SKILL.md
@@ -470,8 +470,8 @@ Return only the sections needed for the request, but keep the result concrete. I
 4. Source dependencies and downward, upward, and horizontal communication.
 5. Important domain terms, model boundaries, and DDD choices.
 6. Findings from the completeness, orthogonality, DRY, and extensibility checks.
-7. Incremental implementation, validation, and affected project artifacts when changes
-   are proposed; otherwise, validation and the retained architecture.
+7. For design work or accepted changes, incremental implementation, validation, and
+   affected project artifacts; otherwise, validation and the retained architecture.
 
 For design work, if several solutions remain valid, recommend one first. State the
 conditions under which another solution would become better.

--- a/.agents/skills/design-domain-modular-architecture/agents/openai.yaml
+++ b/.agents/skills/design-domain-modular-architecture/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Design Domain Modular Architecture"
-  short_description: "Design technology-neutral domain module boundaries"
-  default_prompt: "Use $design-domain-modular-architecture to design or review technology-neutral, domain-centered module boundaries and dependencies."
+  short_description: "Design framework-independent domain module boundaries"
+  default_prompt: "Use $design-domain-modular-architecture to design or review framework-independent, domain-centered module boundaries and dependencies."

--- a/.agents/skills/design-domain-modular-architecture/agents/openai.yaml
+++ b/.agents/skills/design-domain-modular-architecture/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Design Domain Modular Architecture"
+  short_description: "Design practical domain-centered module boundaries"
+  default_prompt: "Use $design-domain-modular-architecture to design or review practical domain-centered module boundaries and dependencies."

--- a/.agents/skills/design-domain-modular-architecture/agents/openai.yaml
+++ b/.agents/skills/design-domain-modular-architecture/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Design Domain Modular Architecture"
-  short_description: "Design practical domain-centered module boundaries"
-  default_prompt: "Use $design-domain-modular-architecture to design or review practical domain-centered module boundaries and dependencies."
+  short_description: "Design technology-neutral domain module boundaries"
+  default_prompt: "Use $design-domain-modular-architecture to design or review technology-neutral, domain-centered module boundaries and dependencies."

--- a/.agents/skills/design-domain-modular-architecture/agents/openai.yaml
+++ b/.agents/skills/design-domain-modular-architecture/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Design Domain Modular Architecture"
-  short_description: "Design framework-independent domain module boundaries"
-  default_prompt: "Use $design-domain-modular-architecture to design or review framework-independent, domain-centered module boundaries and dependencies."
+  short_description: "Design domain-centered modular architectures"
+  default_prompt: "Use $design-domain-modular-architecture to turn an applicable domain model, architecture direction, and project constraints into module boundaries, ownership, dependencies, and communication."

--- a/.agents/skills/validation-driven-design/EXAMPLES.md
+++ b/.agents/skills/validation-driven-design/EXAMPLES.md
@@ -26,6 +26,10 @@ peer authority merely because its terminology is reused.
 
 ### 3. Iterative probes
 
+The selected direction is translated into a concrete module structure. That structural pass returns
+claims about responsibility ownership, dependency direction, and extension boundaries. The probes
+below test those claims; an adopted refinement changes only the affected structural decisions.
+
 1. An end-to-end slice compiles one policy, runs it, and publishes an audit. It confirms connectivity
    but exposes ambiguous refusal staging and identity.
 2. Two independent runtimes consume each other's canonical artifacts. A mutation test reveals one

--- a/.agents/skills/validation-driven-design/REFERENCE.md
+++ b/.agents/skills/validation-driven-design/REFERENCE.md
@@ -4,9 +4,9 @@ Use this file for detailed templates, proof obligations, and delivery gates. `SK
 owns the design workflow; this file does not restate it.
 
 Contents: [modes and authority](#1-engagement-modes-and-authority-map) ·
-[claims](#2-claim-and-evidence-ladder) · [theory](#3-theory-support-matrix) ·
+[claims](#2-claim-evidence-ladder) · [theory](#3-theory-support-matrix) ·
 [external research](#4-external-system-research-matrix) · [validation](#5-validation-portfolio) ·
-[quality gates](#6-four-design-axes-and-cross-cutting-qualities) ·
+[quality gates](#6-four-design-axes-and-cross-cutting-quality-attributes) ·
 [defect attribution](#7-defect-attribution-ladder) · [delivery](#8-delivery-gates-and-production-planning) ·
 [completion](#9-completion-audit)
 
@@ -18,13 +18,13 @@ Choose mode before building the authority map:
 | --- | --- | --- |
 | `lightweight` | a bounded, reversible decision can be owned by one compact decision record and does not change a public contract, extension contract, or production boundary | owner, requirement/decision, falsifier, affected axes, one discriminating check, non-claims, and human decision gate |
 | `full-design` | a framework/language/runtime or broad, hard-to-reverse claim changes authority, semantics, extension, or production boundaries | the complete workflow, matrices, proof obligations, and delivery gates |
-| `audit-only` | fixed existing artifacts and claims must be evaluated without redesign | fixed baseline/scope, authority and claim audit, design-axis and cross-cutting-quality findings, completion gaps, and recorded human decision outcome; no edits unless requested |
+| `audit-only` | fixed existing artifacts and claims must be evaluated without redesign | fixed baseline/scope, authority and claim audit, design-axis findings, findings about cross-cutting quality attributes, completion gaps, and recorded human decision outcome; no edits unless requested |
 
 Every mode keeps explicit authority, falsifier, non-claims, and human decision ownership. Scale the
 remaining evidence work to claim breadth, reversibility, novelty, and operational risk.
 
-`lightweight` is a ceiling as well as a minimum: start with one compact decision record and
-one discriminating check. Do not create theory/research matrices, a prototype portfolio, the full
+`lightweight` sets the minimum and maximum initial scope: start with one compact decision record
+and one discriminating check. Do not create theory/research matrices, a prototype portfolio, the full
 delivery sequence, or a full completion audit unless the falsifier exposes a specific need; state
 why before expanding. `audit-only` similarly reports only findings inside the pinned claimed scope.
 
@@ -39,7 +39,7 @@ Choose repository-native names, but preserve these ownership roles:
 | Requirements | user outcomes, scope, acceptance criteria, live completion | detailed architecture or evidence by assertion |
 | Architecture narrative | macro topology, responsibilities, cross-cutting invariants, delivery order | duplicate detailed decisions or machine semantics |
 | Decision records | one binding decision, alternatives, consequences, validation | status dashboard or broad narrative |
-| Glossary/context | canonical terms and distinctions | a second architecture specification |
+| Glossary/context | canonical domain terms, distinctions, and model scope | a second architecture specification |
 | Specification/standard | normative semantics, public contracts, conformance requirements, versioning, and designation of normative machine-readable artifacts | architecture rationale, implementation details, evidence, or acceptance state |
 | Executable conformance assets | machine-checkable schemas, executable conformance cases, validators, and observable oracles that realize or test the specification | an independent semantic authority or proof merely because tests pass |
 | Evidence record | prototype/research inputs, outputs, provenance, bounded conclusions | semantic authority or acceptance state |
@@ -60,11 +60,12 @@ For each fact, mark exactly one authoritative source and every derived copy. Pre
 reference over restating a list, algorithm, count, precedence rule, or state machine. Reconcile the
 pinned current artifact revision and any live coordination state after each design iteration.
 
-## 2. Claim and evidence ladder
+## 2. Claim evidence ladder
 
-Use exact, bounded language:
+A claim evidence state records evidence strength or an explicit scope boundary. It is separate from
+an artifact or decision lifecycle status. Use exact, bounded language:
 
-| State | Meaning | Sufficient evidence |
+| Claim evidence state | Meaning | Sufficient evidence |
 | --- | --- | --- |
 | `proposed` | a candidate mechanism | rationale only |
 | `theory-supported` | established theory explains why the mechanism should work | explicit theory-to-invariant mapping and proof boundary |
@@ -86,8 +87,8 @@ Dogfooding uses a separate disposition namespace:
 | `gap-opened` | the observation exposed an unresolved defect, ambiguity, or evidence gate |
 | `no-design-effect` | the observation was instance-local, out of claim scope, or required no normative change |
 
-After recording the disposition, set the affected claim to the applicable maturity state above.
-Never reuse a claim-state label as a dogfooding disposition.
+After recording the disposition, set the affected claim to the applicable claim evidence state above.
+Never reuse a claim evidence state as a dogfooding disposition.
 
 ## 3. Theory-support matrix
 
@@ -126,6 +127,7 @@ Rules:
    otherwise record the evidence form that can discriminate the claim.
 5. Treat an external version change as a deliberate local design decision, never ambient drift.
 6. Compare with non-adoption: importing a standard can cost more authority and surface than it saves.
+7. Treat external systems as architecture evidence, not as authority for local domain meaning.
 
 ## 5. Validation portfolio
 
@@ -136,7 +138,7 @@ Choose validation form by uncertainty:
 | layer connectivity/integration | smallest end-to-end slice |
 | semantic authority/portability | two independent interpreters or compilers consuming each other's artifacts |
 | state/lifecycle/order | executable state-machine or scheduler harness with boundary permutations |
-| orthogonality | add one independent axis, then exercise cross-products and mutation cases |
+| orthogonality | vary one concern while holding the others fixed, then test pairwise and cross-product compositions and ordering cases |
 | extensibility | add an out-of-family capability through public contracts with unchanged core/builds |
 | requirement breadth | research corpus mapped to the coverage matrix, explicitly non-conforming |
 | human interaction/usability | visual or interactive prototype |
@@ -184,17 +186,21 @@ Run another disposable prototype only when the design adds or changes normative 
 extension contract, an authority owner or binding, or a comparably high-risk uncertainty. Otherwise
 move to permanent executable conformance cases and end-to-end production slices.
 
-## 6. Four design axes and cross-cutting qualities
+## 6. Four design axes and cross-cutting quality attributes
 
-The four axes assess design structure. Consistency, reliability, and operability apply across every
-axis; they are not additional peers in the design-axis taxonomy.
+The four axes assess design structure. Consistency, reliability, and operability are quality
+attributes that apply across every axis; they are not additional peers in the design-axis taxonomy.
 
 | Axis | Required questions | Strong evidence | Failure signal |
 | --- | --- | --- | --- |
 | Abstraction | What theory supports the model? Which semantics are public? Which implementation details may vary? | explicit semantic boundaries; preservation/refusal contracts; independent implementations | host behavior, serialization, framework, or optimizer becomes hidden authority |
 | Completeness | Do all known stories, failures, variants, interactions, operations, and production concerns map to observable contracts? | requirements-to-mechanism-to-scenario-to-conformance-case-to-observable matrix | vocabulary/package inventory presented as coverage; important paths only appear in prose |
-| Orthogonality | Does each concern have one owner and independent representation? Are cross-products and precedence closed? | mutation tests; pairwise/cross-product scenarios; canonical ordering/reducers | independent axes share hidden state or leave interaction order to the host |
+| Orthogonality | Does each concern in the selected orthogonal basis have a distinct meaning and reason to change? Is it necessary, non-overlapping, and independently variable? Does composition preserve this independence? | vary one concern while other observations stay fixed; pairwise and cross-product cases; explicit precedence where order matters | a concern can be removed without loss; changing one concern changes unrelated concerns; composition shares hidden state or leaves precedence to the host |
 | Extensibility | What is configuration, extension, framework evolution, or irreducible core? Can an out-of-family case use unchanged core and dispatch? | explicit extension invariance; fixed-build witness; negative capability/refusal cases | each new domain adds core fields, phases, switches, callbacks, or parallel semantics |
+
+Apply the authority rule in [SKILL.md §7](SKILL.md#7-run-design-axis-and-quality-attribute-gates) to
+specialized structural evaluation criteria. Use this table as the default coverage check, not as a
+parallel structural standard.
 
 Also audit consistency, reliability, and operability:
 
@@ -228,7 +234,7 @@ This section exclusively owns the detailed default delivery sequence:
 2. **Permanent conformance foundation:** replace prototype-local authority with versioned rules,
    schemas, fixtures, negative/mutation conformance cases, and reusable harnesses.
 3. **Production end-to-end slice:** exercise the public API/artifact path end to end.
-4. **Known-domain breadth:** close the full requirements coverage matrix without parallel semantics.
+4. **Known-scenario breadth:** close the full requirements coverage matrix without parallel semantics.
 5. **Out-of-family witness:** prove the extension promise against a structurally different consumer.
 6. **Production rollout:** validate security, performance, capacity, observability, recovery,
    compatibility/migration, deployment, rollback, and operational ownership.

--- a/.agents/skills/validation-driven-design/SKILL.md
+++ b/.agents/skills/validation-driven-design/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: validation-driven-design
-description: Designs, audits, and iteratively validates framework, platform, language, protocol, or runtime architectures by combining explicit requirements, mature theory, external-system research, executable prototypes, dogfooding, and cross-artifact reconciliation. Use when creating or redesigning an architecture, writing architecture specifications or decision records, auditing an existing architecture against abstraction/completeness/orthogonality/extensibility, or planning a design for production implementation.
+description: >-
+  Design, audit, and iteratively validate architecture direction under material
+  uncertainty. Use explicit requirements, mature theory, external-system research,
+  executable prototypes, dogfooding, and cross-artifact reconciliation. Use when a
+  decision is novel, disputed, broad, hard to reverse, or insufficiently supported.
+  Also use this skill to write an architecture specification or decision record, or to audit a
+  fixed architecture and its evidence.
 ---
 
 # Validation-Driven Design
@@ -10,6 +16,15 @@ description: Designs, audits, and iteratively validates framework, platform, lan
 Design an architecture under explicit requirements and specifications, then strengthen it through
 evidence-bearing iterations. This skill is for architecture creation, redesign, or architecture
 audit, not routine codebase refactoring, interface styling, generic review, or UI prototyping.
+
+Produce an evidence-bounded architecture direction. Include drivers, constraints, load-bearing
+mechanisms, semantic boundaries, claims, and validation gates. Do not expand into detailed module
+decomposition unless a claim under test requires it.
+
+Treat applicable context, glossary, requirements, and other domain artifacts as current inputs.
+Preserve their sources and established meanings. When they are absent or contradictory, record an
+explicit assumption or open question and coordinate with the user. Do not infer domain knowledge
+from technical theory, external systems, or a prototype.
 
 Preserve the stated product vision as a falsifiable requirement. If evidence contradicts it, reopen
 the architecture or requirement explicitly; never make the work “pass” by silently narrowing the
@@ -29,11 +44,11 @@ conformance case and its minimum fields.
 ## Quick start
 
 1. Choose `lightweight`, `full-design`, or `audit-only` mode; name the artifact owners and human decision owner.
-2. Write goals, non-goals, invariants, quality attributes, production constraints, and claim status.
+2. Write goals, non-goals, invariants, quality attributes, and production constraints. Keep artifact and decision lifecycle status separate from claim evidence state.
 3. Map load-bearing mechanisms to mature theory and external systems; record adoption and proof gaps.
 4. Rank architecture uncertainties and run only the smallest discriminating validation.
 5. Feed dogfooding back into requirements, decisions, terms, specifications, executable conformance cases, and gates.
-6. Audit the four design axes and cross-cutting qualities; keep non-claims explicit.
+6. Audit the four design axes and cross-cutting quality attributes; keep non-claims explicit.
 
 See [REFERENCE.md](REFERENCE.md) for templates and proof obligations, and [EXAMPLES.md](EXAMPLES.md).
 
@@ -47,11 +62,16 @@ without redesign or edits unless the user requests them.
 ### 1. Establish the design contract
 
 - Read repository guidance and current authoritative artifacts before proposing structure.
-- Turn outcomes into traceable requirements, scope, non-goals, invariants, failures, and qualities.
+- Turn outcomes into traceable requirements, scope, non-goals, invariants, failures, and quality attributes.
 - Build one authority map, which can include a one-way reference graph. Give every normative fact
   one owner; derived artifacts reference it.
-- Start a claim ledger: `proposed`, `theory-supported`, `confirmed-narrowly`, `conformance-proven`,
-  `production-proven`, `open`, and `non-claim`.
+- Preserve each supplied claim's source and identifier. Keep artifact or decision lifecycle status
+  separate from claim evidence state. Reuse the repository's claim evidence field when its meaning
+  matches the distinctions below; do not add a second field for claim evidence state. Record an explicit mapping when the names differ.
+- If no claim evidence field exists, start a claim evidence ledger: `proposed`, `theory-supported`,
+  `confirmed-narrowly`, `conformance-proven`, `production-proven`, `open`, and `non-claim`.
+- For iterative work or handoff, give each new driver, claim, and decision a stable identifier that
+  follows repository conventions. Report added, changed, and retired identifiers.
 
 ### 2. Ground the abstractions
 
@@ -70,6 +90,8 @@ without redesign or edits unless the user requests them.
 ### 4. Design seams and alternatives
 
 - Compare at least the selected design, a credible alternative, and the simplest non-adoption path.
+- Design only enough structure to discriminate the load-bearing claim. Treat detailed
+  responsibility and module placement as separate structural decisions unless they are under test.
 - Define ownership, lifecycle, identity, extension, failure, and observability boundaries.
 - Ask whether two independent implementations could both satisfy the prose yet produce different
   observable behavior. If yes, the contract is incomplete.
@@ -86,25 +108,59 @@ without redesign or edits unless the user requests them.
 ### 6. Synthesize dogfooding and iterate
 
 - Classify design effect as `confirmed-no-change`, `refined-adopted`, `gap-opened`, or
-  `no-design-effect`; then update claim maturity separately.
+  `no-design-effect`; then update claim evidence state separately.
 - Attribute defects to the narrowest honest layer: instance/configuration → template/profile →
   extension module/package → framework/schema → irreducible kernel.
 - Update each owning artifact once; remove duplicated normative restatements. Preserve research at a
   fixed reference and promote only durable scenarios, executable conformance cases, or decisions into authority.
+- For each adopted refinement or open gap, report the effect on architecture drivers, constraints,
+  and structural decisions. This lets later work revisit only the affected scope.
 - Stop disposable prototyping when the risk class is resolved. Move remaining proof into permanent
   conformance assets and end-to-end production slices.
 
-### 7. Run design-axis and cross-cutting-quality gates
+### 7. Run design-axis and quality-attribute gates
+
+Treat specialized criteria supplied by a candidate architecture as structural evaluation criteria,
+not acceptance criteria. Bind each criterion to an authoritative requirement, specification,
+decision record, or explicitly scoped architecture contract before using it. Requirements retain
+ownership of acceptance criteria. Use the generic axes below to assess evidence coverage and
+unresolved interactions, not to replace the bound criteria.
 
 - **Abstraction:** theory-grounded boundaries hide implementation choices without hiding semantics.
 - **Completeness:** every known requirement, refusal, interaction, and operational concern maps to a
   mechanism plus an observable verification path.
-- **Orthogonality:** independent concerns have separate owners; their intersections and ordering are
-  explicitly closed and tested.
+- **Orthogonality:** use an **orthogonal basis** as a system metaphor for the load-bearing concerns.
+  Completeness checks whether these concerns cover the current claim scope. Orthogonality checks
+  whether each concern is necessary and non-overlapping. Each concern must have a distinct meaning
+  and reason to change, and it must vary independently. Test their composition for hidden shared
+  state, cross-product effects, and unspecified precedence.
 - **Extensibility:** declared variation enters through extension contracts; an out-of-family witness
   must not require core or host-dispatch changes.
 - Use REFERENCE.md's detailed delivery gates, including migration, security, observability, recovery,
   rollout, and rollback proportional to the real installed base.
+
+## Output
+
+Select the output contract by mode:
+
+- For `full-design`, include all applicable items below.
+- For `lightweight`, return the mode minimum and only the items produced by the selected bounded
+  check. Do not add alternatives, structural-placement decisions, or adopted refinements unless the
+  check required them.
+- For `audit-only`, return the pinned baseline and scope, authorities, observed architecture direction
+  and claims, evidence gaps, design-axis findings, findings about cross-cutting quality attributes, completion
+  gaps, and recorded human decision outcome. Do not propose alternatives, structural placements,
+  refinements, or edits unless the user requests redesign or edits.
+
+The `full-design` output includes:
+
+1. Authority sources, assumptions, and open input conflicts.
+2. Goals, non-goals, architecture drivers, invariants, and quality attributes.
+3. The selected architecture direction and the alternatives considered.
+4. Load-bearing mechanisms, semantic boundaries, claims, claim evidence states, evidence, and non-claims.
+5. Decisions that require concrete structural placement, with stable identifiers for iterative work or handoff.
+6. Validation results, adopted refinements, open gaps, and affected authoritative artifacts.
+7. Remaining gates and the required human decision.
 
 ## Completion
 


### PR DESCRIPTION
## Summary

- add a framework-independent modular-architecture design skill with DDD as its boundary and evolution theory, not a required pattern catalog
- preserve existing context, glossary, architecture, and decision artifacts before deriving a model
- provide a usable default topology, project-specific naming choices, one-way dependencies, and indirect upward communication
- review architectures for completeness, orthogonality, single knowledge authority, and evidence-based extensibility

## Validation

- external `skill-creator/scripts/quick_validate.py` validator: passed; this validator is not part of the repository
- `git diff --check`: passed
- verified that the skill contains no TODOs or Godot-specific terms
