### PR TITLE
docs(skills): add operational pitfalls catalog

### DIFF
--- a/.agents/skills/pitfalls/SKILL.md
+++ b/.agents/skills/pitfalls/SKILL.md
@@ -5,9 +5,9 @@ description: Use PITFALLS.md to prevent repeated environment, tool, permission, 
 
 # Pitfalls
 
-Use the root `PITFALLS.md` before and during work, and maintain it after work. The
-catalog helps an agent avoid a verified tool-call failure without treating one harness's
-limits as universal project policy.
+Use `PITFALLS.md` before and during work, and maintain it after work. The catalog helps
+an agent avoid a verified tool-call failure without treating one harness's limits as
+universal project policy.
 
 ## Workflow
 

--- a/.agents/skills/pitfalls/SKILL.md
+++ b/.agents/skills/pitfalls/SKILL.md
@@ -5,16 +5,20 @@ description: Use PITFALLS.md to prevent repeated environment, tool, permission, 
 
 # Pitfalls
 
-Use `PITFALLS.md` before and during work, and maintain it after work. The catalog helps
-an agent avoid a verified tool-call failure without treating one harness's limits as
-universal project policy.
+In this skill, `PITFALLS.md` means the tracked catalog at the repository top level.
+Resolve that path before reading or writing the catalog; do not create another copy in
+the current directory.
+
+Use the catalog before and during work, and maintain it after work. The catalog helps an
+agent avoid a verified tool-call failure without treating one execution environment's
+limits as universal project policy.
 
 ## Workflow
 
 ### 1. Before work: load applicable guidance
 
-1. Read `PITFALLS.md` if it exists so its relevant entries are in the working context.
-2. Reuse an entry when the current harness and tool call match its context.
+1. Read the catalog if it exists so its relevant entries are in the working context.
+2. Reuse an entry when the current execution environment and tool call match its context.
 
 If the file does not exist, continue normally. Create it only when phase 3 produces a
 verified, reusable entry.
@@ -41,9 +45,9 @@ and general engineering advice in their existing authorities and workflows.
 
 #### Update the catalog
 
-1. Verify the cause and workaround in the current harness when that check is safe and
-   useful. If the evidence comes from another harness, preserve that context instead of
-   presenting it as current.
+1. Verify the cause and workaround in the current execution environment when that check
+   is safe and useful. If the evidence comes from another environment, preserve that
+   context instead of presenting it as current.
 2. Search for an entry with the same root cause. Update that entry instead of adding a
    duplicate symptom.
 3. State the narrow `Applies when` condition. Use guidance language such as `may`,
@@ -52,9 +56,9 @@ and general engineering advice in their existing authorities and workflows.
 4. Record only the evidence needed to recognize, prevent, and recover from the problem.
    If the workaround is only a mitigation, state the remaining limitation.
 5. Remove secrets, personal paths, and machine-specific identifiers. Use portable
-   placeholders such as `/tmp/<task>-uv-cache`.
-6. Re-read the entry as an agent in a different harness. It should not direct that agent
-   to apply an unnecessary workaround.
+   placeholders such as `<writable-temp-dir>/<task>-uv-cache`.
+6. Re-read the entry as an agent in a different execution environment. It should not
+   direct that agent to apply an unnecessary workaround.
 
 Leave the document unchanged when the experience is unverified, speculative, unique to
 the completed task, or already covered by an existing entry.
@@ -66,12 +70,12 @@ Use a stable, descriptive heading and this compact shape:
 ```markdown
 ## <Pitfall name>
 
-- **Applies when:** <environment or harness condition>
+- **Applies when:** <execution-environment condition>
 - **Symptom:** <observable failure>
 - **Cause:** <verified cause>
 - **Prevention:** <pre-run guidance>
 - **Recovery:** <steps after the failure>
-- **Last verified:** <date and relevant tool or harness, when useful>
+- **Last verified:** <date and relevant tool or execution environment, when useful>
 ```
 
 Omit `Last verified` when a date or version would not help a future worker. Delete or

