### PR TITLE
feat(gda): daemon wait-ready — a bounded, explicit engine-session readiness wait (#657)

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,8 +534,8 @@ reported as `script_aborted` with the captured error.
 
 | Command | What it does |
 | ------- | ------------ |
-| `daemon start` | Start the per-project daemon and install the in-game harness; the engine session launches on the first live op (`--windowed` for `screen` capture). |
-| `daemon wait-ready` | Establish the lazily-launched engine session and wait, bounded, until live reads serve — the documented way to be the first live op, so a first `diag errors` right after `daemon start` does not report `engine_session_not_running`. |
+| `daemon start` | Start the per-project daemon and install the in-game harness; the engine session launches on the first operation that requires one (`--windowed` for `screen` capture). |
+| `daemon wait-ready` | Establish the lazily-launched engine session and wait, bounded, until live reads serve — the documented way to trigger the session launch, since the read-only `diag`/`logger` reads never launch one and a first `diag errors` right after `daemon start` reports `engine_session_not_running` by design. |
 | `daemon stop` | Stop the project's daemon and any running engine session. |
 | `daemon status` | Report the daemon's state (running, windowed mode, session). |
 | `daemon install` | Install the in-game `gda` harness into the project without starting a daemon, reporting every path and section it created. Idempotent, and re-syncs a harness from an older `gda`. `daemon start` does this itself, so run it only to make that `project.godot` change deliberately — to review or commit it. |

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ reported as `script_aborted` with the captured error.
 | Command | What it does |
 | ------- | ------------ |
 | `daemon start` | Start the per-project daemon and install the in-game harness; the engine session launches on the first operation that requires one (`--windowed` for `screen` capture). |
-| `daemon wait-ready` | Establish the lazily-launched engine session and wait, bounded, until live reads serve — the documented way to trigger the session launch, since the read-only `diag`/`logger` reads never launch one and a first `diag errors` right after `daemon start` reports `engine_session_not_running` by design. |
+| `daemon wait-ready` | Establish the lazily-launched engine session so live reads serve. Its `--timeout` is the daemon-side budget shared by launch waits and new-work decisions; a synchronous launch call can delay when expiry is observed. This is the documented way to trigger the session launch, since the read-only `diag`/`logger` reads never launch one and a first `diag errors` right after `daemon start` reports `engine_session_not_running` by design. |
 | `daemon stop` | Stop the project's daemon and any running engine session. |
 | `daemon status` | Report the daemon's state (running, windowed mode, session). |
 | `daemon install` | Install the in-game `gda` harness into the project without starting a daemon, reporting every path and section it created. Idempotent, and re-syncs a harness from an older `gda`. `daemon start` does this itself, so run it only to make that `project.godot` change deliberately — to review or commit it. |

--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ reported as `script_aborted` with the captured error.
 | Command | What it does |
 | ------- | ------------ |
 | `daemon start` | Start the per-project daemon and install the in-game harness; the engine session launches on the first live op (`--windowed` for `screen` capture). |
+| `daemon wait-ready` | Establish the lazily-launched engine session and wait, bounded, until live reads serve — the documented way to be the first live op, so a first `diag errors` right after `daemon start` does not report `engine_session_not_running`. |
 | `daemon stop` | Stop the project's daemon and any running engine session. |
 | `daemon status` | Report the daemon's state (running, windowed mode, session). |
 | `daemon install` | Install the in-game `gda` harness into the project without starting a daemon, reporting every path and section it created. Idempotent, and re-syncs a harness from an older `gda`. `daemon start` does this itself, so run it only to make that `project.godot` change deliberately — to review or commit it. |

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=ce484830762f3beaff4c979423c5ae400f9e443d077393808ea1b566fefce7ff -->
+<!-- gda-readme-i18n: source=README.md sha256=8cb5ae07a2d875db3554b7840b6fc90efdca5fa1bd84da220a2de393f6871949 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -549,7 +549,7 @@ silencio en ambos flujos se termina en segundos en lugar de esperar al límite, 
 | Comando | Qué hace |
 | ------- | ------------ |
 | `daemon start` | Arranca el daemon por proyecto e instala el harness dentro del juego; la sesión del motor se lanza en la primera operación que la requiere (`--windowed` para la captura de `screen`). |
-| `daemon wait-ready` | Establece la sesión del motor de lanzamiento perezoso y espera, con límite, hasta que las lecturas live sirvan — la forma documentada de disparar ese lanzamiento explícitamente: las lecturas de solo lectura `diag`/`logger` nunca lanzan una sesión, así que un primer `diag errors` justo después de `daemon start` informa `engine_session_not_running` por diseño. |
+| `daemon wait-ready` | Establece la sesión del motor de lanzamiento perezoso para que las lecturas live respondan. `--timeout` es el presupuesto del daemon compartido por las esperas de lanzamiento y las decisiones de iniciar trabajo nuevo; una llamada de lanzamiento síncrona en curso puede retrasar la detección del vencimiento. Es la forma documentada de disparar ese lanzamiento explícitamente: las lecturas de solo lectura `diag`/`logger` nunca lanzan una sesión, así que un primer `diag errors` justo después de `daemon start` informa `engine_session_not_running` por diseño. |
 | `daemon stop` | Detiene el daemon del proyecto y cualquier sesión del motor en ejecución. |
 | `daemon status` | Informa el estado del daemon (en ejecución, modo con ventana, sesión). |
 | `daemon install` | Instala el harness `gda` dentro del proyecto sin iniciar un daemon, informando cada ruta y sección que creó. Idempotente, y resincroniza un harness de un `gda` anterior. `daemon start` ya lo hace por su cuenta, así que ejecútalo solo para realizar ese cambio en `project.godot` de forma deliberada — para revisarlo o confirmarlo. |

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=6c49dbe1f8202e9cfa46bc8fd79e1c78060238936b0d52e56ec01fd4f2f53e70 -->
+<!-- gda-readme-i18n: source=README.md sha256=3c57da598896485491b50b52cd19a411aecd42efff28a1242fe06c190f8e4462 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -549,6 +549,7 @@ silencio en ambos flujos se termina en segundos en lugar de esperar al límite, 
 | Comando | Qué hace |
 | ------- | ------------ |
 | `daemon start` | Arranca el daemon por proyecto e instala el harness dentro del juego; la sesión del motor se lanza en la primera operación live (`--windowed` para la captura de `screen`). |
+| `daemon wait-ready` | Establece la sesión del motor de lanzamiento perezoso y espera, con límite, hasta que las lecturas live sirvan — la forma documentada de ser la primera operación live, para que un primer `diag errors` justo después de `daemon start` no informe `engine_session_not_running`. |
 | `daemon stop` | Detiene el daemon del proyecto y cualquier sesión del motor en ejecución. |
 | `daemon status` | Informa el estado del daemon (en ejecución, modo con ventana, sesión). |
 | `daemon install` | Instala el harness `gda` dentro del proyecto sin iniciar un daemon, informando cada ruta y sección que creó. Idempotente, y resincroniza un harness de un `gda` anterior. `daemon start` ya lo hace por su cuenta, así que ejecútalo solo para realizar ese cambio en `project.godot` de forma deliberada — para revisarlo o confirmarlo. |

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=3c57da598896485491b50b52cd19a411aecd42efff28a1242fe06c190f8e4462 -->
+<!-- gda-readme-i18n: source=README.md sha256=ce484830762f3beaff4c979423c5ae400f9e443d077393808ea1b566fefce7ff -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -548,8 +548,8 @@ silencio en ambos flujos se termina en segundos en lugar de esperar al límite, 
 
 | Comando | Qué hace |
 | ------- | ------------ |
-| `daemon start` | Arranca el daemon por proyecto e instala el harness dentro del juego; la sesión del motor se lanza en la primera operación live (`--windowed` para la captura de `screen`). |
-| `daemon wait-ready` | Establece la sesión del motor de lanzamiento perezoso y espera, con límite, hasta que las lecturas live sirvan — la forma documentada de ser la primera operación live, para que un primer `diag errors` justo después de `daemon start` no informe `engine_session_not_running`. |
+| `daemon start` | Arranca el daemon por proyecto e instala el harness dentro del juego; la sesión del motor se lanza en la primera operación que la requiere (`--windowed` para la captura de `screen`). |
+| `daemon wait-ready` | Establece la sesión del motor de lanzamiento perezoso y espera, con límite, hasta que las lecturas live sirvan — la forma documentada de disparar ese lanzamiento explícitamente: las lecturas de solo lectura `diag`/`logger` nunca lanzan una sesión, así que un primer `diag errors` justo después de `daemon start` informa `engine_session_not_running` por diseño. |
 | `daemon stop` | Detiene el daemon del proyecto y cualquier sesión del motor en ejecución. |
 | `daemon status` | Informa el estado del daemon (en ejecución, modo con ventana, sesión). |
 | `daemon install` | Instala el harness `gda` dentro del proyecto sin iniciar un daemon, informando cada ruta y sección que creó. Idempotente, y resincroniza un harness de un `gda` anterior. `daemon start` ya lo hace por su cuenta, así que ejecútalo solo para realizar ese cambio en `project.godot` de forma deliberada — para revisarlo o confirmarlo. |

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=6c49dbe1f8202e9cfa46bc8fd79e1c78060238936b0d52e56ec01fd4f2f53e70 -->
+<!-- gda-readme-i18n: source=README.md sha256=3c57da598896485491b50b52cd19a411aecd42efff28a1242fe06c190f8e4462 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -545,6 +545,7 @@ offset プロパティを明示的に設定してください。
 | コマンド | 機能 |
 | ------- | ------------ |
 | `daemon start` | プロジェクトごとのデーモンを起動し、ゲーム内ハーネスをインストールします。エンジンセッションは最初の Live 操作で起動します(`screen` キャプチャには `--windowed`)。 |
+| `daemon wait-ready` | 遅延起動されるエンジンセッションを確立し、Live 読み取りが応答するまで上限つきで待ちます — 「最初の Live 操作」になるための正規の方法で、`daemon start` 直後の最初の `diag errors` が `engine_session_not_running` を報告しなくなります。 |
 | `daemon stop` | プロジェクトのデーモンと、実行中のエンジンセッションを停止します。 |
 | `daemon status` | デーモンの状態(実行中か、ウィンドウモードか、セッション)を報告します。 |
 | `daemon install` | デーモンを起動せずにゲーム内 `gda` harness をプロジェクトへインストールし、作成したパスとセクションをすべて報告します。冪等で、古い `gda` の harness は現行版に再同期されます。`daemon start` 自身がこれを行うため、その `project.godot` の変更を意図的に(レビューやコミットのために)行いたいときにだけ実行します。 |

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=3c57da598896485491b50b52cd19a411aecd42efff28a1242fe06c190f8e4462 -->
+<!-- gda-readme-i18n: source=README.md sha256=ce484830762f3beaff4c979423c5ae400f9e443d077393808ea1b566fefce7ff -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -544,8 +544,8 @@ offset プロパティを明示的に設定してください。
 
 | コマンド | 機能 |
 | ------- | ------------ |
-| `daemon start` | プロジェクトごとのデーモンを起動し、ゲーム内ハーネスをインストールします。エンジンセッションは最初の Live 操作で起動します(`screen` キャプチャには `--windowed`)。 |
-| `daemon wait-ready` | 遅延起動されるエンジンセッションを確立し、Live 読み取りが応答するまで上限つきで待ちます — 「最初の Live 操作」になるための正規の方法で、`daemon start` 直後の最初の `diag errors` が `engine_session_not_running` を報告しなくなります。 |
+| `daemon start` | プロジェクトごとのデーモンを起動し、ゲーム内ハーネスをインストールします。エンジンセッションは、それを必要とする最初の操作で起動します(`screen` キャプチャには `--windowed`)。 |
+| `daemon wait-ready` | 遅延起動されるエンジンセッションを確立し、Live 読み取りが応答するまで上限つきで待ちます — セッション起動を明示的にトリガーする正規の方法です。読み取り専用の `diag`/`logger` はセッションを起動しないため、`daemon start` 直後の最初の `diag errors` は設計上 `engine_session_not_running` を報告します。 |
 | `daemon stop` | プロジェクトのデーモンと、実行中のエンジンセッションを停止します。 |
 | `daemon status` | デーモンの状態(実行中か、ウィンドウモードか、セッション)を報告します。 |
 | `daemon install` | デーモンを起動せずにゲーム内 `gda` harness をプロジェクトへインストールし、作成したパスとセクションをすべて報告します。冪等で、古い `gda` の harness は現行版に再同期されます。`daemon start` 自身がこれを行うため、その `project.godot` の変更を意図的に(レビューやコミットのために)行いたいときにだけ実行します。 |

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=ce484830762f3beaff4c979423c5ae400f9e443d077393808ea1b566fefce7ff -->
+<!-- gda-readme-i18n: source=README.md sha256=8cb5ae07a2d875db3554b7840b6fc90efdca5fa1bd84da220a2de393f6871949 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -545,7 +545,7 @@ offset プロパティを明示的に設定してください。
 | コマンド | 機能 |
 | ------- | ------------ |
 | `daemon start` | プロジェクトごとのデーモンを起動し、ゲーム内ハーネスをインストールします。エンジンセッションは、それを必要とする最初の操作で起動します(`screen` キャプチャには `--windowed`)。 |
-| `daemon wait-ready` | 遅延起動されるエンジンセッションを確立し、Live 読み取りが応答するまで上限つきで待ちます — セッション起動を明示的にトリガーする正規の方法です。読み取り専用の `diag`/`logger` はセッションを起動しないため、`daemon start` 直後の最初の `diag errors` は設計上 `engine_session_not_running` を報告します。 |
+| `daemon wait-ready` | 遅延起動されるエンジンセッションを確立し、Live 読み取りを応答可能にします。`--timeout` は、デーモン側の起動待機と新しい処理の開始判断で共有する予算です。実行中の同期起動呼び出しにより、期限切れの検出が遅れることがあります。これはセッション起動を明示的にトリガーする正規の方法です。読み取り専用の `diag`/`logger` はセッションを起動しないため、`daemon start` 直後の最初の `diag errors` は設計上 `engine_session_not_running` を報告します。 |
 | `daemon stop` | プロジェクトのデーモンと、実行中のエンジンセッションを停止します。 |
 | `daemon status` | デーモンの状態(実行中か、ウィンドウモードか、セッション)を報告します。 |
 | `daemon install` | デーモンを起動せずにゲーム内 `gda` harness をプロジェクトへインストールし、作成したパスとセクションをすべて報告します。冪等で、古い `gda` の harness は現行版に再同期されます。`daemon start` 自身がこれを行うため、その `project.godot` の変更を意図的に(レビューやコミットのために)行いたいときにだけ実行します。 |

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=ce484830762f3beaff4c979423c5ae400f9e443d077393808ea1b566fefce7ff -->
+<!-- gda-readme-i18n: source=README.md sha256=8cb5ae07a2d875db3554b7840b6fc90efdca5fa1bd84da220a2de393f6871949 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -517,7 +517,7 @@ problem 列表只对它到达的那个阶段完整，并非一次覆盖两个阶
 | 命令 | 作用 |
 | ------- | ------------ |
 | `daemon start` | 启动按项目运行的 daemon 并安装游戏内 harness；引擎会话会在第一个需要它的操作时启动（`screen` 截图需加 `--windowed`）。 |
-| `daemon wait-ready` | 建立惰性启动的引擎会话并在有界等待内等到 Live 读取可服务——这是显式触发会话启动的规范做法：只读的 `diag`/`logger` 读取从不启动会话，所以 `daemon start` 之后的第一次 `diag errors` 按设计会报 `engine_session_not_running`。 |
+| `daemon wait-ready` | 建立惰性启动的引擎会话，使 Live 读取可服务。`--timeout` 是 daemon 端由启动等待和新工作决策共享的预算；正在执行的同步启动调用可能延后过期状态的观察。这是显式触发会话启动的规范做法：只读的 `diag`/`logger` 读取从不启动会话，所以 `daemon start` 之后的第一次 `diag errors` 按设计会报 `engine_session_not_running`。 |
 | `daemon stop` | 停止项目的 daemon 以及任何正在运行的引擎会话。 |
 | `daemon status` | 报告 daemon 的状态（是否运行、窗口模式、会话）。 |
 | `daemon install` | 在不启动 daemon 的情况下把游戏内 `gda` harness 安装进项目，并报告它创建的每个路径与配置段。幂等，并会把旧版 `gda` 装下的 harness 同步为当前版本。`daemon start` 自己就会执行这一步，因此只有在你想显式地做出这次 `project.godot` 改动（例如便于审阅或提交）时才需要它。 |

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=6c49dbe1f8202e9cfa46bc8fd79e1c78060238936b0d52e56ec01fd4f2f53e70 -->
+<!-- gda-readme-i18n: source=README.md sha256=3c57da598896485491b50b52cd19a411aecd42efff28a1242fe06c190f8e4462 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -517,6 +517,7 @@ problem 列表只对它到达的那个阶段完整，并非一次覆盖两个阶
 | 命令 | 作用 |
 | ------- | ------------ |
 | `daemon start` | 启动按项目运行的 daemon 并安装游戏内 harness；引擎会话会在第一个 Live 操作时启动（`screen` 截图需加 `--windowed`）。 |
+| `daemon wait-ready` | 建立惰性启动的引擎会话并在有界等待内等到 Live 读取可服务——这是“第一个 Live 操作”的规范做法，如此 `daemon start` 之后的第一次 `diag errors` 就不会报 `engine_session_not_running`。 |
 | `daemon stop` | 停止项目的 daemon 以及任何正在运行的引擎会话。 |
 | `daemon status` | 报告 daemon 的状态（是否运行、窗口模式、会话）。 |
 | `daemon install` | 在不启动 daemon 的情况下把游戏内 `gda` harness 安装进项目，并报告它创建的每个路径与配置段。幂等，并会把旧版 `gda` 装下的 harness 同步为当前版本。`daemon start` 自己就会执行这一步，因此只有在你想显式地做出这次 `project.godot` 改动（例如便于审阅或提交）时才需要它。 |

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=3c57da598896485491b50b52cd19a411aecd42efff28a1242fe06c190f8e4462 -->
+<!-- gda-readme-i18n: source=README.md sha256=ce484830762f3beaff4c979423c5ae400f9e443d077393808ea1b566fefce7ff -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -516,8 +516,8 @@ problem 列表只对它到达的那个阶段完整，并非一次覆盖两个阶
 
 | 命令 | 作用 |
 | ------- | ------------ |
-| `daemon start` | 启动按项目运行的 daemon 并安装游戏内 harness；引擎会话会在第一个 Live 操作时启动（`screen` 截图需加 `--windowed`）。 |
-| `daemon wait-ready` | 建立惰性启动的引擎会话并在有界等待内等到 Live 读取可服务——这是“第一个 Live 操作”的规范做法，如此 `daemon start` 之后的第一次 `diag errors` 就不会报 `engine_session_not_running`。 |
+| `daemon start` | 启动按项目运行的 daemon 并安装游戏内 harness；引擎会话会在第一个需要它的操作时启动（`screen` 截图需加 `--windowed`）。 |
+| `daemon wait-ready` | 建立惰性启动的引擎会话并在有界等待内等到 Live 读取可服务——这是显式触发会话启动的规范做法：只读的 `diag`/`logger` 读取从不启动会话，所以 `daemon start` 之后的第一次 `diag errors` 按设计会报 `engine_session_not_running`。 |
 | `daemon stop` | 停止项目的 daemon 以及任何正在运行的引擎会话。 |
 | `daemon status` | 报告 daemon 的状态（是否运行、窗口模式、会话）。 |
 | `daemon install` | 在不启动 daemon 的情况下把游戏内 `gda` harness 安装进项目，并报告它创建的每个路径与配置段。幂等，并会把旧版 `gda` 装下的 harness 同步为当前版本。`daemon start` 自己就会执行这一步，因此只有在你想显式地做出这次 `project.godot` 改动（例如便于审阅或提交）时才需要它。 |

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -138,9 +138,8 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > which is how an exhausted budget came back whole for a replacement launch.
 >
 > What the instant is, precisely: a **budget for waiting and for committing to new work**, not a
-> hard wall clock. It cannot be the latter — nothing here can interrupt a synchronous system
-> call already in flight, and gda is not going to introduce threads and cancellation to pretend
-> otherwise. So the guarantee is stated as three rules. No phase gets a fresh grace. Every timed
+> hard wall clock. A hard wall-clock limit would require cancellation around synchronous calls;
+> this design does not add that mechanism, so the guarantee is stated as three rules instead. No phase gets a fresh grace. Every timed
 > wait uses what remains, computed where the wait begins rather than where it was decided. And
 > once the instant has passed, the boundary **commits to nothing further** — it does not launch,
 > and a launch already committed is torn down. A slow liveness check, a slow filesystem write, a

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -116,7 +116,8 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > and `gda logger tail` are live operations the daemon serves from the Session log it owns, and they
 > deliberately launch nothing (ADR-0022). The precise rule, and the wording every public surface
 > uses, is that a session launches on **the first operation that REQUIRES an Engine session**.
-> `gda daemon wait-ready` is the explicit, bounded way to BE that operation — the documented
+> `gda daemon wait-ready` is the explicit way to BE that operation, with one daemon-side
+> wait/commit budget — the documented
 > alternative to firing a throwaway read — so an agent can establish the session up front and have
 > its first real read serve, including a first `diag errors`. It is one command in the `daemon`
 > group carried on the live channel (`kind = LIVE`, the `diag errors` precedent); the group-module
@@ -139,7 +140,8 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 >
 > What the instant is, precisely: a **budget for waiting and for committing to new work**, not a
 > hard wall clock. A hard wall-clock limit would require cancellation around synchronous calls;
-> this design does not add that mechanism, so the guarantee is stated as three rules instead. No phase gets a fresh grace. Every timed
+> this design does not add that mechanism, so the guarantee is stated as three rules instead.
+> No phase gets a fresh grace. Every timed
 > wait uses what remains, computed where the wait begins rather than where it was decided. And
 > once the instant has passed, the boundary **commits to nothing further** — it does not launch,
 > and a launch already committed is torn down. A slow liveness check, a slow filesystem write, a

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -130,6 +130,15 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > re-review). A stale session is rebuilt through the same lazy-launch boundary, so `live_timeout`
 > costs a relaunch and, per ADR-0020, the runtime state does not survive it. Correlating replies
 > instead would change the cross-language harness protocol and is left to its own decision.
+>
+> **One deadline, owned by the launch boundary.** Everything that boundary does on a caller's
+> clock draws from a single deadline: retiring the session being replaced, the connect, each
+> handshake frame, and the teardown of a failed launch. Two consequences are not obvious. A
+> socket timeout bounds *inactivity*, so a frame read in chunks must recompute the remaining
+> budget per read or a trickling peer holds the reader indefinitely — the daemon serves one
+> request at a time, so that is every later request too. And retirement is not free: an engine
+> that ignores `SIGTERM` is escalated with what the deadline has left, not with a fresh grace
+> of its own.
 
 ## Decision
 

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -143,7 +143,8 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > indefinitely — the daemon serves one request at a time, so that is every later request too.
 > Retirement is not free: an engine that ignores `SIGTERM` is escalated with what the deadline
 > has left, not with a fresh grace. Collecting a killed child is a duty but not the caller's
-> time, so it is neither charged nor dropped — it happens in the background. And the spawn is
+> time, so it happens in the background — best-effort, since SIGKILL cannot be caught and the
+> cost of a rare miss is one process-table entry the daemon's own exit clears. And the spawn is
 > the one step that cannot be interrupted once begun: the deadline is checked before it and
 > governs everything after, so a spawn that outruns the budget ends in a refusal rather than in
 > a session that came up late.

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -132,13 +132,27 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > instead would change the cross-language harness protocol and is left to its own decision.
 >
 > **One deadline, owned by the launch boundary.** Everything that boundary does on a caller's
-> clock draws from a single deadline: retiring the session being replaced, the connect, each
-> handshake frame, and the teardown of a failed launch. Two consequences are not obvious. A
-> socket timeout bounds *inactivity*, so a frame read in chunks must recompute the remaining
-> budget per read or a trickling peer holds the reader indefinitely — the daemon serves one
-> request at a time, so that is every later request too. And retirement is not free: an engine
-> that ignores `SIGTERM` is escalated with what the deadline has left, not with a fresh grace
-> of its own.
+> clock draws from a single deadline: retiring the session being replaced, the spawn, the
+> connect, each handshake frame, and the teardown of a failed launch. It travels as an
+> **absolute instant**, never as a duration — a duration restarts whatever clock receives it,
+> which is how an exhausted budget came back whole for a replacement launch. When the instant
+> has passed, the boundary REFUSES rather than launching past it.
+>
+> Four consequences are not obvious. A socket timeout bounds *inactivity*, so a frame read in
+> chunks must recompute the remaining budget per read or a trickling peer holds the reader
+> indefinitely — the daemon serves one request at a time, so that is every later request too.
+> Retirement is not free: an engine that ignores `SIGTERM` is escalated with what the deadline
+> has left, not with a fresh grace. Collecting a killed child is a duty but not the caller's
+> time, so it is neither charged nor dropped — it happens in the background. And the spawn is
+> the one step that cannot be interrupted once begun: the deadline is checked before it and
+> governs everything after, so a spawn that outruns the budget ends in a refusal rather than in
+> a session that came up late.
+>
+> The same rule applies to the op relay's own `live_timeout` ceiling, which had the same
+> inactivity shape. Accepted deliberately, and beyond what the `wait-ready` slice needed: a
+> trickled reply now reaches that ceiling where before it completed, and since a timed-out relay
+> marks the channel stale, the consequence is a relaunch and the loss of runtime state. The
+> alternative was to keep publishing a bound that was not one.
 
 ## Decision
 

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -156,7 +156,10 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > miss leaves one process-table entry that the OS clears when the daemon exits and the child is
 > reparented. And retirement is of the engine's **process group**, not of the engine process:
 > gda owns the group (`start_new_session=True`), so the leader's fate does not decide the
-> group's.
+> group's. The captured group id remains a numeric POSIX identifier, not a durable handle. Once
+> every original group member exits, the kernel may reuse that number before teardown observes
+> the empty group; a signal in that narrow window could then reach a new group. This design
+> accepts that residual race instead of adding platform-specific process supervision.
 >
 > The same rule applies to the op relay's own `live_timeout` ceiling, which had the same
 > inactivity shape. Accepted deliberately, and beyond what the `wait-ready` slice needed: a

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -27,7 +27,8 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > session is **launched lazily on the first live op**, not eagerly at `daemon start` —
 > consistent with this ADR's "(re)launched per feedback-loop iteration"; `daemon start`
 > brings up the persistent daemon and the harness install, and the session follows on
