### PR TITLE
docs(gda): document the Control-root zero-size layout in scene create help and the skill

### DIFF
--- a/src/gda/commands/scene.py
+++ b/src/gda/commands/scene.py
@@ -421,12 +421,15 @@ def create(
 ) -> None:
     """Create a new .tscn scene file with the given root node type.
 
-    A Control root is created with zero anchors and zero offsets: a
-    zero-size rect at the origin, not a viewport-filling layout. Container
-    minimum sizes can keep descendants visible and mask this. Fill the
-    viewport by setting the root's anchor_right and anchor_bottom to 1
-    with 'gda node set' (offsets stay 0); confirm with 'gda game rect',
-    which reports the root's rendered rect at runtime.
+    A Control-derived root is created with zero anchors and zero offsets,
+    so it does not fill the viewport. A root class with no intrinsic
+    minimum size (plain Control, Panel, an empty container) renders as a
+    zero-size rect at the origin; a class with an intrinsic minimum (e.g.
+    Button, Label) renders at that minimum instead, still not the
+    viewport. Container minimum sizes can keep descendants visible and
+    mask this. Fill the viewport by setting the root's anchor_right and
+    anchor_bottom to 1 with 'gda node set' (offsets stay 0); confirm with
+    'gda game rect', which reports the root's rendered rect at runtime.
     """
     # Normalization + root-name derivation live in SceneCreateParams (ADR-0015),
     # so this body is a thin argv→model adapter and the --params-json path agrees.