--- a/.agents/skills/pitfalls/SKILL.md
+++ b/.agents/skills/pitfalls/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: pitfalls
+description: Maintain PITFALLS.md, a concise project-scoped catalog of verified, context-dependent environment, tool, permission, sandbox, and tool-invocation problems with proven workarounds. Use after a reusable operational pitfall is confirmed, when one recurs, at wrap-up if its workaround should survive the session, or when explicitly invoked. Do not use for product bugs, code or design issues, review methods, or speculative advice.
+---
+
+# Pitfalls
+
+Maintain the root `PITFALLS.md` as concise operational guidance for future workers.
+The catalog helps an agent avoid a verified tool-call failure without treating one
+harness's limits as universal project policy.
+
+## Scope
+
+Record a pitfall when all of these conditions apply:
+
+- It concerns the environment, a tool, permissions, a sandbox, or tool invocation.
+- The symptom, cause, and workaround have useful evidence.
+- The same condition can plausibly affect a later session.
+- The entry can state when the workaround applies.
+
+Keep product defects, source-code mistakes, architecture, domain design, review methods,
+and general engineering advice in their existing authorities and workflows.
+
+## Workflow
+
+1. Read the current `PITFALLS.md` and inspect the current environment.
+2. Verify the cause and workaround in the current harness when that check is safe and
+   useful. If the evidence comes from another harness, preserve that context instead of
+   presenting it as current.
+3. Search for an entry with the same root cause. Update that entry instead of adding a
+   duplicate symptom.
+4. State the narrow `Applies when` condition. Use guidance language such as `may`,
+   `should`, and `consider`. Reserve absolute language for a demonstrated safety or
+   permission boundary.
+5. Record only the evidence needed to recognize, prevent, and recover from the problem.
+   If the workaround is only a mitigation, state the remaining limitation.
+6. Remove secrets, personal paths, and machine-specific identifiers. Use portable
+   placeholders such as `/tmp/<task>-uv-cache`.
+7. Re-read the entry as an agent in a different harness. It should not direct that agent
+   to apply an unnecessary workaround.
+
+Leave the document unchanged when the experience is unverified, speculative, unique to
+the completed task, or already covered by an existing entry.
+
+## Entry format
+
+Use a stable, descriptive heading and this compact shape:
+
+```markdown
+## <Pitfall name>
+
+- **Applies when:** <environment or harness condition>
+- **Symptom:** <observable failure>
+- **Cause:** <verified cause>
+- **Prevention:** <pre-run guidance>
+- **Recovery:** <steps after the failure>
+- **Last verified:** <date and relevant tool or harness, when useful>
+```
+
+Omit `Last verified` when a date or version would not help a future worker. Delete or
+revise an entry when current evidence shows that it is obsolete; version control keeps
+the old record.
+
+## Ownership and integration
+
+The primary worker should edit `PITFALLS.md`. Parallel subagents should report candidate
+entries to the primary worker so concurrent edits do not create duplicates.
+
+`STATE.md` can point to a relevant catalog entry when it helps the immediate next work.
+It should not copy durable operational guidance from `PITFALLS.md`.
+
+Do not add telemetry, an incident ledger, occurrence counters, an index, a database, or
+a CI gate for this catalog without a separate demonstrated need. Do not auto-commit the
+document; normal task authorization still controls Git and external actions.

--- a/.agents/skills/pitfalls/SKILL.md
+++ b/.agents/skills/pitfalls/SKILL.md
@@ -14,21 +14,16 @@ limits as universal project policy.
 ### 1. Before work: load applicable guidance
 
 1. Read `PITFALLS.md` if it exists so its relevant entries are in the working context.
-2. Inspect the current environment and planned tool calls. Find entries that could apply.
-3. Compare each entry's `Applies when` condition with the current harness. Use its
-   `Prevention` guidance only when the condition matches.
+2. Reuse an entry when the current harness and tool call match its context.
 
 If the file does not exist, continue normally. Create it only when phase 3 produces a
 verified, reusable entry.
 
-### 2. During work: recognize and handle known pitfalls
+### 2. During work: apply or extend the guidance
 
-1. When a tool call fails, search the catalog for a matching symptom and cause.
-2. Check the entry's `Applies when` condition again. If it matches, use the documented
-   `Recovery` guidance and verify the result.
-3. If no entry matches, or the documented recovery does not work, investigate the
-   current failure instead of forcing it into an existing entry. Treat it as a candidate
-   for phase 3 only after evidence supports its cause and workaround.
+Apply a relevant entry when its situation occurs. If no entry applies, or its guidance
+does not work, investigate the failure and carry it to phase 3 only after evidence
+supports the cause and workaround.
 
 ### 3. After work: record new guidance
 

--- a/.agents/skills/pitfalls/SKILL.md
+++ b/.agents/skills/pitfalls/SKILL.md
@@ -84,8 +84,8 @@ the old record.
 
 ## Ownership and integration
 
-The primary worker should edit `PITFALLS.md`. Parallel subagents should report candidate
-entries to the primary worker so concurrent edits do not create duplicates.
+Only the primary worker edits `PITFALLS.md`. Parallel subagents report candidate entries
+to the primary worker so concurrent edits do not create duplicates.
 
 If `STATE.md` exists, it can point to a relevant catalog entry when that entry helps the
 immediate next work. It should not copy durable operational guidance from `PITFALLS.md`.