-> demand.
+> demand. (Since #224 not every live op needs a session; the 2026-08-21 amendment below
+> restates the trigger precisely.)
 
 > **Outcome (2026-06-22, #220) — live op-errors are minted LIVE-category,
 > classifier-source codes, one family per live op.** When `game get` / `game set`
@@ -86,7 +87,8 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 >
 > **Public surface — `gda daemon start --scene <path|UID>`.** It is a **start-time daemon option**:
 > the daemon holds the value and passes it to the engine as `--scene <path|UID>` (an engine option,
-> before `--path`) when the session is **lazily launched on the first live op** (the #7 note above).
+> before `--path`) when the session is **lazily launched** (the #7 note above, restated precisely by
+> the 2026-08-21 amendment: on the first operation that requires a session).
 > With no `--scene`, behaviour is unchanged (runs `main_scene`). The selector accepts a scene **path
 > or UID** (per Godot's `--scene`). Any `scene play` / `game run` ergonomic wrapper is a **separate
 > follow-up**, not part of this amendment.
@@ -105,6 +107,29 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > gda-owned game, headless by default, same harness and live surface (ADR-0019 / 0020), only with a
 > chosen entry scene. The selector-less default is unchanged. Realized by the run-a-scene slice
 > (#278); the surface-inclusion rationale (why `run` is in scope at all) is recorded in ADR-0025.
+
+> **Amendment (2026-08-21, #657) — when a session is launched, and when it is still serving.**
+> Two clarifications; the lazy-launch decision itself is unchanged.
+>
+> **Launch trigger — say "requires", not "live op".** The #7 note above reads "launched lazily on
+> the first live op", true when every live op needed a session. It no longer is: `gda diag errors`
+> and `gda logger tail` are live operations the daemon serves from the Session log it owns, and they
+> deliberately launch nothing (ADR-0022). The precise rule, and the wording every public surface
+> uses, is that a session launches on **the first operation that REQUIRES an Engine session**.
+> `gda daemon wait-ready` is the explicit, bounded way to BE that operation — the documented
+> alternative to firing a throwaway read — so an agent can establish the session up front and have
+> its first real read serve, including a first `diag errors`. It is one command in the `daemon`
+> group carried on the live channel (`kind = LIVE`, the `diag errors` precedent); the group-module
+> consequence is recorded on ADR-0040.
+>
+> **Serving state — the process AND the channel.** A session is serving only while its harness
+> channel can still answer the operation that asked. The daemon therefore marks the channel stale
+> on a dropped or closed connection AND on a relay that timed out: this ADR's one-op-at-a-time RPC
+> carries no request id and a timed-out frame is not drained, so a late reply would be read as the
+> NEXT operation's reply — a validly-framed, semantically wrong answer (reproduced in #725's
+> re-review). A stale session is rebuilt through the same lazy-launch boundary, so `live_timeout`
+> costs a relaunch and, per ADR-0020, the runtime state does not survive it. Correlating replies
+> instead would change the cross-language harness protocol and is left to its own decision.
 
 ## Decision
 

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -135,19 +135,27 @@ tracked by the Phase-2 PRD (#6) and the gda-daemon feature (#7).
 > clock draws from a single deadline: retiring the session being replaced, the spawn, the
 > connect, each handshake frame, and the teardown of a failed launch. It travels as an
 > **absolute instant**, never as a duration — a duration restarts whatever clock receives it,
-> which is how an exhausted budget came back whole for a replacement launch. When the instant
-> has passed, the boundary REFUSES rather than launching past it.
+> which is how an exhausted budget came back whole for a replacement launch.
+>
+> What the instant is, precisely: a **budget for waiting and for committing to new work**, not a
+> hard wall clock. It cannot be the latter — nothing here can interrupt a synchronous system
+> call already in flight, and gda is not going to introduce threads and cancellation to pretend
+> otherwise. So the guarantee is stated as three rules. No phase gets a fresh grace. Every timed
+> wait uses what remains, computed where the wait begins rather than where it was decided. And
+> once the instant has passed, the boundary **commits to nothing further** — it does not launch,
+> and a launch already committed is torn down. A slow liveness check, a slow filesystem write, a
+> slow spawn: each can delay *when* expiry is observed, and none of them earns a new budget.
 >
 > Four consequences are not obvious. A socket timeout bounds *inactivity*, so a frame read in
 > chunks must recompute the remaining budget per read or a trickling peer holds the reader
 > indefinitely — the daemon serves one request at a time, so that is every later request too.
 > Retirement is not free: an engine that ignores `SIGTERM` is escalated with what the deadline
 > has left, not with a fresh grace. Collecting a killed child is a duty but not the caller's
-> time, so it happens in the background — best-effort, since SIGKILL cannot be caught and the
-> cost of a rare miss is one process-table entry the daemon's own exit clears. And the spawn is
-> the one step that cannot be interrupted once begun: the deadline is checked before it and
-> governs everything after, so a spawn that outruns the budget ends in a refusal rather than in
-> a session that came up late.
+> time, so it happens in the background — best-effort, since SIGKILL cannot be caught and a rare
+> miss leaves one process-table entry that the OS clears when the daemon exits and the child is
+> reparented. And retirement is of the engine's **process group**, not of the engine process:
+> gda owns the group (`start_new_session=True`), so the leader's fate does not decide the
+> group's.
 >
 > The same rule applies to the op relay's own `live_timeout` ceiling, which had the same
 > inactivity shape. Accepted deliberately, and beyond what the `wait-ready` slice needed: a

--- a/docs/adr/0040-per-command-group-modules.md
+++ b/docs/adr/0040-per-command-group-modules.md
@@ -4,6 +4,13 @@ status: accepted
 
 # Per-command-group modules: vertical group slices over the shared descriptor core
 
+> **Amendment (2026-08-20, #657):** the module-tree sketch below annotates
+> `daemon.py` as "recipe-backed, not LIVE". Since #657 the group carries ONE
+> `kind = LIVE` command — `daemon wait-ready`, which routes through the live
+> channel (daemon-served, like `diag errors`) because its object is the engine
+> session the daemon holds. The rest of the group stays recipe-backed as
+> decided; the module docstring of `gda.commands.daemon` records the exception.
+
 ADR-0023 made the `HeadlessCommand` descriptor the single per-command registration
 and left one follow-on open: the per-command-group module split, "rejected for now
 ... revisit in its own ADR if the descriptor consolidation proves insufficient."

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -845,7 +845,8 @@ headless is unaffected (4.4+, cross-platform).
   deterministically: a session launches on the first operation that REQUIRES one (ADR-0017),
   and the read-only diag/logger reads never do (ADR-0022), so a first `diag errors` right
   after start reports `engine_session_not_running` by design — `wait-ready` is the
-  documented, bounded way to trigger that launch explicitly. `--timeout` is ONE deadline over the whole
+  documented way to trigger that launch explicitly, with one daemon-side wait/commit budget.
+  `--timeout` is ONE deadline over the whole
   daemon-side readiness attempt — retiring the session being replaced, the
   spawn, the harness connect, the token and scene-verification frames (each read against the
   deadline, not a per-chunk inactivity timeout), and the teardown of a failed launch (a finite

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -846,8 +846,10 @@ headless is unaffected (4.4+, cross-platform).
   and the read-only diag/logger reads never do (ADR-0022), so a first `diag errors` right
   after start reports `engine_session_not_running` by design — `wait-ready` is the
   documented, bounded way to trigger that launch explicitly. `--timeout` bounds the whole
-  daemon-side readiness attempt — the harness connect, the token and scene-verification
-  frames, and the teardown of a failed launch (a finite number in (0, 50], under the live
+  daemon-side readiness attempt on ONE deadline — retiring the session being replaced, the
+  harness connect, the token and scene-verification frames (each read against the deadline,
+  not a per-chunk inactivity timeout), and the teardown of a failed launch (a finite number
+  in (0, 50], under the live
   channel's 60s client-side round-trip bound); success (`{pid, launched}`) means subsequent
   live reads serve, and a repeat while the session is alive is idempotent (`launched:
   false`, nothing relaunched). A session stops serving when its harness channel breaks OR

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -839,8 +839,16 @@ headless is unaffected (4.4+, cross-platform).
   as a verbatim `info` record (the superseded `diag log` view, still `LogRecord[]`). Daemon-served
   and crash-survivable like `diag` (ADR-0022). The opt-in rich `gda_log()` protocol layers on in a
   follow-up slice (#282).
-- **lifecycle (the `daemon` command group):** `gda daemon start` / `stop` / `status`, and `gda daemon
-  install` / `uninstall` for the `gda harness` (ADR-0018). `daemon start --windowed` additionally
+- **lifecycle (the `daemon` command group):** `gda daemon start` / `stop` / `status` /
+  `wait-ready`, and `gda daemon install` / `uninstall` for the `gda harness` (ADR-0018).
+  `daemon wait-ready` (`kind = LIVE`, #657) establishes the lazily-launched engine session
+  deterministically: sessions launch on the first live op (ADR-0017), and the read-only
+  diag/logger reads never launch one (ADR-0022), so a first `diag errors` right after start
+  reports `engine_session_not_running` by design — `wait-ready` is the documented, bounded
+  way to be that first op. `--timeout` bounds the launch's harness-connect wait inside the
+  daemon (a finite number in (0, 50], under the live channel's 60s client-side round-trip
+  bound); success (`{pid, launched}`) means subsequent live reads serve, and a repeat while
+  the session is alive is idempotent (`launched: false`, nothing relaunched). `daemon start --windowed` additionally
   requires the host's desktop session — an on-console GUI login on macOS, `$DISPLAY` /
   `$WAYLAND_DISPLAY` on Linux — because a windowed Godot aborts during `DisplayServer`
   registration without one; it is checked pre-launch (#345) and refused with one of two

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -847,10 +847,12 @@ headless is unaffected (4.4+, cross-platform).
   after start reports `engine_session_not_running` by design — `wait-ready` is the
   documented, bounded way to trigger that launch explicitly. `--timeout` bounds the whole
   daemon-side readiness attempt on ONE deadline — retiring the session being replaced, the
-  harness connect, the token and scene-verification frames (each read against the deadline,
-  not a per-chunk inactivity timeout), and the teardown of a failed launch (a finite number
-  in (0, 50], under the live
-  channel's 60s client-side round-trip bound); success (`{pid, launched}`) means subsequent
+  spawn, the harness connect, the token and scene-verification frames (each read against the
+  deadline, not a per-chunk inactivity timeout), and the teardown of a failed launch (a finite
+  number in (0, 50], under the live channel's 60s client-side round-trip bound). A deadline
+  already spent is a refusal, not a fresh budget: nothing is launched past it. The one step
+  gda cannot interrupt is the spawn itself, so a spawn that outruns the budget ends in that
+  same refusal; success (`{pid, launched}`) means subsequent
   live reads serve, and a repeat while the session is alive is idempotent (`launched:
   false`, nothing relaunched). A session stops serving when its harness channel breaks OR
   when a relay hits `live_timeout` — the one-op-at-a-time RPC carries no request id, so a

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -845,14 +845,15 @@ headless is unaffected (4.4+, cross-platform).
   deterministically: a session launches on the first operation that REQUIRES one (ADR-0017),
   and the read-only diag/logger reads never do (ADR-0022), so a first `diag errors` right
   after start reports `engine_session_not_running` by design — `wait-ready` is the
-  documented, bounded way to trigger that launch explicitly. `--timeout` bounds the whole
-  daemon-side readiness attempt on ONE deadline — retiring the session being replaced, the
+  documented, bounded way to trigger that launch explicitly. `--timeout` is ONE deadline over the whole
+  daemon-side readiness attempt — retiring the session being replaced, the
   spawn, the harness connect, the token and scene-verification frames (each read against the
   deadline, not a per-chunk inactivity timeout), and the teardown of a failed launch (a finite
-  number in (0, 50], under the live channel's 60s client-side round-trip bound). A deadline
-  already spent is a refusal, not a fresh budget: nothing is launched past it. The one step
-  gda cannot interrupt is the spawn itself, so a spawn that outruns the budget ends in that
-  same refusal; success (`{pid, launched}`) means subsequent
+  number in (0, 50], under the live channel's 60s client-side round-trip bound). It is a budget
+  for waiting and for committing to new work rather than a hard wall clock — no phase gets a
+  fresh grace, every timed wait uses what remains, and once it is spent nothing further is
+  launched — but a synchronous step already in flight (a filesystem write, the spawn itself)
+  can delay when that expiry is observed. Success (`{pid, launched}`) means subsequent
   live reads serve, and a repeat while the session is alive is idempotent (`launched:
   false`, nothing relaunched). A session stops serving when its harness channel breaks OR
   when a relay hits `live_timeout` — the one-op-at-a-time RPC carries no request id, so a

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -845,10 +845,15 @@ headless is unaffected (4.4+, cross-platform).
   deterministically: a session launches on the first operation that REQUIRES one (ADR-0017),
   and the read-only diag/logger reads never do (ADR-0022), so a first `diag errors` right
   after start reports `engine_session_not_running` by design — `wait-ready` is the
-  documented, bounded way to trigger that launch explicitly. `--timeout` bounds the launch's harness-connect wait inside the
-  daemon (a finite number in (0, 50], under the live channel's 60s client-side round-trip
-  bound); success (`{pid, launched}`) means subsequent live reads serve, and a repeat while
-  the session is alive is idempotent (`launched: false`, nothing relaunched). `daemon start --windowed` additionally
+  documented, bounded way to trigger that launch explicitly. `--timeout` bounds the whole
+  daemon-side readiness attempt — the harness connect, the token and scene-verification
+  frames, and the teardown of a failed launch (a finite number in (0, 50], under the live
+  channel's 60s client-side round-trip bound); success (`{pid, launched}`) means subsequent
+  live reads serve, and a repeat while the session is alive is idempotent (`launched:
+  false`, nothing relaunched). A session stops serving when its harness channel breaks OR
+  when a relay hits `live_timeout` — the one-op-at-a-time RPC carries no request id, so a
+  late reply can no longer be attributed — and the next operation that requires a session
+  relaunches it, losing runtime state (ADR-0017 amendment, ADR-0020). `daemon start --windowed` additionally
   requires the host's desktop session — an on-console GUI login on macOS, `$DISPLAY` /
   `$WAYLAND_DISPLAY` on Linux — because a windowed Godot aborts during `DisplayServer`
   registration without one; it is checked pre-launch (#345) and refused with one of two

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -842,10 +842,10 @@ headless is unaffected (4.4+, cross-platform).
 - **lifecycle (the `daemon` command group):** `gda daemon start` / `stop` / `status` /
   `wait-ready`, and `gda daemon install` / `uninstall` for the `gda harness` (ADR-0018).
   `daemon wait-ready` (`kind = LIVE`, #657) establishes the lazily-launched engine session
-  deterministically: sessions launch on the first live op (ADR-0017), and the read-only
-  diag/logger reads never launch one (ADR-0022), so a first `diag errors` right after start
-  reports `engine_session_not_running` by design — `wait-ready` is the documented, bounded
-  way to be that first op. `--timeout` bounds the launch's harness-connect wait inside the
+  deterministically: a session launches on the first operation that REQUIRES one (ADR-0017),
+  and the read-only diag/logger reads never do (ADR-0022), so a first `diag errors` right
+  after start reports `engine_session_not_running` by design — `wait-ready` is the
+  documented, bounded way to trigger that launch explicitly. `--timeout` bounds the launch's harness-connect wait inside the
   daemon (a finite number in (0, 50], under the live channel's 60s client-side round-trip
   bound); success (`{pid, launched}`) means subsequent live reads serve, and a repeat while
   the session is alive is idempotent (`launched: false`, nothing relaunched). `daemon start --windowed` additionally

--- a/src/gda/commands/daemon.py
+++ b/src/gda/commands/daemon.py
@@ -211,13 +211,15 @@ class DaemonStatusResult(BaseModel):
 
 
 class DaemonWaitReadyParams(BaseModel):
-    """The params of ``gda daemon wait-ready``: the bounded readiness wait (#657).
+    """The params of ``gda daemon wait-ready``: the readiness budget (#657).
 
     The daemon launches its engine session LAZILY on the first operation that
-    requires one (ADR-0017); this command is the explicit, bounded way to BE
-    that operation. ``timeout`` is the daemon-side budget for the launch — every
-    wait in it draws from one instant and none is renewed — not a poll interval
-    and not a sleep loop: one request, one launch, one answer. The (0, 50] cap is the shared
+    requires one (ADR-0017); this command is the explicit way to BE that
+    operation. ``timeout`` is the daemon-side budget for the launch — every wait
+    and new-work decision draws from one instant and none is renewed — not a poll
+    interval and not a sleep loop: one request, one launch, one answer. A
+    synchronous call already in flight can delay when expiry is observed. The
+    (0, 50] cap is the shared
     ``gda.daemon.server.WAIT_READY_TIMEOUT_MAX``, which the daemon re-enforces
     at its IPC boundary for non-gda clients.
     """
@@ -228,11 +230,13 @@ class DaemonWaitReadyParams(BaseModel):
         le=WAIT_READY_TIMEOUT_MAX,
         allow_inf_nan=False,
         description=(
-            "How many seconds to let the engine session's launch take — engine "
-            "boot, the project's autoloads, and the in-game harness connecting "
-            "back and completing its handshake. Bounds the wait inside the "
-            "daemon; when exhausted the reply is 'engine_session_not_running' "
-            "carrying the launch diagnostics. Must be a finite number in "
+            "The daemon-side budget, in seconds, shared by the engine launch's "
+            "waits and new-work decisions: engine boot, the project's autoloads, "
+            "and the in-game harness connecting back and completing its handshake. "
+            "A synchronous call already in flight can delay when expiry is "
+            "observed. When the budget is exhausted, the reply is "
+            "'engine_session_not_running' carrying the launch diagnostics. Must "
+            "be a finite number in "
             f"(0, {int(WAIT_READY_TIMEOUT_MAX)}]: the live channel bounds the "
             "whole request round trip at 60s client-side, so the wait has to "
             f"resolve inside it. Defaults to {int(CONNECT_TIMEOUT)}."
@@ -1111,8 +1115,10 @@ def daemon_wait_ready(
         CONNECT_TIMEOUT,
         "--timeout",
         help=(
-            "Seconds to let the session launch take (engine boot + autoloads + "
-            "harness connect) before the daemon reports "
+            "Daemon-side budget for the session launch's waits and new-work "
+            "decisions (engine boot + autoloads + harness connect). A synchronous "
+            "call already in flight can delay when expiry is observed. When the "
+            "budget is exhausted, the daemon reports "
             "'engine_session_not_running' with the launch diagnostics. A finite "
             f"number in (0, 50]; defaults to {int(CONNECT_TIMEOUT)}."
         ),
@@ -1123,7 +1129,7 @@ def daemon_wait_ready(
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Establish the engine session and wait, bounded, until live reads serve.
+    """Establish the engine session under one budget until live reads serve.
 
     The daemon launches its engine session LAZILY, on the first operation that
     REQUIRES one (ADR-0017) — and a read-only diagnostic never does: right
@@ -1136,9 +1142,10 @@ def daemon_wait_ready(
     (ADR-0009) — and returns once the in-game harness has connected, after
     which live reads (including a first `diag errors`) serve. Idempotent while
     a session is alive: `launched: false`, nothing relaunched. With no daemon
-    it reports `daemon_not_running`; a launch that cannot complete within
-    `--timeout` reports `engine_session_not_running` with the launch
-    diagnostics.
+    it reports `daemon_not_running`; when the daemon-side `--timeout` budget is
+    exhausted, it reports `engine_session_not_running` with the launch
+    diagnostics. The budget governs waits and new-work decisions, not the wall
+    time of a synchronous call already in flight.
     """
     # The params model owns the bounds (ADR-0015); this argv body only
     # translates a model refusal into the Click usage error.

--- a/src/gda/commands/daemon.py
+++ b/src/gda/commands/daemon.py
@@ -215,9 +215,9 @@ class DaemonWaitReadyParams(BaseModel):
 
     The daemon launches its engine session LAZILY on the first operation that
     requires one (ADR-0017); this command is the explicit, bounded way to BE
-    that operation. ``timeout`` bounds the launch's whole readiness handshake
-    inside the daemon — not a poll interval and not a sleep loop: one request,
-    one launch, one answer. The (0, 50] cap is the shared
+    that operation. ``timeout`` is the daemon-side budget for the launch — every
+    wait in it draws from one instant and none is renewed — not a poll interval
+    and not a sleep loop: one request, one launch, one answer. The (0, 50] cap is the shared
     ``gda.daemon.server.WAIT_READY_TIMEOUT_MAX``, which the daemon re-enforces
     at its IPC boundary for non-gda clients.
     """

--- a/src/gda/commands/daemon.py
+++ b/src/gda/commands/daemon.py
@@ -47,10 +47,11 @@ from gda.daemon.discovery import (
 )
 from gda.display import WindowedUnavailable, windowed_unavailable
 from gda.daemon.protocol import read_message, write_message
-from gda.daemon.server import STATUS_OP, STOP_OP
-from gda.dispatch import dispatch_recipe
+from gda.daemon.server import STATUS_OP, STOP_OP, WAIT_READY_OP
+from gda.daemon.session import CONNECT_TIMEOUT
+from gda.dispatch import dispatch_domain, dispatch_recipe, params_or_bad_parameter
 from gda.errors import Failure, make_failure, unresolvable_binary_failure
-from gda.execution import MIN_LIVE_VERSION
+from gda.execution import MIN_LIVE_VERSION, ExecutionKind
 from gda.harness.install import (
     HarnessSnapshot,
     install_harness,
@@ -197,6 +198,52 @@ class DaemonStatusResult(BaseModel):
             "(alongside `running: false`), or a daemon is running (`running: true`) "
             "but its bounded STATUS_OP round trip missed transiently."
         ),
+    )
+
+
+class DaemonWaitReadyParams(BaseModel):
+    """The params of ``gda daemon wait-ready``: the bounded readiness wait (#657).
+
+    The daemon launches its engine session LAZILY on the first live op
+    (ADR-0017); this command is the explicit, bounded way to BE that first op.
+    ``timeout`` bounds the launch's harness-connect wait inside the daemon — not
+    a poll interval and not a sleep loop: one request, one launch, one answer.
+    """
+
+    timeout: float = Field(
+        default=CONNECT_TIMEOUT,
+        gt=0,
+        le=50,
+        allow_inf_nan=False,
+        description=(
+            "How many seconds to let the engine session's launch take — engine "
+            "boot, the project's autoloads, and the in-game harness connecting "
+            "back. Bounds the wait inside the daemon; when exhausted the reply "
+            "is 'engine_session_not_running' carrying the launch diagnostics. "
+            "Must be a finite number in (0, 50]: the live channel bounds the "
+            "whole request round trip at 60s client-side, so the wait has to "
+            f"resolve inside it. Defaults to {int(CONNECT_TIMEOUT)}."
+        ),
+    )
+
+
+class DaemonWaitReadyResult(BaseModel):
+    """The result of ``gda daemon wait-ready``: the engine session serves (#657).
+
+    Success IS the readiness contract: the session's harness has connected and
+    presented its token, so subsequent live reads — including a first ``gda diag
+    errors``, which deliberately never launches a session itself (ADR-0022) —
+    serve without a warm-up read.
+    """
+
+    pid: int = Field(description="The serving gda-daemon's process id.")
+    launched: bool = Field(
+        description=(
+            "Whether THIS call launched the engine session (true), or one was "
+            "already serving (false — idempotent, nothing was relaunched). "
+            "Sessions stay lazily launched (ADR-0017); this command is the "
+            "documented way to be the first live op."
+        )
     )
 
 
@@ -797,6 +844,12 @@ def render_daemon_status(status: "DaemonStatusResult") -> str:
     return "daemon not running"
 
 
+def render_daemon_wait_ready(ready: "DaemonWaitReadyResult") -> str:
+    """Render a `gda daemon wait-ready` outcome for humans."""
+    state = "launched now" if ready.launched else "already serving"
+    return f"engine session ready ({state}; daemon pid {ready.pid})"
+
+
 def render_daemon_install(installed: "DaemonInstallResult") -> str:
     """Render a `gda daemon install` outcome for humans.
 
@@ -903,6 +956,19 @@ DAEMON_STATUS_COMMAND: HeadlessCommand[DaemonStatusResult] = HeadlessCommand(
     output_model=DaemonStatusResult,
     render=render_daemon_status,
     recipe=_daemon_status_recipe,
+)
+
+# `wait-ready` is the group's one `kind = LIVE` command (#657): it routes through
+# the live channel — the daemon socket, `classify_live`, the 60s client bound —
+# like `diag errors` does, and is daemon-served rather than harness-relayed. The
+# rest of the group stays the recipe-run lifecycle family (ADR-0017); this one is
+# about the SESSION the daemon holds, which is exactly the live channel's object.
+DAEMON_WAIT_READY_COMMAND: HeadlessCommand[DaemonWaitReadyResult] = HeadlessCommand(
+    operation=WAIT_READY_OP,
+    input_model=DaemonWaitReadyParams,
+    output_model=DaemonWaitReadyResult,
+    render=render_daemon_wait_ready,
+    kind=ExecutionKind.LIVE,
 )
 
 DAEMON_INSTALL_COMMAND: HeadlessCommand[DaemonInstallResult] = HeadlessCommand(
@@ -1020,6 +1086,51 @@ def daemon_status(
     dispatch_recipe(
         DAEMON_STATUS_COMMAND,
         DaemonStatusParams(),
+        json_output=json_output,
+        godot=godot,
+        project=project,
+    )
+
+
+@_app.command(name="wait-ready", cls=DAEMON_WAIT_READY_COMMAND.command_class())
+def daemon_wait_ready(
+    timeout: float = typer.Option(
+        CONNECT_TIMEOUT,
+        "--timeout",
+        help=(
+            "Seconds to let the session launch take (engine boot + autoloads + "
+            "harness connect) before the daemon reports "
+            "'engine_session_not_running' with the launch diagnostics. A finite "
+            f"number in (0, 50]; defaults to {int(CONNECT_TIMEOUT)}."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = DAEMON_WAIT_READY_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Establish the engine session and wait, bounded, until live reads serve.
+
+    The daemon launches its engine session LAZILY on the first live op
+    (ADR-0017), so right after `gda daemon start` a read-only diagnostic like
+    `gda diag errors` reports `engine_session_not_running` — expected, not a
+    defect: a read must never be the thing that runs the project's code
+    (ADR-0022). This command is the documented way to be that first op
+    deliberately: it asks the daemon to launch the session — running the
+    project's autoloads and its scene, inside the trusted-project assumption
+    (ADR-0009) — and returns once the in-game harness has connected, after
+    which live reads (including a first `diag errors`) serve. Idempotent while
+    a session is alive: `launched: false`, nothing relaunched. With no daemon
+    it reports `daemon_not_running`; a launch that cannot complete within
+    `--timeout` reports `engine_session_not_running` with the launch
+    diagnostics.
+    """
+    # The params model owns the bounds (ADR-0015); this argv body only
+    # translates a model refusal into the Click usage error.
+    dispatch_domain(
+        DAEMON_WAIT_READY_COMMAND,
+        params_or_bad_parameter(DaemonWaitReadyParams, timeout=timeout),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/commands/daemon.py
+++ b/src/gda/commands/daemon.py
@@ -17,12 +17,16 @@ one, so the two stay distinct.
 
 The group is a deliberate extension of ADR-0005's domain-object grouping to an
 infrastructure object (gda-daemon), not a top-level meta singleton. None of its
-operations is a sentinel op, so — like ``export run`` — each runs a recipe:
-``start`` gates the platform (live is UNIX-only, ADR-0021), performs the reported
-idempotent harness install (ADR-0018), spawns the detached daemon, and waits until
-it is accepting; ``stop`` asks it to shut down; ``status`` reports liveness from
-the pidfile; and ``install`` / ``uninstall`` are the harness half of the lifecycle
-on their own — the same install ``start`` folds in, and its paired removal.
+operations is a sentinel op. The lifecycle commands each run a recipe — like
+``export run``: ``start`` gates the platform (live is UNIX-only, ADR-0021),
+performs the reported idempotent harness install (ADR-0018), spawns the detached
+daemon, and waits until it is accepting; ``stop`` asks it to shut down;
+``status`` reports liveness from the pidfile; and ``install`` / ``uninstall``
+are the harness half of the lifecycle on their own — the same install ``start``
+folds in, and its paired removal. The ONE exception (#657, ADR-0040 amendment)
+is ``wait-ready``: ``kind = LIVE``, routed through the daemon socket and
+``classify_live`` like ``diag errors``, because its object is the engine session
+the running daemon holds — not the daemon process lifecycle.
 """
 
 import os
@@ -47,7 +51,12 @@ from gda.daemon.discovery import (
 )
 from gda.display import WindowedUnavailable, windowed_unavailable
 from gda.daemon.protocol import read_message, write_message
-from gda.daemon.server import STATUS_OP, STOP_OP, WAIT_READY_OP
+from gda.daemon.server import (
+    STATUS_OP,
+    STOP_OP,
+    WAIT_READY_OP,
+    WAIT_READY_TIMEOUT_MAX,
+)
 from gda.daemon.session import CONNECT_TIMEOUT
 from gda.dispatch import dispatch_domain, dispatch_recipe, params_or_bad_parameter
 from gda.errors import Failure, make_failure, unresolvable_binary_failure
@@ -204,23 +213,27 @@ class DaemonStatusResult(BaseModel):
 class DaemonWaitReadyParams(BaseModel):
     """The params of ``gda daemon wait-ready``: the bounded readiness wait (#657).
 
-    The daemon launches its engine session LAZILY on the first live op
-    (ADR-0017); this command is the explicit, bounded way to BE that first op.
-    ``timeout`` bounds the launch's harness-connect wait inside the daemon — not
-    a poll interval and not a sleep loop: one request, one launch, one answer.
+    The daemon launches its engine session LAZILY on the first operation that
+    requires one (ADR-0017); this command is the explicit, bounded way to BE
+    that operation. ``timeout`` bounds the launch's whole readiness handshake
+    inside the daemon — not a poll interval and not a sleep loop: one request,
+    one launch, one answer. The (0, 50] cap is the shared
+    ``gda.daemon.server.WAIT_READY_TIMEOUT_MAX``, which the daemon re-enforces
+    at its IPC boundary for non-gda clients.
     """
 
     timeout: float = Field(
         default=CONNECT_TIMEOUT,
         gt=0,
-        le=50,
+        le=WAIT_READY_TIMEOUT_MAX,
         allow_inf_nan=False,
         description=(
             "How many seconds to let the engine session's launch take — engine "
             "boot, the project's autoloads, and the in-game harness connecting "
-            "back. Bounds the wait inside the daemon; when exhausted the reply "
-            "is 'engine_session_not_running' carrying the launch diagnostics. "
-            "Must be a finite number in (0, 50]: the live channel bounds the "
+            "back and completing its handshake. Bounds the wait inside the "
+            "daemon; when exhausted the reply is 'engine_session_not_running' "
+            "carrying the launch diagnostics. Must be a finite number in "
+            f"(0, {int(WAIT_READY_TIMEOUT_MAX)}]: the live channel bounds the "
             "whole request round trip at 60s client-side, so the wait has to "
             f"resolve inside it. Defaults to {int(CONNECT_TIMEOUT)}."
         ),
@@ -242,7 +255,7 @@ class DaemonWaitReadyResult(BaseModel):
             "Whether THIS call launched the engine session (true), or one was "
             "already serving (false — idempotent, nothing was relaunched). "
             "Sessions stay lazily launched (ADR-0017); this command is the "
-            "documented way to be the first live op."
+            "documented way to trigger that launch explicitly."
         )
     )
 
@@ -1112,12 +1125,13 @@ def daemon_wait_ready(
 ) -> None:
     """Establish the engine session and wait, bounded, until live reads serve.
 
-    The daemon launches its engine session LAZILY on the first live op
-    (ADR-0017), so right after `gda daemon start` a read-only diagnostic like
-    `gda diag errors` reports `engine_session_not_running` — expected, not a
-    defect: a read must never be the thing that runs the project's code
-    (ADR-0022). This command is the documented way to be that first op
-    deliberately: it asks the daemon to launch the session — running the
+    The daemon launches its engine session LAZILY, on the first operation that
+    REQUIRES one (ADR-0017) — and a read-only diagnostic never does: right
+    after `gda daemon start`, `gda diag errors` reports
+    `engine_session_not_running` by design, because a read must never be the
+    thing that runs the project's code (ADR-0022). This command is the
+    documented way to trigger the launch explicitly: it asks the daemon to
+    launch the session — running the
     project's autoloads and its scene, inside the trusted-project assumption
     (ADR-0009) — and returns once the in-game harness has connected, after
     which live reads (including a first `diag errors`) serve. Idempotent while

--- a/src/gda/daemon/protocol.py
+++ b/src/gda/daemon/protocol.py
@@ -48,9 +48,17 @@ def read_frame(sock: socket.socket, deadline: float | None = None) -> bytes | No
     return _recv_exactly(sock, length, deadline)
 
 
-def write_message(sock: socket.socket, obj: Any) -> None:
-    """Send ``obj`` as one length-prefixed JSON frame."""
-    write_frame(sock, json.dumps(obj).encode("utf-8"))
+def write_message(sock: socket.socket, obj: Any, deadline: float | None = None) -> None:
+    """Send one JSON frame, optionally within an absolute ``deadline``.
+
+    Serialization happens before the timed write. If it spends the budget, no
+    bytes are committed; otherwise ``sendall`` receives only the time left on
+    the caller's round-trip instant.
+    """
+    payload = json.dumps(obj).encode("utf-8")
+    if deadline is not None:
+        _set_timeout_from_deadline(sock, deadline)
+    write_frame(sock, payload)
 
 
 def read_message(sock: socket.socket, deadline: float | None = None) -> Any | None:
@@ -81,16 +89,21 @@ def _recv_exactly(
     remaining = count
     while remaining > 0:
         if deadline is not None:
-            left = deadline - time.monotonic()
-            if left <= 0:
-                raise TimeoutError("the frame did not arrive before the deadline")
-            sock.settimeout(left)
+            _set_timeout_from_deadline(sock, deadline)
         chunk = sock.recv(remaining)
         if not chunk:
             return None
         chunks.append(chunk)
         remaining -= len(chunk)
     return b"".join(chunks)
+
+
+def _set_timeout_from_deadline(sock: socket.socket, deadline: float) -> None:
+    """Give the next socket operation only the time left on ``deadline``."""
+    left = deadline - time.monotonic()
+    if left <= 0:
+        raise TimeoutError("the frame deadline has expired")
+    sock.settimeout(left)
 
 
 def result_reply(payload: Any) -> dict:

--- a/src/gda/daemon/protocol.py
+++ b/src/gda/daemon/protocol.py
@@ -53,9 +53,14 @@ def write_message(sock: socket.socket, obj: Any) -> None:
     write_frame(sock, json.dumps(obj).encode("utf-8"))
 
 
-def read_message(sock: socket.socket) -> Any | None:
-    """Read one length-prefixed JSON frame, or ``None`` if the peer closed."""
-    body = read_frame(sock)
+def read_message(sock: socket.socket, deadline: float | None = None) -> Any | None:
+    """Read one length-prefixed JSON frame, or ``None`` if the peer closed.
+
+    ``deadline`` bounds the whole frame the way :func:`read_frame` documents; a
+    caller that promises a round-trip ceiling passes the instant that ceiling
+    expires, since the socket's own timeout would only bound inactivity.
+    """
+    body = read_frame(sock, deadline)
     if body is None:
         return None
     return json.loads(body.decode("utf-8"))

--- a/src/gda/daemon/protocol.py
+++ b/src/gda/daemon/protocol.py
@@ -15,6 +15,7 @@ classified exactly like a headless engine run's.
 import json
 import socket
 import struct
+import time
 from typing import Any
 
 from gda.exit_codes import EXIT_LIVE
@@ -29,13 +30,22 @@ def write_frame(sock: socket.socket, payload: bytes) -> None:
     sock.sendall(_LENGTH.pack(len(payload)) + payload)
 
 
-def read_frame(sock: socket.socket) -> bytes | None:
-    """Read one length-prefixed frame's payload, or ``None`` if the peer closed."""
-    header = _recv_exactly(sock, _LENGTH.size)
+def read_frame(sock: socket.socket, deadline: float | None = None) -> bytes | None:
+    """Read one length-prefixed frame's payload, or ``None`` if the peer closed.
+
+    ``deadline`` is an ABSOLUTE ``time.monotonic()`` instant that bounds the whole
+    frame, header and payload together. Without it the socket's own timeout applies
+    per ``recv``, which bounds INACTIVITY rather than the read: a peer that sends
+    one byte just inside the timeout restarts it every time and holds the reader
+    for as long as it likes (#725 re-review — a 0.05s-bounded launch handshake was
+    held for 2.1s by a one-byte-per-40ms trickle, and the rate is the attacker's to
+    choose). Callers that promise a bound pass the instant that bound expires.
+    """
+    header = _recv_exactly(sock, _LENGTH.size, deadline)
     if header is None:
         return None
     (length,) = _LENGTH.unpack(header)
-    return _recv_exactly(sock, length)
+    return _recv_exactly(sock, length, deadline)
 
 
 def write_message(sock: socket.socket, obj: Any) -> None:
@@ -51,11 +61,25 @@ def read_message(sock: socket.socket) -> Any | None:
     return json.loads(body.decode("utf-8"))
 
 
-def _recv_exactly(sock: socket.socket, count: int) -> bytes | None:
-    """Read exactly ``count`` bytes, or ``None`` if the peer closed mid-frame."""
+def _recv_exactly(
+    sock: socket.socket, count: int, deadline: float | None = None
+) -> bytes | None:
+    """Read exactly ``count`` bytes, or ``None`` if the peer closed mid-frame.
+
+    With a ``deadline``, the budget left on it is recomputed and applied BEFORE
+    every ``recv`` — the socket's timeout is per-call, so setting it once would
+    only bound each individual wait, not the read. An exhausted budget raises
+    ``TimeoutError`` (an ``OSError``, which is what the frame's callers already
+    handle) rather than issuing a read that could still block.
+    """
     chunks: list[bytes] = []
     remaining = count
     while remaining > 0:
+        if deadline is not None:
+            left = deadline - time.monotonic()
+            if left <= 0:
+                raise TimeoutError("the frame did not arrive before the deadline")
+            sock.settimeout(left)
         chunk = sock.recv(remaining)
         if not chunk:
             return None

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -77,7 +77,7 @@ class SessionHandle(Protocol):
 
     def request(self, operation: str, params: dict) -> dict: ...
 
-    def close(self, grace: float = ...) -> None: ...
+    def close(self, deadline: float | None = ...) -> None: ...
 
 
 class _Established(NamedTuple):
@@ -417,21 +417,21 @@ class DaemonServer:
     def _ensure_session(
         self, diagnostics: list[str] | None = None, timeout: float | None = None
     ) -> "_Established | None":
-        if self._session is not None and self._session.alive():
-            return _Established(self._session, launched=False)
-        # ONE deadline — an absolute instant, held HERE — for everything this
-        # boundary does on the caller's clock (#725 re-review): retiring the session
-        # it is replacing AND launching the replacement. Retirement is not free (a
-        # stale session's engine may ignore SIGTERM) and neither is a spawn, so
-        # charging either to nobody made the bound a per-phase allowance rather than
-        # a bound. Phases receive the INSTANT, never a duration: a duration restarts
-        # whatever clock it lands on, which is how an exhausted budget came back as
-        # a fresh one for the launch.
+        # ONE deadline — an absolute instant, taken at ENTRY — for everything this
+        # boundary does on the caller's clock (#725 re-review): the liveness check,
+        # retiring the session it is replacing, and launching the replacement.
+        # Retirement is not free (a stale session's engine may ignore SIGTERM) and
+        # neither is a spawn, so charging either to nobody made the bound a
+        # per-phase allowance rather than a bound. Every phase receives the INSTANT,
+        # never a duration: a duration is a fresh budget to whatever receives it,
+        # which is how an exhausted one came back whole one layer down.
         deadline = time.monotonic() + (
             timeout if timeout is not None else CONNECT_TIMEOUT
         )
+        if self._session is not None and self._session.alive():
+            return _Established(self._session, launched=False)
         if self._session is not None:
-            self._session.close(max(deadline - time.monotonic(), 0.0))
+            self._session.close(deadline)
             self._session = None
         if not self.godot:
             return None

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -111,7 +111,7 @@ class SessionLaunch(Protocol):
         harness_socket: Path,
         token: str,
         log_file: Optional[Path] = None,
-        timeout: float = CONNECT_TIMEOUT,
+        deadline: Optional[float] = None,
         windowed: bool = False,
         scene: Optional[str] = None,
         diagnostics: Optional[list[str]] = None,
@@ -419,23 +419,31 @@ class DaemonServer:
     ) -> "_Established | None":
         if self._session is not None and self._session.alive():
             return _Established(self._session, launched=False)
-        # ONE deadline for everything this boundary does on the caller's clock
-        # (#725 re-review): retiring the session it is replacing AND launching the
-        # replacement. Retirement is not free — a stale session's engine may ignore
-        # SIGTERM — and charging it to nobody let a `wait-ready --timeout 0.3` spend
-        # 5s here before the launch it was bounding even began, with the
-        # single-threaded serve loop blocked for all of it. Each phase gets only
-        # what the previous one left.
-        budget = timeout if timeout is not None else CONNECT_TIMEOUT
-        deadline = time.monotonic() + budget
-
-        def _left() -> float:
-            return max(deadline - time.monotonic(), 0.0)
-
+        # ONE deadline — an absolute instant, held HERE — for everything this
+        # boundary does on the caller's clock (#725 re-review): retiring the session
+        # it is replacing AND launching the replacement. Retirement is not free (a
+        # stale session's engine may ignore SIGTERM) and neither is a spawn, so
+        # charging either to nobody made the bound a per-phase allowance rather than
+        # a bound. Phases receive the INSTANT, never a duration: a duration restarts
+        # whatever clock it lands on, which is how an exhausted budget came back as
+        # a fresh one for the launch.
+        deadline = time.monotonic() + (
+            timeout if timeout is not None else CONNECT_TIMEOUT
+        )
         if self._session is not None:
-            self._session.close(_left())
+            self._session.close(max(deadline - time.monotonic(), 0.0))
             self._session = None
         if not self.godot:
+            return None
+        if time.monotonic() >= deadline:
+            # Retirement used the whole budget. Launching now would be launching
+            # past the bound, so this is a refusal, reported like any other failed
+            # launch — with the reason, since an empty one reads as a mystery.
+            if diagnostics is not None:
+                diagnostics.append(
+                    "the readiness deadline expired while the previous engine "
+                    "session was retired; no replacement was launched"
+                )
             return None
         # The AUTHORITATIVE no-display guard (#345): a windowed session needs a usable
         # host DisplayServer, else a windowed Godot aborts during DisplayServer
@@ -469,10 +477,11 @@ class DaemonServer:
             self.paths.harness_socket,
             self._token,
             log_file=self.paths.session_log,
-            # A caller-bounded readiness-handshake wait (#657, `daemon wait-ready
-            # --timeout`); None means the launcher's own default is the budget.
-            # What arrives here is what retiring the previous session left of it.
-            timeout=max(_left(), 0.001),
+            # The caller's own deadline (#657 `daemon wait-ready --timeout`, #725
+            # re-review), not a duration derived from it: the launcher spends what
+            # is left of THIS instant on the spawn, the connect, the handshake
+            # frames, and its teardown.
+            deadline=deadline,
             windowed=self.windowed,
             scene=self.scene,
             diagnostics=diagnostics,

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -13,6 +13,7 @@ import os
 import secrets
 import signal
 import socket
+import time
 from pathlib import Path
 from typing import Callable, NamedTuple, Optional, Protocol
 
@@ -76,7 +77,7 @@ class SessionHandle(Protocol):
 
     def request(self, operation: str, params: dict) -> dict: ...
 
-    def close(self) -> None: ...
+    def close(self, grace: float = ...) -> None: ...
 
 
 class _Established(NamedTuple):
@@ -418,8 +419,21 @@ class DaemonServer:
     ) -> "_Established | None":
         if self._session is not None and self._session.alive():
             return _Established(self._session, launched=False)
+        # ONE deadline for everything this boundary does on the caller's clock
+        # (#725 re-review): retiring the session it is replacing AND launching the
+        # replacement. Retirement is not free — a stale session's engine may ignore
+        # SIGTERM — and charging it to nobody let a `wait-ready --timeout 0.3` spend
+        # 5s here before the launch it was bounding even began, with the
+        # single-threaded serve loop blocked for all of it. Each phase gets only
+        # what the previous one left.
+        budget = timeout if timeout is not None else CONNECT_TIMEOUT
+        deadline = time.monotonic() + budget
+
+        def _left() -> float:
+            return max(deadline - time.monotonic(), 0.0)
+
         if self._session is not None:
-            self._session.close()
+            self._session.close(_left())
             self._session = None
         if not self.godot:
             return None
@@ -456,8 +470,9 @@ class DaemonServer:
             self._token,
             log_file=self.paths.session_log,
             # A caller-bounded readiness-handshake wait (#657, `daemon wait-ready
-            # --timeout`); None keeps the launcher's own default.
-            timeout=timeout if timeout is not None else CONNECT_TIMEOUT,
+            # --timeout`); None means the launcher's own default is the budget.
+            # What arrives here is what retiring the previous session left of it.
+            timeout=max(_left(), 0.001),
             windowed=self.windowed,
             scene=self.scene,
             diagnostics=diagnostics,

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -8,12 +8,13 @@ liveness, ``__stop__`` graceful shutdown); any other op is a project live op,
 served by the engine session, which is (re)launched lazily on demand.
 """
 
+import math
 import os
 import secrets
 import signal
 import socket
 from pathlib import Path
-from typing import Callable, Optional, Protocol
+from typing import Callable, NamedTuple, Optional, Protocol
 
 from gda.daemon.diag import parse_errors, parse_log_records
 from gda.daemon.discovery import DaemonPaths, acquire_pidfile, ensure_runtime_dir
@@ -42,13 +43,22 @@ LOG_OPS = (DIAG_ERRORS_OP, LOGGER_TAIL_OP)
 # The daemon-served readiness op (#657): `gda daemon wait-ready`. Like the LOG_OPS
 # it is answered by the daemon rather than relayed to the harness — but unlike
 # them it deliberately LAUNCHES the engine session (the documented, bounded way to
-# be ADR-0017's "first live op"), so it is not in their read-only family.
+# trigger ADR-0017's lazy launch), so it is not in their read-only family.
 WAIT_READY_OP = "daemon-wait-ready"
 
-# Every LIVE op the daemon answers ITSELF rather than relaying to the harness —
-# the single authority the cross-language op-table guard subtracts before
-# demanding a harness-side `const OP_…` mirror (PR #650 guards, #657).
+# Every LIVE op the daemon answers ITSELF rather than relaying to the harness.
+# The single membership authority (#725 review): production routing keys on this
+# tuple (`_handle` -> `_handle_daemon_served`), and the cross-language op-table
+# guard subtracts the same tuple before demanding a harness-side `const OP_…`
+# mirror (PR #650 guards, #657) — so the two cannot drift.
 DAEMON_SERVED_OPS = (*LOG_OPS, WAIT_READY_OP)
+
+# The wire contract's cap on a wait-ready launch bound (#657): the live channel
+# bounds one whole request round trip at 60s client-side
+# (gda.live_runner.LIVE_REQUEST_TIMEOUT), so the daemon-side wait must resolve
+# comfortably inside it. One authority for both enforcement points: the CLI
+# params model (ADR-0015) and the daemon's own IPC-boundary check below.
+WAIT_READY_TIMEOUT_MAX = 50.0
 
 
 class SessionHandle(Protocol):
@@ -67,6 +77,19 @@ class SessionHandle(Protocol):
     def request(self, operation: str, params: dict) -> dict: ...
 
     def close(self) -> None: ...
+
+
+class _Established(NamedTuple):
+    """A serving session plus the fact of who launched it (#725 review).
+
+    ``launched`` is decided by the launch owner (``_ensure_session``) at the
+    moment it reuses or launches — never re-derived by a caller, whose separate
+    ``alive()`` sample raced the decision (a process exiting between the two
+    samples made a call that DID launch report ``launched: false``).
+    """
+
+    session: SessionHandle
+    launched: bool
 
 
 class SessionLaunch(Protocol):
@@ -216,61 +239,91 @@ class DaemonServer:
         if op == STOP_OP:
             self._stopping = True
             return {"ok": True, "pid": os.getpid()}
-        if op in LOG_OPS:
-            # `gda diag errors` / `gda logger tail` are daemon-served: the daemon
-            # reads the Session log it owns rather than relaying to the harness
-            # (#224, #281).
-            return self._handle_log(op, request.get("params", {}))
-        if op == WAIT_READY_OP:
-            # `gda daemon wait-ready` is daemon-served too (#657) — but unlike the
-            # LOG_OPS it deliberately LAUNCHES: it is the explicit, bounded way to
-            # establish the lazily-launched session (ADR-0017) so an agent's first
-            # real read serves.
-            return self._handle_wait_ready(request.get("params", {}))
+        if op in DAEMON_SERVED_OPS:
+            # Daemon-answered, never relayed. Membership is decided by the ONE
+            # tuple the cross-language guard also reads (#725 review), so an op
+            # declared daemon-served is intercepted here by construction.
+            return self._handle_daemon_served(op, request.get("params", {}))
         # A project live op. Serialized against the one session (single writer).
         outcome = self._session_or_refusal()
         if isinstance(outcome, dict):
             return outcome
-        return outcome.request(op, request.get("params", {}))
+        return outcome.session.request(op, request.get("params", {}))
+
+    def _handle_daemon_served(self, op: str, params: dict) -> dict:
+        """Dispatch one DAEMON_SERVED_OPS member to its daemon-side handler."""
+        if op in LOG_OPS:
+            # `gda diag errors` / `gda logger tail`: the daemon reads the Session
+            # log it owns rather than relaying to the harness (#224, #281).
+            return self._handle_log(op, params)
+        if op == WAIT_READY_OP:
+            # `gda daemon wait-ready` (#657) — unlike the LOG_OPS it deliberately
+            # LAUNCHES: the explicit, bounded way to establish the lazily-launched
+            # session (ADR-0017) so an agent's first real read serves.
+            return self._handle_wait_ready(params)
+        # A DAEMON_SERVED_OPS member with no handler is a gda defect: refuse it
+        # loudly rather than silently relaying it to a harness that never
+        # declared it. Unreachable while the tuple is composed from LOG_OPS and
+        # WAIT_READY_OP above; the parity test drives every member through here.
+        return error_reply(
+            "unknown_operation", f"daemon-served op {op!r} has no daemon handler"
+        )
 
     def _handle_wait_ready(self, params: dict) -> dict:
         """Establish the engine session and report readiness (#657).
 
         The bounded-wait half of ADR-0017's lazy launch: sessions still launch
-        lazily on the first live op, and THIS op is the explicit way to be that
-        first op — its success means the harness has connected and presented its
-        token, so subsequent live reads (including a first ``diag errors``, which
-        never launches) serve. ``timeout`` bounds the launch's harness-connect
-        wait; an already-serving session returns immediately with
-        ``launched: false`` and is never relaunched.
+        lazily on the first operation that requires one, and THIS op is the
+        explicit way to be that operation — its success means the harness has
+        connected and presented its token, so subsequent live reads (including a
+        first ``diag errors``, which never launches) serve. ``timeout`` bounds
+        the launch's whole readiness handshake; an already-serving session
+        returns immediately with ``launched: false`` and is never relaunched.
+        ``launched`` is reported by the launch owner (``_ensure_session``), not
+        inferred here — a pre-sampled ``alive()`` raced the launch decision and
+        could report ``false`` for a call that did launch (#725 review).
         """
-        already = self._session is not None and self._session.alive()
-        raw_timeout = params.get("timeout")
-        timeout = (
-            float(raw_timeout)
-            if isinstance(raw_timeout, (int, float))
-            and not isinstance(raw_timeout, bool)
-            else None
-        )
+        raw = params.get("timeout")
+        timeout: float | None = None
+        if raw is not None:
+            # The same finite (0, 50] rule the params model enforces (ADR-0015),
+            # re-checked at the IPC boundary (#725 review): this socket can be
+            # driven by clients other than gda's CLI, and an unbounded or
+            # non-finite value here would defeat the very bound this op promises.
+            if (
+                isinstance(raw, bool)
+                or not isinstance(raw, (int, float))
+                or not math.isfinite(raw)
+                or not 0 < raw <= WAIT_READY_TIMEOUT_MAX
+            ):
+                return error_reply(
+                    "invalid_params",
+                    "wait-ready timeout must be a finite number in "
+                    f"(0, {int(WAIT_READY_TIMEOUT_MAX)}]; got {raw!r}",
+                )
+            timeout = float(raw)
         outcome = self._session_or_refusal(timeout=timeout)
         if isinstance(outcome, dict):
             return outcome
-        return result_reply({"pid": os.getpid(), "launched": not already})
+        return result_reply({"pid": os.getpid(), "launched": outcome.launched})
 
     def _session_or_refusal(
         self, timeout: float | None = None
-    ) -> "SessionHandle | dict":
-        """The serving session, or the typed error reply for why there is none.
+    ) -> "_Established | dict":
+        """The serving session — with whether this call launched it — or the typed refusal.
 
         The one launch boundary every session-needing op goes through (#657
         extracted it from the live-op branch so ``wait-ready`` shares it exactly).
-        The scene selector is verified ONCE at launch (in the harness): a mismatch
-        is a typed live_scene_not_found, never a silent fall back to main_scene and
-        never a per-request re-check (#278, ADR-0017 amendment, ADR-0020).
+        ``launched`` travels with the session because only the launch owner knows
+        it (#725 review): sampling ``alive()`` before and after raced the
+        decision. The scene selector is verified ONCE at launch (in the harness):
+        a mismatch is a typed live_scene_not_found, never a silent fall back to
+        main_scene and never a per-request re-check (#278, ADR-0017 amendment,
+        ADR-0020).
         """
         launch_diagnostics: list[str] = []
         try:
-            session = self._ensure_session(launch_diagnostics, timeout=timeout)
+            established = self._ensure_session(launch_diagnostics, timeout=timeout)
         except SceneMismatch as mismatch:
             detail = (
                 f"no scene named {mismatch.requested!r} exists in the project"
@@ -304,14 +357,14 @@ class DaemonServer:
                 diagnostics=unavailable.reason,
                 probe=unavailable.verdict.probe,
             )
-        if session is None:
+        if established is None:
             return error_reply(
                 "engine_session_not_running",
                 "the gda-daemon could not launch an engine session (no Godot binary, "
                 "or the engine died / the harness did not connect)",
                 diagnostics=self._launch_failure_diagnostics(launch_diagnostics),
             )
-        return session
+        return established
 
     def _handle_log(self, op: str, params: dict) -> dict:
         """Serve a daemon-side log op from the Session log this daemon owns (#224, #281).
@@ -362,9 +415,9 @@ class DaemonServer:
 
     def _ensure_session(
         self, diagnostics: list[str] | None = None, timeout: float | None = None
-    ) -> SessionHandle | None:
+    ) -> "_Established | None":
         if self._session is not None and self._session.alive():
-            return self._session
+            return _Established(self._session, launched=False)
         if self._session is not None:
             self._session.close()
             self._session = None
@@ -402,14 +455,16 @@ class DaemonServer:
             self.paths.harness_socket,
             self._token,
             log_file=self.paths.session_log,
-            # A caller-bounded harness-connect wait (#657, `daemon wait-ready
+            # A caller-bounded readiness-handshake wait (#657, `daemon wait-ready
             # --timeout`); None keeps the launcher's own default.
             timeout=timeout if timeout is not None else CONNECT_TIMEOUT,
             windowed=self.windowed,
             scene=self.scene,
             diagnostics=diagnostics,
         )
-        return self._session
+        if self._session is None:
+            return None
+        return _Established(self._session, launched=True)
 
     def _launch_failure_diagnostics(self, child_diagnostics: list[str]) -> str:
         """Best-effort diagnostics for a failed engine-session launch (#345).

--- a/src/gda/daemon/server.py
+++ b/src/gda/daemon/server.py
@@ -39,6 +39,17 @@ DIAG_ERRORS_OP = "diag-errors"
 LOGGER_TAIL_OP = "logger-tail"
 LOG_OPS = (DIAG_ERRORS_OP, LOGGER_TAIL_OP)
 
+# The daemon-served readiness op (#657): `gda daemon wait-ready`. Like the LOG_OPS
+# it is answered by the daemon rather than relayed to the harness — but unlike
+# them it deliberately LAUNCHES the engine session (the documented, bounded way to
+# be ADR-0017's "first live op"), so it is not in their read-only family.
+WAIT_READY_OP = "daemon-wait-ready"
+
+# Every LIVE op the daemon answers ITSELF rather than relaying to the harness —
+# the single authority the cross-language op-table guard subtracts before
+# demanding a harness-side `const OP_…` mirror (PR #650 guards, #657).
+DAEMON_SERVED_OPS = (*LOG_OPS, WAIT_READY_OP)
+
 
 class SessionHandle(Protocol):
     """What the server consumes of a session (#723 review): a structural contract.
@@ -210,13 +221,56 @@ class DaemonServer:
             # reads the Session log it owns rather than relaying to the harness
             # (#224, #281).
             return self._handle_log(op, request.get("params", {}))
+        if op == WAIT_READY_OP:
+            # `gda daemon wait-ready` is daemon-served too (#657) — but unlike the
+            # LOG_OPS it deliberately LAUNCHES: it is the explicit, bounded way to
+            # establish the lazily-launched session (ADR-0017) so an agent's first
+            # real read serves.
+            return self._handle_wait_ready(request.get("params", {}))
         # A project live op. Serialized against the one session (single writer).
-        # The scene selector is verified ONCE at launch (in the harness): a mismatch
-        # is a typed live_scene_not_found, never a silent fall back to main_scene and
-        # never a per-request re-check (#278, ADR-0017 amendment, ADR-0020).
+        outcome = self._session_or_refusal()
+        if isinstance(outcome, dict):
+            return outcome
+        return outcome.request(op, request.get("params", {}))
+
+    def _handle_wait_ready(self, params: dict) -> dict:
+        """Establish the engine session and report readiness (#657).
+
+        The bounded-wait half of ADR-0017's lazy launch: sessions still launch
+        lazily on the first live op, and THIS op is the explicit way to be that
+        first op — its success means the harness has connected and presented its
+        token, so subsequent live reads (including a first ``diag errors``, which
+        never launches) serve. ``timeout`` bounds the launch's harness-connect
+        wait; an already-serving session returns immediately with
+        ``launched: false`` and is never relaunched.
+        """
+        already = self._session is not None and self._session.alive()
+        raw_timeout = params.get("timeout")
+        timeout = (
+            float(raw_timeout)
+            if isinstance(raw_timeout, (int, float))
+            and not isinstance(raw_timeout, bool)
+            else None
+        )
+        outcome = self._session_or_refusal(timeout=timeout)
+        if isinstance(outcome, dict):
+            return outcome
+        return result_reply({"pid": os.getpid(), "launched": not already})
+
+    def _session_or_refusal(
+        self, timeout: float | None = None
+    ) -> "SessionHandle | dict":
+        """The serving session, or the typed error reply for why there is none.
+
+        The one launch boundary every session-needing op goes through (#657
+        extracted it from the live-op branch so ``wait-ready`` shares it exactly).
+        The scene selector is verified ONCE at launch (in the harness): a mismatch
+        is a typed live_scene_not_found, never a silent fall back to main_scene and
+        never a per-request re-check (#278, ADR-0017 amendment, ADR-0020).
+        """
         launch_diagnostics: list[str] = []
         try:
-            session = self._ensure_session(launch_diagnostics)
+            session = self._ensure_session(launch_diagnostics, timeout=timeout)
         except SceneMismatch as mismatch:
             detail = (
                 f"no scene named {mismatch.requested!r} exists in the project"
@@ -257,7 +311,7 @@ class DaemonServer:
                 "or the engine died / the harness did not connect)",
                 diagnostics=self._launch_failure_diagnostics(launch_diagnostics),
             )
-        return session.request(op, request.get("params", {}))
+        return session
 
     def _handle_log(self, op: str, params: dict) -> dict:
         """Serve a daemon-side log op from the Session log this daemon owns (#224, #281).
@@ -307,7 +361,7 @@ class DaemonServer:
         return result_reply({"records": records})
 
     def _ensure_session(
-        self, diagnostics: list[str] | None = None
+        self, diagnostics: list[str] | None = None, timeout: float | None = None
     ) -> SessionHandle | None:
         if self._session is not None and self._session.alive():
             return self._session
@@ -348,6 +402,9 @@ class DaemonServer:
             self.paths.harness_socket,
             self._token,
             log_file=self.paths.session_log,
+            # A caller-bounded harness-connect wait (#657, `daemon wait-ready
+            # --timeout`); None keeps the launcher's own default.
+            timeout=timeout if timeout is not None else CONNECT_TIMEOUT,
             windowed=self.windowed,
             scene=self.scene,
             diagnostics=diagnostics,

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -100,7 +100,7 @@ class EngineSession:
         proc: subprocess.Popen,
         conn: socket.socket | None,
         log_file: Optional[Path] = None,
-        group: Optional[int] = None,
+        owned_pgid: Optional[int] = None,
     ) -> None:
         self._proc = proc
         self._conn = conn
@@ -112,7 +112,7 @@ class EngineSession:
         # no pid to read a group from — after which nothing retires whatever the
         # engine started. A pid can also be reused; the id captured at spawn is
         # the only one known to be this session's.
-        self._group = group
+        self._owned_pgid = owned_pgid
 
     def alive(self) -> bool:
         # Liveness is the PROCESS and the CHANNEL (#725 review): a session whose
@@ -140,8 +140,7 @@ class EngineSession:
             # so a trickled reply would hold this single-threaded daemon far past
             # the ``live_timeout`` the message promises.
             deadline = time.monotonic() + OP_TIMEOUT
-            self._conn.settimeout(OP_TIMEOUT)
-            write_message(self._conn, {"op": operation, "params": params})
+            write_message(self._conn, {"op": operation, "params": params}, deadline)
             reply = read_frame(self._conn, deadline)  # the raw ADR-0002 sentinel
         except TimeoutError:
             # Latched stale too (#725 re-review). The earlier reading — "a slow op
@@ -198,7 +197,7 @@ class EngineSession:
                 self._conn.close()
             except OSError:
                 pass
-        _terminate(self._proc, deadline, group=self._group)
+        _terminate(self._proc, deadline, owned_pgid=self._owned_pgid)
 
 
 def launch_session(
@@ -347,8 +346,9 @@ def launch_session(
     # the token read forever — and the daemon serves one request at a time, so that
     # silence froze every later live and control request with it (#725 review).
     # Captured immediately after the spawn, while the leader certainly holds its
-    # pid, and validated against gda's own group (#725 re-review).
-    group = _own_group(proc)
+    # pid, and validated as the leader of a group other than gda's (#725
+    # re-review).
+    owned_pgid = _capture_owned_pgid(proc)
 
     def _teardown() -> None:
         # Teardown draws from the same deadline (#725 re-review). A failure path is
@@ -356,7 +356,7 @@ def launch_session(
         # used to add a fresh five-second grace ON TOP of the caller's bound — 5.3s
         # for a `wait-ready --timeout 0.3` — with the serve loop blocked for all of
         # it. Nothing left means kill now.
-        _terminate(proc, deadline, group=group)
+        _terminate(proc, deadline, owned_pgid=owned_pgid)
 
     if _left() <= 0:
         # The spawn itself outran the budget — the one step that cannot be
@@ -428,7 +428,7 @@ def launch_session(
         _close(conn)
         _teardown()
         raise SceneMismatch(scene if scene is not None else "", str(current))
-    return EngineSession(proc, conn, log_file=log_file, group=group)
+    return EngineSession(proc, conn, log_file=log_file, owned_pgid=owned_pgid)
 
 
 def _child_exit_diagnostic(proc: subprocess.Popen, budget: float) -> str:
@@ -466,7 +466,7 @@ def _close(conn: socket.socket) -> None:
 def _terminate(
     proc: subprocess.Popen,
     deadline: Optional[float] = None,
-    group: Optional[int] = None,
+    owned_pgid: Optional[int] = None,
 ) -> None:
     """SIGTERM the engine group, then SIGKILL it if it has not exited by ``deadline``.
 
@@ -492,9 +492,10 @@ def _terminate(
     order matters both ways: a descendant given SIGTERM may legitimately still be
     finishing (killing it the instant the leader exits truncates that), and a
     descendant that ignores SIGTERM must not outlive the session (letting the
-    leader's exit end the teardown orphaned it). ``group`` comes from the OWNER —
-    captured at spawn — because it cannot be recovered here: polling the leader
-    reaps it, and a reaped leader has no pid to read a group from.
+    leader's exit end the teardown orphaned it). ``owned_pgid`` comes from the
+    OWNER — captured and validated at spawn — because it cannot be recovered
+    here: polling the leader reaps it, and a reaped leader has no pid to read a
+    group from.
 
     An immediate escalation costs no diagnostics: Godot's file logger flushes
     every error, and every print in a debug build (``core/io/logger.cpp``,
@@ -508,62 +509,71 @@ def _terminate(
     """
     if deadline is None:
         deadline = time.monotonic() + TERMINATE_GRACE
-    if group is None:
+    if owned_pgid is None:
         # No owner told us, so recover what can still be recovered — accurate for
         # a leader that has not been reaped, ``None`` once it has.
-        group = _own_group(proc)
-    if proc.poll() is None:
-        _signal_engine(proc, group, signal.SIGTERM)
+        owned_pgid = _capture_owned_pgid(proc)
+    leader_running = proc.poll() is None
+    if owned_pgid is not None or leader_running:
+        # Group ownership is independent of leader liveness. A preceding
+        # `alive()` or launch diagnostic may already have reaped the leader, but
+        # its descendants still need the graceful signal before the deadline.
+        _signal_engine(proc, owned_pgid, signal.SIGTERM)
     while time.monotonic() < deadline:
         # Polled rather than blocked on the leader: the leader exiting is not the
         # group being done, and blocking on it cannot observe the difference.
         # ``poll`` also reaps the leader, keeping its ``returncode`` honest.
         proc.poll()
-        if not _group_standing(group, proc):
+        if not _group_standing(owned_pgid, proc):
             return
         time.sleep(min(_RETIRE_POLL, max(deadline - time.monotonic(), 0.0)))
     # The deadline arrived with the session still standing.
     if proc.poll() is None:
-        _signal_engine(proc, group, signal.SIGKILL)
+        _signal_engine(proc, owned_pgid, signal.SIGKILL)
         _reap_in_background(proc)
-    elif group is not None:
+    elif owned_pgid is not None:
         try:
-            os.killpg(group, signal.SIGKILL)
+            os.killpg(owned_pgid, signal.SIGKILL)
         except OSError:
             pass  # already empty: nothing left to retire
 
 
-def _group_standing(group: Optional[int], proc: subprocess.Popen) -> bool:
+def _group_standing(owned_pgid: Optional[int], proc: subprocess.Popen) -> bool:
     """Whether anything gda owns for this session is still running."""
-    if group is None:
+    if owned_pgid is None:
         return proc.poll() is None
     try:
-        os.killpg(group, 0)
-    except OSError:
+        os.killpg(owned_pgid, 0)
+    except ProcessLookupError:
         return False  # no members left
+    except OSError:
+        # Permission and transient signal failures do not prove absence. Waiting
+        # to the existing deadline is safer than declaring a live group empty.
+        return True
     return True
 
 
-def _own_group(proc: subprocess.Popen) -> Optional[int]:
-    """The process group gda owns for ``proc``, or ``None`` if there is none.
+def _capture_owned_pgid(proc: subprocess.Popen) -> Optional[int]:
+    """The process-group id led and owned by ``proc``, or ``None``.
 
     ``None`` when the leader is already reaped (its pid, and so its group id, is
-    gone) and when the group turns out to be gda's OWN — signalling that would
-    take the daemon down with the engine, and it means the launch never got its
-    own session.
+    gone), when ``proc`` is only a member of somebody else's group, and when the
+    group turns out to be gda's OWN. Only ``pgid == pid`` proves the ownership
+    established by ``Popen(start_new_session=True)``; signalling any other group
+    could terminate unrelated processes.
     """
     try:
-        group = os.getpgid(proc.pid)
+        pgid = os.getpgid(proc.pid)
     except OSError:
         return None
-    return None if group == os.getpgrp() else group
+    return pgid if pgid == proc.pid and pgid != os.getpgrp() else None
 
 
-def _signal_engine(proc: subprocess.Popen, group: Optional[int], sig: int) -> None:
+def _signal_engine(proc: subprocess.Popen, owned_pgid: Optional[int], sig: int) -> None:
     """Signal the engine's whole process group, or the child alone if it has none."""
-    if group is not None:
+    if owned_pgid is not None:
         try:
-            os.killpg(group, sig)
+            os.killpg(owned_pgid, sig)
             return
         except OSError:
             pass

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -34,6 +34,9 @@ OP_TIMEOUT = 30.0
 # when the caller set no deadline of its own (``EngineSession.close``). A launch
 # teardown draws its grace from the launch deadline instead (#725 re-review).
 TERMINATE_GRACE = 5.0
+# The formality after a SIGKILL: long enough to reap a process the kernel has
+# already stopped, short enough that it is never a wait anyone notices.
+_REAP_GRACE = 0.5
 
 
 class SceneMismatch(Exception):
@@ -123,9 +126,15 @@ class EngineSession:
                 "engine_disconnected", "the engine session has no live connection"
             )
         try:
+            # ONE absolute deadline for the whole relay, not a per-recv inactivity
+            # timeout (#725 re-review): the reply is read in as many chunks as the
+            # peer chooses to send, and a socket timeout restarts on each of them,
+            # so a trickled reply would hold this single-threaded daemon far past
+            # the ``live_timeout`` the message promises.
+            deadline = time.monotonic() + OP_TIMEOUT
             self._conn.settimeout(OP_TIMEOUT)
             write_message(self._conn, {"op": operation, "params": params})
-            reply = read_frame(self._conn)  # the raw ADR-0002 sentinel string
+            reply = read_frame(self._conn, deadline)  # the raw ADR-0002 sentinel
         except TimeoutError:
             # Latched stale too (#725 re-review). The earlier reading — "a slow op
             # is not a broken channel" — priced only the churn of relaunching. The
@@ -161,13 +170,22 @@ class EngineSession:
             "exit_code": 0,
         }
 
-    def close(self) -> None:
+    def close(self, grace: float = TERMINATE_GRACE) -> None:
+        """Drop the channel and end the engine, within ``grace`` (#725 re-review).
+
+        The grace is a budget the CALLER may shorten, because retiring a session
+        is work done on someone's clock: ``_ensure_session`` retires a stale one
+        before launching its replacement, and a `daemon wait-ready --timeout 0.3`
+        that spends five seconds here has not honoured its bound, whatever the
+        launch after it does. The default stands for the callers with no clock of
+        their own — daemon shutdown, and the tests.
+        """
         if self._conn is not None:
             try:
                 self._conn.close()
             except OSError:
                 pass
-        _terminate(self._proc)
+        _terminate(self._proc, grace=grace)
 
 
 def launch_session(
@@ -286,9 +304,6 @@ def launch_session(
     # request with it.
     deadline = time.monotonic() + timeout
 
-    def _remaining() -> float:
-        return max(deadline - time.monotonic(), 0.001)
-
     def _teardown() -> None:
         # Teardown draws from the SAME deadline (#725 re-review). A failure path
         # is reached with the budget already spent, so a child that ignores
@@ -308,10 +323,13 @@ def launch_session(
         _teardown()
         return None
 
-    # The harness's first frame is the auth token.
-    conn.settimeout(_remaining())
+    # The harness's first frame is the auth token. The frame is read against the
+    # ABSOLUTE deadline, not a relative socket timeout: a socket timeout bounds
+    # each ``recv``, so a peer trickling one byte at a time restarts it on every
+    # chunk (#725 re-review — a 0.05s bound was held for 0.7s, and the trickle
+    # rate is the peer's to choose).
     try:
-        presented = read_frame(conn)
+        presented = read_frame(conn, deadline)
     except OSError:  # includes the deadline expiring mid-read
         presented = None
     if presented is None:
@@ -332,9 +350,8 @@ def launch_session(
     # (#278). A mismatch — including Godot's silent main_scene fallback for a bad
     # uid — tears the session down and raises SceneMismatch so the daemon surfaces a
     # typed live_scene_not_found rather than serving the wrong scene.
-    conn.settimeout(_remaining())
     try:
-        verify_frame = read_frame(conn)
+        verify_frame = read_frame(conn, deadline)
     except OSError:
         verify_frame = None
     if verify_frame is None:
@@ -397,6 +414,15 @@ def _terminate(proc: subprocess.Popen, grace: float = TERMINATE_GRACE) -> None:
     immediate; the diagnostics that failure path reads are unaffected, because
     Godot's file logger flushes every error, and every print in a debug build
     (``core/io/logger.cpp``, ``application/run/flush_stdout_on_print.debug``).
+
+    A killed child is then REAPED before returning, so teardown finishes what it
+    started: without it ``returncode`` stayed ``None`` and the exited child was
+    left for whatever happened to call ``poll()`` next — in a long-lived daemon,
+    possibly nothing (#725 re-review). ``_REAP_GRACE`` is the only interval this
+    function spends outside the caller's budget, and it is deliberately tiny: a
+    SIGKILL'd process is reapable in microseconds, so the wait is a formality
+    rather than a wait, and a child that somehow outlasts even that is left
+    unreaped rather than allowed to block the serve loop.
     """
     if proc.poll() is not None:
         return
@@ -413,4 +439,8 @@ def _terminate(proc: subprocess.Popen, grace: float = TERMINATE_GRACE) -> None:
         try:
             proc.kill()
         except OSError:
+            pass
+        try:
+            proc.wait(timeout=_REAP_GRACE)
+        except (subprocess.TimeoutExpired, OSError):
             pass

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -461,10 +461,15 @@ def _terminate(proc: subprocess.Popen, deadline: Optional[float] = None) -> None
     closing the channel and signalling the engine consume the budget too. A
     caller with no clock of its own mints one from ``TERMINATE_GRACE``.
 
-    The escalation covers the ENGINE'S PROCESS GROUP, matching the SIGTERM that
-    preceded it. The session is launched with ``start_new_session=True``, so gda
-    owns that group and everything the engine started inside it; killing only
-    the leader left a descendant that also ignored SIGTERM alive and orphaned.
+    What is retired is the ENGINE'S PROCESS GROUP, not the engine process. The
+    session is launched with ``start_new_session=True``, so gda owns that group
+    and everything the engine started inside it, and the leader's fate does not
+    decide the group's: a leader that OBEYED the group SIGTERM used to end the
+    teardown while a descendant that ignored it kept running, orphaned (#725
+    re-review). The group is therefore signalled again — SIGKILL — once the
+    leader is gone, whatever ended it, and even when it had already exited before
+    this call. The group id is read once, up front, from the leader while it
+    still holds its pid.
 
     An immediate escalation costs no diagnostics: Godot's file logger flushes
     every error, and every print in a debug build (``core/io/logger.cpp``,
@@ -472,26 +477,40 @@ def _terminate(proc: subprocess.Popen, deadline: Optional[float] = None) -> None
 
     A killed child is still collected — rather than left with no ``returncode``
     for whatever happens to poll it next — but off this clock, best-effort: see
-    :func:`_reap_in_background`. So this function never returns later than
-    ``deadline``.
+    :func:`_reap_in_background`. What this function guarantees about the deadline
+    is that it starts no fresh blocking wait after it; a synchronous call already
+    in flight can still delay the return.
     """
     if deadline is None:
         deadline = time.monotonic() + TERMINATE_GRACE
-    if proc.poll() is not None:
-        return
+    # Read BEFORE anything can reap the leader: the group id is the leader's pid,
+    # and a reaped leader has neither.
     try:
         group = os.getpgid(proc.pid)
     except OSError:
         group = None
-    _signal_engine(proc, group, signal.SIGTERM)
-    try:
-        # Recomputed HERE, immediately before the only blocking step: everything
-        # above — the caller's channel close, the poll, the signal — spent from
-        # the same budget.
-        proc.wait(timeout=max(deadline - time.monotonic(), 0.0))
-    except subprocess.TimeoutExpired:
-        _signal_engine(proc, group, signal.SIGKILL)
-        _reap_in_background(proc)
+    if group is not None and group == os.getpgrp():
+        # Never signal our own group — that would take the daemon down with the
+        # engine. Only reachable if the launch did not get its own session.
+        group = None
+    if proc.poll() is None:
+        _signal_engine(proc, group, signal.SIGTERM)
+        try:
+            # Recomputed HERE, immediately before the only blocking step:
+            # everything above — the caller's channel close, the poll, the signal
+            # — spent from the same budget.
+            proc.wait(timeout=max(deadline - time.monotonic(), 0.0))
+        except subprocess.TimeoutExpired:
+            _signal_engine(proc, group, signal.SIGKILL)
+            _reap_in_background(proc)
+            return
+    # The leader is gone — by its own exit, by the SIGTERM, or before gda arrived.
+    # The GROUP is not gone with it, and gda owns it.
+    if group is not None:
+        try:
+            os.killpg(group, signal.SIGKILL)
+        except OSError:
+            pass  # an empty group is the normal case: nothing left to retire
 
 
 def _signal_engine(proc: subprocess.Popen, group: Optional[int], sig: int) -> None:
@@ -522,8 +541,8 @@ def _reap_in_background(proc: subprocess.Popen) -> "threading.Thread":
     never keep gda alive — so it is not drained at shutdown, and a collection that
     fails is swallowed rather than reported. Giving it a managed lifecycle would buy
     a guarantee nothing needs: SIGKILL cannot be caught, so the wait ends on its own
-    in every case anyone has observed, and the cost of the rare miss is one entry in
-    a process table that the daemon's own exit clears.
+    in every case anyone has observed, and the cost of a rare miss is one process-table
+    entry — when the daemon exits, the child is reparented to init and reaped there.
     """
     reaper = threading.Thread(
         target=_reap, args=(proc,), name=f"gda-reap-{proc.pid}", daemon=True

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -17,6 +17,7 @@ import os
 import signal
 import socket
 import subprocess
+import threading
 import time
 from pathlib import Path
 from typing import Optional
@@ -34,9 +35,6 @@ OP_TIMEOUT = 30.0
 # when the caller set no deadline of its own (``EngineSession.close``). A launch
 # teardown draws its grace from the launch deadline instead (#725 re-review).
 TERMINATE_GRACE = 5.0
-# The formality after a SIGKILL: long enough to reap a process the kernel has
-# already stopped, short enough that it is never a wait anyone notices.
-_REAP_GRACE = 0.5
 
 
 class SceneMismatch(Exception):
@@ -195,7 +193,7 @@ def launch_session(
     harness_socket: Path,
     token: str,
     log_file: Optional[Path] = None,
-    timeout: float = CONNECT_TIMEOUT,
+    deadline: Optional[float] = None,
     windowed: bool = False,
     scene: Optional[str] = None,
     diagnostics: Optional[list[str]] = None,
@@ -255,6 +253,31 @@ def launch_session(
         if diagnostics is not None:
             diagnostics.append(message)
 
+    # The caller's deadline, taken BEFORE anything is spent (#725 re-review). It is
+    # an absolute instant, not a duration, because a duration restarts whatever
+    # clock receives it: this function used to derive its own AFTER truncating the
+    # log and spawning the engine, so the spawn was charged to nobody — a
+    # `--timeout 0.05` launch whose spawn alone took 0.12s still SUCCEEDED. A caller
+    # with a bound of its own passes the same instant it is honouring; a caller with
+    # none (a direct launch, a test) gets the engine-boot default from here.
+    budget = (
+        CONNECT_TIMEOUT if deadline is None else max(deadline - time.monotonic(), 0.0)
+    )
+    if deadline is None:
+        deadline = time.monotonic() + CONNECT_TIMEOUT
+
+    def _left() -> float:
+        return max(deadline - time.monotonic(), 0.0)
+
+    if _left() <= 0:
+        # Nothing left to launch WITHIN, so nothing is spawned. The spawn is the
+        # one step here that cannot be interrupted once begun — the deadline is
+        # checked before it and drives everything after it, so a spawn that
+        # outruns the budget ends in this refusal rather than in a session that
+        # came up past the caller's bound.
+        _record("the readiness deadline expired before the engine was launched")
+        return None
+
     log_args = ["--log-file", str(log_file)] if log_file is not None else []
     if log_file is not None:
         # Truncate the Session log BEFORE spawning (#345 finding 2). Godot's
@@ -296,30 +319,28 @@ def launch_session(
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    # ONE monotonic deadline for the WHOLE readiness handshake (#725 review):
-    # accept, the token frame, and the scene-verification frame all draw down the
-    # same budget. Bounding only the accept let a peer that connected and then
-    # went silent block the token read forever — and the daemon serves one
-    # request at a time, so that silence froze every later live and control
-    # request with it.
-    deadline = time.monotonic() + timeout
 
+    # Everything from here draws down the ONE deadline taken above: the accept, the
+    # token frame, the scene-verification frame, and the teardown of a failure.
+    # Bounding only the accept let a peer that connected and then went silent block
+    # the token read forever — and the daemon serves one request at a time, so that
+    # silence froze every later live and control request with it (#725 review).
     def _teardown() -> None:
-        # Teardown draws from the SAME deadline (#725 re-review). A failure path
-        # is reached with the budget already spent, so a child that ignores
-        # SIGTERM used to add a fresh five-second grace ON TOP of the caller's
-        # bound — 5.3s for a `wait-ready --timeout 0.3` — with the single-threaded
-        # serve loop blocked for all of it. Nothing left means kill now.
-        _terminate(proc, grace=max(deadline - time.monotonic(), 0.0))
+        # Teardown draws from the same deadline (#725 re-review). A failure path is
+        # reached with the budget already spent, so a child that ignores SIGTERM
+        # used to add a fresh five-second grace ON TOP of the caller's bound — 5.3s
+        # for a `wait-ready --timeout 0.3` — with the serve loop blocked for all of
+        # it. Nothing left means kill now.
+        _terminate(proc, grace=_left())
 
-    harness_listener.settimeout(timeout)
+    harness_listener.settimeout(_left())
     try:
         conn, _ = harness_listener.accept()
     except OSError:  # includes socket.timeout
         # No harness connected within the timeout. Poll the child BEFORE tearing it
         # down: this is where a windowed-no-DisplayServer abort (child died by
         # signal) is told apart from a genuinely hung harness (child still alive).
-        _record(_child_exit_diagnostic(proc, timeout))
+        _record(_child_exit_diagnostic(proc, budget))
         _teardown()
         return None
 
@@ -371,7 +392,7 @@ def launch_session(
     return EngineSession(proc, conn, log_file=log_file)
 
 
-def _child_exit_diagnostic(proc: subprocess.Popen, timeout: float) -> str:
+def _child_exit_diagnostic(proc: subprocess.Popen, budget: float) -> str:
     """A best-effort launch-failure reason from the child's liveness (#345).
 
     Called on a failure path BEFORE terminating the child (spawned with
@@ -385,7 +406,7 @@ def _child_exit_diagnostic(proc: subprocess.Popen, timeout: float) -> str:
     """
     code = proc.poll()
     if code is None:
-        return f"the engine started but the harness did not connect within {timeout:.0f}s; session terminated"
+        return f"the engine started but the harness did not connect within {budget:.0f}s; session terminated"
     if code < 0:
         signum = -code
         try:
@@ -415,14 +436,10 @@ def _terminate(proc: subprocess.Popen, grace: float = TERMINATE_GRACE) -> None:
     Godot's file logger flushes every error, and every print in a debug build
     (``core/io/logger.cpp``, ``application/run/flush_stdout_on_print.debug``).
 
-    A killed child is then REAPED before returning, so teardown finishes what it
-    started: without it ``returncode`` stayed ``None`` and the exited child was
-    left for whatever happened to call ``poll()`` next — in a long-lived daemon,
-    possibly nothing (#725 re-review). ``_REAP_GRACE`` is the only interval this
-    function spends outside the caller's budget, and it is deliberately tiny: a
-    SIGKILL'd process is reapable in microseconds, so the wait is a formality
-    rather than a wait, and a child that somehow outlasts even that is left
-    unreaped rather than allowed to block the serve loop.
+    A killed child is still REAPED — teardown finishes what it started, rather
+    than leaving an exited child with no ``returncode`` for whatever happens to
+    poll it next — but off this clock: see :func:`_reap_in_background` (#725
+    re-review). So this function never returns later than ``grace``.
     """
     if proc.poll() is not None:
         return
@@ -440,7 +457,33 @@ def _terminate(proc: subprocess.Popen, grace: float = TERMINATE_GRACE) -> None:
             proc.kill()
         except OSError:
             pass
-        try:
-            proc.wait(timeout=_REAP_GRACE)
-        except (subprocess.TimeoutExpired, OSError):
-            pass
+        _reap_in_background(proc)
+
+
+def _reap_in_background(proc: subprocess.Popen) -> "threading.Thread":
+    """Collect a SIGKILL'd child off the caller's clock (#725 re-review).
+
+    The escalation is reached with the budget already spent, so waiting here — even
+    briefly — is time the caller did not agree to and, in the daemon, time every
+    queued request waits too: a fixed half-second allowance turned a 0.01s-bounded
+    `wait-ready` into 0.5s. But a child that is never collected stays a zombie with
+    no ``returncode``, so the duty cannot simply be dropped. It is neither
+    charged nor dropped: one short-lived thread owns the collection and this
+    function returns at once. The thread is a daemon thread — a killed engine must
+    never keep gda alive — and it ends when the child does, which SIGKILL
+    guarantees.
+    """
+    reaper = threading.Thread(
+        target=_reap, args=(proc,), name=f"gda-reap-{proc.pid}", daemon=True
+    )
+    reaper.start()
+    return reaper
+
+
+def _reap(proc: subprocess.Popen) -> None:
+    try:
+        proc.wait()
+    except (OSError, subprocess.SubprocessError):
+        # Nothing left to do about a child that cannot be collected, and a
+        # traceback out of a daemon thread would land in the daemon's output.
+        pass

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -35,6 +35,8 @@ OP_TIMEOUT = 30.0
 # when the caller set no deadline of its own (``EngineSession.close``). A launch
 # teardown draws its grace from the launch deadline instead (#725 re-review).
 TERMINATE_GRACE = 5.0
+# How often teardown re-checks whether the engine's process group has emptied.
+_RETIRE_POLL = 0.005
 
 
 class SceneMismatch(Exception):
@@ -98,11 +100,19 @@ class EngineSession:
         proc: subprocess.Popen,
         conn: socket.socket | None,
         log_file: Optional[Path] = None,
+        group: Optional[int] = None,
     ) -> None:
         self._proc = proc
         self._conn = conn
         self.log_file = log_file
         self._channel_stale = False
+        # The process group gda owns for this session, captured at spawn and
+        # REMEMBERED (#725 re-review). It cannot be rediscovered at teardown:
+        # ``alive()`` polls the leader, which reaps it, and a reaped leader has
+        # no pid to read a group from — after which nothing retires whatever the
+        # engine started. A pid can also be reused; the id captured at spawn is
+        # the only one known to be this session's.
+        self._group = group
 
     def alive(self) -> bool:
         # Liveness is the PROCESS and the CHANNEL (#725 review): a session whose
@@ -188,7 +198,7 @@ class EngineSession:
                 self._conn.close()
             except OSError:
                 pass
-        _terminate(self._proc, deadline)
+        _terminate(self._proc, deadline, group=self._group)
 
 
 def launch_session(
@@ -336,13 +346,17 @@ def launch_session(
     # Bounding only the accept let a peer that connected and then went silent block
     # the token read forever — and the daemon serves one request at a time, so that
     # silence froze every later live and control request with it (#725 review).
+    # Captured immediately after the spawn, while the leader certainly holds its
+    # pid, and validated against gda's own group (#725 re-review).
+    group = _own_group(proc)
+
     def _teardown() -> None:
         # Teardown draws from the same deadline (#725 re-review). A failure path is
         # reached with the budget already spent, so a child that ignores SIGTERM
         # used to add a fresh five-second grace ON TOP of the caller's bound — 5.3s
         # for a `wait-ready --timeout 0.3` — with the serve loop blocked for all of
         # it. Nothing left means kill now.
-        _terminate(proc, deadline)
+        _terminate(proc, deadline, group=group)
 
     if _left() <= 0:
         # The spawn itself outran the budget — the one step that cannot be
@@ -414,7 +428,7 @@ def launch_session(
         _close(conn)
         _teardown()
         raise SceneMismatch(scene if scene is not None else "", str(current))
-    return EngineSession(proc, conn, log_file=log_file)
+    return EngineSession(proc, conn, log_file=log_file, group=group)
 
 
 def _child_exit_diagnostic(proc: subprocess.Popen, budget: float) -> str:
@@ -449,7 +463,11 @@ def _close(conn: socket.socket) -> None:
         pass
 
 
-def _terminate(proc: subprocess.Popen, deadline: Optional[float] = None) -> None:
+def _terminate(
+    proc: subprocess.Popen,
+    deadline: Optional[float] = None,
+    group: Optional[int] = None,
+) -> None:
     """SIGTERM the engine group, then SIGKILL it if it has not exited by ``deadline``.
 
     ``deadline`` is an absolute instant, and the wait is measured from it at the
@@ -463,13 +481,20 @@ def _terminate(proc: subprocess.Popen, deadline: Optional[float] = None) -> None
 
     What is retired is the ENGINE'S PROCESS GROUP, not the engine process. The
     session is launched with ``start_new_session=True``, so gda owns that group
-    and everything the engine started inside it, and the leader's fate does not
-    decide the group's: a leader that OBEYED the group SIGTERM used to end the
-    teardown while a descendant that ignored it kept running, orphaned (#725
-    re-review). The group is therefore signalled again — SIGKILL — once the
-    leader is gone, whatever ended it, and even when it had already exited before
-    this call. The group id is read once, up front, from the leader while it
-    still holds its pid.
+    and everything the engine started inside it, and the leader's fate decides
+    neither when the group is done nor how it ends (#725 re-review): a leader
+    that OBEYED the group SIGTERM used to end the teardown while a descendant
+    that ignored it kept running, orphaned — and a leader that exited on its own
+    used to end it while its descendant had not been signalled at all.
+
+    So the wait is for the GROUP to empty, within the same deadline, and only a
+    group still standing when the deadline arrives is escalated to SIGKILL. That
+    order matters both ways: a descendant given SIGTERM may legitimately still be
+    finishing (killing it the instant the leader exits truncates that), and a
+    descendant that ignores SIGTERM must not outlive the session (letting the
+    leader's exit end the teardown orphaned it). ``group`` comes from the OWNER —
+    captured at spawn — because it cannot be recovered here: polling the leader
+    reaps it, and a reaped leader has no pid to read a group from.
 
     An immediate escalation costs no diagnostics: Godot's file logger flushes
     every error, and every print in a debug build (``core/io/logger.cpp``,
@@ -483,34 +508,55 @@ def _terminate(proc: subprocess.Popen, deadline: Optional[float] = None) -> None
     """
     if deadline is None:
         deadline = time.monotonic() + TERMINATE_GRACE
-    # Read BEFORE anything can reap the leader: the group id is the leader's pid,
-    # and a reaped leader has neither.
-    try:
-        group = os.getpgid(proc.pid)
-    except OSError:
-        group = None
-    if group is not None and group == os.getpgrp():
-        # Never signal our own group — that would take the daemon down with the
-        # engine. Only reachable if the launch did not get its own session.
-        group = None
+    if group is None:
+        # No owner told us, so recover what can still be recovered — accurate for
+        # a leader that has not been reaped, ``None`` once it has.
+        group = _own_group(proc)
     if proc.poll() is None:
         _signal_engine(proc, group, signal.SIGTERM)
-        try:
-            # Recomputed HERE, immediately before the only blocking step:
-            # everything above — the caller's channel close, the poll, the signal
-            # — spent from the same budget.
-            proc.wait(timeout=max(deadline - time.monotonic(), 0.0))
-        except subprocess.TimeoutExpired:
-            _signal_engine(proc, group, signal.SIGKILL)
-            _reap_in_background(proc)
+    while time.monotonic() < deadline:
+        # Polled rather than blocked on the leader: the leader exiting is not the
+        # group being done, and blocking on it cannot observe the difference.
+        # ``poll`` also reaps the leader, keeping its ``returncode`` honest.
+        proc.poll()
+        if not _group_standing(group, proc):
             return
-    # The leader is gone — by its own exit, by the SIGTERM, or before gda arrived.
-    # The GROUP is not gone with it, and gda owns it.
-    if group is not None:
+        time.sleep(min(_RETIRE_POLL, max(deadline - time.monotonic(), 0.0)))
+    # The deadline arrived with the session still standing.
+    if proc.poll() is None:
+        _signal_engine(proc, group, signal.SIGKILL)
+        _reap_in_background(proc)
+    elif group is not None:
         try:
             os.killpg(group, signal.SIGKILL)
         except OSError:
-            pass  # an empty group is the normal case: nothing left to retire
+            pass  # already empty: nothing left to retire
+
+
+def _group_standing(group: Optional[int], proc: subprocess.Popen) -> bool:
+    """Whether anything gda owns for this session is still running."""
+    if group is None:
+        return proc.poll() is None
+    try:
+        os.killpg(group, 0)
+    except OSError:
+        return False  # no members left
+    return True
+
+
+def _own_group(proc: subprocess.Popen) -> Optional[int]:
+    """The process group gda owns for ``proc``, or ``None`` if there is none.
+
+    ``None`` when the leader is already reaped (its pid, and so its group id, is
+    gone) and when the group turns out to be gda's OWN — signalling that would
+    take the daemon down with the engine, and it means the launch never got its
+    own session.
+    """
+    try:
+        group = os.getpgid(proc.pid)
+    except OSError:
+        return None
+    return None if group == os.getpgrp() else group
 
 
 def _signal_engine(proc: subprocess.Popen, group: Optional[int], sig: int) -> None:

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -17,6 +17,7 @@ import os
 import signal
 import socket
 import subprocess
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -96,15 +97,23 @@ class EngineSession:
         self._proc = proc
         self._conn = conn
         self.log_file = log_file
+        self._channel_stale = False
 
     def alive(self) -> bool:
-        return self._proc.poll() is None
+        # Liveness is the PROCESS and the CHANNEL (#725 review): a session whose
+        # harness connection was observed broken cannot serve, however alive the
+        # engine process is — calling it alive made `daemon wait-ready` report a
+        # serving state the very next read disproved. Staleness is latched at
+        # the observation point (a failed relay in ``request``), so the next
+        # session-needing op rebuilds through the shared launch boundary.
+        return self._proc.poll() is None and not self._channel_stale
 
     def request(self, operation: str, params: dict) -> dict:
         """Relay one live op to the harness; return the CLI reply dict."""
         if self._conn is None:
             # A session whose harness never connected has no channel to relay on
             # — report it as a dropped connection rather than crash on ``None``.
+            self._channel_stale = True
             return error_reply(
                 "engine_disconnected", "the engine session has no live connection"
             )
@@ -113,15 +122,21 @@ class EngineSession:
             write_message(self._conn, {"op": operation, "params": params})
             reply = read_frame(self._conn)  # the raw ADR-0002 sentinel string
         except TimeoutError:
+            # Deliberately NOT latched stale: a slow op is not a broken channel,
+            # and relaunching on every live_timeout would turn one long frame
+            # into a session churn. (A late reply CAN leave the stream framing
+            # dirty; that recovery question predates this slice and stays open.)
             return error_reply(
                 "live_timeout",
                 f"the engine session did not return within {int(OP_TIMEOUT)}s",
             )
         except OSError:
+            self._channel_stale = True
             return error_reply(
                 "engine_disconnected", "the engine session dropped the connection"
             )
         if reply is None:
+            self._channel_stale = True
             return error_reply(
                 "engine_disconnected", "the engine session closed before replying"
             )
@@ -248,6 +263,17 @@ def launch_session(
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
+    # ONE monotonic deadline for the WHOLE readiness handshake (#725 review):
+    # accept, the token frame, and the scene-verification frame all draw down the
+    # same budget. Bounding only the accept let a peer that connected and then
+    # went silent block the token read forever — and the daemon serves one
+    # request at a time, so that silence froze every later live and control
+    # request with it.
+    deadline = time.monotonic() + timeout
+
+    def _remaining() -> float:
+        return max(deadline - time.monotonic(), 0.001)
+
     harness_listener.settimeout(timeout)
     try:
         conn, _ = harness_listener.accept()
@@ -260,11 +286,19 @@ def launch_session(
         return None
 
     # The harness's first frame is the auth token.
+    conn.settimeout(_remaining())
     try:
         presented = read_frame(conn)
-    except OSError:
+    except OSError:  # includes the deadline expiring mid-read
         presented = None
-    if presented is None or presented.decode("utf-8", "replace") != token:
+    if presented is None:
+        _record(
+            "the harness connected but sent no auth token within the launch deadline"
+        )
+        _close(conn)
+        _terminate(proc)
+        return None
+    if presented.decode("utf-8", "replace") != token:
         _record("the harness connected but presented an invalid auth token")
         _close(conn)
         _terminate(proc)
@@ -275,6 +309,7 @@ def launch_session(
     # (#278). A mismatch — including Godot's silent main_scene fallback for a bad
     # uid — tears the session down and raises SceneMismatch so the daemon surfaces a
     # typed live_scene_not_found rather than serving the wrong scene.
+    conn.settimeout(_remaining())
     try:
         verify_frame = read_frame(conn)
     except OSError:

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -30,6 +30,10 @@ CONNECT_TIMEOUT = 25.0
 # Bounds one live op against the harness so a stuck op cannot hang the daemon
 # forever; surfaced as the registered ``live_timeout`` (ADR-0021).
 OP_TIMEOUT = 30.0
+# How long a SIGTERM'd engine may take to exit before it is escalated to SIGKILL,
+# when the caller set no deadline of its own (``EngineSession.close``). A launch
+# teardown draws its grace from the launch deadline instead (#725 re-review).
+TERMINATE_GRACE = 5.0
 
 
 class SceneMismatch(Exception):
@@ -101,9 +105,10 @@ class EngineSession:
 
     def alive(self) -> bool:
         # Liveness is the PROCESS and the CHANNEL (#725 review): a session whose
-        # harness connection was observed broken cannot serve, however alive the
-        # engine process is — calling it alive made `daemon wait-ready` report a
-        # serving state the very next read disproved. Staleness is latched at
+        # harness channel was observed broken — dropped, closed, or left
+        # response-ambiguous by a timed-out relay — cannot serve, however alive
+        # the engine process is; calling it alive made `daemon wait-ready` report
+        # a serving state the very next read disproved. Staleness is latched at
         # the observation point (a failed relay in ``request``), so the next
         # session-needing op rebuilds through the shared launch boundary.
         return self._proc.poll() is None and not self._channel_stale
@@ -122,10 +127,20 @@ class EngineSession:
             write_message(self._conn, {"op": operation, "params": params})
             reply = read_frame(self._conn)  # the raw ADR-0002 sentinel string
         except TimeoutError:
-            # Deliberately NOT latched stale: a slow op is not a broken channel,
-            # and relaunching on every live_timeout would turn one long frame
-            # into a session churn. (A late reply CAN leave the stream framing
-            # dirty; that recovery question predates this slice and stays open.)
+            # Latched stale too (#725 re-review). The earlier reading — "a slow op
+            # is not a broken channel" — priced only the churn of relaunching. The
+            # real price is worse: this protocol carries no request id and the
+            # timed-out frame is NOT drained, so a late reply is indistinguishable
+            # from the NEXT op's reply. Reproduced on the pre-fix head: op A times
+            # out, op B reads A's late payload and returns it as B's result — a
+            # validly-framed, semantically WRONG answer. A channel that can answer
+            # with another operation's result cannot serve, so the session is dead
+            # to the daemon from here; the next session-needing op rebuilds it
+            # through the shared launch boundary. The cost is a relaunch after an
+            # op that outran OP_TIMEOUT (state does not survive it — CONTEXT.md
+            # "State consistency"); correlating replies instead would change the
+            # cross-language harness protocol and belongs to its own decision.
+            self._channel_stale = True
             return error_reply(
                 "live_timeout",
                 f"the engine session did not return within {int(OP_TIMEOUT)}s",
@@ -274,6 +289,14 @@ def launch_session(
     def _remaining() -> float:
         return max(deadline - time.monotonic(), 0.001)
 
+    def _teardown() -> None:
+        # Teardown draws from the SAME deadline (#725 re-review). A failure path
+        # is reached with the budget already spent, so a child that ignores
+        # SIGTERM used to add a fresh five-second grace ON TOP of the caller's
+        # bound — 5.3s for a `wait-ready --timeout 0.3` — with the single-threaded
+        # serve loop blocked for all of it. Nothing left means kill now.
+        _terminate(proc, grace=max(deadline - time.monotonic(), 0.0))
+
     harness_listener.settimeout(timeout)
     try:
         conn, _ = harness_listener.accept()
@@ -282,7 +305,7 @@ def launch_session(
         # down: this is where a windowed-no-DisplayServer abort (child died by
         # signal) is told apart from a genuinely hung harness (child still alive).
         _record(_child_exit_diagnostic(proc, timeout))
-        _terminate(proc)
+        _teardown()
         return None
 
     # The harness's first frame is the auth token.
@@ -296,12 +319,12 @@ def launch_session(
             "the harness connected but sent no auth token within the launch deadline"
         )
         _close(conn)
-        _terminate(proc)
+        _teardown()
         return None
     if presented.decode("utf-8", "replace") != token:
         _record("the harness connected but presented an invalid auth token")
         _close(conn)
-        _terminate(proc)
+        _teardown()
         return None
 
     # The harness's second frame is the launch-time scene verification: it reports
@@ -317,7 +340,7 @@ def launch_session(
     if verify_frame is None:
         _record("the harness connected but closed before the scene-verification frame")
         _close(conn)
-        _terminate(proc)
+        _teardown()
         return None
     try:
         verify = json.loads(verify_frame.decode("utf-8", "replace"))
@@ -326,7 +349,7 @@ def launch_session(
     if not isinstance(verify, dict) or not verify.get("scene_ok", False):
         current = verify.get("current", "") if isinstance(verify, dict) else ""
         _close(conn)
-        _terminate(proc)
+        _teardown()
         raise SceneMismatch(scene if scene is not None else "", str(current))
     return EngineSession(proc, conn, log_file=log_file)
 
@@ -363,7 +386,18 @@ def _close(conn: socket.socket) -> None:
         pass
 
 
-def _terminate(proc: subprocess.Popen) -> None:
+def _terminate(proc: subprocess.Popen, grace: float = TERMINATE_GRACE) -> None:
+    """SIGTERM the engine, then SIGKILL it if it has not exited within ``grace``.
+
+    ``grace`` is a BUDGET, not a fixed pause: the launch paths pass what remains
+    of their readiness deadline (#725 re-review), because the daemon serves one
+    request at a time and a child that ignores SIGTERM used to start a fresh
+    five-second wait AFTER the caller's budget was already spent — a 0.3s-bounded
+    ``daemon wait-ready`` measured 5.3s. With nothing left the escalation is
+    immediate; the diagnostics that failure path reads are unaffected, because
+    Godot's file logger flushes every error, and every print in a debug build
+    (``core/io/logger.cpp``, ``application/run/flush_stdout_on_print.debug``).
+    """
     if proc.poll() is not None:
         return
     try:
@@ -374,7 +408,7 @@ def _terminate(proc: subprocess.Popen) -> None:
         except OSError:
             pass
     try:
-        proc.wait(timeout=5)
+        proc.wait(timeout=max(grace, 0.0))
     except subprocess.TimeoutExpired:
         try:
             proc.kill()

--- a/src/gda/daemon/session.py
+++ b/src/gda/daemon/session.py
@@ -168,22 +168,27 @@ class EngineSession:
             "exit_code": 0,
         }
 
-    def close(self, grace: float = TERMINATE_GRACE) -> None:
-        """Drop the channel and end the engine, within ``grace`` (#725 re-review).
+    def close(self, deadline: Optional[float] = None) -> None:
+        """Drop the channel and end the engine, by ``deadline`` (#725 re-review).
 
-        The grace is a budget the CALLER may shorten, because retiring a session
-        is work done on someone's clock: ``_ensure_session`` retires a stale one
-        before launching its replacement, and a `daemon wait-ready --timeout 0.3`
-        that spends five seconds here has not honoured its bound, whatever the
-        launch after it does. The default stands for the callers with no clock of
-        their own — daemon shutdown, and the tests.
+        An absolute instant, because retiring a session is work done on someone's
+        clock: ``_ensure_session`` retires a stale one before launching its
+        replacement, and a `daemon wait-ready --timeout 0.3` that spends five
+        seconds here has not honoured its bound, whatever the launch after it
+        does. An instant rather than a duration, because a duration is a fresh
+        budget to whatever receives it — closing the channel and signalling the
+        engine take time too, and a grace measured from before them is not the
+        bound the caller was given. A caller with no clock of its own — daemon
+        shutdown, the tests — mints one here.
         """
+        if deadline is None:
+            deadline = time.monotonic() + TERMINATE_GRACE
         if self._conn is not None:
             try:
                 self._conn.close()
             except OSError:
                 pass
-        _terminate(self._proc, grace=grace)
+        _terminate(self._proc, deadline)
 
 
 def launch_session(
@@ -270,11 +275,6 @@ def launch_session(
         return max(deadline - time.monotonic(), 0.0)
 
     if _left() <= 0:
-        # Nothing left to launch WITHIN, so nothing is spawned. The spawn is the
-        # one step here that cannot be interrupted once begun — the deadline is
-        # checked before it and drives everything after it, so a spawn that
-        # outruns the budget ends in this refusal rather than in a session that
-        # came up past the caller's bound.
         _record("the readiness deadline expired before the engine was launched")
         return None
 
@@ -300,6 +300,17 @@ def launch_session(
     # The harness tail also carries the selector (empty string when none) so the
     # harness can verify the loaded scene against it at launch (#278).
     requested_scene = scene if scene is not None else ""
+    if _left() <= 0:
+        # Re-checked immediately before the spawn (#725 re-review). The preparation
+        # above is not free — truncating the Session log is a filesystem write that
+        # can block — and a gate that only ran before it let the deadline pass and
+        # the engine start anyway, 0.076s late in a probe. This is the LAST
+        # interruptible point: after this line the spawn is committed.
+        _record(
+            "the readiness deadline expired while preparing the launch; "
+            "the engine was not started"
+        )
+        return None
     proc = subprocess.Popen(
         [
             str(binary),
@@ -331,7 +342,21 @@ def launch_session(
         # used to add a fresh five-second grace ON TOP of the caller's bound — 5.3s
         # for a `wait-ready --timeout 0.3` — with the serve loop blocked for all of
         # it. Nothing left means kill now.
-        _terminate(proc, grace=_left())
+        _terminate(proc, deadline)
+
+    if _left() <= 0:
+        # The spawn itself outran the budget — the one step that cannot be
+        # interrupted once begun. Reported as WHAT HAPPENED (#725 re-review):
+        # falling through would refuse a moment later blaming the harness for
+        # sending no auth token, which is a different failure and can be plainly
+        # false — the token may already be queued on a connection that was made
+        # while the engine was still starting.
+        _record(
+            "the readiness deadline expired while the engine was starting; "
+            "the session was torn down"
+        )
+        _teardown()
+        return None
 
     harness_listener.settimeout(_left())
     try:
@@ -424,40 +449,63 @@ def _close(conn: socket.socket) -> None:
         pass
 
 
-def _terminate(proc: subprocess.Popen, grace: float = TERMINATE_GRACE) -> None:
-    """SIGTERM the engine, then SIGKILL it if it has not exited within ``grace``.
+def _terminate(proc: subprocess.Popen, deadline: Optional[float] = None) -> None:
+    """SIGTERM the engine group, then SIGKILL it if it has not exited by ``deadline``.
 
-    ``grace`` is a BUDGET, not a fixed pause: the launch paths pass what remains
-    of their readiness deadline (#725 re-review), because the daemon serves one
-    request at a time and a child that ignores SIGTERM used to start a fresh
-    five-second wait AFTER the caller's budget was already spent — a 0.3s-bounded
-    ``daemon wait-ready`` measured 5.3s. With nothing left the escalation is
-    immediate; the diagnostics that failure path reads are unaffected, because
-    Godot's file logger flushes every error, and every print in a debug build
-    (``core/io/logger.cpp``, ``application/run/flush_stdout_on_print.debug``).
+    ``deadline`` is an absolute instant, and the wait is measured from it at the
+    moment the wait begins — not from whenever the caller decided (#725
+    re-review). The daemon serves one request at a time, so a child that ignores
+    SIGTERM used to add a fresh five-second wait AFTER the caller's budget was
+    spent (a 0.3s-bounded ``daemon wait-ready`` measured 5.3s); converting the
+    instant to a duration up front had the same shape one layer down, since
+    closing the channel and signalling the engine consume the budget too. A
+    caller with no clock of its own mints one from ``TERMINATE_GRACE``.
 
-    A killed child is still REAPED — teardown finishes what it started, rather
-    than leaving an exited child with no ``returncode`` for whatever happens to
-    poll it next — but off this clock: see :func:`_reap_in_background` (#725
-    re-review). So this function never returns later than ``grace``.
+    The escalation covers the ENGINE'S PROCESS GROUP, matching the SIGTERM that
+    preceded it. The session is launched with ``start_new_session=True``, so gda
+    owns that group and everything the engine started inside it; killing only
+    the leader left a descendant that also ignored SIGTERM alive and orphaned.
+
+    An immediate escalation costs no diagnostics: Godot's file logger flushes
+    every error, and every print in a debug build (``core/io/logger.cpp``,
+    ``application/run/flush_stdout_on_print.debug``).
+
+    A killed child is still collected — rather than left with no ``returncode``
+    for whatever happens to poll it next — but off this clock, best-effort: see
+    :func:`_reap_in_background`. So this function never returns later than
+    ``deadline``.
     """
+    if deadline is None:
+        deadline = time.monotonic() + TERMINATE_GRACE
     if proc.poll() is not None:
         return
     try:
-        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        group = os.getpgid(proc.pid)
     except OSError:
+        group = None
+    _signal_engine(proc, group, signal.SIGTERM)
+    try:
+        # Recomputed HERE, immediately before the only blocking step: everything
+        # above — the caller's channel close, the poll, the signal — spent from
+        # the same budget.
+        proc.wait(timeout=max(deadline - time.monotonic(), 0.0))
+    except subprocess.TimeoutExpired:
+        _signal_engine(proc, group, signal.SIGKILL)
+        _reap_in_background(proc)
+
+
+def _signal_engine(proc: subprocess.Popen, group: Optional[int], sig: int) -> None:
+    """Signal the engine's whole process group, or the child alone if it has none."""
+    if group is not None:
         try:
-            proc.terminate()
+            os.killpg(group, sig)
+            return
         except OSError:
             pass
     try:
-        proc.wait(timeout=max(grace, 0.0))
-    except subprocess.TimeoutExpired:
-        try:
-            proc.kill()
-        except OSError:
-            pass
-        _reap_in_background(proc)
+        proc.terminate() if sig == signal.SIGTERM else proc.kill()
+    except OSError:
+        pass
 
 
 def _reap_in_background(proc: subprocess.Popen) -> "threading.Thread":
@@ -467,11 +515,15 @@ def _reap_in_background(proc: subprocess.Popen) -> "threading.Thread":
     briefly — is time the caller did not agree to and, in the daemon, time every
     queued request waits too: a fixed half-second allowance turned a 0.01s-bounded
     `wait-ready` into 0.5s. But a child that is never collected stays a zombie with
-    no ``returncode``, so the duty cannot simply be dropped. It is neither
-    charged nor dropped: one short-lived thread owns the collection and this
-    function returns at once. The thread is a daemon thread — a killed engine must
-    never keep gda alive — and it ends when the child does, which SIGKILL
-    guarantees.
+    no ``returncode``, so the duty is not dropped either: one short-lived thread
+    owns the collection and this function returns at once.
+
+    BEST-EFFORT, deliberately. The thread is a daemon thread — a killed engine must
+    never keep gda alive — so it is not drained at shutdown, and a collection that
+    fails is swallowed rather than reported. Giving it a managed lifecycle would buy
+    a guarantee nothing needs: SIGKILL cannot be caught, so the wait ends on its own
+    in every case anyone has observed, and the cost of the rare miss is one entry in
+    a process table that the daemon's own exit clears.
     """
     reaper = threading.Thread(
         target=_reap, args=(proc,), name=f"gda-reap-{proc.pid}", daemon=True

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -644,7 +644,9 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         EXIT_LIVE,
         ErrorCodeSource.CLASSIFIER,
         "A live operation did not return from the engine session before the"
-        " daemon's timeout.",
+        " daemon's timeout. The session is discarded: its reply is no longer"
+        " attributable, so the next operation relaunches it and runtime state"
+        " does not survive.",
     ),
     # The harness-lifecycle refusal (#225, ADR-0018): `gda daemon uninstall`
     # removes the harness autoload + files, which would yank the autoload out from

--- a/src/gda/live_runner.py
+++ b/src/gda/live_runner.py
@@ -83,10 +83,7 @@ class DaemonRunner:
                 # the reply arrives in as many as the daemon sends — so 60s of
                 # socket timeout was 60s of inactivity, not 60s of waiting.
                 deadline = time.monotonic() + LIVE_REQUEST_TIMEOUT
-                left = deadline - time.monotonic()
-                if left <= 0:
-                    raise TimeoutError("the live request deadline has expired")
-                sock.settimeout(left)
+                sock.settimeout(LIVE_REQUEST_TIMEOUT)
                 sock.connect(str(cli_socket))
                 write_message(sock, {"op": operation, "params": params}, deadline)
                 reply = read_message(sock, deadline)

--- a/src/gda/live_runner.py
+++ b/src/gda/live_runner.py
@@ -83,9 +83,12 @@ class DaemonRunner:
                 # the reply arrives in as many as the daemon sends — so 60s of
                 # socket timeout was 60s of inactivity, not 60s of waiting.
                 deadline = time.monotonic() + LIVE_REQUEST_TIMEOUT
-                sock.settimeout(LIVE_REQUEST_TIMEOUT)
+                left = deadline - time.monotonic()
+                if left <= 0:
+                    raise TimeoutError("the live request deadline has expired")
+                sock.settimeout(left)
                 sock.connect(str(cli_socket))
-                write_message(sock, {"op": operation, "params": params})
+                write_message(sock, {"op": operation, "params": params}, deadline)
                 reply = read_message(sock, deadline)
         except TimeoutError:
             return _live_error_result(

--- a/src/gda/live_runner.py
+++ b/src/gda/live_runner.py
@@ -16,6 +16,7 @@ becomes ``engine_disconnected``. Both ride the normal classify pipeline via
 
 import os
 import socket
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -26,7 +27,10 @@ from gda.runner import GodotRunner, RunResult
 
 # Bounds a live call so it never hangs the CLI forever; generous because the
 # daemon may launch the engine session on the first op (ADR-0017). A timeout is
-# surfaced as the registered ``live_timeout`` (ADR-0021).
+# surfaced as the registered ``live_timeout`` (ADR-0021). Applied as an ABSOLUTE
+# instant over the whole round trip, not as a per-recv socket timeout: the reply
+# arrives in as many chunks as the daemon sends, and a socket timeout restarts on
+# each of them (#725 re-review).
 LIVE_REQUEST_TIMEOUT = 60.0
 
 
@@ -74,10 +78,15 @@ class DaemonRunner:
     def _request(self, cli_socket: Path, operation: str, params: dict) -> RunResult:
         try:
             with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                # An absolute instant, so the ceiling covers the WHOLE round
+                # trip (#725 re-review). A socket timeout bounds each recv, and
+                # the reply arrives in as many as the daemon sends — so 60s of
+                # socket timeout was 60s of inactivity, not 60s of waiting.
+                deadline = time.monotonic() + LIVE_REQUEST_TIMEOUT
                 sock.settimeout(LIVE_REQUEST_TIMEOUT)
                 sock.connect(str(cli_socket))
                 write_message(sock, {"op": operation, "params": params})
-                reply = read_message(sock)
+                reply = read_message(sock, deadline)
         except TimeoutError:
             return _live_error_result(
                 "live_timeout",

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -136,8 +136,9 @@ refusal hints the command form) and a bare `gda --json` with no command (`Missin
 Prerequisites: run `gda daemon start` first (optionally `--scene <res://...>` to boot a
 specific scene instead of the project's main scene); the engine session launches lazily on
 the first operation that requires one. To establish the session deterministically, run
-`gda daemon wait-ready` (bounded by `--timeout`, idempotent while the session is alive) —
-success means live reads serve. This matters for the read-only diagnostics: `diag errors` /
+`gda daemon wait-ready` (`--timeout` budgets daemon waits and new-work decisions;
+a synchronous launch call can delay expiry observation; idempotent while the session is
+alive) — success means live reads serve. This matters for the read-only diagnostics: `diag errors` /
 `logger tail` never launch a session themselves, so right after `daemon start` they report
 `engine_session_not_running` by design — expected, not a defect; run `wait-ready` first.
 A `live_timeout` discards the session (its late reply can no longer be attributed), so the
@@ -166,7 +167,7 @@ already-running daemon's lazy Engine-session launch; only the outer
 
 | Group | Commands |
 | ----- | -------- |
-| `daemon` | `start`, `wait-ready`, `stop`, `status`, `install`, `uninstall` (lifecycle; `start` installs the in-game harness itself, so `install` is only for doing that step deliberately — e.g. to review or commit the `project.godot` change — and `uninstall` reverses it; `wait-ready` establishes the lazily-launched engine session, bounded by `--timeout`, so a first `diag errors` serves instead of reporting `engine_session_not_running`) |
+| `daemon` | `start`, `wait-ready`, `stop`, `status`, `install`, `uninstall` (lifecycle; `start` installs the in-game harness itself, so `install` is only for doing that step deliberately — e.g. to review or commit the `project.godot` change — and `uninstall` reverses it; `wait-ready` establishes the lazily-launched engine session, with `--timeout` shared by its waits and new-work decisions, so a first `diag errors` serves instead of reporting `engine_session_not_running`) |
 | `game` | `tree`, `get`, `rect`, `set` (the running game's runtime scene graph) |
 | `diag` | `errors` (structured runtime errors with callstacks; survive a crash) |
 | `logger` | `tail` (the running game's structured log stream; `--raw` for verbatim lines, `--level <min>` to filter by severity, `--limit N`) |

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -135,10 +135,10 @@ refusal hints the command form) and a bare `gda --json` with no command (`Missin
 
 Prerequisites: run `gda daemon start` first (optionally `--scene <res://...>` to boot a
 specific scene instead of the project's main scene); the engine session launches lazily on
-the first live op. To establish the session deterministically, run `gda daemon wait-ready`
-(bounded by `--timeout`, idempotent while the session is alive) — success means live reads
-serve. This matters for the read-only diagnostics: `diag errors` / `logger tail` never
-launch a session themselves, so right after `daemon start` they report
+the first operation that requires one. To establish the session deterministically, run
+`gda daemon wait-ready` (bounded by `--timeout`, idempotent while the session is alive) —
+success means live reads serve. This matters for the read-only diagnostics: `diag errors` /
+`logger tail` never launch a session themselves, so right after `daemon start` they report
 `engine_session_not_running` by design — expected, not a defect; run `wait-ready` first.
 `screen capture` needs a windowed session
 (`gda daemon start --windowed`).
@@ -242,7 +242,7 @@ gda export run --preset "Linux/X11" --output "$PWD/game/build/game.zip" --projec
 Live: observe the running game, then tear down.
 
 ```bash
-gda daemon start --project game --json     # launches the session on the first live op
+gda daemon start --project game --json     # the session launches on the first op that needs one
 gda game tree --project game --json        # the runtime scene tree, after _ready
 gda daemon stop --project game --json
 ```

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -140,6 +140,8 @@ the first operation that requires one. To establish the session deterministicall
 success means live reads serve. This matters for the read-only diagnostics: `diag errors` /
 `logger tail` never launch a session themselves, so right after `daemon start` they report
 `engine_session_not_running` by design — expected, not a defect; run `wait-ready` first.
+A `live_timeout` discards the session (its late reply can no longer be attributed), so the
+next operation starts a fresh game and the runtime state you had set is gone.
 `screen capture` needs a windowed session
 (`gda daemon start --windowed`).
 

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -135,7 +135,12 @@ refusal hints the command form) and a bare `gda --json` with no command (`Missin
 
 Prerequisites: run `gda daemon start` first (optionally `--scene <res://...>` to boot a
 specific scene instead of the project's main scene); the engine session launches lazily on
-the first live op. `screen capture` needs a windowed session
+the first live op. To establish the session deterministically, run `gda daemon wait-ready`
+(bounded by `--timeout`, idempotent while the session is alive) — success means live reads
+serve. This matters for the read-only diagnostics: `diag errors` / `logger tail` never
+launch a session themselves, so right after `daemon start` they report
+`engine_session_not_running` by design — expected, not a defect; run `wait-ready` first.
+`screen capture` needs a windowed session
 (`gda daemon start --windowed`).
 
 A windowed session needs the host's real desktop session — an on-console GUI login on
@@ -159,7 +164,7 @@ already-running daemon's lazy Engine-session launch; only the outer
 
 | Group | Commands |
 | ----- | -------- |
-| `daemon` | `start`, `stop`, `status`, `install`, `uninstall` (lifecycle; `start` installs the in-game harness itself, so `install` is only for doing that step deliberately — e.g. to review or commit the `project.godot` change — and `uninstall` reverses it) |
+| `daemon` | `start`, `wait-ready`, `stop`, `status`, `install`, `uninstall` (lifecycle; `start` installs the in-game harness itself, so `install` is only for doing that step deliberately — e.g. to review or commit the `project.godot` change — and `uninstall` reverses it; `wait-ready` establishes the lazily-launched engine session, bounded by `--timeout`, so a first `diag errors` serves instead of reporting `engine_session_not_running`) |
 | `game` | `tree`, `get`, `rect`, `set` (the running game's runtime scene graph) |
 | `diag` | `errors` (structured runtime errors with callstacks; survive a crash) |
 | `logger` | `tail` (the running game's structured log stream; `--raw` for verbatim lines, `--level <min>` to filter by severity, `--limit N`) |

--- a/tests/support.py
+++ b/tests/support.py
@@ -128,7 +128,8 @@ def no_engine_teardown(monkeypatch) -> None:
     a real child and must NOT call this.
     """
     monkeypatch.setattr(
-        "gda.daemon.session._terminate", lambda proc, deadline=None, group=None: None
+        "gda.daemon.session._terminate",
+        lambda proc, deadline=None, owned_pgid=None: None,
     )
 
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -117,6 +117,19 @@ def inject_runner(monkeypatch, result: RunResult) -> FakeRunner:
     return fake
 
 
+def no_engine_teardown(monkeypatch) -> None:
+    """No-op the engine teardown for a test whose session process is a stand-in (#725).
+
+    ``_terminate`` signals a REAL child and reaps it; a fake process has no ``pid``
+    to signal, so a test that fakes one must neutralize it. Named and shared rather
+    than open-coded per test because this mock HIDES a real interaction — teardown
+    is charged to the caller's readiness deadline (#725 re-review), and a suite that
+    only ever mocks it cannot see that. A test that exercises teardown itself takes
+    a real child and must NOT call this.
+    """
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
+
+
 def inject_live_runner(monkeypatch, result: RunResult) -> FakeRunner:
     """Swap the CLI's LIVE (daemon) runner seam for a ``FakeRunner`` (#7).
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -128,7 +128,7 @@ def no_engine_teardown(monkeypatch) -> None:
     a real child and must NOT call this.
     """
     monkeypatch.setattr(
-        "gda.daemon.session._terminate", lambda proc, deadline=None: None
+        "gda.daemon.session._terminate", lambda proc, deadline=None, group=None: None
     )
 
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -127,7 +127,9 @@ def no_engine_teardown(monkeypatch) -> None:
     only ever mocks it cannot see that. A test that exercises teardown itself takes
     a real child and must NOT call this.
     """
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
+    monkeypatch.setattr(
+        "gda.daemon.session._terminate", lambda proc, deadline=None: None
+    )
 
 
 def inject_live_runner(monkeypatch, result: RunResult) -> FakeRunner:

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -14,6 +14,7 @@ import json
 import os
 import socket
 import subprocess
+import time
 from typing import cast
 
 import pytest
@@ -80,7 +81,7 @@ def test_launch_session_passes_log_file_arg_and_remembers_path(monkeypatch, tmp_
         tmp_path / "h.sock",
         "tok",
         log_file=log_file,
-        timeout=0.1,
+        deadline=time.monotonic() + 0.1,
     )
 
     argv = captured["argv"]
@@ -129,7 +130,7 @@ def _capture_launch_argv(monkeypatch, project, **launch_kw):
         cast(socket.socket, _NoAcceptListener()),
         project / "h.sock",
         "tok",
-        timeout=0.1,
+        deadline=time.monotonic() + 0.1,
         **launch_kw,
     )
     return captured["argv"]
@@ -223,7 +224,7 @@ def _launch_with_fake_harness(monkeypatch, tmp_path, *, token, verify, scene):
             cast(socket.socket, _OneShotListener(daemon_end)),
             tmp_path / "h.sock",
             token,
-            timeout=1.0,
+            deadline=time.monotonic() + 1.0,
             scene=scene,
         )
     finally:
@@ -285,7 +286,7 @@ def test_launch_returns_none_on_bad_token(monkeypatch, tmp_path):
             cast(socket.socket, _OneShotListener(daemon_end)),
             tmp_path / "h.sock",
             "tok",
-            timeout=1.0,
+            deadline=time.monotonic() + 1.0,
             scene="res://B.tscn",
         )
     finally:
@@ -325,7 +326,7 @@ def test_failed_launch_records_signal_death_when_child_already_died(
         cast(socket.socket, _NoAcceptListener()),
         tmp_path / "h.sock",
         "tok",
-        timeout=0.1,
+        deadline=time.monotonic() + 0.1,
         diagnostics=diagnostics,
     )
 
@@ -351,7 +352,7 @@ def test_failed_launch_records_harness_hung_when_child_still_alive(
         cast(socket.socket, _NoAcceptListener()),
         tmp_path / "h.sock",
         "tok",
-        timeout=0.1,
+        deadline=time.monotonic() + 0.1,
         diagnostics=diagnostics,
     )
 

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -23,6 +23,7 @@ from gda.daemon.protocol import write_frame
 from gda.daemon.server import DaemonServer
 from gda.daemon.session import EngineSession, SceneMismatch, launch_session
 from gda.parser import parse_result
+from tests.support import no_engine_teardown
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
@@ -60,7 +61,7 @@ def test_launch_session_passes_log_file_arg_and_remembers_path(monkeypatch, tmp_
 
     monkeypatch.setattr(subprocess, "Popen", _ImmediatePopen)
     # _terminate kills the (fake) proc on the accept-timeout path; no-op it.
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
+    no_engine_teardown(monkeypatch)
 
     class _NoAcceptListener:
         """A harness listener whose accept() times out at once: launch returns
@@ -113,7 +114,7 @@ def _capture_launch_argv(monkeypatch, project, **launch_kw):
             return None
 
     monkeypatch.setattr(subprocess, "Popen", _ImmediatePopen)
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
+    no_engine_teardown(monkeypatch)
 
     class _NoAcceptListener:
         def settimeout(self, _):
@@ -204,7 +205,7 @@ def _launch_with_fake_harness(monkeypatch, tmp_path, *, token, verify, scene):
     via pytest.raises in the caller).
     """
     monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc())
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
+    no_engine_teardown(monkeypatch)
     daemon_end, harness_end = socket.socketpair()
     # The harness presents its token, then the scene-verification frame.
     write_frame(
@@ -274,7 +275,7 @@ def test_launch_returns_none_on_bad_token(monkeypatch, tmp_path):
     # A wrong token aborts the handshake BEFORE the verification frame: a generic
     # launch failure (None), distinct from a scene mismatch.
     monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc())
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
+    no_engine_teardown(monkeypatch)
     daemon_end, harness_end = socket.socketpair()
     write_frame(harness_end, b"WRONG")
     try:
@@ -315,7 +316,7 @@ def test_failed_launch_records_signal_death_when_child_already_died(
     # A child that reports it aborted by SIGABRT (returncode -6) — what a windowed
     # session with no usable DisplayServer does before the harness can connect.
     monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(-6))
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
+    no_engine_teardown(monkeypatch)
 
     diagnostics: list[str] = []
     outcome = launch_session(
@@ -341,7 +342,7 @@ def test_failed_launch_records_harness_hung_when_child_still_alive(
     # A child still alive (poll() is None) when the harness never connected: the
     # "engine up, harness hung" case, distinct from a crashed child.
     monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(None))
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
+    no_engine_teardown(monkeypatch)
 
     diagnostics: list[str] = []
     outcome = launch_session(
@@ -375,7 +376,7 @@ def test_failed_launch_diagnostics_excludes_stale_session_log(
     # A REAL launch_session runs (truncating the log), spawns a fake child that dies
     # pre-logger by SIGABRT and writes nothing, and no harness connects -> None.
     monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(-6))
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
+    no_engine_teardown(monkeypatch)
     server._harness_listener = cast(socket.socket, _NoAcceptListener())
 
     reply = server._handle({"op": "game-tree", "params": {}})

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -38,6 +38,12 @@ class _FakeProc:
     def poll(self):
         return self.returncode
 
+    # gda's OWN pid, deliberately: teardown reads the pid to find the process
+    # group it owns, and the own-group guard then resolves this stand-in to no
+    # group at all. An invented pid would instead resolve to whichever real
+    # process holds it — which a test would then signal.
+    pid = os.getpid()
+
 
 def _project(tmp_path):
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -60,7 +60,7 @@ def test_launch_session_passes_log_file_arg_and_remembers_path(monkeypatch, tmp_
 
     monkeypatch.setattr(subprocess, "Popen", _ImmediatePopen)
     # _terminate kills the (fake) proc on the accept-timeout path; no-op it.
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
 
     class _NoAcceptListener:
         """A harness listener whose accept() times out at once: launch returns
@@ -113,7 +113,7 @@ def _capture_launch_argv(monkeypatch, project, **launch_kw):
             return None
 
     monkeypatch.setattr(subprocess, "Popen", _ImmediatePopen)
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
 
     class _NoAcceptListener:
         def settimeout(self, _):
@@ -204,7 +204,7 @@ def _launch_with_fake_harness(monkeypatch, tmp_path, *, token, verify, scene):
     via pytest.raises in the caller).
     """
     monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc())
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
     daemon_end, harness_end = socket.socketpair()
     # The harness presents its token, then the scene-verification frame.
     write_frame(
@@ -274,7 +274,7 @@ def test_launch_returns_none_on_bad_token(monkeypatch, tmp_path):
     # A wrong token aborts the handshake BEFORE the verification frame: a generic
     # launch failure (None), distinct from a scene mismatch.
     monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc())
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
     daemon_end, harness_end = socket.socketpair()
     write_frame(harness_end, b"WRONG")
     try:
@@ -315,7 +315,7 @@ def test_failed_launch_records_signal_death_when_child_already_died(
     # A child that reports it aborted by SIGABRT (returncode -6) — what a windowed
     # session with no usable DisplayServer does before the harness can connect.
     monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(-6))
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
 
     diagnostics: list[str] = []
     outcome = launch_session(
@@ -341,7 +341,7 @@ def test_failed_launch_records_harness_hung_when_child_still_alive(
     # A child still alive (poll() is None) when the harness never connected: the
     # "engine up, harness hung" case, distinct from a crashed child.
     monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(None))
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
 
     diagnostics: list[str] = []
     outcome = launch_session(
@@ -375,7 +375,7 @@ def test_failed_launch_diagnostics_excludes_stale_session_log(
     # A REAL launch_session runs (truncating the log), spawns a fake child that dies
     # pre-logger by SIGABRT and writes nothing, and no harness connects -> None.
     monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(-6))
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
     server._harness_listener = cast(socket.socket, _NoAcceptListener())
 
     reply = server._handle({"op": "game-tree", "params": {}})

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -7,6 +7,8 @@ engine), so the no-session and control-op paths stay covered in the fast suite.
 import os
 import socket
 import subprocess
+import threading
+import time
 from typing import cast
 
 import pytest
@@ -415,6 +417,45 @@ def test_engine_session_request_times_out_as_live_timeout(monkeypatch):
     finally:
         daemon_end.close()
         silent_harness.close()
+
+
+def test_a_trickled_reply_cannot_outlast_the_relays_own_bound(monkeypatch):
+    # The relay reads the reply in as many chunks as the harness sends, and a
+    # socket timeout restarts on each one — so OP_TIMEOUT bounded INACTIVITY, not
+    # the relay, and `did not return within Ns` was not true of a trickle. Same
+    # absolute-deadline rule the handshake frames now use (#725 re-review). The
+    # harness is trusted (ADR-0009), so this is honesty about the published
+    # bound rather than a defence.
+    monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.3)
+    daemon_end, harness = socket.socketpair()
+    session = EngineSession(cast(subprocess.Popen, _FakeProc()), daemon_end)
+
+    def _trickle() -> None:
+        # A WELL-FORMED reply, so a relay that waits it out succeeds — the point
+        # is that it must not, however valid the eventual answer.
+        body = build_result({"nodes": []}).encode("utf-8")
+        wire = len(body).to_bytes(4, "big") + body
+        for byte in wire:  # every byte lands inside the bound, resetting it
+            try:
+                harness.sendall(bytes([byte]))
+            except OSError:
+                return
+            time.sleep(0.2)
+
+    trickler = threading.Thread(target=_trickle, daemon=True)
+    trickler.start()
+    started = time.monotonic()
+    try:
+        reply = session.request("game-tree", {})
+        elapsed = time.monotonic() - started
+    finally:
+        daemon_end.close()
+        harness.close()
+        trickler.join(timeout=5)
+
+    outcome = parse_result(reply["stdout"])
+    assert outcome.get("error", {}).get("code") == "live_timeout", outcome
+    assert elapsed < 1.5, f"the trickled reply held the relay for {elapsed:.1f}s"
 
 
 def test_a_timed_out_relay_leaves_the_session_dead_to_the_daemon(monkeypatch):

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -12,6 +12,7 @@ from typing import cast
 import pytest
 
 from gda.daemon.discovery import daemon_paths
+from gda.daemon.protocol import read_message, write_frame
 from gda.daemon.server import DaemonServer
 from gda.daemon.session import EngineSession
 from gda.display import WindowedUnavailable
@@ -21,7 +22,7 @@ from gda.commands.daemon import (
     run_daemon_stop_operation,
 )
 from gda.errors import Failure
-from gda.parser import parse_result
+from gda.parser import build_result, parse_result
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
@@ -414,6 +415,30 @@ def test_engine_session_request_times_out_as_live_timeout(monkeypatch):
     finally:
         daemon_end.close()
         silent_harness.close()
+
+
+def test_a_timed_out_relay_leaves_the_session_dead_to_the_daemon(monkeypatch):
+    # #725 re-review finding 1: this protocol carries no request id and a
+    # timed-out frame is never drained, so a LATE reply is indistinguishable
+    # from the next op's reply. Reproduced before the fix: op A times out, the
+    # harness answers late, op B returns A's payload as its own. A channel that
+    # can answer with another operation's result is not serving — the timeout
+    # must latch it stale (with the engine PROCESS still alive throughout) so
+    # the next session-needing op rebuilds it through the launch boundary.
+    monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
+    daemon_end, harness = socket.socketpair()
+    proc = _FakeProc()
+    session = EngineSession(cast(subprocess.Popen, proc), daemon_end)
+    try:
+        first = session.request("game-tree", {})
+        assert parse_result(first["stdout"])["error"]["code"] == "live_timeout"
+        assert read_message(harness) == {"op": "game-tree", "params": {}}
+        write_frame(harness, build_result({"answer": "late"}).encode("utf-8"))
+        assert proc.poll() is None  # the engine itself never died
+        assert session.alive() is False
+    finally:
+        daemon_end.close()
+        harness.close()
 
 
 def test_daemon_status_on_non_unix_is_live_unsupported_platform(monkeypatch, tmp_path):

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -20,6 +20,7 @@ import os
 import signal
 import socket
 import subprocess
+import sys
 import threading
 import time
 from contextlib import contextmanager
@@ -42,6 +43,12 @@ from gda.errors import Failure
 from gda.parser import parse_result
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+
+
+# A stand-in engine that survives SIGTERM, so a teardown's escalation is observable.
+_IGNORES_SIGTERM = (
+    "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)"
+)
 
 
 def _project(tmp_path: Path) -> Path:
@@ -433,7 +440,7 @@ def test_a_silent_handshake_peer_cannot_hold_the_launch_past_the_deadline(
     # and then never speaks used to block the token read forever — here the
     # REAL launch_session must give up within the bound and record why.
     monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _Proc(code=None))
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
     paths = daemon_paths(_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -472,7 +479,7 @@ def test_a_stuck_handshake_does_not_freeze_the_daemon(
     # must come back typed within its bound, and — the daemon serving one
     # request at a time — the NEXT control request must still be served.
     monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _Proc(code=None))
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
     paths = daemon_paths(_project(tmp_path))
     server = DaemonServer(paths, godot="godot")  # the real launch seam default
 
@@ -505,7 +512,7 @@ def test_wait_ready_rebuilds_a_session_whose_channel_broke(
     # very next read disproves — the engine process is still alive throughout.
     # The relaunch path close()s the stale session, whose real _terminate needs
     # a real process; the fake has none.
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
     ours, theirs = socket.socketpair()
     theirs.close()
     zombie = EngineSession(cast(subprocess.Popen, _Proc(code=None)), conn=ours)
@@ -531,6 +538,89 @@ def test_wait_ready_rebuilds_a_session_whose_channel_broke(
     assert second is not None and parse_result(second["stdout"])["launched"] is True
     assert served is not None and served["stdout"] == "served:game-tree"
     assert len(launches) == 2
+
+
+def test_wait_ready_rebuilds_a_session_whose_relay_timed_out(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # #725 re-review finding 1, through the daemon: a relay that times out leaves
+    # the channel response-ambiguous (no request id, the frame is never drained),
+    # so wait-ready must NOT certify it. Before the fix the daemon reported
+    # `launched: false` over that channel and the next read went back to it.
+    monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
+    ours, silent_harness = socket.socketpair()
+    desynced = EngineSession(cast(subprocess.Popen, _Proc(code=None)), conn=ours)
+
+    launches: list = []
+
+    def _launch(*args, **kwargs):
+        launches.append(1)
+        return desynced if len(launches) == 1 else _ServedSession()
+
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_launch)
+
+    try:
+        with _serving(server, paths, monkeypatch):
+            first = _request(paths, {"op": "daemon-wait-ready", "params": {}})
+            timed_out = _request(paths, {"op": "game-tree", "params": {}})
+            second = _request(paths, {"op": "daemon-wait-ready", "params": {}})
+            served = _request(paths, {"op": "game-tree", "params": {}})
+    finally:
+        silent_harness.close()
+
+    assert first is not None and parse_result(first["stdout"])["launched"] is True
+    assert timed_out is not None
+    assert parse_result(timed_out["stdout"])["error"]["code"] == "live_timeout"
+    assert second is not None and parse_result(second["stdout"])["launched"] is True
+    assert served is not None and served["stdout"] == "served:game-tree"
+    assert len(launches) == 2
+
+
+def test_a_teardown_cannot_outlast_the_readiness_deadline(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # #725 re-review finding 2: teardown draws from the caller's deadline. An
+    # engine child that ignores SIGTERM used to start a FRESH five-second grace
+    # after the readiness budget was already spent — a measured 5.3s for
+    # `--timeout 0.3` — and the daemon serves one request at a time, so the whole
+    # round trip and every request behind it waited it out.
+    real_popen = subprocess.Popen
+    spawned: list = []
+
+    def _spawn_stubborn_child(argv, **kwargs):
+        proc = real_popen([sys.executable, "-c", _IGNORES_SIGTERM], **kwargs)
+        spawned.append(proc)
+        return proc
+
+    monkeypatch.setattr(subprocess, "Popen", _spawn_stubborn_child)
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot")  # the real launch + teardown
+
+    try:
+        with _serving(server, paths, monkeypatch):
+            started = time.monotonic()
+            reply = _request(
+                paths,
+                {"op": "daemon-wait-ready", "params": {"timeout": 0.3}},
+                timeout=20.0,
+            )
+            elapsed = time.monotonic() - started
+            behind = time.monotonic()
+            status = _request(paths, {"op": "__status__"})
+            queued = time.monotonic() - behind
+    finally:
+        for proc in spawned:
+            proc.kill()
+
+    assert reply is not None
+    assert (
+        parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    )
+    assert elapsed < 2.0, f"teardown held the round trip for {elapsed:.1f}s"
+    assert status is not None and status["ok"] is True
+    assert queued < 1.0, f"the next control request waited {queued:.1f}s"
 
 
 def test_launched_is_reported_by_the_launch_owner(

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -59,6 +59,19 @@ _SCHEDULING_SLACK = 0.35
 # arrives during interpreter startup still kills it by the default disposition —
 # a teardown test that raced the startup would exercise the ordinary path and
 # prove nothing (observed: `_terminate` 1ms after spawn returned -15, not -9).
+# The same stand-in, plus a descendant inside its process group that is just as
+# stubborn — so an escalation that reaches only the leader is observable.
+_IGNORES_SIGTERM_WITH_CHILD = (
+    "import signal, subprocess, sys, time;"
+    "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+    "child = subprocess.Popen([sys.executable, '-c',"
+    ' "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN);'
+    ' print(chr(120), flush=True); time.sleep(120)"'
+    "], stdout=subprocess.PIPE,"
+    " text=True);"
+    "child.stdout.readline();"
+    "print(child.pid, flush=True); time.sleep(120)"
+)
 _IGNORES_SIGTERM = (
     "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
     "print('ready', flush=True); time.sleep(60)"
@@ -113,9 +126,9 @@ class _ServedSession:
     def request(self, operation: str, params: dict) -> dict:
         return {"stdout": f"served:{operation}", "stderr": "", "exit_code": 0}
 
-    def close(self, grace: float = 0.0) -> None:
+    def close(self, deadline: "float | None" = None) -> None:
         self.closed = True
-        self.close_grace = grace
+        self.close_deadline = deadline
 
 
 def _request(paths, payload: dict, timeout: float = 5.0):
@@ -613,6 +626,97 @@ def test_a_slow_spawn_cannot_revive_the_callers_expired_deadline(
     assert outcome is None
 
 
+def test_launch_preparation_that_crosses_the_deadline_spawns_nothing(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # #725 fourth re-review: the deadline was gated BEFORE the Session-log
+    # truncation but not after it. That truncation is a filesystem write and can
+    # block, so a 0.12s write against a 0.05s deadline still reached `Popen` —
+    # 0.076s past the bound. The gate belongs at the last interruptible point.
+    spawned: list = []
+
+    def _record_spawn(argv, **kwargs):
+        spawned.append(time.monotonic())
+        return _Proc(code=None)
+
+    real_write = Path.write_bytes
+
+    def _slow_write(self, data):
+        time.sleep(0.12)
+        return real_write(self, data)
+
+    monkeypatch.setattr(subprocess, "Popen", _record_spawn)
+    monkeypatch.setattr(Path, "write_bytes", _slow_write)
+    no_engine_teardown(monkeypatch)
+    paths = daemon_paths(_project(tmp_path))
+    paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(paths.harness_socket))
+    listener.listen()
+
+    diagnostics: list[str] = []
+    try:
+        outcome = launch_session(
+            paths.project,
+            "godot",
+            listener,
+            paths.harness_socket,
+            "expected-token",
+            log_file=paths.session_log,
+            deadline=time.monotonic() + 0.05,
+            diagnostics=diagnostics,
+        )
+    finally:
+        listener.close()
+
+    assert outcome is None
+    assert not spawned, "the engine was started after the deadline had passed"
+    assert any("preparing the launch" in reason for reason in diagnostics), diagnostics
+
+
+def test_a_deadline_spent_by_the_spawn_is_not_blamed_on_the_harness(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # #725 fourth re-review: the spawn is the one uninterruptible step, so it CAN
+    # outrun the budget — but the refusal has to say so. It used to fall through
+    # and report that the harness sent no auth token, which is a different
+    # failure and plainly false here: the token is already queued.
+    def _slow_popen(argv, **kwargs):
+        time.sleep(0.12)
+        return _Proc(code=None)
+
+    monkeypatch.setattr(subprocess, "Popen", _slow_popen)
+    no_engine_teardown(monkeypatch)
+    paths = daemon_paths(_project(tmp_path))
+    paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(paths.harness_socket))
+    listener.listen()
+    peer = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    peer.connect(str(paths.harness_socket))
+    write_frame(peer, b"expected-token")
+    write_frame(peer, b'{"scene_ok": true, "current": "res://main.tscn"}')
+
+    diagnostics: list[str] = []
+    try:
+        outcome = launch_session(
+            paths.project,
+            "godot",
+            listener,
+            paths.harness_socket,
+            "expected-token",
+            deadline=time.monotonic() + 0.05,
+            diagnostics=diagnostics,
+        )
+    finally:
+        peer.close()
+        listener.close()
+
+    assert outcome is None
+    assert any("while the engine was starting" in r for r in diagnostics), diagnostics
+    assert not any("auth token" in r for r in diagnostics), diagnostics
+
+
 def test_retiring_a_stale_session_is_charged_to_the_callers_deadline(
     tmp_path, daemon_runtime_dir, monkeypatch
 ):
@@ -720,6 +824,74 @@ class _SlowToCollect:
         return self._proc.wait()
 
 
+def test_the_termination_wait_is_measured_when_it_begins(monkeypatch):
+    # #725 fourth re-review: the deadline reached teardown as a DURATION, so the
+    # work before the only blocking step — the caller's channel close, the poll,
+    # the signal — was spent and then the full original grace was handed to
+    # `wait()` anyway. Probed at 0.08s of pre-wait work against a 0.05s budget:
+    # `wait()` still received 0.05. The remainder is recomputed where it is used.
+    given: list = []
+
+    class _SlowPoll:
+        pid = 1
+
+        def __init__(self) -> None:
+            self.polls = 0
+
+        def poll(self):
+            self.polls += 1
+            if self.polls == 1:
+                time.sleep(0.08)  # pre-wait work that outlives the whole budget
+            return None
+
+        def terminate(self) -> None: ...
+
+        def kill(self) -> None: ...
+
+        def wait(self, timeout=None):
+            given.append(timeout)
+            raise subprocess.TimeoutExpired("engine", timeout or 0)
+
+    monkeypatch.setattr(os, "getpgid", lambda pid: 1)
+    monkeypatch.setattr(os, "killpg", lambda pgid, sig: None)
+    _terminate(cast(subprocess.Popen, _SlowPoll()), time.monotonic() + 0.05)
+
+    assert given, "the engine was never waited on"
+    assert given[0] == 0, f"the wait was given a revived {given[0]}s budget"
+
+
+def test_the_escalation_covers_the_group_the_engine_owns(monkeypatch):
+    # #725 fourth re-review: SIGTERM went to the process group, SIGKILL only to
+    # the leader — so a descendant that also ignored SIGTERM was left alive and
+    # orphaned. The session is spawned with `start_new_session=True`, so gda owns
+    # that group; the escalation must match the signal that preceded it.
+    leader = _REAL_POPEN(
+        [sys.executable, "-c", _IGNORES_SIGTERM_WITH_CHILD],
+        stdout=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    assert leader.stdout is not None
+    descendant = int(leader.stdout.readline().strip())
+    try:
+        _terminate(leader, time.monotonic() + 0.05)
+        end = time.monotonic() + 5.0
+        while time.monotonic() < end:
+            try:
+                os.kill(descendant, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.01)
+        else:
+            raise AssertionError(f"the descendant {descendant} outlived the group kill")
+    finally:
+        for pid in (descendant, leader.pid):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
 def test_teardown_does_not_wait_for_the_kernel_to_collect_the_child(monkeypatch):
     # #725 third re-review: the escalation to SIGKILL is reached with the budget
     # ALREADY spent, so ANY fixed allowance after it is time the caller never
@@ -729,7 +901,7 @@ def test_teardown_does_not_wait_for_the_kernel_to_collect_the_child(monkeypatch)
     slow = _SlowToCollect(_stubborn_child(start_new_session=True))
     try:
         started = time.monotonic()
-        _terminate(cast(subprocess.Popen, slow), grace=0.05)
+        _terminate(cast(subprocess.Popen, slow), time.monotonic() + 0.05)
         elapsed = time.monotonic() - started
         assert elapsed < 0.05 + _SCHEDULING_SLACK, (
             f"teardown spent {elapsed:.2f}s waiting past a 0.05s grace"
@@ -745,7 +917,7 @@ def test_a_killed_engine_is_still_collected(monkeypatch):
     # long-lived daemon, possibly nothing.
     stubborn = _stubborn_child(start_new_session=True)
     try:
-        _terminate(stubborn, grace=0.05)
+        _terminate(stubborn, time.monotonic() + 0.05)
         # `returncode` is read directly, never through `poll()` — poll() would
         # collect the child itself and pass with no reaper at all.
         end = time.monotonic() + 10.0
@@ -883,9 +1055,21 @@ def test_a_teardown_cannot_outlast_the_readiness_deadline(
     monkeypatch.setattr(subprocess, "Popen", _spawn_stubborn_child)
     paths = daemon_paths(_project(tmp_path))
     server = DaemonServer(paths, godot="godot")  # the real launch + teardown
+    queued: list = []
+
+    def _control_request_behind_it() -> None:
+        # Enqueued WHILE wait-ready is being served, so this measures what a
+        # caller behind the bounded one actually waits — not what it waits once
+        # the bounded one has already returned.
+        time.sleep(0.05)
+        at = time.monotonic()
+        reply = _request(paths, {"op": "__status__"}, timeout=20.0)
+        queued.append((reply, time.monotonic() - at))
 
     try:
         with _serving(server, paths, monkeypatch):
+            behind = threading.Thread(target=_control_request_behind_it, daemon=True)
+            behind.start()
             started = time.monotonic()
             reply = _request(
                 paths,
@@ -893,9 +1077,7 @@ def test_a_teardown_cannot_outlast_the_readiness_deadline(
                 timeout=20.0,
             )
             elapsed = time.monotonic() - started
-            behind = time.monotonic()
-            status = _request(paths, {"op": "__status__"})
-            queued = time.monotonic() - behind
+            behind.join(timeout=20.0)
     finally:
         for proc in spawned:
             proc.kill()
@@ -904,9 +1086,14 @@ def test_a_teardown_cannot_outlast_the_readiness_deadline(
     assert (
         parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
     )
-    assert elapsed < 2.0, f"teardown held the round trip for {elapsed:.1f}s"
+    assert elapsed < 0.3 + _SCHEDULING_SLACK, (
+        f"a 0.3s-bounded wait-ready took {elapsed:.2f}s"
+    )
+    status, waited = queued[0]
     assert status is not None and status["ok"] is True
-    assert queued < 1.0, f"the next control request waited {queued:.1f}s"
+    assert waited < 0.3 + _SCHEDULING_SLACK, (
+        f"the request queued behind it waited {waited:.2f}s"
+    )
 
 
 def test_launched_is_reported_by_the_launch_owner(

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -47,6 +47,12 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 
 _REAL_POPEN = subprocess.Popen
 
+# What a bounded round trip may add on top of the bound itself: IPC, thread
+# scheduling, and the daemon's own accept. Small on purpose — these assertions
+# exist to pin the PUBLIC bound, so slack that swallows a restored full-duration
+# wait would pin nothing.
+_SCHEDULING_SLACK = 0.35
+
 
 # A stand-in engine that survives SIGTERM, so a teardown's escalation is observable.
 # It announces itself: the handler is installed by the CHILD, so a SIGTERM that
@@ -422,13 +428,14 @@ def test_wait_ready_launches_once_and_reports_the_bounded_wait(
     session = _ServedSession()
 
     def _launch(*args, **kwargs):
-        launches.append(kwargs.get("timeout"))
+        launches.append(kwargs.get("deadline"))
         return session
 
     paths = daemon_paths(_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
+        asked = time.monotonic()
         first = _request(paths, {"op": "daemon-wait-ready", "params": {"timeout": 7.5}})
         again = _request(paths, {"op": "daemon-wait-ready", "params": {}})
 
@@ -437,12 +444,14 @@ def test_wait_ready_launches_once_and_reports_the_bounded_wait(
     assert verdict == {"pid": os.getpid(), "launched": True}
     assert again is not None
     assert parse_result(again["stdout"])["launched"] is False
-    # One launch, bounded by the caller's timeout — and by no more than it: what
-    # reaches the launcher is what the shared deadline has left after retiring the
-    # session being replaced (#725 re-review), which here is nearly all of it
-    # because there was nothing to retire.
+    # One launch, and what reaches the launcher is the caller's own DEADLINE —
+    # an instant it cannot outlive, not a duration it could restart (#725
+    # re-review). It is no later than 7.5s after the request was made, and (with
+    # nothing to retire here) not meaningfully earlier either.
     assert len(launches) == 1
-    assert 7.4 < launches[0] <= 7.5
+    # The slack is the request's own transit: the daemon starts the clock when it
+    # RECEIVES the call, so the instant is 7.5s from there, not from here.
+    assert asked < launches[0] <= asked + 7.5 + _SCHEDULING_SLACK
 
 
 def test_wait_ready_relays_the_typed_launch_failure(
@@ -491,7 +500,7 @@ def test_a_silent_handshake_peer_cannot_hold_the_launch_past_the_deadline(
             listener,
             paths.harness_socket,
             "expected-token",
-            timeout=0.3,
+            deadline=time.monotonic() + 0.3,
             diagnostics=diagnostics,
         )
         elapsed = time.monotonic() - started
@@ -549,7 +558,7 @@ def test_a_trickling_handshake_peer_cannot_hold_the_launch_past_the_deadline(
             listener,
             paths.harness_socket,
             "expected-token",
-            timeout=0.05,
+            deadline=time.monotonic() + 0.05,
         )
         elapsed = time.monotonic() - started
     finally:
@@ -561,6 +570,49 @@ def test_a_trickling_handshake_peer_cannot_hold_the_launch_past_the_deadline(
     assert elapsed < 0.5, f"the trickling peer held the launch for {elapsed:.2f}s"
 
 
+def test_a_slow_spawn_cannot_revive_the_callers_expired_deadline(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # #725 third re-review: the launcher used to take a DURATION and start its own
+    # clock with it — after truncating the log and spawning the engine. So the
+    # spawn was charged to nobody and an exhausted budget came back whole: a
+    # 0.05s-bounded launch whose spawn alone took 0.12s still SUCCEEDED, with both
+    # handshake frames already queued. It takes the caller's absolute instant now,
+    # so a spawn that outruns the budget ends in a refusal, not a session.
+    no_engine_teardown(monkeypatch)
+
+    def _slow_popen(argv, **kwargs):
+        time.sleep(0.12)  # a spawn that costs more than the whole budget
+        return _Proc(code=None)
+
+    monkeypatch.setattr(subprocess, "Popen", _slow_popen)
+    paths = daemon_paths(_project(tmp_path))
+    paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(paths.harness_socket))
+    listener.listen()
+    peer = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    peer.connect(str(paths.harness_socket))
+    # Both frames are ALREADY waiting, so nothing but the clock can refuse this.
+    write_frame(peer, b"expected-token")
+    write_frame(peer, b'{"scene_ok": true, "current": "res://main.tscn"}')
+
+    try:
+        outcome = launch_session(
+            paths.project,
+            "godot",
+            listener,
+            paths.harness_socket,
+            "expected-token",
+            deadline=time.monotonic() + 0.05,
+        )
+    finally:
+        peer.close()
+        listener.close()
+
+    assert outcome is None
+
+
 def test_retiring_a_stale_session_is_charged_to_the_callers_deadline(
     tmp_path, daemon_runtime_dir, monkeypatch
 ):
@@ -568,9 +620,11 @@ def test_retiring_a_stale_session_is_charged_to_the_callers_deadline(
     # replacing, and that retirement is work on the CALLER's clock. A stale
     # session whose engine ignores SIGTERM used to be closed on its own
     # five-second grace before the bounded launch even began — 5.0s for a
-    # `wait-ready --timeout 0.3`, with the serve loop blocked throughout. NOTE:
-    # no `no_engine_teardown` here on purpose — the real teardown IS the subject,
-    # and mocking it is exactly what hid this interaction.
+    # `wait-ready --timeout 0.3`, with the serve loop blocked throughout. When
+    # retirement uses the whole budget there is nothing left to launch WITHIN, so
+    # the boundary refuses instead of reviving the bound for a replacement.
+    # NOTE: no `no_engine_teardown` here on purpose — the real teardown IS the
+    # subject, and mocking it is exactly what hid this interaction.
     monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
     stubborn = _stubborn_child(start_new_session=True)
     ours, silent_harness = socket.socketpair()
@@ -579,11 +633,21 @@ def test_retiring_a_stale_session_is_charged_to_the_callers_deadline(
     launches: list = []
 
     def _launch(*args, **kwargs):
-        launches.append(kwargs.get("timeout"))
+        launches.append(kwargs.get("deadline"))
         return stale if len(launches) == 1 else None
 
     paths = daemon_paths(_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
+    queued: list = []
+
+    def _control_request_behind_it() -> None:
+        # Enqueued WHILE wait-ready is being served, not after it returns: the
+        # daemon serves one request at a time, so this is what a caller behind the
+        # bounded one actually waits.
+        time.sleep(0.05)
+        at = time.monotonic()
+        reply = _request(paths, {"op": "__status__"}, timeout=20.0)
+        queued.append((reply, time.monotonic() - at))
 
     try:
         with _serving(server, paths, monkeypatch):
@@ -591,6 +655,8 @@ def test_retiring_a_stale_session_is_charged_to_the_callers_deadline(
                 _request(paths, {"op": "daemon-wait-ready", "params": {}}) is not None
             )
             timed_out = _request(paths, {"op": "game-tree", "params": {}})
+            behind = threading.Thread(target=_control_request_behind_it, daemon=True)
+            behind.start()
             started = time.monotonic()
             reply = _request(
                 paths,
@@ -598,9 +664,7 @@ def test_retiring_a_stale_session_is_charged_to_the_callers_deadline(
                 timeout=20.0,
             )
             elapsed = time.monotonic() - started
-            behind = time.monotonic()
-            status = _request(paths, {"op": "__status__"})
-            queued = time.monotonic() - behind
+            behind.join(timeout=20.0)
     finally:
         silent_harness.close()
         stubborn.kill()
@@ -611,26 +675,86 @@ def test_retiring_a_stale_session_is_charged_to_the_callers_deadline(
     assert (
         parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
     )
-    assert elapsed < 2.0, f"retiring the stale session took {elapsed:.1f}s"
+    assert elapsed < 0.3 + _SCHEDULING_SLACK, (
+        f"a 0.3s-bounded wait-ready took {elapsed:.2f}s"
+    )
+    # Retirement used the whole budget, so no replacement was launched past it.
+    assert len(launches) == 1
+    status, waited = queued[0]
     assert status is not None and status["ok"] is True
-    assert queued < 1.0, f"the next control request waited {queued:.1f}s"
-    # The replacement launch got what retirement left of the same 0.3s, never a
-    # fresh budget of its own.
-    assert len(launches) == 2 and launches[1] is not None and launches[1] <= 0.3
+    assert waited < 0.3 + _SCHEDULING_SLACK, (
+        f"the request queued behind it waited {waited:.2f}s"
+    )
 
 
-def test_a_killed_engine_is_reaped_by_the_teardown_that_killed_it(monkeypatch):
-    # #725 re-review finding 3: after the grace expires the child is SIGKILLed,
-    # and teardown must finish what it started. Without the reap `returncode`
-    # stayed None and the exited child was left for whatever happened to call
-    # poll() next — in a long-lived daemon, possibly nothing.
+class _SlowToCollect:
+    """A killed child the kernel has not made reapable yet — the worst case.
+
+    A real SIGKILL is collectable in microseconds, so only a stand-in shows what a
+    fixed post-kill allowance costs when collection is NOT instant (a child in
+    uninterruptible I/O, a loaded host). It wraps a real child so the signalling
+    is real; only the collection blocks, until the test releases it.
+    """
+
+    def __init__(self, proc: subprocess.Popen) -> None:
+        self._proc = proc
+        self.released = threading.Event()
+        self.returncode = None
+
+    @property
+    def pid(self) -> int:
+        return self._proc.pid
+
+    def poll(self):
+        return self._proc.poll()
+
+    def terminate(self) -> None:
+        self._proc.terminate()
+
+    def kill(self) -> None:
+        self._proc.kill()
+
+    def wait(self, timeout=None):
+        if not self.released.wait(timeout):
+            raise subprocess.TimeoutExpired("engine", timeout or 0)
+        return self._proc.wait()
+
+
+def test_teardown_does_not_wait_for_the_kernel_to_collect_the_child(monkeypatch):
+    # #725 third re-review: the escalation to SIGKILL is reached with the budget
+    # ALREADY spent, so ANY fixed allowance after it is time the caller never
+    # agreed to — and in the daemon, time every queued request waits too. A
+    # half-second one turned a 0.01s-bounded wait-ready into 0.5s. Collection is
+    # now a background duty, so teardown returns as soon as it has killed.
+    slow = _SlowToCollect(_stubborn_child(start_new_session=True))
+    try:
+        started = time.monotonic()
+        _terminate(cast(subprocess.Popen, slow), grace=0.05)
+        elapsed = time.monotonic() - started
+        assert elapsed < 0.05 + _SCHEDULING_SLACK, (
+            f"teardown spent {elapsed:.2f}s waiting past a 0.05s grace"
+        )
+    finally:
+        slow.released.set()
+        slow.kill()
+
+
+def test_a_killed_engine_is_still_collected(monkeypatch):
+    # The other half: not waiting must not become not collecting. An uncollected
+    # child keeps a None returncode for whatever happens to poll it next — in a
+    # long-lived daemon, possibly nothing.
     stubborn = _stubborn_child(start_new_session=True)
     try:
         _terminate(stubborn, grace=0.05)
-        assert stubborn.returncode is not None, "the killed child was never reaped"
+        # `returncode` is read directly, never through `poll()` — poll() would
+        # collect the child itself and pass with no reaper at all.
+        end = time.monotonic() + 10.0
+        while stubborn.returncode is None and time.monotonic() < end:
+            time.sleep(0.01)
+        assert stubborn.returncode is not None, "the killed child was never collected"
         assert stubborn.returncode < 0  # ended by a signal, not by its own exit
     finally:
-        if stubborn.poll() is None:
+        if stubborn.returncode is None:
             stubborn.kill()
 
 

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -374,3 +374,52 @@ def test_a_session_dying_mid_request_reports_disconnect_then_relaunches(
     assert len(launches) == 2
     # Every launch was asked to log to the one DaemonPaths-derived path (#674).
     assert launches == [paths.session_log, paths.session_log]
+
+
+def test_wait_ready_launches_once_and_reports_the_bounded_wait(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # #657 over the real socket: the wait-ready op IS the first live op — it
+    # launches through the seam with the caller's bound as the harness-connect
+    # timeout and reports launched=true; a repeat while the session is alive is
+    # idempotent (launched=false, no relaunch).
+    launches: list = []
+    session = _ServedSession()
+
+    def _launch(*args, **kwargs):
+        launches.append(kwargs.get("timeout"))
+        return session
+
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_launch)
+
+    with _serving(server, paths, monkeypatch):
+        first = _request(paths, {"op": "daemon-wait-ready", "params": {"timeout": 7.5}})
+        again = _request(paths, {"op": "daemon-wait-ready", "params": {}})
+
+    assert first is not None
+    verdict = parse_result(first["stdout"])
+    assert verdict == {"pid": os.getpid(), "launched": True}
+    assert again is not None
+    assert parse_result(again["stdout"])["launched"] is False
+    assert launches == [7.5]  # one launch, bounded by the caller's timeout
+
+
+def test_wait_ready_relays_the_typed_launch_failure(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # The wait shares the live ops' one launch boundary, so a failed launch is
+    # the same typed refusal a live op gets — not a bespoke wait-ready error.
+    def _launch(*args, **kwargs):
+        return None
+
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_launch)
+
+    with _serving(server, paths, monkeypatch):
+        reply = _request(paths, {"op": "daemon-wait-ready", "params": {}})
+
+    assert reply is not None
+    assert (
+        parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    )

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -36,19 +36,46 @@ from gda.daemon.discovery import (
     daemon_pid,
     read_pidfile,
 )
-from gda.daemon.protocol import read_message, write_message
+from gda.daemon.protocol import read_message, write_frame, write_message
 from gda.daemon.server import DAEMON_SERVED_OPS, DaemonServer
-from gda.daemon.session import EngineSession, launch_session
+from gda.daemon.session import EngineSession, _terminate, launch_session
 from gda.errors import Failure
 from gda.parser import parse_result
+from tests.support import no_engine_teardown
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
+_REAL_POPEN = subprocess.Popen
+
 
 # A stand-in engine that survives SIGTERM, so a teardown's escalation is observable.
+# It announces itself: the handler is installed by the CHILD, so a SIGTERM that
+# arrives during interpreter startup still kills it by the default disposition —
+# a teardown test that raced the startup would exercise the ordinary path and
+# prove nothing (observed: `_terminate` 1ms after spawn returned -15, not -9).
 _IGNORES_SIGTERM = (
-    "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)"
+    "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+    "print('ready', flush=True); time.sleep(60)"
 )
+
+
+def _stubborn_child(**kwargs) -> subprocess.Popen:
+    """Spawn the SIGTERM-ignoring stand-in and return it only once it IS stubborn.
+
+    Bound to the REAL ``Popen``: a test that fakes the launch spawn patches
+    ``subprocess.Popen`` itself, and spawning through the patched name would
+    recurse.
+    """
+    kwargs.pop("stdout", None)
+    proc = _REAL_POPEN(
+        [sys.executable, "-c", _IGNORES_SIGTERM],
+        stdout=subprocess.PIPE,
+        text=True,
+        **kwargs,
+    )
+    assert proc.stdout is not None
+    assert proc.stdout.readline().strip() == "ready"
+    return proc
 
 
 def _project(tmp_path: Path) -> Path:
@@ -80,8 +107,9 @@ class _ServedSession:
     def request(self, operation: str, params: dict) -> dict:
         return {"stdout": f"served:{operation}", "stderr": "", "exit_code": 0}
 
-    def close(self) -> None:
+    def close(self, grace: float = 0.0) -> None:
         self.closed = True
+        self.close_grace = grace
 
 
 def _request(paths, payload: dict, timeout: float = 5.0):
@@ -409,7 +437,12 @@ def test_wait_ready_launches_once_and_reports_the_bounded_wait(
     assert verdict == {"pid": os.getpid(), "launched": True}
     assert again is not None
     assert parse_result(again["stdout"])["launched"] is False
-    assert launches == [7.5]  # one launch, bounded by the caller's timeout
+    # One launch, bounded by the caller's timeout — and by no more than it: what
+    # reaches the launcher is what the shared deadline has left after retiring the
+    # session being replaced (#725 re-review), which here is nearly all of it
+    # because there was nothing to retire.
+    assert len(launches) == 1
+    assert 7.4 < launches[0] <= 7.5
 
 
 def test_wait_ready_relays_the_typed_launch_failure(
@@ -440,7 +473,7 @@ def test_a_silent_handshake_peer_cannot_hold_the_launch_past_the_deadline(
     # and then never speaks used to block the token read forever — here the
     # REAL launch_session must give up within the bound and record why.
     monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _Proc(code=None))
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
+    no_engine_teardown(monkeypatch)
     paths = daemon_paths(_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -471,6 +504,136 @@ def test_a_silent_handshake_peer_cannot_hold_the_launch_past_the_deadline(
     assert any("no auth token" in reason for reason in diagnostics)
 
 
+@pytest.mark.parametrize("frame", ["token", "verification"])
+def test_a_trickling_handshake_peer_cannot_hold_the_launch_past_the_deadline(
+    tmp_path, daemon_runtime_dir, monkeypatch, frame
+):
+    # #725 re-review finding 1: silence is not the only way to hold the reader.
+    # A socket timeout bounds each recv, so a peer that sends ONE BYTE just
+    # inside it restarts the clock on every chunk and the frame never ends. Both
+    # handshake frames are read in chunks, so both are exposed; the deadline has
+    # to be recomputed per recv, not set once per frame. Measured before the fix
+    # at a 0.04s/byte trickle on a 0.05s bound: 0.7s for the token frame, 2.1s
+    # for the verification frame — and the trickle rate is the peer's to choose.
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _Proc(code=None))
+    no_engine_teardown(monkeypatch)
+    paths = daemon_paths(_project(tmp_path))
+    paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(paths.harness_socket))
+    listener.listen()
+    peer = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    peer.connect(str(paths.harness_socket))
+
+    def _trickle() -> None:
+        if frame == "verification":
+            write_frame(peer, b"expected-token")  # the token frame arrives whole
+            body = b'{"scene_ok": true, "current": "res://main.tscn"}'
+        else:
+            body = b"expected-token"
+        wire = len(body).to_bytes(4, "big") + body
+        for byte in wire:  # each byte lands inside the 0.05s bound, resetting it
+            try:
+                peer.sendall(bytes([byte]))
+            except OSError:
+                return
+            time.sleep(0.04)
+
+    trickler = threading.Thread(target=_trickle, daemon=True)
+    trickler.start()
+    started = time.monotonic()
+    try:
+        outcome = launch_session(
+            paths.project,
+            "godot",
+            listener,
+            paths.harness_socket,
+            "expected-token",
+            timeout=0.05,
+        )
+        elapsed = time.monotonic() - started
+    finally:
+        peer.close()
+        listener.close()
+        trickler.join(timeout=5)
+
+    assert outcome is None
+    assert elapsed < 0.5, f"the trickling peer held the launch for {elapsed:.2f}s"
+
+
+def test_retiring_a_stale_session_is_charged_to_the_callers_deadline(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # #725 re-review finding 2: the launch boundary retires the session it is
+    # replacing, and that retirement is work on the CALLER's clock. A stale
+    # session whose engine ignores SIGTERM used to be closed on its own
+    # five-second grace before the bounded launch even began — 5.0s for a
+    # `wait-ready --timeout 0.3`, with the serve loop blocked throughout. NOTE:
+    # no `no_engine_teardown` here on purpose — the real teardown IS the subject,
+    # and mocking it is exactly what hid this interaction.
+    monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
+    stubborn = _stubborn_child(start_new_session=True)
+    ours, silent_harness = socket.socketpair()
+    stale = EngineSession(stubborn, conn=ours)
+
+    launches: list = []
+
+    def _launch(*args, **kwargs):
+        launches.append(kwargs.get("timeout"))
+        return stale if len(launches) == 1 else None
+
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_launch)
+
+    try:
+        with _serving(server, paths, monkeypatch):
+            assert (
+                _request(paths, {"op": "daemon-wait-ready", "params": {}}) is not None
+            )
+            timed_out = _request(paths, {"op": "game-tree", "params": {}})
+            started = time.monotonic()
+            reply = _request(
+                paths,
+                {"op": "daemon-wait-ready", "params": {"timeout": 0.3}},
+                timeout=20.0,
+            )
+            elapsed = time.monotonic() - started
+            behind = time.monotonic()
+            status = _request(paths, {"op": "__status__"})
+            queued = time.monotonic() - behind
+    finally:
+        silent_harness.close()
+        stubborn.kill()
+
+    assert timed_out is not None
+    assert parse_result(timed_out["stdout"])["error"]["code"] == "live_timeout"
+    assert reply is not None
+    assert (
+        parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
+    )
+    assert elapsed < 2.0, f"retiring the stale session took {elapsed:.1f}s"
+    assert status is not None and status["ok"] is True
+    assert queued < 1.0, f"the next control request waited {queued:.1f}s"
+    # The replacement launch got what retirement left of the same 0.3s, never a
+    # fresh budget of its own.
+    assert len(launches) == 2 and launches[1] is not None and launches[1] <= 0.3
+
+
+def test_a_killed_engine_is_reaped_by_the_teardown_that_killed_it(monkeypatch):
+    # #725 re-review finding 3: after the grace expires the child is SIGKILLed,
+    # and teardown must finish what it started. Without the reap `returncode`
+    # stayed None and the exited child was left for whatever happened to call
+    # poll() next — in a long-lived daemon, possibly nothing.
+    stubborn = _stubborn_child(start_new_session=True)
+    try:
+        _terminate(stubborn, grace=0.05)
+        assert stubborn.returncode is not None, "the killed child was never reaped"
+        assert stubborn.returncode < 0  # ended by a signal, not by its own exit
+    finally:
+        if stubborn.poll() is None:
+            stubborn.kill()
+
+
 def test_a_stuck_handshake_does_not_freeze_the_daemon(
     tmp_path, daemon_runtime_dir, monkeypatch
 ):
@@ -479,7 +642,7 @@ def test_a_stuck_handshake_does_not_freeze_the_daemon(
     # must come back typed within its bound, and — the daemon serving one
     # request at a time — the NEXT control request must still be served.
     monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _Proc(code=None))
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
+    no_engine_teardown(monkeypatch)
     paths = daemon_paths(_project(tmp_path))
     server = DaemonServer(paths, godot="godot")  # the real launch seam default
 
@@ -512,7 +675,7 @@ def test_wait_ready_rebuilds_a_session_whose_channel_broke(
     # very next read disproves — the engine process is still alive throughout.
     # The relaunch path close()s the stale session, whose real _terminate needs
     # a real process; the fake has none.
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
+    no_engine_teardown(monkeypatch)
     ours, theirs = socket.socketpair()
     theirs.close()
     zombie = EngineSession(cast(subprocess.Popen, _Proc(code=None)), conn=ours)
@@ -548,7 +711,7 @@ def test_wait_ready_rebuilds_a_session_whose_relay_timed_out(
     # so wait-ready must NOT certify it. Before the fix the daemon reported
     # `launched: false` over that channel and the next read went back to it.
     monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
-    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc, grace=0.0: None)
+    no_engine_teardown(monkeypatch)
     ours, silent_harness = socket.socketpair()
     desynced = EngineSession(cast(subprocess.Popen, _Proc(code=None)), conn=ours)
 
@@ -586,11 +749,10 @@ def test_a_teardown_cannot_outlast_the_readiness_deadline(
     # after the readiness budget was already spent — a measured 5.3s for
     # `--timeout 0.3` — and the daemon serves one request at a time, so the whole
     # round trip and every request behind it waited it out.
-    real_popen = subprocess.Popen
     spawned: list = []
 
     def _spawn_stubborn_child(argv, **kwargs):
-        proc = real_popen([sys.executable, "-c", _IGNORES_SIGTERM], **kwargs)
+        proc = _stubborn_child(**kwargs)
         spawned.append(proc)
         return proc
 

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -36,8 +36,8 @@ from gda.daemon.discovery import (
     read_pidfile,
 )
 from gda.daemon.protocol import read_message, write_message
-from gda.daemon.server import DaemonServer
-from gda.daemon.session import EngineSession
+from gda.daemon.server import DAEMON_SERVED_OPS, DaemonServer
+from gda.daemon.session import EngineSession, launch_session
 from gda.errors import Failure
 from gda.parser import parse_result
 
@@ -423,3 +423,204 @@ def test_wait_ready_relays_the_typed_launch_failure(
     assert (
         parse_result(reply["stdout"])["error"]["code"] == "engine_session_not_running"
     )
+
+
+def test_a_silent_handshake_peer_cannot_hold_the_launch_past_the_deadline(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # #725 review finding 1, at the launcher: ONE monotonic deadline spans
+    # accept, the token frame, and the verification frame. A peer that connects
+    # and then never speaks used to block the token read forever — here the
+    # REAL launch_session must give up within the bound and record why.
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _Proc(code=None))
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    paths = daemon_paths(_project(tmp_path))
+    paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(paths.harness_socket))
+    listener.listen()
+    silent = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    silent.connect(str(paths.harness_socket))  # queued for the launch's accept
+
+    diagnostics: list[str] = []
+    started = time.monotonic()
+    try:
+        outcome = launch_session(
+            paths.project,
+            "godot",
+            listener,
+            paths.harness_socket,
+            "expected-token",
+            timeout=0.3,
+            diagnostics=diagnostics,
+        )
+        elapsed = time.monotonic() - started
+    finally:
+        silent.close()
+        listener.close()
+
+    assert outcome is None
+    assert elapsed < 3.0, f"the silent peer held the launch for {elapsed:.1f}s"
+    assert any("no auth token" in reason for reason in diagnostics)
+
+
+def test_a_stuck_handshake_does_not_freeze_the_daemon(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # #725 review finding 1, end to end: the REAL launch_session runs inside the
+    # serve loop while a peer occupies the harness socket silently. wait-ready
+    # must come back typed within its bound, and — the daemon serving one
+    # request at a time — the NEXT control request must still be served.
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _Proc(code=None))
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot")  # the real launch seam default
+
+    with _serving(server, paths, monkeypatch):
+        silent = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        silent.connect(str(paths.harness_socket))
+        try:
+            reply = _request(
+                paths,
+                {"op": "daemon-wait-ready", "params": {"timeout": 0.3}},
+                timeout=10.0,
+            )
+            assert reply is not None
+            assert (
+                parse_result(reply["stdout"])["error"]["code"]
+                == "engine_session_not_running"
+            )
+            status = _request(paths, {"op": "__status__"})
+            assert status is not None and status["ok"] is True
+        finally:
+            silent.close()
+
+
+def test_wait_ready_rebuilds_a_session_whose_channel_broke(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # #725 review finding 2: a relay that hits a broken harness channel latches
+    # the session stale, so the NEXT wait-ready relaunches through the shared
+    # boundary instead of reporting a serving state (launched: false) that the
+    # very next read disproves — the engine process is still alive throughout.
+    # The relaunch path close()s the stale session, whose real _terminate needs
+    # a real process; the fake has none.
+    monkeypatch.setattr("gda.daemon.session._terminate", lambda proc: None)
+    ours, theirs = socket.socketpair()
+    theirs.close()
+    zombie = EngineSession(cast(subprocess.Popen, _Proc(code=None)), conn=ours)
+
+    launches: list = []
+
+    def _launch(*args, **kwargs):
+        launches.append(1)
+        return zombie if len(launches) == 1 else _ServedSession()
+
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_launch)
+
+    with _serving(server, paths, monkeypatch):
+        first = _request(paths, {"op": "daemon-wait-ready", "params": {}})
+        read = _request(paths, {"op": "game-tree", "params": {}})
+        second = _request(paths, {"op": "daemon-wait-ready", "params": {}})
+        served = _request(paths, {"op": "game-tree", "params": {}})
+
+    assert first is not None and parse_result(first["stdout"])["launched"] is True
+    assert read is not None
+    assert parse_result(read["stdout"])["error"]["code"] == "engine_disconnected"
+    assert second is not None and parse_result(second["stdout"])["launched"] is True
+    assert served is not None and served["stdout"] == "served:game-tree"
+    assert len(launches) == 2
+
+
+def test_launched_is_reported_by_the_launch_owner(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # #725 review finding 3 (TOCTOU): the launch fact travels WITH the launch
+    # decision. A liveness that flips between two samples must never yield a
+    # call that launched yet reported launched: false — the invariant is
+    # "launched == (a launch actually happened on this call)".
+    class _FlipSession(_ServedSession):
+        def __init__(self) -> None:
+            super().__init__()
+            self.polls = 0
+
+        def alive(self) -> bool:
+            self.polls += 1
+            return self.polls == 1  # alive at the first sample, gone at the next
+
+    launches: list = []
+    flip = _FlipSession()
+
+    def _launch(*args, **kwargs):
+        launches.append(1)
+        return flip if len(launches) == 1 else _ServedSession()
+
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_launch)
+
+    with _serving(server, paths, monkeypatch):
+        first = _request(paths, {"op": "daemon-wait-ready", "params": {}})
+        second = _request(paths, {"op": "daemon-wait-ready", "params": {}})
+
+    assert first is not None and parse_result(first["stdout"])["launched"] is True
+    assert second is not None
+    launched_second = parse_result(second["stdout"])["launched"]
+    assert launched_second == (len(launches) == 2), (
+        f"launched={launched_second} but launches={len(launches)} — the reported "
+        "fact desynced from what the launch owner actually did"
+    )
+
+
+def test_every_declared_daemon_served_op_is_intercepted_not_relayed(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # #725 review finding 4: DAEMON_SERVED_OPS is the routing authority, so a
+    # mutation that declares an op daemon-served without intercepting it must
+    # fail HERE — every member is driven through the real loop with a session
+    # cached, and none may reach the session's relay.
+    class _RecordingSession(_ServedSession):
+        def __init__(self) -> None:
+            super().__init__()
+            self.relayed: list[str] = []
+
+        def request(self, operation: str, params: dict) -> dict:
+            self.relayed.append(operation)
+            return super().request(operation, params)
+
+    session = _RecordingSession()
+
+    def _launch(*args, **kwargs):
+        return session
+
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_launch)
+
+    with _serving(server, paths, monkeypatch):
+        primed = _request(paths, {"op": "daemon-wait-ready", "params": {}})
+        assert primed is not None
+        for op in DAEMON_SERVED_OPS:
+            reply = _request(paths, {"op": op, "params": {}})
+            assert reply is not None, op
+
+    assert session.relayed == []
+
+
+def test_the_wire_boundary_re_enforces_the_wait_ready_bound(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # #725 review finding 4: the finite (0, 50] rule holds at the IPC boundary
+    # too — this socket can be driven by clients other than gda's CLI, and an
+    # unbounded or non-finite value would defeat the bound the op promises.
+    paths = daemon_paths(_project(tmp_path))
+    server = DaemonServer(paths, godot="godot", launch=_no_launch)
+
+    with _serving(server, paths, monkeypatch):
+        for bad in (-1, 0, 1000, float("inf"), float("nan"), True, "10"):
+            reply = _request(
+                paths, {"op": "daemon-wait-ready", "params": {"timeout": bad}}
+            )
+            assert reply is not None, bad
+            assert parse_result(reply["stdout"])["error"]["code"] == "invalid_params", (
+                bad
+            )

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -72,6 +72,18 @@ _IGNORES_SIGTERM_WITH_CHILD = (
     "child.stdout.readline();"
     "print(child.pid, flush=True); time.sleep(120)"
 )
+# A leader that OBEYS SIGTERM, whose descendant does not — the asymmetric case,
+# where the leader's own death used to end the teardown with the group alive.
+_OBEYS_SIGTERM_WITH_STUBBORN_CHILD = (
+    "import subprocess, sys, time;"
+    "child = subprocess.Popen([sys.executable, '-c',"
+    ' "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN);'
+    ' print(chr(120), flush=True); time.sleep(120)"'
+    "], stdout=subprocess.PIPE,"
+    " text=True);"
+    "child.stdout.readline();"
+    "print(child.pid, flush=True); time.sleep(120)"
+)
 _IGNORES_SIGTERM = (
     "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
     "print('ready', flush=True); time.sleep(60)"
@@ -110,6 +122,17 @@ class _Proc:
 
     def poll(self):
         return self.code
+
+    @property
+    def pid(self) -> int:
+        # Deliberately absent rather than invented: teardown reads the pid to
+        # retire the engine's process GROUP, and a made-up one resolves to some
+        # unrelated process that would then be signalled. A test whose stand-in
+        # reaches real teardown wants `no_engine_teardown`.
+        raise AssertionError(
+            "this stand-in engine process has no pid; a test that lets it reach "
+            "the real teardown must request no_engine_teardown"
+        )
 
 
 class _ServedSession:
@@ -401,6 +424,7 @@ def test_a_session_dying_mid_request_reports_disconnect_then_relaunches(
     # connection breaks during the relay (the real EngineSession.request maps
     # that to engine_disconnected), the engine process then dies, and the NEXT
     # live op relaunches through the seam and serves.
+    no_engine_teardown(monkeypatch)  # the dying session is a stand-in, not a child
     ours, theirs = socket.socketpair()
     theirs.close()  # the harness end is gone: the relay write breaks mid-request
     proc = _Proc(code=None)  # alive at the pre-request liveness check
@@ -860,36 +884,63 @@ def test_the_termination_wait_is_measured_when_it_begins(monkeypatch):
     assert given[0] == 0, f"the wait was given a revived {given[0]}s budget"
 
 
-def test_the_escalation_covers_the_group_the_engine_owns(monkeypatch):
-    # #725 fourth re-review: SIGTERM went to the process group, SIGKILL only to
-    # the leader — so a descendant that also ignored SIGTERM was left alive and
-    # orphaned. The session is spawned with `start_new_session=True`, so gda owns
-    # that group; the escalation must match the signal that preceded it.
+def _leader_with_descendant(source: str) -> "tuple[subprocess.Popen, int]":
+    """Spawn a group leader that reports its descendant's pid, and both are up."""
     leader = _REAL_POPEN(
-        [sys.executable, "-c", _IGNORES_SIGTERM_WITH_CHILD],
+        [sys.executable, "-c", source],
         stdout=subprocess.PIPE,
         text=True,
         start_new_session=True,
     )
     assert leader.stdout is not None
-    descendant = int(leader.stdout.readline().strip())
+    return leader, int(leader.stdout.readline().strip())
+
+
+def _assert_gone(pid: int, what: str) -> None:
+    end = time.monotonic() + 5.0
+    while time.monotonic() < end:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"the {what} {pid} outlived the group retirement")
+
+
+def _reap_group(*pids: int) -> None:
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+def test_the_group_is_retired_even_when_the_leader_obeys_sigterm(monkeypatch):
+    # #725 fifth re-review: the escalation was decided from the LEADER alone, so
+    # a leader that obeyed the group SIGTERM ended the teardown — `wait()`
+    # succeeded, the SIGKILL branch was skipped — while a descendant that
+    # ignored it kept running, orphaned (probed: leader -15 in 0.001s,
+    # descendant alive). gda owns the group, so the group is what gets retired.
+    leader, descendant = _leader_with_descendant(_OBEYS_SIGTERM_WITH_STUBBORN_CHILD)
+    try:
+        _terminate(leader, time.monotonic() + 5.0)
+        assert leader.returncode == -signal.SIGTERM  # the leader DID obey
+        _assert_gone(descendant, "descendant")
+    finally:
+        _reap_group(descendant, leader.pid)
+
+
+def test_the_escalation_covers_the_group_the_engine_owns(monkeypatch):
+    # #725 fourth re-review: SIGTERM went to the process group, SIGKILL only to
+    # the leader — so a descendant that also ignored SIGTERM was left alive and
+    # orphaned. The session is spawned with `start_new_session=True`, so gda owns
+    # that group; the escalation must match the signal that preceded it.
+    leader, descendant = _leader_with_descendant(_IGNORES_SIGTERM_WITH_CHILD)
     try:
         _terminate(leader, time.monotonic() + 0.05)
-        end = time.monotonic() + 5.0
-        while time.monotonic() < end:
-            try:
-                os.kill(descendant, 0)
-            except ProcessLookupError:
-                break
-            time.sleep(0.01)
-        else:
-            raise AssertionError(f"the descendant {descendant} outlived the group kill")
+        _assert_gone(descendant, "descendant")
     finally:
-        for pid in (descendant, leader.pid):
-            try:
-                os.kill(pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
+        _reap_group(descendant, leader.pid)
 
 
 def test_teardown_does_not_wait_for_the_kernel_to_collect_the_child(monkeypatch):

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -38,9 +38,15 @@ from gda.daemon.discovery import (
 )
 from gda.daemon.protocol import read_message, write_frame, write_message
 from gda.daemon.server import DAEMON_SERVED_OPS, DaemonServer
-from gda.daemon.session import EngineSession, _terminate, launch_session
+from gda.daemon.session import (
+    EngineSession,
+    _own_group,
+    _terminate,
+    launch_session,
+)
 from gda.errors import Failure
-from gda.parser import parse_result
+from gda.live_runner import DaemonRunner
+from gda.parser import build_result, parse_result
 from tests.support import no_engine_teardown
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
@@ -84,6 +90,39 @@ _OBEYS_SIGTERM_WITH_STUBBORN_CHILD = (
     "child.stdout.readline();"
     "print(child.pid, flush=True); time.sleep(120)"
 )
+# A leader that EXITS AT ONCE, leaving a stubborn descendant in its group —
+# so the group must survive the leader being reaped by a liveness check.
+_EXITS_LEAVING_STUBBORN_CHILD = (
+    "import subprocess, sys;"
+    "child = subprocess.Popen([sys.executable, '-c',"
+    ' "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN);'
+    ' print(chr(120), flush=True); time.sleep(120)"'
+    "], stdout=subprocess.PIPE,"
+    " text=True);"
+    "child.stdout.readline(); print(child.pid, flush=True)"
+)
+# A leader that obeys SIGTERM, whose descendant handles SIGTERM by doing 0.2s of
+# work and touching a marker — so a teardown that kills the group the instant
+# the leader exits is observable as a MISSING marker.
+_CLEANING_CHILD = (
+    "import signal, time\n"
+    "def _cleanup(sig, frame):\n"
+    "    time.sleep(0.2)\n"
+    "    open({marker!r}, 'w').close()\n"
+    "    raise SystemExit(0)\n"
+    "signal.signal(signal.SIGTERM, _cleanup)\n"
+    "print('ready', flush=True)\n"
+    "time.sleep(120)\n"
+)
+_OBEYS_SIGTERM_WITH_CLEANING_CHILD = (
+    "import subprocess, sys, time\n"
+    "source = '''" + _CLEANING_CHILD + "'''\n"
+    "child = subprocess.Popen([sys.executable, '-c', source],"
+    " stdout=subprocess.PIPE, text=True)\n"
+    "child.stdout.readline()\n"
+    "print(child.pid, flush=True)\n"
+    "time.sleep(120)\n"
+)
 _IGNORES_SIGTERM = (
     "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
     "print('ready', flush=True); time.sleep(60)"
@@ -123,16 +162,11 @@ class _Proc:
     def poll(self):
         return self.code
 
-    @property
-    def pid(self) -> int:
-        # Deliberately absent rather than invented: teardown reads the pid to
-        # retire the engine's process GROUP, and a made-up one resolves to some
-        # unrelated process that would then be signalled. A test whose stand-in
-        # reaches real teardown wants `no_engine_teardown`.
-        raise AssertionError(
-            "this stand-in engine process has no pid; a test that lets it reach "
-            "the real teardown must request no_engine_teardown"
-        )
+    # gda's OWN pid, deliberately: teardown reads the pid to find the process
+    # group it owns, and the own-group guard then resolves this stand-in to no
+    # group at all. An invented pid would instead resolve to whichever real
+    # process holds it — which a test would then signal.
+    pid = os.getpid()
 
 
 class _ServedSession:
@@ -848,16 +882,17 @@ class _SlowToCollect:
         return self._proc.wait()
 
 
-def test_the_termination_wait_is_measured_when_it_begins(monkeypatch):
-    # #725 fourth re-review: the deadline reached teardown as a DURATION, so the
-    # work before the only blocking step — the caller's channel close, the poll,
-    # the signal — was spent and then the full original grace was handed to
-    # `wait()` anyway. Probed at 0.08s of pre-wait work against a 0.05s budget:
-    # `wait()` still received 0.05. The remainder is recomputed where it is used.
-    given: list = []
+def test_teardown_adds_no_waiting_after_work_that_spent_the_deadline(monkeypatch):
+    # #725 re-review: the deadline reached teardown as a DURATION, so the work
+    # before the wait — the caller's channel close, the poll, the signal — was
+    # spent and the full original grace was handed to the wait anyway (probed at
+    # 0.08s of pre-wait work against a 0.05s budget: the wait still got 0.05).
+    # The remainder is re-read where it is used, so work that already spent the
+    # budget is followed by no waiting at all — only by the escalation.
+    killed: list = []
 
     class _SlowPoll:
-        pid = 1
+        pid = os.getpid()  # resolves to gda's own group, so no signal escapes
 
         def __init__(self) -> None:
             self.polls = 0
@@ -870,18 +905,20 @@ def test_the_termination_wait_is_measured_when_it_begins(monkeypatch):
 
         def terminate(self) -> None: ...
 
-        def kill(self) -> None: ...
+        def kill(self) -> None:
+            killed.append(time.monotonic())
 
         def wait(self, timeout=None):
-            given.append(timeout)
             raise subprocess.TimeoutExpired("engine", timeout or 0)
 
-    monkeypatch.setattr(os, "getpgid", lambda pid: 1)
-    monkeypatch.setattr(os, "killpg", lambda pgid, sig: None)
+    started = time.monotonic()
     _terminate(cast(subprocess.Popen, _SlowPoll()), time.monotonic() + 0.05)
+    elapsed = time.monotonic() - started
 
-    assert given, "the engine was never waited on"
-    assert given[0] == 0, f"the wait was given a revived {given[0]}s budget"
+    assert killed, "the engine was never escalated"
+    assert elapsed < 0.08 + _SCHEDULING_SLACK, (
+        f"teardown waited {elapsed:.2f}s after a budget already spent"
+    )
 
 
 def _leader_with_descendant(source: str) -> "tuple[subprocess.Popen, int]":
@@ -913,6 +950,89 @@ def _reap_group(*pids: int) -> None:
             os.kill(pid, signal.SIGKILL)
         except ProcessLookupError:
             pass
+
+
+def test_the_live_clients_ceiling_covers_the_whole_round_trip(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    # #725 re-review: the client set the socket timeout once and read the reply
+    # in as many chunks as the daemon sent, so its published 60s was a per-recv
+    # INACTIVITY timeout, not a round-trip ceiling — a trickling daemon could
+    # hold the CLI indefinitely. Same absolute-instant rule as every other read.
+    monkeypatch.setattr("gda.live_runner.LIVE_REQUEST_TIMEOUT", 0.3)
+    paths = daemon_paths(_project(tmp_path))
+    paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(paths.cli_socket))
+    listener.listen()
+
+    def _trickle() -> None:
+        conn, _ = listener.accept()
+        read_message(conn)
+        body = build_result({"ok": True}).encode("utf-8")
+        wire = len(body).to_bytes(4, "big") + body
+        for byte in wire:  # each byte lands inside the bound, resetting it
+            try:
+                conn.sendall(bytes([byte]))
+            except OSError:
+                return
+            time.sleep(0.2)
+
+    daemon = threading.Thread(target=_trickle, daemon=True)
+    daemon.start()
+    started = time.monotonic()
+    try:
+        # The request leg itself: daemon discovery is not what is under test.
+        result = DaemonRunner(paths.project)._request(paths.cli_socket, "game-tree", {})
+        elapsed = time.monotonic() - started
+    finally:
+        listener.close()
+        daemon.join(timeout=5)
+
+    assert elapsed < 0.3 + _SCHEDULING_SLACK, (
+        f"the trickled reply held the CLI for {elapsed:.2f}s"
+    )
+    assert parse_result(result.stdout)["error"]["code"] == "live_timeout"
+
+
+def test_the_owner_keeps_the_group_a_reaped_leader_cannot_name(tmp_path):
+    # #725 re-review: the group id is the LEADER'S pid, and `EngineSession.alive()`
+    # polls the leader — which reaps it. Rediscovering the group at teardown then
+    # returned nothing and the engine's descendants were never retired (probed:
+    # leader exited 0, group unrecoverable, descendant alive). The owner captures
+    # the group at spawn and keeps it.
+    leader, descendant = _leader_with_descendant(_EXITS_LEAVING_STUBBORN_CHILD)
+    group = _own_group(leader)
+    session = EngineSession(leader, conn=None, group=group)
+    try:
+        end = time.monotonic() + 5.0
+        while session.alive() and time.monotonic() < end:
+            time.sleep(0.01)  # the liveness check that reaps the leader
+        assert not session.alive()
+        assert _own_group(leader) is None, "the reaped leader still names a group"
+        session.close(time.monotonic() + 5.0)
+        _assert_gone(descendant, "descendant")
+    finally:
+        _reap_group(descendant, leader.pid)
+
+
+def test_a_descendant_may_finish_its_own_cleanup_inside_the_deadline(tmp_path):
+    # #725 re-review, the other side of group ownership: SIGKILL used to follow
+    # the moment the LEADER exited, so a descendant still running its own SIGTERM
+    # handler was truncated even with the whole budget left. The wait is for the
+    # group, so a descendant that completes within the deadline gets to.
+    marker = tmp_path / "cleanup-done"
+    leader, descendant = _leader_with_descendant(
+        _OBEYS_SIGTERM_WITH_CLEANING_CHILD.format(marker=str(marker))
+    )
+    try:
+        started = time.monotonic()
+        _terminate(leader, time.monotonic() + 5.0, group=_own_group(leader))
+        elapsed = time.monotonic() - started
+        assert marker.exists(), "the descendant's cleanup was cut short"
+        assert elapsed < 5.0, "teardown waited out the whole deadline"
+    finally:
+        _reap_group(descendant, leader.pid)
 
 
 def test_the_group_is_retired_even_when_the_leader_obeys_sigterm(monkeypatch):

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -25,6 +25,7 @@ import threading
 import time
 from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
@@ -1037,8 +1038,16 @@ def test_the_live_client_write_uses_only_the_round_trip_budget_left(monkeypatch)
             raise TimeoutError
 
     monkeypatch.setattr("gda.live_runner.LIVE_REQUEST_TIMEOUT", 0.1)
+    # Replace the runner's module binding, not ``socket.socket`` on the shared
+    # stdlib module: another thread may legitimately create a real socket while
+    # this test runs.
     monkeypatch.setattr(
-        "gda.live_runner.socket.socket", lambda *args, **kwargs: _AccumulatingSocket()
+        "gda.live_runner.socket",
+        SimpleNamespace(
+            AF_UNIX=socket.AF_UNIX,
+            SOCK_STREAM=socket.SOCK_STREAM,
+            socket=lambda *args, **kwargs: _AccumulatingSocket(),
+        ),
     )
     started = time.monotonic()
     result = DaemonRunner(Path("."))._request(Path("unused.sock"), "game-tree", {})

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -40,7 +40,8 @@ from gda.daemon.protocol import read_message, write_frame, write_message
 from gda.daemon.server import DAEMON_SERVED_OPS, DaemonServer
 from gda.daemon.session import (
     EngineSession,
-    _own_group,
+    _capture_owned_pgid,
+    _group_standing,
     _terminate,
     launch_session,
 )
@@ -122,6 +123,14 @@ _OBEYS_SIGTERM_WITH_CLEANING_CHILD = (
     "child.stdout.readline()\n"
     "print(child.pid, flush=True)\n"
     "time.sleep(120)\n"
+)
+_EXITS_LEAVING_CLEANING_CHILD = (
+    "import subprocess, sys\n"
+    "source = '''" + _CLEANING_CHILD + "'''\n"
+    "child = subprocess.Popen([sys.executable, '-c', source],"
+    " stdout=subprocess.PIPE, text=True)\n"
+    "child.stdout.readline()\n"
+    "print(child.pid, flush=True)\n"
 )
 _IGNORES_SIGTERM = (
     "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
@@ -921,7 +930,9 @@ def test_teardown_adds_no_waiting_after_work_that_spent_the_deadline(monkeypatch
     )
 
 
-def _leader_with_descendant(source: str) -> "tuple[subprocess.Popen, int]":
+def _leader_with_descendant(
+    source: str,
+) -> "tuple[subprocess.Popen, int, int | None]":
     """Spawn a group leader that reports its descendant's pid, and both are up."""
     leader = _REAL_POPEN(
         [sys.executable, "-c", source],
@@ -929,8 +940,11 @@ def _leader_with_descendant(source: str) -> "tuple[subprocess.Popen, int]":
         text=True,
         start_new_session=True,
     )
+    # Match production: ownership is captured immediately after Popen, not after
+    # reading output from a leader whose source may already have exited.
+    owned_pgid = _capture_owned_pgid(leader)
     assert leader.stdout is not None
-    return leader, int(leader.stdout.readline().strip())
+    return leader, int(leader.stdout.readline().strip()), owned_pgid
 
 
 def _assert_gone(pid: int, what: str) -> None:
@@ -995,25 +1009,113 @@ def test_the_live_clients_ceiling_covers_the_whole_round_trip(
     assert parse_result(result.stdout)["error"]["code"] == "live_timeout"
 
 
+def test_the_live_client_write_uses_only_the_round_trip_budget_left(monkeypatch):
+    # #725 re-review: passing the absolute instant only to the reply read left
+    # connect and request send on independent full socket timeouts. Work in the
+    # first leg therefore gave the second a fresh grace, despite the published
+    # whole-round-trip ceiling.
+    send_timeouts: list[float] = []
+
+    class _AccumulatingSocket:
+        timeout = 0.0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def settimeout(self, timeout: float) -> None:
+            self.timeout = timeout
+
+        def connect(self, path: str) -> None:
+            time.sleep(0.06)
+
+        def sendall(self, data: bytes) -> None:
+            send_timeouts.append(self.timeout)
+            time.sleep(self.timeout)
+            raise TimeoutError
+
+    monkeypatch.setattr("gda.live_runner.LIVE_REQUEST_TIMEOUT", 0.1)
+    monkeypatch.setattr(
+        "gda.live_runner.socket.socket", lambda *args, **kwargs: _AccumulatingSocket()
+    )
+    started = time.monotonic()
+    result = DaemonRunner(Path("."))._request(Path("unused.sock"), "game-tree", {})
+    elapsed = time.monotonic() - started
+
+    assert send_timeouts, "the request was never written"
+    assert 0 < send_timeouts[0] < 0.08, (
+        f"the write received a fresh {send_timeouts[0]:.3f}s timeout"
+    )
+    assert elapsed < 0.1 + _SCHEDULING_SLACK
+    assert parse_result(result.stdout)["error"]["code"] == "live_timeout"
+
+
 def test_the_owner_keeps_the_group_a_reaped_leader_cannot_name(tmp_path):
     # #725 re-review: the group id is the LEADER'S pid, and `EngineSession.alive()`
     # polls the leader — which reaps it. Rediscovering the group at teardown then
     # returned nothing and the engine's descendants were never retired (probed:
     # leader exited 0, group unrecoverable, descendant alive). The owner captures
     # the group at spawn and keeps it.
-    leader, descendant = _leader_with_descendant(_EXITS_LEAVING_STUBBORN_CHILD)
-    group = _own_group(leader)
-    session = EngineSession(leader, conn=None, group=group)
+    leader, descendant, owned_pgid = _leader_with_descendant(
+        _EXITS_LEAVING_STUBBORN_CHILD
+    )
+    session = EngineSession(leader, conn=None, owned_pgid=owned_pgid)
     try:
         end = time.monotonic() + 5.0
         while session.alive() and time.monotonic() < end:
             time.sleep(0.01)  # the liveness check that reaps the leader
         assert not session.alive()
-        assert _own_group(leader) is None, "the reaped leader still names a group"
+        assert _capture_owned_pgid(leader) is None, (
+            "the reaped leader still names a group"
+        )
         session.close(time.monotonic() + 5.0)
         _assert_gone(descendant, "descendant")
     finally:
         _reap_group(descendant, leader.pid)
+
+
+def test_a_reaped_leader_does_not_prevent_descendant_cleanup(tmp_path):
+    # Capturing the group fixed its identity after `alive()` reaped the leader,
+    # but teardown still gated SIGTERM on that leader being alive. The stored
+    # group must receive its graceful signal independently of the leader.
+    marker = tmp_path / "cleanup-after-leader"
+    leader, descendant, owned_pgid = _leader_with_descendant(
+        _EXITS_LEAVING_CLEANING_CHILD.format(marker=str(marker))
+    )
+    session = EngineSession(leader, conn=None, owned_pgid=owned_pgid)
+    try:
+        end = time.monotonic() + 5.0
+        while session.alive() and time.monotonic() < end:
+            time.sleep(0.01)
+        assert not session.alive()
+        started = time.monotonic()
+        session.close(time.monotonic() + 1.0)
+        elapsed = time.monotonic() - started
+        assert marker.exists(), "the reaped leader prevented the group SIGTERM"
+        assert elapsed < 1.0, "teardown waited out the whole deadline"
+    finally:
+        _reap_group(descendant, leader.pid)
+
+
+def test_only_a_process_group_leader_can_be_claimed_as_owned(monkeypatch):
+    class _GroupMember:
+        pid = 1234
+
+    monkeypatch.setattr(os, "getpgid", lambda pid: 1200)
+    monkeypatch.setattr(os, "getpgrp", lambda: 1100)
+
+    assert _capture_owned_pgid(cast(subprocess.Popen, _GroupMember())) is None
+
+
+def test_a_permission_error_does_not_mean_the_group_is_empty(monkeypatch):
+    def _permission_denied(group: int, sig: int) -> None:
+        raise PermissionError
+
+    monkeypatch.setattr(os, "killpg", _permission_denied)
+
+    assert _group_standing(1234, cast(subprocess.Popen, _Proc()))
 
 
 def test_a_descendant_may_finish_its_own_cleanup_inside_the_deadline(tmp_path):
@@ -1022,12 +1124,16 @@ def test_a_descendant_may_finish_its_own_cleanup_inside_the_deadline(tmp_path):
     # handler was truncated even with the whole budget left. The wait is for the
     # group, so a descendant that completes within the deadline gets to.
     marker = tmp_path / "cleanup-done"
-    leader, descendant = _leader_with_descendant(
+    leader, descendant, owned_pgid = _leader_with_descendant(
         _OBEYS_SIGTERM_WITH_CLEANING_CHILD.format(marker=str(marker))
     )
     try:
         started = time.monotonic()
-        _terminate(leader, time.monotonic() + 5.0, group=_own_group(leader))
+        _terminate(
+            leader,
+            time.monotonic() + 5.0,
+            owned_pgid=owned_pgid,
+        )
         elapsed = time.monotonic() - started
         assert marker.exists(), "the descendant's cleanup was cut short"
         assert elapsed < 5.0, "teardown waited out the whole deadline"
@@ -1041,9 +1147,11 @@ def test_the_group_is_retired_even_when_the_leader_obeys_sigterm(monkeypatch):
     # succeeded, the SIGKILL branch was skipped — while a descendant that
     # ignored it kept running, orphaned (probed: leader -15 in 0.001s,
     # descendant alive). gda owns the group, so the group is what gets retired.
-    leader, descendant = _leader_with_descendant(_OBEYS_SIGTERM_WITH_STUBBORN_CHILD)
+    leader, descendant, owned_pgid = _leader_with_descendant(
+        _OBEYS_SIGTERM_WITH_STUBBORN_CHILD
+    )
     try:
-        _terminate(leader, time.monotonic() + 5.0)
+        _terminate(leader, time.monotonic() + 5.0, owned_pgid=owned_pgid)
         assert leader.returncode == -signal.SIGTERM  # the leader DID obey
         _assert_gone(descendant, "descendant")
     finally:
@@ -1055,9 +1163,11 @@ def test_the_escalation_covers_the_group_the_engine_owns(monkeypatch):
     # the leader — so a descendant that also ignored SIGTERM was left alive and
     # orphaned. The session is spawned with `start_new_session=True`, so gda owns
     # that group; the escalation must match the signal that preceded it.
-    leader, descendant = _leader_with_descendant(_IGNORES_SIGTERM_WITH_CHILD)
+    leader, descendant, owned_pgid = _leader_with_descendant(
+        _IGNORES_SIGTERM_WITH_CHILD
+    )
     try:
-        _terminate(leader, time.monotonic() + 0.05)
+        _terminate(leader, time.monotonic() + 0.05, owned_pgid=owned_pgid)
         _assert_gone(descendant, "descendant")
     finally:
         _reap_group(descendant, leader.pid)

--- a/tests/test_daemon_wait_ready_commands.py
+++ b/tests/test_daemon_wait_ready_commands.py
@@ -1,0 +1,139 @@
+"""`gda daemon wait-ready` — the bounded session-readiness wait (#657).
+
+Engine-free: a fake daemon runner at the LIVE seam exercises the full
+Typer -> classify_live -> JSON pipeline, and the no-daemon attach-or-fail path
+runs the real ``DaemonRunner`` against an empty runtime dir. The daemon-side
+launch behavior is in the socket-lifecycle suite; the served-first-read
+regression is the e2e.
+"""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.exit_codes import EXIT_LIVE
+from gda.runner import RunResult
+from tests.support import inject_live_runner, sentinel
+
+
+def _project(tmp_path):
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return tmp_path
+
+
+READY = {"pid": 4242, "launched": True}
+
+
+def test_wait_ready_reports_the_established_session_as_json(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch, RunResult(stdout=sentinel(READY), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["daemon", "wait-ready", "--project", str(_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data == {"pid": 4242, "launched": True}
+    # Routed through the LIVE seam, carrying the default bound.
+    assert fake.calls == [("daemon-wait-ready", {"timeout": 25.0})]
+
+
+def test_wait_ready_passes_the_caller_bound_through(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch, RunResult(stdout=sentinel(READY), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "daemon",
+            "wait-ready",
+            "--timeout",
+            "10",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert fake.calls == [("daemon-wait-ready", {"timeout": 10.0})]
+
+
+def test_wait_ready_human_output_names_the_launch_state(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch, RunResult(stdout=sentinel(READY), stderr="", exit_code=0)
+    )
+
+    result = CliRunner().invoke(
+        app, ["daemon", "wait-ready", "--project", str(_project(tmp_path))]
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "engine session ready (launched now; daemon pid 4242)" in result.stdout
+
+
+def test_wait_ready_human_output_reports_an_already_serving_session(
+    monkeypatch, tmp_path
+):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel({"pid": 4242, "launched": False}), stderr="", exit_code=0
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app, ["daemon", "wait-ready", "--project", str(_project(tmp_path))]
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "already serving" in result.stdout
+
+
+def test_wait_ready_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):
+    # No fake: the real DaemonRunner + discovery run against an empty runtime dir.
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
+
+    result = CliRunner().invoke(
+        app, ["daemon", "wait-ready", "--project", str(_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "daemon_not_running"
+    assert "gda daemon start" in error["message"]
+
+
+def test_wait_ready_refuses_an_out_of_range_bound_on_argv(monkeypatch, tmp_path):
+    # The params model owns the (0, 50] bound (ADR-0015): the argv path
+    # translates its refusal into the Click usage error. 50 caps the wait under
+    # the live channel's 60s client-side round-trip bound.
+    project = str(_project(tmp_path))
+    for bad in ("0", "60", "inf", "nan"):
+        result = CliRunner().invoke(
+            app, ["daemon", "wait-ready", "--timeout", bad, "--project", project]
+        )
+        assert result.exit_code == 2, f"--timeout {bad}: {result.stdout}"
+
+
+def test_wait_ready_refuses_an_out_of_range_bound_on_params_json(monkeypatch, tmp_path):
+    # The same rule on the structured path, as the structured refusal.
+    result = CliRunner().invoke(
+        app,
+        [
+            "daemon",
+            "wait-ready",
+            "--params-json",
+            json.dumps({"timeout": 60}),
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 4, result.stdout + result.stderr
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -119,6 +119,59 @@ def test_daemon_serves_a_real_runtime_tree(tmp_path, daemon_runtime_dir):
 
 
 @pytest.mark.e2e
+def test_wait_ready_makes_a_first_diag_errors_serve(tmp_path, daemon_runtime_dir):
+    # #657's acceptance path, end to end: start a daemon, reach a SERVED
+    # `diag errors` through the documented bounded wait as the FIRST live read —
+    # no warm-up live op, no sleep loop. Without the wait, the first
+    # `diag errors` reports engine_session_not_running by design (it must never
+    # be the thing that launches the project's code, ADR-0022).
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    try:
+        started = run("daemon", "start")
+        assert started.returncode == 0, started.stdout + started.stderr
+
+        ready = run("daemon", "wait-ready")
+        assert ready.returncode == 0, ready.stdout + ready.stderr
+        verdict = json.loads(ready.stdout)
+        assert verdict["launched"] is True
+
+        # The very next read serves — the session the wait established is the
+        # one the daemon holds, so the read launches nothing.
+        errors = run("diag", "errors")
+        assert errors.returncode == 0, errors.stdout + errors.stderr
+        assert "errors" in json.loads(errors.stdout)
+
+        # Idempotent while the session is alive: nothing is relaunched.
+        again = run("daemon", "wait-ready")
+        assert again.returncode == 0, again.stdout + again.stderr
+        assert json.loads(again.stdout)["launched"] is False
+
+        assert json.loads(run("daemon", "stop").stdout)["stopped"] is True
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
 def test_daemon_serves_game_get_set_round_trip(tmp_path, daemon_runtime_dir):
     # The #220 DoD: a real daemon → engine session → `game set` mutates a runtime
     # property, applied at a frame boundary, and `game get` observes the change —

--- a/tests/test_live_contract_guards.py
+++ b/tests/test_live_contract_guards.py
@@ -23,7 +23,7 @@ import typer
 
 from gda.cli import app
 from gda.daemon.diag import LOG_BEGIN, parse_errors, parse_log_records
-from gda.daemon.server import LOG_OPS
+from gda.daemon.server import DAEMON_SERVED_OPS, LOG_OPS
 from gda.daemon.session import CONNECT_TIMEOUT, LAUNCH_MARKER, OP_TIMEOUT
 from gda.execution import ExecutionKind
 from gda.live_runner import LIVE_REQUEST_TIMEOUT
@@ -113,10 +113,11 @@ def test_log_ops_are_part_of_the_live_command_surface():
 
 def test_relayed_live_ops_mirror_the_harness_op_table():
     # The cross-language op-name contract: every LIVE op the daemon RELAYS (i.e. the
-    # LIVE surface minus the daemon-served LOG_OPS) must be an op the GDScript
-    # harness declares, and vice versa. A one-sided rename here is invisible to the
+    # LIVE surface minus the DAEMON_SERVED_OPS the daemon answers itself — the log
+    # reads and the wait-ready launch, #657) must be an op the GDScript harness
+    # declares, and vice versa. A one-sided rename here is invisible to the
     # unit suite otherwise: the CLI would ask for an op the harness never answers.
-    relayed = _live_operations() - set(LOG_OPS)
+    relayed = _live_operations() - set(DAEMON_SERVED_OPS)
     harness_ops = _harness_operations()
 
     unserved = relayed - harness_ops
@@ -130,7 +131,7 @@ def test_relayed_live_ops_mirror_the_harness_op_table():
         f"harness ops no CLI command can reach: {sorted(unreachable)}. Register a "
         "LIVE command descriptor with that operation name, or remove the const from "
         f"{GDA_HARNESS_GD.name}. (Daemon-SERVED ops belong in "
-        "gda.daemon.server.LOG_OPS, not in the harness op table.)"
+        "gda.daemon.server.DAEMON_SERVED_OPS, not in the harness op table.)"
     )
 
 


### PR DESCRIPTION
## What

W4 slot 1, second half (stacked on #674's merged server shape, per the wave plan). `gda daemon wait-ready`: the documented, bounded way to establish the lazily-launched engine session, per issue #657 (GDA-DF-031 reframed — no race, no defect; a start-time ergonomics gap).

- **Contract**: a session launches lazily on the **first operation that REQUIRES one** — the precise form of ADR-0017's lazy launch, which this slice's dated amendment restates, since `diag errors` / `logger tail` are live operations the daemon serves from the Session log and they deliberately launch nothing (ADR-0022). `wait-ready` is the explicit way to *be* that operation: success (`{pid, launched}`) means the in-game harness has connected **and** presented its token, so subsequent live reads serve — including a first `diag errors`. Idempotent while a session is alive (`launched: false`, nothing relaunched), and `launched` is reported by the launch owner rather than sampled around it, so a call that launched can never report `false`.
- **Shape**: a `kind = LIVE` command in the `daemon` group (`diag errors` precedent: daemon-served, harness-never-relayed; routed and classified through the live channel — `DaemonRunner`, `classify_live`, the schema/constraints self-description all come free). The daemon answers a new `daemon-wait-ready` op through the **same launch boundary every session-needing op uses** — `_session_or_refusal`, extracted from the live-op branch and returning a typed `_Established(session, launched)` — so a failed launch, scene mismatch, or windowed refusal is byte-identically the same typed error on both paths.
- **Bound**: `--timeout` ((0, 50], model-owned per ADR-0015, argv via `params_or_bad_parameter`, **re-enforced at the daemon IPC boundary** as a typed `invalid_params`) rides to the daemon, and the launch boundary turns it into **one absolute instant** covering everything it does on the caller's clock: retiring the session being replaced, the spawn, the harness connect, each handshake frame, and the teardown of a failed launch. It is a budget for **waiting and for committing to new work**, not a hard wall clock — nothing here can interrupt a synchronous call already in flight, and gda is not adding threads and cancellation to pretend otherwise. Three rules instead: no phase gets a fresh grace; every timed wait uses what remains, computed where the wait begins; and once the instant is spent the boundary commits to nothing further. Three edges it has to survive, because the daemon serves one request at a time: a socket timeout bounds INACTIVITY, so a frame read in chunks recomputes its budget per read; an engine that ignores `SIGTERM` is escalated with what the deadline has left; and collecting a killed child is a background duty (best-effort), never a wait. What teardown retires is the process GROUP the session owns — captured at spawn, since a reaped leader can no longer name it — and it waits for that group to empty rather than for the leader to exit. The live channel's own 60s ceiling now covers the whole round trip too, on the same absolute-instant rule.
- **Serving state**: a session serves only while its **process and its harness channel** can answer. The channel is latched stale on a dropped or closed connection **and on a relay that timed out** — the one-op-at-a-time RPC carries no request id and a timed-out frame is not drained, so a late reply would be read as the *next* operation's reply — and the next session-needing op rebuilds through the same launch boundary. `live_timeout` therefore costs a relaunch, and runtime state does not survive it (ADR-0020). The relay read is bounded the same way as the handshake frames, so `did not return within 30s` is true of a trickled reply too.
- **Guard**: `DAEMON_SERVED_OPS` (= LOG_OPS + wait-ready) is the single **runtime** authority for daemon-answered ops: `_handle` routes on it, the PR #650 cross-language op-table guard reads it, and a declared member with no handler refuses loudly instead of silently relaying. `WAIT_READY_TIMEOUT_MAX` is the one bound constant, consumed by both the params model (`le=`) and the wire check.
- **Docs** (skill owner this wave): ADR-0017 gains the dated amendment above (launch trigger, serving state, and the single deadline the launch boundary owns); ADR-0040 records the `daemon` group's one `kind = LIVE`, recipe-less command. Command help, SKILL.md (prereq paragraph + daemon row), README daemon table + all three translations, and the command catalog all use the precise launch rule and state that a first `diag errors` right after `start` reporting `engine_session_not_running` is expected.

## Acceptance criteria → evidence

1. *Deterministic served state, no warm-up read, no sleep loops* — e2e `test_wait_ready_makes_a_first_diag_errors_serve`: real `daemon start` → `daemon wait-ready` (`launched: true`) → `diag errors` **as the first read** serves → repeat wait-ready (`launched: false`) → stop. Real Godot 4.6.3.
2. *Skill and help state the lifecycle and readiness contract* — see the docs list above; the SKILL surface-sync guard pins the daemon row.
3. *Regression test through the documented path as the first live call* — the e2e above, plus socket-level fast tests driving the REAL serve loop over real UDS: launch-once + idempotent repeat + caller bound passed through; failed launch relays the typed refusal.

Plus the review-driven regressions, each red-proofed against the head it was found on:

- a silent handshake peer cannot hold the launch past the deadline (at the launcher, and end to end with the next control request still served);
- a session whose harness channel broke, and a session whose relay timed out, are both rebuilt by the next `wait-ready` instead of certified;
- `launched == (a launch actually happened on this call)` under a liveness that flips between samples;
- every declared `DAEMON_SERVED_OPS` member is intercepted, never relayed;
- the wire boundary refuses negative / zero / over-limit / `inf` / `nan` / boolean / string timeouts;
- a SIGTERM-ignoring engine child cannot hold the round trip, or the request enqueued *while it runs*, past the caller's bound — whether it is the child of the launch being bounded or of the stale session being retired;
- a spawn that outruns the whole budget yields a refusal, not a session, even with both handshake frames already queued;
- a peer that trickles either handshake frame one byte at a time cannot outlast the bound, and neither can a trickled op reply;
- teardown does not wait for the kernel to collect the child, and on the ordinary path the child is collected;
- the termination wait is measured when it begins, not when it was decided;
- what teardown retires is the process GROUP the engine owns — proved for a leader that ignores `SIGTERM` and for one that obeys it while a descendant does not;
- launch preparation that crosses the deadline spawns nothing, and a deadline spent by the spawn itself is reported as that, never as a missing auth token;
- the owner still knows the group after a liveness check has reaped the leader, and a descendant may finish its own `SIGTERM` cleanup inside the remaining deadline;
- a trickled reply cannot hold the CLI past `LIVE_REQUEST_TIMEOUT`.

## Validation

- Fast suite: **1748 passed**; pyright 0 errors; ruff clean (`format` included); `git diff --check` clean; i18n stamps unchanged.
- Red-proofs, each against the head its finding was raised on — `a35b49a4` (5, one of which *hangs* there rather than failing), `59671962` (3), `b8ac5706` (5), `cdb3c900` (3), `29b22d34` (4), `b196c829` (1), and `dc04d62b` (3: a descendant orphaned once the leader was reaped; a descendant's cleanup cut short; a trickled reply holding the CLI past its ceiling).
- Two assertions are deliberately not red on the head that introduced their subject, and say so rather than hiding in a count: "a killed child is still collected" (the reap already existed on `cdb3c900`) and the ordinary-path collection assertion — the daemon-thread reaper is unjoined and swallows failures, so no test can prove collection in general.
- Real-engine e2e, serial under the shared lock: **59 passed** across the daemon and live suites (`daemon`, `game`, `diag`, `logger`, `perf`, `input`, `harness install`, `mcp live`, `screen`).
- Surface: one intended `gda schema` change across the whole slice beyond the new command itself — `daemon wait-ready`'s timeout description now states what the budget covers instead of implying a hard wall clock. Every other command's schema entry is byte-identical.

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)
