### PR TITLE
docs(skills): coordinate architecture design workflows

### DIFF
--- a/.agents/skills/design-domain-modular-architecture/SKILL.md
+++ b/.agents/skills/design-domain-modular-architecture/SKILL.md
@@ -76,8 +76,8 @@ Establish only the facts that can change the design:
 - The rules, state, and invariants that carry domain complexity.
 - The scope in which each model and language applies.
 - The architecture drivers, load-bearing mechanisms, and semantic boundaries.
-- The supplied claims, evidence, assumptions, open questions, and claim evidence states. A claim evidence state classifies evidence strength or an explicit scope boundary.
-  Use project values and ordering when supplied; otherwise, use `open` for a claim that needs evidence and do not define a broader ladder here.
+- The supplied claims, evidence, assumptions, open questions, and claim evidence states. A claim evidence state classifies evidence strength or an explicit scope boundary, not artifact or decision lifecycle status. Reuse project values and ordering only when the project explicitly classifies them as claim evidence states; never copy lifecycle status into this field.
+  If no such vocabulary exists, record `open`, meaning that the available evidence does not establish the claim at its required scope. Record evidence separately; do not invent or infer a stronger state or ordering.
 - The capabilities that need independent reuse, testing, deployment, or evolution.
 - The observed variation points, team size, change rate, and maintenance budget.
 

--- a/.agents/skills/design-domain-modular-architecture/SKILL.md
+++ b/.agents/skills/design-domain-modular-architecture/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: design-domain-modular-architecture
 description: >-
-  Design and review framework-independent, domain-centered modular architectures.
-  Turn available domain context and architecture constraints into module boundaries, ownership, dependencies, communication, and evolution paths. Use when
-  structuring or modularizing a system, assigning responsibilities, reviewing coupling,
-  or planning an incremental structural change. Prefer this skill when no project- or framework-specific modular topology governs the primary structure.
+  Design and review domain-centered modular architectures for software systems.
+  Turn available domain context, architecture direction, and project constraints into module boundaries, ownership, dependencies, communication, and evolution paths.
+  Use when structuring or modularizing a system, assigning responsibilities, reviewing coupling,
+  adapting an existing topology, or planning an incremental structural change.
 ---
 
 # Design Domain Modular Architecture
@@ -30,10 +30,10 @@ For analysis or review-only work, describe the observed architecture and report
 verified findings. Recommend a change only when evidence shows that the current design
 does not meet the applicable criteria.
 
-Use the default topology in this skill only when no project- or framework-specific
-modular topology already governs the system. When one exists, preserve its module names
-and dependency rules. Use the DDD guidance here to judge language, ownership, and
-evolution within those boundaries.
+Apply this method to any modular structure. When the project already defines a topology,
+treat its module names, dependency rules, and composition mechanisms as current constraints.
+Review them against the current goal and structural criteria. Recommend evidence-supported changes when they no longer fit.
+Use the default topology only when no governing topology exists; do not silently replace an existing topology with it.
 
 ## Respect Existing Project Authority
 
@@ -42,7 +42,7 @@ already govern language and architecture. These can include:
 
 - Repository and directory instructions.
 - Context maps and context documents.
-- Glossaries and ubiquitous-language documents.
+- Glossaries and documents that define the Ubiquitous Language.
 - Architecture documents and ADRs.
 - Requirements, specifications, and design documents.
 - Module manifests, public interfaces, tests, and code conventions.

--- a/.agents/skills/design-domain-modular-architecture/SKILL.md
+++ b/.agents/skills/design-domain-modular-architecture/SKILL.md
@@ -2,7 +2,7 @@
 name: design-domain-modular-architecture
 description: >-
   Design and review domain-centered modular architectures for software systems.
-  Turn available domain context, architecture direction, and project constraints into module boundaries, ownership, dependencies, communication, and evolution paths.
+  Turn the applicable domain model, architecture direction, and project constraints into module boundaries, ownership, dependencies, communication, and evolution paths.
   Use when structuring or modularizing a system, assigning responsibilities, reviewing coupling,
   adapting an existing topology, or planning an incremental structural change.
 ---
@@ -30,8 +30,7 @@ For analysis or review-only work, describe the observed architecture and report
 verified findings. Recommend a change only when evidence shows that the current design
 does not meet the applicable criteria.
 
-Apply this method to any modular structure. When the project already defines a topology,
-treat its module names, dependency rules, and composition mechanisms as current constraints.
+Apply this method to any modular structure. Treat an existing topology, its module names, dependency rules, and composition mechanisms as current constraints.
 Review them against the current goal and structural criteria. Recommend evidence-supported changes when they no longer fit.
 Use the default topology only when no governing topology exists; do not silently replace an existing topology with it.
 
@@ -77,7 +76,8 @@ Establish only the facts that can change the design:
 - The rules, state, and invariants that carry domain complexity.
 - The scope in which each model and language applies.
 - The architecture drivers, load-bearing mechanisms, and semantic boundaries.
-- The supplied claims, claim evidence states, evidence, assumptions, and open questions.
+- The supplied claims, evidence, assumptions, open questions, and claim evidence states. A claim evidence state classifies evidence strength or an explicit scope boundary.
+  Use project values and ordering when supplied; otherwise, use `open` for a claim that needs evidence and do not define a broader ladder here.
 - The capabilities that need independent reuse, testing, deployment, or evolution.
 - The observed variation points, team size, change rate, and maintenance budget.
 
@@ -374,21 +374,21 @@ structure. It does not define the experiment charter, claim evidence state, or a
 
 1. Define the current goal, evidence, constraints, success conditions, and excluded scope.
 2. Read the existing domain, language, architecture, and decision artifacts.
-3. Identify the applicable domain model, architecture drivers, invariants, selected mechanisms, assumptions, and open claims.
+3. Identify the applicable domain model, architecture drivers, invariants, load-bearing mechanisms, assumptions, and open claims.
 4. Map each required capability, rule, state, use case, and external effect to an owner.
 5. Choose module and context boundaries, topology, and project-appropriate names.
 6. For design work, recommend one concrete module tree and give representative contents for each area. For review-only work, record the observed tree and verified findings.
 7. Trace source dependencies and downward, upward, and horizontal communication.
 8. Add only the DDD building blocks and communication mechanisms that solve observed problems.
 9. Review structural completeness, orthogonality, DRY, and extensibility.
