### PR TITLE
feat(gda): complete activation gestures and guard the viewport-enter notify (#647, #652)

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,9 +581,10 @@ edge-triggered controls.
 | Command | What it does |
 | ------- | ------------ |
 | `input key` | Inject a key event (with modifiers). |
-| `input mouse-click` | Inject a mouse click at `(x, y)`. |
+| `input mouse-click` | Inject a complete click gesture (move, press, release) at `(x, y)`. |
 | `input mouse-move` | Inject mouse motion to `(x, y)`. |
 | `input action` | Press/release a mapped input action. |
+| `input tap` | Tap one key or action: press, hold, release across frames. |
 | `input sequence` | Inject a multi-frame event timeline. |
 
 Mouse events report the injected viewport coordinate through `event.position`.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=8cb5ae07a2d875db3554b7840b6fc90efdca5fa1bd84da220a2de393f6871949 -->
+<!-- gda-readme-i18n: source=README.md sha256=9412ce784d9839d437daa861f8b097a788f8e401dbb36130c2180b323b78350f -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -595,9 +595,10 @@ variables de script getter-only/no-op o controles edge-triggered.
 | Comando | Qué hace |
 | ------- | ------------ |
 | `input key` | Inyecta un evento de tecla (con modificadores). |
-| `input mouse-click` | Inyecta un clic de ratón en `(x, y)`. |
+| `input mouse-click` | Inyecta el gesto de clic completo (movimiento, pulsación, liberación) en `(x, y)`. |
 | `input mouse-move` | Inyecta un movimiento de ratón hacia `(x, y)`. |
 | `input action` | Presiona/suelta una acción de entrada mapeada. |
+| `input tap` | Toca una tecla o acción: pulsa, mantiene y suelta a lo largo de varios frames. |
 | `input sequence` | Inyecta una línea de tiempo de eventos de varios frames. |
 
 Los eventos de ratón informan la coordenada inyectada del viewport mediante

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=8cb5ae07a2d875db3554b7840b6fc90efdca5fa1bd84da220a2de393f6871949 -->
+<!-- gda-readme-i18n: source=README.md sha256=9412ce784d9839d437daa861f8b097a788f8e401dbb36130c2180b323b78350f -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -590,9 +590,10 @@ Live の `game set --property position` は `node set` と同じ `Control` ポ�
 | コマンド | 機能 |
 | ------- | ------------ |
 | `input key` | キーイベントを(修飾キー付きで)注入します。 |
-| `input mouse-click` | `(x, y)` の位置にマウスクリックを注入します。 |
+| `input mouse-click` | `(x, y)` の位置に完全なクリックジェスチャ(移動、押下、解放)を注入します。 |
 | `input mouse-move` | `(x, y)` へのマウス移動を注入します。 |
 | `input action` | マッピング済みの入力アクションを押下/解放します。 |
+| `input tap` | キーまたはアクションを 1 回タップします(押下、保持、解放を複数フレームで実行)。 |
 | `input sequence` | 複数フレームにわたるイベントのタイムラインを注入します。 |
 
 マウスイベントは、注入されたビューポート座標を `event.position` で報告します。

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -565,7 +565,7 @@ Live `game set --property position` 遵循与 `node set` 相同的 `Control` 策
 | `input mouse-click` | 在 `(x, y)` 处注入完整的点击手势(移动、按下、释放)。 |
 | `input mouse-move` | 将鼠标移动到 `(x, y)`。 |
 | `input action` | 按下/释放一个已映射的输入动作。 |
-| `input tap` | 轻按一个按键或动作:跨帧完成按下、保持、释放。 |
+| `input tap` | 轻按一个按键或动作：跨帧完成按下、保持、释放。 |
 | `input sequence` | 注入一条跨多帧的事件时间线。 |
 
 鼠标事件会在 `event.position` 中携带注入的视口坐标。Godot 在 daemon 会话中可能让

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=8cb5ae07a2d875db3554b7840b6fc90efdca5fa1bd84da220a2de393f6871949 -->
+<!-- gda-readme-i18n: source=README.md sha256=9412ce784d9839d437daa861f8b097a788f8e401dbb36130c2180b323b78350f -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -562,9 +562,10 @@ Live `game set --property position` 遵循与 `node set` 相同的 `Control` 策
 | 命令 | 作用 |
 | ------- | ------------ |
 | `input key` | 注入一个按键事件（带修饰键）。 |
-| `input mouse-click` | 在 `(x, y)` 处注入一次鼠标点击。 |
+| `input mouse-click` | 在 `(x, y)` 处注入完整的点击手势(移动、按下、释放)。 |
 | `input mouse-move` | 将鼠标移动到 `(x, y)`。 |
 | `input action` | 按下/释放一个已映射的输入动作。 |
+| `input tap` | 轻按一个按键或动作:跨帧完成按下、保持、释放。 |
 | `input sequence` | 注入一条跨多帧的事件时间线。 |
 
 鼠标事件会在 `event.position` 中携带注入的视口坐标。Godot 在 daemon 会话中可能让

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -764,12 +764,34 @@ headless is unaffected (4.4+, cross-platform).
   (ADR-0019).
 - **`input` (input simulation):** runtime input injection into the running game
   (shipped, #221). Single-frame ops `input key <KEY> [--modifiers …] [--released]`,
-  `input mouse-click <x> <y> [--button left|right|middle] [--double]` /
   `input mouse-move <x> <y>`, and `input action <NAME> [--release] [--strength F]`
-  each inject one event at a frame boundary (ADR-0020); the multi-frame
+  each inject one event at a frame boundary (ADR-0020). The **activation
+  gestures** (#652) are multi-frame: `input mouse-click <x> <y> [--button
+  left|right|middle] [--double]` injects the COMPLETE click its name implies —
+  the initial move, the press, and the release, one per process frame across a
+  3-frame window — because Godot's UI activates on the release (a bare press
+  never emits a default `Button`'s `pressed` and leaves it held down,
+  GDA-DF-004); and `input tap (--key K [--modifiers …] | --action NAME
+  [--strength F]) [--hold-frames N] [--settle-frames M]` performs the complete
+  press-hold-release of one key or one InputMap action — press at window frame
+  0, release after N (default 2, at least 1) process frames, then M (default 2)
+  settle frames so the game observes the release before the op returns — because
+  a press/release pair contained in one immediate frame reports success without
+  advancing a focused UI (GDA-DF-034). Both gesture results report the injected
+  `phases` (each phase's window frame) and the focused Control's runtime path
+  before/after the gesture (`focus_before` / `focus_after`, null when nothing
+  holds focus) — the activation evidence the engine exposes. Repeated injected
+  mouse events add no harness-owned warnings to `diag errors` (#647): the
+  harness notifies the viewport's mouse-enter state only on a real edge,
+  mirroring it from the root Window's `mouse_entered`/`mouse_exited` signals.
+  The multi-frame
   `input sequence --events <JSON>` applies a list of events across one selected
   clock and returns as one blocking payload, on the gda harness's time-windowed
-  multi-frame base (the same base `perf monitor` uses, #223). Existing sequence
+  multi-frame base (the same base `perf monitor` uses, #223). A sequence
+  `mouse_click` event is a whole click at ONE clock offset — the harness pushes
+  the press and then the release on the same frame, which fully activates a
+  default `Button` (mouse activation, unlike a focused-UI key tap, does not need
+  the pair split across frames). Existing sequence
   event `frame` offsets are explicitly the harness/process-frame clock advanced by
   the harness `_process` loop; they are preserved for compatibility and are **not**
   Godot's fixed physics frames. For deterministic simulation-duration input, use
@@ -791,7 +813,9 @@ headless is unaffected (4.4+, cross-platform).
   leave `Viewport.get_mouse_position()` and `Node2D.get_global_mouse_position()`
   stale in daemon sessions, so game code should read the injected coordinate from
   the input event. The modifier
-  set, mouse-button enum, action strength range (0..1), per-event shape, and the
+  set, mouse-button enum, action strength range (0..1), per-event shape, the
+  tap's exactly-one-target rule and window (`hold_frames + settle_frames + 1` ≤
+  the per-window ceiling), and the
   sequence's selected-clock window (`max(frame)+1` or `max(physics_frame)+1` ≤ the
   per-window ceiling, the same bound `perf monitor` enforces, #223) are bounded
   **model-side** (ADR-0015), so an

--- a/src/gda/commands/input.py
+++ b/src/gda/commands/input.py
@@ -208,10 +208,12 @@ class InputMouseMoveResult(BaseModel):
         default="mouse_move", description="The injected event kind ('mouse_move')."
     )
     position: list[float] = Field(
+        min_length=2,
+        max_length=2,
         description=(
             "The viewport position the event was injected at, as [x, y]. This "
             "mirrors event.position; engine-tracked mouse positions may remain stale."
-        )
+        ),
     )
     button: str | None = Field(
         default=None, description="Always null for a move (a historical field)."
@@ -259,10 +261,12 @@ class InputMouseClickResult(BaseModel):
         default="mouse_click", description="The injected event kind ('mouse_click')."
     )
     position: list[float] = Field(
+        min_length=2,
+        max_length=2,
         description=(
             "The viewport position the gesture was injected at, as [x, y]. This "
             "mirrors event.position; engine-tracked mouse positions may remain stale."
-        )
+        ),
     )
     button: Literal["left", "right", "middle"] = Field(
         description="The clicked button: left, right, or middle."
@@ -467,22 +471,32 @@ class InputTapResult(BaseModel):
         default="tap", description="The injected event kind ('tap')."
     )
     key: str | None = Field(
-        default=None, description="The tapped key name; null for an action tap."
+        default=None,
+        min_length=1,
+        description="The tapped key name; null for an action tap.",
     )
     keycode: int | None = Field(
         default=None,
-        description="The Godot keycode the key resolved to; null for an action tap.",
+        ge=1,
+        description=(
+            "The Godot keycode the key resolved to (a successful tap never "
+            "echoes KEY_NONE); null for an action tap."
+        ),
     )
     modifiers: list[str] | None = Field(
         default=None,
         description="The modifiers held through a key tap; null for an action tap.",
     )
     action: str | None = Field(
-        default=None, description="The tapped action name; null for a key tap."
+        default=None,
+        min_length=1,
+        description="The tapped action name; null for a key tap.",
     )
     strength: float | None = Field(
         default=None,
-        description="The action press strength applied; null for a key tap.",
+        ge=0.0,
+        le=1.0,
+        description="The action press strength applied, 0..1; null for a key tap.",
     )
     hold_frames: int = Field(
         ge=1, description="Process frames held between the press and the release."
@@ -534,6 +548,10 @@ class InputTapResult(BaseModel):
                 "a tap result carries exactly one target family: "
                 "key + keycode + modifiers, or action + strength."
             )
+        if self.modifiers is not None:
+            # The same vocabulary rule the request enforces, from its one home:
+            # a reply echoing a modifier outside it is contract drift.
+            _validate_modifiers(self.modifiers)
         if self.frames != self.hold_frames + self.settle_frames + 1:
             raise ValueError(
                 "a tap result's frames is hold_frames + settle_frames + 1."

--- a/src/gda/commands/input.py
+++ b/src/gda/commands/input.py
@@ -132,13 +132,18 @@ class InputKeyResult(BaseModel):
 
 
 class InputMouseClickParams(BaseModel):
-    """The params of ``gda input mouse-click``: inject a mouse button click (#221).
+    """The params of ``gda input mouse-click``: inject a complete click gesture (#221, #652).
 
-    Pushes an ``InputEventMouseButton`` at viewport position ``(x, y)`` into the
-    running game's root viewport. ``button`` selects which button (left/right/
-    middle); ``double`` marks the event a double click. A single-frame op (the
-    press is injected at one frame boundary, ADR-0020). The injected coordinate is
-    reliable as ``InputEventMouseButton.position``. Godot does not reliably update
+    Injects the COMPLETE click gesture at viewport position ``(x, y)`` into the
+    running game's root viewport: the initial mouse move, the button press, and
+    the button release, one per process frame across a 3-frame window. Godot's
+    UI activates on the RELEASE — a bare press never emits a default ``Button``'s
+    ``pressed`` and leaves the button held down (GDA-DF-004) — so the gesture,
+    not a lone press event, is what the op's name promises; the initial move
+    settles hover state at the click position first. Each phase applies at its
+    own frame boundary (ADR-0020). ``button`` selects which button (left/right/
+    middle); ``double`` marks the press a double click. The injected coordinate
+    is reliable as the mouse events' ``position``. Godot does not reliably update
     the engine-tracked mouse position in daemon sessions, so
     ``Viewport.get_mouse_position()`` / ``Node2D.get_global_mouse_position()`` may
     remain stale; read the mouse event position for the injected coordinate.
@@ -190,18 +195,16 @@ class InputMouseMoveParams(BaseModel):
 
 
 class InputMouseResult(BaseModel):
-    """The result of a ``gda input mouse-click`` / ``mouse-move`` op: the mouse event injected (#221).
+    """The result of ``gda input mouse-move``: the motion event injected (#221).
 
-    Echoes the event ``kind`` (``mouse_click`` or ``mouse_move``), the viewport
-    ``position`` it was pushed at as ``[x, y]``, and — for a click — the ``button``
-    and whether it was a ``double`` click (both null for a move). This echoed
-    position mirrors the mouse event's position; engine-tracked mouse positions may
-    remain stale.
+    Echoes the event ``kind`` (``mouse_move``), the viewport ``position`` it was
+    pushed to as ``[x, y]``, and the historically shared ``button`` / ``double``
+    fields (always null for a move; ``mouse-click`` now reports its own gesture
+    result, :class:`InputMouseClickResult`). This echoed position mirrors the
+    mouse event's position; engine-tracked mouse positions may remain stale.
     """
 
-    kind: str = Field(
-        description="The injected event kind: 'mouse_click' or 'mouse_move'."
-    )
+    kind: str = Field(description="The injected event kind ('mouse_move').")
     position: list[float] = Field(
         description=(
             "The viewport position the event was injected at, as [x, y]. This "
@@ -209,11 +212,71 @@ class InputMouseResult(BaseModel):
         )
     )
     button: str | None = Field(
-        default=None, description="The clicked button (a click only); null for a move."
+        default=None, description="Always null for a move (a historical field)."
     )
     double: bool | None = Field(
         default=None,
-        description="Whether the click was a double click; null for a move.",
+        description="Always null for a move (a historical field).",
+    )
+
+
+class InputEventPhase(BaseModel):
+    """One phase of an injected activation gesture (#652).
+
+    The structured evidence that an activation op injected the COMPLETE gesture
+    rather than a bare press: the 0-based process-frame offset within the op's
+    window, and the phase applied there (``move``, ``press``, or ``release``).
+    """
+
+    frame: int = Field(
+        description="The 0-based process-frame offset within the op's window."
+    )
+    phase: str = Field(
+        description="The gesture phase applied at this frame: move, press, or release."
+    )
+
+
+class InputMouseClickResult(BaseModel):
+    """The result of ``gda input mouse-click``: the complete click gesture injected (#652).
+
+    ``phases`` reports each injected phase and the window frame it landed on
+    (move at 0, press at 1, release at 2); ``focus_before`` / ``focus_after``
+    report the root viewport's focused Control around the gesture (null when
+    none) — the activation evidence the engine exposes. The echoed ``position``
+    mirrors the mouse events' position; engine-tracked mouse positions may
+    remain stale.
+    """
+
+    kind: str = Field(
+        default="mouse_click", description="The injected event kind ('mouse_click')."
+    )
+    position: list[float] = Field(
+        description=(
+            "The viewport position the gesture was injected at, as [x, y]. This "
+            "mirrors event.position; engine-tracked mouse positions may remain stale."
+        )
+    )
+    button: str = Field(description="The clicked button: left, right, or middle.")
+    double: bool = Field(description="Whether the press was marked a double click.")
+    phases: list[InputEventPhase] = Field(
+        description=(
+            "The injected gesture phases and their window frames: the initial "
+            "move at frame 0, the press at frame 1, the release at frame 2."
+        )
+    )
+    focus_before: str | None = Field(
+        default=None,
+        description=(
+            "The runtime path of the focused Control before the gesture, or null "
+            "when nothing held focus."
+        ),
+    )
+    focus_after: str | None = Field(
+        default=None,
+        description=(
+            "The runtime path of the focused Control after the release, or null "
+            "when nothing holds focus."
+        ),
     )
 
 
@@ -258,6 +321,158 @@ class InputActionResult(BaseModel):
     pressed: bool = Field(description="True for a press, false for a release.")
     strength: float = Field(
         description="The press strength applied (0.0 on a release)."
+    )
+
+
+class InputTapParams(BaseModel):
+    """The params of ``gda input tap``: a complete press-hold-release of one key or action (#652).
+
+    Godot needs the press and the release to land on SEPARATE process frames for
+    a focused-UI activation: a pair contained in one immediate frame reports
+    success without advancing the focused UI (GDA-DF-034). A tap presses at
+    window frame 0, holds for ``hold_frames`` process frames, releases at frame
+    ``hold_frames``, then lets ``settle_frames`` more frames run so the game
+    observes the release before the op returns. Exactly one of ``key`` /
+    ``action`` selects the target; ``modifiers`` ride a key tap only,
+    ``strength`` an action tap only. The whole window —
+    ``hold_frames + settle_frames + 1`` frames — is bounded model-side to the
+    shared per-window ceiling (ADR-0015, #223). The two failures that need the
+    live engine are deferred to the harness: an unresolvable key name is
+    ``live_invalid_key``, an action missing from the running ``InputMap`` is
+    ``live_unknown_action``.
+    """
+
+    key: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "The Godot key name to tap (e.g. Right, Space). Exactly one of key/action."
+        ),
+    )
+    action: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "The input action to tap (must be in the running InputMap). Exactly "
+            "one of key/action."
+        ),
+    )
+    modifiers: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Modifier keys held through a KEY tap, any of: shift, ctrl, alt, "
+            "meta. Not valid with an action tap."
+        ),
+    )
+    strength: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "The analog press strength of an ACTION tap, 0..1 (default 1.0). "
+            "Not valid with a key tap."
+        ),
+    )
+    hold_frames: int = Field(
+        default=2,
+        ge=1,
+        description=(
+            "Process frames to hold between the press (window frame 0) and the "
+            "release; at least 1 — the release must land on a later frame than "
+            "the press for Godot to advance a focused UI."
+        ),
+    )
+    settle_frames: int = Field(
+        default=2,
+        ge=0,
+        description=(
+            "Process frames to run AFTER the release, so the game observes it "
+            "before the op returns."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _check_tap(self) -> "InputTapParams":
+        # Exactly one target, and each target family keeps its own fields — the
+        # GDA-DF-037 lesson: a foreign field silently inert is worse than a
+        # refusal that names the rule.
+        if (self.key is None) == (self.action is None):
+            raise ValueError("a tap targets exactly one of 'key' or 'action'.")
+        if self.action is not None and self.modifiers:
+            raise ValueError(
+                "'modifiers' rides a key tap only; an action tap has no modifiers."
+            )
+        if self.key is not None and self.strength is not None:
+            raise ValueError(
+                "'strength' rides an action tap only; a key tap has no strength."
+            )
+        _validate_modifiers(self.modifiers)
+        window = self.hold_frames + self.settle_frames + 1
+        if window > MAX_WINDOW_FRAMES:
+            raise ValueError(
+                f"the tap requests a {window}-frame window (hold_frames + "
+                f"settle_frames + 1), exceeding the maximum of {MAX_WINDOW_FRAMES} "
+                "(the gda harness's per-window ceiling). Use smaller frame counts."
+            )
+        return self
+
+
+class InputTapResult(BaseModel):
+    """The result of ``gda input tap``: the complete tap the harness injected (#652).
+
+    Echoes the target — ``key`` + ``keycode`` + ``modifiers`` for a key tap,
+    ``action`` + ``strength`` for an action tap; the other family is null — the
+    frame counts, the injected ``phases`` (the press at window frame 0, the
+    release at frame ``hold_frames``), and the focus evidence around the gesture.
+    """
+
+    kind: str = Field(default="tap", description="The injected event kind ('tap').")
+    key: str | None = Field(
+        default=None, description="The tapped key name; null for an action tap."
+    )
+    keycode: int | None = Field(
+        default=None,
+        description="The Godot keycode the key resolved to; null for an action tap.",
+    )
+    modifiers: list[str] | None = Field(
+        default=None,
+        description="The modifiers held through a key tap; null for an action tap.",
+    )
+    action: str | None = Field(
+        default=None, description="The tapped action name; null for a key tap."
+    )
+    strength: float | None = Field(
+        default=None,
+        description="The action press strength applied; null for a key tap.",
+    )
+    hold_frames: int = Field(
+        description="Process frames held between the press and the release."
+    )
+    settle_frames: int = Field(
+        description="Process frames run after the release before the op returned."
+    )
+    frames: int = Field(
+        description="The total window: hold_frames + settle_frames + 1."
+    )
+    phases: list[InputEventPhase] = Field(
+        description=(
+            "The injected phases and their window frames: the press at frame 0, "
+            "the release at frame hold_frames."
+        )
+    )
+    focus_before: str | None = Field(
+        default=None,
+        description=(
+            "The runtime path of the focused Control before the press, or null "
+            "when nothing held focus."
+        ),
+    )
+    focus_after: str | None = Field(
+        default=None,
+        description=(
+            "The runtime path of the focused Control after the tap, or null "
+            "when nothing holds focus."
+        ),
     )
 
 
@@ -468,7 +683,11 @@ class KeySequenceEvent(_SequenceEvent):
 class MouseClickSequenceEvent(_SequenceEvent):
     """A whole mouse click in a sequence: press and release at one clock offset.
 
-    Use :class:`MouseButtonSequenceEvent` instead when the press and the release
+    The harness pushes the press and then the release on the SAME frame — a
+    same-frame pair fully activates a default ``Button``, whose ``pressed``
+    fires on the release (#652; mouse activation, unlike a focused-UI key tap,
+    does not need the pair split across frames). Use
+    :class:`MouseButtonSequenceEvent` instead when the press and the release
     must sit at different offsets (a drag).
     """
 
@@ -714,12 +933,40 @@ def render_input_key(injected: "InputKeyResult") -> str:
 
 
 def render_input_mouse(injected: "InputMouseResult") -> str:
-    """Render an injected mouse event as a click or a move at its position (#221)."""
+    """Render an injected mouse motion event at its position (#221)."""
     x, y = injected.position
-    if injected.kind == "mouse_click":
-        double = " double" if injected.double else ""
-        return f"{injected.button} click{double} at ({x}, {y})"
     return f"mouse move to ({x}, {y})"
+
+
+def _render_focus(before: str | None, after: str | None) -> str:
+    """The focus-evidence tail of an activation render, empty when focus held still."""
+    if before == after:
+        return ""
+    return f"; focus {before or 'none'} -> {after or 'none'}"
+
+
+def render_input_mouse_click(injected: "InputMouseClickResult") -> str:
+    """Render a click gesture as its phases at their frames, plus focus evidence (#652)."""
+    x, y = injected.position
+    double = " double" if injected.double else ""
+    gesture = " -> ".join(f"{p.phase}@{p.frame}" for p in injected.phases)
+    focus = _render_focus(injected.focus_before, injected.focus_after)
+    return f"{injected.button} click{double} at ({x}, {y}): {gesture}{focus}"
+
+
+def render_input_tap(injected: "InputTapResult") -> str:
+    """Render a tap as its target, phases, and settle window, plus focus evidence (#652)."""
+    target = (
+        f"key {injected.key}"
+        if injected.key is not None
+        else f"action {injected.action}"
+    )
+    gesture = " -> ".join(f"{p.phase}@{p.frame}" for p in injected.phases)
+    focus = _render_focus(injected.focus_before, injected.focus_after)
+    return (
+        f"tap {target}: {gesture}, settled {injected.settle_frames} frames"
+        f" ({injected.frames}-frame window){focus}"
+    )
 
 
 def render_input_action(injected: "InputActionResult") -> str:
@@ -743,11 +990,11 @@ INPUT_KEY_COMMAND: HeadlessCommand[InputKeyResult] = HeadlessCommand(
 )
 
 
-INPUT_MOUSE_CLICK_COMMAND: HeadlessCommand[InputMouseResult] = HeadlessCommand(
+INPUT_MOUSE_CLICK_COMMAND: HeadlessCommand[InputMouseClickResult] = HeadlessCommand(
     operation="input-mouse-click",
     input_model=InputMouseClickParams,
-    output_model=InputMouseResult,
-    render=render_input_mouse,
+    output_model=InputMouseClickResult,
+    render=render_input_mouse_click,
     kind=ExecutionKind.LIVE,
 )
 
@@ -770,6 +1017,15 @@ INPUT_ACTION_COMMAND: HeadlessCommand[InputActionResult] = HeadlessCommand(
 )
 
 
+INPUT_TAP_COMMAND: HeadlessCommand[InputTapResult] = HeadlessCommand(
+    operation="input-tap",
+    input_model=InputTapParams,
+    output_model=InputTapResult,
+    render=render_input_tap,
+    kind=ExecutionKind.LIVE,
+)
+
+
 INPUT_SEQUENCE_COMMAND: HeadlessCommand[InputSequenceResult] = HeadlessCommand(
     operation="input-sequence",
     input_model=InputSequenceParams,
@@ -781,9 +1037,10 @@ INPUT_SEQUENCE_COMMAND: HeadlessCommand[InputSequenceResult] = HeadlessCommand(
 
 # The input command group (Phase 2, ADR-0019, #221): runtime input simulation into
 # the RUNNING game, served LIVE through gda-daemon (`kind = LIVE`). Single-frame
-# ops (`input key`, `input mouse-click/mouse-move`, `input action`) inject one event
-# at a frame boundary; `input sequence` reuses #223's time-windowed multi-frame base
-# to apply events across frames in one blocking call. Like `game` / `perf`, a domain-
+# ops (`input key`, `input mouse-move`, `input action`) inject one event at a frame
+# boundary; the activation gestures (`input mouse-click`, `input tap`, #652) and
+# `input sequence` reuse #223's time-windowed multi-frame base to apply their
+# events across frames in one blocking call. Like `game` / `perf`, a domain-
 # object group marked live by `kind`, not by the tree (ADR-0019). The mouse ops are
 # flat two-token commands (`mouse-click` / `mouse-move`) directly under `input`, not a
 # nested `mouse` sub-group: a 3-token name would break the mechanical
@@ -852,14 +1109,17 @@ def input_mouse_click(
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Inject a mouse button click into the running game (live).
+    """Inject a complete mouse click gesture into the running game (live).
 
     Routes through gda-daemon to the engine session (kind = LIVE, ADR-0017) and
-    pushes an InputEventMouseButton at the viewport position into the running
-    game's root viewport. Read the injected coordinate from the mouse event's
-    position; Godot may leave Viewport.get_mouse_position() /
-    Node2D.get_global_mouse_position() stale in daemon sessions. With no daemon it
-    reports `daemon_not_running`.
+    injects the WHOLE activation gesture at the viewport position: the initial
+    move, the press, and the release, one per process frame across a 3-frame
+    window. Godot's UI activates on the release (a bare press never emits a
+    Button's `pressed`), so the result reports the injected phases plus the
+    focused Control before and after the gesture. Read the injected coordinate
+    from the mouse events' position; Godot may leave
+    Viewport.get_mouse_position() / Node2D.get_global_mouse_position() stale in
+    daemon sessions. With no daemon it reports `daemon_not_running`.
     """
     dispatch_domain(
         INPUT_MOUSE_CLICK_COMMAND,
@@ -936,6 +1196,94 @@ def input_action(
     )
     dispatch_domain(
         INPUT_ACTION_COMMAND,
+        params,
+        json_output=json_output,
+        godot=godot,
+        project=project,
+    )
+
+
+@_app.command(name="tap", cls=INPUT_TAP_COMMAND.command_class())
+def input_tap(
+    key: Optional[str] = typer.Option(
+        None,
+        "--key",
+        help="The Godot key name to tap (e.g. Right, Space). Exactly one of --key/--action.",
+    ),
+    action: Optional[str] = typer.Option(
+        None,
+        "--action",
+        help=(
+            "The input action to tap (must be in the running InputMap). Exactly "
+            "one of --key/--action."
+        ),
+    ),
+    modifiers: list[str] = typer.Option(
+        [],
+        "--modifiers",
+        help=(
+            "Modifier keys held through a KEY tap (repeatable): shift, ctrl, "
+            "alt, meta. Not valid with --action."
+        ),
+    ),
+    strength: Optional[float] = typer.Option(
+        None,
+        "--strength",
+        min=0.0,
+        max=1.0,
+        help=(
+            "The analog press strength of an ACTION tap, 0..1 (default 1.0). "
+            "Not valid with --key."
+        ),
+    ),
+    hold_frames: int = typer.Option(
+        2,
+        "--hold-frames",
+        min=1,
+        help=(
+            "Process frames to hold between the press and the release (at least "
+            "1: the release must land on a later frame than the press)."
+        ),
+    ),
+    settle_frames: int = typer.Option(
+        2,
+        "--settle-frames",
+        min=0,
+        help=(
+            "Process frames to run after the release, so the game observes it "
+            "before the op returns."
+        ),
+    ),
+    json_output: bool = json_option(),
+    schema: bool = INPUT_TAP_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Tap one key or input action: press, hold, release across frames (live).
+
+    Routes through gda-daemon to the engine session (kind = LIVE, ADR-0017).
+    Godot needs the press and the release on SEPARATE process frames to advance
+    a focused UI — a pair contained in one immediate frame reports success
+    without advancing it — so the tap presses at window frame 0, holds for
+    --hold-frames process frames, releases, then runs --settle-frames more
+    frames before returning. The result reports the injected phases plus the
+    focused Control before and after the tap. Exactly one of --key/--action; an
+    unresolvable key is `live_invalid_key`, an action absent from the running
+    InputMap is `live_unknown_action`. With no daemon it reports
+    `daemon_not_running`.
+    """
+    params = params_or_bad_parameter(
+        InputTapParams,
+        key=key,
+        action=action,
+        modifiers=modifiers,
+        strength=strength,
+        hold_frames=hold_frames,
+        settle_frames=settle_frames,
+    )
+    dispatch_domain(
+        INPUT_TAP_COMMAND,
         params,
         json_output=json_output,
         godot=godot,

--- a/src/gda/commands/input.py
+++ b/src/gda/commands/input.py
@@ -194,7 +194,7 @@ class InputMouseMoveParams(BaseModel):
     )
 
 
-class InputMouseResult(BaseModel):
+class InputMouseMoveResult(BaseModel):
     """The result of ``gda input mouse-move``: the motion event injected (#221).
 
     Echoes the event ``kind`` (``mouse_move``), the viewport ``position`` it was
@@ -204,7 +204,9 @@ class InputMouseResult(BaseModel):
     mouse event's position; engine-tracked mouse positions may remain stale.
     """
 
-    kind: str = Field(description="The injected event kind ('mouse_move').")
+    kind: Literal["mouse_move"] = Field(
+        default="mouse_move", description="The injected event kind ('mouse_move')."
+    )
     position: list[float] = Field(
         description=(
             "The viewport position the event was injected at, as [x, y]. This "
@@ -226,12 +228,15 @@ class InputEventPhase(BaseModel):
     The structured evidence that an activation op injected the COMPLETE gesture
     rather than a bare press: the 0-based process-frame offset within the op's
     window, and the phase applied there (``move``, ``press``, or ``release``).
+    Both fields are constrained so a payload outside the gesture vocabulary
+    fails output validation (``contract_violation``) instead of passing through
+    as a successful result.
     """
 
     frame: int = Field(
-        description="The 0-based process-frame offset within the op's window."
+        ge=0, description="The 0-based process-frame offset within the op's window."
     )
-    phase: str = Field(
+    phase: Literal["move", "press", "release"] = Field(
         description="The gesture phase applied at this frame: move, press, or release."
     )
 
@@ -242,12 +247,15 @@ class InputMouseClickResult(BaseModel):
     ``phases`` reports each injected phase and the window frame it landed on
     (move at 0, press at 1, release at 2); ``focus_before`` / ``focus_after``
     report the root viewport's focused Control around the gesture (null when
-    none) — the activation evidence the engine exposes. The echoed ``position``
+    none) — the activation evidence the engine exposes. The gesture contract is
+    VALIDATED here, not merely described: a payload whose phases are not
+    exactly that sequence fails output validation (``contract_violation``)
+    rather than passing through as a success. The echoed ``position``
     mirrors the mouse events' position; engine-tracked mouse positions may
     remain stale.
     """
 
-    kind: str = Field(
+    kind: Literal["mouse_click"] = Field(
         default="mouse_click", description="The injected event kind ('mouse_click')."
     )
     position: list[float] = Field(
@@ -256,7 +264,9 @@ class InputMouseClickResult(BaseModel):
             "mirrors event.position; engine-tracked mouse positions may remain stale."
         )
     )
-    button: str = Field(description="The clicked button: left, right, or middle.")
+    button: Literal["left", "right", "middle"] = Field(
+        description="The clicked button: left, right, or middle."
+    )
     double: bool = Field(description="Whether the press was marked a double click.")
     phases: list[InputEventPhase] = Field(
         description=(
@@ -278,6 +288,20 @@ class InputMouseClickResult(BaseModel):
             "when nothing holds focus."
         ),
     )
+
+    @model_validator(mode="after")
+    def _check_gesture(self) -> "InputMouseClickResult":
+        # The gesture IS the contract (#652): a reply whose phases are not
+        # exactly move@0 -> press@1 -> release@2 is not a click this CLI
+        # version understands (a stale or drifted harness), so it must fail
+        # output validation and classify as contract_violation.
+        expected = [(0, "move"), (1, "press"), (2, "release")]
+        if [(p.frame, p.phase) for p in self.phases] != expected:
+            raise ValueError(
+                "a mouse-click result reports exactly the phases move@0, "
+                "press@1, release@2."
+            )
+        return self
 
 
 class InputActionParams(BaseModel):
@@ -369,7 +393,9 @@ class InputTapParams(BaseModel):
         ge=0.0,
         le=1.0,
         description=(
-            "The analog press strength of an ACTION tap, 0..1 (default 1.0). "
+            "The analog press strength of an ACTION tap, 0..1. Omitted on an "
+            "action tap, this model normalizes it to 1.0 (the declared null "
+            "default only marks it unset, so a key tap can refuse it by name). "
             "Not valid with a key tap."
         ),
     )
@@ -406,6 +432,13 @@ class InputTapParams(BaseModel):
             raise ValueError(
                 "'strength' rides an action tap only; a key tap has no strength."
             )
+        if self.action is not None and self.strength is None:
+            # The params model owns the derived default (ADR-0015): normalizing
+            # here means argv and --params-json both send an explicit 1.0 to the
+            # harness, whose own fallback stays defensive only. The field's
+            # declared default remains null purely to distinguish "omitted" from
+            # "set", so the key-tap refusal above can name a real mistake.
+            self.strength = 1.0
         _validate_modifiers(self.modifiers)
         window = self.hold_frames + self.settle_frames + 1
         if window > MAX_WINDOW_FRAMES:
@@ -424,9 +457,15 @@ class InputTapResult(BaseModel):
     ``action`` + ``strength`` for an action tap; the other family is null — the
     frame counts, the injected ``phases`` (the press at window frame 0, the
     release at frame ``hold_frames``), and the focus evidence around the gesture.
+    The evidence is VALIDATED, not merely described: exactly one target family,
+    ``frames == hold_frames + settle_frames + 1``, and exactly the phases
+    press@0 / release@hold_frames — a reply outside that contract fails output
+    validation (``contract_violation``) instead of passing through as a success.
     """
 
-    kind: str = Field(default="tap", description="The injected event kind ('tap').")
+    kind: Literal["tap"] = Field(
+        default="tap", description="The injected event kind ('tap')."
+    )
     key: str | None = Field(
         default=None, description="The tapped key name; null for an action tap."
     )
@@ -446,13 +485,14 @@ class InputTapResult(BaseModel):
         description="The action press strength applied; null for a key tap.",
     )
     hold_frames: int = Field(
-        description="Process frames held between the press and the release."
+        ge=1, description="Process frames held between the press and the release."
     )
     settle_frames: int = Field(
-        description="Process frames run after the release before the op returned."
+        ge=0,
+        description="Process frames run after the release before the op returned.",
     )
     frames: int = Field(
-        description="The total window: hold_frames + settle_frames + 1."
+        ge=2, description="The total window: hold_frames + settle_frames + 1."
     )
     phases: list[InputEventPhase] = Field(
         description=(
@@ -474,6 +514,37 @@ class InputTapResult(BaseModel):
             "when nothing holds focus."
         ),
     )
+
+    @model_validator(mode="after")
+    def _check_tap_evidence(self) -> "InputTapResult":
+        # The tap evidence IS the contract (#652): one target family, honest
+        # frame arithmetic, and exactly the two phases the op injects. A reply
+        # outside this is a stale or drifted harness — it must fail output
+        # validation and classify as contract_violation, never pass as success.
+        key_fields = (self.key, self.keycode, self.modifiers)
+        action_fields = (self.action, self.strength)
+        key_tap = all(f is not None for f in key_fields) and all(
+            f is None for f in action_fields
+        )
+        action_tap = all(f is not None for f in action_fields) and all(
+            f is None for f in key_fields
+        )
+        if not (key_tap or action_tap):
+            raise ValueError(
+                "a tap result carries exactly one target family: "
+                "key + keycode + modifiers, or action + strength."
+            )
+        if self.frames != self.hold_frames + self.settle_frames + 1:
+            raise ValueError(
+                "a tap result's frames is hold_frames + settle_frames + 1."
+            )
+        expected = [(0, "press"), (self.hold_frames, "release")]
+        if [(p.frame, p.phase) for p in self.phases] != expected:
+            raise ValueError(
+                "a tap result reports exactly the phases press@0 and "
+                "release@hold_frames."
+            )
+        return self
 
 
 # The event types a `gda input sequence` may carry. A sequence event reuses the
@@ -932,7 +1003,7 @@ def render_input_key(injected: "InputKeyResult") -> str:
     return f"key {injected.key}{mods} {state} (keycode {injected.keycode})"
 
 
-def render_input_mouse(injected: "InputMouseResult") -> str:
+def render_input_mouse_move(injected: "InputMouseMoveResult") -> str:
     """Render an injected mouse motion event at its position (#221)."""
     x, y = injected.position
     return f"mouse move to ({x}, {y})"
@@ -999,11 +1070,11 @@ INPUT_MOUSE_CLICK_COMMAND: HeadlessCommand[InputMouseClickResult] = HeadlessComm
 )
 
 
-INPUT_MOUSE_MOVE_COMMAND: HeadlessCommand[InputMouseResult] = HeadlessCommand(
+INPUT_MOUSE_MOVE_COMMAND: HeadlessCommand[InputMouseMoveResult] = HeadlessCommand(
     operation="input-mouse-move",
     input_model=InputMouseMoveParams,
-    output_model=InputMouseResult,
-    render=render_input_mouse,
+    output_model=InputMouseMoveResult,
+    render=render_input_mouse_move,
     kind=ExecutionKind.LIVE,
 )
 

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -40,6 +40,7 @@ const OP_INPUT_KEY := "input-key"
 const OP_INPUT_MOUSE_CLICK := "input-mouse-click"
 const OP_INPUT_MOUSE_MOVE := "input-mouse-move"
 const OP_INPUT_ACTION := "input-action"
+const OP_INPUT_TAP := "input-tap"
 const OP_INPUT_SEQUENCE := "input-sequence"
 const OP_SCREEN_CAPTURE := "screen-capture"
 const OP_SCREEN_FRAMES := "screen-frames"
@@ -143,6 +144,17 @@ func _ready() -> void:
 	# editor run, a plain run, and a shipped build never have their process mode
 	# touched — the ADR-0018 inertness guarantee is unaffected.
 	process_mode = Node.PROCESS_MODE_ALWAYS
+	# Mirror the root viewport's mouse-entered state (#647). The engine keeps it
+	# private (Viewport.gui.mouse_in_viewport has no getter), but the root Window
+	# emits mouse_entered/mouse_exited on the SAME notifications that flip it —
+	# for an OS-driven enter in a windowed session and for the harness's own
+	# notify_mouse_entered() alike — so these two connections track it faithfully.
+	# _prepare_mouse_input consults the mirror to notify only on a real edge;
+	# re-notifying an already-entered viewport is an engine warning that pollutes
+	# `gda diag errors` with harness-owned noise. Scoped inside the daemon-launched
+	# gate: a human editor run and a plain run get no connections (ADR-0018).
+	get_tree().root.mouse_entered.connect(func() -> void: _mouse_in_viewport = true)
+	get_tree().root.mouse_exited.connect(func() -> void: _mouse_in_viewport = false)
 	var socket_path: String = user_args[idx + 1]
 	var token: String = user_args[idx + 2]
 	# The requested scene selector (#278) follows the token; "" (or absent) = none.
@@ -353,6 +365,8 @@ func _run(request) -> Variant:
 			return _handle_input_mouse_move(params)
 		OP_INPUT_ACTION:
 			return _handle_input_action(params)
+		OP_INPUT_TAP:
+			return _handle_input_tap(params)
 		OP_INPUT_SEQUENCE:
 			return _handle_input_sequence(params)
 		OP_SCREEN_CAPTURE:
@@ -738,11 +752,22 @@ func _input_viewport() -> Viewport:
 
 var _last_injected_mouse_position: Variant = null
 var _injected_mouse_button_mask := 0
+# Whether the root viewport currently believes the mouse is in its area, mirrored
+# from the root Window's mouse_entered/mouse_exited signals (connected at _ready,
+# #647). Starts false: a fresh engine session has received no enter notification.
+var _mouse_in_viewport := false
 
 
 func _prepare_mouse_input() -> Viewport:
 	var viewport := _input_viewport()
-	viewport.notify_mouse_entered()
+	# Notify only on a real edge (#647): notify_mouse_entered() on an
+	# already-entered viewport is an engine warning ("The Viewport was previously
+	# notified...") that lands in the Session log and pollutes `gda diag errors`
+	# on every injected mouse event after the first. The mirror also covers an
+	# OS-driven enter in a windowed session (no notify needed at all) and an
+	# OS-driven exit (the next injection re-notifies).
+	if not _mouse_in_viewport:
+		viewport.notify_mouse_entered()
 	return viewport
 
 
@@ -798,18 +823,17 @@ func _mouse_button_mask(button: String) -> int:
 			return MOUSE_BUTTON_MASK_LEFT
 
 
-# Push a mouse-button event at a viewport position. Shared by the single-frame
-# click op and a sequence mouse-click event.
-func _push_mouse_click(pos: Vector2, button: String, double: bool) -> void:
-	var viewport := _prepare_mouse_input()
-	var event := InputEventMouseButton.new()
-	event.button_index = _mouse_button_index(button)
-	event.button_mask = _mouse_button_mask(button)
-	event.position = pos
-	event.pressed = true
-	event.double_click = double
-	viewport.push_input(event, true)
-	_last_injected_mouse_position = pos
+# Push a WHOLE mouse click — the press, then the release — on one frame. A bare
+# press never completes an activation: a default Button emits `pressed` only on
+# the release, so a "click" that stops at the press leaves the button held down
+# forever (#652, GDA-DF-004). Used by a sequence `mouse_click` event, which puts
+# the whole click at one clock offset (a same-frame pair fully activates a
+# Button, verified against a live engine); the standalone `input mouse-click` op
+# spreads its move/press/release gesture across frames instead (see
+# _handle_input_mouse_click).
+func _push_whole_mouse_click(pos: Vector2, button: String, double: bool) -> void:
+	_push_mouse_button_phase(pos, button, true, double)
+	_push_mouse_button_phase(pos, button, false, false)
 
 
 func _push_mouse_button_phase(pos: Vector2, button: String, pressed: bool, double: bool) -> void:
@@ -867,22 +891,61 @@ func _handle_input_key(params: Dictionary) -> String:
 	})
 
 
-# input mouse-click: inject an InputEventMouseButton at (x, y) into the root
-# viewport. A single-frame op (pushed at one frame boundary, ADR-0020).
-func _handle_input_mouse_click(params: Dictionary) -> String:
+# The runtime path of the root viewport's current focus owner, or null with no
+# focused Control — the before/after focus evidence the activation ops report
+# (#652). A pure read; the engine exposes no equivalent "was the event handled"
+# evidence, so focus is the observable half.
+func _focus_owner_path() -> Variant:
+	var owner := _input_viewport().gui_get_focus_owner()
+	if owner == null:
+		return null
+	return String(owner.get_path())
+
+
+# input mouse-click: inject the COMPLETE click gesture at (x, y) into the root
+# viewport — the initial move, the press, and the release, one per process frame
+# (frames 0/1/2 of a 3-frame window on the #223 multi-frame base). The gesture is
+# what the op's name implies: a bare press never completes a UI activation (a
+# default Button emits `pressed` only on the release) and leaves the button held
+# down forever (#652, GDA-DF-004); the initial move settles hover state at the
+# click position first. Each phase applies at its own frame boundary (ADR-0020).
+func _handle_input_mouse_click(params: Dictionary) -> Variant:
 	var x := _float_param(params, "x", 0.0)
 	var y := _float_param(params, "y", 0.0)
 	var button := _string_param(params, "button")
 	if button.is_empty():
 		button = "left"
 	var double := bool(params.get("double", false))
-	_push_mouse_click(Vector2(x, y), button, double)
-	return _ok({
-		"kind": "mouse_click",
-		"position": [x, y],
-		"button": button,
-		"double": double,
-	})
+	var pos := Vector2(x, y)
+	var focus_before: Variant = _focus_owner_path()
+	var frame_box := {"n": 0}
+	var sample := func() -> Variant:
+		var current := int(frame_box["n"])
+		match current:
+			0:
+				_push_mouse_move(pos)
+			1:
+				_push_mouse_button_phase(pos, button, true, double)
+			2:
+				# A release is never a double click; the double flag rides the press.
+				_push_mouse_button_phase(pos, button, false, false)
+		frame_box["n"] = current + 1
+		return current
+	var finalize := func(_samples: Array) -> String:
+		return _ok({
+			"kind": "mouse_click",
+			"position": [x, y],
+			"button": button,
+			"double": double,
+			"phases": [
+				{"frame": 0, "phase": "move"},
+				{"frame": 1, "phase": "press"},
+				{"frame": 2, "phase": "release"},
+			],
+			"focus_before": focus_before,
+			"focus_after": _focus_owner_path(),
+		})
+	return _begin_window(3, sample, finalize)
 
 
 # input mouse-move: inject an InputEventMouseMotion to (x, y) into the root
@@ -919,6 +982,74 @@ func _handle_input_action(params: Dictionary) -> String:
 		"pressed": not release,
 		"strength": 0.0 if release else strength,
 	})
+
+
+# input tap: the complete press-hold-release gesture for ONE key or ONE action
+# (#652). Godot needs the press and the release to land on separate process
+# frames for a UI activation — a pair contained in one immediate frame reports
+# success without advancing the focused UI (GDA-DF-034) — so the tap presses at
+# window frame 0, holds for `hold_frames` frames, releases at frame
+# `hold_frames`, then lets `settle_frames` more frames run so the game observes
+# the release before the op returns. Built on the #223 multi-frame base; the
+# frame counts are bounded model-side (ADR-0015). Validation is up front: an
+# unresolvable key is live_invalid_key, an action missing from the running
+# InputMap is live_unknown_action — the same two live-only failures the
+# single-event ops defer to the harness.
+func _handle_input_tap(params: Dictionary) -> Variant:
+	var hold := _int_param(params, "hold_frames", 2)
+	var settle := _int_param(params, "settle_frames", 2)
+	var key := _string_param(params, "key")
+	var action := _string_param(params, "action")
+	var press := Callable()
+	var release := Callable()
+	var echo := {}
+	if not action.is_empty():
+		if not InputMap.has_action(action):
+			return _error(LIVE_ERROR_UNKNOWN_ACTION,
+					"the running InputMap has no action: " + action)
+		var strength := _float_param(params, "strength", 1.0)
+		press = func() -> void: Input.action_press(action, strength)
+		release = func() -> void: Input.action_release(action)
+		echo = {"action": action, "strength": strength}
+	else:
+		var keycode := _resolve_keycode(key)
+		if keycode == KEY_NONE:
+			return _error(LIVE_ERROR_INVALID_KEY,
+					"could not resolve key name to a keycode: " + key)
+		var modifiers: Array = params.get("modifiers", [])
+		if typeof(modifiers) != TYPE_ARRAY:
+			modifiers = []
+		press = func() -> void:
+			_input_viewport().push_input(_make_key_event(keycode, modifiers, true))
+		release = func() -> void:
+			_input_viewport().push_input(_make_key_event(keycode, modifiers, false))
+		echo = {"key": key, "keycode": keycode, "modifiers": modifiers}
+	var focus_before: Variant = _focus_owner_path()
+	var frame_box := {"n": 0}
+	var sample := func() -> Variant:
+		var current := int(frame_box["n"])
+		if current == 0:
+			press.call()
+		elif current == hold:
+			release.call()
+		frame_box["n"] = current + 1
+		return current
+	var finalize := func(_samples: Array) -> String:
+		var payload := {
+			"kind": "tap",
+			"hold_frames": hold,
+			"settle_frames": settle,
+			"frames": hold + settle + 1,
+			"phases": [
+				{"frame": 0, "phase": "press"},
+				{"frame": hold, "phase": "release"},
+			],
+			"focus_before": focus_before,
+			"focus_after": _focus_owner_path(),
+		}
+		payload.merge(echo)
+		return _ok(payload)
+	return _begin_window(hold + settle + 1, sample, finalize)
 
 
 # input sequence: inject a list of events across either process or physics frames,
@@ -1010,7 +1141,7 @@ func _apply_sequence_event(event: Dictionary) -> Variant:
 			var button := _string_param(event, "button")
 			if button.is_empty():
 				button = "left"
-			_push_mouse_click(
+			_push_whole_mouse_click(
 					Vector2(_float_param(event, "x", 0.0), _float_param(event, "y", 0.0)),
 					button, bool(event.get("double", false)))
 			return null

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -184,8 +184,8 @@ and the release, one per process frame — and `gda input tap --key K` /
 process frames, releases, then runs `--settle-frames` (default 2) more frames so
 the game observes the release before the op returns. Both report the injected
 `phases` and the focused Control before/after as activation evidence. Reach for
-`gda input key --released` or a `mouse_button` sequence phase only when a single
-edge is the point (a hold, a drag).
+`gda input key <KEY> --released` or a `mouse_button` sequence phase only when a
+single edge is the point (a hold, a drag).
 
 `gda input sequence` events are a discriminated union on `type`: each kind accepts
 only its own fields, and `gda input sequence --schema` publishes them per kind. The

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -172,8 +172,20 @@ already-running daemon's lazy Engine-session launch; only the outer
 | `diag` | `errors` (structured runtime errors with callstacks; survive a crash) |
 | `logger` | `tail` (the running game's structured log stream; `--raw` for verbatim lines, `--level <min>` to filter by severity, `--limit N`) |
 | `perf` | `monitors`, `monitor` (counters now / a property-or-signal timeline) |
-| `input` | `key`, `mouse-click`, `mouse-move`, `action`, `sequence` |
+| `input` | `key`, `mouse-click`, `mouse-move`, `action`, `tap`, `sequence` |
 | `screen` | `capture`, `frames` (viewport PNGs; needs `--windowed`) |
+
+For a UI activation, use the gesture commands, not a lone event. Godot activates a
+`Button` on the RELEASE, so a bare press never emits `pressed`; and a focused UI
+does not advance when the press and the release land on the same process frame.
+`gda input mouse-click` injects the whole gesture — the initial move, the press,
+and the release, one per process frame — and `gda input tap --key K` /
+`gda input tap --action NAME` presses at frame 0, holds `--hold-frames` (default 2)
+process frames, releases, then runs `--settle-frames` (default 2) more frames so
+the game observes the release before the op returns. Both report the injected
+`phases` and the focused Control before/after as activation evidence. Reach for
+`gda input key --released` or a `mouse_button` sequence phase only when a single
+edge is the point (a hold, a drag).
 
 `gda input sequence` events are a discriminated union on `type`: each kind accepts
 only its own fields, and `gda input sequence --schema` publishes them per kind. The

--- a/tests/support.py
+++ b/tests/support.py
@@ -691,11 +691,54 @@ INPUT_KEY_RESULT = {
     "pressed": True,
 }
 
+# A click is the COMPLETE activation gesture (#652): the harness reports the
+# move/press/release phases at their window frames plus the focus evidence
+# around the gesture.
 INPUT_MOUSE_CLICK_RESULT = {
     "kind": "mouse_click",
     "position": [100.0, 200.0],
     "button": "left",
     "double": False,
+    "phases": [
+        {"frame": 0, "phase": "move"},
+        {"frame": 1, "phase": "press"},
+        {"frame": 2, "phase": "release"},
+    ],
+    "focus_before": None,
+    "focus_after": "/root/Main/Btn",
+}
+
+# A tap is the press-hold-release gesture for one key or one action (#652); the
+# key form echoes key/keycode/modifiers, the action form action/strength.
+INPUT_TAP_KEY_RESULT = {
+    "kind": "tap",
+    "key": "Right",
+    "keycode": 4194321,
+    "modifiers": [],
+    "hold_frames": 2,
+    "settle_frames": 2,
+    "frames": 5,
+    "phases": [
+        {"frame": 0, "phase": "press"},
+        {"frame": 2, "phase": "release"},
+    ],
+    "focus_before": "/root/Main/A",
+    "focus_after": "/root/Main/B",
+}
+
+INPUT_TAP_ACTION_RESULT = {
+    "kind": "tap",
+    "action": "jump",
+    "strength": 1.0,
+    "hold_frames": 2,
+    "settle_frames": 2,
+    "frames": 5,
+    "phases": [
+        {"frame": 0, "phase": "press"},
+        {"frame": 2, "phase": "release"},
+    ],
+    "focus_before": None,
+    "focus_after": None,
 }
 
 INPUT_MOUSE_MOVE_RESULT = {

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -158,6 +158,70 @@ PHYSICS_ACTION_PROJECT_GODOT = project_godot(
     )
 )
 
+# A standard enabled Button plus counters for its activation signals (#652,
+# #647). A default Button emits `pressed` only on the RELEASE of a complete
+# click, so the counters expose whether an injected "click" performed the whole
+# gesture or left the button held down (GDA-DF-004). `motion_seen` records the
+# gesture's initial mouse move riding `_input`.
+BUTTON_UI_GD = (
+    "extends Control\n"
+    "@export var pressed_count: int = 0\n"
+    "@export var down_count: int = 0\n"
+    "@export var up_count: int = 0\n"
+    "@export var motion_seen: bool = false\n"
+    "func _ready() -> void:\n"
+    "\t$Btn.pressed.connect(func() -> void: pressed_count += 1)\n"
+    "\t$Btn.button_down.connect(func() -> void: down_count += 1)\n"
+    "\t$Btn.button_up.connect(func() -> void: up_count += 1)\n"
+    "func _input(event: InputEvent) -> void:\n"
+    "\tif event is InputEventMouseMotion:\n"
+    "\t\tmotion_seen = true\n"
+)
+BUTTON_MAIN_TSCN = (
+    "[gd_scene load_steps=2 format=3]\n\n"
+    '[ext_resource type="Script" path="res://ui.gd" id="1"]\n\n'
+    '[node name="Main" type="Control"]\n'
+    "anchor_right = 1.0\n"
+    "anchor_bottom = 1.0\n"
+    'script = ExtResource("1")\n\n'
+    '[node name="Btn" type="Button" parent="."]\n'
+    "offset_right = 100.0\n"
+    "offset_bottom = 40.0\n"
+    'text = "Go"\n'
+)
+
+# A focus-driven UI (#652, GDA-DF-034): three Buttons in a VBoxContainer, the
+# first focused at startup. One `ui_down` activation (the Down key) must move
+# focus exactly ONE button; the focus neighbors come from the container layout.
+FOCUS_UI_GD = "extends VBoxContainer\nfunc _ready() -> void:\n\t$A.grab_focus()\n"
+FOCUS_MAIN_TSCN = (
+    "[gd_scene load_steps=2 format=3]\n\n"
+    '[ext_resource type="Script" path="res://ui.gd" id="1"]\n\n'
+    '[node name="Main" type="VBoxContainer"]\n'
+    "offset_right = 120.0\n"
+    "offset_bottom = 120.0\n"
+    'script = ExtResource("1")\n\n'
+    '[node name="A" type="Button" parent="."]\n'
+    'text = "A"\n\n'
+    '[node name="B" type="Button" parent="."]\n'
+    'text = "B"\n\n'
+    '[node name="C" type="Button" parent="."]\n'
+    'text = "C"\n'
+)
+
+# An action-edge observer (#652): counts each press edge and each release edge
+# of `move_right`, so one tap must produce exactly one of each.
+TAP_ACTION_PLAYER_GD = (
+    "extends Node2D\n"
+    "@export var pressed_edges: int = 0\n"
+    "@export var released_edges: int = 0\n"
+    "func _process(_delta: float) -> void:\n"
+    '\tif Input.is_action_just_pressed("move_right"):\n'
+    "\t\tpressed_edges += 1\n"
+    '\tif Input.is_action_just_released("move_right"):\n'
+    "\t\treleased_edges += 1\n"
+)
+
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
 
@@ -736,6 +800,199 @@ def test_input_action_unknown_action_reports_live_unknown_action(
         assert json.loads(missing.stdout)["error"]["code"] == "live_unknown_action"
     finally:
         run("daemon", "stop")
+
+
+def _button_project(tmp_path):
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(BUTTON_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "ui.gd").write_text(BUTTON_UI_GD, encoding="utf-8")
+
+
+def _gda_json(tmp_path, env, *args):
+    return subprocess.run(
+        [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=90,
+    )
+
+
+def _property_value(tmp_path, env, node, name):
+    got = _gda_json(tmp_path, env, "game", "get", node, "--property", name)
+    assert got.returncode == 0, got.stdout + got.stderr
+    return next(p for p in json.loads(got.stdout)["properties"] if p["name"] == name)[
+        "value"
+    ]
+
+
+@pytest.mark.e2e
+def test_mouse_click_performs_the_complete_activation_gesture(
+    tmp_path, daemon_runtime_dir
+):
+    # The #652 DoD (GDA-DF-004): `input mouse-click` on a standard enabled
+    # Button emits `pressed` — the whole move/press/release gesture, not a bare
+    # press that leaves the button held down forever. Repeated clicks keep
+    # activating, because each gesture releases what it pressed.
+    _button_project(tmp_path)
+    env = {**os.environ}
+
+    try:
+        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+
+        first = _gda_json(tmp_path, env, "input", "mouse-click", "50", "20")
+        assert first.returncode == 0, first.stdout + first.stderr
+        doc = json.loads(first.stdout)
+        # The structured gesture evidence: the three phases at their frames.
+        assert doc["phases"] == [
+            {"frame": 0, "phase": "move"},
+            {"frame": 1, "phase": "press"},
+            {"frame": 2, "phase": "release"},
+        ]
+
+        # The Button observed the COMPLETE activation: down, up, and `pressed`.
+        assert _property_value(tmp_path, env, "/root/Main", "pressed_count") == 1
+        assert _property_value(tmp_path, env, "/root/Main", "down_count") == 1
+        assert _property_value(tmp_path, env, "/root/Main", "up_count") == 1
+        # The gesture included the initial move (GDA-DF-004's "initial move").
+        assert _property_value(tmp_path, env, "/root/Main", "motion_seen") is True
+
+        second = _gda_json(tmp_path, env, "input", "mouse-click", "50", "20")
+        assert second.returncode == 0, second.stdout + second.stderr
+        assert _property_value(tmp_path, env, "/root/Main", "pressed_count") == 2
+        assert _property_value(tmp_path, env, "/root/Main", "up_count") == 2
+    finally:
+        _gda_json(tmp_path, env, "daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_repeated_mouse_input_adds_no_harness_owned_warnings(
+    tmp_path, daemon_runtime_dir
+):
+    # #647: notify_mouse_entered() on an already-entered viewport is an engine
+    # warning that lands in the Session log. After repeated mouse ops, `diag
+    # errors` must carry no harness-owned viewport-enter noise, so an empty
+    # result stays usable as clean runtime evidence after a multi-click playtest.
+    _button_project(tmp_path)
+    env = {**os.environ}
+
+    try:
+        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+
+        assert (
+            _gda_json(tmp_path, env, "input", "mouse-click", "50", "20").returncode == 0
+        )
+        assert (
+            _gda_json(tmp_path, env, "input", "mouse-click", "50", "20").returncode == 0
+        )
+        assert (
+            _gda_json(tmp_path, env, "input", "mouse-move", "10", "10").returncode == 0
+        )
+
+        diag = _gda_json(tmp_path, env, "diag", "errors")
+        assert diag.returncode == 0, diag.stdout + diag.stderr
+        errors = json.loads(diag.stdout)["errors"]
+        assert not any("previously notified" in error["message"] for error in errors), (
+            errors
+        )
+    finally:
+        _gda_json(tmp_path, env, "daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_sequence_mouse_click_event_activates_a_button(tmp_path, daemon_runtime_dir):
+    # A sequence `mouse_click` event is a WHOLE click at one clock offset
+    # (#652): the harness pushes the press and the release on the same frame,
+    # which fully activates a default Button.
+    _button_project(tmp_path)
+    env = {**os.environ}
+
+    try:
+        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+
+        injected = _gda_json(
+            tmp_path,
+            env,
+            "input",
+            "sequence",
+            "--events",
+            '[{"type": "mouse_click", "x": 50, "y": 20}]',
+        )
+        assert injected.returncode == 0, injected.stdout + injected.stderr
+
+        assert _property_value(tmp_path, env, "/root/Main", "pressed_count") == 1
+        assert _property_value(tmp_path, env, "/root/Main", "up_count") == 1
+    finally:
+        _gda_json(tmp_path, env, "daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_tap_advances_a_focus_driven_ui_exactly_once_repeatably(
+    tmp_path, daemon_runtime_dir
+):
+    # The #652 tap DoD (GDA-DF-034): one key tap advances a focus-driven UI
+    # exactly ONE step, and does so repeatably — the press and the release land
+    # on separate process frames, and only the press navigates.
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(FOCUS_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "ui.gd").write_text(FOCUS_UI_GD, encoding="utf-8")
+    env = {**os.environ}
+
+    try:
+        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+
+        first = _gda_json(tmp_path, env, "input", "tap", "--key", "Down")
+        assert first.returncode == 0, first.stdout + first.stderr
+        doc = json.loads(first.stdout)
+        assert doc["phases"] == [
+            {"frame": 0, "phase": "press"},
+            {"frame": 2, "phase": "release"},
+        ]
+        # Exactly one step: A -> B, evidenced by the op's own focus read-back.
+        assert doc["focus_before"] == "/root/Main/A", doc
+        assert doc["focus_after"] == "/root/Main/B", doc
+
+        second = _gda_json(tmp_path, env, "input", "tap", "--key", "Down")
+        assert second.returncode == 0, second.stdout + second.stderr
+        doc = json.loads(second.stdout)
+        # Repeatably: the next tap advances exactly one more step, B -> C.
+        assert doc["focus_before"] == "/root/Main/B", doc
+        assert doc["focus_after"] == "/root/Main/C", doc
+    finally:
+        _gda_json(tmp_path, env, "daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_tap_action_produces_exactly_one_press_and_release_edge(
+    tmp_path, daemon_runtime_dir
+):
+    # The action leg of the tap (#652): one tap of an InputMap action produces
+    # exactly one press edge and one release edge, observed by the game's own
+    # is_action_just_pressed / is_action_just_released polling.
+    (tmp_path / "project.godot").write_text(ACTION_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(ACTION_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "player.gd").write_text(TAP_ACTION_PLAYER_GD, encoding="utf-8")
+    env = {**os.environ}
+
+    try:
+        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+
+        first = _gda_json(tmp_path, env, "input", "tap", "--action", "move_right")
+        assert first.returncode == 0, first.stdout + first.stderr
+        doc = json.loads(first.stdout)
+        assert doc["action"] == "move_right"
+        assert doc["key"] is None
+
+        node = "/root/Main/Player"
+        assert _property_value(tmp_path, env, node, "pressed_edges") == 1
+        assert _property_value(tmp_path, env, node, "released_edges") == 1
+
+        second = _gda_json(tmp_path, env, "input", "tap", "--action", "move_right")
+        assert second.returncode == 0, second.stdout + second.stderr
+        assert _property_value(tmp_path, env, node, "pressed_edges") == 2
+        assert _property_value(tmp_path, env, node, "released_edges") == 2
+    finally:
+        _gda_json(tmp_path, env, "daemon", "stop")
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -19,7 +19,7 @@ import subprocess
 import pytest
 
 from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import GDA_CMD, assert_windowed_ok
 
 from .conftest import project_godot
 
@@ -866,13 +866,11 @@ def test_mouse_click_performs_the_complete_activation_gesture(
 
 
 @pytest.mark.e2e
-def test_repeated_mouse_input_adds_no_harness_owned_warnings(
-    tmp_path, daemon_runtime_dir
-):
-    # #647: notify_mouse_entered() on an already-entered viewport is an engine
-    # warning that lands in the Session log. After repeated mouse ops, `diag
-    # errors` must carry no harness-owned viewport-enter noise, so an empty
-    # result stays usable as clean runtime evidence after a multi-click playtest.
+def test_two_clicks_leave_diag_errors_empty(tmp_path, daemon_runtime_dir):
+    # The #647 defect mechanism, pinned where every environment can run it: two
+    # successful clicks in a (headless) session, then `diag errors` must be
+    # EMPTY — not merely free of one known message — so a consumer can use an
+    # empty result as clean runtime evidence after a multi-click playtest.
     _button_project(tmp_path)
     env = {**os.environ}
 
@@ -885,16 +883,34 @@ def test_repeated_mouse_input_adds_no_harness_owned_warnings(
         assert (
             _gda_json(tmp_path, env, "input", "mouse-click", "50", "20").returncode == 0
         )
-        assert (
-            _gda_json(tmp_path, env, "input", "mouse-move", "10", "10").returncode == 0
-        )
 
         diag = _gda_json(tmp_path, env, "diag", "errors")
         assert diag.returncode == 0, diag.stdout + diag.stderr
-        errors = json.loads(diag.stdout)["errors"]
-        assert not any("previously notified" in error["message"] for error in errors), (
-            errors
-        )
+        assert json.loads(diag.stdout)["errors"] == []
+    finally:
+        _gda_json(tmp_path, env, "daemon", "stop")
+
+
+@pytest.mark.e2e
+@pytest.mark.usefixtures("windowed_host")
+def test_two_windowed_clicks_leave_diag_errors_empty(tmp_path, daemon_runtime_dir):
+    # The exact #647 reproduction: a WINDOWED daemon session, two successful
+    # clicks, an empty `diag errors`. The windowed path also carries the
+    # OS-driven mouse enter/exit branch of the harness's signal mirror, which
+    # the headless twin cannot exercise. Gated on a real display
+    # (tests.support.require_windowed_host); a capability refusal skips, a
+    # confined run fails loudly (#345/#667).
+    _button_project(tmp_path)
+    env = {**os.environ}
+
+    try:
+        assert_windowed_ok(_gda_json(tmp_path, env, "daemon", "start", "--windowed"))
+
+        assert_windowed_ok(_gda_json(tmp_path, env, "input", "mouse-click", "50", "20"))
+        assert_windowed_ok(_gda_json(tmp_path, env, "input", "mouse-click", "50", "20"))
+
+        diag = assert_windowed_ok(_gda_json(tmp_path, env, "diag", "errors"))
+        assert json.loads(diag.stdout)["errors"] == []
     finally:
         _gda_json(tmp_path, env, "daemon", "stop")
 

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -726,6 +726,14 @@ _MALFORMED_TAP_REPLIES = [
     {**INPUT_TAP_KEY_RESULT, "frames": 1},
     # A phase outside the gesture vocabulary, at a negative frame.
     {**INPUT_TAP_KEY_RESULT, "phases": [{"frame": -7, "phase": "noop"}]},
+    # Field bounds mirroring the request contract (#732 recheck): an empty
+    # action name, an out-of-range strength, an empty key name, an echoed
+    # KEY_NONE, and a modifier outside the vocabulary are all contract drift.
+    {**INPUT_TAP_ACTION_RESULT, "action": ""},
+    {**INPUT_TAP_ACTION_RESULT, "strength": 2.0},
+    {**INPUT_TAP_KEY_RESULT, "key": ""},
+    {**INPUT_TAP_KEY_RESULT, "keycode": 0},
+    {**INPUT_TAP_KEY_RESULT, "modifiers": ["control"]},
 ]
 
 _MALFORMED_CLICK_REPLIES = [
@@ -733,6 +741,9 @@ _MALFORMED_CLICK_REPLIES = [
     {**INPUT_MOUSE_CLICK_RESULT, "kind": "mouse_move"},
     # A button outside the enum.
     {**INPUT_MOUSE_CLICK_RESULT, "button": "bogus"},
+    # A position that is not an [x, y] pair (#732 recheck): an empty one used
+    # to classify as success and then crash the human renderer's unpack.
+    {**INPUT_MOUSE_CLICK_RESULT, "position": []},
     # The right phases in the wrong order.
     {
         **INPUT_MOUSE_CLICK_RESULT,
@@ -798,33 +809,34 @@ def test_malformed_click_reply_is_a_contract_violation(monkeypatch, tmp_path):
         )
 
 
-def test_mouse_move_reply_with_a_foreign_kind_is_a_contract_violation(
-    monkeypatch, tmp_path
-):
-    inject_live_runner(
-        monkeypatch,
-        RunResult(
-            stdout=sentinel({**INPUT_MOUSE_MOVE_RESULT, "kind": "mouse_click"}),
-            stderr="",
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app,
-        [
-            "input",
-            "mouse-move",
-            "1",
-            "2",
-            "--project",
-            str(_project(tmp_path)),
-            "--json",
-        ],
-    )
-
-    assert result.exit_code == EXIT_PARSE, result.stdout
-    assert json.loads(result.stdout)["error"]["code"] == "contract_violation"
+def test_malformed_mouse_move_reply_is_a_contract_violation(monkeypatch, tmp_path):
+    malformed = [
+        # A kind outside the contract.
+        {**INPUT_MOUSE_MOVE_RESULT, "kind": "mouse_click"},
+        # A position that is not an [x, y] pair (#732 recheck).
+        {**INPUT_MOUSE_MOVE_RESULT, "position": [1.0]},
+    ]
+    for payload in malformed:
+        inject_live_runner(
+            monkeypatch,
+            RunResult(stdout=sentinel(payload), stderr="", exit_code=0),
+        )
+        result = CliRunner().invoke(
+            app,
+            [
+                "input",
+                "mouse-move",
+                "1",
+                "2",
+                "--project",
+                str(_project(tmp_path)),
+                "--json",
+            ],
+        )
+        assert result.exit_code == EXIT_PARSE, (payload, result.stdout)
+        assert json.loads(result.stdout)["error"]["code"] == "contract_violation", (
+            payload
+        )
 
 
 # --- input sequence (multi-frame, time-windowed base) -------------------------

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -25,6 +25,8 @@ from tests.support import (
     INPUT_MOUSE_CLICK_RESULT,
     INPUT_MOUSE_MOVE_RESULT,
     INPUT_SEQUENCE_RESULT,
+    INPUT_TAP_ACTION_RESULT,
+    INPUT_TAP_KEY_RESULT,
     error_sentinel,
     inject_live_runner,
     sentinel,
@@ -134,10 +136,10 @@ def test_input_key_schema_reports_kind_live():
     assert schema["kind"] == "live"
 
 
-# --- input mouse-click / mouse-move (single-frame) ----------------------------
+# --- input mouse-click (the activation gesture) / mouse-move (single-frame) ----
 
 
-def test_input_mouse_click_injects_a_click_through_the_live_channel(
+def test_input_mouse_click_injects_the_whole_gesture_through_the_live_channel(
     monkeypatch, tmp_path
 ):
     fake = inject_live_runner(
@@ -165,6 +167,15 @@ def test_input_mouse_click_injects_a_click_through_the_live_channel(
     data = json.loads(result.stdout)
     assert data["kind"] == "mouse_click"
     assert data["position"] == [100.0, 200.0]
+    # The result carries the COMPLETE gesture's evidence (#652): the three
+    # phases at their window frames, and the focus state around the gesture.
+    assert data["phases"] == [
+        {"frame": 0, "phase": "move"},
+        {"frame": 1, "phase": "press"},
+        {"frame": 2, "phase": "release"},
+    ]
+    assert data["focus_before"] is None
+    assert data["focus_after"] == "/root/Main/Btn"
     # The position, button, and double flag are threaded to the operation params.
     assert fake.calls == [
         (
@@ -174,6 +185,15 @@ def test_input_mouse_click_injects_a_click_through_the_live_channel(
     ]
 
 
+def _flat_help(result) -> str:
+    """The rendered help as plain flowing text, so phrase assertions survive
+    the terminal renderer's wrapping (the assertions are about content):
+    ANSI codes and panel borders out, line breaks collapsed to spaces."""
+    text = re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
+    text = re.sub(r"[│╭╮╰╯─]", " ", text)
+    return re.sub(r"\s+", " ", text)
+
+
 def test_input_mouse_help_documents_tracked_position_limitation():
     click = CliRunner().invoke(app, ["input", "mouse-click", "--help"])
     move = CliRunner().invoke(app, ["input", "mouse-move", "--help"])
@@ -181,11 +201,23 @@ def test_input_mouse_help_documents_tracked_position_limitation():
     assert click.exit_code == 0, click.stdout + click.stderr
     assert move.exit_code == 0, move.stdout + move.stderr
     for result in (click, move):
-        assert "mouse event" in result.stdout
-        assert "position" in result.stdout
-        assert "get_mouse_position()" in result.stdout
-        assert "get_global_mouse_position()" in result.stdout
-        assert "stale in daemon sessions" in result.stdout
+        flat = _flat_help(result)
+        assert "position" in flat
+        assert "get_mouse_position()" in flat
+        assert "get_global_mouse_position()" in flat
+        assert "stale in daemon sessions" in flat
+
+
+def test_input_mouse_click_help_states_the_activation_frame_semantics():
+    # The #652 acceptance: the help states the minimum frame semantics Godot
+    # needs for a UI activation — the whole gesture, activating on the release.
+    result = CliRunner().invoke(app, ["input", "mouse-click", "--help"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    flat = _flat_help(result)
+    assert "the initial move, the press, and the release" in flat
+    assert "one per process frame" in flat
+    assert "activates on the release" in flat
 
 
 def test_input_mouse_move_injects_a_motion_through_the_live_channel(
@@ -365,6 +397,256 @@ def test_input_action_strength_over_range_argv_is_a_usage_error(monkeypatch, tmp
 
 def test_input_action_schema_reports_kind_live():
     result = CliRunner().invoke(app, ["input", "action", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout)["kind"] == "live"
+
+
+# --- input tap (the press-hold-release activation gesture, #652) ---------------
+
+
+def test_input_tap_key_dispatches_the_press_hold_release_window(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_TAP_KEY_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "tap",
+            "--key",
+            "Right",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["kind"] == "tap"
+    assert data["key"] == "Right"
+    assert data["action"] is None
+    # The gesture evidence (#652): press at frame 0, release at frame
+    # hold_frames, and the focus state around the tap.
+    assert data["phases"] == [
+        {"frame": 0, "phase": "press"},
+        {"frame": 2, "phase": "release"},
+    ]
+    assert data["focus_before"] == "/root/Main/A"
+    assert data["focus_after"] == "/root/Main/B"
+    # The safe defaults: hold 2 process frames, settle 2 more (a 5-frame window).
+    assert fake.calls == [
+        (
+            "input-tap",
+            {
+                "key": "Right",
+                "action": None,
+                "modifiers": [],
+                "strength": None,
+                "hold_frames": 2,
+                "settle_frames": 2,
+            },
+        )
+    ]
+
+
+def test_input_tap_action_threads_strength_and_frame_counts(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_TAP_ACTION_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "tap",
+            "--action",
+            "jump",
+            "--strength",
+            "0.5",
+            "--hold-frames",
+            "6",
+            "--settle-frames",
+            "0",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["kind"] == "tap"
+    assert data["action"] == "jump"
+    assert data["key"] is None
+    assert fake.calls == [
+        (
+            "input-tap",
+            {
+                "key": None,
+                "action": "jump",
+                "modifiers": [],
+                "strength": 0.5,
+                "hold_frames": 6,
+                "settle_frames": 0,
+            },
+        )
+    ]
+
+
+def test_input_tap_requires_exactly_one_target(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_TAP_KEY_RESULT), stderr="", exit_code=0),
+    )
+
+    neither = CliRunner().invoke(
+        app,
+        ["input", "tap", "--project", str(_project(tmp_path)), "--json"],
+    )
+    both = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "tap",
+            "--key",
+            "Right",
+            "--action",
+            "jump",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert neither.exit_code == 2, neither.stdout + neither.stderr
+    assert both.exit_code == 2, both.stdout + both.stderr
+    assert "exactly one of 'key' or 'action'" in neither.stderr + both.stderr
+    assert fake.calls == []
+
+
+def test_input_tap_rejects_the_other_targets_fields(monkeypatch, tmp_path):
+    # The GDA-DF-037 lesson carried over: a foreign field is refused with the
+    # rule named, never silently inert.
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_TAP_KEY_RESULT), stderr="", exit_code=0),
+    )
+
+    modifiers_on_action = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "tap",
+            "--action",
+            "jump",
+            "--modifiers",
+            "shift",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+    strength_on_key = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "tap",
+            "--key",
+            "Right",
+            "--strength",
+            "0.5",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert modifiers_on_action.exit_code == 2
+    assert "rides a key tap only" in modifiers_on_action.stderr
+    assert strength_on_key.exit_code == 2
+    assert "rides an action tap only" in strength_on_key.stderr
+    assert fake.calls == []
+
+
+def test_input_tap_window_is_bounded_to_the_shared_ceiling(monkeypatch, tmp_path):
+    # hold + settle + 1 must fit the same per-window ceiling a sequence obeys:
+    # an over-range tap is refused model-side, never a live stall (ADR-0015).
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_TAP_KEY_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "tap",
+            "--key",
+            "Right",
+            "--hold-frames",
+            str(MAX_WINDOW_FRAMES),
+            "--settle-frames",
+            "0",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2, result.stdout + result.stderr
+    assert str(MAX_WINDOW_FRAMES) in result.stderr
+    assert fake.calls == []
+
+
+def test_input_tap_hold_frames_zero_is_a_usage_error(monkeypatch, tmp_path):
+    # hold_frames >= 1 is the GDA-DF-034 floor: a same-frame press+release
+    # reports success without advancing the focused UI, so the model refuses it.
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_TAP_KEY_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "tap",
+            "--key",
+            "Right",
+            "--hold-frames",
+            "0",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2, result.stdout + result.stderr
+    stripped = re.sub(r"\x1b\[[0-9;]*m", "", result.stderr)
+    assert "--hold-frames" in stripped, stripped
+    assert fake.calls == []
+
+
+def test_input_tap_help_states_the_activation_frame_semantics():
+    # The #652 acceptance: the help states the minimum frame semantics Godot
+    # needs for a UI activation — press and release on separate process frames.
+    result = CliRunner().invoke(app, ["input", "tap", "--help"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    flat = _flat_help(result)
+    assert "SEPARATE process frames" in flat
+    assert "presses at window frame 0" in flat
+    assert "--hold-frames" in flat
+    assert "--settle-frames" in flat
+
+
+def test_input_tap_schema_reports_kind_live():
+    result = CliRunner().invoke(app, ["input", "tap", "--schema"])
 
     assert result.exit_code == 0, result.stdout + result.stderr
     assert json.loads(result.stdout)["kind"] == "live"

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -16,7 +16,7 @@ import re
 from typer.testing import CliRunner
 
 from gda.cli import app
-from gda.exit_codes import EXIT_LIVE
+from gda.exit_codes import EXIT_LIVE, EXIT_PARSE
 from gda.models import MAX_WINDOW_FRAMES
 from gda.runner import RunResult
 from tests.support import (
@@ -650,6 +650,181 @@ def test_input_tap_schema_reports_kind_live():
 
     assert result.exit_code == 0, result.stdout + result.stderr
     assert json.loads(result.stdout)["kind"] == "live"
+
+
+def test_input_tap_omitted_action_strength_is_normalized_model_side(
+    monkeypatch, tmp_path
+):
+    # The params model owns the derived default (ADR-0015): an action tap with
+    # no --strength sends an explicit 1.0 on BOTH invocation paths, so the
+    # harness fallback stays defensive only and the wire never carries the
+    # "null means 1.0" split the schema cannot express.
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(INPUT_TAP_ACTION_RESULT), stderr="", exit_code=0),
+    )
+
+    argv = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "tap",
+            "--action",
+            "jump",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+    params_json = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "tap",
+            "--params-json",
+            '{"action": "jump"}',
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert argv.exit_code == 0, argv.stdout + argv.stderr
+    assert params_json.exit_code == 0, params_json.stdout + params_json.stderr
+    assert [call[1]["strength"] for call in fake.calls] == [1.0, 1.0]
+    # A key tap has no strength: it stays null on the wire, never 1.0.
+    fake.calls.clear()
+    fake.result = RunResult(
+        stdout=sentinel(INPUT_TAP_KEY_RESULT), stderr="", exit_code=0
+    )
+    key = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "tap",
+            "--key",
+            "Right",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+    assert key.exit_code == 0, key.stdout + key.stderr
+    assert fake.calls[0][1]["strength"] is None
+
+
+# Malformed harness replies for the two activation gestures (#652). The output
+# models VALIDATE the gesture evidence, so a reply outside the contract — a
+# stale or drifted harness — is the structured contract_violation, never a
+# silently-successful CLI/MCP result.
+_MALFORMED_TAP_REPLIES = [
+    # A kind outside the contract.
+    {**INPUT_TAP_KEY_RESULT, "kind": "wrong"},
+    # Both target families present at once.
+    {**INPUT_TAP_KEY_RESULT, "action": "jump", "strength": 1.0},
+    # Frame arithmetic that disagrees with hold + settle + 1.
+    {**INPUT_TAP_KEY_RESULT, "frames": 1},
+    # A phase outside the gesture vocabulary, at a negative frame.
+    {**INPUT_TAP_KEY_RESULT, "phases": [{"frame": -7, "phase": "noop"}]},
+]
+
+_MALFORMED_CLICK_REPLIES = [
+    # A kind outside the contract.
+    {**INPUT_MOUSE_CLICK_RESULT, "kind": "mouse_move"},
+    # A button outside the enum.
+    {**INPUT_MOUSE_CLICK_RESULT, "button": "bogus"},
+    # The right phases in the wrong order.
+    {
+        **INPUT_MOUSE_CLICK_RESULT,
+        "phases": [
+            {"frame": 0, "phase": "press"},
+            {"frame": 1, "phase": "move"},
+            {"frame": 2, "phase": "release"},
+        ],
+    },
+    # The release phase missing entirely.
+    {
+        **INPUT_MOUSE_CLICK_RESULT,
+        "phases": INPUT_MOUSE_CLICK_RESULT["phases"][:2],
+    },
+]
+
+
+def test_malformed_tap_reply_is_a_contract_violation(monkeypatch, tmp_path):
+    for payload in _MALFORMED_TAP_REPLIES:
+        inject_live_runner(
+            monkeypatch,
+            RunResult(stdout=sentinel(payload), stderr="", exit_code=0),
+        )
+        result = CliRunner().invoke(
+            app,
+            [
+                "input",
+                "tap",
+                "--key",
+                "Right",
+                "--project",
+                str(_project(tmp_path)),
+                "--json",
+            ],
+        )
+        assert result.exit_code == EXIT_PARSE, (payload, result.stdout)
+        assert json.loads(result.stdout)["error"]["code"] == "contract_violation", (
+            payload
+        )
+
+
+def test_malformed_click_reply_is_a_contract_violation(monkeypatch, tmp_path):
+    for payload in _MALFORMED_CLICK_REPLIES:
+        inject_live_runner(
+            monkeypatch,
+            RunResult(stdout=sentinel(payload), stderr="", exit_code=0),
+        )
+        result = CliRunner().invoke(
+            app,
+            [
+                "input",
+                "mouse-click",
+                "1",
+                "2",
+                "--project",
+                str(_project(tmp_path)),
+                "--json",
+            ],
+        )
+        assert result.exit_code == EXIT_PARSE, (payload, result.stdout)
+        assert json.loads(result.stdout)["error"]["code"] == "contract_violation", (
+            payload
+        )
+
+
+def test_mouse_move_reply_with_a_foreign_kind_is_a_contract_violation(
+    monkeypatch, tmp_path
+):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel({**INPUT_MOUSE_MOVE_RESULT, "kind": "mouse_click"}),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "mouse-move",
+            "1",
+            "2",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_PARSE, result.stdout
+    assert json.loads(result.stdout)["error"]["code"] == "contract_violation"
 
 
 # --- input sequence (multi-frame, time-windowed base) -------------------------


### PR DESCRIPTION
## W4 slice: input activation gestures (#647 + #652)

One slice for both issues because they share the harness mouse path: the incomplete click (#652) and the viewport-enter warning it triggers on every repeat (#647).

Both defects were **reproduced against a live engine on the base tip `b6e9760c` before any change**:

- Two "successful" `gda input mouse-click` calls on a standard enabled `Button` left `pressed_count == 0`, `down_count == 1`, `up_count == 0` — the press was injected, the release never was, the button stayed held forever and `pressed` never fired (GDA-DF-004).
- The second click put the exact #647 warning into `gda diag errors`, callstack `_prepare_mouse_input` → `_push_mouse_click`.
- A clean-state probe also answered a design question: a **same-frame** press+release pair fully activates a `Button` (pressed/down/up each +1), so a sequence `mouse_click` event can honor its documented "whole click at one clock offset" contract without splitting frames.

### What changed

**`mouse-click` is now the complete gesture** (#652). The op runs on the #223 multi-frame base: the initial move at window frame 0, the press at 1, the release at 2. The result reports the injected `phases` and the focused Control before/after the gesture (`focus_before` / `focus_after`) — the activation evidence the engine exposes. A sequence `mouse_click` event now pushes press **and** release (same frame); the press-only `_push_mouse_click` helper is gone.

**New `gda input tap`** (#652, GDA-DF-034): the press-hold-release of exactly one key or one InputMap action — press at frame 0, hold `--hold-frames` (default 2, ≥ 1) process frames, release, then `--settle-frames` (default 2) more frames so the game observes the release before the op returns. Godot does not advance a focused UI when the pair lands on one immediate frame, and `hold_frames >= 1` encodes that floor. Exactly-one-target, the per-family fields (modifiers = key only, strength = action only, refused by name per the GDA-DF-037 lesson), and the window ceiling (`hold + settle + 1 <= 600`) are all model-side (ADR-0015). The two live-only failures stay deferred to the harness (`live_invalid_key`, `live_unknown_action`).

**The viewport-enter notify is edge-guarded** (#647). The engine keeps `gui.mouse_in_viewport` private, but the root `Window` emits `mouse_entered`/`mouse_exited` on the same notifications that flip it (engine source: `viewport.cpp` NOTIFICATION_VP_MOUSE_ENTER/EXIT; `window.cpp` emits on both), so the harness mirrors the state via two signal connections (inside the daemon-launched gate, ADR-0018 inertness untouched) and notifies only on a real edge. This also covers a windowed session where the OS mouse genuinely enters (no notify at all) or leaves (the next injection re-arms).

### Public-surface impact

`gda schema` diff against base, verified entry-by-entry: **added** `input tap`; **changed** `input mouse-click` (params + result carry the gesture contract); `input mouse-move` and `input sequence` change **descriptions only** (the shared result model was split, the `mouse_click` event kind's docstring now states the same-frame fact). Docs synced: command catalog, SKILL.md (surface table + a "use the gesture commands for activation" guidance block), all four READMEs (+ i18n re-stamp). The #652 acceptance "help and `--schema` state the minimum frame semantics" lands in the params docstrings and command help, pinned by two help tests.

### Validation

- Fast suite **1762 passed**; pyright 0 errors; ruff check + format clean; `git diff --check` clean.
- Real-engine e2e, serial: the input suite **15 passed** (5 new: complete-gesture click with `pressed`/`down`/`up` counters and the initial move observed; repeated mouse ops leave `diag errors` free of the harness-owned warning; a sequence `mouse_click` activates a Button; a key tap advances a 3-button focus UI **exactly once, twice in a row** (A→B then B→C, via the op's own focus read-back); an action tap produces exactly one press edge and one release edge, twice in a row). Adjacent suites re-run: harness-install / game / daemon / diag **35 passed**.
- **Red-proof on base `b6e9760c`**: all 10 new/changed unit tests and all 5 new e2e regressions fail there, each with the failure the fix removes (`KeyError: 'phases'`; the #647 warning present; `pressed_count 0 == 1`; `unknown_command` for tap). One note: the `hold-frames 0` usage test originally passed on base for the wrong reason (unknown command is also exit 2); it now also asserts the error names `--hold-frames`, and is red on base.

Closes #647
Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)
