### PR TITLE
fix(gda): preflight and redirect the Godot user-data root for the headless launch

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,18 +78,37 @@ _Avoid_: consistency, coherence, sync
 The one-shot `godot --headless` spawn primitive that the Phase-1 channels share —
 the sentinel op-dispatch runner, the native-export runner, and the `gda script run`
 user-script runner (ADR-0031). Given the binary, an argv tail, an optional working
-directory, and a timeout, it builds `[binary, --headless, *args]`, captures bytes
-with the timeout, and normalizes the outcome into a `Raw run` (the single home of
-the spawn / timeout / launch-failure / UTF-8-decode handling). Each channel
-contributes only its argv tail and the export-only cwd.
+directory, and a timeout, it builds `[binary, --headless, --log-file <gda-owned
+path>, *args]`, captures bytes with the timeout, and normalizes the outcome into a
+`Raw run` (the single home of the spawn / timeout / launch-failure / UTF-8-decode
+handling). Each channel contributes only its argv tail and the export-only cwd. It
+also owns the launch's `User-data placement` — resolved and preflighted here, once,
+so no channel plumbs it (#653).
 _Avoid_: spawn helper, subprocess wrapper
+
+**User-data placement**:
+Where one `Headless launch` puts the engine's log and, when redirected, `user://`.
+gda always owns the **log** target and passes it as `--log-file`, because Godot
+builds its file logger before any project code runs and dies with signal 11 if it
+cannot open the log — and because the engine default is one per-project rotated
+file that concurrent invocations contend over. By default the target is a private
+temporary file, so a read-only application-data directory is not fatal; the
+per-invocation `--user-data-root` (env `GDA_USER_DATA_ROOT`) instead places the log
+*and* `user://` under a caller-chosen directory, since Godot has no
+`--user-data-dir` flag and the platform data variable is the only lever. The
+placement is **created, not inspected**, before the spawn — that creation IS the
+preflight — and a placement gda cannot make usable is a typed refusal
+(`user_data_unwritable`) rather than an engine crash. Headless only: a live
+`Engine session`'s log is daemon-owned (ADR-0022).
+_Avoid_: log redirect, user dir, sandbox
 
 **Raw run**:
 The normalized outcome a `Headless launch` returns — `{stdout, stderr, exit_code,
 launch_failure}`, unparsed — before any classification. `launch_failure` is set
-only when the primitive synthesized the result (binary missing, timed out) rather
-than the engine returning one, so the classifier keys environment failures on
-that typed reason, not on the overloaded exit code. Those launch-backed channels
+only when the primitive synthesized the result (binary missing, timed out, or the
+`User-data placement` was refused) rather than the engine returning one, so the
+classifier keys environment failures on that typed reason, not on the overloaded
+exit code. Those launch-backed channels
 all return the one `RunResult` shape. Normally internal, it is **promoted to a
 public result by `gda script run`** — the one operation whose success result *is*
 a Raw run (minus `launch_failure`, which is lifted out into an `Error envelope`),

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -143,7 +143,7 @@ operation, and parse codes the CLI assigns).
 | --- | --- | --- | --- | --- |
 | `binary_not_found` | `environment` | `runner` | `127` | The Godot binary could not be launched. |
 | `launch_timeout` | `environment` | `runner` | `124` | Godot launched but did not return before the runner timeout. |
-| `user_data_unwritable` | `environment` | `runner` | `127` | Godot's user-data location is not writable, so the launch was refused. |
+| `user_data_unwritable` | `environment` | `runner` | `127` | The log or user-data placement for the launch could not be made usable, so the launch was refused. |
 | `unsupported_version` | `version` | `version_gate` | `3` | The detected Godot version is below the supported minimum. |
 | `engine_crashed` | `operation` | `classifier` | `4` | Godot terminated abnormally, such as by signal death. |
 | `operation_failed` | `operation` | `classifier` | `4` | The engine or operation failed without a valid registered operation error envelope. |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -143,6 +143,7 @@ operation, and parse codes the CLI assigns).
 | --- | --- | --- | --- | --- |
 | `binary_not_found` | `environment` | `runner` | `127` | The Godot binary could not be launched. |
 | `launch_timeout` | `environment` | `runner` | `124` | Godot launched but did not return before the runner timeout. |
+| `user_data_unwritable` | `environment` | `runner` | `127` | Godot's user-data location is not writable, so the launch was refused. |
 | `unsupported_version` | `version` | `version_gate` | `3` | The detected Godot version is below the supported minimum. |
 | `engine_crashed` | `operation` | `classifier` | `4` | Godot terminated abnormally, such as by signal death. |
 | `operation_failed` | `operation` | `classifier` | `4` | The engine or operation failed without a valid registered operation error envelope. |

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -253,3 +253,17 @@ added incrementally under ADR-0025 if a concrete need appears.
   dispatch channels.
 - **Large output** streams through stdout like any headless result; if a future need surfaces, the
   ADR-0002 result-file escape hatch applies, but it is not committed here.
+
+> **Amendment 2026-08-17 (#653).** The shared `launch()` primitive this decision reuses has since
+> grown a third responsibility, so what `script run` inherits from it is wider than described
+> above. `launch()` now also owns each launch's **`User-data placement`**: it always passes a
+> gda-owned `--log-file` (Godot builds its file logger before any project code and dies with
+> signal 11 if it cannot open the log; the engine default is additionally one per-project rotated
+> file that concurrent invocations contend over), and it preflights that placement by creating it.
+> Two consequences for this ADR's own contract, neither of which changes the passthrough decision:
+> the argv is `[binary, --headless, --log-file <path>, *args]` rather than `[binary, --headless,
+> *args]`; and `Raw run.launch_failure` has a third value, `USER_DATA_UNWRITABLE`, which — like the
+> existing two — is lifted out of the promoted `script run` success result into an `Error envelope`
+> (`user_data_unwritable`). The per-invocation `--user-data-root` also makes `user://` writable for
+> a `script run` under a restricted profile. See CONTEXT.md's `User-data placement` entry for the
+> shared-language definition.

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -148,8 +148,9 @@ def main(
         "so a read-only application-data directory is not fatal and concurrent "
         "runs do not share one log; pass this when `user://` itself must be "
         "writable. Godot reads the export templates and editor settings from that "
-        "same directory, so an export run under it finds no installed templates. "
-        "A live session is unaffected: the daemon owns its log (ADR-0022).",
+        "same directory, so a release/debug 'export run' under it finds no "
+        "installed templates unless you place them there ('--mode pack' needs "
+        "none). A live session is unaffected: the daemon owns its log (ADR-0022).",
     ),
 ) -> None:
     """An agent-facing Godot CLI with structured output."""

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -38,6 +38,7 @@ from gda.commands import (
 )
 from gda.headless import root_json, set_root_json
 from gda.provenance import build_version_provenance, render_version_line
+from gda.runner import USER_DATA_ROOT_ENV, set_user_data_root
 
 app = typer.Typer(
     name="gda",
@@ -138,6 +139,17 @@ def main(
         "--json after the command; with --version it emits structured install "
         "provenance (`--help` stays text).",
     ),
+    user_data_root: Optional[str] = typer.Option(
+        None,
+        "--user-data-root",
+        help="Directory to place Godot's user data under for this invocation: the "
+        f"engine log and `user://` (overrides ${USER_DATA_ROOT_ENV}). By default "
+        "gda redirects only the engine log, to a private temporary file, so a "
+        "read-only application-data directory is not fatal and concurrent runs do "
+        "not share one log; pass this when `user://` itself must be writable. It "
+        "also moves the export templates and editor settings Godot reads from that "
+        "directory.",
+    ),
 ) -> None:
     """An agent-facing Godot CLI with structured output."""
     # This callback keeps gda a command *group* so meta commands like `gda info`