-10. Link each load-bearing structural claim to its driver or invariant, module decision, claim evidence state, evidence, disconfirming condition, and unresolved validation need.
+10. Link each load-bearing structural claim to its driver or invariant and module decision. Record its claim evidence state, evidence, disconfirming condition, and unresolved validation need.
     For iterative work or handoff, use stable repository-native identifiers and report added, changed, and retired identifiers.
     For design work or accepted changes, also plan reversible migration slices and reconcile affected artifacts; otherwise stop.
 
 ## Review the Architecture
 
 These checks evaluate structural fitness. Preserve the artifact lifecycle status, claim evidence state, and evidence from authoritative inputs.
-Treat an unsupported conclusion as a structural claim that still requires validation; do not increase its claim evidence state.
+Treat an unsupported conclusion as a structural claim that still requires validation; do not advance its claim evidence state.
 
 ### Completeness
 
@@ -475,13 +475,13 @@ extension seams only for changes the current evidence supports.
 
 Return only the sections needed for the request, but keep the result concrete. Include:
 
-1. Domain and architecture authority sources, constraints, assumptions, and preserved artifact or decision lifecycle status and claim evidence state.
+1. Domain and architecture authority sources, constraints, and assumptions. Preserve artifact or decision lifecycle status and claim evidence state.
 2. A recommended architecture profile, module tree, and exact local names for design work, or the observed architecture and verified findings for review-only work.
 3. The mapping from architecture drivers, invariants, and capabilities to responsibility and knowledge owners.
 4. Source dependencies and downward, upward, and horizontal communication.
 5. Important domain terms, model boundaries, and DDD choices.
 6. Findings from the structural completeness, orthogonality, DRY, and extensibility checks.
-7. Load-bearing structural claims linked to their drivers or invariants, module decisions, claim evidence states, evidence, disconfirming conditions, and open validation questions.
+7. Load-bearing structural claims linked to their drivers or invariants and module decisions. For each claim, include its claim evidence state, evidence, disconfirming condition, and open validation questions.
    Use stable identifiers for iterative work or handoff.
 8. For design work or accepted changes, incremental implementation, validation needs, and affected project artifacts; otherwise, validation needs and the retained architecture.
 

--- a/.agents/skills/design-domain-modular-architecture/SKILL.md
+++ b/.agents/skills/design-domain-modular-architecture/SKILL.md
@@ -77,12 +77,12 @@ Establish only the facts that can change the design:
 - The rules, state, and invariants that carry domain complexity.
 - The scope in which each model and language applies.
 - The architecture drivers, load-bearing mechanisms, and semantic boundaries.
-- The supplied claims, claim status, evidence, assumptions, and open questions.
+- The supplied claims, claim evidence states, evidence, assumptions, and open questions.
 - The capabilities that need independent reuse, testing, deployment, or evolution.
 - The observed variation points, team size, change rate, and maintenance budget.
 
-Ask only questions whose answers would materially change the architecture. Continue with explicit,
-reasonable assumptions for the rest. Preserve any supplied source, identifier, claim status, and evidence for each structure-sensitive input.
+Ask only questions whose answers would materially change the architecture. Continue with explicit assumptions for the rest.
+Preserve each structure-sensitive input's source, identifier, artifact or decision lifecycle status, claim evidence state, and evidence.
 
 ## Start with a Usable Default
 
@@ -355,8 +355,7 @@ Establish only the large-scale rules needed now. Change module boundaries when n
 domain knowledge or implementation evidence shows that the current structure no longer
 expresses the model, duplicates ownership, or obstructs common changes.
 
-When new evidence changes an architecture driver, domain meaning, invariant, or claim status,
-revisit only the affected module boundaries and their dependents. Preserve unaffected owners and contracts.
+When new evidence changes an architecture driver, domain meaning, invariant, or claim evidence state, revisit only the affected module boundaries and their dependents. Preserve unaffected owners and contracts.
 
 Do not preserve an obsolete plan only because it was defined early. Do not add a
 speculative extension point to prepare for an unverified future.
@@ -369,7 +368,7 @@ let production depend on experiments. Before promotion, classify each accepted
 responsibility, move or reimplement it under the correct owner, and add its tests.
 
 This section governs only placement, dependency direction, and promotion into the modular
-structure. It does not define the experiment charter, claim status, or acceptance decision.
+structure. It does not define the experiment charter, claim evidence state, or acceptance decision.
 
 ## Workflow
 
@@ -382,13 +381,14 @@ structure. It does not define the experiment charter, claim status, or acceptanc
 7. Trace source dependencies and downward, upward, and horizontal communication.
 8. Add only the DDD building blocks and communication mechanisms that solve observed problems.
 9. Review structural completeness, orthogonality, DRY, and extensibility.
-10. Report load-bearing structural claims, disconfirming conditions, and unresolved validation needs.
+10. Link each load-bearing structural claim to its driver or invariant, module decision, claim evidence state, evidence, disconfirming condition, and unresolved validation need.
+    For iterative work or handoff, use stable repository-native identifiers and report added, changed, and retired identifiers.
     For design work or accepted changes, also plan reversible migration slices and reconcile affected artifacts; otherwise stop.
 
 ## Review the Architecture
 
-These checks evaluate structural fitness. Preserve the claim status and evidence supplied by authoritative
-inputs. Treat an unsupported conclusion as a structural claim that still requires validation; do not increase its claim status.
+These checks evaluate structural fitness. Preserve the artifact lifecycle status, claim evidence state, and evidence from authoritative inputs.
+Treat an unsupported conclusion as a structural claim that still requires validation; do not increase its claim evidence state.
 
 ### Completeness
 
@@ -475,13 +475,14 @@ extension seams only for changes the current evidence supports.
 
 Return only the sections needed for the request, but keep the result concrete. Include:
 
-1. Domain and architecture authority sources, constraints, assumptions, and preserved claim status.
+1. Domain and architecture authority sources, constraints, assumptions, and preserved artifact or decision lifecycle status and claim evidence state.
 2. A recommended architecture profile, module tree, and exact local names for design work, or the observed architecture and verified findings for review-only work.
 3. The mapping from architecture drivers, invariants, and capabilities to responsibility and knowledge owners.
 4. Source dependencies and downward, upward, and horizontal communication.
 5. Important domain terms, model boundaries, and DDD choices.
 6. Findings from the structural completeness, orthogonality, DRY, and extensibility checks.
