### PR TITLE
fix(gda): keep the harness serving live operations while the SceneTree is paused

### DIFF
--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -129,6 +129,20 @@ func _ready() -> void:
 	# protocol is now active. Set before the connect attempt — the log file is
 	# daemon-owned regardless of whether the live-op IPC connection then succeeds.
 	_daemon_launched = true
+	# Keep serving live operations while the game's SceneTree is paused (#656).
+	# A real pause menu sets SceneTree.paused = true; the harness's default
+	# process mode (PROCESS_MODE_INHERIT, effectively pausable at the top of the
+	# tree) would then stop THIS node's own _process from ticking too — freezing
+	# the one loop that serves the socket at exactly the state an agent needs to
+	# inspect, and with no way back in: resuming the game needs an input op, and
+	# input injection is itself served from this same loop. PROCESS_MODE_ALWAYS
+	# keeps the harness ticking through a pause, independent of the game's own
+	# process-mode tree — mirroring how a real pause-menu script must set its own
+	# process mode to keep handling "resume" input while paused. Scoped inside
+	# this daemon-launched gate (the same condition gda_log() checks), so a human
+	# editor run, a plain run, and a shipped build never have their process mode
+	# touched — the ADR-0018 inertness guarantee is unaffected.
+	process_mode = Node.PROCESS_MODE_ALWAYS
 	var socket_path: String = user_args[idx + 1]
 	var token: String = user_args[idx + 2]
 	# The requested scene selector (#278) follows the token; "" (or absent) = none.

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -41,7 +41,7 @@ HARNESS_RES_PATH = f"res://{HARNESS_RES_DIR}/{HARNESS_FILE}"
 # copy to it (#225). The installed copy declares its version in a leading header
 # (`# gda-harness-version: <N>`); a mismatch re-materializes via the content
 # compare. NOT the package version — the harness changes far less often.
-HARNESS_VERSION = "6"
+HARNESS_VERSION = "7"
 
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -115,6 +115,11 @@ Godot may leave `Viewport.get_mouse_position()` and
 `Node2D.get_global_mouse_position()` stale in daemon sessions, so game code that
 needs the injected coordinate should read it from the input event.
 
+Live operations keep serving even while `SceneTree.paused` is true, but injected
+input still only reaches nodes whose process mode is `PROCESS_MODE_ALWAYS` or
+`PROCESS_MODE_WHEN_PAUSED` — a paused game's ordinary handlers will not see it, so
+drive resume through a pause-menu-style always-processing handler.
+
 ### Structured logging from game code
 
 To emit a record `gda logger tail` reads back as a rich, field-carrying `LogRecord`,

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -689,8 +689,14 @@ def test_daemon_game_set_edge_trigger_reports_unverified_then_side_effect_is_rea
         run("daemon", "stop")
 
 
-def _gda(tmp_path, env):
-    """A `gda <args> --project <tmp> --godot <GODOT> --json` subprocess helper."""
+def _gda(tmp_path, env, timeout=90):
+    """A `gda <args> --project <tmp> --godot <GODOT> --json` subprocess helper.
+
+    ``timeout`` defaults to 90s (the value every existing call site relied on
+    implicitly); a windowed session is heavier to launch, so callers that start
+    one pass a larger value (e.g. ``timeout=120``, matching the windowed e2e
+    tests elsewhere) instead of hand-rolling a near-duplicate of this helper.
+    """
 
     def run(*args):
         return subprocess.run(
@@ -706,7 +712,7 @@ def _gda(tmp_path, env):
             capture_output=True,
             text=True,
             env=env,
-            timeout=90,
+            timeout=timeout,
         )
 
     return run
