### PR TITLE
docs(skills): add iterative VDD research fan-out

### DIFF
--- a/.agents/skills/validation-driven-design/SKILL.md
+++ b/.agents/skills/validation-driven-design/SKILL.md
@@ -60,22 +60,20 @@ and add a step when its falsifier or risk requires it; do not generate full matr
 default. In `audit-only` mode, pin the baseline, evaluate the claimed scope, report gaps, and stop
 without redesign or edits unless the user requests them.
 
-For `full-design`, after section 1 establishes the design contract, run sections 2 and 3 as a bounded
-research fan-out followed by primary-agent synthesis when subagents are available and the research
-questions can be separated. Before fan-out, set a task-specific charter count or time budget and
-state when to stop or defer research. Derive non-overlapping research charters from the design
-contract. Define a distinct design question, hypothesis, or evidence angle for each charter. For
-each load-bearing question, include one charter that seeks counterevidence or a credible alternative.
+For `full-design`, use the current design needs, constraints, and applicable artifacts from section 1
+as shared input to iterative research fan-out followed by primary-agent synthesis. Based on the
+research complexity, delegate the research to an appropriate number of subagents. Each subagent
+independently explores relevant theories, external systems, primary sources, counterevidence, and
+open questions. If subagents are unavailable, run separate sequential research passes and disclose
+the missing independence.
 
-Treat subagent reports as research leads, not as evidence or authority. Let subagents identify
-candidate theories, external systems, and primary sources within their charters unless the design
-contract or pinned scope names the research target. The primary agent must inspect the load-bearing
-primary sources, compare their provenance, and identify shared upstream sources and coverage gaps.
-Open targeted follow-up research only for a named gap in source provenance or coverage; keep other
-questions open and defer them. The primary agent must reconcile duplicate findings and conflicts
-and own the integrated conclusion. Keep unresolved conflicts open; do not settle them by vote. If
-subagents are unavailable or the questions cannot be separated, run separate sequential research
-passes and disclose the missing independence.
+Treat subagent reports as research leads, not as evidence or authority. After each research wave,
+the primary agent must inspect the load-bearing primary sources, compare their provenance, reconcile
+agreements and conflicts, and identify evidence gaps. It must synthesize and report the results
+accurately, including unresolved conflicts and limitations, then recommend one or two design
+directions or next research steps with their evidence and trade-offs. Through a human-in-the-loop
+gate, the designated human decision owner decides whether to stop, update the design direction, or
+run another exploratory or targeted research wave. Keep unresolved gaps open.
 
 In `lightweight` mode, use research fan-out only when the selected falsifier requires independent
 evidence. In `audit-only` mode, use it only to verify evidence within the pinned scope. Do not let
@@ -99,8 +97,8 @@ research fan-out expand either mode or replace the independent adversarial revie
 ### 2. Ground the abstractions
 
 - Select mature theory for the actual design question, not for prestige or vocabulary.
-- When research is fanned out, divide theory research by design question, hypothesis, or evidence
-  angle. Name a specific theory in a charter only when it is already in scope.
+- When research is fanned out, each subagent independently identifies theories relevant to the
+  current design needs.
 - State the mechanism, invariant, representation boundary, proof boundary, and a disconfirming case.
 - When semantics and execution differ, separate authoring form, typed/validated meaning, canonical
   public semantics, and implementation-private execution.
@@ -108,9 +106,8 @@ research fan-out expand either mode or replace the independent adversarial revie
 ### 3. Research external systems
 
 - Prefer pinned primary specifications and mature implementations.
-- When research is fanned out, divide external-system research by problem, mechanism, or evidence
-  angle. Name a specific system in a charter only when it is already in scope or synthesis reveals
-  a coverage gap. Require pinned primary sources and explicit counterevidence or exclusions.
+- When research is fanned out, each subagent independently identifies relevant external systems and
+  primary sources. Require pinned primary sources and explicit counterevidence or exclusions.
 - Record each influence's problem, adoption, owner, exclusions, dependency, evidence, and upgrade.
 - External systems are provenance unless the local contract explicitly makes one normative. Never
   create peer authorities or unsupported “compatible with” claims.

--- a/.agents/skills/validation-driven-design/SKILL.md
+++ b/.agents/skills/validation-driven-design/SKILL.md
@@ -62,14 +62,18 @@ without redesign or edits unless the user requests them.
 
 For `full-design`, run steps 2 and 3 as a bounded research fan-out followed by primary-agent
 synthesis when subagents are available and the research questions can be separated. Derive
