### PR TITLE
fix(gda): surface a failed rollback on the daemon-start exception path

### DIFF
--- a/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
+++ b/docs/adr/0018-gda-harness-lifecycle-and-concurrent-editor-boundary.md
@@ -124,7 +124,7 @@ so two instances can touch the project at once.
 > that fails (a read-only `project.godot` is enough) leaves the harness on disk and raises.
 > A failed start now restores the project to its exact pre-start bytes, and the structured
 > failure reports the outcome in its `diagnostics` — what was put back, or, if the
-> restoration itself fails, which paths (files and created directories) still differ. A start that wrote nothing restores
+> restoration itself fails, which paths (files and created directories) still differ — a path whose state cannot even be read is reported as unmeasurable residue rather than letting the measurement failure displace the original error. A start that wrote nothing restores
 > nothing, so a pre-existing installation is never disturbed. An exception still propagates
 > to the caller unchanged; only the residue is gone.
 >

--- a/src/gda/commands/daemon.py
+++ b/src/gda/commands/daemon.py
@@ -537,16 +537,24 @@ def run_daemon_start_operation(
     # The restore is driven by the SNAPSHOT alone, never by the install's receipt: a
     # receipt cannot describe how to undo an install that re-materialized a stale
     # body or re-pointed an existing entry (both CREATE nothing), and a half-finished
-    # install has no receipt at all. The exception arm re-raises unchanged, so the
-    # caller still sees the original error exactly as before — only the residue is
-    # gone.
+    # install has no receipt at all. The exception arm re-raises the ORIGINAL error
+    # as the primary failure; when the restore itself also fails, that outcome and
+    # the measured residual paths ride along as an exception note (PR #688 review) —
+    # silently dropping them would hide residue ADR-0018 requires reporting.
     snapshot = HarnessSnapshot.capture(project)
     try:
         installed = install_harness(project)
         (spawn or _spawn_daemon)(project, str(binary), windowed, scene)
         pid = _await_ready(paths)
-    except BaseException:
-        _restore_start_install(snapshot)
+    except BaseException as exc:
+        outcome = _restore_start_install(snapshot)
+        if isinstance(outcome, OSError):
+            pending = ", ".join(snapshot.pending())
+            exc.add_note(
+                f"additionally, the harness install could NOT be rolled back "
+                f"({outcome}); these paths still differ from their pre-start "
+                f"state: {pending}"
+            )
         raise
     if pid is None:
         return _failed_start_failure(snapshot)

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -351,17 +351,30 @@ class HarnessSnapshot:
         put right by hand — files whose bytes differ, then directories that were
         absent at capture but still exist (a restore can fail after the files are
         already back, leaving only directory residue; PR #680 recheck 3).
+
+        NEVER raises for a per-path I/O failure: this runs on error-reporting
+        paths, where a thrown measurement would displace the original failure
+        (PR #688 recheck). A path that cannot be read cannot be confirmed
+        restored, so it IS residue — reported with the reason it could not be
+        measured; the other paths stay individually measured.
         """
-        residue = [
-            _res_path(self.project, path)
-            for path, before in self.files
-            if (path.read_bytes() if path.exists() else None) != before
-        ]
-        residue.extend(
-            _res_path(self.project, directory)
-            for directory in self.absent_directories
-            if directory.is_dir()
-        )
+        residue: list[str] = []
+        for path, before in self.files:
+            label = _res_path(self.project, path)
+            try:
+                current = path.read_bytes() if path.exists() else None
+            except OSError as exc:
+                residue.append(f"{label} (state unmeasurable: {exc})")
+                continue
+            if current != before:
+                residue.append(label)
+        for directory in self.absent_directories:
+            label = _res_path(self.project, directory)
+            try:
+                if directory.is_dir():
+                    residue.append(label)
+            except OSError as exc:
+                residue.append(f"{label} (state unmeasurable: {exc})")
         return tuple(residue)
 
 

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -1058,6 +1058,42 @@ def test_original_failure_carries_the_rollback_failure_as_a_note(
     assert "project.godot" in notes
 
 
+def test_original_failure_survives_when_restore_and_measurement_both_fail(
+    tmp_path, short_runtime, monkeypatch
+):
+    # PR #688 recheck: the same filesystem condition can break the restore AND the
+    # residual measurement (an unreadable project.godot does both). The original
+    # operation error must stay the primary exception — never displaced by a thrown
+    # measurement — and the note must still report the rollback failure with the
+    # unmeasurable path named as residue.
+    project = _project(tmp_path)
+    project_godot = project / "project.godot"
+
+    def spawn_boom(*args, **kwargs):
+        # The reviewer's real-I/O shape: the project file becomes unreadable
+        # immediately before the operation fails, after the install mutated it.
+        project_godot.chmod(0o000)
+        raise OSError("injected: original spawn failure")
+
+    monkeypatch.setattr(daemon_ops, "_spawn_daemon", spawn_boom)
+
+    try:
+        with pytest.raises(
+            OSError, match="injected: original spawn failure"
+        ) as excinfo:
+            daemon_ops.run_daemon_start_operation(
+                project, "godot", version_check=_OK_VERSION
+            )
+    finally:
+        project_godot.chmod(0o644)
+
+    notes = "\n".join(getattr(excinfo.value, "__notes__", []))
+    assert "could NOT be rolled back" in notes
+    assert "project.godot (state unmeasurable: " in notes
+    # The paths the measurement COULD read are still individually reported.
+    assert f"res://{HARNESS_RES_DIR}/{HARNESS_FILE}" in notes
+
+
 # --- the mutation receipt on both halves (#654) -------------------------------
 
 

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -1026,6 +1026,38 @@ def test_failed_start_names_directory_residue_when_only_the_rmdir_fails(
     assert f"res://{HARNESS_RES_DIR}/{HARNESS_FILE}" not in failure.error.diagnostics
 
 
+def test_original_failure_carries_the_rollback_failure_as_a_note(
+    tmp_path, short_runtime, monkeypatch
+):
+    # PR #688 review: when the start fails AND the snapshot restore also fails, the
+    # original error must stay the primary failure without swallowing the rollback
+    # outcome — it carries an exception note naming the restore failure and the
+    # measured residual paths, per ADR-0018's report-what-still-differs requirement.
+    project = _project(tmp_path)
+
+    def spawn_boom(*args, **kwargs):
+        raise OSError("injected: original spawn failure")
+
+    monkeypatch.setattr(daemon_ops, "_spawn_daemon", spawn_boom)
+
+    def restore_boom(self):
+        raise OSError("injected: restore cannot write")
+
+    monkeypatch.setattr(HarnessSnapshot, "restore", restore_boom)
+
+    with pytest.raises(OSError, match="injected: original spawn failure") as excinfo:
+        daemon_ops.run_daemon_start_operation(
+            project, "godot", version_check=_OK_VERSION
+        )
+
+    notes = "\n".join(getattr(excinfo.value, "__notes__", []))
+    assert "could NOT be rolled back" in notes
+    assert "injected: restore cannot write" in notes
+    # The residual delta is measured off the snapshot, files then directories.
+    assert f"res://{HARNESS_RES_DIR}/{HARNESS_FILE}" in notes
+    assert "project.godot" in notes
+
+
 # --- the mutation receipt on both halves (#654) -------------------------------
 
 

--- a/tests/test_harness_install.py
+++ b/tests/test_harness_install.py
@@ -740,6 +740,30 @@ def test_snapshot_pending_names_what_a_failed_restore_leaves_behind(tmp_path):
     )
 
 
+def test_snapshot_pending_marks_an_unreadable_path_instead_of_raising(tmp_path):
+    # PR #688 recheck: pending() runs on error-reporting paths, where a thrown
+    # measurement would displace the original failure. A path that cannot be read
+    # cannot be confirmed restored — it is reported as unmeasurable residue while
+    # every other path stays individually measured.
+    (tmp_path / "project.godot").write_text(_NO_AUTOLOAD, encoding="utf-8")
+    snapshot = HarnessSnapshot.capture(tmp_path)
+    install_harness(tmp_path)
+
+    project_godot = tmp_path / "project.godot"
+    project_godot.chmod(0o000)
+    try:
+        residue = snapshot.pending()
+    finally:
+        project_godot.chmod(0o644)
+
+    assert residue[0].startswith("project.godot (state unmeasurable: ")
+    assert residue[1:] == (
+        HARNESS_RES_PATH,
+        "res://addons",
+        f"res://{HARNESS_RES_DIR}",
+    )
+
+
 def test_ready_gates_on_template_feature_as_its_first_statement():
     # ADR-0028 defence in depth: an EXPORTED build must self-disable the harness,
     # "regardless of launch args". That holds iff `if OS.has_feature("template"):


### PR DESCRIPTION
## Summary

Closes the P2 found in PR #688's adversarial review (exact head `37dfa709`): the daemon-start
exception arm called `_restore_start_install(snapshot)` and re-raised, discarding the restore
outcome. When the operation AND the rollback both fail, the caller saw only the original error
while mutated harness/config residue went unreported — against ADR-0018's requirement to report
the paths that still differ when restoration fails.

The original exception stays the primary failure; a failed restore now rides along as an
exception note (`BaseException.add_note()`, the reviewer's suggested smallest closure) carrying
the rollback error and the measured `snapshot.pending()` paths, in the same wording family as
the readiness-failure path's diagnostics.

## Validation

- New regression `test_original_failure_carries_the_rollback_failure_as_a_note` combines an
  injected spawn failure with an injected restore failure and asserts the note names the
  rollback error, the harness script path, and `project.godot`. **Red against `37dfa709`**
  (stash probe: no notes attached), green with the fix.
- `uv run pytest -m "not e2e"` — 1300 passed, 406 deselected.
- `uv run ruff check` / `uv run ruff format --check` — clean.
- `uv run pyright` — 0 errors.
- `gda schema` byte-identical before/after (stash compare, `06f2669e…`) — runtime behavior only,
  no surface change. No Godot e2e needed (fault-injection is unit-tier; the engine path is
  unchanged).

Follow-up to #654's transaction work; part of the wave tracked by #688.

🤖 Generated with [Claude Code](https://claude.com/claude-code)