--- a/.agents/skills/pitfalls/SKILL.md
+++ b/.agents/skills/pitfalls/SKILL.md
@@ -1,15 +1,38 @@
 ---
 name: pitfalls
-description: Maintain PITFALLS.md, a concise project-scoped catalog of verified, context-dependent environment, tool, permission, sandbox, and tool-invocation problems with proven workarounds. Use after a reusable operational pitfall is confirmed, when one recurs, at wrap-up if its workaround should survive the session, or when explicitly invoked. Do not use for product bugs, code or design issues, review methods, or speculative advice.
+description: Use PITFALLS.md to prevent repeated environment, tool, permission, sandbox, and tool-invocation failures, and maintain it with verified context-dependent guidance. Use before project tool work, when a matching operational pitfall occurs, after confirming a reusable new pitfall, or when explicitly invoked. Do not use for product bugs, code or design issues, review methods, or speculative advice.
 ---
 
 # Pitfalls
 
-Maintain the root `PITFALLS.md` as concise operational guidance for future workers.
-The catalog helps an agent avoid a verified tool-call failure without treating one
-harness's limits as universal project policy.
+Use the root `PITFALLS.md` before and during work, and maintain it after work. The
+catalog helps an agent avoid a verified tool-call failure without treating one harness's
+limits as universal project policy.
 
-## Scope
+## Workflow
+
+### 1. Before work: load applicable guidance
+
+1. Read `PITFALLS.md` if it exists so its relevant entries are in the working context.
+2. Inspect the current environment and planned tool calls. Find entries that could apply.
+3. Compare each entry's `Applies when` condition with the current harness. Use its
+   `Prevention` guidance only when the condition matches.
+
+If the file does not exist, continue normally. Create it only when phase 3 produces a
+verified, reusable entry.
+
+### 2. During work: recognize and handle known pitfalls
+
+1. When a tool call fails, search the catalog for a matching symptom and cause.
+2. Check the entry's `Applies when` condition again. If it matches, use the documented
+   `Recovery` guidance and verify the result.
+3. If no entry matches, or the documented recovery does not work, investigate the
+   current failure instead of forcing it into an existing entry. Treat it as a candidate
+   for phase 3 only after evidence supports its cause and workaround.
+
+### 3. After work: record new guidance
+
+#### Recording scope
 
 Record a pitfall when all of these conditions apply:
 
@@ -21,22 +44,21 @@ Record a pitfall when all of these conditions apply:
 Keep product defects, source-code mistakes, architecture, domain design, review methods,
 and general engineering advice in their existing authorities and workflows.
 
-## Workflow
+#### Update the catalog
 
-1. Read the current `PITFALLS.md` and inspect the current environment.
-2. Verify the cause and workaround in the current harness when that check is safe and
+1. Verify the cause and workaround in the current harness when that check is safe and
    useful. If the evidence comes from another harness, preserve that context instead of
    presenting it as current.
-3. Search for an entry with the same root cause. Update that entry instead of adding a
+2. Search for an entry with the same root cause. Update that entry instead of adding a
    duplicate symptom.
-4. State the narrow `Applies when` condition. Use guidance language such as `may`,
+3. State the narrow `Applies when` condition. Use guidance language such as `may`,
    `should`, and `consider`. Reserve absolute language for a demonstrated safety or
    permission boundary.
-5. Record only the evidence needed to recognize, prevent, and recover from the problem.
+4. Record only the evidence needed to recognize, prevent, and recover from the problem.
    If the workaround is only a mitigation, state the remaining limitation.
-6. Remove secrets, personal paths, and machine-specific identifiers. Use portable
+5. Remove secrets, personal paths, and machine-specific identifiers. Use portable
    placeholders such as `/tmp/<task>-uv-cache`.
-7. Re-read the entry as an agent in a different harness. It should not direct that agent
+6. Re-read the entry as an agent in a different harness. It should not direct that agent
    to apply an unnecessary workaround.
 
 Leave the document unchanged when the experience is unverified, speculative, unique to

--- a/.agents/skills/pitfalls/SKILL.md
+++ b/.agents/skills/pitfalls/SKILL.md
@@ -66,9 +66,5 @@ the old record.
 The primary worker should edit `PITFALLS.md`. Parallel subagents should report candidate
 entries to the primary worker so concurrent edits do not create duplicates.
 