-non-overlapping research charters from the design contract. For each load-bearing question, include
-one charter that seeks counterevidence or a credible alternative.
+non-overlapping research charters from the design contract. Define a distinct design question,
+hypothesis, or evidence angle for each charter. For each load-bearing question, include one charter
+that seeks counterevidence or a credible alternative.
 
-Treat subagent reports as research leads, not as evidence or authority. The primary agent must
-inspect the cited primary sources, reconcile duplicate findings and conflicts, and own the integrated
-conclusion. Keep unresolved conflicts open; do not settle them by vote. If subagents are unavailable
-or the questions cannot be separated, run separate sequential research passes and disclose the
-missing independence.
+Treat subagent reports as research leads, not as evidence or authority. Let subagents identify
+candidate theories, external systems, and primary sources within their charters unless the design
+contract or pinned scope names the research target. The primary agent must inspect the load-bearing
+primary sources, compare their provenance, identify shared upstream sources and coverage gaps, and
+run targeted follow-up research when needed. It must reconcile duplicate findings and conflicts and
+own the integrated conclusion. Keep unresolved conflicts open; do not settle them by vote. If
+subagents are unavailable or the questions cannot be separated, run separate sequential research
+passes and disclose the missing independence.
 
 In `lightweight` mode, use research fan-out only when the selected falsifier requires independent
 evidence. In `audit-only` mode, use it only to verify evidence within the pinned scope. Do not let
@@ -93,8 +97,8 @@ research fan-out expand either mode or replace the independent adversarial revie
 ### 2. Ground the abstractions
 
 - Select mature theory for the actual design question, not for prestige or vocabulary.
-- When research is fanned out, give each subagent a distinct theory candidate or design question. Do
-  not assign the same general survey to every subagent.
+- When research is fanned out, divide theory research by design question, hypothesis, or evidence
+  angle. Assign a theory only when it is already in scope.
 - State the mechanism, invariant, representation boundary, proof boundary, and a disconfirming case.
 - When semantics and execution differ, separate authoring form, typed/validated meaning, canonical
   public semantics, and implementation-private execution.
@@ -102,8 +106,9 @@ research fan-out expand either mode or replace the independent adversarial revie
 ### 3. Research external systems
 
 - Prefer pinned primary specifications and mature implementations.
-- When research is fanned out, give each subagent a distinct external system or source family.
-  Require pinned primary sources and explicit counterevidence or exclusions.
+- When research is fanned out, divide external-system research by problem, mechanism, or evidence
+  angle. Assign a specific system or source family only when it is already in scope or synthesis
+  reveals a coverage gap. Require pinned primary sources and explicit counterevidence or exclusions.
 - Record each influence's problem, adoption, owner, exclusions, dependency, evidence, and upgrade.
 - External systems are provenance unless the local contract explicitly makes one normative. Never
   create peer authorities or unsupported “compatible with” claims.

--- a/.agents/skills/validation-driven-design/SKILL.md
+++ b/.agents/skills/validation-driven-design/SKILL.md
@@ -60,18 +60,20 @@ and add a step when its falsifier or risk requires it; do not generate full matr
 default. In `audit-only` mode, pin the baseline, evaluate the claimed scope, report gaps, and stop
 without redesign or edits unless the user requests them.
 
-For `full-design`, run steps 2 and 3 as a bounded research fan-out followed by primary-agent
-synthesis when subagents are available and the research questions can be separated. Derive
-non-overlapping research charters from the design contract. Define a distinct design question,
-hypothesis, or evidence angle for each charter. For each load-bearing question, include one charter
-that seeks counterevidence or a credible alternative.
+For `full-design`, after section 1 establishes the design contract, run sections 2 and 3 as a bounded
+research fan-out followed by primary-agent synthesis when subagents are available and the research
+questions can be separated. Before fan-out, set a task-specific charter count or time budget and
+state when to stop or defer research. Derive non-overlapping research charters from the design
+contract. Define a distinct design question, hypothesis, or evidence angle for each charter. For
+each load-bearing question, include one charter that seeks counterevidence or a credible alternative.
 
 Treat subagent reports as research leads, not as evidence or authority. Let subagents identify
 candidate theories, external systems, and primary sources within their charters unless the design
 contract or pinned scope names the research target. The primary agent must inspect the load-bearing