--- a/src/gda/commands/scene.py
+++ b/src/gda/commands/scene.py
@@ -419,7 +419,15 @@ def create(
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Create a new .tscn scene file with the given root node type."""
+    """Create a new .tscn scene file with the given root node type.
+
+    A Control root is created with zero anchors and zero offsets: a
+    zero-size rect at the origin, not a viewport-filling layout. Container
+    minimum sizes can keep descendants visible and mask this. Fill the
+    viewport by setting the root's anchor_right and anchor_bottom to 1
+    with 'gda node set' (offsets stay 0); confirm with 'gda game rect',
+    which reports the root's rendered rect at runtime.
+    """
     # Normalization + root-name derivation live in SceneCreateParams (ADR-0015),
     # so this body is a thin argv→model adapter and the --params-json path agrees.
     dispatch_domain(

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -169,13 +169,16 @@ children of a `Container` are layout-managed; use those offset properties
 explicitly instead. Live `game set --property position` mirrors this policy, while
 `game rect` remains a read-only rendered-geometry query.
 
-`scene create` with a `Control`-derived `--root-type` (`Control`, `Panel`, any
-container) writes a root with zero anchors and zero offsets — a zero-size rect
-at the origin, not a viewport-filling layout.
-Container minimum sizes can keep descendants visible and mask this until
-`game rect` reports the root, and its child layers, at `[0, 0]` size. Fix it by
-setting the root's `anchor_right` and `anchor_bottom` to `1` with `node set`
-(offsets stay `0`); confirm with `game rect`.
+`scene create` with a `Control-derived` `--root-type` writes a root with zero
+anchors and zero offsets, so it does not fill the viewport. A root class with
+no intrinsic minimum size (plain `Control`, `Panel`, an empty container)
+renders as a zero-size rect at the origin; a class with an intrinsic minimum
+(e.g. `Button`, `Label`) renders at that minimum instead — still not the
+viewport. Container minimum sizes can keep descendants visible and mask a
+zero-size root until `game rect` reports the root, and its child layers, at
+their true (possibly zero) size. Fix it by setting the root's `anchor_right`
+and `anchor_bottom` to `1` with `node set` (offsets stay `0`); confirm with
+`game rect`.
 
 **Attach a script — `script attach`, never `node set --property script`.**
 `script attach` is the one authoritative way to bind a `.gd` script to a node: it

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -169,8 +169,9 @@ children of a `Container` are layout-managed; use those offset properties
 explicitly instead. Live `game set --property position` mirrors this policy, while
 `game rect` remains a read-only rendered-geometry query.
 
-`scene create --root-type Control` writes a root with zero anchors and zero
-offsets — a zero-size rect at the origin, not a viewport-filling layout.
+`scene create` with a `Control`-derived `--root-type` (`Control`, `Panel`, any
+container) writes a root with zero anchors and zero offsets — a zero-size rect
+at the origin, not a viewport-filling layout.
 Container minimum sizes can keep descendants visible and mask this until
 `game rect` reports the root, and its child layers, at `[0, 0]` size. Fix it by
 setting the root's `anchor_right` and `anchor_bottom` to `1` with `node set`

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -169,6 +169,13 @@ children of a `Container` are layout-managed; use those offset properties
 explicitly instead. Live `game set --property position` mirrors this policy, while
 `game rect` remains a read-only rendered-geometry query.
 
+`scene create --root-type Control` writes a root with zero anchors and zero
+offsets — a zero-size rect at the origin, not a viewport-filling layout.
+Container minimum sizes can keep descendants visible and mask this until
+`game rect` reports the root, and its child layers, at `[0, 0]` size. Fix it by
+setting the root's `anchor_right` and `anchor_bottom` to `1` with `node set`
+(offsets stay `0`); confirm with `game rect`.
+
 **Attach a script — `script attach`, never `node set --property script`.**
 `script attach` is the one authoritative way to bind a `.gd` script to a node: it
 verifies the script compiles, checks its base type against the node, and reports any

--- a/tests/test_skill_surface_sync.py
+++ b/tests/test_skill_surface_sync.py
@@ -108,3 +108,34 @@ def test_gate_catches_a_dropped_command():
     assert "delete" in parse_skill_groups(BUNDLED).get("scene", set())
     doctored = BUNDLED.replace("`get-exports`, `delete`", "`get-exports`")
     assert parse_skill_groups(doctored).get("scene") != surface_groups().get("scene")
+
+
+def test_scene_create_control_root_note_agrees_with_skill():
+    # `gda scene create --help` (the command docstring, projected verbatim into
+    # `gda schema`'s "scene create" description) and this Scene-authoring section
+    # independently document the same Control-derived zero-size root pitfall
+    # (GDA-DF-006, #672) in two hand-maintained prose surfaces. They already diverged
+    # once — a scope fix (Control -> Control-derived) landed in SKILL.md without the
+    # matching help-text edit (PR #676 review) — so this is a minimal token-level guard,
+    # not a full prose-equality pin: the two surfaces deliberately differ in voice, but
+    # must name the same fix properties, the same check command, and agree on the same
+    # root-class scope.
+    by_name = {
+        c["name"]: c["description"]
+        for c in build_surface_manifest(app).model_dump()["commands"]
+    }
+    scene_create_description = by_name["scene create"]
+
+    load_bearing_tokens = ["anchor_right", "anchor_bottom", "game rect"]
+    for token in load_bearing_tokens:
+        assert token in scene_create_description, (
+            f"'scene create' help text missing {token!r}: {scene_create_description!r}"
+        )
+        assert token in BUNDLED, f"SKILL.md missing {token!r}"
+
+    assert "Control-derived" in scene_create_description, (
+        "'scene create' help text dropped the Control-derived scope token"
+    )
+    assert "Control-derived" in BUNDLED, (
+        "SKILL.md dropped the Control-derived scope token"
+    )

--- a/tests/test_skill_surface_sync.py
+++ b/tests/test_skill_surface_sync.py
@@ -15,6 +15,8 @@ meta commands (`info` / `schema` / `skill`) live in prose, not the tables, and a
 
 import re
 
+import pytest
+
 from gda.cli import app
 from gda.commands.meta import read_skill_text
 from gda.surface import build_surface_manifest
@@ -139,11 +141,48 @@ def _extract_scene_create_root_note(text: str) -> str:
     return text[start:end]
 
 
-def _normalize_whitespace(text: str) -> str:
+def _normalize_prose(text: str) -> str:
     # Both surfaces hand-wrap their prose at ~88 columns, so a load-bearing phrase
     # can straddle a line break (e.g. "...no intrinsic\nminimum size..."). Collapsing
-    # whitespace runs to a single space keeps token matching robust to rewrapping.
-    return re.sub(r"\s+", " ", text)
+    # whitespace runs to a single space keeps matching robust to rewrapping; stripping
+    # backticks lets one clause pattern cover both voices (SKILL.md backticks class
+    # names and commands, the help text does not).
+    return re.sub(r"\s+", " ", text.replace("`", ""))
+
+
+# The conditional this guard exists for, as ORDERED clauses rather than vocabulary:
+# review round 2's recheck showed a one-word mutation ("no intrinsic minimum" ->
+# "an intrinsic minimum") reverses the meaning while keeping every token present.
+# `[^;]*` confines each pattern to one semicolon-delimited clause, so pairing the
+# wrong condition with the wrong consequence cannot match across the clause break.
+_SEMANTIC_CLAUSES = [
+    (
+        "a root with NO intrinsic minimum renders zero-size",
+        r"no intrinsic minimum[^;]*zero-size rect",
+    ),
+    (
+        "a root WITH an intrinsic minimum renders at that minimum",
+        r"an intrinsic minimum[^;]*renders at that minimum instead",
+    ),
+]
+
+
+def _assert_control_root_semantics(normalized: str, surface: str) -> None:
+    """Assert one surface carries the Control-root facts, conditional included."""
+    for label, pattern in _SEMANTIC_CLAUSES:
+        assert re.search(pattern, normalized), (
+            f"{surface} lost the clause [{label}] (pattern {pattern!r}): {normalized!r}"
+        )
+    for token in [
+        "zero anchors",
+        "zero offsets",
+        "anchor_right",
+        "anchor_bottom",
+        "node set",
+        "game rect",
+        "Control-derived",
+    ]:
+        assert token in normalized, f"{surface} missing {token!r}: {normalized!r}"
 
 
 def test_scene_create_control_root_note_agrees_with_skill():
@@ -158,31 +197,35 @@ def test_scene_create_control_root_note_agrees_with_skill():
     # since `game rect` / `node set` also occur elsewhere in SKILL.md for unrelated
     # reasons (PR #676 review round 2 recheck). This guards the SPECIFIC paragraph
     # for the SPECIFIC semantic facts the round corrected — the zero anchors/offsets
-    # behavior, the intrinsic-minimum-size conditional, the fix properties, and the
-    # check command — as tokens, not full prose equality (the two surfaces
-    # deliberately differ in voice).
+    # behavior, the intrinsic-minimum-size conditional AS A RELATIONSHIP (ordered
+    # clause patterns, not vocabulary: the second recheck showed a one-word mutation
+    # keeps every token while reversing the conditional), the fix properties, and
+    # the check command — never full prose equality (the two surfaces deliberately
+    # differ in voice).
     by_name = {
         c["name"]: c["description"]
         for c in build_surface_manifest(app).model_dump()["commands"]
     }
-    scene_create_description = _normalize_whitespace(by_name["scene create"])
-    skill_paragraph = _normalize_whitespace(_extract_scene_create_root_note(BUNDLED))
+    _assert_control_root_semantics(
+        _normalize_prose(by_name["scene create"]), "'scene create' help text"
+    )
+    _assert_control_root_semantics(
+        _normalize_prose(_extract_scene_create_root_note(BUNDLED)),
+        "SKILL.md's Control-root paragraph",
+    )
 
-    load_bearing_tokens = [
-        "zero anchors",
-        "zero offsets",
-        "intrinsic minimum",
-        "zero-size",
-        "anchor_right",
-        "anchor_bottom",
-        "node set",
-        "game rect",
-        "Control-derived",
-    ]
-    for token in load_bearing_tokens:
-        assert token in scene_create_description, (
-            f"'scene create' help text missing {token!r}: {scene_create_description!r}"
-        )
-        assert token in skill_paragraph, (
-            f"SKILL.md's Control-root paragraph missing {token!r}: {skill_paragraph!r}"
+
+def test_control_root_guard_catches_a_reversed_conditional():
+    # The negative sentinel from PR #676's second recheck: flipping "no intrinsic
+    # minimum" to "an intrinsic minimum" preserves every vocabulary token while
+    # claiming a root WITH a minimum renders zero-size. The clause guard must go
+    # red on exactly that mutation — vocabulary checks alone stayed green on it.
+    paragraph = _extract_scene_create_root_note(BUNDLED)
+    mutated = paragraph.replace(
+        "no intrinsic minimum size", "an intrinsic minimum size"
+    )
+    assert mutated != paragraph, "mutation site missing — paragraph reworded?"
+    with pytest.raises(AssertionError, match="NO intrinsic minimum"):
+        _assert_control_root_semantics(
+            _normalize_prose(mutated), "mutated SKILL.md paragraph"
         )

--- a/tests/test_skill_surface_sync.py
+++ b/tests/test_skill_surface_sync.py
@@ -110,32 +110,79 @@ def test_gate_catches_a_dropped_command():
     assert parse_skill_groups(doctored).get("scene") != surface_groups().get("scene")
 
 
+# The Scene-authoring paragraph documenting the Control-root zero-size pitfall
+# (GDA-DF-006, #672), anchored on its stable opening line.
+_SCENE_CREATE_ROOT_NOTE_ANCHOR = "`scene create` with a `Control-derived`"
+
+
+def _extract_scene_create_root_note(text: str) -> str:
+    """Extract just the Control-root zero-size paragraph from the bundled skill.
+
+    Scoped to this one paragraph, not a search across the whole file: SKILL.md
+    mentions `game rect` and `node set` elsewhere for unrelated reasons, so an
+    unscoped token search can stay green even if THIS paragraph's semantic
+    content regresses (PR #676 review round 2 recheck). If the anchor line is
+    ever reworded away, this fails loudly with a clear message rather than
+    silently matching an empty or wrong span.
+    """
+    start = text.find(_SCENE_CREATE_ROOT_NOTE_ANCHOR)
+    assert start != -1, (
+        "SKILL.md's Control-root zero-size paragraph anchor "
+        f"{_SCENE_CREATE_ROOT_NOTE_ANCHOR!r} was not found in the bundled skill — "
+        "the paragraph was reworded or removed; update this anchor to match."
+    )
+    end = text.find("\n\n", start)
+    assert end != -1, (
+        "the Control-root paragraph starting at the anchor never reaches a "
+        "blank-line paragraph break"
+    )
+    return text[start:end]
+
+
+def _normalize_whitespace(text: str) -> str:
+    # Both surfaces hand-wrap their prose at ~88 columns, so a load-bearing phrase
+    # can straddle a line break (e.g. "...no intrinsic\nminimum size..."). Collapsing
+    # whitespace runs to a single space keeps token matching robust to rewrapping.
+    return re.sub(r"\s+", " ", text)
+
+
 def test_scene_create_control_root_note_agrees_with_skill():
     # `gda scene create --help` (the command docstring, projected verbatim into
-    # `gda schema`'s "scene create" description) and this Scene-authoring section
-    # independently document the same Control-derived zero-size root pitfall
-    # (GDA-DF-006, #672) in two hand-maintained prose surfaces. They already diverged
-    # once — a scope fix (Control -> Control-derived) landed in SKILL.md without the
-    # matching help-text edit (PR #676 review) — so this is a minimal token-level guard,
-    # not a full prose-equality pin: the two surfaces deliberately differ in voice, but
-    # must name the same fix properties, the same check command, and agree on the same
-    # root-class scope.
+    # `gda schema`'s "scene create" description) and the SKILL.md Scene-authoring
+    # paragraph independently document the same Control-derived zero-size root
+    # pitfall (GDA-DF-006, #672) in two hand-maintained prose surfaces. They have
+    # already diverged twice: a scope fix (Control -> Control-derived) landed in
+    # SKILL.md without the matching help-text edit (PR #676 review round 1); and an
+    # earlier version of this test searched tokens across the whole bundled skill,
+    # so it could stay green even if the zero-size-is-conditional fact regressed,
+    # since `game rect` / `node set` also occur elsewhere in SKILL.md for unrelated
+    # reasons (PR #676 review round 2 recheck). This guards the SPECIFIC paragraph
+    # for the SPECIFIC semantic facts the round corrected — the zero anchors/offsets
+    # behavior, the intrinsic-minimum-size conditional, the fix properties, and the
+    # check command — as tokens, not full prose equality (the two surfaces
+    # deliberately differ in voice).
     by_name = {
         c["name"]: c["description"]
         for c in build_surface_manifest(app).model_dump()["commands"]
     }
-    scene_create_description = by_name["scene create"]
+    scene_create_description = _normalize_whitespace(by_name["scene create"])
+    skill_paragraph = _normalize_whitespace(_extract_scene_create_root_note(BUNDLED))
 
-    load_bearing_tokens = ["anchor_right", "anchor_bottom", "game rect"]
+    load_bearing_tokens = [
+        "zero anchors",
+        "zero offsets",
+        "intrinsic minimum",
+        "zero-size",
+        "anchor_right",
+        "anchor_bottom",
+        "node set",
+        "game rect",
+        "Control-derived",
+    ]
     for token in load_bearing_tokens:
         assert token in scene_create_description, (
             f"'scene create' help text missing {token!r}: {scene_create_description!r}"
         )
-        assert token in BUNDLED, f"SKILL.md missing {token!r}"
-
-    assert "Control-derived" in scene_create_description, (
-        "'scene create' help text dropped the Control-derived scope token"
-    )
-    assert "Control-derived" in BUNDLED, (
-        "SKILL.md dropped the Control-derived scope token"
-    )
+        assert token in skill_paragraph, (
+            f"SKILL.md's Control-root paragraph missing {token!r}: {skill_paragraph!r}"
+        )


### PR DESCRIPTION
## Summary

Dogfooding source GDA-DF-006: `gda scene create ui/main.tscn --root-type Control` creates a valid root with zero anchors/offsets and no viewport-filling layout. Container minimum sizes can make descendants visible and mask the problem until `gda game rect` shows the root, and its child layers, at `[0, 0]` size.

This is a documentation-only change: no input model, schema, or CLI-flag change. It states the behavior, the fix, and the check in two surfaces:

- **`gda scene create --help`** (`src/gda/commands/scene.py`, `create()` docstring): a paragraph after the existing one-line summary, stating the zero-anchor/zero-offset behavior, the fix (`anchor_right`/`anchor_bottom` to `1` via `gda node set`), and the `gda game rect` check.
- **The bundled skill** (`src/gda/skill/SKILL.md`, "Scene authoring" section): a paragraph placed right after the existing Control-layout/`offset_*` paragraph (the natural neighbor), stating the same behavior, fix, and check in the skill's prose voice.

README.md is untouched — this is a per-command layout pitfall, not onboarding material (repo convention: no per-command pitfalls in README).

**Review round 2** (external adversarial review, see the PR comments below) found the round-1 wording overstated the claim: it said any Control root renders as a literal zero-size rect, but that is only true for a root class with no intrinsic minimum size. A class with an intrinsic minimum (`Button`, `Label`, …) renders at that minimum instead — still not the viewport, but not `[0, 0]` either. Both surfaces are now reworded to state this precisely, and a new test (`tests/test_skill_surface_sync.py::test_scene_create_control_root_note_agrees_with_skill`) guards the two hand-maintained prose surfaces against drifting apart again — they had already diverged once mid-review (a scope-only fix landed in SKILL.md, `ca00f092`, without the matching `scene.py` edit).

**Review round 3** (recheck of round 2's fix) found the new test itself was too weak: it searched its tokens across the whole bundled skill, so `game rect` / `node set` could be satisfied by an unrelated occurrence, and it did not guard the semantic facts round 2 actually corrected (zero anchors/offsets, the intrinsic-minimum conditional). Scoped the assertion to just the Scene-authoring paragraph (anchor-extracted, failing loudly if the anchor disappears) and widened the checked tokens to cover the corrected facts. No prose or `--help`/`gda schema` change — test-only.

**Review round 4** (recheck of round 3's fix) showed the strengthened test still guarded vocabulary, not the conditional: a one-word mutation ("no intrinsic minimum" → "an intrinsic minimum") reversed the guarded meaning while keeping every token present, and the test stayed green. The assertions are now ORDERED clause patterns — `no intrinsic minimum[^;]*zero-size rect` and `an intrinsic minimum[^;]*renders at that minimum instead` — each confined to one semicolon-delimited clause so a condition cannot pair with the wrong consequence, matched on whitespace-collapsed, backtick-stripped prose so one pattern covers both surfaces' voices. The reviewer's reversal mutation is landed as a negative sentinel test (`test_control_root_guard_catches_a_reversed_conditional`) that applies exactly that flip to the extracted paragraph and requires the guard to raise. Test-only; no prose or surface change.

## Public-surface diff (every intended change)

1. `src/gda/commands/scene.py` — `create()` docstring gains a paragraph (shown in `gda scene create --help`, not in the `gda scene --help` command-table short_help, which still reads the unchanged first line).
2. `src/gda/skill/SKILL.md` — one new paragraph in "Scene authoring".
3. `tests/test_skill_surface_sync.py` — `test_scene_create_control_root_note_agrees_with_skill` (added round 2; paragraph-scoped in round 3; round 4 replaced token coverage with ordered condition/consequence clause patterns) plus the round-4 negative sentinel `test_control_root_guard_catches_a_reversed_conditional`. No behavior change; not part of the public surface.

Verified via `gda schema` diff (structured JSON, parsed and compared field-by-field, not textual): the **only** field that changed anywhere in the whole manifest, at every round, is `commands[name="scene create"].description`. No other command, no input/output/error schema, changed shape.

Final `gda scene create --help` diff (baseline before round 1 vs. current head):
```
 A Control-derived root is created with zero anchors and zero offsets,
 so it does not fill the viewport. A root class with no intrinsic
 minimum size (plain Control, Panel, an empty container) renders as a
 zero-size rect at the origin; a class with an intrinsic minimum (e.g.
 Button, Label) renders at that minimum instead, still not the
 viewport. Container minimum sizes can keep descendants visible and
 mask this. Fill the viewport by setting the root's anchor_right and
 anchor_bottom to 1 with 'gda node set' (offsets stay 0); confirm with
 'gda game rect', which reports the root's rendered rect at runtime.
```
(inserted after the existing one-line summary; everything else in `--help` — arguments, options, `gda scene --help` command table — unchanged.)

## Validation

- Reproduced the documented behavior against a real Godot 4.6.3 project, both rounds:
  - Round 1: `gda scene create ui/main.tscn --root-type Control --project <tmp>` then `gda node get` shows `anchor_left/top/right/bottom = 0` and `offset_left/top/right/bottom = 0`; `gda node set --property anchor_right --value 1` (and `anchor_bottom`) applied cleanly.
  - Round 2 (the reviewer's exact probe): live `gda daemon start --scene res://ui/<name>.tscn` + `gda game rect /root/<name>` against four root types confirms the conditional claim precisely — `Control` -> `[0, 0]`, `Panel` -> `[0, 0]`, `Button` -> `[8, 8]`, `Label` -> `[1, 23]`. Also confirmed the fix is universal: setting `anchor_right`/`anchor_bottom` to `1` on the `Button` root made it fill the viewport (`[64, 64]`), same as a plain `Control` root.
  - Round 3: red/green probe on the strengthened test — temporarily replaced "intrinsic minimum" with "special-case size" in the SKILL.md paragraph, reran the test, it failed naming the missing token; reverted before committing. Separately confirmed in-memory that doctoring the paragraph's anchor line raises a loud extraction assertion rather than matching an empty span.
  - Round 4: the reversal mutation itself is now a committed negative sentinel test (it mutates the extracted paragraph in-memory and requires the clause guard to raise), so the red proof runs on every CI run instead of being a one-off probe. The guard also fails on the symmetric mutations (reversing the second clause, or swapping the consequences).
- `uv run pytest -m "not e2e"` — 1197 passed, 390 deselected on the current head (`tests/test_skill_surface_sync.py` → 5 passed, sentinel included); 1196 at rounds 2–3.
- `uv run ruff check` — all checks passed.
- `uv run ruff format --check` — 426 files already formatted.
- `uv run pyright` — 0 errors, 0 warnings, 0 informations.
- `gda schema` byte-identical to the round-2 head (`e7cf5cdb`) after round 3 — confirming the test-only fix touched no public surface.
- No Godot e2e run: this is a docs-only slice (help text + skill prose + one unit test), no engine-run behavior changed, so no e2e gate applies. The documented behavior itself was reproduced manually against a live Godot session (see above), not via an automated e2e test.

Closes #672