-`STATE.md` can point to a relevant catalog entry when it helps the immediate next work.
-It should not copy durable operational guidance from `PITFALLS.md`.
-
-Do not add telemetry, an incident ledger, occurrence counters, an index, a database, or
-a CI gate for this catalog without a separate demonstrated need. Do not auto-commit the
-document; normal task authorization still controls Git and external actions.
+If `STATE.md` exists, it can point to a relevant catalog entry when that entry helps the
+immediate next work. It should not copy durable operational guidance from `PITFALLS.md`.

--- a/.agents/skills/state/SKILL.md
+++ b/.agents/skills/state/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: state
-description: Update STATE.md — the lightweight cross-session "daily report" of project progress. Rewrite (never append) the current milestone/phase, what this session completed or changed, pitfalls worth reusing, the recommended next issues/tasks, and the filtered-and-inherited backlog of unfinished cross-session items. Use at the end of a working session, when wrapping up, or when explicitly invoked.
+description: Update STATE.md — the lightweight cross-session "daily report" of project progress. Rewrite (never append) the current milestone/phase, what this session completed or changed, experience relevant to the next work, the recommended next issues/tasks, and the filtered-and-inherited backlog of unfinished cross-session items. Use at the end of a working session, when wrapping up, or when explicitly invoked.
 ---
 
 # State
 
 Maintain `STATE.md` at the repo root: a lightweight **cross-session daily report** so the next
-worker learns in ~15 lines where the project is, what the last session did, which pitfalls to
-reuse, what to pick up next, and which unfinished items must not be forgotten. This is the
+worker learns in ~15 lines where the project is, what the last session did, which immediate
+experience to reuse, what to pick up next, and which unfinished items must not be forgotten. This is the
 feedback loop that makes development experience **compound** instead of re-discovering project
 status every session.
 
@@ -72,10 +72,12 @@ unchanged — at most refresh the date. Don't churn the file with non-progress.
      tracker provides a reference. If no tracker exists, keep every item. Also keep every item when
      no authorized writer can create the tracker record. The visible overflow is the signal that
      the items still need a durable home.
-5. **Add pitfalls/experience only if it serves "Next up".** Include a note **only when this
-   session's work is continuous with or related to the recommended next work**, so the note will
-   actually get reused. If the next work is unrelated, **omit it** — experience that doesn't help
-   the next task is noise, not a war-story archive.
+5. **Add experience only if it serves "Next up".** Include a note **only when this session's
+   work is continuous with or related to the recommended next work**, so the note will actually
+   get reused. If the next work is unrelated, **omit it** — experience that doesn't help the next
+   task is noise, not a war-story archive. When the project has a `PITFALLS.md`, keep durable
+   environment, tool, permission, sandbox, and tool-invocation guidance there instead. STATE.md
+   may point to a relevant entry; it should not copy that entry.
 6. **Rewrite `STATE.md` from the template.** Overwrite the file; never append. Keep it to 15 lines
    or fewer. If the no-loss rule in step 4 leaves more than five Backlog items, allow one extra line
    for each extra item. Do not drop an item to meet the line limit. Omit content bullets that are