-7. Load-bearing structural claims, disconfirming conditions, and unresolved validation questions.
+7. Load-bearing structural claims linked to their drivers or invariants, module decisions, claim evidence states, evidence, disconfirming conditions, and open validation questions.
+   Use stable identifiers for iterative work or handoff.
 8. For design work or accepted changes, incremental implementation, validation needs, and affected project artifacts; otherwise, validation needs and the retained architecture.
 
 For design work, if several solutions remain valid, recommend one first. State the conditions under which another solution would become better.

--- a/.agents/skills/design-domain-modular-architecture/SKILL.md
+++ b/.agents/skills/design-domain-modular-architecture/SKILL.md
@@ -1,15 +1,20 @@
 ---
 name: design-domain-modular-architecture
-description: Design and review framework-independent, domain-centered modular software architectures with domain models as the basis for boundaries, ownership, dependencies, and evolution. Use when no project- or framework-specific modular topology governs the primary structure, or to reason about domain boundaries within an existing topology while structuring a new system, modularizing a codebase, reviewing coupling, or planning an incremental architecture change.
+description: >-
+  Design and review framework-independent, domain-centered modular architectures.
+  Turn available domain context and architecture constraints into module boundaries, ownership, dependencies, communication, and evolution paths. Use when
+  structuring or modularizing a system, assigning responsibilities, reviewing coupling,
+  or planning an incremental structural change. Prefer this skill when no project- or framework-specific modular topology governs the primary structure.
 ---
 
 # Design Domain Modular Architecture
 
 ## Goal
 
-Design the smallest usable architecture that gives the current system complete and
-distinct responsibilities, one authority for each rule, one-way dependencies, and
-clear extension paths.
+Translate the current architecture direction and applicable domain model into the
+smallest usable modular structure. Give the current system complete and distinct
+responsibilities, one authority for each rule, one-way dependencies, and clear
+extension paths.
 
 Use Domain-Driven Design (DDD) as the theoretical basis for judging module boundaries
 and evolution. Do not treat it as a set of patterns that every project must implement.
@@ -32,7 +37,7 @@ evolution within those boundaries.
 
 ## Respect Existing Project Authority
 
-Before defining a domain model or naming modules, inspect the project artifacts that
+Before assigning module or context boundaries, inspect the project artifacts that
 already govern language and architecture. These can include:
 
 - Repository and directory instructions.
@@ -57,10 +62,10 @@ Do not infer a DDD meaning from a filename alone. For example, a file named
 Report conflicts between authoritative artifacts and explain their architecture
 impact. Do not hide a conflict by selecting one source without explanation.
 
-When the project has no relevant artifacts, derive the smallest useful language and
-model from the request, code, tests, and examples. Mark facts that cannot be verified
-as assumptions. Do not require a new glossary, context map, or ADR unless the user asks
-for one or the change needs a durable decision record.
+When the applicable domain artifacts are absent or materially inconsistent, report the
+gap and continue only with explicit assumptions agreed with the user. Do not invent
+domain knowledge from directory or code structure. Require a new glossary, context map,
+or ADR only when the user asks for one or the change needs a durable decision record.
 
 ## Frame the System
 
@@ -71,11 +76,13 @@ Establish only the facts that can change the design:
 - The databases, frameworks, operating systems, and external services involved.
 - The rules, state, and invariants that carry domain complexity.
 - The scope in which each model and language applies.
+- The architecture drivers, load-bearing mechanisms, and semantic boundaries.
+- The supplied claims, claim status, evidence, assumptions, and open questions.
 - The capabilities that need independent reuse, testing, deployment, or evolution.
 - The observed variation points, team size, change rate, and maintenance budget.
 
-Ask only questions whose answers would materially change the architecture. Continue
-with explicit, reasonable assumptions for the rest.
+Ask only questions whose answers would materially change the architecture. Continue with explicit,
+reasonable assumptions for the rest. Preserve any supplied source, identifier, claim status, and evidence for each structure-sensitive input.
 
 ## Start with a Usable Default
 
@@ -348,6 +355,9 @@ Establish only the large-scale rules needed now. Change module boundaries when n
 domain knowledge or implementation evidence shows that the current structure no longer
 expresses the model, duplicates ownership, or obstructs common changes.
 
+When new evidence changes an architecture driver, domain meaning, invariant, or claim status,
+revisit only the affected module boundaries and their dependents. Preserve unaffected owners and contracts.
+
 Do not preserve an obsolete plan only because it was defined early. Do not add a
 speculative extension point to prepare for an unverified future.
 
@@ -358,24 +368,27 @@ need looser internal rules. Allow experiments to depend on production modules; n
 let production depend on experiments. Before promotion, classify each accepted
 responsibility, move or reimplement it under the correct owner, and add its tests.
 
+This section governs only placement, dependency direction, and promotion into the modular
+structure. It does not define the experiment charter, claim status, or acceptance decision.
+
 ## Workflow
 
 1. Define the current goal, evidence, constraints, success conditions, and excluded scope.
-2. Read the existing context, language, architecture, and decision artifacts.
-3. Confirm the needed domain model and identify the owners of rules, state, invariants,
-   use cases, and external effects.
-4. Choose module boundaries, topology, and project-appropriate names.
-5. For design work, recommend one concrete module tree and give representative contents
-   for each area. For review-only work, record the observed tree and verified findings.
-6. Trace source dependencies and downward, upward, and horizontal communication.
-7. Add only the DDD building blocks and communication mechanisms that solve observed
-   problems.
-8. Review completeness, orthogonality, DRY, and extensibility.
-9. For design work or accepted changes, plan reversible migration slices, validation,
-   and reconciliation of affected project artifacts. Otherwise, report validation and
-   stop.
+2. Read the existing domain, language, architecture, and decision artifacts.
+3. Identify the applicable domain model, architecture drivers, invariants, selected mechanisms, assumptions, and open claims.
+4. Map each required capability, rule, state, use case, and external effect to an owner.
+5. Choose module and context boundaries, topology, and project-appropriate names.
+6. For design work, recommend one concrete module tree and give representative contents for each area. For review-only work, record the observed tree and verified findings.
+7. Trace source dependencies and downward, upward, and horizontal communication.
+8. Add only the DDD building blocks and communication mechanisms that solve observed problems.
+9. Review structural completeness, orthogonality, DRY, and extensibility.
+10. Report load-bearing structural claims, disconfirming conditions, and unresolved validation needs.
+    For design work or accepted changes, also plan reversible migration slices and reconcile affected artifacts; otherwise stop.
 
 ## Review the Architecture
