### PR TITLE
fix(gda): make gda the verdict authority for script run (ADR-0031 amendment)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -130,7 +130,9 @@ operation, and parse codes the CLI assigns).
 | `unsupported_property_type` | `operation` | `operation` | `4` | An Object-typed property expects a type `node set` / `resource set` cannot yet assign a `res://` resource to: a script `class_name`-typed property (deferred to the ADR-0032 resolver) or an Object property with no declared engine class (ADR-0033, #363). |
 | `no_search_match` | `operation` | `operation` | `4` | A search-replace script edit found no occurrence of the search string. |
 | `invalid_line_range` | `operation` | `operation` | `4` | A line-range script edit specified lines outside the script's bounds, or end before start. |
-| `script_compile_failed` | `operation` | `operation` | `4` | A script could not be attached to a node because it does not compile. |
+| `script_compile_failed` | `operation` | `operation` | `4` | A script does not compile, so the requested work could not proceed: `script attach` refuses to bind it to a node, and `script run` reports that the entry script (or a dependency it preloads) never ran (#651). |
+| `script_not_found` | `operation` | `classifier` | `4` | A `script run` entry script does not exist in the project, so the engine never ran it — read from stderr, since the engine still exits 0 (#651). |
+| `script_failed` | `operation` | `classifier` | `4` | A `script run --strict` script ran to completion and chose a non-zero exit status; strict mode maps that opted-in failure onto the uniform error envelope. Never reported without `--strict` (ADR-0031 amendment, #651). |
 | `incompatible_script_type` | `operation` | `operation` | `4` | A script compiles but its native base type is incompatible with the target node's type. |
 | `signal_not_found` | `operation` | `operation` | `4` | A requested signal does not exist on the source node. |
 | `already_connected` | `operation` | `operation` | `4` | A signal is already connected to the target node's method. |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -63,19 +63,34 @@ An operation failure payload has this wire shape:
 The GDScript payload owns only `code` and `message`. `gda` owns the public
 `GdaError` wrapper: it validates that the code is registered, assigns the
 `operation` category, preserves the message, and copies stderr into diagnostics.
+(`diagnostics` is a free-form string, so a channel with better evidence to offer
+may fill it differently: `script run --strict` carries the user script's own
+stdout *and* stderr there under fixed labels, because for that failure the
+script's output is the diagnostic — see the ADR-0031 amendment.)
 
 ### stderr as advisory diagnostics
 
-stderr is still **never** parsed for the success/failure *outcome* or for stable
-error codes — those come only from the exit code and the stdout sentinel, as
-above. A command **may**, however, surface engine error text from stderr as
-**advisory, best-effort diagnostics** on its *success* result, when a useful
-detail is available nowhere else. `script validate` (#118) is the established
-case: when it reports `valid=false`, the per-error `line` and `message` exist
-only in the engine's stderr (no bound API exposes them), so `gda` parses them
-into the result's `diagnostics`. This stays within the contract: the diagnostics
-are advisory (they may hold only the first error, and `column` is unavailable on
-the standard build), and they never determine the outcome or a stable code.
+On **this sentinel channel**, stderr is still **never** parsed for the
+success/failure *outcome* or for stable error codes — those come only from the
+exit code and the stdout sentinel, as above. A command **may**, however, surface
+engine error text from stderr as **advisory, best-effort diagnostics** on its
+*success* result, when a useful detail is available nowhere else. `script
+validate` (#118) is the established case: when it reports `valid=false`, the
+per-error `line` and `message` exist only in the engine's stderr (no bound API
+exposes them), so `gda` parses them into the result's `diagnostics`. This stays
+within the contract: the diagnostics are advisory (they may hold only the first
+error, and `column` is unavailable on the standard build), and they never
+determine the outcome or a stable code.
+
+> **Scope note (2026-08-15, #651).** The rule above governs the sentinel channel,
+> where an outcome is always available from the exit code plus the sentinel.
+> ADR-0031's `script run` is a **different execution shape**: the entry script is
+> the user's own, so it emits no sentinel, and the engine exits `0` even when it
+> never ran the script. There, the engine's error stream is the *only* evidence of
+> the outcome, so that channel **does** derive its verdict from parsed stderr —
+> keyed on recognized engine sentences, never on free-text matching. This does not
+> relax the sentinel rule; it records that the sentinel rule presupposes a sentinel.
+> See the ADR-0031 amendment.
 
 ## `GdaError.code` registry
 
@@ -133,7 +148,7 @@ operation, and parse codes the CLI assigns).
 | `script_compile_failed` | `operation` | `operation` | `4` | A script does not compile, so the requested work could not proceed: `script attach` refuses to bind it to a node, and `script run` reports that the entry script (or a dependency it preloads) never ran (#651). |
 | `script_not_found` | `operation` | `classifier` | `4` | A `script run` entry script does not exist in the project, so the engine never ran it — read from stderr, since the engine still exits 0 (#651). |
 | `script_failed` | `operation` | `classifier` | `4` | A `script run --strict` script ran to completion and chose a non-zero exit status; strict mode maps that opted-in failure onto the uniform error envelope. Never reported without `--strict` (ADR-0031 amendment, #651). |
-| `incompatible_script_type` | `operation` | `operation` | `4` | A script compiles but its native base type is incompatible with the target node's type. |
+| `incompatible_script_type` | `operation` | `operation` | `4` | A script compiles but its base type is incompatible with the requested use: `script attach`'s target node type, or `script run`'s requirement that a one-shot entry script extend `SceneTree`/`MainLoop` (#651). |
 | `signal_not_found` | `operation` | `operation` | `4` | A requested signal does not exist on the source node. |
 | `already_connected` | `operation` | `operation` | `4` | A signal is already connected to the target node's method. |
 | `connection_not_found` | `operation` | `operation` | `4` | A requested signal-to-method connection does not exist on the source node. |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -105,6 +105,27 @@ the standard build), and they never determine the outcome or a stable code.
 > `invalid_path` already does for a CLI-side path rejection. The GDScript mirror is
 > derived from operation-source *membership*, which such reuse does not change.
 
+> **Scope note, extended 2026-08-16 (#651 review recheck) — naming the sentences
+> this qualifies.** Two accepted sentences read as an exclusive rule and are the
+> ones the paragraph above narrows: the registry section's "GDScript mirrors only
+> the rows whose source is `operation`, because only those codes can be reported by
+> headless operations", and the `Source` column's implied "the source that may
+> report it".
+>
+> Both stay true of what they actually govern — **mirror membership and the
+> sentinel channel**: `operations.gd` declares exactly the `operation`-source rows,
+> and only those may come back through the ADR-0002 sentinel as an operation's own
+> report. Neither constrains the **Python classifier**, which may assign any
+> registered code whose semantics match the failure it recognized, including an
+> `operation`-source one — a practice `invalid_path` established long before #651.
+>
+> So: `source` is an **origin-and-membership** field, never an emitter whitelist.
+> Nothing derives behavior from the exclusive reading — `classify_run` keys on
+> operation-source *membership* to validate a sentinel-reported code, and the
+> mirror test keys on the same membership — so this is a correction to the recorded
+> meaning, not a change to the contract. `src/gda/error_codes.py`'s module
+> docstring is the single home of this definition.
+
 ## `GdaError.code` registry
 
 `GdaError.code` values are a public ABI for agents. Their authoritative source is

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -97,6 +97,13 @@ the standard build), and they never determine the outcome or a stable code.
 >
 > Neither relaxes the sentinel rules; both record that those rules presuppose a
 > sentinel. See the ADR-0031 amendment.
+>
+> One consequence for the registry below: a row's `source` names the code's
+> **authoritative origin channel**, not an exclusive list of what may emit it. When
+> the classifier recognizes the same semantic failure from the engine's output
+> rather than from a sentinel, it may assign an `operation`-source code — as
+> `invalid_path` already does for a CLI-side path rejection. The GDScript mirror is
+> derived from operation-source *membership*, which such reuse does not change.
 
 ## `GdaError.code` registry
 

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -63,34 +63,40 @@ An operation failure payload has this wire shape:
 The GDScript payload owns only `code` and `message`. `gda` owns the public
 `GdaError` wrapper: it validates that the code is registered, assigns the
 `operation` category, preserves the message, and copies stderr into diagnostics.
-(`diagnostics` is a free-form string, so a channel with better evidence to offer
-may fill it differently: `script run --strict` carries the user script's own
-stdout *and* stderr there under fixed labels, because for that failure the
-script's output is the diagnostic — see the ADR-0031 amendment.)
 
 ### stderr as advisory diagnostics
 
-On **this sentinel channel**, stderr is still **never** parsed for the
-success/failure *outcome* or for stable error codes — those come only from the
-exit code and the stdout sentinel, as above. A command **may**, however, surface
-engine error text from stderr as **advisory, best-effort diagnostics** on its
-*success* result, when a useful detail is available nowhere else. `script
-validate` (#118) is the established case: when it reports `valid=false`, the
-per-error `line` and `message` exist only in the engine's stderr (no bound API
-exposes them), so `gda` parses them into the result's `diagnostics`. This stays
-within the contract: the diagnostics are advisory (they may hold only the first
-error, and `column` is unavailable on the standard build), and they never
-determine the outcome or a stable code.
+stderr is still **never** parsed for the success/failure *outcome* or for stable
+error codes — those come only from the exit code and the stdout sentinel, as
+above. A command **may**, however, surface engine error text from stderr as
+**advisory, best-effort diagnostics** on its *success* result, when a useful
+detail is available nowhere else. `script validate` (#118) is the established
+case: when it reports `valid=false`, the per-error `line` and `message` exist
+only in the engine's stderr (no bound API exposes them), so `gda` parses them
+into the result's `diagnostics`. This stays within the contract: the diagnostics
+are advisory (they may hold only the first error, and `column` is unavailable on
+the standard build), and they never determine the outcome or a stable code.
 
-> **Scope note (2026-08-15, #651).** The rule above governs the sentinel channel,
-> where an outcome is always available from the exit code plus the sentinel.
-> ADR-0031's `script run` is a **different execution shape**: the entry script is
-> the user's own, so it emits no sentinel, and the engine exits `0` even when it
-> never ran the script. There, the engine's error stream is the *only* evidence of
-> the outcome, so that channel **does** derive its verdict from parsed stderr —
-> keyed on recognized engine sentences, never on free-text matching. This does not
-> relax the sentinel rule; it records that the sentinel rule presupposes a sentinel.
-> See the ADR-0031 amendment.
+> **Scope note (2026-08-15, #651) — the two rules above presuppose the sentinel
+> channel, which ADR-0031's `script run` does not have.** Both the "stderr is never
+> parsed for the outcome" rule and the "copies stderr into diagnostics" wrapper
+> behaviour are stated for the sentinel pipeline, where an outcome is always
+> available from the exit code plus the stdout sentinel, and where the engine's
+> stderr is the only diagnostic on offer. `script run` (ADR-0031) is a **different
+> execution shape**: the entry script is the user's own, so it emits no sentinel,
+> and the engine exits `0` even when it never ran the script. Two consequences,
+> both scoped to that channel:
+>
+> - **Outcome.** The engine's error stream is the *only* evidence that the script
+>   never ran, so that channel **does** derive its verdict from parsed stderr —
+>   keyed on recognized engine sentences, never on free-text matching.
+> - **Diagnostics.** `GdaError.diagnostics` is a free-form string, so a channel
+>   with better evidence to offer may fill it differently: `script run --strict`
+>   carries the user script's own stdout *and* stderr there under fixed labels,
+>   because for that failure the script's output *is* the diagnostic.
+>
+> Neither relaxes the sentinel rules; both record that those rules presuppose a
+> sentinel. See the ADR-0031 amendment.
 
 ## `GdaError.code` registry
 

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -11,9 +11,15 @@ status: accepted
 > left implicit, and adds one opt-in inversion.
 >
 > **1. A script that never ran is a failure, by default.** Godot reports **three** such shapes
-> **only on stderr — and still exits `0`** (verified against Godot 4.6.3): a missing `--script` entry
-> point; an entry script (or a dependency it preloads) that fails to parse or compile; and one that
-> compiles but does not extend `SceneTree`/`MainLoop`, so it can never be a one-shot entry point.
+> **only on stderr — and still exits `0`**: a missing `--script` entry point; an entry script (or a
+> dependency it preloads) that fails to parse or compile; and one that compiles but does not extend
+> `SceneTree`/`MainLoop`, so it can never be a one-shot entry point. The first two were verified
+> against Godot 4.6.3 as reliably reproducible. The **third is not**: its exit-0 form is real and
+> captured, but the engine more often prints nothing and simply keeps idling — falling through to
+> the project's main loop — which surfaces as `launch_timeout` (#655). That is a failure by another
+> route, so gda never reports success for it either way; only the exit-0 form is what this decision
+> has to correct.
+>
 > Passing that status through made `gda script run res://does-not-exist.gd` return
 > `{"exit_status": 0}`, which no reading of the contract calls a successful run. These are
 > **defects, not the contract**: the passthrough exists because gda does not know a user script's

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -10,16 +10,29 @@ status: accepted
 > decision below is unchanged for a **completed** run; this note draws the line the original text
 > left implicit, and adds one opt-in inversion.
 >
-> **1. A script that never ran is a failure, by default.** Godot reports a missing `--script` entry
-> point, and an entry script (or a dependency it preloads) that fails to parse or compile, **only on
-> stderr — and still exits `0`** (verified against Godot 4.6.3). Passing that status through made
-> `gda script run res://does-not-exist.gd` return `{"exit_status": 0}`, which no reading of the
-> contract calls a successful run. These are **defects, not the contract**: the passthrough exists
-> because gda does not know a user script's *semantics*, and a script that never started has none.
-> They now classify to the registered `script_not_found` / `script_compile_failed` **Error
-> envelope** (both `operation` category, exit `4`). The verdict is read from the engine's error
-> stream, never from the exit code, and is keyed on the **entry script's own `res://` path** — a
-> running script that itself fails to load some *other* resource stays a success.
+> **1. A script that never ran is a failure, by default.** Godot reports **three** such shapes
+> **only on stderr — and still exits `0`** (verified against Godot 4.6.3): a missing `--script` entry
+> point; an entry script (or a dependency it preloads) that fails to parse or compile; and one that
+> compiles but does not extend `SceneTree`/`MainLoop`, so it can never be a one-shot entry point.
+> Passing that status through made `gda script run res://does-not-exist.gd` return
+> `{"exit_status": 0}`, which no reading of the contract calls a successful run. These are
+> **defects, not the contract**: the passthrough exists because gda does not know a user script's
+> *semantics*, and a script that never started has none. They now classify to an **Error envelope**
+> (all `operation` category, exit `4`):
+>
+> | shape | code |
+> | --- | --- |
+> | the entry script does not exist | `script_not_found` (new) |
+> | the entry script or a preloaded dependency does not compile | `script_compile_failed` (reused) |
+> | the entry script compiles but is not a `SceneTree`/`MainLoop` | `incompatible_script_type` (reused) |
+>
+> The two reused codes already name these exact conditions for `script attach`; only the genuinely
+> new condition — "the engine could not load the entry script, so the run never happened" — is
+> minted. The verdict is read from the engine's error stream, never from the exit code, and is keyed
+> on the **entry script's own `res://` path**: a running script that itself fails to load some
+> *other* resource stays a success. When a run emits several of these, the earliest-stage, most
+> specific cause wins (missing > compile > parse > load > not-a-main-loop) — the engine reports the
+> whole cascade, and only the first cause explains the rest.
 >
 > **2. `--strict` inverts the non-zero-exit default, opt-in only.** The considered option
 > "map a non-zero *script* exit to a synthesized `script_failed`" stays **rejected as the default**,
@@ -28,10 +41,13 @@ status: accepted
 > step — cannot express that with a command that always exits `0` (GDA-DF-017). `--strict` is that
 > expression: for that invocation, a completed run with a non-zero `exit_status` becomes the
 > registered `script_failed` envelope. The child status is **not** propagated as gda's process exit
-> code — a script's `quit(3)` would alias `EXIT_VERSION` — so strict exits `4` and keeps the status
-> readable in the message and the script's stderr in `diagnostics`. The script's **stdout is not
-> carried by the envelope**; re-run without `--strict` to read the full passthrough result.
-> Without the flag, behaviour is exactly as decided below.
+> code — a script's `quit(3)` would alias `EXIT_VERSION` — so strict exits `4`.
+>
+> The envelope keeps the evidence the flag exists to act on. `diagnostics` carries **both** of the
+> script's streams under the fixed labels `--- script stdout ---` and `--- script stderr ---` (both
+> sections always present, empty when the stream was). Carrying stderr alone would defeat the flag's
+> own use case: a GDScript test runner reports through `print()`, i.e. stdout, so a CI caller would
+> receive a failure with no content. Without the flag, behaviour is exactly as decided below.
 >
 > **3. The success result gains classified `diagnostics`.** Recognized script errors parsed out of
 > the engine's stderr are surfaced as structured entries alongside the verbatim `stderr`, so a
@@ -40,10 +56,14 @@ status: accepted
 > success/failure verdict, never the parsed text. Not interpreting the *script's* semantics was
 > never a reason to ignore the *engine's* report.
 >
-> **Not decided here:** a script that compiles but does not extend `SceneTree`/`MainLoop` also never
-> runs, and the engine reports it the same way. It is parsed and surfaced as a diagnostic
-> (`not_a_main_loop`) but does **not** flip the verdict — it is neither missing nor non-compiling,
-> so it needs a code and a decision of its own.
+> **Shape of the two diagnostics channels — deliberately different, and not symmetric.** The
+> structured `ScriptError[]` of point 3 appears **only on success results**, which are typed models
+> free to carry any shape. The **failure** channel is ADR-0004's `GdaError`, whose `diagnostics` is a
+> free-form `str`, so everything a failure reports — the labelled streams of point 2, the engine
+> stderr behind a point-1 verdict — is **prose**. The child's numeric exit status likewise survives
+> only as message prose, not as a structured field. Giving the failure channel structured
+> diagnostics means changing the ADR-0004 envelope, which is a decision of its own; #655 flags it.
+> This amendment deliberately does **not** make that change.
 
 ADR-0010 recognised **two** execution mechanisms for [headless operations](../../CONTEXT.md):
 ① GDScript op-dispatch under the ADR-0002 sentinel contract (the default), and ② native engine

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -4,6 +4,47 @@ status: accepted
 
 # Headless script-run execution: a third shape — pass the user script's run through, classify only launch/crash
 
+> **Amendment (2026-08-15, #651) — `gda` is the authority on whether the engine RAN the script;
+> the script stays the authority on what its own exit status means.** Dogfooding (GDA-DF-007,
+> GDA-DF-017, GDA-DF-032) found the passthrough reporting success for runs that never happened. The
+> decision below is unchanged for a **completed** run; this note draws the line the original text
+> left implicit, and adds one opt-in inversion.
+>
+> **1. A script that never ran is a failure, by default.** Godot reports a missing `--script` entry
+> point, and an entry script (or a dependency it preloads) that fails to parse or compile, **only on
+> stderr — and still exits `0`** (verified against Godot 4.6.3). Passing that status through made
+> `gda script run res://does-not-exist.gd` return `{"exit_status": 0}`, which no reading of the
+> contract calls a successful run. These are **defects, not the contract**: the passthrough exists
+> because gda does not know a user script's *semantics*, and a script that never started has none.
+> They now classify to the registered `script_not_found` / `script_compile_failed` **Error
+> envelope** (both `operation` category, exit `4`). The verdict is read from the engine's error
+> stream, never from the exit code, and is keyed on the **entry script's own `res://` path** — a
+> running script that itself fails to load some *other* resource stays a success.
+>
+> **2. `--strict` inverts the non-zero-exit default, opt-in only.** The considered option
+> "map a non-zero *script* exit to a synthesized `script_failed`" stays **rejected as the default**,
+> for the reason recorded below: the Raw-run promotion is what lets a user script use its exit codes
+> freely. But a caller whose gate *is* the process exit code — a shell `&&` chain, a conventional CI
+> step — cannot express that with a command that always exits `0` (GDA-DF-017). `--strict` is that
+> expression: for that invocation, a completed run with a non-zero `exit_status` becomes the
+> registered `script_failed` envelope. The child status is **not** propagated as gda's process exit
+> code — a script's `quit(3)` would alias `EXIT_VERSION` — so strict exits `4` and keeps the status
+> readable in the message and the script's stderr in `diagnostics`. The script's **stdout is not
+> carried by the envelope**; re-run without `--strict` to read the full passthrough result.
+> Without the flag, behaviour is exactly as decided below.
+>
+> **3. The success result gains classified `diagnostics`.** Recognized script errors parsed out of
+> the engine's stderr are surfaced as structured entries alongside the verbatim `stderr`, so a
+> runtime GDScript error the script *survived* (leaving a clean `exit_status`) is visible without
+> matching engine prose. Advisory, in ADR-0002's sense: the stable outcome is still the
+> success/failure verdict, never the parsed text. Not interpreting the *script's* semantics was
+> never a reason to ignore the *engine's* report.
+>
+> **Not decided here:** a script that compiles but does not extend `SceneTree`/`MainLoop` also never
+> runs, and the engine reports it the same way. It is parsed and surfaced as a diagnostic
+> (`not_a_main_loop`) but does **not** flip the verdict — it is neither missing nor non-compiling,
+> so it needs a code and a decision of its own.
+
 ADR-0010 recognised **two** execution mechanisms for [headless operations](../../CONTEXT.md):
 ① GDScript op-dispatch under the ADR-0002 sentinel contract (the default), and ② native engine
 CLI mode for editor-only capabilities (e.g. `--export-*`), whose outcome `gda` classifies from the

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -68,8 +68,14 @@ status: accepted
 > free-form `str`, so everything a failure reports — the labelled streams of point 2, the engine
 > stderr behind a point-1 verdict — is **prose**. The child's numeric exit status likewise survives
 > only as message prose, not as a structured field. Giving the failure channel structured
-> diagnostics means changing the ADR-0004 envelope, which is a decision of its own; #655 flags it.
+> diagnostics means changing the ADR-0004 envelope, which is a decision of its own; **#655 owns it**.
 > This amendment deliberately does **not** make that change.
+>
+> This bounds how far #651's "preserve the raw process status and stderr as secondary evidence"
+> criterion is met here: **fully on the success path** (verbatim `stdout`/`stderr` plus the typed
+> `ScriptError[]`), **partially on failure paths** — the evidence is there, as labelled prose in
+> `diagnostics` and a status named in the message, but it is not typed. That gap is the deferral
+> above, not an oversight.
 
 ADR-0010 recognised **two** execution mechanisms for [headless operations](../../CONTEXT.md):
 ① GDScript op-dispatch under the ADR-0002 sentinel contract (the default), and ② native engine

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -68,7 +68,8 @@ status: accepted
 > free-form `str`, so everything a failure reports — the labelled streams of point 2, the engine
 > stderr behind a point-1 verdict — is **prose**. The child's numeric exit status likewise survives
 > only as message prose, not as a structured field. Giving the failure channel structured
-> diagnostics means changing the ADR-0004 envelope, which is a decision of its own; **#655 owns it**.
+> diagnostics means changing the ADR-0004 envelope, which is a decision of its own; **#687 owns it**
+> (#655's timeout envelope names the same constraint and adopts #687's outcome).
 > This amendment deliberately does **not** make that change.
 >
 > This bounds how far #651's "preserve the raw process status and stderr as secondary evidence"

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -1347,15 +1347,16 @@ def run_script(
     non-zero status, so a shell ``&&`` chain or CI gate stops on it; that envelope
     carries the script's own stdout and stderr in its ``diagnostics``.
 
-    A script that never RAN is a failure either way. Godot reports all three of these
-    on stderr and still exits 0, so gda decides them from the engine's error stream,
-    not its exit code: a missing res:// entry script is ``script_not_found``; an
-    entry script (or a dependency it preloads) that fails to parse or compile is
+    A script that never RAN is a failure either way. Godot reports these on stderr and
+    still exits 0, so gda decides them from the engine's error stream, not its exit
+    code: a missing res:// entry script is ``script_not_found``; an entry script (or a
+    dependency it preloads) that fails to parse or compile is
     ``script_compile_failed``; and one that compiles but does not extend
     ``SceneTree``/``MainLoop``, so it cannot be an entry point at all, is
-    ``incompatible_script_type``. Recognized script errors — including a runtime
-    GDScript error the script itself survived — are also surfaced as structured
-    ``diagnostics`` on a successful result.
+    ``incompatible_script_type`` — though that last shape may instead leave the engine
+    idling with nothing on stderr, which surfaces as ``launch_timeout``. Recognized
+    script errors — including a runtime GDScript error the script itself survived —
+    are also surfaced as structured ``diagnostics`` on a successful result.
 
     Only a gda-/engine-level failure (binary not launchable, timeout, or a signal
     crash) is a ``binary_not_found`` / ``launch_timeout`` / ``engine_crashed``

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -547,8 +547,11 @@ class ScriptRunParams(BaseModel):
             "Treat a non-zero script exit status as a gda failure: emit the error "
             "envelope with code 'script_failed' and exit 4, instead of the default "
             "passthrough success. Opt-in, for shell '&&' chains and CI gates that "
-            "key on the process exit code. A script that never ran (missing, or a "
-            "failed load/compile) fails either way (ADR-0031 amendment)."
+            "key on the process exit code. The envelope keeps the evidence: its "
+            "message names the exit status, and its 'diagnostics' string carries "
+            "BOTH of the script's streams under the fixed labels "
+            "'--- script stdout ---' and '--- script stderr ---'. A script that "
+            "never ran fails either way (ADR-0031 amendment)."
         ),
     )
 
@@ -615,13 +618,14 @@ class ScriptRunResult(BaseModel):
 #   export channel uses, into its existing codes (``binary_not_found`` /
 #   ``launch_timeout`` / ``engine_crashed``). No new GDScript-mirrored codes.
 # - **the script never RAN** — the engine exited normally but its stderr proves it
-#   could not load the entry script (missing, or a failed parse/compile of the
-#   script or a dependency it preloads) → an **Error envelope** carrying
-#   ``script_not_found`` / ``script_compile_failed`` (#651, ADR-0031 amendment).
-#   Godot reports all of these on stderr and STILL exits 0, so passing that status
-#   through reported a phantom success. gda is the authority on whether the engine
-#   ran what it was asked to; the verdict is read from the parsed stderr evidence
-#   (:mod:`gda.script_errors`), never from the exit code.
+#   could not run the entry script: it is missing, it (or a dependency it preloads)
+#   failed to parse/compile, or it compiles but is not a ``SceneTree``/``MainLoop``
+#   → an **Error envelope** carrying ``script_not_found`` /
+#   ``script_compile_failed`` / ``incompatible_script_type`` (#651, ADR-0031
+#   amendment). Godot reports all of these on stderr and STILL exits 0, so passing
+#   that status through reported a phantom success. gda is the authority on whether
+#   the engine ran what it was asked to; the verdict is read from the parsed stderr
+#   evidence (:mod:`gda.script_errors`), never from the exit code.
 # - **the script ran to completion** — the engine exited normally
 #   (``exit_code >= 0``) → a **success** :class:`ScriptRunResult` carrying
 #   ``{exit_status, stdout, stderr, diagnostics}`` **passed through verbatim, even
@@ -677,16 +681,29 @@ class LaunchFn(Protocol):
     ) -> RunResult: ...
 
 
-# The verdict a proven entry-load failure maps to (#651). ``script_compile_failed``
-# is REUSED from ``script attach`` rather than duplicated: the condition is the same
-# one it already names — this script does not compile — and ADR-0002 prefers reusing
-# a code and discriminating via the message. The generic ``LOAD_FAILED`` (the engine
-# gave up on the entry point without naming a missing file) lands there too: the
-# file was readable, so "could not be loaded or compiled" is what gda actually knows.
+# The verdict each proven entry-load failure maps to (#651). Two of the three codes
+# are REUSED from ``script attach`` rather than duplicated, because the conditions
+# are the ones it already names (ADR-0002 — reuse the code, discriminate via the
+# message):
+#
+# - ``script_compile_failed`` — this script does not compile. The engine's explicit
+#   load-failure sentence (COMPILE_FAILED), the parse diagnostic behind it
+#   (PARSE_ERROR), and the generic give-up (LOAD_FAILED) all land here: whichever
+#   sentence the engine chose, what gda knows is that the entry could not be loaded
+#   or compiled.
+# - ``incompatible_script_type`` — this script compiles, but its base type is wrong
+#   for the requested use. ``script attach`` means "wrong for the target node";
+#   ``script run`` means "does not extend SceneTree/MainLoop, so it cannot be a
+#   one-shot entry point". Same condition, different target.
+#
+# Every kind in ``_ENTRY_FAILURE_PRECEDENCE`` MUST have a row here — a missing row
+# would be a KeyError on a real failure path, so a test pins the two in lockstep.
 _ENTRY_FAILURE_CODES: dict[ScriptErrorKind, str] = {
     ScriptErrorKind.SCRIPT_MISSING: "script_not_found",
     ScriptErrorKind.COMPILE_FAILED: "script_compile_failed",
+    ScriptErrorKind.PARSE_ERROR: "script_compile_failed",
     ScriptErrorKind.LOAD_FAILED: "script_compile_failed",
+    ScriptErrorKind.NOT_A_MAIN_LOOP: "incompatible_script_type",
 }
 
 
@@ -769,7 +786,7 @@ def run_script_run_operation(
     # The script RAN. Its own status is data by default (the ADR-0031 crux) and a
     # gda failure only when the caller opted in with --strict.
     if strict and raw.exit_code != 0:
-        return script_exit_status_failure(script, raw.exit_code, raw.stderr)
+        return script_exit_status_failure(script, raw.exit_code, raw.stdout, raw.stderr)
 
     # The public promotion of the internal Raw run: the thin boundary DTO built by
     # dropping launch_failure (lifted into the Error envelope above) and renaming
@@ -1306,7 +1323,10 @@ def run_script(
         help=(
             "Fail when the script exits non-zero: emit the 'script_failed' error "
             "envelope and exit 4 instead of the default passthrough success. For "
-            "shell '&&' chains and CI gates. A script that never ran fails either way."
+            "shell '&&' chains and CI gates. The envelope's message names the exit "
+            "status and its diagnostics carry both script streams, labelled "
+            "'--- script stdout ---' / '--- script stderr ---'. A script that never "
+            "ran fails either way."
         ),
     ),
     json_output: bool = json_option(),
@@ -1324,15 +1344,18 @@ def run_script(
     assertion-failed logic-seam test) is data the agent reads, not a gda failure —
     read ``exit_status``, do not assume ``success == zero``. Pass ``--strict`` to
     invert that one default and get the ``script_failed`` envelope (exit 4) for a
-    non-zero status, so a shell ``&&`` chain or CI gate stops on it.
+    non-zero status, so a shell ``&&`` chain or CI gate stops on it; that envelope
+    carries the script's own stdout and stderr in its ``diagnostics``.
 
-    A script that never RAN is a failure either way: a missing res:// entry script is
-    ``script_not_found``, and an entry script (or a dependency it preloads) that
-    fails to parse or compile is ``script_compile_failed`` — Godot reports both on
-    stderr and still exits 0, so gda decides these from the engine's error stream,
-    not its exit code. Recognized script errors — including a runtime GDScript error
-    the script itself survived — are also surfaced as structured ``diagnostics`` on a
-    successful result.
+    A script that never RAN is a failure either way. Godot reports all three of these
+    on stderr and still exits 0, so gda decides them from the engine's error stream,
+    not its exit code: a missing res:// entry script is ``script_not_found``; an
+    entry script (or a dependency it preloads) that fails to parse or compile is
+    ``script_compile_failed``; and one that compiles but does not extend
+    ``SceneTree``/``MainLoop``, so it cannot be an entry point at all, is
+    ``incompatible_script_type``. Recognized script errors — including a runtime
+    GDScript error the script itself survived — are also surfaced as structured
+    ``diagnostics`` on a successful result.
 
     Only a gda-/engine-level failure (binary not launchable, timeout, or a signal
     crash) is a ``binary_not_found`` / ``launch_timeout`` / ``engine_crashed``

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -30,6 +30,8 @@ from gda.errors import (
     Failure,
     classify_launch_or_crash,
     classify_run,
+    script_did_not_run_failure,
+    script_exit_status_failure,
     script_path_invalid_failure,
     script_run_project_not_found_failure,
     unresolvable_binary_failure,
@@ -44,6 +46,12 @@ from gda.headless import (
 )
 from gda.models import CREATED_DIRS_DESC, NormalizedPath
 from gda.runner import RunResult, launch
+from gda.script_errors import (
+    ScriptError,
+    ScriptErrorKind,
+    entry_load_failure,
+    parse_script_errors,
+)
 
 
 class ScriptCreateParams(BaseModel):
@@ -533,6 +541,16 @@ class ScriptRunParams(BaseModel):
     path: str = Field(
         description="The res:// path of the script to run (e.g. res://tests/logic.gd)."
     )
+    strict: bool = Field(
+        default=False,
+        description=(
+            "Treat a non-zero script exit status as a gda failure: emit the error "
+            "envelope with code 'script_failed' and exit 4, instead of the default "
+            "passthrough success. Opt-in, for shell '&&' chains and CI gates that "
+            "key on the process exit code. A script that never ran (missing, or a "
+            "failed load/compile) fails either way (ADR-0031 amendment)."
+        ),
+    )
 
 
 class ScriptRunResult(BaseModel):
@@ -548,21 +566,36 @@ class ScriptRunResult(BaseModel):
     ``exit_status``. Agents must read ``exit_status`` and must not assume
     ``success == zero``.
 
-    NOTE: a second passthrough consumer should promote this to a shared
-    ``RawRunResult`` model. Do NOT build that shared abstraction now: there is only
-    one consumer today (``export run`` returns a different domain shape — the
-    produced artifact — and does not reuse the raw run).
+    Not interpreting the script's semantics is NOT the same as not reading the
+    engine's: ``diagnostics`` carries the recognized script errors gda parsed out
+    of the engine's stderr (#651), so a runtime GDScript error that the script
+    swallowed — leaving a clean ``exit_status`` — is still visible structurally
+    rather than only as prose inside ``stderr``.
+
+    NOTE: a second passthrough consumer should promote the raw
+    ``{exit_status, stdout, stderr}`` core to a shared ``RawRunResult`` model. Do
+    NOT build that shared abstraction now: there is only one consumer today
+    (``export run`` returns a different domain shape — the produced artifact — and
+    does not reuse the raw run).
     """
 
     exit_status: int = Field(
         description=(
             "The user script's own process exit code, passed through verbatim — "
             "non-zero (e.g. a deliberate quit(1)) is still a SUCCESS result, not a "
-            "gda failure (ADR-0031)."
+            "gda failure, unless --strict was passed (ADR-0031)."
         )
     )
     stdout: str = Field(description="The script's standard output, captured verbatim.")
     stderr: str = Field(description="The script's standard error, captured verbatim.")
+    diagnostics: list[ScriptError] = Field(
+        default_factory=list,
+        description=(
+            "Recognized script errors parsed out of the engine's stderr, in "
+            "emission order; empty when the run reported none. Advisory and "
+            "best-effort — the verbatim stream stays in 'stderr'."
+        ),
+    )
 
 
 # --- The ScriptRun operation — ``gda script run``'s user-script passthrough run
@@ -581,12 +614,22 @@ class ScriptRunResult(BaseModel):
 #   classified by the SAME shared :func:`gda.errors.classify_launch_or_crash` the
 #   export channel uses, into its existing codes (``binary_not_found`` /
 #   ``launch_timeout`` / ``engine_crashed``). No new GDScript-mirrored codes.
+# - **the script never RAN** — the engine exited normally but its stderr proves it
+#   could not load the entry script (missing, or a failed parse/compile of the
+#   script or a dependency it preloads) → an **Error envelope** carrying
+#   ``script_not_found`` / ``script_compile_failed`` (#651, ADR-0031 amendment).
+#   Godot reports all of these on stderr and STILL exits 0, so passing that status
+#   through reported a phantom success. gda is the authority on whether the engine
+#   ran what it was asked to; the verdict is read from the parsed stderr evidence
+#   (:mod:`gda.script_errors`), never from the exit code.
 # - **the script ran to completion** — the engine exited normally
 #   (``exit_code >= 0``) → a **success** :class:`ScriptRunResult` carrying
-#   ``{exit_status, stdout, stderr}`` **passed through verbatim, even when
-#   ``exit_status != 0``**. gda does not interpret the script's semantics: a
+#   ``{exit_status, stdout, stderr, diagnostics}`` **passed through verbatim, even
+#   when ``exit_status != 0``**. gda does not interpret the script's semantics: a
 #   deliberate ``quit(1)`` (e.g. an assertion-failed logic-seam test) is meaningful
-#   DATA the agent reads, not a gda failure.
+#   DATA the agent reads, not a gda failure. Under the opt-in ``--strict`` that one
+#   default is inverted — a non-zero status becomes the ``script_failed`` envelope —
+#   for the shell-chain / CI callers whose gate IS the process exit code.
 #
 # Two explicit pre-run ABI edges (ADR-0031), both decided at the CLI before any
 # launch and returned as a structured ``GdaError`` (never a crash): a non-``res://``
@@ -634,21 +677,37 @@ class LaunchFn(Protocol):
     ) -> RunResult: ...
 
 
+# The verdict a proven entry-load failure maps to (#651). ``script_compile_failed``
+# is REUSED from ``script attach`` rather than duplicated: the condition is the same
+# one it already names — this script does not compile — and ADR-0002 prefers reusing
+# a code and discriminating via the message. The generic ``LOAD_FAILED`` (the engine
+# gave up on the entry point without naming a missing file) lands there too: the
+# file was readable, so "could not be loaded or compiled" is what gda actually knows.
+_ENTRY_FAILURE_CODES: dict[ScriptErrorKind, str] = {
+    ScriptErrorKind.SCRIPT_MISSING: "script_not_found",
+    ScriptErrorKind.COMPILE_FAILED: "script_compile_failed",
+    ScriptErrorKind.LOAD_FAILED: "script_compile_failed",
+}
+
+
 def run_script_run_operation(
     *,
     script: str,
     godot: Optional[str],
     project: Optional[Path],
+    strict: bool = False,
     make_launch: Optional[LaunchFn] = None,
     timeout: float = DEFAULT_SCRIPT_RUN_TIMEOUT_SECONDS,
 ) -> ScriptRunResult | Failure:
-    """Run ``script run``'s validate → launch → classify recipe (ADR-0031).
+    """Run ``script run``'s validate → launch → classify recipe (ADR-0031, #651).
 
     Returns its outcome instead of emitting or exiting: the passthrough
-    :class:`ScriptRunResult` on a clean engine exit (even a non-zero
-    ``exit_status``) or a :class:`~gda.errors.Failure` — a pre-run ABI-edge
-    failure (``invalid_path`` / ``project_not_found``) or a
-    ``classify_launch_or_crash`` env/crash outcome. ``project`` is the
+    :class:`ScriptRunResult` on a completed run (even a non-zero ``exit_status``)
+    or a :class:`~gda.errors.Failure` — a pre-run ABI-edge failure
+    (``invalid_path`` / ``project_not_found``), a ``classify_launch_or_crash``
+    env/crash outcome, the ``script_not_found`` / ``script_compile_failed`` verdict
+    for a script the engine never ran, or — with ``strict`` — ``script_failed`` for
+    a completed run that chose a non-zero status. ``project`` is the
     already-resolved directory (resolution stays CLI-side, ADR-0006); ``None``
     means none resolved. ``make_launch`` is the injected headless-launch seam;
     ``None`` (the default) uses the real deep-module :func:`gda.runner.launch`,
@@ -692,13 +751,35 @@ def run_script_run_operation(
     crash = classify_launch_or_crash(raw, binary)
     if crash is not None:
         return crash
+
+    # The engine exited normally, so the exit status is ITS answer — but the engine
+    # answers 0 whether the script ran or was never loadable at all. Read the stderr
+    # evidence before trusting the status (#651): a proven entry-load failure means
+    # the passthrough has nothing to pass through, so it is a gda verdict, not data.
+    diagnostics = parse_script_errors(raw.stderr)
+    did_not_run = entry_load_failure(diagnostics, script)
+    if did_not_run is not None:
+        return script_did_not_run_failure(
+            _ENTRY_FAILURE_CODES[did_not_run.kind],
+            script,
+            did_not_run.message,
+            raw.stderr,
+        )
+
+    # The script RAN. Its own status is data by default (the ADR-0031 crux) and a
+    # gda failure only when the caller opted in with --strict.
+    if strict and raw.exit_code != 0:
+        return script_exit_status_failure(script, raw.exit_code, raw.stderr)
+
     # The public promotion of the internal Raw run: the thin boundary DTO built by
     # dropping launch_failure (lifted into the Error envelope above) and renaming
-    # exit_code → exit_status. This is the one success result that can be non-zero.
+    # exit_code → exit_status, plus the parsed diagnostics. This is the one success
+    # result that can be non-zero.
     return ScriptRunResult(
         exit_status=raw.exit_code,
         stdout=raw.stdout,
         stderr=raw.stderr,
+        diagnostics=diagnostics,
     )
 
 
@@ -862,14 +943,27 @@ def render_script_run(ran: "ScriptRunResult") -> str:
     ``script run`` passes the user script's own output through verbatim (ADR-0031),
     so the human view leads with the ``exit_status`` — which can be non-zero on a
     SUCCESS (a deliberate ``quit(1)``) — then the script's stdout and stderr as it
-    emitted them (each trailing newline trimmed; empty streams are omitted).
+    emitted them (each trailing newline trimmed; empty streams are omitted). Any
+    recognized script errors follow as a short classified summary (#651): the
+    verbatim lines are already in the stderr block above, so this adds only the
+    ``kind`` and location a reader would otherwise have to infer.
     """
     parts = [f"exit_status: {ran.exit_status}"]
     if ran.stdout:
         parts.append(ran.stdout.rstrip("\n"))
     if ran.stderr:
         parts.append(ran.stderr.rstrip("\n"))
+    for diag in ran.diagnostics:
+        parts.append(f"  {diag.kind.value}: {_render_script_error_location(diag)}")
     return "\n".join(parts)
+
+
+def _render_script_error_location(diag: "ScriptError") -> str:
+    """``<path>:<line>: <message>`` for a diagnostic, dropping the parts it lacks."""
+    where = diag.path or ""
+    if diag.path is not None and diag.line is not None:
+        where = f"{diag.path}:{diag.line}"
+    return f"{where}: {diag.message}" if where else diag.message
 
 
 SCRIPT_CREATE_COMMAND: HeadlessCommand[ScriptCreateResult] = HeadlessCommand(
@@ -934,6 +1028,7 @@ def _script_run_recipe(params, *, project, godot):
         script=params.path,
         godot=godot,
         project=project,
+        strict=params.strict,
     )
 
 
@@ -1205,6 +1300,15 @@ def run_script(
         ...,
         help="The res:// path of the script to run (e.g. res://tests/logic.gd).",
     ),
+    strict: bool = typer.Option(
+        False,
+        "--strict",
+        help=(
+            "Fail when the script exits non-zero: emit the 'script_failed' error "
+            "envelope and exit 4 instead of the default passthrough success. For "
+            "shell '&&' chains and CI gates. A script that never ran fails either way."
+        ),
+    ),
     json_output: bool = json_option(),
     schema: bool = SCRIPT_RUN_COMMAND.schema_option(),
     params_json: Optional[str] = params_json_option(),
@@ -1218,14 +1322,26 @@ def run_script(
     ONE command whose success result can carry a non-zero ``exit_status``: gda does
     not interpret the script's semantics, so a deliberate ``quit(1)`` (e.g. an
     assertion-failed logic-seam test) is data the agent reads, not a gda failure —
-    read ``exit_status``, do not assume ``success == zero``. Only a gda-/engine-level
-    failure (binary not launchable, timeout, or a signal crash) is an Error envelope
-    (``binary_not_found`` / ``launch_timeout`` / ``engine_crashed``). A non-res://
-    path or no resolved project is a structured ``invalid_path`` / ``project_not_found``.
+    read ``exit_status``, do not assume ``success == zero``. Pass ``--strict`` to
+    invert that one default and get the ``script_failed`` envelope (exit 4) for a
+    non-zero status, so a shell ``&&`` chain or CI gate stops on it.
+
+    A script that never RAN is a failure either way: a missing res:// entry script is
+    ``script_not_found``, and an entry script (or a dependency it preloads) that
+    fails to parse or compile is ``script_compile_failed`` — Godot reports both on
+    stderr and still exits 0, so gda decides these from the engine's error stream,
+    not its exit code. Recognized script errors — including a runtime GDScript error
+    the script itself survived — are also surfaced as structured ``diagnostics`` on a
+    successful result.
+
+    Only a gda-/engine-level failure (binary not launchable, timeout, or a signal
+    crash) is a ``binary_not_found`` / ``launch_timeout`` / ``engine_crashed``
+    envelope. A non-res:// path or no resolved project is a structured
+    ``invalid_path`` / ``project_not_found``.
     """
     dispatch_recipe(
         SCRIPT_RUN_COMMAND,
-        ScriptRunParams(path=path),
+        ScriptRunParams(path=path, strict=strict),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -49,6 +49,7 @@ from gda.runner import RunResult, launch
 from gda.script_errors import (
     ScriptError,
     ScriptErrorKind,
+    canonical_res_path,
     entry_load_failure,
     parse_script_errors,
 )
@@ -703,6 +704,7 @@ _ENTRY_FAILURE_CODES: dict[ScriptErrorKind, str] = {
     ScriptErrorKind.COMPILE_FAILED: "script_compile_failed",
     ScriptErrorKind.PARSE_ERROR: "script_compile_failed",
     ScriptErrorKind.LOAD_FAILED: "script_compile_failed",
+    ScriptErrorKind.RESOURCE_LOAD_FAILED: "script_compile_failed",
     ScriptErrorKind.NOT_A_MAIN_LOOP: "incompatible_script_type",
 }
 
@@ -740,6 +742,16 @@ def run_script_run_operation(
     # Then require a resolved project — a res:// path needs one to resolve.
     if project is None:
         return script_run_project_not_found_failure()
+
+    # ONE canonical resource identity for the rest of this operation (#651 review
+    # claim 1). Fixed HERE, at the operation's input boundary, so the argv handed to
+    # the engine and every later comparison and message use the same spelling. The
+    # engine canonicalizes internally before it names a path in an error, so a raw
+    # `res://dir/../bad.gd` would never match the `res://bad.gd` it reports back —
+    # and the entry-load verdict would silently fall through to a phantom success.
+    # Done after the res:// gate so the rejection message still quotes what the user
+    # actually typed.
+    script = canonical_res_path(script)
 
     try:
         binary = resolve_godot_binary(godot)

--- a/src/gda/daemon/diag.py
+++ b/src/gda/daemon/diag.py
@@ -6,136 +6,37 @@ A pure function over a Godot engine log file's text — no daemon, no engine —
 log) and serves ``diag`` daemon-side by reading that one file, which captures
 BOTH the game's print output and its errors.
 
-Godot writes an error as a two-line pair (verified against the engine's
-``core/io/logger.cpp`` ``Logger::log_error``)::
-
-    <TYPE>: <message>
-       at: <function> (<file>:<line>)
-
-where ``<TYPE>`` is one of ``ERROR`` / ``WARNING`` / ``SCRIPT ERROR`` /
-``SHADER ERROR``. Print output is plain lines. A runtime GDScript error carries
-a multi-line call stack after the ``at:`` line — a ``GDScript backtrace (most
-recent call first):`` marker then one ``[N] <function> (<file>:<line>)`` frame
-line per stack frame (#283); ``parse_errors`` folds those frames into the
-error's ordered ``callstack`` (frame ``[0]`` equals the ``at:`` location).
-
-The parsing is **best-effort**: a line that is neither a recognized ``<TYPE>:``
-header nor the ``   at:`` follow-on (a backtrace, an interleaved print line) is
-skipped for ``errors`` and never raises. The verbatim whole-log view is served by
-:func:`parse_log_records` with ``raw`` set (ADR-0026).
+The engine's own error-line format — the two-line ``<TYPE>: <message>`` /
+``   at: <function> (<file>:<line>)`` pair and its optional GDScript backtrace —
+is parsed by :mod:`gda.engine_log`, which this module imports downward and
+re-exports :func:`parse_errors` from. That parser was extracted from here (#651)
+once a second consumer appeared: the format is the *engine's*, not the daemon's,
+and the Phase-1 ``script run`` channel reads the same lines off a one-shot
+process's stderr. What stays here is what is genuinely daemon-side: the
+``LogRecord`` view of a whole Session log (ADR-0026), including the opt-in
+``<<<GDA:LOG>>>`` protocol. The verbatim whole-log view is served by
+:func:`parse_log_records` with ``raw`` set.
 """
 
 import json
-import re
 
-# A ``<TYPE>: <message>`` header. The TYPE strings come straight from the engine's
-# ``Logger::error_type_string`` — kept anchored to line start so a print line that
-# merely contains the word "ERROR" is not mistaken for an error header.
-_ERROR_HEADER = re.compile(r"^(ERROR|WARNING|SCRIPT ERROR|SHADER ERROR): (.*)$")
-
-# The engine's follow-on location line: ``   at: <function> (<file>:<line>)``.
-# Leading whitespace varies by ErrorType indent, so it is matched loosely.
-_AT_LINE = re.compile(
-    r"^\s*at:\s*(?P<function>.*?)\s*\((?P<file>.*):(?P<line>\d+)\)\s*$"
+from gda.engine_log import (
+    AT_LINE as _AT_LINE,
+)
+from gda.engine_log import (
+    ERROR_HEADER as _ERROR_HEADER,
+)
+from gda.engine_log import (
+    lines as _lines,
+)
+from gda.engine_log import (
+    parse_errors,
 )
 
-# After the ``at:`` line, a runtime GDScript error MAY carry a full call stack:
-# a marker line ``GDScript backtrace (most recent call first):`` then one frame
-# line per stack frame, ``       [N] <function> (<file>:<line>)`` (verified
-# against Godot 4.6.3). Frames are ordered most-recent-first; frame ``[0]``
-# equals the ``at:`` location. push_error / warnings carry no backtrace.
-_BACKTRACE_MARKER = re.compile(r"^\s*GDScript backtrace\b.*:\s*$")
-_FRAME_LINE = re.compile(
-    r"^\s*\[\d+\]\s*(?P<function>.*?)\s*\((?P<file>.*):(?P<line>\d+)\)\s*$"
-)
-
-# The engine ``<TYPE>`` string -> the normalized, machine-stable ``level``.
-_LEVEL_BY_TYPE = {
-    "ERROR": "error",
-    "WARNING": "warning",
-    "SCRIPT ERROR": "script_error",
-    "SHADER ERROR": "shader_error",
-}
-
-
-def _as_text(data: str | bytes) -> str:
-    """Decode bytes best-effort; pass text through (never raises on bad UTF-8)."""
-    if isinstance(data, bytes):
-        return data.decode("utf-8", "replace")
-    return data
-
-
-def _lines(data: str | bytes) -> list[str]:
-    text = _as_text(data)
-    if not text:
-        return []
-    return text.splitlines()
-
-
-def parse_errors(data: str | bytes, limit: int | None = None) -> list[dict]:
-    """Structured errors from a Session log's text — best-effort (#224).
-
-    Returns ``{level, message, function, file, line, callstack}`` per recognized
-    error header (warnings included, distinguished by ``level``). The optional
-    ``at:`` follow-on fills ``function``/``file``/``line``; absent, they are
-    ``None`` (a bare error without a location is not a failure). ``callstack`` is
-    the ordered ``{function, file, line}`` frames from the optional ``GDScript
-    backtrace`` block (most-recent-first; frame ``[0]`` equals the ``at:``
-    location); a push_error / warning carries no backtrace, so ``callstack`` is
-    ``[]``. Unrecognized/continuation lines (interleaved print output) are
-    skipped. ``limit`` tails the most recent ``N`` errors. Empty input -> ``[]``.
-    """
-    lines = _lines(data)
-    errors: list[dict] = []
-    i = 0
-    while i < len(lines):
-        header = _ERROR_HEADER.match(lines[i])
-        if header is None:
-            i += 1
-            continue
-        type_str, message = header.group(1), header.group(2)
-        entry: dict = {
-            "level": _LEVEL_BY_TYPE[type_str],
-            "message": message,
-            "function": None,
-            "file": None,
-            "line": None,
-            "callstack": [],
-        }
-        # The next line MAY be the engine's ``at:`` location follow-on; if so,
-        # consume it. Anything else (the next header, an output line) is left for
-        # the next iteration.
-        if i + 1 < len(lines):
-            at = _AT_LINE.match(lines[i + 1])
-            if at is not None:
-                entry["function"] = at.group("function") or None
-                entry["file"] = at.group("file") or None
-                entry["line"] = int(at.group("line"))
-                i += 1
-        # After the ``at:`` line, the engine MAY emit a ``GDScript backtrace``
-        # marker followed by ``[N] func (file:line)`` frame lines. Consume the
-        # marker and every contiguous frame line into ``callstack``; a non-frame
-        # line (the next header, a print line) ends the block, left for the next
-        # iteration.
-        if i + 1 < len(lines) and _BACKTRACE_MARKER.match(lines[i + 1]):
-            i += 1
-            while i + 1 < len(lines):
-                frame = _FRAME_LINE.match(lines[i + 1])
-                if frame is None:
-                    break
-                entry["callstack"].append(
-                    {
-                        "function": frame.group("function") or None,
-                        "file": frame.group("file") or None,
-                        "line": int(frame.group("line")),
-                    }
-                )
-                i += 1
-        errors.append(entry)
-        i += 1
-    if limit is not None and limit >= 0:
-        return errors[-limit:] if limit else []
-    return errors
+# ``parse_errors`` is re-exported: it was this module's public API before the
+# extraction (the daemon server and the diag tests import it from here), so the
+# move stays source-compatible for every existing consumer.
+__all__ = ["parse_errors", "parse_log_records", "LOG_BEGIN"]
 
 
 # --- The structured `LogRecord` channel (#281, ADR-0026) -----------------------

--- a/src/gda/engine_log.py
+++ b/src/gda/engine_log.py
@@ -1,0 +1,138 @@
+"""Parse Godot's error-line format out of any engine output capture (#651).
+
+The single home of **how the engine formats an error**, extracted from
+``gda.daemon.diag`` so both of its consumers can import it downward (ADR-0000's
+component order, ADR-0040's module direction): the Phase-2 daemon reads a
+`Session log` file, and the Phase-1 ``script run`` channel reads a one-shot
+process's stderr. Same engine, same format, one parser — and this module sits
+below both, importing nothing from ``daemon`` or ``commands``.
+
+Godot writes an error as a two-line pair (verified against the engine's
+``core/io/logger.cpp`` ``Logger::log_error``)::
+
+    <TYPE>: <message>
+       at: <function> (<file>:<line>)
+
+where ``<TYPE>`` is one of ``ERROR`` / ``WARNING`` / ``SCRIPT ERROR`` /
+``SHADER ERROR``. Print output is plain lines. A runtime GDScript error carries
+a multi-line call stack after the ``at:`` line — a ``GDScript backtrace (most
+recent call first):`` marker then one ``[N] <function> (<file>:<line>)`` frame
+line per stack frame (#283); :func:`parse_errors` folds those frames into the
+error's ordered ``callstack`` (frame ``[0]`` equals the ``at:`` location).
+
+The parsing is **best-effort**: a line that is neither a recognized ``<TYPE>:``
+header nor the ``   at:`` follow-on (a backtrace, an interleaved print line) is
+skipped for ``errors`` and never raises.
+"""
+
+import re
+
+# A ``<TYPE>: <message>`` header. The TYPE strings come straight from the engine's
+# ``Logger::error_type_string`` — kept anchored to line start so a print line that
+# merely contains the word "ERROR" is not mistaken for an error header.
+ERROR_HEADER = re.compile(r"^(ERROR|WARNING|SCRIPT ERROR|SHADER ERROR): (.*)$")
+
+# The engine's follow-on location line: ``   at: <function> (<file>:<line>)``.
+# Leading whitespace varies by ErrorType indent, so it is matched loosely.
+AT_LINE = re.compile(
+    r"^\s*at:\s*(?P<function>.*?)\s*\((?P<file>.*):(?P<line>\d+)\)\s*$"
+)
+
+# After the ``at:`` line, a runtime GDScript error MAY carry a full call stack:
+# a marker line ``GDScript backtrace (most recent call first):`` then one frame
+# line per stack frame, ``       [N] <function> (<file>:<line>)`` (verified
+# against Godot 4.6.3). Frames are ordered most-recent-first; frame ``[0]``
+# equals the ``at:`` location. push_error / warnings carry no backtrace.
+BACKTRACE_MARKER = re.compile(r"^\s*GDScript backtrace\b.*:\s*$")
+FRAME_LINE = re.compile(
+    r"^\s*\[\d+\]\s*(?P<function>.*?)\s*\((?P<file>.*):(?P<line>\d+)\)\s*$"
+)
+
+# The engine ``<TYPE>`` string -> the normalized, machine-stable ``level``.
+LEVEL_BY_TYPE = {
+    "ERROR": "error",
+    "WARNING": "warning",
+    "SCRIPT ERROR": "script_error",
+    "SHADER ERROR": "shader_error",
+}
+
+
+def as_text(data: str | bytes) -> str:
+    """Decode bytes best-effort; pass text through (never raises on bad UTF-8)."""
+    if isinstance(data, bytes):
+        return data.decode("utf-8", "replace")
+    return data
+
+
+def lines(data: str | bytes) -> list[str]:
+    """Split an output capture into lines, tolerating bytes and empty input."""
+    text = as_text(data)
+    if not text:
+        return []
+    return text.splitlines()
+
+
+def parse_errors(data: str | bytes, limit: int | None = None) -> list[dict]:
+    """Structured errors from an engine output capture — best-effort (#224).
+
+    Returns ``{level, message, function, file, line, callstack}`` per recognized
+    error header (warnings included, distinguished by ``level``). The optional
+    ``at:`` follow-on fills ``function``/``file``/``line``; absent, they are
+    ``None`` (a bare error without a location is not a failure). ``callstack`` is
+    the ordered ``{function, file, line}`` frames from the optional ``GDScript
+    backtrace`` block (most-recent-first; frame ``[0]`` equals the ``at:``
+    location); a push_error / warning carries no backtrace, so ``callstack`` is
+    ``[]``. Unrecognized/continuation lines (interleaved print output) are
+    skipped. ``limit`` tails the most recent ``N`` errors. Empty input -> ``[]``.
+    """
+    captured = lines(data)
+    errors: list[dict] = []
+    i = 0
+    while i < len(captured):
+        header = ERROR_HEADER.match(captured[i])
+        if header is None:
+            i += 1
+            continue
+        type_str, message = header.group(1), header.group(2)
+        entry: dict = {
+            "level": LEVEL_BY_TYPE[type_str],
+            "message": message,
+            "function": None,
+            "file": None,
+            "line": None,
+            "callstack": [],
+        }
+        # The next line MAY be the engine's ``at:`` location follow-on; if so,
+        # consume it. Anything else (the next header, an output line) is left for
+        # the next iteration.
+        if i + 1 < len(captured):
+            at = AT_LINE.match(captured[i + 1])
+            if at is not None:
+                entry["function"] = at.group("function") or None
+                entry["file"] = at.group("file") or None
+                entry["line"] = int(at.group("line"))
+                i += 1
+        # After the ``at:`` line, the engine MAY emit a ``GDScript backtrace``
+        # marker followed by ``[N] func (file:line)`` frame lines. Consume the
+        # marker and every contiguous frame line into ``callstack``; a non-frame
+        # line (the next header, a print line) ends the block, left for the next
+        # iteration.
+        if i + 1 < len(captured) and BACKTRACE_MARKER.match(captured[i + 1]):
+            i += 1
+            while i + 1 < len(captured):
+                frame = FRAME_LINE.match(captured[i + 1])
+                if frame is None:
+                    break
+                entry["callstack"].append(
+                    {
+                        "function": frame.group("function") or None,
+                        "file": frame.group("file") or None,
+                        "line": int(frame.group("line")),
+                    }
+                )
+                i += 1
+        errors.append(entry)
+        i += 1
+    if limit is not None and limit >= 0:
+        return errors[-limit:] if limit else []
+    return errors

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -346,7 +346,36 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
-        "A script could not be attached to a node because it does not compile.",
+        "A script does not compile, so the requested work could not proceed: "
+        "`script attach` refuses to bind it to a node, and `script run` reports "
+        "that the entry script (or a dependency it preloads) never ran.",
+    ),
+    # `script run`'s two verdict codes (#651, ADR-0031 amendment). Both are decided
+    # by gda from the engine's stderr AFTER the run, so both are CLASSIFIER-source
+    # and NOT GDScript-mirrored — the entry script is the user's own and emits no
+    # ADR-0002 sentinel. A missing entry script reuses no existing code because the
+    # generic `path_not_found` is operation-reported (operations.gd mints it for a
+    # path the OPERATION resolved), whereas this one is read out of stderr for a run
+    # the engine exited 0 from. A failed COMPILE, by contrast, reuses
+    # `script_compile_failed` above rather than minting a near-duplicate: the
+    # condition is the same one `script attach` already names (ADR-0002 — reuse the
+    # code, discriminate via the message).
+    ErrorCodeSpec(
+        "script_not_found",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.CLASSIFIER,
+        "A `script run` entry script does not exist in the project, so the engine "
+        "never ran it (it still exits 0; gda reads the failure from stderr).",
+    ),
+    ErrorCodeSpec(
+        "script_failed",
+        ErrorCategory.OPERATION,
+        EXIT_OPERATION,
+        ErrorCodeSource.CLASSIFIER,
+        "A `script run --strict` script ran to completion and chose a non-zero exit "
+        "status; strict mode maps that opted-in failure onto the uniform error "
+        "envelope. Never reported without --strict (ADR-0031).",
     ),
     ErrorCodeSpec(
         "incompatible_script_type",

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -1,9 +1,23 @@
 """Authoritative registry of public ``GdaError.code`` values.
 
 The registry is the machine-readable companion to ADR-0002's table. Every code
-emitted in a public ``GdaError`` must be declared here; GDScript mirrors only
-the ``operation`` source subset because only those codes are reported by
-headless operations.
+emitted in a public ``GdaError`` must be declared here.
+
+**What ``source`` means.** It names a code's *authoritative origin channel* — the
+layer that defines the failure and owns reporting it — and it governs **GDScript
+mirror membership**: ``operations.gd`` declares exactly the ``operation``-source
+codes, because those are the ones a headless operation may report back through
+the ADR-0002 sentinel.
+
+It is **not an exclusive emitter list**. The Python classifier may additionally
+assign any registered code whose semantics match the failure it recognized —
+including an ``operation``-source one — when it learns of that failure from the
+engine's own output rather than from a sentinel. This predates the
+classifier-side reuse in #651: ``script_path_invalid_failure`` has long minted
+operation-source ``invalid_path`` from the CLI. Two consequences worth stating
+because they have been misread: reuse-vs-mint is decided by **semantic match**,
+never by ``source``; and classifier reuse adds no member and removes none, so the
+mirror derivation is untouched by it.
 """
 
 from dataclasses import dataclass
@@ -21,7 +35,13 @@ from gda.models import ErrorCategory
 
 
 class ErrorCodeSource(str, Enum):
-    """Where a public ``GdaError.code`` originates."""
+    """A code's authoritative origin channel — see the module docstring.
+
+    The layer that defines the failure and owns reporting it, and the key the
+    GDScript mirror's membership is derived from. NOT an exclusive emitter list:
+    the Python classifier may also assign a code whose semantics match a failure
+    it recognized from the engine's output.
+    """
 
     RUNNER = "runner"
     CLASSIFIER = "classifier"
@@ -37,10 +57,11 @@ class ErrorCodeSpec:
     A single row fully defines a code's public ABI: its coarse ``category``, the
     process ``exit_code`` a shell consumer keys on (per-code, not per-category:
     within ENVIRONMENT, ``binary_not_found`` exits 127 but ``launch_timeout``
-    exits 124), the ``source`` that may report it, and its ``description``.
-    Failure construction derives ``category`` and ``exit_code`` from here, so it
-    no longer restates either at the call site — both come from the row
-    (ADR-0002, #141).
+    exits 124), the ``source`` that authoritatively owns it — an origin channel
+    and the mirror-membership key, not an exclusive emitter list (see the module
+    docstring) — and its ``description``. Failure construction derives
+    ``category`` and ``exit_code`` from here, so it no longer restates either at
+    the call site — both come from the row (ADR-0002, #141).
     """
 
     code: str
@@ -355,20 +376,8 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
     # CLASSIFIER-source and NOT GDScript-mirrored — the entry script is the user's
     # own and emits no ADR-0002 sentinel.
     #
-    # What `source` means, exactly: it names the code's AUTHORITATIVE ORIGIN
-    # CHANNEL — the layer that defines the failure and is responsible for reporting
-    # it. It is not an exclusive list of everything that may emit the code. gda's
-    # classifier may ADDITIONALLY assign an operation-source code when it
-    # recognizes the SAME semantic failure from the engine's own output rather than
-    # from a sentinel; `script_path_invalid_failure` reusing operation-source
-    # `invalid_path` from the CLI predates this change and is the precedent.
-    #
-    # Nothing downstream depends on `source` being exclusive: the GDScript mirror
-    # is derived from OPERATION-source MEMBERSHIP (operations.gd must declare every
-    # operation-source code), and classifier reuse neither adds nor removes a
-    # member, so the mirror test is unaffected either way.
-    #
-    # Reuse-vs-mint is therefore decided by SEMANTIC MATCH, not by `source`. This
+    # Reuse-vs-mint is decided by SEMANTIC MATCH, not by `source` (the module
+    # docstring is the single home of what `source` does and does not mean). This
     # change reuses operation-source `script_compile_failed` and
     # `incompatible_script_type` from the classifier, because `script run` hits the
     # very conditions they name — a script that does not compile, and one whose

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -350,16 +350,26 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "`script attach` refuses to bind it to a node, and `script run` reports "
         "that the entry script (or a dependency it preloads) never ran.",
     ),
-    # `script run`'s two verdict codes (#651, ADR-0031 amendment). Both are decided
-    # by gda from the engine's stderr AFTER the run, so both are CLASSIFIER-source
-    # and NOT GDScript-mirrored — the entry script is the user's own and emits no
-    # ADR-0002 sentinel. A missing entry script reuses no existing code because the
-    # generic `path_not_found` is operation-reported (operations.gd mints it for a
-    # path the OPERATION resolved), whereas this one is read out of stderr for a run
-    # the engine exited 0 from. A failed COMPILE, by contrast, reuses
-    # `script_compile_failed` above rather than minting a near-duplicate: the
-    # condition is the same one `script attach` already names (ADR-0002 — reuse the
-    # code, discriminate via the message).
+    # `script run`'s two NEW verdict codes (#651, ADR-0031 amendment). Both are
+    # decided by gda from the engine's stderr AFTER the run, so both are
+    # CLASSIFIER-source and NOT GDScript-mirrored — the entry script is the user's
+    # own and emits no ADR-0002 sentinel.
+    #
+    # Reuse-vs-mint is decided by SEMANTIC MATCH, not by a code's `source`: a code's
+    # source records where it canonically originates, and reusing one from another
+    # site is the established pattern (`script_path_invalid_failure` reuses
+    # operation-source `invalid_path` from the CLI). So this change reuses
+    # operation-source `script_compile_failed` and `incompatible_script_type` from
+    # the classifier, because `script run` hits the very conditions they name — a
+    # script that does not compile, and one whose base type is wrong for the
+    # requested use (ADR-0002 — reuse the code, discriminate via the message).
+    #
+    # `script_not_found` is minted rather than reusing `path_not_found` for the
+    # opposite reason: the MEANINGS differ. `path_not_found` is "a file the
+    # operation was asked to act on is absent" — a filesystem fact about an
+    # operand. This is "the engine could not load the entry script, so the run
+    # never happened" — a fact about the run itself, which an agent branches on
+    # differently (re-check the path vs. abandon the result entirely).
     ErrorCodeSpec(
         "script_not_found",
         ErrorCategory.OPERATION,
@@ -382,7 +392,9 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
-        "A script compiles but its native base type is incompatible with the target node's type.",
+        "A script compiles but its base type is incompatible with the requested "
+        "use: `script attach`'s target node type, or `script run`'s requirement "
+        "that a one-shot entry script extend SceneTree/MainLoop.",
     ),
     ErrorCodeSpec(
         "signal_not_found",

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -355,14 +355,25 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
     # CLASSIFIER-source and NOT GDScript-mirrored — the entry script is the user's
     # own and emits no ADR-0002 sentinel.
     #
-    # Reuse-vs-mint is decided by SEMANTIC MATCH, not by a code's `source`: a code's
-    # source records where it canonically originates, and reusing one from another
-    # site is the established pattern (`script_path_invalid_failure` reuses
-    # operation-source `invalid_path` from the CLI). So this change reuses
-    # operation-source `script_compile_failed` and `incompatible_script_type` from
-    # the classifier, because `script run` hits the very conditions they name — a
-    # script that does not compile, and one whose base type is wrong for the
-    # requested use (ADR-0002 — reuse the code, discriminate via the message).
+    # What `source` means, exactly: it names the code's AUTHORITATIVE ORIGIN
+    # CHANNEL — the layer that defines the failure and is responsible for reporting
+    # it. It is not an exclusive list of everything that may emit the code. gda's
+    # classifier may ADDITIONALLY assign an operation-source code when it
+    # recognizes the SAME semantic failure from the engine's own output rather than
+    # from a sentinel; `script_path_invalid_failure` reusing operation-source
+    # `invalid_path` from the CLI predates this change and is the precedent.
+    #
+    # Nothing downstream depends on `source` being exclusive: the GDScript mirror
+    # is derived from OPERATION-source MEMBERSHIP (operations.gd must declare every
+    # operation-source code), and classifier reuse neither adds nor removes a
+    # member, so the mirror test is unaffected either way.
+    #
+    # Reuse-vs-mint is therefore decided by SEMANTIC MATCH, not by `source`. This
+    # change reuses operation-source `script_compile_failed` and
+    # `incompatible_script_type` from the classifier, because `script run` hits the
+    # very conditions they name — a script that does not compile, and one whose
+    # base type is wrong for the requested use (ADR-0002 — reuse the code,
+    # discriminate via the message).
     #
     # `script_not_found` is minted rather than reusing `path_not_found` for the
     # opposite reason: the MEANINGS differ. `path_not_found` is "a file the

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -415,6 +415,50 @@ def script_run_project_not_found_failure() -> Failure:
     )
 
 
+def script_did_not_run_failure(
+    code: str, script: str, detail: str, stderr: str
+) -> Failure:
+    """The ``script run`` verdict for an entry script that never ran (#651).
+
+    ADR-0031 passes a completed run's exit status through verbatim, because gda
+    does not know the user script's semantics. That reasoning does not reach a run
+    where the script never STARTED: Godot reports a missing or non-compiling
+    ``--script`` entry point on stderr and still exits ``0``, so passing that
+    status through reports a phantom success for a failure no reading of the
+    contract calls one. gda is the authority on whether the engine ran what it was
+    asked to, so this is a classifier decision, keyed on the parsed stderr evidence
+    (:func:`gda.script_errors.entry_load_failure`) rather than on the exit code.
+
+    ``code`` is the registered verdict (``script_not_found`` /
+    ``script_compile_failed``), ``detail`` the engine's own sentence, kept in the
+    message so the agent sees WHY without parsing ``diagnostics``.
+    """
+    return make_failure(
+        code,
+        f"script run: {script} did not run — {detail}",
+        stderr,
+    )
+
+
+def script_exit_status_failure(script: str, exit_status: int, stderr: str) -> Failure:
+    """The ``script run --strict`` verdict for a non-zero script exit (#651).
+
+    Opt-in only. The default remains ADR-0031's passthrough — a deliberate
+    ``quit(1)`` is data the agent reads — so ``--strict`` is how a caller says "for
+    THIS run, treat the script's own failure as mine": the shell-chain and CI case,
+    where a zero gda exit silently accepts a failed test suite. The child status is
+    NOT propagated as the process exit code; it is mapped onto the registered
+    ``script_failed``/exit ``4`` so a script's ``quit(3)`` cannot alias an unrelated
+    registry code (``EXIT_VERSION``). The status itself stays readable in the
+    message, and the script's stderr in ``diagnostics``.
+    """
+    return make_failure(
+        "script_failed",
+        f"script run --strict: {script} exited with status {exit_status}",
+        stderr,
+    )
+
+
 def invalid_project_failure(reason: str) -> Failure:
     """The ``project_not_found`` failure for an explicit ``--project``/``$GDA_PROJECT``
     that is empty or is not a Godot project (#353).

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -440,7 +440,39 @@ def script_did_not_run_failure(
     )
 
 
-def script_exit_status_failure(script: str, exit_status: int, stderr: str) -> Failure:
+# The section headers of a `script_failed` envelope's ``diagnostics`` (#651). The
+# layout is fixed and both sections are ALWAYS emitted — an empty stream yields an
+# empty section rather than a missing one — so a consumer can split on the headers
+# without first discovering which streams the script happened to write to.
+SCRIPT_OUTPUT_STDOUT_HEADER = "--- script stdout ---"
+SCRIPT_OUTPUT_STDERR_HEADER = "--- script stderr ---"
+
+
+def _labelled_script_output(stdout: str, stderr: str) -> str:
+    """Both of the child's streams as one labelled ``diagnostics`` string (#651).
+
+    ``GdaError.diagnostics`` is a free-form ``str`` (ADR-0004), and for a failure
+    that IS the script's own — ``script_failed`` — the script's own output is the
+    diagnostic. A GDScript test runner reports through ``print()``, i.e. stdout, so
+    carrying stderr alone would hand a ``--strict`` CI caller a failure with no
+    content. Both streams are labelled rather than concatenated so the caller can
+    still tell which is which.
+    """
+    parts = []
+    for header, stream in (
+        (SCRIPT_OUTPUT_STDOUT_HEADER, stdout),
+        (SCRIPT_OUTPUT_STDERR_HEADER, stderr),
+    ):
+        # Keep each section's payload verbatim, only guaranteeing the newline that
+        # puts the next header on its own line.
+        body = stream if stream.endswith("\n") or not stream else stream + "\n"
+        parts.append(f"{header}\n{body}")
+    return "".join(parts)
+
+
+def script_exit_status_failure(
+    script: str, exit_status: int, stdout: str, stderr: str
+) -> Failure:
     """The ``script run --strict`` verdict for a non-zero script exit (#651).
 
     Opt-in only. The default remains ADR-0031's passthrough — a deliberate
@@ -449,13 +481,19 @@ def script_exit_status_failure(script: str, exit_status: int, stderr: str) -> Fa
     where a zero gda exit silently accepts a failed test suite. The child status is
     NOT propagated as the process exit code; it is mapped onto the registered
     ``script_failed``/exit ``4`` so a script's ``quit(3)`` cannot alias an unrelated
-    registry code (``EXIT_VERSION``). The status itself stays readable in the
-    message, and the script's stderr in ``diagnostics``.
+    registry code (``EXIT_VERSION``).
+
+    The evidence the caller needs is preserved: the status stays readable in the
+    message, and ``diagnostics`` carries BOTH of the script's streams under fixed
+    labels. Carrying stderr alone would defeat the flag's own use case — a GDScript
+    test runner reports through ``print()``. The status survives only as message
+    prose; a structured status field on the failure channel would need an ADR-0004
+    envelope change, deferred to that decision (#655).
     """
     return make_failure(
         "script_failed",
         f"script run --strict: {script} exited with status {exit_status}",
-        stderr,
+        _labelled_script_output(stdout, stderr),
     )
 
 

--- a/src/gda/script_errors.py
+++ b/src/gda/script_errors.py
@@ -1,12 +1,12 @@
 """Classify Godot's script-error stderr lines into structured diagnostics (#651).
 
 The single home of *what Godot's error stream says about a script*. It is the
-read-side companion to :func:`gda.daemon.diag.parse_errors`, which is the single
-home of *how the engine formats an error line* (the two-line ``<TYPE>: <message>``
-/ ``   at: <function> (<file>:<line>)`` shape of ``core/io/logger.cpp``). This
-module reuses that parser verbatim and adds the one thing it does not do: decide
-which of the engine's known script-failure sentences a record is, and which
-``res://`` script the sentence is about.
+read-side companion to :mod:`gda.engine_log`, which is the single home of *how
+the engine formats an error line* (the two-line ``<TYPE>: <message>`` /
+``   at: <function> (<file>:<line>)`` shape of ``core/io/logger.cpp``). This
+module reuses that parser verbatim and adds the two things it does not do: decide
+which of the engine's known script-failure sentences a record is, and resolve
+which ``res://`` resource the sentence is about.
 
 The split matters because the engine reports a failed script run **only** on
 stderr — the process still exits ``0``. A missing entry script, a parse error in
@@ -29,6 +29,15 @@ Recognition is deliberately closed — only the sentences below are classified, 
 whole error stream (the verbatim stream is preserved separately by each caller).
 An unrecognized error or warning is skipped and never raises.
 
+**Resource identity is canonical, on both sides of every comparison.** Godot
+canonicalizes a ``res://`` path before reporting it, so an entry script invoked as
+``res://dir/../bad.gd`` comes back named ``res://bad.gd``. Comparing the engine's
+spelling against the caller's raw one silently missed the match and reported a
+phantom success, so every ``path`` this module produces — and every path
+:func:`entry_load_failure` compares against — is put through
+:func:`canonical_res_path` first. Lexical only: no filesystem access, no symlink
+resolution, so it stays a pure function.
+
 The recognized sentences, verbatim from Godot 4.6.3::
 
     SCRIPT ERROR: Parse Error: <message>
@@ -37,17 +46,20 @@ The recognized sentences, verbatim from Godot 4.6.3::
     ERROR: Attempt to open script 'res://gone.gd' resulted in error 'File not found'.
     ERROR: Can't load script: res://gone.gd
     ERROR: Can't load the script "res://plain.gd" as it doesn't inherit from SceneTree or MainLoop.
+    ERROR: Cannot open file 'res://missing.tres'.
+    ERROR: Failed loading resource: res://missing.tres.
 """
 
+import posixpath
 import re
 from collections.abc import Sequence
 from enum import Enum
 
 from pydantic import BaseModel, Field
 
-from gda.daemon.diag import parse_errors
+from gda.engine_log import parse_errors
 
-# The res:// scheme prefix. A diagnostic's ``path`` is only ever a res:// script:
+# The res:// scheme prefix. A diagnostic's ``path`` is only ever a res:// address:
 # the engine's own ``at:`` frame for an engine-side error names a C++ source file
 # (``modules/gdscript/gdscript.cpp``), which is gda-irrelevant noise.
 _RES_PREFIX = "res://"
@@ -84,34 +96,82 @@ _NOT_A_MAIN_LOOP = re.compile(
     r"SceneTree or MainLoop"
 )
 
+# The two resource-load sentences (#651 review claim 4). Godot emits BOTH for one
+# failed `load()`/`preload()` of a non-script resource, from different layers:
+# `Cannot open file` from the format loader, `Failed loading resource` from
+# ResourceLoader. A missing SCRIPT also produces the second one, beside its own
+# more specific `Attempt to open script` sentence — which outranks it, so the
+# verdict is unaffected (see ``_ENTRY_FAILURE_PRECEDENCE``).
+_CANNOT_OPEN_FILE = re.compile(r"^Cannot open file '(?P<path>[^']*)'")
+
+# `ERROR: Failed loading resource: <path>.` — note the sentence-ending period,
+# which is NOT part of the path and is stripped when the address is read out.
+_FAILED_LOADING_RESOURCE = re.compile(r"^Failed loading resource: (?P<path>\S+?)\.?$")
+
+
+def canonical_res_path(path: str) -> str:
+    """The canonical lexical form of a ``res://`` address (#651 review claim 1).
+
+    ONE resource identity, used on both sides of every comparison and for the argv
+    gda hands the engine. Godot canonicalizes internally before it reports a path,
+    so ``res://dir/../bad.gd`` comes back as ``res://bad.gd``; comparing the
+    engine's spelling against the caller's raw one missed the match and let a
+    failed run report success.
+
+    Collapses ``.``/``..`` segments and duplicate slashes on the path part only
+    (posixpath semantics), leaving the ``res://`` scheme intact. Purely lexical —
+    no filesystem access — so it is safe on a path that does not exist, which is
+    exactly the missing-entry-script case. A non-``res://`` string is returned
+    unchanged: this normalizes an address, it does not validate one.
+    """
+    if not path.startswith(_RES_PREFIX):
+        return path
+    # Strip leading slashes before normpath: POSIX gives exactly two leading
+    # slashes a special meaning ("//a" stays "//a"), which would leave a
+    # `res:////a.gd` spelling uncanonicalized.
+    remainder = path[len(_RES_PREFIX) :].lstrip("/")
+    if not remainder:
+        return _RES_PREFIX
+    # normpath("") is ".", so the empty case is handled above rather than here.
+    return _RES_PREFIX + posixpath.normpath(remainder)
+
 
 class ScriptErrorKind(str, Enum):
-    """What a recognized engine error line says about a script (#651).
+    """What a recognized engine error line says about the resource it names (#651).
 
     A closed, public enum: it is projected into ``--schema`` through the results
-    that carry :class:`ScriptError`. **Five** of the six kinds mean the named
-    script **never ran** — it was missing, unreadable, non-compiling, or unusable
-    as an entry point. Only ``RUNTIME_ERROR`` means the script was loaded and
-    running when the error was raised.
+    that carry :class:`ScriptError`. Every kind except ``RUNTIME_ERROR`` reports
+    that the named resource could **not be loaded or run**; ``RUNTIME_ERROR``
+    reports an error raised by a script that was already executing.
+
+    Whether such a failure ended the *run* depends on **which** resource it names:
+    a load failure naming the entry script means the run never happened, while the
+    same failure naming something the running script merely tried to load does
+    not. :func:`entry_load_failure` is what applies that distinction; a ``kind``
+    alone does not decide it.
     """
 
     #: A compile failure in the named script (its own syntax error, or a
-    #: dependency it preloads that does not resolve). The script never ran.
+    #: dependency it preloads that does not resolve). That script never ran.
     PARSE_ERROR = "parse_error"
     #: A GDScript error raised while the script was already executing. The ONLY
-    #: kind that says the script ran.
+    #: kind that says the named script ran.
     RUNTIME_ERROR = "runtime_error"
-    #: The named script does not exist. It never ran.
+    #: The named script does not exist.
     SCRIPT_MISSING = "script_missing"
     #: The named script exists but could not be loaded (an open failure other
-    #: than a missing file, or the engine giving up on the entry point). It
-    #: never ran.
+    #: than a missing file, or the engine giving up on the entry point).
     LOAD_FAILED = "load_failed"
-    #: The named script was read but did not compile. It never ran.
+    #: The named script was read but did not compile.
     COMPILE_FAILED = "compile_failed"
     #: The named script compiles but does not extend ``SceneTree``/``MainLoop``,
-    #: so it cannot be a one-shot ``--script`` entry point. It never ran.
+    #: so it cannot be a one-shot ``--script`` entry point.
     NOT_A_MAIN_LOOP = "not_a_main_loop"
+    #: A resource the run tried to load could not be loaded — typically a
+    #: ``load()``/``preload()`` of a missing or unreadable non-script resource
+    #: (e.g. a ``.tres``), but the engine reports a missing script this way too,
+    #: beside its more specific sentence.
+    RESOURCE_LOAD_FAILED = "resource_load_failed"
 
 
 #: The kinds that prove a script never ran, in verdict precedence — the order
@@ -127,8 +187,11 @@ class ScriptErrorKind(str, Enum):
 #:    because (2) is the engine's own conclusion, but kept in the list so a
 #:    non-compiling entry is still caught if a build ever emits the diagnostic
 #:    without the conclusion;
-#: 4. ``LOAD_FAILED`` — "can't load", the least specific reason;
-#: 5. ``NOT_A_MAIN_LOOP`` — last because it is only reachable by a script that
+#: 4. ``LOAD_FAILED`` — "can't load", the least specific script-level reason;
+#: 5. ``RESOURCE_LOAD_FAILED`` — the generic resource-layer failure. It is emitted
+#:    beside a missing script's own sentence, so it must rank below it; on its own
+#:    naming the entry it still means the entry never loaded;
+#: 6. ``NOT_A_MAIN_LOOP`` — last because it is only reachable by a script that
 #:    already existed AND compiled; it is a refusal, not a load failure.
 #:
 #: ``RUNTIME_ERROR`` is absent by construction: it is the one kind that proves the
@@ -138,6 +201,7 @@ _ENTRY_FAILURE_PRECEDENCE = (
     ScriptErrorKind.COMPILE_FAILED,
     ScriptErrorKind.PARSE_ERROR,
     ScriptErrorKind.LOAD_FAILED,
+    ScriptErrorKind.RESOURCE_LOAD_FAILED,
     ScriptErrorKind.NOT_A_MAIN_LOOP,
 )
 
@@ -152,10 +216,12 @@ class ScriptError(BaseModel):
 
     kind: ScriptErrorKind = Field(
         description=(
-            "Which known engine script failure this line reports. Five of the six "
-            "mean the named script never ran: 'script_missing', 'compile_failed', "
-            "'parse_error', 'load_failed' and 'not_a_main_loop'. Only "
-            "'runtime_error' means the script was loaded and running when it raised."
+            "Which known engine failure this line reports. Every kind except "
+            "'runtime_error' means the named resource could not be loaded or run; "
+            "'runtime_error' means a script was already executing when it raised. "
+            "Whether the RUN failed depends on whether 'path' is the entry script: "
+            "a load failure naming something the running script merely tried to "
+            "load is not a failed run."
         )
     )
     message: str = Field(
@@ -167,7 +233,9 @@ class ScriptError(BaseModel):
     path: str | None = Field(
         default=None,
         description=(
-            "The res:// script this error is about, or null when the engine named none."
+            "The res:// resource this error is about, in canonical form ('.'/'..' "
+            "segments and duplicate slashes collapsed), or null when the engine "
+            "named none."
         ),
     )
     line: int | None = Field(
@@ -201,9 +269,17 @@ def entry_load_failure(
     """The error proving ``script`` never ran as the entry point, or ``None``.
 
     ``script`` is the ``res://`` path the caller asked the engine to run. Matching
-    on that exact path is what keeps the verdict honest: a running script that
-    *itself* loads a missing or broken resource produces the very same engine
-    sentences for a DIFFERENT path, and must not be reported as a failed run.
+    on that path is what keeps the verdict honest: a running script that *itself*
+    loads a missing or broken resource produces the very same engine sentences for
+    a DIFFERENT path, and must not be reported as a failed run.
+
+    Both sides are canonicalized (:func:`canonical_res_path`) before comparison,
+    because the engine reports the canonical spelling of whatever it was given:
+    invoking ``res://dir/../bad.gd`` yields errors naming ``res://bad.gd``, and a
+    raw-string comparison would miss the match and report a phantom success. The
+    paths on ``errors`` are already canonical (the parser canonicalizes on the way
+    in); canonicalizing again here is idempotent and keeps the guarantee local, so
+    a caller passing hand-built errors cannot defeat it.
 
     A dependency's compile failure still fails the entry: the engine reports the
     unresolvable preload as "Failed to load script" naming the **entry** script
@@ -212,11 +288,17 @@ def entry_load_failure(
     Returns the most specific matching error (see ``_ENTRY_FAILURE_PRECEDENCE``);
     ``None`` when the entry point loaded, whatever else went wrong afterwards.
     """
+    entry = canonical_res_path(script)
     for kind in _ENTRY_FAILURE_PRECEDENCE:
         for error in errors:
-            if error.kind is kind and error.path == script:
+            if error.kind is kind and _matches(error.path, entry):
                 return error
     return None
+
+
+def _matches(path: str | None, entry: str) -> bool:
+    """Does a diagnostic's path name the (already canonical) entry script?"""
+    return path is not None and canonical_res_path(path) == entry
 
 
 def _classify(record: dict) -> ScriptError | None:
@@ -245,7 +327,11 @@ def _script_error(record: dict, message: str) -> ScriptError:
         else ScriptErrorKind.RUNTIME_ERROR
     )
     file = record.get("file")
-    path = file if isinstance(file, str) and file.startswith(_RES_PREFIX) else None
+    path = (
+        canonical_res_path(file)
+        if isinstance(file, str) and file.startswith(_RES_PREFIX)
+        else None
+    )
     return ScriptError(
         kind=kind,
         message=message,
@@ -257,11 +343,12 @@ def _script_error(record: dict, message: str) -> ScriptError:
 
 
 def _engine_error(message: str) -> ScriptError | None:
-    """A plain ``ERROR:`` record, if it is one of the known script-load sentences.
+    """A plain ``ERROR:`` record, if it is one of the known load-failure sentences.
 
     The path is read out of the MESSAGE, not the record's ``at:`` frame: these are
-    raised by the engine's own C++ (``main.cpp``, ``gdscript.cpp``), so the frame
-    names an engine source file. No script line is available for any of them.
+    raised by the engine's own C++ (``main.cpp``, ``gdscript.cpp``,
+    ``resource_loader.cpp``), so the frame names an engine source file. No script
+    line is available for any of them.
     """
     open_failed = _OPEN_FAILED.match(message)
     if open_failed is not None:
@@ -270,28 +357,47 @@ def _engine_error(message: str) -> ScriptError | None:
             if open_failed.group("reason") == _FILE_NOT_FOUND
             else ScriptErrorKind.LOAD_FAILED
         )
-        return ScriptError(kind=kind, message=message, path=open_failed.group("path"))
+        return _engine_diagnostic(kind, message, open_failed.group("path"))
     load_failed = _LOAD_FAILED.match(message)
     if load_failed is not None:
-        return ScriptError(
-            kind=ScriptErrorKind.COMPILE_FAILED,
-            message=message,
-            path=load_failed.group("path"),
+        return _engine_diagnostic(
+            ScriptErrorKind.COMPILE_FAILED, message, load_failed.group("path")
         )
     # Checked before the bare `Can't load script:` form — the two sentences share a
     # prefix word, and only the anchored patterns tell them apart.
     not_a_main_loop = _NOT_A_MAIN_LOOP.match(message)
     if not_a_main_loop is not None:
-        return ScriptError(
-            kind=ScriptErrorKind.NOT_A_MAIN_LOOP,
-            message=message,
-            path=not_a_main_loop.group("path"),
+        return _engine_diagnostic(
+            ScriptErrorKind.NOT_A_MAIN_LOOP, message, not_a_main_loop.group("path")
         )
     cant_load = _CANT_LOAD.match(message)
     if cant_load is not None:
-        return ScriptError(
-            kind=ScriptErrorKind.LOAD_FAILED,
-            message=message,
-            path=cant_load.group("path"),
+        return _engine_diagnostic(
+            ScriptErrorKind.LOAD_FAILED, message, cant_load.group("path")
+        )
+    # The resource layer's two sentences (#651 review claim 4). Both name a
+    # res:// address the run tried to load; whether that address is the ENTRY is
+    # what decides the verdict, and that is entry_load_failure's job, not this
+    # classifier's — so a runtime load() of a missing .tres lands here as an
+    # ordinary diagnostic on a successful run.
+    cannot_open = _CANNOT_OPEN_FILE.match(message)
+    if cannot_open is not None:
+        return _engine_diagnostic(
+            ScriptErrorKind.RESOURCE_LOAD_FAILED, message, cannot_open.group("path")
+        )
+    failed_loading = _FAILED_LOADING_RESOURCE.match(message)
+    if failed_loading is not None:
+        return _engine_diagnostic(
+            ScriptErrorKind.RESOURCE_LOAD_FAILED, message, failed_loading.group("path")
         )
     return None
+
+
+def _engine_diagnostic(kind: ScriptErrorKind, message: str, path: str) -> ScriptError:
+    """An engine-side load diagnostic, with its address canonicalized on the way in.
+
+    The one construction point for the message-derived paths, so every address
+    this module publishes is canonical and no future sentence can be added that
+    quietly skips normalization (#651 review claim 1).
+    """
+    return ScriptError(kind=kind, message=message, path=canonical_res_path(path))

--- a/src/gda/script_errors.py
+++ b/src/gda/script_errors.py
@@ -1,0 +1,276 @@
+"""Classify Godot's script-error stderr lines into structured diagnostics (#651).
+
+The single home of *what Godot's error stream says about a script*. It is the
+read-side companion to :func:`gda.daemon.diag.parse_errors`, which is the single
+home of *how the engine formats an error line* (the two-line ``<TYPE>: <message>``
+/ ``   at: <function> (<file>:<line>)`` shape of ``core/io/logger.cpp``). This
+module reuses that parser verbatim and adds the one thing it does not do: decide
+which of the engine's known script-failure sentences a record is, and which
+``res://`` script the sentence is about.
+
+The split matters because the engine reports a failed script run **only** on
+stderr — the process still exits ``0``. A missing entry script, a parse error in
+the entry script, and a parse error in one of its dependencies all leave a clean
+exit status behind (verified against Godot 4.6.3), so a channel that reads only
+the exit code reports a phantom success (#651, dogfooding GDA-DF-007/GDA-DF-032).
+:func:`entry_load_failure` turns the stderr evidence into that missing verdict.
+
+Consumers (the reason this is a module and not a helper inside one command):
+
+- ``gda script run`` (:mod:`gda.commands.script`) — the verdict plus the
+  ``diagnostics`` it carries on its result;
+- the ``script run`` timeout path (#655) — the same diagnostics from the partial
+  stderr captured before the timeout;
+- the scene-startup preflight (#664) — the same script errors from a scene launch.
+
+Everything here is a **pure function of the stderr text**: no engine, no I/O.
+Recognition is deliberately closed — only the sentences below are classified, so
+``diagnostics`` stays a curated high-signal list rather than a re-encoding of the
+whole error stream (the verbatim stream is preserved separately by each caller).
+An unrecognized error or warning is skipped and never raises.
+
+The recognized sentences, verbatim from Godot 4.6.3::
+
+    SCRIPT ERROR: Parse Error: <message>
+              at: GDScript::reload (res://entry.gd:4)
+    ERROR: Failed to load script "res://entry.gd" with error "Parse error".
+    ERROR: Attempt to open script 'res://gone.gd' resulted in error 'File not found'.
+    ERROR: Can't load script: res://gone.gd
+    ERROR: Can't load the script "res://plain.gd" as it doesn't inherit from SceneTree or MainLoop.
+"""
+
+import re
+from collections.abc import Sequence
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from gda.daemon.diag import parse_errors
+
+# The res:// scheme prefix. A diagnostic's ``path`` is only ever a res:// script:
+# the engine's own ``at:`` frame for an engine-side error names a C++ source file
+# (``modules/gdscript/gdscript.cpp``), which is gda-irrelevant noise.
+_RES_PREFIX = "res://"
+
+# The engine's ``SCRIPT ERROR:`` records carry the compile failure as a message
+# prefixed ``Parse Error:``; every other SCRIPT ERROR is a runtime failure raised
+# while the script was already executing.
+_PARSE_ERROR_PREFIX = "Parse Error:"
+
+# `ERROR: Attempt to open script '<path>' resulted in error '<reason>'.` — the
+# engine could not even read the file. The reason distinguishes a missing script
+# (the #651 defect) from any other open failure.
+_OPEN_FAILED = re.compile(
+    r"^Attempt to open script '(?P<path>[^']*)' resulted in error '(?P<reason>[^']*)'"
+)
+_FILE_NOT_FOUND = "File not found"
+
+# `ERROR: Failed to load script "<path>" with error "<reason>".` — the file was
+# read but the script did not compile (its own parse error, or an unresolvable
+# dependency: the entry script is what the engine names either way).
+_LOAD_FAILED = re.compile(
+    r'^Failed to load script "(?P<path>[^"]*)" with error "(?P<reason>[^"]*)"'
+)
+
+# `ERROR: Can't load script: <path>` — main.cpp's `start()` giving up on the
+# `--script` entry point. Emitted alongside the more specific sentences above;
+# on its own it is the generic "the entry never became the main loop".
+_CANT_LOAD = re.compile(r"^Can't load script: (?P<path>\S+?)\.?$")
+
+# `ERROR: Can't load the script "<path>" as it doesn't inherit from SceneTree or
+# MainLoop.` — the script compiled fine but cannot BE the one-shot entry point.
+_NOT_A_MAIN_LOOP = re.compile(
+    r'^Can\'t load the script "(?P<path>[^"]*)" as it doesn\'t inherit from '
+    r"SceneTree or MainLoop"
+)
+
+
+class ScriptErrorKind(str, Enum):
+    """What a recognized engine error line says about a script (#651).
+
+    A closed, public enum: it is projected into ``--schema`` through the results
+    that carry :class:`ScriptError`. The three ``*_FAILED``/``MISSING`` kinds mean
+    the named script **never ran**; the two error kinds mean it was loaded and
+    something went wrong before or during execution.
+    """
+
+    #: A compile failure in the named script (its own syntax error, or a
+    #: dependency it preloads that does not resolve). The script never ran.
+    PARSE_ERROR = "parse_error"
+    #: A GDScript error raised while the script was already executing.
+    RUNTIME_ERROR = "runtime_error"
+    #: The named script does not exist. It never ran.
+    SCRIPT_MISSING = "script_missing"
+    #: The named script exists but could not be loaded (an open failure other
+    #: than a missing file, or the engine giving up on the entry point).
+    LOAD_FAILED = "load_failed"
+    #: The named script was read but did not compile. It never ran.
+    COMPILE_FAILED = "compile_failed"
+    #: The named script compiles but does not extend ``SceneTree``/``MainLoop``,
+    #: so it cannot be a one-shot ``--script`` entry point.
+    NOT_A_MAIN_LOOP = "not_a_main_loop"
+
+
+#: The kinds that prove a script never ran, most specific first. The order IS the
+#: verdict precedence used by :func:`entry_load_failure`: a missing file is a
+#: better explanation than the generic "can't load" the engine emits beside it.
+_ENTRY_FAILURE_PRECEDENCE = (
+    ScriptErrorKind.SCRIPT_MISSING,
+    ScriptErrorKind.COMPILE_FAILED,
+    ScriptErrorKind.LOAD_FAILED,
+)
+
+
+class ScriptError(BaseModel):
+    """One recognized script error read out of the engine's stderr (#651).
+
+    Best-effort and advisory in the ADR-0002 sense — parsed from stderr, not from
+    a bound API — but unlike free-form diagnostics it is *classified*, so an agent
+    can branch on ``kind`` instead of matching engine prose.
+    """
+
+    kind: ScriptErrorKind = Field(
+        description=(
+            "Which known engine script failure this line reports. "
+            "'script_missing', 'compile_failed', 'parse_error', 'load_failed' and "
+            "'not_a_main_loop' all mean the named script never ran; "
+            "'runtime_error' means it was running and raised."
+        )
+    )
+    message: str = Field(
+        description=(
+            "The engine's error text verbatim, with its 'ERROR:'/'SCRIPT ERROR:' "
+            "prefix stripped."
+        )
+    )
+    path: str | None = Field(
+        default=None,
+        description=(
+            "The res:// script this error is about, or null when the engine named none."
+        ),
+    )
+    line: int | None = Field(
+        default=None,
+        description=(
+            "The 1-based line in 'path' the engine reported, or null when it "
+            "reported none (engine-side load errors carry no script line)."
+        ),
+    )
+
+
+def parse_script_errors(stderr: str) -> list[ScriptError]:
+    """Recognized script errors from an engine stderr capture, in emission order.
+
+    Pure and best-effort: an error the engine formats in a way this module does
+    not recognize — and every warning — is skipped rather than guessed at, and
+    malformed input yields ``[]`` instead of raising. Callers keep the verbatim
+    stderr, so nothing is lost by the narrow recognition.
+    """
+    errors: list[ScriptError] = []
+    for record in parse_errors(stderr):
+        recognized = _classify(record)
+        if recognized is not None:
+            errors.append(recognized)
+    return errors
+
+
+def entry_load_failure(
+    errors: Sequence[ScriptError], script: str
+) -> ScriptError | None:
+    """The error proving ``script`` never ran as the entry point, or ``None``.
+
+    ``script`` is the ``res://`` path the caller asked the engine to run. Matching
+    on that exact path is what keeps the verdict honest: a running script that
+    *itself* loads a missing or broken resource produces the very same engine
+    sentences for a DIFFERENT path, and must not be reported as a failed run.
+
+    A dependency's compile failure still fails the entry: the engine reports the
+    unresolvable preload as "Failed to load script" naming the **entry** script
+    (verified against Godot 4.6.3), so no dependency walk is needed here.
+
+    Returns the most specific matching error (see ``_ENTRY_FAILURE_PRECEDENCE``);
+    ``None`` when the entry point loaded, whatever else went wrong afterwards.
+    """
+    for kind in _ENTRY_FAILURE_PRECEDENCE:
+        for error in errors:
+            if error.kind is kind and error.path == script:
+                return error
+    return None
+
+
+def _classify(record: dict) -> ScriptError | None:
+    """One ``parse_errors`` record as a :class:`ScriptError`, or ``None`` if unknown."""
+    level = record.get("level")
+    message = record.get("message") or ""
+    if level == "script_error":
+        return _script_error(record, message)
+    if level != "error":
+        # Warnings and the other engine levels say nothing about a script's fate.
+        return None
+    return _engine_error(message)
+
+
+def _script_error(record: dict, message: str) -> ScriptError:
+    """A ``SCRIPT ERROR:`` record: a compile failure or a runtime failure.
+
+    The location comes from the engine's ``at:`` frame, which for a script error
+    names the script itself (``GDScript::reload (res://entry.gd:4)`` for a parse
+    error, the raising function for a runtime one), so both a ``path`` and a
+    ``line`` are available here — unlike the engine-side load errors below.
+    """
+    kind = (
+        ScriptErrorKind.PARSE_ERROR
+        if message.startswith(_PARSE_ERROR_PREFIX)
+        else ScriptErrorKind.RUNTIME_ERROR
+    )
+    file = record.get("file")
+    path = file if isinstance(file, str) and file.startswith(_RES_PREFIX) else None
+    return ScriptError(
+        kind=kind,
+        message=message,
+        path=path,
+        # A line without a res:// path would be a line number in the engine's own
+        # C++ source, which is meaningless to an agent — so both travel together.
+        line=record.get("line") if path is not None else None,
+    )
+
+
+def _engine_error(message: str) -> ScriptError | None:
+    """A plain ``ERROR:`` record, if it is one of the known script-load sentences.
+
+    The path is read out of the MESSAGE, not the record's ``at:`` frame: these are
+    raised by the engine's own C++ (``main.cpp``, ``gdscript.cpp``), so the frame
+    names an engine source file. No script line is available for any of them.
+    """
+    open_failed = _OPEN_FAILED.match(message)
+    if open_failed is not None:
+        kind = (
+            ScriptErrorKind.SCRIPT_MISSING
+            if open_failed.group("reason") == _FILE_NOT_FOUND
+            else ScriptErrorKind.LOAD_FAILED
+        )
+        return ScriptError(kind=kind, message=message, path=open_failed.group("path"))
+    load_failed = _LOAD_FAILED.match(message)
+    if load_failed is not None:
+        return ScriptError(
+            kind=ScriptErrorKind.COMPILE_FAILED,
+            message=message,
+            path=load_failed.group("path"),
+        )
+    # Checked before the bare `Can't load script:` form — the two sentences share a
+    # prefix word, and only the anchored patterns tell them apart.
+    not_a_main_loop = _NOT_A_MAIN_LOOP.match(message)
+    if not_a_main_loop is not None:
+        return ScriptError(
+            kind=ScriptErrorKind.NOT_A_MAIN_LOOP,
+            message=message,
+            path=not_a_main_loop.group("path"),
+        )
+    cant_load = _CANT_LOAD.match(message)
+    if cant_load is not None:
+        return ScriptError(
+            kind=ScriptErrorKind.LOAD_FAILED,
+            message=message,
+            path=cant_load.group("path"),
+        )
+    return None

--- a/src/gda/script_errors.py
+++ b/src/gda/script_errors.py
@@ -89,35 +89,56 @@ class ScriptErrorKind(str, Enum):
     """What a recognized engine error line says about a script (#651).
 
     A closed, public enum: it is projected into ``--schema`` through the results
-    that carry :class:`ScriptError`. The three ``*_FAILED``/``MISSING`` kinds mean
-    the named script **never ran**; the two error kinds mean it was loaded and
-    something went wrong before or during execution.
+    that carry :class:`ScriptError`. **Five** of the six kinds mean the named
+    script **never ran** — it was missing, unreadable, non-compiling, or unusable
+    as an entry point. Only ``RUNTIME_ERROR`` means the script was loaded and
+    running when the error was raised.
     """
 
     #: A compile failure in the named script (its own syntax error, or a
     #: dependency it preloads that does not resolve). The script never ran.
     PARSE_ERROR = "parse_error"
-    #: A GDScript error raised while the script was already executing.
+    #: A GDScript error raised while the script was already executing. The ONLY
+    #: kind that says the script ran.
     RUNTIME_ERROR = "runtime_error"
     #: The named script does not exist. It never ran.
     SCRIPT_MISSING = "script_missing"
     #: The named script exists but could not be loaded (an open failure other
-    #: than a missing file, or the engine giving up on the entry point).
+    #: than a missing file, or the engine giving up on the entry point). It
+    #: never ran.
     LOAD_FAILED = "load_failed"
     #: The named script was read but did not compile. It never ran.
     COMPILE_FAILED = "compile_failed"
     #: The named script compiles but does not extend ``SceneTree``/``MainLoop``,
-    #: so it cannot be a one-shot ``--script`` entry point.
+    #: so it cannot be a one-shot ``--script`` entry point. It never ran.
     NOT_A_MAIN_LOOP = "not_a_main_loop"
 
 
-#: The kinds that prove a script never ran, most specific first. The order IS the
-#: verdict precedence used by :func:`entry_load_failure`: a missing file is a
-#: better explanation than the generic "can't load" the engine emits beside it.
+#: The kinds that prove a script never ran, in verdict precedence — the order
+#: :func:`entry_load_failure` returns them in when a run emits several. It runs
+#: EARLIEST-STAGE, MOST SPECIFIC first, because the engine reports the whole
+#: cascade and only the first cause explains the rest:
+#:
+#: 1. ``SCRIPT_MISSING`` — a file that does not exist cannot compile, so it
+#:    outranks the generic "can't load" the engine emits beside it;
+#: 2. ``COMPILE_FAILED`` — the engine's explicit "Failed to load script … with
+#:    error …" verdict sentence;
+#: 3. ``PARSE_ERROR`` — the individual diagnostic that CAUSED (2). Ranked below it
+#:    because (2) is the engine's own conclusion, but kept in the list so a
+#:    non-compiling entry is still caught if a build ever emits the diagnostic
+#:    without the conclusion;
+#: 4. ``LOAD_FAILED`` — "can't load", the least specific reason;
+#: 5. ``NOT_A_MAIN_LOOP`` — last because it is only reachable by a script that
+#:    already existed AND compiled; it is a refusal, not a load failure.
+#:
+#: ``RUNTIME_ERROR`` is absent by construction: it is the one kind that proves the
+#: script DID run.
 _ENTRY_FAILURE_PRECEDENCE = (
     ScriptErrorKind.SCRIPT_MISSING,
     ScriptErrorKind.COMPILE_FAILED,
+    ScriptErrorKind.PARSE_ERROR,
     ScriptErrorKind.LOAD_FAILED,
+    ScriptErrorKind.NOT_A_MAIN_LOOP,
 )
 
 
@@ -131,10 +152,10 @@ class ScriptError(BaseModel):
 
     kind: ScriptErrorKind = Field(
         description=(
-            "Which known engine script failure this line reports. "
-            "'script_missing', 'compile_failed', 'parse_error', 'load_failed' and "
-            "'not_a_main_loop' all mean the named script never ran; "
-            "'runtime_error' means it was running and raised."
+            "Which known engine script failure this line reports. Five of the six "
+            "mean the named script never ran: 'script_missing', 'compile_failed', "
+            "'parse_error', 'load_failed' and 'not_a_main_loop'. Only "
+            "'runtime_error' means the script was loaded and running when it raised."
         )
     )
     message: str = Field(

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -68,7 +68,7 @@ envelope as a pass for this command.
 | ----- | -------- |
 | `scene` | `create`, `get`, `list`, `get-exports`, `delete` (`.tscn` files) |
 | `node` | `add`, `get`, `list`, `set`, `remove`, `duplicate`, `move`, `connect-signal`, `disconnect-signal` (nodes within a scene) |
-| `script` | `create`, `get`, `list`, `set`, `delete`, `attach`, `validate`, `run` (`.gd` files; `run` executes a `res://` script one-shot and passes its `exit_status`/`stdout`/`stderr` through — a non-zero `quit()` is still success) |
+| `script` | `create`, `get`, `list`, `set`, `delete`, `attach`, `validate`, `run` (`.gd` files; `run` executes a `res://` script one-shot and passes its `exit_status`/`stdout`/`stderr` through — a non-zero `quit()` is still success, so read `exit_status`, or pass `--strict` to get a `script_failed` failure (exit 4) whose `diagnostics` carries the script's own stdout and stderr; a script that never ran — missing, or a failed parse/compile — always fails) |
 | `project` | `info`, `get`, `set`, `list`, `add-autoload`, `remove-autoload`, `add-input-action`, `remove-input-action`, `find-references`, `dependencies`, `find-unused-resources`, `statistics` |
 | `resource` | `create`, `get`, `set`, `delete`, `uid` (`.tres` files) |
 | `export` | `list`, `get`, `run` (export a preset by name; `--mode` release/debug/pack) |

--- a/tests/test_e2e_script_run.py
+++ b/tests/test_e2e_script_run.py
@@ -28,8 +28,28 @@ prints. A fixture-driven test would only prove the parser matches our fixtures.
 - a runtime GDScript error the script survived → still a SUCCESS, with the error
   surfaced as a classified diagnostic (GDA-DF-007);
 - a deliberate ``quit(1)`` under ``--strict`` → the ``script_failed`` envelope and
-  a non-zero gda process exit (GDA-DF-017), while the default arm above is
-  unchanged.
+  a non-zero gda process exit (GDA-DF-017), carrying the suite's own printed
+  output as evidence, while the default arm above is unchanged.
+
+**No e2e arm for the not-a-main-loop shape, deliberately.** An entry script that
+compiles but does not extend ``SceneTree``/``MainLoop`` also never runs, and gda
+now classifies it as ``incompatible_script_type`` — but the engine has **two**
+behaviours for it and only one is a phantom success:
+
+- it errors (``Can't load the script … as it doesn't inherit from SceneTree or
+  MainLoop``) and exits ``0`` — the phantom success this classification fixes.
+  Observed on a real run and pinned by ``tests/test_script_error_parser.py`` /
+  ``tests/test_script_run_operation.py`` against that verbatim stderr;
+- it errors and then **keeps running** — the engine falls through to the project's
+  normal main loop, which idles forever headless. This is what a clean fixture
+  project does here (reproduced repeatedly; not caused by the import cache or by
+  other non-compiling scripts in the project, both refuted by probe).
+
+The second is already a failure by a different route (``launch_timeout``, the
+#655 path), so gda never reports success either way. Reproducing the first
+on demand is not possible from project contents, and asserting only the weak
+"never a success" invariant would cost a 120s timeout per run for no added
+signal — so this shape stays unit-covered, with real captured stderr.
 
 The launch-timeout and signal-crash arms of the shared classifier are covered by
 ``tests/test_script_run_operation.py`` and ``tests/test_classify_launch_or_crash.py``
@@ -106,6 +126,18 @@ func _initialize() -> void:
 func _boom() -> void:
 \tvar d = null
 \td.missing_method()
+"""
+
+# A failing suite that reports the way a real GDScript test runner does — through
+# print(), i.e. STDOUT. It is the fixture for the --strict evidence assertion:
+# an envelope carrying only stderr would hold none of these lines.
+FAILING_SUITE_GD = """\
+extends SceneTree
+
+func _initialize() -> void:
+\tprint("FAIL test_damage: expected 5 got 4")
+\tprint("1 of 3 tests failed")
+\tquit(1)
 """
 
 
@@ -328,6 +360,41 @@ def test_script_run_strict_fails_on_an_explicit_non_zero_quit(godot_project):
     assert err["code"] == "script_failed"
     assert err["category"] == "operation"
     assert "status 1" in err["message"]
+
+
+@pytest.mark.e2e
+def test_script_run_strict_envelope_carries_the_suites_stdout(godot_project):
+    # The evidence assertion, against the REAL engine: a GDScript suite reports through
+    # print(), so its failure detail is on STDOUT. The --strict envelope must carry it —
+    # a CI caller that only gets an exit code and an empty diagnostics learns nothing.
+    (godot_project / "suite_fail.gd").write_text(FAILING_SUITE_GD, encoding="utf-8")
+
+    run = _run_gda(
+        "script",
+        "run",
+        "res://suite_fail.gd",
+        "--strict",
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+    )
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "script_failed"
+    diagnostics = err["diagnostics"]
+    # Both labelled sections are present, and the suite's own printed failure detail
+    # survives into the envelope.
+    assert "--- script stdout ---" in diagnostics
+    assert "--- script stderr ---" in diagnostics
+    assert "FAIL test_damage: expected 5 got 4" in diagnostics
+    assert "1 of 3 tests failed" in diagnostics
+    # The printed lines are in the stdout section, not misfiled under stderr.
+    stdout_section, _, stderr_section = diagnostics.partition("--- script stderr ---")
+    assert "1 of 3 tests failed" in stdout_section
+    assert "1 of 3 tests failed" not in stderr_section
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_script_run.py
+++ b/tests/test_e2e_script_run.py
@@ -17,6 +17,20 @@ ADR-0031 specifies:
   launch;
 - an unlaunchable binary is the shared classifier's ``binary_not_found``.
 
+The #651 verdict arms are here for a reason the unit tests cannot cover: they
+assert that the ENGINE really does exit ``0`` for a script that never ran, and
+that gda's stderr classification really does fire on what this Godot build
+prints. A fixture-driven test would only prove the parser matches our fixtures.
+
+- a missing ``res://`` entry script → ``script_not_found`` (GDA-DF-032);
+- an entry script whose preloaded dependency does not compile →
+  ``script_compile_failed`` (GDA-DF-007);
+- a runtime GDScript error the script survived → still a SUCCESS, with the error
+  surfaced as a classified diagnostic (GDA-DF-007);
+- a deliberate ``quit(1)`` under ``--strict`` → the ``script_failed`` envelope and
+  a non-zero gda process exit (GDA-DF-017), while the default arm above is
+  unchanged.
+
 The launch-timeout and signal-crash arms of the shared classifier are covered by
 ``tests/test_script_run_operation.py`` and ``tests/test_classify_launch_or_crash.py``
 (forcing them live is flaky and needs no ``script run``-specific wiring — the
@@ -54,6 +68,44 @@ extends SceneTree
 func _initialize() -> void:
 \tprint("assertion failed: expected 5 got 4")
 \tquit(1)
+"""
+
+# --- The #651 fixtures: three shapes the engine reports on stderr while exiting 0.
+
+# An entry script whose dependency does not compile. The engine reports the
+# unresolvable preload as a load failure of THIS script and never runs it — the
+# print below is what a passthrough-only channel wrongly reported success for.
+BAD_DEPENDENCY_GD = """\
+extends SceneTree
+
+const Broken := preload("res://broken_dep.gd")
+
+func _initialize() -> void:
+\tprint("completed: true")
+\tquit(0)
+"""
+
+BROKEN_DEP_GD = """\
+extends RefCounted
+
+func oops() -> void:
+\t@@@ not valid @@@
+"""
+
+# A script that hits a runtime GDScript error, SURVIVES it (the failing call only
+# aborts its own function) and quit(0)s. It really did run, so it stays a success —
+# the error is what the classified diagnostics exist to surface.
+RUNTIME_ERROR_GD = """\
+extends SceneTree
+
+func _initialize() -> void:
+\t_boom()
+\tprint("still alive")
+\tquit(0)
+
+func _boom() -> void:
+\tvar d = null
+\td.missing_method()
 """
 
 
@@ -168,6 +220,139 @@ def test_script_run_without_a_project_is_project_not_found(tmp_path):
     err = json.loads(run.stdout)["error"]
     assert err["code"] == "project_not_found"
     assert err["category"] == "operation"
+
+
+@pytest.mark.e2e
+def test_script_run_missing_script_is_script_not_found(godot_project):
+    # GDA-DF-032 against the REAL engine: Godot exits 0 for a res:// script that does
+    # not exist, printing the load errors to stderr only. The verdict must come from
+    # that stderr — a structured failure, never {"exit_status": 0}.
+    run = _run_gda(
+        "script",
+        "run",
+        "res://no-such-script.gd",
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+    )
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "script_not_found"
+    assert err["category"] == "operation"
+    assert "res://no-such-script.gd" in err["message"]
+
+
+@pytest.mark.e2e
+def test_script_run_parse_error_dependency_is_script_compile_failed(godot_project):
+    # GDA-DF-007 against the REAL engine: the entry script compiles only if its
+    # preloaded dependency does. It does not, so the entry never runs — yet Godot
+    # exits 0 and the script's own "completed: true" line is never printed.
+    (godot_project / "suite.gd").write_text(BAD_DEPENDENCY_GD, encoding="utf-8")
+    (godot_project / "broken_dep.gd").write_text(BROKEN_DEP_GD, encoding="utf-8")
+
+    run = _run_gda(
+        "script",
+        "run",
+        "res://suite.gd",
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+    )
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "script_compile_failed"
+    assert err["category"] == "operation"
+    # The engine's stderr is preserved as secondary evidence, naming the dependency
+    # the entry script could not preload.
+    assert "broken_dep.gd" in err["diagnostics"]
+
+
+@pytest.mark.e2e
+def test_script_run_runtime_error_is_a_success_carrying_diagnostics(godot_project):
+    # The third GDA-DF-007 shape: the script RAN, raised, survived and quit(0). ADR-0031
+    # still governs — a completed run is a success — but the error is no longer buried
+    # in stderr prose: it is a classified diagnostic an agent can branch on.
+    (godot_project / "runtime_error.gd").write_text(RUNTIME_ERROR_GD, encoding="utf-8")
+
+    run = _run_gda(
+        "script",
+        "run",
+        "res://runtime_error.gd",
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+        retry=True,
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    data = json.loads(run.stdout)
+    assert data["exit_status"] == 0
+    assert "still alive" in data["stdout"]
+    kinds = [d["kind"] for d in data["diagnostics"]]
+    assert "runtime_error" in kinds
+    runtime = next(d for d in data["diagnostics"] if d["kind"] == "runtime_error")
+    assert runtime["path"] == "res://runtime_error.gd"
+    assert runtime["line"] is not None
+
+
+@pytest.mark.e2e
+def test_script_run_strict_fails_on_an_explicit_non_zero_quit(godot_project):
+    # GDA-DF-017 against the REAL engine: a failing test quit(1)s. By default that is
+    # data and gda exits 0 (asserted above); with --strict the gda PROCESS exits 4, so
+    # a shell `&&` chain and a conventional CI step stop on it — observable without
+    # parsing the JSON.
+    (godot_project / "fail.gd").write_text(FAIL_GD, encoding="utf-8")
+
+    run = _run_gda(
+        "script",
+        "run",
+        "res://fail.gd",
+        "--strict",
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+    )
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "script_failed"
+    assert err["category"] == "operation"
+    assert "status 1" in err["message"]
+
+
+@pytest.mark.e2e
+def test_script_run_strict_leaves_a_passing_script_a_success(godot_project):
+    # --strict changes only the non-zero arm: a clean run is the same passthrough
+    # success, so a CI step can pass --strict unconditionally.
+    (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
+
+    run = _run_gda(
+        "script",
+        "run",
+        "res://hello.gd",
+        "--strict",
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+        retry=True,
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    data = json.loads(run.stdout)
+    assert data["exit_status"] == 0
+    assert data["diagnostics"] == []
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_script_run.py
+++ b/tests/test_e2e_script_run.py
@@ -128,6 +128,18 @@ func _boom() -> void:
 \td.missing_method()
 """
 
+# A script that RAN and tried to load a resource that is not there. It survives the
+# failed load and quit(0)s, so the run is a success — the resource-load errors are
+# diagnostics, not a verdict (#651 review claim 4).
+RUNTIME_RESOURCE_LOAD_GD = """\
+extends SceneTree
+
+func _initialize() -> void:
+\tvar r = load("res://missing.tres")
+\tprint("loaded=", r)
+\tquit(0)
+"""
+
 # A failing suite that reports the way a real GDScript test runner does — through
 # print(), i.e. STDOUT. It is the fixture for the --strict evidence assertion:
 # an envelope carrying only stderr would hold none of these lines.
@@ -333,6 +345,111 @@ def test_script_run_runtime_error_is_a_success_carrying_diagnostics(godot_projec
     runtime = next(d for d in data["diagnostics"] if d["kind"] == "runtime_error")
     assert runtime["path"] == "res://runtime_error.gd"
     assert runtime["line"] is not None
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        "res://sub/../no-such-script.gd",
+        "res://./no-such-script.gd",
+        "res://sub//..//no-such-script.gd",
+    ],
+)
+def test_script_run_missing_entry_verdict_survives_path_aliasing(
+    godot_project, spelling
+):
+    # #651 review claim 1, against the REAL engine: Godot resolves the address
+    # before naming it, so these spellings all come back as `res://no-such-script.gd`.
+    # Comparing the engine's spelling with the caller's raw one used to MISROUTE this
+    # to script_compile_failed (only main.cpp's echoed argv matched). One canonical
+    # identity restores the specific verdict for every spelling.
+    (godot_project / "sub").mkdir(exist_ok=True)
+
+    run = _run_gda(
+        "script",
+        "run",
+        spelling,
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+    )
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "script_not_found"
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        "res://sub/../suite.gd",
+        "res://./suite.gd",
+        "res://sub//..//suite.gd",
+    ],
+)
+def test_script_run_compile_failed_verdict_survives_path_aliasing(
+    godot_project, spelling
+):
+    # The other half of claim 1, and the one that reported outright success before:
+    # a non-compiling entry invoked by a non-canonical spelling never matched the
+    # engine's canonical report, so gda passed the engine's exit 0 straight through.
+    (godot_project / "sub").mkdir(exist_ok=True)
+    (godot_project / "suite.gd").write_text(BAD_DEPENDENCY_GD, encoding="utf-8")
+    (godot_project / "broken_dep.gd").write_text(BROKEN_DEP_GD, encoding="utf-8")
+
+    run = _run_gda(
+        "script",
+        "run",
+        spelling,
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+    )
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "script_compile_failed"
+
+
+@pytest.mark.e2e
+def test_script_run_runtime_resource_load_failure_is_a_success_with_diagnostics(
+    godot_project,
+):
+    # #651 review claim 4, against the REAL engine: the script RAN and its load()
+    # failed. The run is a success (it completed and chose exit 0), and the engine's
+    # resource-load errors are surfaced as classified diagnostics naming the
+    # RESOURCE — not the entry — so the verdict is untouched.
+    (godot_project / "runtime_load.gd").write_text(
+        RUNTIME_RESOURCE_LOAD_GD, encoding="utf-8"
+    )
+
+    run = _run_gda(
+        "script",
+        "run",
+        "res://runtime_load.gd",
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+        retry=True,
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    data = json.loads(run.stdout)
+    assert data["exit_status"] == 0
+    assert "loaded=" in data["stdout"]
+    resource_errors = [
+        d for d in data["diagnostics"] if d["kind"] == "resource_load_failed"
+    ]
+    assert resource_errors, data["diagnostics"]
+    assert all(d["path"] == "res://missing.tres" for d in resource_errors)
 
 
 @pytest.mark.e2e

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1169,7 +1169,8 @@ def test_script_run_command_schema_reports_kind_script_run():
 def test_script_run_command_schema_is_model_derived():
     # `script run` self-describes like any command (ADR-0004): input/output from its
     # typed models, the uniform error envelope. Its output carries the passthrough
-    # {exit_status, stdout, stderr} — the public promotion of the Raw run.
+    # {exit_status, stdout, stderr} — the public promotion of the Raw run — plus the
+    # classified `diagnostics` gda reads out of the engine's stderr (#651).
     from gda.commands.script import ScriptRunParams, ScriptRunResult
 
     doc = json.loads(CliRunner().invoke(app, ["script", "run", "--schema"]).stdout)
@@ -1178,7 +1179,14 @@ def test_script_run_command_schema_is_model_derived():
     assert doc["output"] == ScriptRunResult.model_json_schema()
     assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     # The success output exposes exit_status (can be non-zero on success, ADR-0031).
-    assert set(doc["output"]["properties"]) == {"exit_status", "stdout", "stderr"}
+    assert set(doc["output"]["properties"]) == {
+        "exit_status",
+        "stdout",
+        "stderr",
+        "diagnostics",
+    }
+    # `--strict` is a params field, so the JSON/MCP callers can opt in like argv (#651).
+    assert set(doc["input"]["properties"]) == {"path", "strict"}
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 

--- a/tests/test_script_error_parser.py
+++ b/tests/test_script_error_parser.py
@@ -1,0 +1,169 @@
+"""The engine-stderr script-error classifier (#651).
+
+:mod:`gda.script_errors` is a pure function of an engine stderr capture, so these
+tests drive it with stderr recorded VERBATIM from a real ``godot --headless
+--script`` run (Godot 4.6.3, macOS) rather than with invented lines — the parser's
+whole value is that it recognizes what the engine actually prints, and an invented
+fixture would only pin what we imagined it prints.
+
+Each capture below is a failure mode from the #651 dogfooding reports: a missing
+entry script (GDA-DF-032), an entry parse error and a dependency parse error
+(GDA-DF-007), and a runtime GDScript error the script survived (GDA-DF-007). Note
+the exit status recorded in each docstring: the engine exits **0** for every one of
+them, which is exactly why the verdict has to come from here.
+"""
+
+from gda.script_errors import (
+    ScriptErrorKind,
+    entry_load_failure,
+    parse_script_errors,
+)
+
+# `godot --headless --path <proj> --script res://nope.gd`, exit status 0.
+MISSING_STDERR = """\
+ERROR: Attempt to open script 'res://nope.gd' resulted in error 'File not found'.
+   at: load_source_code (modules/gdscript/gdscript.cpp:1127)
+ERROR: Failed loading resource: res://nope.gd.
+   at: _load (core/io/resource_loader.cpp:343)
+ERROR: Can't load script: res://nope.gd
+   at: start (main/main.cpp:4271)
+"""
+
+# `--script res://parse_error.gd`, whose line 4 is not valid GDScript. Exit status 0.
+PARSE_ERROR_STDERR = """\
+SCRIPT ERROR: Parse Error: Expected end of statement after expression, found "Identifier" instead.
+          at: GDScript::reload (res://parse_error.gd:4)
+ERROR: Failed to load script "res://parse_error.gd" with error "Parse error".
+   at: load (modules/gdscript/gdscript.cpp:2907)
+"""
+
+# `--script res://bad_dep.gd`, which preloads a non-compiling res://broken_dep.gd.
+# Exit status 0. The engine names the ENTRY script in the load failure, and the
+# entry's own preload line in the reload frames — the dependency appears only
+# inside the message text.
+BAD_DEPENDENCY_STDERR = """\
+SCRIPT ERROR: Parse Error: Could not preload resource script "res://broken_dep.gd".
+          at: GDScript::reload (res://bad_dep.gd:3)
+SCRIPT ERROR: Parse Error: Could not resolve script "res://broken_dep.gd".
+          at: GDScript::reload (res://bad_dep.gd:3)
+SCRIPT ERROR: Parse Error: Cannot infer the type of "Broken" constant because the value doesn't have a set type.
+          at: GDScript::reload (res://bad_dep.gd:3)
+ERROR: Failed to load script "res://bad_dep.gd" with error "Parse error".
+   at: load (modules/gdscript/gdscript.cpp:2907)
+"""
+
+# `--script res://runtime_error.gd`, which calls a method on null then keeps going
+# and quit(0)s. Exit status 0 — the script RAN; only the diagnostics reveal the bug.
+RUNTIME_ERROR_STDERR = """\
+SCRIPT ERROR: Invalid call. Nonexistent function 'missing_method' in base 'Nil'.
+          at: _boom (res://runtime_error.gd:10)
+          GDScript backtrace (most recent call first):
+              [0] _boom (res://runtime_error.gd:10)
+              [1] _initialize (res://runtime_error.gd:4)
+"""
+
+# `--script res://plain.gd`, a valid script that extends RefCounted. Exit status 0.
+NOT_A_MAIN_LOOP_STDERR = """\
+ERROR: Can't load the script "res://plain.gd" as it doesn't inherit from SceneTree or MainLoop.
+   at: start (main/main.cpp:4286)
+"""
+
+
+def test_missing_script_is_classified_and_located():
+    errors = parse_script_errors(MISSING_STDERR)
+
+    kinds = [(e.kind, e.path) for e in errors]
+    # The definitive File-not-found sentence and main.cpp's give-up line are both
+    # recognized; the generic "Failed loading resource" line is not one of the
+    # closed set and is deliberately skipped rather than guessed at.
+    assert kinds == [
+        (ScriptErrorKind.SCRIPT_MISSING, "res://nope.gd"),
+        (ScriptErrorKind.LOAD_FAILED, "res://nope.gd"),
+    ]
+    # An engine-side load error carries no script line (the at: frame names the
+    # engine's own C++ source, which is meaningless to an agent).
+    assert all(e.line is None for e in errors)
+
+
+def test_missing_script_is_the_entry_verdict():
+    errors = parse_script_errors(MISSING_STDERR)
+    verdict = entry_load_failure(errors, "res://nope.gd")
+
+    # SCRIPT_MISSING wins over the LOAD_FAILED emitted beside it: "the file does
+    # not exist" is the better explanation than "the engine gave up".
+    assert verdict is not None
+    assert verdict.kind is ScriptErrorKind.SCRIPT_MISSING
+
+
+def test_entry_parse_error_carries_the_source_line():
+    errors = parse_script_errors(PARSE_ERROR_STDERR)
+
+    assert [e.kind for e in errors] == [
+        ScriptErrorKind.PARSE_ERROR,
+        ScriptErrorKind.COMPILE_FAILED,
+    ]
+    parse_error = errors[0]
+    assert parse_error.path == "res://parse_error.gd"
+    assert parse_error.line == 4
+    assert "Expected end of statement" in parse_error.message
+    assert entry_load_failure(errors, "res://parse_error.gd") is errors[1]
+
+
+def test_dependency_parse_error_fails_the_entry_script():
+    # The dependency is named only inside the message; the engine reports the
+    # unresolvable preload as a load failure of the ENTRY script, which is what
+    # makes the verdict work without walking the dependency graph.
+    errors = parse_script_errors(BAD_DEPENDENCY_STDERR)
+    verdict = entry_load_failure(errors, "res://bad_dep.gd")
+
+    assert verdict is not None
+    assert verdict.kind is ScriptErrorKind.COMPILE_FAILED
+    assert "broken_dep.gd" in errors[0].message
+    assert errors[0].path == "res://bad_dep.gd"
+
+
+def test_runtime_error_is_not_an_entry_failure():
+    # The script RAN — a runtime error says nothing about whether it loaded, so it
+    # must not flip the verdict (ADR-0031 still governs a completed run).
+    errors = parse_script_errors(RUNTIME_ERROR_STDERR)
+
+    assert [e.kind for e in errors] == [ScriptErrorKind.RUNTIME_ERROR]
+    assert errors[0].path == "res://runtime_error.gd"
+    assert errors[0].line == 10
+    assert entry_load_failure(errors, "res://runtime_error.gd") is None
+
+
+def test_not_a_main_loop_is_recognized_but_is_not_a_load_verdict():
+    # The script compiles and exists; it just cannot BE the entry point. It is
+    # surfaced as a diagnostic, and mapping it to a verdict is left to a decision
+    # of its own rather than folded into the #651 load-failure codes.
+    errors = parse_script_errors(NOT_A_MAIN_LOOP_STDERR)
+
+    assert [e.kind for e in errors] == [ScriptErrorKind.NOT_A_MAIN_LOOP]
+    assert errors[0].path == "res://plain.gd"
+    assert entry_load_failure(errors, "res://plain.gd") is None
+
+
+def test_a_failure_naming_another_script_is_not_the_entry_verdict():
+    # THE false-positive guard: a script that RAN and itself load()ed a missing
+    # resource produces the identical engine sentence for a DIFFERENT path. Keying
+    # the verdict on the entry path is what keeps that a success.
+    errors = parse_script_errors(MISSING_STDERR)
+
+    assert entry_load_failure(errors, "res://entry.gd") is None
+
+
+def test_clean_and_unrecognized_stderr_yield_no_diagnostics():
+    assert parse_script_errors("") == []
+    assert parse_script_errors("just some printed output\n") == []
+    # A warning says nothing about a script's fate, and an ERROR the closed set
+    # does not recognize is skipped rather than guessed at.
+    assert (
+        parse_script_errors(
+            "WARNING: something advisory.\n"
+            "   at: whatever (core/x.cpp:1)\n"
+            "ERROR: An engine error with no known script sentence.\n"
+            "   at: whatever (core/x.cpp:2)\n"
+        )
+        == []
+    )

--- a/tests/test_script_error_parser.py
+++ b/tests/test_script_error_parser.py
@@ -133,15 +133,53 @@ def test_runtime_error_is_not_an_entry_failure():
     assert entry_load_failure(errors, "res://runtime_error.gd") is None
 
 
-def test_not_a_main_loop_is_recognized_but_is_not_a_load_verdict():
-    # The script compiles and exists; it just cannot BE the entry point. It is
-    # surfaced as a diagnostic, and mapping it to a verdict is left to a decision
-    # of its own rather than folded into the #651 load-failure codes.
+def test_not_a_main_loop_is_an_entry_failure():
+    # The script exists and compiles; it just cannot BE the entry point — so it never
+    # ran, which is the whole criterion. Exactly the GDA-DF-032 phantom-success shape
+    # in a different disguise, so it fails like the others.
     errors = parse_script_errors(NOT_A_MAIN_LOOP_STDERR)
 
     assert [e.kind for e in errors] == [ScriptErrorKind.NOT_A_MAIN_LOOP]
     assert errors[0].path == "res://plain.gd"
-    assert entry_load_failure(errors, "res://plain.gd") is None
+    verdict = entry_load_failure(errors, "res://plain.gd")
+    assert verdict is not None
+    assert verdict.kind is ScriptErrorKind.NOT_A_MAIN_LOOP
+
+
+def test_a_parse_error_alone_still_fails_the_entry():
+    # Robustness arm: on this engine a parse error always arrives WITH the "Failed to
+    # load script" conclusion, and that conclusion is what normally decides the
+    # verdict. Should a build ever emit the diagnostic without the conclusion, the
+    # entry still did not compile, so it must still fail.
+    only_the_diagnostic = PARSE_ERROR_STDERR.split("ERROR: Failed to load")[0]
+    errors = parse_script_errors(only_the_diagnostic)
+
+    assert [e.kind for e in errors] == [ScriptErrorKind.PARSE_ERROR]
+    verdict = entry_load_failure(errors, "res://parse_error.gd")
+    assert verdict is not None
+    assert verdict.kind is ScriptErrorKind.PARSE_ERROR
+
+
+def test_every_never_ran_kind_is_an_entry_failure_candidate():
+    # The enum's published description promises that five of the six kinds mean the
+    # script never ran. `entry_load_failure` is what acts on that promise, so the two
+    # must not drift: exactly `runtime_error` is excluded.
+    from gda.script_errors import _ENTRY_FAILURE_PRECEDENCE
+
+    assert set(ScriptErrorKind) - set(_ENTRY_FAILURE_PRECEDENCE) == {
+        ScriptErrorKind.RUNTIME_ERROR
+    }
+
+
+def test_the_earliest_stage_cause_wins_when_several_are_reported():
+    # The engine reports the whole cascade; only the first cause explains the rest.
+    # A missing file outranks the generic "can't load" emitted beside it (asserted
+    # above), and a compile failure outranks the parse diagnostic that caused it.
+    errors = parse_script_errors(PARSE_ERROR_STDERR)
+    verdict = entry_load_failure(errors, "res://parse_error.gd")
+
+    assert verdict is not None
+    assert verdict.kind is ScriptErrorKind.COMPILE_FAILED
 
 
 def test_a_failure_naming_another_script_is_not_the_entry_verdict():

--- a/tests/test_script_error_parser.py
+++ b/tests/test_script_error_parser.py
@@ -13,8 +13,11 @@ the exit status recorded in each docstring: the engine exits **0** for every one
 them, which is exactly why the verdict has to come from here.
 """
 
+import pytest
+
 from gda.script_errors import (
     ScriptErrorKind,
+    canonical_res_path,
     entry_load_failure,
     parse_script_errors,
 )
@@ -73,11 +76,13 @@ def test_missing_script_is_classified_and_located():
     errors = parse_script_errors(MISSING_STDERR)
 
     kinds = [(e.kind, e.path) for e in errors]
-    # The definitive File-not-found sentence and main.cpp's give-up line are both
-    # recognized; the generic "Failed loading resource" line is not one of the
-    # closed set and is deliberately skipped rather than guessed at.
+    # All three sentences the engine emits for one missing entry, in emission
+    # order: the definitive File-not-found one, the resource layer's generic
+    # report, and main.cpp's give-up line. The trailing period of "Failed loading
+    # resource: <path>." is sentence punctuation and is not part of the address.
     assert kinds == [
         (ScriptErrorKind.SCRIPT_MISSING, "res://nope.gd"),
+        (ScriptErrorKind.RESOURCE_LOAD_FAILED, "res://nope.gd"),
         (ScriptErrorKind.LOAD_FAILED, "res://nope.gd"),
     ]
     # An engine-side load error carries no script line (the at: frame names the
@@ -189,6 +194,168 @@ def test_a_failure_naming_another_script_is_not_the_entry_verdict():
     errors = parse_script_errors(MISSING_STDERR)
 
     assert entry_load_failure(errors, "res://entry.gd") is None
+
+
+# --- Canonical resource identity (#651 review claim 1) ------------------------
+#
+# Godot canonicalizes a res:// address before naming it in an error, so the entry
+# spelling the caller used and the spelling the engine reports back can differ.
+# These captures are from real runs invoked with non-canonical spellings; note the
+# engine reports `res://bad.gd` for a `res://sub/../bad.gd` invocation.
+
+ALIASED_COMPILE_STDERR = """\
+SCRIPT ERROR: Parse Error: Expected annotation identifier after "@".
+          at: GDScript::reload (res://bad.gd:4)
+ERROR: Failed to load script "res://bad.gd" with error "Parse error".
+   at: load (modules/gdscript/gdscript.cpp:2907)
+"""
+
+# The missing-entry case mixes the two spellings in ONE capture: the resource
+# layer reports the canonical address, while main.cpp echoes the raw argv.
+ALIASED_MISSING_STDERR = """\
+ERROR: Attempt to open script 'res://gone.gd' resulted in error 'File not found'.
+   at: load_source_code (modules/gdscript/gdscript.cpp:1127)
+ERROR: Failed loading resource: res://gone.gd.
+   at: _load (core/io/resource_loader.cpp:343)
+ERROR: Can't load script: res://sub//..//gone.gd
+   at: start (main/main.cpp:4271)
+"""
+
+
+@pytest.mark.parametrize(
+    ("spelling", "canonical"),
+    [
+        ("res://bad.gd", "res://bad.gd"),
+        ("res://sub/../bad.gd", "res://bad.gd"),
+        ("res://./bad.gd", "res://bad.gd"),
+        ("res://a//b.gd", "res://a/b.gd"),
+        ("res://sub//..//bad.gd", "res://bad.gd"),
+        ("res:///bad.gd", "res://bad.gd"),
+        ("res://a/./b/../c.gd", "res://a/c.gd"),
+        # Degenerate but well-defined: the bare scheme, and a path that cannot be
+        # collapsed further without escaping the project root.
+        ("res://", "res://"),
+        ("res://../outside.gd", "res://../outside.gd"),
+        # Not a res:// address: normalizing an address is not validating one.
+        ("/abs/path.gd", "/abs/path.gd"),
+        ("relative.gd", "relative.gd"),
+    ],
+)
+def test_canonical_res_path_collapses_lexically(spelling, canonical):
+    assert canonical_res_path(spelling) == canonical
+    # Idempotent: canonicalizing a canonical address changes nothing, which is what
+    # lets both the parser and entry_load_failure apply it without coordinating.
+    assert canonical_res_path(canonical) == canonical
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    ["res://bad.gd", "res://sub/../bad.gd", "res://./bad.gd", "res://sub//..//bad.gd"],
+)
+def test_a_compile_failure_matches_every_spelling_of_the_entry(spelling):
+    # THE claim-1 defect: the engine names `res://bad.gd` whatever spelling it was
+    # invoked with, so a raw-string comparison missed the match and the failed run
+    # reported success.
+    errors = parse_script_errors(ALIASED_COMPILE_STDERR)
+    verdict = entry_load_failure(errors, spelling)
+
+    assert verdict is not None, f"{spelling} must resolve to the entry's failure"
+    assert verdict.kind is ScriptErrorKind.COMPILE_FAILED
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        "res://gone.gd",
+        "res://sub/../gone.gd",
+        "res://./gone.gd",
+        "res://sub//..//gone.gd",
+    ],
+)
+def test_a_missing_entry_matches_every_spelling_and_keeps_its_code(spelling):
+    # The second half of claim 1: aliasing also MISROUTED the verdict. The raw
+    # spelling matched only main.cpp's echoed "Can't load script:" line
+    # (LOAD_FAILED -> script_compile_failed), never the File-not-found sentence.
+    # Canonicalizing both sides restores the correct, more specific verdict.
+    errors = parse_script_errors(ALIASED_MISSING_STDERR)
+    verdict = entry_load_failure(errors, spelling)
+
+    assert verdict is not None
+    assert verdict.kind is ScriptErrorKind.SCRIPT_MISSING
+
+
+def test_published_paths_are_canonical():
+    # The addresses gda hands an agent are canonical too, not just the ones it
+    # compares internally — one resource identity everywhere.
+    errors = parse_script_errors(ALIASED_MISSING_STDERR)
+
+    assert {e.path for e in errors} == {"res://gone.gd"}
+
+
+# --- Resource load failures (#651 review claim 4) -----------------------------
+
+# A script that RAN and called load("res://missing.tres"). Exit status 0, and the
+# script is fine — the resource is not. Two sentences from two engine layers.
+RUNTIME_RESOURCE_LOAD_STDERR = """\
+ERROR: Cannot open file 'res://missing.tres'.
+   at: load (scene/resources/resource_format_text.cpp:1430)
+   GDScript backtrace (most recent call first):
+       [0] _initialize (res://runtime_load.gd:4)
+ERROR: Failed loading resource: res://missing.tres.
+   at: _load (core/io/resource_loader.cpp:343)
+   GDScript backtrace (most recent call first):
+       [0] _initialize (res://runtime_load.gd:4)
+"""
+
+# An entry script whose preload() names a missing .tres. The engine reports it as a
+# PARSE error of the entry and a load failure of the entry — the resource itself is
+# named only inside the message.
+ENTRY_PRELOAD_MISSING_STDERR = """\
+SCRIPT ERROR: Parse Error: Preload file "res://missing.tres" does not exist.
+          at: GDScript::reload (res://preload_missing.gd:3)
+SCRIPT ERROR: Parse Error: Cannot infer the type of "R" constant because the value doesn't have a set type.
+          at: GDScript::reload (res://preload_missing.gd:3)
+ERROR: Failed to load script "res://preload_missing.gd" with error "Parse error".
+   at: load (modules/gdscript/gdscript.cpp:2907)
+"""
+
+
+def test_runtime_resource_load_failure_is_a_diagnostic_not_a_verdict():
+    # Issue #651 names resource load failures among the lines to surface. The script
+    # ran, so this must NOT flip the verdict — it names a resource, not the entry.
+    errors = parse_script_errors(RUNTIME_RESOURCE_LOAD_STDERR)
+
+    assert [(e.kind, e.path) for e in errors] == [
+        (ScriptErrorKind.RESOURCE_LOAD_FAILED, "res://missing.tres"),
+        (ScriptErrorKind.RESOURCE_LOAD_FAILED, "res://missing.tres"),
+    ]
+    assert entry_load_failure(errors, "res://runtime_load.gd") is None
+
+
+def test_a_resource_load_failure_naming_the_entry_is_a_verdict():
+    # The same sentence DOES end the run when the address it names is the entry —
+    # the identity match is the whole discriminator.
+    errors = parse_script_errors(
+        "ERROR: Failed loading resource: res://entry.gd.\n"
+        "   at: _load (core/io/resource_loader.cpp:343)\n"
+    )
+    verdict = entry_load_failure(errors, "res://entry.gd")
+
+    assert verdict is not None
+    assert verdict.kind is ScriptErrorKind.RESOURCE_LOAD_FAILED
+
+
+def test_entry_preload_of_a_missing_resource_fails_the_entry():
+    # The entry-preload case: the engine blames the ENTRY (a parse error plus its
+    # load failure) and names the missing resource only in the message text, so the
+    # verdict is the entry's compile failure — no dependency walk needed.
+    errors = parse_script_errors(ENTRY_PRELOAD_MISSING_STDERR)
+    verdict = entry_load_failure(errors, "res://preload_missing.gd")
+
+    assert verdict is not None
+    assert verdict.kind is ScriptErrorKind.COMPILE_FAILED
+    assert "res://missing.tres" in errors[0].message
+    assert errors[0].path == "res://preload_missing.gd"
 
 
 def test_clean_and_unrecognized_stderr_yield_no_diagnostics():

--- a/tests/test_script_run_commands.py
+++ b/tests/test_script_run_commands.py
@@ -51,7 +51,14 @@ def test_clean_run_emits_the_passthrough_result(monkeypatch, tmp_path):
 
     assert result.exit_code == 0, result.stdout + result.stderr
     data = json.loads(result.stdout)
-    assert data == {"exit_status": 0, "stdout": "hi\n", "stderr": ""}
+    assert data == {
+        "exit_status": 0,
+        "stdout": "hi\n",
+        "stderr": "",
+        # A clean run recognizes no script errors, so the #651 diagnostics channel
+        # is present but empty — never absent, so an agent can read it unguarded.
+        "diagnostics": [],
+    }
     # The recipe launched `--path <project> --script <res path>` with cwd=None.
     (_binary, args, cwd, _timeout, _label) = calls[0]
     assert args == ["--path", str(project), "--script", "res://logic.gd"]
@@ -75,6 +82,58 @@ def test_non_zero_script_exit_is_success_process_exits_zero(monkeypatch, tmp_pat
     assert "error" not in data
     assert data["exit_status"] == 1
     assert data["stdout"] == "fail\n"
+
+
+def test_strict_makes_the_process_exit_the_registered_operation_code(
+    monkeypatch, tmp_path
+):
+    # #651 at the CLI boundary: with --strict a quit(1) is observable WITHOUT parsing
+    # the JSON — the process exits 4, the registered operation code. Not 1: the
+    # child's own status is never propagated verbatim, or a script's quit(3) would
+    # alias EXIT_VERSION and a quit(124) the runner's timeout.
+    project = _project(tmp_path)
+    _patch_launch(monkeypatch, RunResult(stdout="fail\n", stderr="", exit_code=1))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "run",
+            "res://logic.gd",
+            "--strict",
+            "--project",
+            str(project),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 4, result.stdout + result.stderr
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "script_failed"
+    assert err["category"] == "operation"
+
+
+def test_strict_is_reachable_through_params_json(monkeypatch, tmp_path):
+    # --strict is a params field, not an argv-only flag (ADR-0015), so gda-mcp and
+    # any JSON caller can opt in exactly as argv does.
+    project = _project(tmp_path)
+    _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=2))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "run",
+            "--params-json",
+            '{"path": "res://logic.gd", "strict": true}',
+            "--project",
+            str(project),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 4, result.stdout + result.stderr
+    assert json.loads(result.stdout)["error"]["code"] == "script_failed"
 
 
 def test_params_json_drives_the_same_recipe(monkeypatch, tmp_path):

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -222,11 +222,12 @@ def test_result_is_the_thin_promotion_dropping_launch_failure():
 
 # --- The #651 verdict: gda decides whether the engine ran what it was asked to.
 #
-# Godot exits 0 for a missing entry script AND for one that fails to parse, so the
-# passthrough reported a phantom success for both. These drive the operation with
-# stderr captured VERBATIM from a real engine run (the same captures the parser's
-# own tests use, see tests/test_script_errors.py) so the fixtures cannot drift into
-# something the engine never prints.
+# Godot exits 0 for a missing entry script, for one that fails to parse, AND for one
+# that is not a SceneTree/MainLoop, so the passthrough reported a phantom success for
+# all three. These drive the operation with stderr captured VERBATIM from a real
+# engine run (the same captures the parser's own tests use, see
+# tests/test_script_error_parser.py) so the fixtures cannot drift into something the
+# engine never prints.
 
 MISSING_STDERR = """\
 ERROR: Attempt to open script 'res://tests/logic.gd' resulted in error 'File not found'.
@@ -250,6 +251,11 @@ SCRIPT ERROR: Invalid call. Nonexistent function 'missing_method' in base 'Nil'.
           GDScript backtrace (most recent call first):
               [0] _boom (res://tests/logic.gd:10)
               [1] _initialize (res://tests/logic.gd:4)
+"""
+
+NOT_A_MAIN_LOOP_STDERR = """\
+ERROR: Can't load the script "res://tests/logic.gd" as it doesn't inherit from SceneTree or MainLoop.
+   at: start (main/main.cpp:4286)
 """
 
 
@@ -307,6 +313,32 @@ def test_runtime_script_error_is_surfaced_as_a_diagnostic_not_a_failure():
     assert outcome.stderr == RUNTIME_ERROR_STDERR
 
 
+def test_not_a_main_loop_entry_is_a_failure_despite_the_zero_exit():
+    # The third never-ran shape: the script exists and compiles, but cannot BE the
+    # entry point, so the engine refuses it and exits 0. It reuses the registered
+    # `incompatible_script_type` — the same condition `script attach` names for a
+    # base type that is wrong for the requested use.
+    outcome, _ = _run(RunResult(stdout="", stderr=NOT_A_MAIN_LOOP_STDERR, exit_code=0))
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "incompatible_script_type"
+    assert outcome.exit_code == EXIT_OPERATION
+    assert "SceneTree" in outcome.error.message
+
+
+def test_every_entry_failure_kind_has_a_verdict_code():
+    # A kind in the precedence list with no row in the code map would be a KeyError
+    # on a real failure path — the one way this pair can break. Pin them in lockstep,
+    # and pin that every code they name is actually registered.
+    from gda.commands.script import _ENTRY_FAILURE_CODES
+    from gda.error_codes import ERROR_CODE_BY_CODE
+    from gda.script_errors import _ENTRY_FAILURE_PRECEDENCE
+
+    assert set(_ENTRY_FAILURE_CODES) == set(_ENTRY_FAILURE_PRECEDENCE)
+    for code in _ENTRY_FAILURE_CODES.values():
+        assert code in ERROR_CODE_BY_CODE
+
+
 def test_strict_maps_a_non_zero_exit_onto_the_registered_failure():
     # GDA-DF-017, opted in: a test that quit(1) becomes the script_failed envelope so
     # a shell `&&` chain stops. The gda exit is the REGISTERED operation code, never
@@ -319,7 +351,45 @@ def test_strict_maps_a_non_zero_exit_onto_the_registered_failure():
     assert outcome.error.code == "script_failed"
     assert outcome.exit_code == EXIT_OPERATION
     assert "status 3" in outcome.error.message
-    assert outcome.error.diagnostics == "boom\n"
+
+
+def test_strict_carries_both_script_streams_as_evidence():
+    # THE point of the flag: a GDScript test runner reports through print(), i.e.
+    # STDOUT. An envelope carrying only stderr would hand a CI caller a failure with
+    # no content, so diagnostics carries both streams under fixed labels.
+    outcome, _ = _run(
+        RunResult(
+            stdout="FAIL test_damage: expected 5 got 4\n",
+            stderr="engine warning\n",
+            exit_code=1,
+        ),
+        strict=True,
+    )
+
+    assert isinstance(outcome, Failure)
+    diagnostics = outcome.error.diagnostics
+    assert "FAIL test_damage: expected 5 got 4" in diagnostics
+    assert "engine warning" in diagnostics
+    assert diagnostics == (
+        "--- script stdout ---\n"
+        "FAIL test_damage: expected 5 got 4\n"
+        "--- script stderr ---\n"
+        "engine warning\n"
+    )
+
+
+def test_strict_evidence_layout_is_stable_when_a_stream_is_empty():
+    # Both sections are ALWAYS present — an empty stream yields an empty section, not
+    # a missing one — so a consumer can split on the labels without first discovering
+    # which streams the script happened to write to.
+    outcome, _ = _run(
+        RunResult(stdout="", stderr="only stderr\n", exit_code=1), strict=True
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.diagnostics == (
+        "--- script stdout ---\n--- script stderr ---\nonly stderr\n"
+    )
 
 
 def test_strict_leaves_a_zero_exit_a_success():

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -313,6 +313,60 @@ def test_runtime_script_error_is_surfaced_as_a_diagnostic_not_a_failure():
     assert outcome.stderr == RUNTIME_ERROR_STDERR
 
 
+def test_a_non_canonical_entry_spelling_still_reaches_the_verdict():
+    # #651 review claim 1, at the operation level: the engine reports the CANONICAL
+    # address it resolved, so an entry invoked as `res://sub/../logic.gd` came back
+    # named `res://tests/logic.gd`... never matching, and the failed run reported
+    # success. The operation now fixes one canonical identity before it launches.
+    outcome, launch = _run(
+        RunResult(stdout="", stderr=PARSE_ERROR_STDERR, exit_code=0),
+        script="res://tests/sub/../logic.gd",
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "script_compile_failed"
+    # The canonical identity is what the engine is asked to run, too, so both sides
+    # of every later comparison agree.
+    (_binary, args, _cwd, _timeout, _label) = launch.calls[0]
+    assert args[-1] == "res://tests/logic.gd"
+    # ...and what the failure message names, so the agent sees one spelling.
+    assert "res://tests/logic.gd" in outcome.error.message
+
+
+def test_a_non_canonical_missing_entry_keeps_the_specific_code():
+    # The misrouting half of claim 1: with a raw comparison the only line matching
+    # the caller's spelling was main.cpp's echo, which maps to script_compile_failed.
+    # Canonicalizing restores script_not_found.
+    outcome, _ = _run(
+        RunResult(stdout="", stderr=MISSING_STDERR, exit_code=0),
+        script="res://tests/./logic.gd",
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "script_not_found"
+
+
+def test_a_runtime_resource_load_failure_stays_a_success():
+    # #651 review claim 4: a script that RAN and failed to load a resource is still
+    # a successful run — the failure names a resource, not the entry — but the
+    # engine's report is now visible as a classified diagnostic instead of prose.
+    stderr = (
+        "ERROR: Cannot open file 'res://missing.tres'.\n"
+        "   at: load (scene/resources/resource_format_text.cpp:1430)\n"
+        "ERROR: Failed loading resource: res://missing.tres.\n"
+        "   at: _load (core/io/resource_loader.cpp:343)\n"
+    )
+    outcome, _ = _run(RunResult(stdout="loaded=<null>\n", stderr=stderr, exit_code=0))
+
+    assert isinstance(outcome, ScriptRunResult)
+    assert outcome.exit_status == 0
+    assert [d.kind.value for d in outcome.diagnostics] == [
+        "resource_load_failed",
+        "resource_load_failed",
+    ]
+    assert outcome.diagnostics[0].path == "res://missing.tres"
+
+
 def test_not_a_main_loop_entry_is_a_failure_despite_the_zero_exit():
     # The third never-ran shape: the script exists and compiles, but cannot BE the
     # entry point, so the engine refuses it and exits 0. It reuses the registered

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -68,6 +68,7 @@ def _run(
     script: str = "res://tests/logic.gd",
     project: Path | None = PROJECT,
     godot: str | None = "/tmp/Godot",
+    strict: bool = False,
 ) -> tuple[ScriptRunResult | Failure, FakeLaunch]:
     """Invoke the operation with the launch seam pinned to a ``FakeLaunch``."""
     launch = FakeLaunch(result)
@@ -75,6 +76,7 @@ def _run(
         script=script,
         godot=godot,
         project=project,
+        strict=strict,
         make_launch=launch,
     )
     return outcome, launch
@@ -205,8 +207,8 @@ def test_empty_godot_is_a_structured_binary_failure_not_a_traceback():
 
 def test_result_is_the_thin_promotion_dropping_launch_failure():
     # The success DTO is the thin boundary promotion of the internal Raw run: it
-    # drops `launch_failure` and renames exit_code→exit_status, carrying nothing
-    # else. (A clean exit never has a launch_failure set anyway.)
+    # drops `launch_failure` and renames exit_code→exit_status, adding only the
+    # #651 diagnostics channel. (A clean exit never has a launch_failure set anyway.)
     outcome, _ = _run(RunResult(stdout="out", stderr="err", exit_code=7))
 
     assert isinstance(outcome, ScriptRunResult)
@@ -214,4 +216,137 @@ def test_result_is_the_thin_promotion_dropping_launch_failure():
         "exit_status": 7,
         "stdout": "out",
         "stderr": "err",
+        "diagnostics": [],
     }
+
+
+# --- The #651 verdict: gda decides whether the engine ran what it was asked to.
+#
+# Godot exits 0 for a missing entry script AND for one that fails to parse, so the
+# passthrough reported a phantom success for both. These drive the operation with
+# stderr captured VERBATIM from a real engine run (the same captures the parser's
+# own tests use, see tests/test_script_errors.py) so the fixtures cannot drift into
+# something the engine never prints.
+
+MISSING_STDERR = """\
+ERROR: Attempt to open script 'res://tests/logic.gd' resulted in error 'File not found'.
+   at: load_source_code (modules/gdscript/gdscript.cpp:1127)
+ERROR: Failed loading resource: res://tests/logic.gd.
+   at: _load (core/io/resource_loader.cpp:343)
+ERROR: Can't load script: res://tests/logic.gd
+   at: start (main/main.cpp:4271)
+"""
+
+PARSE_ERROR_STDERR = """\
+SCRIPT ERROR: Parse Error: Expected end of statement after expression, found "Identifier" instead.
+          at: GDScript::reload (res://tests/logic.gd:4)
+ERROR: Failed to load script "res://tests/logic.gd" with error "Parse error".
+   at: load (modules/gdscript/gdscript.cpp:2907)
+"""
+
+RUNTIME_ERROR_STDERR = """\
+SCRIPT ERROR: Invalid call. Nonexistent function 'missing_method' in base 'Nil'.
+          at: _boom (res://tests/logic.gd:10)
+          GDScript backtrace (most recent call first):
+              [0] _boom (res://tests/logic.gd:10)
+              [1] _initialize (res://tests/logic.gd:4)
+"""
+
+
+def test_missing_entry_script_is_a_failure_despite_the_zero_exit():
+    # GDA-DF-032: the engine exits 0 for a script that does not exist. The verdict
+    # comes from the stderr evidence, never from the exit code.
+    outcome, _ = _run(RunResult(stdout="", stderr=MISSING_STDERR, exit_code=0))
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "script_not_found"
+    assert outcome.exit_code == EXIT_OPERATION
+    assert "res://tests/logic.gd" in outcome.error.message
+    # The raw stderr is preserved as secondary evidence on the envelope.
+    assert outcome.error.diagnostics == MISSING_STDERR
+
+
+def test_entry_parse_error_is_a_failure_despite_the_zero_exit():
+    # GDA-DF-007: a non-compiling entry script also leaves exit 0 behind. The
+    # engine's own sentence is carried in the message so the reason is readable
+    # without parsing `diagnostics`.
+    outcome, _ = _run(RunResult(stdout="", stderr=PARSE_ERROR_STDERR, exit_code=0))
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "script_compile_failed"
+    assert outcome.exit_code == EXIT_OPERATION
+    assert "Parse error" in outcome.error.message
+
+
+def test_a_load_error_for_another_script_stays_a_success():
+    # The false-positive guard at the operation level: a script that RAN and itself
+    # failed to load some OTHER resource must stay a passthrough success.
+    outcome, _ = _run(
+        RunResult(stdout="done\n", stderr=MISSING_STDERR, exit_code=0),
+        script="res://tests/other.gd",
+    )
+
+    assert isinstance(outcome, ScriptRunResult)
+    assert outcome.exit_status == 0
+
+
+def test_runtime_script_error_is_surfaced_as_a_diagnostic_not_a_failure():
+    # GDA-DF-007's third shape: the script ran, hit a GDScript error, survived it and
+    # quit(0). ADR-0031 still governs — the run completed — but the error is no longer
+    # buried in stderr prose: it is a classified diagnostic on the success result.
+    outcome, _ = _run(
+        RunResult(stdout="ok\n", stderr=RUNTIME_ERROR_STDERR, exit_code=0)
+    )
+
+    assert isinstance(outcome, ScriptRunResult)
+    assert outcome.exit_status == 0
+    assert [d.kind.value for d in outcome.diagnostics] == ["runtime_error"]
+    assert outcome.diagnostics[0].path == "res://tests/logic.gd"
+    assert outcome.diagnostics[0].line == 10
+    # The verbatim stream is still there — the diagnostics are additive.
+    assert outcome.stderr == RUNTIME_ERROR_STDERR
+
+
+def test_strict_maps_a_non_zero_exit_onto_the_registered_failure():
+    # GDA-DF-017, opted in: a test that quit(1) becomes the script_failed envelope so
+    # a shell `&&` chain stops. The gda exit is the REGISTERED operation code, never
+    # the child's own status — a script's quit(3) must not alias EXIT_VERSION.
+    outcome, _ = _run(
+        RunResult(stdout="1 test failed\n", stderr="boom\n", exit_code=3), strict=True
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "script_failed"
+    assert outcome.exit_code == EXIT_OPERATION
+    assert "status 3" in outcome.error.message
+    assert outcome.error.diagnostics == "boom\n"
+
+
+def test_strict_leaves_a_zero_exit_a_success():
+    outcome, _ = _run(
+        RunResult(stdout="all green\n", stderr="", exit_code=0), strict=True
+    )
+
+    assert isinstance(outcome, ScriptRunResult)
+    assert outcome.exit_status == 0
+
+
+def test_the_default_still_passes_a_non_zero_exit_through():
+    # The contract ADR-0031 recorded is unchanged without --strict: this is the guard
+    # that the #651 opt-in did not quietly flip the default.
+    outcome, _ = _run(RunResult(stdout="1 test failed\n", stderr="", exit_code=1))
+
+    assert isinstance(outcome, ScriptRunResult)
+    assert outcome.exit_status == 1
+
+
+def test_strict_does_not_shadow_the_never_ran_verdict():
+    # A missing script under --strict must still be script_not_found: "the script
+    # chose to fail" and "the script never ran" are different answers, and the
+    # engine's exit 0 would make strict alone report success.
+    outcome, _ = _run(
+        RunResult(stdout="", stderr=MISSING_STDERR, exit_code=0), strict=True
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "script_not_found"


### PR DESCRIPTION
`gda script run` passed the engine's exit status through unconditionally, so several failures reported success. Godot exits **0** for a `--script` entry point it never ran, reporting the reason on stderr only.

Closes #651

## Behavior matrix

| shape | before | after |
| --- | --- | --- |
| missing `res://` entry script (GDA-DF-032) | `{"exit_status": 0}`, exit 0 | `script_not_found`, exit 4 |
| entry or preloaded dependency fails to parse/compile (GDA-DF-007) | `{"exit_status": 0}`, exit 0 | `script_compile_failed`, exit 4 |
| entry compiles but is not a `SceneTree`/`MainLoop` | `{"exit_status": 0}`, exit 0 | `incompatible_script_type`, exit 4 — but see the caveat below: this shape more often leaves the engine idling, surfacing as `launch_timeout` |
| runtime GDScript error the script survived (GDA-DF-007) | only in `stderr` prose | still a **success**, plus classified `diagnostics` |
| deliberate `quit(1)` (GDA-DF-017) | success, gda exits 0 | unchanged by default; `--strict` → `script_failed`, exit 4, carrying the script's own stdout+stderr |
| any of the above via a non-canonical spelling (`res://dir/../x.gd`) | verdict bypassed → phantom success, or misrouted code | same verdict as the canonical spelling |
| a running script's `load("res://missing.tres")` fails | success, `diagnostics: []` | still a **success**, now carrying `resource_load_failed` diagnostics |

The verdict is read from the engine's error stream, never from the exit code, and is keyed on the **entry script's own `res://` path — in canonical form**. Godot resolves an address before naming it in an error, so one canonical lexical identity (`.`/`..` segments and duplicate slashes collapsed) is fixed at the operation's input boundary and used for the spawn argv, every comparison and every message; the parser canonicalizes each address it publishes, and `entry_load_failure` canonicalizes both sides again. Keying on that path — a running script that itself fails to load some *other* resource stays a success. When a run emits several causes the earliest-stage one wins (missing > compile > parse > load > not-a-main-loop); a test pins that precedence against the code map.

**`--strict` is opt-in.** Per the triage decision the Raw-run promotion is why a user script keeps free use of its exit codes, so the default is untouched. The child status is **not** propagated verbatim — a `quit(3)` would alias `EXIT_VERSION` — so strict exits the registered `EXIT_OPERATION` (4).

## Two new modules

**`src/gda/engine_log.py`** — the engine's error-line format (`Logger::log_error`: the two-line `<TYPE>: <message>` / `at: <fn> (<file>:<line>)` pair plus the GDScript backtrace), **extracted from `gda.daemon.diag`**. It was a Phase-2 module, so a Phase-1 channel importing it reversed ADR-0000's component order and ADR-0040's module direction. Now a leaf importing nothing from `daemon`/`commands`, with both consumers importing downward. `gda.daemon.diag` re-exports `parse_errors`, so every existing consumer and its pinned tests are source-compatible; the move is mechanical and proved by the untouched suites (89 daemon unit tests, plus the diag/logger e2e).

**`src/gda/script_errors.py`** — what those lines *mean for a script run*. This issue owns it; #655 (timeout path) and #664 (scene startup preflight) build on it.

```
ScriptErrorKind        # closed public enum: parse_error | runtime_error | script_missing
                       # | load_failed | compile_failed | not_a_main_loop | resource_load_failed
                       # all but runtime_error mean the named resource could not be loaded or run
ScriptError            # pydantic model: {kind, message, path, line}; path always canonical
canonical_res_path(path: str) -> str
parse_script_errors(stderr: str) -> list[ScriptError]
entry_load_failure(errors: Sequence[ScriptError], script: str) -> ScriptError | None
```

Recognition is a **closed set**, so `diagnostics` stays curated rather than a second encoding of the whole error stream. A `kind` alone never decides the verdict: whether a load failure ended the *run* depends on whether it names the entry, which is `entry_load_failure`'s job.

## Public-surface diff (complete)

`gda schema` diff vs. the base commit: **`script run` only**, no other command's entry changed, no top-level change.

- **New CLI option** `gda script run --strict`.
- **Input schema** (`ScriptRunParams`): `+ strict: boolean, default false`. A params field, not argv-only, so `--params-json` / gda-mcp opt in identically (ADR-0015).
- **Output schema** (`ScriptRunResult`): `+ diagnostics: ScriptError[]` (present-but-empty on a clean run), plus two new `$defs` (`ScriptError`, `ScriptErrorKind`). `exit_status` / `stdout` / `stderr` unchanged; `kind`, `constraints` and the `error` envelope unchanged.
- **`ScriptErrorKind` enum values** (public ABI): `parse_error`, `runtime_error`, `script_missing`, `load_failed`, `compile_failed`, `not_a_main_loop`, **`resource_load_failed`** (added for the resource-load sentences).
- **`ScriptError.path` semantics**: always the **canonical** form of the address, on every diagnostic.
- **`gda skill` output**: the `script` row's `run` clause now documents `--strict` and the never-ran failures. SKILL.md is otherwise untouched (sibling-owned regions avoided).
- **Parser-module extraction: no surface change at all** — verified by the schema diff below.
- **Command description / `--help`**: rewritten to document the three never-ran verdicts and `--strict`, including exactly what the `script_failed` envelope's `diagnostics` carries, and the caveat that the not-a-main-loop shape may instead surface as `launch_timeout`.
- **`ScriptErrorKind` / `ScriptError.kind` description strings** (public ABI via `gda schema`): corrected to say five never-ran kinds, not three.
- **Error-code registry** (Python + ADR-0002 table, kept in lockstep by `tests/test_error_registry.py`):
  - `+ script_not_found` — `operation` / `classifier` / exit `4`
  - `+ script_failed` — `operation` / `classifier` / exit `4`
  - `~ script_compile_failed` — description broadened; category/source/exit **unchanged**
  - `~ incompatible_script_type` — description broadened to cover `script run`'s entry-point requirement; category/source/exit **unchanged**
  - Both broadenings are description-only and so are **not** a `gda schema` diff (the schema's `error` is the envelope shape, which does not enumerate codes) — but they are a public-doc diff, enumerated here.
- **`GdaError.diagnostics` content for `script_failed`**: both script streams under fixed labels. `diagnostics` is a free-form `str` (ADR-0004), so this is **not** a shape change; ADR-0002's prose is synced to say so.
- **No new exit codes** — `exit_codes.py` untouched.
- **No ADR-0004 envelope shape change.**

## ADR amendments

- **ADR-0031** — dated amendment (repo convention: the decision text is preserved, not rewritten). It draws the line the original left implicit: **gda is the authority on whether the engine RAN the script; the script stays the authority on what its own exit status means.** "Synthesize `script_failed`" stays **rejected as the default**; `--strict` is the opt-in expression of it. It also records that the two diagnostics channels are deliberately asymmetric — structured `ScriptError[]` on success results, prose on the ADR-0004 failure envelope (including the child's numeric status, which survives only as message prose). Giving the failure channel structured diagnostics is an ADR-0004 decision, deferred to its dedicated owner **#687** (#655's timeout envelope names the same constraint and adopts #687's outcome).
- **ADR-0002** — one dated scope note, plus the two living registry table rows. The note records that **both** rules it qualifies presuppose the sentinel channel, which ADR-0031's passthrough shape does not have: "stderr is never parsed for the outcome" (there, the error stream is the only evidence of the outcome) and "copies stderr into diagnostics" (there, `--strict` carries the script's own stdout *and* stderr, `diagnostics` being a free-form string). Neither rule is relaxed. Per repo convention the decision text is **untouched** — the ADR-0002 prose diff is pure insertion, exactly like the ADR-0031 amendment.

## Acceptance criteria

| #651 criterion | Status | Where |
| --- | --- | --- |
| By default, a missing `res://` entry script returns a structured failure with a registered code, not `exit_status: 0` | **Satisfied** | `script_not_found`, exit 4; unit + real-engine e2e, incl. non-canonical spellings |
| By default, an entry script (or dependency) that fails to parse/compile is a non-success verdict even though the engine exits 0 | **Satisfied** | `script_compile_failed`, exit 4; unit + real-engine e2e, incl. non-canonical spellings |
| Under `--strict`, an explicit `quit(1)` exits with a registered non-zero code, observable without parsing the JSON; default unchanged | **Satisfied** | `script_failed`, exit 4 (`EXIT_OPERATION`, never the child's status); default arm pinned by its own test |
| Known script-error stderr lines surfaced as structured diagnostics | **Satisfied** | 7-kind `ScriptError[]` incl. resource-load failures; canonical `path`, `line` where the engine reports one |
| The ADR-0031 amendment lands with the change | **Satisfied** | Dated amendment; ADR-0002 gets dated scope notes only, accepted prose untouched |
| Regression tests: missing script, parse-error dependency, runtime script error, explicit failing test | **Satisfied** | All four at unit tier and, except the engine-nondeterministic not-a-main-loop shape, at real-engine e2e tier |
| Preserve the raw process status and stderr as secondary evidence in the structured result | **Satisfied on the success path; PARTIAL on failure paths** | See below |

**The one partial, stated plainly.** On the **success** path the criterion is fully met: `exit_status`, `stdout` and `stderr` are carried verbatim, alongside the typed `ScriptError[]` diagnostics. On **failure** paths the evidence is preserved but **not typed**:

- the parsed `ScriptError[]` is *not* carried — `GdaError.diagnostics` is a free-form `str` (ADR-0004), so a verdict envelope carries the engine's stderr as prose;
- under `--strict` the script's own stdout **and** stderr are carried, but as labelled prose sections (`--- script stdout ---` / `--- script stderr ---`);
- the child's numeric exit status survives only inside the message text, not as a field.

Typed failure-path evidence would change the ADR-0004 `GdaError` envelope — a cross-cutting ABI decision that **#687 owns** (a dedicated issue created at review reconciliation; #655's authoritative scope covers only the string-diagnostics timeout form), and that this PR's own ADR-0031 amendment explicitly defers rather than pre-empting. The gap is recorded there, not left implicit, and is also recorded on issue #651 so the eventual closure is honest. **Residual risk, accepted:** a `--strict` consumer reads the status from message text and splits the labelled sections to separate the streams.

## Validation

Run in the worktree; every gate below was executed, and re-executed after the review round.

| gate | result |
| --- | --- |
| `uv run pytest -m "not e2e"` | **1246 passed**, 396 deselected |
| `uv run ruff check` | passed |
| `uv run ruff format --check` | 428 files formatted |
| `uv run pyright` | 0 errors, 0 warnings |
| `uv run pytest -m e2e tests/test_e2e_script_run.py` (real Godot 4.6.3) | **18 passed** in 7.4s |
| `uv run pytest -m e2e` — diag / logger / script (guards the parser-module move on the real daemon path) | **58 passed** |
| `uv run pytest -m e2e` — script / scene-security / params-json / mcp-stdio / mcp-tracer | **67 passed** |
| `gda schema` + `gda script run --help` before/after diff | only the intended diffs above |

Unit fixtures are stderr **recorded verbatim from real Godot 4.6.3 runs**, not invented lines; the e2e arms then prove the engine really does exit 0 for a script that never ran. The `--strict` evidence row was re-verified by a real run: default → exit 0 with `exit_status: 1`; `--strict` → exit 4 with the suite's printed `FAIL test_damage…` lines inside `diagnostics` (empty before this round, since the suite writes nothing to stderr).

## Decisions worth a reviewer's attention

- **`script_compile_failed` and `incompatible_script_type` are reused, not minted.** Both already name these exact conditions for `script attach`. Reuse-vs-mint is decided by **semantic match**, not by a code's `source` field — `source` records canonical origin, and reusing across sites is established practice in `errors.py`. `script_not_found` is minted because `path_not_found` *means* something else: "a file the operation was asked to act on is absent" vs. "the engine could not load the entry script, so the run never happened", which agents branch on differently.
- **No e2e arm for the not-a-main-loop shape.** The engine has **two** behaviours for it and only one is a phantom success: it either errors and exits 0 (the shape this fix closes — pinned at unit level against real captured stderr), or it errors and **keeps running**, falling through to the project's main loop and idling forever. A clean fixture project does the latter, which is already a failure via `launch_timeout` (the #655 path), so gda never reports success either way. The exit-0 variant is not reproducible from project contents — the import-cache and broken-sibling-script hypotheses were both tested and refuted — so forcing an e2e arm would mean a 120s timeout per run for no added signal. Both behaviours are recorded in the e2e module docstring.

## Shipped agent guidance

The `--strict` guidance lands in `src/gda/skill/SKILL.md` itself — PR-body text is not shipped agent guidance. One clause on the `script` row (line 71), clear of the regions sibling PRs edit:

> `run` executes a `res://` script one-shot and passes its `exit_status`/`stdout`/`stderr` through — a non-zero `quit()` is still success, so read `exit_status`, or pass `--strict` to get a `script_failed` failure (exit 4) whose `diagnostics` carries the script's own stdout and stderr; a script that never ran — missing, or a failed parse/compile — always fails

`README.md` is owned by #672 this wave and was **not** touched.