@@ -1124,6 +1130,14 @@ def test_daemon_serves_screen_capture_while_scenetree_paused(
     # gated like the other windowed e2e tests, so it runs on a developer's local
     # GUI macOS session (or under xvfb on Linux) but skips on CI's display-less
     # godot-e2e job, unlike the headless core test.
+    #
+    # This restores the issue's INTEGRATED paused-session sequence on the one path
+    # that can exercise every op it names in a single session: capture alone could
+    # pass even with a capture-specific regression elsewhere in the harness, so
+    # after the paused capture this continues in the SAME session with a live read,
+    # a resume `input sequence` injection, and a responsiveness proof — the same
+    # read/resume/responsiveness shape the headless test proves without a display,
+    # here proven end-to-end alongside the capture that needs one.
     from gda.display import windowed_unavailable_reason
 
     reason = windowed_unavailable_reason()
@@ -1133,25 +1147,17 @@ def test_daemon_serves_screen_capture_while_scenetree_paused(
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(PAUSE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(PAUSE_PLAYER_GD, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ}, timeout=120)
 
-    env = {**os.environ}
+    def ticker_ticks() -> int:
+        got = run("game", "get", "/root/Main/Ticker", "--property", "ticks")
+        assert got.returncode == 0, got.stdout + got.stderr
+        return json.loads(got.stdout)["properties"][0]["value"]
 
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=120,
-        )
+    def tree_is_paused() -> bool:
+        got = run("game", "get", "/root/Main/Resumer", "--property", "tree_paused")
+        assert got.returncode == 0, got.stdout + got.stderr
+        return json.loads(got.stdout)["properties"][0]["value"]
 
     try:
         started = run("daemon", "start", "--windowed")
@@ -1170,11 +1176,34 @@ def test_daemon_serves_screen_capture_while_scenetree_paused(
         )
         assert paused_set.returncode == 0, paused_set.stdout + paused_set.stderr
         assert json.loads(paused_set.stdout)["verified"] is True
+        assert tree_is_paused() is True
 
         capture_path = tmp_path / "paused.png"
         captured = run("screen", "capture", "--output", str(capture_path))
         assert captured.returncode == 0, captured.stdout + captured.stderr
         assert capture_path.exists()
         assert capture_path.stat().st_size > 0
+
+        # The SAME paused session still serves a live read right after the
+        # capture — the capture's time-windowed harness state did not wedge it.
+        read_while_paused = run("game", "get", "/root/Main/Resumer")
+        assert read_while_paused.returncode == 0, (
+            read_while_paused.stdout + read_while_paused.stderr
+        )
+
+        # Resume input: inject KEY_R via `input sequence`. It reaches ONLY the
+        # Resumer (PROCESS_MODE_ALWAYS) — mirroring a real pause menu's resume
+        # handler — which flips SceneTree.paused back off.
+        events = json.dumps([{"type": "key", "key": "R", "frame": 0}])
+        resumed = run("input", "sequence", "--events", events)
+        assert resumed.returncode == 0, resumed.stdout + resumed.stderr
+        assert json.loads(resumed.stdout)["kind"] == "sequence"
+
+        # The session is genuinely responsive again: the paused flag cleared, and
+        # the default-process-mode Ticker resumes advancing.
+        assert tree_is_paused() is False
+        resumed_before = ticker_ticks()
+        resumed_after = ticker_ticks()
+        assert resumed_after > resumed_before
     finally:
         run("daemon", "stop")

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -1040,13 +1040,90 @@ PAUSE_MAIN_TSCN = (
 
 @pytest.mark.e2e
 def test_daemon_serves_live_ops_while_scenetree_paused(tmp_path, daemon_runtime_dir):
-    # The #656 DoD: opening a real pause menu sets SceneTree.paused, and the
-    # harness must keep serving `game get` / `screen capture` / `input sequence`
-    # through it — and an injected "resume" input must be able to unpause the
-    # session, proving this is not the dead-end the dogfooding note (GDA-DF-013)
-    # reported (input injection is itself a harness op, so if the harness stopped
-    # ticking on pause there would be no way back in). Needs a real DisplayServer
-    # for the capture leg, so this gates like the other windowed e2e tests.
+    # The #656 DoD's headless core: opening a real pause menu sets SceneTree.paused,
+    # and the harness must keep serving `game get` / `input sequence` through it —
+    # and an injected "resume" input must be able to unpause the session, proving
+    # this is not the dead-end the dogfooding note (GDA-DF-013) reported (input
+    # injection is itself a harness op, so if the harness stopped ticking on pause
+    # there would be no way back in). A default (headless) session, so this runs
+    # everywhere a daemon e2e runs — including CI's display-less godot-e2e job; the
+    # `screen capture` leg needs a real DisplayServer and lives in the windowed-gated
+    # test below instead.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(PAUSE_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "player.gd").write_text(PAUSE_PLAYER_GD, encoding="utf-8")
+    run = _gda(tmp_path, {**os.environ})
+
+    def ticker_ticks() -> int:
+        got = run("game", "get", "/root/Main/Ticker", "--property", "ticks")
+        assert got.returncode == 0, got.stdout + got.stderr
+        return json.loads(got.stdout)["properties"][0]["value"]
+
+    def tree_is_paused() -> bool:
+        got = run("game", "get", "/root/Main/Resumer", "--property", "tree_paused")
+        assert got.returncode == 0, got.stdout + got.stderr
+        return json.loads(got.stdout)["properties"][0]["value"]
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+        assert tree_is_paused() is False
+
+        # Pause the game the way a real pause menu does: a live `game set` flips
+        # SceneTree.paused through the Resumer's forwarding property.
+        paused_set = run(
+            "game",
+            "set",
+            "/root/Main/Resumer",
+            "--property",
+            "tree_paused",
+            "--value",
+            "true",
+        )
+        assert paused_set.returncode == 0, paused_set.stdout + paused_set.stderr
+        assert json.loads(paused_set.stdout)["verified"] is True
+        assert tree_is_paused() is True
+
+        # Control: the DEFAULT-process-mode Ticker genuinely stops advancing while
+        # paused — proving the pause took effect, not just that the flag reads back.
+        stalled_before = ticker_ticks()
+        stalled_after = ticker_ticks()
+        assert stalled_after == stalled_before
+
+        # The harness-served ops the #656 acceptance criteria name must still serve
+        # while paused: a live read and an input injection.
+        read_while_paused = run("game", "get", "/root/Main/Resumer")
+        assert read_while_paused.returncode == 0, (
+            read_while_paused.stdout + read_while_paused.stderr
+        )
+
+        # Resume input: inject KEY_R via `input sequence`. It reaches ONLY the
+        # Resumer (PROCESS_MODE_ALWAYS) — mirroring a real pause menu's resume
+        # handler — which flips SceneTree.paused back off.
+        events = json.dumps([{"type": "key", "key": "R", "frame": 0}])
+        resumed = run("input", "sequence", "--events", events)
+        assert resumed.returncode == 0, resumed.stdout + resumed.stderr
+        assert json.loads(resumed.stdout)["kind"] == "sequence"
+
+        # The session is genuinely responsive again: the paused flag cleared, and
+        # the default-process-mode Ticker resumes advancing.
+        assert tree_is_paused() is False
+        resumed_before = ticker_ticks()
+        resumed_after = ticker_ticks()
+        assert resumed_after > resumed_before
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_daemon_serves_screen_capture_while_scenetree_paused(
+    tmp_path, daemon_runtime_dir
+):
+    # The #656 DoD's windowed leg, split from the headless core above because
+    # `screen capture` needs a real DisplayServer (`daemon start --windowed`) —
+    # gated like the other windowed e2e tests, so it runs on a developer's local
+    # GUI macOS session (or under xvfb on Linux) but skips on CI's display-less
+    # godot-e2e job, unlike the headless core test.
     from gda.display import windowed_unavailable_reason
 
     reason = windowed_unavailable_reason()
@@ -1076,20 +1153,9 @@ def test_daemon_serves_live_ops_while_scenetree_paused(tmp_path, daemon_runtime_
             timeout=120,
         )
 
-    def ticker_ticks() -> int:
-        got = run("game", "get", "/root/Main/Ticker", "--property", "ticks")
-        assert got.returncode == 0, got.stdout + got.stderr
-        return json.loads(got.stdout)["properties"][0]["value"]
-
-    def tree_is_paused() -> bool:
-        got = run("game", "get", "/root/Main/Resumer", "--property", "tree_paused")
-        assert got.returncode == 0, got.stdout + got.stderr
-        return json.loads(got.stdout)["properties"][0]["value"]
-
     try:
         started = run("daemon", "start", "--windowed")
         assert started.returncode == 0, started.stdout + started.stderr
-        assert tree_is_paused() is False
 
         # Pause the game the way a real pause menu does: a live `game set` flips
         # SceneTree.paused through the Resumer's forwarding property.
@@ -1104,41 +1170,11 @@ def test_daemon_serves_live_ops_while_scenetree_paused(tmp_path, daemon_runtime_
         )
         assert paused_set.returncode == 0, paused_set.stdout + paused_set.stderr
         assert json.loads(paused_set.stdout)["verified"] is True
-        assert tree_is_paused() is True
-
-        # Control: the DEFAULT-process-mode Ticker genuinely stops advancing while
-        # paused — proving the pause took effect, not just that the flag reads back.
-        stalled_before = ticker_ticks()
-        stalled_after = ticker_ticks()
-        assert stalled_after == stalled_before
-
-        # The harness-served ops the #656 acceptance criteria name must still serve
-        # while paused: a live read, a screen capture, and an input injection.
-        read_while_paused = run("game", "get", "/root/Main/Resumer")
-        assert read_while_paused.returncode == 0, (
-            read_while_paused.stdout + read_while_paused.stderr
-        )
 
         capture_path = tmp_path / "paused.png"
         captured = run("screen", "capture", "--output", str(capture_path))
         assert captured.returncode == 0, captured.stdout + captured.stderr
-        assert captured.returncode == 0
         assert capture_path.exists()
         assert capture_path.stat().st_size > 0
-
-        # Resume input: inject KEY_R via `input sequence`. It reaches ONLY the
-        # Resumer (PROCESS_MODE_ALWAYS) — mirroring a real pause menu's resume
-        # handler — which flips SceneTree.paused back off.
-        events = json.dumps([{"type": "key", "key": "R", "frame": 0}])
-        resumed = run("input", "sequence", "--events", events)
-        assert resumed.returncode == 0, resumed.stdout + resumed.stderr
-        assert json.loads(resumed.stdout)["kind"] == "sequence"
-
-        # The session is genuinely responsive again: the paused flag cleared, and
-        # the default-process-mode Ticker resumes advancing.
-        assert tree_is_paused() is False
-        resumed_before = ticker_ticks()
-        resumed_after = ticker_ticks()
-        assert resumed_after > resumed_before
     finally:
         run("daemon", "stop")

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -992,3 +992,153 @@ def test_scene_verified_once_at_launch_survives_deleting_the_file(
         assert json.loads(again.stdout)["root"]["name"] == "B"
     finally:
         run("daemon", "stop")
+
+
+# #656 (GDA-DF-013): a real pause menu sets SceneTree.paused; a "Resumer" node
+# forwards SceneTree.paused through a script-variable property so a live `game
+# set`/`game get` can drive and observe it (no Node exposes `paused` directly), and
+# reacts to an injected resume key ONLY because it opts into PROCESS_MODE_ALWAYS —
+# the same pattern a real pause-menu script needs to keep handling input while
+# paused. A sibling "Ticker" node keeps the DEFAULT process mode, so its tick count
+# is the control that proves the pause (and later the resume) is real, not just a
+# flag read back.
+PAUSE_PLAYER_GD = (
+    "extends Node2D\n"
+    "@export var is_resumer: bool = false\n"
+    "@export var ticks: int = 0\n"
+    "func _ready() -> void:\n"
+    "\tif is_resumer:\n"
+    "\t\tprocess_mode = Node.PROCESS_MODE_ALWAYS\n"
+    "func _process(_delta: float) -> void:\n"
+    "\tticks += 1\n"
+    "func _input(event: InputEvent) -> void:\n"
+    "\tif not is_resumer:\n"
+    "\t\treturn\n"
+    "\tif event is InputEventKey and event.pressed and event.keycode == KEY_R:\n"
+    "\t\tget_tree().paused = false\n"
+    "var tree_paused: bool:\n"
+    "\tget:\n"
+    "\t\treturn get_tree().paused\n"
+    "\tset(value):\n"
+    "\t\tget_tree().paused = value\n"
+)
+PAUSE_MAIN_TSCN = (
+    "[gd_scene load_steps=2 format=3]\n\n"
+    '[ext_resource type="Script" path="res://player.gd" id="1"]\n\n'
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="Resumer" type="Node2D" parent="."]\n'
+    'script = ExtResource("1")\n'
+    "is_resumer = true\n\n"
+    '[node name="Ticker" type="Node2D" parent="."]\n'
+    'script = ExtResource("1")\n\n'
+    '[node name="Rect" type="ColorRect" parent="."]\n'
+    "offset_right = 64.0\n"
+    "offset_bottom = 64.0\n"
+    "color = Color(0.8, 0.2, 0.2, 1)\n"
+)
+
+
+@pytest.mark.e2e
+def test_daemon_serves_live_ops_while_scenetree_paused(tmp_path, daemon_runtime_dir):
+    # The #656 DoD: opening a real pause menu sets SceneTree.paused, and the
+    # harness must keep serving `game get` / `screen capture` / `input sequence`
+    # through it — and an injected "resume" input must be able to unpause the
+    # session, proving this is not the dead-end the dogfooding note (GDA-DF-013)
+    # reported (input injection is itself a harness op, so if the harness stopped
+    # ticking on pause there would be no way back in). Needs a real DisplayServer
+    # for the capture leg, so this gates like the other windowed e2e tests.
+    from gda.display import windowed_unavailable_reason
+
+    reason = windowed_unavailable_reason()
+    if reason is not None:
+        pytest.skip(reason)
+
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(PAUSE_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "player.gd").write_text(PAUSE_PLAYER_GD, encoding="utf-8")
+
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+        )
+
+    def ticker_ticks() -> int:
+        got = run("game", "get", "/root/Main/Ticker", "--property", "ticks")
+        assert got.returncode == 0, got.stdout + got.stderr
+        return json.loads(got.stdout)["properties"][0]["value"]
+
+    def tree_is_paused() -> bool:
+        got = run("game", "get", "/root/Main/Resumer", "--property", "tree_paused")
+        assert got.returncode == 0, got.stdout + got.stderr
+        return json.loads(got.stdout)["properties"][0]["value"]
+
+    try:
+        started = run("daemon", "start", "--windowed")
+        assert started.returncode == 0, started.stdout + started.stderr
+        assert tree_is_paused() is False
+
+        # Pause the game the way a real pause menu does: a live `game set` flips
+        # SceneTree.paused through the Resumer's forwarding property.
+        paused_set = run(
+            "game",
+            "set",
+            "/root/Main/Resumer",
+            "--property",
+            "tree_paused",
+            "--value",
+            "true",
+        )
+        assert paused_set.returncode == 0, paused_set.stdout + paused_set.stderr
+        assert json.loads(paused_set.stdout)["verified"] is True
+        assert tree_is_paused() is True
+
+        # Control: the DEFAULT-process-mode Ticker genuinely stops advancing while
+        # paused — proving the pause took effect, not just that the flag reads back.
+        stalled_before = ticker_ticks()
+        stalled_after = ticker_ticks()
+        assert stalled_after == stalled_before
+
+        # The harness-served ops the #656 acceptance criteria name must still serve
+        # while paused: a live read, a screen capture, and an input injection.
+        read_while_paused = run("game", "get", "/root/Main/Resumer")
+        assert read_while_paused.returncode == 0, (
+            read_while_paused.stdout + read_while_paused.stderr
+        )
+
+        capture_path = tmp_path / "paused.png"
+        captured = run("screen", "capture", "--output", str(capture_path))
+        assert captured.returncode == 0, captured.stdout + captured.stderr
+        assert captured.returncode == 0
+        assert capture_path.exists()
+        assert capture_path.stat().st_size > 0
+
+        # Resume input: inject KEY_R via `input sequence`. It reaches ONLY the
+        # Resumer (PROCESS_MODE_ALWAYS) — mirroring a real pause menu's resume
+        # handler — which flips SceneTree.paused back off.
+        events = json.dumps([{"type": "key", "key": "R", "frame": 0}])
+        resumed = run("input", "sequence", "--events", events)
+        assert resumed.returncode == 0, resumed.stdout + resumed.stderr
+        assert json.loads(resumed.stdout)["kind"] == "sequence"
+
+        # The session is genuinely responsive again: the paused flag cleared, and
+        # the default-process-mode Ticker resumes advancing.
+        assert tree_is_paused() is False
+        resumed_before = ticker_ticks()
+        resumed_after = ticker_ticks()
+        assert resumed_after > resumed_before
+    finally:
+        run("daemon", "stop")


### PR DESCRIPTION
## Summary

Dogfooding source GDA-DF-013: opening a real pause menu sets `SceneTree.paused = true`. The daemon-launched `GdaHarness` autoload inherited the default process mode, so its socket-serving `_process` loop stopped ticking too — freezing the live workflow at exactly the state an agent needs to inspect, with no way back in (resuming the game needs an input op, and input injection is itself served from that same loop).

- `_ready` now sets `process_mode = Node.PROCESS_MODE_ALWAYS`, scoped **inside** the existing daemon-launched gate (the same condition `gda_log()` checks) — a human editor run, a plain run, and a shipped build never have their process mode touched. ADR-0018's inertness guarantee is unaffected.
- Bumped `HARNESS_VERSION` (`src/gda/harness/install.py`, 6 → 7) per the documented convention, so `installed_harness_version()` / the reported `harness_synced` stay honest about which harness body is installed. Note the resync itself doesn't strictly need the bump: `_materialize`'s content-compare is version-header **+ body**, so the changed body alone would already have triggered a re-materialize on the next `daemon start` even without it — the bump is about keeping the reported version number meaningful, not about making the resync fire.
- `src/gda/skill/SKILL.md`'s live-operations section gained one sentence: injected input while paused only reaches `PROCESS_MODE_ALWAYS`/`PROCESS_MODE_WHEN_PAUSED` nodes, so drive resume through a pause-menu-style always-processing handler. This is a **public surface change** — `gda skill` emits `SKILL.md` verbatim, so its output gains exactly this paragraph (diffed locally, confirmed to be the only change: 4 new lines after the mouse-position-staleness caveat, before "### Structured logging from game code"; nothing else in the file touched, in particular not sibling #672's "Scene authoring" paragraph).