+
+These checks evaluate structural fitness. Preserve the claim status and evidence supplied by authoritative
+inputs. Treat an unsupported conclusion as a structural claim that still requires validation; do not increase its claim status.
 
 ### Completeness
 
@@ -462,19 +475,16 @@ extension seams only for changes the current evidence supports.
 
 Return only the sections needed for the request, but keep the result concrete. Include:
 
-1. Current constraints, assumptions, and the authority sources consulted.
-2. A recommended architecture profile, module tree, and exact local names for design
-   work, or the observed architecture and verified findings for review-only work.
-3. Responsibility placement, capability ownership, and authoritative sources for shared
-   rules and knowledge.
+1. Domain and architecture authority sources, constraints, assumptions, and preserved claim status.
+2. A recommended architecture profile, module tree, and exact local names for design work, or the observed architecture and verified findings for review-only work.
+3. The mapping from architecture drivers, invariants, and capabilities to responsibility and knowledge owners.
 4. Source dependencies and downward, upward, and horizontal communication.
 5. Important domain terms, model boundaries, and DDD choices.
-6. Findings from the completeness, orthogonality, DRY, and extensibility checks.
-7. For design work or accepted changes, incremental implementation, validation, and
-   affected project artifacts; otherwise, validation and the retained architecture.
+6. Findings from the structural completeness, orthogonality, DRY, and extensibility checks.
+7. Load-bearing structural claims, disconfirming conditions, and unresolved validation questions.
+8. For design work or accepted changes, incremental implementation, validation needs, and affected project artifacts; otherwise, validation needs and the retained architecture.
 
-For design work, if several solutions remain valid, recommend one first. State the
-conditions under which another solution would become better.
+For design work, if several solutions remain valid, recommend one first. State the conditions under which another solution would become better.
 
 ## Avoid Overdesign
 

--- a/.agents/skills/design-domain-modular-architecture/agents/openai.yaml
+++ b/.agents/skills/design-domain-modular-architecture/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Design Domain Modular Architecture"
   short_description: "Design framework-independent domain module boundaries"
-  default_prompt: "Use $design-domain-modular-architecture to design or review framework-independent, domain-centered module boundaries and dependencies."
+  default_prompt: "Use $design-domain-modular-architecture to turn domain context and architecture constraints into module boundaries, ownership, dependencies, and communication."

--- a/.agents/skills/design-domain-modular-architecture/agents/openai.yaml
+++ b/.agents/skills/design-domain-modular-architecture/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Design Domain Modular Architecture"
-  short_description: "Design framework-independent domain module boundaries"
+  short_description: "Design domain-centered modular architectures"
   default_prompt: "Use $design-domain-modular-architecture to turn domain context and architecture constraints into module boundaries, ownership, dependencies, and communication."

--- a/.agents/skills/design-domain-modular-architecture/agents/openai.yaml
+++ b/.agents/skills/design-domain-modular-architecture/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Design Domain Modular Architecture"
   short_description: "Design domain-centered modular architectures"
-  default_prompt: "Use $design-domain-modular-architecture to turn domain context and architecture constraints into module boundaries, ownership, dependencies, and communication."
+  default_prompt: "Use $design-domain-modular-architecture to turn an applicable domain model, architecture direction, and project constraints into module boundaries, ownership, dependencies, and communication."

--- a/.agents/skills/validation-driven-design/EXAMPLES.md
+++ b/.agents/skills/validation-driven-design/EXAMPLES.md
@@ -26,6 +26,10 @@ peer authority merely because its terminology is reused.
 
 ### 3. Iterative probes
 
+The selected direction is translated into a concrete module structure. That structural pass returns
+claims about responsibility ownership, dependency direction, and extension boundaries. The probes
+below test those claims; an adopted refinement changes only the affected structural decisions.
+
 1. An end-to-end slice compiles one policy, runs it, and publishes an audit. It confirms connectivity
    but exposes ambiguous refusal staging and identity.
 2. Two independent runtimes consume each other's canonical artifacts. A mutation test reveals one

