### PR TITLE
refactor(gda-balancing): deepen exact resolved model binding

### DIFF
--- a/libs/gda-balancing/src/gda_balancing/application/execution_sessions.py
+++ b/libs/gda-balancing/src/gda_balancing/application/execution_sessions.py
@@ -15,9 +15,11 @@ from gda_balancing.domain.authority.context import AdmittedAuthorityContext
 from gda_balancing.domain.diagnostics import Schema2RefusalReport
 from gda_balancing.domain.experiment import CheckedExperiment, check_experiment_value
 from gda_balancing.domain.model import (
+    ExactResolvedModelBinding,
     authority_context_for_checked,
     check_model_source_value,
     compile_checked_model,
+    project_compiled_model_binding,
 )
 
 
@@ -72,7 +74,7 @@ class _OrderedGate:
 @dataclass
 class _ExecutionSession:
     authority_context: AdmittedAuthorityContext
-    model_artifacts: dict[str, dict[str, Any]]
+    model_binding: ExactResolvedModelBinding
     revisions: dict[str, CheckedExperiment]
     gate: _OrderedGate = field(default_factory=_OrderedGate)
 
@@ -113,9 +115,13 @@ class ExecutionSessions:
                 return checked_model
             authority_context = authority_context_for_checked(checked_model)
             model_artifacts = compile_checked_model(checked_model)
+            model_binding = project_compiled_model_binding(
+                model_artifacts,
+                authority_context,
+            )
             checked_experiment = check_experiment_value(
                 experiment_specification,
-                model_artifacts,
+                model_binding,
                 authority_context=authority_context,
             )
             if isinstance(checked_experiment, Schema2RefusalReport):
@@ -123,16 +129,14 @@ class ExecutionSessions:
             session_id = secrets.token_urlsafe(24)
             session = _ExecutionSession(
                 authority_context=authority_context,
-                model_artifacts=model_artifacts,
+                model_binding=model_binding,
                 revisions={checked_experiment.content_identity: checked_experiment},
             )
             with self._registry_lock:
                 self._sessions[session_id] = session
         return ExecutionSessionCreated(
             session_id=session_id,
-            resolved_model_identity=str(
-                model_artifacts["resolved-model"]["content_identity"]
-            ),
+            resolved_model_identity=str(model_binding.resolved_model_identity),
             revision_id=checked_experiment.content_identity,
         )
 
@@ -148,7 +152,7 @@ class ExecutionSessions:
             with self._execution_gate.hold():
                 checked = check_experiment_value(
                     experiment_specification,
-                    session.model_artifacts,
+                    session.model_binding,
                     authority_context=session.authority_context,
                 )
                 if isinstance(checked, Schema2RefusalReport):

--- a/libs/gda-balancing/src/gda_balancing/domain/artifact_errors.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/artifact_errors.py
@@ -3,3 +3,16 @@
 
 class PublishedArtifactIntegrityError(RuntimeError):
     """An authenticated publication named the target but failed verification."""
+
+    def __init__(self, message: str, *, logical_name: str | None = None) -> None:
+        super().__init__(message)
+        self.logical_name = logical_name
+
+
+class PublishedArtifactUnavailable(LookupError):
+    """No authenticated publication contains one requested exact member."""
+
+    def __init__(self, logical_name: str, artifact_kind: str) -> None:
+        super().__init__(logical_name)
+        self.logical_name = logical_name
+        self.artifact_kind = artifact_kind

--- a/libs/gda-balancing/src/gda_balancing/domain/experiment.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/experiment.py
@@ -26,17 +26,24 @@ from gda_balancing.domain.diagnostics import (
     Schema2Diagnostic,
     Schema2RefusalReport,
 )
-from gda_balancing.domain.artifact_errors import PublishedArtifactIntegrityError
+from gda_balancing.domain.artifact_errors import (
+    PublishedArtifactIntegrityError,
+    PublishedArtifactUnavailable,
+)
 from gda_balancing.infrastructure.input_bytes import (
     read_bounded_input_with_sha256,
 )
-from gda_balancing.domain.model import admit_resolved_model
+from gda_balancing.domain.model import (
+    EXACT_RESOLVED_MODEL_BINDING_MEMBERS,
+    ExactResolvedModelBinding,
+    ExactResolvedModelBindingError,
+    resolve_published_model_binding,
+)
 from gda_balancing.domain.operation_program import (
     expanded_operation_body,
     operation_coordinate,
     selected_operation_index,
 )