@@ -150,8 +162,13 @@ def main(
     # inert: handing it to the shared option layer makes the invoked command's own
     # `--json` inherit it, so the root and post-command spellings mean the same
     # thing — accepting a flag that silently returned human text would be worse than
-    # the loud usage error it replaced. The hand-over happens in the option's own
-    # callback (`_record_root_json`), so this body has nothing left to do.
+    # the loud usage error it replaced. The --json hand-over happens in the
+    # option's own callback (`_record_root_json`), so it needs no line here.
+    # `--user-data-root` is a root option because it is process-wide ENVIRONMENT
+    # placement, not an operation parameter: it applies to whichever command runs,
+    # on every channel that spawns an engine, and the runner reads it there (#653).
+    # Handing it over here keeps the knowledge running downward.
+    set_user_data_root(user_data_root)
 
 
 meta_commands.register(app)

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -142,13 +142,14 @@ def main(
     user_data_root: Optional[str] = typer.Option(
         None,
         "--user-data-root",
-        help="Directory to place Godot's user data under for this invocation: the "
-        f"engine log and `user://` (overrides ${USER_DATA_ROOT_ENV}). By default "
-        "gda redirects only the engine log, to a private temporary file, so a "
-        "read-only application-data directory is not fatal and concurrent runs do "
-        "not share one log; pass this when `user://` itself must be writable. It "
-        "also moves the export templates and editor settings Godot reads from that "
-        "directory.",
+        help="Directory to place Godot's user data under for a HEADLESS launch: "
+        f"the engine log and `user://` (overrides ${USER_DATA_ROOT_ENV}). By "
+        "default gda redirects only the engine log, to a private temporary file, "
+        "so a read-only application-data directory is not fatal and concurrent "
+        "runs do not share one log; pass this when `user://` itself must be "
+        "writable. Godot reads the export templates and editor settings from that "
+        "same directory, so an export run under it finds no installed templates. "
+        "A live session is unaffected: the daemon owns its log (ADR-0022).",
     ),
 ) -> None:
     """An agent-facing Godot CLI with structured output."""

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -87,6 +87,13 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "Godot launched but did not return before the runner timeout.",
     ),
     ErrorCodeSpec(
+        "user_data_unwritable",
+        ErrorCategory.ENVIRONMENT,
+        EXIT_NOT_FOUND,
+        ErrorCodeSource.RUNNER,
+        "Godot's user-data location is not writable, so the launch was refused.",
+    ),
+    ErrorCodeSpec(
         "unsupported_version",
         ErrorCategory.VERSION,
         EXIT_VERSION,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -91,7 +91,13 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.ENVIRONMENT,
         EXIT_NOT_FOUND,
         ErrorCodeSource.RUNNER,
-        "Godot's user-data location is not writable, so the launch was refused.",
+        # Deliberately about the PLACEMENT, not about Godot's own directory: the
+        # same code covers a private temporary log target that could not be created
+        # (where Godot's location may be perfectly writable) and a redirected root
+        # whose derived data path is unusable. Naming only the latter sent readers
+        # to fix the wrong directory; the diagnostics name which one it was.
+        "The log or user-data placement for the launch could not be made usable, "
+        "so the launch was refused.",
     ),
     ErrorCodeSpec(
         "unsupported_version",

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -208,7 +208,8 @@ def classify_launch_or_crash(raw: RunResult, binary: Path | None) -> Failure | N
         # user-data directory, and the log path.
         return make_failure(
             "user_data_unwritable",
-            "Godot's user data location is not writable; the launch was refused",
+            "the log or user data placement for this launch is not usable; "
+            "the launch was refused",
             raw.stderr,
         )
     if raw.exit_code < 0:

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -20,6 +20,8 @@ engine. The decision tree, top to bottom (``code`` in parentheses; the four
 - launch NOT_FOUND → environment / binary_not_found  (runner could not launch it)
 - launch TIMEOUT   → environment / launch_timeout     (runner launched it but it
   hung past the timeout)
+- launch USER_DATA_UNWRITABLE → environment / user_data_unwritable (the engine log
+  target gda owns could not be created, so the launch was refused, #653)
 - exit < 0  → operation   / engine_crashed         (engine killed by a signal)
 - exit ≠ 0  → operation   / <operation code>        (operation reported a structured
   failure via the ADR-0002 error envelope — e.g. path_not_found)
@@ -196,6 +198,17 @@ def classify_launch_or_crash(raw: RunResult, binary: Path | None) -> Failure | N
         return make_failure(
             "launch_timeout",
             "Godot launched but did not return before the timeout",
+            raw.stderr,
+        )
+    if raw.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE:
+        # Refused before the spawn (issue #653): the engine builds its file logger
+        # ahead of any project code and dies with signal 11 when it cannot open the
+        # log, so this environment problem would otherwise arrive as an
+        # `engine_crashed` backtrace. The runner's diagnostics name the binary, the
+        # user-data directory, and the log path.
+        return make_failure(
+            "user_data_unwritable",
+            "Godot's user data location is not writable; the launch was refused",
             raw.stderr,
         )
     if raw.exit_code < 0:

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -212,12 +212,14 @@ class UserDataUnwritable(OSError):
         cause: str,
         *,
         data_path: Optional[Path] = None,
+        data_location: Optional[str] = None,
         log_file: Optional[Path] = None,
         log_location: Optional[str] = None,
     ) -> None:
         super().__init__(cause)
         self.cause = cause
         self.data_path = data_path
+        self.data_location = data_location
         self.log_file = log_file
         self.log_location = log_location
 
@@ -349,7 +351,16 @@ def _user_data_unwritable_stderr(
     could not act on either. Prose only: this text becomes
     ``GdaError.diagnostics``, whose ADR-0004 shape is unchanged.
     """
-    if root is None:
+    if failure.data_path is None and failure.data_location is not None:
+        # The placement was never prepared (an unresolvable root), so there is no
+        # resolved path to name — render the unavailable fields explicitly rather
+        # than dropping the three-path shape this diagnostic guarantees.
+        where_suffix = ""
+        remedy = (
+            "pass a non-empty --user-data-root directory (an explicit empty "
+            "value is refused rather than silently ignored, mirroring --godot)"
+        )
+    elif root is None:
         where_suffix = " (engine default; gda is not redirecting user://)"
         remedy = (
             "gda redirects only the engine log by default, not user://; "
@@ -362,7 +373,11 @@ def _user_data_unwritable_stderr(
             f"gda redirects user:// under {root} for this invocation, so that "
             "directory and the platform path derived from it must both be writable"
         )
-    where = f"{failure.data_path}{where_suffix}" if failure.data_path else "unknown"
+    where = (
+        f"{failure.data_path}{where_suffix}"
+        if failure.data_path
+        else (failure.data_location or "unknown")
+    )
     log_target = (
         str(failure.log_file)
         if failure.log_file is not None
@@ -434,13 +449,17 @@ def launch(
     except ValueError as exc:
         # An explicit but empty --user-data-root. There is no placement to prepare,
         # so it is the same unusable-placement outcome, reported before any spawn
-        # (mirrors how an empty --godot becomes binary_not_found, #33).
+        # (mirrors how an empty --godot becomes binary_not_found, #33) — through
+        # the SHARED formatter, so the three-path diagnostic shape holds with the
+        # unavailable fields rendered explicitly.
+        refusal = UserDataUnwritable(
+            str(exc),
+            data_location="unresolved (--user-data-root is empty)",
+            log_location="not attempted (no placement was prepared)",
+        )
         return RunResult(
             stdout="",
-            stderr=(
-                "gda: Godot user data placement could not be resolved; the launch "
-                f"was refused before the engine started\ngda:   cause:     {exc}\n"
-            ),
+            stderr=_user_data_unwritable_stderr(binary, None, refusal),
             exit_code=EXIT_NOT_FOUND,
             launch_failure=LaunchFailure.USER_DATA_UNWRITABLE,
         )

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -73,6 +73,10 @@ class RunResult:
 # parameter: it is set once from the root ``--user-data-root`` option (the same
 # hand-over shape as ``gda.headless.set_root_json``) and every later launch on any
 # channel inherits it, so no channel has to plumb it through the runner seam.
+#
+# ``None`` means the option was ABSENT. An empty string means it was given empty,
+# which is a different thing and must not collapse into absence — see
+# :func:`resolve_user_data_root`.
 _user_data_root_override: Optional[str] = None
 
 
@@ -82,9 +86,14 @@ def set_user_data_root(value: Optional[str]) -> None:
     The write half of the option's contract, owned here beside the resolver that
     reads it, so knowledge runs downward: the CLI composition root CALLS this to
     hand the flag over instead of this module reaching up into it.
+
+    The value is stored VERBATIM, including an empty string: collapsing ``""`` to
+    ``None`` here would silently demote an explicit (if mistaken) flag to "absent"
+    and let ``$GDA_USER_DATA_ROOT`` win, inverting the documented flag > env
+    precedence.
     """
     global _user_data_root_override
-    _user_data_root_override = value or None
+    _user_data_root_override = value
 
 
 def resolve_user_data_root(
@@ -96,7 +105,12 @@ def resolve_user_data_root(
     ``None`` — the common case — means gda redirects nothing but the engine log,
     which it always owns (see :func:`user_data_placement`). Mirrors
     :func:`gda.binary.resolve_godot_binary`'s precedence so the two environment
-    knobs read the same way.
+    knobs read the same way, including how each treats an empty value: an explicit
+    but EMPTY flag raises, because an explicit value is a deliberate choice and an
+    empty one is a mistake we surface rather than silently override — whereas an
+    empty ENVIRONMENT variable falls through to the default, since an unset and a
+    blank variable are the same intent. Getting this wrong let an empty flag
+    silently hand precedence to the environment.
 
     The root is ABSOLUTIZED, and it must be: gda and the engine do not share a
     working directory, so a relative root would name two different places. gda
@@ -114,8 +128,16 @@ def resolve_user_data_root(
     """
     if env is None:
         env = os.environ
-    raw = explicit or _user_data_root_override or env.get(USER_DATA_ROOT_ENV)
-    return Path(raw).expanduser().absolute() if raw else None
+    given = explicit if explicit is not None else _user_data_root_override
+    if given is not None:
+        if not given:
+            raise ValueError("explicit --user-data-root is empty")
+        raw = given
+    else:
+        raw = env.get(USER_DATA_ROOT_ENV)
+        if not raw:
+            return None
+    return Path(raw).expanduser().absolute()
 
 
 def engine_data_path(
@@ -176,7 +198,28 @@ def data_path_env(root: Path, platform: Optional[str] = None) -> dict[str, str]:
 
 
 class UserDataUnwritable(OSError):
-    """gda's own engine-log target could not be created (issue #653)."""
+    """gda could not make one launch's user-data placement usable (issue #653).
+
+    Carries the paths it actually RESOLVED and ATTEMPTED, so the refusal
+    diagnostics can name them instead of re-deriving or paraphrasing them. Either
+    may be ``None`` when the failure happened before that path was known — a
+    temporary directory that could not be created has no log path yet, so the
+    attempted *location* is reported instead.
+    """
+
+    def __init__(
+        self,
+        cause: str,
+        *,
+        data_path: Optional[Path] = None,
+        log_file: Optional[Path] = None,
+        log_location: Optional[str] = None,
+    ) -> None:
+        super().__init__(cause)
+        self.cause = cause
+        self.data_path = data_path
+        self.log_file = log_file
+        self.log_location = log_location
 
 
 @dataclass(frozen=True)
@@ -216,9 +259,18 @@ def user_data_placement(
     Without a ``root`` the log goes to a private temporary directory, removed on
     exit — an isolated, writable target that keeps a read-only application-data
     directory from being fatal at all, and gives concurrent invocations separate
-    files. With a ``root`` the log lands at ``<root>/logs/godot.log`` and the
-    child's platform data variable is overridden, so ``user://`` resolves under
-    ``root`` too.
+    files. Nothing else is preflighted in this mode, deliberately: the engine's own
+    ``user://`` location is none of gda's business when gda is not redirecting it,
+    and most commands never touch it.
+
+    With a ``root``, gda IS redirecting ``user://``, and so it owns that promise
+    too: the log lands at ``<root>/logs/godot.log``, the child's platform data
+    variable is overridden, and **the platform-derived data path is created and
+    probed as well**. Creating ``root`` alone is not enough — the engine appends a
+    platform layout to it (``<root>/Library/Application Support`` on macOS), and
+    that derived path can be unusable while ``root`` is perfectly writable, e.g.
+    blocked by a regular file. gda would then have preflighted only the log,
+    reported success, and left the script with an unopenable ``user://``.
     """
     if env is None:
         env = os.environ
@@ -228,8 +280,18 @@ def user_data_placement(
             if root is None:
                 # A fully locked-down temporary directory makes this itself fail;
                 # it is inside the guard so that too is a typed refusal, not a
-                # traceback escaping the primitive.
-                temp_root = tempfile.mkdtemp(prefix="gda-log-")
+                # traceback escaping the primitive. There is no log path to name
+                # yet, so the attempted LOCATION is carried instead.
+                try:
+                    temp_root = tempfile.mkdtemp(prefix="gda-log-")
+                except OSError as exc:
+                    raise UserDataUnwritable(
+                        str(exc),
+                        data_path=engine_data_path(env),
+                        log_location=(
+                            f"a private directory under {tempfile.gettempdir()}"
+                        ),
+                    ) from exc
                 log_file = Path(temp_root) / "godot.log"
                 child_env = None
                 data_path = engine_data_path(env)
@@ -237,51 +299,83 @@ def user_data_placement(
                 child_env = {**env, **data_path_env(root)}
                 log_file = root / "logs" / "godot.log"
                 data_path = engine_data_path(child_env)
-                # A redirected user:// root must exist before the engine tries to
-                # create <root>/…/app_userdata/<project> inside it.
-                root.mkdir(parents=True, exist_ok=True)
-            log_file.parent.mkdir(parents=True, exist_ok=True)
-            # Truncate-or-create: the probe that proves the engine's own
-            # ``FileAccess::open(..., WRITE)`` will succeed, and the same
-            # per-launch truncation the daemon does for a Session log (ADR-0022).
-            log_file.write_bytes(b"")
-        except OSError as exc:
-            raise UserDataUnwritable(str(exc)) from exc
+            try:
+                if root is not None and data_path is not None:
+                    _probe_data_path(data_path)
+                log_file.parent.mkdir(parents=True, exist_ok=True)
+                # Truncate-or-create: the probe that proves the engine's own
+                # ``FileAccess::open(..., WRITE)`` will succeed, and the same
+                # per-launch truncation the daemon does for a Session log (ADR-0022).
+                log_file.write_bytes(b"")
+            except OSError as exc:
+                raise UserDataUnwritable(
+                    str(exc), data_path=data_path, log_file=log_file
+                ) from exc
+        except UserDataUnwritable:
+            raise
         yield UserDataPlacement(log_file=log_file, data_path=data_path, env=child_env)
     finally:
         if temp_root is not None:
             shutil.rmtree(temp_root, ignore_errors=True)
 
 
-def _user_data_unwritable_stderr(binary: Path, root: Optional[Path], cause: str) -> str:
+def _probe_data_path(data_path: Path) -> None:
+    """Create ``data_path`` and prove a subdirectory can be made inside it.
+
+    The ``user://`` half of the preflight, and it takes the same shape as the log
+    half — create the thing, do not merely inspect it — because that is what the
+    engine will do: ``OS::ensure_user_data_dir`` calls ``make_dir_recursive`` on
+    ``<data_path>/app_userdata/<project name>``. So the probe creates and removes a
+    throwaway directory rather than checking a permission bit, which would miss an
+    immutable flag, a full filesystem, or a read-only mount. Raises ``OSError`` for
+    the caller to map.
+    """
+    data_path.mkdir(parents=True, exist_ok=True)
+    probe = tempfile.mkdtemp(prefix=".gda-probe-", dir=data_path)
+    os.rmdir(probe)
+
+
+def _user_data_unwritable_stderr(
+    binary: Path, root: Optional[Path], failure: UserDataUnwritable
+) -> str:
     """The diagnostics prose for a refused launch (issue #653).
 
     Names the three paths an agent needs to act on — the resolved binary, the
-    directory Godot resolves ``user://`` under, and the log target gda could not
-    create — plus whether gda is redirecting ``user://`` at all. Prose only: this
-    text becomes ``GdaError.diagnostics``, whose ADR-0004 shape is unchanged.
+    directory Godot resolves ``user://`` under, and the log target gda tried to
+    create — plus whether gda is redirecting ``user://`` at all. The paths come
+    from the failure itself, which RESOLVED them: paraphrasing them here ("under
+    <root>", "a private temporary directory") named neither the platform-derived
+    data path the engine would use nor the file actually attempted, so a reader
+    could not act on either. Prose only: this text becomes
+    ``GdaError.diagnostics``, whose ADR-0004 shape is unchanged.
     """
     if root is None:
-        data_path = engine_data_path()
-        where = f"{data_path} (engine default)" if data_path else "unknown"
-        redirect = (
+        where_suffix = " (engine default; gda is not redirecting user://)"
+        remedy = (
             "gda redirects only the engine log by default, not user://; "
             f"pass --user-data-root <writable dir> (or set {USER_DATA_ROOT_ENV}) "
             "to place both the log and user:// under a writable directory"
         )
-        log_file = "a private temporary directory"
     else:
-        where = f"under {root} (--user-data-root)"
-        redirect = f"gda redirects user:// under {root} for this invocation"
-        log_file = str(root / "logs" / "godot.log")
+        where_suffix = " (--user-data-root)"
+        remedy = (
+            f"gda redirects user:// under {root} for this invocation, so that "
+            "directory and the platform path derived from it must both be writable"
+        )
+    where = f"{failure.data_path}{where_suffix}" if failure.data_path else "unknown"
+    log_target = (
+        str(failure.log_file)
+        if failure.log_file is not None
+        else (failure.log_location or "unknown")
+    )
     return (
-        "gda: Godot user data is not writable; the launch was refused before the "
+        "gda: Godot user data is not usable; the launch was refused before the "
         "engine started\n"
         f"gda:   binary:    {binary}\n"
         f"gda:   user data: {where}\n"
-        f"gda:   log file:  {log_file}\n"
-        f"gda:   cause:     {cause}\n"
-        f"gda: {redirect}.\n"
+        f"gda:   log file:  {log_target}\n"
+        f"gda:   cause:     {failure.cause}\n"
+        f"gda: {remedy}.\n"
     )
 
 
@@ -335,7 +429,21 @@ def launch(
     because it is an engine option and the sentinel channel's tail ends in the
     ``--`` user-args separator.
     """
-    root = resolve_user_data_root()
+    try:
+        root = resolve_user_data_root()
+    except ValueError as exc:
+        # An explicit but empty --user-data-root. There is no placement to prepare,
+        # so it is the same unusable-placement outcome, reported before any spawn
+        # (mirrors how an empty --godot becomes binary_not_found, #33).
+        return RunResult(
+            stdout="",
+            stderr=(
+                "gda: Godot user data placement could not be resolved; the launch "
+                f"was refused before the engine started\ngda:   cause:     {exc}\n"
+            ),
+            exit_code=EXIT_NOT_FOUND,
+            launch_failure=LaunchFailure.USER_DATA_UNWRITABLE,
+        )
     try:
         with user_data_placement(root) as placement:
             # Only the preparation above can raise UserDataUnwritable: the spawn
@@ -351,7 +459,7 @@ def launch(
     except UserDataUnwritable as exc:
         return RunResult(
             stdout="",
-            stderr=_user_data_unwritable_stderr(binary, root, str(exc)),
+            stderr=_user_data_unwritable_stderr(binary, root, exc),
             exit_code=EXIT_NOT_FOUND,
             launch_failure=LaunchFailure.USER_DATA_UNWRITABLE,
         )

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -97,11 +97,25 @@ def resolve_user_data_root(
     which it always owns (see :func:`user_data_placement`). Mirrors
     :func:`gda.binary.resolve_godot_binary`'s precedence so the two environment
     knobs read the same way.
+
+    The root is ABSOLUTIZED, and it must be: gda and the engine do not share a
+    working directory, so a relative root would name two different places. gda
+    creates the log target relative to its OWN cwd, while the engine resolves the
+    relative ``--log-file`` against ``--path`` (and the export channel spawns with
+    ``cwd = <project>`` outright). The preflight would then pass for a file the
+    engine never opens, and the engine would die in ``rotate_file()`` on the file
+    it actually tried — reintroducing the very crash this machinery removes, plus
+    leaking an ``app_userdata`` tree into the project. A relative
+    ``XDG_DATA_HOME`` is ignored by the Linux engine outright
+    (``OS_LinuxBSD::get_data_path``), which would silently not redirect ``user://``
+    at all. Same bug class, and the same fix, as the export channel's ``--path``
+    (see ``gda.export_runner``, #344): ``absolute()`` rather than ``resolve()``, to
+    keep the codebase's symlink-agnostic path handling.
     """
     if env is None:
         env = os.environ
     raw = explicit or _user_data_root_override or env.get(USER_DATA_ROOT_ENV)
-    return Path(raw).expanduser() if raw else None
+    return Path(raw).expanduser().absolute() if raw else None
 
 
 def engine_data_path(

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -8,10 +8,16 @@ exercised against a fake runner without touching a real engine (ADR-0001).
 
 import enum
 import json
+import os
+import shutil
 import subprocess
+import sys
+import tempfile
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Optional, Protocol
 
 # The codes the runner synthesizes when it never got a result from the engine.
 # Defined once in gda.exit_codes (the full exit-code ABI); imported here because
@@ -25,6 +31,11 @@ OPERATIONS_GD = Path(__file__).parent / "ops" / "operations.gd"
 # the CLI fails loudly instead of blocking forever.
 DEFAULT_TIMEOUT_SECONDS = 60.0
 
+# The environment variable naming a per-invocation user-data root, the env half of
+# the `--user-data-root` option (issue #653). Same flag > env precedence shape as
+# ``GDA_GODOT`` / ``GDA_PROJECT``.
+USER_DATA_ROOT_ENV = "GDA_USER_DATA_ROOT"
+
 
 class LaunchFailure(enum.Enum):
     """Why the runner never obtained a result from the engine (issue #15).
@@ -37,6 +48,11 @@ class LaunchFailure(enum.Enum):
 
     NOT_FOUND = "not_found"  # the binary could not be launched
     TIMEOUT = "timeout"  # launched, but did not return before the runner timeout
+    # The engine log target gda owns could not be created, so the launch was
+    # REFUSED rather than attempted: Godot's file logger dereferences a null
+    # ``FileAccess`` when it cannot open its log, dying with signal 11 before any
+    # project code runs (issue #653).
+    USER_DATA_UNWRITABLE = "user_data_unwritable"
 
 
 @dataclass
@@ -50,6 +66,209 @@ class RunResult:
     # out) instead of the engine returning one; ``None`` means the exit_code is
     # the engine's own (issue #15).
     launch_failure: "LaunchFailure | None" = None
+
+
+# The per-invocation user-data root the CLI resolved, or ``None`` for the engine
+# default. Process-wide because it is process-wide CONFIG, not an operation
+# parameter: it is set once from the root ``--user-data-root`` option (the same
+# hand-over shape as ``gda.headless.set_root_json``) and every later launch on any
+# channel inherits it, so no channel has to plumb it through the runner seam.
+_user_data_root_override: Optional[str] = None
+
+
+def set_user_data_root(value: Optional[str]) -> None:
+    """Record the root ``--user-data-root`` for every later :func:`launch`.
+
+    The write half of the option's contract, owned here beside the resolver that
+    reads it, so knowledge runs downward: the CLI composition root CALLS this to
+    hand the flag over instead of this module reaching up into it.
+    """
+    global _user_data_root_override
+    _user_data_root_override = value or None
+
+
+def resolve_user_data_root(
+    explicit: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> Optional[Path]:
+    """Resolve the per-invocation user-data root: flag > env > engine default.
+
+    ``None`` — the common case — means gda redirects nothing but the engine log,
+    which it always owns (see :func:`user_data_placement`). Mirrors
+    :func:`gda.binary.resolve_godot_binary`'s precedence so the two environment
+    knobs read the same way.
+    """
+    if env is None:
+        env = os.environ
+    raw = explicit or _user_data_root_override or env.get(USER_DATA_ROOT_ENV)
+    return Path(raw).expanduser() if raw else None
+
+
+def engine_data_path(
+    env: Optional[Mapping[str, str]] = None, platform: Optional[str] = None
+) -> Optional[Path]:
+    """The directory Godot resolves ``user://`` under, per the engine's own rules.
+
+    Mirrors the platform ``OS::get_data_path()`` implementations so a failure can
+    NAME the directory an agent has to make writable (issue #653) — verified
+    against the engine source:
+
+    - macOS: ``$HOME/Library/Application Support`` (``OS_MacOS::get_config_path``,
+      which ``get_data_path`` returns verbatim);
+    - Windows: ``%APPDATA%`` (``OS_Windows::get_data_path``);
+    - Linux/BSD: ``$XDG_DATA_HOME`` when it is an ABSOLUTE path, else
+      ``$HOME/.local/share`` (``OS_LinuxBSD::get_data_path``).
+
+    The engine then appends ``app_userdata/<project name>``; gda deliberately stops
+    at the root, which is the part that is unwritable in a restricted profile and
+    the part gda can name without parsing ``project.godot``. ``None`` when the
+    platform's variable is unset, so the caller reports "unknown" rather than a
+    fabricated path.
+    """
+    if env is None:
+        env = os.environ
+    if platform is None:
+        platform = sys.platform
+    if platform == "win32":
+        appdata = env.get("APPDATA")
+        return Path(appdata) if appdata else None
+    home = env.get("HOME")
+    if platform == "darwin":
+        return Path(home) / "Library" / "Application Support" if home else None
+    xdg = env.get("XDG_DATA_HOME")
+    if xdg and Path(xdg).is_absolute():
+        return Path(xdg)
+    return Path(home) / ".local" / "share" if home else None
+
+
+def data_path_env(root: Path, platform: Optional[str] = None) -> dict[str, str]:
+    """The child-environment overrides that move Godot's data path under ``root``.
+
+    Godot has NO ``--user-data-dir`` flag (verified against the engine source: the
+    spelling appears nowhere in ``main/`` or ``core/``), so the only per-invocation
+    lever on ``user://`` is the platform variable :func:`engine_data_path` reads.
+    Each platform therefore keeps its own layout UNDER ``root`` rather than
+    resolving to ``root`` itself — the contract is "user data lands under this
+    directory", and the resolved path is reported, never guessed at by the caller.
+    """
+    if platform is None:
+        platform = sys.platform
+    if platform == "win32":
+        return {"APPDATA": str(root)}
+    if platform == "darwin":
+        # macOS resolves the data path from $HOME alone, so HOME is the only lever.
+        return {"HOME": str(root)}
+    return {"XDG_DATA_HOME": str(root)}
+
+
+class UserDataUnwritable(OSError):
+    """gda's own engine-log target could not be created (issue #653)."""
+
+
+@dataclass(frozen=True)
+class UserDataPlacement:
+    """Where ONE headless launch puts Godot's user data.
+
+    ``log_file`` is always gda-owned: the engine's default ``user://logs/godot.log``
+    is a per-project path shared by every concurrent invocation AND rotated
+    (``max_log_files`` 5), so two parallel runs contend over the same
+    rotation-sensitive file. ``--log-file`` both moves it per invocation and
+    disables rotation outright (``max_files = 1``, verified in ``Main::setup``).
+
+    ``env`` is the FULL child environment when a root redirects ``user://``, else
+    ``None`` to inherit gda's own.
+    """
+
+    log_file: Path
+    data_path: Optional[Path]
+    env: Optional[dict[str, str]]
+
+
+@contextmanager
+def user_data_placement(
+    root: Optional[Path] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> Iterator[UserDataPlacement]:
+    """Prepare — and preflight — one launch's user-data placement (issue #653).
+
+    Godot builds its file logger BEFORE it runs any project code, and
+    ``RotatedFileLogger`` dereferences the ``FileAccess`` it failed to open, so a
+    log target it cannot write kills the process with signal 11 in
+    ``rotate_file()`` — reported as a noisy ``engine_crashed`` backtrace rather
+    than the environment problem it is. gda therefore takes the log target over
+    and CREATES it here, before spawning: the creation IS the preflight, and it
+    fails as a typed :class:`UserDataUnwritable` instead of as a crash.
+
+    Without a ``root`` the log goes to a private temporary directory, removed on
+    exit — an isolated, writable target that keeps a read-only application-data
+    directory from being fatal at all, and gives concurrent invocations separate
+    files. With a ``root`` the log lands at ``<root>/logs/godot.log`` and the
+    child's platform data variable is overridden, so ``user://`` resolves under
+    ``root`` too.
+    """
+    if env is None:
+        env = os.environ
+    temp_root: Optional[str] = None
+    try:
+        try:
+            if root is None:
+                # A fully locked-down temporary directory makes this itself fail;
+                # it is inside the guard so that too is a typed refusal, not a
+                # traceback escaping the primitive.
+                temp_root = tempfile.mkdtemp(prefix="gda-log-")
+                log_file = Path(temp_root) / "godot.log"
+                child_env = None
+                data_path = engine_data_path(env)
+            else:
+                child_env = {**env, **data_path_env(root)}
+                log_file = root / "logs" / "godot.log"
+                data_path = engine_data_path(child_env)
+                # A redirected user:// root must exist before the engine tries to
+                # create <root>/…/app_userdata/<project> inside it.
+                root.mkdir(parents=True, exist_ok=True)
+            log_file.parent.mkdir(parents=True, exist_ok=True)
+            # Truncate-or-create: the probe that proves the engine's own
+            # ``FileAccess::open(..., WRITE)`` will succeed, and the same
+            # per-launch truncation the daemon does for a Session log (ADR-0022).
+            log_file.write_bytes(b"")
+        except OSError as exc:
+            raise UserDataUnwritable(str(exc)) from exc
+        yield UserDataPlacement(log_file=log_file, data_path=data_path, env=child_env)
+    finally:
+        if temp_root is not None:
+            shutil.rmtree(temp_root, ignore_errors=True)
+
+
+def _user_data_unwritable_stderr(binary: Path, root: Optional[Path], cause: str) -> str:
+    """The diagnostics prose for a refused launch (issue #653).
+
+    Names the three paths an agent needs to act on — the resolved binary, the
+    directory Godot resolves ``user://`` under, and the log target gda could not
+    create — plus whether gda is redirecting ``user://`` at all. Prose only: this
+    text becomes ``GdaError.diagnostics``, whose ADR-0004 shape is unchanged.
+    """
+    if root is None:
+        data_path = engine_data_path()
+        where = f"{data_path} (engine default)" if data_path else "unknown"
+        redirect = (
+            "gda redirects only the engine log by default, not user://; "
+            f"pass --user-data-root <writable dir> (or set {USER_DATA_ROOT_ENV}) "
+            "to place both the log and user:// under a writable directory"
+        )
+        log_file = "a private temporary directory"
+    else:
+        where = f"under {root} (--user-data-root)"
+        redirect = f"gda redirects user:// under {root} for this invocation"
+        log_file = str(root / "logs" / "godot.log")
+    return (
+        "gda: Godot user data is not writable; the launch was refused before the "
+        "engine started\n"
+        f"gda:   binary:    {binary}\n"
+        f"gda:   user data: {where}\n"
+        f"gda:   log file:  {log_file}\n"
+        f"gda:   cause:     {cause}\n"
+        f"gda: {redirect}.\n"
+    )
 
 
 def launch(
@@ -91,8 +310,50 @@ def launch(
       message is kept as advisory stderr to disambiguate which mode occurred;
     - otherwise → the engine's own ``returncode`` with ``launch_failure=None``,
       and stdout/stderr decoded as UTF-8 with ``errors="replace"`` (see below).
+
+    Every launch also carries gda's own ``--log-file`` (issue #653). The engine
+    builds its file logger before any project code runs and dies with signal 11 if
+    it cannot open the log, so gda owns that target: it is created (the preflight)
+    and passed explicitly, which keeps a read-only application-data directory from
+    being fatal and stops concurrent invocations sharing one rotated file. A target
+    gda cannot create is refused HERE as ``LaunchFailure.USER_DATA_UNWRITABLE``
+    rather than handed to the engine to crash on. ``--log-file`` precedes ``*args``
+    because it is an engine option and the sentinel channel's tail ends in the
+    ``--`` user-args separator.
     """
-    cmd = [str(binary), "--headless", *args]
+    root = resolve_user_data_root()
+    try:
+        with user_data_placement(root) as placement:
+            # Only the preparation above can raise UserDataUnwritable: the spawn
+            # itself maps every OSError to the NOT_FOUND result below.
+            return _spawn(
+                binary,
+                args,
+                cwd=cwd,
+                timeout=timeout,
+                timeout_label=timeout_label,
+                placement=placement,
+            )
+    except UserDataUnwritable as exc:
+        return RunResult(
+            stdout="",
+            stderr=_user_data_unwritable_stderr(binary, root, str(exc)),
+            exit_code=EXIT_NOT_FOUND,
+            launch_failure=LaunchFailure.USER_DATA_UNWRITABLE,
+        )
+
+
+def _spawn(
+    binary: Path,
+    args: list[str],
+    *,
+    cwd: Path | None,
+    timeout: float,
+    timeout_label: str,
+    placement: UserDataPlacement,
+) -> RunResult:
+    """Run one prepared launch and normalize its outcome — see :func:`launch`."""
+    cmd = [str(binary), "--headless", "--log-file", str(placement.log_file), *args]
     try:
         # Capture raw bytes (no ``text=True``): Godot's ``JSON.stringify`` emits
         # UTF-8, but ``text=True`` would decode with the host locale, which
@@ -108,6 +369,10 @@ def launch(
             # channel resolves a relative output path against this CWD, and the
             # spawn shape stays byte-identical to the pre-#185 ``str(project)``.
             cwd=str(cwd) if cwd is not None else None,
+            # ``None`` (the common case) inherits gda's own environment; a full
+            # child environment is built only when ``--user-data-root`` overrides
+            # the platform variable Godot resolves ``user://`` from (#653).
+            env=placement.env,
         )
     except subprocess.TimeoutExpired:
         return RunResult(

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -45,8 +45,9 @@ debugging. `info` / `schema` / `skill` are top-level meta commands (no group).
   `gda --user-data-root DIR <group> <command>` (or set `$GDA_USER_DATA_ROOT`) to
   place the log and `user://` under `DIR`; a target `gda` cannot create is refused
   as `user_data_unwritable` before the engine starts. Two limits: Godot reads the
-  **export templates** from that same directory, so do not combine it with
-  `export run` (the export reports no installed templates); and live sessions are
+  **export templates** from that same directory, so a `release`/`debug`
+  `export run` under it reports none installed unless you put templates there —
+  `--mode pack` needs no templates and works normally; and live sessions are
   unaffected either way — the daemon owns their log.
 
 ## Structured output & errors

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -36,9 +36,6 @@ debugging. `info` / `schema` / `skill` are top-level meta commands (no group).
   fails. Run it first in a long session and keep the output: an editable install
   can change revision under you mid-run, so this is what ties your results to the
   code that produced them. Bare `gda --version` stays one human-readable line.
-- **User data** — each headless run's engine log goes to a private temporary file,
-  so a read-only Godot application-data directory is not fatal and concurrent runs
-  never contend. If a script needs a writable `user://`, pass
 - **User data (headless runs)** — each headless run's engine log goes to a private
   temporary file, so a read-only Godot application-data directory is not fatal and
   concurrent runs never contend. If a script needs a writable `user://`, pass

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -39,9 +39,15 @@ debugging. `info` / `schema` / `skill` are top-level meta commands (no group).
 - **User data** — each headless run's engine log goes to a private temporary file,
   so a read-only Godot application-data directory is not fatal and concurrent runs
   never contend. If a script needs a writable `user://`, pass
+- **User data (headless runs)** — each headless run's engine log goes to a private
+  temporary file, so a read-only Godot application-data directory is not fatal and
+  concurrent runs never contend. If a script needs a writable `user://`, pass
   `gda --user-data-root DIR <group> <command>` (or set `$GDA_USER_DATA_ROOT`) to
   place the log and `user://` under `DIR`; a target `gda` cannot create is refused
-  as `user_data_unwritable` before the engine starts.
+  as `user_data_unwritable` before the engine starts. Two limits: Godot reads the
+  **export templates** from that same directory, so do not combine it with
+  `export run` (the export reports no installed templates); and live sessions are
+  unaffected either way — the daemon owns their log.
 
 ## Structured output & errors
 
@@ -56,7 +62,7 @@ Branch on the stable `category`/`code` and the **exit code**, never on prose:
 | Exit | Meaning |
 | ---- | ------- |
 | `0`   | success |
-| `127` | environment unusable: Godot binary not found, or its user data is unwritable |
+| `127` | environment unusable: `binary_not_found`, `user_data_unwritable`, `live_unsupported_platform`, `live_windowed_unavailable` |
 | `124` | engine timed out |
 | `3`   | engine version too old |
 | `4`   | operation-reported failure |

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -36,6 +36,12 @@ debugging. `info` / `schema` / `skill` are top-level meta commands (no group).
   fails. Run it first in a long session and keep the output: an editable install
   can change revision under you mid-run, so this is what ties your results to the
   code that produced them. Bare `gda --version` stays one human-readable line.
+- **User data** — each headless run's engine log goes to a private temporary file,
+  so a read-only Godot application-data directory is not fatal and concurrent runs
+  never contend. If a script needs a writable `user://`, pass
+  `gda --user-data-root DIR <group> <command>` (or set `$GDA_USER_DATA_ROOT`) to
+  place the log and `user://` under `DIR`; a target `gda` cannot create is refused
+  as `user_data_unwritable` before the engine starts.
 
 ## Structured output & errors
 
@@ -50,7 +56,7 @@ Branch on the stable `category`/`code` and the **exit code**, never on prose:
 | Exit | Meaning |
 | ---- | ------- |
 | `0`   | success |
-| `127` | Godot binary not found |
+| `127` | environment unusable: Godot binary not found, or its user data is unwritable |
 | `124` | engine timed out |
 | `3`   | engine version too old |
 | `4`   | operation-reported failure |

--- a/tests/test_e2e_user_data.py
+++ b/tests/test_e2e_user_data.py
@@ -45,7 +45,7 @@ from pathlib import Path
 import pytest
 
 from gda.binary import resolve_godot_binary
-from gda.runner import engine_data_path
+from gda.runner import data_path_env, engine_data_path
 from tests.support import GDA_CMD
 
 GODOT = resolve_godot_binary()
@@ -270,6 +270,53 @@ def test_unwritable_log_target_is_a_typed_environment_error(
     assert str(data_path / "denied") in diagnostics
     assert str(data_path / "denied" / "logs" / "godot.log") in diagnostics
     assert "handle_crash" not in diagnostics
+
+
+@pytest.mark.e2e
+def test_a_root_whose_derived_data_path_is_blocked_is_refused(
+    tmp_path, logging_project
+):
+    # Creating the root and the log target is not enough to keep the `user://`
+    # promise: the engine appends a platform layout to the root, and that DERIVED
+    # path can be unusable while the root and its `logs/` are perfectly writable.
+    #
+    # Before the derived-path probe this was the worst possible outcome — a
+    # SUCCESSFUL result. gda preflighted only the log, the engine printed "Could not
+    # create directory" to stderr and still exited 0, and the script ran with an
+    # unopenable `user://` while `script run` reported exit_status 0. So this arm
+    # asserts BOTH the typed refusal and that the project never executed.
+    root = tmp_path / "udr"
+    derived = engine_data_path(data_path_env(root), platform=sys.platform)
+    assert derived is not None
+    # Block the derived path with a regular FILE at its first component under root.
+    blocker = derived
+    while blocker.parent != root and blocker.parent != blocker:
+        blocker = blocker.parent
+    blocker.parent.mkdir(parents=True, exist_ok=True)
+    blocker.write_text("not a directory", encoding="utf-8")
+
+    run = _run_gda(
+        "--user-data-root",
+        str(root),
+        "script",
+        "run",
+        "res://persist.gd",
+        "--project",
+        str(logging_project),
+        "--json",
+        env={**os.environ, "GDA_GODOT": str(GODOT)},
+    )
+
+    assert run.returncode == 127, run.stdout + run.stderr
+    error = json.loads(run.stdout)["error"]
+    assert error["code"] == "user_data_unwritable"
+    assert error["category"] == "environment"
+    # The diagnostics name the DERIVED path — the one to fix — not just the root.
+    assert str(derived) in error["diagnostics"]
+    # The project never ran: no engine banner, no script output, no false success.
+    assert "USER_DIR=" not in run.stdout
+    assert "WRITE_FAILED" not in run.stdout
+    assert "exit_status" not in run.stdout
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_user_data.py
+++ b/tests/test_e2e_user_data.py
@@ -22,6 +22,17 @@ is safe here because every gda launch now writes to its OWN private log target, 
 the shared-``user://logs`` contention #180 worked around project-side cannot occur;
 and the single raw-engine control run is confined to its own fake HOME.
 
+**A PROJECT is required to reproduce the crash — ``gda info`` cannot.** The issue
+lists ``info`` among the commands that died, but that does not reproduce on Godot
+4.6.3 and there is no arm for it here. ``info`` is projectless, and ``Main::setup``
+builds the file logger only when ``!project_manager && !editor && …``; a projectless
+run takes the project-manager branch, so no ``RotatedFileLogger`` is ever
+constructed and there is nothing to crash. Verified directly: the projectless
+sentinel op under the restriction emits its result with zero ``handle_crash`` lines,
+with and without the fix. ``info`` is still covered here for the *refusal* path,
+which does apply to it: gda creates a log target for every launch, projectless
+included.
+
 Permissions are restored in fixture teardown, including on failure.
 """
 
@@ -50,6 +61,25 @@ config/name="gda-user-data-e2e"
 """
 
 MARKER = "USER-DATA-E2E-OK"
+
+# A pack-mode preset: `--mode pack` produces project data only, so the export-channel
+# arm below needs no installed export templates and runs on any machine.
+EXPORT_PRESETS_CFG = """\
+[preset.0]
+
+name="Linux/X11"
+platform="Linux/X11"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="build/game.x86_64"
+
+[preset.0.options]
+
+binary_format/embed_pck=false
+"""
 
 HELLO_GD = f"""\
 extends SceneTree
@@ -95,6 +125,21 @@ def restricted_home(tmp_path):
         yield home, data_path
     finally:
         data_path.chmod(0o755)
+
+
+@pytest.fixture
+def writable_home(tmp_path):
+    """A WRITABLE fake HOME, so a run's resolved ``user://`` can be inspected.
+
+    The normal-profile twin of :func:`restricted_home`: it isolates the assertion
+    from the developer's real application-data directory without restricting
+    anything, so a test can assert what the engine did and did not create there.
+    """
+    home = tmp_path / "writable-home"
+    data_path = engine_data_path({"HOME": str(home)}, platform=sys.platform)
+    assert data_path is not None, f"no data path for platform {sys.platform}"
+    data_path.mkdir(parents=True)
+    return home, data_path
 
 
 @pytest.fixture
@@ -149,26 +194,25 @@ def test_control_unprotected_launch_really_does_die_on_the_restriction(
 
 
 @pytest.mark.e2e
-@pytest.mark.parametrize("command", ["info", "script-validate"])
-def test_commands_complete_under_a_read_only_app_data_dir(
-    restricted_home, logging_project, command
+def test_script_validate_completes_under_a_read_only_app_data_dir(
+    restricted_home, logging_project
 ):
-    # AC: the default isolated log target lets a headless command complete where it
-    # previously died in the engine's logger. `info` is projectless; `script
-    # validate` runs against the project — both go through the same primitive.
+    # AC: the default isolated log target lets a project-backed headless command
+    # complete where it previously died in the engine's logger. Project-backed is
+    # the load-bearing word — see the module docstring on why `info` cannot be an
+    # arm here. Red-proof: the control arm above pins that this same project and
+    # restriction really do kill an unprotected launch.
     home, _ = restricted_home
-    if command == "info":
-        args = ["info"]
-    else:
-        args = [
-            "script",
-            "validate",
-            str(logging_project / "hello.gd"),
-            "--project",
-            str(logging_project),
-        ]
 
-    run = _run_gda(*args, "--json", env=_env(home))
+    run = _run_gda(
+        "script",
+        "validate",
+        str(logging_project / "hello.gd"),
+        "--project",
+        str(logging_project),
+        "--json",
+        env=_env(home),
+    )
 
     assert run.returncode == 0, run.stdout + run.stderr
     assert "handle_crash" not in run.stderr
@@ -232,17 +276,23 @@ def test_unwritable_log_target_is_a_typed_environment_error(
 def test_user_data_root_makes_user_writable_again(restricted_home, logging_project):
     # The persistence half: user:// is redirectable per invocation, so a script that
     # persists works under the restricted profile too.
+    #
+    # Driven through the FLAG rather than the env twin (review finding F2), so the
+    # real-engine tier exercises the CLI hand-over too, not only the env path that
+    # bypasses it.
     home, _ = restricted_home
     root = logging_project.parent / "udr"
 
     run = _run_gda(
+        "--user-data-root",
+        str(root),
         "script",
         "run",
         "res://persist.gd",
         "--project",
         str(logging_project),
         "--json",
-        env=_env(home, GDA_USER_DATA_ROOT=str(root)),
+        env=_env(home),
     )
 
     assert run.returncode == 0, run.stdout + run.stderr
@@ -255,11 +305,22 @@ def test_user_data_root_makes_user_writable_again(restricted_home, logging_proje
 
 
 @pytest.mark.e2e
-def test_concurrent_invocations_do_not_share_a_log_target(logging_project):
+def test_concurrent_invocations_never_touch_the_shared_rotated_log(
+    writable_home, logging_project
+):
     # AC: independent concurrent invocations must not contend over one
-    # rotation-sensitive log file. Run unrestricted (the normal profile) so the only
-    # thing under test is contention, and use a project with file logging ENABLED —
-    # the shape that used to race in rotate_file().
+    # rotation-sensitive log file. The assertion that carries the weight is the
+    # NEGATIVE one: the engine's shared `user://logs/` for this project is never
+    # created at all, so there is no shared target left to rotate or race on. Six
+    # successes alone would prove nothing — they pass just as well while every run
+    # writes the same file.
+    #
+    # A writable fake HOME (not the restricted one) so the run is the NORMAL
+    # profile and the resolved user:// dir can be inspected deterministically
+    # without touching the developer's real one. File logging is at the engine
+    # default here — the exact shape that used to race in rotate_file().
+    home, data_path = writable_home
+
     procs = [
         subprocess.Popen(
             [
@@ -274,7 +335,7 @@ def test_concurrent_invocations_do_not_share_a_log_target(logging_project):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            env={**os.environ, "GDA_GODOT": str(GODOT)},
+            env=_env(home),
         )
         for _ in range(6)
     ]
@@ -286,3 +347,101 @@ def test_concurrent_invocations_do_not_share_a_log_target(logging_project):
         assert code == 0, out + err
         assert "handle_crash" not in err
         assert "error" not in json.loads(out)
+
+    # The engine DID resolve user:// (it creates app_userdata eagerly), but no
+    # rotated log directory may appear anywhere beneath the data path. Globbed
+    # rather than spelled out, because the layout below the data path differs per
+    # platform (`Godot/app_userdata/…` vs `godot/app_userdata/…`).
+    shared_logs = list(data_path.rglob("logs"))
+    assert not shared_logs, (
+        f"a shared user://logs was created, so concurrent runs still contend: "
+        f"{shared_logs}"
+    )
+
+
+# --------------------------------------------------------------------------
+# A relative --user-data-root (review finding F1)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+def test_relative_root_on_the_sentinel_channel_lands_under_gda_cwd(
+    tmp_path, logging_project
+):
+    # gda and the engine do not share a working directory: gda would create the log
+    # relative to its own cwd while the engine resolved the relative --log-file
+    # against --path. The preflight then passed for a file the engine never opened
+    # and the engine died in rotate_file() on the one it did — the very crash this
+    # change removes, reintroduced by a relative path.
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+
+    run = subprocess.run(
+        [
+            *GDA_CMD,
+            "--user-data-root",
+            "./rel",
+            "script",
+            "validate",
+            str(logging_project / "hello.gd"),
+            "--project",
+            str(logging_project),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(workdir),
+        env={**os.environ, "GDA_GODOT": str(GODOT)},
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "handle_crash" not in run.stderr
+    assert json.loads(run.stdout)["valid"] is True
+    # Resolved against gda's cwd, exactly once...
+    assert (workdir / "rel" / "logs" / "godot.log").exists()
+    # ...and NOT leaked into the project the engine was pointed at.
+    assert not (logging_project / "rel").exists()
+
+
+@pytest.mark.e2e
+def test_relative_root_on_the_export_channel_lands_under_gda_cwd(
+    tmp_path, logging_project
+):
+    # The export channel is the sharper case: it spawns with cwd = <project>, so a
+    # relative --log-file resolves there for certain. `--mode pack` needs no export
+    # templates, so this runs on any machine.
+    (logging_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    workdir = tmp_path / "workdir-export"
+    workdir.mkdir()
+    artifact = logging_project / "dist" / "packed.pck"
+
+    run = subprocess.run(
+        [
+            *GDA_CMD,
+            "--user-data-root",
+            "./rel",
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--mode",
+            "pack",
+            "--output",
+            str(artifact),
+            "--project",
+            str(logging_project),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(workdir),
+        env={**os.environ, "GDA_GODOT": str(GODOT)},
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "handle_crash" not in run.stderr
+    assert artifact.exists()
+    assert (workdir / "rel" / "logs" / "godot.log").exists()
+    assert not (logging_project / "rel").exists()

--- a/tests/test_e2e_user_data.py
+++ b/tests/test_e2e_user_data.py
@@ -288,6 +288,12 @@ def test_a_root_whose_derived_data_path_is_blocked_is_refused(
     root = tmp_path / "udr"
     derived = engine_data_path(data_path_env(root), platform=sys.platform)
     assert derived is not None
+    if derived == root:
+        pytest.skip(
+            "flat user-data shape (XDG): the derived path IS the root, so it "
+            "cannot be blocked while the root stays writable — the nested-shape "
+            "refusal is exercised ungated by the unit tier"
+        )
     # Block the derived path with a regular FILE at its first component under root.
     blocker = derived
     while blocker.parent != root and blocker.parent != blocker:

--- a/tests/test_e2e_user_data.py
+++ b/tests/test_e2e_user_data.py
@@ -1,0 +1,282 @@
+"""e2e: a headless launch survives a read-only application-data directory (#653).
+
+The dogfooding failure (GDA-DF-001/014/042/030/028) is a filesystem-restricted
+process where the *project* is writable but Godot's application-data directory is
+not. Godot builds its file logger before any project code runs, and
+``RotatedFileLogger::rotate_file()`` dereferences the ``FileAccess`` it could not
+open — so EVERY command performing a headless launch died with signal 11 and was
+reported as ``engine_crashed`` plus a C++ backtrace, rather than as the
+environment problem it is.
+
+These are real-engine tests because the claim is about the engine's own startup
+order and crash behaviour: a fake runner would only prove that gda passes a flag.
+The control arm deliberately spawns the raw engine, without gda's ``--log-file``,
+to prove the restriction still breaks an unprotected launch — so the protected
+arms cannot pass for the wrong reason (e.g. because the sandbox turned out to be
+writable after all).
+
+**These fixtures deliberately leave file logging at the engine default** instead of
+using ``conftest.project_godot``, which disables it. Disabling it is exactly what
+would hide the bug: with no ``RotatedFileLogger`` there is no crash to survive. It
+is safe here because every gda launch now writes to its OWN private log target, so
+the shared-``user://logs`` contention #180 worked around project-side cannot occur;
+and the single raw-engine control run is confined to its own fake HOME.
+
+Permissions are restored in fixture teardown, including on failure.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+from gda.runner import engine_data_path
+from tests.support import GDA_CMD
+
+GODOT = resolve_godot_binary()
+
+# A project whose file logging is at the ENGINE DEFAULT (on for desktop), i.e. what
+# a real user project looks like — see the module docstring.
+DEFAULT_LOGGING_PROJECT = """\
+config_version=5
+
+[application]
+
+config/name="gda-user-data-e2e"
+"""
+
+MARKER = "USER-DATA-E2E-OK"
+
+HELLO_GD = f"""\
+extends SceneTree
+
+func _initialize() -> void:
+\tprint("{MARKER}")
+\tquit(0)
+"""
+
+# Writes to user:// and reports what it resolved, so the persistence arm can assert
+# BOTH that the write landed and where.
+PERSIST_GD = """\
+extends SceneTree
+
+func _initialize() -> void:
+\tprint("USER_DIR=", OS.get_user_data_dir())
+\tvar f = FileAccess.open("user://probe.txt", FileAccess.WRITE)
+\tif f == null:
+\t\tprint("WRITE_FAILED")
+\t\tquit(1)
+\tf.store_string("ok")
+\tf.close()
+\tprint("WRITE_OK")
+\tquit(0)
+"""
+
+
+@pytest.fixture
+def restricted_home(tmp_path):
+    """A HOME whose Godot application-data directory cannot be written.
+
+    Mirrors the dogfooding profile: the project is writable, the app-data root is
+    not. The directory tree is pre-created and only the final component is locked,
+    so this is a permission restriction and NOT a bare empty HOME (which perturbs
+    the engine's first-run behaviour). The mode is always restored.
+    """
+    home = tmp_path / "home"
+    data_path = engine_data_path({"HOME": str(home)}, platform=sys.platform)
+    assert data_path is not None, f"no data path for platform {sys.platform}"
+    data_path.mkdir(parents=True)
+    data_path.chmod(0o555)
+    try:
+        yield home, data_path
+    finally:
+        data_path.chmod(0o755)
+
+
+@pytest.fixture
+def logging_project(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "project.godot").write_text(DEFAULT_LOGGING_PROJECT, encoding="utf-8")
+    (project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
+    (project / "persist.gd").write_text(PERSIST_GD, encoding="utf-8")
+    return project
+
+
+def _env(home: Path, **extra: str) -> dict:
+    """gda's environment for a restricted run.
+
+    ``$GDA_GODOT`` is set explicitly because the binary default is ``~``-relative:
+    with HOME redirected it would otherwise resolve inside the fake home.
+    """
+    return {**os.environ, "HOME": str(home), "GDA_GODOT": str(GODOT), **extra}
+
+
+def _run_gda(*args: str, env: dict) -> subprocess.CompletedProcess:
+    return subprocess.run([*GDA_CMD, *args], capture_output=True, text=True, env=env)
+
+
+@pytest.mark.e2e
+def test_control_unprotected_launch_really_does_die_on_the_restriction(
+    restricted_home, logging_project
+):
+    # The control: the raw engine, without gda's --log-file, must NOT complete.
+    # If this ever starts passing, the restriction is not being applied and the
+    # protected arms below prove nothing.
+    home, _ = restricted_home
+    proc = subprocess.run(
+        [
+            str(GODOT),
+            "--headless",
+            "--path",
+            str(logging_project),
+            "--script",
+            "res://hello.gd",
+        ],
+        capture_output=True,
+        text=True,
+        env=_env(home),
+    )
+
+    assert MARKER not in proc.stdout, (
+        "the engine completed under the restriction, so this profile does not "
+        "reproduce the failure: " + proc.stdout + proc.stderr
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("command", ["info", "script-validate"])
+def test_commands_complete_under_a_read_only_app_data_dir(
+    restricted_home, logging_project, command
+):
+    # AC: the default isolated log target lets a headless command complete where it
+    # previously died in the engine's logger. `info` is projectless; `script
+    # validate` runs against the project — both go through the same primitive.
+    home, _ = restricted_home
+    if command == "info":
+        args = ["info"]
+    else:
+        args = [
+            "script",
+            "validate",
+            str(logging_project / "hello.gd"),
+            "--project",
+            str(logging_project),
+        ]
+
+    run = _run_gda(*args, "--json", env=_env(home))
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "handle_crash" not in run.stderr
+    assert "RotatedFileLogger" not in run.stderr
+    payload = json.loads(run.stdout)
+    assert "error" not in payload
+
+
+@pytest.mark.e2e
+def test_script_run_completes_under_a_read_only_app_data_dir(
+    restricted_home, logging_project
+):
+    home, _ = restricted_home
+
+    run = _run_gda(
+        "script",
+        "run",
+        "res://hello.gd",
+        "--project",
+        str(logging_project),
+        "--json",
+        env=_env(home),
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    data = json.loads(run.stdout)
+    assert data["exit_status"] == 0
+    assert MARKER in data["stdout"]
+    # The engine crash signature must be gone, not merely reclassified.
+    assert "handle_crash" not in data["stderr"]
+    assert "Program crashed with signal" not in data["stderr"]
+
+
+@pytest.mark.e2e
+def test_unwritable_log_target_is_a_typed_environment_error(
+    restricted_home, logging_project
+):
+    # When gda's OWN target cannot be created either, the launch is refused with a
+    # typed environment code before the engine starts — never a signal-11 backtrace.
+    home, data_path = restricted_home
+
+    run = _run_gda(
+        "info",
+        "--project",
+        str(logging_project),
+        "--json",
+        env=_env(home, GDA_USER_DATA_ROOT=str(data_path / "denied")),
+    )
+
+    assert run.returncode == 127, run.stdout + run.stderr
+    error = json.loads(run.stdout)["error"]
+    assert error["code"] == "user_data_unwritable"
+    assert error["category"] == "environment"
+    # The diagnostics name the three paths an agent has to act on.
+    diagnostics = error["diagnostics"]
+    assert str(GODOT) in diagnostics
+    assert str(data_path / "denied") in diagnostics
+    assert str(data_path / "denied" / "logs" / "godot.log") in diagnostics
+    assert "handle_crash" not in diagnostics
+
+
+@pytest.mark.e2e
+def test_user_data_root_makes_user_writable_again(restricted_home, logging_project):
+    # The persistence half: user:// is redirectable per invocation, so a script that
+    # persists works under the restricted profile too.
+    home, _ = restricted_home
+    root = logging_project.parent / "udr"
+
+    run = _run_gda(
+        "script",
+        "run",
+        "res://persist.gd",
+        "--project",
+        str(logging_project),
+        "--json",
+        env=_env(home, GDA_USER_DATA_ROOT=str(root)),
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    data = json.loads(run.stdout)
+    assert data["exit_status"] == 0, data["stdout"] + data["stderr"]
+    assert "WRITE_OK" in data["stdout"]
+    # It really resolved under the requested root, not the restricted default.
+    assert str(root) in data["stdout"]
+    assert (root / "logs" / "godot.log").exists()
+
+
+@pytest.mark.e2e
+def test_concurrent_invocations_do_not_share_a_log_target(logging_project):
+    # AC: independent concurrent invocations must not contend over one
+    # rotation-sensitive log file. Run unrestricted (the normal profile) so the only
+    # thing under test is contention, and use a project with file logging ENABLED —
+    # the shape that used to race in rotate_file().
+    procs = [
+        subprocess.Popen(
+            [*GDA_CMD, "info", "--project", str(logging_project), "--json"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={**os.environ, "GDA_GODOT": str(GODOT)},
+        )
+        for _ in range(6)
+    ]
+    # communicate() before returncode: draining the pipes is what lets each child
+    # exit, so waiting first can deadlock on a full pipe buffer.
+    results = [(*p.communicate(), p.returncode) for p in procs]
+
+    for out, err, code in results:
+        assert code == 0, out + err
+        assert "handle_crash" not in err
+        assert "error" not in json.loads(out)

--- a/tests/test_e2e_user_data.py
+++ b/tests/test_e2e_user_data.py
@@ -212,8 +212,6 @@ def test_unwritable_log_target_is_a_typed_environment_error(
 
     run = _run_gda(
         "info",
-        "--project",
-        str(logging_project),
         "--json",
         env=_env(home, GDA_USER_DATA_ROOT=str(data_path / "denied")),
     )
@@ -264,7 +262,15 @@ def test_concurrent_invocations_do_not_share_a_log_target(logging_project):
     # the shape that used to race in rotate_file().
     procs = [
         subprocess.Popen(
-            [*GDA_CMD, "info", "--project", str(logging_project), "--json"],
+            [
+                *GDA_CMD,
+                "script",
+                "validate",
+                str(logging_project / "hello.gd"),
+                "--project",
+                str(logging_project),
+                "--json",
+            ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -134,8 +134,10 @@ def test_builds_headless_argv_from_binary_and_tail(monkeypatch):
 
     launch(Path("/x/Godot"), ["--path", "/p", "--version"], cwd=None, timeout=60.0)
 
-    # The primitive always prepends `[binary, --headless]` to the caller's tail.
-    assert captured["cmd"] == ["/x/Godot", "--headless", "--path", "/p", "--version"]
+    # The primitive always prepends `[binary, --headless, --log-file <gda path>]`
+    # to the caller's tail: gda owns the engine log target on every launch (#653).
+    assert captured["cmd"][:3] == ["/x/Godot", "--headless", "--log-file"]
+    assert captured["cmd"][4:] == ["--path", "/p", "--version"]
 
 
 def test_engine_output_is_decoded_as_utf8_regardless_of_host_locale(monkeypatch):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -47,9 +47,13 @@ def test_projectless_run_builds_the_script_dispatch_tail(monkeypatch):
 
     runner.run("info", {"a": 1})
 
-    assert rec.cmd == [
-        "/x/Godot",
-        "--headless",
+    # gda owns the engine log target on every launch (#653), so `--log-file <path>`
+    # sits with the other ENGINE options, ahead of this channel's tail — and so
+    # ahead of the `--` separator, which must stay the last engine-side argument.
+    assert rec.cmd is not None
+    assert rec.cmd[:2] == ["/x/Godot", "--headless"]
+    assert rec.cmd[2] == "--log-file"
+    assert rec.cmd[4:] == [
         "--script",
         str(OPERATIONS_GD),
         "--",
@@ -71,7 +75,9 @@ def test_run_against_a_project_passes_path(monkeypatch):
     runner.run("scene-get", {})
 
     assert rec.cmd is not None
-    assert rec.cmd[:5] == ["/x/Godot", "--headless", "--path", str(project), "--script"]
+    # gda's `--log-file <path>` (#653) precedes this channel's tail; --path leads it.
+    assert rec.cmd[:3] == ["/x/Godot", "--headless", "--log-file"]
+    assert rec.cmd[4:7] == ["--path", str(project), "--script"]
     # A sentinel op runs against --path, never with a working directory.
     assert rec.kwargs is not None and rec.kwargs.get("cwd") is None
 

--- a/tests/test_user_data_placement.py
+++ b/tests/test_user_data_placement.py
@@ -24,6 +24,7 @@ from gda.cli import app
 from gda.errors import Failure, classify_launch_or_crash
 from gda.exit_codes import EXIT_NOT_FOUND
 from gda.models import ErrorCategory
+import gda.runner as runner_module
 from gda.runner import (
     USER_DATA_ROOT_ENV,
     LaunchFailure,
@@ -387,15 +388,17 @@ def test_explicit_root_probes_the_platform_derived_data_path(monkeypatch, tmp_pa
 
     monkeypatch.setattr(subprocess, "run", _must_not_spawn)
     root = tmp_path / "udr"
-    derived = engine_data_path(data_path_env(root))
-    assert derived is not None
+    # The probe logic is shape-agnostic; pin a NESTED derivation so this runs
+    # identically on every platform (the real macOS shape nests under
+    # Library/Application Support; Linux's XDG shape is flat — derived == root —
+    # where "derived blocked while root writable" cannot be constructed, which
+    # made the real-helper version of this test walk to "/" on Linux CI).
+    derived = root / "nested" / "data"
+    monkeypatch.setattr(runner_module, "engine_data_path", lambda *a, **k: derived)
     # Block the derived path with a FILE, so it can never be created, while leaving
     # `root` and `<root>/logs` writable.
-    blocker = derived
-    while blocker.parent != root and blocker.parent != blocker:
-        blocker = blocker.parent
-    blocker.parent.mkdir(parents=True, exist_ok=True)
-    blocker.write_text("not a directory")
+    derived.parent.parent.mkdir(parents=True, exist_ok=True)
+    derived.parent.write_text("not a directory")
     set_user_data_root(str(root))
 
     result = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)

--- a/tests/test_user_data_placement.py
+++ b/tests/test_user_data_placement.py
@@ -1,0 +1,335 @@
+"""gda owns the engine log target of every headless launch (issue #653).
+
+Godot builds its file logger before it runs any project code, and
+``RotatedFileLogger::rotate_file()`` dereferences the ``FileAccess`` it failed to
+open — so a log target the engine cannot write kills the process with signal 11,
+which reached an agent as an ``engine_crashed`` backtrace rather than as the
+environment problem it is. The engine has NO ``--user-data-dir`` flag (verified
+against the engine source), so gda's levers are ``--log-file`` for the log and the
+platform data variable for ``user://``.
+
+These are the unit-tier guards on that contract; the real-engine proof — a genuinely
+unwritable application-data directory — lives in ``test_e2e_user_data.py``.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from gda.errors import Failure, classify_launch_or_crash
+from gda.exit_codes import EXIT_NOT_FOUND
+from gda.models import ErrorCategory
+from gda.runner import (
+    USER_DATA_ROOT_ENV,
+    LaunchFailure,
+    data_path_env,
+    engine_data_path,
+    launch,
+    resolve_user_data_root,
+    set_user_data_root,
+    user_data_placement,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_root_override():
+    """Keep the process-wide root override off unless a test sets it."""
+    set_user_data_root(None)
+    yield
+    set_user_data_root(None)
+
+
+class _RecordingRun:
+    """A ``subprocess.run`` double recording the call and returning a clean exit."""
+
+    def __init__(self) -> None:
+        self.cmd: list[str] | None = None
+        self.kwargs: dict | None = None
+
+    def __call__(self, cmd, **kwargs):
+        self.cmd = cmd
+        self.kwargs = kwargs
+
+        class _Proc:
+            stdout = b""
+            stderr = b""
+            returncode = 0
+
+        return _Proc()
+
+
+def _log_file_arg(cmd: list[str]) -> Path:
+    return Path(cmd[cmd.index("--log-file") + 1])
+
+
+# --------------------------------------------------------------------------
+# The default: an isolated, gda-owned log target
+# --------------------------------------------------------------------------
+
+
+def test_default_launch_redirects_the_log_to_a_gda_owned_file(monkeypatch):
+    # The crash fix: the engine never resolves `user://logs/godot.log`, because gda
+    # hands it a target it has already created.
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        log_file = _log_file_arg(cmd)
+        # Created BEFORE the spawn — that creation is the preflight, and it is what
+        # guarantees the engine's own FileAccess open cannot fail.
+        seen["name"] = log_file.name
+        seen["existed"] = log_file.exists()
+
+        class _Proc:
+            stdout = b""
+            stderr = b""
+            returncode = 0
+
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert seen == {"name": "godot.log", "existed": True}
+
+
+def test_default_launch_does_not_touch_the_child_environment(monkeypatch):
+    # Without a root, gda redirects the LOG only: `user://`, the export templates
+    # and the editor settings all stay where the engine puts them by default.
+    rec = _RecordingRun()
+    monkeypatch.setattr(subprocess, "run", rec)
+
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert rec.kwargs is not None and rec.kwargs.get("env") is None
+
+
+def test_default_log_target_is_removed_after_the_run(monkeypatch):
+    seen: dict[str, Path] = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["log"] = _log_file_arg(cmd)
+
+        class _Proc:
+            stdout = b""
+            stderr = b""
+            returncode = 0
+
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    # A private temporary directory, cleaned up so repeated invocations do not
+    # accumulate stale logs.
+    assert not seen["log"].exists()
+    assert not seen["log"].parent.exists()
+
+
+def test_concurrent_default_launches_get_distinct_log_targets(monkeypatch):
+    # The non-contention guarantee: the engine default is ONE per-project
+    # `user://logs/godot.log` that is also rotated (max_log_files 5), so parallel
+    # invocations fight over the same rotation-sensitive file. Two gda launches
+    # must never name the same target.
+    targets: list[Path] = []
+
+    def fake_run(cmd, **kwargs):
+        targets.append(_log_file_arg(cmd))
+
+        class _Proc:
+            stdout = b""
+            stderr = b""
+            returncode = 0
+
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert targets[0] != targets[1]
+
+
+# --------------------------------------------------------------------------
+# The preflight refusal
+# --------------------------------------------------------------------------
+
+
+def test_unwritable_log_root_is_refused_before_the_spawn(monkeypatch, tmp_path):
+    # The whole point: refuse with a typed reason instead of letting the engine
+    # segfault in its logger. `subprocess.run` must never be reached.
+    def _must_not_spawn(*args, **kwargs):  # pragma: no cover - guard
+        raise AssertionError("the engine must not be spawned")
+
+    monkeypatch.setattr(subprocess, "run", _must_not_spawn)
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o555)
+    try:
+        set_user_data_root(str(locked / "root"))
+
+        result = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+    finally:
+        locked.chmod(0o755)
+
+    assert result.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE
+    assert result.exit_code == EXIT_NOT_FOUND
+    assert result.stdout == ""
+
+
+def test_refusal_diagnostics_name_binary_user_data_and_log_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o555)
+    root = locked / "root"
+    try:
+        set_user_data_root(str(root))
+
+        result = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+    finally:
+        locked.chmod(0o755)
+
+    # An agent must be able to act without reading gda's source: the three paths
+    # it would have to fix are all named.
+    assert "/x/Godot" in result.stderr
+    assert str(root) in result.stderr
+    assert str(root / "logs" / "godot.log") in result.stderr
+
+
+def test_default_root_refusal_names_the_engine_resolved_user_data_dir(monkeypatch):
+    # With no --user-data-root, the failure must still name where `user://` lives
+    # — the engine's own resolved directory — and say gda is not redirecting it.
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+
+    def _explode(*args, **kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr("gda.runner.tempfile.mkdtemp", _explode)
+
+    result = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert result.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE
+    data_path = engine_data_path()
+    assert data_path is not None and str(data_path) in result.stderr
+    assert "--user-data-root" in result.stderr
+    assert USER_DATA_ROOT_ENV in result.stderr
+
+
+def test_refusal_classifies_as_the_environment_error_code():
+    # The registry row: ENVIRONMENT category, the shared 127 environment exit.
+    from gda.runner import RunResult
+
+    raw = RunResult(
+        stdout="",
+        stderr="gda: Godot user data is not writable\n",
+        exit_code=EXIT_NOT_FOUND,
+        launch_failure=LaunchFailure.USER_DATA_UNWRITABLE,
+    )
+
+    outcome = classify_launch_or_crash(raw, Path("/x/Godot"))
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "user_data_unwritable"
+    assert outcome.error.category is ErrorCategory.ENVIRONMENT
+    assert outcome.exit_code == EXIT_NOT_FOUND
+    # It is NOT the engine_crashed backtrace this used to arrive as.
+    assert outcome.error.diagnostics == raw.stderr
+
+
+# --------------------------------------------------------------------------
+# --user-data-root
+# --------------------------------------------------------------------------
+
+
+def test_root_redirects_both_the_log_and_the_platform_data_variable(
+    monkeypatch, tmp_path
+):
+    rec = _RecordingRun()
+    monkeypatch.setattr(subprocess, "run", rec)
+    root = tmp_path / "udr"
+    set_user_data_root(str(root))
+
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert rec.cmd is not None
+    assert _log_file_arg(rec.cmd) == root / "logs" / "godot.log"
+    # The child gets a FULL environment carrying the platform override, so
+    # `user://` resolves under the same root as the log.
+    assert rec.kwargs is not None
+    env = rec.kwargs["env"]
+    assert env is not None
+    assert set(data_path_env(root).items()) <= set(env.items())
+    # The root itself is created, so the engine can build app_userdata/<name> in it.
+    assert root.is_dir()
+
+
+def test_root_precedence_is_flag_then_env_then_engine_default(monkeypatch):
+    monkeypatch.setenv(USER_DATA_ROOT_ENV, "/from/env")
+    assert resolve_user_data_root() == Path("/from/env")
+
+    set_user_data_root("/from/flag")
+    assert resolve_user_data_root() == Path("/from/flag")
+
+    set_user_data_root(None)
+    monkeypatch.delenv(USER_DATA_ROOT_ENV)
+    assert resolve_user_data_root() is None
+
+
+def test_root_expands_a_user_relative_path(monkeypatch):
+    monkeypatch.setenv(USER_DATA_ROOT_ENV, "~/gda-user-data")
+    resolved = resolve_user_data_root()
+    assert resolved is not None and "~" not in str(resolved)
+
+
+# --------------------------------------------------------------------------
+# The engine's own resolution rules, mirrored for reporting and redirect
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("platform", "env", "expected"),
+    [
+        # OS_MacOS::get_config_path(), which get_data_path() returns verbatim.
+        ("darwin", {"HOME": "/h"}, "/h/Library/Application Support"),
+        # OS_Windows::get_data_path().
+        ("win32", {"APPDATA": "/a"}, "/a"),
+        # OS_LinuxBSD::get_data_path(): XDG_DATA_HOME when absolute, else
+        # $HOME/.local/share.
+        ("linux", {"HOME": "/h", "XDG_DATA_HOME": "/xdg"}, "/xdg"),
+        ("linux", {"HOME": "/h", "XDG_DATA_HOME": "rel"}, "/h/.local/share"),
+        ("linux", {"HOME": "/h"}, "/h/.local/share"),
+    ],
+)
+def test_engine_data_path_mirrors_the_engine_per_platform(platform, env, expected):
+    assert engine_data_path(env, platform=platform) == Path(expected)
+
+
+def test_engine_data_path_is_unknown_when_the_variable_is_unset():
+    # Report "unknown" rather than fabricate a path gda cannot know.
+    assert engine_data_path({}, platform="darwin") is None
+    assert engine_data_path({}, platform="win32") is None
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected"),
+    [
+        ("darwin", {"HOME": "/r"}),
+        ("win32", {"APPDATA": "/r"}),
+        ("linux", {"XDG_DATA_HOME": "/r"}),
+    ],
+)
+def test_data_path_env_targets_the_variable_that_platform_reads(platform, expected):
+    # The redirect must set exactly the variable engine_data_path reads back, or
+    # the reported path and the real one diverge.
+    assert data_path_env(Path("/r"), platform=platform) == expected
+
+
+def test_placement_reports_the_redirected_data_path(tmp_path):
+    root = tmp_path / "udr"
+    with user_data_placement(root, env={"HOME": "/h"}) as placement:
+        assert placement.data_path is not None
+        assert str(root) in str(placement.data_path)

--- a/tests/test_user_data_placement.py
+++ b/tests/test_user_data_placement.py
@@ -437,6 +437,13 @@ def test_an_empty_explicit_flag_is_refused_not_demoted_to_the_environment(monkey
     assert result.exit_code == EXIT_NOT_FOUND
     # The environment value must NOT have been used.
     assert "/from/env" not in result.stderr
+    # The three-path diagnostic shape holds even here: the refusal goes through
+    # the shared formatter, with the unavailable fields rendered explicitly
+    # instead of dropped (PR #696 follow-up recheck).
+    assert "binary:    /x/Godot" in result.stderr
+    assert "user data: unresolved (--user-data-root is empty)" in result.stderr
+    assert "log file:  not attempted (no placement was prepared)" in result.stderr
+    assert "non-empty --user-data-root" in result.stderr
 
 
 def test_an_empty_flag_beats_the_environment_in_the_resolver(monkeypatch):

--- a/tests/test_user_data_placement.py
+++ b/tests/test_user_data_placement.py
@@ -17,6 +17,9 @@ from pathlib import Path
 
 import pytest
 
+from typer.testing import CliRunner
+
+from gda.cli import app
 from gda.errors import Failure, classify_launch_or_crash
 from gda.exit_codes import EXIT_NOT_FOUND
 from gda.models import ErrorCategory
@@ -30,6 +33,7 @@ from gda.runner import (
     set_user_data_root,
     user_data_placement,
 )
+from tests.support import VERSION_INFO, sentinel
 
 
 @pytest.fixture(autouse=True)
@@ -41,18 +45,25 @@ def _no_root_override():
 
 
 class _RecordingRun:
-    """A ``subprocess.run`` double recording the call and returning a clean exit."""
+    """A ``subprocess.run`` double recording the call and returning a clean exit.
 
-    def __init__(self) -> None:
+    ``payload`` is the raw stdout the fake engine writes; the CLI-seam tests pass a
+    real ADR-0002 sentinel so the command SUCCEEDS, and the argv assertion is then
+    made on a working invocation rather than on one that happened to fail late.
+    """
+
+    def __init__(self, payload: str = "") -> None:
         self.cmd: list[str] | None = None
         self.kwargs: dict | None = None
+        self._payload = payload.encode()
 
     def __call__(self, cmd, **kwargs):
         self.cmd = cmd
         self.kwargs = kwargs
+        payload = self._payload
 
         class _Proc:
-            stdout = b""
+            stdout = payload
             stderr = b""
             returncode = 0
 
@@ -267,6 +278,46 @@ def test_root_redirects_both_the_log_and_the_platform_data_variable(
     assert root.is_dir()
 
 
+def test_a_relative_root_is_absolutized_against_gda_cwd(monkeypatch, tmp_path):
+    # gda and the engine do NOT share a working directory, so a relative root names
+    # two different places: gda creates the log relative to its own cwd while the
+    # engine resolves the relative --log-file against --path (and the export channel
+    # spawns with cwd=<project>). The preflight would then pass for a file the engine
+    # never opens, and the engine would die in rotate_file() on the one it did —
+    # reintroducing the crash. Same bug class as the export channel's --path (#344).
+    rec = _RecordingRun()
+    monkeypatch.setattr(subprocess, "run", rec)
+    monkeypatch.chdir(tmp_path)
+    set_user_data_root("./rel")
+
+    launch(Path("/x/Godot"), ["--path", "/some/project"], cwd=None, timeout=60.0)
+
+    assert rec.cmd is not None
+    log_file = _log_file_arg(rec.cmd)
+    assert log_file.is_absolute()
+    assert log_file == tmp_path / "rel" / "logs" / "godot.log"
+
+
+def test_a_relative_root_absolutizes_the_platform_override_too(monkeypatch, tmp_path):
+    # The env half must be absolutized as well, and for an extra reason: the Linux
+    # engine IGNORES a relative XDG_DATA_HOME outright (OS_LinuxBSD::get_data_path),
+    # so a relative root would silently not redirect `user://` at all while the docs
+    # promise it does.
+    rec = _RecordingRun()
+    monkeypatch.setattr(subprocess, "run", rec)
+    monkeypatch.chdir(tmp_path)
+    set_user_data_root("./rel")
+
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert rec.kwargs is not None
+    env = rec.kwargs["env"]
+    assert env is not None
+    for value in data_path_env(tmp_path / "rel").values():
+        assert Path(value).is_absolute()
+    assert set(data_path_env(tmp_path / "rel").items()) <= set(env.items())
+
+
 def test_root_precedence_is_flag_then_env_then_engine_default(monkeypatch):
     monkeypatch.setenv(USER_DATA_ROOT_ENV, "/from/env")
     assert resolve_user_data_root() == Path("/from/env")
@@ -333,3 +384,44 @@ def test_placement_reports_the_redirected_data_path(tmp_path):
     with user_data_placement(root, env={"HOME": "/h"}) as placement:
         assert placement.data_path is not None
         assert str(root) in str(placement.data_path)
+
+
+# --------------------------------------------------------------------------
+# The CLI seam: the OPTION, not just the environment variable
+# --------------------------------------------------------------------------
+
+
+def test_the_root_option_reaches_the_launch(monkeypatch, tmp_path):
+    # The option travels CLI → root callback → set_user_data_root → the runner, a
+    # hand-over seam with no other test on it: every other arm here drives the env
+    # twin, which bypasses the CLI entirely. Without this, deleting the root
+    # callback's `set_user_data_root(...)` line leaves the whole suite green and the
+    # flag silently inert — a live risk, since a sibling change rewrites exactly
+    # those lines in `gda.cli`.
+    rec = _RecordingRun(sentinel(VERSION_INFO))
+    monkeypatch.setattr(subprocess, "run", rec)
+    monkeypatch.delenv(USER_DATA_ROOT_ENV, raising=False)
+    root = tmp_path / "from-the-flag"
+
+    result = CliRunner().invoke(app, ["--user-data-root", str(root), "info", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    assert rec.cmd is not None
+    assert _log_file_arg(rec.cmd) == root / "logs" / "godot.log"
+    assert rec.kwargs is not None and rec.kwargs["env"] is not None
+
+
+def test_without_the_root_option_the_launch_keeps_the_engine_default(
+    monkeypatch, tmp_path
+):
+    # The negative half: absent the flag (and the env twin), nothing is redirected
+    # but the log — so this pair fails if the option is wired to always-on as well
+    # as if it is wired to nothing.
+    rec = _RecordingRun(sentinel(VERSION_INFO))
+    monkeypatch.setattr(subprocess, "run", rec)
+    monkeypatch.delenv(USER_DATA_ROOT_ENV, raising=False)
+
+    result = CliRunner().invoke(app, ["info", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    assert rec.kwargs is not None and rec.kwargs["env"] is None

--- a/tests/test_user_data_placement.py
+++ b/tests/test_user_data_placement.py
@@ -13,6 +13,7 @@ unwritable application-data directory — lives in ``test_e2e_user_data.py``.
 """
 
 import subprocess
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -72,6 +73,23 @@ class _RecordingRun:
 
 def _log_file_arg(cmd: list[str]) -> Path:
     return Path(cmd[cmd.index("--log-file") + 1])
+
+
+def _permission_denied(prefix: str):
+    """A ``mkdtemp`` double that denies only the call carrying ``prefix``.
+
+    The data-path probe and the temporary-log directory both go through
+    ``mkdtemp``, so a blanket double could not tell which one a test meant to break.
+    """
+
+    real = tempfile.mkdtemp
+
+    def fake(*args, **kwargs):
+        if kwargs.get("prefix") == prefix:
+            raise PermissionError(13, "Permission denied")
+        return real(*args, **kwargs)
+
+    return fake
 
 
 # --------------------------------------------------------------------------
@@ -205,10 +223,14 @@ def test_refusal_diagnostics_name_binary_user_data_and_log_path(monkeypatch, tmp
         locked.chmod(0o755)
 
     # An agent must be able to act without reading gda's source: the three paths
-    # it would have to fix are all named.
+    # it would have to fix are all named — and the user-data one is the
+    # PLATFORM-DERIVED path the engine would really use, not the bare root. A
+    # paraphrase ("under <root>") pointed at a directory that is not the one to fix.
     assert "/x/Godot" in result.stderr
-    assert str(root) in result.stderr
     assert str(root / "logs" / "godot.log") in result.stderr
+    derived = engine_data_path(data_path_env(root))
+    assert derived is not None
+    assert str(derived) in result.stderr
 
 
 def test_default_root_refusal_names_the_engine_resolved_user_data_dir(monkeypatch):
@@ -228,6 +250,43 @@ def test_default_root_refusal_names_the_engine_resolved_user_data_dir(monkeypatc
     assert data_path is not None and str(data_path) in result.stderr
     assert "--user-data-root" in result.stderr
     assert USER_DATA_ROOT_ENV in result.stderr
+    # This refusal is about gda's OWN temporary target, not Godot's directory, so it
+    # must name where that target was attempted — otherwise the shared code sends
+    # the reader off to fix a directory that may be perfectly writable.
+    assert tempfile.gettempdir() in result.stderr
+    assert "not redirecting user://" in result.stderr
+
+
+def test_the_two_refusal_shapes_point_at_different_directories(monkeypatch, tmp_path):
+    # The one code covers two distinct placements (registry wording), so the
+    # diagnostics — not the code — must disambiguate which one failed. Pinned as a
+    # PAIR: the default-branch refusal must not blame the explicit root's derived
+    # path, and vice versa.
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr("gda.runner.tempfile.mkdtemp", _permission_denied("gda-log-"))
+
+    default_refusal = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    monkeypatch.undo()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o555)
+    root = locked / "root"
+    try:
+        set_user_data_root(str(root))
+        root_refusal = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+    finally:
+        locked.chmod(0o755)
+
+    assert default_refusal.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE
+    assert root_refusal.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE
+    # The default refusal talks about the temporary target and does NOT blame the root.
+    assert tempfile.gettempdir() in default_refusal.stderr
+    assert str(root) not in default_refusal.stderr
+    # The explicit-root refusal talks about the root and not the temporary dir.
+    assert str(root) in root_refusal.stderr
+    assert "not redirecting user://" not in root_refusal.stderr
 
 
 def test_refusal_classifies_as_the_environment_error_code():
@@ -316,6 +375,80 @@ def test_a_relative_root_absolutizes_the_platform_override_too(monkeypatch, tmp_
     for value in data_path_env(tmp_path / "rel").values():
         assert Path(value).is_absolute()
     assert set(data_path_env(tmp_path / "rel").items()) <= set(env.items())
+
+
+def test_explicit_root_probes_the_platform_derived_data_path(monkeypatch, tmp_path):
+    # Creating `root` alone is not enough: the engine appends a platform layout to
+    # it, and that DERIVED path can be unusable while `root` is perfectly writable
+    # — here blocked by a regular file. gda used to preflight only the log, report
+    # success, and leave the script with an unopenable `user://`.
+    def _must_not_spawn(*args, **kwargs):  # pragma: no cover - guard
+        raise AssertionError("the engine must not be spawned")
+
+    monkeypatch.setattr(subprocess, "run", _must_not_spawn)
+    root = tmp_path / "udr"
+    derived = engine_data_path(data_path_env(root))
+    assert derived is not None
+    # Block the derived path with a FILE, so it can never be created, while leaving
+    # `root` and `<root>/logs` writable.
+    blocker = derived
+    while blocker.parent != root and blocker.parent != blocker:
+        blocker = blocker.parent
+    blocker.parent.mkdir(parents=True, exist_ok=True)
+    blocker.write_text("not a directory")
+    set_user_data_root(str(root))
+
+    result = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert result.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE
+    assert result.exit_code == EXIT_NOT_FOUND
+    assert str(derived) in result.stderr
+
+
+def test_the_probe_creates_the_derived_path_and_leaves_no_litter(tmp_path):
+    # The probe takes the engine's own shape — make_dir_recursive under the data
+    # path — so it CREATES a throwaway directory rather than inspecting a
+    # permission bit, which would miss a read-only mount or a full filesystem. It
+    # must clean up after itself.
+    root = tmp_path / "udr"
+    with user_data_placement(root, env={"HOME": str(tmp_path / "h")}) as placement:
+        assert placement.data_path is not None
+        assert placement.data_path.is_dir()
+        assert not list(placement.data_path.glob(".gda-probe-*"))
+
+
+def test_an_empty_explicit_flag_is_refused_not_demoted_to_the_environment(monkeypatch):
+    # `--user-data-root ""` is an explicit, deliberate — if mistaken — choice, so it
+    # is surfaced, exactly as an empty `--godot` is. Collapsing it to "absent" let
+    # $GDA_USER_DATA_ROOT win instead, silently inverting flag > env.
+    def _must_not_spawn(*args, **kwargs):  # pragma: no cover - guard
+        raise AssertionError("the engine must not be spawned")
+
+    monkeypatch.setattr(subprocess, "run", _must_not_spawn)
+    monkeypatch.setenv(USER_DATA_ROOT_ENV, "/from/env")
+    set_user_data_root("")
+
+    result = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert result.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE
+    assert result.exit_code == EXIT_NOT_FOUND
+    # The environment value must NOT have been used.
+    assert "/from/env" not in result.stderr
+
+
+def test_an_empty_flag_beats_the_environment_in_the_resolver(monkeypatch):
+    monkeypatch.setenv(USER_DATA_ROOT_ENV, "/from/env")
+    set_user_data_root("")
+    with pytest.raises(ValueError, match="empty"):
+        resolve_user_data_root()
+
+
+def test_an_empty_environment_value_falls_through_to_the_default(monkeypatch):
+    # Unlike the flag: an unset and a blank variable are the same intent, so an
+    # empty env value is the engine default, not an error (matches --godot/$GDA_GODOT).
+    monkeypatch.setenv(USER_DATA_ROOT_ENV, "")
+    set_user_data_root(None)
+    assert resolve_user_data_root() is None
 
 
 def test_root_precedence_is_flag_then_env_then_engine_default(monkeypatch):


### PR DESCRIPTION
## Summary

In a filesystem-restricted process where the project is writable but Godot's
application-data directory is not, **every** command performing a `Headless launch`
died with signal 11 before any project code ran, and `gda` reported it as
`engine_crashed` plus a C++ backtrace instead of a typed environment refusal
(dogfooding GDA-DF-001/014/042/030/028, ~30 reconfirmations).

`gda` now **owns the engine log target of every headless launch**, in the launch
primitive (`gda.runner.launch`) once, so the sentinel, export and `script run`
channels all inherit it.

Closes #653

## Root cause, verified against the engine source

The crash is **not** the user-data directory failing to be created — that is a
non-fatal `ERR_FAIL_COND_MSG` (`core/os/os.cpp`, `OS::ensure_user_data_dir`). The
crash is the **file logger**: `Main::setup` attaches a `RotatedFileLogger`, which
dereferences the `FileAccess` it failed to open, so an unopenable log target
segfaults in `rotate_file()` before project code runs.

Reproduced locally against Godot 4.6.3 with an unwritable
`$HOME/Library/Application Support`:

```
ERROR: Could not create directory: 'user://logs'.
handle_crash: Program crashed with signal 11
[2] RotatedFileLogger::rotate_file() ...
[5] Main::setup(char const*, int, char**, bool) ...
```

Confirmed by a second, independent trigger of the same code path: `--log-file
/dev/null` also segfaults in `rotate_file()` — the open fails, not the directory
creation. That is why the preflight below **creates and opens** the target rather
than merely stat-ing the directory.

## Engine-verified redirect mechanism

| Want | Mechanism | Evidence |
| --- | --- | --- |
| Redirect the log | `--log-file <path>` | `main/main.cpp:1512` parses it; `main/main.cpp:2320-2336` uses it as `base_path` **and forces `max_files = 1`** ("Ensure log file name respects the specified override by disabling log rotation"), and opens it with `ACCESS_FILESYSTEM`, not `ACCESS_USERDATA` — so it is never resolved through `user://` |
| Redirect `user://` | the platform data variable | there is **no `--user-data-dir` flag**: the spelling appears nowhere in `main/` or `core/`, and passing it changes nothing (verified empirically — the crash was unchanged) |

`user://` resolution, mirrored in `gda.runner.engine_data_path`:

- macOS — `$HOME/Library/Application Support` (`platform/macos/os_macos.mm:433-441`:
  `get_data_path()` returns `get_config_path()`, which reads `HOME`)
- Linux/BSD — `$XDG_DATA_HOME` when absolute, else `$HOME/.local/share`
  (`platform/linuxbsd/os_linuxbsd.cpp:911-916`)
- Windows — `%APPDATA%` (`platform/windows/os_windows.cpp:2418-2424`)

`XDG_DATA_HOME` does **not** redirect `user://` on macOS — confirmed empirically,
and independently corroborated by this repo's own pre-existing skip reason in
`tests/test_e2e_export_run.py:355`.

Default log path is `user://logs/godot.log` with `max_log_files = 5` and
`enable_file_logging.pc = true` (`main/main.cpp:2312-2314`), i.e. on desktop every
default headless run creates and **rotates** one per-project log — which is the
concurrency contention this issue also asks about.

## What changed

1. **Every launch carries `--log-file` at a target `gda` has already created.**
   The creation *is* the preflight: it proves the engine's own
   `FileAccess::open(..., WRITE)` will succeed, and it mirrors the truncate-before-spawn
   the daemon already does for a `Session log` (ADR-0022).
2. **Default target = a private temporary file**, removed after the run. A read-only
   application-data directory is therefore no longer fatal at all, and — since
   `--log-file` also disables rotation — concurrent invocations never share a
   rotation-sensitive file.
3. **A placement `gda` cannot make usable is refused before the spawn** as the new
   `user_data_unwritable` code, with prose diagnostics naming the resolved binary,
   the platform-resolved user-data path and the attempted log target. The ADR-0004
   envelope *shape* is unchanged.
   With an explicit root, the preflight covers **both** halves: the log target *and*
   the platform-derived data path the engine appends to the root
   (`<root>/Library/Application Support` on macOS). Creating the root alone is not
   enough — the derived path can be unusable while the root is perfectly writable,
   and gda would then have promised a `user://` redirect it did not deliver.
4. **`--user-data-root <dir>`** (root option, `$GDA_USER_DATA_ROOT` as the env half)
   places both the log and `user://` under a caller-chosen directory, by overriding
   the platform variable above for the child process.

Placement lives entirely in the launch primitive, so no channel plumbs it and the
`RunnerFactory` seam is untouched.

## Option naming: the pair-form for #668

**Form: `--<resource>-root <dir>`** — a per-invocation directory that `gda`
redirects one engine-owned write target into, with a `GDA_<RESOURCE>_ROOT` env
twin at the same precedence (flag > env > engine default), matching
`--godot`/`$GDA_GODOT` and `--project`/`$GDA_PROJECT`.

So #668's project-import-cache root should be **`--import-cache-root`** /
`$GDA_IMPORT_CACHE_ROOT`. Rationale for the shape:

- it names the *resource* being relocated, not the mechanism (`--log-file` would
  have been mechanism-specific and could not have grown to cover `user://`);
- `root` — not `dir` or `path` — because the value is a directory the engine's own
  layout is created *under*, not the final path. This matters: the resolved
  location is platform-specific (`<root>/Library/Application Support/...` on macOS
  vs `<root>/godot/...` on Linux), so the contract is "lands under this directory"
  and the exact path is reported, never assumed;
- root-level rather than per-command, because it is process-wide *environment
  placement* that applies to whichever command runs, on every channel that spawns
  an engine. Declaring it once also keeps it off all ~66 per-command signatures and
  out of `gda schema`.

## Surface diff (enumerated)

Baseline captured before the first edit; diffed after.

- `gda schema` — **byte-identical**. The option is CLI-level, not an input-model
  field, so no per-command contract changed.
- `gda script run --help` — **byte-identical**.
- `gda --help` — one intended addition, `--user-data-root TEXT`, plus the column
  re-wrap Typer applies to the pre-existing `--version` / `--json` / `--help` rows
  because the option column widened to fit the new name. No wording changed.
- `gda skill` (i.e. `src/gda/skill/SKILL.md`, emitted verbatim) — two intended
  additions, enumerated below.
- **Authoritative contract reconciled** (no new ADR): CONTEXT.md's `Headless launch`
  and `Raw run` entries described an argv of `[binary, --headless, *args]` and a
  `launch_failure` covering only missing-binary/timeout, both of which this change
  outgrew; a new `User-data placement` term now carries the shared-language
  definition. ADR-0031 gets a dated, **append-only** amendment on the launch
  primitive it reuses — zero accepted-prose lines modified.
- New error code `user_data_unwritable` in the ADR-0002 table and
  `gda/error_codes.py`. **No new exit bucket** — it reuses the existing ENVIRONMENT
  exit `127`, alongside `binary_not_found`, `live_unsupported_platform` and
  `live_windowed_unavailable`.

### Registry row added (both places)

| Code | Category | Source | Exit Code | Meaning |
| --- | --- | --- | --- | --- |
| `user_data_unwritable` | `environment` | `runner` | `127` | The log or user-data placement for the launch could not be made usable, so the launch was refused. |

The description is deliberately about the **placement**, not about Godot's own
directory: the same code covers a private temporary log target that could not be
created — where Godot's location may be perfectly writable — and a redirected root
whose derived data path is unusable. Naming only the latter sent readers to fix the
wrong directory; the diagnostics say which one it was, and a paired test pins that
each refusal blames only its own.

`tests/test_error_registry.py` (the ADR↔Python drift guard) stays green.

### `gda skill` output diff

The Skill is a shipped doc surface, so the guidance lives in the artifact, not in
this PR body. Two additions to `## Setup` and the exit-code table:

```diff
@@ ## Setup @@
+- **User data (headless runs)** — each headless run's engine log goes to a private
+  temporary file, so a read-only Godot application-data directory is not fatal and
+  concurrent runs never contend. If a script needs a writable `user://`, pass
+  `gda --user-data-root DIR <group> <command>` (or set `$GDA_USER_DATA_ROOT`) to
+  place the log and `user://` under `DIR`; a target `gda` cannot create is refused
+  as `user_data_unwritable` before the engine starts. Two limits: Godot reads the
+  **export templates** from that same directory, so do not combine it with
+  `export run` (the export reports no installed templates); and live sessions are
+  unaffected either way — the daemon owns their log.

@@ ## Structured output & errors @@
-| `127` | Godot binary not found |
+| `127` | environment unusable: `binary_not_found`, `user_data_unwritable`, `live_unsupported_platform`, `live_windowed_unavailable` |
```

The exit-code row is a correctness fix this change forces: `user_data_unwritable`
reuses exit `127`, so the old row would have told an agent that `127` means only a
missing binary. It now enumerates all four codes on that exit (review F6).

Ownership note: the wave's Skill owner is #659 (PR #692), which merges first, so
this branch takes the serialized rebase. **Three collision points, not one:**

1. `src/gda/skill/SKILL.md` — the `## Setup` region (#692 adds a Provenance bullet
   there; this adds a User-data bullet).
2. `src/gda/cli.py` — the `from gda.headless import set_root_json` import line, which
   #692's rebase deletes and this PR extends with a second import.
3. `src/gda/cli.py` — the root-callback body: this PR's `set_user_data_root(...)` is
   appended directly after the `set_root_json(ctx, json_output)` line that #692
   deletes.

Point 3 is a **silent** sever — the flag would parse and do nothing. It is now
covered by `test_the_root_option_reaches_the_launch`, verified red-proof by
no-op-ing the hand-over (review F2).

## Validation

| Gate | Result |
| --- | --- |
| `uv run pytest -m "not e2e"` | 1333 passed, 415 deselected |
| same, `GITHUB_ACTIONS=true` | 1333 passed |
| `uv run ruff check` | passed |
| `uv run ruff format --check` | passed |
| `uv run pyright` | 0 errors, 0 warnings |
| e2e `tests/test_e2e_user_data.py` | 9 passed |
| e2e regression `info`, `script` | 56 passed |
| e2e regression `script_run`, `op_robustness` | 22 passed |
| e2e regression `export`, `export_run` | 15 passed, 1 skipped (pre-existing Linux-only skip) |
| e2e regression `daemon`, `scene` | 50 passed |

All e2e runs were foreground under the shared lock, with a bounded retry that fails
the gate on exhaustion. Every permission change is restored in fixture teardown;
verified afterwards that no test directory was left unwritable and that the real
`~/Library/Application Support/Godot` was untouched.

### The e2e regression is guarded against passing for the wrong reason

`tests/test_e2e_user_data.py` builds a real unwritable application-data directory
under a fake `HOME` (tree pre-created, only the final component locked — not a bare
empty `HOME`, which perturbs Godot's first-run behaviour). It includes a **control
arm** that spawns the raw engine *without* `gda`'s `--log-file` and asserts it does
**not** complete; if the sandbox ever stopped reproducing the restriction, the
control fails rather than the protected arms silently passing.

These fixtures deliberately leave file logging at the **engine default** rather than
using `conftest.project_godot`, which disables it — disabling it is exactly what
would hide the bug, since with no `RotatedFileLogger` there is no crash to survive.

Worth noting: `tests/conftest.py` documents that the e2e tier had to disable file
logging project-side (#180) precisely because concurrent launches raced in
`rotate_file()`. This change fixes that contention at the source, for all users
rather than for `gda`'s own fixtures. The conftest workaround is left in place
(out of scope here).

## Acceptance criteria

| AC | Status |
| --- | --- |
| Unwritable app-data dir → typed structured environment error before project code, no signal-11 backtrace | **Met, in the stronger form.** The engine crash path is not entered at all: with the default isolated target the command *completes* (`test_commands_complete_under_a_read_only_app_data_dir`, `test_script_run_completes_...`). The typed `user_data_unwritable` refusal covers the residual case where `gda`'s own target is unwritable too (`test_unwritable_log_target_is_a_typed_environment_error`). Deviation is deliberate — see below. |
| New code registered in the ENVIRONMENT category with its exit bucket | Met — table above; reuses exit `127`, no new bucket |
| A documented per-invocation option (or default isolated root) lets `script validate/run` and `info` complete under a workspace-restricted profile | Met by the **default** isolated root, proven at the real-engine tier for `script validate` and `script run`. **`info` is corrected, not proven:** see the non-repro note below |
| Failure diagnostics name resolved binary, `user://` root, log path | Met — asserted at unit and e2e tier |
| Concurrent default invocations don't share a crashing log target | Met — per-invocation targets (unit) plus 6 concurrent real-engine invocations (e2e) |
| Persistence case covered or explicitly split | Met via the **strong** branch: `--user-data-root` makes `user://` redirectable for `script run` (`test_user_data_root_makes_user_writable_again` asserts the write lands *and* resolves under the requested root). No script-side "declares writable user data" mechanism was built. |

### Correction: `gda info` never crashed

The issue lists `info` among the commands that died. That does **not** reproduce on
Godot 4.6.3, and this PR no longer claims it does. `info` is projectless, and
`Main::setup` builds the file logger only when `!project_manager && !editor && …`;
a projectless run takes the project-manager branch, so no `RotatedFileLogger` is
ever constructed and there is nothing to crash. Verified directly — the projectless
sentinel op under the restriction emits its result with zero `handle_crash` lines,
with *and* without this fix.

An earlier revision of this PR asserted an `info` arm that therefore passed with the
fix removed. It has been dropped rather than kept as a green smoke, and the finding
is recorded in the e2e module docstring (review F4a). `info` is still covered for the
*refusal* path, which does apply to it: gda creates a log target for every launch,
projectless included.

### Deliberate deviation on AC 1 — formally amended on the issue

Recorded as an accepted amendment to the acceptance criteria: https://github.com/aigengame/godot-agent/issues/653#issuecomment-5313363800

The issue offered two shapes — refuse with a typed error, *or* default to an
isolated writable root. I implemented both, with the isolation as the default,
because refusing is wrong for the common case: `gda info`, `scene create` and most
commands never touch `user://`, so failing them because the application-data
directory is read-only would preserve the very pain this issue is about. `gda`
refuses only what it cannot make work — its own log target.

## Flagged for the orchestrator

- **SKILL.md now lands in this PR** (adjudicated: the Skill owner #659 / PR #692
  merges first, so this hunk takes the serialized rebase). Diff enumerated above.
- **Known bound.** A `gda` process killed by a signal cannot remove its temporary
  log directory; the leftover is a tiny file in `$TMPDIR`, which the OS reaps.
  Normal exits (including every failure path) clean up — asserted by
  `test_default_log_target_is_removed_after_the_run`.
- `--user-data-root` also moves the export templates and editor settings Godot
  reads from that directory — so an `export run` under it finds none (measured:
  `templates_installed` flips true→false). Now stated in both the option help and
  the Skill; it is opt-in and per-invocation, and the default never touches the
  child environment.
- **Explicit non-goal: the live/daemon channel.** `--user-data-root` redirects
  HEADLESS launches only. A live `Engine session` is spawned by the daemon, which
  already owns its `--log-file` (ADR-0022) and so is immune to this failure by
  construction; it does not read this option. The option help and the Skill are
  scoped to say so, rather than promising "this invocation" generally (review F5).
