### PR TITLE
feat(gda): texture projection — inspectable identity for path-less resource values (#666)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -187,9 +187,9 @@ emits** — the `get` reads (`project`/`node`/`resource get`), the value echoed 
 `node set`/`resource set`, the per-entry value of `project list` and `scene
 get-exports`, and the live `game get` read — so a value reads the same
 everywhere. Two controls keep the shared projection safe on the live side: the
-whitelist bounds the kinds that emit storage properties (inline), and the
-texture kind is safe by construction — a fixed getter shape with its one
-expensive readback behind the explicit digest opt-in (ADR-0035).
+whitelist bounds the Object classes whose storage properties the inline kind
+emits, and the texture kind is safe by construction — a fixed getter shape
+with its one expensive readback behind the explicit digest opt-in (ADR-0035).
 _Avoid_: value rendering, str dump, serialization, descriptor
 
 ### Failure reporting

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -186,8 +186,10 @@ fallback** for anything else. One projection shared across **every value gda
 emits** — the `get` reads (`project`/`node`/`resource get`), the value echoed by
 `node set`/`resource set`, the per-entry value of `project list` and `scene
 get-exports`, and the live `game get` read — so a value reads the same
-everywhere; the whitelist is the boundary that keeps the shared projection safe
-on the live side (ADR-0035).
+everywhere. Two controls keep the shared projection safe on the live side: the
+whitelist bounds the kinds that emit storage properties (inline), and the
+texture kind is safe by construction — a fixed getter shape with its one
+expensive readback behind the explicit digest opt-in (ADR-0035).
 _Avoid_: value rendering, str dump, serialization, descriptor
 
 ### Failure reporting

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -174,10 +174,13 @@ _Avoid_: console output, stdout dump
 The read-side contract for rendering a Godot value into the structured JSON a
 successful result carries. Scalars and the small fixed-shape value types pass
 through directly; a `Dictionary`/`Array` (and the packed-array family) projects
-recursively; and an `Object` is rendered by one of three **projection kinds** — a
+recursively; and an `Object` is rendered by one of four **projection kinds** — a
 **reference projection** for a `Resource` that has a `res://` path (named by type
 and path, never inlined — the read-side mirror of ADR-0033's write-side
-reference), an **inline value projection** for a whitelisted path-less value
+reference), a **texture projection** for a PATH-LESS `Texture2D` (named by type
+and dimensions, with the former `str()` form under `object_string` — its
+discriminator — and an opt-in content `digest`; ADR-0035 amendment, #666), an
+**inline value projection** for a whitelisted path-less value
 `Object` (named by type plus its projected fields), or a plain **string
 fallback** for anything else. One projection shared across **every value gda
 emits** — the `get` reads (`project`/`node`/`resource get`), the value echoed by

--- a/docs/adr/0035-value-projection-compound-variants-to-structured-json.md
+++ b/docs/adr/0035-value-projection-compound-variants-to-structured-json.md
@@ -138,8 +138,21 @@ get-exports`, and the live `game get` read (and any future live value-returning 
 > threads through the shared projection): computing it needs `Texture2D.get_image()`, a GPU-to-CPU
 > readback on the live side, so every ordinary read keeps it `null`. When requested it is
 > `"sha256:"` + the hex digest over the image's dimensions, format, and raw bytes; an image the
-> engine cannot read back keeps `null`. The same projection serves headless and live reads (one
+> engine cannot read back keeps `null`. The field is **required-but-nullable** — the producer
+> always emits the key. The same projection serves headless and live reads (one
 > value shape everywhere); the headless read commands do not expose the opt-in flag today — a
 > path-less texture only exists where runtime code constructed one, so on the headless side the
 > digest field is always `null`. The mirrored shared-coercion block and
 > `tests/test_harness_coercion_mirror.py` are preserved.
+>
+> Two boundary rules complete the kind. **Path-less means EMPTY**: a non-empty, non-`res://`
+> `resource_path` (a `user://` path, `take_over_path`) stays the string fallback it always was —
+> only the empty path takes this kind. **`object_string` is a reserved key**: the inline value
+> projection's exclusion list drops a whitelisted class's own storage property of that name rather
+> than copying it, so the presence-based discrimination cannot be spoofed by a custom
+> `@export var object_string`. And the live-side risk story now has **two controls, stated
+> explicitly**: the inline whitelist remains the boundary for projections that EMIT STORAGE
+> PROPERTIES (this ADR's original rule, unchanged for that kind), while the texture kind is safe by
+> CONSTRUCTION — a fixed shape read off cheap getters, with the one expensive operation
+> (`get_image()`) behind the explicit digest opt-in. The historical whitelist prose above is
+> preserved as written; it now governs the inline kind specifically.

--- a/docs/adr/0035-value-projection-compound-variants-to-structured-json.md
+++ b/docs/adr/0035-value-projection-compound-variants-to-structured-json.md
@@ -111,3 +111,35 @@ get-exports`, and the live `game get` read (and any future live value-returning 
   origin).** The deferred inline sub-resource work of ADR-0033 has a read-side counterpart here: a
   path-less inline value Object is projected (whitelisted), not referenced.
 - **`CONTEXT.md` gains the `Value projection` glossary term** in this same change.
+
+> **Amendment (2026-08-24, #666) — a fourth projection kind: the texture projection.**
+> Dogfooding GDA-DF-011: a path-less `Texture2D` (e.g. `ImageTexture.create_from_image()`, whose
+> `resource_path` is intentionally empty) fell to the string fallback — an instance ID that proves two
+> objects differ but cannot say what either shows. This amendment adds a **texture projection** for
+> path-less `Texture2D` values: `{"type": <Class>, "width": <int>, "height": <int>, "object_string":
+> "<the former str() form>", "digest": <"sha256:…" | null>}`. It revises three rules of this ADR,
+> named explicitly because the shapes are public ABI:
+>
+> 1. **"The reference projection shape `{type, resource_path}` is fixed as public ABI"** — unchanged
+>    in shape, but no longer the only projection a `Texture2D` can take: one WITH a `res://` path
+>    still projects as a reference (dimensions are NOT added to the reference shape); only a
+>    path-less one takes the new kind.
+> 2. **"The two Object projection kinds are discriminated by the presence of `resource_path`"** — the
+>    texture projection carries its own discriminator instead: the presence of **`object_string`**,
+>    which the other object shapes never emit. It does NOT emit `resource_path` (not even null), so
+>    the reference branch stays unambiguous.
+> 3. **"A curated per-type field table — rejected"** — still rejected. The texture projection is a
+>    **new projection kind** (like the reference kind, a fixed shape read off getters), not a
+>    whitelist entry: the inline kind emits storage properties, and `Texture2D`'s dimensions are
+>    getters while `ImageTexture`'s storage property is a large `image` payload — exactly the
+>    live-side risk the whitelist isolates.
+>
+> `digest` is an **explicit opt-in** (`game get --texture-digest`; the wire param `texture_digest`
+> threads through the shared projection): computing it needs `Texture2D.get_image()`, a GPU-to-CPU
+> readback on the live side, so every ordinary read keeps it `null`. When requested it is
+> `"sha256:"` + the hex digest over the image's dimensions, format, and raw bytes; an image the
+> engine cannot read back keeps `null`. The same projection serves headless and live reads (one
+> value shape everywhere); the headless read commands do not expose the opt-in flag today — a
+> path-less texture only exists where runtime code constructed one, so on the headless side the
+> digest field is always `null`. The mirrored shared-coercion block and
+> `tests/test_harness_coercion_mirror.py` are preserved.

--- a/docs/adr/0035-value-projection-compound-variants-to-structured-json.md
+++ b/docs/adr/0035-value-projection-compound-variants-to-structured-json.md
@@ -128,11 +128,13 @@ get-exports`, and the live `game get` read (and any future live value-returning 
 >    texture projection carries its own discriminator instead: the presence of **`object_string`**,
 >    which the other object shapes never emit. It does NOT emit `resource_path` (not even null), so
 >    the reference branch stays unambiguous.
-> 3. **"A curated per-type field table — rejected"** — still rejected. The texture projection is a
->    **new projection kind** (like the reference kind, a fixed shape read off getters), not a
->    whitelist entry: the inline kind emits storage properties, and `Texture2D`'s dimensions are
->    getters while `ImageTexture`'s storage property is a large `image` payload — exactly the
->    live-side risk the whitelist isolates.
+> 3. **"A curated per-type field table — rejected"** — superseded **narrowly, for this one type**,
+>    per the issue's triage decision, which this dated note records: the GENERAL curated-table
+>    mechanism (a registry of per-class field maps) remains rejected, and the fixed `Texture2D`
+>    projector is its one narrow exception — a **new projection kind** (like the reference kind, a
+>    fixed shape read off getters), not a whitelist entry: the inline kind emits storage
+>    properties, and `Texture2D`'s dimensions are getters while `ImageTexture`'s storage property
+>    is a large `image` payload — exactly the live-side risk the whitelist isolates.
 >
 > `digest` is an **explicit opt-in** (`game get --texture-digest`; the wire param `texture_digest`
 > threads through the shared projection): computing it needs `Texture2D.get_image()`, a GPU-to-CPU

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -276,7 +276,7 @@ separate headless-only contract.
 
 Whitespace around a value or a component is tolerated. A property of any other type is still
 reported by `node get` — compound values arrive structured through the shared value projection
-(ADR-0035): packed arrays project as JSON arrays, and an `Object` as a reference / inline value
+(ADR-0035): packed arrays project as JSON arrays, and an `Object` as a reference / texture / inline value
 projection or the `str()` fallback (see [`project`](#project)) — but `node set` cannot coerce to
 those remaining types yet and refuses with `uncoercible_value` unless a separate assignment contract
 below applies.
@@ -630,7 +630,11 @@ setting by its full `section/key` name (e.g. `application/config/name`) and repo
 JSON projection, the **same projection** `node get` reports for a node property. Compound values
 arrive **structured** (ADR-0035): a `Dictionary` projects to a JSON object, an `Array` or packed
 array to a JSON array, and an embedded `Object` renders as a **reference projection**
-(`{type, resource_path}` for a Resource with a `res://` path), an **inline value projection**
+(`{type, resource_path}` for a Resource with a `res://` path), a **texture projection**
+(`{type, width, height, object_string, digest}` for a PATH-LESS `Texture2D` — a runtime-created
+`ImageTexture` the reference kind cannot name; `object_string` keeps the former `str()` form and
+is the kind's discriminator, `digest` stays null unless a read opts in; ADR-0035 amendment,
+#666), an **inline value projection**
 (`{type, …storage properties}` for a whitelisted path-less value Object — `InputEvent` subclasses,
 e.g. the `InputEventKey`s of an `input/*` action), or the `str()` fallback for any other Object. A
 setting that does not exist is a clean `unknown_setting` error (exit 4), distinguishing a typo'd key
@@ -749,7 +753,10 @@ headless is unaffected (4.4+, cross-platform).
   `verified` to distinguish a matched read-back from a completed set whose value did not
   stick. When a property is explicitly named, storage properties are preferred and plain
   attached-script variables are addressable as a fallback; unfiltered `game get` keeps the
-  storage-property listing.
+  storage-property listing. `game get --texture-digest` (shipped, #666) opts a read into
+  the content digest of each PATH-LESS `Texture2D` value's **texture projection**
+  (ADR-0035 amendment): the digest needs `Texture2D.get_image()`, a GPU-to-CPU readback,
+  so without the flag the projection's `digest` field stays null.
   `game rect` (shipped, #419) reads a running
   `Control`'s rendered viewport-space rectangle via `Control.get_global_rect()`, returning
   `position` and `size` as the existing Vector2 projection. These commands address the

--- a/src/gda/commands/game.py
+++ b/src/gda/commands/game.py
@@ -99,6 +99,17 @@ class GameGetParams(BaseModel):
             "default storage-property listing."
         ),
     )
+    texture_digest: bool = Field(
+        default=False,
+        description=(
+            "Compute the content digest for each PATH-LESS Texture2D value in "
+            "this read (#666): its TextureProjection's `digest` field becomes "
+            "'sha256:' + the hex digest over the image's dimensions, format, "
+            "and raw bytes, so two same-class textures with different content "
+            "are distinguishable. Opt-in because it needs Texture2D.get_image(), "
+            "a GPU-to-CPU readback; without it the digest field stays null."
+        ),
+    )
 
 
 class GameGetResult(BaseModel):
@@ -340,6 +351,15 @@ def game_get(
             "script variable. Without it, list only the storage surface."
         ),
     ),
+    texture_digest: bool = typer.Option(
+        False,
+        "--texture-digest",
+        help=(
+            "Compute the sha256 content digest for each path-less Texture2D "
+            "value in this read (a GPU-to-CPU readback; without it the "
+            "TextureProjection's digest stays null)."
+        ),
+    ),
     json_output: bool = json_option(),
     schema: bool = GAME_GET_COMMAND.schema_option(),
     params_json: Optional[str] = params_json_option(),
@@ -356,10 +376,13 @@ def game_get(
     `live_unknown_property`. A named plain script variable on the node's attached
     script is addressable explicitly after storage properties are checked; unfiltered
     reads keep the storage-property listing and do not dump script variables.
+    A path-less Texture2D value projects as a TextureProjection ({type, width,
+    height, object_string, digest}, ADR-0035 amendment #666); `--texture-digest`
+    opts into its content digest.
     """
     dispatch_domain(
         GAME_GET_COMMAND,
-        GameGetParams(node=node, property=property),
+        GameGetParams(node=node, property=property, texture_digest=texture_digest),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/commands/game.py
+++ b/src/gda/commands/game.py
@@ -120,11 +120,15 @@ class GameGetResult(BaseModel):
     its storage properties, each a typed :class:`NodeProperty`; an explicitly named
     plain attached-script variable can also appear as the single returned property.
     Each value goes through the same recursive value projection the headless reads
-    use (ADR-0035): compound values arrive structured, and a whitelisted value Object
-    (an ``InputEvent`` subclass) as an :class:`InlineValueProjection` — while a
-    NON-whitelisted runtime Object (e.g. a live ``Node``-valued property) stays the
-    ``str()`` fallback, the whitelist being the boundary that keeps the shared
-    projection safe on the live side.
+    use (ADR-0035): compound values arrive structured; a ``res://``-pathed Resource
+    is a :class:`ReferenceProjection`, a path-less ``Texture2D`` a
+    :class:`TextureProjection` (#666), a whitelisted value Object
+    (an ``InputEvent`` subclass) an :class:`InlineValueProjection` — while any
+    other runtime Object (e.g. a live ``Node``-valued property) stays the
+    ``str()`` fallback. The whitelist bounds the Object classes whose storage
+    properties the inline kind emits; the texture kind is safe by construction
+    (a fixed getter shape, its one expensive readback behind
+    ``--texture-digest``).
     """
 
     path: str = Field(description="The addressed node's runtime (absolute) path.")

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -398,6 +398,9 @@ func _handle_game_get(params: Dictionary) -> String:
 		return _error(LIVE_ERROR_NODE_NOT_FOUND,
 				"no node at runtime path: " + path)
 
+	# The texture-digest opt-in (#666): threaded into the shared projection so
+	# a path-less Texture2D value carries its content digest on request.
+	var texture_digest := bool(params.get("texture_digest", false))
 	var wanted := _string_param(params, "property")
 	var has_filter := params.has("property") and not wanted.is_empty()
 	var properties: Array = []
@@ -410,10 +413,11 @@ func _handle_game_get(params: Dictionary) -> String:
 		properties.append({
 			"name": prop_name,
 			"type": _type_name(int(prop.get("type", TYPE_NIL))),
-			"value": _jsonify(node.get(prop_name)),
+			"value": _jsonify(node.get(prop_name), 0, texture_digest),
 		})
 	if has_filter and properties.is_empty():
-		var script_property := _explicit_script_variable_property(node, wanted)
+		var script_property := _explicit_script_variable_property(
+				node, wanted, texture_digest)
 		if not script_property.is_empty():
 			properties.append(script_property)
 	if has_filter and properties.is_empty():
@@ -428,7 +432,8 @@ func _handle_game_get(params: Dictionary) -> String:
 	})
 
 
-func _explicit_script_variable_property(node: Node, prop_name: String) -> Dictionary:
+func _explicit_script_variable_property(
+		node: Node, prop_name: String, texture_digest: bool = false) -> Dictionary:
 	for prop in node.get_property_list():
 		if String(prop.get("name", "")) != prop_name:
 			continue
@@ -442,7 +447,7 @@ func _explicit_script_variable_property(node: Node, prop_name: String) -> Dictio
 		return {
 			"name": prop_name,
 			"type": _type_name(declared_type),
-			"value": _jsonify(value),
+			"value": _jsonify(value, 0, texture_digest),
 		}
 	return {}
 
@@ -1479,7 +1484,7 @@ const JSONIFY_BOOKKEEPING_PROPS: Array[String] = [
 # its string form rather than crashing JSON.stringify on an unencodable
 # Variant, and the depth cap bounds the recursion on the compound arms — so
 # the projection is always JSON-encodable.
-func _jsonify(value: Variant, depth: int = 0) -> Variant:
+func _jsonify(value: Variant, depth: int = 0, texture_digest: bool = false) -> Variant:
 	match typeof(value):
 		TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING, TYPE_STRING_NAME:
 			return value
@@ -1499,7 +1504,7 @@ func _jsonify(value: Variant, depth: int = 0) -> Variant:
 			# keys that collide after stringification resolve last-wins by
 			# assignment order (deterministic, ADR-0035).
 			for key in value.keys():
-				out[str(key)] = _jsonify(value[key], depth + 1)
+				out[str(key)] = _jsonify(value[key], depth + 1, texture_digest)
 			return out
 		TYPE_ARRAY, TYPE_PACKED_BYTE_ARRAY, TYPE_PACKED_INT32_ARRAY, \
 		TYPE_PACKED_INT64_ARRAY, TYPE_PACKED_FLOAT32_ARRAY, \
@@ -1513,7 +1518,7 @@ func _jsonify(value: Variant, depth: int = 0) -> Variant:
 			# [x, y]; an element type with no structured arm of its own (e.g.
 			# Vector3) stays str(), per the fixed-shape list above.
 			for element in value:
-				items.append(_jsonify(element, depth + 1))
+				items.append(_jsonify(element, depth + 1, texture_digest))
 			return items
 		TYPE_OBJECT:
 			# A freed live Object (harness side) must not be introspected.
@@ -1527,6 +1532,38 @@ func _jsonify(value: Variant, depth: int = 0) -> Variant:
 			# counts as a reference too.
 			if value is Resource and String(value.resource_path).begins_with("res://"):
 				return {"type": value.get_class(), "resource_path": value.resource_path}
+			# Texture projection (#666, ADR-0035 amendment): a PATH-LESS Texture2D
+			# — a runtime-created texture (ImageTexture.create_from_image) has no
+			# res:// path, so the reference arm above cannot name it and the string
+			# fallback's instance ID cannot say what it shows. A fixed shape read
+			# off cheap getters: class + dimensions. `object_string` keeps the old
+			# str() form as secondary diagnostics and is this kind's DISCRIMINATOR
+			# (no other object shape emits it; `resource_path` stays
+			# reference-only, not even null here). `digest` is opt-in
+			# (texture_digest): get_image() is a GPU-to-CPU readback on the live
+			# side, not a price every read should pay; an image the engine cannot
+			# read back keeps digest null. Dimensions and format prefix the hashed
+			# bytes so same-bytes textures of different shapes do not collide.
+			if value is Texture2D:
+				var texture_projection := {
+					"type": value.get_class(),
+					"width": value.get_width(),
+					"height": value.get_height(),
+					"object_string": str(value),
+					"digest": null,
+				}
+				if texture_digest:
+					var image: Image = value.get_image()
+					if image != null and not image.is_empty():
+						var ctx := HashingContext.new()
+						if ctx.start(HashingContext.HASH_SHA256) == OK:
+							var shape := "%dx%d:%d:" % [
+								image.get_width(), image.get_height(), image.get_format(),
+							]
+							ctx.update(shape.to_utf8_buffer())
+							ctx.update(image.get_data())
+							texture_projection["digest"] = "sha256:" + ctx.finish().hex_encode()
+				return texture_projection
 			# Inline value projection: a whitelisted path-less value Object
 			# (InputEvent subclasses initially) projects its own storage
 			# properties. The whitelist is the risk-isolation boundary that
@@ -1540,7 +1577,7 @@ func _jsonify(value: Variant, depth: int = 0) -> Variant:
 					var prop_name := String(prop.get("name", ""))
 					if prop_name in JSONIFY_BOOKKEEPING_PROPS:
 						continue
-					projected[prop_name] = _jsonify(value.get(prop_name), depth + 1)
+					projected[prop_name] = _jsonify(value.get(prop_name), depth + 1, texture_digest)
 				# Assigned AFTER the loop so the discriminator shadows a
 				# storage property named "type" (ADR-0035 documents the
 				# shadowing — order matters).

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -1464,12 +1464,17 @@ func _type_name(type: int) -> String:
 # the backstop against a pathological self-referential Dictionary live-side.
 const JSONIFY_MAX_DEPTH := 16
 
-# The Object/Resource base bookkeeping properties an inline value projection
-# excludes (ADR-0035): every InputEvent IS a Resource, so without the exclusion
-# a path-less value Object would emit an empty resource_path and masquerade as
-# a reference projection; the exclusion also drops noise.
+# The properties an inline value projection excludes (ADR-0035): the
+# Object/Resource base bookkeeping — every InputEvent IS a Resource, so
+# without the exclusion a path-less value Object would emit an empty
+# resource_path and masquerade as a reference projection (and the rest is
+# noise) — plus the RESERVED discriminator key `object_string` (#666): only
+# the texture projection emits it, so an inline class's own storage property
+# of that name is dropped, not copied — otherwise a presence-based consumer
+# would misclassify the inline projection as a texture.
 const JSONIFY_BOOKKEEPING_PROPS: Array[String] = [
 	"resource_path", "resource_name", "resource_local_to_scene", "script",
+	"object_string",
 ]
 
 # The read-side Value projection (ADR-0035, grown from issue #55): render a
@@ -1535,8 +1540,10 @@ func _jsonify(value: Variant, depth: int = 0, texture_digest: bool = false) -> V
 			# Texture projection (#666, ADR-0035 amendment): a PATH-LESS Texture2D
 			# — a runtime-created texture (ImageTexture.create_from_image) has no
 			# res:// path, so the reference arm above cannot name it and the string
-			# fallback's instance ID cannot say what it shows. A fixed shape read
-			# off cheap getters: class + dimensions. `object_string` keeps the old
+			# fallback's instance ID cannot say what it shows. PATH-LESS only:
+			# a non-empty, non-res:// path (user://, take_over_path) stays the
+			# string fallback it always was — #666's scope is the empty path. A
+			# fixed shape read off cheap getters: class + dimensions. `object_string` keeps the old
 			# str() form as secondary diagnostics and is this kind's DISCRIMINATOR
 			# (no other object shape emits it; `resource_path` stays
 			# reference-only, not even null here). `digest` is opt-in
@@ -1544,7 +1551,7 @@ func _jsonify(value: Variant, depth: int = 0, texture_digest: bool = false) -> V
 			# side, not a price every read should pay; an image the engine cannot
 			# read back keeps digest null. Dimensions and format prefix the hashed
 			# bytes so same-bytes textures of different shapes do not collide.
-			if value is Texture2D:
+			if value is Texture2D and String(value.resource_path).is_empty():
 				var texture_projection := {
 					"type": value.get_class(),
 					"width": value.get_width(),

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -87,7 +87,7 @@ HARNESS_ADDONS_RES_PATH = f"res://{HARNESS_ADDONS_DIR}"
 # copy to it (#225). The installed copy declares its version in a leading header
 # (`# gda-harness-version: <N>`); a mismatch re-materializes via the content
 # compare. NOT the package version — the harness changes far less often.
-HARNESS_VERSION = "7"
+HARNESS_VERSION = "8"
 
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -544,10 +544,12 @@ VALUE_PROJECTION_DESC = (
     "object for a Dictionary (keys stringified); a JSON array for an Array "
     "or packed array (elements re-projected). An Object value renders as a "
     "ReferenceProjection ({type, resource_path}) for a Resource with a "
-    "res:// path, an InlineValueProjection ({type, …storage properties}) "
-    "for a whitelisted path-less value Object (InputEvent subclasses), or "
-    "its str() form for any other Object — branch on the presence of "
-    "resource_path."
+    "res:// path, a TextureProjection ({type, width, height, object_string, "
+    "digest}) for a PATH-LESS Texture2D (#666), an InlineValueProjection "
+    "({type, …storage properties}) for a whitelisted path-less value Object "
+    "(InputEvent subclasses), or its str() form for any other Object — "
+    "branch on the presence of resource_path (reference) or object_string "
+    "(texture)."
 )
 
 # The set-echo variant: the set commands echo the value they set through the
@@ -651,6 +653,39 @@ class InlineValueProjection(BaseModel):
     )
 
 
+class TextureProjection(BaseModel):
+    """A path-less ``Texture2D`` value named by class and dimensions (#666).
+
+    The fourth projection kind (ADR-0035 amendment): a runtime-created texture
+    (``ImageTexture.create_from_image()``) has no ``res://`` path, so the
+    reference kind cannot name it and the string fallback's instance ID cannot
+    say what it shows. Discriminated by the PRESENCE of ``object_string`` —
+    the other object shapes never emit it, and this shape never emits
+    ``resource_path`` (not even null), so the reference branch stays
+    unambiguous. ``digest`` stays null unless the read opted in
+    (``game get --texture-digest``): computing it needs
+    ``Texture2D.get_image()``, a GPU-to-CPU readback on the live side.
+    """
+
+    type: str = Field(description="The texture's engine class (e.g. ImageTexture).")
+    width: int = Field(description="The texture's width in pixels.")
+    height: int = Field(description="The texture's height in pixels.")
+    object_string: str = Field(
+        description=(
+            "The former str() form (class + instance ID), kept as secondary "
+            "diagnostics; its presence is this kind's discriminator."
+        )
+    )
+    digest: str | None = Field(
+        default=None,
+        description=(
+            "'sha256:' + the hex digest over the image's dimensions, format, "
+            "and raw bytes — null unless the read opted in (--texture-digest) "
+            "or when the engine cannot read the image back."
+        ),
+    )
+
+
 def projected_value_schema_extra(schema: dict[str, Any]) -> None:
     """Attach the named Object-projection shapes to a projected ``value`` field.
 
@@ -658,12 +693,13 @@ def projected_value_schema_extra(schema: dict[str, Any]) -> None:
     the ADR-0035 bounded exception to ADR-0004 — so the stable projection
     shapes cannot ride along as the field's type (a union would materialize
     matching dicts as model instances and change the runtime payload).
-    Attaching their schemas as the field's ``$defs`` keeps ReferenceProjection
-    and InlineValueProjection named and consumable in every emitted command
-    schema (``--schema`` / gda-mcp) instead of prose-only.
+    Attaching their schemas as the field's ``$defs`` keeps ReferenceProjection,
+    TextureProjection, and InlineValueProjection named and consumable in every
+    emitted command schema (``--schema`` / gda-mcp) instead of prose-only.
     """
     schema["$defs"] = {
         "ReferenceProjection": ReferenceProjection.model_json_schema(),
+        "TextureProjection": TextureProjection.model_json_schema(),
         "InlineValueProjection": InlineValueProjection.model_json_schema(),
     }
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -641,8 +641,11 @@ class InlineValueProjection(BaseModel):
     properties, each re-projected>}``. The ``Object``/``Resource`` base
     bookkeeping (``resource_path``, ``resource_name``,
     ``resource_local_to_scene``, ``script``) is excluded — so an inline
-    projection never masquerades as a :class:`ReferenceProjection` — and the
-    ``type`` discriminator is assigned last, shadowing any storage property of
+    projection never masquerades as a :class:`ReferenceProjection` — and so is
+    the RESERVED key ``object_string`` (#666): only a
+    :class:`TextureProjection` emits it, so an inline class's own storage
+    property of that name is dropped rather than copied. The ``type``
+    discriminator is assigned last, shadowing any storage property of
     that name. The storage properties vary per class, hence ``extra="allow"``.
     """
 
@@ -677,11 +680,11 @@ class TextureProjection(BaseModel):
         )
     )
     digest: str | None = Field(
-        default=None,
         description=(
             "'sha256:' + the hex digest over the image's dimensions, format, "
-            "and raw bytes — null unless the read opted in (--texture-digest) "
-            "or when the engine cannot read the image back."
+            "and raw bytes — always PRESENT, and null unless the read opted "
+            "in (--texture-digest) or when the engine cannot read the image "
+            "back (required-but-nullable: the producer always emits the key)."
         ),
     )
 

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -718,8 +718,8 @@ class NodeProperty(BaseModel):
     value projection (ADR-0035) — left as arbitrary JSON so every Godot type
     is carried uniformly through one field: a scalar stays a scalar, a Vector2
     becomes ``[x, y]``, a Dictionary a JSON object, an Object a
-    :class:`ReferenceProjection` / :class:`InlineValueProjection` / ``str()``
-    fallback.
+    :class:`ReferenceProjection` / :class:`TextureProjection` /
+    :class:`InlineValueProjection` / ``str()`` fallback.
     """
 
     name: str

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -535,8 +535,9 @@ NormalizedPath = Annotated[str, AfterValidator(normalize_path)]
 # (ADR-0035): the shared field description for the dynamically-shaped `value`
 # fields. The field itself stays `Any` — a value's shape is not statically
 # knowable, a deliberate, bounded exception to ADR-0004's model-driven-output
-# rule — so the stable parts are surfaced here and by the two named projection
-# models (ReferenceProjection / InlineValueProjection) below.
+# rule — so the stable parts are surfaced here and by the three named
+# projection models (ReferenceProjection / TextureProjection /
+# InlineValueProjection) below.
 VALUE_PROJECTION_DESC = (
     "Rendered through the one recursive read-side value projection "
     "(ADR-0035): a scalar for a scalar type; a flat number list for a "

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -5425,12 +5425,17 @@ func _type_name(type: int) -> String:
 # the backstop against a pathological self-referential Dictionary live-side.
 const JSONIFY_MAX_DEPTH := 16
 
-# The Object/Resource base bookkeeping properties an inline value projection
-# excludes (ADR-0035): every InputEvent IS a Resource, so without the exclusion
-# a path-less value Object would emit an empty resource_path and masquerade as
-# a reference projection; the exclusion also drops noise.
+# The properties an inline value projection excludes (ADR-0035): the
+# Object/Resource base bookkeeping — every InputEvent IS a Resource, so
+# without the exclusion a path-less value Object would emit an empty
+# resource_path and masquerade as a reference projection (and the rest is
+# noise) — plus the RESERVED discriminator key `object_string` (#666): only
+# the texture projection emits it, so an inline class's own storage property
+# of that name is dropped, not copied — otherwise a presence-based consumer
+# would misclassify the inline projection as a texture.
 const JSONIFY_BOOKKEEPING_PROPS: Array[String] = [
 	"resource_path", "resource_name", "resource_local_to_scene", "script",
+	"object_string",
 ]
 
 # The read-side Value projection (ADR-0035, grown from issue #55): render a
@@ -5496,8 +5501,10 @@ func _jsonify(value: Variant, depth: int = 0, texture_digest: bool = false) -> V
 			# Texture projection (#666, ADR-0035 amendment): a PATH-LESS Texture2D
 			# — a runtime-created texture (ImageTexture.create_from_image) has no
 			# res:// path, so the reference arm above cannot name it and the string
-			# fallback's instance ID cannot say what it shows. A fixed shape read
-			# off cheap getters: class + dimensions. `object_string` keeps the old
+			# fallback's instance ID cannot say what it shows. PATH-LESS only:
+			# a non-empty, non-res:// path (user://, take_over_path) stays the
+			# string fallback it always was — #666's scope is the empty path. A
+			# fixed shape read off cheap getters: class + dimensions. `object_string` keeps the old
 			# str() form as secondary diagnostics and is this kind's DISCRIMINATOR
 			# (no other object shape emits it; `resource_path` stays
 			# reference-only, not even null here). `digest` is opt-in
@@ -5505,7 +5512,7 @@ func _jsonify(value: Variant, depth: int = 0, texture_digest: bool = false) -> V
 			# side, not a price every read should pay; an image the engine cannot
 			# read back keeps digest null. Dimensions and format prefix the hashed
 			# bytes so same-bytes textures of different shapes do not collide.
-			if value is Texture2D:
+			if value is Texture2D and String(value.resource_path).is_empty():
 				var texture_projection := {
 					"type": value.get_class(),
 					"width": value.get_width(),

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -5445,7 +5445,7 @@ const JSONIFY_BOOKKEEPING_PROPS: Array[String] = [
 # its string form rather than crashing JSON.stringify on an unencodable
 # Variant, and the depth cap bounds the recursion on the compound arms — so
 # the projection is always JSON-encodable.
-func _jsonify(value: Variant, depth: int = 0) -> Variant:
+func _jsonify(value: Variant, depth: int = 0, texture_digest: bool = false) -> Variant:
 	match typeof(value):
 		TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING, TYPE_STRING_NAME:
 			return value
@@ -5465,7 +5465,7 @@ func _jsonify(value: Variant, depth: int = 0) -> Variant:
 			# keys that collide after stringification resolve last-wins by
 			# assignment order (deterministic, ADR-0035).
 			for key in value.keys():
-				out[str(key)] = _jsonify(value[key], depth + 1)
+				out[str(key)] = _jsonify(value[key], depth + 1, texture_digest)
 			return out
 		TYPE_ARRAY, TYPE_PACKED_BYTE_ARRAY, TYPE_PACKED_INT32_ARRAY, \
 		TYPE_PACKED_INT64_ARRAY, TYPE_PACKED_FLOAT32_ARRAY, \
@@ -5479,7 +5479,7 @@ func _jsonify(value: Variant, depth: int = 0) -> Variant:
 			# [x, y]; an element type with no structured arm of its own (e.g.
 			# Vector3) stays str(), per the fixed-shape list above.
 			for element in value:
-				items.append(_jsonify(element, depth + 1))
+				items.append(_jsonify(element, depth + 1, texture_digest))
 			return items
 		TYPE_OBJECT:
 			# A freed live Object (harness side) must not be introspected.
@@ -5493,6 +5493,38 @@ func _jsonify(value: Variant, depth: int = 0) -> Variant:
 			# counts as a reference too.
 			if value is Resource and String(value.resource_path).begins_with("res://"):
 				return {"type": value.get_class(), "resource_path": value.resource_path}
+			# Texture projection (#666, ADR-0035 amendment): a PATH-LESS Texture2D
+			# — a runtime-created texture (ImageTexture.create_from_image) has no
+			# res:// path, so the reference arm above cannot name it and the string
+			# fallback's instance ID cannot say what it shows. A fixed shape read
+			# off cheap getters: class + dimensions. `object_string` keeps the old
+			# str() form as secondary diagnostics and is this kind's DISCRIMINATOR
+			# (no other object shape emits it; `resource_path` stays
+			# reference-only, not even null here). `digest` is opt-in
+			# (texture_digest): get_image() is a GPU-to-CPU readback on the live
+			# side, not a price every read should pay; an image the engine cannot
+			# read back keeps digest null. Dimensions and format prefix the hashed
+			# bytes so same-bytes textures of different shapes do not collide.
+			if value is Texture2D:
+				var texture_projection := {
+					"type": value.get_class(),
+					"width": value.get_width(),
+					"height": value.get_height(),
+					"object_string": str(value),
+					"digest": null,
+				}
+				if texture_digest:
+					var image: Image = value.get_image()
+					if image != null and not image.is_empty():
+						var ctx := HashingContext.new()
+						if ctx.start(HashingContext.HASH_SHA256) == OK:
+							var shape := "%dx%d:%d:" % [
+								image.get_width(), image.get_height(), image.get_format(),
+							]
+							ctx.update(shape.to_utf8_buffer())
+							ctx.update(image.get_data())
+							texture_projection["digest"] = "sha256:" + ctx.finish().hex_encode()
+				return texture_projection
 			# Inline value projection: a whitelisted path-less value Object
 			# (InputEvent subclasses initially) projects its own storage
 			# properties. The whitelist is the risk-isolation boundary that
@@ -5506,7 +5538,7 @@ func _jsonify(value: Variant, depth: int = 0) -> Variant:
 					var prop_name := String(prop.get("name", ""))
 					if prop_name in JSONIFY_BOOKKEEPING_PROPS:
 						continue
-					projected[prop_name] = _jsonify(value.get(prop_name), depth + 1)
+					projected[prop_name] = _jsonify(value.get(prop_name), depth + 1, texture_digest)
 				# Assigned AFTER the loop so the discriminator shadows a
 				# storage property named "type" (ADR-0035 documents the
 				# shadowing — order matters).

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -168,7 +168,7 @@ already-running daemon's lazy Engine-session launch; only the outer
 | Group | Commands |
 | ----- | -------- |
 | `daemon` | `start`, `wait-ready`, `stop`, `status`, `install`, `uninstall` (lifecycle; `start` installs the in-game harness itself, so `install` is only for doing that step deliberately — e.g. to review or commit the `project.godot` change — and `uninstall` reverses it; `wait-ready` establishes the lazily-launched engine session, with `--timeout` shared by its waits and new-work decisions, so a first `diag errors` serves instead of reporting `engine_session_not_running`) |
-| `game` | `tree`, `get`, `rect`, `set` (the running game's runtime scene graph) |
+| `game` | `tree`, `get`, `rect`, `set` (the running game's runtime scene graph; `get --texture-digest` opts a read into content digests for path-less `Texture2D` values) |
 | `diag` | `errors` (structured runtime errors with callstacks; survive a crash) |
 | `logger` | `tail` (the running game's structured log stream; `--raw` for verbatim lines, `--level <min>` to filter by severity, `--limit N`) |
 | `perf` | `monitors`, `monitor` (counters: a one-frame snapshot, or with `--frames` a bounded window with statistics and optional `--budget` verdicts / a per-node timeline) |

--- a/tests/test_e2e_game.py
+++ b/tests/test_e2e_game.py
@@ -37,3 +37,102 @@ def test_game_tree_without_a_daemon_reports_daemon_not_running(tmp_path):
     assert error["code"] == "daemon_not_running"
     assert error["category"] == "live"
     assert "gda daemon start" in error["message"]
+
+
+# A Player that builds PATH-LESS ImageTextures at runtime (#666): two with
+# different content and a third repeating the first's, so the digest opt-in can
+# prove distinguishability AND stability. Deliberately path-less — the exact
+# GDA-DF-011 shape the string fallback could not identify.
+TEXTURE_PLAYER_GD = (
+    "extends Node2D\n"
+    "@export var tex_a: Texture2D\n"
+    "@export var tex_b: Texture2D\n"
+    "@export var tex_a2: Texture2D\n"
+    "func _ready() -> void:\n"
+    "\ttex_a = _make(Color.RED)\n"
+    "\ttex_b = _make(Color.BLUE)\n"
+    "\ttex_a2 = _make(Color.RED)\n"
+    "func _make(c: Color) -> ImageTexture:\n"
+    "\tvar img := Image.create(2, 3, false, Image.FORMAT_RGBA8)\n"
+    "\timg.fill(c)\n"
+    "\treturn ImageTexture.create_from_image(img)\n"
+)
+TEXTURE_MAIN_TSCN = (
+    "[gd_scene load_steps=2 format=3]\n\n"
+    '[ext_resource type="Script" path="res://player.gd" id="1"]\n\n'
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="Player" type="Node2D" parent="."]\n'
+    'script = ExtResource("1")\n'
+)
+
+
+@pytest.mark.e2e
+def test_game_get_projects_a_path_less_texture_with_optional_digest(
+    tmp_path, daemon_runtime_dir
+):
+    # The #666 DoD (GDA-DF-011): a live `game get` on a path-less ImageTexture
+    # returns the TextureProjection — type + dimensions, the old str() form
+    # under object_string, NO resource_path key — with digest null by default;
+    # with --texture-digest, two same-class textures with different content
+    # get different digests and same-content textures the same one.
+    from .conftest import project_godot
+
+    (tmp_path / "project.godot").write_text(
+        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
+    )
+    (tmp_path / "main.tscn").write_text(TEXTURE_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "player.gd").write_text(TEXTURE_PLAYER_GD, encoding="utf-8")
+
+    from gda.binary import resolve_godot_binary
+
+    godot = resolve_godot_binary()
+    env = {**os.environ}
+
+    def run(*args):
+        return subprocess.run(
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(tmp_path),
+                "--godot",
+                str(godot),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=90,
+        )
+
+    def texture_value(prop, *extra):
+        got = run("game", "get", "/root/Main/Player", "--property", prop, *extra)
+        assert got.returncode == 0, got.stdout + got.stderr
+        return next(
+            p for p in json.loads(got.stdout)["properties"] if p["name"] == prop
+        )["value"]
+
+    try:
+        assert run("daemon", "start").returncode == 0
+
+        # Without the opt-in: the projection names the texture, digest stays
+        # null, and the readback is never paid.
+        plain = texture_value("tex_a")
+        assert plain["type"] == "ImageTexture"
+        assert plain["width"] == 2
+        assert plain["height"] == 3
+        assert "ImageTexture" in plain["object_string"]
+        assert plain["digest"] is None
+        assert "resource_path" not in plain
+
+        # With the opt-in: different content, different digest; same content,
+        # the same digest — the identity GDA-DF-011 could not establish.
+        tex_a = texture_value("tex_a", "--texture-digest")
+        tex_b = texture_value("tex_b", "--texture-digest")
+        tex_a2 = texture_value("tex_a2", "--texture-digest")
+        assert tex_a["digest"].startswith("sha256:")
+        assert tex_b["digest"].startswith("sha256:")
+        assert tex_a["digest"] != tex_b["digest"]
+        assert tex_a2["digest"] == tex_a["digest"]
+    finally:
+        run("daemon", "stop")

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -3225,3 +3225,85 @@ def test_node_get_projects_a_path_less_texture_headless(godot_project):
     assert "ImageTexture" in value["object_string"]
     assert value["digest"] is None
     assert "resource_path" not in value
+
+
+@pytest.mark.e2e
+def test_node_get_keeps_non_res_pathed_textures_on_the_string_fallback(godot_project):
+    # The #736 review's boundary probe: #666's scope is the EMPTY path. A
+    # texture that acquired a non-res:// path (take_over_path("user://…"))
+    # stays the string fallback it always was — the texture projection must
+    # not widen past path-less.
+    (godot_project / "holder.gd").write_text(
+        "extends Node2D\n"
+        "@export var tex: Texture2D\n"
+        "func _init() -> void:\n"
+        "\tvar img := Image.create(2, 2, false, Image.FORMAT_RGBA8)\n"
+        "\timg.fill(Color.RED)\n"
+        "\tvar owned := ImageTexture.create_from_image(img)\n"
+        '\towned.take_over_path("user://owned-texture")\n'
+        "\ttex = owned\n",
+        encoding="utf-8",
+    )
+    scene_path = godot_project / "main.tscn"
+    scene_path.write_text(
+        "[gd_scene load_steps=2 format=3]\n\n"
+        '[ext_resource type="Script" path="res://holder.gd" id="1"]\n\n'
+        '[node name="Main" type="Node2D"]\n'
+        'script = ExtResource("1")\n',
+        encoding="utf-8",
+    )
+
+    gda = _gda_project(godot_project)
+    got = gda("node", "get", "res://main.tscn", "--node", ".", "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    value = next(p for p in json.loads(got.stdout)["properties"] if p["name"] == "tex")[
+        "value"
+    ]
+    assert isinstance(value, str), value
+    assert "ImageTexture" in value
+
+
+@pytest.mark.e2e
+def test_inline_projection_drops_a_storage_property_named_object_string(
+    godot_project,
+):
+    # The #736 review's spoof probe: `object_string` is the texture kind's
+    # presence-based discriminator, so the inline projection must DROP a
+    # whitelisted class's own storage property of that name rather than copy
+    # it — otherwise this custom InputEvent would masquerade as a texture.
+    (godot_project / "my_event.gd").write_text(
+        "extends InputEventAction\n"
+        '@export var object_string: String = "boom"\n'
+        "@export var honest_field: int = 7\n",
+        encoding="utf-8",
+    )
+    (godot_project / "holder.gd").write_text(
+        "extends Node2D\n"
+        "@export var ev: InputEvent\n"
+        "func _init() -> void:\n"
+        '\tev = load("res://my_event.gd").new()\n',
+        encoding="utf-8",
+    )
+    scene_path = godot_project / "main.tscn"
+    scene_path.write_text(
+        "[gd_scene load_steps=2 format=3]\n\n"
+        '[ext_resource type="Script" path="res://holder.gd" id="1"]\n\n'
+        '[node name="Main" type="Node2D"]\n'
+        'script = ExtResource("1")\n',
+        encoding="utf-8",
+    )
+
+    gda = _gda_project(godot_project)
+    got = gda("node", "get", "res://main.tscn", "--node", ".", "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    value = next(p for p in json.loads(got.stdout)["properties"] if p["name"] == "ev")[
+        "value"
+    ]
+    # An inline projection: its own honest storage property survives, the
+    # reserved discriminator does not, and no texture fields appear.
+    assert value["type"] == "InputEventAction"
+    assert value["honest_field"] == 7
+    assert "object_string" not in value
+    assert "width" not in value and "digest" not in value

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -3183,3 +3183,45 @@ def test_node_add_with_external_edit_during_instantiate_yields_file_changed_exte
     assert _no_gda_temp_siblings(godot_project), sorted(
         p.name for p in godot_project.rglob(".gda-*")
     )
+
+
+@pytest.mark.e2e
+def test_node_get_projects_a_path_less_texture_headless(godot_project):
+    # The #666 headless leg: the SAME texture projection serves headless reads
+    # (one value shape everywhere, ADR-0035). A script's _init constructs a
+    # PATH-LESS ImageTexture into an @export var; `node get` instantiates the
+    # scene (the ADR-0009 project-code execution surface), so the read value is
+    # the runtime-constructed texture — type + dimensions, the old str() form
+    # under object_string, digest null (the opt-in flag is live-only today),
+    # and NO resource_path key.
+    (godot_project / "holder.gd").write_text(
+        "extends Node2D\n"
+        "@export var tex: Texture2D\n"
+        "func _init() -> void:\n"
+        "\tvar img := Image.create(4, 5, false, Image.FORMAT_RGBA8)\n"
+        "\timg.fill(Color.GREEN)\n"
+        "\ttex = ImageTexture.create_from_image(img)\n",
+        encoding="utf-8",
+    )
+    scene_path = godot_project / "main.tscn"
+    scene_path.write_text(
+        "[gd_scene load_steps=2 format=3]\n\n"
+        '[ext_resource type="Script" path="res://holder.gd" id="1"]\n\n'
+        '[node name="Main" type="Node2D"]\n'
+        'script = ExtResource("1")\n',
+        encoding="utf-8",
+    )
+
+    gda = _gda_project(godot_project)
+    got = gda("node", "get", "res://main.tscn", "--node", ".", "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    value = next(p for p in json.loads(got.stdout)["properties"] if p["name"] == "tex")[
+        "value"
+    ]
+    assert value["type"] == "ImageTexture"
+    assert value["width"] == 4
+    assert value["height"] == 5
+    assert "ImageTexture" in value["object_string"]
+    assert value["digest"] is None
+    assert "resource_path" not in value

--- a/tests/test_game_commands.py
+++ b/tests/test_game_commands.py
@@ -128,7 +128,12 @@ def test_game_get_emits_runtime_properties_through_the_live_channel(
     assert {p["name"] for p in data["properties"]} == {"position", "visible"}
     # Routed through the LIVE seam, dispatching game-get with the node arg; the
     # optional property is absent (read the whole surface).
-    assert fake.calls == [("game-get", {"node": "/root/Main/Player", "property": None})]
+    assert fake.calls == [
+        (
+            "game-get",
+            {"node": "/root/Main/Player", "property": None, "texture_digest": False},
+        )
+    ]
 
 
 def test_game_get_passes_the_property_filter_through_the_live_channel(
@@ -156,8 +161,72 @@ def test_game_get_passes_the_property_filter_through_the_live_channel(
     assert result.exit_code == 0, result.stdout + result.stderr
     # The filter is threaded to the operation params (the harness applies it).
     assert fake.calls == [
-        ("game-get", {"node": "/root/Main/Player", "property": "position"})
+        (
+            "game-get",
+            {
+                "node": "/root/Main/Player",
+                "property": "position",
+                "texture_digest": False,
+            },
+        )
     ]
+
+
+def test_game_get_threads_the_texture_digest_opt_in(monkeypatch, tmp_path):
+    # The #666 digest opt-in: --texture-digest rides the wire to the harness,
+    # which threads it into the shared value projection; without the flag the
+    # TextureProjection's digest field stays null (the GPU-to-CPU readback is
+    # never paid silently).
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(GAME_GET_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "game",
+            "get",
+            "/root/Main/Player",
+            "--property",
+            "sprite_texture",
+            "--texture-digest",
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert fake.calls == [
+        (
+            "game-get",
+            {
+                "node": "/root/Main/Player",
+                "property": "sprite_texture",
+                "texture_digest": True,
+            },
+        )
+    ]
+
+
+def test_game_get_schema_names_the_texture_projection(monkeypatch):
+    # The TextureProjection shape is published beside the other named
+    # projection kinds in the value field's $defs (ADR-0035 amendment #666),
+    # so a schema client learns the shape without invoking gda.
+    result = CliRunner().invoke(app, ["game", "get", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    schema = json.loads(result.stdout)
+    defs = schema["output"]["$defs"]["NodeProperty"]["properties"]["value"]["$defs"]
+    assert set(defs) >= {
+        "ReferenceProjection",
+        "TextureProjection",
+        "InlineValueProjection",
+    }
+    texture = defs["TextureProjection"]["properties"]
+    assert set(texture) == {"type", "width", "height", "object_string", "digest"}
+    assert "resource_path" not in texture
 
 
 def test_game_get_missing_node_reports_live_node_not_found(monkeypatch, tmp_path):

--- a/tests/test_game_commands.py
+++ b/tests/test_game_commands.py
@@ -227,6 +227,18 @@ def test_game_get_schema_names_the_texture_projection(monkeypatch):
     texture = defs["TextureProjection"]["properties"]
     assert set(texture) == {"type", "width", "height", "object_string", "digest"}
     assert "resource_path" not in texture
+    # digest is required-but-nullable (#736 review): the producer always emits
+    # the key, so a payload missing it must fail the published shape — while
+    # null stays a legal value (the opt-in absent, or readback unavailable).
+    assert set(defs["TextureProjection"]["required"]) == {
+        "type",
+        "width",
+        "height",
+        "object_string",
+        "digest",
+    }
+    digest_branch = defs["TextureProjection"]["properties"]["digest"]["anyOf"]
+    assert {"type": "null"} in digest_branch
 
 
 def test_game_get_missing_node_reports_live_node_not_found(monkeypatch, tmp_path):

--- a/tests/test_harness_install.py
+++ b/tests/test_harness_install.py
@@ -795,3 +795,43 @@ def test_ready_gates_on_template_feature_as_its_first_statement():
             break
     assert body[0] == 'if OS.has_feature("template"):', body
     assert body[1] == "return", body
+
+
+# The bundled harness bytes, PINNED to the version that declares them (#736
+# review follow-up). W4 changed gda_harness.gd three times (#732, #735, #736)
+# while HARNESS_VERSION stayed "7": the sync path never noticed, because its
+# decision is a CONTENT compare — which is exactly why the omission was silent.
+# This pin makes it loud. Updating it is part of every harness change:
+#   1. edit gda_harness.gd;
+#   2. bump HARNESS_VERSION in src/gda/harness/install.py;
+#   3. update BOTH pins below (the test's failure message carries the new hash).
+PINNED_HARNESS_VERSION = "8"
+PINNED_HARNESS_SHA256 = (
+    "cd1993632ba8eb308c9a2990d9a5c2570aa6bbbcc0e2e5f5845213e024d867aa"
+)
+
+
+def test_bundled_harness_bytes_are_pinned_to_the_declared_version():
+    # Two failure directions, each with its own instruction:
+    # - the harness bytes changed but HARNESS_VERSION did not -> the hash
+    #   mismatches: bump the version AND re-pin;
+    # - HARNESS_VERSION was bumped but this pin was not -> the version
+    #   mismatches: re-pin to the new (version, hash) pair.
+    import hashlib
+    from pathlib import Path
+
+    from gda.harness import install
+
+    bundled = Path(install.__file__).parent / HARNESS_FILE
+    digest = hashlib.sha256(bundled.read_bytes()).hexdigest()
+
+    assert HARNESS_VERSION == PINNED_HARNESS_VERSION, (
+        f"HARNESS_VERSION is {HARNESS_VERSION!r} but this pin says "
+        f"{PINNED_HARNESS_VERSION!r}: update PINNED_HARNESS_VERSION and "
+        f"PINNED_HARNESS_SHA256 (current bytes: {digest})."
+    )
+    assert digest == PINNED_HARNESS_SHA256, (
+        f"the bundled gda_harness.gd changed (sha256 {digest}) without a "
+        "version bump: bump HARNESS_VERSION in src/gda/harness/install.py and "
+        "update PINNED_HARNESS_VERSION / PINNED_HARNESS_SHA256 in this file."
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -61,6 +61,7 @@ from gda.models import (
     InlineValueProjection,
     NodeProperty,
     ReferenceProjection,
+    TextureProjection,
 )
 
 
@@ -1433,5 +1434,6 @@ def test_every_projected_value_field_exposes_the_named_projection_defs():
         defs = schema["properties"]["value"]["$defs"]
         assert defs == {
             "ReferenceProjection": ReferenceProjection.model_json_schema(),
+            "TextureProjection": TextureProjection.model_json_schema(),
             "InlineValueProjection": InlineValueProjection.model_json_schema(),
         }, model.__name__

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -644,7 +644,11 @@ def test_project_get_schema_emits_model_derived_contract_without_other_args():
     # The emitted command schema exposes the named Object-projection shapes on
     # the Any-typed value field (ADR-0035 → ADR-0004), not prose alone.
     value_defs = doc["output"]["properties"]["value"]["$defs"]
-    assert set(value_defs) == {"ReferenceProjection", "InlineValueProjection"}
+    assert set(value_defs) == {
+        "ReferenceProjection",
+        "TextureProjection",
+        "InlineValueProjection",
+    }
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -158,6 +158,7 @@ def test_scene_get_exports_schema_emits_model_derived_contract_without_other_arg
     assert "value projection" in export_value["description"]
     assert set(export_value["$defs"]) == {
         "ReferenceProjection",
+        "TextureProjection",
         "InlineValueProjection",
     }
     jsonschema.Draft202012Validator.check_schema(doc["input"])


### PR DESCRIPTION
## W4 slice: texture projection — inspectable identity for path-less resource values (#666)

**The gap (GDA-DF-011):** `game get` on a path-less `ImageTexture` (e.g. `create_from_image()`, whose `resource_path` is intentionally empty) fell to ADR-0035's string fallback — `():<ImageTexture#-92233…>` — an instance ID that proves two objects differ but cannot say what either shows.

### The ADR-0035 amendment (the issue's blocked-by item)

A dated amendment on ADR-0035 adds a **fourth projection kind** — the **texture projection** — and names the three revised rules the issue requires:

1. the reference shape `{type, resource_path}` stays fixed (no dimensions added to it); a `Texture2D` WITH a `res://` path still projects as a reference — only a path-less one takes the new kind;
2. the new kind carries its own discriminator — the presence of **`object_string`**, which no other object shape emits — and never emits `resource_path` (not even null), so the reference branch stays unambiguous;
3. the per-type field table stays rejected: this is a new projection *kind* (a fixed shape read off getters, like the reference kind), not a whitelist entry — the inline kind emits storage properties, and `ImageTexture`'s storage property is a large `image` payload, exactly the live-side risk the whitelist isolates.

### What shipped

**The shape**: `{"type", "width", "height", "object_string", "digest"}` for a path-less `Texture2D` — class + dimensions off cheap getters, the former `str()` form retained under `object_string` as secondary diagnostics, and `digest` null by default.

**The digest opt-in**: `game get --texture-digest` (wire param `texture_digest`, threaded through the shared projection's recursion so nested textures get it too). Computing it needs `Texture2D.get_image()` — a GPU-to-CPU readback on the live side — so no ordinary read pays it. The digest is `sha256:` over the image's dimensions, format, and raw bytes (the shape prefix keeps same-bytes textures of different shapes from colliding); an image the engine cannot read back keeps null. The flag is live-only today: a path-less texture only exists where runtime code constructed one, so headless reads carry the projection with `digest` always null — stated in the amendment.

**One projection everywhere**: the arm lives in the mirrored shared-coercion block (`operations.gd` ↔ `gda_harness.gd` byte-identical; the mirror test is untouched and green), so the same shape serves the headless reads (`node`/`resource`/`project get`, `project list`, `scene get-exports`, set echoes) and the live `game get`.

**Published, not prose-only**: `TextureProjection` joins `ReferenceProjection` / `InlineValueProjection` as a named model in every projected `value` field's `$defs`, and the shared `VALUE_PROJECTION_DESC` names the kind and its discriminator. `CONTEXT.md`'s `Value projection` term and the command catalog's projection and `game` sections are updated; SKILL.md's `game` row notes the opt-in.

### Acceptance criteria → evidence

| AC | Evidence |
| --- | --- |
| Live `game get` on a path-less `ImageTexture` returns `{type, dimensions}`, no `resource_path` | e2e: a 2×3 runtime texture projects `{type: ImageTexture, width: 2, height: 3, object_string, digest: null}`; `"resource_path" not in value` asserted |
| Digest opt-in distinguishes same-class different-content textures; null without it | same e2e: red vs blue textures get different `sha256:` digests, a repeat of red gets the identical digest; the plain read asserts `digest is None` |
| The same projection serves headless reads | e2e: `node get` on a scene whose script `_init` constructs a 4×5 path-less texture returns the same shape (digest null) |
| The ADR-0035 amendment naming the three revised rules lands with the change | the dated amendment block on ADR-0035 |

### Validation

- Fast suite **1783 passed**; pyright 0 errors; ruff check + format clean; `git diff --check` clean; the coercion-mirror test green (both `.gd` files changed byte-identically).
- Real-engine e2e, serial: game + harness-install **6 passed**; the full node suite (103 tests, the whole headless read surface over the changed shared block) **passed**.
- **Red-proof on dev tip `977ae71c`**: the digest-flag test dies on `unknown_option`, both `$defs` tests on the missing `TextureProjection`, `tests/test_models.py` on its import, and both new e2e tests on the old string fallback.
- `gda schema` diff vs the dev tip, entry-by-entry: exactly the ten value-carrying read/set surfaces changed (`game get/set`, `node get/set`, `project get/list/set`, `resource get/set`, `scene get-exports`) — the shared `$defs` + description, plus `game get`'s new flag and its argv-binding metadata. No command added or removed.

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)