--- a/.agents/skills/validation-driven-design/REFERENCE.md
+++ b/.agents/skills/validation-driven-design/REFERENCE.md
@@ -6,7 +6,7 @@ owns the design workflow; this file does not restate it.
 Contents: [modes and authority](#1-engagement-modes-and-authority-map) ·
 [claims](#2-claim-evidence-ladder) · [theory](#3-theory-support-matrix) ·
 [external research](#4-external-system-research-matrix) · [validation](#5-validation-portfolio) ·
-[quality gates](#6-four-design-axes-and-cross-cutting-qualities) ·
+[quality gates](#6-four-design-axes-and-cross-cutting-quality-attributes) ·
 [defect attribution](#7-defect-attribution-ladder) · [delivery](#8-delivery-gates-and-production-planning) ·
 [completion](#9-completion-audit)
 
@@ -18,7 +18,7 @@ Choose mode before building the authority map:
 | --- | --- | --- |
 | `lightweight` | a bounded, reversible decision can be owned by one compact decision record and does not change a public contract, extension contract, or production boundary | owner, requirement/decision, falsifier, affected axes, one discriminating check, non-claims, and human decision gate |
 | `full-design` | a framework/language/runtime or broad, hard-to-reverse claim changes authority, semantics, extension, or production boundaries | the complete workflow, matrices, proof obligations, and delivery gates |
-| `audit-only` | fixed existing artifacts and claims must be evaluated without redesign | fixed baseline/scope, authority and claim audit, design-axis and cross-cutting-quality findings, completion gaps, and recorded human decision outcome; no edits unless requested |
+| `audit-only` | fixed existing artifacts and claims must be evaluated without redesign | fixed baseline/scope, authority and claim audit, design-axis findings, findings about cross-cutting quality attributes, completion gaps, and recorded human decision outcome; no edits unless requested |
 
 Every mode keeps explicit authority, falsifier, non-claims, and human decision ownership. Scale the
 remaining evidence work to claim breadth, reversibility, novelty, and operational risk.
@@ -186,10 +186,10 @@ Run another disposable prototype only when the design adds or changes normative 
 extension contract, an authority owner or binding, or a comparably high-risk uncertainty. Otherwise
 move to permanent executable conformance cases and end-to-end production slices.
 
-## 6. Four design axes and cross-cutting qualities
+## 6. Four design axes and cross-cutting quality attributes
 
-The four axes assess design structure. Consistency, reliability, and operability apply across every
-axis; they are not additional peers in the design-axis taxonomy.
+The four axes assess design structure. Consistency, reliability, and operability are quality
+attributes that apply across every axis; they are not additional peers in the design-axis taxonomy.
 
 | Axis | Required questions | Strong evidence | Failure signal |
 | --- | --- | --- | --- |
@@ -198,8 +198,9 @@ axis; they are not additional peers in the design-axis taxonomy.
 | Orthogonality | Does each concern in the selected orthogonal basis have a distinct meaning and reason to change? Is it necessary, non-overlapping, and independently variable? Does composition preserve this independence? | vary one concern while other observations stay fixed; pairwise and cross-product cases; explicit precedence where order matters | a concern can be removed without loss; changing one concern changes unrelated concerns; composition shares hidden state or leaves precedence to the host |
 | Extensibility | What is configuration, extension, framework evolution, or irreducible core? Can an out-of-family case use unchanged core and dispatch? | explicit extension invariance; fixed-build witness; negative capability/refusal cases | each new domain adds core fields, phases, switches, callbacks, or parallel semantics |
 
-When a candidate architecture defines specialized structural criteria, bind evidence to those
-criteria. Use this table as the default coverage check, not as a parallel structural standard.
+Apply the authority rule in [SKILL.md §7](SKILL.md#7-run-design-axis-and-quality-attribute-gates) to
+specialized structural evaluation criteria. Use this table as the default coverage check, not as a
+parallel structural standard.
 
 Also audit consistency, reliability, and operability:
 

--- a/.agents/skills/validation-driven-design/REFERENCE.md
+++ b/.agents/skills/validation-driven-design/REFERENCE.md
@@ -60,11 +60,12 @@ For each fact, mark exactly one authoritative source and every derived copy. Pre
 reference over restating a list, algorithm, count, precedence rule, or state machine. Reconcile the
 pinned current artifact revision and any live coordination state after each design iteration.
 
-## 2. Claim and evidence ladder
+## 2. Claim evidence ladder
 
-Use exact, bounded language:
+A claim evidence state records evidence strength or an explicit scope boundary. It is separate from
+an artifact or decision lifecycle status. Use exact, bounded language:
 
-| State | Meaning | Sufficient evidence |
+| Claim evidence state | Meaning | Sufficient evidence |
 | --- | --- | --- |
 | `proposed` | a candidate mechanism | rationale only |
 | `theory-supported` | established theory explains why the mechanism should work | explicit theory-to-invariant mapping and proof boundary |
@@ -86,8 +87,8 @@ Dogfooding uses a separate disposition namespace:
 | `gap-opened` | the observation exposed an unresolved defect, ambiguity, or evidence gate |
 | `no-design-effect` | the observation was instance-local, out of claim scope, or required no normative change |
 
-After recording the disposition, set the affected claim to the applicable maturity state above.
-Never reuse a claim-state label as a dogfooding disposition.
+After recording the disposition, set the affected claim to the applicable claim evidence state above.
+Never reuse a claim evidence state as a dogfooding disposition.
 
 ## 3. Theory-support matrix
 

--- a/.agents/skills/validation-driven-design/REFERENCE.md
+++ b/.agents/skills/validation-driven-design/REFERENCE.md
@@ -4,7 +4,7 @@ Use this file for detailed templates, proof obligations, and delivery gates. `SK
 owns the design workflow; this file does not restate it.
 
 Contents: [modes and authority](#1-engagement-modes-and-authority-map) ·
-[claims](#2-claim-and-evidence-ladder) · [theory](#3-theory-support-matrix) ·
+[claims](#2-claim-evidence-ladder) · [theory](#3-theory-support-matrix) ·
 [external research](#4-external-system-research-matrix) · [validation](#5-validation-portfolio) ·
 [quality gates](#6-four-design-axes-and-cross-cutting-qualities) ·
 [defect attribution](#7-defect-attribution-ladder) · [delivery](#8-delivery-gates-and-production-planning) ·

--- a/.agents/skills/validation-driven-design/REFERENCE.md
+++ b/.agents/skills/validation-driven-design/REFERENCE.md
@@ -23,8 +23,8 @@ Choose mode before building the authority map:
 Every mode keeps explicit authority, falsifier, non-claims, and human decision ownership. Scale the
 remaining evidence work to claim breadth, reversibility, novelty, and operational risk.
 
-`lightweight` is a ceiling as well as a minimum: start with one compact decision record and
-one discriminating check. Do not create theory/research matrices, a prototype portfolio, the full
+`lightweight` sets the minimum and maximum initial scope: start with one compact decision record
+and one discriminating check. Do not create theory/research matrices, a prototype portfolio, the full
 delivery sequence, or a full completion audit unless the falsifier exposes a specific need; state
 why before expanding. `audit-only` similarly reports only findings inside the pinned claimed scope.
 
@@ -39,7 +39,7 @@ Choose repository-native names, but preserve these ownership roles:
 | Requirements | user outcomes, scope, acceptance criteria, live completion | detailed architecture or evidence by assertion |
 | Architecture narrative | macro topology, responsibilities, cross-cutting invariants, delivery order | duplicate detailed decisions or machine semantics |
 | Decision records | one binding decision, alternatives, consequences, validation | status dashboard or broad narrative |
-| Glossary/context | canonical terms and distinctions | a second architecture specification |
+| Glossary/context | canonical domain terms, distinctions, and model scope | a second architecture specification |
 | Specification/standard | normative semantics, public contracts, conformance requirements, versioning, and designation of normative machine-readable artifacts | architecture rationale, implementation details, evidence, or acceptance state |
 | Executable conformance assets | machine-checkable schemas, executable conformance cases, validators, and observable oracles that realize or test the specification | an independent semantic authority or proof merely because tests pass |
 | Evidence record | prototype/research inputs, outputs, provenance, bounded conclusions | semantic authority or acceptance state |
@@ -126,6 +126,7 @@ Rules:
    otherwise record the evidence form that can discriminate the claim.
 5. Treat an external version change as a deliberate local design decision, never ambient drift.
 6. Compare with non-adoption: importing a standard can cost more authority and surface than it saves.
+7. Treat external systems as architecture evidence, not as authority for local domain meaning.
 
 ## 5. Validation portfolio
 
@@ -196,6 +197,9 @@ axis; they are not additional peers in the design-axis taxonomy.
 | Orthogonality | Does each concern have one owner and independent representation? Are cross-products and precedence closed? | mutation tests; pairwise/cross-product scenarios; canonical ordering/reducers | independent axes share hidden state or leave interaction order to the host |
 | Extensibility | What is configuration, extension, framework evolution, or irreducible core? Can an out-of-family case use unchanged core and dispatch? | explicit extension invariance; fixed-build witness; negative capability/refusal cases | each new domain adds core fields, phases, switches, callbacks, or parallel semantics |
 
+When a candidate architecture defines specialized structural criteria, bind evidence to those
+criteria. Use this table as the default coverage check, not as a parallel structural standard.
+
 Also audit consistency, reliability, and operability:
 
 - **Consistency:** one owner per fact; terminology, requirement, decision, specification, and live state agree.
@@ -228,7 +232,7 @@ This section exclusively owns the detailed default delivery sequence:
 2. **Permanent conformance foundation:** replace prototype-local authority with versioned rules,
    schemas, fixtures, negative/mutation conformance cases, and reusable harnesses.
 3. **Production end-to-end slice:** exercise the public API/artifact path end to end.
-4. **Known-domain breadth:** close the full requirements coverage matrix without parallel semantics.
+4. **Known-scenario breadth:** close the full requirements coverage matrix without parallel semantics.
 5. **Out-of-family witness:** prove the extension promise against a structurally different consumer.
 6. **Production rollout:** validate security, performance, capacity, observability, recovery,
    compatibility/migration, deployment, rollback, and operational ownership.

--- a/.agents/skills/validation-driven-design/REFERENCE.md
+++ b/.agents/skills/validation-driven-design/REFERENCE.md
@@ -138,7 +138,7 @@ Choose validation form by uncertainty:
 | layer connectivity/integration | smallest end-to-end slice |
 | semantic authority/portability | two independent interpreters or compilers consuming each other's artifacts |
 | state/lifecycle/order | executable state-machine or scheduler harness with boundary permutations |
-| orthogonality | add one independent axis, then exercise cross-products and mutation cases |
+| orthogonality | vary one concern while holding the others fixed, then test pairwise and cross-product compositions and ordering cases |
 | extensibility | add an out-of-family capability through public contracts with unchanged core/builds |
 | requirement breadth | research corpus mapped to the coverage matrix, explicitly non-conforming |
 | human interaction/usability | visual or interactive prototype |
@@ -195,7 +195,7 @@ axis; they are not additional peers in the design-axis taxonomy.
 | --- | --- | --- | --- |
 | Abstraction | What theory supports the model? Which semantics are public? Which implementation details may vary? | explicit semantic boundaries; preservation/refusal contracts; independent implementations | host behavior, serialization, framework, or optimizer becomes hidden authority |
 | Completeness | Do all known stories, failures, variants, interactions, operations, and production concerns map to observable contracts? | requirements-to-mechanism-to-scenario-to-conformance-case-to-observable matrix | vocabulary/package inventory presented as coverage; important paths only appear in prose |
-| Orthogonality | Does each concern have one owner and independent representation? Are cross-products and precedence closed? | mutation tests; pairwise/cross-product scenarios; canonical ordering/reducers | independent axes share hidden state or leave interaction order to the host |
+| Orthogonality | Does each concern in the selected orthogonal basis have a distinct meaning and reason to change? Is it necessary, non-overlapping, and independently variable? Does composition preserve this independence? | vary one concern while other observations stay fixed; pairwise and cross-product cases; explicit precedence where order matters | a concern can be removed without loss; changing one concern changes unrelated concerns; composition shares hidden state or leaves precedence to the host |
 | Extensibility | What is configuration, extension, framework evolution, or irreducible core? Can an out-of-family case use unchanged core and dispatch? | explicit extension invariance; fixed-build witness; negative capability/refusal cases | each new domain adds core fields, phases, switches, callbacks, or parallel semantics |
 
 When a candidate architecture defines specialized structural criteria, bind evidence to those

--- a/.agents/skills/validation-driven-design/SKILL.md
+++ b/.agents/skills/validation-driven-design/SKILL.md
@@ -48,7 +48,7 @@ conformance case and its minimum fields.
 3. Map load-bearing mechanisms to mature theory and external systems; record adoption and proof gaps.
 4. Rank architecture uncertainties and run only the smallest discriminating validation.
 5. Feed dogfooding back into requirements, decisions, terms, specifications, executable conformance cases, and gates.
-6. Audit the four design axes and cross-cutting qualities; keep non-claims explicit.
+6. Audit the four design axes and cross-cutting quality attributes; keep non-claims explicit.
 
 See [REFERENCE.md](REFERENCE.md) for templates and proof obligations, and [EXAMPLES.md](EXAMPLES.md).
 
@@ -62,7 +62,7 @@ without redesign or edits unless the user requests them.
 ### 1. Establish the design contract
 
 - Read repository guidance and current authoritative artifacts before proposing structure.
-- Turn outcomes into traceable requirements, scope, non-goals, invariants, failures, and qualities.
+- Turn outcomes into traceable requirements, scope, non-goals, invariants, failures, and quality attributes.
 - Build one authority map, which can include a one-way reference graph. Give every normative fact
   one owner; derived artifacts reference it.
 - Preserve each supplied claim's source and identifier. Keep artifact or decision lifecycle status
@@ -118,11 +118,13 @@ without redesign or edits unless the user requests them.
 - Stop disposable prototyping when the risk class is resolved. Move remaining proof into permanent
   conformance assets and end-to-end production slices.
 
-### 7. Run design-axis and cross-cutting-quality gates
+### 7. Run design-axis and quality-attribute gates
 
-When the candidate architecture supplies specialized structural criteria, use them as the acceptance
-criteria for the applicable claims. Use the generic axes below to assess evidence coverage and
-unresolved interactions, not to replace those criteria.
+Treat specialized criteria supplied by a candidate architecture as structural evaluation criteria,
+not acceptance criteria. Bind each criterion to an authoritative requirement, specification,
+decision record, or explicitly scoped architecture contract before using it. Requirements retain
+ownership of acceptance criteria. Use the generic axes below to assess evidence coverage and
+unresolved interactions, not to replace the bound criteria.
 
 - **Abstraction:** theory-grounded boundaries hide implementation choices without hiding semantics.
 - **Completeness:** every known requirement, refusal, interaction, and operational concern maps to a
@@ -139,10 +141,21 @@ unresolved interactions, not to replace those criteria.
 
 ## Output
 
-Return only the sections needed for the request, but preserve traceability. Include:
+Select the output contract by mode:
+
+- For `full-design`, include all applicable items below.
+- For `lightweight`, return the mode minimum and only the items produced by the selected bounded
+  check. Do not add alternatives, structural-placement decisions, or adopted refinements unless the
+  check required them.
+- For `audit-only`, return the pinned baseline and scope, authorities, observed architecture direction
+  and claims, evidence gaps, design-axis findings, findings about cross-cutting quality attributes, completion
+  gaps, and recorded human decision outcome. Do not propose alternatives, structural placements,
+  refinements, or edits unless the user requests redesign or edits.
+
+The `full-design` output includes:
 
 1. Authority sources, assumptions, and open input conflicts.
-2. Goals, non-goals, architecture drivers, invariants, and quality constraints.
+2. Goals, non-goals, architecture drivers, invariants, and quality attributes.
 3. The selected architecture direction and the alternatives considered.
 4. Load-bearing mechanisms, semantic boundaries, claims, claim evidence states, evidence, and non-claims.
 5. Decisions that require concrete structural placement, with stable identifiers for iterative work or handoff.

--- a/.agents/skills/validation-driven-design/SKILL.md
+++ b/.agents/skills/validation-driven-design/SKILL.md
@@ -44,7 +44,7 @@ conformance case and its minimum fields.
 ## Quick start
 
 1. Choose `lightweight`, `full-design`, or `audit-only` mode; name the artifact owners and human decision owner.
-2. Write goals, non-goals, invariants, quality attributes, and production constraints. Record the status of inputs and claims.
+2. Write goals, non-goals, invariants, quality attributes, and production constraints. Keep artifact and decision lifecycle status separate from claim evidence state.
 3. Map load-bearing mechanisms to mature theory and external systems; record adoption and proof gaps.
 4. Rank architecture uncertainties and run only the smallest discriminating validation.
 5. Feed dogfooding back into requirements, decisions, terms, specifications, executable conformance cases, and gates.
@@ -65,10 +65,13 @@ without redesign or edits unless the user requests them.
 - Turn outcomes into traceable requirements, scope, non-goals, invariants, failures, and qualities.
 - Build one authority map, which can include a one-way reference graph. Give every normative fact
   one owner; derived artifacts reference it.
-- Preserve the source, identifier, and maturity of each supplied claim. Classify unsupported input
-  as an explicit assumption or open question; do not create a parallel status system.
-- Start a claim ledger: `proposed`, `theory-supported`, `confirmed-narrowly`, `conformance-proven`,
-  `production-proven`, `open`, and `non-claim`.
+- Preserve each supplied claim's source and identifier. Keep artifact or decision lifecycle status
+  separate from claim evidence state. Reuse the repository's claim evidence field when its meaning
+  matches the distinctions below; do not write a second evidence-state field. Record an explicit mapping when the names differ.
+- If no claim evidence field exists, start a claim evidence ledger: `proposed`, `theory-supported`,
+  `confirmed-narrowly`, `conformance-proven`, `production-proven`, `open`, and `non-claim`.
+- For iterative work or handoff, give each new driver, claim, and decision a stable identifier that
+  follows repository conventions. Report added, changed, and retired identifiers.
 
 ### 2. Ground the abstractions
 
@@ -105,7 +108,7 @@ without redesign or edits unless the user requests them.
 ### 6. Synthesize dogfooding and iterate
 
 - Classify design effect as `confirmed-no-change`, `refined-adopted`, `gap-opened`, or
-  `no-design-effect`; then update claim maturity separately.
+  `no-design-effect`; then update claim evidence state separately.
 - Attribute defects to the narrowest honest layer: instance/configuration → template/profile →
   extension module/package → framework/schema → irreducible kernel.
 - Update each owning artifact once; remove duplicated normative restatements. Preserve research at a
@@ -138,8 +141,8 @@ Return only the sections needed for the request, but preserve traceability. Incl
 1. Authority sources, assumptions, and open input conflicts.
 2. Goals, non-goals, architecture drivers, invariants, and quality constraints.
 3. The selected architecture direction and the alternatives considered.
-4. Load-bearing mechanisms, semantic boundaries, claims, status, evidence, and non-claims.
-5. Decisions that require concrete structural placement.
+4. Load-bearing mechanisms, semantic boundaries, claims, claim evidence states, evidence, and non-claims.
+5. Decisions that require concrete structural placement, with stable identifiers for iterative work or handoff.
 6. Validation results, adopted refinements, open gaps, and affected authoritative artifacts.
 7. Remaining gates and the required human decision.
 

--- a/.agents/skills/validation-driven-design/SKILL.md
+++ b/.agents/skills/validation-driven-design/SKILL.md
@@ -127,8 +127,11 @@ unresolved interactions, not to replace those criteria.
 - **Abstraction:** theory-grounded boundaries hide implementation choices without hiding semantics.
 - **Completeness:** every known requirement, refusal, interaction, and operational concern maps to a
   mechanism plus an observable verification path.
-- **Orthogonality:** independent concerns have separate owners; their intersections and ordering are
-  explicitly closed and tested.
+- **Orthogonality:** use an **orthogonal basis** as a system metaphor for the load-bearing concerns.
+  Completeness checks whether these concerns cover the current claim scope. Orthogonality checks
+  whether each concern is necessary and non-overlapping. Each concern must have a distinct meaning
+  and reason to change, and it must vary independently. Test their composition for hidden shared
+  state, cross-product effects, and unspecified precedence.
 - **Extensibility:** declared variation enters through extension contracts; an out-of-family witness
   must not require core or host-dispatch changes.
 - Use REFERENCE.md's detailed delivery gates, including migration, security, observability, recovery,

--- a/.agents/skills/validation-driven-design/SKILL.md
+++ b/.agents/skills/validation-driven-design/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: validation-driven-design
-description: Designs, audits, and iteratively validates framework, platform, language, protocol, or runtime architectures by combining explicit requirements, mature theory, external-system research, executable prototypes, dogfooding, and cross-artifact reconciliation. Use when creating or redesigning an architecture, writing architecture specifications or decision records, auditing an existing architecture against abstraction/completeness/orthogonality/extensibility, or planning a design for production implementation.
+description: >-
+  Design, audit, and iteratively validate architecture direction under material
+  uncertainty. Use explicit requirements, mature theory, external-system research,
+  executable prototypes, dogfooding, and cross-artifact reconciliation. Use when a
+  decision is novel, disputed, broad, hard to reverse, or insufficiently supported.
+  Also use this skill to write an architecture specification or decision record, or to audit a
+  fixed architecture and its evidence.
 ---
 
 # Validation-Driven Design
@@ -10,6 +16,15 @@ description: Designs, audits, and iteratively validates framework, platform, lan
 Design an architecture under explicit requirements and specifications, then strengthen it through
 evidence-bearing iterations. This skill is for architecture creation, redesign, or architecture
 audit, not routine codebase refactoring, interface styling, generic review, or UI prototyping.
+
+Produce an evidence-bounded architecture direction. Include drivers, constraints, load-bearing
+mechanisms, semantic boundaries, claims, and validation gates. Do not expand into detailed module
+decomposition unless a claim under test requires it.
+
+Treat applicable context, glossary, requirements, and other domain artifacts as current inputs.
+Preserve their sources and established meanings. When they are absent or contradictory, record an
+explicit assumption or open question and coordinate with the user. Do not infer domain knowledge
+from technical theory, external systems, or a prototype.
 
 Preserve the stated product vision as a falsifiable requirement. If evidence contradicts it, reopen
 the architecture or requirement explicitly; never make the work “pass” by silently narrowing the
@@ -29,7 +44,7 @@ conformance case and its minimum fields.
 ## Quick start
 
 1. Choose `lightweight`, `full-design`, or `audit-only` mode; name the artifact owners and human decision owner.
-2. Write goals, non-goals, invariants, quality attributes, production constraints, and claim status.
+2. Write goals, non-goals, invariants, quality attributes, and production constraints. Record the status of inputs and claims.
 3. Map load-bearing mechanisms to mature theory and external systems; record adoption and proof gaps.
 4. Rank architecture uncertainties and run only the smallest discriminating validation.
 5. Feed dogfooding back into requirements, decisions, terms, specifications, executable conformance cases, and gates.
@@ -50,6 +65,8 @@ without redesign or edits unless the user requests them.
 - Turn outcomes into traceable requirements, scope, non-goals, invariants, failures, and qualities.
 - Build one authority map, which can include a one-way reference graph. Give every normative fact
   one owner; derived artifacts reference it.
+- Preserve the source, identifier, and maturity of each supplied claim. Classify unsupported input
+  as an explicit assumption or open question; do not create a parallel status system.
 - Start a claim ledger: `proposed`, `theory-supported`, `confirmed-narrowly`, `conformance-proven`,
   `production-proven`, `open`, and `non-claim`.
 
@@ -70,6 +87,8 @@ without redesign or edits unless the user requests them.
 ### 4. Design seams and alternatives
 
 - Compare at least the selected design, a credible alternative, and the simplest non-adoption path.
+- Design only enough structure to discriminate the load-bearing claim. Treat detailed
+  responsibility and module placement as separate structural decisions unless they are under test.
 - Define ownership, lifecycle, identity, extension, failure, and observability boundaries.
 - Ask whether two independent implementations could both satisfy the prose yet produce different
   observable behavior. If yes, the contract is incomplete.
@@ -91,10 +110,16 @@ without redesign or edits unless the user requests them.
   extension module/package → framework/schema → irreducible kernel.
 - Update each owning artifact once; remove duplicated normative restatements. Preserve research at a
   fixed reference and promote only durable scenarios, executable conformance cases, or decisions into authority.
+- For each adopted refinement or open gap, report the effect on architecture drivers, constraints,
+  and structural decisions. This lets later work revisit only the affected scope.
 - Stop disposable prototyping when the risk class is resolved. Move remaining proof into permanent
   conformance assets and end-to-end production slices.
 
 ### 7. Run design-axis and cross-cutting-quality gates
+
+When the candidate architecture supplies specialized structural criteria, use them as the acceptance
+criteria for the applicable claims. Use the generic axes below to assess evidence coverage and
+unresolved interactions, not to replace those criteria.
 
 - **Abstraction:** theory-grounded boundaries hide implementation choices without hiding semantics.
 - **Completeness:** every known requirement, refusal, interaction, and operational concern maps to a
@@ -105,6 +130,18 @@ without redesign or edits unless the user requests them.
   must not require core or host-dispatch changes.
 - Use REFERENCE.md's detailed delivery gates, including migration, security, observability, recovery,
   rollout, and rollback proportional to the real installed base.
+
+## Output
+
+Return only the sections needed for the request, but preserve traceability. Include:
+
+1. Authority sources, assumptions, and open input conflicts.
+2. Goals, non-goals, architecture drivers, invariants, and quality constraints.
+3. The selected architecture direction and the alternatives considered.
+4. Load-bearing mechanisms, semantic boundaries, claims, status, evidence, and non-claims.
+5. Decisions that require concrete structural placement.
+6. Validation results, adopted refinements, open gaps, and affected authoritative artifacts.
+7. Remaining gates and the required human decision.
 
 ## Completion
 

--- a/.agents/skills/validation-driven-design/SKILL.md
+++ b/.agents/skills/validation-driven-design/SKILL.md
@@ -67,7 +67,7 @@ without redesign or edits unless the user requests them.
   one owner; derived artifacts reference it.
 - Preserve each supplied claim's source and identifier. Keep artifact or decision lifecycle status
   separate from claim evidence state. Reuse the repository's claim evidence field when its meaning
-  matches the distinctions below; do not write a second evidence-state field. Record an explicit mapping when the names differ.
+  matches the distinctions below; do not add a second field for claim evidence state. Record an explicit mapping when the names differ.
 - If no claim evidence field exists, start a claim evidence ledger: `proposed`, `theory-supported`,
   `confirmed-narrowly`, `conformance-proven`, `production-proven`, `open`, and `non-claim`.
 - For iterative work or handoff, give each new driver, claim, and decision a stable identifier that


### PR DESCRIPTION
## Summary

- narrow `validation-driven-design` to evidence-bounded architecture direction and add a traceable output contract
- let `design-domain-modular-architecture` consume architecture drivers and return falsifiable structural claims
- keep both skills independent while allowing repeated direction, structure, validation, and revision cycles

## Independence and coordination

- neither skill names or requires the other
- VDD remains responsible for claim status, evidence, prototypes, and delivery gates
- DDMA remains responsible for module boundaries, ownership, dependencies, communication, and structural migration
- generic inputs and outputs support repeated direction -> structure -> validation -> revision cycles

This PR is stacked on #631. Retarget it to `main` after #631 merges.

## Validation

- `quick_validate.py` passed for both skills
- `git diff --check`
- terminology and prose review against ASD-STE100 Issue 9
- stale-term and explicit-coupling scans
