### PR TITLE
Promote the gda dogfooding wave 2 slices to main

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,18 +78,37 @@ _Avoid_: consistency, coherence, sync
 The one-shot `godot --headless` spawn primitive that the Phase-1 channels share —
 the sentinel op-dispatch runner, the native-export runner, and the `gda script run`
 user-script runner (ADR-0031). Given the binary, an argv tail, an optional working
-directory, and a timeout, it builds `[binary, --headless, *args]`, captures bytes
-with the timeout, and normalizes the outcome into a `Raw run` (the single home of
-the spawn / timeout / launch-failure / UTF-8-decode handling). Each channel
-contributes only its argv tail and the export-only cwd.
+directory, and a timeout, it builds `[binary, --headless, --log-file <gda-owned
+path>, *args]`, captures bytes with the timeout, and normalizes the outcome into a
+`Raw run` (the single home of the spawn / timeout / launch-failure / UTF-8-decode
+handling). Each channel contributes only its argv tail and the export-only cwd. It
+also owns the launch's `User-data placement` — resolved and preflighted here, once,
+so no channel plumbs it (#653).
 _Avoid_: spawn helper, subprocess wrapper
+
+**User-data placement**:
+Where one `Headless launch` puts the engine's log and, when redirected, `user://`.
+gda always owns the **log** target and passes it as `--log-file`, because Godot
+builds its file logger before any project code runs and dies with signal 11 if it
+cannot open the log — and because the engine default is one per-project rotated
+file that concurrent invocations contend over. By default the target is a private
+temporary file, so a read-only application-data directory is not fatal; the
+per-invocation `--user-data-root` (env `GDA_USER_DATA_ROOT`) instead places the log
+*and* `user://` under a caller-chosen directory, since Godot has no
+`--user-data-dir` flag and the platform data variable is the only lever. The
+placement is **created, not inspected**, before the spawn — that creation IS the
+preflight — and a placement gda cannot make usable is a typed refusal
+(`user_data_unwritable`) rather than an engine crash. Headless only: a live
+`Engine session`'s log is daemon-owned (ADR-0022).
+_Avoid_: log redirect, user dir, sandbox
 
 **Raw run**:
 The normalized outcome a `Headless launch` returns — `{stdout, stderr, exit_code,
 launch_failure}`, unparsed — before any classification. `launch_failure` is set
-only when the primitive synthesized the result (binary missing, timed out) rather
-than the engine returning one, so the classifier keys environment failures on
-that typed reason, not on the overloaded exit code. Those launch-backed channels
+only when the primitive synthesized the result (binary missing, timed out, or the
+`User-data placement` was refused) rather than the engine returning one, so the
+classifier keys environment failures on that typed reason, not on the overloaded
+exit code. Those launch-backed channels
 all return the one `RunResult` shape. Normally internal, it is **promoted to a
 public result by `gda script run`** — the one operation whose success result *is*
 a Raw run (minus `launch_failure`, which is lifted out into an `Error envelope`),

--- a/README.md
+++ b/README.md
@@ -554,6 +554,7 @@ input event.
 | `--schema`  | Emit the command's input/output JSON Schema contract (no Godot spawned). |
 | `--godot`   | Path to the Godot binary (overrides `$GDA_GODOT` and the default). |
 | `--project` | Godot project directory for `res://` resolution (overrides `$GDA_PROJECT`; defaults to the current directory if it is a project). Domain commands only. Resolving a project runs that project's code — see [Project code execution](#configuration). |
+| `--version` | Print the installed `gda` version. With `--json`, emit structured install provenance instead — version, executable, interpreter and imported-package paths, install kind (`wheel`, `editable`, or `unknown` when the install metadata cannot be read), and an editable install's source checkout with its Git revision and dirty state (no Godot spawned). Useful as a preflight before a long run: an editable install can change revision while the run is in progress. |
 | `--help`    | Show usage for `gda` or any command.                                |
 
 ---

--- a/README.md
+++ b/README.md
@@ -421,6 +421,14 @@ does not compile is still a successful operation: exit `0`, no top-level `error`
 and `valid: false` with `error_string` / `diagnostics`. Operation problems such as
 a missing file still use the normal Error envelope.
 
+The result also reports `project_root`: the project the script was compiled against,
+which is the root its `res://` dependencies resolved to (`null` when no project was
+resolved). Read it before acting on a `valid: false` — a verdict full of missing
+`res://` dependencies, plus the type errors derived from them, usually means the wrong
+project rather than a broken script. A script *outside* the resolved project is refused
+up front with `project_not_found`, naming both the file and the project, instead of
+reporting those false errors; pass `--project` for the project that owns the file.
+
 **`project`** — the project as a whole (settings, autoloads, static analysis)
 
 | Command | What it does |

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=bb3fb3e81210910899b8cfd05144fa9f969d9d214a0436f5e002a1f496c37f0e -->
+<!-- gda-readme-i18n: source=README.md sha256=4690a415ebcff975162adcdeb87ea78a23afdcd40a7f80c578a11fad3570559a -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -568,6 +568,7 @@ de entrada.
 | `--schema`  | Emite el contrato JSON Schema de entrada/salida del comando (sin lanzar Godot). |
 | `--godot`   | Ruta al binario de Godot (anula `$GDA_GODOT` y el valor por defecto). |
 | `--project` | Directorio del proyecto de Godot para la resolución de `res://` (anula `$GDA_PROJECT`; por defecto, el directorio actual si es un proyecto). Solo comandos de dominio. Resolver un proyecto ejecuta el código de ese proyecto — consulta [Ejecución del código del proyecto](#configuration). |
+| `--version` | Imprime la versión instalada de `gda`. Con `--json`, emite en su lugar la procedencia estructurada de la instalación: versión, rutas del ejecutable, del intérprete y del paquete realmente importado, tipo de instalación (`wheel`, `editable`, o `unknown` cuando los metadatos de la instalación no se pueden leer) y, para una instalación editable, el directorio de código fuente con su revisión de Git y su estado de cambios sin confirmar (sin lanzar Godot). Útil como comprobación previa a una ejecución larga: una instalación editable puede cambiar de revisión mientras la ejecución está en curso. |
 | `--help`    | Muestra el uso de `gda` o de cualquier comando.                     |
 
 ---

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7e7ef59df7e407b072ba03aa8dd6fb0325c4043a1e064f1ffb98cafa3230dc6a -->
+<!-- gda-readme-i18n: source=README.md sha256=bb3fb3e81210910899b8cfd05144fa9f969d9d214a0436f5e002a1f496c37f0e -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -432,6 +432,15 @@ script que no compila sigue siendo una operación exitosa: salida `0`, sin `erro
 de nivel superior, y `valid: false` con `error_string` / `diagnostics`. Los
 problemas de operación, como un archivo inexistente, siguen usando el Error envelope
 normal.
+
+El resultado también informa `project_root`: el proyecto contra el que se compiló el
+script, es decir, la raíz a la que se resolvieron sus dependencias `res://` (`null`
+cuando no se resolvió ningún proyecto). Léelo antes de actuar sobre un `valid: false`:
+un veredicto lleno de dependencias `res://` inexistentes, más los errores de tipo
+derivados de ellas, suele significar el proyecto equivocado y no un script roto. Un
+script *fuera* del proyecto resuelto se rechaza de entrada con `project_not_found`,
+nombrando tanto el archivo como el proyecto, en lugar de informar esos errores falsos;
+pasa `--project` con el proyecto al que pertenece el archivo.
 
 **`project`** — el proyecto en su conjunto (ajustes, autoloads, análisis estático)
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=bb3fb3e81210910899b8cfd05144fa9f969d9d214a0436f5e002a1f496c37f0e -->
+<!-- gda-readme-i18n: source=README.md sha256=4690a415ebcff975162adcdeb87ea78a23afdcd40a7f80c578a11fad3570559a -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -568,6 +568,7 @@ Godot は daemon セッション内で `get_mouse_position()` /
 | `--schema`  | コマンドの入出力 JSON Schema 契約を出力します(Godot は起動されません)。 |
 | `--godot`   | Godot バイナリへのパス(`$GDA_GODOT` とデフォルトを上書きします)。 |
 | `--project` | `res://` 解決のための Godot プロジェクトディレクトリ(`$GDA_PROJECT` を上書き。プロジェクトであればカレントディレクトリがデフォルト)。ドメインコマンドのみ。プロジェクトの解決はそのプロジェクトのコードを実行します — [プロジェクトコードの実行](#configuration) を参照してください。 |
+| `--version` | インストール済みの `gda` のバージョンを表示します。`--json` を付けると、代わりに構造化されたインストール来歴を出力します — バージョン、実行ファイル・インタプリタ・実際に読み込まれたパッケージのパス、インストール種別(`wheel`、`editable`、またはインストールメタデータが読めない場合は `unknown`)、そして editable インストールの場合はソースチェックアウトとその Git リビジョンおよび未コミット変更の有無です(Godot は起動されません)。長時間の実行前のプリフライトに便利です: editable インストールは実行中にリビジョンが変わり得ます。 |
 | `--help`    | `gda` または任意のコマンドの使い方を表示します。 |
 
 ---

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7e7ef59df7e407b072ba03aa8dd6fb0325c4043a1e064f1ffb98cafa3230dc6a -->
+<!-- gda-readme-i18n: source=README.md sha256=bb3fb3e81210910899b8cfd05144fa9f969d9d214a0436f5e002a1f496c37f0e -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -436,6 +436,14 @@ offset プロパティを明示的に設定してください。
 コンパイルできないスクリプトも成功した操作として扱われます。終了コードは `0`、トップレベルの
 `error` はなく、`valid: false` と `error_string` / `diagnostics` が返ります。存在しない
 ファイルなどの操作上の問題は、通常どおり Error envelope を使います。
+
+結果には `project_root` も含まれます。これはスクリプトのコンパイル対象となったプロジェクト、
+つまり `res://` 依存の解決先となったルートです(プロジェクトが解決されなかった場合は `null`)。
+`valid: false` に対処する前にこれを確認してください。存在しない `res://` 依存とそこから派生した
+型エラーばかりの結果は、通常スクリプトの不具合ではなくプロジェクトの選択ミスを意味します。
+解決されたプロジェクトの**外**にあるスクリプトは、その偽のエラー群を報告する代わりに、
+ファイルとプロジェクトの両方を示した `project_not_found` で事前に拒否されます。その場合は
+そのファイルを所有するプロジェクトを `--project` で指定してください。
 
 **`project`** — プロジェクト全体(設定、オートロード、静的解析)
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=bb3fb3e81210910899b8cfd05144fa9f969d9d214a0436f5e002a1f496c37f0e -->
+<!-- gda-readme-i18n: source=README.md sha256=4690a415ebcff975162adcdeb87ea78a23afdcd40a7f80c578a11fad3570559a -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -546,6 +546,7 @@ Live `game set --property position` 遵循与 `node set` 相同的 `Control` 策
 | `--schema`  | 输出该命令的输入/输出 JSON Schema 契约（不会启动 Godot）。 |
 | `--godot`   | Godot 二进制文件的路径（覆盖 `$GDA_GODOT` 和默认值）。 |
 | `--project` | 用于 `res://` 解析的 Godot 项目目录（覆盖 `$GDA_PROJECT`；若当前目录本身是个项目则默认用它）。仅限领域命令。解析一个项目会运行该项目的代码——参见[项目代码执行](#configuration)。 |
+| `--version` | 打印已安装的 `gda` 版本。加上 `--json` 时，改为输出结构化的安装溯源信息——版本，可执行文件、解释器与实际导入的包所在路径，安装类型（`wheel`、`editable`，或在安装元数据无法读取时为 `unknown`），以及 editable 安装所对应的源码检出目录、Git 版本号和是否有未提交改动（不会启动 Godot）。适合在长时间运行前作为预检：editable 安装的代码可能在运行过程中变更版本。 |
 | `--help`    | 显示 `gda` 或任意命令的用法。                                |
 
 ---

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7e7ef59df7e407b072ba03aa8dd6fb0325c4043a1e064f1ffb98cafa3230dc6a -->
+<!-- gda-readme-i18n: source=README.md sha256=bb3fb3e81210910899b8cfd05144fa9f969d9d214a0436f5e002a1f496c37f0e -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -417,6 +417,12 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 对 `script validate --json`，要读取结果对象里的 `valid` 字段。脚本编译失败仍然算一次成功操作：
 退出码为 `0`，没有顶层 `error`，并以 `valid: false` 携带 `error_string` / `diagnostics`。
 缺失文件等操作层问题仍然采用标准的 Error envelope。
+
+结果还会报告 `project_root`：脚本编译时所针对的项目，也就是其 `res://` 依赖解析到的根目录
+（未解析到项目时为 `null`）。在处理 `valid: false` 之前请先读它——若诊断里满是缺失的 `res://`
+依赖以及由此派生的类型错误，通常说明项目选错了，而不是脚本本身有问题。位于所解析项目**之外**
+的脚本会被提前拒绝并返回 `project_not_found`，同时指明文件与项目，而不是报出那一连串假错误；
+此时请用 `--project` 指定真正拥有该文件的项目。
 
 **`project`** — 作为整体的项目（设置、autoload、静态分析）
 

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -143,6 +143,7 @@ operation, and parse codes the CLI assigns).
 | --- | --- | --- | --- | --- |
 | `binary_not_found` | `environment` | `runner` | `127` | The Godot binary could not be launched. |
 | `launch_timeout` | `environment` | `runner` | `124` | Godot launched but did not return before the runner timeout. |
+| `user_data_unwritable` | `environment` | `runner` | `127` | The log or user-data placement for the launch could not be made usable, so the launch was refused. |
 | `unsupported_version` | `version` | `version_gate` | `3` | The detected Godot version is below the supported minimum. |
 | `engine_crashed` | `operation` | `classifier` | `4` | Godot terminated abnormally, such as by signal death. |
 | `operation_failed` | `operation` | `classifier` | `4` | The engine or operation failed without a valid registered operation error envelope. |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -64,6 +64,17 @@ The GDScript payload owns only `code` and `message`. `gda` owns the public
 `GdaError` wrapper: it validates that the code is registered, assigns the
 `operation` category, preserves the message, and copies stderr into diagnostics.
 
+> **Scope note (2026-08-17, #667) — the shape above is the GDScript-emitted
+> *headless* payload, and stays exactly that.** The Phase-2 **live** channel reuses
+> this envelope but is emitted by Python (the daemon and the daemon IPC client), and
+> it carries one OPTIONAL extra key: `probe`, the host-probe context behind a windowed
+> refusal (ADR-0004 amendment). The two channels validate against **different models**
+> — `OperationErrorEnvelope` (headless) stays `extra="forbid"` and probe-less, because
+> a GDScript operation has no host probe to report; `LiveErrorEnvelope` accepts the
+> optional key. The key is omitted when absent, so every payload either language
+> emitted before is byte-identical. This widens no cross-language contract: GDScript
+> neither emits nor reads `probe`.
+
 ### stderr as advisory diagnostics
 
 stderr is still **never** parsed for the success/failure *outcome* or for stable
@@ -223,6 +234,7 @@ operation, and parse codes the CLI assigns).
 | `live_display_unavailable` | `live` | `classifier` | `6` | A live `screen` capture ran on a headless engine session (the dummy DisplayServer cannot read pixels); start the daemon windowed with `gda daemon start --windowed` (Phase 2, #222). |
 | `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
 | `live_windowed_unavailable` | `environment` | `classifier` | `127` | A windowed live session (`gda daemon start --windowed`) was requested but the host has no usable DisplayServer (no on-console GUI session / no `$DISPLAY`), so the session cannot come up; refused before spawning Godot (Phase 2, #345). |
+| `live_windowed_permission_denied` | `environment` | `classifier` | `127` | A windowed live session (`gda daemon start --windowed`) was requested but this process is denied the window-server lookup (e.g. a sandbox), so gda cannot tell whether the host has one; re-run outside the restriction to find out rather than recording the host as display-less (Phase 2, #667). |
 
 ## Considered options
 

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -156,7 +156,7 @@ operation, and parse codes the CLI assigns).
 | `save_failed` | `operation` | `operation` | `4` | A scene could not be packed or saved. |
 | `delete_failed` | `operation` | `operation` | `4` | A file could not be removed from disk. |
 | `file_changed_externally` | `operation` | `operation` | `4` | A read-modify-write operation's target file changed on disk between the read and the write, so the write was refused to avoid clobbering the external edit. |
-| `project_not_found` | `operation` | `operation` | `4` | gda ran without a usable resolved Godot project: an operation needed one and none was resolved, or an explicit `--project` was empty, or a `--project`/`$GDA_PROJECT` does not name a Godot project (no `project.godot`). |
+| `project_not_found` | `operation` | `operation` | `4` | gda has no resolved Godot project usable for the requested target: an operation needed one and none was resolved, or an explicit `--project` was empty, or a `--project`/`$GDA_PROJECT` does not name a Godot project (no `project.godot`), or the target lies outside the resolved project (whose `res://` dependencies would then resolve against the wrong root). |
 | `path_not_found` | `operation` | `operation` | `4` | A requested file does not exist. |
 | `not_a_scene` | `operation` | `operation` | `4` | A requested file cannot be loaded as a `PackedScene`. |
 | `parent_not_found` | `operation` | `operation` | `4` | A requested parent node path does not resolve to a node in the scene. |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -233,8 +233,8 @@ operation, and parse codes the CLI assigns).
 | `live_invalid_event_spec` | `live` | `classifier` | `6` | A live input sequence event has a type the harness does not recognize (Phase 2, #221). |
 | `live_display_unavailable` | `live` | `classifier` | `6` | A live `screen` capture ran on a headless engine session (the dummy DisplayServer cannot read pixels); start the daemon windowed with `gda daemon start --windowed` (Phase 2, #222). |
 | `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
-| `live_windowed_unavailable` | `environment` | `classifier` | `127` | A windowed live session (`gda daemon start --windowed`) was requested but the host has no usable DisplayServer (no on-console GUI session / no `$DISPLAY`), so the session cannot come up; refused before spawning Godot (Phase 2, #345). |
-| `live_windowed_permission_denied` | `environment` | `classifier` | `127` | A windowed live session (`gda daemon start --windowed`) was requested but this process is denied the window-server lookup (e.g. a sandbox), so gda cannot tell whether the host has one; re-run outside the restriction to find out rather than recording the host as display-less (Phase 2, #667). |
+| `live_windowed_unavailable` | `environment` | `classifier` | `127` | A windowed Engine session (`gda daemon start --windowed`) was requested but the host has no usable DisplayServer (no on-console GUI session / no `$DISPLAY`), so the session cannot come up; refused before spawning Godot (Phase 2, #345). |
+| `live_windowed_permission_denied` | `environment` | `classifier` | `127` | A windowed Engine session (`gda daemon start --windowed`) was requested but this process is denied the window-server lookup (e.g. a sandbox), so gda cannot tell whether the host has one; re-run outside the restriction to find out rather than recording the host as display-less (Phase 2, #667). |
 
 ## Considered options
 

--- a/docs/adr/0004-schema-flag-self-description.md
+++ b/docs/adr/0004-schema-flag-self-description.md
@@ -24,6 +24,56 @@ status: accepted
 > the surrounding prose cannot drift. Like `kind`, gda-mcp ignores it (ADR-0012),
 > so it stays a strict superset — backward compatible.
 
+> **Amendment (2026-08-16, #667):** the uniform failure envelope (`GdaError`, the
+> `error` half of every command's `--schema`) gains ONE optional key — `probe`, an
+> `EnvironmentProbe` `{name, platform}` naming the host call that decided an
+> ENVIRONMENT failure `gda` resolved by probing the machine rather than by running
+> the engine (`CGSessionCopyCurrentDictionary`,
+> `bootstrap_look_up(com.apple.windowserver.active)`, `$DISPLAY / $WAYLAND_DISPLAY`).
+> Motivation: `--windowed` refusals had two causes — no window server was detected
+> (`live_windowed_unavailable`), versus the window-server lookup was REFUSED
+> (`live_windowed_permission_denied`, which proves confinement, not that one exists) —
+> distinguishable only by reading English prose, so automation recorded a sandbox
+> boundary as a machine-capability gap and silently skipped rendered QA (dogfooding
+> GDA-DF-029).
+>
+> Three properties keep it additive:
+>
+> - **Optional and OMITTED, never `null`.** `emit_failure` serializes with
+>   `exclude_none`, so every failure that sets no probe emits byte-identically to
+>   before. Only the two windowed-refusal codes — `live_windowed_unavailable` and
+>   `live_windowed_permission_denied` — set one today.
+> - **The stable trio is untouched.** `category` / `code` / `message` (and
+>   `diagnostics`) keep their contract; `probe` is context ABOUT the classification,
+>   never a substitute for branching on `code`. `gda-mcp` passes the envelope through
+>   to its `is_error` channel unchanged and needs no adapter work (ADR-0012).
+> - **Schema-derived, zero per-command cost.** `error` is still the one shared
+>   `GdaErrorEnvelope` schema, identical for every command — it changed once, for all.
+>
+> **Scope boundary with #687.** #687 owns the separate, larger decision on whether the
+> failure ABI carries operation-scoped typed EVIDENCE — a script's numeric exit status,
+> parsed `ScriptError[]`, a timeout's elapsed seconds (#651, #655). This amendment
+> deliberately does NOT decide that and does not pre-empt its shape: `probe` answers
+> only "which host call decided this environment verdict", a fixed two-string context
+> with no per-operation variation. The two axes compose — an evidence key adopted by
+> #687 would sit alongside `probe` under the same "optional keys are omitted when
+> absent" rule established here — and #687 stays free to adopt, reshape, or decline
+> typed evidence on its own merits.
+>
+> **Carried on the daemon relay too** (revised on review, 2026-08-17). The refusal
+> that actually gates every live op is the daemon's lazy-launch guard, not the CLI's
+> optional fail-fast, so leaving `probe` off the relay made the AUTHORITATIVE path the
+> poorer one — and #667's acceptance criterion is unqualified. The live channel's
+> envelope therefore takes the same optional key: `LiveError` is `{code, message,
+> probe?}` and `classify_live` carries it into the public `GdaError`.
+>
+> The two channels keep **separate models**, which is what keeps this narrow: the
+> headless sentinel (`OperationError`, GDScript-emitted) stays strict, `extra="forbid"`
+> and probe-less, because a GDScript operation has no host probe to report and widening
+> it would invite a key the other language can never fill. On the wire the key is
+> omitted when absent, so every other live reply and every headless envelope is
+> byte-identical to before.
+
 ADR-0000 lists `--schema` as a core capability without defining it. We fix its
 semantics here, and deliberately scope out an overloaded interpretation.
 

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -78,6 +78,61 @@ status: accepted
 > `diagnostics` and a status named in the message, but it is not typed. That gap is the deferral
 > above, not an oversight.
 
+> **Amendment (2026-08-16, #675) — `script run` accepts BOTH script-path forms; the `res://`-only
+> scope below is superseded.** That scope rests on a rationale that does not hold: "consistent with
+> the rest of the `script` command group (which all act on `res://`)". The rest of the group takes a
+> **project-relative** path as well, through the shared path normalization every path-taking command
+> uses (ADR-0006, ADR-0015). `script run` alone refused it, so a caller who addressed a script one way
+> for `script validate` had to rewrite it for `script run` (dogfooding GDA-DF-019).
+>
+> **`script run` now accepts the project-relative form beside `res://`.** A project-relative path is
+> lifted onto the scheme it is already relative to — the `res://` root of the resolved `--project`
+> (ADR-0006) — and then put through the same `canonical_res_path` the amendment above introduced. Both
+> spellings therefore converge on **one** address before any launch, so the argv handed to the engine,
+> the entry-load verdict matching, and every message keep the single canonical identity that amendment
+> established. No second normalization rule is added.
+>
+> **The success result gains a `path` field** carrying that canonical `res://` address. A caller who
+> addressed the script project-relatively reads back what the engine was actually asked to run —
+> otherwise the accepted form and the form every failure message quotes would differ with nothing to
+> connect them. This is a schema addition in ADR-0004's sense, moving with the implementation.
+>
+> **What stays refused**, all decided before any launch as `invalid_path`: an **absolute** path;
+> **another engine scheme** (`user://`, `uid://` — lifting one would splice a second scheme into a
+> res:// address and send the engine after a path nobody typed); a path naming the project **root**
+> (`""`, `"."`, `"sub/.."`, and the `res://` / `res://.` spellings — a directory, not a script); and a
+> path **escaping above the root** (`".."`, `"../outside.gd"`, and their `res://` spellings). The ABI
+> edge below names "a non-`res://` **or absolute** script path"; only its first half is lifted here.
+>
+> The last two are refused for a reason beyond tidiness, and both were **verified**. The engine
+> answers a root or escape address with `Can't load script: res://.` / `res://..`, whose address the
+> error parser reads back with the sentence period stripped — so it never matches the entry, the
+> never-ran verdict misses it, and the run reports a phantom `exit_status: 0`. Worse, an escape that
+> *resolves* (`../outside.gd`) **executes a script outside the project**, which is precisely the
+> ADR-0009 widening cited just below as the reason absolute paths stay refused; admitting it by the
+> relative spelling would make that reasoning false. Both shapes are reachable on the pre-amendment
+> `res://` spelling too, so this closes a pre-existing hole rather than one the widening created — but
+> the widening is what made them reachable from the ordinary project-relative form, so they are closed
+> here. The residual parser weakness (a trailing-period strip that mis-reads `res://..`) is **not**
+> addressed here; it belongs to the error parser and is tracked separately.
+>
+> Absolute stays refused for two **verified** reasons, not merely as deferred scope. First, the engine
+> reports a failed run under the **`res://` spelling even when launched with an absolute in-project
+> path**, so accepting absolute without also mapping it back to `res://` would break the
+> canonical-identity match the verdict above depends on and reopen the phantom success it closed.
+> Second, `--script <absolute path OUTSIDE the project>` really **does execute** (verified against
+> Godot 4.6.3), so accepting absolute would widen the
+> [Project-code execution surface](../../CONTEXT.md) past ADR-0009's Trusted project — a trust
+> decision that belongs in its own ADR, not in a path-form amendment. `script validate` does accept an
+> absolute path today, so the two commands are **not** at full parity; the shared representation this
+> amendment establishes is the two **portable** forms, which is what an agent needs to address a
+> script once and use it for either.
+>
+> The `script validate` result still echoes the path spelling it was given, as every sentinel
+> operation does. Making one operation report a canonical form would trade this inconsistency for a
+> different one, so it is left alone deliberately; the convergence decided here is `script run`'s,
+> whose path must be canonical because its verdict machinery matches on it.
+
 ADR-0010 recognised **two** execution mechanisms for [headless operations](../../CONTEXT.md):
 ① GDScript op-dispatch under the ADR-0002 sentinel contract (the default), and ② native engine
 CLI mode for editor-only capabilities (e.g. `--export-*`), whose outcome `gda` classifies from the

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -253,3 +253,17 @@ added incrementally under ADR-0025 if a concrete need appears.
   dispatch channels.
 - **Large output** streams through stdout like any headless result; if a future need surfaces, the
   ADR-0002 result-file escape hatch applies, but it is not committed here.
+
+> **Amendment 2026-08-17 (#653).** The shared `launch()` primitive this decision reuses has since
+> grown a third responsibility, so what `script run` inherits from it is wider than described
+> above. `launch()` now also owns each launch's **`User-data placement`**: it always passes a
+> gda-owned `--log-file` (Godot builds its file logger before any project code and dies with
+> signal 11 if it cannot open the log; the engine default is additionally one per-project rotated
+> file that concurrent invocations contend over), and it preflights that placement by creating it.
+> Two consequences for this ADR's own contract, neither of which changes the passthrough decision:
+> the argv is `[binary, --headless, --log-file <path>, *args]` rather than `[binary, --headless,
+> *args]`; and `Raw run.launch_failure` has a third value, `USER_DATA_UNWRITABLE`, which — like the
+> existing two — is lifted out of the promoted `script run` success result into an `Error envelope`
+> (`user_data_unwritable`). The per-invocation `--user-data-root` also makes `user://` writable for
+> a `script run` under a restricted profile. See CONTEXT.md's `User-data placement` entry for the
+> shared-language definition.

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -459,6 +459,21 @@ parsed Python-side and may carry only the **first** error. **`column` is always 
 standard Godot build (the engine exposes no column for a parse error). `validate` reuses existing
 codes only (no new ones).
 
+**Project context** (#658): the result carries `project_root` — the project the script was
+compiled against, i.e. the root its `res://` dependencies resolved to, absolute, and `null` when
+gda ran projectless. It is **required and nullable**, so every verdict carries the key. It exists
+because a script compiled against the wrong project reports every `res://` dependency as missing
+plus the type errors derived from them, which reads as a broken script; `project_root` is what
+tells the two apart. A target **outside** the resolved project is **refused before parsing** with
+`project_not_found` naming both the file and the project, rather than emitting that false cascade.
+Containment follows the engine's own addressing: a relative path is anchored at the resolved
+project (not gda's cwd), an engine-virtual path (`res://`, `user://`, `uid://`) is inside by
+construction, and a file reached through a symlink into the project counts as inside — except when
+a `..` traversal could cross that symlink, where only the fully resolved location decides. gda
+never derives the project from the target path (ADR-0006), so a script under a project **nested
+inside** the resolved one is contained and not refused; `project_root` is what surfaces that
+mismatch, pending the ADR-0006 amendment tracked in #697.
+
 | Command | Description |
 | --- | --- |
 | `gda script create` | Create a `.gd` script (template or content) |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -732,8 +732,9 @@ headless is unaffected (4.4+, cross-platform).
   restriction is what settles it. Conversely a sandbox that hides the window server rather
   than refusing the lookup is indistinguishable from an absent session. A refusal that
   originates in `daemon start --windowed` carries the deciding host call as the envelope's
-  `probe` `{name, platform}` (ADR-0004 amendment); the daemon-relayed form carries the code
-  and prose only, since the daemon→CLI wire envelope has no `probe` key.
+  `probe` `{name, platform}` (ADR-0004 amendment); a refusal relayed from an already-running
+  daemon carries it too — the live wire's error payload gained an optional `probe` key, and
+  `classify_live` preserves it into the public envelope.
 
 Out of scope (editor context, ADR-0017): UndoRedo-aware mutation, the editor's
 open-scene tree, saving the open scene, editor errors/screenshots, run-editor-script,

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -719,7 +719,21 @@ headless is unaffected (4.4+, cross-platform).
   and crash-survivable like `diag` (ADR-0022). The opt-in rich `gda_log()` protocol layers on in a
   follow-up slice (#282).
 - **lifecycle (the `daemon` command group):** `gda daemon start` / `stop` / `status`, and `gda daemon
-  install` / `uninstall` for the `gda harness` (ADR-0018).
+  install` / `uninstall` for the `gda harness` (ADR-0018). `daemon start --windowed` additionally
+  requires the host's desktop session — an on-console GUI login on macOS, `$DISPLAY` /
+  `$WAYLAND_DISPLAY` on Linux — because a windowed Godot aborts during `DisplayServer`
+  registration without one; it is checked pre-launch (#345) and refused with one of two
+  ENVIRONMENT codes (#667): `live_windowed_unavailable` when nothing refused the probe and no
+  session is reachable (skip rendered QA here) and `live_windowed_permission_denied` when the
+  window-server lookup itself was refused, e.g. a sandbox (re-run outside the restriction).
+  The second code does NOT mean the host has a window server — macOS refuses the lookup
+  before resolving the name, so a broadly-confined process is refused whether or not one
+  exists; it means only that gda was not allowed to ask, and re-running outside the
+  restriction is what settles it. Conversely a sandbox that hides the window server rather
+  than refusing the lookup is indistinguishable from an absent session. A refusal that
+  originates in `daemon start --windowed` carries the deciding host call as the envelope's
+  `probe` `{name, platform}` (ADR-0004 amendment); the daemon-relayed form carries the code
+  and prose only, since the daemon→CLI wire envelope has no `probe` key.
 
 Out of scope (editor context, ADR-0017): UndoRedo-aware mutation, the editor's
 open-scene tree, saving the open scene, editor errors/screenshots, run-editor-script,

--- a/examples/platformer/panda-adventure/docs/gadr/0007-visual-smoke-seam.md
+++ b/examples/platformer/panda-adventure/docs/gadr/0007-visual-smoke-seam.md
@@ -33,11 +33,17 @@ The model:
   when a future slice adds a player-visible feature, it adds a checkpoint (a
   capture and/or a check) to this scenario — never a new windowed session.
 - **Display-gated: a desktop tier, not a CI gate.** Gated exactly like
-  `test_e2e_screenshot.py`: `gda.display.windowed_unavailable_reason()`
-  pre-checks the window server, and the daemon's typed no-display refusals
-  (`live_windowed_unavailable` / `live_display_unavailable`, #345) are
-  honored as skips — visible under `-rs`, never silent. CI keeps the headless
-  seams; the visual-smoke seam runs pre-merge on a real desktop.
+  `test_e2e_screenshot.py`, through the one shared policy in `tests/display_gate.py`
+  (pre-check and post-start race path alike, #345, #667). The reaction depends on
+  WHICH refusal, because they are not the same fact:
+  - **capability** (`live_windowed_unavailable` / `live_display_unavailable`) — the
+    host cannot show a window, so the tier **skips**, visibly under `-rs`, never
+    silent. CI keeps the headless seams; the visual-smoke seam runs pre-merge on a
+    real desktop.
+  - **permission** (`live_windowed_permission_denied`) — the host may well be able
+    to; this RUN is confined. The tier **fails loudly** with the re-run remediation,
+    like the engine gate does for a missing binary: skipping would report a green
+    visual tier whose rendered acceptance never executed.
 - **Engine-side pixel decode.** Captures are analyzed by the engine's own
   `Image` API through `gda script run` (`tests/gdscript/check_pixels.gd`),
   preserving the repo's no-image-decode-dependency convention (no Pillow).

--- a/examples/platformer/panda-adventure/tests/display_gate.py
+++ b/examples/platformer/panda-adventure/tests/display_gate.py
@@ -47,6 +47,9 @@ def require_windowed_host() -> None:
     verdict = windowed_unavailable()
     if verdict is None:
         return
-    if verdict.code == WINDOWED_PERMISSION_DENIED_CODE:
-        pytest.fail(_CONFINED_REMEDIATION.format(detail=verdict.reason))
+    # ONE cascade owner per root: delegate to handle_no_display_code so the
+    # cross-root parity test covers the preflight too (PR #702 recheck). The
+    # trailing skip is the conservative fallback for a verdict code the handler
+    # does not classify — a non-None verdict must never proceed to a spawn.
+    handle_no_display_code(verdict.code, verdict.reason)
     pytest.skip(verdict.reason)

--- a/examples/platformer/panda-adventure/tests/display_gate.py
+++ b/examples/platformer/panda-adventure/tests/display_gate.py
@@ -1,0 +1,52 @@
+"""The windowed-display gate for the game's visual tiers (#345, #667).
+
+One owner for the reaction policy in THIS context. The game's tests are a separate
+pytest root and cannot import the toolkit's own test-support package, so the policy
+is restated here rather than shared; it must stay in step with the toolkit's copy.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# The reaction is NOT uniform, and treating it as uniform is the bug this replaces:
+#
+# - CAPABILITY (`live_windowed_unavailable`, `live_display_unavailable`) — the host
+#   cannot show a window. Nothing to run, so SKIP (visible under `-rs`).
+# - PERMISSION (`live_windowed_permission_denied`) — the host may well be able to;
+#   this RUN is confined. Skipping would green the visual tier with the rendered
+#   acceptance unexecuted, which is exactly the defect #667 exists to stop, so FAIL
+#   with the remediation. This matches the engine gate in ``conftest.py``, which also
+#   fails loudly rather than skipping when the environment cannot deliver what the
+#   tier needs.
+WINDOWED_CAPABILITY_CODES = frozenset(
+    {"live_windowed_unavailable", "live_display_unavailable"}
+)
+WINDOWED_PERMISSION_DENIED_CODE = "live_windowed_permission_denied"
+
+_CONFINED_REMEDIATION = (
+    "the windowed session was refused because this RUN is confined ({detail}). "
+    "Rendered acceptance did NOT execute; this is a loud failure rather than a skip "
+    "so a sandboxed run cannot green the visual tier with it unexecuted (#667). "
+    "Re-run outside the sandbox/restriction."
+)
+
+
+def handle_no_display_code(code, detail: str = "") -> None:
+    """Skip on a capability refusal, FAIL on a permission refusal, else return."""
+    if code == WINDOWED_PERMISSION_DENIED_CODE:
+        pytest.fail(_CONFINED_REMEDIATION.format(detail=detail or code))
+    if code in WINDOWED_CAPABILITY_CODES:
+        pytest.skip(f"windowed session unavailable ({code})")
+
+
+def require_windowed_host() -> None:
+    """Pre-flight gda's host display probe with the same reaction policy."""
+    from gda.display import windowed_unavailable
+
+    verdict = windowed_unavailable()
+    if verdict is None:
+        return
+    if verdict.code == WINDOWED_PERMISSION_DENIED_CODE:
+        pytest.fail(_CONFINED_REMEDIATION.format(detail=verdict.reason))
+    pytest.skip(verdict.reason)

--- a/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
+++ b/examples/platformer/panda-adventure/tests/test_e2e_screenshot.py
@@ -27,9 +27,8 @@ import sys
 import pytest
 
 from gda.binary import resolve_godot_binary
-from gda.display import windowed_unavailable_reason
-
 import build_config
+from display_gate import handle_no_display_code, require_windowed_host
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
@@ -45,13 +44,6 @@ PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 _COPY_IGNORE = shutil.ignore_patterns(
     "tests", ".godot", "build", "generated", "__pycache__"
 )
-
-# Daemon error codes that mean "this environment cannot show a window" (the windowed
-# start was refused pre-launch, or the live session has no display) — a skip signal,
-# not a test failure. `live_windowed_unavailable` is the typed pre-launch refusal gda
-# now returns for `daemon start --windowed` on a display-less host (#345), replacing
-# the generic `engine_session_not_running` this used to key on.
-_NO_DISPLAY_CODES = {"live_windowed_unavailable", "live_display_unavailable"}
 
 
 def _error_code(stdout: str) -> str | None:
@@ -75,9 +67,7 @@ def test_windowed_daemon_captures_the_running_viewport(tmp_path, daemon_runtime_
     # can't launch there. Uses gda's shared display helper (the same one gda's
     # `daemon start --windowed` precondition keys on, #345), so the pre-check and the
     # tool agree. Runs for real on a genuine desktop (macOS Aqua / Linux+DISPLAY).
-    reason = windowed_unavailable_reason()
-    if reason is not None:
-        pytest.skip(reason)
+    require_windowed_host()
     project = _make_project_copy(tmp_path / "game")
     env = {**os.environ}
     out = tmp_path / "shot.png"
@@ -102,29 +92,26 @@ def test_windowed_daemon_captures_the_running_viewport(tmp_path, daemon_runtime_
     try:
         started = run("daemon", "start", "--windowed")
         if started.returncode != 0:
-            # gda refuses `daemon start --windowed` pre-launch with the typed
-            # live_windowed_unavailable where no DisplayServer is usable (#345); the
-            # pre-check above should have caught it, but honor it as a skip if it slips
-            # through (env race), not a failure.
+            # gda refuses `daemon start --windowed` pre-launch with a typed display
+            # code (#345). The pre-check above should have caught it, but honor it if
+            # it slips through — via the shared policy, because the reaction SPLITS
+            # (#667): a CAPABILITY verdict is an env race and skips, a
+            # live_windowed_permission_denied says this whole run is confined and
+            # FAILS loudly. Anything else is a real failure.
             code = _error_code(started.stdout)
-            if code in _NO_DISPLAY_CODES:
-                pytest.skip(
-                    f"windowed session unavailable in this environment ({code})"
-                )
+            handle_no_display_code(code)
             raise AssertionError(started.stdout + started.stderr)
         assert json.loads(started.stdout)["windowed"] is True
 
         # `screen capture` writes a real PNG of the running game's viewport. The
-        # windowed session launches lazily here; if this environment can't bring up
-        # a window server after all (despite the pre-check), the daemon reports a
-        # display/session code — skip rather than fail (env limitation, not a bug).
+        # windowed session launches lazily here; if this environment can't bring up a
+        # window server after all (despite the pre-check), the daemon reports a
+        # display/session code — routed through the shared policy: a capability code
+        # skips (env limitation, not a bug), a permission code fails loudly (#667).
         cap = run("screen", "capture", "--output", str(out))
         if cap.returncode != 0:
             code = _error_code(cap.stdout)
-            if code in _NO_DISPLAY_CODES:
-                pytest.skip(
-                    f"windowed session unavailable in this environment ({code})"
-                )
+            handle_no_display_code(code)
             raise AssertionError(cap.stdout + cap.stderr)  # a real capture failure
         doc = json.loads(cap.stdout)
         assert doc["format"] == "png"

--- a/examples/platformer/panda-adventure/tests/test_obstacle_texture_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_obstacle_texture_e2e.py
@@ -38,9 +38,8 @@ import time
 import pytest
 
 from gda.binary import resolve_godot_binary
-from gda.display import windowed_unavailable_reason
-
 import build_config
+from display_gate import handle_no_display_code, require_windowed_host
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
@@ -52,7 +51,6 @@ PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 _COPY_IGNORE = shutil.ignore_patterns(
     "tests", ".godot", "build", "generated", "__pycache__"
 )
-_NO_DISPLAY_CODES = {"live_windowed_unavailable", "live_display_unavailable"}
 
 
 def _error_code(stdout: str) -> str | None:
@@ -106,9 +104,7 @@ def _make_project_copy(dst):
 
 @pytest.mark.e2e
 def test_obstacle_renders_the_texture(tmp_path, daemon_runtime_dir):
-    reason = windowed_unavailable_reason()
-    if reason is not None:
-        pytest.skip(reason)
+    require_windowed_host()
     project = _make_project_copy(tmp_path / "game")
     env = {**os.environ}
     out = tmp_path / "shot.png"
@@ -134,8 +130,7 @@ def test_obstacle_renders_the_texture(tmp_path, daemon_runtime_dir):
         started = run("daemon", "start", "--windowed")
         if started.returncode != 0:
             code = _error_code(started.stdout)
-            if code in _NO_DISPLAY_CODES:
-                pytest.skip(f"windowed session unavailable ({code})")
+            handle_no_display_code(code)
             raise AssertionError(started.stdout + started.stderr)
         assert json.loads(started.stdout)["windowed"] is True
 
@@ -157,8 +152,7 @@ def test_obstacle_renders_the_texture(tmp_path, daemon_runtime_dir):
         cap = run("screen", "capture", "--output", str(out))
         if cap.returncode != 0:
             code = _error_code(cap.stdout)
-            if code in _NO_DISPLAY_CODES:
-                pytest.skip(f"windowed session unavailable ({code})")
+            handle_no_display_code(code)
             raise AssertionError(cap.stdout + cap.stderr)
         doc = json.loads(cap.stdout)
         assert doc["format"] == "png"

--- a/examples/platformer/panda-adventure/tests/test_visual_smoke_e2e.py
+++ b/examples/platformer/panda-adventure/tests/test_visual_smoke_e2e.py
@@ -83,6 +83,7 @@ import pytest
 from gda.binary import resolve_godot_binary
 
 import build_config
+from display_gate import handle_no_display_code, require_windowed_host
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
@@ -93,10 +94,6 @@ GAME_DIR = build_config.GAME_DIR
 _COPY_IGNORE = shutil.ignore_patterns(
     "tests", ".godot", "build", "generated", "__pycache__"
 )
-
-# Daemon error codes meaning "this environment cannot show a window" — a skip
-# signal, not a failure (the test_e2e_screenshot.py precedent, #345).
-_NO_DISPLAY_CODES = {"live_windowed_unavailable", "live_display_unavailable"}
 
 _HUD_LABEL = "/root/Main/Hud/Stats/%sLabel"
 
@@ -333,11 +330,7 @@ def _error_code(stdout: str) -> str | None:
 def test_player_visible_surface_renders_in_the_windowed_viewport(
     tmp_path, daemon_runtime_dir
 ):
-    from gda.display import windowed_unavailable_reason
-
-    reason = windowed_unavailable_reason()
-    if reason is not None:
-        pytest.skip(reason)
+    require_windowed_host()
 
     project = _make_project_copy(tmp_path / "game")
 
@@ -463,8 +456,7 @@ def test_player_visible_surface_renders_in_the_windowed_viewport(
         cap = run("screen", "capture", "--output", str(out))
         if cap.returncode != 0:
             code = _error_code(cap.stdout)
-            if code in _NO_DISPLAY_CODES:
-                pytest.skip(f"windowed session unavailable ({code})")
+            handle_no_display_code(code)
             raise AssertionError(cap.stdout + cap.stderr)
         doc = json.loads(cap.stdout)
         assert doc["format"] == "png"
@@ -483,19 +475,19 @@ def test_player_visible_surface_renders_in_the_windowed_viewport(
         started = run("daemon", "start", "--windowed")
         if started.returncode != 0:
             code = _error_code(started.stdout)
-            if code in _NO_DISPLAY_CODES:
-                pytest.skip(f"windowed session unavailable ({code})")
+            handle_no_display_code(code)
             raise AssertionError(started.stdout + started.stderr)
         assert json.loads(started.stdout)["windowed"] is True
 
         # The Engine session launches lazily on the first live op; if this
         # environment can't bring up a window after all (env race past the
-        # pre-check), the daemon reports a display code — skip, not fail.
+        # pre-check), the daemon reports a display code — the shared policy decides
+        # the reaction: a capability code skips, live_windowed_permission_denied
+        # fails loudly because a confined run must not pass silently (#667).
         tree = run("game", "tree")
         if tree.returncode != 0:
             code = _error_code(tree.stdout)
-            if code in _NO_DISPLAY_CODES:
-                pytest.skip(f"windowed session unavailable ({code})")
+            handle_no_display_code(code)
             raise AssertionError(tree.stdout + tree.stderr)
 
         # --- Beat 1: boot. HUD live, Player landed, camera settled — this

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -9,10 +9,11 @@ Mounting IS the registration — the live Typer tree stays the only registry
 (ADR-0012/0023), so nothing here is a parallel table to keep in sync.
 
 Also here: the root ``--version`` / ``--json`` options and the no-op root callback
-that keeps ``gda`` a command *group*. ``gda.cli:app`` is the packaged entry point.
+that keeps ``gda`` a command *group*. ``--version`` renders through
+``gda.provenance``, which owns the payload itself. ``gda.cli:app`` is the packaged
+entry point.
 """
 
-from importlib.metadata import version as package_version
 from typing import Optional
 
 import typer
@@ -35,7 +36,8 @@ from gda.commands import (
     shader as shader_commands,
     theme as theme_commands,
 )
-from gda.headless import set_root_json
+from gda.headless import root_json, set_root_json
+from gda.provenance import build_version_provenance, render_version_line
 
 app = typer.Typer(
     name="gda",
@@ -77,10 +79,33 @@ screen_commands.register(app)
 daemon_commands.register(app)
 
 
-def _version_callback(value: Optional[bool]) -> None:
-    if value:
-        typer.echo(f"gda {package_version('gda')}")
-        raise typer.Exit()
+def _record_root_json(ctx: typer.Context, value: bool) -> bool:
+    """Hand a root ``--json`` to the shared option layer as soon as it is bound.
+
+    Recorded from the option's OWN callback rather than the group-callback body so
+    the value is in place before any other root option is processed — which is what
+    lets ``--version`` below render either form (#659). How the value travels is the
+    option layer's contract (``gda.headless.set_root_json``), not this module's.
+    """
+    set_root_json(ctx, value)
+    return value
+
+
+def _version_callback(ctx: typer.Context, value: Optional[bool]) -> None:
+    """Render the root ``--version``: a human line, or the provenance payload.
+
+    ``--json`` selects the structured form (#659), so an agent's evidence collector
+    reads which ``gda`` ran — version, executable, interpreter, install kind, and an
+    editable install's source checkout and revision — instead of parsing one line of
+    prose. No Godot is spawned either way.
+    """
+    if not value or ctx.resilient_parsing:
+        return
+    if root_json(ctx):
+        typer.echo(build_version_provenance().model_dump_json())
+    else:
+        typer.echo(render_version_line())
+    raise typer.Exit()
 
 
 @app.callback()
@@ -90,23 +115,28 @@ def main(
         None,
         "--version",
         callback=_version_callback,
-        is_eager=True,
-        help="Show the installed gda version and exit.",
+        # NOT eager, deliberately (#659). Click orders parameter processing by
+        # `(not is_eager, argv index)`, so an EAGER `--version` would run in argv
+        # order against the eager `--json` below and never see it in the
+        # `gda --version --json` spelling — the exact spelling the dogfooding report
+        # used. Non-eager, it sorts after EVERY eager parameter instead, so `--json`
+        # is bound first in BOTH orders. The trade is that click's own eager
+        # `--help` now wins over `--version` when both are given, which is the
+        # conventional precedence anyway.
+        help="Show the installed gda version and exit; with --json, emit structured "
+        "install provenance instead (no Godot is spawned).",
     ),
     json_output: bool = typer.Option(
         False,
         "--json",
-        # Eager, so the flag is bound before the OTHER eager root options run their
-        # callbacks — but only for the `--json`-FIRST spelling: click processes
-        # eager params in argv order, so `gda --version --json` still runs the
-        # version callback first, with this flag unbound. A root payload that must
-        # serve both orders (#659) therefore cannot be rendered from inside an eager
-        # `--version` callback. (A SUBCOMMAND is unaffected either way: this
-        # callback body runs before click parses one.)
+        callback=_record_root_json,
+        # Eager, so the flag is bound before every non-eager root option — notably
+        # `--version`, whose callback reads it. (A SUBCOMMAND is unaffected either
+        # way: this callback body runs before click parses one.)
         is_eager=True,
         help="Emit the invoked command's result as JSON — the same as passing "
-        "--json after the command; the root itself prints no JSON payload "
-        "(`--help` stays text).",
+        "--json after the command; with --version it emits structured install "
+        "provenance (`--help` stays text).",
     ),
 ) -> None:
     """An agent-facing Godot CLI with structured output."""
@@ -117,13 +147,11 @@ def main(
     # `--json` is accepted here so the ONE documented rule an agent follows —
     # "always pass --json" — never dies with exit 2 on the discovery surface
     # (`gda --json --help`, `gda --json <group> <command> …`, #671). It is NOT
-    # inert: handing it to the shared option layer here makes the invoked command's
-    # own `--json` inherit it, so the root and post-command spellings mean the same
+    # inert: handing it to the shared option layer makes the invoked command's own
+    # `--json` inherit it, so the root and post-command spellings mean the same
     # thing — accepting a flag that silently returned human text would be worse than
-    # the loud usage error it replaced. How the value travels is that layer's
-    # contract (gda.headless.set_root_json), not this module's. The root itself has
-    # no result to serialize; a root JSON payload (`--version --json`) is #659.
-    set_root_json(ctx, json_output)
+    # the loud usage error it replaced. The hand-over happens in the option's own
+    # callback (`_record_root_json`), so this body has nothing left to do.
 
 
 meta_commands.register(app)

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -38,6 +38,7 @@ from gda.commands import (
 )
 from gda.headless import root_json, set_root_json
 from gda.provenance import build_version_provenance, render_version_line
+from gda.runner import USER_DATA_ROOT_ENV, set_user_data_root
 
 app = typer.Typer(
     name="gda",
@@ -138,6 +139,19 @@ def main(
         "--json after the command; with --version it emits structured install "
         "provenance (`--help` stays text).",
     ),
+    user_data_root: Optional[str] = typer.Option(
+        None,
+        "--user-data-root",
+        help="Directory to place Godot's user data under for a HEADLESS launch: "
+        f"the engine log and `user://` (overrides ${USER_DATA_ROOT_ENV}). By "
+        "default gda redirects only the engine log, to a private temporary file, "
+        "so a read-only application-data directory is not fatal and concurrent "
+        "runs do not share one log; pass this when `user://` itself must be "
+        "writable. Godot reads the export templates and editor settings from that "
+        "same directory, so a release/debug 'export run' under it finds no "
+        "installed templates unless you place them there ('--mode pack' needs "
+        "none). A live session is unaffected: the daemon owns its log (ADR-0022).",
+    ),
 ) -> None:
     """An agent-facing Godot CLI with structured output."""
     # This callback keeps gda a command *group* so meta commands like `gda info`
@@ -150,8 +164,13 @@ def main(
     # inert: handing it to the shared option layer makes the invoked command's own
     # `--json` inherit it, so the root and post-command spellings mean the same
     # thing — accepting a flag that silently returned human text would be worse than
-    # the loud usage error it replaced. The hand-over happens in the option's own
-    # callback (`_record_root_json`), so this body has nothing left to do.
+    # the loud usage error it replaced. The --json hand-over happens in the
+    # option's own callback (`_record_root_json`), so it needs no line here.
+    # `--user-data-root` is a root option because it is process-wide ENVIRONMENT
+    # placement, not an operation parameter: it applies to whichever command runs,
+    # on every channel that spawns an engine, and the runner reads it there (#653).
+    # Handing it over here keeps the knowledge running downward.
+    set_user_data_root(user_data_root)
 
 
 meta_commands.register(app)

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -150,7 +150,7 @@ def main(
         "writable. Godot reads the export templates and editor settings from that "
         "same directory, so a release/debug 'export run' under it finds no "
         "installed templates unless you place them there ('--mode pack' needs "
-        "none). A live session is unaffected: the daemon owns its log (ADR-0022).",
+        "none). An Engine session is unaffected: the daemon owns its log (ADR-0022).",
     ),
 ) -> None:
     """An agent-facing Godot CLI with structured output."""

--- a/src/gda/commands/daemon.py
+++ b/src/gda/commands/daemon.py
@@ -43,7 +43,7 @@ from gda.daemon.discovery import (
     daemon_pid,
     within_uds_limit,
 )
-from gda.display import windowed_unavailable_reason
+from gda.display import WindowedUnavailable, windowed_unavailable
 from gda.daemon.protocol import read_message, write_message
 from gda.daemon.server import STATUS_OP, STOP_OP
 from gda.dispatch import dispatch_recipe
@@ -252,10 +252,12 @@ _VERSION_RE = re.compile(r"(\d+)\.(\d+)")
 # Seams tests override to avoid launching a real process / running the engine.
 SpawnDaemon = Callable[[Path, str, bool, Optional[str]], None]
 VersionCheck = Callable[[str], Optional[tuple]]
-# The pre-launch host-display precondition seam (#345): returns the reason a
-# windowed session cannot come up here, or None when it can. Injected in unit tests
-# so a display-less CI host does not spuriously refuse a windowed start.
-DisplayCheck = Callable[[], Optional[str]]
+# The pre-launch host-display precondition seam (#345, #667): returns the verdict
+# for why a windowed session cannot come up here — which registered code, the prose,
+# and the probe that decided it — or None when it can. Injected in unit tests so a
+# display-less CI host does not spuriously refuse a windowed start, and so the
+# capability/permission split is exercised without needing a real sandbox.
+DisplayCheck = Callable[[], Optional[WindowedUnavailable]]
 
 
 def _is_unix() -> bool:
@@ -522,9 +524,22 @@ def run_daemon_start_operation(
         # pre-launch, pre-harness-install, WITHOUT spawning — with the typed
         # live_windowed_unavailable (ENVIRONMENT / 127), mirroring the platform
         # precondition above. `daemon start` is where `windowed` already flows in.
-        reason = (display_check or windowed_unavailable_reason)()
-        if reason is not None:
-            return make_failure("live_windowed_unavailable", reason, "")
+        #
+        # The probe decides WHICH refusal (#667): no detected window-server session
+        # is live_windowed_unavailable; a DENIED window-server lookup — which proves
+        # nothing about whether the host has one — is live_windowed_permission_denied,
+        # i.e. "skip rendered QA here" versus "re-run outside the restriction to find
+        # out". Both carry
+        # the deciding probe as machine-readable envelope context (ADR-0004
+        # amendment) so an agent branches without parsing the sentence.
+        unavailable = (display_check or windowed_unavailable)()
+        if unavailable is not None:
+            return make_failure(
+                unavailable.code,
+                unavailable.reason,
+                "",
+                probe=unavailable.probe,
+            )
 
     # The harness install happens BEFORE the daemon exists, so everything from the
     # install onward runs against a project gda has already mutated. The snapshot is

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -19,11 +19,12 @@ targets the standard build) and a dedicated decision.
 import re
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Protocol, runtime_checkable
+from typing import Any, Optional, Protocol, runtime_checkable
 
 import typer
 from pydantic import BaseModel, Field, model_validator
 
+from gda import dispatch
 from gda.binary import resolve_godot_binary
 from gda.dispatch import dispatch_domain, dispatch_recipe
 from gda.errors import (
@@ -32,6 +33,7 @@ from gda.errors import (
     classify_run,
     script_did_not_run_failure,
     script_exit_status_failure,
+    script_outside_project_failure,
     script_path_invalid_failure,
     script_run_project_not_found_failure,
     unresolvable_binary_failure,
@@ -45,6 +47,7 @@ from gda.headless import (
     project_option,
 )
 from gda.models import CREATED_DIRS_DESC, NormalizedPath
+from gda.project import path_outside_project
 from gda.runner import RunResult, launch
 from gda.script_errors import (
     ScriptError,
@@ -504,6 +507,18 @@ class ScriptValidateResult(BaseModel):
     ``diagnostics`` is a best-effort list parsed from the engine's stderr (the
     only place line/message are available); it may hold only the first error, and
     is empty when the script is valid or nothing could be parsed.
+
+    ``project_root`` names the project the script was compiled against, so a
+    reader can tell a real compile error from one caused by the wrong project
+    context without re-deriving gda's resolution (#658). It is REQUIRED and
+    nullable, not optional: every public result carries the key (``null`` means
+    projectless), so an agent can read it unconditionally. The engine's sentinel
+    does not report it — ADR-0006 keeps the project CLI-side, and the engine is
+    told it through ``--path`` — so the ``before`` validator below supplies the
+    key for the internal sentinel parse and the CLI stamps the real value
+    immediately after (:func:`_script_validate_recipe`). The leniency is
+    therefore inward-facing only: it never reaches the published contract, which
+    lists ``project_root`` in ``required``.
     """
 
     path: str
@@ -524,6 +539,36 @@ class ScriptValidateResult(BaseModel):
             "(line + message). May hold only the first error; empty when valid."
         ),
     )
+    project_root: str | None = Field(
+        description=(
+            "The Godot project this script was compiled against — the root its "
+            "res:// dependencies resolved to, reported as an absolute path "
+            "(ADR-0006: --project, then $GDA_PROJECT, then the current "
+            "directory). Always present; null when gda ran projectless (no "
+            "project resolved), where only filesystem paths resolve. A script "
+            "whose res:// dependencies were reported missing with a null or "
+            "unexpected root here has a project-context problem, not a source "
+            "problem."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _supply_absent_project_root(cls, data: Any) -> Any:
+        """Fill the key the ENGINE never sends, so the field can stay required.
+
+        ``project_root`` is gda's own addition to the engine's answer: the
+        ADR-0002 sentinel this model is parsed from carries only the fields
+        ``operations.gd`` reports. Declaring the field required — so it appears
+        in the published ``required`` list every consumer reads — would make
+        that internal parse fail, so the absent key is supplied as ``null``
+        here and the recipe stamps the resolved project immediately after.
+        Anything that DOES carry the key (the recipe's own ``model_copy``, a
+        round-trip of an emitted result) passes through untouched.
+        """
+        if isinstance(data, dict) and "project_root" not in data:
+            return {**data, "project_root": None}
+        return data
 
 
 class ScriptRunParams(BaseModel):
@@ -954,10 +999,19 @@ def render_script_attach(attached: "ScriptAttachResult") -> str:
 
 
 def render_script_validate(validated: "ScriptValidateResult") -> str:
-    """Render a validate result: valid/invalid plus best-effort diagnostics."""
+    """Render a validate result: valid/invalid plus best-effort diagnostics.
+
+    An INVALID verdict leads with the project the script was compiled against
+    (#658), before the diagnostics rather than after them: when the root is the
+    wrong one, every diagnostic below it is an artefact of that single mistake,
+    and the reader needs to see the cause before the cascade. A valid verdict
+    stays the one-line answer — the root only explains a failure.
+    """
     if validated.valid:
         return f"valid {validated.path}"
     lines = [f"invalid {validated.path}"]
+    root = validated.project_root or "(none resolved: projectless)"
+    lines.append(f"  project: {root}")
     if validated.error_string is not None:
         lines.append(f"  {validated.error_string}")
     for diag in validated.diagnostics:
@@ -1037,12 +1091,90 @@ SCRIPT_ATTACH_COMMAND: HeadlessCommand[ScriptAttachResult] = HeadlessCommand(
     render=render_script_attach,
 )
 
+
+def _script_validate_recipe(
+    params: ScriptValidateParams,
+    *,
+    project: Optional[Path],
+    godot: Optional[str],
+) -> ScriptValidateResult | Failure:
+    """Refuse → compile → report the root: ``script validate``'s recipe (#658).
+
+    The sentinel op still does the compiling (``cmd.execute``, as the export
+    recipe runs its preflight); this wraps it in the two decisions only the CLI
+    can make, because ADR-0006 keeps project resolution CLI-side and the engine
+    is TOLD the project through ``--path``, never asked about it.
+
+    First the refusal. A script outside the resolved project is refused HERE,
+    before the engine is spawned, so the false ``res://`` dependency cascade is
+    never produced (see :func:`~gda.errors.script_outside_project_failure`).
+    Only a *resolved* project can be missed, so projectless is not a refusal:
+    with no project resolved, gda validates a standalone script by filesystem
+    path exactly as before (ADR-0006's projectless fallback). Whether the script
+    belongs to some OTHER project is not asked — deriving a project from the
+    target path is what ADR-0006 rejected, and discovering the nearest
+    ``project.godot`` waits on an amendment to it.
+
+    Then the report: the resolved project is stamped onto the result as
+    ``project_root``, so a caller reading a ``valid=false`` verdict sees which
+    root the ``res://`` dependencies resolved against instead of inferring it.
+    Both the report and the refusal name the project in its RESOLVED form: the
+    flag may be spelled relatively (``--project game``), and a bare ``game`` in a
+    machine-readable result or in a "this is outside that" message tells the
+    reader nothing about which directory was meant.
+
+    ``project`` arrives ALREADY resolved from ``dispatch_recipe`` (an invalid
+    ``--project``/``$GDA_PROJECT`` became a structured ``project_not_found``
+    before this runs, #353); ``None`` means projectless. ``params`` is the model
+    built once by the caller, identical on the argv and ``--params-json`` paths
+    (ADR-0015).
+    """
+    root = None
+    if project is not None:
+        root = project.expanduser().resolve()
+        outside = path_outside_project(params.path, project)
+        if outside is not None:
+            return script_outside_project_failure(outside, root)
+    # The runner seam is read off the module at call time — never imported by
+    # name — so a test monkeypatch on ``gda.dispatch.make_runner`` still binds.
+    # Naming the HEADLESS factory directly is correct only while this command is
+    # HEADLESS: unlike ``gda.dispatch._emit``, which picks the factory from
+    # ``cmd.kind``, a recipe states its own channel. Changing this command's
+    # ``kind`` (or reusing this recipe for a live twin) must change this line
+    # too — the descriptor would otherwise say one channel and the run take
+    # another. The registry invariant test pins the recipe set, not this pairing.
+    outcome = SCRIPT_VALIDATE_COMMAND.execute(
+        params,
+        godot=godot,
+        project=project,
+        make_runner=dispatch.make_runner,
+    )
+    if isinstance(outcome, Failure):
+        return outcome
+    # A copy, not an in-place set: the classified result is the engine's answer,
+    # and ``project_root`` is gda's addition to it, so the union is built rather
+    # than the parsed model mutated after validation.
+    return outcome.model_copy(
+        update={"project_root": str(root) if root is not None else None}
+    )
+
+
+# ``script validate`` stays a HEADLESS sentinel op — the engine does the
+# compiling — but carries a ``recipe`` (ADR-0023) because two parts of its
+# contract are decided at the CLI, where ADR-0006's resolved project lives: the
+# outside-the-project refusal and the ``project_root`` on the result. The recipe
+# channel is the ONE descriptor-driven hook both input paths share, so argv and
+# ``--params-json`` get the same behaviour (ADR-0015) without the shared dispatch
+# tail learning anything about this command. ``classify`` is untouched: the recipe
+# runs the same ``cmd.execute``, so the stderr diagnostics are still parsed in by
+# :func:`classify_script_validate`.
 SCRIPT_VALIDATE_COMMAND: HeadlessCommand[ScriptValidateResult] = HeadlessCommand(
     operation="script-validate",
     input_model=ScriptValidateParams,
     output_model=ScriptValidateResult,
     render=render_script_validate,
     classify=classify_script_validate,
+    recipe=_script_validate_recipe,
 )
 
 
@@ -1313,8 +1445,20 @@ def validate_script(
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Syntax/compile-check a .gd script; invalid exits 0 with valid=false."""
-    dispatch_domain(
+    """Syntax/compile-check a .gd script; invalid exits 0 with valid=false.
+
+    The script is compiled against the resolved project (ADR-0006: --project, then
+    $GDA_PROJECT, then the current directory) — the root its res:// dependencies
+    resolve against — and the result reports that root as 'project_root'. Read it
+    before trusting a verdict: a script compiled against the wrong project reports
+    every res:// dependency as missing, plus the type errors derived from them.
+
+    A script OUTSIDE the resolved project is refused with 'project_not_found'
+    before it is parsed, naming both the file and the project, rather than
+    reporting that false cascade. gda never derives the project from the script's
+    own path (ADR-0006), so pass --project for the project that owns the file.
+    """
+    dispatch_recipe(
         SCRIPT_VALIDATE_COMMAND,
         ScriptValidateParams(path=path),
         json_output=json_output,

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -572,20 +572,31 @@ class ScriptValidateResult(BaseModel):
 
 
 class ScriptRunParams(BaseModel):
-    """The operation params of ``gda script run`` (issue #343, ADR-0031).
+    """The operation params of ``gda script run`` (issue #343, ADR-0031, #675).
 
-    ``path`` is the ``res://`` path of the user script to run as a one-shot
-    ``godot --headless --path <project> --script <res://…>``. It is res://-only
-    (a res:// path resolves against the ``--project`` context, ADR-0006): an
-    absolute or non-``res://`` path is the ``invalid_path`` failure. A plain
-    ``str`` (NOT ``NormalizedPath``) because a res:// path is an engine-virtual
-    address, not a filesystem path — filesystem normalization would collapse the
-    ``res://`` double slash. The project is process context (``--project``), not
-    an operation param.
+    ``path`` is the user script to run as a one-shot ``godot --headless --path
+    <project> --script <res://…>``, addressed in EITHER of the two PORTABLE forms —
+    project-relative (``tests/logic.gd``) or ``res://`` (``res://tests/logic.gd``) —
+    which the rest of the ``script`` group takes as well. Both resolve against the
+    ``--project`` context (ADR-0006) and converge on one canonical ``res://`` address
+    in the operation. Refused with ``invalid_path`` (ADR-0031 amendment): an absolute
+    path, another engine scheme (``user://``, ``uid://``), a path naming the project
+    root, and one escaping above it (``..``). ``script validate`` does take an
+    absolute path, so the two are not at full parity. It carries the same
+    ``NormalizedPath`` as every other path field, so both input paths normalize
+    identically (ADR-0015) and a ``~`` prefix expands to the absolute path it means —
+    and is refused as one — rather than being read as a directory named ``~`` under
+    the project. The project is process context (``--project``), not an operation
+    param.
     """
 
-    path: str = Field(
-        description="The res:// path of the script to run (e.g. res://tests/logic.gd)."
+    path: NormalizedPath = Field(
+        description=(
+            "The script to run, project-relative (tests/logic.gd) or as a res:// "
+            "path (res://tests/logic.gd). An absolute path, another engine scheme "
+            "(user://, uid://), or a path naming or escaping above the project "
+            "root is refused."
+        )
     )
     strict: bool = Field(
         default=False,
@@ -621,6 +632,12 @@ class ScriptRunResult(BaseModel):
     swallowed — leaving a clean ``exit_status`` — is still visible structurally
     rather than only as prose inside ``stderr``.
 
+    ``path`` is the one field that is gda's own rather than the run's: the two
+    accepted input forms (project-relative and ``res://``) converge on a single
+    canonical ``res://`` address, and this reports which one ran (#675). Without
+    it a project-relative caller would have no way to connect the path they typed
+    to the one every failure message quotes.
+
     NOTE: a second passthrough consumer should promote the raw
     ``{exit_status, stdout, stderr}`` core to a shared ``RawRunResult`` model. Do
     NOT build that shared abstraction now: there is only one consumer today
@@ -628,6 +645,14 @@ class ScriptRunResult(BaseModel):
     does not reuse the raw run).
     """
 
+    path: str = Field(
+        description=(
+            "The canonical res:// path of the script that was run (#675). Both "
+            "accepted input forms — project-relative and res:// — converge on this "
+            "one address, so a caller who addressed the script project-relatively "
+            "reads back what the engine was actually asked to run."
+        )
+    )
     exit_status: int = Field(
         description=(
             "The user script's own process exit code, passed through verbatim — "
@@ -682,9 +707,13 @@ class ScriptRunResult(BaseModel):
 #   for the shell-chain / CI callers whose gate IS the process exit code.
 #
 # Two explicit pre-run ABI edges (ADR-0031), both decided at the CLI before any
-# launch and returned as a structured ``GdaError`` (never a crash): a non-``res://``
-# or absolute script path → ``invalid_path``; no resolved project →
-# ``project_not_found``.
+# launch and returned as a structured ``GdaError`` (never a crash): a path that is
+# not a project-scoped script address → ``invalid_path``; no resolved project →
+# ``project_not_found``. The path edge is the narrowed one (ADR-0031 amendment,
+# #675): the project-relative form the rest of the group accepts is now accepted
+# here too, lifted onto res:// — while an absolute path, another engine scheme, and
+# a path naming or escaping above the project root stay refused
+# (:func:`_project_scoped_res_path`).
 #
 # Like ``export run`` (:mod:`gda.commands.export`), :func:`run_script_run_operation`
 # RETURNS its outcome (``ScriptRunResult | Failure``) instead of emitting or
@@ -701,9 +730,83 @@ class ScriptRunResult(BaseModel):
 # block forever. Bounds a hung engine so the CLI fails loudly (as launch_timeout).
 DEFAULT_SCRIPT_RUN_TIMEOUT_SECONDS = 120.0
 
-# The res:// scheme prefix: script run is res://-only (ADR-0031). A res:// path
-# resolves against the --project context, unlike an absolute/filesystem path.
+# The res:// scheme prefix — the ONE address form script run works in internally.
+# Both accepted input spellings are folded onto it (ADR-0031 amendment, #675): a
+# res:// path is already one, and a project-relative path is relative to exactly
+# this root. An absolute/filesystem path is not, which is why it stays refused.
 _RES_PREFIX = "res://"
+
+# The canonical remainders that name the project ROOT itself rather than a script
+# inside it. Both spellings occur: an EMPTY remainder (`res://`) and one that
+# normalizes to `.` (`res://.`), so the degenerate check must cover the pair.
+_ROOT_REMAINDERS = frozenset({"", "."})
+
+
+def _project_scoped_res_path(script: str) -> str | None:
+    """The canonical ``res://`` address of an accepted script path, or ``None`` (#675).
+
+    The single acceptance gate for ``script run``'s path argument, applied BEFORE any
+    launch so every refusal is a structured ``invalid_path`` and never an engine
+    failure. It accepts the two PORTABLE forms — a ``res://`` address and a
+    project-relative path — and folds them onto one address through the shared
+    :func:`canonical_res_path`, so the argv, the entry-load verdict and the reported
+    path cannot diverge by input spelling.
+
+    Returns ``None`` for the five shapes that are not project-scoped script
+    addresses. Each must be caught HERE, because each is otherwise launched:
+
+    - an **absolute** path — outside the ``--project`` context (the reasons it stays
+      refused are recorded on :func:`gda.errors.script_path_invalid_failure`);
+    - **another engine scheme** (``user://``, ``uid://``) — lifting one would splice a
+      second scheme into a res:// address (``user://x.gd`` → ``res://user:/x.gd``) and
+      send the engine hunting for a path the caller never typed;
+    - a leading ``~`` — a HOME reference, which is a filesystem address form, not a
+      project-relative one. It reaches here only when the shared normalizer could not
+      expand it (an unknown user, #699); a resolvable ``~/x.gd`` was already expanded
+      to the absolute path refused above. So both tilde outcomes land on one refusal
+      instead of one being refused and the other spliced into ``res://~user/x.gd``;
+    - a path that names the project **root** (``""``, ``"."``, ``"sub/.."``) — it names
+      a directory, not a script. An unset shell variable makes ``gda script run
+      "$SCRIPT"`` exactly this;
+    - a path that **escapes above the root** (``".."``, ``"../outside.gd"``, and their
+      ``res://`` spellings) — the project is the whole addressable scope, so an
+      upward escape names something the ``--project`` contract does not cover.
+
+    The last two are load-bearing for the same reason, and it is not tidiness. The
+    engine answers a root address with ``Can't load script: res://.`` (or
+    ``res://..``), whose address the error parser reads back with the sentence period
+    stripped — ``res://`` for the first, ``res://.`` for the second. Neither matches
+    the entry, so the never-ran verdict misses it and the run reports a PHANTOM
+    SUCCESS. And an escape that RESOLVES (``../outside.gd``) executes a script outside
+    the project entirely, which would widen the Project-code execution surface past
+    ADR-0009's Trusted project — the very consequence the amendment cites for keeping
+    absolute paths refused, so admitting it by the relative spelling would make that
+    reasoning false. Refusing both before the launch closes them without touching the
+    error parser's own res:// handling.
+
+    The escape test is on the canonical remainder's first SEGMENT, not a string
+    prefix: ``res://..foo.gd`` is a legal file whose name merely starts with two dots,
+    and must stay accepted.
+    """
+    if Path(script).is_absolute():
+        return None
+    if "://" in script and not script.startswith(_RES_PREFIX):
+        return None
+    # Only a LEADING `~` is a home reference (expanduser's own rule), so `sub/~x.gd`
+    # stays a legal project-relative filename.
+    if script.startswith("~"):
+        return None
+    lifted = script if script.startswith(_RES_PREFIX) else _RES_PREFIX + script
+    canonical = canonical_res_path(lifted)
+    # What the canonical address names UNDER the project root. canonical_res_path has
+    # already collapsed `.`/`..`, so a remainder that STILL leads with a `..` segment
+    # is an irreducible upward escape, and an empty/`.` one is the root itself.
+    remainder = canonical[len(_RES_PREFIX) :]
+    if remainder in _ROOT_REMAINDERS:
+        return None
+    if remainder == ".." or remainder.startswith("../"):
+        return None
+    return canonical
 
 
 class LaunchFn(Protocol):
@@ -763,7 +866,11 @@ def run_script_run_operation(
     make_launch: Optional[LaunchFn] = None,
     timeout: float = DEFAULT_SCRIPT_RUN_TIMEOUT_SECONDS,
 ) -> ScriptRunResult | Failure:
-    """Run ``script run``'s validate → launch → classify recipe (ADR-0031, #651).
+    """Run ``script run``'s validate → launch → classify recipe (ADR-0031, #651, #675).
+
+    ``script`` is the user script in either accepted form — project-relative or
+    ``res://`` (#675); both are folded onto one canonical ``res://`` address before
+    the launch, and that address is what the result reports.
 
     Returns its outcome instead of emitting or exiting: the passthrough
     :class:`ScriptRunResult` on a completed run (even a non-zero ``exit_status``)
@@ -780,23 +887,27 @@ def run_script_run_operation(
     """
     run_launch = make_launch or launch
     # Pre-run ABI edges (ADR-0031), decided BEFORE any launch so they never surface
-    # as a crash or a raw engine failure. Path first (it is the direct argument):
-    # res://-only — an absolute or non-res:// path cannot resolve against --path.
-    if not script.startswith(_RES_PREFIX):
+    # as a crash or a raw engine failure. Path first (it is the direct argument).
+    #
+    # ONE gate does both halves of the path edge (ADR-0031 amendment, #675): it
+    # ACCEPTS the two portable forms — the project-relative path the rest of the
+    # script group also takes, and the res:// address — and REFUSES everything that
+    # is not a project-scoped script address. What it returns is the single canonical
+    # resource identity for the rest of this operation (#651 review claim 1, extended
+    # to both forms): fixed HERE, at the input boundary, so the argv handed to the
+    # engine and every later comparison and message use the same spelling. The engine
+    # canonicalizes internally before it names a path in an error, so a raw
+    # `res://dir/../bad.gd` would never match the `res://bad.gd` it reports back — and
+    # the entry-load verdict would silently fall through to a phantom success. The
+    # raw `script` is kept for the refusal message, so it still quotes what the user
+    # actually typed.
+    canonical = _project_scoped_res_path(script)
+    if canonical is None:
         return script_path_invalid_failure(script)
-    # Then require a resolved project — a res:// path needs one to resolve.
+    # Then require a resolved project — BOTH accepted forms resolve against one.
     if project is None:
         return script_run_project_not_found_failure()
-
-    # ONE canonical resource identity for the rest of this operation (#651 review
-    # claim 1). Fixed HERE, at the operation's input boundary, so the argv handed to
-    # the engine and every later comparison and message use the same spelling. The
-    # engine canonicalizes internally before it names a path in an error, so a raw
-    # `res://dir/../bad.gd` would never match the `res://bad.gd` it reports back —
-    # and the entry-load verdict would silently fall through to a phantom success.
-    # Done after the res:// gate so the rejection message still quotes what the user
-    # actually typed.
-    script = canonical_res_path(script)
+    script = canonical
 
     try:
         binary = resolve_godot_binary(godot)
@@ -850,6 +961,7 @@ def run_script_run_operation(
     # exit_code → exit_status, plus the parsed diagnostics. This is the one success
     # result that can be non-zero.
     return ScriptRunResult(
+        path=script,
         exit_status=raw.exit_code,
         stdout=raw.stdout,
         stderr=raw.stderr,
@@ -1471,7 +1583,12 @@ def validate_script(
 def run_script(
     path: str = typer.Argument(
         ...,
-        help="The res:// path of the script to run (e.g. res://tests/logic.gd).",
+        help=(
+            "The script to run, project-relative (tests/logic.gd) or as a res:// "
+            "path (res://tests/logic.gd). An absolute path, another engine scheme "
+            "(user://, uid://), or a path naming or escaping above the project "
+            "root is refused."
+        ),
     ),
     strict: bool = typer.Option(
         False,
@@ -1493,7 +1610,16 @@ def run_script(
 ) -> None:
     """Run a user script one-shot and pass its exit_status/stdout/stderr through.
 
-    Runs the user's own res:// script as ``godot --headless --path <project>
+    Address the script in either portable form — project-relative
+    (``tests/logic.gd``) or as a ``res://`` path — the same two the rest of the
+    ``script`` group takes. Both resolve against the ``--project`` context and are
+    reported back as one canonical ``res://`` ``path`` on the result. An absolute
+    path, another engine scheme (``user://``, ``uid://``), and a path naming or
+    escaping above the project root (``..``) are refused before any launch; note
+    ``script validate`` does accept
+    an absolute path, so the two commands are not at full parity.
+
+    Runs the user's own script as ``godot --headless --path <project>
     --script <res://…>`` and returns its result verbatim (ADR-0031). This is the
     ONE command whose success result can carry a non-zero ``exit_status``: gda does
     not interpret the script's semantics, so a deliberate ``quit(1)`` (e.g. an
@@ -1516,8 +1642,8 @@ def run_script(
 
     Only a gda-/engine-level failure (binary not launchable, timeout, or a signal
     crash) is a ``binary_not_found`` / ``launch_timeout`` / ``engine_crashed``
-    envelope. A non-res:// path or no resolved project is a structured
-    ``invalid_path`` / ``project_not_found``.
+    envelope. A path that is not a project-scoped script address, or no resolved
+    project, is a structured ``invalid_path`` / ``project_not_found``.
     """
     dispatch_recipe(
         SCRIPT_RUN_COMMAND,

--- a/src/gda/daemon/protocol.py
+++ b/src/gda/daemon/protocol.py
@@ -18,6 +18,7 @@ import struct
 from typing import Any
 
 from gda.exit_codes import EXIT_LIVE
+from gda.models import EnvironmentProbe
 from gda.parser import build_result, error_envelope
 
 _LENGTH = struct.Struct(">I")  # 4-byte big-endian frame length
@@ -74,7 +75,12 @@ def result_reply(payload: Any) -> dict:
     return _reply(payload, 0)
 
 
-def error_reply(code: str, message: str, diagnostics: str = "") -> dict:
+def error_reply(
+    code: str,
+    message: str,
+    diagnostics: str = "",
+    probe: EnvironmentProbe | None = None,
+) -> dict:
     """A daemon→CLI reply carrying a LIVE error envelope (exit ``EXIT_LIVE``).
 
     The single builder for a daemon- or client-synthesized live failure (no session,
@@ -86,8 +92,21 @@ def error_reply(code: str, message: str, diagnostics: str = "") -> dict:
     — the wire envelope shape ``{stdout, stderr, exit_code}`` is unchanged — so it
     flows the established ``stderr`` → ``RunResult.stderr`` → ``GdaError.diagnostics``
     path, staying within ADR-0002's advisory-stderr carve-out.
+
+    ``probe`` is the optional structured host-probe context (#667). Unlike
+    ``diagnostics`` it cannot ride ``stderr`` — it is DATA an agent branches on, not
+    advisory prose — so it is carried as an optional key inside the error envelope,
+    omitted when absent. That keeps every other reply byte-identical while letting
+    the daemon's authoritative windowed refusal deliver the same envelope the CLI's
+    own fail-fast does.
     """
-    return _reply(error_envelope(code, message), EXIT_LIVE, stderr=diagnostics)
+    return _reply(
+        error_envelope(
+            code, message, probe.model_dump() if probe is not None else None
+        ),
+        EXIT_LIVE,
+        stderr=diagnostics,
+    )
 
 
 def _reply(payload: Any, exit_code: int, stderr: str = "") -> dict:

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -23,7 +23,7 @@ from gda.daemon.session import (
     WindowedDisplayUnavailable,
     launch_session,
 )
-from gda.display import windowed_unavailable_reason
+from gda.display import WindowedUnavailable, windowed_unavailable
 
 # Control ops on the CLI socket — daemon lifetime, not project domain ops.
 STATUS_OP = "__status__"
@@ -48,7 +48,7 @@ class DaemonServer:
         godot: str = "",
         windowed: bool = False,
         scene: str | None = None,
-        display_check: Optional[Callable[[], Optional[str]]] = None,
+        display_check: Optional[Callable[[], Optional[WindowedUnavailable]]] = None,
     ) -> None:
         self.paths = paths
         self.godot = godot
@@ -66,7 +66,7 @@ class DaemonServer:
         # windowed session cannot come up on this host, or None when it can. Injectable
         # so tests drive the guard without a real display; defaults to the shared
         # gda.display probe. Consulted only for a windowed session.
-        self._display_check = display_check or windowed_unavailable_reason
+        self._display_check = display_check or windowed_unavailable
         self._token = secrets.token_hex(16)
         self._stopping = False
         self._listener: socket.socket | None = None
@@ -180,14 +180,23 @@ class DaemonServer:
             )
         except WindowedDisplayUnavailable as unavailable:
             # The authoritative no-display guard fired at the launch boundary (#345):
-            # no windowed engine was spawned. Surface the typed
-            # live_windowed_unavailable, carrying the probe's reason as diagnostics.
+            # no windowed engine was spawned. Surface the code the PROBE decided —
+            # live_windowed_unavailable, or live_windowed_permission_denied when this
+            # process is denied the window-server lookup (which proves nothing about
+            # whether the host has one, #667) — carrying
+            # the probe's reason as diagnostics. The remediation differs per code, so
+            # the message is the verdict's own rather than one shared sentence.
+            #
+            # This is the AUTHORITATIVE refusal — the one that fires on the lazy
+            # launch every live op goes through — so it carries the same
+            # machine-readable `probe` context the CLI fail-fast does, via the live
+            # envelope's optional key (#667 review). Reporting less here than at the
+            # optional fail-fast would make the authoritative path the poorer one.
             return error_reply(
-                "live_windowed_unavailable",
-                "a windowed engine session cannot launch: the host has no usable "
-                f"DisplayServer ({unavailable.reason}). Run the daemon headless, or "
-                "start it on a host with an on-console GUI session / $DISPLAY",
+                unavailable.verdict.code,
+                f"a windowed engine session cannot launch: {unavailable.reason}",
                 diagnostics=unavailable.reason,
+                probe=unavailable.verdict.probe,
             )
         if session is None:
             return error_reply(
@@ -264,9 +273,9 @@ class DaemonServer:
         # the same check as an OPTIONAL fail-fast, but this is the one that guarantees a
         # doomed windowed engine is never spawned even when start slipped through.
         if self.windowed:
-            reason = self._display_check()
-            if reason is not None:
-                raise WindowedDisplayUnavailable(reason)
+            verdict = self._display_check()
+            if verdict is not None:
+                raise WindowedDisplayUnavailable(verdict)
         # A res:// / filesystem scene selector that names no file is rejected HERE,
         # at the launch boundary (NOT per-request — finding 1), as a typed
         # SceneMismatch. Godot does not fall-back-and-run for a missing res:// path:

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Optional
 
 from gda.daemon.protocol import error_reply, read_frame, write_message
+from gda.display import WindowedUnavailable
 
 LAUNCH_MARKER = "gda-daemon"
 # Engine boot + autoload + harness connect; a windowed/cold start can be slow.
@@ -61,14 +62,19 @@ class WindowedDisplayUnavailable(Exception):
     windowed daemon's pre-launch host-display check fails — a windowed Godot would
     abort during ``DisplayServer`` registration otherwise (#345). Mirrors
     :class:`SceneMismatch`: a typed launch-boundary signal the daemon maps to the
-    ``live_windowed_unavailable`` error code, distinct from a generic launch failure
-    (``launch_session`` returns ``None``). ``reason`` is the host-display probe's
-    human-readable explanation.
+    probe's own error code — ``live_windowed_unavailable`` when no window-server
+    session is detected, ``live_windowed_permission_denied`` when this process is
+    denied the window-server lookup (which proves nothing about whether the host
+    has one, #667) — distinct from a generic launch failure
+    (``launch_session`` returns ``None``). It carries the whole ``verdict`` rather
+    than only its prose, so the daemon relays the code the probe decided instead of
+    re-deciding it here.
     """
 
-    def __init__(self, reason: str) -> None:
-        super().__init__(reason)
-        self.reason = reason
+    def __init__(self, verdict: WindowedUnavailable) -> None:
+        super().__init__(verdict.reason)
+        self.verdict = verdict
+        self.reason = verdict.reason
 
 
 class EngineSession:

--- a/src/gda/display.py
+++ b/src/gda/display.py
@@ -1,4 +1,4 @@
-"""Host DisplayServer probe for windowed live sessions (#345).
+"""Host DisplayServer probe for windowed live sessions (#345, #667).
 
 A windowed [Engine session](../../CONTEXT.md) (``gda daemon start --windowed``)
 needs a usable host ``DisplayServer`` to bring up a real viewport; on a host with
@@ -6,8 +6,24 @@ none, Godot aborts during ``DisplayServer`` / AppKit registration BEFORE its fil
 logger is installed, so the failure is otherwise only a generic
 ``engine_session_not_running`` with an empty log tail (#345 Part A). This module
 answers, PRE-LAUNCH, whether THIS host can show a window, so ``gda daemon start
---windowed`` can refuse fast with the typed ``live_windowed_unavailable``
-(ENVIRONMENT / exit 127) instead of spawning a doomed engine.
+--windowed`` can refuse fast with a typed ENVIRONMENT failure (exit 127) instead
+of spawning a doomed engine.
+
+It answers with a *verdict*, not a bare boolean, because "no window here" has two
+causes that need OPPOSITE reactions from an agent (#667):
+
+- nothing refused us and there is no session — ``live_windowed_unavailable``: as far
+  as gda can tell this machine cannot do rendered QA, so skip it;
+- the window-server lookup was REFUSED — ``live_windowed_permission_denied``: this
+  process may not even ask, so re-run outside the restriction. Reading this as the
+  first cause is exactly the dogfooded defect (GDA-DF-029): a sandboxed run was
+  recorded as a machine-capability gap and rendered QA was silently skipped.
+
+The second verdict deliberately claims only that the LOOKUP was denied — never that
+a window server exists. Seatbelt evaluates a mach-lookup deny per name and before
+resolution, so a blanket-deny profile refuses an unregistered name too; inferring
+existence from the refusal would tell a display-less confined CI Mac that its host
+has a window server (#667 review).
 
 Platform-dispatched (live is UNIX-only via ``live_unsupported_platform``, ADR-0021,
 so Windows is a documented, unreachable-today stub seam — a single clean slot, not a
@@ -18,9 +34,14 @@ refactor):
   session; it is NULL over SSH and in headless / sandbox sessions **even when**
   ``launchctl managername`` reports "Aqua". So we deliberately do NOT use
   ``launchctl`` or ``$DISPLAY`` on macOS — that NULL is exactly what predicts a
-  windowed Godot will abort during window-server registration.
+  windowed Godot will abort during window-server registration. The API reports NULL
+  with no error code, so the NULL alone cannot say WHY;
+  :func:`_macos_window_server_denial` answers the one further question that IS
+  answerable — was the lookup refused, and how broadly.
 - **Linux**: a non-empty ``$DISPLAY`` (X11) or ``$WAYLAND_DISPLAY`` (Wayland), so a
-  run under ``xvfb-run`` (which sets ``DISPLAY``) passes.
+  run under ``xvfb-run`` (which sets ``DISPLAY``) passes. No permission split: the
+  variables are readable regardless of confinement, so a Linux verdict is always the
+  capability one.
 - **Windows**: unreachable today; the stub reports "usable" so it never spuriously
   gates on a path live never reaches.
 """
@@ -30,38 +51,152 @@ from __future__ import annotations
 import ctypes
 import os
 import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from gda.models import EnvironmentProbe
+
+_CORE_GRAPHICS = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
+_CORE_FOUNDATION = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+_LIBSYSTEM = "/usr/lib/libSystem.B.dylib"
+
+# The mach service a process must reach to talk to the macOS window server. It is
+# the name sandbox profiles gate (`(allow mach-lookup (global-name …))`), and the
+# one CGSessionCopyCurrentDictionary itself needs — denying it is what makes that
+# API return NULL (verified: a seatbelt profile denying ONLY this name flips the
+# CoreGraphics probe to NULL while the rest of the host is untouched).
+_WINDOW_SERVER_SERVICE = b"com.apple.windowserver.active"
+
+# A name nothing registers, used as the CONTROL lookup (#667 review). Its whole job
+# is to reveal how broad the confinement is — see _macos_window_server_denial.
+_CONTROL_SERVICE = b"com.gda.probe.control.unregistered"
+
+# bootstrap_look_up statuses, from bootstrap.h.
+#
+# What these DO and DO NOT prove (#667 review corrected the original claim):
+# seatbelt evaluates a mach-lookup deny rule PER NAME and BEFORE the name is
+# resolved, so a blanket-deny profile returns NOT_PRIVILEGED for a name nobody
+# registered just as readily as for a real one. NOT_PRIVILEGED therefore proves
+# exactly one thing — "the policy refused THIS lookup" — and carries NO information
+# about whether a window server exists on the host. Claiming existence from it was
+# the falsified inference: a display-less CI Mac under a broad-deny profile would be
+# told the host HAS a window server.
+#
+# UNKNOWN_SERVICE is the not-registered answer, and is only meaningful when the
+# lookup was allowed to resolve at all.
+_BOOTSTRAP_NOT_PRIVILEGED = 1100
+_BOOTSTRAP_UNKNOWN_SERVICE = 1102
+
+# How broad a denial the control lookup revealed. Both mean "denied", so both take
+# the permission verdict; they differ only in what the probe can honestly say about
+# the confinement, never about whether a window server exists.
+_DENIAL_NAME_SPECIFIC = "name-specific"
+_DENIAL_BLANKET = "blanket"
+# The control lookup answered something we have no reading for (it succeeded, or
+# failed with an unrelated status). The target refusal still stands — that is what
+# the verdict reports — but nothing may be said about how broad the confinement is.
+_DENIAL_UNKNOWN_BREADTH = "unknown-breadth"
+
+# What each breadth may honestly say. None of the three claims a window server
+# exists — that is the caller's fixed clause — they differ only in how much they
+# can say about the confinement itself.
+_DENIAL_BREADTH_PROSE = {
+    _DENIAL_NAME_SPECIFIC: (
+        "the denial is specific to that service (a control lookup of an unregistered "
+        "name still resolved normally), which is the signature of a sandbox profile "
+        "that gates the window server"
+    ),
+    _DENIAL_BLANKET: (
+        "a control lookup of an unregistered name was refused too, so this process is "
+        "broadly confined and the probe learned only that much"
+    ),
+    _DENIAL_UNKNOWN_BREADTH: (
+        "a control lookup of an unregistered name returned neither the refusal nor "
+        "the not-registered status, so how broad the confinement is stays unknown"
+    ),
+}
 
 
-def has_usable_display() -> bool:
-    """Whether THIS host has a usable ``DisplayServer`` for a windowed session (#345)."""
-    if sys.platform == "darwin":
-        return _macos_has_window_server()
-    if sys.platform.startswith("linux"):
-        return _linux_has_display()
-    return _other_platform_has_display()
+@dataclass(frozen=True)
+class WindowedUnavailable:
+    """Why a windowed live session cannot come up on THIS host (#345, #667).
+
+    ``code`` is the registered ``Gda error code`` the refusal must report —
+    ``live_windowed_unavailable`` (nothing refused us and no session is reachable) or
+    ``live_windowed_permission_denied`` (the lookup itself was refused, so whether a
+    window server exists is unknown).
+    ``reason`` is the prose for the message/diagnostics, and ``probe`` is the
+    machine-readable :class:`~gda.models.EnvironmentProbe` naming the OS call that
+    decided this verdict, so an agent branches on data rather than on the sentence.
+    """
+
+    code: str
+    reason: str
+    probe: EnvironmentProbe
 
 
-def windowed_unavailable_reason() -> str | None:
-    """Why a windowed live session can't come up on THIS host, or ``None`` if it can.
+def windowed_unavailable() -> WindowedUnavailable | None:
+    """The windowed-session verdict for THIS host, or ``None`` if one can launch.
 
     The single decision point both the ``gda daemon start --windowed`` precondition
-    (``gda.commands.daemon``) and the windowed e2e gates key on, so they agree: ``None`` means
-    "a windowed session can launch here", a string is the skip/refusal reason.
+    (``gda.commands.daemon``), the daemon's authoritative launch-boundary guard
+    (``gda.daemon.server``) and the windowed e2e gates key on, so they agree:
+    ``None`` means "a windowed session can launch here", a verdict is the
+    skip/refusal.
     """
-    if has_usable_display():
-        return None
     if sys.platform == "darwin":
-        return (
-            "no usable macOS window-server session (CGSessionCopyCurrentDictionary "
-            "returned NULL — e.g. SSH / CI / sandbox); a windowed Godot session cannot "
-            "register with the window server here"
-        )
+        return _macos_verdict()
     if sys.platform.startswith("linux"):
-        return (
-            "headless Linux has no DisplayServer ($DISPLAY / $WAYLAND_DISPLAY unset); "
-            "run under a virtual framebuffer such as xvfb-run, which sets DISPLAY"
+        return _linux_verdict()
+    return _other_platform_verdict()
+
+
+def _macos_verdict() -> WindowedUnavailable | None:
+    """The macOS verdict: an on-console GUI session, else WHY not.
+
+    ``CGSessionCopyCurrentDictionary`` decides the capability question; when it says
+    NULL, the window-server mach lookup decides the permission question. Ordering
+    matters — the denial probe runs ONLY on the failure path, so a healthy desktop
+    pays nothing for it.
+    """
+    if _macos_has_window_server():
+        return None
+    denial = _macos_window_server_denial()
+    if denial is not None:
+        breadth = _DENIAL_BREADTH_PROSE[denial]
+        return WindowedUnavailable(
+            code="live_windowed_permission_denied",
+            reason=(
+                "this process is denied the macOS window-server lookup "
+                "(bootstrap_look_up of com.apple.windowserver.active returned "
+                f"BOOTSTRAP_NOT_PRIVILEGED — e.g. a sandbox); {breadth}. gda cannot "
+                "tell from a refused lookup whether this host HAS a window server, "
+                "only that this process may not ask: re-run outside the "
+                "sandbox/restriction to find out — if a windowed session comes up "
+                "there, this was a permission boundary; if it fails the same way, "
+                "the host genuinely has none"
+            ),
+            probe=EnvironmentProbe(
+                name="bootstrap_look_up(com.apple.windowserver.active)",
+                platform=sys.platform,
+            ),
         )
-    return "this host has no usable DisplayServer for a windowed session"
+    return WindowedUnavailable(
+        code="live_windowed_unavailable",
+        reason=(
+            "no usable macOS window-server session (CGSessionCopyCurrentDictionary "
+            "returned NULL — e.g. SSH / CI / a headless host); a windowed Godot "
+            "session cannot register with the window server here. Run the daemon "
+            "headless instead, or start it on a host with an on-console GUI session. "
+            "No permission denial was detected, so this reads as an absent GUI "
+            "session; if the run IS confined, a sandbox that hides the window server "
+            "rather than refusing it is indistinguishable from an absent one here — "
+            "re-run outside the sandbox to tell them apart"
+        ),
+        probe=EnvironmentProbe(
+            name="CGSessionCopyCurrentDictionary", platform=sys.platform
+        ),
+    )
 
 
 def _macos_has_window_server() -> bool:
@@ -76,9 +211,7 @@ def _macos_has_window_server() -> bool:
     genuine no-display abort at the session-launch site.
     """
     try:
-        cg = ctypes.cdll.LoadLibrary(
-            "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
-        )
+        cg = ctypes.cdll.LoadLibrary(_CORE_GRAPHICS)
         cg.CGSessionCopyCurrentDictionary.restype = ctypes.c_void_p
         session = cg.CGSessionCopyCurrentDictionary()
     except Exception:
@@ -86,9 +219,7 @@ def _macos_has_window_server() -> bool:
     if not session:
         return False
     try:  # release the copied CFDictionary to avoid a leak
-        cf = ctypes.cdll.LoadLibrary(
-            "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
-        )
+        cf = ctypes.cdll.LoadLibrary(_CORE_FOUNDATION)
         cf.CFRelease.argtypes = [ctypes.c_void_p]
         cf.CFRelease(ctypes.c_void_p(session))
     except Exception:
@@ -96,12 +227,127 @@ def _macos_has_window_server() -> bool:
     return True
 
 
-def _linux_has_display() -> bool:
-    """A non-empty ``$DISPLAY`` (X11) or ``$WAYLAND_DISPLAY`` (Wayland) — so xvfb-run passes."""
-    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+def _macos_window_server_denial() -> str | None:
+    """Was this process DENIED the window-server lookup, and how broadly? (#667)
+
+    ``CGSessionCopyCurrentDictionary`` returns NULL with no error code, so it cannot
+    say whether the window server is absent or merely out of reach. Asking the
+    bootstrap namespace directly answers a NARROWER question that is still worth
+    asking: was the lookup *refused*? ``BOOTSTRAP_NOT_PRIVILEGED`` means the policy
+    said no — which an absent service never produces on its own, so it is real
+    evidence of confinement.
+
+    What it is NOT evidence of is that a window server exists. Seatbelt evaluates a
+    mach-lookup deny PER NAME and BEFORE resolving it, so a blanket-deny profile
+    refuses an unregistered name just as readily (verified). That is why the CONTROL
+    lookup exists: a name nothing registers is looked up too, and its answer says how
+    broad the confinement is —
+
+    - control ``UNKNOWN_SERVICE`` + target refused → the denial is **name-specific**:
+      lookups do resolve here, and this one name is gated. The sandbox signature.
+    - control refused as well → **blanket** confinement; the probe learned only that
+      this process is confined.
+    - control answered anything else (it resolved, or failed with an unrelated
+      status) → **unknown breadth**: the target refusal stands, but nothing may be
+      said about how wide the confinement is.
+
+    None of the three licenses a claim about the host's display: all report the same
+    permission verdict, and the caller's wording says so. Returns ``None`` when there
+    is no denial evidence at all, including any failure to run the probe (symbol gone
+    on a future macOS, unexpected ``ctypes`` state) — so the refusal then behaves
+    exactly as it did before this probe existed.
+    """
+    try:
+        lookup = _bootstrap_lookup()
+    except Exception:
+        return None
+    return _classify_denial(lookup)
 
 
-def _other_platform_has_display() -> bool:
+def _classify_denial(lookup: "Callable[[bytes], int]") -> str | None:
+    """Map the target + control lookup statuses onto a denial breadth (#667).
+
+    Split from the ``ctypes`` wiring so the decision — the part with the actual
+    reasoning in it — is exercised by handing it a fake ``lookup`` on ANY host,
+    including a Linux CI runner with no libSystem at all.
+    """
+    if lookup(_WINDOW_SERVER_SERVICE) != _BOOTSTRAP_NOT_PRIVILEGED:
+        return None
+    control = lookup(_CONTROL_SERVICE)
+    if control == _BOOTSTRAP_UNKNOWN_SERVICE:
+        return _DENIAL_NAME_SPECIFIC
+    if control == _BOOTSTRAP_NOT_PRIVILEGED:
+        return _DENIAL_BLANKET
+    # Every OTHER control answer — it somehow succeeded, or failed with an unrelated
+    # status — is matched explicitly rather than folded into "blanket". Only a
+    # REFUSED control licenses the blanket reading; treating an unexpected status as
+    # one would invent a fact about the confinement from a result we cannot read.
+    return _DENIAL_UNKNOWN_BREADTH
+
+
+def _bootstrap_lookup() -> "Callable[[bytes], int]":
+    """Bind ``bootstrap_look_up`` and return a name → status callable.
+
+    Raises if the symbol or the bootstrap port cannot be bound, which the caller
+    treats as "no denial evidence".
+    """
+    libsystem = ctypes.CDLL(_LIBSYSTEM)
+    bootstrap_port = ctypes.c_uint32.in_dll(libsystem, "bootstrap_port")
+    libsystem.bootstrap_look_up.restype = ctypes.c_int32
+    libsystem.bootstrap_look_up.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_char_p,
+        ctypes.POINTER(ctypes.c_uint32),
+    ]
+
+    def _lookup(name: bytes) -> int:
+        service_port = ctypes.c_uint32(0)
+        status = libsystem.bootstrap_look_up(
+            bootstrap_port.value, name, ctypes.byref(service_port)
+        )
+        if status == 0 and service_port.value:
+            # The lookup handed back a send right; drop it — this probe wants the
+            # STATUS, not the port, and leaking a right per failed start would be a
+            # slow leak in a long-lived daemon.
+            _release_mach_port(libsystem, service_port.value)
+        return status
+
+    return _lookup
+
+
+def _release_mach_port(libsystem: ctypes.CDLL, port: int) -> None:
+    """Best-effort deallocation of a send right the denial probe received."""
+    try:
+        libsystem.mach_task_self.restype = ctypes.c_uint32
+        libsystem.mach_port_deallocate.restype = ctypes.c_int32
+        libsystem.mach_port_deallocate.argtypes = [ctypes.c_uint32, ctypes.c_uint32]
+        libsystem.mach_port_deallocate(libsystem.mach_task_self(), port)
+    except Exception:
+        pass
+
+
+def _linux_verdict() -> WindowedUnavailable | None:
+    """A non-empty ``$DISPLAY`` (X11) or ``$WAYLAND_DISPLAY`` (Wayland) — so xvfb-run passes.
+
+    Environment variables are readable under any confinement, so an unset pair means
+    there is no display to reach — never "a display we are not allowed to reach".
+    Linux therefore has no permission verdict.
+    """
+    if os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"):
+        return None
+    return WindowedUnavailable(
+        code="live_windowed_unavailable",
+        reason=(
+            "headless Linux has no DisplayServer ($DISPLAY / $WAYLAND_DISPLAY unset); "
+            "run under a virtual framebuffer such as xvfb-run, which sets DISPLAY"
+        ),
+        probe=EnvironmentProbe(
+            name="$DISPLAY / $WAYLAND_DISPLAY", platform=sys.platform
+        ),
+    )
+
+
+def _other_platform_verdict() -> WindowedUnavailable | None:
     """Windows stub seam — unreachable today (live is UNIX-only, ADR-0021).
 
     Live operations gate on a UNIX platform (``live_unsupported_platform``) long
@@ -110,4 +356,4 @@ def _other_platform_has_display() -> bool:
     ``GetSystemMetrics(SM_CMONITORS)``) is ever wired in; reports "usable" so it never
     spuriously gates on an unreachable path.
     """
-    return True
+    return None

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -87,6 +87,19 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "Godot launched but did not return before the runner timeout.",
     ),
     ErrorCodeSpec(
+        "user_data_unwritable",
+        ErrorCategory.ENVIRONMENT,
+        EXIT_NOT_FOUND,
+        ErrorCodeSource.RUNNER,
+        # Deliberately about the PLACEMENT, not about Godot's own directory: the
+        # same code covers a private temporary log target that could not be created
+        # (where Godot's location may be perfectly writable) and a redirected root
+        # whose derived data path is unusable. Naming only the latter sent readers
+        # to fix the wrong directory; the diagnostics name which one it was.
+        "The log or user-data placement for the launch could not be made usable, "
+        "so the launch was refused.",
+    ),
+    ErrorCodeSpec(
         "unsupported_version",
         ErrorCategory.VERSION,
         EXIT_VERSION,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -786,7 +786,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.ENVIRONMENT,
         EXIT_NOT_FOUND,
         ErrorCodeSource.CLASSIFIER,
-        "A windowed live session was requested (`gda daemon start --windowed`) but"
+        "A windowed Engine session was requested (`gda daemon start --windowed`) but"
         " the host has no usable DisplayServer (no on-console GUI session / no"
         " $DISPLAY), so the session cannot come up; refused before spawning Godot.",
     ),
@@ -807,7 +807,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.ENVIRONMENT,
         EXIT_NOT_FOUND,
         ErrorCodeSource.CLASSIFIER,
-        "A windowed live session was requested (`gda daemon start --windowed`) but"
+        "A windowed Engine session was requested (`gda daemon start --windowed`) but"
         " this process is denied the window-server lookup (e.g. a sandbox), so gda"
         " cannot tell whether the host has one; re-run outside the restriction to"
         " find out rather than recording the host as display-less.",

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -186,7 +186,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
-        "gda ran without a usable resolved Godot project: an operation needed one and none was resolved, or an explicit --project was empty, or a --project/$GDA_PROJECT does not name a Godot project (no project.godot).",
+        "gda has no resolved Godot project usable for the requested target: an operation needed one and none was resolved, or an explicit --project was empty, or a --project/$GDA_PROJECT does not name a Godot project (no project.godot), or the target lies outside the resolved project (whose res:// dependencies would then resolve against the wrong root).",
     ),
     ErrorCodeSpec(
         "path_not_found",

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -790,6 +790,28 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         " the host has no usable DisplayServer (no on-console GUI session / no"
         " $DISPLAY), so the session cannot come up; refused before spawning Godot.",
     ),
+    # The PERMISSION half of the pre-launch display precondition (#667). Same
+    # category/exit as `live_windowed_unavailable` — both refuse a windowed start
+    # pre-launch — but a different FACT about the world, and so a different code: the
+    # window-server lookup was REFUSED, so gda never got to observe whether a session
+    # exists. Conflating them is what the dogfooding (GDA-DF-029) hit — a sandboxed
+    # run read as a machine-capability gap, so rendered QA was silently skipped
+    # instead of retried outside the sandbox. The code deliberately does not claim
+    # the host HAS a window server: seatbelt refuses an unregistered name under a
+    # blanket-deny profile too, so the refusal proves confinement, not existence
+    # (#667 review). Distinct from `live_display_unavailable`, the harness's
+    # CAPTURE-time code for a session started headless. Classifier-source, NOT
+    # GDScript-mirrored.
+    ErrorCodeSpec(
+        "live_windowed_permission_denied",
+        ErrorCategory.ENVIRONMENT,
+        EXIT_NOT_FOUND,
+        ErrorCodeSource.CLASSIFIER,
+        "A windowed live session was requested (`gda daemon start --windowed`) but"
+        " this process is denied the window-server lookup (e.g. a sandbox), so gda"
+        " cannot tell whether the host has one; re-run outside the restriction to"
+        " find out rather than recording the host as display-less.",
+    ),
 )
 
 ERROR_CODE_BY_CODE: dict[str, ErrorCodeSpec] = {spec.code: spec for spec in ERROR_CODES}

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -415,6 +415,34 @@ def script_run_project_not_found_failure() -> Failure:
     )
 
 
+def script_outside_project_failure(location: Path, project: Path) -> Failure:
+    """The ``project_not_found`` refusal for a target outside the resolved project (#658).
+
+    ADR-0006 resolves ONE project per call (``--project`` > ``$GDA_PROJECT`` >
+    cwd) and deliberately does not derive it from the target path. A target that
+    lies outside that project would still be compiled against it, so every
+    ``res://`` dependency it names resolves against the wrong root: the engine
+    reports a cascade of missing-file and derived type errors for a file that is
+    perfectly valid in its own project, and the single project-context mistake is
+    buried under them. gda therefore refuses *before* the target is parsed and
+    reports the mismatch itself, naming both sides so the reader can see which
+    one is wrong.
+
+    It reuses ``project_not_found`` rather than minting a code: the failure is
+    that no project usable for this target was resolved, and the remedy is the
+    project context (``--project``) — the same class of mistake, and the same
+    branch an agent takes, as ``script run``'s projectless edge (ADR-0031).
+    """
+    return make_failure(
+        "project_not_found",
+        f"{location} is outside the resolved Godot project {project}: its res:// "
+        "dependencies would resolve against the wrong root, so nothing was "
+        "parsed. Pass --project for the project that owns this file, or name a "
+        "file inside the resolved one.",
+        "",
+    )
+
+
 def script_did_not_run_failure(
     code: str, script: str, detail: str, stderr: str
 ) -> Failure:

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -20,6 +20,8 @@ engine. The decision tree, top to bottom (``code`` in parentheses; the four
 - launch NOT_FOUND → environment / binary_not_found  (runner could not launch it)
 - launch TIMEOUT   → environment / launch_timeout     (runner launched it but it
   hung past the timeout)
+- launch USER_DATA_UNWRITABLE → environment / user_data_unwritable (the engine log
+  target gda owns could not be created, so the launch was refused, #653)
 - exit < 0  → operation   / engine_crashed         (engine killed by a signal)
 - exit ≠ 0  → operation   / <operation code>        (operation reported a structured
   failure via the ADR-0002 error envelope — e.g. path_not_found)
@@ -196,6 +198,18 @@ def classify_launch_or_crash(raw: RunResult, binary: Path | None) -> Failure | N
         return make_failure(
             "launch_timeout",
             "Godot launched but did not return before the timeout",
+            raw.stderr,
+        )
+    if raw.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE:
+        # Refused before the spawn (issue #653): the engine builds its file logger
+        # ahead of any project code and dies with signal 11 when it cannot open the
+        # log, so this environment problem would otherwise arrive as an
+        # `engine_crashed` backtrace. The runner's diagnostics name the binary, the
+        # user-data directory, and the log path.
+        return make_failure(
+            "user_data_unwritable",
+            "the log or user data placement for this launch is not usable; "
+            "the launch was refused",
             raw.stderr,
         )
     if raw.exit_code < 0:

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -50,7 +50,12 @@ from gda.error_codes import (
     LIVE_ERROR_CODES,
     OPERATION_ERROR_CODES,
 )
-from gda.models import GdaError, OperationErrorEnvelope
+from gda.models import (
+    EnvironmentProbe,
+    GdaError,
+    LiveErrorEnvelope,
+    OperationErrorEnvelope,
+)
 from gda.parser import parse_result
 from gda.runner import LaunchFailure, RunResult
 
@@ -68,7 +73,12 @@ class Failure:
     exit_code: int
 
 
-def make_failure(code: str, message: str, stderr: str) -> Failure:
+def make_failure(
+    code: str,
+    message: str,
+    stderr: str,
+    probe: EnvironmentProbe | None = None,
+) -> Failure:
     """Build a ``Failure`` from the parts that actually vary per failure.
 
     Only ``code``, the per-occurrence ``message`` (it embeds the binary path,
@@ -78,6 +88,11 @@ def make_failure(code: str, message: str, stderr: str) -> Failure:
     (ADR-0002, #141) rather than re-stated — and re-checked — at each site. The
     ``GdaError`` wrapping lives here once, so the call sites read as the taxonomy
     itself: a ``(code, message)`` row per failure mode.
+
+    ``probe`` is the optional :class:`EnvironmentProbe` context (ADR-0004
+    amendment, #667): the host call that decided an ENVIRONMENT failure gda
+    resolved by probing the machine rather than by running the engine. It stays
+    ``None`` — and so out of the emitted JSON entirely — for every other failure.
     """
     spec = ERROR_CODE_BY_CODE.get(code)
     if spec is None:
@@ -88,6 +103,7 @@ def make_failure(code: str, message: str, stderr: str) -> Failure:
             code=code,
             message=message,
             diagnostics=stderr,
+            probe=probe,
         ),
         exit_code=spec.exit_code,
     )
@@ -296,16 +312,18 @@ def classify_run(
 
 # Codes the daemon IPC client / the daemon surface through the live sentinel that
 # classify_run would otherwise misroute. The LIVE codes are live-runtime failures;
-# ``live_unsupported_platform`` and ``live_windowed_unavailable`` are
-# ENVIRONMENT-category pre-launch preconditions but still arrive via the live path
-# (``live_windowed_unavailable`` is raised at the daemon's session-launch boundary and
-# relayed as a live reply, #345), so classify_live must surface them too — else
-# classify_run falls back to operation_failed for a non-operation code.
+# ``live_unsupported_platform``, ``live_windowed_unavailable`` and
+# ``live_windowed_permission_denied`` are ENVIRONMENT-category pre-launch
+# preconditions but still arrive via the live path (both windowed codes are raised at
+# the daemon's session-launch boundary and relayed as a live reply, #345/#667), so
+# classify_live must surface them too — else classify_run falls back to
+# operation_failed for a non-operation code.
 # ``project_not_found`` is deliberately NOT here — it is an operation-source code
 # classify_run already maps, so it falls through to the shared decision tree.
 _LIVE_CLIENT_CODES = LIVE_ERROR_CODES | {
     "live_unsupported_platform",
     "live_windowed_unavailable",
+    "live_windowed_permission_denied",
 }
 
 
@@ -317,13 +335,25 @@ def _live_error_from_payload(result: RunResult) -> Failure | None:
     the daemon-channel codes to their registered ``Failure`` directly; any other
     envelope returns ``None`` so the shared ``classify_run`` decision tree handles
     it (e.g. ``project_not_found``).
+
+    Parsed with :class:`LiveErrorEnvelope` rather than the headless
+    ``OperationErrorEnvelope`` because the live channel may carry the optional
+    ``probe`` context (#667) — the strict headless model would reject that envelope
+    outright and drop the whole failure to ``operation_failed``. The probe rides
+    through to the public envelope, so a windowed refusal from the daemon's
+    authoritative launch boundary reports exactly what the CLI fail-fast reports.
     """
-    pair = _operation_error_from_payload(result)
-    if pair is None:
+    try:
+        payload = parse_result(result.stdout)
+    except ValueError:
         return None
-    code, message = pair
-    if code in _LIVE_CLIENT_CODES:
-        return make_failure(code, message, result.stderr)
+    try:
+        envelope = LiveErrorEnvelope.model_validate(payload)
+    except ValidationError:
+        return None
+    error = envelope.error
+    if error.code in _LIVE_CLIENT_CODES:
+        return make_failure(error.code, error.message, result.stderr, probe=error.probe)
     return None
 
 

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -382,18 +382,34 @@ def export_templates_missing_failure(preset: str, templates_version: str) -> Fai
 
 
 def script_path_invalid_failure(path: str) -> Failure:
-    """The ``invalid_path`` failure for a ``script run`` path that is not ``res://`` (ADR-0031).
+    """The ``invalid_path`` failure for a non-project-scoped ``script run`` path (ADR-0031, #675).
 
-    ``script run`` is res://-only: a res:// path resolves against the ``--project``
-    context (ADR-0006), and the motivating need is project-scoped. An absolute or
-    otherwise non-``res://`` path is a structured ``invalid_path`` failure decided
-    at the CLI, *before* any engine launch — never a crash or a raw engine failure
-    (an explicit ABI edge of ADR-0031). Kept beside the other pre-run failures so
-    the whole taxonomy reads from one place.
+    ``script run`` is project-scoped: it takes the two PORTABLE forms — a
+    project-relative path and a ``res://`` address — which both resolve against the
+    ``--project`` context (ADR-0006). It refuses four shapes, all decided at the
+    CLI *before* any engine launch, never as a crash or a raw engine failure (an
+    explicit ABI edge of ADR-0031): an **absolute** path, **another engine scheme**
+    (``user://``, ``uid://``), a path naming the project **root** (``""``, ``"."``),
+    and a path **escaping above the root** (``".."``, ``"../outside.gd"``). The
+    message names the accepted forms rather than the rejected shape, so it reads the
+    same for all four.
+
+    Absolute stays refused for two verified reasons, not merely as deferred scope.
+    The engine reports a failed run under the ``res://`` spelling even when launched
+    with an absolute in-project path, so accepting one without also mapping it back
+    to ``res://`` would break the canonical-identity match the never-ran verdict
+    depends on (#651) and reopen the phantom success it closed. And ``--script``
+    with an absolute path OUTSIDE the project really does execute, so accepting
+    absolute would widen the Project-code execution surface past ADR-0009's Trusted
+    project — a trust decision that needs its own ADR. Note ``script validate`` does
+    accept an absolute path today; the asymmetry is deliberate, and bounded to the
+    two portable forms.
+
+    Kept beside the other pre-run failures so the whole taxonomy reads from one place.
     """
     return make_failure(
         "invalid_path",
-        f"script run requires a res:// script path, got: {path!r}",
+        f"script run requires a project-relative or res:// script path, got: {path!r}",
         "",
     )
 

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -329,8 +329,16 @@ def emit_failure(failure: Failure) -> NoReturn:
     exit code. Shared by the sentinel-pipeline commands (via :meth:`HeadlessCommand.run`)
     and the native-export command (``export run``), which classifies its own
     subprocess outcome but emits failures through this same channel.
+
+    ``exclude_none`` keeps the envelope's OPTIONAL context keys (``probe``, the
+    ADR-0004 amendment of #667) out of the JSON entirely when a failure has none,
+    rather than emitting them as ``null``. So adding such a key leaves every
+    failure that does not set it byte-identical — the property that makes the
+    optional-context axis additive for existing consumers. The required keys
+    (``category`` / ``code`` / ``message`` / ``diagnostics``) are never ``None``,
+    so none of them can be dropped by this.
     """
-    typer.echo(GdaErrorEnvelope(error=failure.error).model_dump_json())
+    typer.echo(GdaErrorEnvelope(error=failure.error).model_dump_json(exclude_none=True))
     raise typer.Exit(code=failure.exit_code)
 
 

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -88,12 +88,23 @@ ROOT_JSON_META_KEY = "gda.root_json"
 def set_root_json(ctx: typer.Context, value: bool) -> None:
     """Record a root ``--json`` for the command the root is about to invoke.
 
-    The write half of the root-flag contract, owned HERE next to the option that
-    reads it (:func:`_inherit_root_json`), so the knowledge runs downward: the CLI
-    composition root CALLS this to hand the flag over, instead of this module
-    reaching up into that module's private parameter names.
+    The write half of the root-flag contract, owned HERE next to the options that
+    read it (:func:`_inherit_root_json`, :func:`root_json`), so the knowledge runs
+    downward: the CLI composition root CALLS this to hand the flag over, instead of
+    this module reaching up into that module's private parameter names.
     """
     ctx.meta[ROOT_JSON_META_KEY] = bool(value)
+
+
+def root_json(ctx: typer.Context) -> bool:
+    """Whether a root ``--json`` was recorded for this invocation (#659).
+
+    The read half of the same contract, for the ONE reader that is not a command:
+    the root's own ``--version``, which renders either a human line or the
+    structured provenance payload and so must ask the same question a command's
+    inherited flag asks — without re-deriving where the answer is kept.
+    """
+    return bool(ctx.meta.get(ROOT_JSON_META_KEY, False))
 
 
 def _inherit_root_json(
@@ -115,7 +126,7 @@ def _inherit_root_json(
     wiring, including the ``--params-json`` dispatch path, which reads
     ``ctx.params`` after this callback has run.
     """
-    return bool(value) or bool(ctx.meta.get(ROOT_JSON_META_KEY, False))
+    return bool(value) or root_json(ctx)
 
 
 def json_option() -> bool:

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -262,10 +262,28 @@ def normalize_path(path: str) -> str:
     :func:`gda.project.is_engine_virtual_path` — the same test the project
     containment check reads, so the two cannot disagree about what ``res://``
     means.
+
+    **Total: it never raises** (#699). ``Path.expanduser()`` raises ``RuntimeError``
+    for a ``~unknownuser/…`` prefix it cannot resolve, which crashed every
+    ``NormalizedPath`` consumer with a bare traceback. Such a path is passed through
+    UNCHANGED instead. Two reasons it is swallowed rather than re-raised:
+
+    - Normalization is a **convenience**, not a validity check — it saves the caller
+      a shell. Whether a path is usable is decided by whoever consumes it (the
+      operation that opens it, or a command's own path gate), and an unresolvable
+      ``~user`` is simply a path that does not exist there.
+    - Raising would not even fix the crash. The argv path constructs its params model
+      DIRECTLY in the command body, so a ``ValueError`` becomes a pydantic
+      ``ValidationError`` that escapes as a bare traceback anyway; only
+      ``--params-json`` catches it. Staying total is what repairs BOTH input paths,
+      for every consumer, without a per-command guard.
     """
     if is_engine_virtual_path(path):
         return path
-    return str(Path(path).expanduser())
+    try:
+        return str(Path(path).expanduser())
+    except RuntimeError:
+        return path
 
 
 # The one reusable path-field type: a ``str`` whose value is run through

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -18,6 +18,7 @@ from pydantic import (
 )
 
 from gda.execution import ExecutionKind
+from gda.project import is_engine_virtual_path
 
 
 class ErrorCategory(str, Enum):
@@ -256,8 +257,13 @@ def normalize_path(path: str) -> str:
     Lives here, not at the CLI layer, so the argv path and the ``--params-json``
     path normalize identically (ADR-0015): the model is the single home of
     normalization, applied wherever the model is constructed.
+
+    Which paths are engine-virtual is ADR-0006's rule, owned by
+    :func:`gda.project.is_engine_virtual_path` — the same test the project
+    containment check reads, so the two cannot disagree about what ``res://``
+    means.
     """
-    if "://" in path:
+    if is_engine_virtual_path(path):
         return path
     return str(Path(path).expanduser())
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -47,19 +47,61 @@ class ErrorCategory(str, Enum):
     LIVE = "live"
 
 
+# WHY this exists (kept as a comment, not a docstring): a model docstring becomes
+# the schema `description`, and the error envelope's schema is repeated for EVERY
+# command in `gda schema` — so rationale here would be paid ~67 times by every agent
+# reading the manifest. The decision and its reasoning live in the ADR-0004
+# amendment (#667); the docstring below stays the one-line contract.
+#
+# The short version: gda decides some ENVIRONMENT failures by asking the host a
+# question directly ("can a window open here?") rather than by observing an engine
+# run. WHICH OS call answered separates "this machine cannot do it" from "this
+# PROCESS was not allowed to" — skip the capability, versus retry outside the
+# restriction. #667: automation read a sandbox denial as a machine-capability gap
+# and silently skipped rendered QA, because that fact lived only in prose.
+class EnvironmentProbe(BaseModel):
+    """The host call that decided an environment failure: its ``name`` and ``platform``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Descriptions are deliberately terse: each one is repeated per command in the
+    # manifest, so prose here is paid ~67 times over (#667 review measured the cost).
+    name: str = Field(
+        description="The OS call that decided this failure, e.g. CGSessionCopyCurrentDictionary."
+    )
+    platform: str = Field(
+        description="The sys.platform the probe ran on, e.g. darwin or linux."
+    )
+
+
 class GdaError(BaseModel):
     """A structured, stable failure of a ``gda`` operation (issue #3).
 
     Emitted as ``{"error": <this>}`` on stdout so an agent reacts to failure
     modes programmatically without parsing prose. ``category`` is the coarse,
     process-exit-code-aligned bucket; ``code`` is the finer, stable identifier;
-    ``diagnostics`` carries the engine/script stderr surfaced per ADR-0002.
+    ``diagnostics`` carries the engine/script stderr surfaced per ADR-0002;
+    ``probe`` is optional context on the few environment failures gda decides by
+    probing the host (ADR-0004 amendment, #667).
     """
 
     category: ErrorCategory
     code: str
     message: str
     diagnostics: str = ""
+    # OMITTED — not ``null`` — from every failure that sets none: the emit path
+    # (:func:`gda.headless.emit_failure`) serializes with ``exclude_none``, so each
+    # other code's envelope JSON stays byte-identical to the pre-amendment contract.
+    # Deliberately the minimal axis — WHICH host call decided — never the
+    # operation-scoped typed EVIDENCE of a failure (parsed script errors, exit
+    # statuses), which is #687's separate decision (ADR-0004 amendment, #667).
+    probe: EnvironmentProbe | None = Field(
+        default=None,
+        description=(
+            "Which host probe decided this environment failure; the key is omitted "
+            "(never null) on failures that have none."
+        ),
+    )
 
 
 class GdaErrorEnvelope(BaseModel):
@@ -92,6 +134,38 @@ class OperationErrorEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     error: OperationError
+
+
+class LiveError(BaseModel):
+    """A live-channel failure payload: the operation shape plus optional probe context.
+
+    The daemon and the daemon IPC client report a live failure with the same ADR-0002
+    envelope a headless operation uses, so this is :class:`OperationError` — with one
+    addition. A windowed refusal at the daemon's authoritative launch boundary is
+    decided by a HOST PROBE, and that context has to survive the relay, or the
+    authoritative path would report a strictly poorer failure than the CLI's own
+    fail-fast (#667). ``probe`` is therefore optional here and ABSENT from every other
+    live envelope.
+
+    The headless sentinel stays strict and probe-less: a GDScript operation has no host
+    probe to report, so widening :class:`OperationError` would invite a key the other
+    language can never fill. Two models, one per channel, is what keeps the
+    cross-language contract narrow while the live channel carries what it actually knows.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    message: str
+    probe: EnvironmentProbe | None = None
+
+
+class LiveErrorEnvelope(BaseModel):
+    """The sentinel payload shape for a live-channel failure (``{"error": {...}}``)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    error: LiveError
 
 
 class LiveStackConstraints(BaseModel):

--- a/src/gda/parser.py
+++ b/src/gda/parser.py
@@ -50,11 +50,23 @@ def build_result(payload: Any) -> str:
     return f"{RESULT_BEGIN}{json.dumps(payload)}{RESULT_END}\n"
 
 
-def error_envelope(code: str, message: str) -> dict:
+def error_envelope(code: str, message: str, probe: dict | None = None) -> dict:
     """The ADR-0002 operation-error payload — ``{"error": {"code", "message"}}``.
 
     The one place that envelope dict is built (it mirrors
     :class:`~gda.models.OperationErrorEnvelope`); wrap it with :func:`build_result`
     to synthesize a sentinel error result.
+
+    ``probe`` is the OPTIONAL live-channel extension (#667): the daemon relays a
+    windowed refusal that a HOST PROBE decided, and the probe context has to survive
+    the relay or the authoritative lazy-launch path would report a strictly poorer
+    failure than the CLI fail-fast does. The key is omitted entirely when absent, so
+    every other envelope on this wire — and the whole GDScript-emitted headless
+    sentinel, whose model stays ``extra="forbid"`` with no ``probe`` — is
+    byte-identical to before. Only the live envelope model
+    (:class:`~gda.models.LiveErrorEnvelope`) accepts it.
     """
-    return {"error": {"code": code, "message": message}}
+    error: dict = {"code": code, "message": message}
+    if probe is not None:
+        error["probe"] = probe
+    return {"error": error}

--- a/src/gda/project.py
+++ b/src/gda/project.py
@@ -66,6 +66,22 @@ def _has_dotdot(path: Path) -> bool:
     return ".." in path.parts
 
 
+def _expand_user(path: Path) -> Path:
+    """``Path.expanduser()``, total: an unresolvable ``~user`` stays literal.
+
+    ``expanduser`` raises ``RuntimeError`` for a ``~unknownuser/…`` prefix it
+    cannot resolve. The shared normalizer deliberately passes such a path
+    through unchanged (#699 — bash treats an unresolvable ``~user`` as a
+    literal name), so the containment layer must be total the same way: the
+    literal path simply will not exist, and the consumer reports that
+    structurally instead of a RuntimeError escaping as a traceback.
+    """
+    try:
+        return path.expanduser()
+    except RuntimeError:
+        return path
+
+
 def project_anchored(path: str, project: Path) -> Path:
     """``path`` as the ENGINE will address it under ``--path project``.
 
@@ -80,10 +96,10 @@ def project_anchored(path: str, project: Path) -> Path:
     The single anchoring rule, so the containment check and the engine cannot
     disagree about which file a relative argument names.
     """
-    target = Path(path).expanduser()
+    target = _expand_user(Path(path))
     if target.is_absolute():
         return target
-    return project.expanduser() / target
+    return _expand_user(project) / target
 
 
 def path_outside_project(path: str, project: Path) -> Path | None:
@@ -134,7 +150,7 @@ def path_outside_project(path: str, project: Path) -> Path | None:
     """
     if is_engine_virtual_path(path):
         return None
-    root = project.expanduser()
+    root = _expand_user(project)
     candidate = project_anchored(path, project)
     location = candidate.resolve()
     if location.is_relative_to(root.resolve()):
@@ -147,7 +163,7 @@ def path_outside_project(path: str, project: Path) -> Path | None:
 
 def _project_or_raise(raw: str, source: str) -> Path:
     """Expand ``raw`` to a project directory, or raise if it is not one."""
-    candidate = Path(raw).expanduser()
+    candidate = _expand_user(Path(raw))
     if not (candidate / PROJECT_MARKER).exists():
         raise ValueError(
             f"{source} is not a Godot project (no {PROJECT_MARKER}): {candidate}"

--- a/src/gda/project.py
+++ b/src/gda/project.py
@@ -28,6 +28,123 @@ GDA_PROJECT_ENV = "GDA_PROJECT"
 PROJECT_MARKER = "project.godot"
 
 
+# The engine-resolved virtual path schemes ADR-0006 names. An exact prefix set,
+# NOT a "contains ://" test: a colon is a legal POSIX filename character, so
+# `/work/outside://deck.gd` is an ordinary — and ordinarily *outside* —
+# filesystem path that a substring test would wave through as virtual.
+ENGINE_VIRTUAL_PREFIXES = ("res://", "user://", "uid://")
+
+
+def is_engine_virtual_path(path: str) -> bool:
+    """True when ``path`` is an engine-resolved virtual path (``res://``, …).
+
+    ADR-0006's one test for "the engine resolves this against the project, gda
+    does not touch it", decided by the documented scheme PREFIXES
+    (:data:`ENGINE_VIRTUAL_PREFIXES`) rather than by looking for ``://``
+    anywhere in the string. Owned here, in the project-resolution module, and
+    read by both callers of the rule: :func:`gda.models.normalize_path` (which
+    passes such a path through unexpanded) and :func:`path_outside_project`
+    (which can make no filesystem statement about one).
+    """
+    return path.startswith(ENGINE_VIRTUAL_PREFIXES)
+
+
+def _lexical_abs(path: Path) -> Path:
+    """``path`` made absolute and ``..``-free WITHOUT following symlinks.
+
+    ``os.path.abspath`` is by definition ``normpath(join(os.getcwd(), path))``:
+    it anchors a relative path at the cwd and collapses ``..`` textually, so a
+    symlink on the way keeps the spelling the caller used. That is the opposite
+    of ``Path.resolve()``, and both readings are needed — see
+    :func:`path_outside_project`.
+    """
+    return Path(os.path.abspath(path))
+
+
+def _has_dotdot(path: Path) -> bool:
+    """True when ``path``'s spelling contains a ``..`` traversal component."""
+    return ".." in path.parts
+
+
+def project_anchored(path: str, project: Path) -> Path:
+    """``path`` as the ENGINE will address it under ``--path project``.
+
+    A relative filesystem path is anchored at the PROJECT, not at gda's cwd,
+    because that is what the engine does: launched with ``--path <project>``, a
+    one-shot op that opens ``deck.gd`` opens ``<project>/deck.gd`` regardless of
+    where gda was invoked (verified against the engine). It is also what the
+    README promises — point gda at a project once and relative paths resolve
+    inside it. An absolute path is already fully addressed and is returned
+    unchanged; ``~`` is expanded either way.
+
+    The single anchoring rule, so the containment check and the engine cannot
+    disagree about which file a relative argument names.
+    """
+    target = Path(path).expanduser()
+    if target.is_absolute():
+        return target
+    return project.expanduser() / target
+
+
+def path_outside_project(path: str, project: Path) -> Path | None:
+    """The location of ``path`` when it falls OUTSIDE ``project``.
+
+    The containment check behind the "this target does not belong to the
+    resolved project" refusal. Returns ``None`` when the path belongs to the
+    project, and otherwise the target's real location, so the caller can name
+    *where* it actually is in its diagnostic.
+
+    An engine-virtual path is inside by construction: it addresses the project
+    the engine was launched with, and gda can make no filesystem statement
+    about one.
+
+    A filesystem path is first anchored the way the engine will address it
+    (:func:`project_anchored`), then read in up to two ways — it belongs to the
+    project when EITHER says so, because a symlink makes the two answer
+    different, equally true questions:
+
+    - **Resolved** (``Path.resolve()``, symlinks followed): "are these two
+      spellings the same place?" The project may be named by one spelling and
+      the target by another — on macOS the temp directory alone (``/tmp`` →
+      ``/private/tmp``) is enough — and only this reading sees through that.
+      Always consulted.
+    - **Lexical** (:func:`_lexical_abs`, symlinks preserved): "did the caller
+      address this file through the project's own tree?" A monorepo that links
+      a shared library into the project (``game/addons/lib -> ../../libs/lib``)
+      answers yes, and so does the engine — Godot walks the project directory
+      and follows that link, so the file really is in the project's ``res://``
+      namespace. Refusing it on its ``resolve()``d location would reject a call
+      that works, in a message naming a path the caller never typed.
+
+    The lexical reading is only sound while no ``..`` is in play, so it is
+    consulted ONLY when neither the anchored candidate nor the project spelling
+    carries a ``..`` component. A ``..`` that follows a symlink collapses
+    textually to a place the filesystem never visits — ``game/pivot/../deck.gd``
+    with ``game/pivot -> ../outside/deep`` reads as ``game/deck.gd`` lexically
+    while really naming ``outside/deck.gd`` — so trusting the lexical reading
+    there would accept a target that is genuinely outside. Without a ``..``, a
+    symlink can only redirect *downward* from a path that does start inside the
+    project, which is the legitimate case above. When the guard withholds the
+    lexical reading, containment falls back to the resolved reading alone: a
+    symlinked-in file addressed with a ``..`` in its path is refused, and the
+    caller can name it without the ``..``.
+
+    ``resolve()`` is non-strict, so a path that does not exist still yields the
+    location it would occupy rather than raising.
+    """
+    if is_engine_virtual_path(path):
+        return None
+    root = project.expanduser()
+    candidate = project_anchored(path, project)
+    location = candidate.resolve()
+    if location.is_relative_to(root.resolve()):
+        return None
+    if not _has_dotdot(candidate) and not _has_dotdot(root):
+        if _lexical_abs(candidate).is_relative_to(_lexical_abs(root)):
+            return None
+    return location
+
+
 def _project_or_raise(raw: str, source: str) -> Path:
     """Expand ``raw`` to a project directory, or raise if it is not one."""
     candidate = Path(raw).expanduser()

--- a/src/gda/provenance.py
+++ b/src/gda/provenance.py
@@ -1,0 +1,481 @@
+"""The structured install provenance behind ``gda --version --json`` (#659).
+
+A long agent run needs to record WHICH ``gda`` produced its evidence. Dogfooding
+found two ways that failed: ``gda --version`` printed one human line an evidence
+collector had to parse (GDA-DF-018), and the ``gda`` a ``PATH`` lookup resolved
+turned out to be an *editable* install whose source checkout changed revision
+mid-run, with nothing in the output to disclose it (GDA-DF-043).
+
+So this module answers "which gda is running, and where did it come from" as one
+model:
+
+* the installed ``gda`` version, the executable that ran, and the interpreter
+  running it;
+* the directory the ``gda`` package was actually IMPORTED from — the one field
+  read from the loaded module rather than from installer metadata, so a
+  ``sys.path`` shadow cannot leave the rest of the payload confidently wrong;
+* the install kind — a built ``wheel`` (no source checkout), an ``editable``
+  install, or ``unknown``, read from the PEP 610 ``direct_url.json`` the installer
+  recorded, since the version string alone cannot tell them apart and ``pip show``
+  is unavailable in a ``uv`` environment;
+* for an editable install, the source checkout: its root, its Git revision, and
+  whether the working tree is dirty — the three facts GDA-DF-043 needed;
+* the Godot binary ``gda`` would use, resolved without launching it.
+
+A note on ``unknown``: "no record at all" and "a record I could not read" lead to
+OPPOSITE conclusions, so the read seam keeps them apart in three arms
+(:class:`RecordState`) instead of one nullable answer. Only "no record" — how an
+ordinary index install looks — implies a wheel. A record that is present but
+malformed, present but saying nothing, or that could not be retrieved at all means
+the install could be either, and a preflight built to prevent false provenance must
+not answer a question it cannot answer. All three yield ``unknown``, never a
+confident ``wheel``, and none of them fails the preflight: the payload is still
+emitted, reporting everything it does know.
+
+**It never launches Godot.** The motivating environment is a restricted profile
+where an engine spawn crashes, which is exactly when provenance matters most — so
+the engine version key is OMITTED, with a stated reason in its place, rather than
+making the preflight depend on the thing it is meant to diagnose. Reading the Git
+revision does run ``git``; that is a different process
+from the one under suspicion, it degrades to ``None`` when unavailable, and it runs
+with the inherited repository-redirect variables stripped (:data:`GIT_REDIRECT_ENV`)
+so a gda called from inside another repository's hook cannot be handed that
+repository's revision.
+
+There is deliberately no schema or protocol version here: ``gda`` has none, and
+inventing one would create a contract nothing else honors.
+
+The whole payload is built by :func:`build_version_provenance`, kept free of the
+CLI so a later self-diagnosis command (#670) can embed it without re-deriving any
+of it.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from importlib.metadata import Distribution, PackageNotFoundError
+from importlib.metadata import version as package_version
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import urlparse
+from urllib.request import url2pathname
+
+from pydantic import BaseModel, Field, SerializerFunctionWrapHandler, model_serializer
+
+from gda.binary import resolve_godot_binary
+
+# The distribution name to introspect — this package's own.
+DISTRIBUTION = "gda"
+
+# How long a provenance ``git`` call may take before it is treated as
+# unresolvable. Generous for a local repository, bounded so a wedged ``git`` (a
+# stale index lock, a network-backed filesystem) cannot hang a preflight whose
+# whole point is to run when the environment is already unhealthy.
+GIT_TIMEOUT_SECONDS = 5.0
+
+# Why the engine version is absent. Stated in the payload rather than silently
+# omitted, so a reader can tell "not detected" from "not detectable here".
+GODOT_VERSION_NEEDS_A_LAUNCH = (
+    "the engine reports its version only from a running process, and this surface "
+    "never launches Godot; run `gda info --json` for it"
+)
+
+
+class InstallKind(str, Enum):
+    """How the running ``gda`` was installed.
+
+    ``WHEEL`` is any built, non-editable install (from an index, or from a local
+    wheel or source directory): the code that runs is a copy, so there is no
+    source checkout to report. ``EDITABLE`` is an install that imports straight
+    out of a working tree (``pip install -e`` / ``uv sync``), so the code that runs
+    can change without the version changing — the case GDA-DF-043 hit.
+
+    ``UNKNOWN`` is the answer whenever gda cannot READ the install metadata as the
+    shape PEP 610 defines — whether the record is off-spec, says nothing at all, or
+    could not be retrieved. It is not a third kind of install; it is the refusal to
+    guess between the other two. A record gda could not read, reported as ``WHEEL``,
+    would tell a reader "immutable copy, nothing can change under you" about an
+    install that may well be editable — precisely the false provenance this surface
+    exists to prevent. Only ONE observation earns ``WHEEL``: the installer recorded
+    no direct-URL origin at all, which is what an ordinary index install looks like.
+    """
+
+    WHEEL = "wheel"
+    EDITABLE = "editable"
+    UNKNOWN = "unknown"
+
+
+class RecordState(str, Enum):
+    """Whether the running ``gda``'s PEP 610 install record could be read at all.
+
+    Three arms, kept apart because collapsing any two of them is how the payload
+    starts lying. ``ABSENT`` is the reader saying "no such file" — the shape of an
+    ordinary index install, and the ONLY arm that safely implies a built wheel.
+    ``PRESENT`` carries the bytes, whatever they say, for the classifier to judge.
+    ``UNREADABLE`` is a record gda failed to retrieve: not evidence of a wheel, and
+    not a reason to fail a preflight either.
+    """
+
+    ABSENT = "absent"
+    PRESENT = "present"
+    UNREADABLE = "unreadable"
+
+
+@dataclass(frozen=True)
+class DirectUrlRecord:
+    """A PEP 610 ``direct_url.json`` as far as it could be read, unjudged.
+
+    ``text`` is the raw document and is set only on :attr:`RecordState.PRESENT` —
+    handed over verbatim, whitespace-only included. A record that exists but says
+    nothing is *off-spec*, not absent, and blanking it at the read seam is one of
+    the two ways a damaged editable install used to be reported as a wheel.
+    """
+
+    state: RecordState
+    text: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class InstallOrigin:
+    """What the PEP 610 record says about where the running ``gda`` came from.
+
+    ``source_root`` is set only for an ``EDITABLE`` install whose recorded origin
+    names a local directory — so a caller reads the checkout off this one field
+    without re-deciding whether a checkout applies.
+    """
+
+    kind: InstallKind
+    source_root: Optional[Path] = None
+
+
+class SourceCheckout(BaseModel):
+    """The working tree an editable install imports from.
+
+    ``revision``/``dirty`` are ``None`` when they cannot be resolved — no ``git``
+    on ``PATH``, the root is not inside a repository, or the call failed or timed
+    out. ``dirty`` counts untracked files as dirty, because an untracked module in
+    the checkout is still code the editable install can import — and it counts them
+    regardless of the repository's ``status.showUntrackedFiles`` setting, which
+    would otherwise let a config choice hide exactly that code.
+
+    These stay explicit ``null`` rather than omitted keys (unlike
+    ``GodotProvenance.version``): here the null IS the finding — gda looked at a
+    named checkout and could not resolve its state — while an omitted key would
+    read as "not applicable".
+    """
+
+    root: str
+    revision: Optional[str] = None
+    dirty: Optional[bool] = None
+
+
+class GodotProvenance(BaseModel):
+    """The engine side of the provenance, resolved WITHOUT launching Godot.
+
+    ``binary`` is what ``$GDA_GODOT`` → the built-in default resolves to. That is
+    the whole precedence reachable here: ``--godot`` is a per-COMMAND option, and
+    this surface is the root, which has none — so the reported path is the engine a
+    command with no ``--godot`` would use, and an explicit flag on a later command
+    still overrides it. It is reported as resolved, not checked for existence,
+    because probing the file is a different question from "which engine would this
+    gda use".
+
+    ``version`` appears ONLY when the version is obtainable without a launch — it
+    is not today — and is otherwise OMITTED, with ``version_unavailable_reason`` in
+    its place; the reason is likewise omitted once a version is present. That is
+    #659's contract ("only when obtainable, otherwise omitted with a stated
+    reason") and it follows the omitted-never-null convention gda uses elsewhere:
+    a null would claim gda looked and found nothing, when in fact it declined to
+    look. Exactly one of the two keys is present at any time.
+    """
+
+    binary: str
+    version: Optional[str] = None
+    version_unavailable_reason: Optional[str] = None
+
+    @model_serializer(mode="wrap")
+    def _omit_the_inapplicable_key(
+        self, handler: SerializerFunctionWrapHandler
+    ) -> dict[str, Any]:
+        # A ``None`` on this model means "does not apply", not "looked and found
+        # nothing", so the key is dropped rather than serialized as null. ``binary``
+        # is required and never None, so this only ever affects the version pair.
+        return {key: value for key, value in handler(self).items() if value is not None}
+
+
+class VersionProvenance(BaseModel):
+    """The ``gda --version --json`` payload: which ``gda`` ran, and from where."""
+
+    gda_version: str = Field(description="The installed gda distribution version.")
+    executable: str = Field(
+        description="The absolute path of the gda entry point that is running "
+        "(the console script, or the __main__ module under `python -m gda`)."
+    )
+    interpreter: str = Field(
+        description="The absolute path of the Python interpreter running gda."
+    )
+    package_path: str = Field(
+        description="The absolute directory the running gda PACKAGE was imported "
+        "from. Every other field here is read from distribution metadata; this one "
+        "is read from the loaded module, so a mismatch between them (a PYTHONPATH "
+        "or sys.path shadow) is visible instead of silent."
+    )
+    install_kind: InstallKind = Field(
+        description="Whether gda was installed as a built wheel or as an editable "
+        "install importing from a source checkout — or `unknown` when the install "
+        "metadata exists but cannot be read, in which case gda refuses to guess "
+        "between the two rather than claiming the immutable one."
+    )
+    source: Optional[SourceCheckout] = Field(
+        default=None,
+        description="The source checkout an editable install imports from; null "
+        "for a wheel (no checkout), for an unknown install kind, and for an "
+        "editable install whose recorded location is not a resolvable local path.",
+    )
+    godot: GodotProvenance = Field(
+        description="The engine gda would use, resolved without launching it."
+    )
+
+
+def read_direct_url_record(distribution: str = DISTRIBUTION) -> DirectUrlRecord:
+    """Read ``distribution``'s PEP 610 ``direct_url.json`` WITHOUT judging it.
+
+    The one seam through which install provenance enters this module. It reports
+    which of :class:`RecordState`'s three arms happened and flattens none of them:
+    only a reader that says "no such file" is ``ABSENT``; any content — including
+    whitespace — is ``PRESENT`` and travels on to :func:`classify_install`; a reader
+    that raises is ``UNREADABLE``.
+
+    A distribution that is not installed is ``UNREADABLE``, not ``ABSENT``: gda did
+    not learn that no record exists, it failed to look. (It cannot be observed in
+    practice, because :func:`build_version_provenance` reads the version from the
+    same metadata and would fail first — but classifying a metadata failure onto the
+    one arm that implies a wheel would be wrong on principle.)
+
+    ``ABSENT`` requires POSITIVE missing-file evidence. The obvious reader —
+    ``Distribution.read_text()`` — cannot supply it: the stdlib implementation
+    suppresses ``PermissionError``, ``IsADirectoryError``, ``NotADirectoryError``
+    and friends, returning the same ``None`` it returns for a missing record, and
+    promoting that ambiguity to ``ABSENT`` is exactly the confident-wheel
+    misreport this seam exists to prevent. So the record is read from the
+    distribution's own metadata directory (``PathDistribution``'s ``_path`` — a
+    ``pathlib.Path`` for a directory-backed install, a zip path for an
+    archive-backed one; ``locate_file`` is NOT it, that resolves installed files
+    relative to site-packages), where the outcomes stay distinct: only a genuine
+    "no such file" is ``ABSENT``; every other read failure is ``UNREADABLE``. An
+    exotic ``Distribution`` subclass without ``_path`` offers only the abstract
+    ``read_text``, whose ambiguous ``None`` — or its own raise — degrades to
+    ``UNREADABLE``, never promoted to the one arm that earns a confident wheel.
+    """
+    try:
+        dist = Distribution.from_name(distribution)
+    except PackageNotFoundError:
+        return DirectUrlRecord(RecordState.UNREADABLE)
+    metadata_dir = getattr(dist, "_path", None)
+    if metadata_dir is None:
+        # The abstract reader can RAISE before producing text or its ambiguous
+        # None — both land in the same UNREADABLE boundary as the path-backed
+        # branch's failures; only real text is PRESENT.
+        try:
+            raw = dist.read_text("direct_url.json")
+        except (OSError, KeyError, ValueError):
+            return DirectUrlRecord(RecordState.UNREADABLE)
+        if raw is None:
+            return DirectUrlRecord(RecordState.UNREADABLE)
+        return DirectUrlRecord(RecordState.PRESENT, raw)
+    try:
+        raw = (metadata_dir / "direct_url.json").read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return DirectUrlRecord(RecordState.ABSENT)
+    except (OSError, KeyError, ValueError):
+        # PermissionError / IsADirectoryError / NotADirectoryError are OSErrors;
+        # KeyError is an archive member miss on older zip-path backends.
+        return DirectUrlRecord(RecordState.UNREADABLE)
+    return DirectUrlRecord(RecordState.PRESENT, raw)
+
+
+def classify_install(record: DirectUrlRecord) -> InstallOrigin:
+    """Decide the install kind (and the checkout, if any) from a PEP 610 record.
+
+    Pure, so every branch is testable without an installer. The rule it enforces is
+    that exactly one observation may produce a confident ``WHEEL`` — the installer
+    recorded no direct-URL origin (``ABSENT``) — and one may produce ``EDITABLE``: a
+    readable record whose ``dir_info.editable`` is the boolean ``true``. Everything
+    else is ``UNKNOWN``: a record gda could not retrieve, unparseable JSON (a
+    whitespace-only document included), a non-object document, a non-object
+    ``dir_info``, or an ``editable`` that is not the boolean the spec types it as.
+    PEP 610 says an absent ``editable`` defaults to false, so that stays a wheel.
+    """
+    if record.state is RecordState.UNREADABLE:
+        return InstallOrigin(InstallKind.UNKNOWN)
+    if record.state is RecordState.ABSENT:
+        return InstallOrigin(InstallKind.WHEEL)
+    try:
+        # A `PRESENT` record always carries its text; an empty or whitespace-only
+        # document fails to parse here, which is the intended `UNKNOWN`.
+        parsed = json.loads(record.text or "")
+    except json.JSONDecodeError:
+        return InstallOrigin(InstallKind.UNKNOWN)
+    if not isinstance(parsed, dict):
+        return InstallOrigin(InstallKind.UNKNOWN)
+    if "dir_info" not in parsed:
+        # A direct-URL install of an archive or a VCS clone: built, and what runs is
+        # a copy, so there is no checkout to report.
+        return InstallOrigin(InstallKind.WHEEL)
+    dir_info = parsed["dir_info"]
+    if not isinstance(dir_info, dict):
+        return InstallOrigin(InstallKind.UNKNOWN)
+    editable = dir_info.get("editable", False)
+    if editable is False:
+        return InstallOrigin(InstallKind.WHEEL)
+    if editable is not True:
+        # Truthiness is not the test: `"editable": "false"` and `"editable": 1` are
+        # both outside the spec, and guessing which side they fall on is how a
+        # mutable checkout gets reported as an immutable copy.
+        return InstallOrigin(InstallKind.UNKNOWN)
+    return InstallOrigin(InstallKind.EDITABLE, _recorded_source_root(parsed))
+
+
+def _recorded_source_root(direct_url: Optional[dict[str, Any]]) -> Optional[Path]:
+    """The local directory a PEP 610 record points at, if it names one.
+
+    PEP 610 records the origin as a URL; only a ``file:`` URL names a directory on
+    this machine, so anything else yields ``None`` and the checkout is reported as
+    unresolvable rather than guessed at.
+    """
+    if direct_url is None:
+        return None
+    url = direct_url.get("url")
+    if not isinstance(url, str):
+        return None
+    parsed = urlparse(url)
+    if parsed.scheme != "file":
+        return None
+    path = url2pathname(parsed.path)
+    return Path(path) if path else None
+
+
+# Git environment variables that redirect git at a repository OTHER than the one
+# ``-C`` names — ``$GIT_DIR`` in particular WINS over ``-C``. gda is invoked from
+# exactly the places that set them (a git hook, ``git rebase --exec``, ``git bisect
+# run``, a CI wrapper), where inheriting them would make this surface report another
+# repository's HEAD as this checkout's revision: a ``root`` and a ``revision`` from
+# different trees, silently, which is worse than the ``None`` this module promises
+# when an answer is unavailable. So they are dropped for the provenance calls.
+GIT_REDIRECT_ENV = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_COMMON_DIR",
+)
+
+
+def _git_env() -> dict[str, str]:
+    """The environment the provenance ``git`` calls run in."""
+    env = {k: v for k, v in os.environ.items() if k not in GIT_REDIRECT_ENV}
+    # A read-only preflight must never take (or wait on) the agent's own
+    # `index.lock`: `git status` would otherwise refresh the index on disk.
+    env["GIT_OPTIONAL_LOCKS"] = "0"
+    return env
+
+
+def _git_output(source_root: Path, *args: str) -> Optional[str]:
+    """Run ``git -C <source_root> <args>`` and return stdout, or ``None``.
+
+    ``None`` for every way the answer can be unavailable — ``git`` missing, the
+    root not being a repository, a non-zero exit, or the timeout — so a caller
+    reports "not resolvable" instead of guessing. ``-C`` gives the usual Git
+    meaning of "the repository containing this directory", so a source root nested
+    below the repository root still resolves — and :func:`_git_env` makes ``-C``
+    the only thing that decides which repository is read.
+    """
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(source_root), *args],
+            capture_output=True,
+            text=True,
+            timeout=GIT_TIMEOUT_SECONDS,
+            env=_git_env(),
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout
+
+
+def _source_checkout(source_root: Path) -> SourceCheckout:
+    """Describe ``source_root`` as a checkout, resolving Git state when possible."""
+    revision = _git_output(source_root, "rev-parse", "HEAD")
+    # `--untracked-files=all` on the command line, not left to the repository's
+    # `status.showUntrackedFiles`: with that set to `no`, an untracked module sitting
+    # in the checkout — importable by the editable install, and therefore code that
+    # can run — would leave `dirty` reading false. The flag makes the answer a
+    # property of the tree rather than of someone's git config.
+    status = _git_output(source_root, "status", "--porcelain", "--untracked-files=all")
+    return SourceCheckout(
+        root=str(source_root),
+        revision=revision.strip() if revision else None,
+        dirty=None if status is None else bool(status.strip()),
+    )
+
+
+def _running_executable() -> str:
+    """The absolute path of the ``gda`` entry point that is running.
+
+    ``sys.argv[0]`` is what actually started this process — the console script the
+    ``PATH`` lookup resolved, or the ``__main__`` module under ``python -m gda`` —
+    which is the fact GDA-DF-043 needed and which ``shutil.which("gda")`` would
+    only re-guess. Symlinks are left unresolved: the path that ran is the honest
+    answer, and resolving it would hide a shim.
+    """
+    raw = sys.argv[0] if sys.argv and sys.argv[0] else sys.executable
+    return os.path.abspath(raw)
+
+
+def _imported_package_path() -> str:
+    """The directory the running ``gda`` package was IMPORTED from.
+
+    Every other field is read from distribution metadata, which describes what an
+    installer recorded — not what Python actually loaded. A ``sys.path`` shadow (a
+    ``PYTHONPATH`` entry, a ``gda`` directory in the cwd) makes a wheel install
+    truthfully report ``wheel`` while the code that ran is a mutable source tree.
+    This module lives INSIDE the package, so its own ``__file__`` is that code's
+    address, and reporting it makes ``install_kind`` falsifiable rather than
+    something a reader has to take on trust.
+    """
+    return os.path.abspath(os.path.dirname(__file__))
+
+
+def build_version_provenance() -> VersionProvenance:
+    """Build the ``gda --version --json`` payload; never launches Godot."""
+    origin = classify_install(read_direct_url_record())
+    return VersionProvenance(
+        gda_version=package_version(DISTRIBUTION),
+        executable=_running_executable(),
+        interpreter=sys.executable,
+        package_path=_imported_package_path(),
+        install_kind=origin.kind,
+        # `source_root` is set only when the origin is an editable install naming a
+        # local directory — a wheel has no checkout, an unknown kind has none gda
+        # will vouch for, and an editable install recorded at a non-local URL has one
+        # that cannot be named. All three are honestly `null`, not a fabricated path.
+        source=_source_checkout(origin.source_root)
+        if origin.source_root is not None
+        else None,
+        godot=GodotProvenance(
+            binary=str(resolve_godot_binary()),
+            # No version, so the key is omitted and the reason takes its place.
+            version=None,
+            version_unavailable_reason=GODOT_VERSION_NEEDS_A_LAUNCH,
+        ),
+    )
+
+
+def render_version_line() -> str:
+    """The human one-liner ``gda --version`` prints without ``--json``."""
+    return f"gda {package_version(DISTRIBUTION)}"

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -8,10 +8,16 @@ exercised against a fake runner without touching a real engine (ADR-0001).
 
 import enum
 import json
+import os
+import shutil
 import subprocess
+import sys
+import tempfile
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Optional, Protocol
 
 # The codes the runner synthesizes when it never got a result from the engine.
 # Defined once in gda.exit_codes (the full exit-code ABI); imported here because
@@ -25,6 +31,11 @@ OPERATIONS_GD = Path(__file__).parent / "ops" / "operations.gd"
 # the CLI fails loudly instead of blocking forever.
 DEFAULT_TIMEOUT_SECONDS = 60.0
 
+# The environment variable naming a per-invocation user-data root, the env half of
+# the `--user-data-root` option (issue #653). Same flag > env precedence shape as
+# ``GDA_GODOT`` / ``GDA_PROJECT``.
+USER_DATA_ROOT_ENV = "GDA_USER_DATA_ROOT"
+
 
 class LaunchFailure(enum.Enum):
     """Why the runner never obtained a result from the engine (issue #15).
@@ -37,6 +48,11 @@ class LaunchFailure(enum.Enum):
 
     NOT_FOUND = "not_found"  # the binary could not be launched
     TIMEOUT = "timeout"  # launched, but did not return before the runner timeout
+    # The engine log target gda owns could not be created, so the launch was
+    # REFUSED rather than attempted: Godot's file logger dereferences a null
+    # ``FileAccess`` when it cannot open its log, dying with signal 11 before any
+    # project code runs (issue #653).
+    USER_DATA_UNWRITABLE = "user_data_unwritable"
 
 
 @dataclass
@@ -50,6 +66,332 @@ class RunResult:
     # out) instead of the engine returning one; ``None`` means the exit_code is
     # the engine's own (issue #15).
     launch_failure: "LaunchFailure | None" = None
+
+
+# The per-invocation user-data root the CLI resolved, or ``None`` for the engine
+# default. Process-wide because it is process-wide CONFIG, not an operation
+# parameter: it is set once from the root ``--user-data-root`` option (the same
+# hand-over shape as ``gda.headless.set_root_json``) and every later launch on any
+# channel inherits it, so no channel has to plumb it through the runner seam.
+#
+# ``None`` means the option was ABSENT. An empty string means it was given empty,
+# which is a different thing and must not collapse into absence — see
+# :func:`resolve_user_data_root`.
+_user_data_root_override: Optional[str] = None
+
+
+def set_user_data_root(value: Optional[str]) -> None:
+    """Record the root ``--user-data-root`` for every later :func:`launch`.
+
+    The write half of the option's contract, owned here beside the resolver that
+    reads it, so knowledge runs downward: the CLI composition root CALLS this to
+    hand the flag over instead of this module reaching up into it.
+
+    The value is stored VERBATIM, including an empty string: collapsing ``""`` to
+    ``None`` here would silently demote an explicit (if mistaken) flag to "absent"
+    and let ``$GDA_USER_DATA_ROOT`` win, inverting the documented flag > env
+    precedence.
+    """
+    global _user_data_root_override
+    _user_data_root_override = value
+
+
+def resolve_user_data_root(
+    explicit: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> Optional[Path]:
+    """Resolve the per-invocation user-data root: flag > env > engine default.
+
+    ``None`` — the common case — means gda redirects nothing but the engine log,
+    which it always owns (see :func:`user_data_placement`). Mirrors
+    :func:`gda.binary.resolve_godot_binary`'s precedence so the two environment
+    knobs read the same way, including how each treats an empty value: an explicit
+    but EMPTY flag raises, because an explicit value is a deliberate choice and an
+    empty one is a mistake we surface rather than silently override — whereas an
+    empty ENVIRONMENT variable falls through to the default, since an unset and a
+    blank variable are the same intent. Getting this wrong let an empty flag
+    silently hand precedence to the environment.
+
+    The root is ABSOLUTIZED, and it must be: gda and the engine do not share a
+    working directory, so a relative root would name two different places. gda
+    creates the log target relative to its OWN cwd, while the engine resolves the
+    relative ``--log-file`` against ``--path`` (and the export channel spawns with
+    ``cwd = <project>`` outright). The preflight would then pass for a file the
+    engine never opens, and the engine would die in ``rotate_file()`` on the file
+    it actually tried — reintroducing the very crash this machinery removes, plus
+    leaking an ``app_userdata`` tree into the project. A relative
+    ``XDG_DATA_HOME`` is ignored by the Linux engine outright
+    (``OS_LinuxBSD::get_data_path``), which would silently not redirect ``user://``
+    at all. Same bug class, and the same fix, as the export channel's ``--path``
+    (see ``gda.export_runner``, #344): ``absolute()`` rather than ``resolve()``, to
+    keep the codebase's symlink-agnostic path handling.
+    """
+    if env is None:
+        env = os.environ
+    given = explicit if explicit is not None else _user_data_root_override
+    if given is not None:
+        if not given:
+            raise ValueError("explicit --user-data-root is empty")
+        raw = given
+    else:
+        raw = env.get(USER_DATA_ROOT_ENV)
+        if not raw:
+            return None
+    return Path(raw).expanduser().absolute()
+
+
+def engine_data_path(
+    env: Optional[Mapping[str, str]] = None, platform: Optional[str] = None
+) -> Optional[Path]:
+    """The directory Godot resolves ``user://`` under, per the engine's own rules.
+
+    Mirrors the platform ``OS::get_data_path()`` implementations so a failure can
+    NAME the directory an agent has to make writable (issue #653) — verified
+    against the engine source:
+
+    - macOS: ``$HOME/Library/Application Support`` (``OS_MacOS::get_config_path``,
+      which ``get_data_path`` returns verbatim);
+    - Windows: ``%APPDATA%`` (``OS_Windows::get_data_path``);
+    - Linux/BSD: ``$XDG_DATA_HOME`` when it is an ABSOLUTE path, else
+      ``$HOME/.local/share`` (``OS_LinuxBSD::get_data_path``).
+
+    The engine then appends ``app_userdata/<project name>``; gda deliberately stops
+    at the root, which is the part that is unwritable in a restricted profile and
+    the part gda can name without parsing ``project.godot``. ``None`` when the
+    platform's variable is unset, so the caller reports "unknown" rather than a
+    fabricated path.
+    """
+    if env is None:
+        env = os.environ
+    if platform is None:
+        platform = sys.platform
+    if platform == "win32":
+        appdata = env.get("APPDATA")
+        return Path(appdata) if appdata else None
+    home = env.get("HOME")
+    if platform == "darwin":
+        return Path(home) / "Library" / "Application Support" if home else None
+    xdg = env.get("XDG_DATA_HOME")
+    if xdg and Path(xdg).is_absolute():
+        return Path(xdg)
+    return Path(home) / ".local" / "share" if home else None
+
+
+def data_path_env(root: Path, platform: Optional[str] = None) -> dict[str, str]:
+    """The child-environment overrides that move Godot's data path under ``root``.
+
+    Godot has NO ``--user-data-dir`` flag (verified against the engine source: the
+    spelling appears nowhere in ``main/`` or ``core/``), so the only per-invocation
+    lever on ``user://`` is the platform variable :func:`engine_data_path` reads.
+    Each platform therefore keeps its own layout UNDER ``root`` rather than
+    resolving to ``root`` itself — the contract is "user data lands under this
+    directory", and the resolved path is reported, never guessed at by the caller.
+    """
+    if platform is None:
+        platform = sys.platform
+    if platform == "win32":
+        return {"APPDATA": str(root)}
+    if platform == "darwin":
+        # macOS resolves the data path from $HOME alone, so HOME is the only lever.
+        return {"HOME": str(root)}
+    return {"XDG_DATA_HOME": str(root)}
+
+
+class UserDataUnwritable(OSError):
+    """gda could not make one launch's user-data placement usable (issue #653).
+
+    Carries the paths it actually RESOLVED and ATTEMPTED, so the refusal
+    diagnostics can name them instead of re-deriving or paraphrasing them. Either
+    may be ``None`` when the failure happened before that path was known — a
+    temporary directory that could not be created has no log path yet, so the
+    attempted *location* is reported instead.
+    """
+
+    def __init__(
+        self,
+        cause: str,
+        *,
+        data_path: Optional[Path] = None,
+        data_location: Optional[str] = None,
+        log_file: Optional[Path] = None,
+        log_location: Optional[str] = None,
+    ) -> None:
+        super().__init__(cause)
+        self.cause = cause
+        self.data_path = data_path
+        self.data_location = data_location
+        self.log_file = log_file
+        self.log_location = log_location
+
+
+@dataclass(frozen=True)
+class UserDataPlacement:
+    """Where ONE headless launch puts Godot's user data.
+
+    ``log_file`` is always gda-owned: the engine's default ``user://logs/godot.log``
+    is a per-project path shared by every concurrent invocation AND rotated
+    (``max_log_files`` 5), so two parallel runs contend over the same
+    rotation-sensitive file. ``--log-file`` both moves it per invocation and
+    disables rotation outright (``max_files = 1``, verified in ``Main::setup``).
+
+    ``env`` is the FULL child environment when a root redirects ``user://``, else
+    ``None`` to inherit gda's own.
+    """
+
+    log_file: Path
+    data_path: Optional[Path]
+    env: Optional[dict[str, str]]
+
+
+@contextmanager
+def user_data_placement(
+    root: Optional[Path] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> Iterator[UserDataPlacement]:
+    """Prepare — and preflight — one launch's user-data placement (issue #653).
+
+    Godot builds its file logger BEFORE it runs any project code, and
+    ``RotatedFileLogger`` dereferences the ``FileAccess`` it failed to open, so a
+    log target it cannot write kills the process with signal 11 in
+    ``rotate_file()`` — reported as a noisy ``engine_crashed`` backtrace rather
+    than the environment problem it is. gda therefore takes the log target over
+    and CREATES it here, before spawning: the creation IS the preflight, and it
+    fails as a typed :class:`UserDataUnwritable` instead of as a crash.
+
+    Without a ``root`` the log goes to a private temporary directory, removed on
+    exit — an isolated, writable target that keeps a read-only application-data
+    directory from being fatal at all, and gives concurrent invocations separate
+    files. Nothing else is preflighted in this mode, deliberately: the engine's own
+    ``user://`` location is none of gda's business when gda is not redirecting it,
+    and most commands never touch it.
+
+    With a ``root``, gda IS redirecting ``user://``, and so it owns that promise
+    too: the log lands at ``<root>/logs/godot.log``, the child's platform data
+    variable is overridden, and **the platform-derived data path is created and
+    probed as well**. Creating ``root`` alone is not enough — the engine appends a
+    platform layout to it (``<root>/Library/Application Support`` on macOS), and
+    that derived path can be unusable while ``root`` is perfectly writable, e.g.
+    blocked by a regular file. gda would then have preflighted only the log,
+    reported success, and left the script with an unopenable ``user://``.
+    """
+    if env is None:
+        env = os.environ
+    temp_root: Optional[str] = None
+    try:
+        try:
+            if root is None:
+                # A fully locked-down temporary directory makes this itself fail;
+                # it is inside the guard so that too is a typed refusal, not a
+                # traceback escaping the primitive. There is no log path to name
+                # yet, so the attempted LOCATION is carried instead.
+                try:
+                    temp_root = tempfile.mkdtemp(prefix="gda-log-")
+                except OSError as exc:
+                    raise UserDataUnwritable(
+                        str(exc),
+                        data_path=engine_data_path(env),
+                        log_location=(
+                            f"a private directory under {tempfile.gettempdir()}"
+                        ),
+                    ) from exc
+                log_file = Path(temp_root) / "godot.log"
+                child_env = None
+                data_path = engine_data_path(env)
+            else:
+                child_env = {**env, **data_path_env(root)}
+                log_file = root / "logs" / "godot.log"
+                data_path = engine_data_path(child_env)
+            try:
+                if root is not None and data_path is not None:
+                    _probe_data_path(data_path)
+                log_file.parent.mkdir(parents=True, exist_ok=True)
+                # Truncate-or-create: the probe that proves the engine's own
+                # ``FileAccess::open(..., WRITE)`` will succeed, and the same
+                # per-launch truncation the daemon does for a Session log (ADR-0022).
+                log_file.write_bytes(b"")
+            except OSError as exc:
+                raise UserDataUnwritable(
+                    str(exc), data_path=data_path, log_file=log_file
+                ) from exc
+        except UserDataUnwritable:
+            raise
+        yield UserDataPlacement(log_file=log_file, data_path=data_path, env=child_env)
+    finally:
+        if temp_root is not None:
+            shutil.rmtree(temp_root, ignore_errors=True)
+
+
+def _probe_data_path(data_path: Path) -> None:
+    """Create ``data_path`` and prove a subdirectory can be made inside it.
+
+    The ``user://`` half of the preflight, and it takes the same shape as the log
+    half — create the thing, do not merely inspect it — because that is what the
+    engine will do: ``OS::ensure_user_data_dir`` calls ``make_dir_recursive`` on
+    ``<data_path>/app_userdata/<project name>``. So the probe creates and removes a
+    throwaway directory rather than checking a permission bit, which would miss an
+    immutable flag, a full filesystem, or a read-only mount. Raises ``OSError`` for
+    the caller to map.
+    """
+    data_path.mkdir(parents=True, exist_ok=True)
+    probe = tempfile.mkdtemp(prefix=".gda-probe-", dir=data_path)
+    os.rmdir(probe)
+
+
+def _user_data_unwritable_stderr(
+    binary: Path, root: Optional[Path], failure: UserDataUnwritable
+) -> str:
+    """The diagnostics prose for a refused launch (issue #653).
+
+    Names the three paths an agent needs to act on — the resolved binary, the
+    directory Godot resolves ``user://`` under, and the log target gda tried to
+    create — plus whether gda is redirecting ``user://`` at all. The paths come
+    from the failure itself, which RESOLVED them: paraphrasing them here ("under
+    <root>", "a private temporary directory") named neither the platform-derived
+    data path the engine would use nor the file actually attempted, so a reader
+    could not act on either. Prose only: this text becomes
+    ``GdaError.diagnostics``, whose ADR-0004 shape is unchanged.
+    """
+    if failure.data_path is None and failure.data_location is not None:
+        # The placement was never prepared (an unresolvable root), so there is no
+        # resolved path to name — render the unavailable fields explicitly rather
+        # than dropping the three-path shape this diagnostic guarantees.
+        where_suffix = ""
+        remedy = (
+            "pass a non-empty --user-data-root directory (an explicit empty "
+            "value is refused rather than silently ignored, mirroring --godot)"
+        )
+    elif root is None:
+        where_suffix = " (engine default; gda is not redirecting user://)"
+        remedy = (
+            "gda redirects only the engine log by default, not user://; "
+            f"pass --user-data-root <writable dir> (or set {USER_DATA_ROOT_ENV}) "
+            "to place both the log and user:// under a writable directory"
+        )
+    else:
+        where_suffix = " (--user-data-root)"
+        remedy = (
+            f"gda redirects user:// under {root} for this invocation, so that "
+            "directory and the platform path derived from it must both be writable"
+        )
+    where = (
+        f"{failure.data_path}{where_suffix}"
+        if failure.data_path
+        else (failure.data_location or "unknown")
+    )
+    log_target = (
+        str(failure.log_file)
+        if failure.log_file is not None
+        else (failure.log_location or "unknown")
+    )
+    return (
+        "gda: Godot user data is not usable; the launch was refused before the "
+        "engine started\n"
+        f"gda:   binary:    {binary}\n"
+        f"gda:   user data: {where}\n"
+        f"gda:   log file:  {log_target}\n"
+        f"gda:   cause:     {failure.cause}\n"
+        f"gda: {remedy}.\n"
+    )
 
 
 def launch(
@@ -91,8 +433,68 @@ def launch(
       message is kept as advisory stderr to disambiguate which mode occurred;
     - otherwise → the engine's own ``returncode`` with ``launch_failure=None``,
       and stdout/stderr decoded as UTF-8 with ``errors="replace"`` (see below).
+
+    Every launch also carries gda's own ``--log-file`` (issue #653). The engine
+    builds its file logger before any project code runs and dies with signal 11 if
+    it cannot open the log, so gda owns that target: it is created (the preflight)
+    and passed explicitly, which keeps a read-only application-data directory from
+    being fatal and stops concurrent invocations sharing one rotated file. A target
+    gda cannot create is refused HERE as ``LaunchFailure.USER_DATA_UNWRITABLE``
+    rather than handed to the engine to crash on. ``--log-file`` precedes ``*args``
+    because it is an engine option and the sentinel channel's tail ends in the
+    ``--`` user-args separator.
     """
-    cmd = [str(binary), "--headless", *args]
+    try:
+        root = resolve_user_data_root()
+    except ValueError as exc:
+        # An explicit but empty --user-data-root. There is no placement to prepare,
+        # so it is the same unusable-placement outcome, reported before any spawn
+        # (mirrors how an empty --godot becomes binary_not_found, #33) — through
+        # the SHARED formatter, so the three-path diagnostic shape holds with the
+        # unavailable fields rendered explicitly.
+        refusal = UserDataUnwritable(
+            str(exc),
+            data_location="unresolved (--user-data-root is empty)",
+            log_location="not attempted (no placement was prepared)",
+        )
+        return RunResult(
+            stdout="",
+            stderr=_user_data_unwritable_stderr(binary, None, refusal),
+            exit_code=EXIT_NOT_FOUND,
+            launch_failure=LaunchFailure.USER_DATA_UNWRITABLE,
+        )
+    try:
+        with user_data_placement(root) as placement:
+            # Only the preparation above can raise UserDataUnwritable: the spawn
+            # itself maps every OSError to the NOT_FOUND result below.
+            return _spawn(
+                binary,
+                args,
+                cwd=cwd,
+                timeout=timeout,
+                timeout_label=timeout_label,
+                placement=placement,
+            )
+    except UserDataUnwritable as exc:
+        return RunResult(
+            stdout="",
+            stderr=_user_data_unwritable_stderr(binary, root, exc),
+            exit_code=EXIT_NOT_FOUND,
+            launch_failure=LaunchFailure.USER_DATA_UNWRITABLE,
+        )
+
+
+def _spawn(
+    binary: Path,
+    args: list[str],
+    *,
+    cwd: Path | None,
+    timeout: float,
+    timeout_label: str,
+    placement: UserDataPlacement,
+) -> RunResult:
+    """Run one prepared launch and normalize its outcome — see :func:`launch`."""
+    cmd = [str(binary), "--headless", "--log-file", str(placement.log_file), *args]
     try:
         # Capture raw bytes (no ``text=True``): Godot's ``JSON.stringify`` emits
         # UTF-8, but ``text=True`` would decode with the host locale, which
@@ -108,6 +510,10 @@ def launch(
             # channel resolves a relative output path against this CWD, and the
             # spawn shape stays byte-identical to the pre-#185 ``str(project)``.
             cwd=str(cwd) if cwd is not None else None,
+            # ``None`` (the common case) inherits gda's own environment; a full
+            # child environment is built only when ``--user-data-root`` overrides
+            # the platform variable Godot resolves ``user://`` from (#653).
+            env=placement.env,
         )
     except subprocess.TimeoutExpired:
         return RunResult(

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -114,6 +114,24 @@ specific scene instead of the project's main scene); the engine session launches
 the first live op. `screen capture` needs a windowed session
 (`gda daemon start --windowed`).
 
+A windowed session needs the host's real desktop session — an on-console GUI login on
+macOS, `$DISPLAY` / `$WAYLAND_DISPLAY` on Linux. Over SSH, on a headless CI box, or from
+a sandbox that blocks the window server, `daemon start --windowed` refuses before
+spawning Godot. Branch on the code, not the sentence:
+
+- `live_windowed_unavailable` — nothing refused the probe and no session is reachable, so
+  this host cannot show a window. Skip the rendered check; headless live ops (`game`,
+  `perf`, `input`, `diag`, `logger`) still work.
+- `live_windowed_permission_denied` — this process is not allowed to even look up the
+  window server (e.g. a sandbox). It does NOT mean the host has one: macOS refuses the
+  lookup before resolving it, so a broadly-confined process is refused either way. Re-run
+  outside the restriction to find out; do not record the machine as display-less on this
+  code alone.
+
+A refusal from `gda daemon start --windowed` carries `error.probe` `{name, platform}`
+naming the OS call that decided. The same codes relayed from an already-running daemon
+carry the code and message only.
+
 | Group | Commands |
 | ----- | -------- |
 | `daemon` | `start`, `stop`, `status`, `uninstall` (lifecycle; installs the in-game harness) |

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -27,6 +27,15 @@ debugging. `info` / `schema` / `skill` are top-level meta commands (no group).
   that project's autoloads at engine startup.
 - **Projectless** — meta commands and file-path-only operations run with no
   project; they resolve filesystem paths but not `res://`.
+- **Provenance** — `gda --version --json` reports which `gda` is running: its
+  version, the executable and interpreter paths, `package_path` (the directory the
+  running code was imported from), `install_kind` (`wheel`, `editable`, or
+  `unknown` when the install metadata cannot be read — gda will not guess), and,
+  for an editable install, the `source` checkout with its Git `revision` and
+  `dirty` flag. No Godot is spawned, so it also works where an engine spawn
+  fails. Run it first in a long session and keep the output: an editable install
+  can change revision under you mid-run, so this is what ties your results to the
+  code that produced them. Bare `gda --version` stays one human-readable line.
 
 ## Structured output & errors
 

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -36,6 +36,16 @@ debugging. `info` / `schema` / `skill` are top-level meta commands (no group).
   fails. Run it first in a long session and keep the output: an editable install
   can change revision under you mid-run, so this is what ties your results to the
   code that produced them. Bare `gda --version` stays one human-readable line.
+- **User data (headless runs)** — each headless run's engine log goes to a private
+  temporary file, so a read-only Godot application-data directory is not fatal and
+  concurrent runs never contend. If a script needs a writable `user://`, pass
+  `gda --user-data-root DIR <group> <command>` (or set `$GDA_USER_DATA_ROOT`) to
+  place the log and `user://` under `DIR`; a target `gda` cannot create is refused
+  as `user_data_unwritable` before the engine starts. Two limits: Godot reads the
+  **export templates** from that same directory, so a `release`/`debug`
+  `export run` under it reports none installed unless you put templates there —
+  `--mode pack` needs no templates and works normally; and live sessions are
+  unaffected either way — the daemon owns their log.
 
 ## Structured output & errors
 
@@ -50,7 +60,7 @@ Branch on the stable `category`/`code` and the **exit code**, never on prose:
 | Exit | Meaning |
 | ---- | ------- |
 | `0`   | success |
-| `127` | Godot binary not found |
+| `127` | environment unusable: `binary_not_found`, `user_data_unwritable`, `live_unsupported_platform`, `live_windowed_unavailable` |
 | `124` | engine timed out |
 | `3`   | engine version too old |
 | `4`   | operation-reported failure |

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -52,7 +52,12 @@ Some commands carry a verdict inside a successful result. For
 `gda script validate --json`, read the result's `valid` field: a script that does
 not compile exits `0` with no top-level `error`, and reports `valid=false` plus
 `error_string` / `diagnostics`. Do not treat exit `0` or the absence of an Error
-envelope as a pass for this command.
+envelope as a pass for this command. Check the result's `project_root` before you
+act on a `valid=false`: it names the project the script was compiled against, and
+a verdict full of missing-`res://` errors (plus the type errors derived from them)
+usually means the wrong project, not a broken script — `null` means no project was
+resolved at all. Pass `--project` for the project that owns the file and re-read
+the verdict.
 
 ## Discovery
 

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -44,7 +44,7 @@ debugging. `info` / `schema` / `skill` are top-level meta commands (no group).
   as `user_data_unwritable` before the engine starts. Two limits: Godot reads the
   **export templates** from that same directory, so a `release`/`debug`
   `export run` under it reports none installed unless you put templates there —
-  `--mode pack` needs no templates and works normally; and live sessions are
+  `--mode pack` needs no templates and works normally; and Engine sessions are
   unaffected either way — the daemon owns their log.
 
 ## Structured output & errors
@@ -60,7 +60,7 @@ Branch on the stable `category`/`code` and the **exit code**, never on prose:
 | Exit | Meaning |
 | ---- | ------- |
 | `0`   | success |
-| `127` | environment unusable: `binary_not_found`, `user_data_unwritable`, `live_unsupported_platform`, `live_windowed_unavailable` |
+| `127` | environment unusable: `binary_not_found`, `user_data_unwritable`, `live_unsupported_platform`, `live_windowed_unavailable`, `live_windowed_permission_denied` |
 | `124` | engine timed out |
 | `3`   | engine version too old |
 | `4`   | operation-reported failure |
@@ -129,8 +129,9 @@ spawning Godot. Branch on the code, not the sentence:
   code alone.
 
 A refusal from `gda daemon start --windowed` carries `error.probe` `{name, platform}`
-naming the OS call that decided. The same codes relayed from an already-running daemon
-carry the code and message only.
+naming the OS call that decided — including when the refusal is relayed from an
+already-running daemon's lazy Engine-session launch; only the outer
+`{stdout, stderr, exit_code}` transport shape is probe-less.
 
 | Group | Commands |
 | ----- | -------- |

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -81,7 +81,7 @@ two spellings are still usage errors (exit `2`) — `gda <group> --json` (a grou
 | ----- | -------- |
 | `scene` | `create`, `get`, `list`, `get-exports`, `delete` (`.tscn` files) |
 | `node` | `add`, `get`, `list`, `set`, `remove`, `duplicate`, `move`, `connect-signal`, `disconnect-signal` (nodes within a scene) |
-| `script` | `create`, `get`, `list`, `set`, `delete`, `attach`, `validate`, `run` (`.gd` files; `run` executes a `res://` script one-shot and passes its `exit_status`/`stdout`/`stderr` through — a non-zero `quit()` is still success, so read `exit_status`, or pass `--strict` to get a `script_failed` failure (exit 4) whose `diagnostics` carries the script's own stdout and stderr; a script that never ran — missing, or a failed parse/compile — always fails) |
+| `script` | `create`, `get`, `list`, `set`, `delete`, `attach`, `validate`, `run` (`.gd` files; `run` executes a project script one-shot (address it project-relative or as `res://` — the two portable forms, which `script validate` takes too; `run` alone refuses absolute paths) and passes its `exit_status`/`stdout`/`stderr` through — a non-zero `quit()` is still success, so read `exit_status`, or pass `--strict` to get a `script_failed` failure (exit 4) whose `diagnostics` carries the script's own stdout and stderr; a script that never ran — missing, or a failed parse/compile — always fails) |
 | `project` | `info`, `get`, `set`, `list`, `add-autoload`, `remove-autoload`, `add-input-action`, `remove-input-action`, `find-references`, `dependencies`, `find-unused-resources`, `statistics` |
 | `resource` | `create`, `get`, `set`, `delete`, `uid` (`.tres` files) |
 | `export` | `list`, `get`, `run` (export a preset by name; `--mode` release/debug/pack) |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,3 +118,17 @@ def daemon_runtime_dir(monkeypatch):
     monkeypatch.setenv("XDG_RUNTIME_DIR", runtime)
     yield Path(runtime)
     shutil.rmtree(runtime, ignore_errors=True)
+
+
+@pytest.fixture
+def windowed_host():
+    """Gate a test that needs a real windowed engine session (#345, #667).
+
+    A fixture rather than a ``skipif`` marker because the reaction is not uniform: a
+    confined run must FAIL, and a ``skipif`` can only skip. The policy itself lives in
+    one place (``tests.support.require_windowed_host``), shared with the post-start
+    race path so both cannot drift apart again.
+    """
+    from tests.support import require_windowed_host
+
+    require_windowed_host()

--- a/tests/support.py
+++ b/tests/support.py
@@ -767,8 +767,11 @@ def require_windowed_host():
     verdict = windowed_unavailable()
     if verdict is None:
         return
-    if verdict.code == WINDOWED_PERMISSION_DENIED_CODE:
-        pytest.fail(_CONFINED_REMEDIATION.format(detail=verdict.reason))
+    # ONE cascade owner per root: delegate to handle_no_display_code so the
+    # cross-root parity test covers the preflight too (PR #702 recheck). The
+    # trailing skip is the conservative fallback for a verdict code the handler
+    # does not classify — a non-None verdict must never proceed to a spawn.
+    handle_no_display_code(verdict.code, verdict.reason)
     pytest.skip(verdict.reason)
 
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -701,3 +701,101 @@ INPUT_SEQUENCE_RESULT = {
     "events": 3,
     "frames": 5,
 }
+
+
+# --- The windowed-display test gate (#345, #667) -----------------------------
+#
+# One owner PER PYTEST ROOT for the reaction policy, because the reaction is NOT
+# uniform and scattered per-test sets are what let the wrong one spread: the gates
+# used to skip on every no-display code, so a confined run greened the suite with
+# the rendered acceptance unexecuted — the exact GDA-DF-029 behaviour #667 exists
+# to stop. A second, deliberate copy of this policy lives in
+# examples/platformer/panda-adventure/tests/display_gate.py (a separate pytest
+# root that cannot import this package) — keep the two in step when editing
+# either side.
+#
+# The two reactions, and why they differ:
+#
+# - CAPABILITY (`live_windowed_unavailable`, `live_display_unavailable`): the host
+#   genuinely cannot show a window. There is nothing to run, so SKIP is honest and a
+#   visible `-rs` line records it.
+# - PERMISSION (`live_windowed_permission_denied`): the host may well be able to —
+#   this RUN is confined. The verdict is about the whole environment, not a
+#   momentary display state, so it cannot be waited out or retried into passing.
+#   Skipping would hide unexecuted rendered acceptance behind a green suite, so it
+#   FAILS, carrying the remediation the error itself gives: re-run outside the
+#   restriction.
+WINDOWED_CAPABILITY_CODES = frozenset(
+    {"live_windowed_unavailable", "live_display_unavailable"}
+)
+WINDOWED_PERMISSION_DENIED_CODE = "live_windowed_permission_denied"
+
+_CONFINED_REMEDIATION = (
+    "the windowed session was refused because this RUN is confined "
+    "({detail}). Rendered acceptance did NOT execute; this is a loud failure "
+    "rather than a skip so a sandboxed run cannot green the suite with it "
+    "unexecuted (#667). Re-run outside the sandbox/restriction."
+)
+
+
+def handle_no_display_code(code, detail=""):
+    """Apply the reaction policy to a gda error ``code``, if it is a display refusal.
+
+    Skips on a capability refusal, FAILS on a permission refusal, and returns
+    normally for anything else so the caller can raise its own assertion. Used on the
+    post-start race path, where a live call reports the refusal even though the
+    pre-flight probe passed.
+    """
+    import pytest
+
+    if code == WINDOWED_PERMISSION_DENIED_CODE:
+        pytest.fail(_CONFINED_REMEDIATION.format(detail=detail or code))
+    if code in WINDOWED_CAPABILITY_CODES:
+        pytest.skip(f"windowed session unavailable in this environment ({code})")
+
+
+def require_windowed_host():
+    """Pre-flight the host display probe with the same reaction policy.
+
+    ``None`` verdict → return and run the test. A capability verdict → skip. A
+    permission verdict → fail: a confined run must be loud, not green.
+    """
+    import pytest
+
+    from gda.display import windowed_unavailable
+
+    verdict = windowed_unavailable()
+    if verdict is None:
+        return
+    if verdict.code == WINDOWED_PERMISSION_DENIED_CODE:
+        pytest.fail(_CONFINED_REMEDIATION.format(detail=verdict.reason))
+    pytest.skip(verdict.reason)
+
+
+def gda_error_code(stdout):
+    """The ``error.code`` of a gda ``--json`` failure envelope, or ``None``."""
+    try:
+        return json.loads(stdout).get("error", {}).get("code")
+    except (ValueError, AttributeError):
+        return None
+
+
+def assert_windowed_ok(result):
+    """Assert a windowed-tier command succeeded, applying the display policy FIRST.
+
+    The post-start race path for the repo's own e2e tiers. A windowed session can be
+    refused *after* the pre-flight probe passed — the daemon re-checks at its
+    authoritative launch boundary, and a live op can hit that on the lazy launch — and
+    when it is, the reaction has to be the SAME one the pre-flight would have applied:
+    a capability refusal skips, a permission refusal fails loudly with the
+    remediation. Asserting ``returncode == 0`` straight away instead turned a
+    capability verdict into a false RED here while the game's tiers skipped on it —
+    one verdict, two meanings (#667 recheck).
+
+    Anything that is not a display refusal falls through to the ordinary assertion,
+    so a real regression still fails with the command's own output.
+    """
+    if result.returncode != 0:
+        handle_no_display_code(gda_error_code(result.stdout))
+    assert result.returncode == 0, result.stdout + result.stderr
+    return result

--- a/tests/test_command_descriptor_registry.py
+++ b/tests/test_command_descriptor_registry.py
@@ -153,6 +153,12 @@ _RECIPE_OPERATIONS = {
     # run, fulfilled by a CLI-side recipe (it emits no ADR-0002 sentinel) like export
     # run, so it carries a recipe rather than routing to `cmd.emit`.
     "script-run",
+    # `script validate` is the one recipe that still RUNS the sentinel op (via
+    # `cmd.execute`, as the export recipe does for its preflight): it carries a
+    # recipe because the outside-the-project refusal and the `project_root` on its
+    # result are decided from ADR-0006's CLI-resolved project, which `cmd.emit`
+    # does not expose to a command (#658).
+    "script-validate",
     "daemon-start",
     "daemon-stop",
     "daemon-status",

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -19,7 +19,9 @@ from typer.testing import CliRunner
 
 import gda.commands.daemon as daemon_ops
 from gda.cli import app
+from gda.display import WindowedUnavailable
 from gda.errors import Failure
+from gda.models import EnvironmentProbe
 from gda.harness.install import (
     HARNESS_FILE,
     HARNESS_RES_DIR,
@@ -37,6 +39,24 @@ from gda.commands.daemon import (
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
 _OK_VERSION = lambda binary: (4, 6)  # noqa: E731
+
+
+def _unavailable(
+    code: str = "live_windowed_unavailable",
+    name: str = "CGSessionCopyCurrentDictionary",
+    platform: str = "darwin",
+) -> WindowedUnavailable:
+    """A fake host-probe verdict (#345, #667).
+
+    The refusal mapping is a pure function of this verdict, so injecting one covers
+    BOTH windowed outcomes on ANY host — no display, no sandbox, and no capability
+    gate needed. The real probe is proven separately against a real sandbox.
+    """
+    return WindowedUnavailable(
+        code=code,
+        reason=f"no windowed session here (test: {code})",
+        probe=EnvironmentProbe(name=name, platform=platform),
+    )
 
 
 def _project(tmp_path):
@@ -231,7 +251,7 @@ def test_windowed_start_without_a_display_is_live_windowed_unavailable(
         windowed=True,
         spawn=lambda p, b, w, s: spawned.append((p, b, w, s)),
         version_check=_OK_VERSION,
-        display_check=lambda: "no usable DisplayServer (test)",
+        display_check=lambda: _unavailable(),
     )
 
     assert isinstance(outcome, Failure), outcome
@@ -241,6 +261,87 @@ def test_windowed_start_without_a_display_is_live_windowed_unavailable(
     assert spawned == []  # never spawned Godot
     # Pre-harness-install too: a doomed windowed start must not mutate the project.
     assert not (project / HARNESS_RES_DIR / HARNESS_FILE).exists()
+    # #667: the deciding host call rides the envelope as DATA, not only as prose.
+    assert outcome.error.probe is not None
+    assert outcome.error.probe.name == "CGSessionCopyCurrentDictionary"
+    assert outcome.error.probe.platform == "darwin"
+
+
+def test_windowed_start_denied_by_a_sandbox_is_a_distinct_permission_code(
+    tmp_path, short_runtime, monkeypatch
+):
+    # #667 (dogfooding GDA-DF-029): a windowed start refused because THIS PROCESS may
+    # denied the window-server lookup is NOT the same failure as a host where none was
+    # detected. It
+    # reports the distinct live_windowed_permission_denied so automation retries
+    # outside the sandbox instead of recording the machine as display-less — while
+    # keeping the ENVIRONMENT/127 bucket of its sibling (the refusal is the same
+    # pre-launch refusal). Ungated: the verdict is injected, so this runs on every
+    # host including a display-less CI runner.
+    project = _project(tmp_path)
+    monkeypatch.setattr(daemon_ops, "daemon_pid", lambda paths: None)
+    spawned: list = []
+
+    outcome = daemon_ops.run_daemon_start_operation(
+        project,
+        None,
+        windowed=True,
+        spawn=lambda p, b, w, s: spawned.append((p, b, w, s)),
+        version_check=_OK_VERSION,
+        display_check=lambda: _unavailable(
+            code="live_windowed_permission_denied",
+            name="bootstrap_look_up(com.apple.windowserver.active)",
+        ),
+    )
+
+    assert isinstance(outcome, Failure), outcome
+    assert outcome.error.code == "live_windowed_permission_denied"
+    # Deliberately NOT live_display_unavailable (the harness's capture-time code) and
+    # NOT live_windowed_unavailable (the machine-capability verdict).
+    assert outcome.error.category.value == "environment"
+    assert outcome.exit_code == 127  # the same bucket as live_windowed_unavailable
+    assert spawned == []  # still refused pre-launch, still no project mutation
+    assert not (project / HARNESS_RES_DIR / HARNESS_FILE).exists()
+    assert outcome.error.probe is not None
+    assert (
+        outcome.error.probe.name == "bootstrap_look_up(com.apple.windowserver.active)"
+    )
+    assert outcome.error.probe.platform == "darwin"
+
+
+def test_windowed_refusal_json_carries_the_probe_and_others_are_unchanged(tmp_path):
+    # #667 / the ADR-0004 amendment: `probe` is emitted for a failure that HAS one and
+    # OMITTED entirely — not `null` — for every failure that does not, so each other
+    # code's envelope JSON stays byte-identical to before the field existed.
+    from gda.errors import make_failure
+    from gda.models import GdaErrorEnvelope
+
+    with_probe = make_failure(
+        "live_windowed_permission_denied",
+        "denied",
+        "",
+        probe=EnvironmentProbe(name="bootstrap_look_up(x)", platform="darwin"),
+    )
+    without = make_failure("binary_not_found", "nope", "")
+
+    with_json = json.loads(
+        GdaErrorEnvelope(error=with_probe.error).model_dump_json(exclude_none=True)
+    )
+    without_json = json.loads(
+        GdaErrorEnvelope(error=without.error).model_dump_json(exclude_none=True)
+    )
+
+    assert with_json["error"]["probe"] == {
+        "name": "bootstrap_look_up(x)",
+        "platform": "darwin",
+    }
+    assert "probe" not in without_json["error"]
+    assert set(without_json["error"]) == {
+        "category",
+        "code",
+        "message",
+        "diagnostics",
+    }
 
 
 def test_headless_start_never_consults_the_display_check(

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -14,6 +14,8 @@ import pytest
 from gda.daemon.discovery import daemon_paths
 from gda.daemon.server import DaemonServer
 from gda.daemon.session import EngineSession
+from gda.display import WindowedUnavailable
+from gda.models import EnvironmentProbe
 from gda.commands.daemon import (
     run_daemon_status_operation,
     run_daemon_stop_operation,
@@ -27,6 +29,18 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 class _FakeProc:
     def poll(self):
         return None
+
+
+def _unavailable(
+    code: str = "live_windowed_unavailable",
+    name: str = "CGSessionCopyCurrentDictionary",
+) -> WindowedUnavailable:
+    """A fake host-probe verdict, so the relay is covered on any host (#345, #667)."""
+    return WindowedUnavailable(
+        code=code,
+        reason=f"no usable DisplayServer (test: {code})",
+        probe=EnvironmentProbe(name=name, platform="darwin"),
+    )
 
 
 def test_live_op_without_a_launchable_session_is_engine_session_not_running(tmp_path):
@@ -223,7 +237,7 @@ def test_windowed_no_display_is_live_windowed_unavailable_without_launching(
         daemon_paths(tmp_path),
         godot="godot",
         windowed=True,
-        display_check=lambda: "no usable DisplayServer (test)",
+        display_check=lambda: _unavailable(),
     )
     server._harness_listener = cast(socket.socket, object())
 
@@ -233,8 +247,66 @@ def test_windowed_no_display_is_live_windowed_unavailable_without_launching(
     error = parse_result(reply["stdout"])["error"]
     assert error["code"] == "live_windowed_unavailable"
     # The probe's reason rides the advisory diagnostics (existing stderr) field.
-    assert "no usable DisplayServer (test)" in reply["stderr"]
+    assert "no usable DisplayServer (test" in reply["stderr"]
     assert server._session is None  # nothing launched or cached
+
+
+def test_windowed_denied_relays_the_permission_code_not_the_capability_one(
+    tmp_path, monkeypatch
+):
+    # #667: the launch-boundary guard relays the code the PROBE decided, so a sandbox
+    # denial reaching the daemon path is reported as live_windowed_permission_denied
+    # rather than collapsing into live_windowed_unavailable. This is the
+    # AUTHORITATIVE refusal (it fires on the lazy launch every live op goes through),
+    # so it also carries the machine-readable `probe` — deliberately widening the live
+    # wire envelope with that ONE optional key (#667 review), rather than reporting
+    # less here than the optional CLI fail-fast reports.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+
+    def _must_not_launch(*a, **k):
+        raise AssertionError("launch_session must not be called with no usable display")
+
+    monkeypatch.setattr("gda.daemon.server.launch_session", _must_not_launch)
+    server = DaemonServer(
+        daemon_paths(tmp_path),
+        godot="godot",
+        windowed=True,
+        display_check=lambda: _unavailable(code="live_windowed_permission_denied"),
+    )
+    server._harness_listener = cast(socket.socket, object())
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+    assert reply is not None
+
+    error = parse_result(reply["stdout"])["error"]
+    assert error["code"] == "live_windowed_permission_denied"
+    # The one deliberate wire widening: `probe` rides the live envelope as data.
+    assert set(error) == {"code", "message", "probe"}
+    assert error["probe"] == {
+        "name": "CGSessionCopyCurrentDictionary",
+        "platform": "darwin",
+    }
+    assert "live_windowed_permission_denied" in reply["stderr"]
+    assert server._session is None
+
+
+def test_a_relayed_refusal_without_a_probe_keeps_the_narrow_wire_shape(
+    tmp_path, monkeypatch
+):
+    # The widening is OPTIONAL: every live reply that has no probe — which is all of
+    # them except the windowed refusals — is byte-identical to before, so the key can
+    # never appear as a null for the harness-emitted and daemon-synthesized codes.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    monkeypatch.setattr("gda.daemon.server.launch_session", lambda *a, **k: None)
+    server = DaemonServer(daemon_paths(tmp_path), godot="godot")
+    server._harness_listener = cast(socket.socket, object())
+
+    reply = server._handle({"op": "game-tree", "params": {}})
+    assert reply is not None
+
+    error = parse_result(reply["stdout"])["error"]
+    assert error["code"] == "engine_session_not_running"
+    assert set(error) == {"code", "message"}
 
 
 def test_windowed_with_a_usable_display_reaches_launch(tmp_path, monkeypatch):
@@ -272,7 +344,7 @@ def test_headless_windowed_false_never_consults_the_display_check(
     # session needs no window server; only a windowed session is gated.
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
 
-    def _boom() -> str:
+    def _boom() -> WindowedUnavailable | None:
         raise AssertionError("a headless daemon must not run the display check")
 
     monkeypatch.setattr("gda.daemon.server.launch_session", lambda *a, **k: None)

--- a/tests/test_display_probe.py
+++ b/tests/test_display_probe.py
@@ -1,0 +1,470 @@
+"""The host-display probe's verdict logic (#345, #667).
+
+``gda.display`` answers ONE question with two possible refusals, and the split is
+what #667 is about: "no window server was detected here" (skip rendered QA) versus
+"the window-server lookup was REFUSED" (re-run outside the restriction). Reading the
+second as the first is the dogfooded defect (GDA-DF-029). The second refusal claims
+nothing about whether a window server exists — macOS refuses the lookup per name and
+before resolving it — so a guard below pins that no branch reasserts existence.
+
+Tiering follows from where the risk is:
+
+- The **verdict logic** — which code, which probe name, which platform — is a pure
+  function of the host answers, so it is tested by injecting those answers. UNGATED:
+  it runs on every host, including a display-less CI runner, which is exactly where a
+  regression would otherwise hide.
+- The **real macOS denial probe** needs a real sandbox to mean anything, so that one
+  leg is capability-gated on macOS + a working ``sandbox-exec`` + an actual desktop
+  session, and skips honestly elsewhere.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gda.display import (
+    _DENIAL_BLANKET,
+    _DENIAL_NAME_SPECIFIC,
+    _DENIAL_UNKNOWN_BREADTH,
+    WindowedUnavailable,
+    _linux_verdict,
+    _macos_verdict,
+    _macos_window_server_denial,
+    windowed_unavailable,
+)
+
+# --- the verdict logic (ungated) --------------------------------------------
+
+
+def test_macos_with_a_window_server_can_launch_windowed(monkeypatch):
+    monkeypatch.setattr("gda.display._macos_has_window_server", lambda: True)
+    # The denial probe must not even run on the success path: a healthy desktop pays
+    # nothing for the #667 split.
+    monkeypatch.setattr(
+        "gda.display._macos_window_server_denial",
+        lambda: pytest.fail("the denial probe ran on the success path"),
+    )
+
+    assert _macos_verdict() is None
+
+
+def test_macos_without_a_window_server_is_the_capability_verdict(monkeypatch):
+    # CGSession said NULL and nothing denied us: as far as gda can tell the host has
+    # no GUI session (SSH / CI / headless). The capability code, naming CGSession as
+    # the probe that decided it.
+    monkeypatch.setattr("gda.display._macos_has_window_server", lambda: False)
+    monkeypatch.setattr("gda.display._macos_window_server_denial", lambda: None)
+
+    verdict = _macos_verdict()
+
+    assert verdict is not None
+    assert verdict.code == "live_windowed_unavailable"
+    assert verdict.probe.name == "CGSessionCopyCurrentDictionary"
+    assert verdict.probe.platform == sys.platform
+    # The remaining ambiguity is disclosed rather than hidden: a sandbox that HIDES
+    # the window server (rather than refusing the lookup) lands here too.
+    assert "outside the sandbox" in verdict.reason
+    # F5: the actionable remediation the pre-#667 message carried is still here.
+    assert "Run the daemon headless" in verdict.reason
+
+
+@pytest.mark.parametrize(
+    ("denial", "expected_breadth"),
+    [
+        (_DENIAL_NAME_SPECIFIC, "specific to that service"),
+        (_DENIAL_BLANKET, "broadly confined"),
+        (_DENIAL_UNKNOWN_BREADTH, "stays unknown"),
+    ],
+)
+def test_macos_denied_window_server_is_the_permission_verdict(
+    monkeypatch, denial, expected_breadth
+):
+    # CGSession said NULL and the window-server lookup was REFUSED. Both control
+    # outcomes take the permission code with the same probe name; they differ only in
+    # how much confinement the probe could honestly characterise.
+    monkeypatch.setattr("gda.display._macos_has_window_server", lambda: False)
+    monkeypatch.setattr("gda.display._macos_window_server_denial", lambda: denial)
+
+    verdict = _macos_verdict()
+
+    assert verdict is not None
+    assert verdict.code == "live_windowed_permission_denied"
+    assert verdict.probe.name == "bootstrap_look_up(com.apple.windowserver.active)"
+    assert verdict.probe.platform == sys.platform
+    assert expected_breadth in verdict.reason
+    assert "re-run outside the" in verdict.reason
+
+
+@pytest.mark.parametrize(
+    "denial", [_DENIAL_NAME_SPECIFIC, _DENIAL_BLANKET, _DENIAL_UNKNOWN_BREADTH]
+)
+def test_no_denial_branch_claims_the_host_has_a_window_server(monkeypatch, denial):
+    # The #667-review regression guard. A refused lookup is evaluated per name and
+    # BEFORE resolution, so it proves confinement, NOT existence — a blanket-deny
+    # profile on a display-less CI Mac lands here too. Neither branch may tell the
+    # caller the host HAS a window server, and both must say gda cannot tell.
+    monkeypatch.setattr("gda.display._macos_has_window_server", lambda: False)
+    monkeypatch.setattr("gda.display._macos_window_server_denial", lambda: denial)
+
+    verdict = _macos_verdict()
+    assert verdict is not None
+    reason = verdict.reason
+
+    # The claim is explicitly negated: gda says it CANNOT tell.
+    assert (
+        "cannot tell from a refused lookup whether this host HAS a window server"
+        in reason
+    )
+    # And none of the affirmative phrasings — including the exact sentence the
+    # original implementation shipped — may reappear.
+    for forbidden in (
+        "The host itself HAS a window server",
+        "is a permission boundary, not a missing display",
+        "HAS a window server, so",
+    ):
+        assert forbidden not in reason
+
+
+@pytest.mark.parametrize(
+    ("target", "control", "expected"),
+    [
+        # The window server refused, a name nobody registers resolved normally: the
+        # denial is specific to that service — the sandbox-profile signature.
+        (1100, 1102, _DENIAL_NAME_SPECIFIC),
+        # BOTH refused. Seatbelt evaluates the deny per name and before resolution,
+        # so this is a broadly-confined process and the probe learned only that.
+        (1100, 1100, _DENIAL_BLANKET),
+        # Control answered something we have no reading for. Only a REFUSED control
+        # licenses the blanket reading, so these must NOT be folded into it — that
+        # would invent a fact about the confinement from an unreadable result.
+        (1100, 0, _DENIAL_UNKNOWN_BREADTH),  # the control name somehow resolved
+        (1100, 5, _DENIAL_UNKNOWN_BREADTH),  # an arbitrary unrelated error
+        # Not refused at all -> no denial evidence, whatever the control says.
+        (1102, 1102, None),
+        (0, 1102, None),
+    ],
+)
+def test_the_control_lookup_characterises_the_denial(target, control, expected):
+    # Ungated: the status -> breadth mapping is handed a fake lookup, so it runs on
+    # any host including a Linux CI runner with no libSystem.
+    from gda.display import _CONTROL_SERVICE, _WINDOW_SERVER_SERVICE, _classify_denial
+
+    statuses = {_WINDOW_SERVER_SERVICE: target, _CONTROL_SERVICE: control}
+
+    assert _classify_denial(lambda name: statuses[name]) is expected
+
+
+def test_the_control_lookup_is_skipped_when_the_target_was_not_refused():
+    # The control costs a second mach round-trip, so it must only run once the
+    # target has actually been refused.
+    from gda.display import _WINDOW_SERVER_SERVICE, _classify_denial
+
+    asked: list[bytes] = []
+
+    def _lookup(name: bytes) -> int:
+        asked.append(name)
+        return 0
+
+    assert _classify_denial(_lookup) is None
+    assert asked == [_WINDOW_SERVER_SERVICE]
+
+
+def test_the_denial_probe_falls_back_when_it_cannot_run(monkeypatch):
+    # The denial probe is best-effort private-ish plumbing (a libSystem symbol). If it
+    # cannot run at all — a future macOS drops the symbol, ctypes misbehaves — the
+    # refusal must behave exactly as it did before the probe existed, never crash a
+    # `daemon start`.
+    def _explode():
+        raise OSError("no libSystem here")
+
+    monkeypatch.setattr("gda.display.ctypes.CDLL", lambda _path: _explode())
+    assert _macos_window_server_denial() is None
+
+    monkeypatch.setattr("gda.display._macos_has_window_server", lambda: False)
+    fallback = _macos_verdict()
+    assert fallback is not None
+    assert fallback.code == "live_windowed_unavailable"
+
+
+@pytest.mark.parametrize("variable", ["DISPLAY", "WAYLAND_DISPLAY"])
+def test_linux_with_a_display_can_launch_windowed(monkeypatch, variable):
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.setenv(variable, ":0")
+
+    assert _linux_verdict() is None
+
+
+def test_linux_without_a_display_is_the_capability_verdict(monkeypatch):
+    # No permission split on Linux: the environment variables are readable under any
+    # confinement, so an unset pair always means "no display to reach".
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+
+    verdict = _linux_verdict()
+
+    assert verdict is not None
+    assert verdict.code == "live_windowed_unavailable"
+    assert verdict.probe.name == "$DISPLAY / $WAYLAND_DISPLAY"
+
+
+def test_the_verdict_carries_a_registered_error_code():
+    # Whatever the probe decides must be a code the failure builder accepts — the
+    # refusal sites pass `verdict.code` straight into `make_failure`.
+    from gda.error_codes import ERROR_CODE_BY_CODE
+
+    for code in ("live_windowed_unavailable", "live_windowed_permission_denied"):
+        spec = ERROR_CODE_BY_CODE[code]
+        assert spec.category.value == "environment"
+        assert spec.exit_code == 127
+
+
+# --- the real macOS denial probe (capability-gated) --------------------------
+
+# Denies ONLY the window-server name: everything else, including an unregistered
+# control name, still resolves. The sandbox-profile signature.
+_NAME_SPECIFIC_PROFILE = (
+    "(version 1)\n"
+    "(allow default)\n"
+    '(deny mach-lookup (global-name "com.apple.windowserver.active"))\n'
+)
+
+# Denies every mach-lookup. The case that falsified the original spike claim: the
+# control name is refused too, so the refusal says nothing about what exists.
+_BLANKET_PROFILE = (
+    "(version 1)\n"
+    "(deny default)\n"
+    "(allow process*)\n"
+    "(allow file*)\n"
+    "(allow sysctl*)\n"
+    "(allow signal)\n"
+    "(allow ipc-posix-shm)\n"
+)
+
+_PROBE_SCRIPT = textwrap.dedent(
+    """
+    import json
+    from gda.display import windowed_unavailable
+    verdict = windowed_unavailable()
+    from gda.display import _macos_window_server_denial
+    print(json.dumps(
+        None if verdict is None
+        else {
+            "code": verdict.code,
+            "probe": verdict.probe.name,
+            "denial": _macos_window_server_denial(),
+            "claims_existence": "cannot tell from a refused lookup" not in verdict.reason,
+        }
+    ))
+    """
+)
+
+
+def _sandbox_exec_works(tmp_path: Path) -> bool:
+    """Can this host actually run a seatbelt profile? (else the leg is meaningless)"""
+    if sys.platform != "darwin" or shutil.which("sandbox-exec") is None:
+        return False
+    profile = tmp_path / "preflight.sb"
+    profile.write_text("(version 1)\n(allow default)\n", encoding="utf-8")
+    try:
+        probe = subprocess.run(
+            ["sandbox-exec", "-f", str(profile), "/usr/bin/true"],
+            capture_output=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return probe.returncode == 0
+
+
+def _verdict_under(profile: Path | None, tmp_path: Path) -> dict | None:
+    script = tmp_path / "probe.py"
+    script.write_text(_PROBE_SCRIPT, encoding="utf-8")
+    argv = [sys.executable, str(script)]
+    if profile is not None:
+        argv = ["sandbox-exec", "-f", str(profile), *argv]
+    run = subprocess.run(argv, capture_output=True, text=True, timeout=60)
+    assert run.returncode == 0, f"probe failed: {run.stderr}"
+    return json.loads(run.stdout.strip())
+
+
+@pytest.mark.parametrize(
+    ("profile_body", "expected_denial"),
+    [
+        (_NAME_SPECIFIC_PROFILE, _DENIAL_NAME_SPECIFIC),
+        (_BLANKET_PROFILE, _DENIAL_BLANKET),
+    ],
+)
+def test_a_real_sandbox_denial_is_classified_as_a_permission_problem(
+    tmp_path, profile_body, expected_denial
+):
+    # The end-to-end proof against a REAL seatbelt sandbox rather than a fake: on a
+    # host that HAS a desktop session, a refused window-server lookup must flip the
+    # verdict to the permission code — not to live_windowed_unavailable, which is
+    # what the dogfooding saw and what made automation record the machine as
+    # display-less.
+    #
+    # Both profiles are exercised because they are the two halves of the corrected
+    # finding (#667 review): the blanket one refuses the unregistered control name
+    # too, which is exactly why NEITHER may claim the host has a window server.
+    if not _sandbox_exec_works(tmp_path):
+        pytest.skip("needs macOS with a working sandbox-exec")
+    if windowed_unavailable() is not None:
+        pytest.skip("needs a real on-console desktop session to deny access TO")
+
+    profile = tmp_path / "profile.sb"
+    profile.write_text(profile_body, encoding="utf-8")
+
+    # The control: unsandboxed on this same host, a windowed session can launch.
+    assert _verdict_under(None, tmp_path) is None
+
+    denied = _verdict_under(profile, tmp_path)
+    assert denied is not None
+
+    assert denied["code"] == "live_windowed_permission_denied"
+    assert denied["probe"] == "bootstrap_look_up(com.apple.windowserver.active)"
+    assert denied["denial"] == expected_denial
+    # Neither branch may assert the host has a window server.
+    assert denied["claims_existence"] is False
+
+
+def test_the_probe_returns_a_verdict_or_none_on_this_host():
+    # A cheap always-on sanity check that the real probe runs without raising on
+    # whatever host the suite is on, whatever it concludes.
+    verdict = windowed_unavailable()
+    assert verdict is None or isinstance(verdict, WindowedUnavailable)
+
+
+# --- the test-side gate policy (ungated) -------------------------------------
+#
+# The gate helper decides whether an environment refusal SKIPS or FAILS, and the
+# whole point of #667 is that those two reactions are not interchangeable. Tabled
+# here so the policy itself is covered, not just the probe that feeds it.
+
+
+@pytest.mark.parametrize(
+    ("code", "reaction"),
+    [
+        ("live_windowed_unavailable", "skipped"),
+        ("live_display_unavailable", "skipped"),
+        ("live_windowed_permission_denied", "failed"),
+        ("engine_session_not_running", "returned"),
+        (None, "returned"),
+    ],
+)
+def test_the_no_display_reaction_policy(code, reaction):
+    from tests.support import handle_no_display_code
+
+    if reaction == "returned":
+        # Not a display refusal: the helper stays out of the way so the caller can
+        # raise its own assertion for a genuine failure.
+        handle_no_display_code(code)
+        return
+
+    with pytest.raises(BaseException) as caught:
+        handle_no_display_code(code)
+
+    outcome = type(caught.value).__name__
+    if reaction == "skipped":
+        assert outcome == "Skipped"
+    else:
+        assert outcome == "Failed"
+        # The failure has to carry the remediation, or a confined CI run reads as a
+        # plain breakage instead of "you are sandboxed".
+        assert "Re-run outside the sandbox/restriction" in str(caught.value)
+        assert "did NOT execute" in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    ("verdict_code", "reaction"),
+    [
+        ("live_windowed_unavailable", "Skipped"),
+        ("live_windowed_permission_denied", "Failed"),
+    ],
+)
+def test_the_preflight_gate_applies_the_same_policy(
+    monkeypatch, verdict_code, reaction
+):
+    # The pre-flight probe path and the post-start race path must agree — they used
+    # to be written out separately at five call sites, which is how the wrong
+    # reaction spread in the first place.
+    from gda.models import EnvironmentProbe
+    from tests.support import require_windowed_host
+
+    monkeypatch.setattr(
+        "gda.display.windowed_unavailable",
+        lambda: WindowedUnavailable(
+            code=verdict_code,
+            reason=f"test verdict ({verdict_code})",
+            probe=EnvironmentProbe(name="probe", platform="darwin"),
+        ),
+    )
+
+    with pytest.raises(BaseException) as caught:
+        require_windowed_host()
+
+    assert type(caught.value).__name__ == reaction
+
+
+def test_the_preflight_gate_runs_the_test_when_a_window_can_open(monkeypatch):
+    from tests.support import require_windowed_host
+
+    monkeypatch.setattr("gda.display.windowed_unavailable", lambda: None)
+
+    require_windowed_host()  # must not raise
+
+
+@pytest.mark.parametrize(
+    ("returncode", "code", "reaction"),
+    [
+        (0, None, "passed"),
+        (6, "live_display_unavailable", "Skipped"),
+        (127, "live_windowed_unavailable", "Skipped"),
+        (127, "live_windowed_permission_denied", "Failed"),
+        (4, "operation_failed", "Failed"),  # a real regression still fails
+        (1, None, "Failed"),  # unparseable output still fails
+    ],
+)
+def test_the_post_start_assertion_applies_the_policy_before_asserting(
+    returncode, code, reaction
+):
+    # The repo's own e2e windowed tiers assert success through this helper, so a
+    # refusal arriving AFTER the pre-flight probe passed gets the same reaction the
+    # pre-flight would have applied. Before the #667 recheck those branches asserted
+    # returncode == 0 directly, so a capability verdict was a false RED here while the
+    # game's tiers skipped on it — one verdict, two meanings.
+    import json as _json
+
+    from tests.support import assert_windowed_ok
+
+    class _Result:
+        def __init__(self):
+            self.returncode = returncode
+            self.stdout = (
+                _json.dumps({"error": {"code": code, "message": "x"}})
+                if code is not None
+                else ("{}" if returncode == 0 else "not json")
+            )
+            self.stderr = ""
+
+    if reaction == "passed":
+        assert assert_windowed_ok(_Result()).returncode == 0
+        return
+
+    with pytest.raises(BaseException) as caught:
+        assert_windowed_ok(_Result())
+
+    outcome = type(caught.value).__name__
+    if reaction == "Skipped":
+        assert outcome == "Skipped"
+    elif code == "live_windowed_permission_denied":
+        assert outcome == "Failed"
+        assert "Re-run outside the sandbox/restriction" in str(caught.value)
+    else:
+        # Not a display refusal: the ordinary assertion, carrying the command output.
+        assert outcome == "AssertionError"

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -31,7 +31,7 @@ from gda.harness.install import (
     installed_harness_version,
 )
 
-from tests.support import GDA_CMD
+from tests.support import GDA_CMD, assert_windowed_ok
 
 from .conftest import project_godot
 
@@ -968,12 +968,13 @@ def test_daemon_status_surfaces_the_windowed_display_mode(tmp_path, daemon_runti
         # --windowed` now refuses PRE-LAUNCH with live_windowed_unavailable on a host
         # with no usable DisplayServer (#345), so gate this half on the shared display
         # helper — the headless portions above already ran.
-        from gda.display import windowed_unavailable_reason
+        from tests.support import require_windowed_host
 
-        reason = windowed_unavailable_reason()
-        if reason is not None:
-            pytest.skip(reason)
-        assert run("daemon", "start", "--windowed").returncode == 0
+        require_windowed_host()
+        # Two separate observations: the precheck above and the CLI's own guard.
+        # A capability verdict slipping in between must SKIP (permission-denied
+        # must fail loudly) — the shared policy, not a bare returncode assertion.
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
         windowed = json.loads(run("daemon", "status").stdout)
         assert windowed["running"] is True
         assert windowed["windowed"] is True
@@ -1262,11 +1263,9 @@ def test_daemon_serves_screen_capture_while_scenetree_paused(
     # a resume `input sequence` injection, and a responsiveness proof — the same
     # read/resume/responsiveness shape the headless test proves without a display,
     # here proven end-to-end alongside the capture that needs one.
-    from gda.display import windowed_unavailable_reason
+    from tests.support import require_windowed_host
 
-    reason = windowed_unavailable_reason()
-    if reason is not None:
-        pytest.skip(reason)
+    require_windowed_host()
 
     (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(PAUSE_MAIN_TSCN, encoding="utf-8")
@@ -1284,8 +1283,10 @@ def test_daemon_serves_screen_capture_while_scenetree_paused(
         return json.loads(got.stdout)["properties"][0]["value"]
 
     try:
-        started = run("daemon", "start", "--windowed")
-        assert started.returncode == 0, started.stdout + started.stderr
+        # Display refusals on the windowed start / capture branches go through the
+        # shared policy first (capability -> skip, permission -> loud fail); anything
+        # else still falls through to the ordinary assertion.
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
 
         # Pause the game the way a real pause menu does: a live `game set` flips
         # SceneTree.paused through the Resumer's forwarding property.
@@ -1303,8 +1304,7 @@ def test_daemon_serves_screen_capture_while_scenetree_paused(
         assert tree_is_paused() is True
 
         capture_path = tmp_path / "paused.png"
-        captured = run("screen", "capture", "--output", str(capture_path))
-        assert captured.returncode == 0, captured.stdout + captured.stderr
+        assert_windowed_ok(run("screen", "capture", "--output", str(capture_path)))
         assert capture_path.exists()
         assert capture_path.stat().st_size > 0
 

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -26,8 +26,7 @@ import subprocess
 import pytest
 
 from gda.binary import resolve_godot_binary
-from gda.display import windowed_unavailable_reason
-from tests.support import GDA_CMD
+from tests.support import GDA_CMD, assert_windowed_ok
 
 from .conftest import project_godot
 
@@ -56,16 +55,17 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 # "macOS always has one" assumption: headless macOS (SSH / CI / sandbox) has no
 # on-console window-server session even though `launchctl managername` reports
 # "Aqua", and a windowed Godot aborts in AppKit registration there — so the gate is
-# the shared `gda.display.windowed_unavailable_reason()` helper (#345), which probes
+# the shared `gda.display.windowed_unavailable()` helper (#345), which probes
 # CGSessionCopyCurrentDictionary on macOS and $DISPLAY/$WAYLAND_DISPLAY on Linux,
 # skipping BEFORE spawning (and crashing) Godot. The headless-guard and no-daemon
 # screen tests below still run. Forward-compatible: wire Xvfb into CI (DISPLAY set)
 # and these run rather than skip.
-_NO_DISPLAY_REASON = windowed_unavailable_reason()
-_needs_display = pytest.mark.skipif(
-    _NO_DISPLAY_REASON is not None,
-    reason=_NO_DISPLAY_REASON or "the host has a usable DisplayServer",
-)
+# A fixture, not a skipif: the reaction differs by verdict (#667). A host that
+# CANNOT show a window skips; a run that is merely CONFINED fails loudly, because
+# skipping there greens the suite with the rendered acceptance unexecuted. The
+# policy has one owner — `tests.support.require_windowed_host` — shared with the
+# post-start race path and the daemon suite.
+_needs_display = pytest.mark.usefixtures("windowed_host")
 
 
 def _scaffold(tmp_path):
@@ -98,12 +98,13 @@ def test_windowed_daemon_captures_a_single_viewport_frame(tmp_path, daemon_runti
     out = tmp_path / "shot.png"
 
     try:
-        started = run("daemon", "start", "--windowed")
-        assert started.returncode == 0, started.stdout + started.stderr
+        # A refusal on the start / first-live-op / capture branches is routed through
+        # the shared display policy before the ordinary assertion: a capability
+        # verdict skips (as the game's tiers do), a permission verdict fails loudly.
+        started = assert_windowed_ok(run("daemon", "start", "--windowed"))
         assert json.loads(started.stdout)["windowed"] is True
 
-        cap = run("screen", "capture", "--output", str(out))
-        assert cap.returncode == 0, cap.stdout + cap.stderr
+        cap = assert_windowed_ok(run("screen", "capture", "--output", str(out)))
         doc = json.loads(cap.stdout)
         assert doc["path"] == str(out)
         assert doc["width"] > 0 and doc["height"] > 0
@@ -128,9 +129,10 @@ def test_windowed_daemon_inline_embeds_the_base64(tmp_path, daemon_runtime_dir):
     out = tmp_path / "shot.png"
 
     try:
-        assert run("daemon", "start", "--windowed").returncode == 0
-        cap = run("screen", "capture", "--inline", "--output", str(out))
-        assert cap.returncode == 0, cap.stdout + cap.stderr
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
+        cap = assert_windowed_ok(
+            run("screen", "capture", "--inline", "--output", str(out))
+        )
         doc = json.loads(cap.stdout)
         import base64
 
@@ -150,9 +152,10 @@ def test_windowed_daemon_captures_a_frame_window(tmp_path, daemon_runtime_dir):
     out_dir = tmp_path / "frames"
 
     try:
-        assert run("daemon", "start", "--windowed").returncode == 0
-        frames = run("screen", "frames", "--frames", "3", "--output-dir", str(out_dir))
-        assert frames.returncode == 0, frames.stdout + frames.stderr
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
+        frames = assert_windowed_ok(
+            run("screen", "frames", "--frames", "3", "--output-dir", str(out_dir))
+        )
         doc = json.loads(frames.stdout)
         assert doc["count"] == 3
         assert len(doc["frames"]) == 3

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -19,6 +19,8 @@ from gda.runner import OPERATIONS_GD
 
 from tests.support import GDA_CMD
 
+from .conftest import project_godot
+
 GODOT = resolve_godot_binary()
 
 
@@ -894,6 +896,289 @@ def test_script_validate_wrong_extension_yields_invalid_path(godot_project):
 
     err = _assert_operation_error(validated, "invalid_path")
     assert ".gd" in err["message"]
+
+
+# --- script validate: project context (#658, GDA-DF-035) ---
+
+
+def _nested_project_script(root):
+    """A project NESTED in a plain workspace dir, holding a res://-dependent script.
+
+    The GDA-DF-035 shape: a game project that lives inside a larger repository,
+    with a script whose ``res://`` preload only resolves against the project's own
+    root. Returns ``(workspace, project, script)``.
+    """
+    workspace = root / "workspace"
+    project = workspace / "game"
+    (project / "scripts").mkdir(parents=True)
+    (project / "project.godot").write_text(
+        project_godot("gda-e2e-nested"), encoding="utf-8"
+    )
+    (project / "scripts" / "card.gd").write_text(
+        "extends Node\n\nclass_name Card\n\nfunc rank() -> int:\n\treturn 3\n",
+        encoding="utf-8",
+    )
+    script = project / "deck.gd"
+    script.write_text(
+        "extends Node\n\n"
+        'const Card = preload("res://scripts/card.gd")\n\n'
+        "func top() -> int:\n"
+        "\tvar c := Card.new()\n"
+        "\treturn c.rank()\n",
+        encoding="utf-8",
+    )
+    return workspace, project, script
+
+
+@pytest.mark.e2e
+def test_script_validate_verdict_is_root_dependent_and_names_the_root(tmp_path):
+    # The #658 regression, against the real engine: the SAME script under a nested
+    # project, validated from an ancestor directory, gets opposite verdicts
+    # depending on which project it was compiled against — and `project_root` says
+    # which one produced each. That is the reading GDA-DF-035 lacked: from the
+    # ancestor, `res://scripts/card.gd` is missing and a type-inference error is
+    # DERIVED from that miss, on a script that is perfectly valid in its own
+    # project. gda resolves no project from the target path (ADR-0006), so the
+    # ancestor run stays projectless — `project_root: null` is the signal that the
+    # dependency errors are about the missing project context, not the source.
+    workspace, project, script = _nested_project_script(tmp_path)
+
+    from_ancestor = subprocess.run(
+        [
+            *GDA_CMD,
+            "script",
+            "validate",
+            "game/deck.gd",
+            "--godot",
+            str(GODOT),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=workspace,
+    )
+
+    assert from_ancestor.returncode == 0, from_ancestor.stdout + from_ancestor.stderr
+    wrong_root = json.loads(from_ancestor.stdout)
+    assert wrong_root["project_root"] is None
+    assert wrong_root["valid"] is False
+    # The false cascade the issue reports: the preload miss plus at least one
+    # error derived from it.
+    assert any(
+        "res://scripts/card.gd" in diag["message"] for diag in wrong_root["diagnostics"]
+    )
+
+    with_owning_project = _gda(
+        "script", "validate", str(script), "--project", str(project), "--json"
+    )
+
+    assert with_owning_project.returncode == 0, (
+        with_owning_project.stdout + with_owning_project.stderr
+    )
+    right_root = json.loads(with_owning_project.stdout)
+    assert right_root["valid"] is True
+    assert right_root["diagnostics"] == []
+    assert right_root["project_root"] == str(project)
+
+
+@pytest.mark.e2e
+def test_script_validate_refuses_a_script_outside_the_resolved_project(tmp_path):
+    # The refusal at the real-engine tier: pointed at a project that does not own
+    # the script, gda reports the mismatch itself rather than the engine's false
+    # dependency errors — and names both sides. The refusal is structured
+    # (project_not_found, exit 4), so an agent branches on it instead of reading a
+    # cascade of parse errors that describe nothing wrong with the file.
+    _, project, script = _nested_project_script(tmp_path)
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / "project.godot").write_text(
+        project_godot("gda-e2e-other"), encoding="utf-8"
+    )
+
+    validated = _gda(
+        "script", "validate", str(script), "--project", str(other), "--json"
+    )
+
+    err = _assert_operation_error(validated, "project_not_found")
+    assert str(script) in err["message"]
+    assert str(other) in err["message"]
+    # Refused BEFORE parsing: no engine ran, so no diagnostic about the file.
+    assert "res://scripts/card.gd" not in validated.stdout
+    assert err["diagnostics"] == ""
+
+
+@pytest.mark.e2e
+def test_script_validate_accepts_a_file_symlinked_into_the_project(tmp_path):
+    # The containment check judges a symlinked file by BOTH readings, and this is
+    # the real-engine proof of the lexical one: the monorepo shared-addon layout
+    # (game/addons/cardlib -> ../../libs/cardlib), where the file physically lives
+    # outside the project but is addressed through the project's own tree.
+    #
+    # The engine agrees with that reading — the script's `res://addons/cardlib/
+    # card.gd` preload resolves THROUGH the link — so `valid` is true. Judging the
+    # target by its resolve()d location alone would refuse a call that demonstrably
+    # works, and name a path the caller never typed.
+    #
+    # The second half is the guard that this is not a blanket escape hatch: the
+    # SAME physical file, addressed by its outside spelling, is still refused.
+    project = tmp_path / "game"
+    (project / "addons").mkdir(parents=True)
+    (project / "project.godot").write_text(
+        project_godot("gda-e2e-symlinked"), encoding="utf-8"
+    )
+    library = tmp_path / "libs" / "cardlib"
+    library.mkdir(parents=True)
+    (library / "card.gd").write_text(
+        "extends Node\n\nclass_name SymlinkedCard\n\nfunc rank() -> int:\n\treturn 3\n",
+        encoding="utf-8",
+    )
+    (library / "deck.gd").write_text(
+        "extends Node\n\n"
+        'const Card = preload("res://addons/cardlib/card.gd")\n\n'
+        "func top() -> int:\n"
+        "\tvar c := Card.new()\n"
+        "\treturn c.rank()\n",
+        encoding="utf-8",
+    )
+    (project / "addons" / "cardlib").symlink_to(library, target_is_directory=True)
+    through_the_link = project / "addons" / "cardlib" / "deck.gd"
+
+    validated = _gda(
+        "script", "validate", str(through_the_link), "--project", str(project), "--json"
+    )
+
+    assert validated.returncode == 0, validated.stdout + validated.stderr
+    data = json.loads(validated.stdout)
+    assert data["valid"] is True, data
+    assert data["diagnostics"] == []
+    assert data["project_root"] == str(project)
+
+    # Same file, outside spelling: outside under both readings, so still refused.
+    from_outside = _gda(
+        "script",
+        "validate",
+        str(library / "deck.gd"),
+        "--project",
+        str(project),
+        "--json",
+    )
+
+    _assert_operation_error(from_outside, "project_not_found")
+
+
+@pytest.mark.e2e
+def test_script_validate_relative_target_from_an_ancestor_cwd_agrees_with_the_engine(
+    tmp_path,
+):
+    # The full chain, against the real engine: run from the workspace ABOVE the
+    # project and name both the project and the script relatively. gda hands the
+    # path to the engine unchanged and the engine anchors it at `--path game`, so
+    # the containment check has to anchor it there too — judging it against gda's
+    # own cwd refused an invocation the engine validates fine, and that the README
+    # documents. Both channels are covered because the argv and --params-json
+    # paths share the recipe.
+    project = tmp_path / "game"
+    project.mkdir()
+    (project / "project.godot").write_text(
+        project_godot("gda-e2e-ancestor"), encoding="utf-8"
+    )
+    (project / "deck.gd").write_text(
+        "extends Node\n\nfunc top() -> int:\n\treturn 3\n", encoding="utf-8"
+    )
+
+    def from_workspace(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [*GDA_CMD, *args, "--godot", str(GODOT)],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+        )
+
+    argv = from_workspace(
+        "script", "validate", "deck.gd", "--project", "game", "--json"
+    )
+
+    assert argv.returncode == 0, argv.stdout + argv.stderr
+    data = json.loads(argv.stdout)
+    assert data["valid"] is True, data
+    # The engine found game/deck.gd, and the reported root is absolute — not the
+    # bare relative "game" that was typed.
+    assert data["project_root"] == str(project)
+
+    params_json = from_workspace(
+        "script",
+        "validate",
+        "--params-json",
+        json.dumps({"path": "deck.gd"}),
+        "--project",
+        "game",
+        "--json",
+    )
+
+    assert params_json.returncode == 0, params_json.stdout + params_json.stderr
+    assert json.loads(params_json.stdout) == data
+
+
+@pytest.mark.e2e
+def test_script_validate_refuses_a_symlink_dot_dot_pivot_out_of_the_project(tmp_path):
+    # The containment bypass, at the real-engine tier: with
+    # `game/pivot -> ../outside/deep`, the input `game/pivot/../deck.gd` collapses
+    # textually to `game/deck.gd` while really naming `outside/deck.gd`. Trusting
+    # the lexical reading there let the engine COMPILE the outside script and
+    # report a verdict on it. It must now be refused, and no verdict may appear.
+    project = tmp_path / "game"
+    project.mkdir()
+    (project / "project.godot").write_text(
+        project_godot("gda-e2e-pivot"), encoding="utf-8"
+    )
+    outside = tmp_path / "outside"
+    (outside / "deep").mkdir(parents=True)
+    (outside / "deck.gd").write_text(
+        "extends Node\n\nfunc outside_secret() -> int:\n\treturn 99\n", encoding="utf-8"
+    )
+    (project / "pivot").symlink_to(outside / "deep", target_is_directory=True)
+
+    validated = _gda(
+        "script",
+        "validate",
+        str(project / "pivot" / ".." / "deck.gd"),
+        "--project",
+        str(project),
+        "--json",
+    )
+
+    err = _assert_operation_error(validated, "project_not_found")
+    # The refusal names where the target REALLY is, not the collapsed spelling.
+    assert str((outside / "deck.gd").resolve()) in err["message"]
+    # Nothing was compiled: no verdict, and no engine diagnostic about the file.
+    assert '"valid"' not in validated.stdout
+    assert err["diagnostics"] == ""
+
+
+@pytest.mark.e2e
+def test_script_validate_refuses_an_outside_path_that_merely_contains_a_scheme(
+    tmp_path,
+):
+    # A colon is a legal POSIX filename character, so `<dir>://deck.gd` is an
+    # ordinary filesystem path. Classifying it as engine-virtual skipped
+    # containment and the engine opened the outside file; it is now refused.
+    project = tmp_path / "game"
+    project.mkdir()
+    (project / "project.godot").write_text(
+        project_godot("gda-e2e-scheme"), encoding="utf-8"
+    )
+    odd = tmp_path / "outside:"
+    odd.mkdir()
+    (odd / "deck.gd").write_text(
+        "extends Node\n\nfunc scheme_secret() -> int:\n\treturn 7\n", encoding="utf-8"
+    )
+
+    validated = _gda(
+        "script", "validate", f"{odd}//deck.gd", "--project", str(project), "--json"
+    )
+
+    _assert_operation_error(validated, "project_not_found")
+    assert '"valid"' not in validated.stdout
 
 
 # --- script attach (issue #118) ---

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -764,6 +764,25 @@ def test_script_validate_valid_script_reports_valid_true_no_diagnostics(godot_pr
 
 
 @pytest.mark.e2e
+@pytest.mark.parametrize("form", ["ok.gd", "res://ok.gd"])
+def test_script_validate_accepts_both_path_forms(godot_project, form):
+    # The `script validate` half of #675's AC: the group has always taken both the
+    # project-relative and the res:// form, and `script run` now takes the same two
+    # (see tests/test_e2e_script_run.py). Pinned here so the shared representation is
+    # a guarded contract on BOTH commands rather than an accident of this build —
+    # the property that lets an agent address a script once and use it for either.
+    gda = _gda_project(godot_project)
+    (godot_project / "ok.gd").write_text("extends Node\n", encoding="utf-8")
+
+    validated = gda("script", "validate", form, "--json")
+
+    assert validated.returncode == 0, validated.stdout + validated.stderr
+    data = json.loads(validated.stdout)
+    assert data["valid"] is True
+    assert data["diagnostics"] == []
+
+
+@pytest.mark.e2e
 def test_script_validate_broken_script_is_success_with_a_real_diagnostic(godot_project):
     # The mechanism gate's hard half: a deliberately BROKEN script is a SUCCESSFUL
     # op (exit 0) reporting valid=false, and at least one diagnostic with a real

--- a/tests/test_e2e_script_run.py
+++ b/tests/test_e2e_script_run.py
@@ -12,7 +12,9 @@ ADR-0031 specifies:
 - a script that ``quit(1)`` → still a **SUCCESS** carrying ``exit_status != 0`` and
   a **zero** gda process exit (the crux: gda does not interpret the script's
   semantics, so a deliberate non-zero quit is data, not a gda failure);
-- the pre-run ABI edges — a non-``res://`` path and no resolved project — are
+- both accepted script-path forms — project-relative and ``res://`` (#675) — run
+  the same script and report the same canonical ``res://`` ``path``;
+- the pre-run ABI edges — an ABSOLUTE path and no resolved project — are
   structured ``invalid_path`` / ``project_not_found`` failures decided before any
   launch;
 - an unlaunchable binary is the shared classifier's ``binary_not_found``.
@@ -226,13 +228,45 @@ def test_script_run_non_zero_quit_is_success_not_a_gda_failure(godot_project):
 
 
 @pytest.mark.e2e
-def test_script_run_non_res_path_is_invalid_path(godot_project):
-    # A non-res:// path is a structured invalid_path decided BEFORE any launch — an
-    # explicit ABI edge (ADR-0031), never a crash or raw engine failure.
+@pytest.mark.parametrize("form", ["hello.gd", "res://hello.gd"])
+def test_script_run_accepts_both_path_forms(godot_project, form):
+    # The #675 AC against the real engine: the project-relative form the rest of the
+    # script group accepts now runs here too, and both forms report back the ONE
+    # canonical res:// address — so a caller need not rewrite a path between
+    # `script validate` and `script run`.
+    (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
+
     run = _run_gda(
         "script",
         "run",
-        "hello.gd",  # not res://
+        form,
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+        retry=True,
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    data = json.loads(run.stdout)
+    assert data["path"] == "res://hello.gd"
+    assert data["exit_status"] == 0
+    assert "hello from script run" in data["stdout"]
+
+
+@pytest.mark.e2e
+def test_script_run_absolute_path_is_invalid_path(godot_project):
+    # Absolute stays refused (#675) even for a script that EXISTS in the project: the
+    # engine would report its errors under the res:// spelling, which would break the
+    # canonical-identity match the never-ran verdict depends on. A structured
+    # invalid_path decided BEFORE any launch — an explicit ABI edge (ADR-0031).
+    (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
+
+    run = _run_gda(
+        "script",
+        "run",
+        str(godot_project / "hello.gd"),  # absolute, even though it EXISTS
         "--project",
         str(godot_project),
         "--godot",
@@ -242,6 +276,55 @@ def test_script_run_non_res_path_is_invalid_path(godot_project):
 
     assert run.returncode == 4, run.stdout + run.stderr
     err = json.loads(run.stdout)["error"]
+    assert err["code"] == "invalid_path"
+    assert err["category"] == "operation"
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "script",
+    [
+        "",
+        ".",
+        "sub/..",
+        "user://x.gd",
+        "uid://cabc123",
+        # Escapes above the project root, in both spellings.
+        "..",
+        "sub/../..",
+        "../outside.gd",
+        "res://..",
+        "res://../outside.gd",
+    ],
+)
+def test_script_run_non_project_scoped_paths_are_refused_before_launch(
+    godot_project, script
+):
+    # Accepting the project-relative form must not accept everything merely
+    # non-absolute. Against the REAL engine, because these are exactly the cases where
+    # the engine's own report defeats the verdict: `gda script run ""` normalized to
+    # `res://.`, launched, and the engine's `Can't load script: res://.` parsed back
+    # as `res://` — no match, so a run that never happened reported exit 0 SUCCESS.
+    # `..` did the same one level up. The other-scheme cases spawned the engine
+    # against `res://user:/x.gd`, an address the caller never typed. And a RESOLVABLE
+    # escape (`../outside.gd`) actually executed a script outside the project — the
+    # ADR-0009 widening the amendment cites as its reason for refusing absolute paths,
+    # so it must not be reachable by the relative spelling either.
+    run = _run_gda(
+        "script",
+        "run",
+        script,
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+    )
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    data = json.loads(run.stdout)
+    assert "exit_status" not in data, "a refused path must never report a run"
+    err = data["error"]
     assert err["code"] == "invalid_path"
     assert err["category"] == "operation"
 
@@ -354,6 +437,11 @@ def test_script_run_runtime_error_is_a_success_carrying_diagnostics(godot_projec
         "res://sub/../no-such-script.gd",
         "res://./no-such-script.gd",
         "res://sub//..//no-such-script.gd",
+        # #675: the project-relative form is lifted onto res:// BEFORE the same
+        # canonicalization runs, so its aliases must reach the verdict identically.
+        "no-such-script.gd",
+        "sub/../no-such-script.gd",
+        "./no-such-script.gd",
     ],
 )
 def test_script_run_missing_entry_verdict_survives_path_aliasing(
@@ -389,6 +477,12 @@ def test_script_run_missing_entry_verdict_survives_path_aliasing(
         "res://sub/../suite.gd",
         "res://./suite.gd",
         "res://sub//..//suite.gd",
+        # #675: the same guard for the newly accepted form. A broken entry addressed
+        # project-relatively must still classify script_compile_failed — if the lift
+        # bypassed the canonical identity, this would regress to a phantom success.
+        "suite.gd",
+        "sub/../suite.gd",
+        "./suite.gd",
     ],
 )
 def test_script_run_compile_failed_verdict_survives_path_aliasing(

--- a/tests/test_e2e_user_data.py
+++ b/tests/test_e2e_user_data.py
@@ -1,0 +1,500 @@
+"""e2e: a headless launch survives a read-only application-data directory (#653).
+
+The dogfooding failure (GDA-DF-001/014/042/030/028) is a filesystem-restricted
+process where the *project* is writable but Godot's application-data directory is
+not. Godot builds its file logger before any project code runs, and
+``RotatedFileLogger::rotate_file()`` dereferences the ``FileAccess`` it could not
+open — so EVERY command performing a headless launch died with signal 11 and was
+reported as ``engine_crashed`` plus a C++ backtrace, rather than as the
+environment problem it is.
+
+These are real-engine tests because the claim is about the engine's own startup
+order and crash behaviour: a fake runner would only prove that gda passes a flag.
+The control arm deliberately spawns the raw engine, without gda's ``--log-file``,
+to prove the restriction still breaks an unprotected launch — so the protected
+arms cannot pass for the wrong reason (e.g. because the sandbox turned out to be
+writable after all).
+
+**These fixtures deliberately leave file logging at the engine default** instead of
+using ``conftest.project_godot``, which disables it. Disabling it is exactly what
+would hide the bug: with no ``RotatedFileLogger`` there is no crash to survive. It
+is safe here because every gda launch now writes to its OWN private log target, so
+the shared-``user://logs`` contention #180 worked around project-side cannot occur;
+and the single raw-engine control run is confined to its own fake HOME.
+
+**A PROJECT is required to reproduce the crash — ``gda info`` cannot.** The issue
+lists ``info`` among the commands that died, but that does not reproduce on Godot
+4.6.3 and there is no arm for it here. ``info`` is projectless, and ``Main::setup``
+builds the file logger only when ``!project_manager && !editor && …``; a projectless
+run takes the project-manager branch, so no ``RotatedFileLogger`` is ever
+constructed and there is nothing to crash. Verified directly: the projectless
+sentinel op under the restriction emits its result with zero ``handle_crash`` lines,
+with and without the fix. ``info`` is still covered here for the *refusal* path,
+which does apply to it: gda creates a log target for every launch, projectless
+included.
+
+Permissions are restored in fixture teardown, including on failure.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+from gda.runner import data_path_env, engine_data_path
+from tests.support import GDA_CMD
+
+GODOT = resolve_godot_binary()
+
+# A project whose file logging is at the ENGINE DEFAULT (on for desktop), i.e. what
+# a real user project looks like — see the module docstring.
+DEFAULT_LOGGING_PROJECT = """\
+config_version=5
+
+[application]
+
+config/name="gda-user-data-e2e"
+"""
+
+MARKER = "USER-DATA-E2E-OK"
+
+# A pack-mode preset: `--mode pack` produces project data only, so the export-channel
+# arm below needs no installed export templates and runs on any machine.
+EXPORT_PRESETS_CFG = """\
+[preset.0]
+
+name="Linux/X11"
+platform="Linux/X11"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="build/game.x86_64"
+
+[preset.0.options]
+
+binary_format/embed_pck=false
+"""
+
+HELLO_GD = f"""\
+extends SceneTree
+
+func _initialize() -> void:
+\tprint("{MARKER}")
+\tquit(0)
+"""
+
+# Writes to user:// and reports what it resolved, so the persistence arm can assert
+# BOTH that the write landed and where.
+PERSIST_GD = """\
+extends SceneTree
+
+func _initialize() -> void:
+\tprint("USER_DIR=", OS.get_user_data_dir())
+\tvar f = FileAccess.open("user://probe.txt", FileAccess.WRITE)
+\tif f == null:
+\t\tprint("WRITE_FAILED")
+\t\tquit(1)
+\tf.store_string("ok")
+\tf.close()
+\tprint("WRITE_OK")
+\tquit(0)
+"""
+
+
+@pytest.fixture
+def restricted_home(tmp_path):
+    """A HOME whose Godot application-data directory cannot be written.
+
+    Mirrors the dogfooding profile: the project is writable, the app-data root is
+    not. The directory tree is pre-created and only the final component is locked,
+    so this is a permission restriction and NOT a bare empty HOME (which perturbs
+    the engine's first-run behaviour). The mode is always restored.
+    """
+    home = tmp_path / "home"
+    data_path = engine_data_path({"HOME": str(home)}, platform=sys.platform)
+    assert data_path is not None, f"no data path for platform {sys.platform}"
+    data_path.mkdir(parents=True)
+    data_path.chmod(0o555)
+    try:
+        yield home, data_path
+    finally:
+        data_path.chmod(0o755)
+
+
+@pytest.fixture
+def writable_home(tmp_path):
+    """A WRITABLE fake HOME, so a run's resolved ``user://`` can be inspected.
+
+    The normal-profile twin of :func:`restricted_home`: it isolates the assertion
+    from the developer's real application-data directory without restricting
+    anything, so a test can assert what the engine did and did not create there.
+    """
+    home = tmp_path / "writable-home"
+    data_path = engine_data_path({"HOME": str(home)}, platform=sys.platform)
+    assert data_path is not None, f"no data path for platform {sys.platform}"
+    data_path.mkdir(parents=True)
+    return home, data_path
+
+
+@pytest.fixture
+def logging_project(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "project.godot").write_text(DEFAULT_LOGGING_PROJECT, encoding="utf-8")
+    (project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
+    (project / "persist.gd").write_text(PERSIST_GD, encoding="utf-8")
+    return project
+
+
+def _env(home: Path, **extra: str) -> dict:
+    """gda's environment for a restricted run.
+
+    ``$GDA_GODOT`` is set explicitly because the binary default is ``~``-relative:
+    with HOME redirected it would otherwise resolve inside the fake home.
+    """
+    return {**os.environ, "HOME": str(home), "GDA_GODOT": str(GODOT), **extra}
+
+
+def _run_gda(*args: str, env: dict) -> subprocess.CompletedProcess:
+    return subprocess.run([*GDA_CMD, *args], capture_output=True, text=True, env=env)
+
+
+@pytest.mark.e2e
+def test_control_unprotected_launch_really_does_die_on_the_restriction(
+    restricted_home, logging_project
+):
+    # The control: the raw engine, without gda's --log-file, must NOT complete.
+    # If this ever starts passing, the restriction is not being applied and the
+    # protected arms below prove nothing.
+    home, _ = restricted_home
+    proc = subprocess.run(
+        [
+            str(GODOT),
+            "--headless",
+            "--path",
+            str(logging_project),
+            "--script",
+            "res://hello.gd",
+        ],
+        capture_output=True,
+        text=True,
+        env=_env(home),
+    )
+
+    assert MARKER not in proc.stdout, (
+        "the engine completed under the restriction, so this profile does not "
+        "reproduce the failure: " + proc.stdout + proc.stderr
+    )
+
+
+@pytest.mark.e2e
+def test_script_validate_completes_under_a_read_only_app_data_dir(
+    restricted_home, logging_project
+):
+    # AC: the default isolated log target lets a project-backed headless command
+    # complete where it previously died in the engine's logger. Project-backed is
+    # the load-bearing word — see the module docstring on why `info` cannot be an
+    # arm here. Red-proof: the control arm above pins that this same project and
+    # restriction really do kill an unprotected launch.
+    home, _ = restricted_home
+
+    run = _run_gda(
+        "script",
+        "validate",
+        str(logging_project / "hello.gd"),
+        "--project",
+        str(logging_project),
+        "--json",
+        env=_env(home),
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "handle_crash" not in run.stderr
+    assert "RotatedFileLogger" not in run.stderr
+    payload = json.loads(run.stdout)
+    assert "error" not in payload
+
+
+@pytest.mark.e2e
+def test_script_run_completes_under_a_read_only_app_data_dir(
+    restricted_home, logging_project
+):
+    home, _ = restricted_home
+
+    run = _run_gda(
+        "script",
+        "run",
+        "res://hello.gd",
+        "--project",
+        str(logging_project),
+        "--json",
+        env=_env(home),
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    data = json.loads(run.stdout)
+    assert data["exit_status"] == 0
+    assert MARKER in data["stdout"]
+    # The engine crash signature must be gone, not merely reclassified.
+    assert "handle_crash" not in data["stderr"]
+    assert "Program crashed with signal" not in data["stderr"]
+
+
+@pytest.mark.e2e
+def test_unwritable_log_target_is_a_typed_environment_error(
+    restricted_home, logging_project
+):
+    # When gda's OWN target cannot be created either, the launch is refused with a
+    # typed environment code before the engine starts — never a signal-11 backtrace.
+    home, data_path = restricted_home
+
+    run = _run_gda(
+        "info",
+        "--json",
+        env=_env(home, GDA_USER_DATA_ROOT=str(data_path / "denied")),
+    )
+
+    assert run.returncode == 127, run.stdout + run.stderr
+    error = json.loads(run.stdout)["error"]
+    assert error["code"] == "user_data_unwritable"
+    assert error["category"] == "environment"
+    # The diagnostics name the three paths an agent has to act on.
+    diagnostics = error["diagnostics"]
+    assert str(GODOT) in diagnostics
+    assert str(data_path / "denied") in diagnostics
+    assert str(data_path / "denied" / "logs" / "godot.log") in diagnostics
+    assert "handle_crash" not in diagnostics
+
+
+@pytest.mark.e2e
+def test_a_root_whose_derived_data_path_is_blocked_is_refused(
+    tmp_path, logging_project
+):
+    # Creating the root and the log target is not enough to keep the `user://`
+    # promise: the engine appends a platform layout to the root, and that DERIVED
+    # path can be unusable while the root and its `logs/` are perfectly writable.
+    #
+    # Before the derived-path probe this was the worst possible outcome — a
+    # SUCCESSFUL result. gda preflighted only the log, the engine printed "Could not
+    # create directory" to stderr and still exited 0, and the script ran with an
+    # unopenable `user://` while `script run` reported exit_status 0. So this arm
+    # asserts BOTH the typed refusal and that the project never executed.
+    root = tmp_path / "udr"
+    derived = engine_data_path(data_path_env(root), platform=sys.platform)
+    assert derived is not None
+    if derived == root:
+        pytest.skip(
+            "flat user-data shape (XDG): the derived path IS the root, so it "
+            "cannot be blocked while the root stays writable — the nested-shape "
+            "refusal is exercised ungated by the unit tier"
+        )
+    # Block the derived path with a regular FILE at its first component under root.
+    blocker = derived
+    while blocker.parent != root and blocker.parent != blocker:
+        blocker = blocker.parent
+    blocker.parent.mkdir(parents=True, exist_ok=True)
+    blocker.write_text("not a directory", encoding="utf-8")
+
+    run = _run_gda(
+        "--user-data-root",
+        str(root),
+        "script",
+        "run",
+        "res://persist.gd",
+        "--project",
+        str(logging_project),
+        "--json",
+        env={**os.environ, "GDA_GODOT": str(GODOT)},
+    )
+
+    assert run.returncode == 127, run.stdout + run.stderr
+    error = json.loads(run.stdout)["error"]
+    assert error["code"] == "user_data_unwritable"
+    assert error["category"] == "environment"
+    # The diagnostics name the DERIVED path — the one to fix — not just the root.
+    assert str(derived) in error["diagnostics"]
+    # The project never ran: no engine banner, no script output, no false success.
+    assert "USER_DIR=" not in run.stdout
+    assert "WRITE_FAILED" not in run.stdout
+    assert "exit_status" not in run.stdout
+
+
+@pytest.mark.e2e
+def test_user_data_root_makes_user_writable_again(restricted_home, logging_project):
+    # The persistence half: user:// is redirectable per invocation, so a script that
+    # persists works under the restricted profile too.
+    #
+    # Driven through the FLAG rather than the env twin (review finding F2), so the
+    # real-engine tier exercises the CLI hand-over too, not only the env path that
+    # bypasses it.
+    home, _ = restricted_home
+    root = logging_project.parent / "udr"
+
+    run = _run_gda(
+        "--user-data-root",
+        str(root),
+        "script",
+        "run",
+        "res://persist.gd",
+        "--project",
+        str(logging_project),
+        "--json",
+        env=_env(home),
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    data = json.loads(run.stdout)
+    assert data["exit_status"] == 0, data["stdout"] + data["stderr"]
+    assert "WRITE_OK" in data["stdout"]
+    # It really resolved under the requested root, not the restricted default.
+    assert str(root) in data["stdout"]
+    assert (root / "logs" / "godot.log").exists()
+
+
+@pytest.mark.e2e
+def test_concurrent_invocations_never_touch_the_shared_rotated_log(
+    writable_home, logging_project
+):
+    # AC: independent concurrent invocations must not contend over one
+    # rotation-sensitive log file. The assertion that carries the weight is the
+    # NEGATIVE one: the engine's shared `user://logs/` for this project is never
+    # created at all, so there is no shared target left to rotate or race on. Six
+    # successes alone would prove nothing — they pass just as well while every run
+    # writes the same file.
+    #
+    # A writable fake HOME (not the restricted one) so the run is the NORMAL
+    # profile and the resolved user:// dir can be inspected deterministically
+    # without touching the developer's real one. File logging is at the engine
+    # default here — the exact shape that used to race in rotate_file().
+    home, data_path = writable_home
+
+    procs = [
+        subprocess.Popen(
+            [
+                *GDA_CMD,
+                "script",
+                "validate",
+                str(logging_project / "hello.gd"),
+                "--project",
+                str(logging_project),
+                "--json",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=_env(home),
+        )
+        for _ in range(6)
+    ]
+    # communicate() before returncode: draining the pipes is what lets each child
+    # exit, so waiting first can deadlock on a full pipe buffer.
+    results = [(*p.communicate(), p.returncode) for p in procs]
+
+    for out, err, code in results:
+        assert code == 0, out + err
+        assert "handle_crash" not in err
+        assert "error" not in json.loads(out)
+
+    # The engine DID resolve user:// (it creates app_userdata eagerly), but no
+    # rotated log directory may appear anywhere beneath the data path. Globbed
+    # rather than spelled out, because the layout below the data path differs per
+    # platform (`Godot/app_userdata/…` vs `godot/app_userdata/…`).
+    shared_logs = list(data_path.rglob("logs"))
+    assert not shared_logs, (
+        f"a shared user://logs was created, so concurrent runs still contend: "
+        f"{shared_logs}"
+    )
+
+
+# --------------------------------------------------------------------------
+# A relative --user-data-root (review finding F1)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+def test_relative_root_on_the_sentinel_channel_lands_under_gda_cwd(
+    tmp_path, logging_project
+):
+    # gda and the engine do not share a working directory: gda would create the log
+    # relative to its own cwd while the engine resolved the relative --log-file
+    # against --path. The preflight then passed for a file the engine never opened
+    # and the engine died in rotate_file() on the one it did — the very crash this
+    # change removes, reintroduced by a relative path.
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+
+    run = subprocess.run(
+        [
+            *GDA_CMD,
+            "--user-data-root",
+            "./rel",
+            "script",
+            "validate",
+            str(logging_project / "hello.gd"),
+            "--project",
+            str(logging_project),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(workdir),
+        env={**os.environ, "GDA_GODOT": str(GODOT)},
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "handle_crash" not in run.stderr
+    assert json.loads(run.stdout)["valid"] is True
+    # Resolved against gda's cwd, exactly once...
+    assert (workdir / "rel" / "logs" / "godot.log").exists()
+    # ...and NOT leaked into the project the engine was pointed at.
+    assert not (logging_project / "rel").exists()
+
+
+@pytest.mark.e2e
+def test_relative_root_on_the_export_channel_lands_under_gda_cwd(
+    tmp_path, logging_project
+):
+    # The export channel is the sharper case: it spawns with cwd = <project>, so a
+    # relative --log-file resolves there for certain. `--mode pack` needs no export
+    # templates, so this runs on any machine.
+    (logging_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    workdir = tmp_path / "workdir-export"
+    workdir.mkdir()
+    artifact = logging_project / "dist" / "packed.pck"
+
+    run = subprocess.run(
+        [
+            *GDA_CMD,
+            "--user-data-root",
+            "./rel",
+            "export",
+            "run",
+            "--preset",
+            "Linux/X11",
+            "--mode",
+            "pack",
+            "--output",
+            str(artifact),
+            "--project",
+            str(logging_project),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(workdir),
+        env={**os.environ, "GDA_GODOT": str(GODOT)},
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "handle_crash" not in run.stderr
+    assert artifact.exists()
+    assert (workdir / "rel" / "logs" / "godot.log").exists()
+    assert not (logging_project / "rel").exists()

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -175,6 +175,80 @@ def test_live_windowed_unavailable_flows_through_classify_live():
     assert outcome.error.diagnostics == "why-here"
 
 
+def test_live_windowed_permission_denied_flows_through_classify_live():
+    # #667: the sandbox-denial sibling is raised at the same daemon launch boundary
+    # and relayed the same way, so it needs the same whitelist entry — without it
+    # classify_run would misroute an ENVIRONMENT code to operation_failed. It
+    # resolves to its own registered environment/127 shape, distinct from
+    # live_windowed_unavailable, so an agent can tell "retry outside the sandbox"
+    # from "this host cannot show a window".
+    from gda.daemon.protocol import error_reply
+    from gda.errors import _LIVE_CLIENT_CODES, Failure, classify_live
+    from gda.commands.game import GameTreeResult
+    from gda.runner import RunResult
+
+    assert "live_windowed_permission_denied" in _LIVE_CLIENT_CODES
+
+    reply = error_reply(
+        "live_windowed_permission_denied",
+        "denied the window-server lookup",
+        diagnostics="why-here",
+    )
+    outcome = classify_live(RunResult(**reply), None, GameTreeResult)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "live_windowed_permission_denied"
+    assert outcome.error.category is ErrorCategory.ENVIRONMENT
+    assert outcome.exit_code == 127
+    assert outcome.error.diagnostics == "why-here"
+    # No probe was put on this reply, so none comes out — the key is optional.
+    assert outcome.error.probe is None
+
+
+def test_a_relayed_windowed_refusal_carries_probe_to_the_public_json():
+    # #667 review: the AUTHORITATIVE refusal is the daemon's lazy-launch guard, so the
+    # probe context must survive the whole daemon-reply -> live-classifier -> public
+    # envelope path, not just the CLI fail-fast. Walks that path end to end with the
+    # REAL builders and the REAL emit serialization at both ends.
+    import json
+
+    from gda.daemon.protocol import error_reply
+    from gda.errors import Failure, classify_live
+    from gda.commands.game import GameTreeResult
+    from gda.models import EnvironmentProbe, GdaErrorEnvelope
+    from gda.runner import RunResult
+
+    probe = EnvironmentProbe(
+        name="bootstrap_look_up(com.apple.windowserver.active)", platform="darwin"
+    )
+    reply = error_reply(
+        "live_windowed_permission_denied",
+        "a windowed engine session cannot launch: denied",
+        diagnostics="why-here",
+        probe=probe,
+    )
+
+    outcome = classify_live(RunResult(**reply), None, GameTreeResult)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "live_windowed_permission_denied"
+    assert outcome.error.category is ErrorCategory.ENVIRONMENT
+    assert outcome.exit_code == 127
+    assert outcome.error.probe is not None
+    assert outcome.error.probe.name == (
+        "bootstrap_look_up(com.apple.windowserver.active)"
+    )
+    assert outcome.error.probe.platform == "darwin"
+    # And it survives to the public JSON an agent actually reads.
+    emitted = json.loads(
+        GdaErrorEnvelope(error=outcome.error).model_dump_json(exclude_none=True)
+    )
+    assert emitted["error"]["probe"] == {
+        "name": "bootstrap_look_up(com.apple.windowserver.active)",
+        "platform": "darwin",
+    }
+
+
 def test_harness_live_error_codes_are_registered_live_codes():
     # The per-op LIVE failures the gda harness reports (#220) are registered
     # LIVE-category classifier-source codes: because their category is LIVE,

--- a/tests/test_json_flag_acceptance.py
+++ b/tests/test_json_flag_acceptance.py
@@ -16,6 +16,10 @@ loud `No such option` it replaced. So the root flag is INHERITED by the invoked
 command (`gda.headless._inherit_root_json`), and the tests below pin that
 equivalence, not just the exit code.
 
+The root itself later grew one payload of its own — `--version` (#659) — so the
+final section here pins that both argv orders reach it; its shape is pinned in
+`tests/test_version_provenance.py`.
+
 These are fast tests: nothing here spawns Godot.
 """
 
@@ -177,19 +181,32 @@ def test_skill_documents_the_json_placement_contract():
     assert "exit `2`" in text
 
 
-# --- what the root flag does NOT do (the honest contract for #659) ------------
+# --- the root flag now carries a payload of its own (#659) --------------------
 
 
-def test_root_version_stays_text_in_both_json_orders():
-    # #671 delivers flag ACCEPTANCE at the root; a JSON `--version` PAYLOAD is
-    # #659's slice. Until then both orders print the same plain text. #659 flips
-    # these expectations — that is the intended hand-off, so update this test
-    # together with the payload.
+def test_root_version_is_structured_in_both_json_orders():
+    # #671 delivered flag ACCEPTANCE at the root and recorded, as a test, that the
+    # root itself still had no JSON payload. #659 delivers that payload, so this
+    # is the flipped expectation: BOTH argv orders return it — which only holds
+    # because `--version` stopped being an eager option (click processes eager
+    # parameters in argv order). The payload's own contract is pinned in
+    # tests/test_version_provenance.py; here only the equivalence matters.
+    payloads = []
     for args in (["--json", "--version"], ["--version", "--json"]):
         result = CliRunner().invoke(app, args)
 
         assert result.exit_code == 0, result.stdout
-        assert result.stdout == f"gda {version('gda')}\n", args
+        payloads.append(json.loads(result.stdout))
+
+    assert payloads[0] == payloads[1]
+    assert payloads[0]["gda_version"] == version("gda")
+
+
+def test_root_version_without_the_flag_stays_text():
+    result = CliRunner().invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.stdout == f"gda {version('gda')}\n"
 
 
 # --- the real out-of-process CLI ---------------------------------------------

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -134,8 +134,10 @@ def test_builds_headless_argv_from_binary_and_tail(monkeypatch):
 
     launch(Path("/x/Godot"), ["--path", "/p", "--version"], cwd=None, timeout=60.0)
 
-    # The primitive always prepends `[binary, --headless]` to the caller's tail.
-    assert captured["cmd"] == ["/x/Godot", "--headless", "--path", "/p", "--version"]
+    # The primitive always prepends `[binary, --headless, --log-file <gda path>]`
+    # to the caller's tail: gda owns the engine log target on every launch (#653).
+    assert captured["cmd"][:3] == ["/x/Godot", "--headless", "--log-file"]
+    assert captured["cmd"][4:] == ["--path", "/p", "--version"]
 
 
 def test_engine_output_is_decoded_as_utf8_regardless_of_host_locale(monkeypatch):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -134,7 +134,59 @@ def test_error_envelope_round_trips_a_failure():
 
     assert isinstance(envelope.error, GdaError)
     assert envelope.error.code == "path_not_found"
-    assert json.loads(envelope.model_dump_json()) == payload
+    # `exclude_none` is the public emit convention (ADR-0004 amendment, #667): the
+    # envelope's optional context keys are OMITTED, never emitted as `null`, so a
+    # failure that sets none is byte-identical to the pre-amendment contract.
+    assert json.loads(envelope.model_dump_json(exclude_none=True)) == payload
+    # And the ONLY thing that convention drops is the optional context. Pinning the
+    # difference — rather than just asserting the filtered form — keeps this a real
+    # guard: a future optional key that a consumer would see as `null` fails here.
+    raw = json.loads(envelope.model_dump_json())
+    assert set(raw["error"]) - set(payload["error"]) == {"probe"}
+    assert raw["error"]["probe"] is None
+
+
+def test_the_emitted_failure_envelope_omits_probe_entirely():
+    # The ABI guard for the ADR-0004 amendment, through the REAL emit path rather
+    # than a hand-rolled dump (#667 review): dropping `exclude_none` from
+    # emit_failure would add `"probe": null` to EVERY failure gda emits, which is
+    # exactly the break the amendment's additive argument rests on not happening.
+    # `--godot ""` fails binary resolution before anything is spawned, so this is a
+    # fast, engine-free, ungated check that runs in every CI tier.
+    from typer.testing import CliRunner
+
+    from gda.cli import app
+
+    result = CliRunner().invoke(app, ["info", "--godot", "", "--json"])
+
+    assert result.exit_code == 127
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "binary_not_found"
+    assert "probe" not in error
+    assert set(error) == {"category", "code", "message", "diagnostics"}
+
+
+def test_error_envelope_round_trips_a_failure_carrying_probe_context():
+    # The other half of the amendment: a host-probe ENVIRONMENT failure DOES carry
+    # the deciding call as data, and that shape round-trips through the same model.
+    payload = {
+        "error": {
+            "category": "environment",
+            "code": "live_windowed_permission_denied",
+            "message": "denied the macOS window-server lookup",
+            "diagnostics": "",
+            "probe": {
+                "name": "bootstrap_look_up(com.apple.windowserver.active)",
+                "platform": "darwin",
+            },
+        }
+    }
+
+    envelope = GdaErrorEnvelope.model_validate(payload)
+
+    assert envelope.error.probe is not None
+    assert envelope.error.probe.platform == "darwin"
+    assert json.loads(envelope.model_dump_json(exclude_none=True)) == payload
 
 
 def test_scene_create_result_round_trips():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -544,7 +544,15 @@ def test_script_validate_result_round_trips_a_valid_script():
     assert validated.valid is True
     assert validated.error_string is None
     assert validated.diagnostics == []
-    assert json.loads(validated.model_dump_json()) == payload
+    # `project_root` is NOT in the sentinel payload: the engine is told the
+    # project through --path and never reports it back, so the CLI stamps the
+    # ADR-0006-resolved root onto the result after classification (#658). The
+    # model therefore defaults it to null and the emitted object always carries
+    # the key.
+    assert json.loads(validated.model_dump_json()) == {
+        **payload,
+        "project_root": None,
+    }
 
 
 def test_script_validate_result_round_trips_an_invalid_script_with_diagnostics():
@@ -566,7 +574,11 @@ def test_script_validate_result_round_trips_an_invalid_script_with_diagnostics()
     assert validated.diagnostics[0].line == 3
     assert validated.diagnostics[0].column is None
     assert validated.diagnostics[0].message == "Parse Error: bad token."
-    assert json.loads(validated.model_dump_json()) == payload
+    # Sentinel-absent, CLI-stamped — see the valid-script round-trip above.
+    assert json.loads(validated.model_dump_json()) == {
+        **payload,
+        "project_root": None,
+    }
 
 
 def test_export_list_result_round_trips_enumerated_presets():

--- a/tests/test_params_json.py
+++ b/tests/test_params_json.py
@@ -491,6 +491,72 @@ _PARITY_TABLE = [
 ]
 
 
+# An unresolvable `~user` prefix: `Path.expanduser()` raises RuntimeError for it, and
+# that raise used to escape as a bare traceback from EVERY NormalizedPath consumer
+# (#699, and a changed-path regression for `script run` once its path became a
+# NormalizedPath). The normalizer is total now, so these pin both halves: the
+# conversion at the normalizer itself, and one command proving the surface inherits it.
+_UNEXPANDABLE = "~nosuchuser_gda_test/x.gd"
+
+
+def test_normalize_path_is_total_for_an_unexpandable_tilde():
+    # The unit regression at the single home. `Path.expanduser()` raises RuntimeError
+    # when it cannot resolve `~user`; normalization is a CONVENIENCE, not a validity
+    # check, so the path passes through unchanged instead of raising. Whether it is
+    # usable is decided by the consumer that opens it.
+    from gda.models import normalize_path
+
+    assert normalize_path(_UNEXPANDABLE) == _UNEXPANDABLE
+
+
+def test_normalize_path_still_expands_a_resolvable_tilde():
+    # The guard on the guard: making the normalizer total must not disable the
+    # expansion it exists for.
+    from gda.models import normalize_path
+
+    assert normalize_path("~/proj/main.tscn") == str(
+        Path("~/proj/main.tscn").expanduser()
+    )
+
+
+@pytest.mark.parametrize("channel", ["argv", "params-json"])
+def test_an_unexpandable_tilde_is_structured_on_a_sibling_command(
+    channel, monkeypatch, tmp_path
+):
+    # Surface-wide inheritance, proved on a command that is NOT `script run`: the fix
+    # lives in the shared normalizer, so every NormalizedPath consumer gets a
+    # structured envelope instead of the RuntimeError traceback (#699). `script
+    # validate` reaches the engine, which reports the path it cannot find — a
+    # different CODE from `script run`'s own pre-launch gate (`path_not_found` vs
+    # `invalid_path`), but structured either way, which is what the contract requires.
+    # Both channels, because the argv body builds the params model DIRECTLY: a
+    # normalizer that raised would still crash here even though --params-json caught it.
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel(
+                {"path": _UNEXPANDABLE, "valid": True, "error_string": None}
+            ),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    argv = ["script", "validate"]
+    argv += (
+        [_UNEXPANDABLE]
+        if channel == "argv"
+        else ["--params-json", json.dumps({"path": _UNEXPANDABLE})]
+    )
+
+    result = CliRunner().invoke(app, [*argv, "--project", str(tmp_path), "--json"])
+
+    assert "Traceback" not in (result.stderr or ""), result.stderr
+    assert result.exception is None or result.exit_code != 1, result.exception
+    # It reached the operation with the tilde intact, rather than dying in validation.
+    assert json.loads(result.stdout)["path"] == _UNEXPANDABLE
+
+
 @pytest.mark.parametrize(
     "case_id, argv, params_object, canned",
     _PARITY_TABLE,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -11,7 +11,14 @@ from pathlib import Path
 
 import pytest
 
-from gda.project import GDA_PROJECT_ENV, PROJECT_MARKER, resolve_project_dir
+from gda.project import (
+    GDA_PROJECT_ENV,
+    PROJECT_MARKER,
+    is_engine_virtual_path,
+    path_outside_project,
+    project_anchored,
+    resolve_project_dir,
+)
 
 
 def _make_project(path: Path) -> Path:
@@ -64,3 +71,177 @@ def test_explicit_non_project_dir_is_rejected(tmp_path):
 def test_explicit_empty_string_is_not_silently_swallowed(tmp_path):
     with pytest.raises(ValueError):
         resolve_project_dir("", env={GDA_PROJECT_ENV: str(_make_project(tmp_path))})
+
+
+# --- containment: does this target belong to the resolved project? (#658) -----
+
+
+def test_path_inside_the_project_is_not_outside(tmp_path):
+    proj = _make_project(tmp_path / "game")
+    script = proj / "actors" / "hero.gd"
+
+    assert path_outside_project(str(script), proj) is None
+
+
+def test_path_in_a_sibling_tree_is_outside_and_reports_its_location(tmp_path):
+    # The refusal's evidence: the caller must be able to name WHERE the target
+    # actually is, so the check returns the resolved location rather than a bool.
+    proj = _make_project(tmp_path / "game")
+    script = tmp_path / "other" / "hero.gd"
+
+    assert path_outside_project(str(script), proj) == script.resolve()
+
+
+def test_engine_virtual_paths_are_never_outside(tmp_path):
+    # res:// (and its user:// / uid:// siblings) address the project the engine
+    # was launched with, so they are inside by construction — gda makes no
+    # filesystem statement about them (ADR-0006).
+    proj = _make_project(tmp_path / "game")
+
+    assert path_outside_project("res://hero.gd", proj) is None
+    assert path_outside_project("user://save.gd", proj) is None
+    assert path_outside_project("uid://abc123", proj) is None
+
+
+def test_a_colon_bearing_filesystem_path_is_not_treated_as_virtual(tmp_path):
+    # A colon is a legal POSIX filename character, so "contains ://" is not a
+    # scheme test: `/work/outside://deck.gd` is an ordinary filesystem path that
+    # happens to hold the sequence, and it is OUTSIDE. Waving it through as
+    # engine-virtual skipped containment entirely and the engine opened the
+    # outside file.
+    proj = _make_project(tmp_path / "game")
+    odd = tmp_path / "outside:" / "deck.gd"
+
+    assert is_engine_virtual_path(str(odd)) is False
+    assert path_outside_project(str(odd), proj) == odd.resolve()
+    # ...and the same sequence inside the project is still contained.
+    assert path_outside_project(str(proj / "weird:" / "deck.gd"), proj) is None
+
+
+def test_a_symlinked_project_spelling_still_contains_its_own_files(tmp_path):
+    # The RESOLVED reading: the SAME directory reached by two spellings compares
+    # equal. Without it the check would refuse every correct call made through a
+    # symlinked project path — on macOS the temp dir alone (/tmp -> /private/tmp)
+    # is such a spelling.
+    proj = _make_project(tmp_path / "game")
+    link = tmp_path / "game-link"
+    link.symlink_to(proj, target_is_directory=True)
+
+    assert path_outside_project(str(link / "hero.gd"), proj) is None
+    assert path_outside_project(str(proj / "hero.gd"), link) is None
+
+
+def test_a_directory_symlinked_into_the_project_is_inside(tmp_path):
+    # The LEXICAL reading, and the regression that motivates it: the monorepo
+    # shared-addon layout, where the project links a library that physically
+    # lives outside it (game/addons/lib -> ../../libs/lib). The caller addressed
+    # the file through the project's own tree and Godot follows the same link, so
+    # the file IS in the project's res:// namespace. Judging it by its resolved
+    # location alone would refuse a call that works, in a message naming a path
+    # the caller never typed.
+    proj = _make_project(tmp_path / "game")
+    (proj / "addons").mkdir()
+    library = tmp_path / "libs" / "cardlib"
+    library.mkdir(parents=True)
+    (library / "card.gd").write_text("extends Node\n", encoding="utf-8")
+    (proj / "addons" / "cardlib").symlink_to(library, target_is_directory=True)
+
+    assert path_outside_project(str(proj / "addons" / "cardlib" / "card.gd"), proj) is (
+        None
+    )
+
+
+def test_a_file_symlinked_into_the_project_is_inside(tmp_path):
+    # The same rule for a single linked FILE, not just a linked directory.
+    proj = _make_project(tmp_path / "game")
+    shared = tmp_path / "shared" / "card.gd"
+    shared.parent.mkdir(parents=True)
+    shared.write_text("extends Node\n", encoding="utf-8")
+    (proj / "card.gd").symlink_to(shared)
+
+    assert path_outside_project(str(proj / "card.gd"), proj) is None
+
+
+def test_a_dot_dot_escape_is_still_outside(tmp_path):
+    # The lexical reading must not become an escape hatch: `..` is collapsed
+    # textually, so a path that climbs out of the project is outside under BOTH
+    # readings and stays refused.
+    proj = _make_project(tmp_path / "game")
+    escaped = str(proj / ".." / "elsewhere" / "hero.gd")
+
+    assert (
+        path_outside_project(escaped, proj)
+        == (tmp_path / "elsewhere" / "hero.gd").resolve()
+    )
+
+
+def test_a_symlink_followed_by_dot_dot_does_not_pass_as_inside(tmp_path):
+    # The lexical reading is only sound while no `..` is in play. With
+    # `game/pivot -> ../outside/deep`, the input `game/pivot/../deck.gd` collapses
+    # TEXTUALLY to `game/deck.gd` (inside) while really naming
+    # `outside/deck.gd` — so trusting the lexical reading here accepted a target
+    # that is genuinely outside, and the engine compiled it.
+    proj = _make_project(tmp_path / "game")
+    outside = tmp_path / "outside"
+    (outside / "deep").mkdir(parents=True)
+    (outside / "deck.gd").write_text("extends Node\n", encoding="utf-8")
+    (proj / "pivot").symlink_to(outside / "deep", target_is_directory=True)
+
+    bypass = str(proj / "pivot" / ".." / "deck.gd")
+
+    assert path_outside_project(bypass, proj) == (outside / "deck.gd").resolve()
+
+
+def test_a_relative_path_is_anchored_at_the_project_not_the_cwd(tmp_path, monkeypatch):
+    # A relative target is anchored where the ENGINE anchors it: at the resolved
+    # project. Launched with `--path <project>`, a one-shot op that opens
+    # `deck.gd` opens `<project>/deck.gd` no matter where gda was invoked, and the
+    # README promises the same. Anchoring at the invoker cwd instead refused an
+    # ordinary `gda script validate deck.gd --project game` run from an ancestor
+    # directory, which the engine validates fine.
+    proj = _make_project(tmp_path / "game")
+    monkeypatch.chdir(tmp_path)
+
+    assert path_outside_project("deck.gd", proj) is None
+    assert path_outside_project("scripts/deck.gd", proj) is None
+    # A relative project spelling anchors identically.
+    assert path_outside_project("deck.gd", Path("game")) is None
+    # `..` still climbs out of the project, and is refused from either spelling.
+    assert (
+        path_outside_project("../elsewhere/hero.gd", proj)
+        == (tmp_path / "elsewhere" / "hero.gd").resolve()
+    )
+
+
+def test_a_nonexistent_path_is_still_classified(tmp_path):
+    # The check runs BEFORE the engine opens anything, so it must not depend on
+    # the target existing (a missing file inside the project is the operation's
+    # own path_not_found, reported by the engine as before).
+    proj = _make_project(tmp_path / "game")
+
+    assert path_outside_project(str(proj / "gone.gd"), proj) is None
+    assert path_outside_project(str(tmp_path / "gone.gd"), proj) is not None
+
+
+def test_a_project_nested_inside_the_resolved_one_is_not_refused(tmp_path):
+    # The deliberate scope line (#658): a script in a project NESTED under the
+    # resolved one is contained, so it is NOT refused — finding the nearest
+    # project.godot is exactly the derivation ADR-0006 rejected, and waits on an
+    # amendment. The mismatch stays visible through the result's project_root.
+    outer = _make_project(tmp_path / "outer")
+    _make_project(outer / "inner")
+
+    assert path_outside_project(str(outer / "inner" / "deck.gd"), outer) is None
+
+
+def test_project_anchored_matches_how_the_engine_addresses_a_path(tmp_path):
+    # The one anchoring rule the containment check and the engine share: relative
+    # at the project, absolute untouched. Pinned separately from containment so a
+    # future caller (the op argv, a batch mode) reuses the same rule rather than
+    # re-deciding it.
+    proj = tmp_path / "game"
+    absolute = tmp_path / "elsewhere" / "hero.gd"
+
+    assert project_anchored("deck.gd", proj) == proj / "deck.gd"
+    assert project_anchored("scripts/deck.gd", proj) == proj / "scripts" / "deck.gd"
+    assert project_anchored(str(absolute), proj) == absolute

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -47,9 +47,13 @@ def test_projectless_run_builds_the_script_dispatch_tail(monkeypatch):
 
     runner.run("info", {"a": 1})
 
-    assert rec.cmd == [
-        "/x/Godot",
-        "--headless",
+    # gda owns the engine log target on every launch (#653), so `--log-file <path>`
+    # sits with the other ENGINE options, ahead of this channel's tail — and so
+    # ahead of the `--` separator, which must stay the last engine-side argument.
+    assert rec.cmd is not None
+    assert rec.cmd[:2] == ["/x/Godot", "--headless"]
+    assert rec.cmd[2] == "--log-file"
+    assert rec.cmd[4:] == [
         "--script",
         str(OPERATIONS_GD),
         "--",
@@ -71,7 +75,9 @@ def test_run_against_a_project_passes_path(monkeypatch):
     runner.run("scene-get", {})
 
     assert rec.cmd is not None
-    assert rec.cmd[:5] == ["/x/Godot", "--headless", "--path", str(project), "--script"]
+    # gda's `--log-file <path>` (#653) precedes this channel's tail; --path leads it.
+    assert rec.cmd[:3] == ["/x/Godot", "--headless", "--log-file"]
+    assert rec.cmd[4:7] == ["--path", str(project), "--script"]
     # A sentinel op runs against --path, never with a working directory.
     assert rec.kwargs is not None and rec.kwargs.get("cwd") is None
 

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -636,6 +636,13 @@ def test_script_validate_schema_emits_model_derived_contract_without_other_args(
     assert doc["error"] == GdaErrorEnvelope.model_json_schema()
     assert "valid" in doc["output"]["properties"]
     assert "diagnostics" in doc["output"]["properties"]
+    # project_root is REQUIRED and nullable (#658): every emitted verdict carries
+    # the key, so an agent reads it unconditionally rather than probing for it.
+    assert "project_root" in doc["output"]["required"]
+    assert doc["output"]["properties"]["project_root"]["anyOf"] == [
+        {"type": "string"},
+        {"type": "null"},
+    ]
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
@@ -687,12 +694,28 @@ def test_sample_script_results_validate_against_emitted_output_schemas():
         },
         schema=attach_doc["output"],
     )
+    # The validate sample carries project_root: it is REQUIRED on the public
+    # result (#658), because the CLI stamps the ADR-0006-resolved project onto
+    # every emitted verdict. A payload without it is the engine's internal
+    # sentinel half, not something gda ever emits.
     jsonschema.validate(
         instance={
             "path": "res://broken.gd",
             "valid": False,
             "error_string": "Parse error.",
             "diagnostics": [{"line": 3, "column": None, "message": "Parse Error: ..."}],
+            "project_root": "/work/game",
+        },
+        schema=validate_doc["output"],
+    )
+    # ...and projectless still satisfies it, since the field is nullable.
+    jsonschema.validate(
+        instance={
+            "path": "/work/standalone.gd",
+            "valid": True,
+            "error_string": None,
+            "diagnostics": [],
+            "project_root": None,
         },
         schema=validate_doc["output"],
     )

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1193,7 +1193,8 @@ def test_script_run_command_schema_is_model_derived():
     # `script run` self-describes like any command (ADR-0004): input/output from its
     # typed models, the uniform error envelope. Its output carries the passthrough
     # {exit_status, stdout, stderr} — the public promotion of the Raw run — plus the
-    # classified `diagnostics` gda reads out of the engine's stderr (#651).
+    # classified `diagnostics` gda reads out of the engine's stderr (#651) and the
+    # canonical res:// `path` both accepted input forms converge on (#675).
     from gda.commands.script import ScriptRunParams, ScriptRunResult
 
     doc = json.loads(CliRunner().invoke(app, ["script", "run", "--schema"]).stdout)
@@ -1201,8 +1202,10 @@ def test_script_run_command_schema_is_model_derived():
     assert doc["input"] == ScriptRunParams.model_json_schema()
     assert doc["output"] == ScriptRunResult.model_json_schema()
     assert doc["error"] == GdaErrorEnvelope.model_json_schema()
-    # The success output exposes exit_status (can be non-zero on success, ADR-0031).
+    # The success output exposes exit_status (can be non-zero on success, ADR-0031)
+    # and `path`, the declared schema addition of the ADR-0031 path-form amendment.
     assert set(doc["output"]["properties"]) == {
+        "path",
         "exit_status",
         "stdout",
         "stderr",

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -514,6 +514,246 @@ def test_script_validate_help_mentions_valid_false_success_result():
     assert "invalid exits 0 with valid=false" in result.stdout
 
 
+# --- project context: the refusal and the reported root (#658) ----------------
+
+
+def _project(tmp_path, name: str):
+    """A directory Godot counts as a project (it holds the marker)."""
+    proj = tmp_path / name
+    proj.mkdir(parents=True, exist_ok=True)
+    (proj / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return proj
+
+
+def test_script_validate_refuses_a_script_outside_the_resolved_project(
+    monkeypatch, tmp_path
+):
+    # GDA-DF-035: compiling a script against a project that does not own it makes
+    # every res:// dependency resolve against the wrong root, so the engine
+    # reports a cascade of false missing-file and derived type errors. gda refuses
+    # instead — BEFORE the engine runs, which is what `fake.calls == []` pins —
+    # and names both sides so the reader sees which one is wrong.
+    proj = _project(tmp_path, "game")
+    outsider = tmp_path / "elsewhere" / "deck.gd"
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["script", "validate", str(outsider), "--project", str(proj), "--json"],
+    )
+
+    assert result.exit_code == 4
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "project_not_found"
+    assert error["category"] == "operation"
+    # Both locations are named: where the file is, and which project was resolved.
+    assert str(outsider.resolve()) in error["message"]
+    assert str(proj.resolve()) in error["message"]
+    # Nothing was parsed: no engine call was made at all.
+    assert fake.calls == []
+
+
+def test_script_validate_refusal_is_identical_on_the_params_json_path(
+    monkeypatch, tmp_path
+):
+    # ADR-0015 parity: --params-json builds the same model and must reach the same
+    # refusal. The check lives on the command's recipe — the one hook both input
+    # paths share — not in the argv body, which --params-json bypasses.
+    proj = _project(tmp_path, "game")
+    outsider = tmp_path / "elsewhere" / "deck.gd"
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "validate",
+            "--params-json",
+            json.dumps({"path": str(outsider)}),
+            "--project",
+            str(proj),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout)["error"]["code"] == "project_not_found"
+    assert fake.calls == []
+
+
+def test_script_validate_reports_the_resolved_project_root(monkeypatch, tmp_path):
+    # The result names the root its res:// dependencies resolved against, so a
+    # reader can tell a real compile error from a wrong-project one without
+    # re-deriving gda's resolution.
+    proj = _project(tmp_path, "game")
+    script = proj / "deck.gd"
+    payload = {"path": str(script), "valid": True, "error_string": None}
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["script", "validate", str(script), "--project", str(proj), "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["project_root"] == str(proj)
+
+
+def test_script_validate_reports_a_null_project_root_when_projectless(
+    monkeypatch, tmp_path
+):
+    # Projectless (no --project, no $GDA_PROJECT, cwd is not a project) stays
+    # supported: a standalone script is still validated by filesystem path, and
+    # the null root tells the reader that res:// resolved against no project of
+    # gda's choosing — so any res:// dependency error is not to be trusted.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("GDA_PROJECT", raising=False)
+    payload = {"path": "/tmp/proj/ok.gd", "valid": True, "error_string": None}
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["script", "validate", "/tmp/proj/ok.gd", "--json"]
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["project_root"] is None
+    # The engine still ran: projectless is not a refusal.
+    assert fake.calls == [("script-validate", {"path": "/tmp/proj/ok.gd"})]
+
+
+def test_script_validate_does_not_refuse_a_res_path(monkeypatch, tmp_path):
+    # A res:// path addresses the resolved project by construction (ADR-0006), so
+    # containment makes no filesystem claim about it — it is never refused.
+    proj = _project(tmp_path, "game")
+    payload = {"path": "res://deck.gd", "valid": True, "error_string": None}
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["script", "validate", "res://deck.gd", "--project", str(proj), "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls == [("script-validate", {"path": "res://deck.gd"})]
+
+
+def test_script_validate_does_not_refuse_a_colon_bearing_path_as_virtual(
+    monkeypatch, tmp_path
+):
+    # A colon is legal in a POSIX filename, so a path merely CONTAINING "://" is
+    # an ordinary filesystem path — and this one is outside the project, so it is
+    # refused rather than waved through as engine-virtual (which skipped
+    # containment entirely and let the engine open the outside file).
+    proj = _project(tmp_path, "game")
+    odd = tmp_path / "outside:" / "deck.gd"
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["script", "validate", str(odd), "--project", str(proj), "--json"]
+    )
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout)["error"]["code"] == "project_not_found"
+    assert fake.calls == []
+
+
+def _ancestor_cwd_project(monkeypatch, tmp_path):
+    """A project one level below the cwd, with a script in it (the #658 A shape)."""
+    proj = _project(tmp_path, "game")
+    monkeypatch.chdir(tmp_path)
+    return proj
+
+
+def test_script_validate_accepts_a_relative_target_from_an_ancestor_cwd(
+    monkeypatch, tmp_path
+):
+    # An ordinary invocation that the containment check used to refuse: run from
+    # the workspace ABOVE the project, naming both the project and the script
+    # relatively. The engine anchors `deck.gd` at `--path game`, and the README
+    # promises exactly that, so gda must not judge it against its own cwd.
+    proj = _ancestor_cwd_project(monkeypatch, tmp_path)
+    payload = {"path": "deck.gd", "valid": True, "error_string": None}
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["script", "validate", "deck.gd", "--project", "game", "--json"]
+    )
+
+    assert result.exit_code == 0, result.stdout
+    # The op receives the path unchanged — the engine does the anchoring — and the
+    # reported root is absolute, not the bare relative "game" the caller typed.
+    assert fake.calls == [("script-validate", {"path": "deck.gd"})]
+    assert json.loads(result.stdout)["project_root"] == str(proj)
+
+
+def test_script_validate_relative_target_parity_on_the_params_json_path(
+    monkeypatch, tmp_path
+):
+    # ADR-0015 parity for the same shape: --params-json must anchor identically.
+    proj = _ancestor_cwd_project(monkeypatch, tmp_path)
+    payload = {"path": "deck.gd", "valid": True, "error_string": None}
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "validate",
+            "--params-json",
+            json.dumps({"path": "deck.gd"}),
+            "--project",
+            "game",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert fake.calls == [("script-validate", {"path": "deck.gd"})]
+    assert json.loads(result.stdout)["project_root"] == str(proj)
+
+
+def test_script_validate_still_refuses_a_relative_target_that_climbs_out(
+    monkeypatch, tmp_path
+):
+    # Anchoring at the project is not a blanket accept: a relative path that
+    # climbs out of the project with `..` is still outside, from either spelling.
+    _ancestor_cwd_project(monkeypatch, tmp_path)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "validate",
+            "../elsewhere/deck.gd",
+            "--project",
+            "game",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout)["error"]["code"] == "project_not_found"
+    assert fake.calls == []
+
+
 def test_script_validate_invalid_script_is_success_with_parsed_diagnostics(monkeypatch):
     # Validating an INVALID script is a SUCCESSFUL op (exit 0): the sentinel says
     # valid=false, and the per-command classifier parses the line/message
@@ -625,6 +865,52 @@ def test_script_validate_human_output_invalid_lists_diagnostics(monkeypatch):
     assert "invalid /tmp/proj/broken.gd" in result.stdout
     assert "Parse error." in result.stdout
     assert "line 3: Parse Error: the message." in result.stdout
+
+
+def test_script_validate_human_output_invalid_leads_with_the_project_root(
+    monkeypatch, tmp_path
+):
+    # An invalid verdict prints the project it was compiled against BEFORE the
+    # diagnostics (#658): when the root is wrong every line below it is an
+    # artefact of that one mistake, so the cause must not sit under the cascade.
+    proj = _project(tmp_path, "game")
+    script = proj / "broken.gd"
+    payload = {"path": str(script), "valid": False, "error_string": "Parse error."}
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["script", "validate", str(script), "--project", str(proj)]
+    )
+
+    assert result.exit_code == 0
+    lines = result.stdout.splitlines()
+    assert lines[0] == f"invalid {script}"
+    assert lines[1] == f"  project: {proj}"
+
+
+def test_script_validate_human_output_names_projectless_explicitly(
+    monkeypatch, tmp_path
+):
+    # With no project resolved the line says so rather than printing an empty
+    # value — "(none resolved: projectless)" is the actionable reading of a
+    # res:// dependency error.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("GDA_PROJECT", raising=False)
+    payload = {
+        "path": "/tmp/proj/broken.gd",
+        "valid": False,
+        "error_string": "Parse error.",
+    }
+    inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(app, ["script", "validate", "/tmp/proj/broken.gd"])
+
+    assert result.exit_code == 0
+    assert "  project: (none resolved: projectless)" in result.stdout
 
 
 def test_script_attach_human_output(monkeypatch):

--- a/tests/test_script_run_commands.py
+++ b/tests/test_script_run_commands.py
@@ -17,6 +17,7 @@ SAME recipe (ADR-0015), not the wrong runner.
 import json
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from gda.cli import app
@@ -52,6 +53,9 @@ def test_clean_run_emits_the_passthrough_result(monkeypatch, tmp_path):
     assert result.exit_code == 0, result.stdout + result.stderr
     data = json.loads(result.stdout)
     assert data == {
+        # The canonical res:// address of what ran (#675) — present on every success
+        # result, whichever of the two accepted forms the caller used.
+        "path": "res://logic.gd",
         "exit_status": 0,
         "stdout": "hi\n",
         "stderr": "",
@@ -160,19 +164,104 @@ def test_params_json_drives_the_same_recipe(monkeypatch, tmp_path):
     assert calls, "the launch seam was never reached via --params-json"
 
 
-def test_non_res_path_emits_invalid_path_envelope(monkeypatch, tmp_path):
+@pytest.mark.parametrize("form", ["logic.gd", "res://logic.gd"])
+def test_both_path_forms_are_accepted_at_the_cli(monkeypatch, tmp_path, form):
+    # AC of #675 at the CLI boundary: ONE script-path representation now serves both
+    # `script validate` and `script run`. Whichever form the caller types, the launch
+    # gets the canonical res:// address and the result reports it back.
+    project = _project(tmp_path)
+    calls = _patch_launch(monkeypatch, RunResult(stdout="ok\n", stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        ["script", "run", form, "--project", str(project), "--json"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout)["path"] == "res://logic.gd"
+    (_binary, args, _cwd, _timeout, _label) = calls[0]
+    assert args == ["--path", str(project), "--script", "res://logic.gd"]
+
+
+def test_params_json_accepts_the_project_relative_form_too(monkeypatch, tmp_path):
+    # ADR-0015: the argv and --params-json paths must agree on the new form as well,
+    # since the acceptance rides on the model's shared NormalizedPath plus the one
+    # operation-side lift — not on argv-only handling.
+    project = _project(tmp_path)
+    calls = _patch_launch(monkeypatch, RunResult(stdout="ok\n", stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "run",
+            "--params-json",
+            '{"path": "logic.gd"}',
+            "--project",
+            str(project),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout)["path"] == "res://logic.gd"
+    (_binary, args, _cwd, _timeout, _label) = calls[0]
+    assert args[-1] == "res://logic.gd"
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        "/abs/logic.gd",
+        "user://x.gd",
+        "uid://cabc123",
+        "",
+        ".",
+        "sub/..",
+        "..",
+        "../outside.gd",
+        "res://../outside.gd",
+        "~nosuchuser_gda_test/x.gd",
+    ],
+)
+def test_a_non_project_scoped_path_emits_invalid_path_envelope(
+    monkeypatch, tmp_path, script
+):
+    # The refusals that survive #675's widening, at the CLI boundary: absolute,
+    # another engine scheme, and a path naming the project root. `""` is the shape a
+    # caller actually hits — an unset variable in `gda script run "$SCRIPT"` — which
+    # reached the engine and came back a phantom exit-0 success before this guard.
     project = _project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
         app,
-        ["script", "run", "logic.gd", "--project", str(project), "--json"],
+        ["script", "run", script, "--project", str(project), "--json"],
     )
 
     assert result.exit_code != 0
     err = json.loads(result.stdout)["error"]
     assert err["code"] == "invalid_path"
     assert not calls, "no engine launch on an invalid path"
+
+
+def test_a_tilde_path_is_refused_as_the_absolute_path_it_means(monkeypatch, tmp_path):
+    # The shared NormalizedPath is what makes this honest (#675): `~/logic.gd` expands
+    # to an absolute path and is refused as one, instead of being lifted into a
+    # nonsense `res://~/logic.gd` naming a directory called `~` inside the project.
+    project = _project(tmp_path)
+    calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
+
+    result = CliRunner().invoke(
+        app,
+        ["script", "run", "~/logic.gd", "--project", str(project), "--json"],
+    )
+
+    assert result.exit_code != 0
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "invalid_path"
+    assert "res://~" not in err["message"]
+    assert not calls
 
 
 def test_no_resolved_project_emits_project_not_found(monkeypatch, tmp_path):
@@ -227,3 +316,36 @@ def test_bad_gda_project_env_is_structured_not_a_traceback(monkeypatch, tmp_path
     err = json.loads(result.stdout)["error"]
     assert err["code"] == "project_not_found"
     assert not calls
+
+
+@pytest.mark.parametrize("channel", ["argv", "params-json"])
+def test_an_unexpandable_tilde_keeps_the_structured_refusal(
+    monkeypatch, tmp_path, channel
+):
+    # Base parity, on BOTH input channels (#699 / external review). Giving
+    # `ScriptRunParams.path` the shared NormalizedPath sent `~nosuchuser/x.gd` into
+    # `Path.expanduser()`, which raises RuntimeError — a bare traceback and exit 1,
+    # where the base branch returned this structured invalid_path envelope. The
+    # normalizer is total now, so the path arrives unexpanded and the command's own
+    # gate refuses it exactly as before.
+    #
+    # Both channels because they FAIL DIFFERENTLY: --params-json wraps model
+    # construction (it would have reported invalid_params), while the argv body builds
+    # the model directly and had nothing to catch the raise at all.
+    project = _project(tmp_path)
+    calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
+    tilde = "~nosuchuser_gda_test/x.gd"
+    argv = ["script", "run"]
+    argv += (
+        [tilde] if channel == "argv" else ["--params-json", json.dumps({"path": tilde})]
+    )
+
+    result = CliRunner().invoke(app, [*argv, "--project", str(project), "--json"])
+
+    assert result.exit_code == 4, result.stdout + (result.stderr or "")
+    err = json.loads(result.stdout)["error"]
+    assert err["code"] == "invalid_path"
+    assert err["category"] == "operation"
+    # The message names the path the caller gave, tilde intact.
+    assert tilde in err["message"]
+    assert not calls, "no engine launch on an invalid path"

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -1,7 +1,7 @@
-"""Direct tests for the ScriptRun operation (issue #343, ADR-0031).
+"""Direct tests for the ScriptRun operation (issue #343, ADR-0031, #675).
 
 ``script run`` is the third execution shape: a user-script passthrough run whose
-recipe — validate the res:// path + require a resolved project, then launch
+recipe — accept either script-path form + require a resolved project, then launch
 ``godot --headless --path <project> --script <res://…>`` and BIFURCATE by whose
 failure it is — lives in :func:`gda.commands.script.run_script_run_operation`, a PURE
 function that RETURNS the outcome (never emits/exits).
@@ -14,14 +14,19 @@ bifurcation is asserted without a real engine and without CliRunner:
   is a SUCCESS ``ScriptRunResult`` with the script's output passed through;
 - a launch failure / signal death is a gda-level Error envelope, classified by
   the SAME shared ``classify_launch_or_crash`` the export channel uses;
-- the two pre-run ABI edges (non-res:// path, no resolved project) are structured
-  failures decided BEFORE any launch.
+- the two pre-run ABI edges (an ABSOLUTE path, no resolved project) are structured
+  failures decided BEFORE any launch;
+- both accepted path forms — project-relative and ``res://`` (#675) — reach the
+  SAME canonical address, so the argv, the entry-load verdict and the reported
+  ``path`` cannot diverge by input spelling.
 
 They are the recipe's own test surface, complementary to the e2e round-trip in
 ``tests/test_e2e_script_run.py`` (real Godot).
 """
 
 from pathlib import Path
+
+import pytest
 
 from gda.commands.script import (  # the single fully-bound descriptor (ADR-0023)
     SCRIPT_RUN_COMMAND,
@@ -162,27 +167,87 @@ def test_signal_death_is_engine_crashed():
     assert "11" in outcome.error.message
 
 
-def test_non_res_path_is_invalid_path_before_any_launch():
-    # A non-res:// path is a structured invalid_path decided BEFORE any launch
-    # (an explicit ABI edge, ADR-0031) — never a crash.
+@pytest.mark.parametrize(
+    "script",
+    [
+        "res://tests/logic.gd",
+        "tests/logic.gd",
+        # The project-relative form is lifted onto res:// and then canonicalized by
+        # the SAME shared helper, so its `./` and `..` noise collapses too.
+        "./tests/logic.gd",
+        "tests/sub/../logic.gd",
+        "tests//logic.gd",
+    ],
+)
+def test_both_path_forms_reach_one_canonical_address(script):
+    # #675: `script run` accepts the project-relative form the rest of the script
+    # group accepts, beside res://. Every accepted spelling must converge on ONE
+    # address — the argv handed to the engine AND the path the result reports — or
+    # the entry-load verdict (which matches on it) would depend on how the caller
+    # happened to type the path.
     outcome, launch = _run(
-        RunResult(stdout="", stderr="", exit_code=0), script="tests/logic.gd"
+        RunResult(stdout="ok\n", stderr="", exit_code=0), script=script
     )
+
+    assert isinstance(outcome, ScriptRunResult), getattr(outcome, "error", None)
+    (_binary, args, _cwd, _timeout, _label) = launch.calls[0]
+    assert args == ["--path", str(PROJECT), "--script", "res://tests/logic.gd"]
+    assert outcome.path == "res://tests/logic.gd"
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        # Absolute: outside the --project context (#675 keeps this refusal).
+        "/abs/logic.gd",
+        # Another engine scheme: lifting one would splice a second scheme into a
+        # res:// address (`res://user:/x.gd`) and hunt a path nobody typed.
+        "user://x.gd",
+        "uid://cabc123",
+        # Collapses to the project ROOT — a directory, not a script. The empty string
+        # is the real-world shape: an unset `gda script run "$SCRIPT"`.
+        "",
+        ".",
+        "./",
+        "sub/..",
+        "res://",
+        "res://.",
+        # Escapes ABOVE the root, in both spellings. `..` phantom-succeeded (the
+        # engine's `Can't load script: res://..` parses back as `res://.`), and
+        # `../outside.gd` actually EXECUTED a script outside the project.
+        "..",
+        "sub/../..",
+        "../outside.gd",
+        "res://..",
+        "res://../outside.gd",
+        "../../etc/passwd",
+        # A leading `~` is a HOME reference — a filesystem address form. It reaches
+        # the operation unexpanded only when the shared normalizer could not resolve
+        # the user (#699); a resolvable `~/x.gd` arrives already expanded to an
+        # absolute path, refused above. Both tilde outcomes end on ONE refusal.
+        "~nosuchuser/x.gd",
+        "~/x.gd",
+    ],
+)
+def test_a_non_project_scoped_path_is_invalid_path_before_any_launch(script):
+    # The path ABI edge (ADR-0031, narrowed by #675): accepting the project-relative
+    # form must not accept everything ELSE that is merely non-absolute. The root and
+    # escape cases are load-bearing — the engine answers `Can't load script: res://.`
+    # / `res://..`, whose address the parser reads back with the sentence period
+    # stripped, so it never matches the entry and the run reported a PHANTOM SUCCESS
+    # (exit 0). A resolvable escape is worse: `../outside.gd` RAN a script outside the
+    # project, which is exactly the ADR-0009 widening the amendment cites as its
+    # reason for refusing absolute paths.
+    outcome, launch = _run(RunResult(stdout="", stderr="", exit_code=0), script=script)
 
     assert isinstance(outcome, Failure)
     assert outcome.error.code == "invalid_path"
     assert not launch.calls, "no engine launch on an invalid path"
-
-
-def test_absolute_path_is_invalid_path():
-    # An absolute filesystem path is likewise res://-only-rejected.
-    outcome, launch = _run(
-        RunResult(stdout="", stderr="", exit_code=0), script="/abs/logic.gd"
-    )
-
-    assert isinstance(outcome, Failure)
-    assert outcome.error.code == "invalid_path"
-    assert not launch.calls
+    # The message quotes what the user typed and names the ACCEPTED forms, so one
+    # wording serves every refused shape and tells the caller what to pass instead.
+    assert repr(script) in outcome.error.message
+    assert "project-relative" in outcome.error.message
+    assert "res://" in outcome.error.message
 
 
 def test_no_resolved_project_is_project_not_found_before_any_launch():
@@ -213,6 +278,9 @@ def test_result_is_the_thin_promotion_dropping_launch_failure():
 
     assert isinstance(outcome, ScriptRunResult)
     assert outcome.model_dump() == {
+        # gda's own field, not the run's: the canonical address both input forms
+        # converge on (#675).
+        "path": "res://tests/logic.gd",
         "exit_status": 7,
         "stdout": "out",
         "stderr": "err",
@@ -344,6 +412,67 @@ def test_a_non_canonical_missing_entry_keeps_the_specific_code():
 
     assert isinstance(outcome, Failure)
     assert outcome.error.code == "script_not_found"
+
+
+@pytest.mark.parametrize(
+    ("script", "stderr", "code"),
+    [
+        ("tests/logic.gd", MISSING_STDERR, "script_not_found"),
+        ("tests/logic.gd", PARSE_ERROR_STDERR, "script_compile_failed"),
+        ("tests/logic.gd", NOT_A_MAIN_LOOP_STDERR, "incompatible_script_type"),
+        # The non-canonical project-relative spellings must land on the verdict too:
+        # the lift happens BEFORE canonicalization, so `..`/`.` inside a relative
+        # path still collapses onto the address the engine reports back.
+        ("tests/sub/../logic.gd", MISSING_STDERR, "script_not_found"),
+        ("./tests/logic.gd", PARSE_ERROR_STDERR, "script_compile_failed"),
+    ],
+)
+def test_a_project_relative_entry_still_reaches_the_verdict(script, stderr, code):
+    # The #675 × #651 interaction, and the reason the new form MUST flow through the
+    # same normalization chain: the entry-load verdict matches the engine's reported
+    # (canonical, res://) address against the caller's. A project-relative path that
+    # skipped the lift would never match, and every never-ran shape would silently
+    # regress to the phantom success #651 removed.
+    outcome, launch = _run(
+        RunResult(stdout="", stderr=stderr, exit_code=0), script=script
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == code
+    assert outcome.exit_code == EXIT_OPERATION
+    # One spelling on every side: the argv, and the message the agent reads.
+    (_binary, args, _cwd, _timeout, _label) = launch.calls[0]
+    assert args[-1] == "res://tests/logic.gd"
+    assert "res://tests/logic.gd" in outcome.error.message
+
+
+@pytest.mark.parametrize("script", ["..foo.gd", "res://..foo.gd", "sub/..foo.gd"])
+def test_a_leading_dot_dot_FILENAME_is_still_accepted(script):
+    # The escape refusal keys on the canonical remainder's first SEGMENT, not on a
+    # string prefix. A file whose NAME merely starts with two dots is legal and must
+    # still run — a naive `startswith("..")` would refuse it.
+    outcome, launch = _run(
+        RunResult(stdout="ok\n", stderr="", exit_code=0), script=script
+    )
+
+    assert isinstance(outcome, ScriptRunResult), getattr(outcome, "error", None)
+    assert outcome.path.endswith("..foo.gd")
+    assert launch.calls, "an accepted path must reach the engine"
+
+
+def test_a_project_relative_load_error_for_another_script_stays_a_success():
+    # The false-positive guard survives the new form: lifting a project-relative path
+    # must not widen what counts as the ENTRY. A script addressed `tests/other.gd`
+    # that itself failed to load `res://tests/logic.gd` is still a passthrough
+    # success — the lift changes the spelling, never the identity being matched.
+    outcome, _ = _run(
+        RunResult(stdout="done\n", stderr=MISSING_STDERR, exit_code=0),
+        script="tests/other.gd",
+    )
+
+    assert isinstance(outcome, ScriptRunResult)
+    assert outcome.exit_status == 0
+    assert outcome.path == "res://tests/other.gd"
 
 
 def test_a_runtime_resource_load_failure_stays_a_success():

--- a/tests/test_sentinel_result.py
+++ b/tests/test_sentinel_result.py
@@ -45,6 +45,45 @@ def test_error_envelope_is_the_operation_error_payload_shape():
     }
 
 
+def test_the_envelope_carries_probe_only_when_one_is_supplied():
+    # #667 review: the live channel may carry structured host-probe context, so the
+    # builder grew ONE optional key. It must be OMITTED (never null) when absent —
+    # that is what keeps every GDScript-emitted headless envelope and every other
+    # live reply byte-identical, and what lets the strict headless
+    # OperationErrorEnvelope keep rejecting extras.
+    probe = {"name": "CGSessionCopyCurrentDictionary", "platform": "darwin"}
+
+    assert error_envelope("live_windowed_permission_denied", "denied", probe) == {
+        "error": {
+            "code": "live_windowed_permission_denied",
+            "message": "denied",
+            "probe": probe,
+        }
+    }
+    assert "probe" not in error_envelope("node_not_found", "no such node")["error"]
+
+
+def test_the_headless_sentinel_model_still_rejects_the_live_probe_key():
+    # The two channels keep DIFFERENT models on purpose: a GDScript operation has no
+    # host probe to report, so the headless sentinel stays strict and probe-less. Only
+    # the live envelope accepts the key.
+    import pytest
+    from pydantic import ValidationError
+
+    from gda.models import LiveErrorEnvelope, OperationErrorEnvelope
+
+    payload = error_envelope(
+        "live_windowed_permission_denied",
+        "denied",
+        {"name": "CGSessionCopyCurrentDictionary", "platform": "darwin"},
+    )
+
+    with pytest.raises(ValidationError):
+        OperationErrorEnvelope.model_validate(payload)
+
+    assert LiveErrorEnvelope.model_validate(payload).error.probe is not None
+
+
 def test_result_reply_carries_the_sentinel_payload_at_exit_zero():
     payload = {"lines": ["a", "b"]}
     assert result_reply(payload) == {

--- a/tests/test_skill_surface_sync.py
+++ b/tests/test_skill_surface_sync.py
@@ -229,3 +229,99 @@ def test_control_root_guard_catches_a_reversed_conditional():
         _assert_control_root_semantics(
             _normalize_prose(mutated), "mutated SKILL.md paragraph"
         )
+
+
+def test_skill_exit_127_row_names_every_registered_127_code():
+    # PR #702 review: the 127 row drifted twice — #696 wrote a four-code list, #694
+    # added a fifth to the registry, and preserving both patches did not reconcile
+    # the combined artifact. Pin the row to the registry so the next 127 code
+    # cannot land without its skill mention.
+    from gda.error_codes import ERROR_CODES
+
+    registered = {spec.code for spec in ERROR_CODES if spec.exit_code == 127}
+    row = next(line for line in BUNDLED.splitlines() if line.startswith("| `127` |"))
+    listed = set(_BACKTICKED.findall(row)) - {"127"}
+    assert listed == registered, (
+        f"SKILL.md's exit-127 row lists {sorted(listed)} but the registry has "
+        f"{sorted(registered)} — keep the enumeration complete"
+    )
+
+
+def test_display_gate_policy_parity_across_the_two_pytest_roots():
+    # PR #702 review: the reaction policy is deliberately duplicated (the game's
+    # pytest root cannot import the toolkit's test package) and both copies say
+    # "stay in step" — this is the executable version of that sentence. Compares
+    # the code classifications AND the observable reactions, so drift in either
+    # copy goes red instead of silently reintroducing the false-green (#667).
+    import importlib.util
+    from pathlib import Path as _P
+
+    import pytest as _pytest
+
+    from tests import support as toolkit
+
+    game_path = (
+        _P(__file__).resolve().parent.parent
+        / "examples/platformer/panda-adventure/tests/display_gate.py"
+    )
+    spec = importlib.util.spec_from_file_location("panda_display_gate", game_path)
+    assert spec is not None and spec.loader is not None, game_path
+    game = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(game)
+
+    assert game.WINDOWED_CAPABILITY_CODES == toolkit.WINDOWED_CAPABILITY_CODES
+    assert (
+        game.WINDOWED_PERMISSION_DENIED_CODE == toolkit.WINDOWED_PERMISSION_DENIED_CODE
+    )
+
+    def reaction(handler, code):
+        try:
+            handler(code, "parity probe")
+        except _pytest.skip.Exception:
+            return "skip"
+        except BaseException as exc:  # pytest.fail raises Failed (BaseException)
+            if type(exc).__name__ == "Failed":
+                return "fail"
+            raise
+        return "pass-through"
+
+    probes = [
+        "live_windowed_unavailable",
+        "live_display_unavailable",
+        "live_windowed_permission_denied",
+        "operation_failed",
+        "daemon_not_running",
+    ]
+    for code in probes:
+        assert reaction(game.handle_no_display_code, code) == reaction(
+            toolkit.handle_no_display_code, code
+        ), f"the two display-gate copies disagree on {code!r}"
+
+    # The PREFLIGHT path too (PR #702 recheck): both require_windowed_host()
+    # functions must react identically to an injected verdict. Both copies read
+    # gda.display.windowed_unavailable at call time, so one monkeypatch drives
+    # both; None / capability / permission cover the whole verdict space.
+    import gda.display as display_module
+
+    class _Verdict:
+        def __init__(self, code):
+            self.code = code
+            self.reason = f"injected {code}"
+
+    def preflight_reaction(fn, verdict, monkeypatch_target=display_module):
+        original = monkeypatch_target.windowed_unavailable
+        setattr(monkeypatch_target, "windowed_unavailable", lambda: verdict)
+        try:
+            return reaction(lambda *_: fn(), None)
+        finally:
+            setattr(monkeypatch_target, "windowed_unavailable", original)
+
+    for verdict in [
+        None,
+        _Verdict("live_windowed_unavailable"),
+        _Verdict("live_display_unavailable"),
+        _Verdict("live_windowed_permission_denied"),
+    ]:
+        assert preflight_reaction(game.require_windowed_host, verdict) == (
+            preflight_reaction(toolkit.require_windowed_host, verdict)
+        ), f"the two preflights disagree on verdict {getattr(verdict, 'code', None)!r}"

--- a/tests/test_user_data_placement.py
+++ b/tests/test_user_data_placement.py
@@ -1,0 +1,570 @@
+"""gda owns the engine log target of every headless launch (issue #653).
+
+Godot builds its file logger before it runs any project code, and
+``RotatedFileLogger::rotate_file()`` dereferences the ``FileAccess`` it failed to
+open — so a log target the engine cannot write kills the process with signal 11,
+which reached an agent as an ``engine_crashed`` backtrace rather than as the
+environment problem it is. The engine has NO ``--user-data-dir`` flag (verified
+against the engine source), so gda's levers are ``--log-file`` for the log and the
+platform data variable for ``user://``.
+
+These are the unit-tier guards on that contract; the real-engine proof — a genuinely
+unwritable application-data directory — lives in ``test_e2e_user_data.py``.
+"""
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.errors import Failure, classify_launch_or_crash
+from gda.exit_codes import EXIT_NOT_FOUND
+from gda.models import ErrorCategory
+import gda.runner as runner_module
+from gda.runner import (
+    USER_DATA_ROOT_ENV,
+    LaunchFailure,
+    data_path_env,
+    engine_data_path,
+    launch,
+    resolve_user_data_root,
+    set_user_data_root,
+    user_data_placement,
+)
+from tests.support import VERSION_INFO, sentinel
+
+
+@pytest.fixture(autouse=True)
+def _no_root_override():
+    """Keep the process-wide root override off unless a test sets it."""
+    set_user_data_root(None)
+    yield
+    set_user_data_root(None)
+
+
+class _RecordingRun:
+    """A ``subprocess.run`` double recording the call and returning a clean exit.
+
+    ``payload`` is the raw stdout the fake engine writes; the CLI-seam tests pass a
+    real ADR-0002 sentinel so the command SUCCEEDS, and the argv assertion is then
+    made on a working invocation rather than on one that happened to fail late.
+    """
+
+    def __init__(self, payload: str = "") -> None:
+        self.cmd: list[str] | None = None
+        self.kwargs: dict | None = None
+        self._payload = payload.encode()
+
+    def __call__(self, cmd, **kwargs):
+        self.cmd = cmd
+        self.kwargs = kwargs
+        payload = self._payload
+
+        class _Proc:
+            stdout = payload
+            stderr = b""
+            returncode = 0
+
+        return _Proc()
+
+
+def _log_file_arg(cmd: list[str]) -> Path:
+    return Path(cmd[cmd.index("--log-file") + 1])
+
+
+def _permission_denied(prefix: str):
+    """A ``mkdtemp`` double that denies only the call carrying ``prefix``.
+
+    The data-path probe and the temporary-log directory both go through
+    ``mkdtemp``, so a blanket double could not tell which one a test meant to break.
+    """
+
+    real = tempfile.mkdtemp
+
+    def fake(*args, **kwargs):
+        if kwargs.get("prefix") == prefix:
+            raise PermissionError(13, "Permission denied")
+        return real(*args, **kwargs)
+
+    return fake
+
+
+# --------------------------------------------------------------------------
+# The default: an isolated, gda-owned log target
+# --------------------------------------------------------------------------
+
+
+def test_default_launch_redirects_the_log_to_a_gda_owned_file(monkeypatch):
+    # The crash fix: the engine never resolves `user://logs/godot.log`, because gda
+    # hands it a target it has already created.
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        log_file = _log_file_arg(cmd)
+        # Created BEFORE the spawn — that creation is the preflight, and it is what
+        # guarantees the engine's own FileAccess open cannot fail.
+        seen["name"] = log_file.name
+        seen["existed"] = log_file.exists()
+
+        class _Proc:
+            stdout = b""
+            stderr = b""
+            returncode = 0
+
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert seen == {"name": "godot.log", "existed": True}
+
+
+def test_default_launch_does_not_touch_the_child_environment(monkeypatch):
+    # Without a root, gda redirects the LOG only: `user://`, the export templates
+    # and the editor settings all stay where the engine puts them by default.
+    rec = _RecordingRun()
+    monkeypatch.setattr(subprocess, "run", rec)
+
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert rec.kwargs is not None and rec.kwargs.get("env") is None
+
+
+def test_default_log_target_is_removed_after_the_run(monkeypatch):
+    seen: dict[str, Path] = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["log"] = _log_file_arg(cmd)
+
+        class _Proc:
+            stdout = b""
+            stderr = b""
+            returncode = 0
+
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    # A private temporary directory, cleaned up so repeated invocations do not
+    # accumulate stale logs.
+    assert not seen["log"].exists()
+    assert not seen["log"].parent.exists()
+
+
+def test_concurrent_default_launches_get_distinct_log_targets(monkeypatch):
+    # The non-contention guarantee: the engine default is ONE per-project
+    # `user://logs/godot.log` that is also rotated (max_log_files 5), so parallel
+    # invocations fight over the same rotation-sensitive file. Two gda launches
+    # must never name the same target.
+    targets: list[Path] = []
+
+    def fake_run(cmd, **kwargs):
+        targets.append(_log_file_arg(cmd))
+
+        class _Proc:
+            stdout = b""
+            stderr = b""
+            returncode = 0
+
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert targets[0] != targets[1]
+
+
+# --------------------------------------------------------------------------
+# The preflight refusal
+# --------------------------------------------------------------------------
+
+
+def test_unwritable_log_root_is_refused_before_the_spawn(monkeypatch, tmp_path):
+    # The whole point: refuse with a typed reason instead of letting the engine
+    # segfault in its logger. `subprocess.run` must never be reached.
+    def _must_not_spawn(*args, **kwargs):  # pragma: no cover - guard
+        raise AssertionError("the engine must not be spawned")
+
+    monkeypatch.setattr(subprocess, "run", _must_not_spawn)
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o555)
+    try:
+        set_user_data_root(str(locked / "root"))
+
+        result = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+    finally:
+        locked.chmod(0o755)
+
+    assert result.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE
+    assert result.exit_code == EXIT_NOT_FOUND
+    assert result.stdout == ""
+
+
+def test_refusal_diagnostics_name_binary_user_data_and_log_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o555)
+    root = locked / "root"
+    try:
+        set_user_data_root(str(root))
+
+        result = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+    finally:
+        locked.chmod(0o755)
+
+    # An agent must be able to act without reading gda's source: the three paths
+    # it would have to fix are all named — and the user-data one is the
+    # PLATFORM-DERIVED path the engine would really use, not the bare root. A
+    # paraphrase ("under <root>") pointed at a directory that is not the one to fix.
+    assert "/x/Godot" in result.stderr
+    assert str(root / "logs" / "godot.log") in result.stderr
+    derived = engine_data_path(data_path_env(root))
+    assert derived is not None
+    assert str(derived) in result.stderr
+
+
+def test_default_root_refusal_names_the_engine_resolved_user_data_dir(monkeypatch):
+    # With no --user-data-root, the failure must still name where `user://` lives
+    # — the engine's own resolved directory — and say gda is not redirecting it.
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+
+    def _explode(*args, **kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr("gda.runner.tempfile.mkdtemp", _explode)
+
+    result = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert result.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE
+    data_path = engine_data_path()
+    assert data_path is not None and str(data_path) in result.stderr
+    assert "--user-data-root" in result.stderr
+    assert USER_DATA_ROOT_ENV in result.stderr
+    # This refusal is about gda's OWN temporary target, not Godot's directory, so it
+    # must name where that target was attempted — otherwise the shared code sends
+    # the reader off to fix a directory that may be perfectly writable.
+    assert tempfile.gettempdir() in result.stderr
+    assert "not redirecting user://" in result.stderr
+
+
+def test_the_two_refusal_shapes_point_at_different_directories(monkeypatch, tmp_path):
+    # The one code covers two distinct placements (registry wording), so the
+    # diagnostics — not the code — must disambiguate which one failed. Pinned as a
+    # PAIR: the default-branch refusal must not blame the explicit root's derived
+    # path, and vice versa.
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr("gda.runner.tempfile.mkdtemp", _permission_denied("gda-log-"))
+
+    default_refusal = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    monkeypatch.undo()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o555)
+    root = locked / "root"
+    try:
+        set_user_data_root(str(root))
+        root_refusal = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+    finally:
+        locked.chmod(0o755)
+
+    assert default_refusal.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE
+    assert root_refusal.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE
+    # The default refusal talks about the temporary target and does NOT blame the root.
+    assert tempfile.gettempdir() in default_refusal.stderr
+    assert str(root) not in default_refusal.stderr
+    # The explicit-root refusal talks about the root and not the temporary dir.
+    assert str(root) in root_refusal.stderr
+    assert "not redirecting user://" not in root_refusal.stderr
+
+
+def test_refusal_classifies_as_the_environment_error_code():
+    # The registry row: ENVIRONMENT category, the shared 127 environment exit.
+    from gda.runner import RunResult
+
+    raw = RunResult(
+        stdout="",
+        stderr="gda: Godot user data is not writable\n",
+        exit_code=EXIT_NOT_FOUND,
+        launch_failure=LaunchFailure.USER_DATA_UNWRITABLE,
+    )
+
+    outcome = classify_launch_or_crash(raw, Path("/x/Godot"))
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "user_data_unwritable"
+    assert outcome.error.category is ErrorCategory.ENVIRONMENT
+    assert outcome.exit_code == EXIT_NOT_FOUND
+    # It is NOT the engine_crashed backtrace this used to arrive as.
+    assert outcome.error.diagnostics == raw.stderr
+
+
+# --------------------------------------------------------------------------
+# --user-data-root
+# --------------------------------------------------------------------------
+
+
+def test_root_redirects_both_the_log_and_the_platform_data_variable(
+    monkeypatch, tmp_path
+):
+    rec = _RecordingRun()
+    monkeypatch.setattr(subprocess, "run", rec)
+    root = tmp_path / "udr"
+    set_user_data_root(str(root))
+
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert rec.cmd is not None
+    assert _log_file_arg(rec.cmd) == root / "logs" / "godot.log"
+    # The child gets a FULL environment carrying the platform override, so
+    # `user://` resolves under the same root as the log.
+    assert rec.kwargs is not None
+    env = rec.kwargs["env"]
+    assert env is not None
+    assert set(data_path_env(root).items()) <= set(env.items())
+    # The root itself is created, so the engine can build app_userdata/<name> in it.
+    assert root.is_dir()
+
+
+def test_a_relative_root_is_absolutized_against_gda_cwd(monkeypatch, tmp_path):
+    # gda and the engine do NOT share a working directory, so a relative root names
+    # two different places: gda creates the log relative to its own cwd while the
+    # engine resolves the relative --log-file against --path (and the export channel
+    # spawns with cwd=<project>). The preflight would then pass for a file the engine
+    # never opens, and the engine would die in rotate_file() on the one it did —
+    # reintroducing the crash. Same bug class as the export channel's --path (#344).
+    rec = _RecordingRun()
+    monkeypatch.setattr(subprocess, "run", rec)
+    monkeypatch.chdir(tmp_path)
+    set_user_data_root("./rel")
+
+    launch(Path("/x/Godot"), ["--path", "/some/project"], cwd=None, timeout=60.0)
+
+    assert rec.cmd is not None
+    log_file = _log_file_arg(rec.cmd)
+    assert log_file.is_absolute()
+    assert log_file == tmp_path / "rel" / "logs" / "godot.log"
+
+
+def test_a_relative_root_absolutizes_the_platform_override_too(monkeypatch, tmp_path):
+    # The env half must be absolutized as well, and for an extra reason: the Linux
+    # engine IGNORES a relative XDG_DATA_HOME outright (OS_LinuxBSD::get_data_path),
+    # so a relative root would silently not redirect `user://` at all while the docs
+    # promise it does.
+    rec = _RecordingRun()
+    monkeypatch.setattr(subprocess, "run", rec)
+    monkeypatch.chdir(tmp_path)
+    set_user_data_root("./rel")
+
+    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert rec.kwargs is not None
+    env = rec.kwargs["env"]
+    assert env is not None
+    for value in data_path_env(tmp_path / "rel").values():
+        assert Path(value).is_absolute()
+    assert set(data_path_env(tmp_path / "rel").items()) <= set(env.items())
+
+
+def test_explicit_root_probes_the_platform_derived_data_path(monkeypatch, tmp_path):
+    # Creating `root` alone is not enough: the engine appends a platform layout to
+    # it, and that DERIVED path can be unusable while `root` is perfectly writable
+    # — here blocked by a regular file. gda used to preflight only the log, report
+    # success, and leave the script with an unopenable `user://`.
+    def _must_not_spawn(*args, **kwargs):  # pragma: no cover - guard
+        raise AssertionError("the engine must not be spawned")
+
+    monkeypatch.setattr(subprocess, "run", _must_not_spawn)
+    root = tmp_path / "udr"
+    # The probe logic is shape-agnostic; pin a NESTED derivation so this runs
+    # identically on every platform (the real macOS shape nests under
+    # Library/Application Support; Linux's XDG shape is flat — derived == root —
+    # where "derived blocked while root writable" cannot be constructed, which
+    # made the real-helper version of this test walk to "/" on Linux CI).
+    derived = root / "nested" / "data"
+    monkeypatch.setattr(runner_module, "engine_data_path", lambda *a, **k: derived)
+    # Block the derived path with a FILE, so it can never be created, while leaving
+    # `root` and `<root>/logs` writable.
+    derived.parent.parent.mkdir(parents=True, exist_ok=True)
+    derived.parent.write_text("not a directory")
+    set_user_data_root(str(root))
+
+    result = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert result.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE
+    assert result.exit_code == EXIT_NOT_FOUND
+    assert str(derived) in result.stderr
+
+
+def test_the_probe_creates_the_derived_path_and_leaves_no_litter(tmp_path):
+    # The probe takes the engine's own shape — make_dir_recursive under the data
+    # path — so it CREATES a throwaway directory rather than inspecting a
+    # permission bit, which would miss a read-only mount or a full filesystem. It
+    # must clean up after itself.
+    root = tmp_path / "udr"
+    with user_data_placement(root, env={"HOME": str(tmp_path / "h")}) as placement:
+        assert placement.data_path is not None
+        assert placement.data_path.is_dir()
+        assert not list(placement.data_path.glob(".gda-probe-*"))
+
+
+def test_an_empty_explicit_flag_is_refused_not_demoted_to_the_environment(monkeypatch):
+    # `--user-data-root ""` is an explicit, deliberate — if mistaken — choice, so it
+    # is surfaced, exactly as an empty `--godot` is. Collapsing it to "absent" let
+    # $GDA_USER_DATA_ROOT win instead, silently inverting flag > env.
+    def _must_not_spawn(*args, **kwargs):  # pragma: no cover - guard
+        raise AssertionError("the engine must not be spawned")
+
+    monkeypatch.setattr(subprocess, "run", _must_not_spawn)
+    monkeypatch.setenv(USER_DATA_ROOT_ENV, "/from/env")
+    set_user_data_root("")
+
+    result = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert result.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE
+    assert result.exit_code == EXIT_NOT_FOUND
+    # The environment value must NOT have been used.
+    assert "/from/env" not in result.stderr
+    # The three-path diagnostic shape holds even here: the refusal goes through
+    # the shared formatter, with the unavailable fields rendered explicitly
+    # instead of dropped (PR #696 follow-up recheck).
+    assert "binary:    /x/Godot" in result.stderr
+    assert "user data: unresolved (--user-data-root is empty)" in result.stderr
+    assert "log file:  not attempted (no placement was prepared)" in result.stderr
+    assert "non-empty --user-data-root" in result.stderr
+
+
+def test_an_empty_flag_beats_the_environment_in_the_resolver(monkeypatch):
+    monkeypatch.setenv(USER_DATA_ROOT_ENV, "/from/env")
+    set_user_data_root("")
+    with pytest.raises(ValueError, match="empty"):
+        resolve_user_data_root()
+
+
+def test_an_empty_environment_value_falls_through_to_the_default(monkeypatch):
+    # Unlike the flag: an unset and a blank variable are the same intent, so an
+    # empty env value is the engine default, not an error (matches --godot/$GDA_GODOT).
+    monkeypatch.setenv(USER_DATA_ROOT_ENV, "")
+    set_user_data_root(None)
+    assert resolve_user_data_root() is None
+
+
+def test_root_precedence_is_flag_then_env_then_engine_default(monkeypatch):
+    monkeypatch.setenv(USER_DATA_ROOT_ENV, "/from/env")
+    assert resolve_user_data_root() == Path("/from/env")
+
+    set_user_data_root("/from/flag")
+    assert resolve_user_data_root() == Path("/from/flag")
+
+    set_user_data_root(None)
+    monkeypatch.delenv(USER_DATA_ROOT_ENV)
+    assert resolve_user_data_root() is None
+
+
+def test_root_expands_a_user_relative_path(monkeypatch):
+    monkeypatch.setenv(USER_DATA_ROOT_ENV, "~/gda-user-data")
+    resolved = resolve_user_data_root()
+    assert resolved is not None and "~" not in str(resolved)
+
+
+# --------------------------------------------------------------------------
+# The engine's own resolution rules, mirrored for reporting and redirect
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("platform", "env", "expected"),
+    [
+        # OS_MacOS::get_config_path(), which get_data_path() returns verbatim.
+        ("darwin", {"HOME": "/h"}, "/h/Library/Application Support"),
+        # OS_Windows::get_data_path().
+        ("win32", {"APPDATA": "/a"}, "/a"),
+        # OS_LinuxBSD::get_data_path(): XDG_DATA_HOME when absolute, else
+        # $HOME/.local/share.
+        ("linux", {"HOME": "/h", "XDG_DATA_HOME": "/xdg"}, "/xdg"),
+        ("linux", {"HOME": "/h", "XDG_DATA_HOME": "rel"}, "/h/.local/share"),
+        ("linux", {"HOME": "/h"}, "/h/.local/share"),
+    ],
+)
+def test_engine_data_path_mirrors_the_engine_per_platform(platform, env, expected):
+    assert engine_data_path(env, platform=platform) == Path(expected)
+
+
+def test_engine_data_path_is_unknown_when_the_variable_is_unset():
+    # Report "unknown" rather than fabricate a path gda cannot know.
+    assert engine_data_path({}, platform="darwin") is None
+    assert engine_data_path({}, platform="win32") is None
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected"),
+    [
+        ("darwin", {"HOME": "/r"}),
+        ("win32", {"APPDATA": "/r"}),
+        ("linux", {"XDG_DATA_HOME": "/r"}),
+    ],
+)
+def test_data_path_env_targets_the_variable_that_platform_reads(platform, expected):
+    # The redirect must set exactly the variable engine_data_path reads back, or
+    # the reported path and the real one diverge.
+    assert data_path_env(Path("/r"), platform=platform) == expected
+
+
+def test_placement_reports_the_redirected_data_path(tmp_path):
+    root = tmp_path / "udr"
+    with user_data_placement(root, env={"HOME": "/h"}) as placement:
+        assert placement.data_path is not None
+        assert str(root) in str(placement.data_path)
+
+
+# --------------------------------------------------------------------------
+# The CLI seam: the OPTION, not just the environment variable
+# --------------------------------------------------------------------------
+
+
+def test_the_root_option_reaches_the_launch(monkeypatch, tmp_path):
+    # The option travels CLI → root callback → set_user_data_root → the runner, a
+    # hand-over seam with no other test on it: every other arm here drives the env
+    # twin, which bypasses the CLI entirely. Without this, deleting the root
+    # callback's `set_user_data_root(...)` line leaves the whole suite green and the
+    # flag silently inert — a live risk, since a sibling change rewrites exactly
+    # those lines in `gda.cli`.
+    rec = _RecordingRun(sentinel(VERSION_INFO))
+    monkeypatch.setattr(subprocess, "run", rec)
+    monkeypatch.delenv(USER_DATA_ROOT_ENV, raising=False)
+    root = tmp_path / "from-the-flag"
+
+    result = CliRunner().invoke(app, ["--user-data-root", str(root), "info", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    assert rec.cmd is not None
+    assert _log_file_arg(rec.cmd) == root / "logs" / "godot.log"
+    assert rec.kwargs is not None and rec.kwargs["env"] is not None
+
+
+def test_without_the_root_option_the_launch_keeps_the_engine_default(
+    monkeypatch, tmp_path
+):
+    # The negative half: absent the flag (and the env twin), nothing is redirected
+    # but the log — so this pair fails if the option is wired to always-on as well
+    # as if it is wired to nothing.
+    rec = _RecordingRun(sentinel(VERSION_INFO))
+    monkeypatch.setattr(subprocess, "run", rec)
+    monkeypatch.delenv(USER_DATA_ROOT_ENV, raising=False)
+
+    result = CliRunner().invoke(app, ["info", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    assert rec.kwargs is not None and rec.kwargs["env"] is None

--- a/tests/test_version_provenance.py
+++ b/tests/test_version_provenance.py
@@ -1,0 +1,773 @@
+"""`gda --version --json` reports which gda ran, and from where (issue #659).
+
+Two dogfooding findings drive this surface. GDA-DF-018: `gda --version --json`
+was rejected, so an evidence collector had to parse one human line. GDA-DF-043:
+the `gda` a `PATH` lookup resolved was an *editable* install whose source checkout
+changed revision mid-run, and the output disclosed none of it.
+
+So these tests pin three things:
+
+- **both argv orders.** `gda --version --json` (the spelling the report used) and
+  `gda --json --version` must produce the same payload. Click processes eager
+  parameters in argv order, so this only holds because `--version` is deliberately
+  NOT eager and therefore sorts after the eager `--json` in both orders.
+- **both install kinds, and the refusal to pick one.** Editable and wheel installs
+  are covered by faking the PEP 610 `direct_url.json` record — a real wheel install
+  cannot be produced from inside the editable checkout the suite runs in. Only a
+  genuinely ABSENT record earns a confident `wheel`; a record gda cannot read as a
+  PEP 610 document — malformed, whitespace-only, or unretrievable — is `unknown`.
+- **no engine launch.** The motivating environment is one where spawning Godot
+  crashes, so a provenance preflight that spawned Godot would be useless there.
+
+These are fast tests: nothing here spawns Godot.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from importlib.metadata import version as installed_version
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+import gda.provenance as provenance
+from gda.cli import app
+from gda.provenance import (
+    DirectUrlRecord,
+    InstallKind,
+    RecordState,
+    build_version_provenance,
+    classify_install,
+    read_direct_url_record,
+)
+from tests.support import GDA_CMD, plain_text
+
+# A git environment that ignores the machine's user/system config, so a CI runner
+# with no `user.email` (or with commit signing on) still builds the fixture repo.
+GIT_ENV = {
+    **os.environ,
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_SYSTEM": os.devnull,
+    "GIT_AUTHOR_NAME": "gda tests",
+    "GIT_AUTHOR_EMAIL": "tests@example.invalid",
+    "GIT_COMMITTER_NAME": "gda tests",
+    "GIT_COMMITTER_EMAIL": "tests@example.invalid",
+}
+
+
+def _git(repo: Path, *args: str) -> str:
+    done = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=GIT_ENV,
+    )
+    return done.stdout
+
+
+def make_git_checkout(repo: Path) -> str:
+    """Create a one-commit git repository at ``repo``; return its HEAD revision.
+
+    The committed file carries the repository's own path, so two fixture repos
+    never share a tree and therefore never share a revision — which is what lets a
+    test tell "read the right repository" from "read any repository".
+    """
+    repo.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-q", str(repo)], check=True, capture_output=True, env=GIT_ENV
+    )
+    (repo / "pyproject.toml").write_text(f"# {repo}\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "init")
+    return _git(repo, "rev-parse", "HEAD").strip()
+
+
+def fake_direct_url(monkeypatch, raw: str | None) -> None:
+    """Serve ``raw`` as the running gda's PEP 610 record; ``None`` means no record.
+
+    The seam hands over RAW text, so a fake can supply a malformed document as
+    easily as a well-formed one — which is the point: the three read arms must reach
+    different conclusions. This helper covers the ABSENT and PRESENT arms; the
+    UNREADABLE and ABSENT arms are driven through the real reader by
+    :func:`real_metadata_dist`, because a faked verdict would not prove the
+    reader produces them.
+    """
+    record = (
+        DirectUrlRecord(RecordState.ABSENT)
+        if raw is None
+        else DirectUrlRecord(RecordState.PRESENT, raw)
+    )
+    monkeypatch.setattr(provenance, "read_direct_url_record", lambda *a, **k: record)
+
+
+def real_metadata_dist(
+    monkeypatch,
+    tmp_path,
+    *,
+    record: str | None = None,
+    mode: int | None = None,
+    as_directory: bool = False,
+) -> Path:
+    """Point gda's metadata at a REAL dist-info directory built on disk.
+
+    Drives the true :func:`read_direct_url_record` end to end — ``locate_file``
+    plus a genuine filesystem read — so every arm is produced by the real
+    reader's behavior (a missing entry, an unreadable mode, a directory sitting
+    where the record should be), never by a faked verdict. The stdlib
+    ``Distribution.read_text()`` would suppress those failures into the same
+    ``None`` as absence, which is exactly the collapse these tests guard
+    against. Carries the true installed version so ``build_version_provenance``
+    still emits a complete payload. Returns the record's path so a test can
+    restore permissions.
+    """
+    from importlib.metadata import PathDistribution
+
+    info = tmp_path / "gda_fixture-0.0.0.dist-info"
+    info.mkdir()
+    (info / "METADATA").write_text(
+        "Metadata-Version: 2.3\nName: gda-fixture\n"
+        f"Version: {installed_version('gda')}\n",
+        encoding="utf-8",
+    )
+    target = info / "direct_url.json"
+    if as_directory:
+        target.mkdir()
+    elif record is not None:
+        target.write_text(record, encoding="utf-8")
+        if mode is not None:
+            target.chmod(mode)
+    dist = PathDistribution(info)
+    monkeypatch.setattr(provenance.Distribution, "from_name", lambda name: dist)
+    return target
+
+
+def fake_editable_install(monkeypatch, root: Path) -> None:
+    """Make gda look like an editable install rooted at ``root`` (PEP 610)."""
+    record = {"url": root.as_uri(), "dir_info": {"editable": True}}
+    fake_direct_url(monkeypatch, json.dumps(record))
+
+
+def fake_wheel_install(monkeypatch) -> None:
+    """Make gda look like an ordinary built install: no PEP 610 record at all."""
+    fake_direct_url(monkeypatch, None)
+
+
+# --- the two argv orders ------------------------------------------------------
+
+
+def test_version_json_works_in_both_argv_orders():
+    # `gda --version --json` is the exact spelling GDA-DF-018 reported as
+    # rejected; `gda --json --version` is the spelling the root-flag rule
+    # (#671, "always pass --json") produces. Both must mean the same thing.
+    after = CliRunner().invoke(app, ["--version", "--json"])
+    before = CliRunner().invoke(app, ["--json", "--version"])
+
+    assert after.exit_code == 0, after.stdout
+    assert before.exit_code == 0, before.stdout
+    assert after.stdout == before.stdout
+    assert json.loads(after.stdout)["gda_version"]
+
+
+def test_bare_version_stays_the_human_one_liner():
+    # The default is unchanged: a human still gets one line, not a JSON blob.
+    result = CliRunner().invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert not result.stdout.startswith("{")
+    assert result.stdout.startswith("gda ")
+
+
+def test_help_wins_over_version_when_both_are_given():
+    # The deliberate trade for making `--version` non-eager: click's own eager
+    # `--help` now takes precedence, which is the conventional order anyway.
+    result = CliRunner().invoke(app, ["--version", "--help"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Usage: gda" in plain_text(result.stdout)
+
+
+# --- the payload --------------------------------------------------------------
+
+
+def test_payload_carries_the_required_provenance_fields():
+    result = CliRunner().invoke(app, ["--version", "--json"])
+
+    payload = json.loads(result.stdout)
+    assert set(payload) == {
+        "gda_version",
+        "executable",
+        "interpreter",
+        "package_path",
+        "install_kind",
+        "source",
+        "godot",
+    }
+    assert payload["install_kind"] in {"wheel", "editable", "unknown"}
+    assert Path(payload["executable"]).is_absolute()
+    assert Path(payload["interpreter"]).is_absolute()
+    assert Path(payload["package_path"]).is_absolute()
+
+
+def test_payload_declares_no_schema_or_protocol_version():
+    # gda has no schema/protocol version; inventing one would create a contract
+    # nothing else honors (#659 says so explicitly).
+    payload = json.loads(CliRunner().invoke(app, ["--version", "--json"]).stdout)
+
+    assert not [key for key in payload if "protocol" in key or "schema" in key]
+
+
+def test_help_advertises_the_structured_form():
+    result = CliRunner().invoke(app, ["--help"])
+
+    assert "install provenance" in plain_text(result.stdout)
+
+
+# --- editable installs --------------------------------------------------------
+
+
+def test_editable_install_reports_its_checkout_and_revision(monkeypatch, tmp_path):
+    checkout = tmp_path / "src-checkout"
+    revision = make_git_checkout(checkout)
+    fake_editable_install(monkeypatch, checkout)
+
+    payload = build_version_provenance()
+
+    assert payload.install_kind is InstallKind.EDITABLE
+    assert payload.source is not None
+    assert payload.source.root == str(checkout)
+    assert payload.source.revision == revision
+    assert payload.source.dirty is False
+
+
+def test_editable_install_reports_a_dirty_working_tree(monkeypatch, tmp_path):
+    # The GDA-DF-043 signal: the checkout the running code is imported from does
+    # not match any committed revision, so the revision alone would mislead.
+    checkout = tmp_path / "src-checkout"
+    make_git_checkout(checkout)
+    (checkout / "scratch.py").write_text("# untracked\n", encoding="utf-8")
+    fake_editable_install(monkeypatch, checkout)
+
+    payload = build_version_provenance()
+
+    assert payload.source is not None
+    assert payload.source.dirty is True
+
+
+def test_dirty_ignores_the_repositorys_untracked_files_config(monkeypatch, tmp_path):
+    # `status.showUntrackedFiles=no` is a real setting people put in a repo or their
+    # global config. With the status call left to it, an untracked module sitting in
+    # the checkout — importable by the editable install, so code that can run —
+    # reported `dirty: false`, contradicting this module's stated contract. The
+    # verdict must be a property of the TREE, not of someone's git config.
+    checkout = tmp_path / "src-checkout"
+    make_git_checkout(checkout)
+    _git(checkout, "config", "status.showUntrackedFiles", "no")
+    (checkout / "runtime_shadow.py").write_text("# untracked\n", encoding="utf-8")
+    fake_editable_install(monkeypatch, checkout)
+
+    payload = build_version_provenance()
+
+    # The config really is in force — this is what gda would have believed.
+    assert _git(checkout, "status", "--porcelain").strip() == ""
+    assert payload.source is not None
+    assert payload.source.dirty is True
+
+
+def test_editable_install_outside_git_reports_null_revision(monkeypatch, tmp_path):
+    # "when resolvable": no repository means null, never a guessed revision.
+    missing = tmp_path / "not-a-repo-and-not-even-there"
+    fake_editable_install(monkeypatch, missing)
+
+    payload = build_version_provenance()
+
+    assert payload.install_kind is InstallKind.EDITABLE
+    assert payload.source is not None
+    assert payload.source.root == str(missing)
+    assert payload.source.revision is None
+    assert payload.source.dirty is None
+
+
+def test_an_inherited_git_dir_cannot_redirect_the_revision(monkeypatch, tmp_path):
+    # `$GIT_DIR` WINS over `git -C`, and gda is invoked from exactly the places
+    # that set it — a git hook, `git rebase --exec`, `git bisect run`, a CI
+    # wrapper. Unscrubbed, the payload paired THIS checkout's `root` with ANOTHER
+    # repository's `revision`, silently: worse than the null this surface promises
+    # when it cannot answer.
+    ours = tmp_path / "ours"
+    theirs = tmp_path / "theirs"
+    our_revision = make_git_checkout(ours)
+    their_revision = make_git_checkout(theirs)
+    assert our_revision != their_revision  # the fixture can tell them apart
+
+    monkeypatch.setenv("GIT_DIR", str(theirs / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(theirs))
+    fake_editable_install(monkeypatch, ours)
+
+    payload = build_version_provenance()
+
+    assert payload.source is not None
+    assert payload.source.root == str(ours)
+    assert payload.source.revision == our_revision
+    assert payload.source.revision != their_revision
+
+
+def test_editable_install_with_a_non_local_url_reports_no_checkout(monkeypatch):
+    # Editable is read from `dir_info.editable`; only a `file:` URL names a
+    # directory on this machine, so a non-local origin stays honestly null
+    # instead of being turned into a fabricated path.
+    fake_direct_url(
+        monkeypatch,
+        json.dumps(
+            {
+                "url": "https://example.invalid/gda.tar.gz",
+                "dir_info": {"editable": True},
+            }
+        ),
+    )
+
+    payload = build_version_provenance()
+
+    assert payload.install_kind is InstallKind.EDITABLE
+    assert payload.source is None
+
+
+def test_the_editable_payload_reaches_the_cli(monkeypatch, tmp_path):
+    checkout = tmp_path / "src-checkout"
+    revision = make_git_checkout(checkout)
+    fake_editable_install(monkeypatch, checkout)
+
+    payload = json.loads(CliRunner().invoke(app, ["--version", "--json"]).stdout)
+
+    assert payload["install_kind"] == "editable"
+    assert payload["source"] == {
+        "root": str(checkout),
+        "revision": revision,
+        "dirty": False,
+    }
+
+
+# --- wheel installs -----------------------------------------------------------
+
+
+def test_wheel_install_reports_no_source_checkout(monkeypatch):
+    # A real wheel install is not producible from inside this editable checkout,
+    # so the distribution metadata is faked: an ordinary index install records no
+    # PEP 610 `direct_url.json` at all.
+    fake_wheel_install(monkeypatch)
+
+    payload = build_version_provenance()
+
+    assert payload.install_kind is InstallKind.WHEEL
+    assert payload.source is None
+    assert payload.gda_version
+
+
+def test_a_built_local_wheel_is_still_a_wheel(monkeypatch, tmp_path):
+    # `pip install ./dist/gda-*.whl` DOES record a direct_url.json — with
+    # `archive_info`, not an editable `dir_info`. The code that runs is still a
+    # copy, so there is no checkout to report.
+    fake_direct_url(
+        monkeypatch,
+        json.dumps(
+            {
+                "url": (tmp_path / "gda-0.0.0-py3-none-any.whl").as_uri(),
+                "archive_info": {},
+            }
+        ),
+    )
+
+    payload = build_version_provenance()
+
+    assert payload.install_kind is InstallKind.WHEEL
+    assert payload.source is None
+
+
+def test_a_non_editable_directory_install_is_a_wheel(monkeypatch, tmp_path):
+    # `pip install .` records `dir_info` with `editable` absent/false; it builds a
+    # wheel, so the checkout it was built from is not what runs.
+    fake_direct_url(monkeypatch, json.dumps({"url": tmp_path.as_uri(), "dir_info": {}}))
+
+    payload = build_version_provenance()
+
+    assert payload.install_kind is InstallKind.WHEEL
+    assert payload.source is None
+
+
+def test_an_explicit_non_editable_dir_info_is_a_wheel(monkeypatch, tmp_path):
+    # PEP 610 types `editable` as a boolean and defaults an absent one to false;
+    # an explicit `false` must reach the same verdict as the absent one above.
+    fake_direct_url(
+        monkeypatch,
+        json.dumps({"url": tmp_path.as_uri(), "dir_info": {"editable": False}}),
+    )
+
+    payload = build_version_provenance()
+
+    assert payload.install_kind is InstallKind.WHEEL
+    assert payload.source is None
+
+
+def test_the_wheel_payload_reaches_the_cli(monkeypatch):
+    fake_wheel_install(monkeypatch)
+
+    payload = json.loads(CliRunner().invoke(app, ["--version", "--json"]).stdout)
+
+    assert payload["install_kind"] == "wheel"
+    assert payload["source"] is None
+
+
+# --- unreadable metadata is `unknown`, never a confident `wheel` --------------
+
+
+def test_malformed_metadata_is_unknown_not_wheel(monkeypatch):
+    # The dangerous collapse: "no record" and "a record I cannot read" both used to
+    # become `wheel` + `source: null`, so a DAMAGED editable install was reported as
+    # an immutable copy — the exact false provenance this surface exists to prevent.
+    fake_direct_url(monkeypatch, "{not json")
+
+    payload = build_version_provenance()
+
+    assert payload.install_kind is InstallKind.UNKNOWN
+    assert payload.source is None
+
+
+def test_a_non_object_record_is_unknown(monkeypatch):
+    fake_direct_url(monkeypatch, '"just a string"')
+
+    assert build_version_provenance().install_kind is InstallKind.UNKNOWN
+
+
+def test_a_non_object_dir_info_is_unknown(monkeypatch):
+    fake_direct_url(monkeypatch, json.dumps({"url": "file:///x", "dir_info": "yes"}))
+
+    assert build_version_provenance().install_kind is InstallKind.UNKNOWN
+
+
+def test_a_non_boolean_editable_is_unknown_not_truthiness(monkeypatch, tmp_path):
+    # PEP 610 types `editable` as a boolean. Reading `"false"` or `1` by truthiness
+    # is how a mutable checkout gets called immutable (or the reverse), so anything
+    # off-spec refuses to answer rather than guessing.
+    for off_spec in ("false", "true", 1, 0, None, [], {}):
+        fake_direct_url(
+            monkeypatch,
+            json.dumps({"url": tmp_path.as_uri(), "dir_info": {"editable": off_spec}}),
+        )
+
+        payload = build_version_provenance()
+
+        assert payload.install_kind is InstallKind.UNKNOWN, off_spec
+        assert payload.source is None, off_spec
+
+
+def test_unknown_never_claims_a_checkout(monkeypatch, tmp_path):
+    # Even when the damaged record names a perfectly good local checkout, an
+    # unresolved kind must not vouch for it.
+    checkout = tmp_path / "src-checkout"
+    make_git_checkout(checkout)
+    fake_direct_url(
+        monkeypatch,
+        json.dumps({"url": checkout.as_uri(), "dir_info": {"editable": "yes"}}),
+    )
+
+    payload = build_version_provenance()
+
+    assert payload.install_kind is InstallKind.UNKNOWN
+    assert payload.source is None
+
+
+def test_malformed_metadata_reaches_the_cli_as_unknown(monkeypatch):
+    fake_direct_url(monkeypatch, "{not json")
+
+    result = CliRunner().invoke(app, ["--version", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["install_kind"] == "unknown"
+    assert payload["source"] is None
+    # …and the rest of the payload still answers what it CAN answer.
+    assert payload["gda_version"] and payload["package_path"]
+
+
+def test_classify_install_is_pure_and_total():
+    # The classifier is the whole decision, so it is exercised directly too: every
+    # read arm to its verdict, with no installer and no filesystem. Only ABSENT
+    # reaches `wheel`; both non-answers reach `unknown`.
+    absent = DirectUrlRecord(RecordState.ABSENT)
+    unreadable = DirectUrlRecord(RecordState.UNREADABLE)
+    editable = DirectUrlRecord(
+        RecordState.PRESENT, '{"url":"file:///x","dir_info":{"editable":true}}'
+    )
+
+    assert classify_install(absent).kind is InstallKind.WHEEL
+    assert classify_install(unreadable).kind is InstallKind.UNKNOWN
+    assert classify_install(editable).kind is InstallKind.EDITABLE
+    assert classify_install(DirectUrlRecord(RecordState.PRESENT, "")).kind is (
+        InstallKind.UNKNOWN
+    )
+    assert classify_install(DirectUrlRecord(RecordState.PRESENT, "  \n")).kind is (
+        InstallKind.UNKNOWN
+    )
+
+
+# --- the imported package, not just the recorded install ----------------------
+
+
+def test_package_path_names_the_module_that_actually_ran():
+    payload = build_version_provenance()
+
+    assert payload.package_path == str(Path(provenance.__file__).parent)
+
+
+def test_package_path_exposes_a_sys_path_shadow(tmp_path):
+    # The falsifiability check. `install_kind`, `source` and the version all come
+    # from distribution METADATA, which describes what an installer recorded — not
+    # what Python loaded. Put a copy of the package earlier on sys.path and the
+    # metadata keeps describing the installed one while a different tree runs, so
+    # without this field the payload would be confidently wrong about the code its
+    # evidence came from.
+    shadow_root = tmp_path / "shadow"
+    shadow_root.mkdir()
+    installed = Path(provenance.__file__).parent
+    shutil.copytree(installed, shadow_root / "gda")
+
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(shadow_root),
+        "PYTHONSAFEPATH": "1",  # keep the cwd from shadowing it back
+    }
+    done = subprocess.run(
+        [*GDA_CMD, "--version", "--json"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+    )
+
+    assert done.returncode == 0, done.stderr
+    payload = json.loads(done.stdout)
+    assert payload["package_path"] == str(shadow_root / "gda")
+    assert payload["package_path"] != str(installed)
+
+
+# --- the read seam has THREE arms, and flattens none of them -------------------
+#
+# The first round of this slice split "malformed" out of "absent" but left two arms
+# still collapsing back: a whitespace-only record and a reader that raised both
+# became "absent", hence a confident `wheel`. These pin all three arms at the
+# reader, and the two once-collapsed ones end to end as well.
+
+
+def test_a_missing_record_is_absent(monkeypatch, tmp_path):
+    # The one arm that legitimately implies a wheel: the entry genuinely does not
+    # exist on disk — positive missing-file evidence, not an ambiguous None.
+    real_metadata_dist(monkeypatch, tmp_path)
+
+    assert read_direct_url_record() == DirectUrlRecord(RecordState.ABSENT)
+
+
+def test_a_malformed_record_is_present_and_handed_over_verbatim(monkeypatch, tmp_path):
+    # The seam does not judge: it returns the bytes and the classifier decides.
+    real_metadata_dist(monkeypatch, tmp_path, record="{not json")
+
+    assert read_direct_url_record() == DirectUrlRecord(RecordState.PRESENT, "{not json")
+
+
+def test_a_whitespace_only_record_is_present_not_absent(monkeypatch, tmp_path):
+    # Was pinned the WRONG way: the seam blanked "   \n" to None, so a record that
+    # exists but says nothing became "absent" and the payload claimed `wheel`. A
+    # record that exists but says nothing is off-spec, not absent.
+    real_metadata_dist(monkeypatch, tmp_path, record="   \n")
+
+    assert read_direct_url_record() == DirectUrlRecord(RecordState.PRESENT, "   \n")
+
+
+def test_an_unreadable_record_is_unreadable_not_absent(monkeypatch, tmp_path):
+    # The stdlib Distribution.read_text() SUPPRESSES PermissionError and returns
+    # None — indistinguishable from absence. The seam must read through the located
+    # entry so a real mode-000 record stays distinct from a missing one.
+    target = real_metadata_dist(monkeypatch, tmp_path, record="{}", mode=0o000)
+    try:
+        record = read_direct_url_record()
+    finally:
+        target.chmod(0o644)
+
+    assert record == DirectUrlRecord(RecordState.UNREADABLE)
+
+
+def test_a_directory_shaped_record_is_unreadable_not_absent(monkeypatch, tmp_path):
+    # IsADirectoryError is another failure the stdlib reader flattens to None: a
+    # directory sitting at direct_url.json is corrupt metadata, not a missing file.
+    real_metadata_dist(monkeypatch, tmp_path, as_directory=True)
+
+    assert read_direct_url_record() == DirectUrlRecord(RecordState.UNREADABLE)
+
+
+def test_a_pathless_distribution_raising_reader_is_unreadable(monkeypatch):
+    # A custom Distribution need not expose PathDistribution's private _path; its
+    # abstract read_text() can RAISE while accessing metadata. That failure must
+    # land in the same UNREADABLE boundary as the path-backed branch's failures —
+    # not escape as a traceback (third-recheck regression).
+    class _PathlessDist:
+        version = installed_version("gda")
+
+        def read_text(self, name: str):
+            raise PermissionError("injected: metadata unreadable")
+
+    monkeypatch.setattr(
+        provenance.Distribution, "from_name", lambda name: _PathlessDist()
+    )
+
+    assert read_direct_url_record() == DirectUrlRecord(RecordState.UNREADABLE)
+
+
+def test_a_pathless_raising_reader_reaches_the_cli_as_unknown(monkeypatch):
+    class _PathlessDist:
+        version = installed_version("gda")
+
+        def read_text(self, name: str):
+            raise PermissionError("injected: metadata unreadable")
+
+    monkeypatch.setattr(
+        provenance.Distribution, "from_name", lambda name: _PathlessDist()
+    )
+
+    result = CliRunner().invoke(app, ["--version", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["install_kind"] == "unknown"
+    assert payload["source"] is None
+    assert payload["gda_version"] and payload["package_path"] and payload["godot"]
+
+
+def test_an_uninstalled_distribution_is_unreadable_not_absent():
+    # gda did not learn that no record exists; it failed to look. Degrades rather
+    # than raising, so a preflight never dies on missing metadata.
+    record = read_direct_url_record("definitely-not-an-installed-distribution")
+
+    assert record == DirectUrlRecord(RecordState.UNREADABLE)
+
+
+def test_a_whitespace_only_record_reaches_the_cli_as_unknown(monkeypatch, tmp_path):
+    real_metadata_dist(monkeypatch, tmp_path, record="   \n")
+
+    result = CliRunner().invoke(app, ["--version", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["install_kind"] == "unknown"
+    assert payload["source"] is None
+    # …and the payload is still emitted in full: degrade, never die.
+    assert payload["gda_version"] and payload["package_path"] and payload["godot"]
+
+
+def test_an_unreadable_record_reaches_the_cli_as_unknown(monkeypatch, tmp_path):
+    # A REAL mode-000 record through the real CLI: the stdlib reader would flatten
+    # this to None/absent; the located-entry read keeps it distinct, and the
+    # preflight degrades to `unknown` with a complete payload instead of dying.
+    target = real_metadata_dist(monkeypatch, tmp_path, record="{}", mode=0o000)
+
+    try:
+        result = CliRunner().invoke(app, ["--version", "--json"])
+    finally:
+        target.chmod(0o644)
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["install_kind"] == "unknown"
+    assert payload["source"] is None
+    assert payload["gda_version"] and payload["package_path"] and payload["godot"]
+
+
+def test_a_missing_record_reaches_the_cli_as_wheel(monkeypatch, tmp_path):
+    # The control for the two arms above: only a genuinely absent record earns the
+    # confident `wheel`, so the tests prove a distinction rather than a constant.
+    real_metadata_dist(monkeypatch, tmp_path)
+
+    payload = json.loads(CliRunner().invoke(app, ["--version", "--json"]).stdout)
+
+    assert payload["install_kind"] == "wheel"
+    assert payload["source"] is None
+
+
+# --- the engine side is resolved WITHOUT a launch -----------------------------
+
+
+def test_godot_version_key_is_omitted_with_a_stated_reason(monkeypatch):
+    # #659's contract is "the engine version appears only when obtainable without a
+    # launch, otherwise OMITTED with a stated reason". A `null` would claim gda
+    # looked and found nothing; the key's ABSENCE plus the reason says it declined
+    # to look — the same omitted-never-null convention gda uses elsewhere. So this
+    # asserts absence, not nullness.
+    monkeypatch.setenv("GDA_GODOT", "/definitely/missing/Godot")
+
+    payload = json.loads(CliRunner().invoke(app, ["--version", "--json"]).stdout)
+
+    assert payload["godot"]["binary"] == "/definitely/missing/Godot"
+    assert "version" not in payload["godot"]
+    assert payload["godot"]["version_unavailable_reason"]
+    assert set(payload["godot"]) == {"binary", "version_unavailable_reason"}
+
+
+def test_a_resolved_godot_version_would_omit_the_reason_instead():
+    # The mirror of the rule: exactly one of the pair is ever present, so a future
+    # spawn-free version source cannot leave a stale null reason beside it.
+    resolved = provenance.GodotProvenance(binary="/x/Godot", version="4.6.3-stable")
+
+    serialized = json.loads(resolved.model_dump_json())
+
+    assert serialized == {"binary": "/x/Godot", "version": "4.6.3-stable"}
+
+
+def test_the_surface_never_launches_godot(monkeypatch):
+    # The whole point: the motivating environment is a restricted profile where an
+    # engine spawn crashes. `gda.runner.launch` is the ONE headless-launch
+    # primitive every engine-spawning channel shares, so tripping it here proves a
+    # launch happened.
+    def _no_launch(*args, **kwargs):
+        raise AssertionError("the provenance surface must not launch Godot")
+
+    monkeypatch.setattr("gda.runner.launch", _no_launch)
+    monkeypatch.setenv("GDA_GODOT", "/definitely/missing/Godot")
+
+    spawned: list[list[str]] = []
+    real_run = subprocess.run
+
+    def _spy(cmd, *args, **kwargs):
+        spawned.append([str(part) for part in cmd])
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", _spy)
+
+    result = CliRunner().invoke(app, ["--version", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    # Whatever it did spawn, it was git resolving the checkout — never the engine.
+    # `assert spawned` first: this checkout IS an editable install, so git runs;
+    # without it, an empty list would satisfy the `all(...)` below vacuously and
+    # the guard would keep passing after it stopped guarding anything.
+    assert spawned
+    assert all(cmd[:1] == ["git"] for cmd in spawned), spawned
+    assert not [cmd for cmd in spawned if "Godot" in " ".join(cmd)]
+
+
+# --- the real out-of-process CLI ---------------------------------------------
+
+
+def test_real_out_of_process_cli_emits_the_payload():
+    # Through a REAL process, so the payload describes an actual invocation rather
+    # than the in-process test runner. Deliberately not marked `e2e`: this repo's
+    # `e2e` marker means "spawns a real Godot process", and this must not.
+    done = subprocess.run(
+        [*GDA_CMD, "--version", "--json"], capture_output=True, text=True
+    )
+
+    assert done.returncode == 0, done.stderr
+    payload = json.loads(done.stdout)
+    assert payload["gda_version"]
+    # `python -m gda` runs the package's __main__, and that is what is reported —
+    # the entry point that actually ran, not a re-guessed `which gda`.
+    assert payload["executable"].endswith(os.path.join("gda", "__main__.py"))
+    assert payload["interpreter"]


### PR DESCRIPTION
## Wave 2 promotion — gda dogfooding milestone

Promotes the wave-2 slices from `feat/gda-dogfooding-dev` to `main`. Tracks the
review-and-merge process for the whole wave.

**Merge method note:** merge commit (NOT squash) — the dev branch carries one clean squashed
commit per issue; squashing the promotion would break release-please's derivation on `main`.
The squash-only gate lives in the branch ruleset (`godot-agent-branch-rules`), temporarily
widened and restored at promotion time.

### Merge order and status

| # | Slice PR | Issue | Status |
| --- | --- | --- | --- |
| 1 | #695 — fix(gda): refuse a script validate outside the resolved project and report the root | #658 | ✅ merged `ca8d5ddc` |
| 2 | #693 — feat(gda): accept both script-path forms for script run (ADR-0031 amendment) | #675 (+ subsumes #699) | ✅ merged `b2910854` (integration fix: containment-layer tilde totality, found by the serial-merge gate) |
| 3 | #692 — feat(gda): report structured install provenance from --version --json | #659 | ✅ merged `1c15c257` (rebased + i18n re-stamped after #695; translations rebuilt three-way) |
| 4 | #696 — fix(gda): preflight and redirect the user:// root for the Headless launch | #653 | ✅ merged `9fb05e9e` (three-point rebase after #692; flag-sentinel test green; duplicate skill bullet from keep-both audited out) |
| 5 | #694 — fix(gda): classify sandbox-denied window-server access (ADR-0004/0002 amendments) | #667 | ✅ merged `1f3b96e0` (registry hunks auto-merged clean) |

### Review trail

Every slice: implementation → internal adversarial review + adjudicated fix rounds → external
adversarial reviews (codex channel) with per-claim reply tables → rechecks until closed. See
each PR's thread.

### Wave validation

- Per-PR CI green on every final head; targeted real-engine e2e per slice under the serialized lock.
- Full-e2e CI: dispatched on the dev-branch ref after the last merge — run
  [32011771629](https://github.com/aigengame/godot-agent/actions/runs/32011771629) (`run-e2e: true`) — **completed: success** (full suite incl. the real-Godot e2e tier, on the integrated dev branch at `1f3b96e0`).

### Follow-ups created during the wave

#697 (ADR-0006 derive-vs-refuse, needs-triage), #698/#700/#701 (ready-for-agent); #699 subsumed
by #693. Issue #653 carries a formal AC-1 amendment (stronger default endorsed).

Closes #658
Closes #675
Closes #699
Closes #659
Closes #653
Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)