-from gda_balancing.domain.publication import find_published_artifact
 from gda_balancing.domain.runtime.scheduler import RuntimeScheduler
 from gda_balancing.domain.structured_values import (
     StructuredValueIndex,
@@ -382,12 +389,12 @@ def check_experiment(
             pointer="",
             message="Experiment Specification is not canonical JSON data",
         )
-    return _check_experiment_value(value, context, model_artifacts=None)
+    return _check_experiment_value(value, context, model_binding=None)
 
 
 def check_experiment_value(
     value: dict[str, Any],
-    model_artifacts: Mapping[str, dict[str, Any]],
+    model_binding: ExactResolvedModelBinding,
     *,
     authority_context: AdmittedAuthorityContext | None = None,
 ) -> CheckedExperiment | Schema2RefusalReport:
@@ -418,7 +425,7 @@ def check_experiment_value(
     return _check_experiment_value(
         admitted_value,
         context,
-        model_artifacts=model_artifacts,
+        model_binding=model_binding,
     )
 
 
@@ -426,7 +433,7 @@ def _check_experiment_value(
     value: dict[str, Any],
     context: AdmittedAuthorityContext,
     *,
-    model_artifacts: Mapping[str, dict[str, Any]] | None,
+    model_binding: ExactResolvedModelBinding | None,
 ) -> CheckedExperiment | Schema2RefusalReport:
     """Apply Experiment semantics after transport-specific ingestion."""
     kernel = context.kernel
@@ -511,71 +518,70 @@ def _check_experiment_value(
 
     model = value["model"]
     artifact_kinds = {
-        "build_receipt": ("build-receipt", "build-receipt"),
-        "package_lock": ("package-lock", "package-lock"),
-        "resolved_model": ("resolved-model", "resolved-model"),
-        "rir": ("rir-semantic-payload", "rir-semantic-payload"),
+        logical_name: artifact_kind
+        for logical_name, artifact_kind in EXACT_RESOLVED_MODEL_BINDING_MEMBERS
     }
     identity_members = {
-        "build_receipt": "build_receipt_identity",
-        "package_lock": "package_lock_identity",
-        "resolved_model": "resolved_model_identity",
-        "rir": "rir_identity",
+        "build-receipt": "build_receipt_identity",
+        "package-lock": "package_lock_identity",
+        "resolved-model": "resolved_model_identity",
+        "rir-semantic-payload": "rir_identity",
     }
-    artifacts: dict[str, dict[str, Any]] = {}
-    for name, (logical_name, kind) in artifact_kinds.items():
-        if model_artifacts is None:
-            try:
-                artifact = find_published_artifact(
-                    model[identity_members[name]],
-                    kind,
-                    language_bundle,
-                )
-            except PublishedArtifactIntegrityError as err:
+    if model_binding is None:
+        try:
+            model_binding = resolve_published_model_binding(
+                {
+                    logical_name: cast(str, model[identity_member])
+                    for logical_name, identity_member in identity_members.items()
+                },
+                context,
+            )
+        except PublishedArtifactUnavailable as err:
+            identity_member = identity_members[err.logical_name]
+            return _refusal(
+                stage="resolution",
+                code="language.resolved_authority_mismatch",
+                identity=experiment_identity,
+                pointer=f"/model/{identity_member}",
+                message=(
+                    f"Exact {err.artifact_kind} is unavailable in the committed "
+                    "artifact store"
+                ),
+            )
+        except PublishedArtifactIntegrityError as err:
+            logical_name = err.logical_name or "build-receipt"
+            kind = artifact_kinds[logical_name]
+            return _refusal(
+                stage="resolution",
+                code="language.resolved_authority_mismatch",
+                identity=experiment_identity,
+                pointer=f"/model/{identity_members[logical_name]}",
+                message=(
+                    f"Exact {kind} publication failed integrity verification: {err}"
+                ),
+            )
+        except ExactResolvedModelBindingError as err:
+            if err.reason == "resolved-model-admission-failed":
                 return _refusal(
                     stage="resolution",
                     code="language.resolved_authority_mismatch",
                     identity=experiment_identity,
-                    pointer=f"/model/{identity_members[name]}",
+                    pointer="/model",
                     message=(
-                        f"Exact {kind} publication failed integrity verification: {err}"
+                        "Experiment model artifacts do not form one admitted "
+                        "Resolved Model"
                     ),
                 )
-            if artifact is None:
-                return _refusal(
-                    stage="resolution",
-                    code="language.resolved_authority_mismatch",
-                    identity=experiment_identity,
-                    pointer=f"/model/{identity_members[name]}",
-                    message=f"Exact {kind} is unavailable in the committed artifact store",
-                )
-        else:
-            artifact = model_artifacts.get(logical_name)
-            if artifact is None or artifact.get("artifact_kind") != kind:
-                return _refusal(
-                    stage="resolution",
-                    code="language.resolved_authority_mismatch",
-                    identity=experiment_identity,
-                    pointer=f"/model/{identity_members[name]}",
-                    message=f"Exact {kind} is unavailable in the supplied Model artifact set",
-                )
-        artifacts[name] = artifact
-    if not admit_resolved_model(
-        {
-            "package-lock": artifacts["package_lock"],
-            "resolved-model": artifacts["resolved_model"],
-            "rir-semantic-payload": artifacts["rir"],
-        },
-        authority_context=context,
-    ).admitted:
-        return _refusal(
-            stage="resolution",
-            code="language.resolved_authority_mismatch",
-            identity=experiment_identity,
-            pointer="/model",
-            message="Experiment model artifacts do not form one admitted Resolved Model",
-        )
-    build = artifacts["build_receipt"]
+            return _refusal(
+                stage="resolution",
+                code="language.resolved_authority_mismatch",
+                identity=experiment_identity,
+                pointer="/model",
+                message="Experiment Model binding disagrees with its exact Build receipt",
+            )
+
+    artifacts = model_binding.artifacts()
+    build = artifacts["build-receipt"]
     expected_build_bindings = {
         "source_identity": model["source_identity"],
         "kernel_identity": value["kernel_identity"],
@@ -587,6 +593,9 @@ def _check_experiment_value(
     if any(
         build.get(name) != expected
         for name, expected in expected_build_bindings.items()
+    ) or any(
+        artifacts[logical_name].get("content_identity") != model[identity_member]
+        for logical_name, identity_member in identity_members.items()
     ):
         return _refusal(
             stage="resolution",
@@ -596,7 +605,7 @@ def _check_experiment_value(
             message="Experiment Model binding disagrees with its exact Build receipt",
         )
 
-    rir = artifacts["rir"]
+    rir = artifacts["rir-semantic-payload"]
     selected = rir["selected_semantics"]
     operations = {
         row["definition"]["id"]: row["definition"] for row in selected["operations"]
@@ -956,8 +965,8 @@ def _check_experiment_value(
         kernel=kernel,
         language_bundle=language_bundle,
         build_receipt=build,
-        package_lock=artifacts["package_lock"],
-        resolved_model=artifacts["resolved_model"],
+        package_lock=artifacts["package-lock"],
+        resolved_model=artifacts["resolved-model"],
         rir=rir,
         authority_context=context,
     )

--- a/libs/gda-balancing/src/gda_balancing/domain/model/__init__.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/__init__.py
@@ -1,6 +1,14 @@
 """Model checking, resolution, lowering, compilation, admission, and inspection."""
 
 from ._admission import admit_resolved_model
+from ._binding import (
+    EXACT_RESOLVED_MODEL_BINDING_MEMBERS,
+    ExactResolvedModelBinding,
+    ExactResolvedModelBindingError,
+    admit_exact_resolved_model_binding,
+    project_compiled_model_binding,
+    resolve_published_model_binding,
+)
 from ._checking import check_model_source, check_model_source_value
 from ._compilation import (
     authority_context_for_checked,
@@ -23,8 +31,12 @@ __all__ = (
     "MODEL_INSPECT_REFUSAL_CATALOG",
     "MODEL_REFUSAL_CATALOG",
     "CheckedModel",
+    "EXACT_RESOLVED_MODEL_BINDING_MEMBERS",
+    "ExactResolvedModelBinding",
+    "ExactResolvedModelBindingError",
     "ModelInspectAdmissionError",
     "admit_resolved_model",
+    "admit_exact_resolved_model_binding",
     "authority_context_for_checked",
     "check_model_source",
     "check_model_source_value",
@@ -32,6 +44,8 @@ __all__ = (
     "compile_checked_model",
     "model_build_command_input_identity",
     "model_source_identity_domain",
+    "project_compiled_model_binding",
+    "resolve_published_model_binding",
     "read_model_explanation",
     "validate_compiled_artifacts",
     "verify_checked_model",

--- a/libs/gda-balancing/src/gda_balancing/domain/model/__init__.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/__init__.py
@@ -5,7 +5,6 @@ from ._binding import (
     EXACT_RESOLVED_MODEL_BINDING_MEMBERS,
     ExactResolvedModelBinding,
     ExactResolvedModelBindingError,
-    admit_exact_resolved_model_binding,
     project_compiled_model_binding,
     resolve_published_model_binding,
 )
@@ -36,7 +35,6 @@ __all__ = (
     "ExactResolvedModelBindingError",
     "ModelInspectAdmissionError",
     "admit_resolved_model",
-    "admit_exact_resolved_model_binding",
     "authority_context_for_checked",
     "check_model_source",
     "check_model_source_value",

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_binding.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_binding.py
@@ -1,0 +1,194 @@
+"""One detached exact Resolved Model binding for Experiment admission."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+from gda_balancing.domain.artifacts import verify_artifact
+from gda_balancing.domain.authority.context import AdmittedAuthorityContext
+from gda_balancing.domain.canonical import (
+    JsonValue,
+    canonical_bytes,
+    parse_canonical_object,
+)
+from gda_balancing.domain.model._admission import admit_resolved_model
+from gda_balancing.domain.publication import find_published_artifacts
+
+
+EXACT_RESOLVED_MODEL_BINDING_MEMBERS = (
+    ("build-receipt", "build-receipt"),
+    ("package-lock", "package-lock"),
+    ("resolved-model", "resolved-model"),
+    ("rir-semantic-payload", "rir-semantic-payload"),
+)
+
+_MEMBER_KINDS = dict(EXACT_RESOLVED_MODEL_BINDING_MEMBERS)
+
+
+class ExactResolvedModelBindingError(ValueError):
+    """One required member or relationship failed exact binding admission."""
+
+    def __init__(
+        self,
+        reason: Literal[
+            "member-set-mismatch",
+            "member-admission-failed",
+            "resolved-model-admission-failed",
+            "build-receipt-binding-mismatch",
+        ],
+        member: str | None,
+        message: str,
+    ) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.member = member
+        self.message = message
+
+
+@dataclass(frozen=True, init=False)
+class ExactResolvedModelBinding:
+    """Canonical detached bytes for one admitted four-member Model binding."""
+
+    _canonical_members: tuple[tuple[str, bytes], ...]
+    resolved_model_identity: str
+
+    def __init__(self) -> None:
+        raise TypeError(
+            "ExactResolvedModelBinding values come from Model binding admission"
+        )
+
+    def artifacts(self) -> dict[str, dict[str, Any]]:
+        """Materialize a detached copy for one Experiment admission."""
+        return {
+            name: parse_canonical_object(data, artifact_name=name)
+            for name, data in self._canonical_members
+        }
+
+
+def project_compiled_model_binding(
+    artifacts: dict[str, dict[str, JsonValue]],
+    authority_context: AdmittedAuthorityContext,
+) -> ExactResolvedModelBinding:
+    """Project verified compiler output into the exact Experiment Model binding."""
+    selected: dict[str, dict[str, Any]] = {}
+    for name in _MEMBER_KINDS:
+        artifact = artifacts.get(name)
+        if artifact is None:
+            raise ExactResolvedModelBindingError(
+                "member-set-mismatch",
+                name,
+                f"exact Model binding has no {name} member",
+            )
+        selected[name] = cast(dict[str, Any], artifact)
+    return admit_exact_resolved_model_binding(selected, authority_context)
+
+
+def resolve_published_model_binding(
+    identities: dict[str, str],
+    authority_context: AdmittedAuthorityContext,
+) -> ExactResolvedModelBinding:
+    """Acquire and admit one committed exact Model binding in one traversal."""
+    requested_names = set(_MEMBER_KINDS)
+    if set(identities) != requested_names:
+        missing = sorted(requested_names - set(identities))
+        extra = sorted(set(identities) - requested_names)
+        member = missing[0] if missing else extra[0]
+        raise ExactResolvedModelBindingError(
+            "member-set-mismatch",
+            member,
+            "exact published Model request member set is not closed",
+        )
+    artifacts = find_published_artifacts(
+        tuple(
+            (logical_name, artifact_kind, identities[logical_name])
+            for logical_name, artifact_kind in EXACT_RESOLVED_MODEL_BINDING_MEMBERS
+        ),
+        authority_context.language_bundle,
+    )
+    return admit_exact_resolved_model_binding(artifacts, authority_context)
+
+
+def admit_exact_resolved_model_binding(
+    artifacts: dict[str, dict[str, Any]],
+    authority_context: AdmittedAuthorityContext,
+) -> ExactResolvedModelBinding:
+    """Detach and admit exactly the four artifacts required by Experiment."""
+    names = set(artifacts)
+    expected_names = set(_MEMBER_KINDS)
+    if names != expected_names:
+        missing = sorted(expected_names - names)
+        extra = sorted(names - expected_names)
+        member = missing[0] if missing else extra[0]
+        raise ExactResolvedModelBindingError(
+            "member-set-mismatch",
+            member,
+            "exact Model binding member set is not closed",
+        )
+
+    detached: dict[str, dict[str, Any]] = {}
+    canonical_members: list[tuple[str, bytes]] = []
+    for name, expected_kind in _MEMBER_KINDS.items():
+        artifact = artifacts[name]
+        try:
+            data = canonical_bytes(cast(JsonValue, artifact))
+            candidate = parse_canonical_object(data, artifact_name=name)
+        except (TypeError, ValueError, UnicodeError) as error:
+            raise ExactResolvedModelBindingError(
+                "member-admission-failed",
+                name,
+                f"exact Model binding member is not canonical: {name}",
+            ) from error
+        if candidate.get("artifact_kind") != expected_kind or not verify_artifact(
+            candidate, authority_context.language_bundle
+        ):
+            raise ExactResolvedModelBindingError(
+                "member-admission-failed",
+                name,
+                f"exact Model binding member failed admission: {name}",
+            )
+        detached[name] = candidate
+        canonical_members.append((name, data))
+
+    if not admit_resolved_model(
+        {
+            "package-lock": detached["package-lock"],
+            "resolved-model": detached["resolved-model"],
+            "rir-semantic-payload": detached["rir-semantic-payload"],
+        },
+        authority_context=authority_context,
+    ).admitted:
+        raise ExactResolvedModelBindingError(
+            "resolved-model-admission-failed",
+            None,
+            "exact Model binding does not contain one admitted Resolved Model",
+        )
+
+    build = detached["build-receipt"]
+    expected_build_bindings = {
+        "kernel_identity": authority_context.kernel["content_identity"],
+        "language_bundle_identity": authority_context.language_bundle[
+            "content_identity"
+        ],
+        "package_lock_identity": detached["package-lock"]["content_identity"],
+        "resolved_model_identity": detached["resolved-model"]["content_identity"],
+        "rir_identity": detached["rir-semantic-payload"]["content_identity"],
+    }
+    if any(
+        build.get(member) != expected
+        for member, expected in expected_build_bindings.items()
+    ):
+        raise ExactResolvedModelBindingError(
+            "build-receipt-binding-mismatch",
+            "build-receipt",
+            "Build receipt does not bind the exact Resolved Model members",
+        )
+
+    binding = object.__new__(ExactResolvedModelBinding)
+    object.__setattr__(binding, "_canonical_members", tuple(canonical_members))
+    object.__setattr__(
+        binding,
+        "resolved_model_identity",
+        cast(str, detached["resolved-model"]["content_identity"]),
+    )
+    return binding

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_binding.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_binding.py
@@ -81,7 +81,7 @@ def project_compiled_model_binding(
                 f"exact Model binding has no {name} member",
             )
         selected[name] = cast(dict[str, Any], artifact)
-    return admit_exact_resolved_model_binding(selected, authority_context)
+    return _admit_exact_resolved_model_binding(selected, authority_context)
 
 
 def resolve_published_model_binding(
@@ -106,10 +106,10 @@ def resolve_published_model_binding(
         ),
         authority_context.language_bundle,
     )
-    return admit_exact_resolved_model_binding(artifacts, authority_context)
+    return _admit_exact_resolved_model_binding(artifacts, authority_context)
 
 
-def admit_exact_resolved_model_binding(
+def _admit_exact_resolved_model_binding(
     artifacts: dict[str, dict[str, Any]],
     authority_context: AdmittedAuthorityContext,
 ) -> ExactResolvedModelBinding:

--- a/libs/gda-balancing/src/gda_balancing/domain/publication.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/publication.py
@@ -10,9 +10,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
-from gda_balancing.domain.artifact_errors import PublishedArtifactIntegrityError
-from gda_balancing.domain.artifact_set import ArtifactSetMemberSpec
+from gda_balancing.domain.artifact_errors import (
+    PublishedArtifactIntegrityError,
+    PublishedArtifactUnavailable,
+)
 from gda_balancing.domain.artifacts import _identified_artifact, _verify_artifact
+from gda_balancing.domain.artifact_set import ArtifactSetMemberSpec
 from gda_balancing.domain.authority.admission import BootstrapAdmission
 from gda_balancing.domain.authority.context import (
     AdmittedAuthorityContext,
@@ -74,20 +77,28 @@ class AuthenticatedArtifactSet:
     artifacts: dict[str, dict[str, Any]]
 
 
-def find_published_artifact(
-    content_identity_value: str,
-    artifact_kind: str,
+def find_published_artifacts(
+    requested: tuple[tuple[str, str, str], ...],
     language_bundle: dict[str, Any],
-) -> dict[str, Any] | None:
-    """Resolve one exact artifact through authenticated committed publications.
+) -> dict[str, dict[str, Any]]:
+    """Resolve one exact named subset through one authenticated store traversal."""
+    names = [logical_name for logical_name, _kind, _identity in requested]
+    if not requested or len(names) != len(set(names)):
+        raise ValueError("published artifact requests require unique logical names")
+    matches = _resolve_published_artifacts(requested, language_bundle)
+    return {name: artifact for name, artifact in zip(names, matches, strict=True)}
 
-    Locators remain transport facts: callers bind semantic identities, while
-    this local-store adapter discovers a locator and then revalidates the
-    authenticated publication frame, artifact schema, and content hash.
-    """
+
+def _resolve_published_artifacts(
+    requested: tuple[tuple[str, str, str], ...],
+    language_bundle: dict[str, Any],
+) -> tuple[dict[str, Any], ...]:
     anchors = _store_root() / "anchors"
     authentication_key = publication_authentication_key()
-    matches: list[dict[str, Any]] = []
+    matches: list[list[dict[str, Any]]] = [[] for _request in requested]
+    integrity_errors: list[PublishedArtifactIntegrityError | None] = [
+        None for _request in requested
+    ]
     for anchor_path in regular_files(anchors, "*/*.json"):
         try:
             index = _verified_anchor(anchor_path, authentication_key)
@@ -146,44 +157,76 @@ def find_published_artifact(
                 or len(member_locators) != len(members)
             ):
                 continue
-            for member in members:
-                if (
-                    not isinstance(member, dict)
-                    or member.get("artifact_kind") != artifact_kind
-                    or member.get("content_identity") != content_identity_value
-                    or not isinstance(member.get("logical_name"), str)
-                ):
+            for request_index, request in enumerate(requested):
+                logical_name, artifact_kind, content_identity_value = request
+                candidates = [
+                    member
+                    for member in members
+                    if isinstance(member, dict)
+                    and member.get("artifact_kind") == artifact_kind
+                    and member.get("content_identity") == content_identity_value
+                    and isinstance(member.get("logical_name"), str)
+                    and member.get("logical_name") == logical_name
+                ]
+                if len(candidates) != 1:
                     continue
+                member = candidates[0]
+                member_name = cast(str, member["logical_name"])
                 try:
                     artifact = _read_canonical_artifact(
-                        invocation_path / f"{member['logical_name']}.json"
+                        invocation_path / f"{member_name}.json"
                     )
-                except (OSError, RuntimeError, PublicationError, ValueError) as err:
-                    raise PublishedArtifactIntegrityError(
-                        "authenticated publication member is unreadable or non-canonical"
-                    ) from err
+                except (OSError, RuntimeError, PublicationError, ValueError):
+                    if integrity_errors[request_index] is None:
+                        integrity_errors[request_index] = (
+                            PublishedArtifactIntegrityError(
+                                "authenticated publication member is unreadable or "
+                                "non-canonical",
+                                logical_name=logical_name,
+                            )
+                        )
+                    continue
                 if not (
                     _verify_artifact(artifact, language_bundle)
                     and artifact.get("artifact_kind") == artifact_kind
                     and artifact.get("content_identity") == content_identity_value
                 ):
-                    raise PublishedArtifactIntegrityError(
-                        "authenticated publication member failed schema or identity "
-                        "verification"
-                    )
-                matches.append(artifact)
-        except PublishedArtifactIntegrityError:
-            raise
+                    if integrity_errors[request_index] is None:
+                        integrity_errors[request_index] = (
+                            PublishedArtifactIntegrityError(
+                                "authenticated publication member failed schema or "
+                                "identity verification",
+                                logical_name=logical_name,
+                            )
+                        )
+                    continue
+                matches[request_index].append(artifact)
         except (OSError, RuntimeError, PublicationError, ValueError):
             continue
-    if not matches:
-        return None
-    canonical = canonical_bytes(cast(JsonValue, matches[0]))
-    if any(canonical_bytes(cast(JsonValue, item)) != canonical for item in matches[1:]):
-        raise PublishedArtifactIntegrityError(
-            "one content identity resolved to different authenticated artifacts"
-        )
-    return matches[0]
+    resolved: list[dict[str, Any]] = []
+    for request, candidates, integrity_error in zip(
+        requested, matches, integrity_errors, strict=True
+    ):
+        logical_name, artifact_kind, _content_identity_value = request
+        if integrity_error is not None:
+            raise integrity_error
+        if not candidates:
+            raise PublishedArtifactUnavailable(
+                logical_name,
+                artifact_kind,
+            )
+        canonical = canonical_bytes(cast(JsonValue, candidates[0]))
+        if any(
+            canonical_bytes(cast(JsonValue, candidate)) != canonical
+            for candidate in candidates[1:]
+        ):
+            raise PublishedArtifactIntegrityError(
+                "one exact artifact request resolved to different authenticated "
+                "artifacts",
+                logical_name=logical_name,
+            )
+        resolved.append(candidates[0])
+    return tuple(resolved)
 
 
 def _write_json(path: Path, value: dict[str, JsonValue]) -> None:

--- a/libs/gda-balancing/src/gda_balancing/domain/publication.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/publication.py
@@ -157,6 +157,8 @@ def _resolve_published_artifacts(
                 or len(member_locators) != len(members)
             ):
                 continue
+            requested_members: list[tuple[int, dict[str, Any]]] = []
+            ambiguous = False
             for request_index, request in enumerate(requested):
                 logical_name, artifact_kind, content_identity_value = request
                 candidates = [
@@ -168,38 +170,43 @@ def _resolve_published_artifacts(
                     and isinstance(member.get("logical_name"), str)
                     and member.get("logical_name") == logical_name
                 ]
-                if len(candidates) != 1:
-                    continue
-                member = candidates[0]
+                if len(candidates) > 1:
+                    if integrity_errors[request_index] is None:
+                        integrity_errors[request_index] = (
+                            PublishedArtifactIntegrityError(
+                                "authenticated publication contains ambiguous exact "
+                                "member descriptors",
+                                logical_name=logical_name,
+                            )
+                        )
+                    ambiguous = True
+                elif len(candidates) == 1:
+                    requested_members.append((request_index, candidates[0]))
+            if ambiguous:
+                continue
+            if not requested_members:
+                continue
+            try:
+                artifacts = _read_complete_publication_members(
+                    invocation_path,
+                    members,
+                    language_bundle,
+                )
+            except (OSError, RuntimeError, PublicationError, ValueError):
+                for request_index, _member in requested_members:
+                    if integrity_errors[request_index] is None:
+                        logical_name = requested[request_index][0]
+                        integrity_errors[request_index] = (
+                            PublishedArtifactIntegrityError(
+                                "authenticated publication contains a missing, damaged, "
+                                "or identity-inconsistent member",
+                                logical_name=logical_name,
+                            )
+                        )
+                continue
+            for request_index, member in requested_members:
                 member_name = cast(str, member["logical_name"])
-                try:
-                    artifact = _read_canonical_artifact(
-                        invocation_path / f"{member_name}.json"
-                    )
-                except (OSError, RuntimeError, PublicationError, ValueError):
-                    if integrity_errors[request_index] is None:
-                        integrity_errors[request_index] = (
-                            PublishedArtifactIntegrityError(
-                                "authenticated publication member is unreadable or "
-                                "non-canonical",
-                                logical_name=logical_name,
-                            )
-                        )
-                    continue
-                if not (
-                    _verify_artifact(artifact, language_bundle)
-                    and artifact.get("artifact_kind") == artifact_kind
-                    and artifact.get("content_identity") == content_identity_value
-                ):
-                    if integrity_errors[request_index] is None:
-                        integrity_errors[request_index] = (
-                            PublishedArtifactIntegrityError(
-                                "authenticated publication member failed schema or "
-                                "identity verification",
-                                logical_name=logical_name,
-                            )
-                        )
-                    continue
+                artifact = artifacts[member_name]
                 matches[request_index].append(artifact)
         except (OSError, RuntimeError, PublicationError, ValueError):
             continue
@@ -227,6 +234,46 @@ def _resolve_published_artifacts(
             )
         resolved.append(candidates[0])
     return tuple(resolved)
+
+
+def _read_complete_publication_members(
+    invocation_path: Path,
+    members: list[Any],
+    language_bundle: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Re-admit every member declared by one selected publication manifest."""
+    artifacts: dict[str, dict[str, Any]] = {}
+    for member in members:
+        if not isinstance(member, dict):
+            raise RuntimeError(
+                "authenticated publication member descriptor is malformed"
+            )
+        logical_name = member.get("logical_name")
+        artifact_kind = member.get("artifact_kind")
+        wire_schema_identity = member.get("wire_schema_identity")
+        content_identity_value = member.get("content_identity")
+        if (
+            not isinstance(logical_name, str)
+            or not isinstance(artifact_kind, str)
+            or not isinstance(wire_schema_identity, str)
+            or not isinstance(content_identity_value, str)
+            or logical_name in artifacts
+        ):
+            raise RuntimeError(
+                "authenticated publication member descriptor is not unique and closed"
+            )
+        artifact = _read_canonical_artifact(invocation_path / f"{logical_name}.json")
+        if (
+            not _verify_artifact(artifact, language_bundle)
+            or artifact.get("artifact_kind") != artifact_kind
+            or artifact.get("wire_schema_identity") != wire_schema_identity
+            or artifact.get("content_identity") != content_identity_value
+        ):
+            raise RuntimeError(
+                "authenticated publication member failed schema or identity verification"
+            )
+        artifacts[logical_name] = artifact
+    return artifacts
 
 
 def _write_json(path: Path, value: dict[str, JsonValue]) -> None:

--- a/libs/gda-balancing/tests/schema2_operation_execution_conformance_support.py
+++ b/libs/gda-balancing/tests/schema2_operation_execution_conformance_support.py
@@ -147,6 +147,7 @@ def candidate_conformance_failures(
     ldb: Any,
     *,
     vector_overrides: dict[str, dict[str, Any]] | None = None,
+    vector_coordinates: set[tuple[str, str, str]] | None = None,
 ) -> list[dict[str, Any]]:
     """Return bounded candidate-graph and execution-vector disagreements."""
     production_admission = _consumer_a(kernel, ldb)
@@ -171,6 +172,9 @@ def candidate_conformance_failures(
     failures: list[dict[str, Any]] = []
     overrides = vector_overrides or {}
     for package_id, package_version, declared in operation_execution_vectors(ldb):
+        coordinate = (package_id, package_version, cast(str, declared["id"]))
+        if vector_coordinates is not None and coordinate not in vector_coordinates:
+            continue
         vector = overrides.get(declared["id"], declared)
         observations = operation_execution_observations(
             kernel,

--- a/libs/gda-balancing/tests/test_exact_resolved_model_binding.py
+++ b/libs/gda-balancing/tests/test_exact_resolved_model_binding.py
@@ -2,14 +2,17 @@
 
 from copy import deepcopy
 import json
+import os
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
+import gda_balancing.domain.publication as publication_module
+from gda_balancing.domain.artifact_errors import PublishedArtifactIntegrityError
 from gda_balancing.domain.authority.context import AdmittedAuthorityContext
 from gda_balancing.domain.artifacts import identified_artifact
-from gda_balancing.domain.canonical import JsonValue, canonical_bytes
+from gda_balancing.domain.canonical import JsonValue, canonical_bytes, content_identity
 from gda_balancing.domain.model import (
     CheckedModel,
     ExactResolvedModelBinding,
@@ -35,6 +38,60 @@ def _compiled_model() -> tuple[
     assert isinstance(checked, CheckedModel)
     context = authority_context_for_checked(checked)
     return compile_checked_model(checked), context
+
+
+def _reidentify(artifact: dict[str, Any], domain: str) -> None:
+    excluded = (
+        {"manifest_locator", "member_locators"}
+        if domain == "artifact-set-receipt-v2"
+        else set()
+    )
+    artifact["content_identity"] = content_identity(
+        domain,
+        cast(
+            JsonValue,
+            {
+                key: value
+                for key, value in artifact.items()
+                if key != "content_identity" and key not in excluded
+            },
+        ),
+    )
+
+
+def _publish_example_model(
+    tmp_path: Path,
+    run_cli,
+    invocation_key: str,
+) -> tuple[
+    AdmittedAuthorityContext,
+    Path,
+    dict[str, str],
+]:
+    artifacts, context = _compiled_model()
+    exit_code, stdout, stderr = run_cli(
+        [
+            "model",
+            "build",
+            str(_EXAMPLE / "model-source.json"),
+            "--out",
+            str(tmp_path / f"resolved-model-{invocation_key[0]}.json"),
+            "--invocation-key",
+            invocation_key,
+        ]
+    )
+    assert (exit_code, stderr) == (0, "")
+    receipt = json.loads(stdout)
+    identities = {
+        name: cast(str, artifacts[name]["content_identity"])
+        for name in (
+            "build-receipt",
+            "package-lock",
+            "resolved-model",
+            "rir-semantic-payload",
+        )
+    }
+    return context, Path(receipt["manifest_locator"]).parent, identities
 
 
 def test_exact_binding_requires_admission() -> None:
@@ -180,3 +237,115 @@ def test_committed_and_compiled_adapters_produce_the_same_exact_binding(
         name: canonical_bytes(cast(JsonValue, artifact))
         for name, artifact in compiled.artifacts().items()
     }
+
+
+def test_published_binding_rejects_damage_to_an_unrequested_member(
+    tmp_path: Path,
+    run_cli,
+) -> None:
+    context, publication_dir, identities = _publish_example_model(
+        tmp_path,
+        run_cli,
+        "b" * 64,
+    )
+    member_path = publication_dir / "capability-manifest.json"
+    original_bytes = member_path.read_bytes()
+    original = json.loads(original_bytes)
+
+    def assert_refused() -> None:
+        with pytest.raises(PublishedArtifactIntegrityError) as caught:
+            resolve_published_model_binding(identities, context)
+        assert caught.value.logical_name == "build-receipt"
+
+    member_path.unlink()
+    assert_refused()
+    member_path.write_bytes(original_bytes)
+
+    member_path.write_bytes(b"not-json")
+    assert_refused()
+    member_path.write_bytes(original_bytes)
+
+    payload = {
+        key: value
+        for key, value in original.items()
+        if key
+        not in {
+            "artifact_kind",
+            "artifact_version",
+            "content_identity",
+            "wire_schema_identity",
+        }
+    }
+    payload["package_lock_identity"] = "sha256:" + ("0" * 64)
+    replacement = identified_artifact(
+        context.language_bundle,
+        "capability-manifest",
+        cast(dict[str, JsonValue], payload),
+    )
+    assert replacement["content_identity"] != original["content_identity"]
+    member_path.write_bytes(canonical_bytes(cast(JsonValue, replacement)))
+    assert_refused()
+
+
+def test_published_binding_rejects_an_ambiguous_descriptor_before_fallback(
+    tmp_path: Path,
+    run_cli,
+) -> None:
+    invocation_key = "c" * 64
+    context, publication_dir, identities = _publish_example_model(
+        tmp_path,
+        run_cli,
+        invocation_key,
+    )
+    _publish_example_model(tmp_path, run_cli, "d" * 64)
+
+    manifest_path = publication_dir / "artifact-set-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    descriptor = deepcopy(
+        next(
+            row for row in manifest["members"] if row["logical_name"] == "build-receipt"
+        )
+    )
+    descriptor["wire_schema_identity"] = "sha256:" + ("0" * 64)
+    manifest["members"].append(descriptor)
+    _reidentify(manifest, "artifact-set-manifest-v2")
+    manifest_path.write_bytes(canonical_bytes(cast(JsonValue, manifest)))
+
+    receipt_path = publication_dir / "artifact-set-receipt.json"
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["manifest_identity"] = manifest["content_identity"]
+    receipt["member_locators"].append(
+        {
+            "logical_name": "build-receipt",
+            "locator": str((publication_dir / "build-receipt.json").absolute()),
+        }
+    )
+    _reidentify(receipt, "artifact-set-receipt-v2")
+    receipt_path.write_bytes(canonical_bytes(cast(JsonValue, receipt)))
+
+    index_path = publication_dir / "publication-index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["receipt_identity"] = receipt["content_identity"]
+    _reidentify(index, "publication-index-v2")
+    index_path.write_bytes(canonical_bytes(cast(JsonValue, index)))
+
+    store = Path(os.environ["GDA_BALANCING_STORE_DIR"])
+    anchor_path = next((store / "anchors").glob(f"*/{invocation_key}.json"))
+    anchor_path.unlink()
+    anchor_path.write_bytes(
+        canonical_bytes(
+            cast(
+                JsonValue,
+                publication_module._authenticated_anchor(
+                    index,
+                    publication_module.publication_authentication_key(),
+                ),
+            )
+        )
+    )
+    anchor_path.chmod(0o444)
+
+    with pytest.raises(PublishedArtifactIntegrityError) as caught:
+        resolve_published_model_binding(identities, context)
+
+    assert caught.value.logical_name == "build-receipt"

--- a/libs/gda-balancing/tests/test_exact_resolved_model_binding.py
+++ b/libs/gda-balancing/tests/test_exact_resolved_model_binding.py
@@ -1,0 +1,182 @@
+"""Exact Resolved Model binding shared by committed and in-memory paths."""
+
+from copy import deepcopy
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from gda_balancing.domain.authority.context import AdmittedAuthorityContext
+from gda_balancing.domain.artifacts import identified_artifact
+from gda_balancing.domain.canonical import JsonValue, canonical_bytes
+from gda_balancing.domain.model import (
+    CheckedModel,
+    ExactResolvedModelBinding,
+    ExactResolvedModelBindingError,
+    authority_context_for_checked,
+    check_model_source_value,
+    compile_checked_model,
+    project_compiled_model_binding,
+    resolve_published_model_binding,
+)
+
+
+_PACKAGE_ROOT = Path(__file__).parents[1]
+_EXAMPLE = _PACKAGE_ROOT / "examples" / "schema2" / "roguelike-reward-build"
+
+
+def _compiled_model() -> tuple[
+    dict[str, dict[str, JsonValue]],
+    AdmittedAuthorityContext,
+]:
+    source = json.loads((_EXAMPLE / "model-source.json").read_text(encoding="utf-8"))
+    checked = check_model_source_value(source)
+    assert isinstance(checked, CheckedModel)
+    context = authority_context_for_checked(checked)
+    return compile_checked_model(checked), context
+
+
+def test_exact_binding_requires_admission() -> None:
+    with pytest.raises(TypeError, match="come from Model binding admission"):
+        ExactResolvedModelBinding()
+
+
+def test_compiled_model_projects_one_detached_exact_binding() -> None:
+    artifacts, context = _compiled_model()
+    expected = {
+        name: canonical_bytes(cast(JsonValue, artifacts[name]))
+        for name in (
+            "build-receipt",
+            "package-lock",
+            "resolved-model",
+            "rir-semantic-payload",
+        )
+    }
+
+    binding = project_compiled_model_binding(artifacts, context)
+    projected = binding.artifacts()
+
+    assert set(projected) == set(expected)
+    assert {
+        name: canonical_bytes(cast(JsonValue, artifact))
+        for name, artifact in projected.items()
+    } == expected
+    assert (
+        binding.resolved_model_identity
+        == artifacts["resolved-model"]["content_identity"]
+    )
+
+    cast(dict[str, Any], artifacts["build-receipt"])["source_identity"] = "changed"
+    cast(list[Any], artifacts["rir-semantic-payload"]["entrypoints"]).clear()
+    projected["package-lock"].clear()
+
+    assert {
+        name: canonical_bytes(cast(JsonValue, artifact))
+        for name, artifact in binding.artifacts().items()
+    } == expected
+
+
+@pytest.mark.parametrize(
+    ("mutation", "reason", "member"),
+    (
+        (
+            lambda values: values.pop("package-lock"),
+            "member-set-mismatch",
+            "package-lock",
+        ),
+        (
+            lambda values: values["package-lock"].__setitem__(
+                "artifact_kind", "resolved-model"
+            ),
+            "member-admission-failed",
+            "package-lock",
+        ),
+        (
+            lambda values: values["build-receipt"].__setitem__(
+                "rir_identity", "sha256:" + ("0" * 64)
+            ),
+            "member-admission-failed",
+            "build-receipt",
+        ),
+    ),
+)
+def test_compiled_model_binding_closes_member_and_relationship_drift(
+    mutation,
+    reason: str,
+    member: str,
+) -> None:
+    artifacts, context = _compiled_model()
+    candidate = deepcopy(artifacts)
+    mutation(candidate)
+
+    with pytest.raises(ExactResolvedModelBindingError) as caught:
+        project_compiled_model_binding(candidate, context)
+
+    assert caught.value.reason == reason
+    assert caught.value.member == member
+
+
+def test_exact_binding_rejects_a_self_valid_build_receipt_with_wrong_relation() -> None:
+    artifacts, context = _compiled_model()
+    candidate = deepcopy(artifacts)
+    build = cast(dict[str, JsonValue], deepcopy(candidate["build-receipt"]))
+    build["rir_identity"] = "sha256:" + ("0" * 64)
+    payload = {
+        name: value
+        for name, value in build.items()
+        if name
+        not in {
+            "artifact_kind",
+            "artifact_version",
+            "content_identity",
+            "wire_schema_identity",
+        }
+    }
+    candidate["build-receipt"] = identified_artifact(
+        context.language_bundle,
+        "build-receipt",
+        payload,
+    )
+
+    with pytest.raises(ExactResolvedModelBindingError) as caught:
+        project_compiled_model_binding(candidate, context)
+
+    assert caught.value.reason == "build-receipt-binding-mismatch"
+    assert caught.value.member == "build-receipt"
+
+
+def test_committed_and_compiled_adapters_produce_the_same_exact_binding(
+    tmp_path: Path,
+    run_cli,
+) -> None:
+    artifacts, context = _compiled_model()
+    exit_code, _stdout, stderr = run_cli(
+        [
+            "model",
+            "build",
+            str(_EXAMPLE / "model-source.json"),
+            "--out",
+            str(tmp_path / "resolved-model.json"),
+            "--invocation-key",
+            "a" * 64,
+        ]
+    )
+    assert (exit_code, stderr) == (0, "")
+
+    compiled = project_compiled_model_binding(artifacts, context)
+    committed = resolve_published_model_binding(
+        {
+            name: cast(str, artifact["content_identity"])
+            for name, artifact in compiled.artifacts().items()
+        },
+        context,
+    )
+
+    assert {
+        name: canonical_bytes(cast(JsonValue, artifact))
+        for name, artifact in committed.artifacts().items()
+    } == {
+        name: canonical_bytes(cast(JsonValue, artifact))
+        for name, artifact in compiled.artifacts().items()
+    }

--- a/libs/gda-balancing/tests/test_http_service.py
+++ b/libs/gda-balancing/tests/test_http_service.py
@@ -237,6 +237,7 @@ def test_admitted_revisions_detach_from_caller_owned_values() -> None:
 
     created = sessions.create(model_source, experiment)
     assert isinstance(created, ExecutionSessionCreated)
+    model_source.clear()
     experiment["seed"]["value"] = baseline_seed + 100
 
     initial_run = sessions.run(created.session_id, created.revision_id)

--- a/libs/gda-balancing/tests/test_schema2_experiment_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_experiment_cli.py
@@ -6698,14 +6698,17 @@ def test_candidate_graph_executes_every_operation_vector_in_two_consumers():
 
 def test_candidate_graph_gate_identifies_an_operation_vector_divergence():
     kernel, ldb = mutable_authorities()
-    package_id, vector = next(
-        (package_id, deepcopy(candidate))
-        for package_id, _package_version, candidate in operation_execution_vectors(ldb)
+    package_id, package_version, vector = next(
+        (package_id, package_version, deepcopy(candidate))
+        for package_id, package_version, candidate in operation_execution_vectors(ldb)
         if candidate["id"] == "structured.select.empty-outcome"
     )
     vector["expect"]["completion"]["id"] = "mutated-outcome"
     failures = candidate_conformance_failures(
-        kernel, ldb, vector_overrides={vector["id"]: vector}
+        kernel,
+        ldb,
+        vector_overrides={vector["id"]: vector},
+        vector_coordinates={(package_id, package_version, vector["id"])},
     )
 
     assert len(failures) == 1
@@ -6719,6 +6722,11 @@ def test_candidate_graph_gate_identifies_an_operation_vector_divergence():
 def test_candidate_graph_gate_identifies_an_adapter_divergence(monkeypatch):
     kernel, ldb = mutable_authorities()
     target = "structured.select.empty-outcome"
+    package_id, package_version, _vector = next(
+        candidate
+        for candidate in operation_execution_vectors(ldb)
+        if candidate[2]["id"] == target
+    )
     evaluate = operation_conformance_module.evaluate_operation_execution_vector
 
     def divergent_production(context, vector, **owner):
@@ -6734,7 +6742,11 @@ def test_candidate_graph_gate_identifies_an_adapter_divergence(monkeypatch):
         divergent_production,
     )
 
-    failures = candidate_conformance_failures(kernel, ldb)
+    failures = candidate_conformance_failures(
+        kernel,
+        ldb,
+        vector_coordinates={(package_id, package_version, target)},
+    )
 
     assert len(failures) == 1
     assert failures[0]["kind"] == "vector-divergence"

--- a/libs/gda-balancing/tests/test_schema2_experiment_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_experiment_cli.py
@@ -31,10 +31,7 @@ import gda_balancing.domain.publication as publication_module
 from gda_balancing.domain.canonical import canonical_bytes, content_identity
 from gda_balancing.domain.diagnostics import ArtifactLocation, Schema2RefusalReport
 from gda_balancing.domain.artifact_errors import PublishedArtifactUnavailable
-from gda_balancing.domain.model import (
-    EXACT_RESOLVED_MODEL_BINDING_MEMBERS,
-    ExactResolvedModelBinding,
-)
+from gda_balancing.domain.model import EXACT_RESOLVED_MODEL_BINDING_MEMBERS
 from gda_balancing.infrastructure.input_bytes import (
     BoundedInputObservation,
     read_bounded_input_with_sha256,
@@ -469,60 +466,6 @@ def test_scenario_contract_union_refuses_cross_entrypoint_conflicts():
             rows,
             contract_name="Scenario Input Contract",
         )
-
-
-def test_experiment_check_reports_cross_entrypoint_contract_conflicts(
-    tmp_path, run_cli, monkeypatch
-):
-    specification_path = _write_built_experiment(tmp_path, run_cli)
-    specification = json.loads(specification_path.read_text(encoding="utf-8"))
-    specification["scenarios"][0]["event_plan"].append(
-        {
-            "kind": "transition-invocation",
-            "root_event_ref": "plan-casts",
-            "logical_time": 1,
-            "priority": 0,
-            "entrypoint": "combat.plan-casts",
-            "payload": [],
-        }
-    )
-    specification_path.write_text(json.dumps(specification), encoding="utf-8")
-
-    original_artifacts = ExactResolvedModelBinding.artifacts
-
-    def artifacts_with_conflicting_entrypoint(self):
-        artifacts = original_artifacts(self)
-        conflicting = deepcopy(artifacts["rir-semantic-payload"])
-        entrypoints = {row["id"]: row for row in conflicting["entrypoints"]}
-        cast_targets = entrypoints["combat.cast"]["scenario_input_contract"]["targets"]
-        plan_targets = entrypoints["combat.plan-casts"]["scenario_input_contract"][
-            "targets"
-        ]
-        cast_target = next(
-            row for row in cast_targets if row["cardinality"] == "required"
-        )
-        plan_target = next(
-            row for row in plan_targets if row["target"] == cast_target["target"]
-        )
-        plan_target["cardinality"] = "optional"
-        artifacts["rir-semantic-payload"] = conflicting
-        return artifacts
-
-    monkeypatch.setattr(
-        ExactResolvedModelBinding,
-        "artifacts",
-        artifacts_with_conflicting_entrypoint,
-    )
-
-    exit_code, stdout, stderr = run_cli(
-        ["experiment", "check", str(specification_path)]
-    )
-
-    assert (exit_code, stderr) == (2, ""), (stdout, stderr)
-    diagnostic = json.loads(stdout)["error"]["diagnostics"][0]
-    assert diagnostic["code"] == "language.source_contract_mismatch"
-    assert diagnostic["primary"]["pointer"] == "/scenarios/0/assignments"
-    assert diagnostic["message"] == "conflicting Scenario Input Contract rows"
 
 
 def _member(receipt: dict[str, Any], logical_name: str) -> dict[str, Any]:

--- a/libs/gda-balancing/tests/test_schema2_experiment_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_experiment_cli.py
@@ -30,6 +30,11 @@ import gda_balancing.domain.model._lowering as model_lowering_module
 import gda_balancing.domain.publication as publication_module
 from gda_balancing.domain.canonical import canonical_bytes, content_identity
 from gda_balancing.domain.diagnostics import ArtifactLocation, Schema2RefusalReport
+from gda_balancing.domain.artifact_errors import PublishedArtifactUnavailable
+from gda_balancing.domain.model import (
+    EXACT_RESOLVED_MODEL_BINDING_MEMBERS,
+    ExactResolvedModelBinding,
+)
 from gda_balancing.infrastructure.input_bytes import (
     BoundedInputObservation,
     read_bounded_input_with_sha256,
@@ -483,17 +488,11 @@ def test_experiment_check_reports_cross_entrypoint_contract_conflicts(
     )
     specification_path.write_text(json.dumps(specification), encoding="utf-8")
 
-    original_find = experiment_admission_module.find_published_artifact
-    original_admit = experiment_admission_module.admit_resolved_model
-    original_rir: dict[str, Any] | None = None
+    original_artifacts = ExactResolvedModelBinding.artifacts
 
-    def find_with_conflicting_entrypoint(content_identity_value, artifact_kind, ldb):
-        nonlocal original_rir
-        artifact = original_find(content_identity_value, artifact_kind, ldb)
-        if artifact_kind != "rir-semantic-payload" or artifact is None:
-            return artifact
-        original_rir = artifact
-        conflicting = deepcopy(artifact)
+    def artifacts_with_conflicting_entrypoint(self):
+        artifacts = original_artifacts(self)
+        conflicting = deepcopy(artifacts["rir-semantic-payload"])
         entrypoints = {row["id"]: row for row in conflicting["entrypoints"]}
         cast_targets = entrypoints["combat.cast"]["scenario_input_contract"]["targets"]
         plan_targets = entrypoints["combat.plan-casts"]["scenario_input_contract"][
@@ -506,28 +505,13 @@ def test_experiment_check_reports_cross_entrypoint_contract_conflicts(
             row for row in plan_targets if row["target"] == cast_target["target"]
         )
         plan_target["cardinality"] = "optional"
-        return conflicting
-
-    def admit_original_model(artifacts, *, authority_context=None):
-        assert original_rir is not None
-        original_artifacts = {
-            **artifacts,
-            "rir-semantic-payload": original_rir,
-        }
-        return original_admit(
-            original_artifacts,
-            authority_context=authority_context,
-        )
+        artifacts["rir-semantic-payload"] = conflicting
+        return artifacts
 
     monkeypatch.setattr(
-        experiment_admission_module,
-        "find_published_artifact",
-        find_with_conflicting_entrypoint,
-    )
-    monkeypatch.setattr(
-        experiment_admission_module,
-        "admit_resolved_model",
-        admit_original_model,
+        ExactResolvedModelBinding,
+        "artifacts",
+        artifacts_with_conflicting_entrypoint,
     )
 
     exit_code, stdout, stderr = run_cli(
@@ -6170,6 +6154,7 @@ def test_symbol_rename_reidentifies_the_exact_experiment_and_downstream_chain(
 def test_artifact_lookup_skips_unrelated_damage_but_refuses_named_member_corruption(
     tmp_path,
     run_cli,
+    monkeypatch,
 ):
     source_value = _rpg_model_source()
     source = tmp_path / "lookup-model.json"
@@ -6206,11 +6191,21 @@ def test_artifact_lookup_skips_unrelated_damage_but_refuses_named_member_corrupt
     )
     unrelated_anchor.parent.mkdir(parents=True)
     unrelated_anchor.write_text("not-json", encoding="utf-8")
+    original_regular_files = publication_module.regular_files
+    traversals = 0
+
+    def counted_regular_files(*args, **kwargs):
+        nonlocal traversals
+        traversals += 1
+        return original_regular_files(*args, **kwargs)
+
+    monkeypatch.setattr(publication_module, "regular_files", counted_regular_files)
     check_exit, check_stdout, check_stderr = run_cli(
         ["experiment", "check", str(specification_path)]
     )
     assert (check_exit, check_stderr) == (0, "")
     assert json.loads(check_stdout)["checked"] is True
+    assert traversals == 1
 
     build_locator = next(
         Path(row["locator"])
@@ -6237,14 +6232,27 @@ def test_artifact_lookup_skips_unrelated_damage_but_refuses_named_member_corrupt
     )
     manifest_path.write_bytes(canonical_bytes(replacement_manifest))
     context = authority_module.packaged_authority_context()
-    assert (
-        publication_module.find_published_artifact(
-            build_record["content_identity"],
-            "build-receipt",
+    with pytest.raises(PublishedArtifactUnavailable):
+        publication_module.find_published_artifacts(
+            tuple(
+                (
+                    logical_name,
+                    artifact_kind,
+                    specification["model"][
+                        {
+                            "build-receipt": "build_receipt_identity",
+                            "package-lock": "package_lock_identity",
+                            "resolved-model": "resolved_model_identity",
+                            "rir-semantic-payload": "rir_identity",
+                        }[logical_name]
+                    ],
+                )
+                for logical_name, artifact_kind in (
+                    EXACT_RESOLVED_MODEL_BINDING_MEMBERS
+                )
+            ),
             context.language_bundle,
         )
-        is None
-    )
     manifest_path.write_bytes(manifest_bytes)
 
     corrupted = json.loads(build_locator.read_text(encoding="utf-8"))
@@ -6261,6 +6269,34 @@ def test_artifact_lookup_skips_unrelated_damage_but_refuses_named_member_corrupt
         "language.resolved_authority_mismatch"
     ]
     assert "failed integrity verification" in error["diagnostics"][0]["message"]
+
+
+def test_artifact_lookup_preserves_model_member_diagnostic_order(
+    tmp_path,
+    run_cli,
+):
+    specification_path = _write_built_experiment(tmp_path, run_cli)
+    specification = json.loads(specification_path.read_text(encoding="utf-8"))
+    specification["model"]["build_receipt_identity"] = "sha256:" + ("0" * 64)
+    specification_path.write_text(json.dumps(specification), encoding="utf-8")
+
+    store = Path(os.environ["GDA_BALANCING_STORE_DIR"])
+    package_lock_path = next(store.glob("invocations/*/*/package-lock.json"))
+    corrupted = json.loads(package_lock_path.read_text(encoding="utf-8"))
+    corrupted["content_identity"] = "sha256:" + ("1" * 64)
+    package_lock_path.write_bytes(canonical_bytes(corrupted))
+
+    exit_code, stdout, stderr = run_cli(
+        ["experiment", "check", str(specification_path)]
+    )
+
+    assert (exit_code, stderr) == (2, "")
+    diagnostic = json.loads(stdout)["error"]["diagnostics"][0]
+    assert diagnostic["code"] == "language.resolved_authority_mismatch"
+    assert diagnostic["primary"]["pointer"] == "/model/build_receipt_identity"
+    assert diagnostic["message"] == (
+        "Exact build-receipt is unavailable in the committed artifact store"
+    )
 
 
 def test_kernel_runtime_contract_vectors_and_rng_execute_in_reference_evaluator():

--- a/libs/gda-balancing/tools/ci.py
+++ b/libs/gda-balancing/tools/ci.py
@@ -48,6 +48,7 @@ SHARDS: Final[dict[str, tuple[str, ...]]] = {
         "test_structured_values.py",
     ),
     "model": (
+        "test_exact_resolved_model_binding.py",
         "test_schema2_model_cli.py",
         "test_schema2_model_lowerer_conformance.py",
     ),


### PR DESCRIPTION
## Summary

- introduce one detached `ExactResolvedModelBinding` for the committed-publication and verified in-memory compilation paths
- authenticate the four required published members in one store traversal while preserving the declared diagnostic order
- retain the cohesive admitted binding in execution sessions instead of the complete compiler artifact mapping
- keep Experiment-specific refusal codes, pointers, messages, and ordering in Experiment admission

## Architecture

- the binding admits exactly the Build receipt, Package Lock, Resolved Model, and RIR
- compiled projection and committed retrieval remain separate adapters over one private admission implementation
- the consumer-side binding member contract is distinct from the complete Model-build publication artifact set
- no Repository, generic artifact container, new identity family, cache, or authority was added

## Validation

- functional implementation required matrix: 1,540 passed and 29 existing skips
- exact final head after interface-only cleanup: 48 focused binding, diagnostic-order, layer, and isolation tests passed
- test inventory: 1,594 tests; no missing, overlapping, uncovered, or unexpected shard entries
- Pyright: 0 errors, 0 warnings
- Ruff and `git diff --check`: passed
- independent final review: Standards 0 findings; Spec 0 findings; DDMA 0 findings

Closes #686
