### PR TITLE
refactor(gda): daemon Tier 2 — DaemonPaths session log, session seam, socket-lifecycle tests (#674)

### DIFF
--- a/src/gda/daemon/discovery.py
+++ b/src/gda/daemon/discovery.py
@@ -46,6 +46,14 @@ class DaemonPaths:
     cli_socket: Path  # CLI <-> daemon UDS
     harness_socket: Path  # daemon <-> harness UDS (path injected into the session)
     pidfile: Path  # liveness + the recorded canonical project path
+    # The daemon-owned Session log (#224): the engine session is launched with
+    # `--log-file` on this path so the daemon can read the running game's
+    # errors/output back to serve `gda diag` / `gda logger`. Under the private
+    # runtime dir (NOT `user://logs` — that shared path caused #180), keyed by the
+    # same slug as the sockets/pidfile; `RotatedFileLogger` truncates it each
+    # launch, making it session-bound (ADR-0020). Derived here with the rest of
+    # the identity (#674) — no consumer re-derives it from a socket filename.
+    session_log: Path
 
 
 def _runtime_dir(env: Mapping[str, str]) -> Path:
@@ -85,6 +93,7 @@ def daemon_paths(project: Path, env: Mapping[str, str] | None = None) -> DaemonP
         cli_socket=runtime / f"{slug}.cli.sock",
         harness_socket=runtime / f"{slug}.harness.sock",
         pidfile=runtime / f"{slug}.pid",
+        session_log=runtime / f"{slug}.session.log",
     )
 
 

--- a/src/gda/daemon/discovery.py
+++ b/src/gda/daemon/discovery.py
@@ -117,16 +117,25 @@ def acquire_pidfile(paths: DaemonPaths, pid: int):
     ``os.kill`` PID-liveness (which a reused PID could spoof). The OS releases the
     lock when the daemon exits or crashes, so liveness self-heals with no cleanup.
     Raises ``OSError`` if another live daemon already holds it (a start race).