## Regression tests (split by display need, integrated sequence on both legs)

Two e2e tests in `tests/test_e2e_daemon.py`, sharing the `_gda()` subprocess helper (now takes an optional `timeout`, default 90, so a windowed caller passes `timeout=120` instead of hand-rolling a near-duplicate helper):

- **`test_daemon_serves_live_ops_while_scenetree_paused`** — the headless core, runs with a default (no `--windowed`) daemon session, so no display gate. Pauses the tree via a live `game set` on a script property that forwards to `SceneTree.paused` (no Node exposes `paused` directly), proves a default-process-mode sibling node genuinely stalls (control), proves `game get` and `input sequence` still serve while paused, injects a resume key via `input sequence` into a `PROCESS_MODE_ALWAYS` node, then proves the session is responsive again (paused flag clears, the default node resumes ticking). This is the test that actually executes in CI's `godot-e2e` job (ubuntu-latest, no DISPLAY/xvfb) and in the nightly full-e2e run, not just on a developer's local GUI machine.
- **`test_daemon_serves_screen_capture_while_scenetree_paused`** — the windowed leg (`daemon start --windowed`), gated by `windowed_unavailable_reason()` like the other windowed e2e tests, so it skips on CI's display-less job and runs on a developer's local GUI macOS session (or under xvfb on Linux). Runs the SAME integrated sequence in one session: pause, paused capture, a live read right after the capture (proving the capture's time-windowed harness state didn't wedge serving), a resume `input sequence` injection, and the paused-flag-cleared / ticker-resumes-advancing responsiveness proof. This restores the issue's end-to-end shape on the one path that also exercises the display-dependent capture — a capture-specific regression can no longer slip through by passing the two split legs independently.