-primary sources, compare their provenance, identify shared upstream sources and coverage gaps, and
-run targeted follow-up research when needed. It must reconcile duplicate findings and conflicts and
-own the integrated conclusion. Keep unresolved conflicts open; do not settle them by vote. If
+primary sources, compare their provenance, and identify shared upstream sources and coverage gaps.
+Open targeted follow-up research only for a named gap in source provenance or coverage; keep other
+questions open and defer them. The primary agent must reconcile duplicate findings and conflicts
+and own the integrated conclusion. Keep unresolved conflicts open; do not settle them by vote. If
 subagents are unavailable or the questions cannot be separated, run separate sequential research
 passes and disclose the missing independence.
 
@@ -98,7 +100,7 @@ research fan-out expand either mode or replace the independent adversarial revie
 
 - Select mature theory for the actual design question, not for prestige or vocabulary.
 - When research is fanned out, divide theory research by design question, hypothesis, or evidence
-  angle. Assign a theory only when it is already in scope.
+  angle. Name a specific theory in a charter only when it is already in scope.
 - State the mechanism, invariant, representation boundary, proof boundary, and a disconfirming case.
 - When semantics and execution differ, separate authoring form, typed/validated meaning, canonical
   public semantics, and implementation-private execution.
@@ -107,8 +109,8 @@ research fan-out expand either mode or replace the independent adversarial revie
 
 - Prefer pinned primary specifications and mature implementations.
 - When research is fanned out, divide external-system research by problem, mechanism, or evidence
-  angle. Assign a specific system or source family only when it is already in scope or synthesis
-  reveals a coverage gap. Require pinned primary sources and explicit counterevidence or exclusions.
+  angle. Name a specific system in a charter only when it is already in scope or synthesis reveals
+  a coverage gap. Require pinned primary sources and explicit counterevidence or exclusions.
 - Record each influence's problem, adoption, owner, exclusions, dependency, evidence, and upgrade.
 - External systems are provenance unless the local contract explicitly makes one normative. Never
   create peer authorities or unsupported “compatible with” claims.

--- a/.agents/skills/validation-driven-design/SKILL.md
+++ b/.agents/skills/validation-driven-design/SKILL.md
@@ -60,23 +60,22 @@ and add a step when its falsifier or risk requires it; do not generate full matr
 default. In `audit-only` mode, pin the baseline, evaluate the claimed scope, report gaps, and stop
 without redesign or edits unless the user requests them.
 
-For `full-design`, use the current design needs, constraints, and applicable artifacts from section 1
-as shared input to iterative research fan-out followed by primary-agent synthesis. Based on the
-research complexity, delegate the research to an appropriate number of subagents. Each subagent
-independently explores relevant theories, external systems, primary sources, counterevidence, and
-open questions. If subagents are unavailable, run separate sequential research passes and disclose
-the missing independence.
+For `full-design`, use the design contract from section 1 as shared input to iterative research
+fan-out followed by primary-agent synthesis. Based on the research complexity, delegate the research
+to an appropriate number of subagents. Each subagent independently explores relevant theories,
+external systems, primary sources, counterevidence, and open questions. If subagents are unavailable,
+run separate sequential research passes and disclose the missing independence.
 
 Treat subagent reports as research leads, not as evidence or authority. After each research wave,
 the primary agent must inspect the load-bearing primary sources, compare their provenance, reconcile
 agreements and conflicts, and identify evidence gaps. It must synthesize and report the results
-accurately, including unresolved conflicts and limitations, then recommend one or two design
-directions or next research steps with their evidence and trade-offs. Through a human-in-the-loop
-gate, the designated human decision owner decides whether to stop, update the design direction, or
+accurately, including unresolved conflicts and limitations, then recommend one or two architecture
+directions or next research steps with their evidence and trade-offs. At the human decision gate,
+the designated human decision owner decides whether to stop, update the architecture direction, or
 run another exploratory or targeted research wave. Keep unresolved gaps open.
 
 In `lightweight` mode, use research fan-out only when the selected falsifier requires independent
