### PR TITLE
docs(release): backfill gda-balancing 0.1.0 foundation

### DIFF
--- a/docs/adr/0037-workspace-members-join-the-single-authority-release-model.md
+++ b/docs/adr/0037-workspace-members-join-the-single-authority-release-model.md
@@ -131,6 +131,12 @@ separate release trains, and no hand-edited version anywhere.**
 > invisible to release-please's changelog. The first member release therefore
 > gets **hand-authored release notes** describing the schema core as a one-time
 > cost of the old discipline; every release after it is fully generated.
+>
+> **First-release changelog outcome (2026-08-21, #528):** the generated
+> `gda-balancing` 0.1.0 notes initially listed only the first releasing change,
+> #579. Closeout for #528 backfilled the repository changelog and the published
+> GitHub Release notes with the #502/#504 foundation summary promised above.
+> The tag, package artifacts, version, and release date did not change.
 
 
 - One ledger now spans both packages; neither `pyproject.toml`, the manifest,

--- a/libs/gda-balancing/CHANGELOG.md
+++ b/libs/gda-balancing/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 0.1.0 (2026-07-22)
 
+### Foundation
+
+* Bootstrapped `gda-balancing` as a separately versioned, tested CLI package
+  with structured result and error surfaces and an engine- and game-isolation
+  gate ([#502](https://github.com/aigengame/godot-agent/issues/502))
+  ([#526](https://github.com/aigengame/godot-agent/pull/526))
+* Delivered the complete Standard Schema 1.0 core with typed validation and
+  refusals, canonical round-tripping, generated structural and rule
+  self-description, and definition-time Formula evaluation
+  ([#504](https://github.com/aigengame/godot-agent/issues/504))
+  ([#527](https://github.com/aigengame/godot-agent/pull/527))
 
 ### ⚠ BREAKING CHANGES
 


### PR DESCRIPTION
## Summary

- backfill the `gda-balancing` 0.1.0 Changelog with the #502/#504 foundation work that landed under the former non-releasing title policy
- record the actual first-release-note closeout in ADR-0037
- keep the repository Changelog aligned with the already-updated published GitHub Release notes

No tag, package artifact, version, release date, workflow, or release policy changes.

## #528 closure evidence

- `release-please-config.json` excludes `libs/gda-balancing` from the root package and gives it a separate component/release PR.
- The live `main` ruleset requires `Member releasing-PR scope guard`.
- The first member Release PR, #580, produced `gda-balancing-v0.1.0`; release workflow run [30076078696](https://github.com/aigengame/godot-agent/actions/runs/30076078696) completed successfully.
- Current Release PR #582 contains the subsequent `gda-balancing` history, while root Release PR #690 contains only `gda` history. This is live evidence that member-only releasing commits do not enter the root release train.
- ADR-0037, ADR-0038, and `libs/gda-balancing/AGENTS.md` record the truthful-title policy and member-only scope.
- The published [gda-balancing v0.1.0 Release notes](https://github.com/aigengame/godot-agent/releases/tag/gda-balancing-v0.1.0) now include the promised foundation summary.

Closes #528.

## Validation

- `git diff --check`
- repository Changelog 0.1.0 body matches the published Release-note body, apart from the CLI-added trailing newline