## Acceptance criteria (issue #656)

- [x] With the SceneTree paused, `game get`, `screen capture`, and `input sequence` still serve — both tests, `screen capture` in the windowed one.
- [x] A daemon regression test pauses the tree, performs a live read and capture, injects resume input, and proves the session stays responsive — the full integrated sequence lives in the windowed test (capture included); the headless test proves the same read/inject/responsiveness shape without needing a display, for CI.
- [x] Non-daemon runs remain inert — the process-mode change is scoped inside the pre-existing `idx == -1` early-return / `_daemon_launched` gate; no new branch outside it.

`diag errors` was left out of the regression tests as a control (per the issue's own note it's daemon-served from the Session log per ADR-0022 and doesn't exercise this fix).

## Validation

Run in the isolated worktree `w1-656` (branch `fix/656-harness-pause-always`, forked from `feat/gda-dogfooding-dev` @ `d0de6bd2`):

- `uv run pytest -m "not e2e"` — 1195 passed (includes the ADR-0026/cross-language contract guards from #650).
- `uv run ruff check` — all checks passed.
- `uv run ruff format --check` — 426 files already formatted.
- `uv run pyright` — 0 errors, 0 warnings.
- `uv run pytest tests/test_e2e_daemon.py -m e2e -q -rs` — 26 passed, **0 skipped**. Re-ran filtered to `-k scenetree_paused -v`: both `test_daemon_serves_live_ops_while_scenetree_paused` and `test_daemon_serves_screen_capture_while_scenetree_paused` PASSED individually — this host has a usable macOS window-server session, so the windowed test executed for real (not skipped); it will skip only on a display-less host such as CI's headless job, by design.
- `uv run pytest tests/test_e2e_game.py -m e2e` — 1 passed.
- `uv run pytest tests/test_e2e_input.py -m e2e` — 10 passed.
- `uv run gda schema` — re-confirmed byte-identical to the pre-change baseline (via `cmp`) after every round of edits, including this one.
- `uv run gda skill` — diffed old vs. new: the only change is the 4-line paragraph noted above.
- Full-e2e CI (scheduled/dispatch-only per repo convention) not run from this PR; the headless regression test is exactly what that CI tier will execute for this fix.

No residual risk identified; no gates skipped or faked.

## Review history

- Internal review round 1 (4 adopted findings: split the test by display need, document the paused-input scope in SKILL.md, fix HARNESS_VERSION prose, remove a duplicate assert).
- External adversarial review (issue comment by qinhaihong-red, pinned to `b73adc89`; DDMA architecture axis passed with no finding). Two findings, both fully adopted:
  - P3: the windowed test's local `run()` duplicated `_gda()` almost verbatim → `_gda()` now takes an optional `timeout`.
  - P2 (Spec): splitting by display need lost the issue's integrated paused-session sequence, since a capture-specific regression could pass both split tests independently → the windowed test now runs the full sequence (pause → capture → live read → resume injection → responsiveness proof) in one session; the headless test is unchanged.
  - If the reviewer's own environment showed the windowed test skipping, that reflects their environment lacking a window server — this worktree's host has one, and both pause tests were confirmed passing (not skipped) above.

## Note for sibling slices

- `src/gda/harness/install.py`'s `HARNESS_VERSION` was bumped 6 → 7 by this PR. Sibling PR #654 (`gda daemon uninstall`) also touches `install.py` on different lines; this PR merges after it, so a trivial rebase may be needed — noted for the orchestrator to coordinate.
- `src/gda/skill/SKILL.md` is owned by sibling slice #672 for this wave, but #672 has landed and the orchestrator confirmed this edit's region (the live-operations input-caveats paragraph) doesn't overlap #672's changes (its "Scene authoring" paragraph is untouched).
- `README.md` and `src/gda/error_codes.py` / the ADR-0002 table (owned by #651) are untouched — this fix adds no new error code and no documented flag/command changed in README's scope.

Closes #656