### PR TITLE
docs(gda): reconcile the wave-2 combined state (terms, probe relay, 127 row)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -233,8 +233,8 @@ operation, and parse codes the CLI assigns).
 | `live_invalid_event_spec` | `live` | `classifier` | `6` | A live input sequence event has a type the harness does not recognize (Phase 2, #221). |
 | `live_display_unavailable` | `live` | `classifier` | `6` | A live `screen` capture ran on a headless engine session (the dummy DisplayServer cannot read pixels); start the daemon windowed with `gda daemon start --windowed` (Phase 2, #222). |
 | `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
-| `live_windowed_unavailable` | `environment` | `classifier` | `127` | A windowed live session (`gda daemon start --windowed`) was requested but the host has no usable DisplayServer (no on-console GUI session / no `$DISPLAY`), so the session cannot come up; refused before spawning Godot (Phase 2, #345). |
-| `live_windowed_permission_denied` | `environment` | `classifier` | `127` | A windowed live session (`gda daemon start --windowed`) was requested but this process is denied the window-server lookup (e.g. a sandbox), so gda cannot tell whether the host has one; re-run outside the restriction to find out rather than recording the host as display-less (Phase 2, #667). |
+| `live_windowed_unavailable` | `environment` | `classifier` | `127` | A windowed Engine session (`gda daemon start --windowed`) was requested but the host has no usable DisplayServer (no on-console GUI session / no `$DISPLAY`), so the session cannot come up; refused before spawning Godot (Phase 2, #345). |
+| `live_windowed_permission_denied` | `environment` | `classifier` | `127` | A windowed Engine session (`gda daemon start --windowed`) was requested but this process is denied the window-server lookup (e.g. a sandbox), so gda cannot tell whether the host has one; re-run outside the restriction to find out rather than recording the host as display-less (Phase 2, #667). |
 
 ## Considered options
 

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -732,8 +732,9 @@ headless is unaffected (4.4+, cross-platform).
   restriction is what settles it. Conversely a sandbox that hides the window server rather
   than refusing the lookup is indistinguishable from an absent session. A refusal that
   originates in `daemon start --windowed` carries the deciding host call as the envelope's
-  `probe` `{name, platform}` (ADR-0004 amendment); the daemon-relayed form carries the code
-  and prose only, since the daemon→CLI wire envelope has no `probe` key.
+  `probe` `{name, platform}` (ADR-0004 amendment); a refusal relayed from an already-running
+  daemon carries it too — the live wire's error payload gained an optional `probe` key, and
+  `classify_live` preserves it into the public envelope.
 
 Out of scope (editor context, ADR-0017): UndoRedo-aware mutation, the editor's
 open-scene tree, saving the open scene, editor errors/screenshots, run-editor-script,

--- a/examples/platformer/panda-adventure/tests/display_gate.py
+++ b/examples/platformer/panda-adventure/tests/display_gate.py
@@ -47,6 +47,9 @@ def require_windowed_host() -> None:
     verdict = windowed_unavailable()
     if verdict is None:
         return
-    if verdict.code == WINDOWED_PERMISSION_DENIED_CODE:
-        pytest.fail(_CONFINED_REMEDIATION.format(detail=verdict.reason))
+    # ONE cascade owner per root: delegate to handle_no_display_code so the
+    # cross-root parity test covers the preflight too (PR #702 recheck). The
+    # trailing skip is the conservative fallback for a verdict code the handler
+    # does not classify — a non-None verdict must never proceed to a spawn.
+    handle_no_display_code(verdict.code, verdict.reason)
     pytest.skip(verdict.reason)

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -150,7 +150,7 @@ def main(
         "writable. Godot reads the export templates and editor settings from that "
         "same directory, so a release/debug 'export run' under it finds no "
         "installed templates unless you place them there ('--mode pack' needs "
-        "none). A live session is unaffected: the daemon owns its log (ADR-0022).",
+        "none). An Engine session is unaffected: the daemon owns its log (ADR-0022).",
     ),
 ) -> None:
     """An agent-facing Godot CLI with structured output."""

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -786,7 +786,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.ENVIRONMENT,
         EXIT_NOT_FOUND,
         ErrorCodeSource.CLASSIFIER,
-        "A windowed live session was requested (`gda daemon start --windowed`) but"
+        "A windowed Engine session was requested (`gda daemon start --windowed`) but"
         " the host has no usable DisplayServer (no on-console GUI session / no"
         " $DISPLAY), so the session cannot come up; refused before spawning Godot.",
     ),
@@ -807,7 +807,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.ENVIRONMENT,
         EXIT_NOT_FOUND,
         ErrorCodeSource.CLASSIFIER,
-        "A windowed live session was requested (`gda daemon start --windowed`) but"
+        "A windowed Engine session was requested (`gda daemon start --windowed`) but"
         " this process is denied the window-server lookup (e.g. a sandbox), so gda"
         " cannot tell whether the host has one; re-run outside the restriction to"
         " find out rather than recording the host as display-less.",

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -44,7 +44,7 @@ debugging. `info` / `schema` / `skill` are top-level meta commands (no group).
   as `user_data_unwritable` before the engine starts. Two limits: Godot reads the
   **export templates** from that same directory, so a `release`/`debug`
   `export run` under it reports none installed unless you put templates there —
-  `--mode pack` needs no templates and works normally; and live sessions are
+  `--mode pack` needs no templates and works normally; and Engine sessions are
   unaffected either way — the daemon owns their log.
 
 ## Structured output & errors
@@ -60,7 +60,7 @@ Branch on the stable `category`/`code` and the **exit code**, never on prose:
 | Exit | Meaning |
 | ---- | ------- |
 | `0`   | success |
-| `127` | environment unusable: `binary_not_found`, `user_data_unwritable`, `live_unsupported_platform`, `live_windowed_unavailable` |
+| `127` | environment unusable: `binary_not_found`, `user_data_unwritable`, `live_unsupported_platform`, `live_windowed_unavailable`, `live_windowed_permission_denied` |
 | `124` | engine timed out |
 | `3`   | engine version too old |
 | `4`   | operation-reported failure |
@@ -129,8 +129,9 @@ spawning Godot. Branch on the code, not the sentence:
   code alone.
 
 A refusal from `gda daemon start --windowed` carries `error.probe` `{name, platform}`
-naming the OS call that decided. The same codes relayed from an already-running daemon
-carry the code and message only.
+naming the OS call that decided — including when the refusal is relayed from an
+already-running daemon's lazy Engine-session launch; only the outer
+`{stdout, stderr, exit_code}` transport shape is probe-less.
 
 | Group | Commands |
 | ----- | -------- |

--- a/tests/support.py
+++ b/tests/support.py
@@ -767,8 +767,11 @@ def require_windowed_host():
     verdict = windowed_unavailable()
     if verdict is None:
         return
-    if verdict.code == WINDOWED_PERMISSION_DENIED_CODE:
-        pytest.fail(_CONFINED_REMEDIATION.format(detail=verdict.reason))
+    # ONE cascade owner per root: delegate to handle_no_display_code so the
+    # cross-root parity test covers the preflight too (PR #702 recheck). The
+    # trailing skip is the conservative fallback for a verdict code the handler
+    # does not classify — a non-None verdict must never proceed to a spawn.
+    handle_no_display_code(verdict.code, verdict.reason)
     pytest.skip(verdict.reason)
 
 

--- a/tests/test_skill_surface_sync.py
+++ b/tests/test_skill_surface_sync.py
@@ -296,3 +296,32 @@ def test_display_gate_policy_parity_across_the_two_pytest_roots():
         assert reaction(game.handle_no_display_code, code) == reaction(
             toolkit.handle_no_display_code, code
         ), f"the two display-gate copies disagree on {code!r}"
+
+    # The PREFLIGHT path too (PR #702 recheck): both require_windowed_host()
+    # functions must react identically to an injected verdict. Both copies read
+    # gda.display.windowed_unavailable at call time, so one monkeypatch drives
+    # both; None / capability / permission cover the whole verdict space.
+    import gda.display as display_module
+
+    class _Verdict:
+        def __init__(self, code):
+            self.code = code
+            self.reason = f"injected {code}"
+
+    def preflight_reaction(fn, verdict, monkeypatch_target=display_module):
+        original = monkeypatch_target.windowed_unavailable
+        setattr(monkeypatch_target, "windowed_unavailable", lambda: verdict)
+        try:
+            return reaction(lambda *_: fn(), None)
+        finally:
+            setattr(monkeypatch_target, "windowed_unavailable", original)
+
+    for verdict in [
+        None,
+        _Verdict("live_windowed_unavailable"),
+        _Verdict("live_display_unavailable"),
+        _Verdict("live_windowed_permission_denied"),
+    ]:
+        assert preflight_reaction(game.require_windowed_host, verdict) == (
+            preflight_reaction(toolkit.require_windowed_host, verdict)
+        ), f"the two preflights disagree on verdict {getattr(verdict, 'code', None)!r}"

--- a/tests/test_skill_surface_sync.py
+++ b/tests/test_skill_surface_sync.py
@@ -229,3 +229,70 @@ def test_control_root_guard_catches_a_reversed_conditional():
         _assert_control_root_semantics(
             _normalize_prose(mutated), "mutated SKILL.md paragraph"
         )
+
+
+def test_skill_exit_127_row_names_every_registered_127_code():
+    # PR #702 review: the 127 row drifted twice — #696 wrote a four-code list, #694
+    # added a fifth to the registry, and preserving both patches did not reconcile
+    # the combined artifact. Pin the row to the registry so the next 127 code
+    # cannot land without its skill mention.
+    from gda.error_codes import ERROR_CODES
+
+    registered = {spec.code for spec in ERROR_CODES if spec.exit_code == 127}
+    row = next(line for line in BUNDLED.splitlines() if line.startswith("| `127` |"))
+    listed = set(_BACKTICKED.findall(row)) - {"127"}
+    assert listed == registered, (
+        f"SKILL.md's exit-127 row lists {sorted(listed)} but the registry has "
+        f"{sorted(registered)} — keep the enumeration complete"
+    )
+
+
+def test_display_gate_policy_parity_across_the_two_pytest_roots():
+    # PR #702 review: the reaction policy is deliberately duplicated (the game's
+    # pytest root cannot import the toolkit's test package) and both copies say
+    # "stay in step" — this is the executable version of that sentence. Compares
+    # the code classifications AND the observable reactions, so drift in either
+    # copy goes red instead of silently reintroducing the false-green (#667).
+    import importlib.util
+    from pathlib import Path as _P
+
+    import pytest as _pytest
+
+    from tests import support as toolkit
+
+    game_path = (
+        _P(__file__).resolve().parent.parent
+        / "examples/platformer/panda-adventure/tests/display_gate.py"
+    )
+    spec = importlib.util.spec_from_file_location("panda_display_gate", game_path)
+    assert spec is not None and spec.loader is not None, game_path
+    game = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(game)
+
+    assert game.WINDOWED_CAPABILITY_CODES == toolkit.WINDOWED_CAPABILITY_CODES
+    assert (
+        game.WINDOWED_PERMISSION_DENIED_CODE == toolkit.WINDOWED_PERMISSION_DENIED_CODE
+    )
+
+    def reaction(handler, code):
+        try:
+            handler(code, "parity probe")
+        except _pytest.skip.Exception:
+            return "skip"
+        except BaseException as exc:  # pytest.fail raises Failed (BaseException)
+            if type(exc).__name__ == "Failed":
+                return "fail"
+            raise
+        return "pass-through"
+
+    probes = [
+        "live_windowed_unavailable",
+        "live_display_unavailable",
+        "live_windowed_permission_denied",
+        "operation_failed",
+        "daemon_not_running",
+    ]
+    for code in probes:
+        assert reaction(game.handle_no_display_code, code) == reaction(
+            toolkit.handle_no_display_code, code
+        ), f"the two display-gate copies disagree on {code!r}"


### PR DESCRIPTION
## Summary

Closes the four findings from promotion PR #702's integration review (pinned to `1f3b96e0`) — all combined-state issues; no source-slice content was lost:

1. **[P3] Canonical term** — the new guidance said "live session" / "windowed live session", which `CONTEXT.md` lists under _Avoid_ for **Engine session**. Fixed in the root `--help` text, the skill's user-data bullet, both registry descriptions (`live_windowed_unavailable`, `live_windowed_permission_denied`) and their ADR-0002 table rows (living registry data).
2. **[P2] Stale probe-relay claim** — the skill and `docs/command-catalog.md` still said a daemon-relayed windowed refusal carries code/prose only; stale since #694's live wire gained its optional `probe` key (`daemon/server.py` → `protocol.py` → `classify_live`, test-pinned). Both surfaces now state the relay carries `error.probe`; only the outer `{stdout, stderr, exit_code}` transport is probe-less.
3. **[P3] Exit-127 enumeration** — the skill's row listed four of five codes (#696 wrote the list before #694 extended the registry — both patches preserved, combined artifact unreconciled). Appended `live_windowed_permission_denied`, and a new **registry→skill sync test** pins the row against the registry's exit-127 set so the next code cannot land without its mention.
4. **[P2] Display-gate policy parity** — the deliberately-duplicated reaction policy (two pytest roots) had only prose "stay in step" notes. A new **parity test** loads the game's `display_gate.py` by path and asserts the capability/permission code sets AND the observable reactions (skip / fail / pass-through) match across five probes, satisfying the RULES.md DRY guard requirement.

## Validation

- `uv run pytest -m "not e2e"` — 1497 passed (both new guards included); `GITHUB_ACTIONS=true` variant identical.
- `uv run ruff check` / `format --check` / `pyright` — clean.
- Surface deltas (all intended, docs/prose only): root `--help` one word, `gda skill` three hunks (term, relay claim, 127 row), command-catalog one passage, registry/ADR-0002 description strings. No schema shape change (`gda schema` descriptions change where the registry strings surface — description-only).

Follow-up to the wave-2 promotion; #702 picks this up on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)