### PR TITLE
ci(balancing): run nightlies through shard matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ permissions:
   contents: read
 
 concurrency:
-  # Scheduled and manually requested unfiltered runs are evidence runs: a push
-  # must not cancel them merely because all three can target refs/heads/main.
-  # PR and push runs still replace stale runs for the same ref.
+  # Scheduled matrix runs and manually requested unfiltered runs are evidence
+  # runs: a push must not cancel them merely because all three can target
+  # refs/heads/main. PR and push runs still replace stale runs for the same ref.
   group: >-
     ${{
       github.workflow
@@ -409,13 +409,16 @@ jobs:
             fi
           done
 
-  balancing-nightly:
-    name: gda-balancing nightly unfiltered suite
+  # Scheduled runs already select the inventory-closed shard matrix above.
+  # Keep this single-process path only as an explicit diagnostic probe; making
+  # it a second nightly suite duplicates coverage and scales with total suite
+  # time instead of the slowest shard.
+  balancing-unfiltered:
+    name: gda-balancing manual unfiltered suite
     if: >-
       ${{
-        github.event_name == 'schedule' ||
-        (github.event_name == 'workflow_dispatch' &&
-          inputs['run-balancing-unfiltered'])
+        github.event_name == 'workflow_dispatch' &&
+        inputs['run-balancing-unfiltered']
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -439,34 +442,34 @@ jobs:
           timeout --signal=TERM --kill-after=30s "${process_timeout}s" \
             uv run --frozen --project libs/gda-balancing pytest \
               libs/gda-balancing/tests -q --durations=50 \
-              --junitxml=test-results/nightly-junit.xml \
-            2>&1 | tee test-results/nightly.log
+              --junitxml=test-results/unfiltered-junit.xml \
+            2>&1 | tee test-results/unfiltered.log
 
-      - name: Summarize durations and verify nightly outcomes
+      - name: Summarize durations and verify unfiltered outcomes
         if: ${{ always() }}
         run: |
           mkdir -p test-results
-          if [ -f test-results/nightly-junit.xml ]; then
+          if [ -f test-results/unfiltered-junit.xml ]; then
             uv run --no-project --python 3.13 python \
               libs/gda-balancing/tools/ci.py summarize-junit \
-              --junit test-results/nightly-junit.xml \
-              --report test-results/nightly-durations.json
+              --junit test-results/unfiltered-junit.xml \
+              --report test-results/unfiltered-durations.json
             uv run --no-project --python 3.13 python \
               libs/gda-balancing/tools/ci.py verify-outcomes \
-              --junit test-results/nightly-junit.xml \
-              --report test-results/nightly-outcomes.json
+              --junit test-results/unfiltered-junit.xml \
+              --report test-results/unfiltered-outcomes.json
           else
-            printf '{"error":"nightly timed out before JUnit was finalized"}\n' \
-              > test-results/nightly-durations.json
-            printf '{"error":"nightly timed out before JUnit was finalized"}\n' \
-              > test-results/nightly-outcomes.json
+            printf '{"error":"unfiltered run timed out before JUnit was finalized"}\n' \
+              > test-results/unfiltered-durations.json
+            printf '{"error":"unfiltered run timed out before JUnit was finalized"}\n' \
+              > test-results/unfiltered-outcomes.json
           fi
 
-      - name: Upload nightly diagnostics
+      - name: Upload unfiltered diagnostics
         if: ${{ always() }}
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: gda-balancing-nightly-diagnostics
+          name: gda-balancing-unfiltered-diagnostics
           path: test-results/
           if-no-files-found: error
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,24 +19,19 @@ on:
         required: false
         default: false
         type: boolean
-      run-balancing-unfiltered:
-        description: "Run the complete unfiltered gda-balancing suite"
-        required: false
-        default: false
-        type: boolean
   schedule:
-    # Nightly (03:24 UTC) — the automatic, dependable trigger for the godot-e2e job
-    # (workflow_dispatch with run-e2e is the on-demand extra). Daily so a regression in
-    # the real-engine tier is caught within a day rather than up to a week.
+    # Nightly (03:24 UTC) runs the complete gda-balancing matrix and the godot-e2e
+    # job. workflow_dispatch with run-e2e is the on-demand engine-test path.
+    # Daily execution detects a regression in either tier within one day.
     - cron: "24 3 * * *"
 
 permissions:
   contents: read
 
 concurrency:
-  # Scheduled matrix runs and manually requested unfiltered runs are evidence
-  # runs: a push must not cancel them merely because all three can target
-  # refs/heads/main. PR and push runs still replace stale runs for the same ref.
+  # Scheduled and manually requested evidence runs must not be cancelled by a
+  # push merely because all three can target refs/heads/main. PR and push runs
+  # still replace stale runs for the same ref.
   group: >-
     ${{
       github.workflow
@@ -408,70 +403,6 @@ jobs:
               exit 1
             fi
           done
-
-  # Scheduled runs already select the inventory-closed shard matrix above.
-  # Keep this single-process path only as an explicit diagnostic probe; making
-  # it a second nightly suite duplicates coverage and scales with total suite
-  # time instead of the slowest shard.
-  balancing-unfiltered:
-    name: gda-balancing manual unfiltered suite
-    if: >-
-      ${{
-        github.event_name == 'workflow_dispatch' &&
-        inputs['run-balancing-unfiltered']
-      }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Set up gda-balancing environment
-        uses: ./.github/actions/setup-python-env
-        with:
-          sync: member
-          save-cache: false
-
-      - name: Run the complete unfiltered suite
-        run: |
-          mkdir -p test-results
-          set -o pipefail
-          process_timeout="$(uv run --no-project --python 3.13 python \
-            libs/gda-balancing/tools/ci.py process-timeout unfiltered)"
-          timeout --signal=TERM --kill-after=30s "${process_timeout}s" \
-            uv run --frozen --project libs/gda-balancing pytest \
-              libs/gda-balancing/tests -q --durations=50 \
-              --junitxml=test-results/unfiltered-junit.xml \
-            2>&1 | tee test-results/unfiltered.log
-
-      - name: Summarize durations and verify unfiltered outcomes
-        if: ${{ always() }}
-        run: |
-          mkdir -p test-results
-          if [ -f test-results/unfiltered-junit.xml ]; then
-            uv run --no-project --python 3.13 python \
-              libs/gda-balancing/tools/ci.py summarize-junit \
-              --junit test-results/unfiltered-junit.xml \
-              --report test-results/unfiltered-durations.json
-            uv run --no-project --python 3.13 python \
-              libs/gda-balancing/tools/ci.py verify-outcomes \
-              --junit test-results/unfiltered-junit.xml \
-              --report test-results/unfiltered-outcomes.json
-          else
-            printf '{"error":"unfiltered run timed out before JUnit was finalized"}\n' \
-              > test-results/unfiltered-durations.json
-            printf '{"error":"unfiltered run timed out before JUnit was finalized"}\n' \
-              > test-results/unfiltered-outcomes.json
-          fi
-
-      - name: Upload unfiltered diagnostics
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: gda-balancing-unfiltered-diagnostics
-          path: test-results/
-          if-no-files-found: error
 
   coinstall-smoke:
     name: Both products co-install

--- a/docs/adr/0038-gda-balancing-leaves-the-uv-workspace.md
+++ b/docs/adr/0038-gda-balancing-leaves-the-uv-workspace.md
@@ -140,12 +140,17 @@ uv project inside the repo, with its own lock under its own directory.**
   > `libs/gda-balancing/tools/ci.py` is the single authority for affecting
   > paths, shard membership, process budgets, logical inventory, and allowed
   > historical skip outcomes; the workflow derives those values rather than
-  > restating them. Nightly, manual evidence, and release validation retain the
-  > complete unfiltered suite. Repository protection adopted the stable
+  > restating them. Repository protection adopted the stable
   > aggregator before the duplicate member test/build steps were removed from
   > the root job. Because this topology changes un-excluded root automation but
   > not the `gda` product, its commits and squash title use non-releasing `ci`
   > types.
+  >
+  > **Outcome (2026-08-11, #597/#635):** scheduled validation uses the same
+  > inventory-closed matrix after the duplicate serial nightly suite exceeded
+  > its process bound while every required shard still passed. The release
+  > workflow retains its exact-SHA unfiltered suite; #597 remains open for that
+  > path's current performance risk.
 - **CI and Release share one exact uv tool version.** The shared
   `setup-python-env` action owns the pin for every project-sync and release
   consumer; workflows may not opt back into a moving `latest` or restate the

--- a/libs/gda-balancing/docs/agents/testing.md
+++ b/libs/gda-balancing/docs/agents/testing.md
@@ -72,11 +72,12 @@ CI also runs the existing outcome check on each JUnit file; undeclared skips
 and xfails fail the job. Balancing-affecting or unknown paths run inventory,
 all six required shards, the separate smoke shard, and the stable
 `gda-balancing required` result. Each test process retains the existing
-eight-minute bound and fifteen-minute job timeout. Scheduled and release flows
-retain their complete unfiltered-suite checks, existing fifteen-minute process
-bound, outcome verification, and diagnostic uploads. Member release PRs remain
-restricted to `libs/gda-balancing/**`; this change does not alter those
-workflows or their ownership boundary.
+eight-minute bound and fifteen-minute job timeout. Scheduled validation uses
+this complete inventory-closed matrix; it does not run the whole suite in one
+process. The release flow retains that single-process check, its fifteen-minute
+process bound, outcome verification, and diagnostic uploads. Member release
+PRs remain restricted to
+`libs/gda-balancing/**`; the workflows keep their existing ownership boundary.
 
 ## Optimizations
 
@@ -156,6 +157,10 @@ three-run performance sample. #597 uses this fixed comparison; the rolling
 20-run p95 protocol introduced with #587 is not a standing gate for this
 refactor.
 
-Nightly and release flows are not restructured by this member change. Any
-future workflow change must be justified independently by measured CI evidence
-and must live in a root-owned, non-releasing PR.
+The member optimization did not restructure nightly or release flows. Later
+root-owned CI evidence showed that the scheduled serial suite exceeded its
+process bound while every inventory-closed shard passed. #635 therefore uses
+the existing matrix for scheduled validation and removes the duplicate serial
+job. The release flow remains unchanged; #597 tracks its current serial-path
+risk. Any further workflow change requires independent CI evidence and a
+root-owned, non-releasing PR.

--- a/tests/test_balancing_ci_wiring.py
+++ b/tests/test_balancing_ci_wiring.py
@@ -106,7 +106,7 @@ def test_scope_diff_preserves_both_sides_of_cross_boundary_renames(tmp_path):
     assert json.loads(policy_guard.stdout)["required"] is True
 
 
-def test_scheduled_unfiltered_run_has_an_isolated_non_cancelling_group():
+def test_scheduled_matrix_and_manual_unfiltered_have_isolated_non_cancelling_groups():
     workflow = _WORKFLOW.read_text(encoding="utf-8")
     concurrency = workflow.split("\nconcurrency:\n", 1)[1].split("\njobs:\n", 1)[0]
 
@@ -115,6 +115,17 @@ def test_scheduled_unfiltered_run_has_an_isolated_non_cancelling_group():
     assert "format('{0}-{1}', github.event_name, github.run_id)" in concurrency
     assert "github.event_name == 'pull_request'" in concurrency
     assert "github.event_name == 'push'" in concurrency
+
+
+def test_scheduled_run_uses_the_full_matrix_and_unfiltered_is_manual_only():
+    workflow = _WORKFLOW.read_text(encoding="utf-8")
+    scope = _workflow_job(workflow, "balancing-scope")
+    unfiltered = _workflow_job(workflow, "balancing-unfiltered")
+
+    assert "classify --all" in scope
+    assert "github.event_name == 'workflow_dispatch'" in unfiltered
+    assert "inputs['run-balancing-unfiltered']" in unfiltered
+    assert "github.event_name == 'schedule'" not in unfiltered
 
 
 def test_workflow_derives_shards_budgets_and_smoke_paths_from_policy():
@@ -148,7 +159,7 @@ def test_workflow_derives_shards_budgets_and_smoke_paths_from_policy():
     _assert_job_timeout(workflow, "balancing-tests", 15)
     _assert_job_timeout(workflow, "balancing-smoke", 15)
     _assert_job_timeout(workflow, "balancing-required", 5)
-    _assert_job_timeout(workflow, "balancing-nightly", 20)
+    _assert_job_timeout(workflow, "balancing-unfiltered", 20)
     _assert_job_timeout(release, "build-release-gda-balancing", 30)
     assert "process-timeout unfiltered" in release
     assert "verify-outcomes" in release

--- a/tests/test_balancing_ci_wiring.py
+++ b/tests/test_balancing_ci_wiring.py
@@ -106,7 +106,7 @@ def test_scope_diff_preserves_both_sides_of_cross_boundary_renames(tmp_path):
     assert json.loads(policy_guard.stdout)["required"] is True
 
 
-def test_scheduled_matrix_and_manual_unfiltered_have_isolated_non_cancelling_groups():
+def test_scheduled_and_manual_evidence_runs_have_isolated_non_cancelling_groups():
     workflow = _WORKFLOW.read_text(encoding="utf-8")
     concurrency = workflow.split("\nconcurrency:\n", 1)[1].split("\njobs:\n", 1)[0]
 
@@ -117,15 +117,25 @@ def test_scheduled_matrix_and_manual_unfiltered_have_isolated_non_cancelling_gro
     assert "github.event_name == 'push'" in concurrency
 
 
-def test_scheduled_run_uses_the_full_matrix_and_unfiltered_is_manual_only():
+def test_scheduled_run_uses_the_full_matrix_without_a_serial_duplicate():
     workflow = _WORKFLOW.read_text(encoding="utf-8")
     scope = _workflow_job(workflow, "balancing-scope")
-    unfiltered = _workflow_job(workflow, "balancing-unfiltered")
+    inventory = _workflow_job(workflow, "balancing-inventory")
+    tests = _workflow_job(workflow, "balancing-tests")
+    smoke = _workflow_job(workflow, "balancing-smoke")
+    required = _workflow_job(workflow, "balancing-required")
 
+    assert "EVENT_NAME: ${{ github.event_name }}" in scope
+    assert 'if [ "$EVENT_NAME" = "pull_request" ]; then' in scope
     assert "classify --all" in scope
-    assert "github.event_name == 'workflow_dispatch'" in unfiltered
-    assert "inputs['run-balancing-unfiltered']" in unfiltered
-    assert "github.event_name == 'schedule'" not in unfiltered
+    for job in (inventory, tests, smoke):
+        assert "needs.balancing-scope.outputs.required == 'true'" in job
+        assert "github.event_name" not in job
+    assert "- balancing-inventory" in required
+    assert "- balancing-tests" in required
+    assert "- balancing-smoke" in required
+    assert "run-balancing-unfiltered" not in workflow
+    assert "balancing-unfiltered:" not in workflow
 
 
 def test_workflow_derives_shards_budgets_and_smoke_paths_from_policy():
@@ -138,7 +148,7 @@ def test_workflow_derives_shards_budgets_and_smoke_paths_from_policy():
 
     assert "required-test-shards" in workflow
     assert "process-timeout required" in workflow
-    assert "process-timeout unfiltered" in workflow
+    assert "process-timeout unfiltered" not in workflow
     assert "shard-paths smoke" in workflow
     assert "libs/gda-balancing/tests/test_e2e_cli.py" not in workflow
     assert "python3 libs/gda-balancing/tools/ci.py" not in workflow
@@ -159,7 +169,6 @@ def test_workflow_derives_shards_budgets_and_smoke_paths_from_policy():
     _assert_job_timeout(workflow, "balancing-tests", 15)
     _assert_job_timeout(workflow, "balancing-smoke", 15)
     _assert_job_timeout(workflow, "balancing-required", 5)
-    _assert_job_timeout(workflow, "balancing-unfiltered", 20)
     _assert_job_timeout(release, "build-release-gda-balancing", 30)
     assert "process-timeout unfiltered" in release
     assert "verify-outcomes" in release


### PR DESCRIPTION
## Summary

- run scheduled gda-balancing validation through the existing inventory-closed shard matrix
- remove the duplicate serial nightly job and its manual fallback
- pin the scheduled matrix boundary in workflow wiring tests
- update the CI architecture and testing documentation

## Assessment

Seven scheduled serial runs reached the unchanged 900-second process bound and exited with code 124. In the same runs, inventory closure, all six semantic shards, smoke, and the stable required result passed. The scheduled workflow already selects the complete matrix through the non-PR `classify --all` path.

This PR removes the redundant serial path instead of increasing its timeout or adding another diagnostic mechanism. It does not claim that the `d066ffe..ae4b157` range is the single performance cause. Issue #597 remains open for hotspot isolation and the unchanged release serial path.

## Coverage boundary

Inventory verification selects all 1,426 current tests and 194 package vectors with no missing, overlap, uncovered, or unexpected entries. Scheduled validation preserves that collection and its assertions, but it no longer runs the whole suite in one process. The release workflow retains the exact-SHA single-process check; #597 tracks its current performance risk.

## Validation

- `uv run --frozen pytest tests/test_balancing_ci_wiring.py -q` — 4 passed
- `uv run --frozen --project libs/gda-balancing pytest libs/gda-balancing/tests/test_ci_policy.py -q` — 11 passed
- inventory verification — 1,426 tests / 194 vectors; no missing, overlap, uncovered, or unexpected entries
- workflow YAML parsing, Ruff, format, and `git diff --check` passed

The actual `schedule` event can run only after merge. The wiring test pins its non-PR classification path and the absence of event gates on inventory, matrix, and smoke jobs.

Refs #597
