### PR TITLE
fix(gda): refuse a script validate outside the resolved project and report the root

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,14 @@ does not compile is still a successful operation: exit `0`, no top-level `error`
 and `valid: false` with `error_string` / `diagnostics`. Operation problems such as
 a missing file still use the normal Error envelope.
 
+The result also reports `project_root`: the project the script was compiled against,
+which is the root its `res://` dependencies resolved to (`null` when no project was
+resolved). Read it before acting on a `valid: false` — a verdict full of missing
+`res://` dependencies, plus the type errors derived from them, usually means the wrong
+project rather than a broken script. A script *outside* the resolved project is refused
+up front with `project_not_found`, naming both the file and the project, instead of
+reporting those false errors; pass `--project` for the project that owns the file.
+
 **`project`** — the project as a whole (settings, autoloads, static analysis)
 
 | Command | What it does |

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7e7ef59df7e407b072ba03aa8dd6fb0325c4043a1e064f1ffb98cafa3230dc6a -->
+<!-- gda-readme-i18n: source=README.md sha256=bb3fb3e81210910899b8cfd05144fa9f969d9d214a0436f5e002a1f496c37f0e -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -432,6 +432,15 @@ script que no compila sigue siendo una operación exitosa: salida `0`, sin `erro
 de nivel superior, y `valid: false` con `error_string` / `diagnostics`. Los
 problemas de operación, como un archivo inexistente, siguen usando el Error envelope
 normal.
+
+El resultado también informa `project_root`: el proyecto contra el que se compiló el
+script, es decir, la raíz a la que se resolvieron sus dependencias `res://` (`null`
+cuando no se resolvió ningún proyecto). Léelo antes de actuar sobre un `valid: false`:
+un veredicto lleno de dependencias `res://` inexistentes, más los errores de tipo
+derivados de ellas, suele significar el proyecto equivocado y no un script roto. Un
+script *fuera* del proyecto resuelto se rechaza de entrada con `project_not_found`,
+nombrando tanto el archivo como el proyecto, en lugar de informar esos errores falsos;
+pasa `--project` con el proyecto al que pertenece el archivo.
 
 **`project`** — el proyecto en su conjunto (ajustes, autoloads, análisis estático)
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7e7ef59df7e407b072ba03aa8dd6fb0325c4043a1e064f1ffb98cafa3230dc6a -->
+<!-- gda-readme-i18n: source=README.md sha256=bb3fb3e81210910899b8cfd05144fa9f969d9d214a0436f5e002a1f496c37f0e -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -436,6 +436,14 @@ offset プロパティを明示的に設定してください。
 コンパイルできないスクリプトも成功した操作として扱われます。終了コードは `0`、トップレベルの
 `error` はなく、`valid: false` と `error_string` / `diagnostics` が返ります。存在しない
 ファイルなどの操作上の問題は、通常どおり Error envelope を使います。
+
+結果には `project_root` も含まれます。これはスクリプトのコンパイル対象となったプロジェクト、
+つまり `res://` 依存の解決先となったルートです(プロジェクトが解決されなかった場合は `null`)。
+`valid: false` に対処する前にこれを確認してください。存在しない `res://` 依存とそこから派生した
+型エラーばかりの結果は、通常スクリプトの不具合ではなくプロジェクトの選択ミスを意味します。
+解決されたプロジェクトの**外**にあるスクリプトは、その偽のエラー群を報告する代わりに、
+ファイルとプロジェクトの両方を示した `project_not_found` で事前に拒否されます。その場合は
+そのファイルを所有するプロジェクトを `--project` で指定してください。
 
 **`project`** — プロジェクト全体(設定、オートロード、静的解析)
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7e7ef59df7e407b072ba03aa8dd6fb0325c4043a1e064f1ffb98cafa3230dc6a -->
+<!-- gda-readme-i18n: source=README.md sha256=bb3fb3e81210910899b8cfd05144fa9f969d9d214a0436f5e002a1f496c37f0e -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -417,6 +417,12 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 对 `script validate --json`，要读取结果对象里的 `valid` 字段。脚本编译失败仍然算一次成功操作：
 退出码为 `0`，没有顶层 `error`，并以 `valid: false` 携带 `error_string` / `diagnostics`。
 缺失文件等操作层问题仍然采用标准的 Error envelope。
+
+结果还会报告 `project_root`：脚本编译时所针对的项目，也就是其 `res://` 依赖解析到的根目录
+（未解析到项目时为 `null`）。在处理 `valid: false` 之前请先读它——若诊断里满是缺失的 `res://`
+依赖以及由此派生的类型错误，通常说明项目选错了，而不是脚本本身有问题。位于所解析项目**之外**
+的脚本会被提前拒绝并返回 `project_not_found`，同时指明文件与项目，而不是报出那一连串假错误；
+此时请用 `--project` 指定真正拥有该文件的项目。
 
 **`project`** — 作为整体的项目（设置、autoload、静态分析）
 

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -156,7 +156,7 @@ operation, and parse codes the CLI assigns).
 | `save_failed` | `operation` | `operation` | `4` | A scene could not be packed or saved. |
 | `delete_failed` | `operation` | `operation` | `4` | A file could not be removed from disk. |
 | `file_changed_externally` | `operation` | `operation` | `4` | A read-modify-write operation's target file changed on disk between the read and the write, so the write was refused to avoid clobbering the external edit. |
-| `project_not_found` | `operation` | `operation` | `4` | gda ran without a usable resolved Godot project: an operation needed one and none was resolved, or an explicit `--project` was empty, or a `--project`/`$GDA_PROJECT` does not name a Godot project (no `project.godot`). |
+| `project_not_found` | `operation` | `operation` | `4` | gda has no resolved Godot project usable for the requested target: an operation needed one and none was resolved, or an explicit `--project` was empty, or a `--project`/`$GDA_PROJECT` does not name a Godot project (no `project.godot`), or the target lies outside the resolved project (whose `res://` dependencies would then resolve against the wrong root). |
 | `path_not_found` | `operation` | `operation` | `4` | A requested file does not exist. |
 | `not_a_scene` | `operation` | `operation` | `4` | A requested file cannot be loaded as a `PackedScene`. |
 | `parent_not_found` | `operation` | `operation` | `4` | A requested parent node path does not resolve to a node in the scene. |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -459,6 +459,21 @@ parsed Python-side and may carry only the **first** error. **`column` is always 
 standard Godot build (the engine exposes no column for a parse error). `validate` reuses existing
 codes only (no new ones).
 