-evidence. In `audit-only` mode, use it only to verify evidence within the pinned scope. Do not let
+research. In `audit-only` mode, use it only to verify evidence within the pinned scope. Do not let
 research fan-out expand either mode or replace the independent adversarial review required by
 [REFERENCE.md §5](REFERENCE.md#5-validation-portfolio).
 
@@ -97,8 +96,6 @@ research fan-out expand either mode or replace the independent adversarial revie
 ### 2. Ground the abstractions
 
 - Select mature theory for the actual design question, not for prestige or vocabulary.
-- When research is fanned out, each subagent independently identifies theories relevant to the
-  current design needs.
 - State the mechanism, invariant, representation boundary, proof boundary, and a disconfirming case.
 - When semantics and execution differ, separate authoring form, typed/validated meaning, canonical
   public semantics, and implementation-private execution.

--- a/.agents/skills/validation-driven-design/SKILL.md
+++ b/.agents/skills/validation-driven-design/SKILL.md
@@ -45,7 +45,8 @@ conformance case and its minimum fields.
 
 1. Choose `lightweight`, `full-design`, or `audit-only` mode; name the artifact owners and human decision owner.
 2. Write goals, non-goals, invariants, quality attributes, and production constraints. Keep artifact and decision lifecycle status separate from claim evidence state.
-3. Map load-bearing mechanisms to mature theory and external systems; record adoption and proof gaps.
+3. Map load-bearing mechanisms to mature theory and external systems; fan out independent research
+   when justified, then verify, synthesize, and record adoption and proof gaps.
 4. Rank architecture uncertainties and run only the smallest discriminating validation.
 5. Feed dogfooding back into requirements, decisions, terms, specifications, executable conformance cases, and gates.
 6. Audit the four design axes and cross-cutting quality attributes; keep non-claims explicit.
@@ -58,6 +59,22 @@ The sections below define the `full-design` route. In `lightweight` mode, execut
 and add a step when its falsifier or risk requires it; do not generate full matrices or portfolios by
 default. In `audit-only` mode, pin the baseline, evaluate the claimed scope, report gaps, and stop
 without redesign or edits unless the user requests them.
+
+For `full-design`, run steps 2 and 3 as a bounded research fan-out followed by primary-agent
+synthesis when subagents are available and the research questions can be separated. Derive
+non-overlapping research charters from the design contract. For each load-bearing question, include
+one charter that seeks counterevidence or a credible alternative.
+
+Treat subagent reports as research leads, not as evidence or authority. The primary agent must
+inspect the cited primary sources, reconcile duplicate findings and conflicts, and own the integrated
+conclusion. Keep unresolved conflicts open; do not settle them by vote. If subagents are unavailable
+or the questions cannot be separated, run separate sequential research passes and disclose the
+missing independence.
+
+In `lightweight` mode, use research fan-out only when the selected falsifier requires independent
+evidence. In `audit-only` mode, use it only to verify evidence within the pinned scope. Do not let
+research fan-out expand either mode or replace the independent adversarial review required by
+[REFERENCE.md §5](REFERENCE.md#5-validation-portfolio).
 
 ### 1. Establish the design contract
 
@@ -76,6 +93,8 @@ without redesign or edits unless the user requests them.
 ### 2. Ground the abstractions
 
 - Select mature theory for the actual design question, not for prestige or vocabulary.
+- When research is fanned out, give each subagent a distinct theory candidate or design question. Do
+  not assign the same general survey to every subagent.
 - State the mechanism, invariant, representation boundary, proof boundary, and a disconfirming case.
 - When semantics and execution differ, separate authoring form, typed/validated meaning, canonical
   public semantics, and implementation-private execution.
@@ -83,6 +102,8 @@ without redesign or edits unless the user requests them.
 ### 3. Research external systems
 
 - Prefer pinned primary specifications and mature implementations.
+- When research is fanned out, give each subagent a distinct external system or source family.
+  Require pinned primary sources and explicit counterevidence or exclusions.
 - Record each influence's problem, adoption, owner, exclusions, dependency, evidence, and upgrade.
 - External systems are provenance unless the local contract explicitly makes one normative. Never
   create peer authorities or unsupported “compatible with” claims.


### PR DESCRIPTION
## Summary

- make `full-design` theory and external-system research use iterative fan-out sized to the research complexity
- let subagents independently explore relevant theories, systems, primary sources, counterevidence, and open questions
- require the primary agent to verify and synthesize each research wave, report limitations, recommend one or two architecture directions or next research steps, and return the continuation decision to the human decision gate
- preserve `lightweight` and `audit-only` scope limits and keep independent adversarial review as a separate validation mechanism

## Rationale

Open research can reveal directions that the primary agent does not know in advance. Up-front non-overlapping charters, fixed research directions, and time budgets can anchor the subagents to an incorrect framing and constrain the feedback process. The revised workflow keeps source verification and synthesis with the primary agent while the designated human decision owner decides whether another exploratory or targeted research wave is justified.

## Validation

- Skill Creator `quick_validate.py` (external Codex system-skill validator): passed
- `git diff --check`: passed
- applicable CI checks: passed

## Scope

This change updates only the VDD workflow authority in `SKILL.md`. `REFERENCE.md` and `EXAMPLES.md` remain unchanged because their evidence templates, examples, and independent-review boundary still apply.
