### PR TITLE
fix(gda): tell a sandbox-denied window server from an absent display (#667)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -64,6 +64,17 @@ The GDScript payload owns only `code` and `message`. `gda` owns the public
 `GdaError` wrapper: it validates that the code is registered, assigns the
 `operation` category, preserves the message, and copies stderr into diagnostics.
 
+> **Scope note (2026-08-17, #667) — the shape above is the GDScript-emitted
+> *headless* payload, and stays exactly that.** The Phase-2 **live** channel reuses
+> this envelope but is emitted by Python (the daemon and the daemon IPC client), and
+> it carries one OPTIONAL extra key: `probe`, the host-probe context behind a windowed
+> refusal (ADR-0004 amendment). The two channels validate against **different models**
+> — `OperationErrorEnvelope` (headless) stays `extra="forbid"` and probe-less, because
+> a GDScript operation has no host probe to report; `LiveErrorEnvelope` accepts the
+> optional key. The key is omitted when absent, so every payload either language
+> emitted before is byte-identical. This widens no cross-language contract: GDScript
+> neither emits nor reads `probe`.
+
 ### stderr as advisory diagnostics
 
 stderr is still **never** parsed for the success/failure *outcome* or for stable

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -222,6 +222,7 @@ operation, and parse codes the CLI assigns).
 | `live_display_unavailable` | `live` | `classifier` | `6` | A live `screen` capture ran on a headless engine session (the dummy DisplayServer cannot read pixels); start the daemon windowed with `gda daemon start --windowed` (Phase 2, #222). |
 | `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
 | `live_windowed_unavailable` | `environment` | `classifier` | `127` | A windowed live session (`gda daemon start --windowed`) was requested but the host has no usable DisplayServer (no on-console GUI session / no `$DISPLAY`), so the session cannot come up; refused before spawning Godot (Phase 2, #345). |
+| `live_windowed_permission_denied` | `environment` | `classifier` | `127` | A windowed live session (`gda daemon start --windowed`) was requested and the host HAS a window server, but this process is denied access to it (e.g. a sandbox); retry outside the restriction rather than treating the host as display-less (Phase 2, #667). |
 
 ## Considered options
 

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -222,7 +222,7 @@ operation, and parse codes the CLI assigns).
 | `live_display_unavailable` | `live` | `classifier` | `6` | A live `screen` capture ran on a headless engine session (the dummy DisplayServer cannot read pixels); start the daemon windowed with `gda daemon start --windowed` (Phase 2, #222). |
 | `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
 | `live_windowed_unavailable` | `environment` | `classifier` | `127` | A windowed live session (`gda daemon start --windowed`) was requested but the host has no usable DisplayServer (no on-console GUI session / no `$DISPLAY`), so the session cannot come up; refused before spawning Godot (Phase 2, #345). |
-| `live_windowed_permission_denied` | `environment` | `classifier` | `127` | A windowed live session (`gda daemon start --windowed`) was requested and the host HAS a window server, but this process is denied access to it (e.g. a sandbox); retry outside the restriction rather than treating the host as display-less (Phase 2, #667). |
+| `live_windowed_permission_denied` | `environment` | `classifier` | `127` | A windowed live session (`gda daemon start --windowed`) was requested but this process is denied the window-server lookup (e.g. a sandbox), so gda cannot tell whether the host has one; re-run outside the restriction to find out rather than recording the host as display-less (Phase 2, #667). |
 
 ## Considered options
 

--- a/docs/adr/0004-schema-flag-self-description.md
+++ b/docs/adr/0004-schema-flag-self-description.md
@@ -24,6 +24,45 @@ status: accepted
 > the surrounding prose cannot drift. Like `kind`, gda-mcp ignores it (ADR-0012),
 > so it stays a strict superset — backward compatible.
 
+> **Amendment (2026-08-16, #667):** the uniform failure envelope (`GdaError`, the
+> `error` half of every command's `--schema`) gains ONE optional key — `probe`, an
+> `EnvironmentProbe` `{name, platform}` naming the host call that decided an
+> ENVIRONMENT failure `gda` resolved by probing the machine rather than by running
+> the engine (`CGSessionCopyCurrentDictionary`,
+> `bootstrap_look_up(com.apple.windowserver.active)`, `$DISPLAY / $WAYLAND_DISPLAY`).
+> Motivation: `--windowed` refusals had two causes — no window server on the host,
+> versus this process denied access to one — distinguishable only by reading English
+> prose, so automation recorded a sandbox boundary as a machine-capability gap and
+> silently skipped rendered QA (dogfooding GDA-DF-029).
+>
+> Three properties keep it additive:
+>
+> - **Optional and OMITTED, never `null`.** `emit_failure` serializes with
+>   `exclude_none`, so every failure that sets no probe emits byte-identically to
+>   before. Only the two windowed-refusal codes set one today.
+> - **The stable trio is untouched.** `category` / `code` / `message` (and
+>   `diagnostics`) keep their contract; `probe` is context ABOUT the classification,
+>   never a substitute for branching on `code`. `gda-mcp` passes the envelope through
+>   to its `is_error` channel unchanged and needs no adapter work (ADR-0012).
+> - **Schema-derived, zero per-command cost.** `error` is still the one shared
+>   `GdaErrorEnvelope` schema, identical for every command — it changed once, for all.
+>
+> **Scope boundary with #687.** #687 owns the separate, larger decision on whether the
+> failure ABI carries operation-scoped typed EVIDENCE — a script's numeric exit status,
+> parsed `ScriptError[]`, a timeout's elapsed seconds (#651, #655). This amendment
+> deliberately does NOT decide that and does not pre-empt its shape: `probe` answers
+> only "which host call decided this environment verdict", a fixed two-string context
+> with no per-operation variation. The two axes compose — an evidence key adopted by
+> #687 would sit alongside `probe` under the same "optional keys are omitted when
+> absent" rule established here — and #687 stays free to adopt, reshape, or decline
+> typed evidence on its own merits.
+>
+> **Not carried on the daemon relay.** The daemon→CLI wire envelope is ADR-0002's
+> `{code, message}` (extra keys rejected), so the launch-boundary guard inside
+> `gda-daemon` relays the code and prose but no `probe`; the field is populated where
+> the probe RAN in-process. Widening the cross-language wire contract is out of scope
+> here.
+
 ADR-0000 lists `--schema` as a core capability without defining it. We fix its
 semantics here, and deliberately scope out an overloaded interpretation.
 

--- a/docs/adr/0004-schema-flag-self-description.md
+++ b/docs/adr/0004-schema-flag-self-description.md
@@ -30,16 +30,19 @@ status: accepted
 > ENVIRONMENT failure `gda` resolved by probing the machine rather than by running
 > the engine (`CGSessionCopyCurrentDictionary`,
 > `bootstrap_look_up(com.apple.windowserver.active)`, `$DISPLAY / $WAYLAND_DISPLAY`).
-> Motivation: `--windowed` refusals had two causes — no window server on the host,
-> versus this process denied access to one — distinguishable only by reading English
-> prose, so automation recorded a sandbox boundary as a machine-capability gap and
-> silently skipped rendered QA (dogfooding GDA-DF-029).
+> Motivation: `--windowed` refusals had two causes — no window server was detected
+> (`live_windowed_unavailable`), versus the window-server lookup was REFUSED
+> (`live_windowed_permission_denied`, which proves confinement, not that one exists) —
+> distinguishable only by reading English prose, so automation recorded a sandbox
+> boundary as a machine-capability gap and silently skipped rendered QA (dogfooding
+> GDA-DF-029).
 >
 > Three properties keep it additive:
 >
 > - **Optional and OMITTED, never `null`.** `emit_failure` serializes with
 >   `exclude_none`, so every failure that sets no probe emits byte-identically to
->   before. Only the two windowed-refusal codes set one today.
+>   before. Only the two windowed-refusal codes — `live_windowed_unavailable` and
+>   `live_windowed_permission_denied` — set one today.
 > - **The stable trio is untouched.** `category` / `code` / `message` (and
 >   `diagnostics`) keep their contract; `probe` is context ABOUT the classification,
 >   never a substitute for branching on `code`. `gda-mcp` passes the envelope through
@@ -57,11 +60,19 @@ status: accepted
 > absent" rule established here — and #687 stays free to adopt, reshape, or decline
 > typed evidence on its own merits.
 >
-> **Not carried on the daemon relay.** The daemon→CLI wire envelope is ADR-0002's
-> `{code, message}` (extra keys rejected), so the launch-boundary guard inside
-> `gda-daemon` relays the code and prose but no `probe`; the field is populated where
-> the probe RAN in-process. Widening the cross-language wire contract is out of scope
-> here.
+> **Carried on the daemon relay too** (revised on review, 2026-08-17). The refusal
+> that actually gates every live op is the daemon's lazy-launch guard, not the CLI's
+> optional fail-fast, so leaving `probe` off the relay made the AUTHORITATIVE path the
+> poorer one — and #667's acceptance criterion is unqualified. The live channel's
+> envelope therefore takes the same optional key: `LiveError` is `{code, message,
+> probe?}` and `classify_live` carries it into the public `GdaError`.
+>
+> The two channels keep **separate models**, which is what keeps this narrow: the
+> headless sentinel (`OperationError`, GDScript-emitted) stays strict, `extra="forbid"`
+> and probe-less, because a GDScript operation has no host probe to report and widening
+> it would invite a key the other language can never fill. On the wire the key is
+> omitted when absent, so every other live reply and every headless envelope is
+> byte-identical to before.
 
 ADR-0000 lists `--schema` as a core capability without defining it. We fix its
 semantics here, and deliberately scope out an overloaded interpretation.

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -708,12 +708,17 @@ headless is unaffected (4.4+, cross-platform).
   requires the host's desktop session — an on-console GUI login on macOS, `$DISPLAY` /
   `$WAYLAND_DISPLAY` on Linux — because a windowed Godot aborts during `DisplayServer`
   registration without one; it is checked pre-launch (#345) and refused with one of two
-  ENVIRONMENT codes (#667): `live_windowed_unavailable` when the host has no window server
-  (skip rendered QA here) and `live_windowed_permission_denied` when it has one this process
-  is denied access to, e.g. a sandbox (re-run outside the restriction). Both carry the
-  deciding host call as the envelope's `probe` `{name, platform}` (ADR-0004 amendment). On
-  macOS a sandbox that hides the window server rather than refusing the lookup is
-  indistinguishable from an absent session — re-running outside the sandbox is how to tell.
+  ENVIRONMENT codes (#667): `live_windowed_unavailable` when nothing refused the probe and no
+  session is reachable (skip rendered QA here) and `live_windowed_permission_denied` when the
+  window-server lookup itself was refused, e.g. a sandbox (re-run outside the restriction).
+  The second code does NOT mean the host has a window server — macOS refuses the lookup
+  before resolving the name, so a broadly-confined process is refused whether or not one
+  exists; it means only that gda was not allowed to ask, and re-running outside the
+  restriction is what settles it. Conversely a sandbox that hides the window server rather
+  than refusing the lookup is indistinguishable from an absent session. A refusal that
+  originates in `daemon start --windowed` carries the deciding host call as the envelope's
+  `probe` `{name, platform}` (ADR-0004 amendment); the daemon-relayed form carries the code
+  and prose only, since the daemon→CLI wire envelope has no `probe` key.
 
 Out of scope (editor context, ADR-0017): UndoRedo-aware mutation, the editor's
 open-scene tree, saving the open scene, editor errors/screenshots, run-editor-script,

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -704,7 +704,16 @@ headless is unaffected (4.4+, cross-platform).
   and crash-survivable like `diag` (ADR-0022). The opt-in rich `gda_log()` protocol layers on in a
   follow-up slice (#282).
 - **lifecycle (the `daemon` command group):** `gda daemon start` / `stop` / `status`, and `gda daemon
-  install` / `uninstall` for the `gda harness` (ADR-0018).
+  install` / `uninstall` for the `gda harness` (ADR-0018). `daemon start --windowed` additionally
+  requires the host's desktop session — an on-console GUI login on macOS, `$DISPLAY` /
+  `$WAYLAND_DISPLAY` on Linux — because a windowed Godot aborts during `DisplayServer`
+  registration without one; it is checked pre-launch (#345) and refused with one of two
+  ENVIRONMENT codes (#667): `live_windowed_unavailable` when the host has no window server
+  (skip rendered QA here) and `live_windowed_permission_denied` when it has one this process
+  is denied access to, e.g. a sandbox (re-run outside the restriction). Both carry the
+  deciding host call as the envelope's `probe` `{name, platform}` (ADR-0004 amendment). On
+  macOS a sandbox that hides the window server rather than refusing the lookup is
+  indistinguishable from an absent session — re-running outside the sandbox is how to tell.
 
 Out of scope (editor context, ADR-0017): UndoRedo-aware mutation, the editor's
 open-scene tree, saving the open scene, editor errors/screenshots, run-editor-script,

--- a/examples/platformer/panda-adventure/docs/gadr/0007-visual-smoke-seam.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0007-visual-smoke-seam.md
@@ -33,12 +33,17 @@ The model:
   when a future slice adds a player-visible feature, it adds a checkpoint (a
   capture and/or a check) to this scenario — never a new windowed session.
 - **Display-gated: a desktop tier, not a CI gate.** Gated exactly like
-  `test_e2e_screenshot.py`: `gda.display.windowed_unavailable()`
-  pre-checks the window server, and the daemon's typed no-display refusals
-  (`live_windowed_unavailable` / `live_windowed_permission_denied` /
-  `live_display_unavailable`, #345, #667) are
-  honored as skips — visible under `-rs`, never silent. CI keeps the headless
-  seams; the visual-smoke seam runs pre-merge on a real desktop.
+  `test_e2e_screenshot.py`, through the one shared policy in `tests/display_gate.py`
+  (pre-check and post-start race path alike, #345, #667). The reaction depends on
+  WHICH refusal, because they are not the same fact:
+  - **capability** (`live_windowed_unavailable` / `live_display_unavailable`) — the
+    host cannot show a window, so the tier **skips**, visibly under `-rs`, never
+    silent. CI keeps the headless seams; the visual-smoke seam runs pre-merge on a
+    real desktop.
+  - **permission** (`live_windowed_permission_denied`) — the host may well be able
+    to; this RUN is confined. The tier **fails loudly** with the re-run remediation,
+    like the engine gate does for a missing binary: skipping would report a green
+    visual tier whose rendered acceptance never executed.
 - **Engine-side pixel decode.** Captures are analyzed by the engine's own
   `Image` API through `gda script run` (`tests/gdscript/check_pixels.gd`),
   preserving the repo's no-image-decode-dependency convention (no Pillow).

--- a/examples/platformer/panda-adventure/docs/gadr/0007-visual-smoke-seam.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0007-visual-smoke-seam.md
@@ -33,9 +33,10 @@ The model:
   when a future slice adds a player-visible feature, it adds a checkpoint (a
   capture and/or a check) to this scenario — never a new windowed session.
 - **Display-gated: a desktop tier, not a CI gate.** Gated exactly like
-  `test_e2e_screenshot.py`: `gda.display.windowed_unavailable_reason()`
+  `test_e2e_screenshot.py`: `gda.display.windowed_unavailable()`
   pre-checks the window server, and the daemon's typed no-display refusals
-  (`live_windowed_unavailable` / `live_display_unavailable`, #345) are
+  (`live_windowed_unavailable` / `live_windowed_permission_denied` /
+  `live_display_unavailable`, #345, #667) are
   honored as skips — visible under `-rs`, never silent. CI keeps the headless
   seams; the visual-smoke seam runs pre-merge on a real desktop.
 - **Engine-side pixel decode.** Captures are analyzed by the engine's own

--- a/examples/platformer/panda-adventure/tests/display_gate.py
+++ b/examples/platformer/panda-adventure/tests/display_gate.py
@@ -1,0 +1,52 @@
+"""The windowed-display gate for the game's visual tiers (#345, #667).
+
+One owner for the reaction policy in THIS context. The game's tests are a separate
+pytest root and cannot import the toolkit's own test-support package, so the policy
+is restated here rather than shared; it must stay in step with the toolkit's copy.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# The reaction is NOT uniform, and treating it as uniform is the bug this replaces:
+#
+# - CAPABILITY (`live_windowed_unavailable`, `live_display_unavailable`) — the host
+#   cannot show a window. Nothing to run, so SKIP (visible under `-rs`).
+# - PERMISSION (`live_windowed_permission_denied`) — the host may well be able to;
+#   this RUN is confined. Skipping would green the visual tier with the rendered
+#   acceptance unexecuted, which is exactly the defect #667 exists to stop, so FAIL
+#   with the remediation. This matches the engine gate in ``conftest.py``, which also
+#   fails loudly rather than skipping when the environment cannot deliver what the
+#   tier needs.
+WINDOWED_CAPABILITY_CODES = frozenset(
+    {"live_windowed_unavailable", "live_display_unavailable"}
+)
+WINDOWED_PERMISSION_DENIED_CODE = "live_windowed_permission_denied"
+
+_CONFINED_REMEDIATION = (
+    "the windowed session was refused because this RUN is confined ({detail}). "
+    "Rendered acceptance did NOT execute; this is a loud failure rather than a skip "
+    "so a sandboxed run cannot green the visual tier with it unexecuted (#667). "
+    "Re-run outside the sandbox/restriction."
+)
+
+
+def handle_no_display_code(code, detail: str = "") -> None:
+    """Skip on a capability refusal, FAIL on a permission refusal, else return."""
+    if code == WINDOWED_PERMISSION_DENIED_CODE:
+        pytest.fail(_CONFINED_REMEDIATION.format(detail=detail or code))
+    if code in WINDOWED_CAPABILITY_CODES:
+        pytest.skip(f"windowed session unavailable ({code})")
+
+
+def require_windowed_host() -> None:
+    """Pre-flight gda's host display probe with the same reaction policy."""
+    from gda.display import windowed_unavailable
+
+    verdict = windowed_unavailable()
+    if verdict is None:
+        return
+    if verdict.code == WINDOWED_PERMISSION_DENIED_CODE:
+        pytest.fail(_CONFINED_REMEDIATION.format(detail=verdict.reason))
+    pytest.skip(verdict.reason)

--- a/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
+++ b/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
@@ -51,7 +51,15 @@ _COPY_IGNORE = shutil.ignore_patterns(
 # not a test failure. `live_windowed_unavailable` is the typed pre-launch refusal gda
 # now returns for `daemon start --windowed` on a display-less host (#345), replacing
 # the generic `engine_session_not_running` this used to key on.
-_NO_DISPLAY_CODES = {"live_windowed_unavailable", "live_display_unavailable"}
+# The daemon's typed no-display refusals. A display state can change between the
+# pre-check and the live call, so any of these is a SKIP, not a failure. Includes
+# live_windowed_permission_denied (#667): a confined run cannot reach the window
+# server, which is an environment gap like the others — never a demo defect.
+_NO_DISPLAY_CODES = {
+    "live_windowed_unavailable",
+    "live_windowed_permission_denied",
+    "live_display_unavailable",
+}
 
 
 def _error_code(stdout: str) -> str | None:

--- a/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
+++ b/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
@@ -27,9 +27,8 @@ import sys
 import pytest
 
 from gda.binary import resolve_godot_binary
-from gda.display import windowed_unavailable
-
 import build_config
+from display_gate import handle_no_display_code, require_windowed_host
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
@@ -45,21 +44,6 @@ PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 _COPY_IGNORE = shutil.ignore_patterns(
     "tests", ".godot", "build", "generated", "__pycache__"
 )
-
-# Daemon error codes that mean "this environment cannot show a window" (the windowed
-# start was refused pre-launch, or the live session has no display) — a skip signal,
-# not a test failure. `live_windowed_unavailable` is the typed pre-launch refusal gda
-# now returns for `daemon start --windowed` on a display-less host (#345), replacing
-# the generic `engine_session_not_running` this used to key on.
-# The daemon's typed no-display refusals. A display state can change between the
-# pre-check and the live call, so any of these is a SKIP, not a failure. Includes
-# live_windowed_permission_denied (#667): a confined run cannot reach the window
-# server, which is an environment gap like the others — never a demo defect.
-_NO_DISPLAY_CODES = {
-    "live_windowed_unavailable",
-    "live_windowed_permission_denied",
-    "live_display_unavailable",
-}
 
 
 def _error_code(stdout: str) -> str | None:
@@ -83,9 +67,7 @@ def test_windowed_daemon_captures_the_running_viewport(tmp_path, daemon_runtime_
     # can't launch there. Uses gda's shared display helper (the same one gda's
     # `daemon start --windowed` precondition keys on, #345), so the pre-check and the
     # tool agree. Runs for real on a genuine desktop (macOS Aqua / Linux+DISPLAY).
-    unavailable = windowed_unavailable()
-    if unavailable is not None:
-        pytest.skip(unavailable.reason)
+    require_windowed_host()
     project = _make_project_copy(tmp_path / "game")
     env = {**os.environ}
     out = tmp_path / "shot.png"
@@ -115,10 +97,7 @@ def test_windowed_daemon_captures_the_running_viewport(tmp_path, daemon_runtime_
             # pre-check above should have caught it, but honor it as a skip if it slips
             # through (env race), not a failure.
             code = _error_code(started.stdout)
-            if code in _NO_DISPLAY_CODES:
-                pytest.skip(
-                    f"windowed session unavailable in this environment ({code})"
-                )
+            handle_no_display_code(code)
             raise AssertionError(started.stdout + started.stderr)
         assert json.loads(started.stdout)["windowed"] is True
 
@@ -129,10 +108,7 @@ def test_windowed_daemon_captures_the_running_viewport(tmp_path, daemon_runtime_
         cap = run("screen", "capture", "--output", str(out))
         if cap.returncode != 0:
             code = _error_code(cap.stdout)
-            if code in _NO_DISPLAY_CODES:
-                pytest.skip(
-                    f"windowed session unavailable in this environment ({code})"
-                )
+            handle_no_display_code(code)
             raise AssertionError(cap.stdout + cap.stderr)  # a real capture failure
         doc = json.loads(cap.stdout)
         assert doc["format"] == "png"

--- a/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
+++ b/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
@@ -27,7 +27,7 @@ import sys
 import pytest
 
 from gda.binary import resolve_godot_binary
-from gda.display import windowed_unavailable_reason
+from gda.display import windowed_unavailable
 
 import build_config
 
@@ -75,9 +75,9 @@ def test_windowed_daemon_captures_the_running_viewport(tmp_path, daemon_runtime_
     # can't launch there. Uses gda's shared display helper (the same one gda's
     # `daemon start --windowed` precondition keys on, #345), so the pre-check and the
     # tool agree. Runs for real on a genuine desktop (macOS Aqua / Linux+DISPLAY).
-    reason = windowed_unavailable_reason()
-    if reason is not None:
-        pytest.skip(reason)
+    unavailable = windowed_unavailable()
+    if unavailable is not None:
+        pytest.skip(unavailable.reason)
     project = _make_project_copy(tmp_path / "game")
     env = {**os.environ}
     out = tmp_path / "shot.png"

--- a/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
+++ b/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
@@ -92,19 +92,22 @@ def test_windowed_daemon_captures_the_running_viewport(tmp_path, daemon_runtime_
     try:
         started = run("daemon", "start", "--windowed")
         if started.returncode != 0:
-            # gda refuses `daemon start --windowed` pre-launch with the typed
-            # live_windowed_unavailable where no DisplayServer is usable (#345); the
-            # pre-check above should have caught it, but honor it as a skip if it slips
-            # through (env race), not a failure.
+            # gda refuses `daemon start --windowed` pre-launch with a typed display
+            # code (#345). The pre-check above should have caught it, but honor it if
+            # it slips through — via the shared policy, because the reaction SPLITS
+            # (#667): a CAPABILITY verdict is an env race and skips, a
+            # live_windowed_permission_denied says this whole run is confined and
+            # FAILS loudly. Anything else is a real failure.
             code = _error_code(started.stdout)
             handle_no_display_code(code)
             raise AssertionError(started.stdout + started.stderr)
         assert json.loads(started.stdout)["windowed"] is True
 
         # `screen capture` writes a real PNG of the running game's viewport. The
-        # windowed session launches lazily here; if this environment can't bring up
-        # a window server after all (despite the pre-check), the daemon reports a
-        # display/session code — skip rather than fail (env limitation, not a bug).
+        # windowed session launches lazily here; if this environment can't bring up a
+        # window server after all (despite the pre-check), the daemon reports a
+        # display/session code — routed through the shared policy: a capability code
+        # skips (env limitation, not a bug), a permission code fails loudly (#667).
         cap = run("screen", "capture", "--output", str(out))
         if cap.returncode != 0:
             code = _error_code(cap.stdout)

--- a/examples/platformer/panda-adventure/tests/test_obstacle_texture_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_obstacle_texture_e2e.py
@@ -38,7 +38,7 @@ import time
 import pytest
 
 from gda.binary import resolve_godot_binary
-from gda.display import windowed_unavailable_reason
+from gda.display import windowed_unavailable
 
 import build_config
 
@@ -106,9 +106,9 @@ def _make_project_copy(dst):
 
 @pytest.mark.e2e
 def test_obstacle_renders_the_texture(tmp_path, daemon_runtime_dir):
-    reason = windowed_unavailable_reason()
-    if reason is not None:
-        pytest.skip(reason)
+    unavailable = windowed_unavailable()
+    if unavailable is not None:
+        pytest.skip(unavailable.reason)
     project = _make_project_copy(tmp_path / "game")
     env = {**os.environ}
     out = tmp_path / "shot.png"

--- a/examples/platformer/panda-adventure/tests/test_obstacle_texture_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_obstacle_texture_e2e.py
@@ -52,7 +52,15 @@ PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 _COPY_IGNORE = shutil.ignore_patterns(
     "tests", ".godot", "build", "generated", "__pycache__"
 )
-_NO_DISPLAY_CODES = {"live_windowed_unavailable", "live_display_unavailable"}
+# The daemon's typed no-display refusals. A display state can change between the
+# pre-check and the live call, so any of these is a SKIP, not a failure. Includes
+# live_windowed_permission_denied (#667): a confined run cannot reach the window
+# server, which is an environment gap like the others — never a demo defect.
+_NO_DISPLAY_CODES = {
+    "live_windowed_unavailable",
+    "live_windowed_permission_denied",
+    "live_display_unavailable",
+}
 
 
 def _error_code(stdout: str) -> str | None:

--- a/examples/platformer/panda-adventure/tests/test_obstacle_texture_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_obstacle_texture_e2e.py
@@ -38,9 +38,8 @@ import time
 import pytest
 
 from gda.binary import resolve_godot_binary
-from gda.display import windowed_unavailable
-
 import build_config
+from display_gate import handle_no_display_code, require_windowed_host
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
@@ -52,15 +51,6 @@ PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 _COPY_IGNORE = shutil.ignore_patterns(
     "tests", ".godot", "build", "generated", "__pycache__"
 )
-# The daemon's typed no-display refusals. A display state can change between the
-# pre-check and the live call, so any of these is a SKIP, not a failure. Includes
-# live_windowed_permission_denied (#667): a confined run cannot reach the window
-# server, which is an environment gap like the others — never a demo defect.
-_NO_DISPLAY_CODES = {
-    "live_windowed_unavailable",
-    "live_windowed_permission_denied",
-    "live_display_unavailable",
-}
 
 
 def _error_code(stdout: str) -> str | None:
@@ -114,9 +104,7 @@ def _make_project_copy(dst):
 
 @pytest.mark.e2e
 def test_obstacle_renders_the_texture(tmp_path, daemon_runtime_dir):
-    unavailable = windowed_unavailable()
-    if unavailable is not None:
-        pytest.skip(unavailable.reason)
+    require_windowed_host()
     project = _make_project_copy(tmp_path / "game")
     env = {**os.environ}
     out = tmp_path / "shot.png"
@@ -142,8 +130,7 @@ def test_obstacle_renders_the_texture(tmp_path, daemon_runtime_dir):
         started = run("daemon", "start", "--windowed")
         if started.returncode != 0:
             code = _error_code(started.stdout)
-            if code in _NO_DISPLAY_CODES:
-                pytest.skip(f"windowed session unavailable ({code})")
+            handle_no_display_code(code)
             raise AssertionError(started.stdout + started.stderr)
         assert json.loads(started.stdout)["windowed"] is True
 
@@ -165,8 +152,7 @@ def test_obstacle_renders_the_texture(tmp_path, daemon_runtime_dir):
         cap = run("screen", "capture", "--output", str(out))
         if cap.returncode != 0:
             code = _error_code(cap.stdout)
-            if code in _NO_DISPLAY_CODES:
-                pytest.skip(f"windowed session unavailable ({code})")
+            handle_no_display_code(code)
             raise AssertionError(cap.stdout + cap.stderr)
         doc = json.loads(cap.stdout)
         assert doc["format"] == "png"

--- a/examples/platformer/panda-adventure/tests/test_visual_smoke_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_visual_smoke_e2e.py
@@ -83,6 +83,7 @@ import pytest
 from gda.binary import resolve_godot_binary
 
 import build_config
+from display_gate import handle_no_display_code, require_windowed_host
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
@@ -93,18 +94,6 @@ GAME_DIR = build_config.GAME_DIR
 _COPY_IGNORE = shutil.ignore_patterns(
     "tests", ".godot", "build", "generated", "__pycache__"
 )
-
-# Daemon error codes meaning "this environment cannot show a window" — a skip
-# signal, not a failure (the test_e2e_screenshot.py precedent, #345).
-# The daemon's typed no-display refusals. A display state can change between the
-# pre-check and the live call, so any of these is a SKIP, not a failure. Includes
-# live_windowed_permission_denied (#667): a confined run cannot reach the window
-# server, which is an environment gap like the others — never a demo defect.
-_NO_DISPLAY_CODES = {
-    "live_windowed_unavailable",
-    "live_windowed_permission_denied",
-    "live_display_unavailable",
-}
 
 _HUD_LABEL = "/root/Main/Hud/Stats/%sLabel"
 
@@ -341,11 +330,7 @@ def _error_code(stdout: str) -> str | None:
 def test_player_visible_surface_renders_in_the_windowed_viewport(
     tmp_path, daemon_runtime_dir
 ):
-    from gda.display import windowed_unavailable
-
-    unavailable = windowed_unavailable()
-    if unavailable is not None:
-        pytest.skip(unavailable.reason)
+    require_windowed_host()
 
     project = _make_project_copy(tmp_path / "game")
 
@@ -471,8 +456,7 @@ def test_player_visible_surface_renders_in_the_windowed_viewport(
         cap = run("screen", "capture", "--output", str(out))
         if cap.returncode != 0:
             code = _error_code(cap.stdout)
-            if code in _NO_DISPLAY_CODES:
-                pytest.skip(f"windowed session unavailable ({code})")
+            handle_no_display_code(code)
             raise AssertionError(cap.stdout + cap.stderr)
         doc = json.loads(cap.stdout)
         assert doc["format"] == "png"
@@ -491,8 +475,7 @@ def test_player_visible_surface_renders_in_the_windowed_viewport(
         started = run("daemon", "start", "--windowed")
         if started.returncode != 0:
             code = _error_code(started.stdout)
-            if code in _NO_DISPLAY_CODES:
-                pytest.skip(f"windowed session unavailable ({code})")
+            handle_no_display_code(code)
             raise AssertionError(started.stdout + started.stderr)
         assert json.loads(started.stdout)["windowed"] is True
 
@@ -502,8 +485,7 @@ def test_player_visible_surface_renders_in_the_windowed_viewport(
         tree = run("game", "tree")
         if tree.returncode != 0:
             code = _error_code(tree.stdout)
-            if code in _NO_DISPLAY_CODES:
-                pytest.skip(f"windowed session unavailable ({code})")
+            handle_no_display_code(code)
             raise AssertionError(tree.stdout + tree.stderr)
 
         # --- Beat 1: boot. HUD live, Player landed, camera settled — this

--- a/examples/platformer/panda-adventure/tests/test_visual_smoke_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_visual_smoke_e2e.py
@@ -333,11 +333,11 @@ def _error_code(stdout: str) -> str | None:
 def test_player_visible_surface_renders_in_the_windowed_viewport(
     tmp_path, daemon_runtime_dir
 ):
-    from gda.display import windowed_unavailable_reason
+    from gda.display import windowed_unavailable
 
-    reason = windowed_unavailable_reason()
-    if reason is not None:
-        pytest.skip(reason)
+    unavailable = windowed_unavailable()
+    if unavailable is not None:
+        pytest.skip(unavailable.reason)
 
     project = _make_project_copy(tmp_path / "game")
 

--- a/examples/platformer/panda-adventure/tests/test_visual_smoke_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_visual_smoke_e2e.py
@@ -96,7 +96,15 @@ _COPY_IGNORE = shutil.ignore_patterns(
 
 # Daemon error codes meaning "this environment cannot show a window" — a skip
 # signal, not a failure (the test_e2e_screenshot.py precedent, #345).
-_NO_DISPLAY_CODES = {"live_windowed_unavailable", "live_display_unavailable"}
+# The daemon's typed no-display refusals. A display state can change between the
+# pre-check and the live call, so any of these is a SKIP, not a failure. Includes
+# live_windowed_permission_denied (#667): a confined run cannot reach the window
+# server, which is an environment gap like the others — never a demo defect.
+_NO_DISPLAY_CODES = {
+    "live_windowed_unavailable",
+    "live_windowed_permission_denied",
+    "live_display_unavailable",
+}
 
 _HUD_LABEL = "/root/Main/Hud/Stats/%sLabel"
 

--- a/examples/platformer/panda-adventure/tests/test_visual_smoke_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_visual_smoke_e2e.py
@@ -481,7 +481,9 @@ def test_player_visible_surface_renders_in_the_windowed_viewport(
 
         # The Engine session launches lazily on the first live op; if this
         # environment can't bring up a window after all (env race past the
-        # pre-check), the daemon reports a display code — skip, not fail.
+        # pre-check), the daemon reports a display code — the shared policy decides
+        # the reaction: a capability code skips, live_windowed_permission_denied
+        # fails loudly because a confined run must not pass silently (#667).
         tree = run("game", "tree")
         if tree.returncode != 0:
             code = _error_code(tree.stdout)

--- a/src/gda/commands/daemon.py
+++ b/src/gda/commands/daemon.py
@@ -525,10 +525,11 @@ def run_daemon_start_operation(
         # live_windowed_unavailable (ENVIRONMENT / 127), mirroring the platform
         # precondition above. `daemon start` is where `windowed` already flows in.
         #
-        # The probe decides WHICH refusal (#667): a host with no window server is
-        # live_windowed_unavailable, but a host that has one this process may not
-        # reach is live_windowed_permission_denied — the difference between "skip
-        # rendered QA on this machine" and "re-run outside the sandbox". Both carry
+        # The probe decides WHICH refusal (#667): no detected window-server session
+        # is live_windowed_unavailable; a DENIED window-server lookup — which proves
+        # nothing about whether the host has one — is live_windowed_permission_denied,
+        # i.e. "skip rendered QA here" versus "re-run outside the restriction to find
+        # out". Both carry
         # the deciding probe as machine-readable envelope context (ADR-0004
         # amendment) so an agent branches without parsing the sentence.
         unavailable = (display_check or windowed_unavailable)()

--- a/src/gda/commands/daemon.py
+++ b/src/gda/commands/daemon.py
@@ -43,7 +43,7 @@ from gda.daemon.discovery import (
     daemon_pid,
     within_uds_limit,
 )
-from gda.display import windowed_unavailable_reason
+from gda.display import WindowedUnavailable, windowed_unavailable
 from gda.daemon.protocol import read_message, write_message
 from gda.daemon.server import STATUS_OP, STOP_OP
 from gda.dispatch import dispatch_recipe
@@ -252,10 +252,12 @@ _VERSION_RE = re.compile(r"(\d+)\.(\d+)")
 # Seams tests override to avoid launching a real process / running the engine.
 SpawnDaemon = Callable[[Path, str, bool, Optional[str]], None]
 VersionCheck = Callable[[str], Optional[tuple]]
-# The pre-launch host-display precondition seam (#345): returns the reason a
-# windowed session cannot come up here, or None when it can. Injected in unit tests
-# so a display-less CI host does not spuriously refuse a windowed start.
-DisplayCheck = Callable[[], Optional[str]]
+# The pre-launch host-display precondition seam (#345, #667): returns the verdict
+# for why a windowed session cannot come up here — which registered code, the prose,
+# and the probe that decided it — or None when it can. Injected in unit tests so a
+# display-less CI host does not spuriously refuse a windowed start, and so the
+# capability/permission split is exercised without needing a real sandbox.
+DisplayCheck = Callable[[], Optional[WindowedUnavailable]]
 
 
 def _is_unix() -> bool:
@@ -522,9 +524,21 @@ def run_daemon_start_operation(
         # pre-launch, pre-harness-install, WITHOUT spawning — with the typed
         # live_windowed_unavailable (ENVIRONMENT / 127), mirroring the platform
         # precondition above. `daemon start` is where `windowed` already flows in.
-        reason = (display_check or windowed_unavailable_reason)()
-        if reason is not None:
-            return make_failure("live_windowed_unavailable", reason, "")
+        #
+        # The probe decides WHICH refusal (#667): a host with no window server is
+        # live_windowed_unavailable, but a host that has one this process may not
+        # reach is live_windowed_permission_denied — the difference between "skip
+        # rendered QA on this machine" and "re-run outside the sandbox". Both carry
+        # the deciding probe as machine-readable envelope context (ADR-0004
+        # amendment) so an agent branches without parsing the sentence.
+        unavailable = (display_check or windowed_unavailable)()
+        if unavailable is not None:
+            return make_failure(
+                unavailable.code,
+                unavailable.reason,
+                "",
+                probe=unavailable.probe,
+            )
 
     # The harness install happens BEFORE the daemon exists, so everything from the
     # install onward runs against a project gda has already mutated. The snapshot is

--- a/src/gda/daemon/protocol.py
+++ b/src/gda/daemon/protocol.py
@@ -18,6 +18,7 @@ import struct
 from typing import Any
 
 from gda.exit_codes import EXIT_LIVE
+from gda.models import EnvironmentProbe
 from gda.parser import build_result, error_envelope
 
 _LENGTH = struct.Struct(">I")  # 4-byte big-endian frame length
@@ -74,7 +75,12 @@ def result_reply(payload: Any) -> dict:
     return _reply(payload, 0)
 
 
-def error_reply(code: str, message: str, diagnostics: str = "") -> dict:
+def error_reply(
+    code: str,
+    message: str,
+    diagnostics: str = "",
+    probe: EnvironmentProbe | None = None,
+) -> dict:
     """A daemon→CLI reply carrying a LIVE error envelope (exit ``EXIT_LIVE``).
 
     The single builder for a daemon- or client-synthesized live failure (no session,
@@ -86,8 +92,21 @@ def error_reply(code: str, message: str, diagnostics: str = "") -> dict:
     — the wire envelope shape ``{stdout, stderr, exit_code}`` is unchanged — so it
     flows the established ``stderr`` → ``RunResult.stderr`` → ``GdaError.diagnostics``
     path, staying within ADR-0002's advisory-stderr carve-out.
+
+    ``probe`` is the optional structured host-probe context (#667). Unlike
+    ``diagnostics`` it cannot ride ``stderr`` — it is DATA an agent branches on, not
+    advisory prose — so it is carried as an optional key inside the error envelope,
+    omitted when absent. That keeps every other reply byte-identical while letting
+    the daemon's authoritative windowed refusal deliver the same envelope the CLI's
+    own fail-fast does.
     """
-    return _reply(error_envelope(code, message), EXIT_LIVE, stderr=diagnostics)
+    return _reply(
+        error_envelope(
+            code, message, probe.model_dump() if probe is not None else None
+        ),
+        EXIT_LIVE,
+        stderr=diagnostics,
+    )
 
 
 def _reply(payload: Any, exit_code: int, stderr: str = "") -> dict:

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -187,16 +187,16 @@ class DaemonServer:
             # the probe's reason as diagnostics. The remediation differs per code, so
             # the message is the verdict's own rather than one shared sentence.
             #
-            # The machine-readable `probe` context does NOT ride this path: the
-            # daemon→CLI wire envelope is ADR-0002's `{code, message}` (extra keys
-            # rejected), so widening it is a cross-language contract change this
-            # slice deliberately does not make. The field is populated where the
-            # probe RAN in-process — `gda daemon start --windowed`, the site the
-            # dogfooding hit — and the code + prose carry the distinction here.
+            # This is the AUTHORITATIVE refusal — the one that fires on the lazy
+            # launch every live op goes through — so it carries the same
+            # machine-readable `probe` context the CLI fail-fast does, via the live
+            # envelope's optional key (#667 review). Reporting less here than at the
+            # optional fail-fast would make the authoritative path the poorer one.
             return error_reply(
                 unavailable.verdict.code,
                 f"a windowed engine session cannot launch: {unavailable.reason}",
                 diagnostics=unavailable.reason,
+                probe=unavailable.verdict.probe,
             )
         if session is None:
             return error_reply(

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -23,7 +23,7 @@ from gda.daemon.session import (
     WindowedDisplayUnavailable,
     launch_session,
 )
-from gda.display import windowed_unavailable_reason
+from gda.display import WindowedUnavailable, windowed_unavailable
 
 # Control ops on the CLI socket — daemon lifetime, not project domain ops.
 STATUS_OP = "__status__"
@@ -48,7 +48,7 @@ class DaemonServer:
         godot: str = "",
         windowed: bool = False,
         scene: str | None = None,
-        display_check: Optional[Callable[[], Optional[str]]] = None,
+        display_check: Optional[Callable[[], Optional[WindowedUnavailable]]] = None,
     ) -> None:
         self.paths = paths
         self.godot = godot
@@ -66,7 +66,7 @@ class DaemonServer:
         # windowed session cannot come up on this host, or None when it can. Injectable
         # so tests drive the guard without a real display; defaults to the shared
         # gda.display probe. Consulted only for a windowed session.
-        self._display_check = display_check or windowed_unavailable_reason
+        self._display_check = display_check or windowed_unavailable
         self._token = secrets.token_hex(16)
         self._stopping = False
         self._listener: socket.socket | None = None
@@ -180,13 +180,21 @@ class DaemonServer:
             )
         except WindowedDisplayUnavailable as unavailable:
             # The authoritative no-display guard fired at the launch boundary (#345):
-            # no windowed engine was spawned. Surface the typed
-            # live_windowed_unavailable, carrying the probe's reason as diagnostics.
+            # no windowed engine was spawned. Surface the code the PROBE decided —
+            # live_windowed_unavailable, or live_windowed_permission_denied when the
+            # host has a window server this process may not reach (#667) — carrying
+            # the probe's reason as diagnostics. The remediation differs per code, so
+            # the message is the verdict's own rather than one shared sentence.
+            #
+            # The machine-readable `probe` context does NOT ride this path: the
+            # daemon→CLI wire envelope is ADR-0002's `{code, message}` (extra keys
+            # rejected), so widening it is a cross-language contract change this
+            # slice deliberately does not make. The field is populated where the
+            # probe RAN in-process — `gda daemon start --windowed`, the site the
+            # dogfooding hit — and the code + prose carry the distinction here.
             return error_reply(
-                "live_windowed_unavailable",
-                "a windowed engine session cannot launch: the host has no usable "
-                f"DisplayServer ({unavailable.reason}). Run the daemon headless, or "
-                "start it on a host with an on-console GUI session / $DISPLAY",
+                unavailable.verdict.code,
+                f"a windowed engine session cannot launch: {unavailable.reason}",
                 diagnostics=unavailable.reason,
             )
         if session is None:
@@ -264,9 +272,9 @@ class DaemonServer:
         # the same check as an OPTIONAL fail-fast, but this is the one that guarantees a
         # doomed windowed engine is never spawned even when start slipped through.
         if self.windowed:
-            reason = self._display_check()
-            if reason is not None:
-                raise WindowedDisplayUnavailable(reason)
+            verdict = self._display_check()
+            if verdict is not None:
+                raise WindowedDisplayUnavailable(verdict)
         # A res:// / filesystem scene selector that names no file is rejected HERE,
         # at the launch boundary (NOT per-request — finding 1), as a typed
         # SceneMismatch. Godot does not fall-back-and-run for a missing res:// path:

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -181,8 +181,9 @@ class DaemonServer:
         except WindowedDisplayUnavailable as unavailable:
             # The authoritative no-display guard fired at the launch boundary (#345):
             # no windowed engine was spawned. Surface the code the PROBE decided —
-            # live_windowed_unavailable, or live_windowed_permission_denied when the
-            # host has a window server this process may not reach (#667) — carrying
+            # live_windowed_unavailable, or live_windowed_permission_denied when this
+            # process is denied the window-server lookup (which proves nothing about
+            # whether the host has one, #667) — carrying
             # the probe's reason as diagnostics. The remediation differs per code, so
             # the message is the verdict's own rather than one shared sentence.
             #

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Optional
 
 from gda.daemon.protocol import error_reply, read_frame, write_message
+from gda.display import WindowedUnavailable
 
 LAUNCH_MARKER = "gda-daemon"
 # Engine boot + autoload + harness connect; a windowed/cold start can be slow.
@@ -61,14 +62,18 @@ class WindowedDisplayUnavailable(Exception):
     windowed daemon's pre-launch host-display check fails — a windowed Godot would
     abort during ``DisplayServer`` registration otherwise (#345). Mirrors
     :class:`SceneMismatch`: a typed launch-boundary signal the daemon maps to the
-    ``live_windowed_unavailable`` error code, distinct from a generic launch failure
-    (``launch_session`` returns ``None``). ``reason`` is the host-display probe's
-    human-readable explanation.
+    probe's own error code — ``live_windowed_unavailable`` when the host has no
+    window server, ``live_windowed_permission_denied`` when it has one this process
+    may not reach (#667) — distinct from a generic launch failure
+    (``launch_session`` returns ``None``). It carries the whole ``verdict`` rather
+    than only its prose, so the daemon relays the code the probe decided instead of
+    re-deciding it here.
     """
 
-    def __init__(self, reason: str) -> None:
-        super().__init__(reason)
-        self.reason = reason
+    def __init__(self, verdict: WindowedUnavailable) -> None:
+        super().__init__(verdict.reason)
+        self.verdict = verdict
+        self.reason = verdict.reason
 
 
 class EngineSession:

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -62,9 +62,10 @@ class WindowedDisplayUnavailable(Exception):
     windowed daemon's pre-launch host-display check fails — a windowed Godot would
     abort during ``DisplayServer`` registration otherwise (#345). Mirrors
     :class:`SceneMismatch`: a typed launch-boundary signal the daemon maps to the
-    probe's own error code — ``live_windowed_unavailable`` when the host has no
-    window server, ``live_windowed_permission_denied`` when it has one this process
-    may not reach (#667) — distinct from a generic launch failure
+    probe's own error code — ``live_windowed_unavailable`` when no window-server
+    session is detected, ``live_windowed_permission_denied`` when this process is
+    denied the window-server lookup (which proves nothing about whether the host
+    has one, #667) — distinct from a generic launch failure
     (``launch_session`` returns ``None``). It carries the whole ``verdict`` rather
     than only its prose, so the daemon relays the code the probe decided instead of
     re-deciding it here.

--- a/src/gda/display.py
+++ b/src/gda/display.py
@@ -1,4 +1,4 @@
-"""Host DisplayServer probe for windowed live sessions (#345).
+"""Host DisplayServer probe for windowed live sessions (#345, #667).
 
 A windowed [Engine session](../../CONTEXT.md) (``gda daemon start --windowed``)
 needs a usable host ``DisplayServer`` to bring up a real viewport; on a host with
@@ -6,8 +6,18 @@ none, Godot aborts during ``DisplayServer`` / AppKit registration BEFORE its fil
 logger is installed, so the failure is otherwise only a generic
 ``engine_session_not_running`` with an empty log tail (#345 Part A). This module
 answers, PRE-LAUNCH, whether THIS host can show a window, so ``gda daemon start
---windowed`` can refuse fast with the typed ``live_windowed_unavailable``
-(ENVIRONMENT / exit 127) instead of spawning a doomed engine.
+--windowed`` can refuse fast with a typed ENVIRONMENT failure (exit 127) instead
+of spawning a doomed engine.
+
+It answers with a *verdict*, not a bare boolean, because "no window here" has two
+causes that need OPPOSITE reactions from an agent (#667):
+
+- the host genuinely has no window server (SSH, CI, a headless box) —
+  ``live_windowed_unavailable``: this machine cannot do rendered QA, skip it;
+- the host HAS one but THIS PROCESS is denied access to it (a sandbox) —
+  ``live_windowed_permission_denied``: retry outside the restriction. Reading this
+  as the first cause is exactly the dogfooded defect (GDA-DF-029): a sandboxed run
+  was recorded as a machine-capability gap and rendered QA was silently skipped.
 
 Platform-dispatched (live is UNIX-only via ``live_unsupported_platform``, ADR-0021,
 so Windows is a documented, unreachable-today stub seam — a single clean slot, not a
@@ -18,9 +28,13 @@ refactor):
   session; it is NULL over SSH and in headless / sandbox sessions **even when**
   ``launchctl managername`` reports "Aqua". So we deliberately do NOT use
   ``launchctl`` or ``$DISPLAY`` on macOS — that NULL is exactly what predicts a
-  windowed Godot will abort during window-server registration.
+  windowed Godot will abort during window-server registration. The API reports NULL
+  with no error code, so the NULL alone cannot say WHY; :func:`_macos_window_server_denied`
+  answers that second question.
 - **Linux**: a non-empty ``$DISPLAY`` (X11) or ``$WAYLAND_DISPLAY`` (Wayland), so a
-  run under ``xvfb-run`` (which sets ``DISPLAY``) passes.
+  run under ``xvfb-run`` (which sets ``DISPLAY``) passes. No permission split: the
+  variables are readable regardless of confinement, so a Linux verdict is always the
+  capability one.
 - **Windows**: unreachable today; the stub reports "usable" so it never spuriously
   gates on a path live never reaches.
 """
@@ -30,38 +44,107 @@ from __future__ import annotations
 import ctypes
 import os
 import sys
+from dataclasses import dataclass
+
+from gda.models import EnvironmentProbe
+
+_CORE_GRAPHICS = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
+_CORE_FOUNDATION = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+_LIBSYSTEM = "/usr/lib/libSystem.B.dylib"
+
+# The mach service a process must reach to talk to the macOS window server. It is
+# the name sandbox profiles gate (`(allow mach-lookup (global-name …))`), and the
+# one CGSessionCopyCurrentDictionary itself needs — denying it is what makes that
+# API return NULL (verified: a seatbelt profile denying ONLY this name flips the
+# CoreGraphics probe to NULL while the rest of the host is untouched).
+_WINDOW_SERVER_SERVICE = b"com.apple.windowserver.active"
+
+# bootstrap_look_up's "the policy refused this lookup" status, from bootstrap.h.
+# The signal #667's spike was looking for: it is returned ONLY for a DENIED lookup.
+# A service that is merely not registered — the state a host with no window-server
+# session is in — returns BOOTSTRAP_UNKNOWN_SERVICE (1102) instead. So this code
+# cannot be produced by an absent session, which is what makes it safe to classify
+# on: false negatives (a sandbox that hides the service as "unknown" instead)
+# degrade to the capability verdict, but a display-less host can never be
+# mis-reported as a permission problem.
+_BOOTSTRAP_NOT_PRIVILEGED = 1100
 
 
-def has_usable_display() -> bool:
-    """Whether THIS host has a usable ``DisplayServer`` for a windowed session (#345)."""
-    if sys.platform == "darwin":
-        return _macos_has_window_server()
-    if sys.platform.startswith("linux"):
-        return _linux_has_display()
-    return _other_platform_has_display()
+@dataclass(frozen=True)
+class WindowedUnavailable:
+    """Why a windowed live session cannot come up on THIS host (#345, #667).
+
+    ``code`` is the registered ``Gda error code`` the refusal must report —
+    ``live_windowed_unavailable`` (no window server here) or
+    ``live_windowed_permission_denied`` (there is one; we are not allowed in).
+    ``reason`` is the prose for the message/diagnostics, and ``probe`` is the
+    machine-readable :class:`~gda.models.EnvironmentProbe` naming the OS call that
+    decided this verdict, so an agent branches on data rather than on the sentence.
+    """
+
+    code: str
+    reason: str
+    probe: EnvironmentProbe
 
 
-def windowed_unavailable_reason() -> str | None:
-    """Why a windowed live session can't come up on THIS host, or ``None`` if it can.
+def windowed_unavailable() -> WindowedUnavailable | None:
+    """The windowed-session verdict for THIS host, or ``None`` if one can launch.
 
     The single decision point both the ``gda daemon start --windowed`` precondition
-    (``gda.commands.daemon``) and the windowed e2e gates key on, so they agree: ``None`` means
-    "a windowed session can launch here", a string is the skip/refusal reason.
+    (``gda.commands.daemon``), the daemon's authoritative launch-boundary guard
+    (``gda.daemon.server``) and the windowed e2e gates key on, so they agree:
+    ``None`` means "a windowed session can launch here", a verdict is the
+    skip/refusal.
     """
-    if has_usable_display():
-        return None
     if sys.platform == "darwin":
-        return (
-            "no usable macOS window-server session (CGSessionCopyCurrentDictionary "
-            "returned NULL — e.g. SSH / CI / sandbox); a windowed Godot session cannot "
-            "register with the window server here"
-        )
+        return _macos_verdict()
     if sys.platform.startswith("linux"):
-        return (
-            "headless Linux has no DisplayServer ($DISPLAY / $WAYLAND_DISPLAY unset); "
-            "run under a virtual framebuffer such as xvfb-run, which sets DISPLAY"
+        return _linux_verdict()
+    return _other_platform_verdict()
+
+
+def _macos_verdict() -> WindowedUnavailable | None:
+    """The macOS verdict: an on-console GUI session, else WHY not.
+
+    ``CGSessionCopyCurrentDictionary`` decides the capability question; when it says
+    NULL, the window-server mach lookup decides the permission question. Ordering
+    matters — the denial probe runs ONLY on the failure path, so a healthy desktop
+    pays nothing for it.
+    """
+    if _macos_has_window_server():
+        return None
+    if _macos_window_server_denied():
+        return WindowedUnavailable(
+            code="live_windowed_permission_denied",
+            reason=(
+                "this process is denied access to the macOS window server "
+                "(bootstrap_look_up of com.apple.windowserver.active returned "
+                "BOOTSTRAP_NOT_PRIVILEGED — e.g. a sandbox that does not allow "
+                "mach-lookup to it). The host itself HAS a window server, so this "
+                "is a permission boundary, not a missing display: re-run outside "
+                "the sandbox/restriction rather than treating this machine as "
+                "unable to show a window"
+            ),
+            probe=EnvironmentProbe(
+                name="bootstrap_look_up(com.apple.windowserver.active)",
+                platform=sys.platform,
+            ),
         )
-    return "this host has no usable DisplayServer for a windowed session"
+    return WindowedUnavailable(
+        code="live_windowed_unavailable",
+        reason=(
+            "no usable macOS window-server session (CGSessionCopyCurrentDictionary "
+            "returned NULL — e.g. SSH / CI / a headless host); a windowed Godot "
+            "session cannot register with the window server here. No permission "
+            "denial was detected, so this reads as an absent GUI session; if the "
+            "run IS confined, a sandbox that hides the window server rather than "
+            "refusing it is indistinguishable from an absent one here — re-run "
+            "outside the sandbox to tell them apart"
+        ),
+        probe=EnvironmentProbe(
+            name="CGSessionCopyCurrentDictionary", platform=sys.platform
+        ),
+    )
 
 
 def _macos_has_window_server() -> bool:
@@ -76,9 +159,7 @@ def _macos_has_window_server() -> bool:
     genuine no-display abort at the session-launch site.
     """
     try:
-        cg = ctypes.cdll.LoadLibrary(
-            "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
-        )
+        cg = ctypes.cdll.LoadLibrary(_CORE_GRAPHICS)
         cg.CGSessionCopyCurrentDictionary.restype = ctypes.c_void_p
         session = cg.CGSessionCopyCurrentDictionary()
     except Exception:
@@ -86,9 +167,7 @@ def _macos_has_window_server() -> bool:
     if not session:
         return False
     try:  # release the copied CFDictionary to avoid a leak
-        cf = ctypes.cdll.LoadLibrary(
-            "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
-        )
+        cf = ctypes.cdll.LoadLibrary(_CORE_FOUNDATION)
         cf.CFRelease.argtypes = [ctypes.c_void_p]
         cf.CFRelease(ctypes.c_void_p(session))
     except Exception:
@@ -96,12 +175,81 @@ def _macos_has_window_server() -> bool:
     return True
 
 
-def _linux_has_display() -> bool:
-    """A non-empty ``$DISPLAY`` (X11) or ``$WAYLAND_DISPLAY`` (Wayland) — so xvfb-run passes."""
-    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+def _macos_window_server_denied() -> bool:
+    """Is this process DENIED the window-server mach service? (#667)
+
+    ``CGSessionCopyCurrentDictionary`` returns NULL with no error code, so it cannot
+    say whether the window server is absent or merely out of reach. Asking the
+    bootstrap namespace for the service directly does distinguish the two, because
+    ``bootstrap_look_up`` reports the two states with DIFFERENT statuses:
+    ``BOOTSTRAP_NOT_PRIVILEGED`` (1100) for a lookup the policy refused, and
+    ``BOOTSTRAP_UNKNOWN_SERVICE`` (1102) for a name nobody registered.
+
+    Only the refusal is claimed here. That direction is the safe one: a lookup that
+    was NOT denied cannot return 1100, so a genuinely display-less host can never be
+    mis-classified as a permission problem, while a sandbox this probe fails to
+    recognize simply falls back to the existing capability verdict.
+
+    Any failure to run the probe at all (symbol gone on a future macOS, unexpected
+    ``ctypes`` state) returns ``False`` — "no denial evidence" — so the refusal
+    behaves exactly as it did before this probe existed.
+    """
+    try:
+        libsystem = ctypes.CDLL(_LIBSYSTEM)
+        bootstrap_port = ctypes.c_uint32.in_dll(libsystem, "bootstrap_port")
+        libsystem.bootstrap_look_up.restype = ctypes.c_int32
+        libsystem.bootstrap_look_up.argtypes = [
+            ctypes.c_uint32,
+            ctypes.c_char_p,
+            ctypes.POINTER(ctypes.c_uint32),
+        ]
+        service_port = ctypes.c_uint32(0)
+        status = libsystem.bootstrap_look_up(
+            bootstrap_port.value, _WINDOW_SERVER_SERVICE, ctypes.byref(service_port)
+        )
+    except Exception:
+        return False
+    if status == 0 and service_port.value:
+        # The lookup handed back a send right; drop it — this probe wants the
+        # STATUS, not the port, and leaking a right per failed start would be a
+        # slow leak in a long-lived daemon.
+        _release_mach_port(libsystem, service_port.value)
+    return status == _BOOTSTRAP_NOT_PRIVILEGED
 
 
-def _other_platform_has_display() -> bool:
+def _release_mach_port(libsystem: ctypes.CDLL, port: int) -> None:
+    """Best-effort deallocation of a send right the denial probe received."""
+    try:
+        libsystem.mach_task_self.restype = ctypes.c_uint32
+        libsystem.mach_port_deallocate.restype = ctypes.c_int32
+        libsystem.mach_port_deallocate.argtypes = [ctypes.c_uint32, ctypes.c_uint32]
+        libsystem.mach_port_deallocate(libsystem.mach_task_self(), port)
+    except Exception:
+        pass
+
+
+def _linux_verdict() -> WindowedUnavailable | None:
+    """A non-empty ``$DISPLAY`` (X11) or ``$WAYLAND_DISPLAY`` (Wayland) — so xvfb-run passes.
+
+    Environment variables are readable under any confinement, so an unset pair means
+    there is no display to reach — never "a display we are not allowed to reach".
+    Linux therefore has no permission verdict.
+    """
+    if os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"):
+        return None
+    return WindowedUnavailable(
+        code="live_windowed_unavailable",
+        reason=(
+            "headless Linux has no DisplayServer ($DISPLAY / $WAYLAND_DISPLAY unset); "
+            "run under a virtual framebuffer such as xvfb-run, which sets DISPLAY"
+        ),
+        probe=EnvironmentProbe(
+            name="$DISPLAY / $WAYLAND_DISPLAY", platform=sys.platform
+        ),
+    )
+
+
+def _other_platform_verdict() -> WindowedUnavailable | None:
     """Windows stub seam — unreachable today (live is UNIX-only, ADR-0021).
 
     Live operations gate on a UNIX platform (``live_unsupported_platform``) long
@@ -110,4 +258,4 @@ def _other_platform_has_display() -> bool:
     ``GetSystemMetrics(SM_CMONITORS)``) is ever wired in; reports "usable" so it never
     spuriously gates on an unreachable path.
     """
-    return True
+    return None

--- a/src/gda/display.py
+++ b/src/gda/display.py
@@ -12,12 +12,18 @@ of spawning a doomed engine.
 It answers with a *verdict*, not a bare boolean, because "no window here" has two
 causes that need OPPOSITE reactions from an agent (#667):
 
-- the host genuinely has no window server (SSH, CI, a headless box) —
-  ``live_windowed_unavailable``: this machine cannot do rendered QA, skip it;
-- the host HAS one but THIS PROCESS is denied access to it (a sandbox) —
-  ``live_windowed_permission_denied``: retry outside the restriction. Reading this
-  as the first cause is exactly the dogfooded defect (GDA-DF-029): a sandboxed run
-  was recorded as a machine-capability gap and rendered QA was silently skipped.
+- nothing refused us and there is no session — ``live_windowed_unavailable``: as far
+  as gda can tell this machine cannot do rendered QA, so skip it;
+- the window-server lookup was REFUSED — ``live_windowed_permission_denied``: this
+  process may not even ask, so re-run outside the restriction. Reading this as the
+  first cause is exactly the dogfooded defect (GDA-DF-029): a sandboxed run was
+  recorded as a machine-capability gap and rendered QA was silently skipped.
+
+The second verdict deliberately claims only that the LOOKUP was denied — never that
+a window server exists. Seatbelt evaluates a mach-lookup deny per name and before
+resolution, so a blanket-deny profile refuses an unregistered name too; inferring
+existence from the refusal would tell a display-less confined CI Mac that its host
+has a window server (#667 review).
 
 Platform-dispatched (live is UNIX-only via ``live_unsupported_platform``, ADR-0021,
 so Windows is a documented, unreachable-today stub seam — a single clean slot, not a
@@ -29,8 +35,9 @@ refactor):
   ``launchctl managername`` reports "Aqua". So we deliberately do NOT use
   ``launchctl`` or ``$DISPLAY`` on macOS — that NULL is exactly what predicts a
   windowed Godot will abort during window-server registration. The API reports NULL
-  with no error code, so the NULL alone cannot say WHY; :func:`_macos_window_server_denied`
-  answers that second question.
+  with no error code, so the NULL alone cannot say WHY;
+  :func:`_macos_window_server_denial` answers the one further question that IS
+  answerable — was the lookup refused, and how broadly.
 - **Linux**: a non-empty ``$DISPLAY`` (X11) or ``$WAYLAND_DISPLAY`` (Wayland), so a
   run under ``xvfb-run`` (which sets ``DISPLAY``) passes. No permission split: the
   variables are readable regardless of confinement, so a Linux verdict is always the
@@ -44,6 +51,7 @@ from __future__ import annotations
 import ctypes
 import os
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from gda.models import EnvironmentProbe
@@ -59,15 +67,31 @@ _LIBSYSTEM = "/usr/lib/libSystem.B.dylib"
 # CoreGraphics probe to NULL while the rest of the host is untouched).
 _WINDOW_SERVER_SERVICE = b"com.apple.windowserver.active"
 
-# bootstrap_look_up's "the policy refused this lookup" status, from bootstrap.h.
-# The signal #667's spike was looking for: it is returned ONLY for a DENIED lookup.
-# A service that is merely not registered — the state a host with no window-server
-# session is in — returns BOOTSTRAP_UNKNOWN_SERVICE (1102) instead. So this code
-# cannot be produced by an absent session, which is what makes it safe to classify
-# on: false negatives (a sandbox that hides the service as "unknown" instead)
-# degrade to the capability verdict, but a display-less host can never be
-# mis-reported as a permission problem.
+# A name nothing registers, used as the CONTROL lookup (#667 review). Its whole job
+# is to reveal how broad the confinement is — see _macos_window_server_denial.
+_CONTROL_SERVICE = b"com.gda.probe.control.unregistered"
+
+# bootstrap_look_up statuses, from bootstrap.h.
+#
+# What these DO and DO NOT prove (#667 review corrected the original claim):
+# seatbelt evaluates a mach-lookup deny rule PER NAME and BEFORE the name is
+# resolved, so a blanket-deny profile returns NOT_PRIVILEGED for a name nobody
+# registered just as readily as for a real one. NOT_PRIVILEGED therefore proves
+# exactly one thing — "the policy refused THIS lookup" — and carries NO information
+# about whether a window server exists on the host. Claiming existence from it was
+# the falsified inference: a display-less CI Mac under a broad-deny profile would be
+# told the host HAS a window server.
+#
+# UNKNOWN_SERVICE is the not-registered answer, and is only meaningful when the
+# lookup was allowed to resolve at all.
 _BOOTSTRAP_NOT_PRIVILEGED = 1100
+_BOOTSTRAP_UNKNOWN_SERVICE = 1102
+
+# How broad a denial the control lookup revealed. Both mean "denied", so both take
+# the permission verdict; they differ only in what the probe can honestly say about
+# the confinement, never about whether a window server exists.
+_DENIAL_NAME_SPECIFIC = "name-specific"
+_DENIAL_BLANKET = "blanket"
 
 
 @dataclass(frozen=True)
@@ -75,8 +99,9 @@ class WindowedUnavailable:
     """Why a windowed live session cannot come up on THIS host (#345, #667).
 
     ``code`` is the registered ``Gda error code`` the refusal must report —
-    ``live_windowed_unavailable`` (no window server here) or
-    ``live_windowed_permission_denied`` (there is one; we are not allowed in).
+    ``live_windowed_unavailable`` (nothing refused us and no session is reachable) or
+    ``live_windowed_permission_denied`` (the lookup itself was refused, so whether a
+    window server exists is unknown).
     ``reason`` is the prose for the message/diagnostics, and ``probe`` is the
     machine-readable :class:`~gda.models.EnvironmentProbe` naming the OS call that
     decided this verdict, so an agent branches on data rather than on the sentence.
@@ -113,17 +138,27 @@ def _macos_verdict() -> WindowedUnavailable | None:
     """
     if _macos_has_window_server():
         return None
-    if _macos_window_server_denied():
+    denial = _macos_window_server_denial()
+    if denial is not None:
+        breadth = (
+            "the denial is specific to that service (a control lookup of an "
+            "unregistered name still resolved normally), which is the signature of "
+            "a sandbox profile that gates the window server"
+            if denial is _DENIAL_NAME_SPECIFIC
+            else "a control lookup of an unregistered name was refused too, so this "
+            "process is broadly confined and the probe learned only that much"
+        )
         return WindowedUnavailable(
             code="live_windowed_permission_denied",
             reason=(
-                "this process is denied access to the macOS window server "
+                "this process is denied the macOS window-server lookup "
                 "(bootstrap_look_up of com.apple.windowserver.active returned "
-                "BOOTSTRAP_NOT_PRIVILEGED — e.g. a sandbox that does not allow "
-                "mach-lookup to it). The host itself HAS a window server, so this "
-                "is a permission boundary, not a missing display: re-run outside "
-                "the sandbox/restriction rather than treating this machine as "
-                "unable to show a window"
+                f"BOOTSTRAP_NOT_PRIVILEGED — e.g. a sandbox); {breadth}. gda cannot "
+                "tell from a refused lookup whether this host HAS a window server, "
+                "only that this process may not ask: re-run outside the "
+                "sandbox/restriction to find out — if a windowed session comes up "
+                "there, this was a permission boundary; if it fails the same way, "
+                "the host genuinely has none"
             ),
             probe=EnvironmentProbe(
                 name="bootstrap_look_up(com.apple.windowserver.active)",
@@ -135,11 +170,12 @@ def _macos_verdict() -> WindowedUnavailable | None:
         reason=(
             "no usable macOS window-server session (CGSessionCopyCurrentDictionary "
             "returned NULL — e.g. SSH / CI / a headless host); a windowed Godot "
-            "session cannot register with the window server here. No permission "
-            "denial was detected, so this reads as an absent GUI session; if the "
-            "run IS confined, a sandbox that hides the window server rather than "
-            "refusing it is indistinguishable from an absent one here — re-run "
-            "outside the sandbox to tell them apart"
+            "session cannot register with the window server here. Run the daemon "
+            "headless instead, or start it on a host with an on-console GUI session. "
+            "No permission denial was detected, so this reads as an absent GUI "
+            "session; if the run IS confined, a sandbox that hides the window server "
+            "rather than refusing it is indistinguishable from an absent one here — "
+            "re-run outside the sandbox to tell them apart"
         ),
         probe=EnvironmentProbe(
             name="CGSessionCopyCurrentDictionary", platform=sys.platform
@@ -175,46 +211,82 @@ def _macos_has_window_server() -> bool:
     return True
 
 
-def _macos_window_server_denied() -> bool:
-    """Is this process DENIED the window-server mach service? (#667)
+def _macos_window_server_denial() -> str | None:
+    """Was this process DENIED the window-server lookup, and how broadly? (#667)
 
     ``CGSessionCopyCurrentDictionary`` returns NULL with no error code, so it cannot
     say whether the window server is absent or merely out of reach. Asking the
-    bootstrap namespace for the service directly does distinguish the two, because
-    ``bootstrap_look_up`` reports the two states with DIFFERENT statuses:
-    ``BOOTSTRAP_NOT_PRIVILEGED`` (1100) for a lookup the policy refused, and
-    ``BOOTSTRAP_UNKNOWN_SERVICE`` (1102) for a name nobody registered.
+    bootstrap namespace directly answers a NARROWER question that is still worth
+    asking: was the lookup *refused*? ``BOOTSTRAP_NOT_PRIVILEGED`` means the policy
+    said no — which an absent service never produces on its own, so it is real
+    evidence of confinement.
 
-    Only the refusal is claimed here. That direction is the safe one: a lookup that
-    was NOT denied cannot return 1100, so a genuinely display-less host can never be
-    mis-classified as a permission problem, while a sandbox this probe fails to
-    recognize simply falls back to the existing capability verdict.
+    What it is NOT evidence of is that a window server exists. Seatbelt evaluates a
+    mach-lookup deny PER NAME and BEFORE resolving it, so a blanket-deny profile
+    refuses an unregistered name just as readily (verified). That is why the CONTROL
+    lookup exists: a name nothing registers is looked up too, and its answer says how
+    broad the confinement is —
 
-    Any failure to run the probe at all (symbol gone on a future macOS, unexpected
-    ``ctypes`` state) returns ``False`` — "no denial evidence" — so the refusal
-    behaves exactly as it did before this probe existed.
+    - control ``UNKNOWN_SERVICE`` + target refused → the denial is **name-specific**:
+      lookups do resolve here, and this one name is gated. The sandbox signature.
+    - control refused as well → **blanket** confinement; the probe learned only that
+      this process is confined.
+
+    Neither branch licenses a claim about the host's display: both report the same
+    permission verdict, and the caller's wording says so. Returns ``None`` when there
+    is no denial evidence at all, including any failure to run the probe (symbol gone
+    on a future macOS, unexpected ``ctypes`` state) — so the refusal then behaves
+    exactly as it did before this probe existed.
     """
     try:
-        libsystem = ctypes.CDLL(_LIBSYSTEM)
-        bootstrap_port = ctypes.c_uint32.in_dll(libsystem, "bootstrap_port")
-        libsystem.bootstrap_look_up.restype = ctypes.c_int32
-        libsystem.bootstrap_look_up.argtypes = [
-            ctypes.c_uint32,
-            ctypes.c_char_p,
-            ctypes.POINTER(ctypes.c_uint32),
-        ]
+        lookup = _bootstrap_lookup()
+    except Exception:
+        return None
+    return _classify_denial(lookup)
+
+
+def _classify_denial(lookup: "Callable[[bytes], int]") -> str | None:
+    """Map the target + control lookup statuses onto a denial breadth (#667).
+
+    Split from the ``ctypes`` wiring so the decision — the part with the actual
+    reasoning in it — is exercised by handing it a fake ``lookup`` on ANY host,
+    including a Linux CI runner with no libSystem at all.
+    """
+    if lookup(_WINDOW_SERVER_SERVICE) != _BOOTSTRAP_NOT_PRIVILEGED:
+        return None
+    if lookup(_CONTROL_SERVICE) == _BOOTSTRAP_UNKNOWN_SERVICE:
+        return _DENIAL_NAME_SPECIFIC
+    return _DENIAL_BLANKET
+
+
+def _bootstrap_lookup() -> "Callable[[bytes], int]":
+    """Bind ``bootstrap_look_up`` and return a name → status callable.
+
+    Raises if the symbol or the bootstrap port cannot be bound, which the caller
+    treats as "no denial evidence".
+    """
+    libsystem = ctypes.CDLL(_LIBSYSTEM)
+    bootstrap_port = ctypes.c_uint32.in_dll(libsystem, "bootstrap_port")
+    libsystem.bootstrap_look_up.restype = ctypes.c_int32
+    libsystem.bootstrap_look_up.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_char_p,
+        ctypes.POINTER(ctypes.c_uint32),
+    ]
+
+    def _lookup(name: bytes) -> int:
         service_port = ctypes.c_uint32(0)
         status = libsystem.bootstrap_look_up(
-            bootstrap_port.value, _WINDOW_SERVER_SERVICE, ctypes.byref(service_port)
+            bootstrap_port.value, name, ctypes.byref(service_port)
         )
-    except Exception:
-        return False
-    if status == 0 and service_port.value:
-        # The lookup handed back a send right; drop it — this probe wants the
-        # STATUS, not the port, and leaking a right per failed start would be a
-        # slow leak in a long-lived daemon.
-        _release_mach_port(libsystem, service_port.value)
-    return status == _BOOTSTRAP_NOT_PRIVILEGED
+        if status == 0 and service_port.value:
+            # The lookup handed back a send right; drop it — this probe wants the
+            # STATUS, not the port, and leaking a right per failed start would be a
+            # slow leak in a long-lived daemon.
+            _release_mach_port(libsystem, service_port.value)
+        return status
+
+    return _lookup
 
 
 def _release_mach_port(libsystem: ctypes.CDLL, port: int) -> None:

--- a/src/gda/display.py
+++ b/src/gda/display.py
@@ -247,8 +247,11 @@ def _macos_window_server_denial() -> str | None:
       lookups do resolve here, and this one name is gated. The sandbox signature.
     - control refused as well → **blanket** confinement; the probe learned only that
       this process is confined.
+    - control answered anything else (it resolved, or failed with an unrelated
+      status) → **unknown breadth**: the target refusal stands, but nothing may be
+      said about how wide the confinement is.
 
-    Neither branch licenses a claim about the host's display: both report the same
+    None of the three licenses a claim about the host's display: all report the same
     permission verdict, and the caller's wording says so. Returns ``None`` when there
     is no denial evidence at all, including any failure to run the probe (symbol gone
     on a future macOS, unexpected ``ctypes`` state) — so the refusal then behaves

--- a/src/gda/display.py
+++ b/src/gda/display.py
@@ -92,6 +92,29 @@ _BOOTSTRAP_UNKNOWN_SERVICE = 1102
 # the confinement, never about whether a window server exists.
 _DENIAL_NAME_SPECIFIC = "name-specific"
 _DENIAL_BLANKET = "blanket"
+# The control lookup answered something we have no reading for (it succeeded, or
+# failed with an unrelated status). The target refusal still stands — that is what
+# the verdict reports — but nothing may be said about how broad the confinement is.
+_DENIAL_UNKNOWN_BREADTH = "unknown-breadth"
+
+# What each breadth may honestly say. None of the three claims a window server
+# exists — that is the caller's fixed clause — they differ only in how much they
+# can say about the confinement itself.
+_DENIAL_BREADTH_PROSE = {
+    _DENIAL_NAME_SPECIFIC: (
+        "the denial is specific to that service (a control lookup of an unregistered "
+        "name still resolved normally), which is the signature of a sandbox profile "
+        "that gates the window server"
+    ),
+    _DENIAL_BLANKET: (
+        "a control lookup of an unregistered name was refused too, so this process is "
+        "broadly confined and the probe learned only that much"
+    ),
+    _DENIAL_UNKNOWN_BREADTH: (
+        "a control lookup of an unregistered name returned neither the refusal nor "
+        "the not-registered status, so how broad the confinement is stays unknown"
+    ),
+}
 
 
 @dataclass(frozen=True)
@@ -140,14 +163,7 @@ def _macos_verdict() -> WindowedUnavailable | None:
         return None
     denial = _macos_window_server_denial()
     if denial is not None:
-        breadth = (
-            "the denial is specific to that service (a control lookup of an "
-            "unregistered name still resolved normally), which is the signature of "
-            "a sandbox profile that gates the window server"
-            if denial is _DENIAL_NAME_SPECIFIC
-            else "a control lookup of an unregistered name was refused too, so this "
-            "process is broadly confined and the probe learned only that much"
-        )
+        breadth = _DENIAL_BREADTH_PROSE[denial]
         return WindowedUnavailable(
             code="live_windowed_permission_denied",
             reason=(
@@ -254,9 +270,16 @@ def _classify_denial(lookup: "Callable[[bytes], int]") -> str | None:
     """
     if lookup(_WINDOW_SERVER_SERVICE) != _BOOTSTRAP_NOT_PRIVILEGED:
         return None
-    if lookup(_CONTROL_SERVICE) == _BOOTSTRAP_UNKNOWN_SERVICE:
+    control = lookup(_CONTROL_SERVICE)
+    if control == _BOOTSTRAP_UNKNOWN_SERVICE:
         return _DENIAL_NAME_SPECIFIC
-    return _DENIAL_BLANKET
+    if control == _BOOTSTRAP_NOT_PRIVILEGED:
+        return _DENIAL_BLANKET
+    # Every OTHER control answer — it somehow succeeded, or failed with an unrelated
+    # status — is matched explicitly rather than folded into "blanket". Only a
+    # REFUSED control licenses the blanket reading; treating an unexpected status as
+    # one would invent a fact about the confinement from a result we cannot read.
+    return _DENIAL_UNKNOWN_BREADTH
 
 
 def _bootstrap_lookup() -> "Callable[[bytes], int]":

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -779,22 +779,25 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
     ),
     # The PERMISSION half of the pre-launch display precondition (#667). Same
     # category/exit as `live_windowed_unavailable` — both refuse a windowed start
-    # pre-launch — but a different FACT about the world, and so a different code:
-    # the host CAN show a window, this process is merely not allowed to reach the
-    # window server. Conflating them is what the dogfooding (GDA-DF-029) hit — a
-    # sandboxed run read as a machine-capability gap, so rendered QA was silently
-    # skipped instead of retried outside the sandbox. Distinct from
-    # `live_display_unavailable`, which is the harness's CAPTURE-time code for a
-    # session that was started headless. Classifier-source, NOT GDScript-mirrored.
+    # pre-launch — but a different FACT about the world, and so a different code: the
+    # window-server lookup was REFUSED, so gda never got to observe whether a session
+    # exists. Conflating them is what the dogfooding (GDA-DF-029) hit — a sandboxed
+    # run read as a machine-capability gap, so rendered QA was silently skipped
+    # instead of retried outside the sandbox. The code deliberately does not claim
+    # the host HAS a window server: seatbelt refuses an unregistered name under a
+    # blanket-deny profile too, so the refusal proves confinement, not existence
+    # (#667 review). Distinct from `live_display_unavailable`, the harness's
+    # CAPTURE-time code for a session started headless. Classifier-source, NOT
+    # GDScript-mirrored.
     ErrorCodeSpec(
         "live_windowed_permission_denied",
         ErrorCategory.ENVIRONMENT,
         EXIT_NOT_FOUND,
         ErrorCodeSource.CLASSIFIER,
-        "A windowed live session was requested (`gda daemon start --windowed`) and"
-        " the host HAS a window server, but this process is denied access to it"
-        " (e.g. a sandbox); retry outside the restriction rather than treating the"
-        " host as display-less.",
+        "A windowed live session was requested (`gda daemon start --windowed`) but"
+        " this process is denied the window-server lookup (e.g. a sandbox), so gda"
+        " cannot tell whether the host has one; re-run outside the restriction to"
+        " find out rather than recording the host as display-less.",
     ),
 )
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -777,6 +777,25 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         " the host has no usable DisplayServer (no on-console GUI session / no"
         " $DISPLAY), so the session cannot come up; refused before spawning Godot.",
     ),
+    # The PERMISSION half of the pre-launch display precondition (#667). Same
+    # category/exit as `live_windowed_unavailable` — both refuse a windowed start
+    # pre-launch — but a different FACT about the world, and so a different code:
+    # the host CAN show a window, this process is merely not allowed to reach the
+    # window server. Conflating them is what the dogfooding (GDA-DF-029) hit — a
+    # sandboxed run read as a machine-capability gap, so rendered QA was silently
+    # skipped instead of retried outside the sandbox. Distinct from
+    # `live_display_unavailable`, which is the harness's CAPTURE-time code for a
+    # session that was started headless. Classifier-source, NOT GDScript-mirrored.
+    ErrorCodeSpec(
+        "live_windowed_permission_denied",
+        ErrorCategory.ENVIRONMENT,
+        EXIT_NOT_FOUND,
+        ErrorCodeSource.CLASSIFIER,
+        "A windowed live session was requested (`gda daemon start --windowed`) and"
+        " the host HAS a window server, but this process is denied access to it"
+        " (e.g. a sandbox); retry outside the restriction rather than treating the"
+        " host as display-less.",
+    ),
 )
 
 ERROR_CODE_BY_CODE: dict[str, ErrorCodeSpec] = {spec.code: spec for spec in ERROR_CODES}

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -48,7 +48,12 @@ from gda.error_codes import (
     LIVE_ERROR_CODES,
     OPERATION_ERROR_CODES,
 )
-from gda.models import EnvironmentProbe, GdaError, OperationErrorEnvelope
+from gda.models import (
+    EnvironmentProbe,
+    GdaError,
+    LiveErrorEnvelope,
+    OperationErrorEnvelope,
+)
 from gda.parser import parse_result
 from gda.runner import LaunchFailure, RunResult
 
@@ -316,13 +321,25 @@ def _live_error_from_payload(result: RunResult) -> Failure | None:
     the daemon-channel codes to their registered ``Failure`` directly; any other
     envelope returns ``None`` so the shared ``classify_run`` decision tree handles
     it (e.g. ``project_not_found``).
+
+    Parsed with :class:`LiveErrorEnvelope` rather than the headless
+    ``OperationErrorEnvelope`` because the live channel may carry the optional
+    ``probe`` context (#667) — the strict headless model would reject that envelope
+    outright and drop the whole failure to ``operation_failed``. The probe rides
+    through to the public envelope, so a windowed refusal from the daemon's
+    authoritative launch boundary reports exactly what the CLI fail-fast reports.
     """
-    pair = _operation_error_from_payload(result)
-    if pair is None:
+    try:
+        payload = parse_result(result.stdout)
+    except ValueError:
         return None
-    code, message = pair
-    if code in _LIVE_CLIENT_CODES:
-        return make_failure(code, message, result.stderr)
+    try:
+        envelope = LiveErrorEnvelope.model_validate(payload)
+    except ValidationError:
+        return None
+    error = envelope.error
+    if error.code in _LIVE_CLIENT_CODES:
+        return make_failure(error.code, error.message, result.stderr, probe=error.probe)
     return None
 
 

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -48,7 +48,7 @@ from gda.error_codes import (
     LIVE_ERROR_CODES,
     OPERATION_ERROR_CODES,
 )
-from gda.models import GdaError, OperationErrorEnvelope
+from gda.models import EnvironmentProbe, GdaError, OperationErrorEnvelope
 from gda.parser import parse_result
 from gda.runner import LaunchFailure, RunResult
 
@@ -66,7 +66,12 @@ class Failure:
     exit_code: int
 
 
-def make_failure(code: str, message: str, stderr: str) -> Failure:
+def make_failure(
+    code: str,
+    message: str,
+    stderr: str,
+    probe: EnvironmentProbe | None = None,
+) -> Failure:
     """Build a ``Failure`` from the parts that actually vary per failure.
 
     Only ``code``, the per-occurrence ``message`` (it embeds the binary path,
@@ -76,6 +81,11 @@ def make_failure(code: str, message: str, stderr: str) -> Failure:
     (ADR-0002, #141) rather than re-stated — and re-checked — at each site. The
     ``GdaError`` wrapping lives here once, so the call sites read as the taxonomy
     itself: a ``(code, message)`` row per failure mode.
+
+    ``probe`` is the optional :class:`EnvironmentProbe` context (ADR-0004
+    amendment, #667): the host call that decided an ENVIRONMENT failure gda
+    resolved by probing the machine rather than by running the engine. It stays
+    ``None`` — and so out of the emitted JSON entirely — for every other failure.
     """
     spec = ERROR_CODE_BY_CODE.get(code)
     if spec is None:
@@ -86,6 +96,7 @@ def make_failure(code: str, message: str, stderr: str) -> Failure:
             code=code,
             message=message,
             diagnostics=stderr,
+            probe=probe,
         ),
         exit_code=spec.exit_code,
     )
@@ -282,16 +293,18 @@ def classify_run(
 
 # Codes the daemon IPC client / the daemon surface through the live sentinel that
 # classify_run would otherwise misroute. The LIVE codes are live-runtime failures;
-# ``live_unsupported_platform`` and ``live_windowed_unavailable`` are
-# ENVIRONMENT-category pre-launch preconditions but still arrive via the live path
-# (``live_windowed_unavailable`` is raised at the daemon's session-launch boundary and
-# relayed as a live reply, #345), so classify_live must surface them too — else
-# classify_run falls back to operation_failed for a non-operation code.
+# ``live_unsupported_platform``, ``live_windowed_unavailable`` and
+# ``live_windowed_permission_denied`` are ENVIRONMENT-category pre-launch
+# preconditions but still arrive via the live path (both windowed codes are raised at
+# the daemon's session-launch boundary and relayed as a live reply, #345/#667), so
+# classify_live must surface them too — else classify_run falls back to
+# operation_failed for a non-operation code.
 # ``project_not_found`` is deliberately NOT here — it is an operation-source code
 # classify_run already maps, so it falls through to the shared decision tree.
 _LIVE_CLIENT_CODES = LIVE_ERROR_CODES | {
     "live_unsupported_platform",
     "live_windowed_unavailable",
+    "live_windowed_permission_denied",
 }
 
 

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -318,8 +318,16 @@ def emit_failure(failure: Failure) -> NoReturn:
     exit code. Shared by the sentinel-pipeline commands (via :meth:`HeadlessCommand.run`)
     and the native-export command (``export run``), which classifies its own
     subprocess outcome but emits failures through this same channel.
+
+    ``exclude_none`` keeps the envelope's OPTIONAL context keys (``probe``, the
+    ADR-0004 amendment of #667) out of the JSON entirely when a failure has none,
+    rather than emitting them as ``null``. So adding such a key leaves every
+    failure that does not set it byte-identical — the property that makes the
+    optional-context axis additive for existing consumers. The required keys
+    (``category`` / ``code`` / ``message`` / ``diagnostics``) are never ``None``,
+    so none of them can be dropped by this.
     """
-    typer.echo(GdaErrorEnvelope(error=failure.error).model_dump_json())
+    typer.echo(GdaErrorEnvelope(error=failure.error).model_dump_json(exclude_none=True))
     raise typer.Exit(code=failure.exit_code)
 
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -63,8 +63,14 @@ class EnvironmentProbe(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    name: str
-    platform: str
+    # Descriptions are deliberately terse: each one is repeated per command in the
+    # manifest, so prose here is paid ~67 times over (#667 review measured the cost).
+    name: str = Field(
+        description="The OS call that decided this failure, e.g. CGSessionCopyCurrentDictionary."
+    )
+    platform: str = Field(
+        description="The sys.platform the probe ran on, e.g. darwin or linux."
+    )
 
 
 class GdaError(BaseModel):
@@ -88,7 +94,13 @@ class GdaError(BaseModel):
     # Deliberately the minimal axis — WHICH host call decided — never the
     # operation-scoped typed EVIDENCE of a failure (parsed script errors, exit
     # statuses), which is #687's separate decision (ADR-0004 amendment, #667).
-    probe: EnvironmentProbe | None = None
+    probe: EnvironmentProbe | None = Field(
+        default=None,
+        description=(
+            "Which host probe decided this environment failure; the key is omitted "
+            "(never null) on failures that have none."
+        ),
+    )
 
 
 class GdaErrorEnvelope(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -46,19 +46,49 @@ class ErrorCategory(str, Enum):
     LIVE = "live"
 
 
+# WHY this exists (kept as a comment, not a docstring): a model docstring becomes
+# the schema `description`, and the error envelope's schema is repeated for EVERY
+# command in `gda schema` — so rationale here would be paid ~67 times by every agent
+# reading the manifest. The decision and its reasoning live in the ADR-0004
+# amendment (#667); the docstring below stays the one-line contract.
+#
+# The short version: gda decides some ENVIRONMENT failures by asking the host a
+# question directly ("can a window open here?") rather than by observing an engine
+# run. WHICH OS call answered separates "this machine cannot do it" from "this
+# PROCESS was not allowed to" — skip the capability, versus retry outside the
+# restriction. #667: automation read a sandbox denial as a machine-capability gap
+# and silently skipped rendered QA, because that fact lived only in prose.
+class EnvironmentProbe(BaseModel):
+    """The host call that decided an environment failure: its ``name`` and ``platform``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    platform: str
+
+
 class GdaError(BaseModel):
     """A structured, stable failure of a ``gda`` operation (issue #3).
 
     Emitted as ``{"error": <this>}`` on stdout so an agent reacts to failure
     modes programmatically without parsing prose. ``category`` is the coarse,
     process-exit-code-aligned bucket; ``code`` is the finer, stable identifier;
-    ``diagnostics`` carries the engine/script stderr surfaced per ADR-0002.
+    ``diagnostics`` carries the engine/script stderr surfaced per ADR-0002;
+    ``probe`` is optional context on the few environment failures gda decides by
+    probing the host (ADR-0004 amendment, #667).
     """
 
     category: ErrorCategory
     code: str
     message: str
     diagnostics: str = ""
+    # OMITTED — not ``null`` — from every failure that sets none: the emit path
+    # (:func:`gda.headless.emit_failure`) serializes with ``exclude_none``, so each
+    # other code's envelope JSON stays byte-identical to the pre-amendment contract.
+    # Deliberately the minimal axis — WHICH host call decided — never the
+    # operation-scoped typed EVIDENCE of a failure (parsed script errors, exit
+    # statuses), which is #687's separate decision (ADR-0004 amendment, #667).
+    probe: EnvironmentProbe | None = None
 
 
 class GdaErrorEnvelope(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -135,6 +135,38 @@ class OperationErrorEnvelope(BaseModel):
     error: OperationError
 
 
+class LiveError(BaseModel):
+    """A live-channel failure payload: the operation shape plus optional probe context.
+
+    The daemon and the daemon IPC client report a live failure with the same ADR-0002
+    envelope a headless operation uses, so this is :class:`OperationError` — with one
+    addition. A windowed refusal at the daemon's authoritative launch boundary is
+    decided by a HOST PROBE, and that context has to survive the relay, or the
+    authoritative path would report a strictly poorer failure than the CLI's own
+    fail-fast (#667). ``probe`` is therefore optional here and ABSENT from every other
+    live envelope.
+
+    The headless sentinel stays strict and probe-less: a GDScript operation has no host
+    probe to report, so widening :class:`OperationError` would invite a key the other
+    language can never fill. Two models, one per channel, is what keeps the
+    cross-language contract narrow while the live channel carries what it actually knows.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    message: str
+    probe: EnvironmentProbe | None = None
+
+
+class LiveErrorEnvelope(BaseModel):
+    """The sentinel payload shape for a live-channel failure (``{"error": {...}}``)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    error: LiveError
+
+
 class LiveStackConstraints(BaseModel):
     """The platform / Godot-version precondition a live-stack command needs (issue #233).
 

--- a/src/gda/parser.py
+++ b/src/gda/parser.py
@@ -50,11 +50,23 @@ def build_result(payload: Any) -> str:
     return f"{RESULT_BEGIN}{json.dumps(payload)}{RESULT_END}\n"
 
 
-def error_envelope(code: str, message: str) -> dict:
+def error_envelope(code: str, message: str, probe: dict | None = None) -> dict:
     """The ADR-0002 operation-error payload — ``{"error": {"code", "message"}}``.
 
     The one place that envelope dict is built (it mirrors
     :class:`~gda.models.OperationErrorEnvelope`); wrap it with :func:`build_result`
     to synthesize a sentinel error result.
+
+    ``probe`` is the OPTIONAL live-channel extension (#667): the daemon relays a
+    windowed refusal that a HOST PROBE decided, and the probe context has to survive
+    the relay or the authoritative lazy-launch path would report a strictly poorer
+    failure than the CLI fail-fast does. The key is omitted entirely when absent, so
+    every other envelope on this wire — and the whole GDScript-emitted headless
+    sentinel, whose model stays ``extra="forbid"`` with no ``probe`` — is
+    byte-identical to before. Only the live envelope model
+    (:class:`~gda.models.LiveErrorEnvelope`) accepts it.
     """
-    return {"error": {"code": code, "message": message}}
+    error: dict = {"code": code, "message": message}
+    if probe is not None:
+        error["probe"] = probe
+    return {"error": error}

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -95,13 +95,18 @@ macOS, `$DISPLAY` / `$WAYLAND_DISPLAY` on Linux. Over SSH, on a headless CI box,
 a sandbox that blocks the window server, `daemon start --windowed` refuses before
 spawning Godot. Branch on the code, not the sentence:
 
-- `live_windowed_unavailable` — this host cannot show a window. Skip the rendered check;
-  headless live ops (`game`, `perf`, `input`, `diag`, `logger`) still work.
-- `live_windowed_permission_denied` — the host CAN, but this process is not allowed to
-  reach the window server (e.g. a sandbox). Re-run outside the restriction; do not record
-  the machine as display-less.
+- `live_windowed_unavailable` — nothing refused the probe and no session is reachable, so
+  this host cannot show a window. Skip the rendered check; headless live ops (`game`,
+  `perf`, `input`, `diag`, `logger`) still work.
+- `live_windowed_permission_denied` — this process is not allowed to even look up the
+  window server (e.g. a sandbox). It does NOT mean the host has one: macOS refuses the
+  lookup before resolving it, so a broadly-confined process is refused either way. Re-run
+  outside the restriction to find out; do not record the machine as display-less on this
+  code alone.
 
-Both carry `error.probe` `{name, platform}` naming the OS call that decided.
+A refusal from `gda daemon start --windowed` carries `error.probe` `{name, platform}`
+naming the OS call that decided. The same codes relayed from an already-running daemon
+carry the code and message only.
 
 | Group | Commands |
 | ----- | -------- |

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -90,6 +90,19 @@ specific scene instead of the project's main scene); the engine session launches
 the first live op. `screen capture` needs a windowed session
 (`gda daemon start --windowed`).
 
+A windowed session needs the host's real desktop session — an on-console GUI login on
+macOS, `$DISPLAY` / `$WAYLAND_DISPLAY` on Linux. Over SSH, on a headless CI box, or from
+a sandbox that blocks the window server, `daemon start --windowed` refuses before
+spawning Godot. Branch on the code, not the sentence:
+
+- `live_windowed_unavailable` — this host cannot show a window. Skip the rendered check;
+  headless live ops (`game`, `perf`, `input`, `diag`, `logger`) still work.
+- `live_windowed_permission_denied` — the host CAN, but this process is not allowed to
+  reach the window server (e.g. a sandbox). Re-run outside the restriction; do not record
+  the machine as display-less.
+
+Both carry `error.probe` `{name, platform}` naming the OS call that decided.
+
 | Group | Commands |
 | ----- | -------- |
 | `daemon` | `start`, `stop`, `status`, `uninstall` (lifecycle; installs the in-game harness) |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,3 +118,17 @@ def daemon_runtime_dir(monkeypatch):
     monkeypatch.setenv("XDG_RUNTIME_DIR", runtime)
     yield Path(runtime)
     shutil.rmtree(runtime, ignore_errors=True)
+
+
+@pytest.fixture
+def windowed_host():
+    """Gate a test that needs a real windowed engine session (#345, #667).
+
+    A fixture rather than a ``skipif`` marker because the reaction is not uniform: a
+    confined run must FAIL, and a ``skipif`` can only skip. The policy itself lives in
+    one place (``tests.support.require_windowed_host``), shared with the post-start
+    race path so both cannot drift apart again.
+    """
+    from tests.support import require_windowed_host
+
+    require_windowed_host()

--- a/tests/support.py
+++ b/tests/support.py
@@ -705,10 +705,14 @@ INPUT_SEQUENCE_RESULT = {
 
 # --- The windowed-display test gate (#345, #667) -----------------------------
 #
-# ONE owner for the reaction policy, because the reaction is NOT uniform and the
-# duplication is what let the wrong one spread: the gates used to skip on every
-# no-display code, so a confined run greened the suite with the rendered acceptance
-# unexecuted — the exact GDA-DF-029 behaviour #667 exists to stop.
+# One owner PER PYTEST ROOT for the reaction policy, because the reaction is NOT
+# uniform and scattered per-test sets are what let the wrong one spread: the gates
+# used to skip on every no-display code, so a confined run greened the suite with
+# the rendered acceptance unexecuted — the exact GDA-DF-029 behaviour #667 exists
+# to stop. A second, deliberate copy of this policy lives in
+# examples/platformer/panda-adventure/tests/display_gate.py (a separate pytest
+# root that cannot import this package) — keep the two in step when editing
+# either side.
 #
 # The two reactions, and why they differ:
 #

--- a/tests/support.py
+++ b/tests/support.py
@@ -701,3 +701,68 @@ INPUT_SEQUENCE_RESULT = {
     "events": 3,
     "frames": 5,
 }
+
+
+# --- The windowed-display test gate (#345, #667) -----------------------------
+#
+# ONE owner for the reaction policy, because the reaction is NOT uniform and the
+# duplication is what let the wrong one spread: the gates used to skip on every
+# no-display code, so a confined run greened the suite with the rendered acceptance
+# unexecuted — the exact GDA-DF-029 behaviour #667 exists to stop.
+#
+# The two reactions, and why they differ:
+#
+# - CAPABILITY (`live_windowed_unavailable`, `live_display_unavailable`): the host
+#   genuinely cannot show a window. There is nothing to run, so SKIP is honest and a
+#   visible `-rs` line records it.
+# - PERMISSION (`live_windowed_permission_denied`): the host may well be able to —
+#   this RUN is confined. The verdict is about the whole environment, not a
+#   momentary display state, so it cannot be waited out or retried into passing.
+#   Skipping would hide unexecuted rendered acceptance behind a green suite, so it
+#   FAILS, carrying the remediation the error itself gives: re-run outside the
+#   restriction.
+WINDOWED_CAPABILITY_CODES = frozenset(
+    {"live_windowed_unavailable", "live_display_unavailable"}
+)
+WINDOWED_PERMISSION_DENIED_CODE = "live_windowed_permission_denied"
+
+_CONFINED_REMEDIATION = (
+    "the windowed session was refused because this RUN is confined "
+    "({detail}). Rendered acceptance did NOT execute; this is a loud failure "
+    "rather than a skip so a sandboxed run cannot green the suite with it "
+    "unexecuted (#667). Re-run outside the sandbox/restriction."
+)
+
+
+def handle_no_display_code(code, detail=""):
+    """Apply the reaction policy to a gda error ``code``, if it is a display refusal.
+
+    Skips on a capability refusal, FAILS on a permission refusal, and returns
+    normally for anything else so the caller can raise its own assertion. Used on the
+    post-start race path, where a live call reports the refusal even though the
+    pre-flight probe passed.
+    """
+    import pytest
+
+    if code == WINDOWED_PERMISSION_DENIED_CODE:
+        pytest.fail(_CONFINED_REMEDIATION.format(detail=detail or code))
+    if code in WINDOWED_CAPABILITY_CODES:
+        pytest.skip(f"windowed session unavailable in this environment ({code})")
+
+
+def require_windowed_host():
+    """Pre-flight the host display probe with the same reaction policy.
+
+    ``None`` verdict → return and run the test. A capability verdict → skip. A
+    permission verdict → fail: a confined run must be loud, not green.
+    """
+    import pytest
+
+    from gda.display import windowed_unavailable
+
+    verdict = windowed_unavailable()
+    if verdict is None:
+        return
+    if verdict.code == WINDOWED_PERMISSION_DENIED_CODE:
+        pytest.fail(_CONFINED_REMEDIATION.format(detail=verdict.reason))
+    pytest.skip(verdict.reason)

--- a/tests/support.py
+++ b/tests/support.py
@@ -770,3 +770,32 @@ def require_windowed_host():
     if verdict.code == WINDOWED_PERMISSION_DENIED_CODE:
         pytest.fail(_CONFINED_REMEDIATION.format(detail=verdict.reason))
     pytest.skip(verdict.reason)
+
+
+def gda_error_code(stdout):
+    """The ``error.code`` of a gda ``--json`` failure envelope, or ``None``."""
+    try:
+        return json.loads(stdout).get("error", {}).get("code")
+    except (ValueError, AttributeError):
+        return None
+
+
+def assert_windowed_ok(result):
+    """Assert a windowed-tier command succeeded, applying the display policy FIRST.
+
+    The post-start race path for the repo's own e2e tiers. A windowed session can be
+    refused *after* the pre-flight probe passed — the daemon re-checks at its
+    authoritative launch boundary, and a live op can hit that on the lazy launch — and
+    when it is, the reaction has to be the SAME one the pre-flight would have applied:
+    a capability refusal skips, a permission refusal fails loudly with the
+    remediation. Asserting ``returncode == 0`` straight away instead turned a
+    capability verdict into a false RED here while the game's tiers skipped on it —
+    one verdict, two meanings (#667 recheck).
+
+    Anything that is not a display refusal falls through to the ordinary assertion,
+    so a real regression still fails with the command's own output.
+    """
+    if result.returncode != 0:
+        handle_no_display_code(gda_error_code(result.stdout))
+    assert result.returncode == 0, result.stdout + result.stderr
+    return result

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -19,7 +19,9 @@ from typer.testing import CliRunner
 
 import gda.commands.daemon as daemon_ops
 from gda.cli import app
+from gda.display import WindowedUnavailable
 from gda.errors import Failure
+from gda.models import EnvironmentProbe
 from gda.harness.install import (
     HARNESS_FILE,
     HARNESS_RES_DIR,
@@ -37,6 +39,24 @@ from gda.commands.daemon import (
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
 _OK_VERSION = lambda binary: (4, 6)  # noqa: E731
+
+
+def _unavailable(
+    code: str = "live_windowed_unavailable",
+    name: str = "CGSessionCopyCurrentDictionary",
+    platform: str = "darwin",
+) -> WindowedUnavailable:
+    """A fake host-probe verdict (#345, #667).
+
+    The refusal mapping is a pure function of this verdict, so injecting one covers
+    BOTH windowed outcomes on ANY host — no display, no sandbox, and no capability
+    gate needed. The real probe is proven separately against a real sandbox.
+    """
+    return WindowedUnavailable(
+        code=code,
+        reason=f"no windowed session here (test: {code})",
+        probe=EnvironmentProbe(name=name, platform=platform),
+    )
 
 
 def _project(tmp_path):
@@ -231,7 +251,7 @@ def test_windowed_start_without_a_display_is_live_windowed_unavailable(
         windowed=True,
         spawn=lambda p, b, w, s: spawned.append((p, b, w, s)),
         version_check=_OK_VERSION,
-        display_check=lambda: "no usable DisplayServer (test)",
+        display_check=lambda: _unavailable(),
     )
 
     assert isinstance(outcome, Failure), outcome
@@ -241,6 +261,86 @@ def test_windowed_start_without_a_display_is_live_windowed_unavailable(
     assert spawned == []  # never spawned Godot
     # Pre-harness-install too: a doomed windowed start must not mutate the project.
     assert not (project / HARNESS_RES_DIR / HARNESS_FILE).exists()
+    # #667: the deciding host call rides the envelope as DATA, not only as prose.
+    assert outcome.error.probe is not None
+    assert outcome.error.probe.name == "CGSessionCopyCurrentDictionary"
+    assert outcome.error.probe.platform == "darwin"
+
+
+def test_windowed_start_denied_by_a_sandbox_is_a_distinct_permission_code(
+    tmp_path, short_runtime, monkeypatch
+):
+    # #667 (dogfooding GDA-DF-029): a windowed start refused because THIS PROCESS may
+    # not reach the window server is NOT the same failure as a host that has none. It
+    # reports the distinct live_windowed_permission_denied so automation retries
+    # outside the sandbox instead of recording the machine as display-less — while
+    # keeping the ENVIRONMENT/127 bucket of its sibling (the refusal is the same
+    # pre-launch refusal). Ungated: the verdict is injected, so this runs on every
+    # host including a display-less CI runner.
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
+    spawned: list = []
+
+    outcome = daemon_ops.run_daemon_start_operation(
+        project,
+        None,
+        windowed=True,
+        spawn=lambda p, b, w, s: spawned.append((p, b, w, s)),
+        version_check=_OK_VERSION,
+        display_check=lambda: _unavailable(
+            code="live_windowed_permission_denied",
+            name="bootstrap_look_up(com.apple.windowserver.active)",
+        ),
+    )
+
+    assert isinstance(outcome, Failure), outcome
+    assert outcome.error.code == "live_windowed_permission_denied"
+    # Deliberately NOT live_display_unavailable (the harness's capture-time code) and
+    # NOT live_windowed_unavailable (the machine-capability verdict).
+    assert outcome.error.category.value == "environment"
+    assert outcome.exit_code == 127  # the same bucket as live_windowed_unavailable
+    assert spawned == []  # still refused pre-launch, still no project mutation
+    assert not (project / HARNESS_RES_DIR / HARNESS_FILE).exists()
+    assert outcome.error.probe is not None
+    assert (
+        outcome.error.probe.name == "bootstrap_look_up(com.apple.windowserver.active)"
+    )
+    assert outcome.error.probe.platform == "darwin"
+
+
+def test_windowed_refusal_json_carries_the_probe_and_others_are_unchanged(tmp_path):
+    # #667 / the ADR-0004 amendment: `probe` is emitted for a failure that HAS one and
+    # OMITTED entirely — not `null` — for every failure that does not, so each other
+    # code's envelope JSON stays byte-identical to before the field existed.
+    from gda.errors import make_failure
+    from gda.models import GdaErrorEnvelope
+
+    with_probe = make_failure(
+        "live_windowed_permission_denied",
+        "denied",
+        "",
+        probe=EnvironmentProbe(name="bootstrap_look_up(x)", platform="darwin"),
+    )
+    without = make_failure("binary_not_found", "nope", "")
+
+    with_json = json.loads(
+        GdaErrorEnvelope(error=with_probe.error).model_dump_json(exclude_none=True)
+    )
+    without_json = json.loads(
+        GdaErrorEnvelope(error=without.error).model_dump_json(exclude_none=True)
+    )
+
+    assert with_json["error"]["probe"] == {
+        "name": "bootstrap_look_up(x)",
+        "platform": "darwin",
+    }
+    assert "probe" not in without_json["error"]
+    assert set(without_json["error"]) == {
+        "category",
+        "code",
+        "message",
+        "diagnostics",
+    }
 
 
 def test_headless_start_never_consults_the_display_check(

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -271,7 +271,8 @@ def test_windowed_start_denied_by_a_sandbox_is_a_distinct_permission_code(
     tmp_path, short_runtime, monkeypatch
 ):
     # #667 (dogfooding GDA-DF-029): a windowed start refused because THIS PROCESS may
-    # not reach the window server is NOT the same failure as a host that has none. It
+    # denied the window-server lookup is NOT the same failure as a host where none was
+    # detected. It
     # reports the distinct live_windowed_permission_denied so automation retries
     # outside the sandbox instead of recording the machine as display-less — while
     # keeping the ENVIRONMENT/127 bucket of its sibling (the refusal is the same

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -256,9 +256,11 @@ def test_windowed_denied_relays_the_permission_code_not_the_capability_one(
 ):
     # #667: the launch-boundary guard relays the code the PROBE decided, so a sandbox
     # denial reaching the daemon path is reported as live_windowed_permission_denied
-    # rather than collapsing into live_windowed_unavailable. The wire envelope is
-    # ADR-0002's {code, message}, so the machine-readable `probe` context does NOT
-    # ride this path — the code and the prose carry the distinction here.
+    # rather than collapsing into live_windowed_unavailable. This is the
+    # AUTHORITATIVE refusal (it fires on the lazy launch every live op goes through),
+    # so it also carries the machine-readable `probe` — deliberately widening the live
+    # wire envelope with that ONE optional key (#667 review), rather than reporting
+    # less here than the optional CLI fail-fast reports.
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
 
     def _must_not_launch(*a, **k):
@@ -278,9 +280,33 @@ def test_windowed_denied_relays_the_permission_code_not_the_capability_one(
 
     error = parse_result(reply["stdout"])["error"]
     assert error["code"] == "live_windowed_permission_denied"
-    assert set(error) == {"code", "message"}  # the wire envelope shape is unchanged
+    # The one deliberate wire widening: `probe` rides the live envelope as data.
+    assert set(error) == {"code", "message", "probe"}
+    assert error["probe"] == {
+        "name": "CGSessionCopyCurrentDictionary",
+        "platform": "darwin",
+    }
     assert "live_windowed_permission_denied" in reply["stderr"]
     assert server._session is None
+
+
+def test_a_relayed_refusal_without_a_probe_keeps_the_narrow_wire_shape(
+    tmp_path, monkeypatch
+):
+    # The widening is OPTIONAL: every live reply that has no probe — which is all of
+    # them except the windowed refusals — is byte-identical to before, so the key can
+    # never appear as a null for the harness-emitted and daemon-synthesized codes.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    monkeypatch.setattr("gda.daemon.server.launch_session", lambda *a, **k: None)
+    server = DaemonServer(daemon_paths(tmp_path), godot="godot")
+    server._harness_listener = cast(socket.socket, object())
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+    assert reply is not None
+
+    error = parse_result(reply["stdout"])["error"]
+    assert error["code"] == "engine_session_not_running"
+    assert set(error) == {"code", "message"}
 
 
 def test_windowed_with_a_usable_display_reaches_launch(tmp_path, monkeypatch):

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -14,6 +14,8 @@ import pytest
 from gda.daemon.discovery import daemon_paths
 from gda.daemon.server import DaemonServer
 from gda.daemon.session import EngineSession
+from gda.display import WindowedUnavailable
+from gda.models import EnvironmentProbe
 from gda.commands.daemon import (
     run_daemon_status_operation,
     run_daemon_stop_operation,
@@ -27,6 +29,18 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 class _FakeProc:
     def poll(self):
         return None
+
+
+def _unavailable(
+    code: str = "live_windowed_unavailable",
+    name: str = "CGSessionCopyCurrentDictionary",
+) -> WindowedUnavailable:
+    """A fake host-probe verdict, so the relay is covered on any host (#345, #667)."""
+    return WindowedUnavailable(
+        code=code,
+        reason=f"no usable DisplayServer (test: {code})",
+        probe=EnvironmentProbe(name=name, platform="darwin"),
+    )
 
 
 def test_live_op_without_a_launchable_session_is_engine_session_not_running(tmp_path):
@@ -223,7 +237,7 @@ def test_windowed_no_display_is_live_windowed_unavailable_without_launching(
         daemon_paths(tmp_path),
         godot="godot",
         windowed=True,
-        display_check=lambda: "no usable DisplayServer (test)",
+        display_check=lambda: _unavailable(),
     )
     server._harness_listener = cast(socket.socket, object())
 
@@ -233,8 +247,40 @@ def test_windowed_no_display_is_live_windowed_unavailable_without_launching(
     error = parse_result(reply["stdout"])["error"]
     assert error["code"] == "live_windowed_unavailable"
     # The probe's reason rides the advisory diagnostics (existing stderr) field.
-    assert "no usable DisplayServer (test)" in reply["stderr"]
+    assert "no usable DisplayServer (test" in reply["stderr"]
     assert server._session is None  # nothing launched or cached
+
+
+def test_windowed_denied_relays_the_permission_code_not_the_capability_one(
+    tmp_path, monkeypatch
+):
+    # #667: the launch-boundary guard relays the code the PROBE decided, so a sandbox
+    # denial reaching the daemon path is reported as live_windowed_permission_denied
+    # rather than collapsing into live_windowed_unavailable. The wire envelope is
+    # ADR-0002's {code, message}, so the machine-readable `probe` context does NOT
+    # ride this path — the code and the prose carry the distinction here.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+
+    def _must_not_launch(*a, **k):
+        raise AssertionError("launch_session must not be called with no usable display")
+
+    monkeypatch.setattr("gda.daemon.server.launch_session", _must_not_launch)
+    server = DaemonServer(
+        daemon_paths(tmp_path),
+        godot="godot",
+        windowed=True,
+        display_check=lambda: _unavailable(code="live_windowed_permission_denied"),
+    )
+    server._harness_listener = cast(socket.socket, object())
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+    assert reply is not None
+
+    error = parse_result(reply["stdout"])["error"]
+    assert error["code"] == "live_windowed_permission_denied"
+    assert set(error) == {"code", "message"}  # the wire envelope shape is unchanged
+    assert "live_windowed_permission_denied" in reply["stderr"]
+    assert server._session is None
 
 
 def test_windowed_with_a_usable_display_reaches_launch(tmp_path, monkeypatch):
@@ -272,7 +318,7 @@ def test_headless_windowed_false_never_consults_the_display_check(
     # session needs no window server; only a windowed session is gated.
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
 
-    def _boom() -> str:
+    def _boom() -> WindowedUnavailable | None:
         raise AssertionError("a headless daemon must not run the display check")
 
     monkeypatch.setattr("gda.daemon.server.launch_session", lambda *a, **k: None)

--- a/tests/test_display_probe.py
+++ b/tests/test_display_probe.py
@@ -417,3 +417,54 @@ def test_the_preflight_gate_runs_the_test_when_a_window_can_open(monkeypatch):
     monkeypatch.setattr("gda.display.windowed_unavailable", lambda: None)
 
     require_windowed_host()  # must not raise
+
+
+@pytest.mark.parametrize(
+    ("returncode", "code", "reaction"),
+    [
+        (0, None, "passed"),
+        (6, "live_display_unavailable", "Skipped"),
+        (127, "live_windowed_unavailable", "Skipped"),
+        (127, "live_windowed_permission_denied", "Failed"),
+        (4, "operation_failed", "Failed"),  # a real regression still fails
+        (1, None, "Failed"),  # unparseable output still fails
+    ],
+)
+def test_the_post_start_assertion_applies_the_policy_before_asserting(
+    returncode, code, reaction
+):
+    # The repo's own e2e windowed tiers assert success through this helper, so a
+    # refusal arriving AFTER the pre-flight probe passed gets the same reaction the
+    # pre-flight would have applied. Before the #667 recheck those branches asserted
+    # returncode == 0 directly, so a capability verdict was a false RED here while the
+    # game's tiers skipped on it — one verdict, two meanings.
+    import json as _json
+
+    from tests.support import assert_windowed_ok
+
+    class _Result:
+        def __init__(self):
+            self.returncode = returncode
+            self.stdout = (
+                _json.dumps({"error": {"code": code, "message": "x"}})
+                if code is not None
+                else ("{}" if returncode == 0 else "not json")
+            )
+            self.stderr = ""
+
+    if reaction == "passed":
+        assert assert_windowed_ok(_Result()).returncode == 0
+        return
+
+    with pytest.raises(BaseException) as caught:
+        assert_windowed_ok(_Result())
+
+    outcome = type(caught.value).__name__
+    if reaction == "Skipped":
+        assert outcome == "Skipped"
+    elif code == "live_windowed_permission_denied":
+        assert outcome == "Failed"
+        assert "Re-run outside the sandbox/restriction" in str(caught.value)
+    else:
+        # Not a display refusal: the ordinary assertion, carrying the command output.
+        assert outcome == "AssertionError"

--- a/tests/test_display_probe.py
+++ b/tests/test_display_probe.py
@@ -119,7 +119,7 @@ def test_no_denial_branch_claims_the_host_has_a_window_server(monkeypatch, denia
     for forbidden in (
         "The host itself HAS a window server",
         "is a permission boundary, not a missing display",
-        "the host has one",
+        "HAS a window server, so",
     ):
         assert forbidden not in reason
 

--- a/tests/test_display_probe.py
+++ b/tests/test_display_probe.py
@@ -26,10 +26,12 @@ from pathlib import Path
 import pytest
 
 from gda.display import (
+    _DENIAL_BLANKET,
+    _DENIAL_NAME_SPECIFIC,
     WindowedUnavailable,
     _linux_verdict,
     _macos_verdict,
-    _macos_window_server_denied,
+    _macos_window_server_denial,
     windowed_unavailable,
 )
 
@@ -41,7 +43,7 @@ def test_macos_with_a_window_server_can_launch_windowed(monkeypatch):
     # The denial probe must not even run on the success path: a healthy desktop pays
     # nothing for the #667 split.
     monkeypatch.setattr(
-        "gda.display._macos_window_server_denied",
+        "gda.display._macos_window_server_denial",
         lambda: pytest.fail("the denial probe ran on the success path"),
     )
 
@@ -49,11 +51,11 @@ def test_macos_with_a_window_server_can_launch_windowed(monkeypatch):
 
 
 def test_macos_without_a_window_server_is_the_capability_verdict(monkeypatch):
-    # CGSession said NULL and nothing denied us: the host genuinely has no GUI
-    # session (SSH / CI / headless). The capability code, naming CGSession as the
-    # probe that decided it.
+    # CGSession said NULL and nothing denied us: as far as gda can tell the host has
+    # no GUI session (SSH / CI / headless). The capability code, naming CGSession as
+    # the probe that decided it.
     monkeypatch.setattr("gda.display._macos_has_window_server", lambda: False)
-    monkeypatch.setattr("gda.display._macos_window_server_denied", lambda: False)
+    monkeypatch.setattr("gda.display._macos_window_server_denial", lambda: None)
 
     verdict = _macos_verdict()
 
@@ -64,14 +66,25 @@ def test_macos_without_a_window_server_is_the_capability_verdict(monkeypatch):
     # The remaining ambiguity is disclosed rather than hidden: a sandbox that HIDES
     # the window server (rather than refusing the lookup) lands here too.
     assert "outside the sandbox" in verdict.reason
+    # F5: the actionable remediation the pre-#667 message carried is still here.
+    assert "Run the daemon headless" in verdict.reason
 
 
-def test_macos_denied_window_server_is_the_permission_verdict(monkeypatch):
-    # CGSession said NULL, but the window-server lookup was REFUSED: the host has a
-    # window server we are not allowed to reach. A different code and a different
-    # probe name, so an agent branches on data.
+@pytest.mark.parametrize(
+    ("denial", "expected_breadth"),
+    [
+        (_DENIAL_NAME_SPECIFIC, "specific to that service"),
+        (_DENIAL_BLANKET, "broadly confined"),
+    ],
+)
+def test_macos_denied_window_server_is_the_permission_verdict(
+    monkeypatch, denial, expected_breadth
+):
+    # CGSession said NULL and the window-server lookup was REFUSED. Both control
+    # outcomes take the permission code with the same probe name; they differ only in
+    # how much confinement the probe could honestly characterise.
     monkeypatch.setattr("gda.display._macos_has_window_server", lambda: False)
-    monkeypatch.setattr("gda.display._macos_window_server_denied", lambda: True)
+    monkeypatch.setattr("gda.display._macos_window_server_denial", lambda: denial)
 
     verdict = _macos_verdict()
 
@@ -79,10 +92,78 @@ def test_macos_denied_window_server_is_the_permission_verdict(monkeypatch):
     assert verdict.code == "live_windowed_permission_denied"
     assert verdict.probe.name == "bootstrap_look_up(com.apple.windowserver.active)"
     assert verdict.probe.platform == sys.platform
-    assert "re-run outside the sandbox" in verdict.reason
+    assert expected_breadth in verdict.reason
+    assert "re-run outside the" in verdict.reason
 
 
-def test_the_denial_probe_failing_falls_back_to_the_capability_verdict(monkeypatch):
+@pytest.mark.parametrize("denial", [_DENIAL_NAME_SPECIFIC, _DENIAL_BLANKET])
+def test_no_denial_branch_claims_the_host_has_a_window_server(monkeypatch, denial):
+    # The #667-review regression guard. A refused lookup is evaluated per name and
+    # BEFORE resolution, so it proves confinement, NOT existence — a blanket-deny
+    # profile on a display-less CI Mac lands here too. Neither branch may tell the
+    # caller the host HAS a window server, and both must say gda cannot tell.
+    monkeypatch.setattr("gda.display._macos_has_window_server", lambda: False)
+    monkeypatch.setattr("gda.display._macos_window_server_denial", lambda: denial)
+
+    verdict = _macos_verdict()
+    assert verdict is not None
+    reason = verdict.reason
+
+    # The claim is explicitly negated: gda says it CANNOT tell.
+    assert (
+        "cannot tell from a refused lookup whether this host HAS a window server"
+        in reason
+    )
+    # And none of the affirmative phrasings — including the exact sentence the
+    # original implementation shipped — may reappear.
+    for forbidden in (
+        "The host itself HAS a window server",
+        "is a permission boundary, not a missing display",
+        "the host has one",
+    ):
+        assert forbidden not in reason
+
+
+@pytest.mark.parametrize(
+    ("target", "control", "expected"),
+    [
+        # The window server refused, a name nobody registers resolved normally: the
+        # denial is specific to that service — the sandbox-profile signature.
+        (1100, 1102, _DENIAL_NAME_SPECIFIC),
+        # BOTH refused. Seatbelt evaluates the deny per name and before resolution,
+        # so this is a broadly-confined process and the probe learned only that.
+        (1100, 1100, _DENIAL_BLANKET),
+        # Not refused at all -> no denial evidence, whatever the control says.
+        (1102, 1102, None),
+        (0, 1102, None),
+    ],
+)
+def test_the_control_lookup_characterises_the_denial(target, control, expected):
+    # Ungated: the status -> breadth mapping is handed a fake lookup, so it runs on
+    # any host including a Linux CI runner with no libSystem.
+    from gda.display import _CONTROL_SERVICE, _WINDOW_SERVER_SERVICE, _classify_denial
+
+    statuses = {_WINDOW_SERVER_SERVICE: target, _CONTROL_SERVICE: control}
+
+    assert _classify_denial(lambda name: statuses[name]) is expected
+
+
+def test_the_control_lookup_is_skipped_when_the_target_was_not_refused():
+    # The control costs a second mach round-trip, so it must only run once the
+    # target has actually been refused.
+    from gda.display import _WINDOW_SERVER_SERVICE, _classify_denial
+
+    asked: list[bytes] = []
+
+    def _lookup(name: bytes) -> int:
+        asked.append(name)
+        return 0
+
+    assert _classify_denial(_lookup) is None
+    assert asked == [_WINDOW_SERVER_SERVICE]
+
+
+def test_the_denial_probe_falls_back_when_it_cannot_run(monkeypatch):
     # The denial probe is best-effort private-ish plumbing (a libSystem symbol). If it
     # cannot run at all — a future macOS drops the symbol, ctypes misbehaves — the
     # refusal must behave exactly as it did before the probe existed, never crash a
@@ -91,7 +172,7 @@ def test_the_denial_probe_failing_falls_back_to_the_capability_verdict(monkeypat
         raise OSError("no libSystem here")
 
     monkeypatch.setattr("gda.display.ctypes.CDLL", lambda _path: _explode())
-    assert _macos_window_server_denied() is False
+    assert _macos_window_server_denial() is None
 
     monkeypatch.setattr("gda.display._macos_has_window_server", lambda: False)
     fallback = _macos_verdict()
@@ -134,16 +215,40 @@ def test_the_verdict_carries_a_registered_error_code():
 
 # --- the real macOS denial probe (capability-gated) --------------------------
 
-_SANDBOX_PROFILE = '(version 1)\n(allow default)\n(deny mach-lookup (global-name "com.apple.windowserver.active"))\n'
+# Denies ONLY the window-server name: everything else, including an unregistered
+# control name, still resolves. The sandbox-profile signature.
+_NAME_SPECIFIC_PROFILE = (
+    "(version 1)\n"
+    "(allow default)\n"
+    '(deny mach-lookup (global-name "com.apple.windowserver.active"))\n'
+)
+
+# Denies every mach-lookup. The case that falsified the original spike claim: the
+# control name is refused too, so the refusal says nothing about what exists.
+_BLANKET_PROFILE = (
+    "(version 1)\n"
+    "(deny default)\n"
+    "(allow process*)\n"
+    "(allow file*)\n"
+    "(allow sysctl*)\n"
+    "(allow signal)\n"
+    "(allow ipc-posix-shm)\n"
+)
 
 _PROBE_SCRIPT = textwrap.dedent(
     """
     import json
     from gda.display import windowed_unavailable
     verdict = windowed_unavailable()
+    from gda.display import _macos_window_server_denial
     print(json.dumps(
         None if verdict is None
-        else {"code": verdict.code, "probe": verdict.probe.name}
+        else {
+            "code": verdict.code,
+            "probe": verdict.probe.name,
+            "denial": _macos_window_server_denial(),
+            "claims_existence": "cannot tell from a refused lookup" not in verdict.reason,
+        }
     ))
     """
 )
@@ -177,29 +282,44 @@ def _verdict_under(profile: Path | None, tmp_path: Path) -> dict | None:
     return json.loads(run.stdout.strip())
 
 
-def test_a_real_sandbox_denial_is_classified_as_a_permission_problem(tmp_path):
-    # The end-to-end proof of the #667 spike finding, against a REAL seatbelt sandbox
-    # rather than a fake: on a host that HAS a desktop session, denying only the
-    # window-server mach lookup must flip the verdict to the permission code — not to
-    # live_windowed_unavailable, which is what the dogfooding saw and what made
-    # automation record the machine as display-less.
+@pytest.mark.parametrize(
+    ("profile_body", "expected_denial"),
+    [
+        (_NAME_SPECIFIC_PROFILE, _DENIAL_NAME_SPECIFIC),
+        (_BLANKET_PROFILE, _DENIAL_BLANKET),
+    ],
+)
+def test_a_real_sandbox_denial_is_classified_as_a_permission_problem(
+    tmp_path, profile_body, expected_denial
+):
+    # The end-to-end proof against a REAL seatbelt sandbox rather than a fake: on a
+    # host that HAS a desktop session, a refused window-server lookup must flip the
+    # verdict to the permission code — not to live_windowed_unavailable, which is
+    # what the dogfooding saw and what made automation record the machine as
+    # display-less.
+    #
+    # Both profiles are exercised because they are the two halves of the corrected
+    # finding (#667 review): the blanket one refuses the unregistered control name
+    # too, which is exactly why NEITHER may claim the host has a window server.
     if not _sandbox_exec_works(tmp_path):
         pytest.skip("needs macOS with a working sandbox-exec")
     if windowed_unavailable() is not None:
         pytest.skip("needs a real on-console desktop session to deny access TO")
 
-    profile = tmp_path / "deny-windowserver.sb"
-    profile.write_text(_SANDBOX_PROFILE, encoding="utf-8")
+    profile = tmp_path / "profile.sb"
+    profile.write_text(profile_body, encoding="utf-8")
 
     # The control: unsandboxed on this same host, a windowed session can launch.
     assert _verdict_under(None, tmp_path) is None
 
     denied = _verdict_under(profile, tmp_path)
+    assert denied is not None
 
-    assert denied == {
-        "code": "live_windowed_permission_denied",
-        "probe": "bootstrap_look_up(com.apple.windowserver.active)",
-    }
+    assert denied["code"] == "live_windowed_permission_denied"
+    assert denied["probe"] == "bootstrap_look_up(com.apple.windowserver.active)"
+    assert denied["denial"] == expected_denial
+    # Neither branch may assert the host has a window server.
+    assert denied["claims_existence"] is False
 
 
 def test_the_probe_returns_a_verdict_or_none_on_this_host():

--- a/tests/test_display_probe.py
+++ b/tests/test_display_probe.py
@@ -1,0 +1,209 @@
+"""The host-display probe's verdict logic (#345, #667).
+
+``gda.display`` answers ONE question with two possible refusals, and the split is
+what #667 is about: "no window server on this host" (skip rendered QA) versus "this
+process may not reach the one that exists" (retry outside the sandbox). Reading the
+second as the first is the dogfooded defect (GDA-DF-029).
+
+Tiering follows from where the risk is:
+
+- The **verdict logic** — which code, which probe name, which platform — is a pure
+  function of the two boolean host answers, so it is tested by injecting those
+  answers. UNGATED: it runs on every host, including a display-less CI runner, which
+  is exactly where a regression would otherwise hide.
+- The **real macOS denial probe** needs a real sandbox to mean anything, so that one
+  leg is capability-gated on macOS + a working ``sandbox-exec`` + an actual desktop
+  session, and skips honestly elsewhere.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gda.display import (
+    WindowedUnavailable,
+    _linux_verdict,
+    _macos_verdict,
+    _macos_window_server_denied,
+    windowed_unavailable,
+)
+
+# --- the verdict logic (ungated) --------------------------------------------
+
+
+def test_macos_with_a_window_server_can_launch_windowed(monkeypatch):
+    monkeypatch.setattr("gda.display._macos_has_window_server", lambda: True)
+    # The denial probe must not even run on the success path: a healthy desktop pays
+    # nothing for the #667 split.
+    monkeypatch.setattr(
+        "gda.display._macos_window_server_denied",
+        lambda: pytest.fail("the denial probe ran on the success path"),
+    )
+
+    assert _macos_verdict() is None
+
+
+def test_macos_without_a_window_server_is_the_capability_verdict(monkeypatch):
+    # CGSession said NULL and nothing denied us: the host genuinely has no GUI
+    # session (SSH / CI / headless). The capability code, naming CGSession as the
+    # probe that decided it.
+    monkeypatch.setattr("gda.display._macos_has_window_server", lambda: False)
+    monkeypatch.setattr("gda.display._macos_window_server_denied", lambda: False)
+
+    verdict = _macos_verdict()
+
+    assert verdict is not None
+    assert verdict.code == "live_windowed_unavailable"
+    assert verdict.probe.name == "CGSessionCopyCurrentDictionary"
+    assert verdict.probe.platform == sys.platform
+    # The remaining ambiguity is disclosed rather than hidden: a sandbox that HIDES
+    # the window server (rather than refusing the lookup) lands here too.
+    assert "outside the sandbox" in verdict.reason
+
+
+def test_macos_denied_window_server_is_the_permission_verdict(monkeypatch):
+    # CGSession said NULL, but the window-server lookup was REFUSED: the host has a
+    # window server we are not allowed to reach. A different code and a different
+    # probe name, so an agent branches on data.
+    monkeypatch.setattr("gda.display._macos_has_window_server", lambda: False)
+    monkeypatch.setattr("gda.display._macos_window_server_denied", lambda: True)
+
+    verdict = _macos_verdict()
+
+    assert verdict is not None
+    assert verdict.code == "live_windowed_permission_denied"
+    assert verdict.probe.name == "bootstrap_look_up(com.apple.windowserver.active)"
+    assert verdict.probe.platform == sys.platform
+    assert "re-run outside the sandbox" in verdict.reason
+
+
+def test_the_denial_probe_failing_falls_back_to_the_capability_verdict(monkeypatch):
+    # The denial probe is best-effort private-ish plumbing (a libSystem symbol). If it
+    # cannot run at all — a future macOS drops the symbol, ctypes misbehaves — the
+    # refusal must behave exactly as it did before the probe existed, never crash a
+    # `daemon start`.
+    def _explode():
+        raise OSError("no libSystem here")
+
+    monkeypatch.setattr("gda.display.ctypes.CDLL", lambda _path: _explode())
+    assert _macos_window_server_denied() is False
+
+    monkeypatch.setattr("gda.display._macos_has_window_server", lambda: False)
+    fallback = _macos_verdict()
+    assert fallback is not None
+    assert fallback.code == "live_windowed_unavailable"
+
+
+@pytest.mark.parametrize("variable", ["DISPLAY", "WAYLAND_DISPLAY"])
+def test_linux_with_a_display_can_launch_windowed(monkeypatch, variable):
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.setenv(variable, ":0")
+
+    assert _linux_verdict() is None
+
+
+def test_linux_without_a_display_is_the_capability_verdict(monkeypatch):
+    # No permission split on Linux: the environment variables are readable under any
+    # confinement, so an unset pair always means "no display to reach".
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+
+    verdict = _linux_verdict()
+
+    assert verdict is not None
+    assert verdict.code == "live_windowed_unavailable"
+    assert verdict.probe.name == "$DISPLAY / $WAYLAND_DISPLAY"
+
+
+def test_the_verdict_carries_a_registered_error_code():
+    # Whatever the probe decides must be a code the failure builder accepts — the
+    # refusal sites pass `verdict.code` straight into `make_failure`.
+    from gda.error_codes import ERROR_CODE_BY_CODE
+
+    for code in ("live_windowed_unavailable", "live_windowed_permission_denied"):
+        spec = ERROR_CODE_BY_CODE[code]
+        assert spec.category.value == "environment"
+        assert spec.exit_code == 127
+
+
+# --- the real macOS denial probe (capability-gated) --------------------------
+
+_SANDBOX_PROFILE = '(version 1)\n(allow default)\n(deny mach-lookup (global-name "com.apple.windowserver.active"))\n'
+
+_PROBE_SCRIPT = textwrap.dedent(
+    """
+    import json
+    from gda.display import windowed_unavailable
+    verdict = windowed_unavailable()
+    print(json.dumps(
+        None if verdict is None
+        else {"code": verdict.code, "probe": verdict.probe.name}
+    ))
+    """
+)
+
+
+def _sandbox_exec_works(tmp_path: Path) -> bool:
+    """Can this host actually run a seatbelt profile? (else the leg is meaningless)"""
+    if sys.platform != "darwin" or shutil.which("sandbox-exec") is None:
+        return False
+    profile = tmp_path / "preflight.sb"
+    profile.write_text("(version 1)\n(allow default)\n", encoding="utf-8")
+    try:
+        probe = subprocess.run(
+            ["sandbox-exec", "-f", str(profile), "/usr/bin/true"],
+            capture_output=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return probe.returncode == 0
+
+
+def _verdict_under(profile: Path | None, tmp_path: Path) -> dict | None:
+    script = tmp_path / "probe.py"
+    script.write_text(_PROBE_SCRIPT, encoding="utf-8")
+    argv = [sys.executable, str(script)]
+    if profile is not None:
+        argv = ["sandbox-exec", "-f", str(profile), *argv]
+    run = subprocess.run(argv, capture_output=True, text=True, timeout=60)
+    assert run.returncode == 0, f"probe failed: {run.stderr}"
+    return json.loads(run.stdout.strip())
+
+
+def test_a_real_sandbox_denial_is_classified_as_a_permission_problem(tmp_path):
+    # The end-to-end proof of the #667 spike finding, against a REAL seatbelt sandbox
+    # rather than a fake: on a host that HAS a desktop session, denying only the
+    # window-server mach lookup must flip the verdict to the permission code — not to
+    # live_windowed_unavailable, which is what the dogfooding saw and what made
+    # automation record the machine as display-less.
+    if not _sandbox_exec_works(tmp_path):
+        pytest.skip("needs macOS with a working sandbox-exec")
+    if windowed_unavailable() is not None:
+        pytest.skip("needs a real on-console desktop session to deny access TO")
+
+    profile = tmp_path / "deny-windowserver.sb"
+    profile.write_text(_SANDBOX_PROFILE, encoding="utf-8")
+
+    # The control: unsandboxed on this same host, a windowed session can launch.
+    assert _verdict_under(None, tmp_path) is None
+
+    denied = _verdict_under(profile, tmp_path)
+
+    assert denied == {
+        "code": "live_windowed_permission_denied",
+        "probe": "bootstrap_look_up(com.apple.windowserver.active)",
+    }
+
+
+def test_the_probe_returns_a_verdict_or_none_on_this_host():
+    # A cheap always-on sanity check that the real probe runs without raising on
+    # whatever host the suite is on, whatever it concludes.
+    verdict = windowed_unavailable()
+    assert verdict is None or isinstance(verdict, WindowedUnavailable)

--- a/tests/test_display_probe.py
+++ b/tests/test_display_probe.py
@@ -1,16 +1,18 @@
 """The host-display probe's verdict logic (#345, #667).
 
 ``gda.display`` answers ONE question with two possible refusals, and the split is
-what #667 is about: "no window server on this host" (skip rendered QA) versus "this
-process may not reach the one that exists" (retry outside the sandbox). Reading the
-second as the first is the dogfooded defect (GDA-DF-029).
+what #667 is about: "no window server was detected here" (skip rendered QA) versus
+"the window-server lookup was REFUSED" (re-run outside the restriction). Reading the
+second as the first is the dogfooded defect (GDA-DF-029). The second refusal claims
+nothing about whether a window server exists — macOS refuses the lookup per name and
+before resolving it — so a guard below pins that no branch reasserts existence.
 
 Tiering follows from where the risk is:
 
 - The **verdict logic** — which code, which probe name, which platform — is a pure
-  function of the two boolean host answers, so it is tested by injecting those
-  answers. UNGATED: it runs on every host, including a display-less CI runner, which
-  is exactly where a regression would otherwise hide.
+  function of the host answers, so it is tested by injecting those answers. UNGATED:
+  it runs on every host, including a display-less CI runner, which is exactly where a
+  regression would otherwise hide.
 - The **real macOS denial probe** needs a real sandbox to mean anything, so that one
   leg is capability-gated on macOS + a working ``sandbox-exec`` + an actual desktop
   session, and skips honestly elsewhere.
@@ -28,6 +30,7 @@ import pytest
 from gda.display import (
     _DENIAL_BLANKET,
     _DENIAL_NAME_SPECIFIC,
+    _DENIAL_UNKNOWN_BREADTH,
     WindowedUnavailable,
     _linux_verdict,
     _macos_verdict,
@@ -75,6 +78,7 @@ def test_macos_without_a_window_server_is_the_capability_verdict(monkeypatch):
     [
         (_DENIAL_NAME_SPECIFIC, "specific to that service"),
         (_DENIAL_BLANKET, "broadly confined"),
+        (_DENIAL_UNKNOWN_BREADTH, "stays unknown"),
     ],
 )
 def test_macos_denied_window_server_is_the_permission_verdict(
@@ -96,7 +100,9 @@ def test_macos_denied_window_server_is_the_permission_verdict(
     assert "re-run outside the" in verdict.reason
 
 
-@pytest.mark.parametrize("denial", [_DENIAL_NAME_SPECIFIC, _DENIAL_BLANKET])
+@pytest.mark.parametrize(
+    "denial", [_DENIAL_NAME_SPECIFIC, _DENIAL_BLANKET, _DENIAL_UNKNOWN_BREADTH]
+)
 def test_no_denial_branch_claims_the_host_has_a_window_server(monkeypatch, denial):
     # The #667-review regression guard. A refused lookup is evaluated per name and
     # BEFORE resolution, so it proves confinement, NOT existence — a blanket-deny
@@ -133,6 +139,11 @@ def test_no_denial_branch_claims_the_host_has_a_window_server(monkeypatch, denia
         # BOTH refused. Seatbelt evaluates the deny per name and before resolution,
         # so this is a broadly-confined process and the probe learned only that.
         (1100, 1100, _DENIAL_BLANKET),
+        # Control answered something we have no reading for. Only a REFUSED control
+        # licenses the blanket reading, so these must NOT be folded into it — that
+        # would invent a fact about the confinement from an unreadable result.
+        (1100, 0, _DENIAL_UNKNOWN_BREADTH),  # the control name somehow resolved
+        (1100, 5, _DENIAL_UNKNOWN_BREADTH),  # an arbitrary unrelated error
         # Not refused at all -> no denial evidence, whatever the control says.
         (1102, 1102, None),
         (0, 1102, None),
@@ -327,3 +338,82 @@ def test_the_probe_returns_a_verdict_or_none_on_this_host():
     # whatever host the suite is on, whatever it concludes.
     verdict = windowed_unavailable()
     assert verdict is None or isinstance(verdict, WindowedUnavailable)
+
+
+# --- the test-side gate policy (ungated) -------------------------------------
+#
+# The gate helper decides whether an environment refusal SKIPS or FAILS, and the
+# whole point of #667 is that those two reactions are not interchangeable. Tabled
+# here so the policy itself is covered, not just the probe that feeds it.
+
+
+@pytest.mark.parametrize(
+    ("code", "reaction"),
+    [
+        ("live_windowed_unavailable", "skipped"),
+        ("live_display_unavailable", "skipped"),
+        ("live_windowed_permission_denied", "failed"),
+        ("engine_session_not_running", "returned"),
+        (None, "returned"),
+    ],
+)
+def test_the_no_display_reaction_policy(code, reaction):
+    from tests.support import handle_no_display_code
+
+    if reaction == "returned":
+        # Not a display refusal: the helper stays out of the way so the caller can
+        # raise its own assertion for a genuine failure.
+        handle_no_display_code(code)
+        return
+
+    with pytest.raises(BaseException) as caught:
+        handle_no_display_code(code)
+
+    outcome = type(caught.value).__name__
+    if reaction == "skipped":
+        assert outcome == "Skipped"
+    else:
+        assert outcome == "Failed"
+        # The failure has to carry the remediation, or a confined CI run reads as a
+        # plain breakage instead of "you are sandboxed".
+        assert "Re-run outside the sandbox/restriction" in str(caught.value)
+        assert "did NOT execute" in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    ("verdict_code", "reaction"),
+    [
+        ("live_windowed_unavailable", "Skipped"),
+        ("live_windowed_permission_denied", "Failed"),
+    ],
+)
+def test_the_preflight_gate_applies_the_same_policy(
+    monkeypatch, verdict_code, reaction
+):
+    # The pre-flight probe path and the post-start race path must agree — they used
+    # to be written out separately at five call sites, which is how the wrong
+    # reaction spread in the first place.
+    from gda.models import EnvironmentProbe
+    from tests.support import require_windowed_host
+
+    monkeypatch.setattr(
+        "gda.display.windowed_unavailable",
+        lambda: WindowedUnavailable(
+            code=verdict_code,
+            reason=f"test verdict ({verdict_code})",
+            probe=EnvironmentProbe(name="probe", platform="darwin"),
+        ),
+    )
+
+    with pytest.raises(BaseException) as caught:
+        require_windowed_host()
+
+    assert type(caught.value).__name__ == reaction
+
+
+def test_the_preflight_gate_runs_the_test_when_a_window_can_open(monkeypatch):
+    from tests.support import require_windowed_host
+
+    monkeypatch.setattr("gda.display.windowed_unavailable", lambda: None)
+
+    require_windowed_host()  # must not raise

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -31,7 +31,7 @@ from gda.harness.install import (
     installed_harness_version,
 )
 
-from tests.support import GDA_CMD
+from tests.support import GDA_CMD, assert_windowed_ok
 
 from .conftest import project_godot
 
@@ -1280,8 +1280,10 @@ def test_daemon_serves_screen_capture_while_scenetree_paused(
         return json.loads(got.stdout)["properties"][0]["value"]
 
     try:
-        started = run("daemon", "start", "--windowed")
-        assert started.returncode == 0, started.stdout + started.stderr
+        # Display refusals on the windowed start / capture branches go through the
+        # shared policy first (capability -> skip, permission -> loud fail); anything
+        # else still falls through to the ordinary assertion.
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
 
         # Pause the game the way a real pause menu does: a live `game set` flips
         # SceneTree.paused through the Resumer's forwarding property.
@@ -1299,8 +1301,7 @@ def test_daemon_serves_screen_capture_while_scenetree_paused(
         assert tree_is_paused() is True
 
         capture_path = tmp_path / "paused.png"
-        captured = run("screen", "capture", "--output", str(capture_path))
-        assert captured.returncode == 0, captured.stdout + captured.stderr
+        assert_windowed_ok(run("screen", "capture", "--output", str(capture_path)))
         assert capture_path.exists()
         assert capture_path.stat().st_size > 0
 

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -968,11 +968,11 @@ def test_daemon_status_surfaces_the_windowed_display_mode(tmp_path, daemon_runti
         # --windowed` now refuses PRE-LAUNCH with live_windowed_unavailable on a host
         # with no usable DisplayServer (#345), so gate this half on the shared display
         # helper — the headless portions above already ran.
-        from gda.display import windowed_unavailable_reason
+        from gda.display import windowed_unavailable
 
-        reason = windowed_unavailable_reason()
-        if reason is not None:
-            pytest.skip(reason)
+        unavailable = windowed_unavailable()
+        if unavailable is not None:
+            pytest.skip(unavailable.reason)
         assert run("daemon", "start", "--windowed").returncode == 0
         windowed = json.loads(run("daemon", "status").stdout)
         assert windowed["running"] is True
@@ -1262,11 +1262,11 @@ def test_daemon_serves_screen_capture_while_scenetree_paused(
     # a resume `input sequence` injection, and a responsiveness proof — the same
     # read/resume/responsiveness shape the headless test proves without a display,
     # here proven end-to-end alongside the capture that needs one.
-    from gda.display import windowed_unavailable_reason
+    from gda.display import windowed_unavailable
 
-    reason = windowed_unavailable_reason()
-    if reason is not None:
-        pytest.skip(reason)
+    unavailable = windowed_unavailable()
+    if unavailable is not None:
+        pytest.skip(unavailable.reason)
 
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(PAUSE_MAIN_TSCN, encoding="utf-8")

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -968,11 +968,9 @@ def test_daemon_status_surfaces_the_windowed_display_mode(tmp_path, daemon_runti
         # --windowed` now refuses PRE-LAUNCH with live_windowed_unavailable on a host
         # with no usable DisplayServer (#345), so gate this half on the shared display
         # helper — the headless portions above already ran.
-        from gda.display import windowed_unavailable
+        from tests.support import require_windowed_host
 
-        unavailable = windowed_unavailable()
-        if unavailable is not None:
-            pytest.skip(unavailable.reason)
+        require_windowed_host()
         assert run("daemon", "start", "--windowed").returncode == 0
         windowed = json.loads(run("daemon", "status").stdout)
         assert windowed["running"] is True
@@ -1262,11 +1260,9 @@ def test_daemon_serves_screen_capture_while_scenetree_paused(
     # a resume `input sequence` injection, and a responsiveness proof — the same
     # read/resume/responsiveness shape the headless test proves without a display,
     # here proven end-to-end alongside the capture that needs one.
-    from gda.display import windowed_unavailable
+    from tests.support import require_windowed_host
 
-    unavailable = windowed_unavailable()
-    if unavailable is not None:
-        pytest.skip(unavailable.reason)
+    require_windowed_host()
 
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(PAUSE_MAIN_TSCN, encoding="utf-8")

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -971,7 +971,10 @@ def test_daemon_status_surfaces_the_windowed_display_mode(tmp_path, daemon_runti
         from tests.support import require_windowed_host
 
         require_windowed_host()
-        assert run("daemon", "start", "--windowed").returncode == 0
+        # Two separate observations: the precheck above and the CLI's own guard.
+        # A capability verdict slipping in between must SKIP (permission-denied
+        # must fail loudly) — the shared policy, not a bare returncode assertion.
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
         windowed = json.loads(run("daemon", "status").stdout)
         assert windowed["running"] is True
         assert windowed["windowed"] is True

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -26,7 +26,7 @@ import subprocess
 import pytest
 
 from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import GDA_CMD, assert_windowed_ok
 
 from .conftest import project_godot
 
@@ -98,12 +98,13 @@ def test_windowed_daemon_captures_a_single_viewport_frame(tmp_path, daemon_runti
     out = tmp_path / "shot.png"
 
     try:
-        started = run("daemon", "start", "--windowed")
-        assert started.returncode == 0, started.stdout + started.stderr
+        # A refusal on the start / first-live-op / capture branches is routed through
+        # the shared display policy before the ordinary assertion: a capability
+        # verdict skips (as the game's tiers do), a permission verdict fails loudly.
+        started = assert_windowed_ok(run("daemon", "start", "--windowed"))
         assert json.loads(started.stdout)["windowed"] is True
 
-        cap = run("screen", "capture", "--output", str(out))
-        assert cap.returncode == 0, cap.stdout + cap.stderr
+        cap = assert_windowed_ok(run("screen", "capture", "--output", str(out)))
         doc = json.loads(cap.stdout)
         assert doc["path"] == str(out)
         assert doc["width"] > 0 and doc["height"] > 0
@@ -128,9 +129,10 @@ def test_windowed_daemon_inline_embeds_the_base64(tmp_path, daemon_runtime_dir):
     out = tmp_path / "shot.png"
 
     try:
-        assert run("daemon", "start", "--windowed").returncode == 0
-        cap = run("screen", "capture", "--inline", "--output", str(out))
-        assert cap.returncode == 0, cap.stdout + cap.stderr
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
+        cap = assert_windowed_ok(
+            run("screen", "capture", "--inline", "--output", str(out))
+        )
         doc = json.loads(cap.stdout)
         import base64
 
@@ -150,9 +152,10 @@ def test_windowed_daemon_captures_a_frame_window(tmp_path, daemon_runtime_dir):
     out_dir = tmp_path / "frames"
 
     try:
-        assert run("daemon", "start", "--windowed").returncode == 0
-        frames = run("screen", "frames", "--frames", "3", "--output-dir", str(out_dir))
-        assert frames.returncode == 0, frames.stdout + frames.stderr
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
+        frames = assert_windowed_ok(
+            run("screen", "frames", "--frames", "3", "--output-dir", str(out_dir))
+        )
         doc = json.loads(frames.stdout)
         assert doc["count"] == 3
         assert len(doc["frames"]) == 3

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -26,7 +26,7 @@ import subprocess
 import pytest
 
 from gda.binary import resolve_godot_binary
-from gda.display import windowed_unavailable_reason
+from gda.display import windowed_unavailable
 from tests.support import GDA_CMD
 
 from .conftest import project_godot
@@ -56,14 +56,15 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 # "macOS always has one" assumption: headless macOS (SSH / CI / sandbox) has no
 # on-console window-server session even though `launchctl managername` reports
 # "Aqua", and a windowed Godot aborts in AppKit registration there — so the gate is
-# the shared `gda.display.windowed_unavailable_reason()` helper (#345), which probes
+# the shared `gda.display.windowed_unavailable()` helper (#345), which probes
 # CGSessionCopyCurrentDictionary on macOS and $DISPLAY/$WAYLAND_DISPLAY on Linux,
 # skipping BEFORE spawning (and crashing) Godot. The headless-guard and no-daemon
 # screen tests below still run. Forward-compatible: wire Xvfb into CI (DISPLAY set)
 # and these run rather than skip.
-_NO_DISPLAY_REASON = windowed_unavailable_reason()
+_NO_DISPLAY = windowed_unavailable()
+_NO_DISPLAY_REASON = None if _NO_DISPLAY is None else _NO_DISPLAY.reason
 _needs_display = pytest.mark.skipif(
-    _NO_DISPLAY_REASON is not None,
+    _NO_DISPLAY is not None,
     reason=_NO_DISPLAY_REASON or "the host has a usable DisplayServer",
 )
 

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -26,7 +26,6 @@ import subprocess
 import pytest
 
 from gda.binary import resolve_godot_binary
-from gda.display import windowed_unavailable
 from tests.support import GDA_CMD
 
 from .conftest import project_godot
@@ -61,12 +60,12 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 # skipping BEFORE spawning (and crashing) Godot. The headless-guard and no-daemon
 # screen tests below still run. Forward-compatible: wire Xvfb into CI (DISPLAY set)
 # and these run rather than skip.
-_NO_DISPLAY = windowed_unavailable()
-_NO_DISPLAY_REASON = None if _NO_DISPLAY is None else _NO_DISPLAY.reason
-_needs_display = pytest.mark.skipif(
-    _NO_DISPLAY is not None,
-    reason=_NO_DISPLAY_REASON or "the host has a usable DisplayServer",
-)
+# A fixture, not a skipif: the reaction differs by verdict (#667). A host that
+# CANNOT show a window skips; a run that is merely CONFINED fails loudly, because
+# skipping there greens the suite with the rendered acceptance unexecuted. The
+# policy has one owner — `tests.support.require_windowed_host` — shared with the
+# post-start race path and the daemon suite.
+_needs_display = pytest.mark.usefixtures("windowed_host")
 
 
 def _scaffold(tmp_path):

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -175,6 +175,36 @@ def test_live_windowed_unavailable_flows_through_classify_live():
     assert outcome.error.diagnostics == "why-here"
 
 
+def test_live_windowed_permission_denied_flows_through_classify_live():
+    # #667: the sandbox-denial sibling is raised at the same daemon launch boundary
+    # and relayed the same way, so it needs the same whitelist entry — without it
+    # classify_run would misroute an ENVIRONMENT code to operation_failed. It
+    # resolves to its own registered environment/127 shape, distinct from
+    # live_windowed_unavailable, so an agent can tell "retry outside the sandbox"
+    # from "this host cannot show a window".
+    from gda.daemon.protocol import error_reply
+    from gda.errors import _LIVE_CLIENT_CODES, Failure, classify_live
+    from gda.commands.game import GameTreeResult
+    from gda.runner import RunResult
+
+    assert "live_windowed_permission_denied" in _LIVE_CLIENT_CODES
+
+    reply = error_reply(
+        "live_windowed_permission_denied",
+        "denied access to the window server",
+        diagnostics="why-here",
+    )
+    outcome = classify_live(RunResult(**reply), None, GameTreeResult)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "live_windowed_permission_denied"
+    assert outcome.error.category is ErrorCategory.ENVIRONMENT
+    assert outcome.exit_code == 127
+    assert outcome.error.diagnostics == "why-here"
+    # Relayed over the ADR-0002 wire envelope, which carries no probe context.
+    assert outcome.error.probe is None
+
+
 def test_harness_live_error_codes_are_registered_live_codes():
     # The per-op LIVE failures the gda harness reports (#220) are registered
     # LIVE-category classifier-source codes: because their category is LIVE,

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -191,7 +191,7 @@ def test_live_windowed_permission_denied_flows_through_classify_live():
 
     reply = error_reply(
         "live_windowed_permission_denied",
-        "denied access to the window server",
+        "denied the window-server lookup",
         diagnostics="why-here",
     )
     outcome = classify_live(RunResult(**reply), None, GameTreeResult)
@@ -201,8 +201,52 @@ def test_live_windowed_permission_denied_flows_through_classify_live():
     assert outcome.error.category is ErrorCategory.ENVIRONMENT
     assert outcome.exit_code == 127
     assert outcome.error.diagnostics == "why-here"
-    # Relayed over the ADR-0002 wire envelope, which carries no probe context.
+    # No probe was put on this reply, so none comes out — the key is optional.
     assert outcome.error.probe is None
+
+
+def test_a_relayed_windowed_refusal_carries_probe_to_the_public_json():
+    # #667 review: the AUTHORITATIVE refusal is the daemon's lazy-launch guard, so the
+    # probe context must survive the whole daemon-reply -> live-classifier -> public
+    # envelope path, not just the CLI fail-fast. Walks that path end to end with the
+    # REAL builders and the REAL emit serialization at both ends.
+    import json
+
+    from gda.daemon.protocol import error_reply
+    from gda.errors import Failure, classify_live
+    from gda.commands.game import GameTreeResult
+    from gda.models import EnvironmentProbe, GdaErrorEnvelope
+    from gda.runner import RunResult
+
+    probe = EnvironmentProbe(
+        name="bootstrap_look_up(com.apple.windowserver.active)", platform="darwin"
+    )
+    reply = error_reply(
+        "live_windowed_permission_denied",
+        "a windowed engine session cannot launch: denied",
+        diagnostics="why-here",
+        probe=probe,
+    )
+
+    outcome = classify_live(RunResult(**reply), None, GameTreeResult)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "live_windowed_permission_denied"
+    assert outcome.error.category is ErrorCategory.ENVIRONMENT
+    assert outcome.exit_code == 127
+    assert outcome.error.probe is not None
+    assert outcome.error.probe.name == (
+        "bootstrap_look_up(com.apple.windowserver.active)"
+    )
+    assert outcome.error.probe.platform == "darwin"
+    # And it survives to the public JSON an agent actually reads.
+    emitted = json.loads(
+        GdaErrorEnvelope(error=outcome.error).model_dump_json(exclude_none=True)
+    )
+    assert emitted["error"]["probe"] == {
+        "name": "bootstrap_look_up(com.apple.windowserver.active)",
+        "platform": "darwin",
+    }
 
 
 def test_harness_live_error_codes_are_registered_live_codes():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -138,6 +138,32 @@ def test_error_envelope_round_trips_a_failure():
     # envelope's optional context keys are OMITTED, never emitted as `null`, so a
     # failure that sets none is byte-identical to the pre-amendment contract.
     assert json.loads(envelope.model_dump_json(exclude_none=True)) == payload
+    # And the ONLY thing that convention drops is the optional context. Pinning the
+    # difference — rather than just asserting the filtered form — keeps this a real
+    # guard: a future optional key that a consumer would see as `null` fails here.
+    raw = json.loads(envelope.model_dump_json())
+    assert set(raw["error"]) - set(payload["error"]) == {"probe"}
+    assert raw["error"]["probe"] is None
+
+
+def test_the_emitted_failure_envelope_omits_probe_entirely():
+    # The ABI guard for the ADR-0004 amendment, through the REAL emit path rather
+    # than a hand-rolled dump (#667 review): dropping `exclude_none` from
+    # emit_failure would add `"probe": null` to EVERY failure gda emits, which is
+    # exactly the break the amendment's additive argument rests on not happening.
+    # `--godot ""` fails binary resolution before anything is spawned, so this is a
+    # fast, engine-free, ungated check that runs in every CI tier.
+    from typer.testing import CliRunner
+
+    from gda.cli import app
+
+    result = CliRunner().invoke(app, ["info", "--godot", "", "--json"])
+
+    assert result.exit_code == 127
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "binary_not_found"
+    assert "probe" not in error
+    assert set(error) == {"category", "code", "message", "diagnostics"}
 
 
 def test_error_envelope_round_trips_a_failure_carrying_probe_context():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -134,7 +134,33 @@ def test_error_envelope_round_trips_a_failure():
 
     assert isinstance(envelope.error, GdaError)
     assert envelope.error.code == "path_not_found"
-    assert json.loads(envelope.model_dump_json()) == payload
+    # `exclude_none` is the public emit convention (ADR-0004 amendment, #667): the
+    # envelope's optional context keys are OMITTED, never emitted as `null`, so a
+    # failure that sets none is byte-identical to the pre-amendment contract.
+    assert json.loads(envelope.model_dump_json(exclude_none=True)) == payload
+
+
+def test_error_envelope_round_trips_a_failure_carrying_probe_context():
+    # The other half of the amendment: a host-probe ENVIRONMENT failure DOES carry
+    # the deciding call as data, and that shape round-trips through the same model.
+    payload = {
+        "error": {
+            "category": "environment",
+            "code": "live_windowed_permission_denied",
+            "message": "denied access to the macOS window server",
+            "diagnostics": "",
+            "probe": {
+                "name": "bootstrap_look_up(com.apple.windowserver.active)",
+                "platform": "darwin",
+            },
+        }
+    }
+
+    envelope = GdaErrorEnvelope.model_validate(payload)
+
+    assert envelope.error.probe is not None
+    assert envelope.error.probe.platform == "darwin"
+    assert json.loads(envelope.model_dump_json(exclude_none=True)) == payload
 
 
 def test_scene_create_result_round_trips():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -173,7 +173,7 @@ def test_error_envelope_round_trips_a_failure_carrying_probe_context():
         "error": {
             "category": "environment",
             "code": "live_windowed_permission_denied",
-            "message": "denied access to the macOS window server",
+            "message": "denied the macOS window-server lookup",
             "diagnostics": "",
             "probe": {
                 "name": "bootstrap_look_up(com.apple.windowserver.active)",

--- a/tests/test_sentinel_result.py
+++ b/tests/test_sentinel_result.py
@@ -45,6 +45,45 @@ def test_error_envelope_is_the_operation_error_payload_shape():
     }
 
 
+def test_the_envelope_carries_probe_only_when_one_is_supplied():
+    # #667 review: the live channel may carry structured host-probe context, so the
+    # builder grew ONE optional key. It must be OMITTED (never null) when absent —
+    # that is what keeps every GDScript-emitted headless envelope and every other
+    # live reply byte-identical, and what lets the strict headless
+    # OperationErrorEnvelope keep rejecting extras.
+    probe = {"name": "CGSessionCopyCurrentDictionary", "platform": "darwin"}
+
+    assert error_envelope("live_windowed_permission_denied", "denied", probe) == {
+        "error": {
+            "code": "live_windowed_permission_denied",
+            "message": "denied",
+            "probe": probe,
+        }
+    }
+    assert "probe" not in error_envelope("node_not_found", "no such node")["error"]
+
+
+def test_the_headless_sentinel_model_still_rejects_the_live_probe_key():
+    # The two channels keep DIFFERENT models on purpose: a GDScript operation has no
+    # host probe to report, so the headless sentinel stays strict and probe-less. Only
+    # the live envelope accepts the key.
+    import pytest
+    from pydantic import ValidationError
+
+    from gda.models import LiveErrorEnvelope, OperationErrorEnvelope
+
+    payload = error_envelope(
+        "live_windowed_permission_denied",
+        "denied",
+        {"name": "CGSessionCopyCurrentDictionary", "platform": "darwin"},
+    )
+
+    with pytest.raises(ValidationError):
+        OperationErrorEnvelope.model_validate(payload)
+
+    assert LiveErrorEnvelope.model_validate(payload).error.probe is not None
+
+
 def test_result_reply_carries_the_sentinel_payload_at_exit_zero():
     payload = {"lines": ["a", "b"]}
     assert result_reply(payload) == {


### PR DESCRIPTION
## Summary

`gda daemon start --windowed` reported `live_windowed_unavailable` for two different
facts about the world: no window server is reachable, and the window-server lookup was
refused outright. They need opposite reactions, so automation read a sandbox boundary
as a machine-capability gap and silently skipped rendered QA (dogfooding GDA-DF-029).

**Spike result: a usable signal exists**, so this takes the classification branch of
the issue. Its strength was **overstated in the first round and corrected on review** —
see below and the [correction comment](https://github.com/aigengame/godot-agent/issues/667#issuecomment-5310776173).

## The spike, as corrected

`CGSessionCopyCurrentDictionary` returns NULL with no error code, so it cannot say WHY.
`bootstrap_look_up` of the window-server mach service does add information — but less
than the first round claimed.

| profile (desktop host) | `com.apple.windowserver.active` | unregistered control name |
| --- | --- | --- |
| unsandboxed | `KERN_SUCCESS` | `BOOTSTRAP_UNKNOWN_SERVICE` (1102) |
| `(allow default)` + deny only that name | **`BOOTSTRAP_NOT_PRIVILEGED` (1100)** | `1102` |
| `(deny default)`, no mach-lookup | **`1100`** | **`1100`** |
| `(allow default)` + deny `file-write*` only | `KERN_SUCCESS` | — |

**What 1100 proves: "the policy refused THIS lookup" — nothing more.** macOS evaluates
a seatbelt `mach-lookup` deny per name and *before* resolving it, so a blanket-deny
profile refuses an unregistered name too (row 3). The first round inferred "the host
HAS a window server" from 1100; that is false, and would have told a display-less CI
Mac under a broad-deny profile that its host has a display, with a remediation that
cannot succeed — the same inverted-failure direction used to reject
`sessionHasGraphicAccess`.

**A control lookup characterises the confinement** without licensing an existence
claim: control `1102` → the denial is **name-specific** (sandbox signature); control
`1100` → **blanket** confinement; any other control answer → **unknown breadth**, which
claims only the target refusal (round-3: folding unreadable statuses into "blanket"
would invent a fact). All three report the same code and all three say gda cannot tell
whether a window server exists.

A **filesystem-only** restriction does not trip the probe at all (row 4), so this never
fires on unrelated confinement.

Also measured and rejected: `launchctl managername` (reports "Aqua" in every row) and
`SessionGetInfo`'s `sessionHasGraphicAccess` (stays true under a denying sandbox, but
can also be true on an auto-logged-in CI box with no reachable window server).

## What changed

- **New registered code `live_windowed_permission_denied`** — ENVIRONMENT, exit 127
  (the same bucket as its sibling), classifier-source, not GDScript-mirrored. It means
  *the window-server lookup was refused*, which holds in both control branches.
  Deliberately not overloading `live_display_unavailable`, the harness's capture-time
  code.
- **`gda.display` returns a verdict, not a reason string** — `WindowedUnavailable
  {code, reason, probe}`. Both refusal sites (the `daemon start` fail-fast and the
  daemon's authoritative launch-boundary guard) relay the code the probe decided. The
  denial probe runs only on the failure path; the control lookup runs only after a
  refusal, so a healthy desktop pays nothing.
- **ADR-0004 amendment** — one optional `probe` `{name, platform}` key on the Error
  envelope. Added as a dated note in the ADR's existing `> **Outcome/Amendment**`
  block at the top of the file (the repo's convention for that ADR); no accepted-prose
  line was modified.
- Docs: ADR-0002 registry row, `docs/command-catalog.md` lifecycle entry, and the
  desktop-session requirement + code-branch guidance in the bundled skill's live
  section.

### Commit `0b6be192`

`examples/platformer/panda-adventure/tests` is a **separate pytest root that PR CI
enforces as its own tier**, and my first head failed it: three e2e gates there imported
the renamed helper, which surfaced as a collection `ImportError`. That commit updates
those three gates plus the gADR-0007 seam description. On review, the same three files'
`_NO_DISPLAY_CODES` skip sets also gained `live_windowed_permission_denied`, so a
display-state race between the pre-check and the live call skips rather than fails.

## The envelope change is additive — proof

`emit_failure` serializes with `exclude_none`, so `probe` is **omitted, never `null`**,
for every failure that does not set one. Guarded through the **real CLI** by an ungated
test (a probe-less `binary_not_found`), not only by hand-rolled model dumps.

Schema diff (`gda schema`, all 67 commands), enumerated exhaustively:

1. `$defs.EnvironmentProbe` added;
2. `GdaError.properties.probe` added — `anyOf[EnvironmentProbe, null]`, `default: null`,
   **not** in `required`;
3. `GdaError.description` extended by one clause.

Unchanged: every existing `GdaError` property byte-identical, `required` unchanged, and
`input` / `output` / `kind` / `constraints` unchanged for all 67 commands. Exactly
**one** distinct error schema across the whole surface, so ADR-0004's "byte-for-byte the
same for every command" invariant holds. `gda daemon start --help` is byte-identical.

**Size: +15.3%** (361781 → 417257 bytes), unchanged by the relay work — `LiveError`
is an internal daemon↔CLI wire model and does not appear in the published `--schema`
surface (verified). The error schema is repeated per command, so
description text is paid ~67 times: the field descriptions added on review (F4) are
+5.4pp of that, after tightening them from a first pass that cost +9.8pp. Model
rationale is kept in comments for the same reason.

`gda-mcp` needs no change: it maps only `input`/`output` and passes the envelope through
to its `is_error` channel.

## Scope boundary with #687

#687 owns whether the failure ABI carries operation-scoped **typed evidence** (a
script's exit status, parsed `ScriptError[]`, #655's timeout fields). This amendment
does not decide that and does not pre-empt its shape: `probe` is a fixed two-string
answer to "which host call decided this environment verdict". The amendment states
explicitly that the two axes compose and that #687 stays free to adopt, reshape, or
decline typed evidence.

**The relay carries `probe` too** (round-3 review). The refusal that actually gates
every live op is the daemon's lazy-launch guard, not the CLI's optional fail-fast, so
leaving the field off the relay made the AUTHORITATIVE path the poorer one while #667's
AC is unqualified. The live envelope therefore takes the same optional key —
`LiveError` is `{code, message, probe?}` — and it is validated end to end (daemon reply
→ `classify_live` → public JSON) on the real builders.

The **cross-language contract is untouched**: the GDScript-emitted headless sentinel
keeps its own strict, probe-less model (`OperationError`, `extra="forbid"`), because a
GDScript operation has no host probe to report. Two models, one per channel. On the
wire the key is omitted when absent, so every other live reply and every headless
envelope is byte-identical.

## Test tiering

**Ungated** (every CI tier runs these; the verdict logic is a pure function of injected
host answers, so no display and no sandbox are needed):

- `tests/test_display_probe.py` — the verdict logic (capability vs both denial
  branches), the status→breadth mapping via a fake lookup, that the control lookup is
  skipped unless the target was refused, the degradation guard (probe raising falls back
  to the old verdict), and a **regression guard that no branch reasserts host-has-a-
  window-server**.
- `tests/test_models.py` — the `exclude_none` ABI guard through the real CLI, plus
  envelope round-trips pinning that the only key the convention drops is `probe`.
- `tests/test_daemon_lifecycle_payload.py` — the denied start returns the new code at
  ENVIRONMENT/127, still pre-launch and non-mutating, with the probe field.
- `tests/test_daemon_server.py` — the daemon relay reports the probe's code, wire
  envelope shape unchanged.
- `tests/test_error_registry.py` — registry + `classify_live` flow.

**Capability-gated** (skips honestly off a capable host): the real-seatbelt leg in
`test_display_probe.py`, gated on macOS + a working `sandbox-exec` + an actual desktop
session to deny access TO. It exercises **both** profiles (name-specific and blanket)
and **ran and passed** on this host.

**The gate policy itself is the round-3 P1 fix.** The e2e gates used to skip on every
no-display code, which meant a sandboxed run greened the suite with the rendered
acceptance unexecuted — the GDA-DF-029 behaviour, reintroduced on the test side. There
is now ONE owner for the reaction per context (`tests/support.py`; the game gets its own
`tests/display_gate.py`, being a separate pytest root that cannot import the toolkit's
test package):

- capability (`live_windowed_unavailable`, `live_display_unavailable`) → **skip**;
- `live_windowed_permission_denied` → **fail**, carrying the re-run remediation.

`_needs_display` became a fixture because a `skipif` can only skip. Coverage, stated
precisely (the recheck caught an earlier overclaim here):

- **pre-flight** — the repo's windowed e2e (via the `windowed_host` fixture) and all
  three game gates, through `require_windowed_host()`.
- **post-start race path** — the game's three gates via `handle_no_display_code()`, and
  the repo's windowed e2e via `assert_windowed_ok()` on exactly the branches that can
  see a display refusal: `daemon start --windowed`, the first live op, and
  `screen capture` / `screen frames`. Other assertions are deliberately not wrapped.

Both reactions are table-tested ungated (including the fall-through cases, so a real
regression still fails with the command's own output), verified against a real seatbelt
profile (confined → `Failed`, unconfined → proceeds), and demonstrated on a real root
e2e test with an injected refusal: capability → `SKIPPED`, permission → `Failed` with
the remediation.

## Gates

- `uv run pytest -m "not e2e"` — 1327 passed (also green with `GITHUB_ACTIONS=true`)
- panda-adventure tier — 480 passed
- `uv run ruff check` / `ruff format --check` / `uv run pyright` — clean
- Godot e2e on a desktop host, under the shared serial lock: `test_e2e_daemon.py` +
  `test_e2e_screen.py` — 32 passed, windowed legs actually executed (not skipped)
- End-to-end reproduction: the real CLI under a real seatbelt sandbox emits
  `live_windowed_permission_denied` with `probe:
  {"name":"bootstrap_look_up(com.apple.windowserver.active)","platform":"darwin"}`

## Merge notes

- **#653 owns `error_codes.py` / ADR-0002 this wave and merges first.** This branch adds
  a registry entry and an ADR row there. Reviewer checked the sibling hunks and they sit
  elsewhere in both files, so a clean rebase is the expected case rather than a conflict.
- **Shared files with other in-flight slices:** `src/gda/errors.py` and
  `src/gda/headless.py` are also touched by #692/#696, in disjoint hunks.
- **`SKILL.md`** is owned by #659 and also edited by #696. This edit is in the live
  section's prerequisites prose, region-disjoint from the command tables.
- README deliberately untouched — flagged rather than assumed: its `--windowed` mention
  is a one-line aside, and the requirement detail belongs with the command docs and the
  skill. Say the word if you want a short clause there.

Closes #667