+**Project context** (#658): the result carries `project_root` — the project the script was
+compiled against, i.e. the root its `res://` dependencies resolved to, absolute, and `null` when
+gda ran projectless. It is **required and nullable**, so every verdict carries the key. It exists
+because a script compiled against the wrong project reports every `res://` dependency as missing
+plus the type errors derived from them, which reads as a broken script; `project_root` is what
+tells the two apart. A target **outside** the resolved project is **refused before parsing** with
+`project_not_found` naming both the file and the project, rather than emitting that false cascade.
+Containment follows the engine's own addressing: a relative path is anchored at the resolved
+project (not gda's cwd), an engine-virtual path (`res://`, `user://`, `uid://`) is inside by
+construction, and a file reached through a symlink into the project counts as inside — except when
+a `..` traversal could cross that symlink, where only the fully resolved location decides. gda
+never derives the project from the target path (ADR-0006), so a script under a project **nested
+inside** the resolved one is contained and not refused; `project_root` is what surfaces that
+mismatch, pending the ADR-0006 amendment tracked in #697.
+
 | Command | Description |
 | --- | --- |
 | `gda script create` | Create a `.gd` script (template or content) |

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -24,6 +24,7 @@ from typing import Optional, Protocol, runtime_checkable
 import typer
 from pydantic import BaseModel, Field, model_validator
 
+from gda import dispatch
 from gda.binary import resolve_godot_binary
 from gda.dispatch import dispatch_domain, dispatch_recipe
 from gda.errors import (
@@ -32,6 +33,7 @@ from gda.errors import (
     classify_run,
     script_did_not_run_failure,
     script_exit_status_failure,
+    script_outside_project_failure,
     script_path_invalid_failure,
     script_run_project_not_found_failure,
     unresolvable_binary_failure,
@@ -45,6 +47,7 @@ from gda.headless import (
     project_option,
 )
 from gda.models import CREATED_DIRS_DESC, NormalizedPath
+from gda.project import path_outside_project
 from gda.runner import RunResult, launch
 from gda.script_errors import (
     ScriptError,
@@ -504,6 +507,10 @@ class ScriptValidateResult(BaseModel):
     ``diagnostics`` is a best-effort list parsed from the engine's stderr (the
     only place line/message are available); it may hold only the first error, and
     is empty when the script is valid or nothing could be parsed.
+
+    ``project_root`` names the project the script was compiled against, so a
+    reader can tell a real compile error from one caused by the wrong project
+    context without re-deriving gda's resolution (#658).
     """
 
     path: str
@@ -522,6 +529,18 @@ class ScriptValidateResult(BaseModel):
         description=(
             "Best-effort advisory diagnostics parsed from the engine's stderr "
             "(line + message). May hold only the first error; empty when valid."
+        ),
+    )
+    project_root: str | None = Field(
+        default=None,
+        description=(
+            "The Godot project this script was compiled against — the root its "
+            "res:// dependencies resolved to (ADR-0006: --project, then "
+            "$GDA_PROJECT, then the current directory). Null when gda ran "
+            "projectless (no project resolved), where only filesystem paths "
+            "resolve; a script whose res:// dependencies were reported missing "
+            "with a null or unexpected root here has a project-context problem, "
+            "not a source problem."
         ),
     )
 
@@ -954,10 +973,19 @@ def render_script_attach(attached: "ScriptAttachResult") -> str:
 
 
 def render_script_validate(validated: "ScriptValidateResult") -> str:
-    """Render a validate result: valid/invalid plus best-effort diagnostics."""
+    """Render a validate result: valid/invalid plus best-effort diagnostics.
+
+    An INVALID verdict leads with the project the script was compiled against
+    (#658), before the diagnostics rather than after them: when the root is the
+    wrong one, every diagnostic below it is an artefact of that single mistake,
+    and the reader needs to see the cause before the cascade. A valid verdict
+    stays the one-line answer — the root only explains a failure.
+    """
     if validated.valid:
         return f"valid {validated.path}"
     lines = [f"invalid {validated.path}"]
+    root = validated.project_root or "(none resolved: projectless)"
+    lines.append(f"  project: {root}")
     if validated.error_string is not None:
         lines.append(f"  {validated.error_string}")
     for diag in validated.diagnostics:
@@ -1037,12 +1065,69 @@ SCRIPT_ATTACH_COMMAND: HeadlessCommand[ScriptAttachResult] = HeadlessCommand(
     render=render_script_attach,
 )
 
+
+def _script_validate_recipe(params, *, project, godot):
+    """Refuse → compile → report the root: ``script validate``'s recipe (#658).
+
+    The sentinel op still does the compiling (``cmd.execute``, as the export
+    recipe runs its preflight); this wraps it in the two decisions only the CLI
+    can make, because ADR-0006 keeps project resolution CLI-side and the engine
+    is TOLD the project through ``--path``, never asked about it.
+
+    First the refusal. A script outside the resolved project is refused HERE,
+    before the engine is spawned, so the false ``res://`` dependency cascade is
+    never produced (see :func:`~gda.errors.script_outside_project_failure`).
+    Only a *resolved* project can be missed, so projectless is not a refusal:
+    with no project resolved, gda validates a standalone script by filesystem
+    path exactly as before (ADR-0006's projectless fallback). Whether the script
+    belongs to some OTHER project is not asked — deriving a project from the
+    target path is what ADR-0006 rejected, and discovering the nearest
+    ``project.godot`` waits on an amendment to it.
+
+    Then the report: the resolved project is stamped onto the result as
+    ``project_root``, so a caller reading a ``valid=false`` verdict sees which
+    root the ``res://`` dependencies resolved against instead of inferring it.
+
+    ``project`` arrives ALREADY resolved from ``dispatch_recipe`` (an invalid
+    ``--project``/``$GDA_PROJECT`` became a structured ``project_not_found``
+    before this runs, #353); ``None`` means projectless. ``params`` is the model
+    built once by the caller, identical on the argv and ``--params-json`` paths
+    (ADR-0015).
+    """
+    if project is not None:
+        outside = path_outside_project(params.path, project)
+        if outside is not None:
+            return script_outside_project_failure(outside, project)
+    # The runner seam is read off the module at call time — never imported by
+    # name — so a test monkeypatch on ``gda.dispatch.make_runner`` still binds.
+    outcome = SCRIPT_VALIDATE_COMMAND.execute(
+        params,
+        godot=godot,
+        project=project,
+        make_runner=dispatch.make_runner,
+    )
+    if isinstance(outcome, Failure):
+        return outcome
+    outcome.project_root = str(project) if project is not None else None
+    return outcome
+
+
+# ``script validate`` stays a HEADLESS sentinel op — the engine does the
+# compiling — but carries a ``recipe`` (ADR-0023) because two parts of its
+# contract are decided at the CLI, where ADR-0006's resolved project lives: the
+# outside-the-project refusal and the ``project_root`` on the result. The recipe
+# channel is the ONE descriptor-driven hook both input paths share, so argv and
+# ``--params-json`` get the same behaviour (ADR-0015) without the shared dispatch
+# tail learning anything about this command. ``classify`` is untouched: the recipe
+# runs the same ``cmd.execute``, so the stderr diagnostics are still parsed in by
+# :func:`classify_script_validate`.
 SCRIPT_VALIDATE_COMMAND: HeadlessCommand[ScriptValidateResult] = HeadlessCommand(
     operation="script-validate",
     input_model=ScriptValidateParams,
     output_model=ScriptValidateResult,
     render=render_script_validate,
     classify=classify_script_validate,
+    recipe=_script_validate_recipe,
 )
 
 
@@ -1313,8 +1398,20 @@ def validate_script(
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Syntax/compile-check a .gd script; invalid exits 0 with valid=false."""
-    dispatch_domain(
+    """Syntax/compile-check a .gd script; invalid exits 0 with valid=false.
+
+    The script is compiled against the resolved project (ADR-0006: --project, then
+    $GDA_PROJECT, then the current directory) — the root its res:// dependencies
+    resolve against — and the result reports that root as 'project_root'. Read it
+    before trusting a verdict: a script compiled against the wrong project reports
+    every res:// dependency as missing, plus the type errors derived from them.
+
+    A script OUTSIDE the resolved project is refused with 'project_not_found'
+    before it is parsed, naming both the file and the project, rather than
+    reporting that false cascade. gda never derives the project from the script's
+    own path (ADR-0006), so pass --project for the project that owns the file.
+    """
+    dispatch_recipe(
         SCRIPT_VALIDATE_COMMAND,
         ScriptValidateParams(path=path),
         json_output=json_output,

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -19,7 +19,7 @@ targets the standard build) and a dedicated decision.
 import re
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Protocol, runtime_checkable
+from typing import Any, Optional, Protocol, runtime_checkable
 
 import typer
 from pydantic import BaseModel, Field, model_validator
@@ -510,7 +510,15 @@ class ScriptValidateResult(BaseModel):
 
     ``project_root`` names the project the script was compiled against, so a
     reader can tell a real compile error from one caused by the wrong project
-    context without re-deriving gda's resolution (#658).
+    context without re-deriving gda's resolution (#658). It is REQUIRED and
+    nullable, not optional: every public result carries the key (``null`` means
+    projectless), so an agent can read it unconditionally. The engine's sentinel
+    does not report it — ADR-0006 keeps the project CLI-side, and the engine is
+    told it through ``--path`` — so the ``before`` validator below supplies the
+    key for the internal sentinel parse and the CLI stamps the real value
+    immediately after (:func:`_script_validate_recipe`). The leniency is
+    therefore inward-facing only: it never reaches the published contract, which
+    lists ``project_root`` in ``required``.
     """
 
     path: str
@@ -532,17 +540,35 @@ class ScriptValidateResult(BaseModel):
         ),
     )
     project_root: str | None = Field(
-        default=None,
         description=(
             "The Godot project this script was compiled against — the root its "
-            "res:// dependencies resolved to (ADR-0006: --project, then "
-            "$GDA_PROJECT, then the current directory). Null when gda ran "
-            "projectless (no project resolved), where only filesystem paths "
-            "resolve; a script whose res:// dependencies were reported missing "
-            "with a null or unexpected root here has a project-context problem, "
-            "not a source problem."
+            "res:// dependencies resolved to, reported as an absolute path "
+            "(ADR-0006: --project, then $GDA_PROJECT, then the current "
+            "directory). Always present; null when gda ran projectless (no "
+            "project resolved), where only filesystem paths resolve. A script "
+            "whose res:// dependencies were reported missing with a null or "
+            "unexpected root here has a project-context problem, not a source "
+            "problem."
         ),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _supply_absent_project_root(cls, data: Any) -> Any:
+        """Fill the key the ENGINE never sends, so the field can stay required.
+
+        ``project_root`` is gda's own addition to the engine's answer: the
+        ADR-0002 sentinel this model is parsed from carries only the fields
+        ``operations.gd`` reports. Declaring the field required — so it appears
+        in the published ``required`` list every consumer reads — would make
+        that internal parse fail, so the absent key is supplied as ``null``
+        here and the recipe stamps the resolved project immediately after.
+        Anything that DOES carry the key (the recipe's own ``model_copy``, a
+        round-trip of an emitted result) passes through untouched.
+        """
+        if isinstance(data, dict) and "project_root" not in data:
+            return {**data, "project_root": None}
+        return data
 
 
 class ScriptRunParams(BaseModel):
@@ -1066,7 +1092,12 @@ SCRIPT_ATTACH_COMMAND: HeadlessCommand[ScriptAttachResult] = HeadlessCommand(
 )
 
 
-def _script_validate_recipe(params, *, project, godot):
+def _script_validate_recipe(
+    params: ScriptValidateParams,
+    *,
+    project: Optional[Path],
+    godot: Optional[str],
+) -> ScriptValidateResult | Failure:
     """Refuse → compile → report the root: ``script validate``'s recipe (#658).
 
     The sentinel op still does the compiling (``cmd.execute``, as the export
@@ -1087,6 +1118,10 @@ def _script_validate_recipe(params, *, project, godot):
     Then the report: the resolved project is stamped onto the result as
     ``project_root``, so a caller reading a ``valid=false`` verdict sees which
     root the ``res://`` dependencies resolved against instead of inferring it.
+    Both the report and the refusal name the project in its RESOLVED form: the
+    flag may be spelled relatively (``--project game``), and a bare ``game`` in a
+    machine-readable result or in a "this is outside that" message tells the
+    reader nothing about which directory was meant.
 
     ``project`` arrives ALREADY resolved from ``dispatch_recipe`` (an invalid
     ``--project``/``$GDA_PROJECT`` became a structured ``project_not_found``
@@ -1094,10 +1129,12 @@ def _script_validate_recipe(params, *, project, godot):
     built once by the caller, identical on the argv and ``--params-json`` paths
     (ADR-0015).
     """
+    root = None
     if project is not None:
+        root = project.expanduser().resolve()
         outside = path_outside_project(params.path, project)
         if outside is not None:
-            return script_outside_project_failure(outside, project)
+            return script_outside_project_failure(outside, root)
     # The runner seam is read off the module at call time — never imported by
     # name — so a test monkeypatch on ``gda.dispatch.make_runner`` still binds.
     # Naming the HEADLESS factory directly is correct only while this command is
@@ -1118,7 +1155,7 @@ def _script_validate_recipe(params, *, project, godot):
     # and ``project_root`` is gda's addition to it, so the union is built rather
     # than the parsed model mutated after validation.
     return outcome.model_copy(
-        update={"project_root": str(project) if project is not None else None}
+        update={"project_root": str(root) if root is not None else None}
     )
 
 

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -1100,6 +1100,12 @@ def _script_validate_recipe(params, *, project, godot):
             return script_outside_project_failure(outside, project)
     # The runner seam is read off the module at call time — never imported by
     # name — so a test monkeypatch on ``gda.dispatch.make_runner`` still binds.
+    # Naming the HEADLESS factory directly is correct only while this command is
+    # HEADLESS: unlike ``gda.dispatch._emit``, which picks the factory from
+    # ``cmd.kind``, a recipe states its own channel. Changing this command's
+    # ``kind`` (or reusing this recipe for a live twin) must change this line
+    # too — the descriptor would otherwise say one channel and the run take
+    # another. The registry invariant test pins the recipe set, not this pairing.
     outcome = SCRIPT_VALIDATE_COMMAND.execute(
         params,
         godot=godot,
@@ -1108,8 +1114,12 @@ def _script_validate_recipe(params, *, project, godot):
     )
     if isinstance(outcome, Failure):
         return outcome
-    outcome.project_root = str(project) if project is not None else None
-    return outcome
+    # A copy, not an in-place set: the classified result is the engine's answer,
+    # and ``project_root`` is gda's addition to it, so the union is built rather
+    # than the parsed model mutated after validation.
+    return outcome.model_copy(
+        update={"project_root": str(project) if project is not None else None}
+    )
 
 
 # ``script validate`` stays a HEADLESS sentinel op — the engine does the

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -186,7 +186,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
-        "gda ran without a usable resolved Godot project: an operation needed one and none was resolved, or an explicit --project was empty, or a --project/$GDA_PROJECT does not name a Godot project (no project.godot).",
+        "gda has no resolved Godot project usable for the requested target: an operation needed one and none was resolved, or an explicit --project was empty, or a --project/$GDA_PROJECT does not name a Godot project (no project.godot), or the target lies outside the resolved project (whose res:// dependencies would then resolve against the wrong root).",
     ),
     ErrorCodeSpec(
         "path_not_found",

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -415,6 +415,34 @@ def script_run_project_not_found_failure() -> Failure:
     )
 
 
+def script_outside_project_failure(location: Path, project: Path) -> Failure:
+    """The ``project_not_found`` refusal for a target outside the resolved project (#658).
+
+    ADR-0006 resolves ONE project per call (``--project`` > ``$GDA_PROJECT`` >
+    cwd) and deliberately does not derive it from the target path. A target that
+    lies outside that project would still be compiled against it, so every
+    ``res://`` dependency it names resolves against the wrong root: the engine
+    reports a cascade of missing-file and derived type errors for a file that is
+    perfectly valid in its own project, and the single project-context mistake is
+    buried under them. gda therefore refuses *before* the target is parsed and
+    reports the mismatch itself, naming both sides so the reader can see which
+    one is wrong.
+
+    It reuses ``project_not_found`` rather than minting a code: the failure is
+    that no project usable for this target was resolved, and the remedy is the
+    project context (``--project``) — the same class of mistake, and the same
+    branch an agent takes, as ``script run``'s projectless edge (ADR-0031).
+    """
+    return make_failure(
+        "project_not_found",
+        f"{location} is outside the resolved Godot project {project}: its res:// "
+        "dependencies would resolve against the wrong root, so nothing was "
+        "parsed. Pass --project for the project that owns this file, or name a "
+        "file inside the resolved one.",
+        "",
+    )
+
+
 def script_did_not_run_failure(
     code: str, script: str, detail: str, stderr: str
 ) -> Failure:

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -18,6 +18,7 @@ from pydantic import (
 )
 
 from gda.execution import ExecutionKind
+from gda.project import is_engine_virtual_path
 
 
 class ErrorCategory(str, Enum):
@@ -256,8 +257,13 @@ def normalize_path(path: str) -> str:
     Lives here, not at the CLI layer, so the argv path and the ``--params-json``
     path normalize identically (ADR-0015): the model is the single home of
     normalization, applied wherever the model is constructed.
+
+    Which paths are engine-virtual is ADR-0006's rule, owned by
+    :func:`gda.project.is_engine_virtual_path` — the same test the project
+    containment check reads, so the two cannot disagree about what ``res://``
+    means.
     """
-    if "://" in path:
+    if is_engine_virtual_path(path):
         return path
     return str(Path(path).expanduser())
 

--- a/src/gda/project.py
+++ b/src/gda/project.py
@@ -28,6 +28,47 @@ GDA_PROJECT_ENV = "GDA_PROJECT"
 PROJECT_MARKER = "project.godot"
 
 
+def is_engine_virtual_path(path: str) -> bool:
+    """True when ``path`` is an engine-resolved virtual path (``res://``, …).
+
+    ADR-0006's one test for "the engine resolves this against the project, gda
+    does not touch it" — ``res://``, ``user://`` and ``uid://`` all carry the
+    ``://`` scheme separator, which a filesystem path never does. Owned here, in
+    the project-resolution module, and read by both callers of the rule:
+    :func:`gda.models.normalize_path` (which passes such a path through
+    unexpanded) and :func:`path_outside_project` (which can make no filesystem
+    statement about one).
+    """
+    return "://" in path
+
+
+def path_outside_project(path: str, project: Path) -> Path | None:
+    """The resolved location of ``path`` when it falls OUTSIDE ``project``.
+
+    The containment check behind the "this target does not belong to the
+    resolved project" refusal. Returns ``None`` when the path belongs to the
+    project — either because it is an engine-virtual path, which by
+    construction addresses the project the engine was launched with, or because
+    its filesystem location is the project directory or a descendant of it.
+    Otherwise it returns that location, so the caller can name *where* the
+    target actually is in its diagnostic.
+
+    Both sides are resolved before comparison: a caller's path may be relative
+    to the cwd, and ``resolve_project_dir`` returns the directory as it was
+    named (``--project /tmp/game``), so comparing raw values would call a
+    contained path "outside" whenever a symlink sits on either side — on macOS
+    the temp directory alone (``/tmp`` → ``/private/tmp``) is enough.
+    ``resolve()`` is non-strict, so a path that does not exist still yields the
+    location it would occupy rather than raising.
+    """
+    if is_engine_virtual_path(path):
+        return None
+    location = Path(path).expanduser().resolve()
+    if location.is_relative_to(project.expanduser().resolve()):
+        return None
+    return location
+
+
 def _project_or_raise(raw: str, source: str) -> Path:
     """Expand ``raw`` to a project directory, or raise if it is not one."""
     candidate = Path(raw).expanduser()

--- a/src/gda/project.py
+++ b/src/gda/project.py
@@ -42,29 +42,62 @@ def is_engine_virtual_path(path: str) -> bool:
     return "://" in path
 
 
+def _lexical_abs(path: Path) -> Path:
+    """``path`` made absolute and ``..``-free WITHOUT following symlinks.
+
+    ``os.path.abspath`` is by definition ``normpath(join(os.getcwd(), path))``:
+    it anchors a relative path at the cwd and collapses ``..`` textually, so a
+    symlink on the way keeps the spelling the caller used. That is the opposite
+    of ``Path.resolve()``, and both readings are needed — see
+    :func:`path_outside_project`.
+    """
+    return Path(os.path.abspath(path))
+
+
 def path_outside_project(path: str, project: Path) -> Path | None:
-    """The resolved location of ``path`` when it falls OUTSIDE ``project``.
+    """The location of ``path`` when it falls OUTSIDE ``project``.
 
     The containment check behind the "this target does not belong to the
     resolved project" refusal. Returns ``None`` when the path belongs to the
-    project — either because it is an engine-virtual path, which by
-    construction addresses the project the engine was launched with, or because
-    its filesystem location is the project directory or a descendant of it.
-    Otherwise it returns that location, so the caller can name *where* the
-    target actually is in its diagnostic.
+    project, and otherwise the target's real location, so the caller can name
+    *where* it actually is in its diagnostic.
 
-    Both sides are resolved before comparison: a caller's path may be relative
-    to the cwd, and ``resolve_project_dir`` returns the directory as it was
-    named (``--project /tmp/game``), so comparing raw values would call a
-    contained path "outside" whenever a symlink sits on either side — on macOS
-    the temp directory alone (``/tmp`` → ``/private/tmp``) is enough.
-    ``resolve()`` is non-strict, so a path that does not exist still yields the
-    location it would occupy rather than raising.
+    An engine-virtual path is inside by construction: it addresses the project
+    the engine was launched with, and gda can make no filesystem statement
+    about it.
+
+    A filesystem path is compared TWICE, and belongs to the project when
+    EITHER reading says so — because a symlink makes the two readings answer
+    different, equally true questions:
+
+    - **Lexically** (:func:`_lexical_abs`, symlinks preserved): "did the caller
+      address this file through the project's own tree?" A monorepo that links
+      a shared library into the project (``game/addons/lib -> ../../libs/lib``)
+      answers yes, and so does the engine — Godot walks the project directory
+      and follows that link, so the file really is in the project's ``res://``
+      namespace. Refusing it on its ``resolve()``d location would reject a call
+      that works, in a message naming a path the caller never typed.
+    - **Resolved** (``Path.resolve()``, symlinks followed): "are these two
+      spellings the same place?" The project may be named by one spelling and
+      the target by another — on macOS the temp directory alone (``/tmp`` →
+      ``/private/tmp``) is enough — and only the resolved reading sees through
+      that.
+
+    Refusing only when BOTH readings say outside keeps the refusal to targets
+    that are outside under every reading. It stays strict about the escape it
+    exists for: ``..`` is collapsed textually, so ``project/../other/x.gd`` is
+    outside lexically as well as resolved. ``resolve()`` is non-strict, so a
+    path that does not exist still yields the location it would occupy rather
+    than raising.
     """
     if is_engine_virtual_path(path):
         return None
-    location = Path(path).expanduser().resolve()
-    if location.is_relative_to(project.expanduser().resolve()):
+    target = Path(path).expanduser()
+    root = project.expanduser()
+    if _lexical_abs(target).is_relative_to(_lexical_abs(root)):
+        return None
+    location = target.resolve()
+    if location.is_relative_to(root.resolve()):
         return None
     return location
 

--- a/src/gda/project.py
+++ b/src/gda/project.py
@@ -28,18 +28,25 @@ GDA_PROJECT_ENV = "GDA_PROJECT"
 PROJECT_MARKER = "project.godot"
 
 
+# The engine-resolved virtual path schemes ADR-0006 names. An exact prefix set,
+# NOT a "contains ://" test: a colon is a legal POSIX filename character, so
+# `/work/outside://deck.gd` is an ordinary — and ordinarily *outside* —
+# filesystem path that a substring test would wave through as virtual.
+ENGINE_VIRTUAL_PREFIXES = ("res://", "user://", "uid://")
+
+
 def is_engine_virtual_path(path: str) -> bool:
     """True when ``path`` is an engine-resolved virtual path (``res://``, …).
 
     ADR-0006's one test for "the engine resolves this against the project, gda
-    does not touch it" — ``res://``, ``user://`` and ``uid://`` all carry the
-    ``://`` scheme separator, which a filesystem path never does. Owned here, in
-    the project-resolution module, and read by both callers of the rule:
-    :func:`gda.models.normalize_path` (which passes such a path through
-    unexpanded) and :func:`path_outside_project` (which can make no filesystem
-    statement about one).
+    does not touch it", decided by the documented scheme PREFIXES
+    (:data:`ENGINE_VIRTUAL_PREFIXES`) rather than by looking for ``://``
+    anywhere in the string. Owned here, in the project-resolution module, and
+    read by both callers of the rule: :func:`gda.models.normalize_path` (which
+    passes such a path through unexpanded) and :func:`path_outside_project`
+    (which can make no filesystem statement about one).
     """
-    return "://" in path
+    return path.startswith(ENGINE_VIRTUAL_PREFIXES)
 
 
 def _lexical_abs(path: Path) -> Path:
@@ -54,6 +61,31 @@ def _lexical_abs(path: Path) -> Path:
     return Path(os.path.abspath(path))
 
 
+def _has_dotdot(path: Path) -> bool:
+    """True when ``path``'s spelling contains a ``..`` traversal component."""
+    return ".." in path.parts
+
+
+def project_anchored(path: str, project: Path) -> Path:
+    """``path`` as the ENGINE will address it under ``--path project``.
+
+    A relative filesystem path is anchored at the PROJECT, not at gda's cwd,
+    because that is what the engine does: launched with ``--path <project>``, a
+    one-shot op that opens ``deck.gd`` opens ``<project>/deck.gd`` regardless of
+    where gda was invoked (verified against the engine). It is also what the
+    README promises — point gda at a project once and relative paths resolve
+    inside it. An absolute path is already fully addressed and is returned
+    unchanged; ``~`` is expanded either way.
+
+    The single anchoring rule, so the containment check and the engine cannot
+    disagree about which file a relative argument names.
+    """
+    target = Path(path).expanduser()
+    if target.is_absolute():
+        return target
+    return project.expanduser() / target
+
+
 def path_outside_project(path: str, project: Path) -> Path | None:
     """The location of ``path`` when it falls OUTSIDE ``project``.
 
@@ -64,41 +96,52 @@ def path_outside_project(path: str, project: Path) -> Path | None:
 
     An engine-virtual path is inside by construction: it addresses the project
     the engine was launched with, and gda can make no filesystem statement
-    about it.
+    about one.
 
-    A filesystem path is compared TWICE, and belongs to the project when
-    EITHER reading says so — because a symlink makes the two readings answer
+    A filesystem path is first anchored the way the engine will address it
+    (:func:`project_anchored`), then read in up to two ways — it belongs to the
+    project when EITHER says so, because a symlink makes the two answer
     different, equally true questions:
 
-    - **Lexically** (:func:`_lexical_abs`, symlinks preserved): "did the caller
+    - **Resolved** (``Path.resolve()``, symlinks followed): "are these two
+      spellings the same place?" The project may be named by one spelling and
+      the target by another — on macOS the temp directory alone (``/tmp`` →
+      ``/private/tmp``) is enough — and only this reading sees through that.
+      Always consulted.
+    - **Lexical** (:func:`_lexical_abs`, symlinks preserved): "did the caller
       address this file through the project's own tree?" A monorepo that links
       a shared library into the project (``game/addons/lib -> ../../libs/lib``)
       answers yes, and so does the engine — Godot walks the project directory
       and follows that link, so the file really is in the project's ``res://``
       namespace. Refusing it on its ``resolve()``d location would reject a call
       that works, in a message naming a path the caller never typed.
-    - **Resolved** (``Path.resolve()``, symlinks followed): "are these two
-      spellings the same place?" The project may be named by one spelling and
-      the target by another — on macOS the temp directory alone (``/tmp`` →
-      ``/private/tmp``) is enough — and only the resolved reading sees through
-      that.
 
-    Refusing only when BOTH readings say outside keeps the refusal to targets
-    that are outside under every reading. It stays strict about the escape it
-    exists for: ``..`` is collapsed textually, so ``project/../other/x.gd`` is
-    outside lexically as well as resolved. ``resolve()`` is non-strict, so a
-    path that does not exist still yields the location it would occupy rather
-    than raising.
+    The lexical reading is only sound while no ``..`` is in play, so it is
+    consulted ONLY when neither the anchored candidate nor the project spelling
+    carries a ``..`` component. A ``..`` that follows a symlink collapses
+    textually to a place the filesystem never visits — ``game/pivot/../deck.gd``
+    with ``game/pivot -> ../outside/deep`` reads as ``game/deck.gd`` lexically
+    while really naming ``outside/deck.gd`` — so trusting the lexical reading
+    there would accept a target that is genuinely outside. Without a ``..``, a
+    symlink can only redirect *downward* from a path that does start inside the
+    project, which is the legitimate case above. When the guard withholds the
+    lexical reading, containment falls back to the resolved reading alone: a
+    symlinked-in file addressed with a ``..`` in its path is refused, and the
+    caller can name it without the ``..``.
+
+    ``resolve()`` is non-strict, so a path that does not exist still yields the
+    location it would occupy rather than raising.
     """
     if is_engine_virtual_path(path):
         return None
-    target = Path(path).expanduser()
     root = project.expanduser()
-    if _lexical_abs(target).is_relative_to(_lexical_abs(root)):
-        return None
-    location = target.resolve()
+    candidate = project_anchored(path, project)
+    location = candidate.resolve()
     if location.is_relative_to(root.resolve()):
         return None
+    if not _has_dotdot(candidate) and not _has_dotdot(root):
+        if _lexical_abs(candidate).is_relative_to(_lexical_abs(root)):
+            return None
     return location
 
 

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -52,7 +52,12 @@ Some commands carry a verdict inside a successful result. For
 `gda script validate --json`, read the result's `valid` field: a script that does
 not compile exits `0` with no top-level `error`, and reports `valid=false` plus
 `error_string` / `diagnostics`. Do not treat exit `0` or the absence of an Error
-envelope as a pass for this command.
+envelope as a pass for this command. Check the result's `project_root` before you
+act on a `valid=false`: it names the project the script was compiled against, and
+a verdict full of missing-`res://` errors (plus the type errors derived from them)
+usually means the wrong project, not a broken script — `null` means no project was
+resolved at all. Pass `--project` for the project that owns the file and re-read
+the verdict.
 
 ## Discovery
 

--- a/tests/test_command_descriptor_registry.py
+++ b/tests/test_command_descriptor_registry.py
@@ -153,6 +153,12 @@ _RECIPE_OPERATIONS = {
     # run, fulfilled by a CLI-side recipe (it emits no ADR-0002 sentinel) like export
     # run, so it carries a recipe rather than routing to `cmd.emit`.
     "script-run",
+    # `script validate` is the one recipe that still RUNS the sentinel op (via
+    # `cmd.execute`, as the export recipe does for its preflight): it carries a
+    # recipe because the outside-the-project refusal and the `project_root` on its
+    # result are decided from ADR-0006's CLI-resolved project, which `cmd.emit`
+    # does not expose to a command (#658).
+    "script-validate",
     "daemon-start",
     "daemon-stop",
     "daemon-status",

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -19,6 +19,8 @@ from gda.runner import OPERATIONS_GD
 
 from tests.support import GDA_CMD
 
+from .conftest import project_godot
+
 GODOT = resolve_godot_binary()
 
 
@@ -894,6 +896,115 @@ def test_script_validate_wrong_extension_yields_invalid_path(godot_project):
 
     err = _assert_operation_error(validated, "invalid_path")
     assert ".gd" in err["message"]
+
+
+# --- script validate: project context (#658, GDA-DF-035) ---
+
+
+def _nested_project_script(root):
+    """A project NESTED in a plain workspace dir, holding a res://-dependent script.
+
+    The GDA-DF-035 shape: a game project that lives inside a larger repository,
+    with a script whose ``res://`` preload only resolves against the project's own
+    root. Returns ``(workspace, project, script)``.
+    """
+    workspace = root / "workspace"
+    project = workspace / "game"
+    (project / "scripts").mkdir(parents=True)
+    (project / "project.godot").write_text(
+        project_godot("gda-e2e-nested"), encoding="utf-8"
+    )
+    (project / "scripts" / "card.gd").write_text(
+        "extends Node\n\nclass_name Card\n\nfunc rank() -> int:\n\treturn 3\n",
+        encoding="utf-8",
+    )
+    script = project / "deck.gd"
+    script.write_text(
+        "extends Node\n\n"
+        'const Card = preload("res://scripts/card.gd")\n\n'
+        "func top() -> int:\n"
+        "\tvar c := Card.new()\n"
+        "\treturn c.rank()\n",
+        encoding="utf-8",
+    )
+    return workspace, project, script
+
+
+@pytest.mark.e2e
+def test_script_validate_verdict_is_root_dependent_and_names_the_root(tmp_path):
+    # The #658 regression, against the real engine: the SAME script under a nested
+    # project, validated from an ancestor directory, gets opposite verdicts
+    # depending on which project it was compiled against — and `project_root` says
+    # which one produced each. That is the reading GDA-DF-035 lacked: from the
+    # ancestor, `res://scripts/card.gd` is missing and a type-inference error is
+    # DERIVED from that miss, on a script that is perfectly valid in its own
+    # project. gda resolves no project from the target path (ADR-0006), so the
+    # ancestor run stays projectless — `project_root: null` is the signal that the
+    # dependency errors are about the missing project context, not the source.
+    workspace, project, script = _nested_project_script(tmp_path)
+
+    from_ancestor = subprocess.run(
+        [
+            *GDA_CMD,
+            "script",
+            "validate",
+            "game/deck.gd",
+            "--godot",
+            str(GODOT),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=workspace,
+    )
+
+    assert from_ancestor.returncode == 0, from_ancestor.stdout + from_ancestor.stderr
+    wrong_root = json.loads(from_ancestor.stdout)
+    assert wrong_root["project_root"] is None
+    assert wrong_root["valid"] is False
+    # The false cascade the issue reports: the preload miss plus at least one
+    # error derived from it.
+    assert any(
+        "res://scripts/card.gd" in diag["message"] for diag in wrong_root["diagnostics"]
+    )
+
+    with_owning_project = _gda(
+        "script", "validate", str(script), "--project", str(project), "--json"
+    )
+
+    assert with_owning_project.returncode == 0, (
+        with_owning_project.stdout + with_owning_project.stderr
+    )
+    right_root = json.loads(with_owning_project.stdout)
+    assert right_root["valid"] is True
+    assert right_root["diagnostics"] == []
+    assert right_root["project_root"] == str(project)
+
+
+@pytest.mark.e2e
+def test_script_validate_refuses_a_script_outside_the_resolved_project(tmp_path):
+    # The refusal at the real-engine tier: pointed at a project that does not own
+    # the script, gda reports the mismatch itself rather than the engine's false
+    # dependency errors — and names both sides. The refusal is structured
+    # (project_not_found, exit 4), so an agent branches on it instead of reading a
+    # cascade of parse errors that describe nothing wrong with the file.
+    _, project, script = _nested_project_script(tmp_path)
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / "project.godot").write_text(
+        project_godot("gda-e2e-other"), encoding="utf-8"
+    )
+
+    validated = _gda(
+        "script", "validate", str(script), "--project", str(other), "--json"
+    )
+
+    err = _assert_operation_error(validated, "project_not_found")
+    assert str(script) in err["message"]
+    assert str(other) in err["message"]
+    # Refused BEFORE parsing: no engine ran, so no diagnostic about the file.
+    assert "res://scripts/card.gd" not in validated.stdout
+    assert err["diagnostics"] == ""
 
 
 # --- script attach (issue #118) ---

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -1066,6 +1066,121 @@ def test_script_validate_accepts_a_file_symlinked_into_the_project(tmp_path):
     _assert_operation_error(from_outside, "project_not_found")
 
 
+@pytest.mark.e2e
+def test_script_validate_relative_target_from_an_ancestor_cwd_agrees_with_the_engine(
+    tmp_path,
+):
+    # The full chain, against the real engine: run from the workspace ABOVE the
+    # project and name both the project and the script relatively. gda hands the
+    # path to the engine unchanged and the engine anchors it at `--path game`, so
+    # the containment check has to anchor it there too — judging it against gda's
+    # own cwd refused an invocation the engine validates fine, and that the README
+    # documents. Both channels are covered because the argv and --params-json
+    # paths share the recipe.
+    project = tmp_path / "game"
+    project.mkdir()
+    (project / "project.godot").write_text(
+        project_godot("gda-e2e-ancestor"), encoding="utf-8"
+    )
+    (project / "deck.gd").write_text(
+        "extends Node\n\nfunc top() -> int:\n\treturn 3\n", encoding="utf-8"
+    )
+
+    def from_workspace(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [*GDA_CMD, *args, "--godot", str(GODOT)],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+        )
+
+    argv = from_workspace(
+        "script", "validate", "deck.gd", "--project", "game", "--json"
+    )
+
+    assert argv.returncode == 0, argv.stdout + argv.stderr
+    data = json.loads(argv.stdout)
+    assert data["valid"] is True, data
+    # The engine found game/deck.gd, and the reported root is absolute — not the
+    # bare relative "game" that was typed.
+    assert data["project_root"] == str(project)
+
+    params_json = from_workspace(
+        "script",
+        "validate",
+        "--params-json",
+        json.dumps({"path": "deck.gd"}),
+        "--project",
+        "game",
+        "--json",
+    )
+
+    assert params_json.returncode == 0, params_json.stdout + params_json.stderr
+    assert json.loads(params_json.stdout) == data
+
+
+@pytest.mark.e2e
+def test_script_validate_refuses_a_symlink_dot_dot_pivot_out_of_the_project(tmp_path):
+    # The containment bypass, at the real-engine tier: with
+    # `game/pivot -> ../outside/deep`, the input `game/pivot/../deck.gd` collapses
+    # textually to `game/deck.gd` while really naming `outside/deck.gd`. Trusting
+    # the lexical reading there let the engine COMPILE the outside script and
+    # report a verdict on it. It must now be refused, and no verdict may appear.
+    project = tmp_path / "game"
+    project.mkdir()
+    (project / "project.godot").write_text(
+        project_godot("gda-e2e-pivot"), encoding="utf-8"
+    )
+    outside = tmp_path / "outside"
+    (outside / "deep").mkdir(parents=True)
+    (outside / "deck.gd").write_text(
+        "extends Node\n\nfunc outside_secret() -> int:\n\treturn 99\n", encoding="utf-8"
+    )
+    (project / "pivot").symlink_to(outside / "deep", target_is_directory=True)
+
+    validated = _gda(
+        "script",
+        "validate",
+        str(project / "pivot" / ".." / "deck.gd"),
+        "--project",
+        str(project),
+        "--json",
+    )
+
+    err = _assert_operation_error(validated, "project_not_found")
+    # The refusal names where the target REALLY is, not the collapsed spelling.
+    assert str((outside / "deck.gd").resolve()) in err["message"]
+    # Nothing was compiled: no verdict, and no engine diagnostic about the file.
+    assert '"valid"' not in validated.stdout
+    assert err["diagnostics"] == ""
+
+
+@pytest.mark.e2e
+def test_script_validate_refuses_an_outside_path_that_merely_contains_a_scheme(
+    tmp_path,
+):
+    # A colon is a legal POSIX filename character, so `<dir>://deck.gd` is an
+    # ordinary filesystem path. Classifying it as engine-virtual skipped
+    # containment and the engine opened the outside file; it is now refused.
+    project = tmp_path / "game"
+    project.mkdir()
+    (project / "project.godot").write_text(
+        project_godot("gda-e2e-scheme"), encoding="utf-8"
+    )
+    odd = tmp_path / "outside:"
+    odd.mkdir()
+    (odd / "deck.gd").write_text(
+        "extends Node\n\nfunc scheme_secret() -> int:\n\treturn 7\n", encoding="utf-8"
+    )
+
+    validated = _gda(
+        "script", "validate", f"{odd}//deck.gd", "--project", str(project), "--json"
+    )
+
+    _assert_operation_error(validated, "project_not_found")
+    assert '"valid"' not in validated.stdout
+
+
 # --- script attach (issue #118) ---
 
 

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -1007,6 +1007,65 @@ def test_script_validate_refuses_a_script_outside_the_resolved_project(tmp_path)
     assert err["diagnostics"] == ""
 
 
+@pytest.mark.e2e
+def test_script_validate_accepts_a_file_symlinked_into_the_project(tmp_path):
+    # The containment check judges a symlinked file by BOTH readings, and this is
+    # the real-engine proof of the lexical one: the monorepo shared-addon layout
+    # (game/addons/cardlib -> ../../libs/cardlib), where the file physically lives
+    # outside the project but is addressed through the project's own tree.
+    #
+    # The engine agrees with that reading — the script's `res://addons/cardlib/
+    # card.gd` preload resolves THROUGH the link — so `valid` is true. Judging the
+    # target by its resolve()d location alone would refuse a call that demonstrably
+    # works, and name a path the caller never typed.
+    #
+    # The second half is the guard that this is not a blanket escape hatch: the
+    # SAME physical file, addressed by its outside spelling, is still refused.
+    project = tmp_path / "game"
+    (project / "addons").mkdir(parents=True)
+    (project / "project.godot").write_text(
+        project_godot("gda-e2e-symlinked"), encoding="utf-8"
+    )
+    library = tmp_path / "libs" / "cardlib"
+    library.mkdir(parents=True)
+    (library / "card.gd").write_text(
+        "extends Node\n\nclass_name SymlinkedCard\n\nfunc rank() -> int:\n\treturn 3\n",
+        encoding="utf-8",
+    )
+    (library / "deck.gd").write_text(
+        "extends Node\n\n"
+        'const Card = preload("res://addons/cardlib/card.gd")\n\n'
+        "func top() -> int:\n"
+        "\tvar c := Card.new()\n"
+        "\treturn c.rank()\n",
+        encoding="utf-8",
+    )
+    (project / "addons" / "cardlib").symlink_to(library, target_is_directory=True)
+    through_the_link = project / "addons" / "cardlib" / "deck.gd"
+
+    validated = _gda(
+        "script", "validate", str(through_the_link), "--project", str(project), "--json"
+    )
+
+    assert validated.returncode == 0, validated.stdout + validated.stderr
+    data = json.loads(validated.stdout)
+    assert data["valid"] is True, data
+    assert data["diagnostics"] == []
+    assert data["project_root"] == str(project)
+
+    # Same file, outside spelling: outside under both readings, so still refused.
+    from_outside = _gda(
+        "script",
+        "validate",
+        str(library / "deck.gd"),
+        "--project",
+        str(project),
+        "--json",
+    )
+
+    _assert_operation_error(from_outside, "project_not_found")
+
+
 # --- script attach (issue #118) ---
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -544,7 +544,15 @@ def test_script_validate_result_round_trips_a_valid_script():
     assert validated.valid is True
     assert validated.error_string is None
     assert validated.diagnostics == []
-    assert json.loads(validated.model_dump_json()) == payload
+    # `project_root` is NOT in the sentinel payload: the engine is told the
+    # project through --path and never reports it back, so the CLI stamps the
+    # ADR-0006-resolved root onto the result after classification (#658). The
+    # model therefore defaults it to null and the emitted object always carries
+    # the key.
+    assert json.loads(validated.model_dump_json()) == {
+        **payload,
+        "project_root": None,
+    }
 
 
 def test_script_validate_result_round_trips_an_invalid_script_with_diagnostics():
@@ -566,7 +574,11 @@ def test_script_validate_result_round_trips_an_invalid_script_with_diagnostics()
     assert validated.diagnostics[0].line == 3
     assert validated.diagnostics[0].column is None
     assert validated.diagnostics[0].message == "Parse Error: bad token."
-    assert json.loads(validated.model_dump_json()) == payload
+    # Sentinel-absent, CLI-stamped — see the valid-script round-trip above.
+    assert json.loads(validated.model_dump_json()) == {
+        **payload,
+        "project_root": None,
+    }
 
 
 def test_export_list_result_round_trips_enumerated_presets():

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -102,16 +102,60 @@ def test_engine_virtual_paths_are_never_outside(tmp_path):
 
 
 def test_a_symlinked_project_spelling_still_contains_its_own_files(tmp_path):
-    # Both sides are resolved before comparison, so the SAME directory reached
-    # by two spellings compares equal. Without this the check would refuse every
-    # correct call made through a symlink — on macOS the temp dir alone
-    # (/tmp -> /private/tmp) is such a spelling.
+    # The RESOLVED reading: the SAME directory reached by two spellings compares
+    # equal. Without it the check would refuse every correct call made through a
+    # symlinked project path — on macOS the temp dir alone (/tmp -> /private/tmp)
+    # is such a spelling.
     proj = _make_project(tmp_path / "game")
     link = tmp_path / "game-link"
     link.symlink_to(proj, target_is_directory=True)
 
     assert path_outside_project(str(link / "hero.gd"), proj) is None
     assert path_outside_project(str(proj / "hero.gd"), link) is None
+
+
+def test_a_directory_symlinked_into_the_project_is_inside(tmp_path):
+    # The LEXICAL reading, and the regression that motivates it: the monorepo
+    # shared-addon layout, where the project links a library that physically
+    # lives outside it (game/addons/lib -> ../../libs/lib). The caller addressed
+    # the file through the project's own tree and Godot follows the same link, so
+    # the file IS in the project's res:// namespace. Judging it by its resolved
+    # location alone would refuse a call that works, in a message naming a path
+    # the caller never typed.
+    proj = _make_project(tmp_path / "game")
+    (proj / "addons").mkdir()
+    library = tmp_path / "libs" / "cardlib"
+    library.mkdir(parents=True)
+    (library / "card.gd").write_text("extends Node\n", encoding="utf-8")
+    (proj / "addons" / "cardlib").symlink_to(library, target_is_directory=True)
+
+    assert path_outside_project(str(proj / "addons" / "cardlib" / "card.gd"), proj) is (
+        None
+    )
+
+
+def test_a_file_symlinked_into_the_project_is_inside(tmp_path):
+    # The same rule for a single linked FILE, not just a linked directory.
+    proj = _make_project(tmp_path / "game")
+    shared = tmp_path / "shared" / "card.gd"
+    shared.parent.mkdir(parents=True)
+    shared.write_text("extends Node\n", encoding="utf-8")
+    (proj / "card.gd").symlink_to(shared)
+
+    assert path_outside_project(str(proj / "card.gd"), proj) is None
+
+
+def test_a_dot_dot_escape_is_still_outside(tmp_path):
+    # The lexical reading must not become an escape hatch: `..` is collapsed
+    # textually, so a path that climbs out of the project is outside under BOTH
+    # readings and stays refused.
+    proj = _make_project(tmp_path / "game")
+    escaped = str(proj / ".." / "elsewhere" / "hero.gd")
+
+    assert (
+        path_outside_project(escaped, proj)
+        == (tmp_path / "elsewhere" / "hero.gd").resolve()
+    )
 
 
 def test_a_relative_path_is_resolved_against_the_cwd(tmp_path, monkeypatch):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -11,7 +11,12 @@ from pathlib import Path
 
 import pytest
 
-from gda.project import GDA_PROJECT_ENV, PROJECT_MARKER, resolve_project_dir
+from gda.project import (
+    GDA_PROJECT_ENV,
+    PROJECT_MARKER,
+    path_outside_project,
+    resolve_project_dir,
+)
 
 
 def _make_project(path: Path) -> Path:
@@ -64,3 +69,80 @@ def test_explicit_non_project_dir_is_rejected(tmp_path):
 def test_explicit_empty_string_is_not_silently_swallowed(tmp_path):
     with pytest.raises(ValueError):
         resolve_project_dir("", env={GDA_PROJECT_ENV: str(_make_project(tmp_path))})
+
+
+# --- containment: does this target belong to the resolved project? (#658) -----
+
+
+def test_path_inside_the_project_is_not_outside(tmp_path):
+    proj = _make_project(tmp_path / "game")
+    script = proj / "actors" / "hero.gd"
+
+    assert path_outside_project(str(script), proj) is None
+
+
+def test_path_in_a_sibling_tree_is_outside_and_reports_its_location(tmp_path):
+    # The refusal's evidence: the caller must be able to name WHERE the target
+    # actually is, so the check returns the resolved location rather than a bool.
+    proj = _make_project(tmp_path / "game")
+    script = tmp_path / "other" / "hero.gd"
+
+    assert path_outside_project(str(script), proj) == script.resolve()
+
+
+def test_engine_virtual_paths_are_never_outside(tmp_path):
+    # res:// (and its user:// / uid:// siblings) address the project the engine
+    # was launched with, so they are inside by construction — gda makes no
+    # filesystem statement about them (ADR-0006).
+    proj = _make_project(tmp_path / "game")
+
+    assert path_outside_project("res://hero.gd", proj) is None
+    assert path_outside_project("user://save.gd", proj) is None
+    assert path_outside_project("uid://abc123", proj) is None
+
+
+def test_a_symlinked_project_spelling_still_contains_its_own_files(tmp_path):
+    # Both sides are resolved before comparison, so the SAME directory reached
+    # by two spellings compares equal. Without this the check would refuse every
+    # correct call made through a symlink — on macOS the temp dir alone
+    # (/tmp -> /private/tmp) is such a spelling.
+    proj = _make_project(tmp_path / "game")
+    link = tmp_path / "game-link"
+    link.symlink_to(proj, target_is_directory=True)
+
+    assert path_outside_project(str(link / "hero.gd"), proj) is None
+    assert path_outside_project(str(proj / "hero.gd"), link) is None
+
+
+def test_a_relative_path_is_resolved_against_the_cwd(tmp_path, monkeypatch):
+    # A caller's path may be relative; it means "relative to where gda was run",
+    # so containment is decided after resolving it there.
+    proj = _make_project(tmp_path / "game")
+    monkeypatch.chdir(proj)
+
+    assert path_outside_project("hero.gd", proj) is None
+    assert (
+        path_outside_project("../elsewhere/hero.gd", proj)
+        == (tmp_path / "elsewhere" / "hero.gd").resolve()
+    )
+
+
+def test_a_nonexistent_path_is_still_classified(tmp_path):
+    # The check runs BEFORE the engine opens anything, so it must not depend on
+    # the target existing (a missing file inside the project is the operation's
+    # own path_not_found, reported by the engine as before).
+    proj = _make_project(tmp_path / "game")
+
+    assert path_outside_project(str(proj / "gone.gd"), proj) is None
+    assert path_outside_project(str(tmp_path / "gone.gd"), proj) is not None
+
+
+def test_a_project_nested_inside_the_resolved_one_is_not_refused(tmp_path):
+    # The deliberate scope line (#658): a script in a project NESTED under the
+    # resolved one is contained, so it is NOT refused — finding the nearest
+    # project.godot is exactly the derivation ADR-0006 rejected, and waits on an
+    # amendment. The mismatch stays visible through the result's project_root.
+    outer = _make_project(tmp_path / "outer")
+    _make_project(outer / "inner")
+
+    assert path_outside_project(str(outer / "inner" / "deck.gd"), outer) is None

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -14,7 +14,9 @@ import pytest
 from gda.project import (
     GDA_PROJECT_ENV,
     PROJECT_MARKER,
+    is_engine_virtual_path,
     path_outside_project,
+    project_anchored,
     resolve_project_dir,
 )
 
@@ -101,6 +103,21 @@ def test_engine_virtual_paths_are_never_outside(tmp_path):
     assert path_outside_project("uid://abc123", proj) is None
 
 
+def test_a_colon_bearing_filesystem_path_is_not_treated_as_virtual(tmp_path):
+    # A colon is a legal POSIX filename character, so "contains ://" is not a
+    # scheme test: `/work/outside://deck.gd` is an ordinary filesystem path that
+    # happens to hold the sequence, and it is OUTSIDE. Waving it through as
+    # engine-virtual skipped containment entirely and the engine opened the
+    # outside file.
+    proj = _make_project(tmp_path / "game")
+    odd = tmp_path / "outside:" / "deck.gd"
+
+    assert is_engine_virtual_path(str(odd)) is False
+    assert path_outside_project(str(odd), proj) == odd.resolve()
+    # ...and the same sequence inside the project is still contained.
+    assert path_outside_project(str(proj / "weird:" / "deck.gd"), proj) is None
+
+
 def test_a_symlinked_project_spelling_still_contains_its_own_files(tmp_path):
     # The RESOLVED reading: the SAME directory reached by two spellings compares
     # equal. Without it the check would refuse every correct call made through a
@@ -158,13 +175,38 @@ def test_a_dot_dot_escape_is_still_outside(tmp_path):
     )
 
 
-def test_a_relative_path_is_resolved_against_the_cwd(tmp_path, monkeypatch):
-    # A caller's path may be relative; it means "relative to where gda was run",
-    # so containment is decided after resolving it there.
+def test_a_symlink_followed_by_dot_dot_does_not_pass_as_inside(tmp_path):
+    # The lexical reading is only sound while no `..` is in play. With
+    # `game/pivot -> ../outside/deep`, the input `game/pivot/../deck.gd` collapses
+    # TEXTUALLY to `game/deck.gd` (inside) while really naming
+    # `outside/deck.gd` — so trusting the lexical reading here accepted a target
+    # that is genuinely outside, and the engine compiled it.
     proj = _make_project(tmp_path / "game")
-    monkeypatch.chdir(proj)
+    outside = tmp_path / "outside"
+    (outside / "deep").mkdir(parents=True)
+    (outside / "deck.gd").write_text("extends Node\n", encoding="utf-8")
+    (proj / "pivot").symlink_to(outside / "deep", target_is_directory=True)
 
-    assert path_outside_project("hero.gd", proj) is None
+    bypass = str(proj / "pivot" / ".." / "deck.gd")
+
+    assert path_outside_project(bypass, proj) == (outside / "deck.gd").resolve()
+
+
+def test_a_relative_path_is_anchored_at_the_project_not_the_cwd(tmp_path, monkeypatch):
+    # A relative target is anchored where the ENGINE anchors it: at the resolved
+    # project. Launched with `--path <project>`, a one-shot op that opens
+    # `deck.gd` opens `<project>/deck.gd` no matter where gda was invoked, and the
+    # README promises the same. Anchoring at the invoker cwd instead refused an
+    # ordinary `gda script validate deck.gd --project game` run from an ancestor
+    # directory, which the engine validates fine.
+    proj = _make_project(tmp_path / "game")
+    monkeypatch.chdir(tmp_path)
+
+    assert path_outside_project("deck.gd", proj) is None
+    assert path_outside_project("scripts/deck.gd", proj) is None
+    # A relative project spelling anchors identically.
+    assert path_outside_project("deck.gd", Path("game")) is None
+    # `..` still climbs out of the project, and is refused from either spelling.
     assert (
         path_outside_project("../elsewhere/hero.gd", proj)
         == (tmp_path / "elsewhere" / "hero.gd").resolve()
@@ -190,3 +232,16 @@ def test_a_project_nested_inside_the_resolved_one_is_not_refused(tmp_path):
     _make_project(outer / "inner")
 
     assert path_outside_project(str(outer / "inner" / "deck.gd"), outer) is None
+
+
+def test_project_anchored_matches_how_the_engine_addresses_a_path(tmp_path):
+    # The one anchoring rule the containment check and the engine share: relative
+    # at the project, absolute untouched. Pinned separately from containment so a
+    # future caller (the op argv, a batch mode) reuses the same rule rather than
+    # re-deciding it.
+    proj = tmp_path / "game"
+    absolute = tmp_path / "elsewhere" / "hero.gd"
+
+    assert project_anchored("deck.gd", proj) == proj / "deck.gd"
+    assert project_anchored("scripts/deck.gd", proj) == proj / "scripts" / "deck.gd"
+    assert project_anchored(str(absolute), proj) == absolute

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -636,6 +636,13 @@ def test_script_validate_schema_emits_model_derived_contract_without_other_args(
     assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     assert "valid" in doc["output"]["properties"]
     assert "diagnostics" in doc["output"]["properties"]
+    # project_root is REQUIRED and nullable (#658): every emitted verdict carries
+    # the key, so an agent reads it unconditionally rather than probing for it.
+    assert "project_root" in doc["output"]["required"]
+    assert doc["output"]["properties"]["project_root"]["anyOf"] == [
+        {"type": "string"},
+        {"type": "null"},
+    ]
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
@@ -687,12 +694,28 @@ def test_sample_script_results_validate_against_emitted_output_schemas():
         },
         schema=attach_doc["output"],
     )
+    # The validate sample carries project_root: it is REQUIRED on the public
+    # result (#658), because the CLI stamps the ADR-0006-resolved project onto
+    # every emitted verdict. A payload without it is the engine's internal
+    # sentinel half, not something gda ever emits.
     jsonschema.validate(
         instance={
             "path": "res://broken.gd",
             "valid": False,
             "error_string": "Parse error.",
             "diagnostics": [{"line": 3, "column": None, "message": "Parse Error: ..."}],
+            "project_root": "/work/game",
+        },
+        schema=validate_doc["output"],
+    )
+    # ...and projectless still satisfies it, since the field is nullable.
+    jsonschema.validate(
+        instance={
+            "path": "/work/standalone.gd",
+            "valid": True,
+            "error_string": None,
+            "diagnostics": [],
+            "project_root": None,
         },
         schema=validate_doc["output"],
     )

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -646,6 +646,114 @@ def test_script_validate_does_not_refuse_a_res_path(monkeypatch, tmp_path):
     assert fake.calls == [("script-validate", {"path": "res://deck.gd"})]
 
 
+def test_script_validate_does_not_refuse_a_colon_bearing_path_as_virtual(
+    monkeypatch, tmp_path
+):
+    # A colon is legal in a POSIX filename, so a path merely CONTAINING "://" is
+    # an ordinary filesystem path — and this one is outside the project, so it is
+    # refused rather than waved through as engine-virtual (which skipped
+    # containment entirely and let the engine open the outside file).
+    proj = _project(tmp_path, "game")
+    odd = tmp_path / "outside:" / "deck.gd"
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["script", "validate", str(odd), "--project", str(proj), "--json"]
+    )
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout)["error"]["code"] == "project_not_found"
+    assert fake.calls == []
+
+
+def _ancestor_cwd_project(monkeypatch, tmp_path):
+    """A project one level below the cwd, with a script in it (the #658 A shape)."""
+    proj = _project(tmp_path, "game")
+    monkeypatch.chdir(tmp_path)
+    return proj
+
+
+def test_script_validate_accepts_a_relative_target_from_an_ancestor_cwd(
+    monkeypatch, tmp_path
+):
+    # An ordinary invocation that the containment check used to refuse: run from
+    # the workspace ABOVE the project, naming both the project and the script
+    # relatively. The engine anchors `deck.gd` at `--path game`, and the README
+    # promises exactly that, so gda must not judge it against its own cwd.
+    proj = _ancestor_cwd_project(monkeypatch, tmp_path)
+    payload = {"path": "deck.gd", "valid": True, "error_string": None}
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["script", "validate", "deck.gd", "--project", "game", "--json"]
+    )
+
+    assert result.exit_code == 0, result.stdout
+    # The op receives the path unchanged — the engine does the anchoring — and the
+    # reported root is absolute, not the bare relative "game" the caller typed.
+    assert fake.calls == [("script-validate", {"path": "deck.gd"})]
+    assert json.loads(result.stdout)["project_root"] == str(proj)
+
+
+def test_script_validate_relative_target_parity_on_the_params_json_path(
+    monkeypatch, tmp_path
+):
+    # ADR-0015 parity for the same shape: --params-json must anchor identically.
+    proj = _ancestor_cwd_project(monkeypatch, tmp_path)
+    payload = {"path": "deck.gd", "valid": True, "error_string": None}
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "validate",
+            "--params-json",
+            json.dumps({"path": "deck.gd"}),
+            "--project",
+            "game",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert fake.calls == [("script-validate", {"path": "deck.gd"})]
+    assert json.loads(result.stdout)["project_root"] == str(proj)
+
+
+def test_script_validate_still_refuses_a_relative_target_that_climbs_out(
+    monkeypatch, tmp_path
+):
+    # Anchoring at the project is not a blanket accept: a relative path that
+    # climbs out of the project with `..` is still outside, from either spelling.
+    _ancestor_cwd_project(monkeypatch, tmp_path)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "validate",
+            "../elsewhere/deck.gd",
+            "--project",
+            "game",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout)["error"]["code"] == "project_not_found"
+    assert fake.calls == []
+
+
 def test_script_validate_invalid_script_is_success_with_parsed_diagnostics(monkeypatch):
     # Validating an INVALID script is a SUCCESSFUL op (exit 0): the sentinel says
     # valid=false, and the per-command classifier parses the line/message

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -514,6 +514,138 @@ def test_script_validate_help_mentions_valid_false_success_result():
     assert "invalid exits 0 with valid=false" in result.stdout
 
 
+# --- project context: the refusal and the reported root (#658) ----------------
+
+
+def _project(tmp_path, name: str):
+    """A directory Godot counts as a project (it holds the marker)."""
+    proj = tmp_path / name
+    proj.mkdir(parents=True, exist_ok=True)
+    (proj / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return proj
+
+
+def test_script_validate_refuses_a_script_outside_the_resolved_project(
+    monkeypatch, tmp_path
+):
+    # GDA-DF-035: compiling a script against a project that does not own it makes
+    # every res:// dependency resolve against the wrong root, so the engine
+    # reports a cascade of false missing-file and derived type errors. gda refuses
+    # instead — BEFORE the engine runs, which is what `fake.calls == []` pins —
+    # and names both sides so the reader sees which one is wrong.
+    proj = _project(tmp_path, "game")
+    outsider = tmp_path / "elsewhere" / "deck.gd"
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["script", "validate", str(outsider), "--project", str(proj), "--json"],
+    )
+
+    assert result.exit_code == 4
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "project_not_found"
+    assert error["category"] == "operation"
+    # Both locations are named: where the file is, and which project was resolved.
+    assert str(outsider.resolve()) in error["message"]
+    assert str(proj.resolve()) in error["message"]
+    # Nothing was parsed: no engine call was made at all.
+    assert fake.calls == []
+
+
+def test_script_validate_refusal_is_identical_on_the_params_json_path(
+    monkeypatch, tmp_path
+):
+    # ADR-0015 parity: --params-json builds the same model and must reach the same
+    # refusal. The check lives on the command's recipe — the one hook both input
+    # paths share — not in the argv body, which --params-json bypasses.
+    proj = _project(tmp_path, "game")
+    outsider = tmp_path / "elsewhere" / "deck.gd"
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "validate",
+            "--params-json",
+            json.dumps({"path": str(outsider)}),
+            "--project",
+            str(proj),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout)["error"]["code"] == "project_not_found"
+    assert fake.calls == []
+
+
+def test_script_validate_reports_the_resolved_project_root(monkeypatch, tmp_path):
+    # The result names the root its res:// dependencies resolved against, so a
+    # reader can tell a real compile error from a wrong-project one without
+    # re-deriving gda's resolution.
+    proj = _project(tmp_path, "game")
+    script = proj / "deck.gd"
+    payload = {"path": str(script), "valid": True, "error_string": None}
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["script", "validate", str(script), "--project", str(proj), "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["project_root"] == str(proj)
+
+
+def test_script_validate_reports_a_null_project_root_when_projectless(
+    monkeypatch, tmp_path
+):
+    # Projectless (no --project, no $GDA_PROJECT, cwd is not a project) stays
+    # supported: a standalone script is still validated by filesystem path, and
+    # the null root tells the reader that res:// resolved against no project of
+    # gda's choosing — so any res:// dependency error is not to be trusted.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("GDA_PROJECT", raising=False)
+    payload = {"path": "/tmp/proj/ok.gd", "valid": True, "error_string": None}
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["script", "validate", "/tmp/proj/ok.gd", "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["project_root"] is None
+    # The engine still ran: projectless is not a refusal.
+    assert fake.calls == [("script-validate", {"path": "/tmp/proj/ok.gd"})]
+
+
+def test_script_validate_does_not_refuse_a_res_path(monkeypatch, tmp_path):
+    # A res:// path addresses the resolved project by construction (ADR-0006), so
+    # containment makes no filesystem claim about it — it is never refused.
+    proj = _project(tmp_path, "game")
+    payload = {"path": "res://deck.gd", "valid": True, "error_string": None}
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["script", "validate", "res://deck.gd", "--project", str(proj), "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [("script-validate", {"path": "res://deck.gd"})]
+
+
 def test_script_validate_invalid_script_is_success_with_parsed_diagnostics(monkeypatch):
     # Validating an INVALID script is a SUCCESSFUL op (exit 0): the sentinel says
     # valid=false, and the per-command classifier parses the line/message
@@ -625,6 +757,52 @@ def test_script_validate_human_output_invalid_lists_diagnostics(monkeypatch):
     assert "invalid /tmp/proj/broken.gd" in result.stdout
     assert "Parse error." in result.stdout
     assert "line 3: Parse Error: the message." in result.stdout
+
+
+def test_script_validate_human_output_invalid_leads_with_the_project_root(
+    monkeypatch, tmp_path
+):
+    # An invalid verdict prints the project it was compiled against BEFORE the
+    # diagnostics (#658): when the root is wrong every line below it is an
+    # artefact of that one mistake, so the cause must not sit under the cascade.
+    proj = _project(tmp_path, "game")
+    script = proj / "broken.gd"
+    payload = {"path": str(script), "valid": False, "error_string": "Parse error."}
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["script", "validate", str(script), "--project", str(proj)]
+    )
+
+    assert result.exit_code == 0
+    lines = result.stdout.splitlines()
+    assert lines[0] == f"invalid {script}"
+    assert lines[1] == f"  project: {proj}"
+
+
+def test_script_validate_human_output_names_projectless_explicitly(
+    monkeypatch, tmp_path
+):
+    # With no project resolved the line says so rather than printing an empty
+    # value — "(none resolved: projectless)" is the actionable reading of a
+    # res:// dependency error.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("GDA_PROJECT", raising=False)
+    payload = {
+        "path": "/tmp/proj/broken.gd",
+        "valid": False,
+        "error_string": "Parse error.",
+    }
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["script", "validate", "/tmp/proj/broken.gd"])
+
+    assert result.exit_code == 0
+    assert "  project: (none resolved: projectless)" in result.stdout
 
 
 def test_script_attach_human_output(monkeypatch):


### PR DESCRIPTION
Closes #658

## What changed

`gda script validate` compiled a script against the resolved project even when
that project does not own it, so every `res://` dependency resolved against the
wrong root. The engine answered with a cascade of missing-file errors plus the
type errors *derived* from them, on a script that is perfectly valid in its own
project (GDA-DF-035) — the one project-context mistake buried under the noise it
caused.

Two changes, both decided at the CLI because that is where ADR-0006's resolved
project lives (the engine is *told* the project through `--path`, never asked):

1. **Refusal before parsing.** A script outside the resolved project is refused
   with the existing `project_not_found` code, naming both the file's location
   and the resolved project. No engine is spawned, so the false cascade is never
   produced.
2. **`project_root` on the success result.** Every successful validate reports
   the project it compiled against (`null` when projectless), so a reader can
   attribute a `valid=false` verdict to its root instead of inferring it.

## What this does NOT fix — stated plainly

**The exact GDA-DF-035 invocation still produces the false cascade on this head.
This PR makes it attributable (`project_root`), not absent.** Running
`gda script validate examples/<game>/<script>.gd` from a repository root that is
not itself a Godot project resolves no project, so there is nothing for the
target to be "outside" of; the engine still resolves `res://` against its cwd and
still reports the missing dependencies. What changed is that the result now says
`"project_root": null`, which is the reading the dogfooding session lacked.

The same holds for a script in a project **nested under** the resolved one: it is
*contained*, so it is not refused. Closing either case requires deriving the
project from the target path — exactly what ADR-0006 rejected — so it needs an
amendment, not an implementation choice here.

Follow-up: **#697** (ADR-0006 amendment: derive-vs-refuse for a target under a
different `project.godot`) carries both reproduced boundaries, the
no-escape-hatch consequence, the `target_outside_project` registry question, and
the README doc note. Both non-refusal boundaries are pinned by tests here
(`test_a_project_nested_inside_the_resolved_one_is_not_refused`,
`test_script_validate_verdict_is_root_dependent_and_names_the_root`) so they stay
deliberate rather than accidental.

## Acceptance criteria → deliverable

| AC (issue #658) | Delivered by | Verified by |
|---|---|---|
| Refuses with a structured diagnostic naming the mismatch; never false dependency errors | `script_outside_project_failure` + the containment check in `_script_validate_recipe`, run **before** any engine spawn | `test_script_validate_refuses_a_script_outside_the_resolved_project` (unit: asserts `fake.calls == []`; e2e: asserts no diagnostic and empty `diagnostics`) |
| Success result reports the resolved project root in `project_root` | `ScriptValidateResult.project_root`, stamped by the recipe | `test_script_validate_reports_the_resolved_project_root`, `…_null_project_root_when_projectless`, e2e `…_verdict_is_root_dependent_and_names_the_root` |
| Regression covers a script under a nested project validated from an ancestor directory | e2e `test_script_validate_verdict_is_root_dependent_and_names_the_root` — same script, two roots, opposite verdicts, each labelled by `project_root` | real engine |

## Error code: reused, not minted

`project_not_found` (existing, `operation` category, exit 4). Semantic match: the
failure is that **no project usable for this target was resolved**, and the
remedy is the project context (`--project`) — the same class of mistake, and the
same agent branch, as `script run`'s projectless ABI edge, which already uses
this code. Sibling #663's batch-mode AC uses the same "outside the one resolved
project" semantics.

The registry description and the ADR-0002 row enumerated three producers, and
this refusal is a contradicting fourth (a project *was* resolved and *is* valid),
so both texts now name it — no new code, no new row, no exit-code change. The
structural pin in `tests/test_error_registry.py`
(`test_adr_registry_matches_python_authoritative_registry`) is green; note it
compares only `(category, source, exit_code)`, so the description column is
**unpinned** — the two description texts were verified to agree by inspection
(word-for-word, differing only in the ADR table's markdown backticks).

## Containment: how a target is judged

Three revisions came out of review; the rule now is:

1. An **engine-virtual** path (`res://`, `user://`, `uid://`, matched by PREFIX) is
   inside by construction — gda makes no filesystem claim about one.
2. A filesystem path is **anchored where the engine anchors it**
   (`project_anchored`): relative at the *resolved project*, absolute untouched.
   Launched with `--path game`, the engine opens `game/deck.gd` for the input
   `deck.gd` no matter where gda was invoked, and the README promises the same.
3. The anchored candidate is then read up to two ways, and belongs to the project
   when **either** says so:
   - **Resolved** (`Path.resolve()`, symlinks followed) — "are these two spellings
     the same place?" (`/tmp` ↔ `/private/tmp`). Always consulted.
   - **Lexical** (`os.path.abspath`, symlinks preserved) — "did the caller address
     this through the project's own tree?" This is what makes the monorepo
     shared-addon layout (`game/addons/lib -> ../../libs/lib`) work: Godot follows
     the same link, so the file really is in the project's `res://` namespace.
     Consulted **only** when neither the candidate nor the project spelling carries
     a `..` component — see below.

**Why the `..` guard.** A `..` that follows a symlink collapses textually to a
place the filesystem never visits: with `game/pivot -> ../outside/deep`, the input
`game/pivot/../deck.gd` reads as `game/deck.gd` lexically while really naming
`outside/deck.gd`. Trusting the lexical reading there accepted a genuinely outside
target and the engine compiled it. Without a `..`, a symlink can only redirect
*downward* from a path that does start inside the project — the legitimate case
above — so the guard costs nothing there. When it withholds the lexical reading,
containment falls back to the resolved reading alone: a symlinked-in file named
*with* a `..` is refused, and the caller can name it without the `..`.

## Public-surface diff (complete, byte-diffed before/after)

`gda schema`: **one** command entry changes, `script validate` — everything else
is byte-identical (`kind` stays `headless`; `input`, `error` and `constraints`
unchanged). The registry/ADR prose above is **not** in the manifest; re-verified
byte-identical after that edit.

1. `script validate` manifest `description` — gains the two project-context
   paragraphs (the command docstring is the manifest description).
2. `ScriptValidateResult` schema `description` — gains one paragraph about
   `project_root`.
3. `ScriptValidateResult.properties.project_root` — **new** property,
   `{"anyOf": [{"type":"string"},{"type":"null"}]}`, appended after `diagnostics`
   so the existing property order is untouched.
4. `ScriptValidateResult.required` — gains `project_root`:
   `["path", "valid"]` → `["path", "valid", "project_root"]`. Required **and**
   nullable, because every emitted verdict carries the key (`null` = projectless),
   so an agent reads it unconditionally instead of probing for it. It is also
   reported as an **absolute** path now; `--project game` used to emit the bare
   relative `"game"`.

`gda script validate --help`: gains exactly the same two paragraphs (no option,
argument, or first-line change).

`gda skill`: **one** hunk, in the existing `script validate` verdict paragraph —
tells the agent to read `project_root` before acting on a `valid=false`, since a
verdict full of missing-`res://` errors usually means the wrong project, not a
broken script (`null` = projectless).

Human-readable output: an **invalid** verdict gains one leading line,
`  project: <root>` (or `  project: (none resolved: projectless)`), placed
*before* the diagnostics — when the root is wrong, every line under it is an
artefact of that one mistake. A `valid` verdict is unchanged.

`README.md` is untouched; its matching gap is recorded in #697.

## Review round: what was wrong, and whether I caused it

An external adversarial review found five issues; all adopted, each reproduced
before fixing and now covered by a regression.

**The relative-path false positive was mine.** `gda script validate deck.gd
--project game`, run from the workspace above the project, was refused as outside.
I verified base behaviour directly against the engine — the pre-refusal chain
passes the path through and the engine, launched with `--path game`, opens
`game/deck.gd` and reports `valid: true`. So this was **a regression my refusal
introduced**, not a pre-existing mismatch that the fix now corrects. It is also
what the README documents ("point `gda` at a project once; relative paths then
resolve *inside* it"), which makes it a documented-behaviour break. Fixed by
anchoring containment where the engine anchors.

**Two containment bypasses**, both reproduced with the engine actually compiling
the outside script: the symlink-then-`..` pivot, and a filesystem path merely
*containing* `://` being classified as engine-virtual (a colon is legal in a POSIX
filename). Both refused now, with the engine never launched.

**Two contract/doc gaps**: `project_root` was absent from the published `required`
list, and neither the README nor `docs/command-catalog.md` mentioned the field or
the refusal.

## Docs

`README.md` (+ the `zh-CN` / `es` / `ja` translations, updated in-language and
re-stamped via `scripts/update_readme_i18n.py`) and `docs/command-catalog.md` now
document `project_root` and the refusal.

> **Coordination:** #692 also has README edits in flight. This PR merges first;
> #692 then rebases and re-stamps the i18n markers.

## Design note

The refusal and the stamping must apply to **both** input paths, and
`--params-json` bypasses the argv body. The descriptor `recipe` (ADR-0023) is the
one hook both paths share, so `script validate` now carries one — while still
running the same sentinel op through `cmd.execute` (as the export recipe does for
its preflight) and the same `classify_script_validate`, so stderr diagnostics are
parsed in exactly as before. `kind` stays `HEADLESS`.

The engine-virtual path rule (`"://"` means the engine resolves it against the
project) now has **one owner**, `gda.project.is_engine_virtual_path`, read by
both `models.normalize_path` and the containment check.

## Validation

Real-engine evidence, reproduced before and after:

```
# from the ancestor (projectless) — the GDA-DF-035 cascade, now attributable
{"path":"inner/deck.gd","valid":false,"diagnostics":[
  {"line":3,"message":"Parse Error: Preload file \"res://scripts/card.gd\" does not exist."},
  {"line":6,"message":"Parse Error: Cannot infer the type of \"c\" variable ..."}],
 "project_root":null}

# pointed at a project that does not own it — refused, no engine run
{"error":{"category":"operation","code":"project_not_found",
 "message":"/…/workspace/inner/deck.gd is outside the resolved Godot project /…/outer: its res:// dependencies would resolve against the wrong root, so nothing was parsed. …"}}

# through an in-project symlink (game/addons/cardlib -> ../../libs/cardlib):
# valid, and its res://addons/cardlib/card.gd preload resolved THROUGH the link
{"path":"/…/game/addons/cardlib/deck.gd","valid":true,"diagnostics":[],
 "project_root":"/…/game"}
```

Gates (all run on the final tree, all green):

- `uv run pytest -m "not e2e"` — 1326 passed, 412 deselected.
- `GITHUB_ACTIONS=true uv run pytest -m "not e2e"` — 1326 passed.
- `uv run ruff check` — clean; `uv run ruff format --check` — 430 files formatted.
- `uv run pyright` — 0 errors, 0 warnings.
- Godot e2e, foreground under the shared lock: `-m e2e -k script_validate` — **12
  passed**, including the three new review regressions (ancestor-cwd relative
  target on both channels, the symlink-`..` pivot, the colon-bearing outside path).
  An earlier round ran the full `tests/test_e2e_script.py` +
  `tests/test_e2e_params_json.py` — 58 passed.
- `uv run pytest tests/test_readme_i18n_sync.py` — 5 passed (translations re-stamped).

## Tests added

- `tests/test_project.py` — 11 containment cases: inside, sibling tree, `res://`/
  `user://`/`uid://`, symlinked *project* spelling (both directions), **directory
  symlinked into the project**, **file symlinked into the project**, **`..`
  escape still outside**, relative path, non-existent path, nested-project scope
  line.
- `tests/test_script_commands.py` — refusal (asserting the engine was **never
  called**), the identical refusal via `--params-json`, `project_root` reported,
  `project_root` null when projectless, `res://` never refused, and the two human
  output shapes.
- `tests/test_e2e_script.py` — the AC3 regression, the real-tier refusal, and the
  symlinked-addon pair (accepted through the link / refused from outside).
- `tests/test_command_descriptor_registry.py` — `script-validate` added to the
  pinned recipe set.