--- a/.agents/skills/state/SKILL.md
+++ b/.agents/skills/state/SKILL.md
@@ -95,7 +95,7 @@ _Cross-session daily report (~15 lines, rewritten each session via the `state` s
 
 - **Phase/milestone:** <current stage, in the project's own terms — omit if you can't confirm the *current* one>
 - **Last session:** <what was completed/changed; one line, e.g. issue #N>
-- **Experience:** <only if it helps "Next up"; link a relevant `PITFALLS.md` entry instead of copying it>
+- **Experience:** <transient experience that helps "Next up", or a link to a relevant `PITFALLS.md` entry; otherwise omit>
 - **Next up:** <recommended items to START next, in execution order, e.g. issue #N>
 - **Backlog:** <unfinished cross-session carry-over NOT selected for "Next up"; one line per item>
   - <interrupted or parked item, anchored to a tracker ref (#N) where one exists> _(since YYYY-MM-DD)_

--- a/.agents/skills/state/SKILL.md
+++ b/.agents/skills/state/SKILL.md
@@ -95,7 +95,7 @@ _Cross-session daily report (~15 lines, rewritten each session via the `state` s
 
 - **Phase/milestone:** <current stage, in the project's own terms — omit if you can't confirm the *current* one>
 - **Last session:** <what was completed/changed; one line, e.g. issue #N>
-- **Pitfalls/experience:** <only if it helps "Next up"; otherwise omit this line>
+- **Experience:** <only if it helps "Next up"; link a relevant `PITFALLS.md` entry instead of copying it>
 - **Next up:** <recommended items to START next, in execution order, e.g. issue #N>
 - **Backlog:** <unfinished cross-session carry-over NOT selected for "Next up"; one line per item>
   - <interrupted or parked item, anchored to a tracker ref (#N) where one exists> _(since YYYY-MM-DD)_

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,11 @@ Read @CONTEXT.md to align with the project's nature and shared language; consult
 
 Read @STATE.md if exists for the latest session state — a lightweight cross-session daily report; the `state` skill is the single authority for its format and fields. Treat it as read-only startup context. Only the **primary worker** updates it, at session end, via the `state` skill; parallel sub-agents and sub-tasks must not write it.
 
-Read @PITFALLS.md if it exists before using project tools in a managed or unfamiliar
-environment. Its entries are context-sensitive guidance: check each **Applies when**
-condition because another harness can have different capabilities. The primary worker
-should maintain it through the `pitfalls` skill. Parallel subagents should report
-candidate entries instead of editing it concurrently.
+Read @PITFALLS.md if it exists before using project tools. Its entries are
+context-sensitive guidance: check each **Applies when** condition because another harness
+can have different capabilities. The primary worker should maintain it through the
+`pitfalls` skill. Parallel subagents should report candidate entries instead of editing
+it concurrently.
 
 ## Agent skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,12 @@ Read @CONTEXT.md to align with the project's nature and shared language; consult
 
 Read @STATE.md if exists for the latest session state — a lightweight cross-session daily report; the `state` skill is the single authority for its format and fields. Treat it as read-only startup context. Only the **primary worker** updates it, at session end, via the `state` skill; parallel sub-agents and sub-tasks must not write it.
 
+Read @PITFALLS.md if it exists before using project tools in a managed or unfamiliar
+environment. Its entries are context-sensitive guidance: check each **Applies when**
+condition because another harness can have different capabilities. The primary worker
+should maintain it through the `pitfalls` skill. Parallel subagents should report
+candidate entries instead of editing it concurrently.
+
 ## Agent skills
 
 ### Issue tracker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,7 @@ Read @RULES.md if exists, to align communication style, collaboration specificat
 
 Read @CONTEXT.md to align with the project's nature and shared language; consult `docs/adr/` for the architecture and the decisions behind it. README.md is human-facing onboarding (install, usage, contributing) and has grown large — read specific sections on demand (e.g. its "Project status" section for current state) rather than the whole file.
 
-Read @STATE.md if it exists for the latest session state — a lightweight cross-session
-daily report. The `state` skill is the single authority for its format and fields, and
-the file is updated at session end.
-
-Read @PITFALLS.md if it exists.
+Read @STATE.md and @PITFALLS.md if they exist.
 
 The primary worker maintains `STATE.md` through the `state` skill and `PITFALLS.md`
 through the `pitfalls` skill. Parallel subagents and sub-tasks treat both files as

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,7 @@ Read @CONTEXT.md to align with the project's nature and shared language; consult
 
 Read @STATE.md if exists for the latest session state — a lightweight cross-session daily report; the `state` skill is the single authority for its format and fields. Treat it as read-only startup context. Only the **primary worker** updates it, at session end, via the `state` skill; parallel sub-agents and sub-tasks must not write it.
 
-Read @PITFALLS.md if it exists before using project tools. Its entries are
-context-sensitive guidance: check each **Applies when** condition because another harness
-can have different capabilities. The primary worker should maintain it through the
+Read @PITFALLS.md if it exists. The primary worker should maintain it through the
 `pitfalls` skill. Parallel subagents should report candidate entries instead of editing
 it concurrently.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,6 @@ Read @CONTEXT.md to align with the project's nature and shared language; consult
 
 Read @STATE.md and @PITFALLS.md if they exist.
 
-The primary worker maintains `STATE.md` through the `state` skill and `PITFALLS.md`
-through the `pitfalls` skill. Parallel subagents and sub-tasks treat both files as
-read-only and report state changes or candidate pitfalls to the primary worker.
-
 ### Issue tracker
 
 Issues and PRDs live as GitHub issues in `aigengame/godot-agent` (via the `gh` CLI). See `docs/agents/issue-tracker.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,15 @@ Read @RULES.md if exists, to align communication style, collaboration specificat
 
 Read @CONTEXT.md to align with the project's nature and shared language; consult `docs/adr/` for the architecture and the decisions behind it. README.md is human-facing onboarding (install, usage, contributing) and has grown large — read specific sections on demand (e.g. its "Project status" section for current state) rather than the whole file.
 
-Read @STATE.md if exists for the latest session state — a lightweight cross-session daily report; the `state` skill is the single authority for its format and fields. Treat it as read-only startup context. Only the **primary worker** updates it, at session end, via the `state` skill; parallel sub-agents and sub-tasks must not write it.
+Read @STATE.md if it exists for the latest session state — a lightweight cross-session
+daily report. The `state` skill is the single authority for its format and fields, and
+the file is updated at session end.
 
-Read @PITFALLS.md if it exists. The primary worker should maintain it through the
-`pitfalls` skill. Parallel subagents should report candidate entries instead of editing
-it concurrently.
+Read @PITFALLS.md if it exists.
+
+The primary worker maintains `STATE.md` through the `state` skill and `PITFALLS.md`
+through the `pitfalls` skill. Parallel subagents and sub-tasks treat both files as
+read-only and report state changes or candidate pitfalls to the primary worker.
 
 ## Agent skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,15 @@ Read @RULES.md if exists, to align communication style, collaboration specificat
 
 Read @CONTEXT.md to align with the project's nature and shared language; consult `docs/adr/` for the architecture and the decisions behind it. README.md is human-facing onboarding (install, usage, contributing) and has grown large — read specific sections on demand (e.g. its "Project status" section for current state) rather than the whole file.
 
+## Agent skills
+
+### State and pitfalls
+
 Read @STATE.md and @PITFALLS.md if they exist.
 
 The primary worker maintains `STATE.md` through the `state` skill and `PITFALLS.md`
 through the `pitfalls` skill. Parallel subagents and sub-tasks treat both files as
 read-only and report state changes or candidate pitfalls to the primary worker.
-
-## Agent skills
 
 ### Issue tracker
 

--- a/PITFALLS.md
+++ b/PITFALLS.md
@@ -2,8 +2,8 @@
 
 _Project-scoped operational guidance for agents. These entries are not universal
 constraints. Apply an entry only when its **Applies when** condition matches the current
-environment. Check the current harness first when that check is practical; another
-harness can have different capabilities._
+environment. Check the current execution environment first when that check is practical;
+another environment can have different capabilities._
 
 ## Writable `uv` and `uvx` paths in a managed sandbox
 
@@ -11,16 +11,17 @@ harness can have different capabilities._
   directory is not writable before the requested command starts.
 - **Symptom:** `uv` reports that it failed to initialize its cache, or `uvx` fails while
   it prepares a tool environment.
-- **Cause:** The default cache or tool directory is outside the harness's writable
-  paths.
+- **Cause:** The default cache or tool directory is outside the execution environment's
+  writable paths.
 - **Prevention:** Consider a task-scoped writable cache such as
-  `UV_CACHE_DIR=/tmp/<task>-uv-cache`. An `uvx` command that installs a tool may also need
-  `UV_TOOL_DIR=/tmp/<task>-uv-tools`. Serial commands can reuse one task cache. Concurrent
-  commands should use separate cache directories.
+  `UV_CACHE_DIR=<writable-temp-dir>/<task>-uv-cache`. An `uvx` command that installs a
+  tool may also need `UV_TOOL_DIR=<writable-temp-dir>/<task>-uv-tools`. On macOS or Linux,
+  `/tmp/...` can be a suitable writable temporary location. Commands can reuse one task
+  cache.
 - **Recovery:** Rerun once with writable, task-scoped paths. If the rerun reaches the
   requested command, treat the first failure as environment evidence rather than a
   product or test failure.
-- **Last verified:** 2026-08-24 in a managed Codex desktop harness.
+- **Last verified:** 2026-08-24 in a managed Codex desktop environment.
 
 ## Writable GitHub CLI cache for run evidence
 
@@ -28,29 +29,31 @@ harness can have different capabilities._
   the default local cache is not writable.
 - **Symptom:** The command fails with an `operation not permitted` or similar local cache
   error before it returns the requested GitHub data.
-- **Cause:** The GitHub CLI is trying to use a cache path outside the harness's writable
-  paths.
+- **Cause:** The GitHub CLI is trying to use a cache path outside the execution
+  environment's writable paths.
 - **Prevention:** For the affected command, consider a task-scoped cache such as
-  `XDG_CACHE_HOME=/tmp/<task>-xdg-cache`.
+  `XDG_CACHE_HOME=<writable-temp-dir>/<task>-xdg-cache`. On macOS or Linux, `/tmp/...`
+  can be a suitable writable temporary location.
 - **Recovery:** Retry the read with the writable cache. Distinguish a repeated GitHub or
   network error from the original local-cache failure.
-- **Last verified:** 2026-08-21 in a managed Codex review harness.
+- **Last verified:** 2026-08-21 in a managed Codex review environment.
 
 ## Restricted Git metadata during isolated review
 
-- **Applies when:** A review harness can read a checkout but cannot update its Git
+- **Applies when:** A review environment can read a checkout but cannot update its Git
   metadata.
 - **Symptom:** `git fetch` cannot write `FETCH_HEAD`, or a linked-worktree command cannot
   update metadata even though the source files are readable.
-- **Cause:** The harness protects `.git` or linked-worktree metadata outside its writable
-  scope.
+- **Cause:** The environment protects `.git` or linked-worktree metadata outside its
+  writable scope.
 - **Prevention:** Check the available permission scope before planning a Git mutation.
   For read-only work, an existing exact commit object or an immutable GitHub snapshot may
   provide sufficient evidence.
 - **Recovery:** For an authorized mutation, request the narrow permission that the Git
   operation needs. For read-only review, use a writable temporary clone or snapshot and
   record the exact commit that was inspected.
-- **Last verified:** 2026-08 in managed review harnesses; recheck the current harness.
+- **Last verified:** 2026-08 in managed review environments; recheck the current
+  environment.
 
 ## GitHub connector and CLI permission differences
 
@@ -81,16 +84,18 @@ harness can have different capabilities._
   result before classifying the change.
 - **Last verified:** 2026-08 in godot-agent review worktrees.
 
-## Rendered Godot validation in a restricted harness
+## Rendered Godot validation in a restricted environment
 
-- **Applies when:** A sandbox or remote harness does not provide the window, display,
-  input, or application-data permissions needed by a rendered Godot run.
+- **Applies when:** A sandbox or remote execution environment does not provide the
+  window, display, input, or application-data permissions needed by a rendered Godot
+  run.
 - **Symptom:** Headless checks pass, while a rendered or interactive run cannot start or
   cannot complete its user path.
-- **Cause:** The harness lacks a runtime capability that the rendered check needs. This
-  does not by itself identify a product defect.
+- **Cause:** The environment lacks a runtime capability that the rendered check needs.
+  This does not by itself identify a product defect.
 - **Prevention:** Separate headless evidence from rendered or human-in-the-loop evidence
   in the validation plan.
-- **Recovery:** Run the rendered check in a capable local harness when possible. Report
-  the passing headless evidence and the remaining rendered-validation gap separately.
-- **Last verified:** 2026-08 in managed Godot review harnesses.
+- **Recovery:** Run the rendered check in a capable local environment when possible.
+  Report the passing headless evidence and the remaining rendered-validation gap
+  separately.
+- **Last verified:** 2026-08 in managed Godot review environments.

--- a/PITFALLS.md
+++ b/PITFALLS.md
@@ -7,8 +7,8 @@ harness can have different capabilities._
 
 ## Writable `uv` and `uvx` paths in a managed sandbox
 
-- **Applies when:** A managed harness denies writes to the default user cache or tool
-  directory, or `uv` fails before it runs the requested command.
+- **Applies when:** A managed environment reports that the default `uv` cache or tool
+  directory is not writable before the requested command starts.
 - **Symptom:** `uv` reports that it failed to initialize its cache, or `uvx` fails while
   it prepares a tool environment.
 - **Cause:** The default cache or tool directory is outside the harness's writable

--- a/PITFALLS.md
+++ b/PITFALLS.md
@@ -1,0 +1,96 @@
+# PITFALLS — godot-agent
+
+_Project-scoped operational guidance for agents. These entries are not universal
+constraints. Apply an entry only when its **Applies when** condition matches the current
+environment. Check the current harness first when that check is practical; another
+harness can have different capabilities._
+
+## Writable `uv` and `uvx` paths in a managed sandbox
+
+- **Applies when:** A managed harness denies writes to the default user cache or tool
+  directory, or `uv` fails before it runs the requested command.
+- **Symptom:** `uv` reports that it failed to initialize its cache, or `uvx` fails while
+  it prepares a tool environment.
+- **Cause:** The default cache or tool directory is outside the harness's writable
+  paths.
+- **Prevention:** Consider a task-scoped writable cache such as
+  `UV_CACHE_DIR=/tmp/<task>-uv-cache`. An `uvx` command that installs a tool may also need
+  `UV_TOOL_DIR=/tmp/<task>-uv-tools`. Serial commands can reuse one task cache. Concurrent
+  commands should use separate cache directories.
+- **Recovery:** Rerun once with writable, task-scoped paths. If the rerun reaches the
+  requested command, treat the first failure as environment evidence rather than a
+  product or test failure.
+- **Last verified:** 2026-08-24 in a managed Codex desktop harness.
+
+## Writable GitHub CLI cache for run evidence
+
+- **Applies when:** A `gh run` command cannot read run logs or other CI evidence because
+  the default local cache is not writable.
+- **Symptom:** The command fails with an `operation not permitted` or similar local cache
+  error before it returns the requested GitHub data.
+- **Cause:** The GitHub CLI is trying to use a cache path outside the harness's writable
+  paths.
+- **Prevention:** For the affected command, consider a task-scoped cache such as
+  `XDG_CACHE_HOME=/tmp/<task>-xdg-cache`.
+- **Recovery:** Retry the read with the writable cache. Distinguish a repeated GitHub or
+  network error from the original local-cache failure.
+- **Last verified:** 2026-08-21 in a managed Codex review harness.
+
+## Restricted Git metadata during isolated review
+
+- **Applies when:** A review harness can read a checkout but cannot update its Git
+  metadata.
+- **Symptom:** `git fetch` cannot write `FETCH_HEAD`, or a linked-worktree command cannot
+  update metadata even though the source files are readable.
+- **Cause:** The harness protects `.git` or linked-worktree metadata outside its writable
+  scope.
+- **Prevention:** Check the available permission scope before planning a Git mutation.
+  For read-only work, an existing exact commit object or an immutable GitHub snapshot may
+  provide sufficient evidence.
+- **Recovery:** For an authorized mutation, request the narrow permission that the Git
+  operation needs. For read-only review, use a writable temporary clone or snapshot and
+  record the exact commit that was inspected.
+- **Last verified:** 2026-08 in managed review harnesses; recheck the current harness.
+
+## GitHub connector and CLI permission differences
+
+- **Applies when:** An authorized GitHub mutation through a connector returns
+  `403 Resource not accessible by integration`.
+- **Symptom:** The connector can read the target but cannot post or edit the requested
+  GitHub artifact.
+- **Cause:** The connector token does not have the required permission. An authenticated
+  local GitHub CLI can have a different permission set.
+- **Prevention:** Use the available GitHub path that has the required permission. For
+  Markdown-heavy content, a body file also avoids shell interpretation.
+- **Recovery:** If the mutation is already authorized, consider the authenticated `gh`
+  CLI. Read the target after an ambiguous failure or retry so the operation does not
+  create a duplicate.
+- **Last verified:** 2026-08 in managed Codex GitHub workflows.
+
+## Repository code versus an installed CLI
+
+- **Applies when:** Validation runs a command name that can resolve to both the current
+  checkout and a globally installed package.
+- **Symptom:** The command reports stale behavior, a different version, or results that do
+  not match the checked-out source.
+- **Cause:** `PATH` selected an installed executable instead of the repository runtime.
+- **Prevention:** Verify the executable and version before judging branch behavior.
+  Prefer the repository's documented environment, such as its local virtual environment
+  or supported module entry point.
+- **Recovery:** Rerun with the repository runtime selected explicitly and compare the
+  result before classifying the change.
+- **Last verified:** 2026-08 in godot-agent review worktrees.
+
+## Rendered Godot validation in a restricted harness
+
+- **Applies when:** A sandbox or remote harness does not provide the window, display,
+  input, or application-data permissions needed by a rendered Godot run.
+- **Symptom:** Headless checks pass, while a rendered or interactive run cannot start or
+  cannot complete its user path.
+- **Cause:** The harness lacks a runtime capability that the rendered check needs. This
+  does not by itself identify a product defect.
+- **Prevention:** Separate headless evidence from rendered or human-in-the-loop evidence
+  in the validation plan.
+- **Recovery:** Run the rendered check in a capable local harness when possible. Report
+  the passing headless evidence and the remaining rendered-validation gap separately.
+- **Last verified:** 2026-08 in managed Godot review harnesses.


### PR DESCRIPTION
## Summary

- add a project-scoped `pitfalls` skill for verified operational guidance
- add a tracked `PITFALLS.md` catalog with six recurring environment and tool-call pitfalls
- connect the catalog to agent startup guidance while keeping `STATE.md` transient

## Design

The catalog is guidance, not policy. Each entry has an `Applies when` condition so an agent can check the current harness before it uses a workaround.

The scope is limited to environment setup, tools, permissions, sandbox behavior, and tool invocation. Product defects, code mistakes, architecture, domain design, and review methods stay with their existing authorities.

The implementation does not add scripts, telemetry, counters, an index, a database, or a CI gate.

## Validation

- `quick_validate.py .agents/skills/pitfalls`: `Skill is valid!`
- `quick_validate.py .agents/skills/state`: `Skill is valid!`
- `git diff --check`

Closes #733
