### PR TITLE
feat(gda)!: argv-binding metadata in the emitted schemas and a discriminated input-event union

### DIFF
--- a/docs/adr/0004-schema-flag-self-description.md
+++ b/docs/adr/0004-schema-flag-self-description.md
@@ -156,7 +156,8 @@ status: accepted
 > authoritative. The projection is the argv form of the operation parameters, not a
 > one-to-one image of `input`: every REQUIRED property has a binding, held by a
 > test, while an optional property the CLI computes from flags rather than takes
-> directly (`script set`'s `mode`, from `--replace` / `--search`) has none. On the
+> directly (`script set`'s and `shader set`'s `mode`, from `--replace` /
+> `--search`) has none. On the
 > aggregate entry the `argv` key is required, its list possibly empty — the same
 > "key always present" guarantee `constraints` has.
 

--- a/docs/adr/0004-schema-flag-self-description.md
+++ b/docs/adr/0004-schema-flag-self-description.md
@@ -112,8 +112,8 @@ status: accepted
 > **Amendment (2026-08-18, #669):** the per-command `--schema` object gains a SIXTH,
 > additive key — `argv`, the list of `ArgvBinding`s naming how each parameter `input`
 > describes is written on a command line (`kind` positional/option, `position` or
-> `option` spelling, `required`, `flag`, `multiple`, and the `input_property` it
-> fills). Motivation: the contract stated a command's required fields but not their
+> `option` spelling, `required`, `flag`, `multiple`, `json_value`, and the
+> `input_property` it fills). Motivation: the contract stated a command's required fields but not their
 > CLI spelling, so an agent could not build argv from it — `screen capture` takes its
 > required output as `--output`, `input mouse-click` takes `x y` positionally, and
 > `input action` takes a positional ACTION it rejects as `--action` (dogfooding
@@ -121,12 +121,15 @@ status: accepted
 >
 > It is additive on the same properties the notes above establish:
 >
-> - **A sibling of the schema halves, never a key inside them.** `input` / `output`
->   stay byte-identical, so gda-mcp's `input_schema` / `output_schema` are unchanged
->   and it needs no adapter work — it maps only `input` / `output` / `description`
->   (ADR-0012). Measured across the whole surface at the time of the change: one
->   `input` differs (`input sequence`, for its own model's per-kind union), and no
->   `output` / `error` / `description` / `kind` / `constraints` does.
+> - **A sibling of the schema halves, never a key inside them.** Adding the key
+>   leaves `input` / `output` byte-identical — a test emits each command's contract
+>   with and without the bindings and requires both halves to match — so gda-mcp's
+>   `input_schema` / `output_schema` are unchanged by it and it needs no adapter
+>   work; it maps only `input` / `output` / `description` (ADR-0012). Measured
+>   across the whole surface at the time of the change, exactly one `input` differs
+>   for an unrelated reason (`input sequence`, whose own params model became a
+>   per-kind union in the same PR), and no `output` / `error` / `description` /
+>   `kind` / `constraints` differs at all.
 > - **Derived, never declared.** The bindings are read off the LIVE Typer/Click
 >   parameters at emission time, through one projection shared by the per-command
 >   `--schema` and the aggregate manifest (ADR-0012's live-tree walk, ADR-0023 §2).
@@ -136,16 +139,26 @@ status: accepted
 >   Reading the registered parameters also makes it correct on every dispatch channel
 >   at once — the sentinel path, the EXPORT / LIVE kinds, and the recipe commands.
 > - **Zero per-command cost**, like the halves it joins: a new command's spelling
->   appears because it registered parameters, not because anyone wrote it down.
+>   appears because it registered parameters, not because anyone wrote it down. The
+>   binding expresses a positional, an option, a valueless flag, a repeated value
+>   and a JSON-encoded one; a registration test fails if the surface ever grows a
+>   Click shape it cannot write (a `--x/--no-x` pair, an n-ary option, a counting
+>   option), so the contract is extended deliberately rather than emitting a
+>   binding no caller can follow.
 >
 > Two boundaries. `argv` covers the OPERATION parameters — the same set
 > `--params-json` treats as exclusive of the individual arguments (ADR-0015) — so the
 > cross-cutting flags every command shares (`--json` / `--schema` / `--params-json` /
 > `--godot` / `--project`) stay out; they are not per-command information. And
-> `input_property` is `null`, not guessed, where a CLI form has no 1:1 property (two
-> flags selecting one field, or a differently-named option): a wrong link would read
-> as authoritative. On the aggregate entry the `argv` key is required, its list
-> possibly empty — the same "key always present" guarantee `constraints` has.
+> `input_property` is `null`, not guessed, where the flag's spelling renames the
+> property it fills (`project list --all` fills `include_defaults`, `skill --dir`
+> fills `install_dir` — the only two on the surface): a wrong link would read as
+> authoritative. The projection is the argv form of the operation parameters, not a
+> one-to-one image of `input`: every REQUIRED property has a binding, held by a
+> test, while an optional property the CLI computes from flags rather than takes
+> directly (`script set`'s `mode`, from `--replace` / `--search`) has none. On the
+> aggregate entry the `argv` key is required, its list possibly empty — the same
+> "key always present" guarantee `constraints` has.
 
 ADR-0000 lists `--schema` as a core capability without defining it. We fix its
 semantics here, and deliberately scope out an overloaded interpretation.

--- a/docs/adr/0004-schema-flag-self-description.md
+++ b/docs/adr/0004-schema-flag-self-description.md
@@ -150,14 +150,16 @@ status: accepted
 > `--params-json` treats as exclusive of the individual arguments (ADR-0015) — so the
 > cross-cutting flags every command shares (`--json` / `--schema` / `--params-json` /
 > `--godot` / `--project`) stay out; they are not per-command information. And
-> `input_property` is `null`, not guessed, where the flag's spelling renames the
-> property it fills (`project list --all` fills `include_defaults`, `skill --dir`
-> fills `install_dir` — the only two on the surface): a wrong link would read as
-> authoritative. The projection is the argv form of the operation parameters, not a
-> one-to-one image of `input`: every REQUIRED property has a binding, held by a
-> test, while an optional property the CLI computes from flags rather than takes
-> directly (`script set`'s and `shader set`'s `mode`, from `--replace` /
-> `--search`) has none. On the
+> `input_property` is `null`, not guessed, where a parameter's property is revealed
+> by neither its name nor its long option: a wrong link would read as authoritative.
+> The surface has **no such parameter** — where an option renames the property it
+> fills (`project list --all` → `include_defaults`, `skill --dir` → `install_dir`)
+> the Python parameter carries the property's name, so the link resolves — and a
+> test holds that every **directly supplyable** property has a binding. The nullable
+> value stays part of the contract for a future parameter that cannot be resolved,
+> rather than being forced into a guess. The one exemption from that guard is a
+> property the CLI COMPUTES rather than takes (`script set`'s and `shader set`'s
+> `mode`, from `--replace` / `--search`), which its own description declares. On the
 > aggregate entry the `argv` key is required, its list possibly empty — the same
 > "key always present" guarantee `constraints` has.
 

--- a/docs/adr/0004-schema-flag-self-description.md
+++ b/docs/adr/0004-schema-flag-self-description.md
@@ -109,6 +109,44 @@ status: accepted
 > an operation reported. The two compose under the same omitted-when-absent rule, and
 > #687 stays free to decide its axis on its own merits.
 
+> **Amendment (2026-08-18, #669):** the per-command `--schema` object gains a SIXTH,
+> additive key — `argv`, the list of `ArgvBinding`s naming how each parameter `input`
+> describes is written on a command line (`kind` positional/option, `position` or
+> `option` spelling, `required`, `flag`, `multiple`, and the `input_property` it
+> fills). Motivation: the contract stated a command's required fields but not their
+> CLI spelling, so an agent could not build argv from it — `screen capture` takes its
+> required output as `--output`, `input mouse-click` takes `x y` positionally, and
+> `input action` takes a positional ACTION it rejects as `--action` (dogfooding
+> GDA-DF-003). The self-description was accurate and still insufficient.
+>
+> It is additive on the same properties the notes above establish:
+>
+> - **A sibling of the schema halves, never a key inside them.** `input` / `output`
+>   stay byte-identical, so gda-mcp's `input_schema` / `output_schema` are unchanged
+>   and it needs no adapter work — it maps only `input` / `output` / `description`
+>   (ADR-0012). Measured across the whole surface at the time of the change: one
+>   `input` differs (`input sequence`, for its own model's per-kind union), and no
+>   `output` / `error` / `description` / `kind` / `constraints` does.
+> - **Derived, never declared.** The bindings are read off the LIVE Typer/Click
+>   parameters at emission time, through one projection shared by the per-command
+>   `--schema` and the aggregate manifest (ADR-0012's live-tree walk, ADR-0023 §2).
+>   An `argv` field on the `HeadlessCommand` descriptor was rejected: a
+>   hand-maintained spelling table is a second authority for a fact the Typer
+>   signature already owns, and it would silently rot the moment a signature changed.
+>   Reading the registered parameters also makes it correct on every dispatch channel
+>   at once — the sentinel path, the EXPORT / LIVE kinds, and the recipe commands.
+> - **Zero per-command cost**, like the halves it joins: a new command's spelling
+>   appears because it registered parameters, not because anyone wrote it down.
+>
+> Two boundaries. `argv` covers the OPERATION parameters — the same set
+> `--params-json` treats as exclusive of the individual arguments (ADR-0015) — so the
+> cross-cutting flags every command shares (`--json` / `--schema` / `--params-json` /
+> `--godot` / `--project`) stay out; they are not per-command information. And
+> `input_property` is `null`, not guessed, where a CLI form has no 1:1 property (two
+> flags selecting one field, or a differently-named option): a wrong link would read
+> as authoritative. On the aggregate entry the `argv` key is required, its list
+> possibly empty — the same "key always present" guarantee `constraints` has.
+
 ADR-0000 lists `--schema` as a core capability without defining it. We fix its
 semantics here, and deliberately scope out an overloaded interpretation.
 

--- a/docs/adr/0012-gda-mcp-tool-surface-generation.md
+++ b/docs/adr/0012-gda-mcp-tool-surface-generation.md
@@ -21,6 +21,17 @@ status: accepted
 > `constraints` — so the addition is backward compatible. On the aggregate entry
 > the `constraints` key is always present, its value nullable.
 
+> **Outcome (2026-08-18, #669):** each manifest entry gained an additive `argv`
+> field (the command's `ArgvBinding` list — how each parameter is written on a
+> command line, ADR-0004's amendment of the same date), so the entry above is now
+> `{name, description, input, output, error, kind, constraints, argv}`. gda-mcp's
+> mapping is unchanged — it ignores `kind` / `constraints` / `argv` — and the two
+> halves it DOES map are untouched, so no registered tool's wire schema changes.
+> The bindings come from the same live-tree walk this ADR established: the walker is
+> already standing in the Typer tree, so it reads each leaf's Click parameters
+> there rather than consulting anything else. On the aggregate entry the `argv` key
+> is always present, its list empty for a command with no operation parameters.
+
 ADR-0011 fixes [gda-mcp](../../CONTEXT.md) as a subprocess adapter that consumes
 `gda`'s public ABI. ADR-0004 / ADR-0005 make each command self-describing
 (`--schema` → `{input, output, error}`) and give a deterministic CLI→MCP name map

--- a/docs/adr/0012-gda-mcp-tool-surface-generation.md
+++ b/docs/adr/0012-gda-mcp-tool-surface-generation.md
@@ -25,8 +25,12 @@ status: accepted
 > field (the command's `ArgvBinding` list — how each parameter is written on a
 > command line, ADR-0004's amendment of the same date), so the entry above is now
 > `{name, description, input, output, error, kind, constraints, argv}`. gda-mcp's
-> mapping is unchanged — it ignores `kind` / `constraints` / `argv` — and the two
-> halves it DOES map are untouched, so no registered tool's wire schema changes.
+> mapping is unchanged — it ignores `kind` / `constraints` / `argv` — and **the
+> `argv` addition leaves both mapped halves byte-identical**, so no registered
+> tool's wire schema changes because of it. (One tool's `input_schema` did change
+> in the same PR for an unrelated reason: `gda input sequence`'s own params model
+> became a per-kind discriminated union. That is a model change, not a
+> manifest-shape one, and it is the only entry whose `input` differs.)
 > The bindings come from the same live-tree walk this ADR established: the walker is
 > already standing in the Typer tree, so it reads each leaf's Click parameters
 > there rather than consulting anything else. On the aggregate entry the `argv` key

--- a/docs/adr/0015-structured-params-input-abi.md
+++ b/docs/adr/0015-structured-params-input-abi.md
@@ -4,6 +4,28 @@ status: accepted
 
 # Structured params input: a uniform `--params-json` channel, the params model as the single source
 
+> **Amendment (2026-08-19, #669):** the emitted contract now DOES carry CLI-binding
+> metadata — an `argv` list alongside the schema halves, naming each parameter's
+> positional slot or option spelling (the
+> [ADR-0004 amendment](0004-schema-flag-self-description.md) of 2026-08-18). Two
+> sentences below are superseded by it: the framing that the dump "deliberately does
+> not encode CLI binding", and the rejected option's claim that encoding it would
+> "reopen ADR-0012's contract".
+>
+> **What this ADR decided remains in force, unchanged.** gda-mcp still forwards an
+> MCP tool's input object **verbatim** through `--params-json`, reconstructs no argv,
+> and ignores `argv` entirely — so the rejected option's real cost, pushing fragile
+> typed-argv encoding (booleans, arrays, nested objects, defaults) into gda-mcp,
+> never materializes. The binding metadata exists for a DIFFERENT consumer: an agent
+> driving the CLI directly, which had no way to learn a required field's spelling
+> without a `--help` round trip (dogfooding GDA-DF-003). Two audiences, two channels,
+> one params model behind both.
+>
+> The distinction the rejection rested on also holds: argv is still not mechanically
+> recoverable from the `input` schema ALONE, which is exactly why the binding is
+> published as a separate, derived projection rather than by enriching the schema —
+> `input` and `output` stay byte-identical, so ADR-0012's mapping is untouched.
+
 gda commands take their params as CLI argv — a mix of positional `Argument`s and
 `--kebab` `Option`s. [gda-mcp](../../CONTEXT.md) (ADR-0011/0012) must forward an MCP
 tool's input object to gda over gda's **public CLI ABI**. ADR-0012's aggregate

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -46,6 +46,10 @@ they are provenance, not status markers.
 
 > `--schema` is a per-command flag, not a command, and ships with **every** domain
 > command as a hard gate (ADR-0004). It is local introspection — no Godot process.
+> Alongside the schemas it emits `argv`: how each parameter is written on a command
+> line (positional and its position, or its `--option` spelling, plus whether it is
+> required, a valueless flag, or repeated), derived from the live command signature
+> so an agent builds argv from the contract instead of from `--help`.
 
 ---
 
@@ -709,7 +713,12 @@ headless is unaffected (4.4+, cross-platform).
   to decide are deferred to the harness: a key name the engine cannot resolve to a
   keycode is `live_invalid_key`, an action absent from the running `InputMap` is
   `live_unknown_action`; a sequence event whose type the harness does not recognize
-  is `live_invalid_event_spec`.
+  is `live_invalid_event_spec`. The per-event shape is a **discriminated union** on
+  `type`: each kind accepts only its own fields, so `--schema` publishes each kind's
+  required and forbidden fields rather than one flat shape. The press/release
+  spelling differs by kind — `pressed` belongs to `mouse_button` alone, an `action`
+  releases with `release`, a `key` with `released` — and a field from another kind is
+  refused with the spelling this kind uses instead.
 - **`screen` / capture:** running-game viewport screenshot, multi-frame capture.
 - **`perf` (runtime performance monitoring):** `perf monitors` snapshots the running
   game's instantaneous Performance counters in one frame (shipped, #223); `perf

--- a/src/gda/commands/input.py
+++ b/src/gda/commands/input.py
@@ -277,6 +277,14 @@ class InputEventType(str, Enum):
     MOUSE_MOVE = "mouse_move"
     ACTION = "action"
 
+    def __repr__(self) -> str:
+        # These members are the union's discriminator tags (#669), and the
+        # unknown-tag refusal renders the expected ones with repr() — where the
+        # default enum repr would put "<InputEventType.KEY: 'key'>" into a public
+        # error message, naming a Python symbol the caller cannot type. Report the
+        # wire value, which is what the caller writes.
+        return repr(self.value)
+
 
 # The press/release synonyms a sequence event may spell its phase with. Each kind
 # uses exactly the one its single-frame op uses (`released` for a key, `release`

--- a/src/gda/commands/input.py
+++ b/src/gda/commands/input.py
@@ -30,7 +30,7 @@ reached the harness without passing the model (a direct daemon caller).
 
 import json
 from enum import Enum
-from typing import Annotated, Literal, Optional, get_args
+from typing import Annotated, Any, Literal, Optional, get_args
 
 import typer
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -292,7 +292,9 @@ class InputEventType(str, Enum):
 # and the flat shape they used to share made a foreign one silently inert — a
 # `release` on a key event PRESSED the key. Declared once here so the rejection
 # can NAME the kind's own spelling instead of only refusing the wrong one; which
-# kind uses which is read off the variant models themselves, never restated.
+# kind uses which is read off the variant models themselves, never restated. A
+# test holds this list to the fields the variants actually declare, so renaming
+# one cannot silently drop the message back to the generic branch.
 _PHASE_FIELDS = ("pressed", "released", "release")
 
 # The shared field descriptions, written once for the whole union: each variant
@@ -317,16 +319,37 @@ _MOUSE_Y_DESC = (
     "The event's y position in the viewport. Read it from the event; "
     "engine-tracked mouse positions may remain stale."
 )
+# Nullable although it always has a value: the flat shape these variants replace
+# defaulted `button` to null and let the harness read that as left, so a producer
+# that dumped an event and replayed it sent an explicit null. Refusing it now
+# would break a caller that was never wrong. Null is normalized back to left, so
+# the payload the harness receives always names a button.
+_BUTTON_DESC = "Which button: left, right, or middle (null means left)."
+
+
+def _left_when_null(
+    event: "MouseClickSequenceEvent | MouseButtonSequenceEvent",
+) -> None:
+    """Normalize an explicit ``button: null`` to the left button, in place."""
+    if event.button is None:
+        event.button = MouseButton.LEFT
 
 
 def _event_kind(model: type[BaseModel]) -> str:
-    """The ``type`` value that selects ``model`` from the union.
+    """The ``type`` value that selects ``model`` from the union, or ``""``.
 
     Read off the variant's own ``Literal`` discriminator annotation, so the kind
-    name has ONE source — the class that declares it — and a new variant needs no
-    entry anywhere else.
+    name has ONE source: the class that declares it.
+
+    TOTAL — it answers ``""`` for a model that declares no discriminator rather
+    than raising. It is only ever called to BUILD A REFUSAL MESSAGE, and a
+    reporting path that throws replaces a structured error with a traceback: the
+    shared base carries no ``type``, so a direct validation of it (which no caller
+    does today, but which is one refactor away) would otherwise die inside the
+    handler meant to explain the mistake.
     """
-    members = get_args(model.model_fields["type"].annotation)
+    field = model.model_fields.get("type")
+    members = get_args(field.annotation) if field is not None else ()
     return str(members[0].value) if members else ""
 
 
@@ -334,7 +357,7 @@ def _kinds_accepting(field: str, exclude: type[BaseModel]) -> list[str]:
     """The other event kinds that DO accept ``field`` (derived from the union)."""
     return [
         _event_kind(model)
-        for model in SEQUENCE_EVENT_MODELS
+        for model in _SEQUENCE_EVENT_MODELS
         if model is not exclude and field in model.model_fields
     ]
 
@@ -350,7 +373,7 @@ def _foreign_field_message(model: type[BaseModel], field: str) -> str:
     kind = _event_kind(model)
     # "an 'action' event", not "a 'action' event": the kind names come from the
     # union, so the article is computed rather than written into a sentence.
-    article = "an" if kind[:1] in "aeiou" else "a"
+    article = "an" if kind[:1] and kind[0] in "aeiou" else "a"
     if field in _PHASE_FIELDS:
         own = [name for name in _PHASE_FIELDS if name in model.model_fields]
         advice = (
@@ -373,10 +396,13 @@ class _SequenceEvent(BaseModel):
     """The clock half every ``gda input sequence`` event shares (#221, #391).
 
     The union's base: it owns the two relative-offset fields and the one-clock
-    rule, so each kind below declares only the fields it actually accepts. That
-    is what makes the emitted contract machine-checkable — a kind's variant
-    schema lists exactly its required fields and forbids the rest — where one
-    flat shape could only describe the per-kind rules in prose (GDA-DF-037).
+    rule, so each kind below declares only the fields it actually accepts. That is
+    what makes a kind's FIELD SET checkable — its variant schema lists exactly the
+    fields it requires and forbids every other kind's — where one flat shape could
+    only describe the per-kind rules in prose (GDA-DF-037). The one-clock rule
+    itself stays a model-side check, as it was: it is a relation between two
+    nullable fields, and expressing it in schema would reject
+    ``{"frame": 1, "physics_frame": null}``, which is well formed.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -449,10 +475,38 @@ class MouseClickSequenceEvent(_SequenceEvent):
     type: Literal[InputEventType.MOUSE_CLICK] = Field(description="The event kind.")
     x: float = Field(description=_MOUSE_X_DESC)
     y: float = Field(description=_MOUSE_Y_DESC)
-    button: MouseButton = Field(
-        default=MouseButton.LEFT, description="Which button: left, right, or middle."
+    button: MouseButton | None = Field(
+        default=MouseButton.LEFT, description=_BUTTON_DESC
     )
     double: bool = Field(default=False, description="Mark the event a double click.")
+
+    @model_validator(mode="after")
+    def _default_button(self) -> "MouseClickSequenceEvent":
+        _left_when_null(self)
+        return self
+
+
+# The press/release phase, stated as a JSON-Schema rule so a client can CHECK it
+# rather than read it (#669). It mirrors ``_check_phase`` below, which stays the
+# enforcing authority — the two are held together by a test that runs one corpus
+# through both the emitted schema and the model and requires the same verdict.
+# Without it the one kind an agent reaches for to build a drag published its
+# fields but not the rule that makes them a press or a release, so the drag path
+# still cost the failed invocation GDA-DF-037 reported.
+_MOUSE_BUTTON_PHASE_SCHEMA: dict[str, Any] = {
+    "oneOf": [
+        # The press: `pressed: true`, and no release on the same event.
+        {
+            "required": ["pressed"],
+            "properties": {"pressed": {"const": True}, "release": {"const": False}},
+        },
+        # The release: `release: true`, with `pressed` left unset (absent or null).
+        {
+            "required": ["release"],
+            "properties": {"release": {"const": True}, "pressed": {"type": "null"}},
+        },
+    ]
+}
 
 
 class MouseButtonSequenceEvent(_SequenceEvent):
@@ -461,14 +515,16 @@ class MouseButtonSequenceEvent(_SequenceEvent):
     The sequence-only kind, for press-drag-release gestures: it carries the held
     button mask onto the motion events in between. It is the ONE kind that spells
     a phase with ``pressed``; exactly one of ``pressed: true`` / ``release: true``
-    is required.
+    is required, and that rule is published as schema, not only as prose.
     """
+
+    model_config = ConfigDict(json_schema_extra=_MOUSE_BUTTON_PHASE_SCHEMA)
 
     type: Literal[InputEventType.MOUSE_BUTTON] = Field(description="The event kind.")
     x: float = Field(description=_MOUSE_X_DESC)
     y: float = Field(description=_MOUSE_Y_DESC)
-    button: MouseButton = Field(
-        default=MouseButton.LEFT, description="Which button: left, right, or middle."
+    button: MouseButton | None = Field(
+        default=MouseButton.LEFT, description=_BUTTON_DESC
     )
     double: bool = Field(default=False, description="Mark the event a double click.")
     pressed: bool | None = Field(
@@ -482,6 +538,7 @@ class MouseButtonSequenceEvent(_SequenceEvent):
 
     @model_validator(mode="after")
     def _check_phase(self) -> "MouseButtonSequenceEvent":
+        _left_when_null(self)
         if self.pressed is None and not self.release:
             raise ValueError(
                 "a 'mouse_button' sequence event requires 'pressed' or 'release'."
@@ -530,22 +587,15 @@ class ActionSequenceEvent(_SequenceEvent):
     )
 
 
-# The union's members, in the order they appear in the emitted `oneOf`. Also the
-# one place the per-kind rejection reads which kinds accept a given field, so the
-# message and the contract come from the same declarations.
-SEQUENCE_EVENT_MODELS: tuple[type[_SequenceEvent], ...] = (
-    KeySequenceEvent,
-    MouseClickSequenceEvent,
-    MouseButtonSequenceEvent,
-    MouseMoveSequenceEvent,
-    ActionSequenceEvent,
-)
-
 # One event of a `gda input sequence`, as a DISCRIMINATED union on `type` (#669).
 # The emitted schema is a `oneOf` with a `type` discriminator mapping, so each
-# kind's required and forbidden fields are machine-checkable: a client validates a
-# candidate event against the published contract instead of learning the per-kind
-# rules from prose or from a failed invocation (GDA-DF-037/GDA-DF-032).
+# kind's field set — what it requires and what it forbids — is machine-checkable:
+# a client validates a candidate event against the published contract instead of
+# learning the per-kind fields from prose or from a failed invocation
+# (GDA-DF-037/GDA-DF-032). The CROSS-FIELD rules are a narrower story: the
+# mouse-button phase is published too (`_MOUSE_BUTTON_PHASE_SCHEMA`), while the
+# one-clock rule, the modifier vocabulary and the window ceiling stay enforced
+# model-side only, as they were before this union.
 InputSequenceEvent = Annotated[
     KeySequenceEvent
     | MouseClickSequenceEvent
@@ -554,6 +604,16 @@ InputSequenceEvent = Annotated[
     | ActionSequenceEvent,
     Field(discriminator="type"),
 ]
+
+# The union's members, READ OFF the union itself rather than re-listed: the
+# per-kind rejection asks which kinds accept a given field, and a hand-kept tuple
+# beside the union would be a second membership list — a sixth variant added to
+# one and not the other would vanish from every "is accepted on:" hint while every
+# test still passed. `InputSequenceEvent` is `Annotated[<union>, Field(...)]`, so
+# the first `get_args` unwraps the annotation and the second yields the members.
+_SEQUENCE_EVENT_MODELS: tuple[type[_SequenceEvent], ...] = get_args(
+    get_args(InputSequenceEvent)[0]
+)
 
 
 class InputSequenceParams(BaseModel):

--- a/src/gda/commands/input.py
+++ b/src/gda/commands/input.py
@@ -340,20 +340,25 @@ def _foreign_field_message(model: type[BaseModel], field: str) -> str:
     from the variant models, so it cannot drift from what they accept.
     """
     kind = _event_kind(model)
+    # "an 'action' event", not "a 'action' event": the kind names come from the
+    # union, so the article is computed rather than written into a sentence.
+    article = "an" if kind[:1] in "aeiou" else "a"
     if field in _PHASE_FIELDS:
         own = [name for name in _PHASE_FIELDS if name in model.model_fields]
         advice = (
-            f"a {kind!r} event spells its press/release phase "
+            f"{article} {kind!r} event spells its press/release phase "
             + " or ".join(repr(name) for name in own)
             if own
-            else f"a {kind!r} event has no press/release phase"
+            else f"{article} {kind!r} event has no press/release phase"
         )
     else:
         accepted = ", ".join(repr(name) for name in model.model_fields)
-        advice = f"a {kind!r} event accepts {accepted}"
+        advice = f"{article} {kind!r} event accepts {accepted}"
     elsewhere = _kinds_accepting(field, model)
     seen = f"; {field!r} is accepted on: {', '.join(elsewhere)}" if elsewhere else ""
-    return f"{field!r} is not valid on a {kind!r} sequence event: {advice}{seen}."
+    return (
+        f"{field!r} is not valid on {article} {kind!r} sequence event: {advice}{seen}."
+    )
 
 
 class _SequenceEvent(BaseModel):

--- a/src/gda/commands/input.py
+++ b/src/gda/commands/input.py
@@ -30,7 +30,7 @@ reached the harness without passing the model (a direct daemon caller).
 
 import json
 from enum import Enum
-from typing import Optional
+from typing import Annotated, Literal, Optional, get_args
 
 import typer
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -278,161 +278,269 @@ class InputEventType(str, Enum):
     ACTION = "action"
 
 
-class InputSequenceEvent(BaseModel):
-    """One event in a ``gda input sequence``, applied at its relative clock offset.
+# The press/release synonyms a sequence event may spell its phase with. Each kind
+# uses exactly the one its single-frame op uses (`released` for a key, `release`
+# for an action, `pressed`/`release` for the sequence-only mouse-button phase),
+# and the flat shape they used to share made a foreign one silently inert — a
+# `release` on a key event PRESSED the key. Declared once here so the rejection
+# can NAME the kind's own spelling instead of only refusing the wrong one; which
+# kind uses which is read off the variant models themselves, never restated.
+_PHASE_FIELDS = ("pressed", "released", "release")
 
-    A tagged union over the single-frame ops: ``type`` selects the event shape and
-    either ``frame`` or ``physics_frame`` places it within the window. ``frame`` is
-    the original harness/process-frame clock, advanced by the harness ``_process``
-    loop; it is not Godot's fixed physics clock. ``physics_frame`` is the explicit
-    physics-clock offset, advanced by Godot ``_physics_process`` ticks, for sequences
-    that need deterministic simulation-duration input holds. Events due at the same
-    clock index are applied together. The type-specific fields mirror the
-    single-frame params — ``key``/``modifiers``/``released`` for a key, ``x``/``y``/
-    ``button``/``double`` for a mouse click, ``x``/``y``/``button`` plus exactly one
-    ``pressed``/``release`` phase for a mouse-button event, ``x``/``y`` for a mouse
-    move, ``action``/``release``/``strength`` for an action. The required fields per
-    type and the shared bounds (modifier set, button enum, strength range) are
-    validated model-side (ADR-0015) so a malformed event is rejected before the
-    harness runs.
-    Mouse event coordinates are reliable as the event's ``position``; engine-tracked
-    mouse positions may remain stale for sequence mouse events too.
+# The shared field descriptions, written once for the whole union: each variant
+# repeats only the fields it accepts, and the manifest repeats every variant per
+# command, so a per-class copy would multiply the same sentence.
+_FRAME_DESC = (
+    "The 0-based relative harness/process-frame offset to apply this event at. "
+    "This is the original `input sequence` clock, driven by the harness "
+    "`_process` loop; it is not Godot's fixed physics clock. Omit both `frame` "
+    "and `physics_frame` to use process frame 0."
+)
+_PHYSICS_FRAME_DESC = (
+    "The 0-based relative physics-frame offset to apply this event at, driven by "
+    "Godot `_physics_process` ticks. Use this instead of `frame` when an input "
+    "hold must map to a deterministic physics simulation duration."
+)
+_MOUSE_X_DESC = (
+    "The event's x position in the viewport. Read it from the event; "
+    "engine-tracked mouse positions may remain stale."
+)
+_MOUSE_Y_DESC = (
+    "The event's y position in the viewport. Read it from the event; "
+    "engine-tracked mouse positions may remain stale."
+)
+
+
+def _event_kind(model: type[BaseModel]) -> str:
+    """The ``type`` value that selects ``model`` from the union.
+
+    Read off the variant's own ``Literal`` discriminator annotation, so the kind
+    name has ONE source — the class that declares it — and a new variant needs no
+    entry anywhere else.
+    """
+    members = get_args(model.model_fields["type"].annotation)
+    return str(members[0].value) if members else ""
+
+
+def _kinds_accepting(field: str, exclude: type[BaseModel]) -> list[str]:
+    """The other event kinds that DO accept ``field`` (derived from the union)."""
+    return [
+        _event_kind(model)
+        for model in SEQUENCE_EVENT_MODELS
+        if model is not exclude and field in model.model_fields
+    ]
+
+
+def _foreign_field_message(model: type[BaseModel], field: str) -> str:
+    """Explain a field that belongs to another event kind, naming what to use here.
+
+    The rejection itself is not the gap — a foreign field was already refused —
+    the gap is that refusing ``pressed`` on an action event never mentioned
+    ``release`` (dogfooding GDA-DF-037). Every part of the sentence is derived
+    from the variant models, so it cannot drift from what they accept.
+    """
+    kind = _event_kind(model)
+    if field in _PHASE_FIELDS:
+        own = [name for name in _PHASE_FIELDS if name in model.model_fields]
+        advice = (
+            f"a {kind!r} event spells its press/release phase "
+            + " or ".join(repr(name) for name in own)
+            if own
+            else f"a {kind!r} event has no press/release phase"
+        )
+    else:
+        accepted = ", ".join(repr(name) for name in model.model_fields)
+        advice = f"a {kind!r} event accepts {accepted}"
+    elsewhere = _kinds_accepting(field, model)
+    seen = f"; {field!r} is accepted on: {', '.join(elsewhere)}" if elsewhere else ""
+    return f"{field!r} is not valid on a {kind!r} sequence event: {advice}{seen}."
+
+
+class _SequenceEvent(BaseModel):
+    """The clock half every ``gda input sequence`` event shares (#221, #391).
+
+    The union's base: it owns the two relative-offset fields and the one-clock
+    rule, so each kind below declares only the fields it actually accepts. That
+    is what makes the emitted contract machine-checkable — a kind's variant
+    schema lists exactly its required fields and forbids the rest — where one
+    flat shape could only describe the per-kind rules in prose (GDA-DF-037).
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    type: InputEventType = Field(description="The event kind.")
-    frame: int | None = Field(
-        default=None,
-        ge=0,
-        description=(
-            "The 0-based relative harness/process-frame offset to apply this event at. "
-            "This is the original `input sequence` clock, driven by the harness "
-            "`_process` loop; it is not Godot's fixed physics clock. Omit both "
-            "`frame` and `physics_frame` to use process frame 0."
-        ),
-    )
+    frame: int | None = Field(default=None, ge=0, description=_FRAME_DESC)
     physics_frame: int | None = Field(
-        default=None,
-        ge=0,
-        description=(
-            "The 0-based relative physics-frame offset to apply this event at, driven "
-            "by Godot `_physics_process` ticks. Use this instead of `frame` when an "
-            "input hold must map to a deterministic physics simulation duration."
-        ),
-    )
-    # key fields
-    key: str | None = Field(default=None, description="A key event's key name.")
-    modifiers: list[str] = Field(
-        default_factory=list, description="A key event's modifier keys."
-    )
-    released: bool = Field(
-        default=False, description="A key event: inject a release instead of a press."
-    )
-    # mouse fields
-    x: float | None = Field(
-        default=None,
-        description=(
-            "A mouse event's x position. Read it from the event; engine-tracked "
-            "mouse positions may remain stale."
-        ),
-    )
-    y: float | None = Field(
-        default=None,
-        description=(
-            "A mouse event's y position. Read it from the event; engine-tracked "
-            "mouse positions may remain stale."
-        ),
-    )
-    button: MouseButton | None = Field(
-        default=None,
-        description=(
-            "A mouse-click or mouse-button event's button; defaults to left for "
-            "mouse-button events."
-        ),
-    )
-    double: bool = Field(
-        default=False, description="A mouse-click event: mark it a double click."
-    )
-    pressed: bool | None = Field(
-        default=None,
-        description=(
-            "A mouse-button event: press the button. Use exactly one of `pressed` "
-            "or `release`."
-        ),
-    )
-    # action fields
-    action: str | None = Field(
-        default=None, description="An action event's action name."
-    )
-    release: bool = Field(
-        default=False,
-        description=(
-            "An action event: release instead of press. A mouse-button event: "
-            "release the button; use exactly one of `pressed` or `release`."
-        ),
-    )
-    strength: float = Field(
-        default=1.0,
-        ge=0.0,
-        le=1.0,
-        description="An action event's press strength, 0..1.",
+        default=None, ge=0, description=_PHYSICS_FRAME_DESC
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def _explain_foreign_fields(cls, data: object) -> object:
+        # Runs BEFORE pydantic's own extra="forbid" refusal, which reports only
+        # "Extra inputs are not permitted" and so leaves the caller to guess this
+        # kind's spelling. Non-dict input (an already-built model) passes through.
+        if not isinstance(data, dict):
+            return data
+        foreign = [key for key in data if key not in cls.model_fields]
+        if foreign:
+            raise ValueError(
+                " ".join(_foreign_field_message(cls, key) for key in foreign)
+            )
+        return data
+
     @model_validator(mode="after")
-    def _check_event_shape(self) -> "InputSequenceEvent":
+    def _check_clock(self) -> "_SequenceEvent":
         # Each event uses exactly one clock. No supplied clock keeps the original
-        # shorthand: process frame 0. Enforced model-side (ADR-0015) so argv JSON and
-        # --params-json reject the same malformed event before it reaches the harness.
+        # shorthand: process frame 0. Enforced model-side (ADR-0015) so argv JSON
+        # and --params-json reject the same malformed event before the harness.
         if self.frame is not None and self.physics_frame is not None:
             raise ValueError(
                 "a sequence event cannot set both 'frame' and 'physics_frame'."
             )
         if self.frame is None and self.physics_frame is None:
             self.frame = 0
-        if self.type is not InputEventType.MOUSE_BUTTON and self.pressed is not None:
-            raise ValueError(
-                "'pressed' is only valid on a 'mouse_button' sequence event."
-            )
-        # Each event type requires its own fields; the shared bounds (modifier set,
-        # strength range, button enum) are enforced by the fields above.
-        if self.type is InputEventType.KEY:
-            if not self.key:
-                raise ValueError("a 'key' sequence event requires 'key'.")
-            _validate_modifiers(self.modifiers)
-        elif self.type is InputEventType.MOUSE_CLICK:
-            if self.x is None or self.y is None:
-                raise ValueError("a 'mouse_click' sequence event requires 'x' and 'y'.")
-        elif self.type is InputEventType.MOUSE_BUTTON:
-            if self.x is None or self.y is None:
-                raise ValueError(
-                    "a 'mouse_button' sequence event requires 'x' and 'y'."
-                )
-            if self.pressed is None and not self.release:
-                raise ValueError(
-                    "a 'mouse_button' sequence event requires 'pressed' or 'release'."
-                )
-            if self.pressed is False:
-                raise ValueError(
-                    "a 'mouse_button' sequence event uses 'pressed: true' to press; "
-                    "use 'release: true' to release."
-                )
-            if self.pressed is True and self.release:
-                raise ValueError(
-                    "a 'mouse_button' sequence event cannot set both 'pressed' and "
-                    "'release'."
-                )
-            if self.release:
-                self.pressed = False
-            if self.button is None:
-                self.button = MouseButton.LEFT
-        elif self.type is InputEventType.MOUSE_MOVE:
-            if self.x is None or self.y is None:
-                raise ValueError("a 'mouse_move' sequence event requires 'x' and 'y'.")
-        elif self.type is InputEventType.ACTION:
-            if not self.action:
-                raise ValueError("an 'action' sequence event requires 'action'.")
         return self
+
+
+class KeySequenceEvent(_SequenceEvent):
+    """A key event in a sequence: the ``gda input key`` shape at a clock offset.
+
+    Pushes an ``InputEventKey`` for ``key`` (with any ``modifiers``) into the
+    running game's root viewport. It presses by default and releases with
+    ``released`` — the action kind's ``release`` is NOT accepted here.
+    """
+
+    type: Literal[InputEventType.KEY] = Field(description="The event kind.")
+    key: str = Field(min_length=1, description="The key name to inject (e.g. Right).")
+    modifiers: list[str] = Field(
+        default_factory=list,
+        description="Modifier keys held with the key, any of: shift, ctrl, alt, meta.",
+    )
+    released: bool = Field(
+        default=False, description="Inject a key RELEASE instead of a press."
+    )
+
+    @model_validator(mode="after")
+    def _check_modifiers(self) -> "KeySequenceEvent":
+        _validate_modifiers(self.modifiers)
+        return self
+
+
+class MouseClickSequenceEvent(_SequenceEvent):
+    """A whole mouse click in a sequence: press and release at one clock offset.
+
+    Use :class:`MouseButtonSequenceEvent` instead when the press and the release
+    must sit at different offsets (a drag).
+    """
+
+    type: Literal[InputEventType.MOUSE_CLICK] = Field(description="The event kind.")
+    x: float = Field(description=_MOUSE_X_DESC)
+    y: float = Field(description=_MOUSE_Y_DESC)
+    button: MouseButton = Field(
+        default=MouseButton.LEFT, description="Which button: left, right, or middle."
+    )
+    double: bool = Field(default=False, description="Mark the event a double click.")
+
+
+class MouseButtonSequenceEvent(_SequenceEvent):
+    """One PHASE of a mouse button in a sequence: the press or the release alone.
+
+    The sequence-only kind, for press-drag-release gestures: it carries the held
+    button mask onto the motion events in between. It is the ONE kind that spells
+    a phase with ``pressed``; exactly one of ``pressed: true`` / ``release: true``
+    is required.
+    """
+
+    type: Literal[InputEventType.MOUSE_BUTTON] = Field(description="The event kind.")
+    x: float = Field(description=_MOUSE_X_DESC)
+    y: float = Field(description=_MOUSE_Y_DESC)
+    button: MouseButton = Field(
+        default=MouseButton.LEFT, description="Which button: left, right, or middle."
+    )
+    double: bool = Field(default=False, description="Mark the event a double click.")
+    pressed: bool | None = Field(
+        default=None,
+        description="Press the button. Use exactly one of `pressed` or `release`.",
+    )
+    release: bool = Field(
+        default=False,
+        description="Release the button. Use exactly one of `pressed` or `release`.",
+    )
+
+    @model_validator(mode="after")
+    def _check_phase(self) -> "MouseButtonSequenceEvent":
+        if self.pressed is None and not self.release:
+            raise ValueError(
+                "a 'mouse_button' sequence event requires 'pressed' or 'release'."
+            )
+        if self.pressed is False:
+            raise ValueError(
+                "a 'mouse_button' sequence event uses 'pressed: true' to press; "
+                "use 'release: true' to release."
+            )
+        if self.pressed is True and self.release:
+            raise ValueError(
+                "a 'mouse_button' sequence event cannot set both 'pressed' and "
+                "'release'."
+            )
+        if self.release:
+            self.pressed = False
+        return self
+
+
+class MouseMoveSequenceEvent(_SequenceEvent):
+    """A mouse motion event in a sequence: the ``gda input mouse-move`` shape."""
+
+    type: Literal[InputEventType.MOUSE_MOVE] = Field(description="The event kind.")
+    x: float = Field(description=_MOUSE_X_DESC)
+    y: float = Field(description=_MOUSE_Y_DESC)
+
+
+class ActionSequenceEvent(_SequenceEvent):
+    """An input action in a sequence: the ``gda input action`` shape.
+
+    Drives ``Input.action_press`` / ``action_release`` for ``action``, which must
+    be declared in the running ``InputMap``. It presses by default and releases
+    with ``release`` — the mouse-button kind's ``pressed`` is NOT accepted here,
+    so a hold is a press event and a later ``release: true`` event.
+    """
+
+    type: Literal[InputEventType.ACTION] = Field(description="The event kind.")
+    action: str = Field(
+        min_length=1, description="The action name (must be in the InputMap)."
+    )
+    release: bool = Field(
+        default=False, description="Release the action instead of pressing it."
+    )
+    strength: float = Field(
+        default=1.0, ge=0.0, le=1.0, description="The analog press strength, 0..1."
+    )
+
+
+# The union's members, in the order they appear in the emitted `oneOf`. Also the
+# one place the per-kind rejection reads which kinds accept a given field, so the
+# message and the contract come from the same declarations.
+SEQUENCE_EVENT_MODELS: tuple[type[_SequenceEvent], ...] = (
+    KeySequenceEvent,
+    MouseClickSequenceEvent,
+    MouseButtonSequenceEvent,
+    MouseMoveSequenceEvent,
+    ActionSequenceEvent,
+)
+
+# One event of a `gda input sequence`, as a DISCRIMINATED union on `type` (#669).
+# The emitted schema is a `oneOf` with a `type` discriminator mapping, so each
+# kind's required and forbidden fields are machine-checkable: a client validates a
+# candidate event against the published contract instead of learning the per-kind
+# rules from prose or from a failed invocation (GDA-DF-037/GDA-DF-032).
+InputSequenceEvent = Annotated[
+    KeySequenceEvent
+    | MouseClickSequenceEvent
+    | MouseButtonSequenceEvent
+    | MouseMoveSequenceEvent
+    | ActionSequenceEvent,
+    Field(discriminator="type"),
+]
 
 
 class InputSequenceParams(BaseModel):
@@ -768,13 +876,28 @@ def input_sequence(
         ...,
         "--events",
         help=(
+            # Both examples are spelled with a space after each ':' and ',' so the
+            # help renderer WRAPS them instead of ellipsizing an unbreakable
+            # word: the one-line form used to be cut off mid-example, which is
+            # not copyable. JSON ignores the extra whitespace.
             "The events to inject, as a JSON array of event objects, each with a "
-            "'type' (key/mouse_click/mouse_button/mouse_move/action), either a relative "
-            "'frame' harness/process-frame offset or a 'physics_frame' physics-clock "
-            "offset, and the type's fields (e.g. "
-            '\'[{"type":"mouse_button","x":10,"y":10,"pressed":true},'
-            '{"type":"mouse_move","x":40,"y":20,"frame":1},'
-            '{"type":"mouse_button","x":40,"y":20,"release":true,"frame":2}]\').'
+            "'type' (key, mouse_click, mouse_button, mouse_move or action), "
+            "either a "
+            "relative 'frame' harness/process-frame offset or a 'physics_frame' "
+            "physics-clock offset, and that type's own fields (--schema publishes "
+            "each type's required and forbidden fields). "
+            "Drag: "
+            '\'[{"type": "mouse_button", "x": 10, "y": 10, "pressed": true}, '
+            '{"type": "mouse_move", "x": 40, "y": 20, "frame": 1}, '
+            '{"type": "mouse_button", "x": 40, "y": 20, "release": true, '
+            '"frame": 2}]\'. '
+            # The action pair the mouse-only example left an agent to infer: an
+            # action presses by default and releases with 'release', never with
+            # the mouse-button kind's 'pressed' (GDA-DF-032).
+            "Action held for 10 process frames: "
+            '\'[{"type": "action", "action": "jump", "frame": 0}, '
+            '{"type": "action", "action": "jump", "release": true, '
+            '"frame": 10}]\'.'
         ),
     ),
     json_output: bool = json_option(),

--- a/src/gda/commands/meta.py
+++ b/src/gda/commands/meta.py
@@ -474,7 +474,7 @@ def register(root: typer.Typer) -> None:
             "--install",
             help="Write the bundled SKILL.md into the skills directory instead of printing it.",
         ),
-        dir: Optional[str] = typer.Option(
+        install_dir: Optional[str] = typer.Option(
             None,
             "--dir",
             help="The skills directory to install into (caller-supplied; the neutral path, "
@@ -514,19 +514,22 @@ def register(root: typer.Typer) -> None:
         # rules are mirrored in SkillParams (so the --params-json path enforces them too,
         # ADR-0015); resolving provider→dir also happens there. The CLI raises the friendly
         # usage errors and otherwise just forwards the raw flags.
-        if dir is not None and provider is not None:
+        if install_dir is not None and provider is not None:
             raise typer.BadParameter(
                 "`--dir` and `--provider` are mutually exclusive: name a directory OR an "
                 "agent, not both"
             )
-        if install and dir is None and provider is None:
+        if install and install_dir is None and provider is None:
             raise typer.BadParameter(
                 "`--install` requires `--dir` or `--provider` (where to write the SKILL.md)"
             )
         dispatch_recipe(
             SKILL_COMMAND,
             SkillParams(
-                install=install, install_dir=dir, provider=provider, scope=scope
+                install=install,
+                install_dir=install_dir,
+                provider=provider,
+                scope=scope,
             ),
             json_output=json_output,
             godot=None,

--- a/src/gda/commands/project.py
+++ b/src/gda/commands/project.py
@@ -871,7 +871,7 @@ def project_get(
 
 @_app.command(name="list", cls=PROJECT_LIST_COMMAND.command_class())
 def project_list(
-    all_settings: bool = typer.Option(
+    include_defaults: bool = typer.Option(
         False,
         "--all",
         help=(
@@ -896,7 +896,7 @@ def project_list(
     """List the project's settings keys (customized only by default; --all adds defaults)."""
     dispatch_domain(
         PROJECT_LIST_COMMAND,
-        ProjectListParams(include_defaults=all_settings, section=section),
+        ProjectListParams(include_defaults=include_defaults, section=section),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -248,22 +248,30 @@ def command_argv_bindings(
     dispatch channel at once — the sentinel path, the EXPORT / LIVE kinds and the
     recipe commands all register the same way, whatever runs them afterwards.
 
-    Two filters decide what an *operation parameter* is, both reusing rules this
-    module already owns rather than restating them: a parameter Click does not
-    expose (its eager ``--help``) never reaches a params model, and
-    :data:`_GLOBAL_OPTION_NAMES` is the same set ``--params-json`` treats as
-    cross-cutting rather than operational (ADR-0015). So ``argv`` covers exactly
-    the parameters ``input`` describes.
+    What counts as an *operation parameter* reuses a rule this module already
+    owns rather than restating it: :data:`_GLOBAL_OPTION_NAMES` is the same set
+    ``--params-json`` treats as cross-cutting rather than operational (ADR-0015).
+    A parameter Click does not expose is skipped as well — none exists on today's
+    surface (Click appends its own ``--help`` in ``get_params``, not here), so
+    that arm is a guard against a future unexposed parameter, which by definition
+    reaches no params model.
+
+    The projection is therefore the argv form of the operation parameters, NOT a
+    one-to-one image of ``input``: every REQUIRED property has a binding (a
+    registration test holds that), while a few optional properties are computed
+    from the CLI rather than typed (``script set``'s ``mode`` comes from
+    ``--replace`` / ``--search``) or named differently by their flag.
 
     Click is duck-typed through ``getattr``, as the surface walker does: it is a
     transitive dependency through Typer, not a direct one.
 
     ``input_property`` is derived, not declared: the emitted property of the same
     name if there is one, else the one the long option spells (``--type`` fills
-    ``type`` though the Python parameter is ``node_type``), else ``None`` where
-    the CLI form genuinely has no 1:1 property — two flags selecting one field,
-    say. Guessing further would be worse than the honest null: a wrong link
-    reads as authoritative.
+    ``type`` though the Python parameter is ``node_type``), else ``None``. The two
+    nulls on today's surface are flags whose spelling renames the property
+    (``project list --all`` fills ``include_defaults``, ``skill --dir`` fills
+    ``install_dir``); guessing past that would be worse than the honest null,
+    since a wrong link reads as authoritative.
     """
     properties = input_model.model_json_schema().get("properties", {})
     bindings: list[ArgvBinding] = []
@@ -282,16 +290,19 @@ def command_argv_bindings(
         # repeatable option is, so both report ``multiple``: Click spells the
         # two differently, an argv author writes both by repeating.
         nargs = getattr(param, "nargs", 1)
+        multiple = bool(getattr(param, "multiple", False)) or nargs == -1
+        bound = _bound_property(name, option, properties)
         bindings.append(
             ArgvBinding(
                 name=name,
-                input_property=_bound_property(name, option, properties),
+                input_property=bound,
                 kind=ArgvKind.ARGUMENT if is_argument else ArgvKind.OPTION,
                 option=option,
                 position=position if is_argument else None,
                 required=bool(getattr(param, "required", False)),
                 flag=bool(getattr(param, "is_flag", False)),
-                multiple=bool(getattr(param, "multiple", False)) or nargs == -1,
+                multiple=multiple,
+                json_value=_takes_a_json_value(bound, properties, multiple),
             )
         )
         if is_argument:
@@ -310,6 +321,29 @@ def _bound_property(
         if spelled in properties:
             return spelled
     return None
+
+
+def _takes_a_json_value(
+    bound: Optional[str], properties: "dict[str, Any]", multiple: bool
+) -> bool:
+    """Whether the parameter's one token is the property's JSON encoding (#669).
+
+    A compound property (an array or object) reaches argv one of two ways: as a
+    REPEATED token, which ``multiple`` already tells the caller, or as a single
+    token carrying its JSON — the shape ``gda input sequence --events`` uses. The
+    second is invisible in the binding otherwise: the property says ``array``, so
+    an agent writing one token per element would build a command line the parser
+    rejects, which is the encoding half of the argv problem this key answers.
+
+    Derived from the two facts already in hand — the linked property's type and
+    whether the parameter repeats — so no command declares it. ``False`` when the
+    parameter has no property link: unknown, and a wrong ``true`` here would send
+    a caller to encode a plain string.
+    """
+    spec = properties.get(bound or "")
+    if not isinstance(spec, dict) or multiple:
+        return False
+    return spec.get("type") in ("array", "object")
 
 
 def schema_command_class(

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -28,7 +28,13 @@ from gda.errors import (
     unresolvable_binary_failure,
 )
 from gda.execution import ExecutionKind, live_stack_constraints
-from gda.models import CommandSchema, GdaErrorEnvelope, LiveStackConstraints
+from gda.models import (
+    ArgvBinding,
+    ArgvKind,
+    CommandSchema,
+    GdaErrorEnvelope,
+    LiveStackConstraints,
+)
 from gda.runner import GodotRunner, RunResult, SubprocessGodotRunner
 
 M = TypeVar("M", bound=BaseModel)
@@ -225,6 +231,87 @@ def _from_command_line(ctx: typer.Context, name: str) -> bool:
     return source is not None and source.name == "COMMANDLINE"
 
 
+def command_argv_bindings(
+    command: object, input_model: type[BaseModel]
+) -> list[ArgvBinding]:
+    """Project ``command``'s live Click parameters into their CLI spelling (#669).
+
+    The one place a command's argv form is derived, shared by the per-command
+    ``--schema`` here and the aggregate manifest builder (``gda.surface``) so the
+    two forms cannot drift — the same shape :func:`command_constraints` gives the
+    live-stack precondition.
+
+    The **live Typer/Click signature is the source**, read at emission time: a
+    spelling table on the descriptor would be a second authority for a fact the
+    signature already owns, which is the parallel registry ADR-0023 §2 rejects.
+    Reading the registered parameters also makes the projection correct on every
+    dispatch channel at once — the sentinel path, the EXPORT / LIVE kinds and the
+    recipe commands all register the same way, whatever runs them afterwards.
+
+    Two filters decide what an *operation parameter* is, both reusing rules this
+    module already owns rather than restating them: a parameter Click does not
+    expose (its eager ``--help``) never reaches a params model, and
+    :data:`_GLOBAL_OPTION_NAMES` is the same set ``--params-json`` treats as
+    cross-cutting rather than operational (ADR-0015). So ``argv`` covers exactly
+    the parameters ``input`` describes.
+
+    Click is duck-typed through ``getattr``, as the surface walker does: it is a
+    transitive dependency through Typer, not a direct one.
+
+    ``input_property`` is derived, not declared: the emitted property of the same
+    name if there is one, else the one the long option spells (``--type`` fills
+    ``type`` though the Python parameter is ``node_type``), else ``None`` where
+    the CLI form genuinely has no 1:1 property — two flags selecting one field,
+    say. Guessing further would be worse than the honest null: a wrong link
+    reads as authoritative.
+    """
+    properties = input_model.model_json_schema().get("properties", {})
+    bindings: list[ArgvBinding] = []
+    position = 0
+    for param in getattr(command, "params", []):
+        if not getattr(param, "expose_value", True):
+            continue
+        name = getattr(param, "name", None)
+        if not isinstance(name, str) or name in _GLOBAL_OPTION_NAMES:
+            continue
+        opts = [str(opt) for opt in getattr(param, "opts", [])]
+        is_argument = getattr(param, "param_type_name", "") == "argument"
+        long_opts = [opt for opt in opts if opt.startswith("--")]
+        option = None if is_argument else next(iter(long_opts or opts), None)
+        # A variadic positional (``nargs=-1``) is repeated the same way a
+        # repeatable option is, so both report ``multiple``: Click spells the
+        # two differently, an argv author writes both by repeating.
+        nargs = getattr(param, "nargs", 1)
+        bindings.append(
+            ArgvBinding(
+                name=name,
+                input_property=_bound_property(name, option, properties),
+                kind=ArgvKind.ARGUMENT if is_argument else ArgvKind.OPTION,
+                option=option,
+                position=position if is_argument else None,
+                required=bool(getattr(param, "required", False)),
+                flag=bool(getattr(param, "is_flag", False)),
+                multiple=bool(getattr(param, "multiple", False)) or nargs == -1,
+            )
+        )
+        if is_argument:
+            position += 1
+    return bindings
+
+
+def _bound_property(
+    name: str, option: Optional[str], properties: "dict[str, Any]"
+) -> Optional[str]:
+    """The ``input`` property this parameter fills, or ``None`` if undecidable."""
+    if name in properties:
+        return name
+    if option is not None:
+        spelled = option.lstrip("-").replace("-", "_")
+        if spelled in properties:
+            return spelled
+    return None
+
+
 def schema_command_class(
     input_model: type[BaseModel],
     output_model: type[BaseModel],
@@ -283,12 +370,20 @@ def schema_command_class(
                 # ``kind`` + ``operation`` — wrapped into the model here so the
                 # per-command ``--schema`` and the aggregate manifest agree.
                 constraints = command_constraints(command)
+                # The CLI spelling of this command's parameters (#669), read off
+                # THIS command object's live Click parameters — the same single
+                # derivation the aggregate manifest uses. Taken after the relaxed
+                # parse above has restored each parameter's declared ``required``,
+                # so the published binding reports the real requirement rather
+                # than the probe's relaxation (issue #36).
+                argv = command_argv_bindings(self, input_model)
                 typer.echo(
                     CommandSchema.of(
                         input_model,
                         output_model,
                         kind=kind,
                         constraints=constraints,
+                        argv=argv,
                     ).model_dump_json()
                 )
                 raise typer.Exit()

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -239,39 +239,18 @@ def command_argv_bindings(
     The one place a command's argv form is derived, shared by the per-command
     ``--schema`` here and the aggregate manifest builder (``gda.surface``) so the
     two forms cannot drift — the same shape :func:`command_constraints` gives the
-    live-stack precondition.
+    live-stack precondition. The rationale, the boundaries and the case inventory
+    live in the ADR-0004 amendment (#669); this is the derivation.
 
-    The **live Typer/Click signature is the source**, read at emission time: a
-    spelling table on the descriptor would be a second authority for a fact the
-    signature already owns, which is the parallel registry ADR-0023 §2 rejects.
-    Reading the registered parameters also makes the projection correct on every
-    dispatch channel at once — the sentinel path, the EXPORT / LIVE kinds and the
-    recipe commands all register the same way, whatever runs them afterwards.
-
-    What counts as an *operation parameter* reuses a rule this module already
-    owns rather than restating it: :data:`_GLOBAL_OPTION_NAMES` is the same set
-    ``--params-json`` treats as cross-cutting rather than operational (ADR-0015).
-    A parameter Click does not expose is skipped as well — none exists on today's
-    surface (Click appends its own ``--help`` in ``get_params``, not here), so
-    that arm is a guard against a future unexposed parameter, which by definition
-    reaches no params model.
-
-    The projection is therefore the argv form of the operation parameters, NOT a
-    one-to-one image of ``input``: every REQUIRED property has a binding (a
-    registration test holds that), while a few optional properties are computed
-    from the CLI rather than typed (``script set``'s ``mode`` comes from
-    ``--replace`` / ``--search``) or named differently by their flag.
+    Which parameters are operational reuses a rule this module already owns:
+    :data:`_GLOBAL_OPTION_NAMES`, the same set ``--params-json`` treats as
+    cross-cutting (ADR-0015). The ``expose_value`` arm has no case on today's
+    surface — Click appends its own ``--help`` in ``get_params``, not here — and
+    guards a future unexposed parameter, which by definition reaches no params
+    model.
 
     Click is duck-typed through ``getattr``, as the surface walker does: it is a
     transitive dependency through Typer, not a direct one.
-
-    ``input_property`` is derived, not declared: the emitted property of the same
-    name if there is one, else the one the long option spells (``--type`` fills
-    ``type`` though the Python parameter is ``node_type``), else ``None``. The two
-    nulls on today's surface are flags whose spelling renames the property
-    (``project list --all`` fills ``include_defaults``, ``skill --dir`` fills
-    ``install_dir``); guessing past that would be worse than the honest null,
-    since a wrong link reads as authoritative.
     """
     properties = input_model.model_json_schema().get("properties", {})
     bindings: list[ArgvBinding] = []
@@ -328,17 +307,12 @@ def _takes_a_json_value(
 ) -> bool:
     """Whether the parameter's one token is the property's JSON encoding (#669).
 
-    A compound property (an array or object) reaches argv one of two ways: as a
-    REPEATED token, which ``multiple`` already tells the caller, or as a single
-    token carrying its JSON — the shape ``gda input sequence --events`` uses. The
-    second is invisible in the binding otherwise: the property says ``array``, so
-    an agent writing one token per element would build a command line the parser
-    rejects, which is the encoding half of the argv problem this key answers.
-
-    Derived from the two facts already in hand — the linked property's type and
-    whether the parameter repeats — so no command declares it. ``False`` when the
-    parameter has no property link: unknown, and a wrong ``true`` here would send
-    a caller to encode a plain string.
+    A compound property reaches argv as a REPEATED token, which ``multiple``
+    already reports, or as a single token carrying its JSON. ``False`` without a
+    property link: unknown, and a wrong ``true`` would send a caller to encode a
+    plain string. Reads a DECLARED ``type`` only, so a compound behind an
+    ``anyOf`` is not seen — no case exists, and a registration test fails if one
+    appears (``tests/test_schema_command.py``).
     """
     spec = properties.get(bound or "")
     if not isinstance(spec, dict) or multiple:

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -15,6 +15,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    model_validator,
 )
 
 from gda.execution import ExecutionKind
@@ -232,6 +233,38 @@ class ArgvKind(str, Enum):
     OPTION = "option"
 
 
+# The two spellings a binding can be, as a JSON-Schema rule so a consumer can
+# CHECK the pairing rather than discover it (#669 review). It mirrors
+# :meth:`ArgvBinding._check_spelling`, which stays the enforcing authority — a
+# corpus test runs one set of combinations through both this published rule and
+# the model and requires the same verdict, so the two cannot drift. Published
+# because the alternative reading is worse than useless: a consumer that sees
+# `position: null` on an option and `option: null` on a positional has to guess
+# which key is authoritative, and a binding claiming both (or neither) would look
+# writable.
+_ARGV_BINDING_SPELLING_SCHEMA: dict[str, Any] = {
+    "oneOf": [
+        # A positional: it has a place, no spelling, and cannot be a bare flag.
+        {
+            "properties": {
+                "kind": {"const": "argument"},
+                "option": {"type": "null"},
+                "position": {"type": "integer"},
+                "flag": {"const": False},
+            },
+        },
+        # An option: it has a spelling and no place.
+        {
+            "properties": {
+                "kind": {"const": "option"},
+                "option": {"type": "string"},
+                "position": {"type": "null"},
+            },
+        },
+    ]
+}
+
+
 class ArgvBinding(BaseModel):
     """How ONE operation parameter is spelled on the command line (#669).
 
@@ -251,7 +284,9 @@ class ArgvBinding(BaseModel):
     (issue #36).
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(
+        extra="forbid", json_schema_extra=_ARGV_BINDING_SPELLING_SCHEMA
+    )
 
     # Descriptions stay terse: the manifest repeats them per parameter of every
     # command, so prose here is paid hundreds of times (the #667 measurement).
@@ -262,8 +297,8 @@ class ArgvBinding(BaseModel):
     )
     input_property: str | None = Field(
         description=(
-            "The `input` schema property this parameter fills, or null where the "
-            "flag's spelling renames it (`--all` fills include_defaults)."
+            "The `input` schema property this parameter fills; null only where the "
+            "binding cannot be resolved to one."
         )
     )
     kind: ArgvKind = Field(description="Positional (argument) or named (option).")
@@ -279,6 +314,30 @@ class ArgvBinding(BaseModel):
     json_value: bool = Field(
         description="Write the whole value as one JSON-encoded token."
     )
+
+    @model_validator(mode="after")
+    def _check_spelling(self) -> "ArgvBinding":
+        """Reject a binding no caller could write (#669 review).
+
+        The type system allows a positional carrying an option spelling, an
+        option carrying a position, or a binding with neither — states the
+        derivation cannot produce but the model could hold, and a consumer
+        reading one would have no way to tell which key to believe. Enforced
+        here, published as ``_ARGV_BINDING_SPELLING_SCHEMA``.
+        """
+        if self.kind is ArgvKind.ARGUMENT:
+            if self.option is not None:
+                raise ValueError("a positional binding carries no option spelling.")
+            if self.position is None:
+                raise ValueError("a positional binding needs its position.")
+            if self.flag:
+                raise ValueError("a positional binding is never a valueless flag.")
+        else:
+            if self.option is None:
+                raise ValueError("an option binding needs its option spelling.")
+            if self.position is not None:
+                raise ValueError("an option binding occupies no position.")
+        return self
 
 
 class CommandSchema(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -220,6 +220,65 @@ class LiveStackConstraints(BaseModel):
     min_godot_version: str | None
 
 
+class ArgvKind(str, Enum):
+    """How one operation parameter is supplied on a ``gda`` command line (#669).
+
+    ``ARGUMENT`` is positional — its place in the command line is its identity;
+    ``OPTION`` is named — its ``--spelling`` is. Typed as an enum so the emitted
+    schema constrains the value rather than leaving it free text.
+    """
+
+    ARGUMENT = "argument"
+    OPTION = "option"
+
+
+class ArgvBinding(BaseModel):
+    """How ONE operation parameter is spelled on the command line (#669).
+
+    The missing half of a command's self-description: ``input`` says WHAT a
+    command needs, this says HOW to write it as argv. Without it an agent knew
+    ``screen capture`` requires an ``output`` but not that it is spelled
+    ``--output``, and that ``input action`` takes its action POSITIONALLY and
+    rejects ``--action`` — so every new command cost a ``--help`` round trip or a
+    failed invocation (dogfooding GDA-DF-003).
+
+    Every field is derived from the live Typer/Click parameter at emission time
+    (ADR-0012's live-tree walk, ADR-0023 §2's "projections, not parallel
+    registries"), never declared on the command descriptor: a hand-maintained
+    spelling table would be a second source of truth for a fact the Typer
+    signature already owns.
+
+    Reading it: ``kind`` picks the spelling rule — a positional goes at
+    ``position`` (0-based, among positionals only), a named one is written as
+    ``option``. ``flag`` marks an option that takes NO value (write it bare),
+    ``multiple`` one that is repeated per value (a repeatable option, or a
+    variadic positional). ``required`` is the DECLARED requirement, unaffected by
+    the relaxed parse ``--schema`` itself uses (issue #36).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Descriptions stay terse: the manifest repeats them per parameter of every
+    # command, so prose here is paid hundreds of times (the #667 measurement).
+    name: str = Field(description="The parameter's CLI name.")
+    input_property: str | None = Field(
+        description=(
+            "The `input` schema property this parameter fills, or null where the "
+            "CLI form has no 1:1 property (e.g. two flags selecting one field)."
+        )
+    )
+    kind: ArgvKind = Field(description="Positional (argument) or named (option).")
+    option: str | None = Field(
+        description="The option spelling, e.g. --output; null for a positional."
+    )
+    position: int | None = Field(
+        description="0-based position among the positionals; null for an option."
+    )
+    required: bool = Field(description="Whether the command line must supply it.")
+    flag: bool = Field(description="A valueless option: write it bare.")
+    multiple: bool = Field(description="Repeat it once per value.")
+
+
 class CommandSchema(BaseModel):
     """A command's self-description: its ``input``, ``output`` and ``error`` JSON Schemas (ADR-0004).
 
@@ -253,6 +312,13 @@ class CommandSchema(BaseModel):
     ``None`` for a command with no live-stack dependence (issue #233). Both forms
     are sourced from the single :func:`gda.execution.live_stack_constraints`
     authority. Additive and ignored by gda-mcp (ADR-0012, ADR-0004).
+
+    ``argv`` carries the command's :class:`ArgvBinding` list — how each of the
+    parameters ``input`` describes is spelled on a command line (issue #669),
+    derived from the live Typer/Click parameters. It is a SIBLING of the schema
+    halves, never a key inside them, so gda-mcp's ``input_schema`` /
+    ``output_schema`` are byte-identical with or without it (ADR-0012); an empty
+    list for a command with no operation parameters.
     """
 
     input: dict[str, Any]
@@ -260,6 +326,7 @@ class CommandSchema(BaseModel):
     error: dict[str, Any]
     kind: ExecutionKind | None = None
     constraints: LiveStackConstraints | None = None
+    argv: list[ArgvBinding] = Field(default_factory=list)
 
     @classmethod
     def of(
@@ -268,6 +335,7 @@ class CommandSchema(BaseModel):
         output_model: type[BaseModel],
         kind: ExecutionKind | None = None,
         constraints: LiveStackConstraints | None = None,
+        argv: "list[ArgvBinding] | None" = None,
     ) -> "CommandSchema":
         """Derive the contract from a command's params and result models.
 
@@ -277,7 +345,10 @@ class CommandSchema(BaseModel):
         serializes to its lowercase string because ``ExecutionKind`` subclasses
         ``str``. ``constraints`` is the command's live-stack precondition or
         ``None`` (issue #233), computed by the caller from the single
-        :func:`gda.execution.live_stack_constraints` authority.
+        :func:`gda.execution.live_stack_constraints` authority. ``argv`` is the
+        command's CLI-spelling projection (issue #669), computed by the caller
+        from the single :func:`gda.headless.command_argv_bindings` derivation off
+        the live Click parameters.
         """
         return cls(
             input=input_model.model_json_schema(),
@@ -285,6 +356,7 @@ class CommandSchema(BaseModel):
             error=GdaErrorEnvelope.model_json_schema(),
             kind=kind,
             constraints=constraints,
+            argv=argv or [],
         )
 
 
@@ -317,6 +389,13 @@ class CommandManifestEntry(BaseModel):
     descriptor, so the self-described surface schema guarantees the key is
     present) while its **value is nullable** (``null`` for non-live-stack
     commands) — a consumer can rely on the key always being there to read.
+
+    ``argv`` mirrors :class:`CommandSchema`'s: how each of the command's
+    parameters is spelled on a command line (issue #669), from the same live
+    Click parameters, so the aggregate and per-command forms agree. **Required**
+    here for the same reason ``kind`` is — every entry is a real command whose
+    signature can be walked — with an empty list where a command takes no
+    operation parameters. Additive and ignored by gda-mcp (ADR-0012).
     """
 
     name: str
@@ -326,6 +405,7 @@ class CommandManifestEntry(BaseModel):
     error: dict[str, Any]
     kind: ExecutionKind
     constraints: LiveStackConstraints | None
+    argv: list[ArgvBinding]
 
 
 class SurfaceManifest(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -252,19 +252,30 @@ class ArgvBinding(BaseModel):
     ``position`` (0-based, among positionals only), a named one is written as
     ``option``. ``flag`` marks an option that takes NO value (write it bare),
     ``multiple`` one that is repeated per value (a repeatable option, or a
-    variadic positional). ``required`` is the DECLARED requirement, unaffected by
-    the relaxed parse ``--schema`` itself uses (issue #36).
+    variadic positional), and ``json_value`` one whose single token is the
+    property's JSON encoding rather than a plain scalar. ``required`` is the
+    DECLARED requirement, unaffected by the relaxed parse ``--schema`` itself uses
+    (issue #36).
+
+    The list is the argv form of a command's operation parameters, not a
+    one-to-one image of ``input``: every required property has a binding, while an
+    optional property the CLI computes from flags rather than takes directly (a
+    mode selected by ``--replace`` / ``--search``) has none.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     # Descriptions stay terse: the manifest repeats them per parameter of every
     # command, so prose here is paid hundreds of times (the #667 measurement).
-    name: str = Field(description="The parameter's CLI name.")
+    name: str = Field(
+        description=(
+            "The parameter's internal name; write it as `option`, or at `position`."
+        )
+    )
     input_property: str | None = Field(
         description=(
             "The `input` schema property this parameter fills, or null where the "
-            "CLI form has no 1:1 property (e.g. two flags selecting one field)."
+            "flag's spelling renames it (`--all` fills include_defaults)."
         )
     )
     kind: ArgvKind = Field(description="Positional (argument) or named (option).")
@@ -277,6 +288,9 @@ class ArgvBinding(BaseModel):
     required: bool = Field(description="Whether the command line must supply it.")
     flag: bool = Field(description="A valueless option: write it bare.")
     multiple: bool = Field(description="Repeat it once per value.")
+    json_value: bool = Field(
+        description="Write the whole value as one JSON-encoded token."
+    )
 
 
 class CommandSchema(BaseModel):

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -236,17 +236,10 @@ class ArgvBinding(BaseModel):
     """How ONE operation parameter is spelled on the command line (#669).
 
     The missing half of a command's self-description: ``input`` says WHAT a
-    command needs, this says HOW to write it as argv. Without it an agent knew
-    ``screen capture`` requires an ``output`` but not that it is spelled
-    ``--output``, and that ``input action`` takes its action POSITIONALLY and
-    rejects ``--action`` — so every new command cost a ``--help`` round trip or a
-    failed invocation (dogfooding GDA-DF-003).
-
-    Every field is derived from the live Typer/Click parameter at emission time
-    (ADR-0012's live-tree walk, ADR-0023 §2's "projections, not parallel
-    registries"), never declared on the command descriptor: a hand-maintained
-    spelling table would be a second source of truth for a fact the Typer
-    signature already owns.
+    command needs, this says HOW to write it as argv. Derived from the live
+    Typer/Click parameter at emission time
+    (:func:`gda.headless.command_argv_bindings`); the rationale, the boundaries
+    and the case inventory are the ADR-0004 amendment (#669).
 
     Reading it: ``kind`` picks the spelling rule — a positional goes at
     ``position`` (0-based, among positionals only), a named one is written as
@@ -256,11 +249,6 @@ class ArgvBinding(BaseModel):
     property's JSON encoding rather than a plain scalar. ``required`` is the
     DECLARED requirement, unaffected by the relaxed parse ``--schema`` itself uses
     (issue #36).
-
-    The list is the argv form of a command's operation parameters, not a
-    one-to-one image of ``input``: every required property has a binding, while an
-    optional property the CLI computes from flags rather than takes directly (a
-    mode selected by ``--replace`` / ``--search``) has none.
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -101,8 +101,11 @@ and re-read the verdict.
 - `gda help <group> <command>` — the same help from the command form; with `--json` it
   comes back as `{command, text}`.
 - `gda <group> <command> --schema` — one command's input/output/error JSON Schema
-  (no Godot spawned).
-- `gda schema` — the **whole** surface as one JSON manifest.
+  (no Godot spawned), plus `argv`: how each parameter is written on a command line
+  (`kind` positional or option, its `position` or `--option` spelling, whether it is
+  `required`, a valueless `flag`, or `multiple`). Build the command line from `argv`
+  and you need no `--help` round trip.
+- `gda schema` — the **whole** surface as one JSON manifest, `argv` included.
 - `gda version --json` — which `gda` is installed and where from; `gda info` — the
   engine's version.
 
@@ -162,6 +165,12 @@ already-running daemon's lazy Engine-session launch; only the outer
 | `perf` | `monitors`, `monitor` (counters now / a property-or-signal timeline) |
 | `input` | `key`, `mouse-click`, `mouse-move`, `action`, `sequence` |
 | `screen` | `capture`, `frames` (viewport PNGs; needs `--windowed`) |
+
+`gda input sequence` events are a discriminated union on `type`: each kind accepts
+only its own fields, and `gda input sequence --schema` publishes them per kind. The
+press/release spelling differs by kind — `pressed` belongs to `mouse_button` alone,
+an `action` releases with `release`, a `key` with `released` — so read the kind's
+variant rather than assuming a shared shape.
 
 For `gda input sequence`, event `frame` offsets are the original
 harness/process-frame clock from the harness `_process` loop; they are not Godot's

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -104,10 +104,9 @@ and re-read the verdict.
   (no Godot spawned), plus `argv`: how each parameter is written on a command line
   (`kind` positional or option, its `position` or `--option` spelling, whether it is
   `required`, a valueless `flag`, `multiple` — repeat it per value — or a
-  `json_value` — one token carrying the value's JSON). Every required input property
-  has a binding, so build the command line from `argv`; `input_property` links a
-  binding back to the property it fills, and is null for the two flags that rename
-  it (`project list --all`, `skill --dir`).
+  `json_value` — one token carrying the value's JSON). Build the command line from
+  `argv`; `input_property` links each binding to the input property it fills, and is
+  null where a flag's spelling renames it.
 - `gda schema` — the **whole** surface as one JSON manifest, `argv` included.
 - `gda version --json` — which `gda` is installed and where from; `gda info` — the
   engine's version.

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -103,8 +103,11 @@ and re-read the verdict.
 - `gda <group> <command> --schema` — one command's input/output/error JSON Schema
   (no Godot spawned), plus `argv`: how each parameter is written on a command line
   (`kind` positional or option, its `position` or `--option` spelling, whether it is
-  `required`, a valueless `flag`, or `multiple`). Build the command line from `argv`
-  and you need no `--help` round trip.
+  `required`, a valueless `flag`, `multiple` — repeat it per value — or a
+  `json_value` — one token carrying the value's JSON). Every required input property
+  has a binding, so build the command line from `argv`; `input_property` links a
+  binding back to the property it fills, and is null for the two flags that rename
+  it (`project list --all`, `skill --dir`).
 - `gda schema` — the **whole** surface as one JSON manifest, `argv` included.
 - `gda version --json` — which `gda` is installed and where from; `gda info` — the
   engine's version.

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -105,8 +105,7 @@ and re-read the verdict.
   (`kind` positional or option, its `position` or `--option` spelling, whether it is
   `required`, a valueless `flag`, `multiple` — repeat it per value — or a
   `json_value` — one token carrying the value's JSON). Build the command line from
-  `argv`; `input_property` links each binding to the input property it fills, and is
-  null where a flag's spelling renames it.
+  `argv`; `input_property` links each binding to the input property it fills.
 - `gda schema` — the **whole** surface as one JSON manifest, `argv` included.
 - `gda version --json` — which `gda` is installed and where from; `gda info` — the
   engine's version.

--- a/src/gda/surface.py
+++ b/src/gda/surface.py
@@ -23,7 +23,7 @@ dispatch (ADR-0011/0012).
 
 import typer
 
-from gda.headless import command_constraints
+from gda.headless import command_argv_bindings, command_constraints
 from gda.models import CommandManifestEntry, CommandSchema, SurfaceManifest
 
 
@@ -93,8 +93,17 @@ def _collect(
     # aggregate and per-command forms cannot drift. ``None`` for a command with no
     # live-stack dependence.
     constraints = command_constraints(gda_command)
+    # The command's argv spelling (issue #669) comes from the same one derivation
+    # the per-command ``--schema`` uses, applied to this leaf's live Click
+    # parameters — the tree this walker is already standing in is the source, so
+    # the aggregate and per-command forms cannot drift.
+    argv = command_argv_bindings(command, input_model)
     schema = CommandSchema.of(
-        input_model, output_model, kind=gda_command.kind, constraints=constraints
+        input_model,
+        output_model,
+        kind=gda_command.kind,
+        constraints=constraints,
+        argv=argv,
     )
     description = (
         getattr(command, "help", None) or getattr(command, "short_help", None) or ""
@@ -113,5 +122,8 @@ def _collect(
             # The entry's required ``constraints`` key (issue #233); its value is
             # the command's live-stack precondition or ``None`` (nullable).
             constraints=schema.constraints,
+            # The entry's required ``argv`` key (issue #669): how each parameter
+            # is spelled on a command line, empty for a command that takes none.
+            argv=schema.argv,
         )
     )

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -663,7 +663,7 @@ def test_export_run_schema_emits_contract_without_engine(monkeypatch):
 
     assert result.exit_code == 0, result.stdout + result.stderr
     schema = json.loads(result.stdout)
-    assert set(schema) == {"input", "output", "error", "kind", "constraints"}
+    assert set(schema) == {"input", "output", "error", "kind", "constraints", "argv"}
     # export run is the one EXPORT-channel command (issue #230); its sibling
     # read-only export commands stay HEADLESS.
     assert schema["kind"] == "export"

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -11,6 +11,7 @@ observed via ``game get``) is the e2e in ``test_e2e_input``.
 """
 
 import json
+import re
 
 from typer.testing import CliRunner
 
@@ -1359,6 +1360,13 @@ def test_an_unknown_field_rejection_lists_the_kinds_accepted_fields(
     assert "'key'" in message
 
 
+# The SGR colour sequences the help renderer emits when it believes it is writing
+# to a terminal. It believes that on GitHub Actions but not in a local run, so a
+# test that reads the rendered help must strip them or it passes locally and fails
+# only in CI.
+_ANSI_SGR = re.compile(r"\x1b\[[0-9;]*m")
+
+
 def test_input_sequence_help_carries_a_copyable_action_example():
     # The help showed only a mouse example, so an action sequence had to be
     # inferred (GDA-DF-032). It now shows the press / release pair too.
@@ -1366,10 +1374,11 @@ def test_input_sequence_help_carries_a_copyable_action_example():
 
     assert result.exit_code == 0, result.stdout
     # The help renderer wraps the example across the option column and frames it
-    # with box borders; normalizing both back out is what a reader copying the
-    # example does. Nothing is ELLIPSIZED away — the whole example survives,
-    # which the one-line spelling it replaced did not.
-    rendered = " ".join(result.stdout.replace("│", " ").split())
+    # with box borders (and colours it); normalizing all three back out is what a
+    # reader copying the example does. Nothing is ELLIPSIZED away — the whole
+    # example survives, which the one-line spelling it replaced did not.
+    plain = _ANSI_SGR.sub("", result.stdout).replace("│", " ")
+    rendered = " ".join(plain.split())
     assert '{"type": "action", "action": "jump", "frame": 0}' in rendered
     assert (
         '{"type": "action", "action": "jump", "release": true, "frame": 10}' in rendered

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -1569,6 +1569,17 @@ def test_a_sequence_variant_keeps_its_single_frame_ops_constraints():
                 continue
             expected = there.annotation
             if (variant_name, field) in _MIRRORED_NULLABLE_EXEMPTIONS:
+                # The exemption only means something while the op side is NOT
+                # nullable: once it becomes nullable too, `| None` collapses
+                # (Optional[Optional[T]] is Optional[T]) and the plain
+                # comparison would keep passing forever — so a resolved
+                # divergence must take its exemption entry with it.
+                if repr(there.annotation | None) == repr(there.annotation):
+                    drift.append(
+                        f"stale exemption ({variant_name!r}, {field!r}): "
+                        f"{params_name}.{field} is itself nullable now — the "
+                        f"divergence is gone, delete the exemption"
+                    )
                 expected = there.annotation | None
             if repr(here.annotation) != repr(expected):
                 drift.append(
@@ -1595,9 +1606,10 @@ def test_a_sequence_variant_keeps_its_single_frame_ops_constraints():
     assert not drift, "sequence variants drifted from their single-frame ops:\n" + (
         "\n".join(drift)
     )
-    # Every exemption must name a pinned mirrored field, so a stale entry (the
-    # divergence got resolved, or the field went away) fails loudly instead of
-    # exempting nothing.
+    # Every exemption must name a pinned mirrored field, so an entry whose field
+    # went away fails loudly instead of exempting nothing. (The other stale form
+    # — the divergence got resolved — is caught above, where an exemption whose
+    # op side is itself nullable is reported as drift.)
     pinned = {
         (variant_name, field)
         for _, variant_name, _, fields in _MIRRORED_MODELS

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -1265,8 +1265,12 @@ def test_each_event_kind_publishes_its_required_and_forbidden_fields():
 
 
 def test_a_schema_client_can_validate_events_without_invoking_gda():
-    # The acceptance property, checked the way a client would: validate candidate
-    # events against the EMITTED schema and get the same verdict gda gives.
+    # The acceptance property for the per-kind FIELD SETS, checked the way a
+    # client would: validate candidate events against the EMITTED schema and get
+    # the same verdict gda gives for what each kind requires and forbids. The
+    # cross-field rules are a narrower claim — the mouse-button phase is published
+    # too (its own test below), while the one-clock rule, the modifier vocabulary
+    # and the window ceiling stay enforced model-side only.
     import jsonschema
 
     schema = _sequence_events_schema()
@@ -1396,3 +1400,112 @@ def test_an_unknown_event_type_lists_the_kinds_a_caller_can_type(monkeypatch, tm
 
     assert "'key', 'mouse_click', 'mouse_button', 'mouse_move', 'action'" in message
     assert "InputEventType" not in message
+
+
+# The mouse-button phase corpus, spanning every combination the two fields can be
+# written in. The point is not any single verdict but that ONE corpus gets the
+# SAME verdict from the published schema and from the model.
+_PHASE_CORPUS = [
+    {"pressed": True},
+    {"release": True},
+    {"pressed": True, "release": False},
+    {"pressed": None, "release": True},
+    {},
+    {"pressed": False},
+    {"pressed": False, "release": True},
+    {"pressed": True, "release": True},
+    {"release": False},
+    {"pressed": None},
+]
+
+
+def test_the_mouse_button_phase_rule_is_checkable_and_matches_the_model():
+    # #669: `mouse_button` is the kind an agent reaches for to build a drag, and
+    # its "exactly one of `pressed: true` / `release: true`" rule used to live only
+    # in prose — so a schema-driven client learned it from a failed invocation
+    # (GDA-DF-037). It is now published as schema, and this pins the published rule
+    # to the enforcing validator so the two cannot drift apart.
+    import jsonschema
+
+    from gda.commands.input import InputSequenceParams
+
+    schema = _sequence_events_schema()
+    for phase in _PHASE_CORPUS:
+        event = {"type": "mouse_button", "x": 1.0, "y": 2.0, **phase}
+        try:
+            jsonschema.validate(instance={"events": [event]}, schema=schema)
+            by_schema = True
+        except jsonschema.ValidationError:
+            by_schema = False
+        try:
+            InputSequenceParams.model_validate({"events": [event]})
+            by_model = True
+        except ValueError:
+            by_model = False
+        assert by_schema == by_model, (phase, by_schema, by_model)
+    # …and the corpus really does span both verdicts, so agreement is not vacuous.
+    accepted = [p for p in _PHASE_CORPUS if p in ({"pressed": True}, {"release": True})]
+    assert accepted
+
+
+def test_an_explicit_null_button_still_means_the_left_button(monkeypatch, tmp_path):
+    # The flat shape these variants replace defaulted `button` to null and let the
+    # harness read that as left, so a producer that dumped an event and replayed it
+    # sent an explicit null. It stays accepted, and normalizes to a named button.
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_SEQUENCE_RESULT), stderr="", exit_code=0),
+    )
+    events = [
+        {"type": "mouse_click", "x": 1.0, "y": 2.0, "button": None},
+        {"type": "mouse_button", "x": 1.0, "y": 2.0, "button": None, "pressed": True},
+    ]
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "sequence",
+            "--events",
+            json.dumps(events),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert [e["button"] for e in fake.calls[0][1]["events"]] == ["left", "left"]
+
+
+def test_every_phase_synonym_is_a_field_some_event_kind_declares():
+    # The rejection names a kind's OWN press/release spelling by intersecting the
+    # phase synonyms with the variant's fields. That list is the one thing about
+    # the union written down separately, so hold it to what the variants declare:
+    # renaming `released` without updating it would silently drop the message back
+    # to the generic branch, with no test noticing.
+    from gda.commands.input import _PHASE_FIELDS, _SEQUENCE_EVENT_MODELS, _event_kind
+
+    declared = {f for model in _SEQUENCE_EVENT_MODELS for f in model.model_fields}
+    assert set(_PHASE_FIELDS) <= declared, set(_PHASE_FIELDS) - declared
+    # …and every kind that carries a phase is reachable through it: the three
+    # phase-bearing kinds each intersect the list, the two phaseless ones do not.
+    with_phase = {
+        _event_kind(m)
+        for m in _SEQUENCE_EVENT_MODELS
+        if set(_PHASE_FIELDS) & set(m.model_fields)
+    }
+    assert with_phase == {"key", "action", "mouse_button"}
+
+
+def test_the_union_members_are_read_off_the_union_itself():
+    # `_SEQUENCE_EVENT_MODELS` feeds every "is accepted on:" hint. Deriving it from
+    # the union rather than re-listing it is what keeps a sixth variant from
+    # joining the contract while vanishing from the messages, so pin that the two
+    # cannot disagree.
+    from gda.commands.input import _SEQUENCE_EVENT_MODELS, _event_kind
+
+    mapping = _sequence_events_schema()["properties"]["events"]["items"][
+        "discriminator"
+    ]["mapping"]
+    assert {_event_kind(m) for m in _SEQUENCE_EVENT_MODELS} == set(mapping)

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -1509,3 +1509,51 @@ def test_the_union_members_are_read_off_the_union_itself():
         "discriminator"
     ]["mapping"]
     assert {_event_kind(m) for m in _SEQUENCE_EVENT_MODELS} == set(mapping)
+
+
+# Each sequence variant and the single-frame op whose shape it mirrors. The
+# variants deliberately REDECLARE those fields (their descriptions differ — a
+# variant explains itself inside a union), so nothing shared is extracted; this
+# pairing is what keeps the redeclaration honest.
+_MIRRORED_MODELS = [
+    ("key", "KeySequenceEvent", "InputKeyParams"),
+    ("mouse_click", "MouseClickSequenceEvent", "InputMouseClickParams"),
+    ("mouse_move", "MouseMoveSequenceEvent", "InputMouseMoveParams"),
+    ("action", "ActionSequenceEvent", "InputActionParams"),
+]
+
+
+def test_a_sequence_variant_keeps_its_single_frame_ops_constraints():
+    # A sequence event and its single-frame op are the same request at a clock
+    # offset, so a bound that holds for one must hold for the other: tightening
+    # `input action --strength` while a sequence action kept 0..∞ would accept
+    # through one door what the other refuses. Compares the CONSTRAINTS (bounds
+    # and defaults) of the fields both declare, not their prose.
+    import gda.commands.input as input_module
+
+    drift: list[str] = []
+    compared = 0
+    for kind, variant_name, params_name in _MIRRORED_MODELS:
+        variant = getattr(input_module, variant_name)
+        params = getattr(input_module, params_name)
+        shared = set(variant.model_fields) & set(params.model_fields)
+        assert shared, (kind, "no shared fields — the pairing is stale")
+        for field in sorted(shared):
+            here, there = variant.model_fields[field], params.model_fields[field]
+            if repr(here.metadata) != repr(there.metadata):
+                drift.append(
+                    f"{variant_name}.{field} bounds {here.metadata} != "
+                    f"{params_name}.{field} bounds {there.metadata}"
+                )
+            if repr(here.default) != repr(there.default):
+                drift.append(
+                    f"{variant_name}.{field} default {here.default!r} != "
+                    f"{params_name}.{field} default {there.default!r}"
+                )
+            compared += 1
+
+    assert not drift, "sequence variants drifted from their single-frame ops:\n" + (
+        "\n".join(drift)
+    )
+    # The comparison really covered the interesting fields, not just `type`.
+    assert compared >= 10, compared

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -1385,3 +1385,14 @@ def test_input_sequence_help_carries_a_copyable_action_example():
     )
     # …beside the mouse example it joins, likewise intact.
     assert '{"type": "mouse_button", "x": 10, "y": 10, "pressed": true}' in rendered
+
+
+def test_an_unknown_event_type_lists_the_kinds_a_caller_can_type(monkeypatch, tmp_path):
+    # The union refuses an unknown `type` by listing the expected tags. They must
+    # read as the WIRE values a caller writes — a bare enum would put
+    # "<InputEventType.KEY: 'key'>" into a public message, naming a Python symbol
+    # that is not typeable in a request.
+    message = _reject(monkeypatch, tmp_path, {"type": "nope", "key": "A"})
+
+    assert "'key', 'mouse_click', 'mouse_button', 'mouse_move', 'action'" in message
+    assert "InputEventType" not in message

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -772,12 +772,17 @@ def test_input_sequence_schema_reports_kind_live():
     events_description = schema["input"]["properties"]["events"]["description"]
     assert "process-clock `frame`" in events_description
     assert "physics-clock `physics_frame`" in events_description
-    event_props = schema["input"]["$defs"]["InputSequenceEvent"]["properties"]
-    event_types = schema["input"]["$defs"]["InputEventType"]["enum"]
-    assert "mouse_button" in event_types
-    assert "harness/process-frame" in event_props["frame"]["description"]
-    assert "physics-frame" in event_props["physics_frame"]["description"]
-    assert "mouse-button event" in event_props["pressed"]["description"]
+    # The kinds are enumerated by the union's discriminator mapping (#669), and
+    # each variant carries the clock descriptions the whole union shares.
+    variants = _variants()
+    assert "mouse_button" in variants
+    key_props = variants["key"]["properties"]
+    assert "harness/process-frame" in key_props["frame"]["description"]
+    assert "physics-frame" in key_props["physics_frame"]["description"]
+    assert (
+        "one of `pressed` or `release`"
+        in variants["mouse_button"]["properties"]["pressed"]["description"]
+    )
 
 
 def test_input_sequence_help_names_process_and_physics_clocks():
@@ -1187,3 +1192,187 @@ def test_input_key_params_json_dispatches_like_argv(monkeypatch, tmp_path):
     assert fake.calls == [
         ("input-key", {"key": "Right", "modifiers": ["shift"], "released": False})
     ]
+
+
+# --- the sequence event is a discriminated union (#669) ------------------------
+#
+# GDA-DF-037 / GDA-DF-032: one flat event shape carried every kind's fields, so
+# the per-kind rules lived only in prose — `pressed` is valid on `mouse_button`
+# alone, an action presses by default and releases with `release`, and a key
+# releases with `released`. Schema-driven automation could not tell the kinds
+# apart without a failed invocation, and a foreign field was silently accepted
+# and ignored (a `release` on a key event PRESSED the key).
+
+
+def _sequence_events_schema() -> dict:
+    result = CliRunner().invoke(app, ["input", "sequence", "--schema"])
+    assert result.exit_code == 0, result.stdout
+    return json.loads(result.stdout)["input"]
+
+
+def _variants() -> dict[str, dict]:
+    """Each event kind's variant schema, resolved through the discriminator."""
+    schema = _sequence_events_schema()
+    mapping = schema["properties"]["events"]["items"]["discriminator"]["mapping"]
+    return {
+        kind: schema["$defs"][ref.rsplit("/", 1)[-1]] for kind, ref in mapping.items()
+    }
+
+
+def test_sequence_events_are_published_as_a_discriminated_union():
+    # The kinds are machine-discoverable: one `oneOf` branch per kind, selected
+    # by the `type` discriminator — not a single shape plus prose.
+    items = _sequence_events_schema()["properties"]["events"]["items"]
+
+    assert items["discriminator"]["propertyName"] == "type"
+    assert set(items["discriminator"]["mapping"]) == {
+        "key",
+        "mouse_click",
+        "mouse_button",
+        "mouse_move",
+        "action",
+    }
+    assert len(items["oneOf"]) == 5
+
+
+def test_each_event_kind_publishes_its_required_and_forbidden_fields():
+    # A schema client can decide each kind's valid fields without a trial
+    # invocation: what it MUST carry, and that nothing else is accepted.
+    variants = _variants()
+
+    assert set(variants["key"]["required"]) == {"type", "key"}
+    assert set(variants["action"]["required"]) == {"type", "action"}
+    assert set(variants["mouse_click"]["required"]) == {"type", "x", "y"}
+    assert set(variants["mouse_move"]["required"]) == {"type", "x", "y"}
+    assert set(variants["mouse_button"]["required"]) == {"type", "x", "y"}
+
+    for kind, variant in variants.items():
+        assert variant["additionalProperties"] is False, kind
+
+    # `pressed` belongs to `mouse_button` alone; an action releases with
+    # `release`, a key with `released`.
+    assert "pressed" in variants["mouse_button"]["properties"]
+    assert "pressed" not in variants["action"]["properties"]
+    assert "pressed" not in variants["key"]["properties"]
+    assert "pressed" not in variants["mouse_move"]["properties"]
+    assert "release" in variants["action"]["properties"]
+    assert "released" in variants["key"]["properties"]
+    assert "released" not in variants["action"]["properties"]
+    # Both clocks stay shared by every kind.
+    for kind, variant in variants.items():
+        assert {"frame", "physics_frame"} <= set(variant["properties"]), kind
+
+
+def test_a_schema_client_can_validate_events_without_invoking_gda():
+    # The acceptance property, checked the way a client would: validate candidate
+    # events against the EMITTED schema and get the same verdict gda gives.
+    import jsonschema
+
+    schema = _sequence_events_schema()
+
+    def check(event: dict) -> bool:
+        try:
+            jsonschema.validate(instance={"events": [event]}, schema=schema)
+        except jsonschema.ValidationError:
+            return False
+        return True
+
+    assert check({"type": "action", "action": "jump"})
+    assert check({"type": "action", "action": "jump", "release": True, "frame": 10})
+    assert check({"type": "mouse_button", "x": 1.0, "y": 2.0, "pressed": True})
+    # …and the mistakes the flat shape used to swallow are rejected.
+    assert not check({"type": "action", "action": "jump", "pressed": True})
+    assert not check({"type": "key", "key": "A", "release": True})
+    assert not check({"type": "mouse_move", "x": 1.0, "y": 2.0, "pressed": True})
+    assert not check({"type": "key"})
+
+
+def _reject(monkeypatch, tmp_path, event: dict) -> str:
+    """Run one malformed event through --params-json; return the error message."""
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_SEQUENCE_RESULT), stderr="", exit_code=0),
+    )
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "sequence",
+            "--params-json",
+            json.dumps({"events": [event]}),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "invalid_params", payload
+    assert fake.calls == []
+    return payload["error"]["message"]
+
+
+def test_a_wrong_kind_field_rejection_names_the_accepted_field(monkeypatch, tmp_path):
+    # The rejection already fired; it did not say what to write instead.
+    message = _reject(
+        monkeypatch, tmp_path, {"type": "action", "action": "j", "pressed": True}
+    )
+
+    assert "'pressed'" in message
+    assert "'release'" in message
+    assert "action" in message
+
+
+def test_a_wrong_kind_field_rejection_names_the_key_events_own_phase_field(
+    monkeypatch, tmp_path
+):
+    # The reverse mistake: an action's `release` on a key event, which used to be
+    # accepted and silently PRESS the key.
+    message = _reject(
+        monkeypatch, tmp_path, {"type": "key", "key": "A", "release": True}
+    )
+
+    assert "'release'" in message
+    assert "'released'" in message
+
+
+def test_a_phaseless_kind_rejection_points_at_the_kind_that_has_a_phase(
+    monkeypatch, tmp_path
+):
+    # `mouse_click` / `mouse_move` have no press/release phase at all; the
+    # rejection names the kind that does rather than a field they lack.
+    message = _reject(
+        monkeypatch,
+        tmp_path,
+        {"type": "mouse_move", "x": 1.0, "y": 2.0, "pressed": True},
+    )
+
+    assert "'pressed'" in message
+    assert "mouse_button" in message
+
+
+def test_an_unknown_field_rejection_lists_the_kinds_accepted_fields(
+    monkeypatch, tmp_path
+):
+    message = _reject(monkeypatch, tmp_path, {"type": "key", "key": "A", "keycode": 65})
+
+    assert "'keycode'" in message
+    assert "'key'" in message
+
+
+def test_input_sequence_help_carries_a_copyable_action_example():
+    # The help showed only a mouse example, so an action sequence had to be
+    # inferred (GDA-DF-032). It now shows the press / release pair too.
+    result = CliRunner().invoke(app, ["input", "sequence", "--help"])
+
+    assert result.exit_code == 0, result.stdout
+    # The help renderer wraps the example across the option column and frames it
+    # with box borders; normalizing both back out is what a reader copying the
+    # example does. Nothing is ELLIPSIZED away — the whole example survives,
+    # which the one-line spelling it replaced did not.
+    rendered = " ".join(result.stdout.replace("│", " ").split())
+    assert '{"type": "action", "action": "jump", "frame": 0}' in rendered
+    assert (
+        '{"type": "action", "action": "jump", "release": true, "frame": 10}' in rendered
+    )
+    # …beside the mouse example it joins, likewise intact.
+    assert '{"type": "mouse_button", "x": 10, "y": 10, "pressed": true}' in rendered

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -1511,35 +1511,70 @@ def test_the_union_members_are_read_off_the_union_itself():
     assert {_event_kind(m) for m in _SEQUENCE_EVENT_MODELS} == set(mapping)
 
 
-# Each sequence variant and the single-frame op whose shape it mirrors. The
-# variants deliberately REDECLARE those fields (their descriptions differ — a
-# variant explains itself inside a union), so nothing shared is extracted; this
-# pairing is what keeps the redeclaration honest.
+# Each sequence variant, the single-frame op whose shape it mirrors, and the
+# PINNED list of mirrored fields. The variants deliberately REDECLARE those
+# fields (their descriptions differ — a variant explains itself inside a union),
+# so nothing shared is extracted; this pairing is what keeps the redeclaration
+# honest. The field lists are pinned rather than intersected: an intersection
+# shrinks when a mirrored field is removed or renamed on one side, which is
+# exactly the drift the guard exists to catch (PR #719 recheck).
 _MIRRORED_MODELS = [
-    ("key", "KeySequenceEvent", "InputKeyParams"),
-    ("mouse_click", "MouseClickSequenceEvent", "InputMouseClickParams"),
-    ("mouse_move", "MouseMoveSequenceEvent", "InputMouseMoveParams"),
-    ("action", "ActionSequenceEvent", "InputActionParams"),
+    ("key", "KeySequenceEvent", "InputKeyParams", ("key", "modifiers", "released")),
+    (
+        "mouse_click",
+        "MouseClickSequenceEvent",
+        "InputMouseClickParams",
+        ("x", "y", "button", "double"),
+    ),
+    ("mouse_move", "MouseMoveSequenceEvent", "InputMouseMoveParams", ("x", "y")),
+    (
+        "action",
+        "ActionSequenceEvent",
+        "InputActionParams",
+        ("action", "release", "strength"),
+    ),
 ]
+
+# The one deliberate annotation divergence: the sequence variant accepts an
+# explicit `button: null` (normalized to left) so a replayed dump of the old
+# flat shape stays valid, while the single-frame op never took null. The
+# exemption is pinned here so it cannot widen silently; the test still requires
+# the variant's annotation to be exactly `Optional[<the op's annotation>]`.
+_MIRRORED_NULLABLE_EXEMPTIONS = {("MouseClickSequenceEvent", "button")}
 
 
 def test_a_sequence_variant_keeps_its_single_frame_ops_constraints():
     # A sequence event and its single-frame op are the same request at a clock
     # offset, so a bound that holds for one must hold for the other: tightening
     # `input action --strength` while a sequence action kept 0..∞ would accept
-    # through one door what the other refuses. Compares the CONSTRAINTS (bounds
-    # and defaults) of the fields both declare, not their prose.
+    # through one door what the other refuses. Compares the CONSTRAINTS
+    # (annotation, bounds, defaults) of the PINNED mirrored fields, not their
+    # prose — and requires each pinned field to exist on both sides, so removing
+    # or renaming one is itself the drift.
     import gda.commands.input as input_module
 
     drift: list[str] = []
-    compared = 0
-    for kind, variant_name, params_name in _MIRRORED_MODELS:
+    for kind, variant_name, params_name, fields in _MIRRORED_MODELS:
         variant = getattr(input_module, variant_name)
         params = getattr(input_module, params_name)
-        shared = set(variant.model_fields) & set(params.model_fields)
-        assert shared, (kind, "no shared fields — the pairing is stale")
-        for field in sorted(shared):
-            here, there = variant.model_fields[field], params.model_fields[field]
+        for field in fields:
+            here = variant.model_fields.get(field)
+            there = params.model_fields.get(field)
+            if here is None or there is None:
+                drift.append(
+                    f"{variant_name}.{field} / {params_name}.{field}: pinned "
+                    f"mirrored field missing on "
+                    f"{'both sides' if here is there else (variant_name if here is None else params_name)}"
+                )
+                continue
+            expected = there.annotation
+            if (variant_name, field) in _MIRRORED_NULLABLE_EXEMPTIONS:
+                expected = there.annotation | None
+            if repr(here.annotation) != repr(expected):
+                drift.append(
+                    f"{variant_name}.{field} annotation {here.annotation!r} != "
+                    f"{params_name}.{field} annotation {there.annotation!r}"
+                )
             if repr(here.metadata) != repr(there.metadata):
                 drift.append(
                     f"{variant_name}.{field} bounds {here.metadata} != "
@@ -1550,10 +1585,24 @@ def test_a_sequence_variant_keeps_its_single_frame_ops_constraints():
                     f"{variant_name}.{field} default {here.default!r} != "
                     f"{params_name}.{field} default {there.default!r}"
                 )
-            compared += 1
+            if repr(here.default_factory) != repr(there.default_factory):
+                drift.append(
+                    f"{variant_name}.{field} default_factory "
+                    f"{here.default_factory!r} != {params_name}.{field} "
+                    f"default_factory {there.default_factory!r}"
+                )
 
     assert not drift, "sequence variants drifted from their single-frame ops:\n" + (
         "\n".join(drift)
     )
-    # The comparison really covered the interesting fields, not just `type`.
-    assert compared >= 10, compared
+    # Every exemption must name a pinned mirrored field, so a stale entry (the
+    # divergence got resolved, or the field went away) fails loudly instead of
+    # exempting nothing.
+    pinned = {
+        (variant_name, field)
+        for _, variant_name, _, fields in _MIRRORED_MODELS
+        for field in fields
+    }
+    assert _MIRRORED_NULLABLE_EXEMPTIONS <= pinned, (
+        _MIRRORED_NULLABLE_EXEMPTIONS - pinned
+    )

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -376,3 +376,35 @@ def test_argv_metadata_rides_outside_the_two_schema_halves_gda_mcp_maps():
         assert "argv" not in entry["input"], entry["name"]
         assert "argv" not in entry["output"], entry["name"]
         assert "ArgvBinding" not in entry["input"].get("$defs", {}), entry["name"]
+
+
+def test_self_described_manifest_describes_the_argv_binding_list():
+    # issue #669: the aggregate entry's `argv` is a HARD part of the
+    # self-described surface schema — the key is required (every entry is a real
+    # command whose signature can be walked) and its items are the named
+    # ArgvBinding shape, so a consumer validating `gda schema --schema`'s manifest
+    # schema can rely on the binding's fields rather than discovering them.
+    result = CliRunner().invoke(app, ["schema", "--schema"])
+    assert result.exit_code == 0, result.stdout
+    manifest_schema = json.loads(result.stdout)["output"]
+
+    entry = manifest_schema["$defs"]["CommandManifestEntry"]
+    assert "argv" in entry["required"], entry["required"]
+    assert entry["properties"]["argv"]["items"] == {"$ref": "#/$defs/ArgvBinding"}
+
+    binding = manifest_schema["$defs"]["ArgvBinding"]
+    # Every field is a required KEY, so a consumer reads them unconditionally;
+    # the optional ones are nullable VALUES (`option` on a positional, `position`
+    # on an option, `input_property` where there is no 1:1 property).
+    assert set(binding["required"]) == {
+        "name",
+        "input_property",
+        "kind",
+        "option",
+        "position",
+        "required",
+        "flag",
+        "multiple",
+    }
+    assert binding["properties"]["kind"]["$ref"] == "#/$defs/ArgvKind"
+    assert manifest_schema["$defs"]["ArgvKind"]["enum"] == ["argument", "option"]

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -330,12 +330,21 @@ def test_real_out_of_process_cli_manifest_covers_the_live_command_tree():
 # --- argv binding in the manifest (issue #669) --------------------------------
 
 
-def test_every_entry_carries_an_argv_binding_list():
-    # issue #669: the manifest is the whole-surface form of the per-command
-    # contract, so the CLI spelling of a command's parameters travels with it —
-    # an agent reading only the dump can construct a valid argv.
+def test_every_required_input_property_has_an_argv_binding():
+    # issue #669: `argv` is the argv form of the operation parameters, not a
+    # one-to-one image of `input` — a few OPTIONAL properties are computed from
+    # flags rather than taken directly. The invariant that AC1 rests on is the
+    # required half: a property an agent MUST supply always has a binding telling
+    # it how, or the command cannot be built from the contract at all.
+    unreachable = []
     for entry in _manifest()["commands"]:
-        assert isinstance(entry["argv"], list), entry["name"]
+        linked = {b["input_property"] for b in entry["argv"] if b["input_property"]}
+        for name in entry["input"].get("required", []):
+            if name not in linked:
+                unreachable.append(f"{entry['name']}: {name}")
+    assert not unreachable, "required properties with no argv binding:\n" + "\n".join(
+        unreachable
+    )
 
 
 def test_entry_argv_matches_the_commands_own_schema_argv():
@@ -367,15 +376,45 @@ def test_every_argv_binding_is_constructible_into_a_command_line():
         assert positions == list(range(len(positions))), entry["name"]
 
 
-def test_argv_metadata_rides_outside_the_two_schema_halves_gda_mcp_maps():
+def test_argv_metadata_cannot_reach_the_two_schema_halves_gda_mcp_maps():
     # The gda-mcp wire-schema answer (#669): gda-mcp maps `input` →
     # `input_schema` and `output` → `output_schema` and ignores every other entry
-    # key (ADR-0012). `argv` is therefore a SIBLING of those halves — never a key
-    # inside them — so no MCP tool's wire schema gains anything from it.
-    for entry in _manifest()["commands"]:
-        assert "argv" not in entry["input"], entry["name"]
-        assert "argv" not in entry["output"], entry["name"]
-        assert "ArgvBinding" not in entry["input"].get("$defs", {}), entry["name"]
+    # key (ADR-0012). Asserting `argv` is absent from the halves would be
+    # tautological — it is not a JSON Schema keyword — so assert the property that
+    # actually matters: emitting a schema WITH bindings leaves both halves
+    # byte-identical to emitting it WITHOUT them. That is what keeps every
+    # registered tool's wire schema unchanged by this addition.
+    from gda.headless import command_argv_bindings
+    from gda.models import CommandSchema
+
+    root = typer.main.get_command(app)
+    checked = 0
+
+    def walk(command, path):
+        nonlocal checked
+        subcommands = getattr(command, "commands", None)
+        if subcommands is not None:
+            for name, subcommand in subcommands.items():
+                walk(subcommand, [*path, name])
+            return
+        input_model = getattr(command, "gda_input_model", None)
+        output_model = getattr(command, "gda_output_model", None)
+        if input_model is None or output_model is None:
+            return
+        bare = CommandSchema.of(input_model, output_model)
+        bound = CommandSchema.of(
+            input_model,
+            output_model,
+            argv=command_argv_bindings(command, input_model),
+        )
+        assert bound.argv == [] or bound.argv, path
+        assert bound.input == bare.input, path
+        assert bound.output == bare.output, path
+        assert bound.error == bare.error, path
+        checked += 1
+
+    walk(root, [])
+    assert checked > 60, checked
 
 
 def test_self_described_manifest_describes_the_argv_binding_list():
@@ -405,6 +444,7 @@ def test_self_described_manifest_describes_the_argv_binding_list():
         "required",
         "flag",
         "multiple",
+        "json_value",
     }
     assert binding["properties"]["kind"]["$ref"] == "#/$defs/ArgvKind"
     assert manifest_schema["$defs"]["ArgvKind"]["enum"] == ["argument", "option"]

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -325,3 +325,54 @@ def test_real_out_of_process_cli_manifest_covers_the_live_command_tree():
     assert {"info", "scene create"} <= names
     # The non-dispatchable `schema` meta command is excluded (Plan A).
     assert "schema" not in names
+
+
+# --- argv binding in the manifest (issue #669) --------------------------------
+
+
+def test_every_entry_carries_an_argv_binding_list():
+    # issue #669: the manifest is the whole-surface form of the per-command
+    # contract, so the CLI spelling of a command's parameters travels with it —
+    # an agent reading only the dump can construct a valid argv.
+    for entry in _manifest()["commands"]:
+        assert isinstance(entry["argv"], list), entry["name"]
+
+
+def test_entry_argv_matches_the_commands_own_schema_argv():
+    # Both schema sites derive the binding from the SAME live Click parameters
+    # (ADR-0012's live-tree walk, ADR-0023 §2's "projections, not parallel
+    # registries"), so the aggregate and per-command forms cannot drift.
+    for entry in _manifest()["commands"]:
+        result = CliRunner().invoke(app, [*entry["name"].split(" "), "--schema"])
+        assert result.exit_code == 0, result.stdout
+        assert entry["argv"] == json.loads(result.stdout)["argv"], entry["name"]
+
+
+def test_every_argv_binding_is_constructible_into_a_command_line():
+    # The acceptance property: for EVERY command, each binding says either where
+    # the value goes positionally or exactly how to spell its option — never
+    # neither, never both — and the positions are a contiguous 0..n-1 run.
+    for entry in _manifest()["commands"]:
+        positions = []
+        for binding in entry["argv"]:
+            where = f"{entry['name']}: {binding['name']}"
+            if binding["kind"] == "argument":
+                assert binding["option"] is None, where
+                assert isinstance(binding["position"], int), where
+                positions.append(binding["position"])
+            else:
+                assert binding["kind"] == "option", where
+                assert binding["position"] is None, where
+                assert str(binding["option"]).startswith("-"), where
+        assert positions == list(range(len(positions))), entry["name"]
+
+
+def test_argv_metadata_rides_outside_the_two_schema_halves_gda_mcp_maps():
+    # The gda-mcp wire-schema answer (#669): gda-mcp maps `input` →
+    # `input_schema` and `output` → `output_schema` and ignores every other entry
+    # key (ADR-0012). `argv` is therefore a SIBLING of those halves — never a key
+    # inside them — so no MCP tool's wire schema gains anything from it.
+    for entry in _manifest()["commands"]:
+        assert "argv" not in entry["input"], entry["name"]
+        assert "argv" not in entry["output"], entry["name"]
+        assert "ArgvBinding" not in entry["input"].get("$defs", {}), entry["name"]

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -389,9 +389,10 @@ def test_argv_metadata_cannot_reach_the_two_schema_halves_gda_mcp_maps():
 
     root = typer.main.get_command(app)
     checked = 0
+    with_bindings = 0
 
     def walk(command, path):
-        nonlocal checked
+        nonlocal checked, with_bindings
         subcommands = getattr(command, "commands", None)
         if subcommands is not None:
             for name, subcommand in subcommands.items():
@@ -407,14 +408,18 @@ def test_argv_metadata_cannot_reach_the_two_schema_halves_gda_mcp_maps():
             output_model,
             argv=command_argv_bindings(command, input_model),
         )
-        assert bound.argv == [] or bound.argv, path
         assert bound.input == bare.input, path
         assert bound.output == bare.output, path
         assert bound.error == bare.error, path
         checked += 1
+        with_bindings += 1 if bound.argv else 0
 
     walk(root, [])
     assert checked > 60, checked
+    # …and the comparison is not vacuous: most of those commands really do carry
+    # bindings, so the halves matched DESPITE the bindings being emitted, not
+    # because there were none to leak.
+    assert with_bindings > 40, with_bindings
 
 
 def test_self_described_manifest_describes_the_argv_binding_list():

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -330,21 +330,42 @@ def test_real_out_of_process_cli_manifest_covers_the_live_command_tree():
 # --- argv binding in the manifest (issue #669) --------------------------------
 
 
-def test_every_required_input_property_has_an_argv_binding():
-    # issue #669: `argv` is the argv form of the operation parameters, not a
-    # one-to-one image of `input` — a few OPTIONAL properties are computed from
-    # flags rather than taken directly. The invariant that AC1 rests on is the
-    # required half: a property an agent MUST supply always has a binding telling
-    # it how, or the command cannot be built from the contract at all.
-    unreachable = []
+# A property the caller cannot supply directly says so in its own description:
+# the CLI derives it from other flags and ignores anything passed in. That phrase
+# is the mechanical exclusion below — no command names are matched.
+_IGNORED_VALUE_MARKER = "a value passed in is ignored"
+
+# …and the properties it excuses today. Pinned so the phrase cannot become a
+# quiet escape hatch: a new computed property has to be acknowledged here.
+_COMPUTED_PROPERTIES = {"script set: mode", "shader set: mode"}
+
+
+def test_every_directly_supplyable_input_property_has_an_argv_binding():
+    # issue #669: an agent reads `input`, then needs `argv` to write what it
+    # found. Every property it can actually supply must therefore have a binding
+    # — not just the required ones, since an optional property with no binding is
+    # equally unreachable from the contract. The only exemption is a property the
+    # CLI COMPUTES (`script set` / `shader set` derive `mode` from `--replace` /
+    # `--search`), which its description already declares.
+    unreachable: list[str] = []
+    computed: set[str] = set()
     for entry in _manifest()["commands"]:
         linked = {b["input_property"] for b in entry["argv"] if b["input_property"]}
-        for name in entry["input"].get("required", []):
-            if name not in linked:
-                unreachable.append(f"{entry['name']}: {name}")
-    assert not unreachable, "required properties with no argv binding:\n" + "\n".join(
-        unreachable
+        for name, spec in entry["input"].get("properties", {}).items():
+            if name in linked:
+                continue
+            where = f"{entry['name']}: {name}"
+            if _IGNORED_VALUE_MARKER in str(spec.get("description", "")):
+                computed.add(where)
+                continue
+            unreachable.append(where)
+
+    assert not unreachable, (
+        "input properties a caller can supply but cannot write on a command line:\n"
+        + "\n".join(unreachable)
     )
+    # The exemption stays the narrow, declared one it claims to be.
+    assert computed == _COMPUTED_PROPERTIES, computed
 
 
 def test_entry_argv_matches_the_commands_own_schema_argv():
@@ -453,3 +474,78 @@ def test_self_described_manifest_describes_the_argv_binding_list():
     }
     assert binding["properties"]["kind"]["$ref"] == "#/$defs/ArgvKind"
     assert manifest_schema["$defs"]["ArgvKind"]["enum"] == ["argument", "option"]
+
+
+# Every pairing of the two spelling keys against each `kind`, valid and not. The
+# point is not any single verdict but that ONE corpus gets the SAME verdict from
+# the published rule and from the model — the two engines disagree readily (a
+# pydantic Rust validator versus Python `jsonschema`), so agreement has to be
+# tested rather than assumed.
+_SPELLING_CORPUS = [
+    {"kind": "argument", "option": None, "position": 0, "flag": False},
+    {"kind": "option", "option": "--out", "position": None, "flag": False},
+    {"kind": "option", "option": "--all", "position": None, "flag": True},
+    # …and the states no caller could write.
+    {"kind": "argument", "option": "--out", "position": 0, "flag": False},
+    {"kind": "argument", "option": None, "position": None, "flag": False},
+    {"kind": "argument", "option": None, "position": 0, "flag": True},
+    {"kind": "option", "option": None, "position": None, "flag": False},
+    {"kind": "option", "option": "--out", "position": 1, "flag": False},
+    {"kind": "option", "option": None, "position": 0, "flag": False},
+]
+
+
+def test_the_published_spelling_rule_matches_the_model():
+    # #669 review: a binding that claims both a position and an option spelling —
+    # or neither — is unwritable, and a consumer reading one cannot tell which key
+    # to believe. The model rejects those states; this pins the PUBLISHED rule to
+    # the model so a client checking the manifest schema reaches the same verdict.
+    import jsonschema
+    import pydantic
+
+    from gda.models import ArgvBinding
+
+    result = CliRunner().invoke(app, ["schema", "--schema"])
+    assert result.exit_code == 0, result.stdout
+    defs = json.loads(result.stdout)["output"]["$defs"]
+    published = {"allOf": [{"$ref": "#/$defs/ArgvBinding"}], "$defs": defs}
+
+    for spelling in _SPELLING_CORPUS:
+        binding = {
+            "name": "x",
+            "input_property": "x",
+            "required": False,
+            "multiple": False,
+            "json_value": False,
+            **spelling,
+        }
+        try:
+            jsonschema.validate(instance=binding, schema=published)
+            by_schema = True
+        except jsonschema.ValidationError:
+            by_schema = False
+        try:
+            ArgvBinding.model_validate(binding)
+            by_model = True
+        except pydantic.ValidationError:
+            by_model = False
+        assert by_schema == by_model, (spelling, by_schema, by_model)
+
+    # …and the corpus spans both verdicts, so agreement is not vacuous.
+    verdicts = set()
+    for spelling in _SPELLING_CORPUS:
+        try:
+            ArgvBinding.model_validate(
+                {
+                    "name": "x",
+                    "input_property": "x",
+                    "required": False,
+                    "multiple": False,
+                    "json_value": False,
+                    **spelling,
+                }
+            )
+            verdicts.add(True)
+        except pydantic.ValidationError:
+            verdicts.add(False)
+    assert verdicts == {True, False}

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1820,3 +1820,51 @@ def test_schema_argv_reports_required_despite_the_relaxed_probe_parse():
     # DECLARED requirement, not the relaxed one.
     assert _argv(["screen", "capture"])["output"]["required"] is True
     assert _argv(["node", "connect-signal"])["from_node"]["required"] is True
+
+
+def test_the_argv_derivation_covers_every_parameter_shape_on_the_surface():
+    # The projection expresses a positional, an option, a valueless flag, a
+    # repeated value and a JSON-encoded value (#669). Click can spell three more
+    # shapes it would report WRONGLY: a `--x/--no-x` pair (the negative spelling
+    # would be dropped), an n-ary option (`nargs > 1`, which is neither single nor
+    # `multiple`), and a counting option (`count=True`, not a bare flag). None
+    # exists today. This guard fails the moment one is introduced, so the contract
+    # is extended deliberately instead of silently emitting a binding that cannot
+    # be written.
+    import typer as _typer
+
+    unsupported: list[str] = []
+
+    def walk(command, path):
+        subcommands = getattr(command, "commands", None)
+        if subcommands is not None:
+            for name, subcommand in subcommands.items():
+                walk(subcommand, [*path, name])
+            return
+        for param in command.params:
+            where = f"{' '.join(path)}: {param.name}"
+            if getattr(param, "secondary_opts", []):
+                unsupported.append(f"{where} (--x/--no-x pair)")
+            if getattr(param, "nargs", 1) not in (1, -1):
+                unsupported.append(f"{where} (nargs={param.nargs})")
+            if getattr(param, "count", False):
+                unsupported.append(f"{where} (counting option)")
+
+    walk(_typer.main.get_command(app), [])
+    assert not unsupported, "argv bindings cannot express:\n" + "\n".join(unsupported)
+
+
+def test_schema_argv_marks_a_json_encoded_value():
+    # `input sequence` takes an ARRAY property through a single `--events` token
+    # that carries its JSON. Without this key an agent reading `input` sees an
+    # array and writes one token per element, which the parser rejects — the
+    # encoding half of the same argv problem (#669).
+    binding = _argv(["input", "sequence"])["events"]
+
+    assert binding["json_value"] is True
+    assert binding["multiple"] is False
+    assert binding["option"] == "--events"
+    # A repeated option carries its values one token at a time instead, so it is
+    # NOT a JSON value; nor is a plain scalar.
+    assert _argv(["input", "key"])["modifiers"]["json_value"] is False
+    assert _argv(["screen", "capture"])["output"]["json_value"] is False

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1793,10 +1793,33 @@ def test_schema_argv_links_a_binding_to_the_input_property_it_fills():
     assert binding["option"] == "--type"
     assert binding["input_property"] == "type"
 
-    # …and it is honestly null rather than guessed where the CLI form names the
-    # property differently: `project list --all` fills `include_defaults`, which
-    # neither the parameter name nor the option spelling reveals.
-    assert _argv(["project", "list"])["all_settings"]["input_property"] is None
+    # …and where the OPTION renames the property, the parameter carries the
+    # property's name so the link still holds: `project list --all` and
+    # `skill --dir` fill `include_defaults` / `install_dir`.
+    assert _argv(["project", "list"])["include_defaults"]["option"] == "--all"
+    assert _argv(["project", "list"])["include_defaults"]["input_property"] == (
+        "include_defaults"
+    )
+    assert _argv(["skill"])["install_dir"]["option"] == "--dir"
+    assert _argv(["skill"])["install_dir"]["input_property"] == "install_dir"
+
+
+def test_an_underivable_link_is_published_as_null_rather_than_guessed():
+    # `input_property` stays nullable BY CONTRACT for a parameter whose property
+    # neither its name nor its long option reveals — a wrong link would read as
+    # authoritative. No command on the surface is in that state (a guard in
+    # test_schema_aggregate holds that), so the rule is pinned on the derivation
+    # itself rather than through a command that would then have to stay broken.
+    from gda.headless import _bound_property
+
+    properties = {"include_defaults": {"type": "boolean"}}
+    assert _bound_property("all_settings", "--all", properties) is None
+    # The two derivations that DO resolve: by parameter name, and by the long
+    # option's spelling (`--type` fills `type` from a `node_type` parameter).
+    assert _bound_property("include_defaults", "--all", properties) == (
+        "include_defaults"
+    )
+    assert _bound_property("node_type", "--type", {"type": {}}) == "type"
 
 
 def test_schema_argv_covers_every_dispatch_channel():

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1868,3 +1868,53 @@ def test_schema_argv_marks_a_json_encoded_value():
     # NOT a JSON value; nor is a plain scalar.
     assert _argv(["input", "key"])["modifiers"]["json_value"] is False
     assert _argv(["screen", "capture"])["output"]["json_value"] is False
+
+
+def _is_compound(spec: dict) -> bool:
+    """Whether a property schema is an array/object, INCLUDING behind an anyOf."""
+    if spec.get("type") in ("array", "object"):
+        return True
+    branches = spec.get("anyOf") or spec.get("oneOf") or []
+    return any(_is_compound(branch) for branch in branches if isinstance(branch, dict))
+
+
+def test_no_parameter_needs_a_json_value_the_derivation_cannot_see():
+    # `json_value` is derived from the LINKED property's declared `type`, so it
+    # sees a bare `array`/`object` but not one behind an `anyOf` — the shape a
+    # nullable compound (`array | null`) takes. Such a parameter would silently
+    # publish `json_value: false` and send an agent to write its value as a plain
+    # token. None exists today, so the derivation is deliberately left narrow; this
+    # fails the moment one appears, forcing the extension rather than a wrong
+    # binding. Same guard shape as the unsupported-Click-shapes test above.
+    import typer as _typer
+
+    from gda.headless import command_argv_bindings
+
+    invisible: list[str] = []
+
+    def walk(command, path):
+        subcommands = getattr(command, "commands", None)
+        if subcommands is not None:
+            for name, subcommand in subcommands.items():
+                walk(subcommand, [*path, name])
+            return
+        input_model = getattr(command, "gda_input_model", None)
+        if input_model is None:
+            return
+        properties = input_model.model_json_schema().get("properties", {})
+        for binding in command_argv_bindings(command, input_model):
+            spec = properties.get(binding.input_property or "")
+            if not isinstance(spec, dict) or binding.multiple or binding.json_value:
+                continue
+            if _is_compound(spec):
+                invisible.append(f"{' '.join(path)}: {binding.name}")
+
+    walk(_typer.main.get_command(app), [])
+    assert not invisible, (
+        "compound properties taking one token that json_value cannot see:\n"
+        + "\n".join(invisible)
+    )
+    # …and the detector is not blind: it recognizes the nullable-compound shape it
+    # is meant to catch, so passing above means absence, not a broken predicate.
+    assert _is_compound({"anyOf": [{"type": "array"}, {"type": "null"}]})
+    assert not _is_compound({"type": "string"})

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1403,16 +1403,27 @@ def test_input_commands_schema_report_kind_live_and_are_model_derived():
     events_description = sequence_input["properties"]["events"]["description"]
     assert "process-clock `frame`" in events_description
     assert "physics-clock `physics_frame`" in events_description
-    sequence_event_props = sequence_input["$defs"]["InputSequenceEvent"]["properties"]
-    sequence_event_types = sequence_input["$defs"]["InputEventType"]["enum"]
-    assert "mouse_button" in sequence_event_types
-    assert "harness/process-frame" in sequence_event_props["frame"]["description"]
-    assert "physics-frame" in sequence_event_props["physics_frame"]["description"]
+    # The event kinds are a discriminated union (#669): each kind's variant is
+    # reached through the discriminator mapping rather than one flat shape.
+    mapping = sequence_input["properties"]["events"]["items"]["discriminator"][
+        "mapping"
+    ]
+    assert "mouse_button" in mapping
+    variants = {
+        kind: sequence_input["$defs"][ref.rsplit("/", 1)[-1]]
+        for kind, ref in mapping.items()
+    }
+    key_props = variants["key"]["properties"]
+    assert "harness/process-frame" in key_props["frame"]["description"]
+    assert "physics-frame" in key_props["physics_frame"]["description"]
     assert (
         "engine-tracked mouse positions may remain stale"
-        in (sequence_event_props["x"]["description"])
+        in (variants["mouse_move"]["properties"]["x"]["description"])
     )
-    assert "mouse-button event" in sequence_event_props["pressed"]["description"]
+    assert (
+        "one of `pressed` or `release`"
+        in variants["mouse_button"]["properties"]["pressed"]["description"]
+    )
 
 
 def test_sample_input_results_validate_against_emitted_output_schemas():

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1688,3 +1688,124 @@ def test_asset_file_schema_spawns_no_godot(monkeypatch):
         result = CliRunner().invoke(app, [*command, "--schema"])
         assert result.exit_code == 0
         assert set(json.loads(result.stdout)) >= {"input", "output", "error"}
+
+
+# --- argv binding in --schema (issue #669, ADR-0004/ADR-0012/ADR-0023 §2) -----
+#
+# GDA-DF-003: the emitted schema stated a command's required fields but not how
+# to SPELL them on a command line — `screen capture` needs `--output` while
+# `input mouse-click` needs positional `x y` and `input action` a positional
+# ACTION it rejects as `--action`. The `argv` key answers that from the live
+# Typer/Click parameters (never a hand-maintained table, ADR-0023 §2).
+
+
+def _argv(command: list[str]) -> dict[str, dict]:
+    """The command's ``--schema`` argv bindings, keyed by binding name."""
+    result = CliRunner().invoke(app, [*command, "--schema"])
+    assert result.exit_code == 0, result.stdout
+    return {b["name"]: b for b in json.loads(result.stdout)["argv"]}
+
+
+def test_schema_argv_names_a_required_options_spelling():
+    # GDA-DF-003 case 1: `screen capture` takes its required `output` as an
+    # OPTION, so the schema must publish the `--output` spelling.
+    binding = _argv(["screen", "capture"])["output"]
+
+    assert binding["kind"] == "option"
+    assert binding["option"] == "--output"
+    assert binding["required"] is True
+    assert binding["position"] is None
+
+
+def test_schema_argv_places_positional_parameters_in_order():
+    # GDA-DF-003 case 2: `input mouse-click` takes `x y` POSITIONALLY — the
+    # schema publishes their order, and that they carry no option spelling.
+    bindings = _argv(["input", "mouse-click"])
+
+    assert bindings["x"]["kind"] == "argument"
+    assert bindings["x"]["position"] == 0
+    assert bindings["x"]["option"] is None
+    assert bindings["y"]["position"] == 1
+    assert bindings["x"]["required"] is True
+
+
+def test_schema_argv_reports_a_positional_that_has_no_option_form():
+    # GDA-DF-003 case 3: `input action` requires a positional ACTION and rejects
+    # `--action`; the schema says so, so no round-trip through `--help` is needed.
+    bindings = _argv(["input", "action"])
+
+    assert bindings["action"]["kind"] == "argument"
+    assert bindings["action"]["position"] == 0
+    assert bindings["action"]["option"] is None
+    assert "--action" not in {b["option"] for b in bindings.values()}
+
+
+def test_schema_argv_distinguishes_valueless_flags_from_repeatable_options():
+    # Constructing argv needs two more facts a JSON Schema cannot carry: a flag
+    # takes NO value (`--released`), and a repeatable option is REPEATED per
+    # value (`--modifiers shift --modifiers ctrl`).
+    bindings = _argv(["input", "key"])
+
+    assert bindings["released"]["flag"] is True
+    assert bindings["released"]["multiple"] is False
+    assert bindings["modifiers"]["flag"] is False
+    assert bindings["modifiers"]["multiple"] is True
+    assert bindings["modifiers"]["option"] == "--modifiers"
+
+
+def test_schema_argv_reports_a_variadic_positional_as_multiple():
+    # `script validate [PATHS]...` takes any number of positional paths (#663).
+    binding = _argv(["script", "validate"])["paths"]
+
+    assert binding["kind"] == "argument"
+    assert binding["multiple"] is True
+
+
+def test_schema_argv_omits_the_shared_cross_cutting_flags():
+    # `argv` describes the OPERATION parameters — the same set `--params-json`
+    # is mutually exclusive with (ADR-0015). The cross-cutting flags every
+    # command shares are not per-command information, so they stay out.
+    for command in (["scene", "create"], ["input", "key"], ["export", "run"]):
+        names = set(_argv(command))
+        assert names.isdisjoint(
+            {"json_output", "schema", "params_json", "godot", "project"}
+        )
+
+
+def test_schema_argv_links_a_binding_to_the_input_property_it_fills():
+    # The join that closes GDA-DF-003: an agent holding a REQUIRED input property
+    # can find its CLI spelling. The link is derived (never declared), so it is
+    # right even where the CLI spelling differs from the Python parameter name —
+    # `node add`'s `node_type` parameter is spelled `--type` and fills `type`.
+    binding = _argv(["node", "add"])["node_type"]
+
+    assert binding["option"] == "--type"
+    assert binding["input_property"] == "type"
+
+    # …and it is honestly null rather than guessed where the CLI form names the
+    # property differently: `project list --all` fills `include_defaults`, which
+    # neither the parameter name nor the option spelling reveals.
+    assert _argv(["project", "list"])["all_settings"]["input_property"] is None
+
+
+def test_schema_argv_covers_every_dispatch_channel():
+    # Several channels bypass the sentinel `cmd.emit` (EXPORT and LIVE by kind,
+    # the daemon lifecycle and screen by recipe). The binding is read off the
+    # live Click parameters, so it is present on all of them, not just the
+    # sentinel path.
+    assert _argv(["export", "run"])["preset"]["option"] == "--preset"
+    assert _argv(["daemon", "start"])["scene"]["option"] == "--scene"
+    assert _argv(["game", "get"])["node"]["kind"] == "argument"
+    assert _argv(["script", "run"])["path"]["kind"] == "argument"
+    # A command with no operation parameters carries an empty list, not a
+    # missing key.
+    result = CliRunner().invoke(app, ["info", "--schema"])
+    assert json.loads(result.stdout)["argv"] == []
+
+
+def test_schema_argv_reports_required_despite_the_relaxed_probe_parse():
+    # The `--schema` probe parses with every parameter's `required` RELAXED so a
+    # bare probe succeeds (issue #36). The published binding must report the
+    # DECLARED requirement, not the relaxed one.
+    assert _argv(["screen", "capture"])["output"]["required"] is True
+    assert _argv(["node", "connect-signal"])["from_node"]["required"] is True


### PR DESCRIPTION
Closes #669

## What this fixes

Two dogfooding defects on the emitted contract:

- **GDA-DF-003** — the schema stated a command's required fields but not their CLI
  spelling, so argv could not be built from it: `screen capture` takes its required
  output as `--output`, `input mouse-click` takes `x y` positionally, `input action`
  takes a positional ACTION it rejects as `--action`.
- **GDA-DF-037 / GDA-DF-032** — one flat `input sequence` event shape carried every
  kind's fields, so the per-kind rules lived only in prose, a foreign field was
  accepted and silently ignored (a `release` on a key event PRESSED the key), and the
  refusal of `pressed` on an action event never said to use `release`.

## Design

**1. `argv`, a projection of the live Typer/Click parameters.** Both schema sites —
the per-command `--schema` and the `gda schema` manifest — now carry an `argv` list
built by one shared derivation (`command_argv_bindings`), the same shape
`command_constraints` already has. Each binding says how to write one parameter:

```json
{"name": "output", "input_property": "output", "kind": "option",
 "option": "--output", "position": null, "required": true,
 "flag": false, "multiple": false, "json_value": false}
```

`position` orders the positionals, `option` gives the spelling, `flag` marks an
option that takes no value, `multiple` one that is repeated per value,
`json_value` one whose single token carries the value's JSON (`input sequence
--events` is the only one on the surface — an agent reading `input` sees an array
and would otherwise write one token per element), and `required` is the DECLARED
requirement, not the relaxed one the `--schema` probe parses with (#36).

The Typer signature stays the single source: no `argv` field was added to the
`HeadlessCommand` descriptor, because a hand-maintained spelling table is the
parallel registry ADR-0023 §2 rejects and would rot the moment a signature changed.
Reading the registered parameters also makes the projection correct on every
dispatch channel at once — the sentinel path, the EXPORT / LIVE kinds, and the
recipe commands (`export run`, the `daemon` lifecycle, `screen`), which is asserted
by a test rather than assumed.

`argv` is the argv form of the OPERATION parameters — the set `--params-json` is
exclusive with (ADR-0015) — so the cross-cutting flags every command shares stay
out. It is not a one-to-one image of `input`: **every required property has a
binding** (pinned by a test), while an optional property the CLI computes from flags
rather than takes directly (`script set`'s `mode`, from `--replace` / `--search`)
has none. `input_property` links a binding back to the property it fills, derived
from the parameter name or the long option; it is `null`, never guessed, for the two
flags on the surface that rename their property (`project list --all` →
`include_defaults`, `skill --dir` → `install_dir`). 130 of 132 bindings link.

**2. `input sequence`'s event type is a discriminated union on `type`.** One variant
per kind, each declaring exactly the fields it accepts, so the emitted schema is a
`oneOf` with a discriminator mapping and every kind's required fields and
`additionalProperties: false` boundary are machine-checkable. `mouse_button`'s
"exactly one of `pressed: true` / `release: true`" rule is published as schema too —
that kind is the one an agent reaches for to build a drag, which is the case
GDA-DF-037 named — and a corpus test requires the published rule and the enforcing
validator to agree on every combination of the two fields.

**3. A foreign field is refused by name AND answered.** The message says which
spelling this kind uses for its press/release phase (`release` for an action,
`released` for a key, `pressed`/`release` for a mouse button), or that the kind has
none and which kinds do. Every part of it is derived from the variant models — the
union's own membership included — so it cannot drift from what they accept.

**4. Help.** The `--events` help gains the action press/release pair beside the mouse
drag example. Both are spelled with a space after each `:` and `,` so the help
renderer WRAPS them instead of ellipsizing an unbreakable word — the old one-line
mouse example was cut off mid-JSON at every terminal width, so it was never copyable.

## gda-mcp wire-schema impact (the recorded answer)

**The `argv` addition changes no registered MCP tool's wire schema.** gda-mcp maps
`input` → `input_schema` and `output` → `output_schema` and ignores every other entry
key (ADR-0012); `argv` is a SIBLING of those halves. A test emits each command's
contract with and without the bindings and requires both halves to be identical, so
this is asserted, not argued.

**One tool's `input_schema` does change, for an unrelated reason in the same PR:**
`gda_input_sequence`, because that command's own params model became the per-kind
union. Measured by diffing `gda schema` before and after, across all 70 commands:

| entry key | commands whose value changed |
| --- | --- |
| `input` | `input sequence` only (its own model's union) |
| `output` / `error` / `description` / `kind` / `constraints` | none |
| new keys | `argv` |

Both schema lookup paths were checked, and they stay pinned separately:

1. **The aggregate manifest → gda-mcp tool registration** (`gda.mcp.server.build_server`,
   pinned by `tests/test_mcp_registration.py` and `tests/test_schema_aggregate.py`).
2. **The per-command `--schema` document** (ADR-0004, pinned by
   `tests/test_schema_command.py`) — gains the additive `argv` key.

The two are asserted to agree binding-for-binding
(`test_entry_argv_matches_the_commands_own_schema_argv`) without being merged.

`libs/gda-balancing`'s own two `wire_schema` lookup paths
(`artifact_wire_schema_identity` / `wire_schema_identity_for_kind`) are a different
subsystem with a separate release train; nothing there derives from gda's command
surface and no file under `libs/` is touched.

## BREAKING CHANGE

`input sequence` no longer accepts an event field belonging to another event kind.
Five shapes that validated before are now rejected — for example
`{"type": "key", "key": "A", "release": true}` and
`{"type": "mouse_move", "x": 1, "y": 2, "button": "right"}`. None of them ever did
anything: the harness reads only the kind's own fields, so those values were
discarded, and the `release`-on-a-key case silently PRESSED the key. Turning them
loud is the point of the change. The published `input_schema` for the
`gda_input_sequence` MCP tool changes shape with it (a flat object → a `oneOf` with a
discriminator), so a client that generated code from it should regenerate.

`button: null` stays accepted (it means left, as before) — the old flat shape
defaulted it to null, so a producer replaying a dumped event would otherwise have
broken.

## Validation

**Gates** — `uv run pytest -q -m "not e2e"` 1661 passed; `ruff check`, `ruff format
--check`, `pyright` all clean. PR CI green.

One CI-only failure was found and fixed on this branch: the help renderer emits SGR
colour sequences when it believes it is writing to a terminal, which it does on
GitHub Actions and not in a local run, so the new copyable-example assertion passed
locally and failed only in CI. The mechanism was reproduced locally with
`GITHUB_ACTIONS=true uv run pytest` before fixing it; the fast suite now passes in
both modes and is run in both.

**Real-engine repro of GDA-DF-003** (Godot 4.x, macOS). A script builds argv for
seven commands from the emitted schema ALONE — no `--help`, no guessing — and runs
them against a real project. Before this change the script cannot run at all: there
is no `argv` key. After, every command succeeds, including the spellings that used to
require a round trip:

```
$ gda scene create res://Main.tscn --root-type Node2D          exit 0
$ gda node add res://Main.tscn --type Sprite2D --name Hero     exit 0   (param node_type → --type)
$ gda script create res://hero.gd --extends Sprite2D           exit 0   (param extends_type → --extends)
$ gda script validate res://hero.gd                            exit 0   (variadic positional)
$ gda resource create res://box.tres --type RectangleShape2D   exit 0
$ gda node set res://Main.tscn --node Hero --property z_index --value 5 exit 0
$ gda node get res://Main.tscn --node Hero                     exit 0
```

**Real-engine verification of the union (GDA-DF-032/037)** — the live e2e drives a
real `gda daemon start`, a real engine session and the real harness with the new
per-kind payload: `tests/test_e2e_input.py` 10 passed, including
`test_input_sequence_physics_frame_hold_matches_predicted_displacement` (an action
press at `physics_frame: 0` and its `release: true` at `physics_frame: N`, verified
against the predicted displacement) and `test_input_sequence_drags_mouse_with_held_button_mask`
(the `mouse_button` phase events). The engine-facing payload is unchanged in kind:
the harness reads every sequence field through `event.get(key, default)`, so an event
that now omits the other kinds' keys behaves exactly as before.

**Rejection message, before → after** (`--params-json`, engine-free):

| event | before | after |
| --- | --- | --- |
| `{"type":"action","action":"jump","pressed":true}` | `'pressed' is only valid on a 'mouse_button' sequence event.` | `'pressed' is not valid on an 'action' sequence event: an 'action' event spells its press/release phase 'release'; 'pressed' is accepted on: mouse_button.` |
| `{"type":"key","key":"A","release":true}` | **accepted** — the key was PRESSED | `'release' is not valid on a 'key' sequence event: a 'key' event spells its press/release phase 'released'; 'release' is accepted on: mouse_button, action.` |
| `{"type":"mouse_move","x":1,"y":2,"pressed":true}` | `'pressed' is only valid on a 'mouse_button' sequence event.` | `'pressed' is not valid on a 'mouse_move' sequence event: a 'mouse_move' event has no press/release phase; 'pressed' is accepted on: mouse_button.` |
| `{"type":"nope",…}` | `Input should be 'key', 'mouse_click', …` | same list of wire values (the enum reports its value, so the tag list never names a Python symbol) |

**Other targeted e2e** (serialized under the shared lock): `test_e2e_input`,
`test_e2e_mcp_stdio`, `test_e2e_params_json` re-run after the review fixes — 16
passed; earlier rounds also ran `test_e2e_mcp_tracer`, `test_e2e_info`,
`test_e2e_mcp_live`, `test_e2e_daemon`, `test_e2e_game` — 41 passed.

## Review round

The branch was put through two independent adversarial reviews (spec-vs-issue and
code-standards) before this was opened for human review. Everything they found is
fixed in `66323231`, each with a guard so the class cannot return silently: the
union's membership is now read off the union instead of re-listed beside it; the
message builder no longer raises a bare `KeyError` from inside a refusal path; the
mouse-button phase rule is published; `button: null` is accepted again;
`json_value` was added; ADR-0012's "no wire schema changes" sentence was corrected;
and three docs (including the published field descriptions) stopped describing a
null-`input_property` rule the code does not implement.

## Residual risks / known limits

- `gda schema` grows ~6% (507 KB → 537 KB) for the 132 bindings. Field descriptions
  are deliberately terse for that reason.
- A foreign field masks a co-occurring missing required one: the pre-validation
  refusal fires first, so `{"type":"action","pressed":true}` reports `pressed` and
  only then the missing `action`. Two round trips where one would do.
- Three per-event rules stay enforced model-side only, as before this change: the
  one-clock rule (a relation between two nullable fields — expressing it in schema
  would wrongly reject `{"frame": 1, "physics_frame": null}`), the modifier
  vocabulary, and the window ceiling. Candidates for a follow-up, out of scope here.
- **Considered and declined:** renaming the two Python parameters behind `--all` /
  `--dir` to match their properties would make all 132 bindings link. It changes two
  unrelated command groups to make this metadata tidier, both properties are
  optional, and the null is honest rather than wrong — revisit if a REQUIRED property
  ever ends up unlinked (the new test fails loudly if one does).
- **Not changed, deliberately:** the README's one-line `--schema` flag description —
  it is still true, and every README edit forces a re-translation of the three
  localized READMEs (`test_readme_i18n_sync`) for a non-load-bearing clause. The
  agent-facing surfaces that carry the contract are updated: ADR-0004, ADR-0012, the
  command catalog, the bundled Skill, and the emitted schema itself.
- Scope boundary with #670 (near-miss command/option hints) is untouched.