+
+    Opened WITHOUT truncation, and truncated only AFTER the lock is won (#723
+    review): ``open("w")`` zeroed the file before ``flock`` could refuse, so a
+    LOSING start erased the live winner's recorded identity — ``daemon_pid``
+    then read the running daemon as not running.
     """
     import fcntl
 
     ensure_runtime_dir(paths)
-    handle = open(paths.pidfile, "w", encoding="utf-8")
+    handle = os.fdopen(
+        os.open(paths.pidfile, os.O_RDWR | os.O_CREAT, 0o644), "r+", encoding="utf-8"
+    )
     try:
         fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError:
         handle.close()
         raise
+    handle.seek(0)
+    handle.truncate()
     handle.write(f"{pid}\n{paths.project}\n")
     handle.flush()
     return handle

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -20,6 +20,7 @@ from gda.daemon.protocol import error_reply, read_message, result_reply, write_m
 from gda.daemon.session import (
     EngineSession,
     SceneMismatch,
+    SessionLaunch,
     WindowedDisplayUnavailable,
     launch_session,
 )
@@ -49,6 +50,7 @@ class DaemonServer:
         windowed: bool = False,
         scene: str | None = None,
         display_check: Optional[Callable[[], Optional[WindowedUnavailable]]] = None,
+        launch: Optional[SessionLaunch] = None,
     ) -> None:
         self.paths = paths
         self.godot = godot
@@ -67,6 +69,11 @@ class DaemonServer:
         # so tests drive the guard without a real display; defaults to the shared
         # gda.display probe. Consulted only for a windowed session.
         self._display_check = display_check or windowed_unavailable
+        # The server↔session seam (#674): how an engine session is launched.
+        # Injectable so unit tests drive the whole serve loop against a fake
+        # session — no Godot binary, no real engine. Resolved at construction
+        # against the module global, so the default stays the real launch.
+        self._launch: SessionLaunch = launch or launch_session
         self._token = secrets.token_hex(16)
         self._stopping = False
         self._listener: socket.socket | None = None
@@ -76,17 +83,19 @@ class DaemonServer:
 
     def serve(self) -> None:
         ensure_runtime_dir(self.paths)
-        self._listener = self._bind(self.paths.cli_socket)
-        self._harness_listener = self._bind(self.paths.harness_socket)
-        # Hold the pidfile's advisory lock for our lifetime — that held lock is the
-        # liveness signal the CLI keys on (ADR-0021); bind first so the socket is
-        # present before we are reported live.
+        # The pidfile's advisory lock is the daemon's mutual exclusion AND its
+        # liveness signal (ADR-0021), so it is taken FIRST: a start that loses the
+        # race fails here, before it can unlink — or leave the cleanup below to
+        # unlink — the winner's live sockets (#674 socket-lifecycle test; binding
+        # first let a losing double-start destroy the winner's slot). Liveness as
+        # the CLI reads it needs the lock AND a bound socket, so the daemon is
+        # still not reported live until the binds below land.
         self._pidfile_handle = acquire_pidfile(self.paths, os.getpid())
-
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            signal.signal(sig, self._on_signal)
-
         try:
+            self._listener = self._bind(self.paths.cli_socket)
+            self._harness_listener = self._bind(self.paths.harness_socket)
+            for sig in (signal.SIGTERM, signal.SIGINT):
+                signal.signal(sig, self._on_signal)
             self._accept_loop()
         finally:
             self._cleanup()
@@ -289,13 +298,13 @@ class DaemonServer:
             if not (self.paths.project / rel).expanduser().is_file():
                 raise SceneMismatch(scene)
         assert self._harness_listener is not None
-        self._session = launch_session(
+        self._session = self._launch(
             self.paths.project,
             self.godot,
             self._harness_listener,
             self.paths.harness_socket,
             self._token,
-            log_file=self._session_log_path(),
+            log_file=self.paths.session_log,
             windowed=self.windowed,
             scene=self.scene,
             diagnostics=diagnostics,
@@ -307,9 +316,9 @@ class DaemonServer:
 
         Combines the child-liveness reason ``launch_session`` observed (the engine
         died by signal, or the harness never connected) with a tail of the daemon-
-        owned Session log, read via the DETERMINISTIC :meth:`_session_log_path` —
-        which needs no live session object, extending ADR-0022's read path to the
-        failed-launch case. NOTE: a windowed-no-``DisplayServer`` abort happens
+        owned Session log, read via the DETERMINISTIC ``DaemonPaths.session_log``
+        (#674) — which needs no live session object, extending ADR-0022's read
+        path to the failed-launch case. NOTE: a windowed-no-``DisplayServer`` abort happens
         BEFORE Godot installs its file logger, so this tail is usually EMPTY for that
         case (the child-signal reason carries it); it carries content for a
         post-logger crash.
@@ -323,22 +332,10 @@ class DaemonServer:
     def _read_session_log_tail(self, max_bytes: int = 2000) -> str:
         """The trailing bytes of the daemon-owned Session log, or "" if unreadable."""
         try:
-            data = self._session_log_path().read_bytes()
+            data = self.paths.session_log.read_bytes()
         except OSError:
             return ""
         return data.decode("utf-8", "replace").strip()[-max_bytes:]
-
-    def _session_log_path(self):
-        """The daemon-owned Session-log path for this project (#224).
-
-        Under the daemon's private runtime dir (NOT ``user://logs`` — that shared
-        path caused #180), keyed by the same project slug the sockets/pidfile use,
-        so the engine's ``--log-file`` writes the running game's errors/output to a
-        path the daemon can read back to serve ``gda diag``. ``RotatedFileLogger``
-        truncates it each launch, making it session-bound (ADR-0020).
-        """
-        slug = self.paths.cli_socket.name.split(".", 1)[0]
-        return self.paths.runtime_dir / f"{slug}.session.log"
 
     def _cleanup(self) -> None:
         if self._session is not None:

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -12,15 +12,15 @@ import os
 import secrets
 import signal
 import socket
-from typing import Callable, Optional
+from pathlib import Path
+from typing import Callable, Optional, Protocol
 
 from gda.daemon.diag import parse_errors, parse_log_records
 from gda.daemon.discovery import DaemonPaths, acquire_pidfile, ensure_runtime_dir
 from gda.daemon.protocol import error_reply, read_message, result_reply, write_message
 from gda.daemon.session import (
-    EngineSession,
+    CONNECT_TIMEOUT,
     SceneMismatch,
-    SessionLaunch,
     WindowedDisplayUnavailable,
     launch_session,
 )
@@ -38,6 +38,49 @@ STOP_OP = "__stop__"
 DIAG_ERRORS_OP = "diag-errors"
 LOGGER_TAIL_OP = "logger-tail"
 LOG_OPS = (DIAG_ERRORS_OP, LOGGER_TAIL_OP)
+
+
+class SessionHandle(Protocol):
+    """What the server consumes of a session (#723 review): a structural contract.
+
+    The server owns this — it names exactly the capabilities the serve loop
+    needs (liveness, one-op relay, the remembered log path, teardown) — so a
+    unit-test fake conforms by shape, with no cast at the seam.
+    :class:`gda.daemon.session.EngineSession` is the concrete implementation.
+    """
+
+    log_file: Optional[Path]
+
+    def alive(self) -> bool: ...
+
+    def request(self, operation: str, params: dict) -> dict: ...
+
+    def close(self) -> None: ...
+
+
+class SessionLaunch(Protocol):
+    """The server↔session seam: the shape of :func:`launch_session` (#674).
+
+    :class:`DaemonServer` takes one so unit tests can drive the whole serve
+    loop — lazy launch, launch failure, session death, relaunch — against a
+    fake :class:`SessionHandle`, with no Godot binary and no real engine. The
+    default is always the real :func:`launch_session`; the seam injects, it
+    never re-implements.
+    """
+
+    def __call__(
+        self,
+        project: Path,
+        binary: str,
+        harness_listener: socket.socket,
+        harness_socket: Path,
+        token: str,
+        log_file: Optional[Path] = None,
+        timeout: float = CONNECT_TIMEOUT,
+        windowed: bool = False,
+        scene: Optional[str] = None,
+        diagnostics: Optional[list[str]] = None,
+    ) -> Optional[SessionHandle]: ...
 
 
 class DaemonServer:
@@ -78,7 +121,7 @@ class DaemonServer:
         self._stopping = False
         self._listener: socket.socket | None = None
         self._harness_listener: socket.socket | None = None
-        self._session: EngineSession | None = None
+        self._session: SessionHandle | None = None
         self._pidfile_handle = None
 
     def serve(self) -> None:
@@ -265,7 +308,7 @@ class DaemonServer:
 
     def _ensure_session(
         self, diagnostics: list[str] | None = None
-    ) -> EngineSession | None:
+    ) -> SessionHandle | None:
         if self._session is not None and self._session.alive():
             return self._session
         if self._session is not None:
@@ -340,11 +383,6 @@ class DaemonServer:
     def _cleanup(self) -> None:
         if self._session is not None:
             self._session.close()
-        if self._pidfile_handle is not None:
-            try:
-                self._pidfile_handle.close()  # releases the advisory lock
-            except OSError:
-                pass
         for sock in (self._listener, self._harness_listener):
             if sock is not None:
                 try:
@@ -359,4 +397,15 @@ class DaemonServer:
             try:
                 os.unlink(path)
             except FileNotFoundError:
+                pass
+        # The advisory lock releases LAST (#723 review): it is the slot's mutual
+        # exclusion (ADR-0021), so it must outlive the slot it guards. Released
+        # before the unlinks above, a successor could acquire and bind a fresh
+        # slot inside this window — which the remaining unlinks would then
+        # destroy, leaving a serving daemon that discovery reports as not
+        # running.
+        if self._pidfile_handle is not None:
+            try:
+                self._pidfile_handle.close()  # releases the advisory lock
+            except OSError:
                 pass

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -18,7 +18,7 @@ import signal
 import socket
 import subprocess
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import Optional
 
 from gda.daemon.protocol import error_reply, read_frame, write_message
 from gda.display import WindowedUnavailable
@@ -138,31 +138,6 @@ class EngineSession:
             except OSError:
                 pass
         _terminate(self._proc)
-
-
-class SessionLaunch(Protocol):
-    """The server↔session seam: the shape of :func:`launch_session` (#674).
-
-    :class:`gda.daemon.server.DaemonServer` takes one so unit tests can drive the
-    whole serve loop — lazy launch, launch failure, session death, relaunch —
-    against a fake session, with no Godot binary and no real engine. The default
-    is always the real :func:`launch_session`; the seam injects, it never
-    re-implements.
-    """
-
-    def __call__(
-        self,
-        project: Path,
-        binary: str,
-        harness_listener: socket.socket,
-        harness_socket: Path,
-        token: str,
-        log_file: Optional[Path] = None,
-        timeout: float = CONNECT_TIMEOUT,
-        windowed: bool = False,
-        scene: Optional[str] = None,
-        diagnostics: Optional[list[str]] = None,
-    ) -> Optional[EngineSession]: ...
 
 
 def launch_session(

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -18,7 +18,7 @@ import signal
 import socket
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Protocol
 
 from gda.daemon.protocol import error_reply, read_frame, write_message
 from gda.display import WindowedUnavailable
@@ -138,6 +138,31 @@ class EngineSession:
             except OSError:
                 pass
         _terminate(self._proc)
+
+
+class SessionLaunch(Protocol):
+    """The server↔session seam: the shape of :func:`launch_session` (#674).
+
+    :class:`gda.daemon.server.DaemonServer` takes one so unit tests can drive the
+    whole serve loop — lazy launch, launch failure, session death, relaunch —
+    against a fake session, with no Godot binary and no real engine. The default
+    is always the real :func:`launch_session`; the seam injects, it never
+    re-implements.
+    """
+
+    def __call__(
+        self,
+        project: Path,
+        binary: str,
+        harness_listener: socket.socket,
+        harness_socket: Path,
+        token: str,
+        log_file: Optional[Path] = None,
+        timeout: float = CONNECT_TIMEOUT,
+        windowed: bool = False,
+        scene: Optional[str] = None,
+        diagnostics: Optional[list[str]] = None,
+    ) -> Optional[EngineSession]: ...
 
 
 def launch_session(

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -368,7 +368,7 @@ def test_failed_launch_diagnostics_excludes_stale_session_log(
     # must NOT leak into the current failure's diagnostics. launch_session truncates
     # the log BEFORE spawning, so the tail reads EMPTY for a pre-logger abort.
     server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
-    log_path = server._session_log_path()
+    log_path = server.paths.session_log
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text("STALE-PREVIOUS-SESSION-OUTPUT", encoding="utf-8")
 

--- a/tests/test_daemon_discovery.py
+++ b/tests/test_daemon_discovery.py
@@ -45,6 +45,13 @@ def test_daemon_paths_are_deterministic_and_canonical_per_project(tmp_path):
     assert paths.cli_socket.parent == tmp_path / "run" / "gda"
     assert paths.pidfile.parent == tmp_path / "run" / "gda"
 
+    # The Session log is part of the same on-disk identity (#674): derived here
+    # beside the sockets — same runtime dir, same slug — so no consumer ever
+    # re-derives it from a socket filename.
+    assert paths.session_log.parent == tmp_path / "run" / "gda"
+    slug = paths.cli_socket.name.removesuffix(".cli.sock")
+    assert paths.session_log.name == f"{slug}.session.log"
+
 
 @pytest.mark.skipif(os.name != "posix", reason="pidfile liveness uses flock (UNIX)")
 def test_daemon_pid_requires_recorded_path_socket_and_held_lock(tmp_path):

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -1,0 +1,301 @@
+"""Socket-lifecycle tests for the gda-daemon server (#674).
+
+These drive the REAL serve loop — real UDS bind, accept, reply, cleanup —
+against a fake engine session injected through the ``SessionLaunch`` seam, so
+the daemon's whole socket lifecycle (bind, stale-slot reclaim, double-start,
+stop/signal cleanup) and its session lifecycle (lazy launch, launch failure,
+death mid-request, relaunch) are covered by the fast suite with no Godot binary
+and no real engine.
+
+Real binds need the short-runtime-dir fixture: a UDS path is bounded by the OS
+``sun_path`` limit, which pytest's long macOS ``tmp_path`` overflows.
+
+``serve()`` installs signal handlers, which only works on the main thread — the
+helpers below run it on a worker thread, so they record the registration
+instead (the SIGTERM test invokes the recorded handler directly, which is
+exactly what the signal delivery would run).
+"""
+
+import os
+import signal
+import socket
+import subprocess
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from gda.commands.daemon import run_daemon_start_operation
+from gda.daemon.discovery import daemon_paths
+from gda.daemon.protocol import read_message, write_message
+from gda.daemon.server import DaemonServer
+from gda.daemon.session import EngineSession
+from gda.errors import Failure
+from gda.parser import parse_result
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+
+def _project(tmp_path: Path) -> Path:
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return tmp_path
+
+
+class _Proc:
+    """A stand-in engine process whose liveness the test flips."""
+
+    def __init__(self, code: "int | None" = None) -> None:
+        self.code = code
+
+    def poll(self):
+        return self.code
+
+
+class _ServedSession:
+    """A fake session that serves every relayed op."""
+
+    log_file = None
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def alive(self) -> bool:
+        return True
+
+    def request(self, operation: str, params: dict) -> dict:
+        return {"stdout": f"served:{operation}", "stderr": "", "exit_code": 0}
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _request(paths, payload: dict, timeout: float = 5.0):
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+        sock.settimeout(timeout)
+        sock.connect(str(paths.cli_socket))
+        write_message(sock, payload)
+        return read_message(sock)
+
+
+def _await_ready(paths, deadline: float = 5.0) -> dict:
+    """Poll until the daemon answers ``__status__`` on its CLI socket."""
+    end = time.monotonic() + deadline
+    while time.monotonic() < end:
+        if paths.cli_socket.exists():
+            try:
+                reply = _request(paths, {"op": "__status__"})
+                if isinstance(reply, dict):
+                    return reply
+            except OSError:
+                pass
+        time.sleep(0.02)
+    raise AssertionError("the daemon socket never became ready")
+
+
+@contextmanager
+def _serving(server: DaemonServer, paths, monkeypatch):
+    # serve() on a worker thread: signal.signal only works on the main thread, so
+    # record the handler registrations instead of installing them.
+    registered: list = []
+    monkeypatch.setattr(signal, "signal", lambda sig, handler: registered.append(sig))
+    thread = threading.Thread(target=server.serve, daemon=True)
+    thread.start()
+    try:
+        _await_ready(paths)
+        yield thread
+    finally:
+        if thread.is_alive():
+            try:
+                _request(paths, {"op": "__stop__"})
+            except OSError:
+                server._on_signal(signal.SIGTERM, None)
+            thread.join(timeout=5)
+
+
+def _no_launch(*args, **kwargs):
+    raise AssertionError("this test must not launch a session")
+
+
+def test_serve_binds_both_sockets_and_answers_status(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_no_launch)
+
+    with _serving(server, paths, monkeypatch):
+        assert paths.cli_socket.exists()
+        assert paths.harness_socket.exists()
+        reply = _request(paths, {"op": "__status__"})
+        assert reply == {"ok": True, "pid": os.getpid(), "windowed": False}
+
+
+def test_a_stale_slot_left_by_a_crash_is_reclaimed(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # A crashed predecessor leaves socket files bound-then-abandoned and a pidfile
+    # whose advisory lock nobody holds. A fresh serve() must reclaim the slot.
+    paths = daemon_paths(_project(tmp_path))
+    paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+    for stale in (paths.cli_socket, paths.harness_socket):
+        abandoned = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        abandoned.bind(str(stale))
+        abandoned.close()  # the file stays on disk; nothing listens
+    paths.pidfile.write_text("999999\n/nowhere\n", encoding="utf-8")
+
+    server = DaemonServer(paths, godot="godot", launch=_no_launch)
+    with _serving(server, paths, monkeypatch):
+        reply = _request(paths, {"op": "__status__"})
+        assert reply is not None and reply["ok"] is True
+
+
+def test_a_double_start_loses_without_touching_the_live_daemons_sockets(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # Two starts race; the pidfile's advisory lock decides. The LOSER must fail
+    # before it can unlink — or leave its cleanup to unlink — the winner's live
+    # socket files: a losing start that destroys the winner's sockets turns one
+    # daemon into zero (the winner keeps serving its open fd, but every new
+    # client connect hits an unlinked path and reads "not running").
+    paths = daemon_paths(_project(tmp_path))
+    winner = DaemonServer(paths, godot="godot", launch=_no_launch)
+
+    with _serving(winner, paths, monkeypatch):
+        loser = DaemonServer(paths, godot="godot", launch=_no_launch)
+        with pytest.raises(OSError):
+            loser.serve()
+
+        # The winner's slot is intact and still serves new connections.
+        assert paths.cli_socket.exists()
+        assert paths.harness_socket.exists()
+        reply = _request(paths, {"op": "__status__"})
+        assert reply is not None and reply["ok"] is True
+
+
+def test_stop_op_unlinks_the_sockets_and_pidfile(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_no_launch)
+
+    with _serving(server, paths, monkeypatch) as thread:
+        reply = _request(paths, {"op": "__stop__"})
+        assert reply is not None and reply["ok"] is True
+        thread.join(timeout=5)
+
+    assert not paths.cli_socket.exists()
+    assert not paths.harness_socket.exists()
+    assert not paths.pidfile.exists()
+
+
+def test_a_termination_signal_cleans_up_the_slot(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # The handler serve() registers for SIGTERM/SIGINT: closing the listener
+    # unblocks the pending accept, the loop exits, cleanup unlinks the slot.
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_no_launch)
+
+    with _serving(server, paths, monkeypatch) as thread:
+        server._on_signal(signal.SIGTERM, None)
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+    assert not paths.cli_socket.exists()
+    assert not paths.harness_socket.exists()
+    assert not paths.pidfile.exists()
+
+
+def test_an_overlong_socket_path_is_refused_at_start(tmp_path, monkeypatch):
+    # The UDS length refusal (ADR-0021): a runtime dir that pushes the derived
+    # socket path over sun_path is refused with a clear typed failure BEFORE any
+    # spawn, instead of the daemon's bind() failing and start timing out vaguely.
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / ("x" * 150)))
+
+    outcome = run_daemon_start_operation(_project(tmp_path), "godot")
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "daemon_not_running"
+    assert "socket path longer" in outcome.error.message
+
+
+def test_the_first_live_op_launches_the_session_lazily_and_reuses_it(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # The whole lazy-launch lifecycle through the REAL loop (ADR-0017): no session
+    # at bind time; the first live op launches one via the seam; the second op
+    # reuses it without relaunching.
+    calls = {"n": 0}
+    session = _ServedSession()
+
+    def _launch(*args, **kwargs):
+        calls["n"] += 1
+        return cast(EngineSession, session)
+
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_launch)
+
+    with _serving(server, paths, monkeypatch):
+        assert calls["n"] == 0  # binding alone launches nothing
+        first = _request(paths, {"op": "game-tree", "params": {}})
+        second = _request(paths, {"op": "perf-monitors", "params": {}})
+
+    assert first is not None and first["stdout"] == "served:game-tree"
+    assert second is not None and second["stdout"] == "served:perf-monitors"
+    assert calls["n"] == 1
+
+
+def test_a_failed_launch_is_the_typed_engine_session_not_running(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    def _launch(*args, **kwargs):
+        return None
+
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_launch)
+
+    with _serving(server, paths, monkeypatch):
+        reply = _request(paths, {"op": "game-tree", "params": {}})
+
+    assert reply is not None
+    assert (
+        parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    )
+
+
+def test_a_session_dying_mid_request_reports_disconnect_then_relaunches(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # Death mid-request, end to end: the session passes the liveness check, its
+    # connection breaks during the relay (the real EngineSession.request maps
+    # that to engine_disconnected), the engine process then dies, and the NEXT
+    # live op relaunches through the seam and serves.
+    ours, theirs = socket.socketpair()
+    theirs.close()  # the harness end is gone: the relay write breaks mid-request
+    proc = _Proc(code=None)  # alive at the pre-request liveness check
+    dying = EngineSession(cast(subprocess.Popen, proc), conn=ours)
+
+    launches: list = []
+
+    def _launch(*args, **kwargs):
+        launches.append(kwargs.get("log_file"))
+        if len(launches) == 1:
+            return dying
+        return cast(EngineSession, _ServedSession())
+
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_launch)
+
+    with _serving(server, paths, monkeypatch):
+        first = _request(paths, {"op": "game-tree", "params": {}})
+        proc.code = 1  # the engine process is now observed dead
+        second = _request(paths, {"op": "game-tree", "params": {}})
+
+    assert first is not None
+    assert parse_result(first["stdout"])["error"]["code"] == "engine_disconnected"
+    assert second is not None and second["stdout"] == "served:game-tree"
+    assert len(launches) == 2
+    # Every launch was asked to log to the one DaemonPaths-derived path (#674).
+    assert launches == [paths.session_log, paths.session_log]

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -190,18 +190,45 @@ def test_stop_op_unlinks_the_sockets_and_pidfile(
     assert not paths.pidfile.exists()
 
 
-def test_a_termination_signal_cleans_up_the_slot(
-    tmp_path, daemon_runtime_dir, monkeypatch
-):
-    # The handler serve() registers for SIGTERM/SIGINT: closing the listener
-    # unblocks the pending accept, the loop exits, cleanup unlinks the slot.
+def test_a_termination_signal_cleans_up_the_slot(tmp_path, daemon_runtime_dir):
+    # The REAL production signal path, in a forked child where serve() runs on
+    # the main thread exactly as the daemon does: SIGTERM interrupts the blocked
+    # accept (EINTR), the registered handler closes the listener and sets the
+    # stop flag, the loop exits, cleanup unlinks the slot. A worker-thread
+    # re-enactment is deliberately NOT used here — on Linux, closing a listener
+    # from another thread does not wake a blocked accept, which is a fact about
+    # threads, not about the signal path under test.
     paths = daemon_paths(_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_no_launch)
 
-    with _serving(server, paths, monkeypatch) as thread:
-        server._on_signal(signal.SIGTERM, None)
-        thread.join(timeout=5)
-        assert not thread.is_alive()
+    child = os.fork()
+    if child == 0:  # the daemon: serve until signalled, then leave pytest silently
+        try:
+            server.serve()
+        finally:
+            os._exit(0)
+
+    try:
+        _await_ready(paths)
+        os.kill(child, signal.SIGTERM)
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            done, _ = os.waitpid(child, os.WNOHANG)
+            if done == child:
+                break
+            time.sleep(0.02)
+        else:
+            os.kill(child, signal.SIGKILL)
+            os.waitpid(child, 0)
+            raise AssertionError("the daemon did not exit on SIGTERM")
+    except BaseException:
+        # Never leak the forked daemon into the rest of the suite.
+        try:
+            os.kill(child, signal.SIGKILL)
+            os.waitpid(child, 0)
+        except (OSError, ChildProcessError):
+            pass
+        raise
 
     assert not paths.cli_socket.exists()
     assert not paths.harness_socket.exists()

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -29,7 +29,12 @@ from typing import cast
 import pytest
 
 from gda.commands.daemon import run_daemon_start_operation
-from gda.daemon.discovery import daemon_paths
+from gda.daemon.discovery import (
+    _pidfile_lock_held,
+    daemon_paths,
+    daemon_pid,
+    read_pidfile,
+)
 from gda.daemon.protocol import read_message, write_message
 from gda.daemon.server import DaemonServer
 from gda.daemon.session import EngineSession
@@ -55,9 +60,9 @@ class _Proc:
 
 
 class _ServedSession:
-    """A fake session that serves every relayed op."""
+    """A fake session that serves every relayed op — a structural SessionHandle."""
 
-    log_file = None
+    log_file: "Path | None" = None
 
     def __init__(self) -> None:
         self.closed = False
@@ -151,14 +156,15 @@ def test_a_stale_slot_left_by_a_crash_is_reclaimed(
         assert reply is not None and reply["ok"] is True
 
 
-def test_a_double_start_loses_without_touching_the_live_daemons_sockets(
+def test_a_double_start_loses_without_touching_the_live_daemons_slot(
     tmp_path, daemon_runtime_dir, monkeypatch
 ):
     # Two starts race; the pidfile's advisory lock decides. The LOSER must fail
-    # before it can unlink — or leave its cleanup to unlink — the winner's live
-    # socket files: a losing start that destroys the winner's sockets turns one
-    # daemon into zero (the winner keeps serving its open fd, but every new
-    # client connect hits an unlinked path and reads "not running").
+    # without disturbing ANY part of the winner's slot (ADR-0021): not its
+    # socket files (a losing start that unlinks them turns one daemon into zero
+    # reachable ones), and not its pidfile CONTENT either — a pre-lock
+    # truncation erases the winner's recorded identity, so status, attach, and
+    # stop all read the live daemon as not running (#723 review).
     paths = daemon_paths(_project(tmp_path))
     winner = DaemonServer(paths, godot="godot", launch=_no_launch)
 
@@ -170,6 +176,48 @@ def test_a_double_start_loses_without_touching_the_live_daemons_sockets(
         # The winner's slot is intact and still serves new connections.
         assert paths.cli_socket.exists()
         assert paths.harness_socket.exists()
+        reply = _request(paths, {"op": "__status__"})
+        assert reply is not None and reply["ok"] is True
+        # And its DISCOVERY identity survives: the recorded pid + project are
+        # untouched, so the liveness contract still reports the winner.
+        assert read_pidfile(paths) == (os.getpid(), paths.project)
+        assert daemon_pid(paths) == os.getpid()
+
+
+def test_cleanup_removes_the_slot_before_releasing_the_lock(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # The reverse half of the slot's critical section (#723 review): the lock is
+    # the slot's mutual exclusion (ADR-0021), so it must outlive the slot it
+    # guards. Released before the unlinks, a successor can acquire and bind a
+    # fresh slot inside the cleanup window — which the predecessor's remaining
+    # unlinks then destroy. Instrumenting unlink pins the order: every slot
+    # path must be removed while the lock is still held.
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_no_launch)
+    slot = {paths.cli_socket, paths.harness_socket, paths.pidfile}
+    held_at_unlink: dict = {}
+    real_unlink = os.unlink
+
+    def _recording_unlink(path, *args, **kwargs):
+        target = Path(path)
+        if target in slot:
+            held_at_unlink[target.name] = _pidfile_lock_held(paths.pidfile)
+        return real_unlink(path, *args, **kwargs)
+
+    with _serving(server, paths, monkeypatch) as thread:
+        monkeypatch.setattr(os, "unlink", _recording_unlink)
+        _request(paths, {"op": "__stop__"})
+        thread.join(timeout=5)
+
+    assert len(held_at_unlink) == 3
+    assert all(held_at_unlink.values()), held_at_unlink
+
+    # The handoff itself: a successor started after the stop owns a fresh slot
+    # and is the one the discovery contract reports.
+    successor = DaemonServer(paths, godot="godot", launch=_no_launch)
+    with _serving(successor, paths, monkeypatch):
+        assert daemon_pid(paths) == os.getpid()
         reply = _request(paths, {"op": "__status__"})
         assert reply is not None and reply["ok"] is True
 
@@ -259,7 +307,7 @@ def test_the_first_live_op_launches_the_session_lazily_and_reuses_it(
 
     def _launch(*args, **kwargs):
         calls["n"] += 1
-        return cast(EngineSession, session)
+        return session
 
     paths = daemon_paths(_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
@@ -310,7 +358,7 @@ def test_a_session_dying_mid_request_reports_disconnect_then_relaunches(
         launches.append(kwargs.get("log_file"))
         if len(launches) == 1:
             return dying
-        return cast(EngineSession, _ServedSession())
+        return _ServedSession()
 
     paths = daemon_paths(_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)


### PR DESCRIPTION
## What

W4 slot 1, first half (the #674 preparatory refactor; #657 wait-ready stacks on the final server shape after this merges). Two behavior-preserving deliverables on the daemon's server↔session boundary, per the issue brief:

1. **Session-log path into `DaemonPaths`.** The path is now a field of the per-project on-disk identity (ADR-0021), derived in `daemon_paths()` beside the sockets and pidfile. `DaemonServer` consumes `paths.session_log`; the string-splitting re-derivation (`_session_log_path`) is gone. No caller derives it from a socket filename anymore.
2. **Server↔session seam + socket-lifecycle tests.** `DaemonServer` takes a `SessionLaunch` (a Protocol matching `launch_session`, which stays the default), so unit tests drive the **real serve loop** — real UDS bind, accept, reply, cleanup — against a fake session. New `tests/test_daemon_socket_lifecycle.py` covers, in the fast suite with no Godot binary:
   - bind + status over the socket; stale-slot reclaim (abandoned socket files + unlocked pidfile); double-start; stop-op cleanup; termination-signal cleanup; the UDS `sun_path` length refusal at `daemon start` (typed `daemon_not_running`, previously untested);
   - the session lifecycle through the seam: lazy launch on the first live op + reuse; launch failure as typed `engine_session_not_running`; **death mid-request** (a real `EngineSession` over a broken socketpair → `engine_disconnected`) followed by relaunch on the next op; and every launch receiving the one `DaemonPaths`-derived log path.

## One found defect, fixed (disclosed deviation from "no behavior change")

The mandated double-start test proved a real destructive race at head: `serve()` bound its sockets **before** taking the pidfile lock, so a LOSING second start unlinked the winner's live socket files during `_bind`, then failed at the lock, and its cleanup unlinked the slot again — turning one live daemon into zero reachable ones (new client connects hit an unlinked path and read "not running"). `serve()` now acquires the pidfile lock — the mutual exclusion AND liveness primitive — **first**, so a loser fails before touching the winner's slot. Red-proofed: the test fails on the pre-fix ordering with exactly that destruction, and passes on the fix. Liveness as the CLI reads it (lock held AND socket bound AND project matches) is unchanged; `daemon start`'s readiness poll (`daemon_pid`) is unaffected.

## Validation

- Fast suite: **1713 passed**; pyright 0 errors; ruff check/format clean.
- Behavior-preserving claim: `gda schema` + all-`--help` dump is **byte-identical** to the base (dev tip `16cc7bb8`).
- Real-engine daemon e2e (`tests/test_e2e_daemon.py`, Godot 4.6.3, serial under the shared lock): **27 passed**.
- The new lifecycle suite runs real UDS binds via the short-runtime-dir fixture (`sun_path` limit) and needs no engine.

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)