### PR TITLE
feat(gda): predicate-gated screen capture with atomic input events (#661)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: true
+          # The harness-version guard compares the PR/push base and head.
+          fetch-depth: 0
 
       - name: Set up Python environment
         uses: ./.github/actions/setup-python-env
@@ -162,6 +164,13 @@ jobs:
           # gda-balancing has its own required matrix and stable aggregator.
           # Keep this required root context scoped to the root project.
           sync: root
+
+      - name: Guard harness version identity
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: python scripts/harness_version_guard.py "$BASE_SHA" "$HEAD_SHA"
 
       - name: Run unit tests
         run: uv run --frozen pytest -m "not e2e"

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -305,6 +305,7 @@ operation, and parse codes the CLI assigns).
 | `live_invalid_key` | `live` | `classifier` | `6` | A live input key event named a key the engine could not resolve to a keycode (Phase 2, #221). |
 | `live_unknown_action` | `live` | `classifier` | `6` | A live input action targeted an action the running game's InputMap does not declare (Phase 2, #221). |
 | `live_invalid_event_spec` | `live` | `classifier` | `6` | A live input sequence event has a type the harness does not recognize (Phase 2, #221). |
+| `live_predicate_unmet` | `live` | `classifier` | `6` | A live `screen capture` predicate (`--await-*`, #661) did not hold within its declared frame bound (Phase 2). |
 | `live_display_unavailable` | `live` | `classifier` | `6` | A live `screen` capture ran on a headless engine session (the dummy DisplayServer cannot read pixels); start the daemon windowed with `gda daemon start --windowed` (Phase 2, #222). |
 | `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
 | `live_windowed_unavailable` | `environment` | `classifier` | `127` | A windowed Engine session (`gda daemon start --windowed`) was requested but the host has no usable DisplayServer (no on-console GUI session / no `$DISPLAY`), so the session cannot come up; refused before spawning Godot (Phase 2, #345). |

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -231,13 +231,17 @@ that implements it (ADR-0002), not by this ADR. The agent-facing contract (typed
 models, `--json`, `--schema` gate, registered `GdaError.code`s) is identical to
 headless.
 
-> **Amendment (2026-08-25, #661):** a multi-frame live operation's declared
-> frame count is a CEILING, not the required duration. The harness window may
-> complete EARLY with a success payload once its outcome is decided (the
-> predicate capture completes on the first frame its predicate holds), provided
-> every input event the request declared has been applied before the reply —
-> an early completion never skips an accepted event. The one-shot RPC shape is
-> unchanged: still exactly one reply per request.
+> **Amendment (2026-08-25, #661; revised same day after the #743 re-review):**
+> a multi-frame live operation's declared frame count is a CEILING, not the
+> required duration. The harness window may complete EARLY with a success
+> payload once its outcome is decided (the predicate capture completes on the
+> first frame its predicate holds), provided every input event the request
+> declared has been applied before the reply — an early completion never skips
+> an accepted event, and a declared event that FAILS makes the reply that
+> typed failure even when a capture already succeeded (the capture payload is
+> discarded; later events still drain, so scheduled releases fire on the error
+> path too). The one-shot RPC shape is unchanged: still exactly one reply per
+> request.
 
 ## Considered options
 

--- a/docs/adr/0017-gda-daemon-live-execution-mechanism.md
+++ b/docs/adr/0017-gda-daemon-live-execution-mechanism.md
@@ -231,6 +231,14 @@ that implements it (ADR-0002), not by this ADR. The agent-facing contract (typed
 models, `--json`, `--schema` gate, registered `GdaError.code`s) is identical to
 headless.
 
+> **Amendment (2026-08-25, #661):** a multi-frame live operation's declared
+> frame count is a CEILING, not the required duration. The harness window may
+> complete EARLY with a success payload once its outcome is decided (the
+> predicate capture completes on the first frame its predicate holds), provided
+> every input event the request declared has been applied before the reply —
+> an early completion never skips an accepted event. The one-shot RPC shape is
+> unchanged: still exactly one reply per request.
+
 ## Considered options
 
 - **Attach to a human-opened editor via an EditorPlugin (godot-mcp-pro's model)** —

--- a/docs/adr/0020-live-state-consistency.md
+++ b/docs/adr/0020-live-state-consistency.md
@@ -60,15 +60,21 @@ engine session's runtime state:
 this Phase-2 live layer under these scoped guarantees — not for the stateless Phase-1
 headless CLI (ADR-0001). Recorded here and via a pointer on ADR-0000.
 
-> **Amendment (2026-08-25, #661):** the predicate-gated capture reads its two
-> facts at the SAME frame boundary: the awaited property as the game last
-> wrote it, and the viewport texture as the engine last presented it — both
-> belong to the frame that just completed, verified frame-by-frame against a
-> live probe. The declared limit: when a game updates a visual one frame
-> AFTER the property it gates on, the captured image trails the property by
-> that game-side frame; the contract tells the caller to gate on the visual's
-> own property when exact pixels matter. Frame coherence per ADR-0020 is
-> engine-side; a game's internal property-to-visual latency is the game's.
+> **Amendment (2026-08-25, #661; revised same day after the #743 re-review):**
+> the predicate-gated capture reads its two facts at the SAME frame boundary,
+> and each window tick EVALUATES BEFORE it injects that tick's input events —
+> so the observed property is always the state of the previously COMPLETED
+> frame, which is exactly the frame the viewport texture presents. Verified
+> live on both trigger paths: a `_process`-driven flip is observed together
+> with its own presentation, and a state written by an injected event's
+> synchronous `_input` callback is observed one boundary later, together with
+> its presentation. Declared consequences: the predicate observes
+> frame-boundary state only — a value overwritten before its frame completes
+> is never observable (the typed unmet error, never a capture of mismatched
+> pixels) — and a game that updates a visual one frame after the property it
+> gates on trails by that game-side frame; gate on the visual's own property
+> when exact pixels matter. Frame coherence per ADR-0020 is engine-side; a
+> game's internal property-to-visual latency is the game's.
 
 ## Considered options
 

--- a/docs/adr/0020-live-state-consistency.md
+++ b/docs/adr/0020-live-state-consistency.md
@@ -60,6 +60,16 @@ engine session's runtime state:
 this Phase-2 live layer under these scoped guarantees — not for the stateless Phase-1
 headless CLI (ADR-0001). Recorded here and via a pointer on ADR-0000.
 
+> **Amendment (2026-08-25, #661):** the predicate-gated capture reads its two
+> facts at the SAME frame boundary: the awaited property as the game last
+> wrote it, and the viewport texture as the engine last presented it — both
+> belong to the frame that just completed, verified frame-by-frame against a
+> live probe. The declared limit: when a game updates a visual one frame
+> AFTER the property it gates on, the captured image trails the property by
+> that game-side frame; the contract tells the caller to gate on the visual's
+> own property when exact pixels matter. Frame coherence per ADR-0020 is
+> engine-side; a game's internal property-to-visual latency is the game's.
+
 ## Considered options
 
 - **Multi-writer concurrent clients** — rejected for Phase 2: it contradicts the

--- a/docs/adr/0040-per-command-group-modules.md
+++ b/docs/adr/0040-per-command-group-modules.md
@@ -101,12 +101,18 @@ src/gda/
 5. **Dependency direction**: `cli` → `commands/*` → `dispatch` → `headless` →
    runners / `errors` / `models` → foundation. A group may import another
    group's public symbol one-way where the language genuinely shares a shape —
-   three such edges exist: `node` → `scene` for `SceneNode` and
+   four such edges exist: `node` → `scene` for `SceneNode` and
    `derive_scene_root_name` (the filename-stem default an `--instance`
    composition reuses); `shader` → `script` for the `ScriptSetMode` edit
-   interface `shader set` reuses; and `logger` → `diag` for the `SourceFrame`
+   interface `shader set` reuses; `logger` → `diag` for the `SourceFrame`
    location and the `--limit` option the two log-reading groups share (the
-   ADR-0022/0026 lineage). No reciprocal group imports. A shape **no single
+   ADR-0022/0026 lineage); and `screen` → `input` for the
+   `InputSequenceEvent` union that `screen capture --await-events` embeds
+   (#661): the event shapes are the input group's owned contract — the
+   discriminated union, its per-kind field rules, and their harness
+   application — and the predicate capture REUSES them verbatim rather than
+   forking a second event vocabulary, so the edge points at the owner and
+   stays one-way (added 2026-08-25). No reciprocal group imports. A shape **no single
    group owns** stays in the `gda.models` core rather than moving into one,
    because several groups read it (`NodeProperty`, `EngineVersion`,
    `MAX_WINDOW_FRAMES`). A shape a **single group does own** moves to that

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -894,9 +894,12 @@ headless is unaffected (4.4+, cross-platform).
   sequence` takes) INSIDE the same window at their process-clock `frame` offsets — the
   atomic input-and-capture form, so a 3–8-frame transient triggered by the input
   cannot be missed by a second CLI round trip; physics-clock offsets are refused. An
-  offset at or beyond the ceiling still fires — the reply waits for every declared
-  event — but can no longer satisfy the predicate, whose scan ends at the ceiling; the
-  published schema and the model accept exactly the same event set (ADR-0015). Every
+  offset at or beyond the PREDICATE ceiling still fires — the reply waits for every
+  declared event — but can no longer satisfy the predicate, whose scan ends at that
+  ceiling. Every event offset is nevertheless at most 599, so the TOTAL drain stays
+  within the shared 600-frame live-window ceiling; both limits and the modifier
+  vocabulary are published in the schema, and the schema/model event sets agree
+  (ADR-0015). Every
   declared event fires before the reply even when the predicate matches first, so no
   injected press is left held — and a declared event that FAILS makes the whole
   capture that typed failure (the capture payload is discarded, no file is written,

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -893,15 +893,26 @@ headless is unaffected (4.4+, cross-platform).
   additionally applies input-sequence events (the same discriminated union `input
   sequence` takes) INSIDE the same window at their process-clock `frame` offsets — the
   atomic input-and-capture form, so a 3–8-frame transient triggered by the input
-  cannot be missed by a second CLI round trip; physics-clock offsets are refused,
-  every offset must be inside the window, and every declared event fires before the
-  reply even when the predicate matches first, so no injected press is left held. The
-  predicate compares JSON scalars (numbers numerically, strings against the String
-  rendering). The coherence contract, verified frame-by-frame against a live probe:
-  the property and the pixels are read at one boundary and both belong to the frame
-  that just COMPLETED — a game that updates a visual one frame after the property it
-  gates on trails by that game-side frame, so gate on the visual's own property when
-  exact pixels matter (ADR-0020 amendment).
+  cannot be missed by a second CLI round trip; physics-clock offsets are refused and
+  every offset must be inside the window (a cross-field bound the emitted JSON Schema
+  cannot state — enforced at validation, disclosed in the field description). Every
+  declared event fires before the reply even when the predicate matches first, so no
+  injected press is left held — and a declared event that FAILS makes the whole
+  capture that typed failure (the capture payload is discarded, no file is written,
+  later events still drain). The predicate compares JSON scalars (numbers
+  numerically, strings against the String rendering). The coherence contract,
+  verified live on both trigger paths (ADR-0020 amendment): each tick EVALUATES
+  BEFORE it injects, so the observed property is always the state of the previously
+  COMPLETED frame — exactly the frame the captured texture presents. A
+  `_process`-driven flip is observed with its own presentation; a state written by an
+  injected event's synchronous callback is observed one boundary later, together with
+  its presentation. Consequences: the predicate sees frame-boundary state only (a
+  value overwritten before its frame completes is never observable — the typed unmet
+  error, never a capture of mismatched pixels); an event's effect is observable from
+  the NEXT boundary (leave one frame between the last state-changing event and the
+  ceiling); and a game that updates a visual one frame after the property it gates on
+  trails by that game-side frame — gate on the visual's own property when exact
+  pixels matter.
 - **`perf` (runtime performance monitoring):** `perf monitors` snapshots the running
   game's instantaneous Performance counters in one frame (shipped, #223); `perf
   monitor --property … --frames N` / `--signal … --frames N` collects a per-frame

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -893,9 +893,10 @@ headless is unaffected (4.4+, cross-platform).
   additionally applies input-sequence events (the same discriminated union `input
   sequence` takes) INSIDE the same window at their process-clock `frame` offsets — the
   atomic input-and-capture form, so a 3–8-frame transient triggered by the input
-  cannot be missed by a second CLI round trip; physics-clock offsets are refused and
-  every offset must be inside the window (a cross-field bound the emitted JSON Schema
-  cannot state — enforced at validation, disclosed in the field description). Every
+  cannot be missed by a second CLI round trip; physics-clock offsets are refused. An
+  offset at or beyond the ceiling still fires — the reply waits for every declared
+  event — but can no longer satisfy the predicate, whose scan ends at the ceiling; the
+  published schema and the model accept exactly the same event set (ADR-0015). Every
   declared event fires before the reply even when the predicate matches first, so no
   injected press is left held — and a declared event that FAILS makes the whole
   capture that typed failure (the capture payload is discarded, no file is written,

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -886,19 +886,22 @@ headless is unaffected (4.4+, cross-platform).
 - **`screen` / capture:** running-game viewport screenshot, multi-frame capture. The
   `--await-*` predicate (shipped, #661) holds a `screen capture` game-side until
   `node.property == value` first holds — checked once per PROCESS frame, up to
-  `--await-frames` (default 60, ceiling 600) — then captures THAT frame and reports the
-  predicate evidence (`observed` value, absolute `engine_frame`, window-relative
-  `frames_waited`); a predicate that never holds is the typed `live_predicate_unmet`
-  carrying the last observed value. `--await-events` additionally applies
-  input-sequence events (the same discriminated union `input sequence` takes) INSIDE
-  the same window at their process-clock `frame` offsets — the atomic
-  input-and-capture form, so a 3–8-frame transient triggered by the input cannot be
-  missed by a second CLI round trip; physics-clock offsets are refused, and every
-  offset must be inside the window. The predicate compares JSON scalars (numbers
-  numerically, strings against the String rendering); evaluation happens at the
-  process-frame boundary and the captured image is the most recently PRESENTED frame,
-  so a property written after that frame's draw can be one frame ahead of the pixels —
-  the documented limit.
+  `--await-frames` (default 60, ceiling 600) — then captures at that SAME frame
+  boundary and reports the predicate evidence (`observed` value, absolute
+  `engine_frame`, window-relative `frames_waited`); a predicate that never holds is
+  the typed `live_predicate_unmet` carrying the last observed value. `--await-events`
+  additionally applies input-sequence events (the same discriminated union `input
+  sequence` takes) INSIDE the same window at their process-clock `frame` offsets — the
+  atomic input-and-capture form, so a 3–8-frame transient triggered by the input
+  cannot be missed by a second CLI round trip; physics-clock offsets are refused,
+  every offset must be inside the window, and every declared event fires before the
+  reply even when the predicate matches first, so no injected press is left held. The
+  predicate compares JSON scalars (numbers numerically, strings against the String
+  rendering). The coherence contract, verified frame-by-frame against a live probe:
+  the property and the pixels are read at one boundary and both belong to the frame
+  that just COMPLETED — a game that updates a visual one frame after the property it
+  gates on trails by that game-side frame, so gate on the visual's own property when
+  exact pixels matter (ADR-0020 amendment).
 - **`perf` (runtime performance monitoring):** `perf monitors` snapshots the running
   game's instantaneous Performance counters in one frame (shipped, #223); `perf
   monitor --property … --frames N` / `--signal … --frames N` collects a per-frame

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -883,7 +883,22 @@ headless is unaffected (4.4+, cross-platform).
   spelling differs by kind — `pressed` belongs to `mouse_button` alone, an `action`
   releases with `release`, a `key` with `released` — and a field from another kind is
   refused with the spelling this kind uses instead.
-- **`screen` / capture:** running-game viewport screenshot, multi-frame capture.
+- **`screen` / capture:** running-game viewport screenshot, multi-frame capture. The
+  `--await-*` predicate (shipped, #661) holds a `screen capture` game-side until
+  `node.property == value` first holds — checked once per PROCESS frame, up to
+  `--await-frames` (default 60, ceiling 600) — then captures THAT frame and reports the
+  predicate evidence (`observed` value, absolute `engine_frame`, window-relative
+  `frames_waited`); a predicate that never holds is the typed `live_predicate_unmet`
+  carrying the last observed value. `--await-events` additionally applies
+  input-sequence events (the same discriminated union `input sequence` takes) INSIDE
+  the same window at their process-clock `frame` offsets — the atomic
+  input-and-capture form, so a 3–8-frame transient triggered by the input cannot be
+  missed by a second CLI round trip; physics-clock offsets are refused, and every
+  offset must be inside the window. The predicate compares JSON scalars (numbers
+  numerically, strings against the String rendering); evaluation happens at the
+  process-frame boundary and the captured image is the most recently PRESENTED frame,
+  so a property written after that frame's draw can be one frame ahead of the pixels —
+  the documented limit.
 - **`perf` (runtime performance monitoring):** `perf monitors` snapshots the running
   game's instantaneous Performance counters in one frame (shipped, #223); `perf
   monitor --property … --frames N` / `--signal … --frames N` collects a per-frame

--- a/scripts/harness_version_guard.py
+++ b/scripts/harness_version_guard.py
@@ -1,0 +1,120 @@
+"""Fail when bundled harness bytes change without a numeric version increase.
+
+The unit-tier hash pin catches accidental edits inside one checkout. This guard
+compares the merge base and head, which is the information a current-snapshot
+test cannot recover: when ``gda_harness.gd`` changes in the reviewed range, the
+head's HARNESS_VERSION must be numerically greater. CI supplies the PR base/head
+or the before/after commits of a push.
+
+Stdlib only, so the workflow can run it without another project dependency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+HARNESS_PATH = "src/gda/harness/gda_harness.gd"
+INSTALL_PATH = "src/gda/harness/install.py"
+_VERSION = re.compile(rb'^HARNESS_VERSION = "([0-9]+)"$', re.MULTILINE)
+
+
+class HarnessVersionGuardError(Exception):
+    """The two revisions cannot prove a valid harness version transition."""
+
+
+def _version(source: bytes, revision: str) -> int:
+    matches = _VERSION.findall(source)
+    if len(matches) != 1:
+        raise HarnessVersionGuardError(
+            f"{revision} must declare exactly one numeric HARNESS_VERSION assignment"
+        )
+    return int(matches[0])
+
+
+def check_change(
+    base_harness: bytes,
+    base_install: bytes,
+    head_harness: bytes,
+    head_install: bytes,
+) -> None:
+    """Require a numeric version increase exactly when harness bytes changed."""
+    if base_harness == head_harness:
+        return
+    base_version = _version(base_install, "base")
+    head_version = _version(head_install, "head")
+    if head_version == base_version:
+        raise HarnessVersionGuardError(
+            "bundled harness bytes changed but HARNESS_VERSION remained "
+            f"{head_version}; increase it and update the current hash pin"
+        )
+    if head_version < base_version:
+        raise HarnessVersionGuardError(
+            "HARNESS_VERSION must increase when bundled harness bytes change "
+            f"(base {base_version}, head {head_version})"
+        )
+
+
+def _git_blob(revision: str, path: str) -> bytes:
+    result = subprocess.run(
+        ["git", "show", f"{revision}:{path}"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode(errors="replace").strip()
+        raise HarnessVersionGuardError(
+            f"cannot read {path} at revision {revision}: {detail}"
+        )
+    return result.stdout
+
+
+def _git_merge_base(base: str, head: str) -> str:
+    result = subprocess.run(
+        ["git", "merge-base", base, head],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode(errors="replace").strip()
+        raise HarnessVersionGuardError(
+            f"cannot resolve merge base for {base} and {head}: {detail}"
+        )
+    merge_base = result.stdout.decode().strip()
+    if not merge_base:
+        raise HarnessVersionGuardError(
+            f"git returned no merge base for {base} and {head}"
+        )
+    return merge_base
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("base", help="base Git revision")
+    parser.add_argument("head", help="head Git revision")
+    args = parser.parse_args(argv)
+
+    try:
+        merge_base = _git_merge_base(args.base, args.head)
+        base_harness = _git_blob(merge_base, HARNESS_PATH)
+        head_harness = _git_blob(args.head, HARNESS_PATH)
+        check_change(
+            base_harness,
+            _git_blob(merge_base, INSTALL_PATH),
+            head_harness,
+            _git_blob(args.head, INSTALL_PATH),
+        )
+    except HarnessVersionGuardError as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    print("harness version transition is valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gda/commands/input.py
+++ b/src/gda/commands/input.py
@@ -711,9 +711,11 @@ class _SequenceEvent(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    frame: int | None = Field(default=None, ge=0, description=_FRAME_DESC)
+    # strict=True: the published schema says `integer`, so the runtime must
+    # not quietly coerce "1" (#743 re-review — schema/model parity, ADR-0015).
+    frame: int | None = Field(default=None, ge=0, strict=True, description=_FRAME_DESC)
     physics_frame: int | None = Field(
-        default=None, ge=0, description=_PHYSICS_FRAME_DESC
+        default=None, ge=0, strict=True, description=_PHYSICS_FRAME_DESC
     )
 
     @model_validator(mode="before")

--- a/src/gda/commands/input.py
+++ b/src/gda/commands/input.py
@@ -46,11 +46,11 @@ from gda.headless import (
 )
 from gda.models import MAX_WINDOW_FRAMES
 
-# The keyboard modifier names a key/sequence event may carry, mapped to the
-# InputEventKey modifier flag the harness sets. Bounding the set model-side means a
-# typo'd modifier ("control" for "ctrl") is a clean usage/invalid_params error, not
-# a silently-dropped flag.
-INPUT_MODIFIERS = ("shift", "ctrl", "alt", "meta")
+# The keyboard modifier names a key/sequence/tap may carry, mapped to the
+# InputEventKey modifier flag the harness sets. A Literal is the ONE authority for
+# runtime validation and the emitted enum (ADR-0015), so a schema client rejects a
+# typo such as "control" before it ever becomes a silently dropped harness flag.
+InputModifier = Literal["shift", "ctrl", "alt", "meta"]
 
 
 class MouseButton(str, Enum):
@@ -64,21 +64,6 @@ class MouseButton(str, Enum):
     LEFT = "left"
     RIGHT = "right"
     MIDDLE = "middle"
-
-
-def _validate_modifiers(modifiers: list[str]) -> list[str]:
-    """Reject any modifier outside the known set (the single home of the rule).
-
-    Shared by ``InputKeyParams`` and a sequence key event so the argv and
-    ``--params-json`` paths — and a sequence event nested in a JSON object —
-    validate modifiers identically (ADR-0015).
-    """
-    unknown = [m for m in modifiers if m not in INPUT_MODIFIERS]
-    if unknown:
-        raise ValueError(
-            f"unknown modifier(s) {unknown}; allowed: {list(INPUT_MODIFIERS)}."
-        )
-    return modifiers
 
 
 class InputKeyParams(BaseModel):
@@ -96,7 +81,7 @@ class InputKeyParams(BaseModel):
         min_length=1,
         description="A Godot key name to inject (e.g. Right, A, Space, Escape).",
     )
-    modifiers: list[str] = Field(
+    modifiers: list[InputModifier] = Field(
         default_factory=list,
         description=(
             "Modifier keys held with the key, any of: shift, ctrl, alt, meta."
@@ -107,11 +92,6 @@ class InputKeyParams(BaseModel):
         strict=True,
         description="Inject a key RELEASE instead of a press (default: press).",
     )
-
-    @model_validator(mode="after")
-    def _check_modifiers(self) -> "InputKeyParams":
-        _validate_modifiers(self.modifiers)
-        return self
 
 
 class InputKeyResult(BaseModel):
@@ -395,7 +375,7 @@ class InputTapParams(BaseModel):
             "one of key/action."
         ),
     )
-    modifiers: list[str] = Field(
+    modifiers: list[InputModifier] = Field(
         default_factory=list,
         description=(
             "Modifier keys held through a KEY tap, any of: shift, ctrl, alt, "
@@ -453,7 +433,6 @@ class InputTapParams(BaseModel):
             # declared default remains null purely to distinguish "omitted" from
             # "set", so the key-tap refusal above can name a real mistake.
             self.strength = 1.0
-        _validate_modifiers(self.modifiers)
         window = self.hold_frames + self.settle_frames + 1
         if window > MAX_WINDOW_FRAMES:
             raise ValueError(
@@ -493,7 +472,7 @@ class InputTapResult(BaseModel):
             "echoes KEY_NONE); null for an action tap."
         ),
     )
-    modifiers: list[str] | None = Field(
+    modifiers: list[InputModifier] | None = Field(
         default=None,
         description="The modifiers held through a key tap; null for an action tap.",
     )
@@ -558,10 +537,6 @@ class InputTapResult(BaseModel):
                 "a tap result carries exactly one target family: "
                 "key + keycode + modifiers, or action + strength."
             )
-        if self.modifiers is not None:
-            # The same vocabulary rule the request enforces, from its one home:
-            # a reply echoing a modifier outside it is contract drift.
-            _validate_modifiers(self.modifiers)
         if self.frames != self.hold_frames + self.settle_frames + 1:
             raise ValueError(
                 "a tap result's frames is hold_frames + settle_frames + 1."
@@ -618,12 +593,16 @@ _FRAME_DESC = (
     "The 0-based relative harness/process-frame offset to apply this event at. "
     "This is the original `input sequence` clock, driven by the harness "
     "`_process` loop; it is not Godot's fixed physics clock. Omit both `frame` "
-    "and `physics_frame` to use process frame 0."
+    "and `physics_frame` to use process frame 0. The largest accepted offset is "
+    f"{MAX_WINDOW_FRAMES - 1}, keeping the total live window within the shared "
+    f"{MAX_WINDOW_FRAMES}-frame ceiling."
 )
 _PHYSICS_FRAME_DESC = (
     "The 0-based relative physics-frame offset to apply this event at, driven by "
     "Godot `_physics_process` ticks. Use this instead of `frame` when an input "
-    "hold must map to a deterministic physics simulation duration."
+    "hold must map to a deterministic physics simulation duration. The largest "
+    f"accepted offset is {MAX_WINDOW_FRAMES - 1}, keeping the total live window "
+    f"within the shared {MAX_WINDOW_FRAMES}-frame ceiling."
 )
 _MOUSE_X_DESC = (
     "The event's x position in the viewport. Read it from the event; "
@@ -723,9 +702,19 @@ class _SequenceEvent(BaseModel):
 
     # strict=True: the published schema says `integer`, so the runtime must
     # not quietly coerce "1" (#743 re-review — schema/model parity, ADR-0015).
-    frame: int | None = Field(default=None, ge=0, strict=True, description=_FRAME_DESC)
+    frame: int | None = Field(
+        default=None,
+        ge=0,
+        le=MAX_WINDOW_FRAMES - 1,
+        strict=True,
+        description=_FRAME_DESC,
+    )
     physics_frame: int | None = Field(
-        default=None, ge=0, strict=True, description=_PHYSICS_FRAME_DESC
+        default=None,
+        ge=0,
+        le=MAX_WINDOW_FRAMES - 1,
+        strict=True,
+        description=_PHYSICS_FRAME_DESC,
     )
 
     @model_validator(mode="before")
@@ -767,7 +756,7 @@ class KeySequenceEvent(_SequenceEvent):
 
     type: Literal[InputEventType.KEY] = Field(description="The event kind.")
     key: str = Field(min_length=1, description="The key name to inject (e.g. Right).")
-    modifiers: list[str] = Field(
+    modifiers: list[InputModifier] = Field(
         default_factory=list,
         description="Modifier keys held with the key, any of: shift, ctrl, alt, meta.",
     )
@@ -776,11 +765,6 @@ class KeySequenceEvent(_SequenceEvent):
         strict=True,
         description="Inject a key RELEASE instead of a press.",
     )
-
-    @model_validator(mode="after")
-    def _check_modifiers(self) -> "KeySequenceEvent":
-        _validate_modifiers(self.modifiers)
-        return self
 
 
 class MouseClickSequenceEvent(_SequenceEvent):
@@ -926,10 +910,10 @@ class ActionSequenceEvent(_SequenceEvent):
 # kind's field set — what it requires and what it forbids — is machine-checkable:
 # a client validates a candidate event against the published contract instead of
 # learning the per-kind fields from prose or from a failed invocation
-# (GDA-DF-037/GDA-DF-032). The CROSS-FIELD rules are a narrower story: the
-# mouse-button phase is published too (`_MOUSE_BUTTON_PHASE_SCHEMA`), while the
-# one-clock rule, the modifier vocabulary and the window ceiling stay enforced
-# model-side only, as they were before this union.
+# (GDA-DF-037/GDA-DF-032). The modifier vocabulary and per-event window ceiling
+# are ordinary schema-visible field constraints. The CROSS-FIELD rules are a
+# narrower story: the mouse-button phase is published too
+# (`_MOUSE_BUTTON_PHASE_SCHEMA`), while the one-clock rule stays model-side.
 InputSequenceEvent = Annotated[
     KeySequenceEvent
     | MouseClickSequenceEvent

--- a/src/gda/commands/input.py
+++ b/src/gda/commands/input.py
@@ -104,6 +104,7 @@ class InputKeyParams(BaseModel):
     )
     released: bool = Field(
         default=False,
+        strict=True,
         description="Inject a key RELEASE instead of a press (default: press).",
     )
 
@@ -150,22 +151,26 @@ class InputMouseClickParams(BaseModel):
     """
 
     x: float = Field(
+        strict=True,
         description=(
             "The click's x position in the viewport. Read it from the mouse event; "
             "engine-tracked mouse positions may remain stale."
-        )
+        ),
     )
     y: float = Field(
+        strict=True,
         description=(
             "The click's y position in the viewport. Read it from the mouse event; "
             "engine-tracked mouse positions may remain stale."
-        )
+        ),
     )
     button: MouseButton = Field(
         default=MouseButton.LEFT,
         description="Which mouse button to click: left, right, or middle.",
     )
-    double: bool = Field(default=False, description="Mark the event a double click.")
+    double: bool = Field(
+        default=False, strict=True, description="Mark the event a double click."
+    )
 
 
 class InputMouseMoveParams(BaseModel):
@@ -181,16 +186,18 @@ class InputMouseMoveParams(BaseModel):
     """
 
     x: float = Field(
+        strict=True,
         description=(
             "The motion's target x position in the viewport. Read it from the "
             "mouse event; engine-tracked mouse positions may remain stale."
-        )
+        ),
     )
     y: float = Field(
+        strict=True,
         description=(
             "The motion's target y position in the viewport. Read it from the "
             "mouse event; engine-tracked mouse positions may remain stale."
-        )
+        ),
     )
 
 
@@ -324,12 +331,15 @@ class InputActionParams(BaseModel):
         min_length=1, description="The input action name (must be in the InputMap)."
     )
     release: bool = Field(
-        default=False, description="Release the action instead of pressing it."
+        default=False,
+        strict=True,
+        description="Release the action instead of pressing it.",
     )
     strength: float = Field(
         default=1.0,
         ge=0.0,
         le=1.0,
+        strict=True,
         description="The analog press strength, 0..1 (ignored on a release).",
     )
 
@@ -762,7 +772,9 @@ class KeySequenceEvent(_SequenceEvent):
         description="Modifier keys held with the key, any of: shift, ctrl, alt, meta.",
     )
     released: bool = Field(
-        default=False, description="Inject a key RELEASE instead of a press."
+        default=False,
+        strict=True,
+        description="Inject a key RELEASE instead of a press.",
     )
 
     @model_validator(mode="after")
@@ -783,12 +795,14 @@ class MouseClickSequenceEvent(_SequenceEvent):
     """
 
     type: Literal[InputEventType.MOUSE_CLICK] = Field(description="The event kind.")
-    x: float = Field(description=_MOUSE_X_DESC)
-    y: float = Field(description=_MOUSE_Y_DESC)
+    x: float = Field(strict=True, description=_MOUSE_X_DESC)
+    y: float = Field(strict=True, description=_MOUSE_Y_DESC)
     button: MouseButton | None = Field(
         default=MouseButton.LEFT, description=_BUTTON_DESC
     )
-    double: bool = Field(default=False, description="Mark the event a double click.")
+    double: bool = Field(
+        default=False, strict=True, description="Mark the event a double click."
+    )
 
     @model_validator(mode="after")
     def _default_button(self) -> "MouseClickSequenceEvent":
@@ -831,18 +845,22 @@ class MouseButtonSequenceEvent(_SequenceEvent):
     model_config = ConfigDict(json_schema_extra=_MOUSE_BUTTON_PHASE_SCHEMA)
 
     type: Literal[InputEventType.MOUSE_BUTTON] = Field(description="The event kind.")
-    x: float = Field(description=_MOUSE_X_DESC)
-    y: float = Field(description=_MOUSE_Y_DESC)
+    x: float = Field(strict=True, description=_MOUSE_X_DESC)
+    y: float = Field(strict=True, description=_MOUSE_Y_DESC)
     button: MouseButton | None = Field(
         default=MouseButton.LEFT, description=_BUTTON_DESC
     )
-    double: bool = Field(default=False, description="Mark the event a double click.")
+    double: bool = Field(
+        default=False, strict=True, description="Mark the event a double click."
+    )
     pressed: bool | None = Field(
         default=None,
+        strict=True,
         description="Press the button. Use exactly one of `pressed` or `release`.",
     )
     release: bool = Field(
         default=False,
+        strict=True,
         description="Release the button. Use exactly one of `pressed` or `release`.",
     )
 
@@ -872,8 +890,8 @@ class MouseMoveSequenceEvent(_SequenceEvent):
     """A mouse motion event in a sequence: the ``gda input mouse-move`` shape."""
 
     type: Literal[InputEventType.MOUSE_MOVE] = Field(description="The event kind.")
-    x: float = Field(description=_MOUSE_X_DESC)
-    y: float = Field(description=_MOUSE_Y_DESC)
+    x: float = Field(strict=True, description=_MOUSE_X_DESC)
+    y: float = Field(strict=True, description=_MOUSE_Y_DESC)
 
 
 class ActionSequenceEvent(_SequenceEvent):
@@ -890,10 +908,16 @@ class ActionSequenceEvent(_SequenceEvent):
         min_length=1, description="The action name (must be in the InputMap)."
     )
     release: bool = Field(
-        default=False, description="Release the action instead of pressing it."
+        default=False,
+        strict=True,
+        description="Release the action instead of pressing it.",
     )
     strength: float = Field(
-        default=1.0, ge=0.0, le=1.0, description="The analog press strength, 0..1."
+        default=1.0,
+        ge=0.0,
+        le=1.0,
+        strict=True,
+        description="The analog press strength, 0..1.",
     )
 
 

--- a/src/gda/commands/screen.py
+++ b/src/gda/commands/screen.py
@@ -172,12 +172,12 @@ class ScreenCaptureParams(BaseModel):
             "'frame' offsets, so a 3-8 frame transient triggered by the input "
             "cannot be missed by a second round trip. An event's effect is "
             "observable from the NEXT frame boundary, so leave at least one "
-            "frame between the last state-changing event and the ceiling. A "
+            "frame between the last state-changing event and the ceiling; an "
+            "offset at or beyond the ceiling still fires (the reply waits for "
+            "every declared event) but can no longer satisfy the predicate. A "
             "declared event that fails makes the whole capture that typed "
-            "failure. Physics-clock offsets are not accepted, and every offset "
-            "must be inside await_frames — a cross-field bound JSON Schema "
-            "cannot state, enforced at validation and disclosed here. Needs "
-            "the await predicate."
+            "failure. Physics-clock offsets are not accepted. Needs the await "
+            "predicate."
         ),
     )
 
@@ -212,21 +212,11 @@ class ScreenCaptureParams(BaseModel):
                 raise ValueError(
                     "'await_events' must be a non-empty list when supplied."
                 )
-            bound = (
-                self.await_frames
-                if self.await_frames is not None
-                else DEFAULT_AWAIT_FRAMES
-            )
             for event in self.await_events:
                 if event.physics_frame is not None:
                     raise ValueError(
                         "a predicate capture applies its events on the process "
                         "clock; 'physics_frame' offsets are not accepted."
-                    )
-                if (event.frame or 0) >= bound:
-                    raise ValueError(
-                        f"an await event's 'frame' offset ({event.frame}) must be "
-                        f"inside the predicate window (await_frames = {bound})."
                     )
         return self
 

--- a/src/gda/commands/screen.py
+++ b/src/gda/commands/screen.py
@@ -65,11 +65,10 @@ def _await_schema_extra(schema: dict) -> None:
     validation and the published schema, so the model validator's cross-field
     rules must be visible to a standard Draft 2020-12 validator too: supplying
     any of the trio (non-null) requires the whole trio; the ceiling and the
-    events need the trio; the events are non-empty and process-clock only. A
-    parity corpus (tests/test_screen_commands.py) keeps validator and model
-    agreeing. One rule stays model-only, disclosed here: an event offset must
-    be INSIDE the window, a value-dependent relation across two fields that
-    Draft 2020-12 cannot state — the schema stays honestly LESS strict there.
+    events need the trio; the events are non-empty and process-clock only. The
+    imported event union publishes its scalar constraints, modifier vocabulary,
+    and shared total-window offset ceiling. A parity corpus
+    (tests/test_screen_commands.py) keeps validator and model agreeing.
     """
     scalar = {"type": ["boolean", "integer", "number", "string"]}
     trio = {
@@ -173,11 +172,13 @@ class ScreenCaptureParams(BaseModel):
             "cannot be missed by a second round trip. An event's effect is "
             "observable from the NEXT frame boundary, so leave at least one "
             "frame between the last state-changing event and the ceiling; an "
-            "offset at or beyond the ceiling still fires (the reply waits for "
-            "every declared event) but can no longer satisfy the predicate. A "
-            "declared event that fails makes the whole capture that typed "
-            "failure. Physics-clock offsets are not accepted. Needs the await "
-            "predicate."
+            "offset at or beyond the predicate ceiling still fires (the reply "
+            "waits for every declared event) but can no longer satisfy the "
+            f"predicate. Every offset remains at most {MAX_WINDOW_FRAMES - 1}, "
+            f"so the total drain stays within the shared {MAX_WINDOW_FRAMES}-frame "
+            "live-window ceiling. A declared event that fails makes the whole "
+            "capture that typed failure. Physics-clock offsets are not accepted. "
+            "Needs the await predicate."
         ),
     )
 

--- a/src/gda/commands/screen.py
+++ b/src/gda/commands/screen.py
@@ -157,6 +157,7 @@ class ScreenCaptureParams(BaseModel):
         default=None,
         ge=1,
         le=MAX_WINDOW_FRAMES,
+        strict=True,
         description=(
             "The predicate window's frame CEILING (default 60): a predicate that "
             "never holds within it is the typed live_predicate_unmet. Needs the "
@@ -169,9 +170,14 @@ class ScreenCaptureParams(BaseModel):
             "The atomic input-and-capture form (#661): input-sequence events "
             "applied inside the SAME predicate window at their process-clock "
             "'frame' offsets, so a 3-8 frame transient triggered by the input "
-            "cannot be missed by a second round trip. Physics-clock offsets are "
-            "not accepted; every offset must be inside await_frames. Needs the "
-            "await predicate."
+            "cannot be missed by a second round trip. An event's effect is "
+            "observable from the NEXT frame boundary, so leave at least one "
+            "frame between the last state-changing event and the ceiling. A "
+            "declared event that fails makes the whole capture that typed "
+            "failure. Physics-clock offsets are not accepted, and every offset "
+            "must be inside await_frames — a cross-field bound JSON Schema "
+            "cannot state, enforced at validation and disclosed here. Needs "
+            "the await predicate."
         ),
     )
 
@@ -264,11 +270,10 @@ class CapturePredicateReport(BaseModel):
 
     node: str = Field(description="The awaited node's absolute runtime path.")
     property: str = Field(description="The awaited property's name.")
-    expected: "bool | int | float | str | None" = Field(
-        default=None, description="The declared predicate value."
+    expected: "bool | int | float | str" = Field(
+        description="The declared predicate value."
     )
-    observed: "bool | int | float | str | None" = Field(
-        default=None,
+    observed: "bool | int | float | str" = Field(
         description=(
             "The property's value on the frame the predicate held (scalars "
             "verbatim; anything else its diagnostic String form). Read at the "
@@ -276,10 +281,10 @@ class CapturePredicateReport(BaseModel):
         ),
     )
     engine_frame: int = Field(
-        description="The engine's absolute process-frame counter at capture."
+        ge=0, description="The engine's absolute process-frame counter at capture."
     )
     frames_waited: int = Field(
-        description="How many window frames passed before the predicate held."
+        ge=0, description="How many window frames passed before the predicate held."
     )
 
 
@@ -379,8 +384,8 @@ LiveRunnerFactory = Callable[[Optional[Path], Optional[Path]], GodotRunner]
 class _PredicateReply(BaseModel):
     node: str
     property: str
-    expected: "bool | int | float | str | None" = None
-    observed: "bool | int | float | str | None" = None
+    expected: "bool | int | float | str"
+    observed: "bool | int | float | str"
     engine_frame: int = Field(ge=0)
     frames_waited: int = Field(ge=0)
 
@@ -755,7 +760,11 @@ def screen_capture(
     events inside the same window (the atomic input-and-capture form) so a short
     transient triggered by the input cannot be missed by a second round trip;
     every declared event fires before the reply, even when the predicate
-    matches first. Needs a WINDOWED
+    matches first, and a declared event that fails makes the whole capture that
+    typed failure. Each tick evaluates BEFORE it injects, so the observed
+    property and the captured pixels always belong to the same completed frame
+    (state an event writes is observed one boundary later, with its
+    presentation). Needs a WINDOWED
     session (`gda daemon start --windowed`); a headless one is
     `live_display_unavailable`. With no daemon it reports `daemon_not_running`.
     """

--- a/src/gda/commands/screen.py
+++ b/src/gda/commands/screen.py
@@ -18,14 +18,16 @@ on a headless session a capture is the typed ``live_display_unavailable`` (#222)
 """
 
 import base64
+import json
 from pathlib import Path
 from typing import Callable, Optional
 
 import typer
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from gda import dispatch
-from gda.dispatch import dispatch_recipe
+from gda.commands.input import InputSequenceEvent
+from gda.dispatch import dispatch_recipe, params_or_bad_parameter
 from gda.errors import Failure, classify_live
 from gda.execution import ExecutionKind
 from gda.headless import (
@@ -50,6 +52,12 @@ from gda.runner import GodotRunner
 # (`gda daemon start --windowed`); a headless one is `live_display_unavailable`.
 
 
+# The predicate window's default frame ceiling (#661): ~1 s at 60 fps, and the
+# harness applies the same default when the wire omits it. The hard ceiling is
+# the shared MAX_WINDOW_FRAMES.
+DEFAULT_AWAIT_FRAMES = 60
+
+
 class ScreenCaptureParams(BaseModel):
     """The params of ``gda screen capture``: where to write one viewport frame (#222).
 
@@ -68,6 +76,97 @@ class ScreenCaptureParams(BaseModel):
         default=False,
         description="Also embed the base64-encoded PNG in the result (default: path only).",
     )
+    await_node: str | None = Field(
+        default=None,
+        description=(
+            "Predicate node: the ABSOLUTE runtime path (e.g. /root/Main/Player) "
+            "whose property gates the capture (#661). Needs await_property and "
+            "await_value with it."
+        ),
+    )
+    await_property: str | None = Field(
+        default=None,
+        description=(
+            "Predicate property on the await_node — a storage property or an "
+            "explicit script variable, exactly what `game get` can read."
+        ),
+    )
+    await_value: "bool | int | float | str | None" = Field(
+        default=None,
+        description=(
+            "Predicate value, a JSON scalar: the capture fires on the first frame "
+            "the property equals it (numbers compare numerically, strings against "
+            "the String rendering; null is not supported)."
+        ),
+    )
+    await_frames: int | None = Field(
+        default=None,
+        ge=1,
+        le=MAX_WINDOW_FRAMES,
+        description=(
+            "The predicate window's frame CEILING (default 60): a predicate that "
+            "never holds within it is the typed live_predicate_unmet. Needs the "
+            "await predicate."
+        ),
+    )
+    await_events: "list[InputSequenceEvent] | None" = Field(
+        default=None,
+        description=(
+            "The atomic input-and-capture form (#661): input-sequence events "
+            "applied inside the SAME predicate window at their process-clock "
+            "'frame' offsets, so a 3-8 frame transient triggered by the input "
+            "cannot be missed by a second round trip. Physics-clock offsets are "
+            "not accepted; every offset must be inside await_frames. Needs the "
+            "await predicate."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _check_await_group(self) -> "ScreenCaptureParams":
+        # Model-side (ADR-0015): argv and --params-json reject identically.
+        trio = [
+            self.await_node is not None,
+            self.await_property is not None,
+            self.await_value is not None,
+        ]
+        if any(trio) and not all(trio):
+            raise ValueError(
+                "an await predicate needs 'await_node', 'await_property', and "
+                "'await_value' together (a JSON null value is not supported)."
+            )
+        has_await = all(trio)
+        if self.await_frames is not None and not has_await:
+            raise ValueError(
+                "'await_frames' needs the await predicate "
+                "(await_node / await_property / await_value)."
+            )
+        if self.await_events is not None:
+            if not has_await:
+                raise ValueError(
+                    "'await_events' needs the await predicate — without one, "
+                    "inject input with `gda input ...` and capture separately."
+                )
+            if not self.await_events:
+                raise ValueError(
+                    "'await_events' must be a non-empty list when supplied."
+                )
+            bound = (
+                self.await_frames
+                if self.await_frames is not None
+                else DEFAULT_AWAIT_FRAMES
+            )
+            for event in self.await_events:
+                if event.physics_frame is not None:
+                    raise ValueError(
+                        "a predicate capture applies its events on the process "
+                        "clock; 'physics_frame' offsets are not accepted."
+                    )
+                if (event.frame or 0) >= bound:
+                    raise ValueError(
+                        f"an await event's 'frame' offset ({event.frame}) must be "
+                        f"inside the predicate window (await_frames = {bound})."
+                    )
+        return self
 
 
 class ScreenCaptureResult(BaseModel):
@@ -88,6 +187,42 @@ class ScreenCaptureResult(BaseModel):
     inline: str | None = Field(
         default=None,
         description="The base64-encoded PNG, present only when --inline was passed.",
+    )
+    predicate: "CapturePredicateReport | None" = Field(
+        default=None,
+        description=(
+            "The predicate report, present only when --await-* gated this "
+            "capture (#661): what held, when, and what was observed."
+        ),
+    )
+
+
+class CapturePredicateReport(BaseModel):
+    """What a ``--await-*`` predicate observed when the capture fired (#661).
+
+    The synchronization evidence: the frame the predicate held (``engine_frame``
+    is the engine's absolute process-frame counter; ``frames_waited`` is the
+    window-relative wait), and the property's ``observed`` value at that frame —
+    the fields #660's capture receipt echoes onward.
+    """
+
+    node: str = Field(description="The awaited node's absolute runtime path.")
+    property: str = Field(description="The awaited property's name.")
+    expected: "bool | int | float | str | None" = Field(
+        default=None, description="The declared predicate value."
+    )
+    observed: "bool | int | float | str | None" = Field(
+        default=None,
+        description=(
+            "The property's value on the frame the predicate held (scalars "
+            "verbatim; anything else its diagnostic String form)."
+        ),
+    )
+    engine_frame: int = Field(
+        description="The engine's absolute process-frame counter at capture."
+    )
+    frames_waited: int = Field(
+        description="How many window frames passed before the predicate held."
     )
 
 
@@ -184,12 +319,22 @@ LiveRunnerFactory = Callable[[Optional[Path], Optional[Path]], GodotRunner]
 # through classify_live just like any live op, surfacing LIVE errors uniformly.
 
 
+class _PredicateReply(BaseModel):
+    node: str
+    property: str
+    expected: "bool | int | float | str | None" = None
+    observed: "bool | int | float | str | None" = None
+    engine_frame: int
+    frames_waited: int
+
+
 class _CaptureReply(BaseModel):
     width: int
     height: int
     format: str = Field(default="png")
     bytes: int
     png_base64: str
+    predicate: "_PredicateReply | None" = None
 
 
 class _FrameReply(BaseModel):
@@ -225,24 +370,42 @@ def _write_png(png_base64: str, destination: Path) -> int:
 
 def run_screen_capture_operation(
     project: Optional[Path],
-    output: Path,
+    params: "ScreenCaptureParams",
     *,
-    inline: bool = False,
     make_runner: Optional[LiveRunnerFactory] = None,
 ) -> "ScreenCaptureResult | Failure":
-    """Capture one viewport frame, write it to ``output``, return the typed result.
+    """Capture one viewport frame, write it to ``params.output``, return the result.
 
     The single-frame recipe: run the ``screen-capture`` live op, surface any LIVE
     failure via ``classify_live`` (so ``daemon_not_running`` /
-    ``live_display_unavailable`` ride the registered-code pipeline), then decode the
-    base64 PNG and write it to ``output``. ``--inline`` additionally embeds the
-    base64 in the result; the default reply is path + dims + bytes + format.
+    ``live_display_unavailable`` — and the predicate's ``live_predicate_unmet``,
+    #661 — ride the registered-code pipeline), then decode the base64 PNG and
+    write it to ``params.output``. With ``--await-*`` the wire params carry the
+    predicate (and the optional atomic input events); the harness holds the
+    capture until the predicate's first holding frame, and the reply's
+    ``predicate`` report is surfaced on the result. ``--inline`` additionally
+    embeds the base64; the default reply is path + dims + bytes + format.
     """
     runner = (make_runner or _default_runner)(None, project)
-    result = runner.run("screen-capture", {})
+    op_params: dict[str, object] = {}
+    if params.await_node is not None:
+        op_params["await"] = {
+            "node": params.await_node,
+            "property": params.await_property,
+            "value": params.await_value,
+            "frames": (
+                params.await_frames
+                if params.await_frames is not None
+                else DEFAULT_AWAIT_FRAMES
+            ),
+        }
+        if params.await_events:
+            op_params["events"] = [event.model_dump() for event in params.await_events]
+    result = runner.run("screen-capture", op_params)
     reply = classify_live(result, None, _CaptureReply)
     if isinstance(reply, Failure):
         return reply
+    output = Path(params.output)
     written = _write_png(reply.png_base64, output)
     return ScreenCaptureResult(
         path=str(output),
@@ -250,7 +413,12 @@ def run_screen_capture_operation(
         height=reply.height,
         bytes=written,
         format=reply.format,
-        inline=reply.png_base64 if inline else None,
+        inline=reply.png_base64 if params.inline else None,
+        predicate=(
+            CapturePredicateReport(**reply.predicate.model_dump())
+            if reply.predicate is not None
+            else None
+        ),
     )
 
 
@@ -292,9 +460,17 @@ def run_screen_frames_operation(
 def render_screen_capture(captured: "ScreenCaptureResult") -> str:
     """Render a captured viewport frame as ``captured WxH -> path`` (#222)."""
     inline = " (+inline)" if captured.inline else ""
-    return (
+    head = (
         f"captured {captured.width}x{captured.height} "
         f"({captured.bytes} bytes) -> {captured.path}{inline}"
+    )
+    if captured.predicate is None:
+        return head
+    pred = captured.predicate
+    return head + (
+        f"\n  predicate {pred.node}.{pred.property} == {pred.expected!r} held "
+        f"after {pred.frames_waited} frames "
+        f"(engine frame {pred.engine_frame}, observed {pred.observed!r})"
     )
 
 
@@ -325,8 +501,7 @@ def render_screen_frames(captured: "ScreenFramesResult") -> str:
 def _screen_capture_recipe(params, *, project, godot):
     return run_screen_capture_operation(
         project,
-        Path(params.output),
-        inline=params.inline,
+        params,
         make_runner=dispatch.make_live_runner,
     )
 
@@ -390,6 +565,45 @@ def screen_capture(
         "--inline",
         help="Also embed the base64-encoded PNG in the result (default: path only).",
     ),
+    await_node: Optional[str] = typer.Option(
+        None,
+        "--await-node",
+        help=(
+            "Predicate node: the absolute runtime path whose property gates the "
+            "capture (#661); needs --await-property and --await-value."
+        ),
+    ),
+    await_property: Optional[str] = typer.Option(
+        None,
+        "--await-property",
+        help="Predicate property on the --await-node (what `game get` can read).",
+    ),
+    await_value: Optional[str] = typer.Option(
+        None,
+        "--await-value",
+        help=(
+            'Predicate value as a JSON scalar (3, 3.5, true, "word"); a bare '
+            "word is taken as a string. Capture fires when the property equals it."
+        ),
+    ),
+    await_frames: Optional[int] = typer.Option(
+        None,
+        "--await-frames",
+        help=(
+            f"Frame ceiling for the predicate window (default "
+            f"{DEFAULT_AWAIT_FRAMES}); an unmet predicate is the typed "
+            "live_predicate_unmet."
+        ),
+    ),
+    await_events: Optional[str] = typer.Option(
+        None,
+        "--await-events",
+        help=(
+            "JSON list of input-sequence events applied INSIDE the predicate "
+            "window at their process-clock 'frame' offsets — the atomic "
+            "input-and-capture form (same shapes as `gda input sequence`)."
+        ),
+    ),
     json_output: bool = json_option(),
     schema: bool = SCREEN_CAPTURE_COMMAND.schema_option(),
     params_json: Optional[str] = params_json_option(),
@@ -401,17 +615,49 @@ def screen_capture(
     Routes through gda-daemon to the engine session (kind = LIVE, ADR-0017): the
     harness reads the viewport texture, PNG-encodes it, and returns it base64 in the
     sentinel; the CLI decodes it and WRITES the PNG to `--output`, returning the path
-    + dims + bytes + format. `--inline` also embeds the base64. Needs a WINDOWED
+    + dims + bytes + format. `--inline` also embeds the base64.
+
+    The `--await-*` predicate (#661) holds the capture game-side until
+    `node.property == value` first holds (checked once per process frame, up to
+    `--await-frames`), then captures THAT frame and reports the predicate
+    evidence; a predicate that never holds is the typed `live_predicate_unmet`.
+    `--await-events` additionally injects input-sequence events inside the same
+    window (the atomic input-and-capture form) so a short transient triggered by
+    the input cannot be missed by a second round trip. Needs a WINDOWED
     session (`gda daemon start --windowed`); a headless one is
     `live_display_unavailable`. With no daemon it reports `daemon_not_running`.
     """
     # Build the params model from the argv options so `output` is validated and
     # ~-normalized through the SAME single source of truth the --params-json path
-    # uses (ADR-0015/ADR-0006) — not a raw, un-normalized Path. Dispatch through the
-    # descriptor's recipe, exactly as the --params-json path does (ADR-0023).
+    # uses (ADR-0015/ADR-0006) — not a raw, un-normalized Path. The value flag is
+    # a JSON scalar (a bare word falls back to a string); the events flag is a
+    # JSON list — both validated by the model, so argv and --params-json reject
+    # identically. Dispatch through the descriptor's recipe (ADR-0023).
+    value: object = None
+    if await_value is not None:
+        try:
+            value = json.loads(await_value)
+        except ValueError:
+            value = await_value
+    events: object = None
+    if await_events is not None:
+        try:
+            events = json.loads(await_events)
+        except ValueError:
+            events = await_events  # not JSON: the model refuses it structurally
+    params = params_or_bad_parameter(
+        ScreenCaptureParams,
+        output=str(output),
+        inline=inline,
+        await_node=await_node,
+        await_property=await_property,
+        await_value=value,
+        await_frames=await_frames,
+        await_events=events,
+    )
     dispatch_recipe(
         SCREEN_CAPTURE_COMMAND,
-        ScreenCaptureParams(output=str(output), inline=inline),
+        params,
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/commands/screen.py
+++ b/src/gda/commands/screen.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, Field, model_validator
 from gda import dispatch
 from gda.commands.input import InputSequenceEvent
 from gda.dispatch import dispatch_recipe, params_or_bad_parameter
-from gda.errors import Failure, classify_live
+from gda.errors import Failure, classify_live, make_failure
 from gda.execution import ExecutionKind
 from gda.headless import (
     HeadlessCommand,
@@ -56,6 +56,56 @@ from gda.runner import GodotRunner
 # harness applies the same default when the wire omits it. The hard ceiling is
 # the shared MAX_WINDOW_FRAMES.
 DEFAULT_AWAIT_FRAMES = 60
+
+
+def _await_schema_extra(schema: dict) -> None:
+    """Publish the await validator's cross-field rules into the schema (#743).
+
+    ADR-0015 makes the params model the ONE authority for both runtime
+    validation and the published schema, so the model validator's cross-field
+    rules must be visible to a standard Draft 2020-12 validator too: supplying
+    any of the trio (non-null) requires the whole trio; the ceiling and the
+    events need the trio; the events are non-empty and process-clock only. A
+    parity corpus (tests/test_screen_commands.py) keeps validator and model
+    agreeing. One rule stays model-only, disclosed here: an event offset must
+    be INSIDE the window, a value-dependent relation across two fields that
+    Draft 2020-12 cannot state — the schema stays honestly LESS strict there.
+    """
+    scalar = {"type": ["boolean", "integer", "number", "string"]}
+    trio = {
+        "properties": {
+            "await_node": {"type": "string"},
+            "await_property": {"type": "string"},
+            "await_value": scalar,
+        },
+        "required": ["await_node", "await_property", "await_value"],
+    }
+
+    def given(name: str, spec: dict) -> dict:
+        return {"if": {"properties": {name: spec}, "required": [name]}, "then": trio}
+
+    schema["allOf"] = [
+        given("await_node", {"type": "string"}),
+        given("await_property", {"type": "string"}),
+        given("await_value", scalar),
+        given("await_frames", {"type": "integer"}),
+        given("await_events", {"type": "array"}),
+    ]
+    events = schema["properties"]["await_events"]
+    for branch in events.get("anyOf", []):
+        if branch.get("type") == "array":
+            branch["minItems"] = 1
+            branch["items"] = {
+                "allOf": [
+                    branch["items"],
+                    {
+                        "not": {
+                            "properties": {"physics_frame": {"type": "integer"}},
+                            "required": ["physics_frame"],
+                        }
+                    },
+                ]
+            }
 
 
 class ScreenCaptureParams(BaseModel):
@@ -95,8 +145,12 @@ class ScreenCaptureParams(BaseModel):
         default=None,
         description=(
             "Predicate value, a JSON scalar: the capture fires on the first frame "
-            "the property equals it (numbers compare numerically, strings against "
-            "the String rendering; null is not supported)."
+            "boundary where the property equals it (numbers compare numerically, "
+            "strings against the String rendering; null is not supported). The "
+            "property and the pixels are read at the SAME boundary — both belong "
+            "to the frame that just completed; a game that updates a visual one "
+            "frame after the property it gates on trails by that game-side frame, "
+            "so gate on the visual's own property when exact pixels matter."
         ),
     )
     await_frames: int | None = Field(
@@ -120,6 +174,8 @@ class ScreenCaptureParams(BaseModel):
             "await predicate."
         ),
     )
+
+    model_config = {"json_schema_extra": lambda schema: _await_schema_extra(schema)}
 
     @model_validator(mode="after")
     def _check_await_group(self) -> "ScreenCaptureParams":
@@ -215,7 +271,8 @@ class CapturePredicateReport(BaseModel):
         default=None,
         description=(
             "The property's value on the frame the predicate held (scalars "
-            "verbatim; anything else its diagnostic String form)."
+            "verbatim; anything else its diagnostic String form). Read at the "
+            "same frame boundary as the captured pixels."
         ),
     )
     engine_frame: int = Field(
@@ -324,8 +381,8 @@ class _PredicateReply(BaseModel):
     property: str
     expected: "bool | int | float | str | None" = None
     observed: "bool | int | float | str | None" = None
-    engine_frame: int
-    frames_waited: int
+    engine_frame: int = Field(ge=0)
+    frames_waited: int = Field(ge=0)
 
 
 class _CaptureReply(BaseModel):
@@ -368,6 +425,75 @@ def _write_png(png_base64: str, destination: Path) -> int:
     return len(raw)
 
 
+def _scalars_match(observed: object, expected: object) -> bool:
+    """The predicate's JSON-scalar equality, mirrored CLI-side (#661).
+
+    The same rule the harness applies: bools strictly, numbers numerically,
+    strings exactly; a null or cross-type pair never matches.
+    """
+    if isinstance(expected, bool) or isinstance(observed, bool):
+        return (
+            isinstance(expected, bool)
+            and isinstance(observed, bool)
+            and (observed is expected)
+        )
+    if isinstance(expected, (int, float)) and isinstance(observed, (int, float)):
+        return float(observed) == float(expected)
+    if isinstance(expected, str) and isinstance(observed, str):
+        return observed == expected
+    return False
+
+
+def _predicate_correlation_error(
+    params: "ScreenCaptureParams", predicate: "_PredicateReply | None"
+) -> "str | None":
+    """Why the reply's predicate report does not answer this request, or None.
+
+    A gated request's success MUST carry the evidence the request asked for
+    (#743 review): the report present, naming this node/property/value, with an
+    observed value that actually satisfies the declared predicate and a wait
+    inside the declared window. A plain request must carry none. Anything else
+    is a harness contract violation, refused BEFORE the output file is written.
+    """
+    if params.await_node is None:
+        if predicate is not None:
+            return (
+                "the harness reply carries a predicate report for a request "
+                "that declared no --await predicate"
+            )
+        return None
+    if predicate is None:
+        return (
+            "the harness reply carries no predicate report for a request "
+            "gated on --await-node/--await-property/--await-value"
+        )
+    bound = (
+        params.await_frames if params.await_frames is not None else DEFAULT_AWAIT_FRAMES
+    )
+    if (
+        predicate.node != params.await_node
+        or predicate.property != params.await_property
+        or not _scalars_match(predicate.expected, params.await_value)
+    ):
+        return (
+            "the harness reply's predicate report does not name the requested "
+            f"predicate ({params.await_node}.{params.await_property} == "
+            f"{params.await_value!r})"
+        )
+    if not _scalars_match(predicate.observed, predicate.expected):
+        return (
+            "the harness reply's predicate report observed "
+            f"{predicate.observed!r}, which does not satisfy the declared "
+            f"predicate value {predicate.expected!r}"
+        )
+    if predicate.frames_waited >= bound:
+        return (
+            f"the harness reply waited {predicate.frames_waited} frames, "
+            f"outside the declared window of {bound}"
+        )
+    return None
+
+
 def run_screen_capture_operation(
     project: Optional[Path],
     params: "ScreenCaptureParams",
@@ -405,6 +531,9 @@ def run_screen_capture_operation(
     reply = classify_live(result, None, _CaptureReply)
     if isinstance(reply, Failure):
         return reply
+    correlation = _predicate_correlation_error(params, reply.predicate)
+    if correlation is not None:
+        return make_failure("contract_violation", correlation, result.stdout)
     output = Path(params.output)
     written = _write_png(reply.png_base64, output)
     return ScreenCaptureResult(
@@ -619,11 +748,14 @@ def screen_capture(
 
     The `--await-*` predicate (#661) holds the capture game-side until
     `node.property == value` first holds (checked once per process frame, up to
-    `--await-frames`), then captures THAT frame and reports the predicate
-    evidence; a predicate that never holds is the typed `live_predicate_unmet`.
-    `--await-events` additionally injects input-sequence events inside the same
-    window (the atomic input-and-capture form) so a short transient triggered by
-    the input cannot be missed by a second round trip. Needs a WINDOWED
+    `--await-frames`), then captures at that SAME frame boundary — the property
+    and the pixels both belong to the frame that just completed — and reports
+    the predicate evidence; a predicate that never holds is the typed
+    `live_predicate_unmet`. `--await-events` additionally injects input-sequence
+    events inside the same window (the atomic input-and-capture form) so a short
+    transient triggered by the input cannot be missed by a second round trip;
+    every declared event fires before the reply, even when the predicate
+    matches first. Needs a WINDOWED
     session (`gda daemon start --windowed`); a headless one is
     `live_display_unavailable`. With no daemon it reports `daemon_not_running`.
     """

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -802,6 +802,18 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCodeSource.CLASSIFIER,
         "A live input sequence event has a type the harness does not recognize.",
     ),
+    # The predicate-capture failure the gda harness reports for #661: a
+    # `screen capture --await-*` predicate that never held within its declared
+    # frame bound. LIVE-category, classifier-source, harness-mirrored like the
+    # other per-op codes; the message carries the last observed value so the
+    # agent can see how far the state got.
+    ErrorCodeSpec(
+        "live_predicate_unmet",
+        ErrorCategory.LIVE,
+        EXIT_LIVE,
+        ErrorCodeSource.CLASSIFIER,
+        "A live capture predicate did not hold within its declared frame bound.",
+    ),
     # The `screen` capture failure the gda harness reports for #222. Same shape as
     # the other per-op LIVE codes (LIVE-category, classifier-source, exit_code
     # EXIT_LIVE, harness-mirrored): a viewport capture needs a real DisplayServer,

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -444,8 +444,7 @@ func _explicit_script_variable_property(
 	for prop in node.get_property_list():
 		if String(prop.get("name", "")) != prop_name:
 			continue
-		var usage := int(prop.get("usage", 0))
-		if (usage & PROPERTY_USAGE_SCRIPT_VARIABLE) == 0:
+		if not _is_script_variable(prop):
 			continue
 		var value: Variant = node.get(prop_name)
 		var declared_type := int(prop.get("type", TYPE_NIL))
@@ -1334,18 +1333,25 @@ func _handle_screen_frames(params: Dictionary) -> Variant:
 
 # screen capture --await (#661): the predicate-gated capture, GDA-DF-023. Input
 # and capture as separate round trips routinely miss a 3-8 frame transient, so
-# the window arms at request arrival and does the whole job game-side: each
-# PROCESS frame it applies the inline input events due at that offset (the
-# atomic input-and-capture form; the events reuse the input-sequence shapes and
+# the window arms at request arrival and does the whole job game-side, on the
+# PROCESS clock (physics-clock event offsets are refused): each frame it first
+# applies the inline input events due at that offset (the atomic
+# input-and-capture form; the events reuse the input-sequence shapes and
 # _apply_sequence_event verbatim), then evaluates the predicate
-# `node.property == value`; the first frame it holds is captured and completes
-# the window EARLY via the _advance_window "complete" arm. A predicate that
-# never holds within `frames` is the typed live_predicate_unmet, carrying the
-# last observed value. Evaluation happens at the process-frame boundary; the
-# captured image is the most recently PRESENTED frame, so a property written
-# after that frame's draw can be one frame ahead of the pixels — the documented
-# limit. Physics-clock event offsets are refused: the capture clock IS the
-# process clock.
+# `node.property == value`. The first holding frame records the evidence
+# (observed value, engine frame, frames waited) and reads the pixels AT THE
+# SAME frame boundary: both reflect the previously COMPLETED frame — the
+# property as the game last wrote it, the viewport texture as the engine last
+# presented it — verified frame-by-frame against a live probe (an autoload
+# observing a per-frame color flip sees the flipped property and the flipped
+# pixel on the SAME tick). If the game updates a visual one frame after the
+# property it gates on, the image trails by that game-side frame — gate on the
+# visual's own property when exact pixels matter. The window replies
+# only after every accepted event has fired — an early match must not leave a
+# scheduled release unexecuted (#743 review) — and the FIRST decided outcome
+# wins: a later event error cannot retract a completed capture, it only drains.
+# A predicate that never holds within `frames` is the typed
+# live_predicate_unmet, carrying the last observed value.
 func _begin_predicate_capture(await_spec: Dictionary, raw_events: Variant) -> Variant:
 	var node_path := String(await_spec.get("node", ""))
 	var node := _resolve_runtime_node(node_path)
@@ -1353,72 +1359,107 @@ func _begin_predicate_capture(await_spec: Dictionary, raw_events: Variant) -> Va
 		return _error(LIVE_ERROR_NODE_NOT_FOUND,
 				"no node at runtime path: " + node_path)
 	var prop := String(await_spec.get("property", ""))
-	if not _runtime_property_exists(node, prop):
+	if not _runtime_property_declared(node, prop):
 		return _error(LIVE_ERROR_UNKNOWN_PROPERTY,
 				_unknown_runtime_property_message(node_path, prop))
 	var expected: Variant = await_spec.get("value", null)
 	var frames := _int_param(await_spec, "frames", 60)
 	var events: Array = raw_events if typeof(raw_events) == TYPE_ARRAY else []
+	var last_event := -1
 	for event in events:
-		if typeof(event) == TYPE_DICTIONARY and _sequence_event_uses_physics(event):
+		if typeof(event) != TYPE_DICTIONARY:
+			continue
+		if _sequence_event_uses_physics(event):
 			return _error(LIVE_ERROR_INVALID_EVENT_SPEC,
 					"a predicate capture applies its events on the process clock; "
 					+ "'physics_frame' offsets are not accepted")
-	var frame_box := {"n": 0, "observed": null}
+		last_event = maxi(last_event, _sequence_event_offset(event))
+	var state := {"n": 0, "observed": null, "outcome": null}
 	_injected_mouse_button_mask = 0
 	var sample := func() -> Variant:
-		var current := int(frame_box["n"])
-		frame_box["n"] = current + 1
+		var current := int(state["n"])
+		state["n"] = current + 1
+		# Input first: every ACCEPTED event fires at its offset, even after the
+		# outcome is decided, so a press injected early is never left held by
+		# an early predicate match or an error (#743 review, ARC-743-001). An
+		# event error is held as the outcome only if none is decided yet; later
+		# events still drain, best effort, so scheduled releases fire.
 		for event in events:
 			if typeof(event) != TYPE_DICTIONARY:
 				continue
 			if _sequence_event_offset(event) != current:
 				continue
 			var err: Variant = _apply_sequence_event(event)
-			if err != null:
-				_injected_mouse_button_mask = 0
-				return {"error": err}
-		if not is_instance_valid(node):
+			if err != null and state["outcome"] == null:
+				state["outcome"] = {"error": err}
+		# Evaluate until decided. The value is read HERE only — the up-front
+		# resolution above is metadata-only, so a scripted getter runs exactly
+		# once per sampled frame (#743 review, ARC-743-002).
+		if state["outcome"] == null:
+			if not is_instance_valid(node):
+				state["outcome"] = {"error": {
+					"code": LIVE_ERROR_NODE_NOT_FOUND,
+					"message": "the awaited node was freed mid-window: " + node_path,
+				}}
+			else:
+				var observed: Variant = node.get(prop)
+				state["observed"] = observed
+				if _predicate_matches(observed, expected):
+					# Capture at the SAME boundary the predicate was observed
+					# at — property and presentation both belong to the frame
+					# that just completed (verified live, see above).
+					var captured := _capture_frame()
+					if captured.has("error"):
+						state["outcome"] = captured
+					else:
+						captured["predicate"] = {
+							"node": node_path,
+							"property": prop,
+							"expected": expected,
+							"observed": _predicate_echo(observed),
+							"engine_frame": Engine.get_process_frames(),
+							"frames_waited": current,
+						}
+						state["outcome"] = {"complete": captured}
+				elif current + 1 >= frames:
+					state["outcome"] = {"error": {
+						"code": LIVE_ERROR_PREDICATE_UNMET,
+						"message": "the predicate " + node_path + "." + prop
+								+ " == " + JSON.stringify(expected)
+								+ " did not hold within " + str(frames)
+								+ " frames (last observed: "
+								+ str(state["observed"]) + ")",
+					}}
+		if state["outcome"] != null and current >= last_event:
 			_injected_mouse_button_mask = 0
-			return {"error": {
-				"code": LIVE_ERROR_NODE_NOT_FOUND,
-				"message": "the awaited node was freed mid-window: " + node_path,
-			}}
-		var observed: Variant = node.get(prop)
-		frame_box["observed"] = observed
-		if not _predicate_matches(observed, expected):
-			return current
-		var captured := _capture_frame()
-		_injected_mouse_button_mask = 0
-		if captured.has("error"):
-			return captured
-		captured["predicate"] = {
-			"node": node_path,
-			"property": prop,
-			"expected": expected,
-			"observed": _predicate_echo(observed),
-			"engine_frame": Engine.get_process_frames(),
-			"frames_waited": current,
-		}
-		return {"complete": captured}
+			return state["outcome"]
+		return current
 	var finalize := func(_samples: Array) -> String:
+		# Defensive only: the sampler decides every path within the budget.
 		_injected_mouse_button_mask = 0
 		return _error(LIVE_ERROR_PREDICATE_UNMET,
 				"the predicate " + node_path + "." + prop + " == "
 				+ JSON.stringify(expected) + " did not hold within "
 				+ str(frames) + " frames (last observed: "
-				+ str(frame_box["observed"]) + ")")
-	return _begin_window(frames, sample, finalize)
+				+ str(state["observed"]) + ")")
+	return _begin_window(maxi(frames, last_event + 1) + 1, sample, finalize)
 
 
-# Whether the node exposes `prop` the way game get resolves properties: a storage
-# property, or an explicit script variable (the same two-step, so the predicate
-# surface and the read surface agree on what a property IS).
-func _runtime_property_exists(node: Node, prop: String) -> bool:
+# The one runtime-property resolution rule, metadata only (#743 review,
+# ARC-743-002): a STORAGE property or an explicit SCRIPT VARIABLE — the same
+# two-step game get resolves with — decided from get_property_list() alone, so
+# resolving NEVER invokes a getter; the owning use case reads the value.
+func _runtime_property_declared(node: Node, prop_name: String) -> bool:
 	for entry in node.get_property_list():
-		if _is_storage_property(entry) and String(entry.get("name", "")) == prop:
+		if String(entry.get("name", "")) != prop_name:
+			continue
+		if _is_storage_property(entry) or _is_script_variable(entry):
 			return true
-	return not _explicit_script_variable_property(node, prop, false).is_empty()
+	return false
+
+
+func _is_script_variable(prop: Dictionary) -> bool:
+	return (int(prop.get("usage", 0)) & PROPERTY_USAGE_SCRIPT_VARIABLE) != 0
 
 
 # JSON-typed predicate equality (#661): bool compares to bool, numbers

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -1338,19 +1338,23 @@ func _handle_screen_frames(params: Dictionary) -> Variant:
 # applies the inline input events due at that offset (the atomic
 # input-and-capture form; the events reuse the input-sequence shapes and
 # _apply_sequence_event verbatim), then evaluates the predicate
-# `node.property == value`. The first holding frame records the evidence
-# (observed value, engine frame, frames waited) and reads the pixels AT THE
-# SAME frame boundary: both reflect the previously COMPLETED frame — the
-# property as the game last wrote it, the viewport texture as the engine last
-# presented it — verified frame-by-frame against a live probe (an autoload
-# observing a per-frame color flip sees the flipped property and the flipped
-# pixel on the SAME tick). If the game updates a visual one frame after the
-# property it gates on, the image trails by that game-side frame — gate on the
-# visual's own property when exact pixels matter. The window replies
-# only after every accepted event has fired — an early match must not leave a
-# scheduled release unexecuted (#743 review) — and the FIRST decided outcome
-# wins: a later event error cannot retract a completed capture, it only drains.
-# A predicate that never holds within `frames` is the typed
+# `node.property == value`. Each tick EVALUATES BEFORE it injects (#743
+# re-review, ARC-743-004): the property is read before this tick's events run,
+# so the observed value is always the state of the previously COMPLETED frame —
+# exactly the frame the viewport texture presents — and the pixels are read at
+# that same boundary. This holds for both trigger paths, verified live: a
+# _process-driven flip is observed with its own presentation, and a state an
+# injected event writes (a synchronous _input callback) is observed one
+# boundary LATER, together with its presentation. Two declared consequences:
+# the predicate sees frame-boundary state only (a value overwritten before its
+# frame completes is never observable — the typed unmet error, not a capture
+# of mismatched pixels), and an event's effect is observable from the NEXT
+# boundary, so the last state-changing event needs at least one frame of
+# window left. The reply waits for every accepted event — an early match must
+# not leave a scheduled release unexecuted — and a DECLARED EVENT FAILURE is
+# the reply even after a capture succeeded (#743 re-review, ARC-743-001): the
+# capture payload is discarded, later events still drain, and the CLI writes
+# no file. A predicate that never holds within `frames` is the typed
 # live_predicate_unmet, carrying the last observed value.
 func _begin_predicate_capture(await_spec: Dictionary, raw_events: Variant) -> Variant:
 	var node_path := String(await_spec.get("node", ""))
@@ -1379,22 +1383,12 @@ func _begin_predicate_capture(await_spec: Dictionary, raw_events: Variant) -> Va
 	var sample := func() -> Variant:
 		var current := int(state["n"])
 		state["n"] = current + 1
-		# Input first: every ACCEPTED event fires at its offset, even after the
-		# outcome is decided, so a press injected early is never left held by
-		# an early predicate match or an error (#743 review, ARC-743-001). An
-		# event error is held as the outcome only if none is decided yet; later
-		# events still drain, best effort, so scheduled releases fire.
-		for event in events:
-			if typeof(event) != TYPE_DICTIONARY:
-				continue
-			if _sequence_event_offset(event) != current:
-				continue
-			var err: Variant = _apply_sequence_event(event)
-			if err != null and state["outcome"] == null:
-				state["outcome"] = {"error": err}
-		# Evaluate until decided. The value is read HERE only — the up-front
-		# resolution above is metadata-only, so a scripted getter runs exactly
-		# once per sampled frame (#743 review, ARC-743-002).
+		# Evaluate BEFORE this tick's events run (#743 re-review): the read
+		# then always sees the previously completed frame — the same frame the
+		# texture presents — never a mid-tick write from a synchronous input
+		# callback. The value is read HERE only; the up-front resolution is
+		# metadata-only, so a scripted getter runs exactly once per sampled
+		# frame (#743 review, ARC-743-002).
 		if state["outcome"] == null:
 			if not is_instance_valid(node):
 				state["outcome"] = {"error": {
@@ -1430,6 +1424,21 @@ func _begin_predicate_capture(await_spec: Dictionary, raw_events: Variant) -> Va
 								+ " frames (last observed: "
 								+ str(state["observed"]) + ")",
 					}}
+		# Then inject: every ACCEPTED event fires at its offset, even after
+		# the outcome is decided, so a press injected early is never left held
+		# (#743 review). A declared event FAILURE becomes the reply — it
+		# replaces a captured success (the CLI then writes no file) but never
+		# an earlier error — while later events still drain, best effort.
+		for event in events:
+			if typeof(event) != TYPE_DICTIONARY:
+				continue
+			if _sequence_event_offset(event) != current:
+				continue
+			var err: Variant = _apply_sequence_event(event)
+			if err != null:
+				var outcome: Variant = state["outcome"]
+				if outcome == null or (outcome as Dictionary).has("complete"):
+					state["outcome"] = {"error": err}
 		if state["outcome"] != null and current >= last_event:
 			_injected_mouse_button_mask = 0
 			return state["outcome"]

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -61,6 +61,7 @@ const LIVE_ERROR_INVALID_KEY := "live_invalid_key"
 const LIVE_ERROR_UNKNOWN_ACTION := "live_unknown_action"
 const LIVE_ERROR_INVALID_EVENT_SPEC := "live_invalid_event_spec"
 const LIVE_ERROR_DISPLAY_UNAVAILABLE := "live_display_unavailable"
+const LIVE_ERROR_PREDICATE_UNMET := "live_predicate_unmet"
 
 # The frame count a time-windowed op may request (#223). A window collects one
 # sample per frame, so an unbounded N would block the one-shot RPC for an unbounded
@@ -306,9 +307,11 @@ func _window_clock() -> String:
 
 
 # Advance the active window one frame. Collects one sample; finalizes once the
-# frame budget is met. A sample handler may abort the window early by returning a
-# Dictionary carrying an "error" key (e.g. a node that vanished mid-window) — that
-# envelope is sent verbatim.
+# frame budget is met. A sample handler may end the window early two ways: a
+# Dictionary carrying an "error" key aborts with that envelope verbatim (e.g. a
+# node that vanished mid-window), and a Dictionary carrying a "complete" key
+# finishes successfully with _ok of that payload (e.g. a predicate capture that
+# just held, #661) — the budget is the CEILING, not the required duration.
 func _advance_window() -> void:
 	var state: Dictionary = _window_state
 	var sampler: Callable = state["sample"]
@@ -317,6 +320,10 @@ func _advance_window() -> void:
 	# (e.g. the monitored node was freed mid-window): send that envelope verbatim.
 	if typeof(sampled) == TYPE_DICTIONARY and (sampled as Dictionary).has("error"):
 		_finish_window(RESULT_BEGIN + JSON.stringify(sampled) + RESULT_END)
+		return
+	# ...or complete it early with a success payload (#661 predicate capture).
+	if typeof(sampled) == TYPE_DICTIONARY and (sampled as Dictionary).has("complete"):
+		_finish_window(_ok((sampled as Dictionary)["complete"]))
 		return
 	var samples: Array = state["samples"]
 	samples.append(sampled)
@@ -1283,11 +1290,14 @@ func _capture_frame() -> Dictionary:
 # CLI writes the file). A 1-frame window so the capture lands on a _process tick
 # after the scene is up and a frame has rendered (the GPU-timing fix). A headless
 # session is the typed live_display_unavailable, refused up front.
-func _handle_screen_capture(_params: Dictionary) -> Variant:
+func _handle_screen_capture(params: Dictionary) -> Variant:
 	if _display_is_headless():
 		return _error(LIVE_ERROR_DISPLAY_UNAVAILABLE,
 				"the engine session is headless (no DisplayServer to render pixels); "
 				+ "start the daemon with `gda daemon start --windowed`")
+	var await_spec: Variant = params.get("await", null)
+	if typeof(await_spec) == TYPE_DICTIONARY:
+		return _begin_predicate_capture(await_spec, params.get("events", []))
 	var sample := func() -> Variant:
 		var frame := _capture_frame()
 		if frame.has("error"):
@@ -1320,6 +1330,129 @@ func _handle_screen_frames(params: Dictionary) -> Variant:
 			"frames": samples,
 		})
 	return _begin_window(frames, sample, finalize)
+
+
+# screen capture --await (#661): the predicate-gated capture, GDA-DF-023. Input
+# and capture as separate round trips routinely miss a 3-8 frame transient, so
+# the window arms at request arrival and does the whole job game-side: each
+# PROCESS frame it applies the inline input events due at that offset (the
+# atomic input-and-capture form; the events reuse the input-sequence shapes and
+# _apply_sequence_event verbatim), then evaluates the predicate
+# `node.property == value`; the first frame it holds is captured and completes
+# the window EARLY via the _advance_window "complete" arm. A predicate that
+# never holds within `frames` is the typed live_predicate_unmet, carrying the
+# last observed value. Evaluation happens at the process-frame boundary; the
+# captured image is the most recently PRESENTED frame, so a property written
+# after that frame's draw can be one frame ahead of the pixels — the documented
+# limit. Physics-clock event offsets are refused: the capture clock IS the
+# process clock.
+func _begin_predicate_capture(await_spec: Dictionary, raw_events: Variant) -> Variant:
+	var node_path := String(await_spec.get("node", ""))
+	var node := _resolve_runtime_node(node_path)
+	if node == null:
+		return _error(LIVE_ERROR_NODE_NOT_FOUND,
+				"no node at runtime path: " + node_path)
+	var prop := String(await_spec.get("property", ""))
+	if not _runtime_property_exists(node, prop):
+		return _error(LIVE_ERROR_UNKNOWN_PROPERTY,
+				_unknown_runtime_property_message(node_path, prop))
+	var expected: Variant = await_spec.get("value", null)
+	var frames := _int_param(await_spec, "frames", 60)
+	var events: Array = raw_events if typeof(raw_events) == TYPE_ARRAY else []
+	for event in events:
+		if typeof(event) == TYPE_DICTIONARY and _sequence_event_uses_physics(event):
+			return _error(LIVE_ERROR_INVALID_EVENT_SPEC,
+					"a predicate capture applies its events on the process clock; "
+					+ "'physics_frame' offsets are not accepted")
+	var frame_box := {"n": 0, "observed": null}
+	_injected_mouse_button_mask = 0
+	var sample := func() -> Variant:
+		var current := int(frame_box["n"])
+		frame_box["n"] = current + 1
+		for event in events:
+			if typeof(event) != TYPE_DICTIONARY:
+				continue
+			if _sequence_event_offset(event) != current:
+				continue
+			var err: Variant = _apply_sequence_event(event)
+			if err != null:
+				_injected_mouse_button_mask = 0
+				return {"error": err}
+		if not is_instance_valid(node):
+			_injected_mouse_button_mask = 0
+			return {"error": {
+				"code": LIVE_ERROR_NODE_NOT_FOUND,
+				"message": "the awaited node was freed mid-window: " + node_path,
+			}}
+		var observed: Variant = node.get(prop)
+		frame_box["observed"] = observed
+		if not _predicate_matches(observed, expected):
+			return current
+		var captured := _capture_frame()
+		_injected_mouse_button_mask = 0
+		if captured.has("error"):
+			return captured
+		captured["predicate"] = {
+			"node": node_path,
+			"property": prop,
+			"expected": expected,
+			"observed": _predicate_echo(observed),
+			"engine_frame": Engine.get_process_frames(),
+			"frames_waited": current,
+		}
+		return {"complete": captured}
+	var finalize := func(_samples: Array) -> String:
+		_injected_mouse_button_mask = 0
+		return _error(LIVE_ERROR_PREDICATE_UNMET,
+				"the predicate " + node_path + "." + prop + " == "
+				+ JSON.stringify(expected) + " did not hold within "
+				+ str(frames) + " frames (last observed: "
+				+ str(frame_box["observed"]) + ")")
+	return _begin_window(frames, sample, finalize)
+
+
+# Whether the node exposes `prop` the way game get resolves properties: a storage
+# property, or an explicit script variable (the same two-step, so the predicate
+# surface and the read surface agree on what a property IS).
+func _runtime_property_exists(node: Node, prop: String) -> bool:
+	for entry in node.get_property_list():
+		if _is_storage_property(entry) and String(entry.get("name", "")) == prop:
+			return true
+	return not _explicit_script_variable_property(node, prop, false).is_empty()
+
+
+# JSON-typed predicate equality (#661): bool compares to bool, numbers
+# numerically (int frame counters match JSON integers), strings against the
+# String rendering (covers StringName), anything else never matches — the
+# predicate is a JSON-scalar contract, not a Variant matcher.
+func _predicate_matches(observed: Variant, expected: Variant) -> bool:
+	match typeof(expected):
+		TYPE_BOOL:
+			return typeof(observed) == TYPE_BOOL and observed == expected
+		TYPE_INT, TYPE_FLOAT:
+			if typeof(observed) == TYPE_INT or typeof(observed) == TYPE_FLOAT:
+				return float(observed) == float(expected)
+			return false
+		TYPE_STRING:
+			if typeof(observed) == TYPE_STRING or typeof(observed) == TYPE_STRING_NAME:
+				return String(observed) == String(expected)
+			return false
+		TYPE_NIL:
+			return typeof(observed) == TYPE_NIL
+	return false
+
+
+# The JSON-safe echo of the observed value for the result (#661; #660's receipt
+# echoes it onward): scalars pass through, everything else the diagnostic
+# String form — the predicate compares scalars, so the echo never needs the
+# full Value projection.
+func _predicate_echo(observed: Variant) -> Variant:
+	match typeof(observed):
+		TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING:
+			return observed
+		TYPE_NIL:
+			return null
+	return str(observed)
 
 
 # Read a float param defensively (the params arrive as arbitrary JSON): a missing

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -87,7 +87,7 @@ HARNESS_ADDONS_RES_PATH = f"res://{HARNESS_ADDONS_DIR}"
 # copy to it (#225). The installed copy declares its version in a leading header
 # (`# gda-harness-version: <N>`); a mismatch re-materializes via the content
 # compare. NOT the package version — the harness changes far less often.
-HARNESS_VERSION = "9"
+HARNESS_VERSION = "10"
 
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -87,7 +87,7 @@ HARNESS_ADDONS_RES_PATH = f"res://{HARNESS_ADDONS_DIR}"
 # copy to it (#225). The installed copy declares its version in a leading header
 # (`# gda-harness-version: <N>`); a mismatch re-materializes via the content
 # compare. NOT the package version — the harness changes far less often.
-HARNESS_VERSION = "8"
+HARNESS_VERSION = "9"
 
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -310,14 +310,26 @@ def _takes_a_json_value(
     A compound property reaches argv as a REPEATED token, which ``multiple``
     already reports, or as a single token carrying its JSON. ``False`` without a
     property link: unknown, and a wrong ``true`` would send a caller to encode a
-    plain string. Reads a DECLARED ``type`` only, so a compound behind an
-    ``anyOf`` is not seen — no case exists, and a registration test fails if one
-    appears (``tests/test_schema_command.py``).
+    plain string. Sees a declared ``type`` and a compound behind an ``anyOf`` /
+    ``oneOf`` — the nullable-compound shape (``list | null``) that
+    ``--await-events`` introduced (#661); a registration test keeps this
+    detector and the published bindings agreeing
+    (``tests/test_schema_command.py``).
     """
     spec = properties.get(bound or "")
     if not isinstance(spec, dict) or multiple:
         return False
-    return spec.get("type") in ("array", "object")
+    return _is_compound_spec(spec)
+
+
+def _is_compound_spec(spec: "dict[str, Any]") -> bool:
+    """Whether a property schema is an array/object, INCLUDING behind an anyOf."""
+    if spec.get("type") in ("array", "object"):
+        return True
+    branches = spec.get("anyOf") or spec.get("oneOf") or []
+    return any(
+        _is_compound_spec(branch) for branch in branches if isinstance(branch, dict)
+    )
 
 
 def schema_command_class(

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -173,7 +173,7 @@ already-running daemon's lazy Engine-session launch; only the outer
 | `logger` | `tail` (the running game's structured log stream; `--raw` for verbatim lines, `--level <min>` to filter by severity, `--limit N`) |
 | `perf` | `monitors`, `monitor` (counters: a one-frame snapshot, or with `--frames` a bounded window with statistics and optional `--budget` verdicts / a per-node timeline) |
 | `input` | `key`, `mouse-click`, `mouse-move`, `action`, `tap`, `sequence` |
-| `screen` | `capture`, `frames` (viewport PNGs; needs `--windowed`. `capture --await-node/--await-property/--await-value [--await-frames] [--await-events]` is the predicate-gated form: it fires on the first frame the property equals the value, optionally injecting input inside the same window — use it for short transients instead of a separate input + capture) |
+| `screen` | `capture`, `frames` (viewport PNGs; needs `--windowed`. `capture --await-node/--await-property/--await-value [--await-frames] [--await-events]` is the predicate-gated form: it fires on the first frame boundary where the property equals the value, optionally injecting input inside the same window — use it for short transients instead of a separate input + capture. The observed property and the pixels belong to the same COMPLETED frame; a value overwritten before its frame completes is never observable, an injected event's effect is observable from the next boundary, and a declared event that fails makes the capture that typed failure) |
 
 For a UI activation, use the gesture commands, not a lone event. Godot activates a
 `Button` on the RELEASE, so a bare press never emits `pressed`; and a focused UI

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -173,7 +173,7 @@ already-running daemon's lazy Engine-session launch; only the outer
 | `logger` | `tail` (the running game's structured log stream; `--raw` for verbatim lines, `--level <min>` to filter by severity, `--limit N`) |
 | `perf` | `monitors`, `monitor` (counters: a one-frame snapshot, or with `--frames` a bounded window with statistics and optional `--budget` verdicts / a per-node timeline) |
 | `input` | `key`, `mouse-click`, `mouse-move`, `action`, `tap`, `sequence` |
-| `screen` | `capture`, `frames` (viewport PNGs; needs `--windowed`) |
+| `screen` | `capture`, `frames` (viewport PNGs; needs `--windowed`. `capture --await-node/--await-property/--await-value [--await-frames] [--await-events]` is the predicate-gated form: it fires on the first frame the property equals the value, optionally injecting input inside the same window — use it for short transients instead of a separate input + capture) |
 
 For a UI activation, use the gesture commands, not a lone event. Godot activates a
 `Button` on the RELEASE, so a bare press never emits `pressed`; and a focused UI

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -213,3 +213,156 @@ def test_screen_capture_with_no_daemon_reports_daemon_not_running(
     error = json.loads(cap.stdout)["error"]
     assert error["code"] == "daemon_not_running"
     assert "gda daemon start" in error["message"]
+
+
+# --- the --await-* predicate capture (#661) ------------------------------------
+
+# A scene with two transient states, each too short for separate input + capture
+# round trips (GDA-DF-023): `phase` cycles 0..7 once per process frame (any given
+# value holds for exactly ONE frame, recurring every 8), and `flash` runs 4->0
+# only after a key press (a ~4-frame input-triggered transient).
+PREDICATE_GD = (
+    "extends Node2D\n"
+    "var tick := 0\n"
+    "var phase := 0\n"
+    "var flash := 0\n"
+    "func _process(_delta: float) -> void:\n"
+    "\ttick += 1\n"
+    "\tphase = tick % 8\n"
+    "\tif flash > 0:\n"
+    "\t\tflash -= 1\n"
+    "func _input(event: InputEvent) -> void:\n"
+    "\tif event is InputEventKey and event.pressed:\n"
+    "\t\tflash = 4\n"
+)
+PREDICATE_TSCN = (
+    "[gd_scene load_steps=2 format=3]\n\n"
+    '[ext_resource type="Script" path="res://main.gd" id="1"]\n\n'
+    '[node name="Main" type="Node2D"]\n'
+    'script = ExtResource("1")\n\n'
+    '[node name="Rect" type="ColorRect" parent="."]\n'
+    "offset_right = 200.0\n"
+    "offset_bottom = 150.0\n"
+    "color = Color(0.9, 0.4, 0.2, 1)\n"
+)
+
+
+def _predicate_scaffold(tmp_path):
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.gd").write_text(PREDICATE_GD, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(PREDICATE_TSCN, encoding="utf-8")
+
+
+@pytest.mark.e2e
+@_needs_display
+def test_await_predicate_captures_a_one_frame_transient_repeatedly(
+    tmp_path, daemon_runtime_dir
+):
+    # AC1 + AC4 (#661): a declared transient state — `phase == 5` holds for
+    # exactly one process frame per 8-frame cycle — is captured deterministically,
+    # with no game-side freeze fixture, on REPEATED runs in one session.
+    _predicate_scaffold(tmp_path)
+    run = _runner(GDA_CMD, tmp_path)
+
+    try:
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
+        for attempt in range(3):
+            out = tmp_path / f"shot{attempt}.png"
+            cap = assert_windowed_ok(
+                run(
+                    "screen",
+                    "capture",
+                    "--output",
+                    str(out),
+                    "--await-node",
+                    "/root/Main",
+                    "--await-property",
+                    "phase",
+                    "--await-value",
+                    "5",
+                )
+            )
+            doc = json.loads(cap.stdout)
+            assert doc["predicate"]["observed"] == 5, doc
+            assert doc["predicate"]["frames_waited"] < 60
+            assert doc["predicate"]["engine_frame"] > 0
+            assert out.read_bytes().startswith(PNG_MAGIC)
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+@_needs_display
+def test_await_predicate_that_never_holds_is_the_typed_error(
+    tmp_path, daemon_runtime_dir
+):
+    # AC2 (#661): a predicate that never holds fails with live_predicate_unmet
+    # after the declared frame bound — in ~a third of a second, not a timeout —
+    # and writes no file.
+    _predicate_scaffold(tmp_path)
+    run = _runner(GDA_CMD, tmp_path)
+    out = tmp_path / "never.png"
+
+    try:
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
+        cap = run(
+            "screen",
+            "capture",
+            "--output",
+            str(out),
+            "--await-node",
+            "/root/Main",
+            "--await-property",
+            "phase",
+            "--await-value",
+            "99",
+            "--await-frames",
+            "20",
+        )
+        assert cap.returncode != 0
+        doc = json.loads(cap.stdout)
+        assert doc["error"]["code"] == "live_predicate_unmet"
+        assert "did not hold within 20 frames" in doc["error"]["message"]
+        assert "last observed" in doc["error"]["message"]
+        assert not out.exists()
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+@_needs_display
+def test_await_events_capture_an_input_triggered_transient(
+    tmp_path, daemon_runtime_dir
+):
+    # The atomic input-and-capture form (#661, GDA-DF-023): the key press and the
+    # predicate ride ONE window, so the ~4-frame `flash` transient the press
+    # triggers cannot be missed by a second CLI round trip. `flash == 1` holds
+    # for exactly one frame after the injected press.
+    _predicate_scaffold(tmp_path)
+    run = _runner(GDA_CMD, tmp_path)
+    out = tmp_path / "flash.png"
+
+    try:
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
+        cap = assert_windowed_ok(
+            run(
+                "screen",
+                "capture",
+                "--output",
+                str(out),
+                "--await-node",
+                "/root/Main",
+                "--await-property",
+                "flash",
+                "--await-value",
+                "1",
+                "--await-events",
+                '[{"type": "key", "key": "Right", "frame": 0}]',
+            )
+        )
+        doc = json.loads(cap.stdout)
+        assert doc["predicate"]["observed"] == 1, doc
+        assert doc["predicate"]["frames_waited"] >= 1
+        assert out.read_bytes().startswith(PNG_MAGIC)
+    finally:
+        run("daemon", "stop")

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -217,23 +217,43 @@ def test_screen_capture_with_no_daemon_reports_daemon_not_running(
 
 # --- the --await-* predicate capture (#661) ------------------------------------
 
-# A scene with two transient states, each too short for separate input + capture
-# round trips (GDA-DF-023): `phase` cycles 0..7 once per process frame (any given
-# value holds for exactly ONE frame, recurring every 8), and `flash` runs 4->0
-# only after a key press (a ~4-frame input-triggered transient).
+# A scene with transient states too short for separate input + capture round
+# trips (GDA-DF-023): `phase` cycles 0..7 once per process frame (any value
+# holds for exactly ONE frame, recurring every 8) and the rect is RED on the
+# `phase == 5` frame alone, so the written PNG proves WHICH frame's
+# presentation was captured (#743 review, Spec 3). `flash` runs 4->0 only
+# after a key press (an input-triggered ~4-frame transient). The `key_down` /
+# `btn_down` / `act_down` flags expose held input state to `game get` (the
+# release-drain proofs, ARC-743-001), and `probe` counts its own getter runs
+# (the metadata-only-resolution proof, ARC-743-002).
 PREDICATE_GD = (
     "extends Node2D\n"
     "var tick := 0\n"
     "var phase := 0\n"
     "var flash := 0\n"
+    "var key_down := false\n"
+    "var btn_down := false\n"
+    "var act_down := false\n"
+    "var probe_reads := 0\n"
+    "var probe: int:\n"
+    "\tget:\n"
+    "\t\tprobe_reads += 1\n"
+    "\t\treturn phase\n"
     "func _process(_delta: float) -> void:\n"
     "\ttick += 1\n"
     "\tphase = tick % 8\n"
     "\tif flash > 0:\n"
     "\t\tflash -= 1\n"
+    '\tact_down = Input.is_action_pressed("qa_probe")\n'
+    "\tvar rect: ColorRect = $Rect\n"
+    "\trect.color = Color(1, 0, 0, 1) if phase == 5 else Color(0.2, 0.6, 0.9, 1)\n"
     "func _input(event: InputEvent) -> void:\n"
-    "\tif event is InputEventKey and event.pressed:\n"
-    "\t\tflash = 4\n"
+    "\tif event is InputEventKey:\n"
+    "\t\tkey_down = event.pressed\n"
+    "\t\tif event.pressed:\n"
+    "\t\t\tflash = 4\n"
+    "\tif event is InputEventMouseButton:\n"
+    "\t\tbtn_down = event.pressed\n"
 )
 PREDICATE_TSCN = (
     "[gd_scene load_steps=2 format=3]\n\n"
@@ -243,24 +263,111 @@ PREDICATE_TSCN = (
     '[node name="Rect" type="ColorRect" parent="."]\n'
     "offset_right = 200.0\n"
     "offset_bottom = 150.0\n"
-    "color = Color(0.9, 0.4, 0.2, 1)\n"
+    "color = Color(0.2, 0.6, 0.9, 1)\n"
+)
+PREDICATE_PROJECT = project_godot(
+    extra=(
+        'run/main_scene="res://main.tscn"\n\n'
+        "[input]\n\n"
+        'qa_probe={\n"deadzone": 0.5,\n"events": []\n}\n'
+    )
 )
 
 
 def _predicate_scaffold(tmp_path):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(PREDICATE_PROJECT, encoding="utf-8")
     (tmp_path / "main.gd").write_text(PREDICATE_GD, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(PREDICATE_TSCN, encoding="utf-8")
 
 
+def _png_pixel(path, px, py):
+    """Decode one pixel of an 8-bit RGB/RGBA PNG (all five row filters)."""
+    import struct
+    import zlib
+
+    data = path.read_bytes()
+    assert data[:8] == PNG_MAGIC
+    pos = 8
+    meta = None
+    idat = b""
+    while pos < len(data):
+        (length,) = struct.unpack(">I", data[pos : pos + 4])
+        tag = data[pos + 4 : pos + 8]
+        chunk = data[pos + 8 : pos + 8 + length]
+        pos += 12 + length
+        if tag == b"IHDR":
+            w, h, depth, color = struct.unpack(">IIBB", chunk[:10])
+            assert depth == 8 and color in (2, 6), (depth, color)
+            meta = (w, h, 3 if color == 2 else 4)
+        elif tag == b"IDAT":
+            idat += chunk
+    assert meta is not None, "PNG carries no IHDR"
+    w, h, ch = meta
+    raw = zlib.decompress(idat)
+    stride = w * ch
+    prev = bytearray(stride)
+    at = 0
+    for row in range(h):
+        f = raw[at]
+        line = bytearray(raw[at + 1 : at + 1 + stride])
+        at += 1 + stride
+        for i in range(stride):
+            a = line[i - ch] if i >= ch else 0
+            b = prev[i]
+            c = prev[i - ch] if i >= ch else 0
+            if f == 1:
+                line[i] = (line[i] + a) & 0xFF
+            elif f == 2:
+                line[i] = (line[i] + b) & 0xFF
+            elif f == 3:
+                line[i] = (line[i] + (a + b) // 2) & 0xFF
+            elif f == 4:
+                pp = a + b - c
+                pa, pb, pc = abs(pp - a), abs(pp - b), abs(pp - c)
+                pr = a if (pa <= pb and pa <= pc) else (b if pb <= pc else c)
+                line[i] = (line[i] + pr) & 0xFF
+        if row == py:
+            return tuple(line[px * ch : px * ch + 3])
+        prev = line
+    raise AssertionError("pixel row out of range")
+
+
+def _assert_red(path):
+    r, g, b = _png_pixel(path, 50, 50)
+    assert r > 200 and b < 80, (r, g, b, str(path))
+
+
+def _game_get(run, prop):
+    got = run("game", "get", "/root/Main", "--property", prop)
+    assert got.returncode == 0, got.stdout + got.stderr
+    return json.loads(got.stdout)["properties"][0]["value"]
+
+
+def _await_capture(run, out, prop, value, *extra):
+    return run(
+        "screen",
+        "capture",
+        "--output",
+        str(out),
+        "--await-node",
+        "/root/Main",
+        "--await-property",
+        prop,
+        "--await-value",
+        value,
+        *extra,
+    )
+
+
 @pytest.mark.e2e
 @_needs_display
-def test_await_predicate_captures_a_one_frame_transient_repeatedly(
+def test_await_predicate_captures_the_matched_frames_pixels_repeatedly(
     tmp_path, daemon_runtime_dir
 ):
-    # AC1 + AC4 (#661): a declared transient state — `phase == 5` holds for
-    # exactly one process frame per 8-frame cycle — is captured deterministically,
-    # with no game-side freeze fixture, on REPEATED runs in one session.
+    # AC1 + AC4 (#661) + #743 Spec 3: `phase == 5` holds for exactly one process
+    # frame per 8-frame cycle and the rect is RED on that frame alone; the
+    # decoded PNG must show the MATCHED frame's presentation — not the frame
+    # before it — on REPEATED captures in one session.
     _predicate_scaffold(tmp_path)
     run = _runner(GDA_CMD, tmp_path)
 
@@ -268,25 +375,12 @@ def test_await_predicate_captures_a_one_frame_transient_repeatedly(
         assert_windowed_ok(run("daemon", "start", "--windowed"))
         for attempt in range(3):
             out = tmp_path / f"shot{attempt}.png"
-            cap = assert_windowed_ok(
-                run(
-                    "screen",
-                    "capture",
-                    "--output",
-                    str(out),
-                    "--await-node",
-                    "/root/Main",
-                    "--await-property",
-                    "phase",
-                    "--await-value",
-                    "5",
-                )
-            )
+            cap = assert_windowed_ok(_await_capture(run, out, "phase", "5"))
             doc = json.loads(cap.stdout)
             assert doc["predicate"]["observed"] == 5, doc
             assert doc["predicate"]["frames_waited"] < 60
             assert doc["predicate"]["engine_frame"] > 0
-            assert out.read_bytes().startswith(PNG_MAGIC)
+            _assert_red(out)
     finally:
         run("daemon", "stop")
 
@@ -305,20 +399,7 @@ def test_await_predicate_that_never_holds_is_the_typed_error(
 
     try:
         assert_windowed_ok(run("daemon", "start", "--windowed"))
-        cap = run(
-            "screen",
-            "capture",
-            "--output",
-            str(out),
-            "--await-node",
-            "/root/Main",
-            "--await-property",
-            "phase",
-            "--await-value",
-            "99",
-            "--await-frames",
-            "20",
-        )
+        cap = _await_capture(run, out, "phase", "99", "--await-frames", "20")
         assert cap.returncode != 0
         doc = json.loads(cap.stdout)
         assert doc["error"]["code"] == "live_predicate_unmet"
@@ -334,10 +415,10 @@ def test_await_predicate_that_never_holds_is_the_typed_error(
 def test_await_events_capture_an_input_triggered_transient(
     tmp_path, daemon_runtime_dir
 ):
-    # The atomic input-and-capture form (#661, GDA-DF-023): the key press and the
-    # predicate ride ONE window, so the ~4-frame `flash` transient the press
-    # triggers cannot be missed by a second CLI round trip. `flash == 1` holds
-    # for exactly one frame after the injected press.
+    # The atomic input-and-capture form (#661, GDA-DF-023): the key press and
+    # the predicate ride ONE window, so the ~4-frame `flash` transient the
+    # press triggers cannot be missed by a second CLI round trip; the declared
+    # release fires before the reply, so no key is left held.
     _predicate_scaffold(tmp_path)
     run = _runner(GDA_CMD, tmp_path)
     out = tmp_path / "flash.png"
@@ -345,24 +426,117 @@ def test_await_events_capture_an_input_triggered_transient(
     try:
         assert_windowed_ok(run("daemon", "start", "--windowed"))
         cap = assert_windowed_ok(
-            run(
-                "screen",
-                "capture",
-                "--output",
-                str(out),
-                "--await-node",
-                "/root/Main",
-                "--await-property",
+            _await_capture(
+                run,
+                out,
                 "flash",
-                "--await-value",
                 "1",
                 "--await-events",
-                '[{"type": "key", "key": "Right", "frame": 0}]',
+                '[{"type": "key", "key": "Right", "frame": 0},'
+                ' {"type": "key", "key": "Right", "released": true, "frame": 3}]',
             )
         )
         doc = json.loads(cap.stdout)
         assert doc["predicate"]["observed"] == 1, doc
         assert doc["predicate"]["frames_waited"] >= 1
         assert out.read_bytes().startswith(PNG_MAGIC)
+        assert _game_get(run, "key_down") is False
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+@_needs_display
+def test_early_match_still_fires_every_scheduled_release(tmp_path, daemon_runtime_dir):
+    # #743 review ARC-743-001: the predicate matches BEFORE the scheduled
+    # release, yet the reply must wait for every accepted event — a key, a
+    # mouse-button phase, and an action are each verified released afterwards,
+    # so no input state leaks into later live operations.
+    _predicate_scaffold(tmp_path)
+    run = _runner(GDA_CMD, tmp_path)
+
+    cases = [
+        (
+            "key_down",
+            '[{"type": "key", "key": "Right", "frame": 0},'
+            ' {"type": "key", "key": "Right", "released": true, "frame": 5}]',
+        ),
+        (
+            "btn_down",
+            '[{"type": "mouse_button", "x": 60, "y": 60, "pressed": true, "frame": 0},'
+            ' {"type": "mouse_button", "x": 60, "y": 60, "release": true, "frame": 5}]',
+        ),
+        (
+            "act_down",
+            '[{"type": "action", "action": "qa_probe", "frame": 0},'
+            ' {"type": "action", "action": "qa_probe", "release": true, "frame": 5}]',
+        ),
+    ]
+    try:
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
+        for index, (flag, events) in enumerate(cases):
+            out = tmp_path / f"held{index}.png"
+            cap = assert_windowed_ok(
+                _await_capture(run, out, flag, "true", "--await-events", events)
+            )
+            doc = json.loads(cap.stdout)
+            # Matched while held (well before the frame-5 release)...
+            assert doc["predicate"]["observed"] is True, doc
+            assert doc["predicate"]["frames_waited"] < 5
+            # ...yet the release still fired before the reply.
+            assert _game_get(run, flag) is False, flag
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+@_needs_display
+def test_unmet_predicate_error_path_still_fires_every_event(
+    tmp_path, daemon_runtime_dir
+):
+    # #743 review ARC-743-001, the ERROR path: the window ends in
+    # live_predicate_unmet, but the declared press/release pair still ran — no
+    # held key survives the failure.
+    _predicate_scaffold(tmp_path)
+    run = _runner(GDA_CMD, tmp_path)
+    out = tmp_path / "never.png"
+
+    try:
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
+        cap = _await_capture(
+            run,
+            out,
+            "phase",
+            "99",
+            "--await-frames",
+            "10",
+            "--await-events",
+            '[{"type": "key", "key": "Right", "frame": 0},'
+            ' {"type": "key", "key": "Right", "released": true, "frame": 4}]',
+        )
+        assert cap.returncode != 0
+        assert json.loads(cap.stdout)["error"]["code"] == "live_predicate_unmet"
+        assert not out.exists()
+        assert _game_get(run, "key_down") is False
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+@_needs_display
+def test_predicate_resolution_never_reads_the_property(tmp_path, daemon_runtime_dir):
+    # #743 review ARC-743-002: resolving the property up front is metadata-only,
+    # so a scripted getter runs EXACTLY once per sampled frame — frames_waited+1
+    # times in total, no pre-read, no re-read at capture.
+    _predicate_scaffold(tmp_path)
+    run = _runner(GDA_CMD, tmp_path)
+    out = tmp_path / "probe.png"
+
+    try:
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
+        cap = assert_windowed_ok(_await_capture(run, out, "probe", "5"))
+        doc = json.loads(cap.stdout)
+        waited = doc["predicate"]["frames_waited"]
+        assert _game_get(run, "probe_reads") == waited + 1
     finally:
         run("daemon", "stop")

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -505,7 +505,10 @@ def test_unmet_predicate_error_path_still_fires_every_event(
 ):
     # #743 review ARC-743-001, the ERROR path: the window ends in
     # live_predicate_unmet, but the declared press/release pair still ran — no
-    # held key survives the failure.
+    # held key survives the failure. The release sits BEYOND the ceiling
+    # (offset 12 > frames 10): an out-of-window offset is accepted (exact
+    # schema/model parity, #743 second re-review) and still fires during the
+    # drain, so the reply arrives only after it.
     _predicate_scaffold(tmp_path)
     run = _runner(GDA_CMD, tmp_path)
     out = tmp_path / "never.png"
@@ -521,7 +524,7 @@ def test_unmet_predicate_error_path_still_fires_every_event(
             "10",
             "--await-events",
             '[{"type": "key", "key": "Right", "frame": 0},'
-            ' {"type": "key", "key": "Right", "released": true, "frame": 4}]',
+            ' {"type": "key", "key": "Right", "released": true, "frame": 12}]',
         )
         assert cap.returncode != 0
         assert json.loads(cap.stdout)["error"]["code"] == "live_predicate_unmet"

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -235,6 +235,7 @@ PREDICATE_GD = (
     "var btn_down := false\n"
     "var act_down := false\n"
     "var probe_reads := 0\n"
+    "var hit := false\n"
     "var probe: int:\n"
     "\tget:\n"
     "\t\tprobe_reads += 1\n"
@@ -252,6 +253,9 @@ PREDICATE_GD = (
     "\t\tkey_down = event.pressed\n"
     "\t\tif event.pressed:\n"
     "\t\t\tflash = 4\n"
+    "\t\t\thit = true\n"
+    "\t\t\tvar marker: ColorRect = $Marker\n"
+    "\t\t\tmarker.color = Color(0, 1, 0, 1)\n"
     "\tif event is InputEventMouseButton:\n"
     "\t\tbtn_down = event.pressed\n"
 )
@@ -262,6 +266,11 @@ PREDICATE_TSCN = (
     'script = ExtResource("1")\n\n'
     '[node name="Rect" type="ColorRect" parent="."]\n'
     "offset_right = 200.0\n"
+    "offset_bottom = 150.0\n"
+    "color = Color(0.2, 0.6, 0.9, 1)\n\n"
+    '[node name="Marker" type="ColorRect" parent="."]\n'
+    "offset_left = 250.0\n"
+    "offset_right = 320.0\n"
     "offset_bottom = 150.0\n"
     "color = Color(0.2, 0.6, 0.9, 1)\n"
 )
@@ -538,5 +547,74 @@ def test_predicate_resolution_never_reads_the_property(tmp_path, daemon_runtime_
         doc = json.loads(cap.stdout)
         waited = doc["predicate"]["frames_waited"]
         assert _game_get(run, "probe_reads") == waited + 1
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+@_needs_display
+def test_input_written_state_is_captured_with_its_own_presentation(
+    tmp_path, daemon_runtime_dir
+):
+    # #743 re-review ARC-743-004 / Spec 1, the same-callback counterexample:
+    # one _input callback writes BOTH the property (`hit`) and the visual (the
+    # Marker rect turns green). Evaluate-before-inject means the state an event
+    # writes is observed one boundary LATER, together with its own
+    # presentation — so the decoded pixels show the matched visual.
+    _predicate_scaffold(tmp_path)
+    run = _runner(GDA_CMD, tmp_path)
+
+    try:
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
+        out = tmp_path / "marker.png"
+        cap = assert_windowed_ok(
+            _await_capture(
+                run,
+                out,
+                "hit",
+                "true",
+                "--await-events",
+                '[{"type": "key", "key": "Right", "frame": 0},'
+                ' {"type": "key", "key": "Right", "released": true, "frame": 2}]',
+            )
+        )
+        doc = json.loads(cap.stdout)
+        assert doc["predicate"]["observed"] is True, doc
+        r, g, b = _png_pixel(out, 260, 50)
+        assert g > 200 and r < 80, (r, g, b)
+        assert _game_get(run, "key_down") is False
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+@_needs_display
+def test_late_event_failure_is_the_reply_and_writes_no_file(
+    tmp_path, daemon_runtime_dir
+):
+    # #743 re-review ARC-743-001 / Spec 2: the predicate matches early, then a
+    # scheduled event FAILS — the reply is that typed failure, no file is
+    # written, and the later declared release still drains (no held action).
+    _predicate_scaffold(tmp_path)
+    run = _runner(GDA_CMD, tmp_path)
+    out = tmp_path / "late.png"
+
+    try:
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
+        cap = _await_capture(
+            run,
+            out,
+            "act_down",
+            "true",
+            "--await-events",
+            '[{"type": "action", "action": "qa_probe", "frame": 0},'
+            ' {"type": "action", "action": "no_such_action", "frame": 5},'
+            ' {"type": "action", "action": "qa_probe", "release": true, "frame": 6}]',
+        )
+        assert cap.returncode != 0
+        doc = json.loads(cap.stdout)
+        assert doc["error"]["code"] == "live_unknown_action"
+        assert not out.exists()
+        assert _game_get(run, "act_down") is False
     finally:
         run("daemon", "stop")

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -72,6 +72,9 @@ HARNESS_LIVE_ERROR_CODES = (
     # #222: a `screen` capture op on a headless engine session — the dummy
     # DisplayServer cannot read pixels (the session was not started --windowed).
     "live_display_unavailable",
+    # #661: a `screen capture --await-*` predicate that never held within its
+    # declared frame bound.
+    "live_predicate_unmet",
 )
 
 

--- a/tests/test_harness_install.py
+++ b/tests/test_harness_install.py
@@ -807,7 +807,7 @@ def test_ready_gates_on_template_feature_as_its_first_statement():
 #   3. update BOTH pins below (the test's failure message carries the new hash).
 PINNED_HARNESS_VERSION = "9"
 PINNED_HARNESS_SHA256 = (
-    "61d506fd8bd3367f62dff9f2ee1c8dd62e26c136851f76a7386b3a1f1a41536b"
+    "792cd4917f4d6cdd35f085ef9737865bf806fb365ce37d810bf0a5b22e3dde2a"
 )
 
 

--- a/tests/test_harness_install.py
+++ b/tests/test_harness_install.py
@@ -805,9 +805,21 @@ def test_ready_gates_on_template_feature_as_its_first_statement():
 #   1. edit gda_harness.gd;
 #   2. bump HARNESS_VERSION in src/gda/harness/install.py;
 #   3. update BOTH pins below (the test's failure message carries the new hash).
-PINNED_HARNESS_VERSION = "9"
+PINNED_HARNESS_VERSION = "10"
 PINNED_HARNESS_SHA256 = (
     "d01ec32763874d17e6e166b51f948b63500c199941d8be56fd571b767ebfe032"
+)
+
+# The immutable version-to-hash history (#743 second re-review): one row per
+# harness version ever DECLARED on this branch's lineage, append-only, so a
+# body change that reuses an existing version number is caught even when the
+# mutable pins above were both edited in the same change — the history makes
+# "new golden hash, unchanged version" visible as a rewritten row in review.
+# Versions are monotonic; gaps are versions consumed by in-PR iterations that
+# never merged. The current pins must be the history's LAST row.
+PINNED_HARNESS_HISTORY: "tuple[tuple[str, str], ...]" = (
+    ("8", "cd1993632ba8eb308c9a2990d9a5c2570aa6bbbcc0e2e5f5845213e024d867aa"),
+    ("10", "d01ec32763874d17e6e166b51f948b63500c199941d8be56fd571b767ebfe032"),
 )
 
 
@@ -833,5 +845,27 @@ def test_bundled_harness_bytes_are_pinned_to_the_declared_version():
     assert digest == PINNED_HARNESS_SHA256, (
         f"the bundled gda_harness.gd changed (sha256 {digest}) without a "
         "version bump: bump HARNESS_VERSION in src/gda/harness/install.py and "
-        "update PINNED_HARNESS_VERSION / PINNED_HARNESS_SHA256 in this file."
+        "update PINNED_HARNESS_VERSION / PINNED_HARNESS_SHA256 in this file, "
+        "APPENDING a new row to PINNED_HARNESS_HISTORY (never rewrite a row)."
     )
+
+
+def test_harness_version_history_is_append_only_and_current():
+    # Two invariants the mutable pins alone cannot state (#743 second
+    # re-review): every declared version maps to exactly one body hash, and
+    # versions only grow. The current pins must be the last history row, so a
+    # harness edit FORCES a new row — a rewritten old row is the tamper signal
+    # a reviewer can see in the diff.
+    versions = [int(version) for version, _ in PINNED_HARNESS_HISTORY]
+    assert versions == sorted(versions) and len(set(versions)) == len(versions), (
+        "PINNED_HARNESS_HISTORY versions must be strictly increasing"
+    )
+    hashes = [digest for _, digest in PINNED_HARNESS_HISTORY]
+    assert len(set(hashes)) == len(hashes), (
+        "two harness versions must never declare the same body hash — "
+        "except never: each row is one distinct body"
+    )
+    assert PINNED_HARNESS_HISTORY[-1] == (
+        PINNED_HARNESS_VERSION,
+        PINNED_HARNESS_SHA256,
+    ), "the current pins must be the last PINNED_HARNESS_HISTORY row"

--- a/tests/test_harness_install.py
+++ b/tests/test_harness_install.py
@@ -798,28 +798,17 @@ def test_ready_gates_on_template_feature_as_its_first_statement():
 
 
 # The bundled harness bytes, PINNED to the version that declares them (#736
-# review follow-up). W4 changed gda_harness.gd three times (#732, #735, #736)
-# while HARNESS_VERSION stayed "7": the sync path never noticed, because its
-# decision is a CONTENT compare — which is exactly why the omission was silent.
-# This pin makes it loud. Updating it is part of every harness change:
+# review follow-up). This current-snapshot guard makes an accidental body edit
+# loud in the unit tier. The cross-revision invariant — changed body bytes MUST
+# increase HARNESS_VERSION — is enforced mechanically by
+# scripts/harness_version_guard.py in the required Python CI job. Updating the
+# harness is therefore three deliberate edits:
 #   1. edit gda_harness.gd;
 #   2. bump HARNESS_VERSION in src/gda/harness/install.py;
-#   3. update BOTH pins below (the test's failure message carries the new hash).
+#   3. update the current pins below (the failure carries the new hash).
 PINNED_HARNESS_VERSION = "10"
 PINNED_HARNESS_SHA256 = (
     "d01ec32763874d17e6e166b51f948b63500c199941d8be56fd571b767ebfe032"
-)
-
-# The immutable version-to-hash history (#743 second re-review): one row per
-# harness version ever DECLARED on this branch's lineage, append-only, so a
-# body change that reuses an existing version number is caught even when the
-# mutable pins above were both edited in the same change — the history makes
-# "new golden hash, unchanged version" visible as a rewritten row in review.
-# Versions are monotonic; gaps are versions consumed by in-PR iterations that
-# never merged. The current pins must be the history's LAST row.
-PINNED_HARNESS_HISTORY: "tuple[tuple[str, str], ...]" = (
-    ("8", "cd1993632ba8eb308c9a2990d9a5c2570aa6bbbcc0e2e5f5845213e024d867aa"),
-    ("10", "d01ec32763874d17e6e166b51f948b63500c199941d8be56fd571b767ebfe032"),
 )
 
 
@@ -845,27 +834,5 @@ def test_bundled_harness_bytes_are_pinned_to_the_declared_version():
     assert digest == PINNED_HARNESS_SHA256, (
         f"the bundled gda_harness.gd changed (sha256 {digest}) without a "
         "version bump: bump HARNESS_VERSION in src/gda/harness/install.py and "
-        "update PINNED_HARNESS_VERSION / PINNED_HARNESS_SHA256 in this file, "
-        "APPENDING a new row to PINNED_HARNESS_HISTORY (never rewrite a row)."
+        "update PINNED_HARNESS_VERSION / PINNED_HARNESS_SHA256 in this file."
     )
-
-
-def test_harness_version_history_is_append_only_and_current():
-    # Two invariants the mutable pins alone cannot state (#743 second
-    # re-review): every declared version maps to exactly one body hash, and
-    # versions only grow. The current pins must be the last history row, so a
-    # harness edit FORCES a new row — a rewritten old row is the tamper signal
-    # a reviewer can see in the diff.
-    versions = [int(version) for version, _ in PINNED_HARNESS_HISTORY]
-    assert versions == sorted(versions) and len(set(versions)) == len(versions), (
-        "PINNED_HARNESS_HISTORY versions must be strictly increasing"
-    )
-    hashes = [digest for _, digest in PINNED_HARNESS_HISTORY]
-    assert len(set(hashes)) == len(hashes), (
-        "two harness versions must never declare the same body hash — "
-        "except never: each row is one distinct body"
-    )
-    assert PINNED_HARNESS_HISTORY[-1] == (
-        PINNED_HARNESS_VERSION,
-        PINNED_HARNESS_SHA256,
-    ), "the current pins must be the last PINNED_HARNESS_HISTORY row"

--- a/tests/test_harness_install.py
+++ b/tests/test_harness_install.py
@@ -805,9 +805,9 @@ def test_ready_gates_on_template_feature_as_its_first_statement():
 #   1. edit gda_harness.gd;
 #   2. bump HARNESS_VERSION in src/gda/harness/install.py;
 #   3. update BOTH pins below (the test's failure message carries the new hash).
-PINNED_HARNESS_VERSION = "8"
+PINNED_HARNESS_VERSION = "9"
 PINNED_HARNESS_SHA256 = (
-    "cd1993632ba8eb308c9a2990d9a5c2570aa6bbbcc0e2e5f5845213e024d867aa"
+    "61d506fd8bd3367f62dff9f2ee1c8dd62e26c136851f76a7386b3a1f1a41536b"
 )
 
 

--- a/tests/test_harness_install.py
+++ b/tests/test_harness_install.py
@@ -807,7 +807,7 @@ def test_ready_gates_on_template_feature_as_its_first_statement():
 #   3. update BOTH pins below (the test's failure message carries the new hash).
 PINNED_HARNESS_VERSION = "9"
 PINNED_HARNESS_SHA256 = (
-    "792cd4917f4d6cdd35f085ef9737865bf806fb365ce37d810bf0a5b22e3dde2a"
+    "d01ec32763874d17e6e166b51f948b63500c199941d8be56fd571b767ebfe032"
 )
 
 

--- a/tests/test_harness_version_guard.py
+++ b/tests/test_harness_version_guard.py
@@ -1,0 +1,59 @@
+"""Cross-revision harness identity guard."""
+
+import pytest
+
+import harness_version_guard
+
+
+def _install(version: str) -> bytes:
+    return f'HARNESS_VERSION = "{version}"\n'.encode()
+
+
+def test_unchanged_harness_needs_no_version_bump():
+    harness_version_guard.check_change(
+        b"same body", _install("10"), b"same body", _install("10")
+    )
+
+
+def test_changed_harness_with_a_higher_version_passes():
+    harness_version_guard.check_change(
+        b"old body", _install("10"), b"new body", _install("11")
+    )
+
+
+def test_changed_harness_with_the_same_version_fails():
+    with pytest.raises(
+        harness_version_guard.HarnessVersionGuardError,
+        match="changed.*HARNESS_VERSION.*10",
+    ):
+        harness_version_guard.check_change(
+            b"old body", _install("10"), b"new body", _install("10")
+        )
+
+
+def test_changed_harness_with_a_lower_version_fails():
+    with pytest.raises(
+        harness_version_guard.HarnessVersionGuardError,
+        match="must increase.*10.*9",
+    ):
+        harness_version_guard.check_change(
+            b"old body", _install("10"), b"new body", _install("9")
+        )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        b"",
+        b'HARNESS_VERSION = "not-an-integer"\n',
+        b'HARNESS_VERSION = "1"\nHARNESS_VERSION = "2"\n',
+    ],
+)
+def test_version_declaration_must_be_one_numeric_assignment(source):
+    with pytest.raises(
+        harness_version_guard.HarnessVersionGuardError,
+        match="exactly one numeric HARNESS_VERSION",
+    ):
+        harness_version_guard.check_change(
+            b"old body", source, b"new body", _install("11")
+        )

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -1738,8 +1738,9 @@ def test_a_schema_client_can_validate_events_without_invoking_gda():
     # client would: validate candidate events against the EMITTED schema and get
     # the same verdict gda gives for what each kind requires and forbids. The
     # cross-field rules are a narrower claim — the mouse-button phase is published
-    # too (its own test below), while the one-clock rule, the modifier vocabulary
-    # and the window ceiling stay enforced model-side only.
+    # too (its own test below), while the one-clock rule stays model-side. The
+    # modifier vocabulary and per-event window ceiling are ordinary field
+    # constraints, so clients must see them here too.
     import jsonschema
 
     schema = _sequence_events_schema()
@@ -1759,6 +1760,8 @@ def test_a_schema_client_can_validate_events_without_invoking_gda():
     assert not check({"type": "key", "key": "A", "release": True})
     assert not check({"type": "mouse_move", "x": 1.0, "y": 2.0, "pressed": True})
     assert not check({"type": "key"})
+    assert not check({"type": "key", "key": "A", "modifiers": ["hyper"]})
+    assert not check({"type": "key", "key": "A", "frame": MAX_WINDOW_FRAMES})
 
 
 def _reject(monkeypatch, tmp_path, event: dict) -> str:

--- a/tests/test_schema_command.py
+++ b/tests/test_schema_command.py
@@ -1933,13 +1933,14 @@ def _is_compound(spec: dict) -> bool:
 
 
 def test_no_parameter_needs_a_json_value_the_derivation_cannot_see():
-    # `json_value` is derived from the LINKED property's declared `type`, so it
-    # sees a bare `array`/`object` but not one behind an `anyOf` — the shape a
-    # nullable compound (`array | null`) takes. Such a parameter would silently
-    # publish `json_value: false` and send an agent to write its value as a plain
-    # token. None exists today, so the derivation is deliberately left narrow; this
-    # fails the moment one appears, forcing the extension rather than a wrong
-    # binding. Same guard shape as the unsupported-Click-shapes test above.
+    # `json_value` is derived from the LINKED property's schema and, since #661's
+    # nullable-compound `--await-events` (`list | null`), sees a compound behind
+    # an `anyOf`/`oneOf` too. This guard keeps the derivation and this detector
+    # agreeing: a compound shape only one of them recognizes (e.g. behind an
+    # `allOf` or a `$ref`) would silently publish `json_value: false` and send an
+    # agent to write its value as a plain token — it fails the moment one
+    # appears, forcing the extension rather than a wrong binding. Same guard
+    # shape as the unsupported-Click-shapes test above.
     import typer as _typer
 
     from gda.headless import command_argv_bindings

--- a/tests/test_screen_commands.py
+++ b/tests/test_screen_commands.py
@@ -743,7 +743,21 @@ def test_await_events_refuse_the_physics_clock(monkeypatch, tmp_path):
     assert "physics_frame" in message
 
 
-def test_await_event_offsets_must_fit_the_window(monkeypatch, tmp_path):
+def test_out_of_window_event_offset_is_accepted_and_rides_the_wire(
+    monkeypatch, tmp_path
+):
+    # #743 second re-review: the offset-inside-window rule was model-only and
+    # JSON Schema cannot state it, so ADR-0015 parity removes it — the model
+    # and the published schema accept EXACTLY the same set. Semantics are
+    # documented instead: the reply waits for every declared event, so an
+    # offset at or beyond the ceiling still fires (it just cannot satisfy the
+    # predicate any more).
+    reply = screen_capture_reply(_PNG_B64, width=8, height=8)
+    reply["predicate"] = _predicate_report()
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(reply), stderr="", exit_code=0),
+    )
     out = tmp_path / "shot.png"
 
     result = CliRunner().invoke(
@@ -758,8 +772,11 @@ def test_await_event_offsets_must_fit_the_window(monkeypatch, tmp_path):
         ),
     )
 
-    message = _usage_error_message(result)
-    assert "must be inside the predicate window" in message
+    assert result.exit_code == 0, result.stdout + result.stderr
+    op, params = fake.calls[0]
+    assert params["await"]["frames"] == 10
+    (event,) = params["events"]
+    assert event["frame"] == 10
 
 
 def test_await_frames_needs_the_predicate(monkeypatch, tmp_path):
@@ -990,8 +1007,9 @@ def test_await_schema_and_model_agree_on_the_cross_field_rules():
             },
             False,
         ),
-        # #743 re-review: the REVERSE divergences — the schema says `integer`,
-        # so the model must not quietly coerce strings (strict clock ints).
+        # #743 re-reviews: the REVERSE divergences — the schema says
+        # `integer`/`number`/`boolean`, so the model must not quietly coerce
+        # strings (strict clock ints, then the whole union's scalars).
         (
             {
                 "output": "x.png",
@@ -1012,6 +1030,89 @@ def test_await_schema_and_model_agree_on_the_cross_field_rules():
             },
             False,
         ),
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": 3,
+                "await_events": [{"type": "key", "key": "Right", "released": "false"}],
+            },
+            False,
+        ),
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": 3,
+                "await_events": [{"type": "mouse_click", "x": "10", "y": 20.0}],
+            },
+            False,
+        ),
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": 3,
+                "await_events": [
+                    {"type": "mouse_click", "x": 10.0, "y": 20.0, "double": "false"}
+                ],
+            },
+            False,
+        ),
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": 3,
+                "await_events": [
+                    {"type": "action", "action": "jump", "strength": "0.5"}
+                ],
+            },
+            False,
+        ),
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": 3,
+                "await_events": [
+                    {"type": "action", "action": "jump", "release": "false"}
+                ],
+            },
+            False,
+        ),
+        # int-for-float stays accepted on BOTH sides (JSON Schema `number`
+        # admits integers; pydantic strict float admits int input).
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": 3,
+                "await_events": [{"type": "mouse_click", "x": 10, "y": 20}],
+            },
+            True,
+        ),
+        # The former model-only residual, now a BOTH-ACCEPT case: the
+        # offset-inside-window rule was removed for exact parity — the drain
+        # applies an out-of-window event anyway, it just cannot satisfy the
+        # predicate (documented in the field description and the catalog).
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": 3,
+                "await_frames": 10,
+                "await_events": [{"type": "key", "key": "Right", "frame": 10}],
+            },
+            True,
+        ),
     ]
     for payload, accepted in corpus:
         schema_ok = validator.is_valid(payload)
@@ -1021,23 +1122,3 @@ def test_await_schema_and_model_agree_on_the_cross_field_rules():
         except pydantic.ValidationError:
             model_ok = False
         assert schema_ok == model_ok == accepted, (payload, schema_ok, model_ok)
-
-    # The disclosed model-only residual, pinned so it stays a KNOWN divergence:
-    # an event offset outside the window passes the schema but not the model —
-    # a cross-field numeric bound Draft 2020-12 cannot state. The disclosure is
-    # PUBLIC: the await_events field description (published in the schema) and
-    # the command catalog both name the rule and that it is validation-enforced.
-    residual = {
-        "output": "x.png",
-        "await_node": "/root/N",
-        "await_property": "p",
-        "await_value": 3,
-        "await_frames": 10,
-        "await_events": [{"type": "key", "key": "Right", "frame": 10}],
-    }
-    assert validator.is_valid(residual)
-    try:
-        ScreenCaptureParams.model_validate(residual)
-        assert False, "the model must refuse an offset outside the window"
-    except pydantic.ValidationError:
-        pass

--- a/tests/test_screen_commands.py
+++ b/tests/test_screen_commands.py
@@ -454,3 +454,358 @@ def test_screen_frames_params_json_over_range_frames_is_invalid_params(
     assert result.exit_code != 0, result.stdout
     assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
     assert fake.calls == []
+
+
+# --- the --await-* predicate capture (#661) ------------------------------------
+
+
+def _capture_argv(out, project, *extra):
+    return [
+        "screen",
+        "capture",
+        "--output",
+        str(out),
+        "--project",
+        str(project),
+        "--json",
+        *extra,
+    ]
+
+
+def _await_argv(out, project, *extra):
+    return _capture_argv(
+        out,
+        project,
+        "--await-node",
+        "/root/Main/VFX",
+        "--await-property",
+        "frame",
+        "--await-value",
+        "3",
+        *extra,
+    )
+
+
+def test_await_predicate_rides_the_wire_with_the_default_ceiling(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel(screen_capture_reply(_PNG_B64, width=8, height=8)),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    out = tmp_path / "shot.png"
+
+    result = CliRunner().invoke(app, _await_argv(out, _project(tmp_path)))
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    # One op, the SAME screen-capture op — the predicate is params, not a new
+    # surface — with the JSON-scalar value (3 the integer, not "3") and the
+    # documented default ceiling.
+    assert fake.calls == [
+        (
+            "screen-capture",
+            {
+                "await": {
+                    "node": "/root/Main/VFX",
+                    "property": "frame",
+                    "value": 3,
+                    "frames": 60,
+                }
+            },
+        )
+    ]
+
+
+def test_await_events_ride_the_same_window_and_report_surfaces(monkeypatch, tmp_path):
+    reply = screen_capture_reply(_PNG_B64, width=8, height=8)
+    reply["predicate"] = {
+        "node": "/root/Main/VFX",
+        "property": "frame",
+        "expected": 3,
+        "observed": 3,
+        "engine_frame": 240,
+        "frames_waited": 5,
+    }
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(reply), stderr="", exit_code=0),
+    )
+    out = tmp_path / "shot.png"
+    events = '[{"type": "key", "key": "Right", "frame": 1}]'
+
+    result = CliRunner().invoke(
+        app,
+        _await_argv(
+            out, _project(tmp_path), "--await-frames", "30", "--await-events", events
+        ),
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    op, params = fake.calls[0]
+    assert op == "screen-capture"
+    assert params["await"]["frames"] == 30
+    # The atomic form: the input-sequence event shapes ride the SAME window.
+    (event,) = params["events"]
+    assert event["type"] == "key"
+    assert event["key"] == "Right"
+    assert event["frame"] == 1
+    # The predicate report is surfaced verbatim on the result.
+    data = json.loads(result.stdout)
+    assert data["predicate"] == {
+        "node": "/root/Main/VFX",
+        "property": "frame",
+        "expected": 3,
+        "observed": 3,
+        "engine_frame": 240,
+        "frames_waited": 5,
+    }
+
+
+def test_await_bare_word_value_is_a_string_predicate(monkeypatch, tmp_path):
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel(screen_capture_reply(_PNG_B64, width=8, height=8)),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    out = tmp_path / "shot.png"
+
+    result = CliRunner().invoke(
+        app,
+        _capture_argv(
+            out,
+            _project(tmp_path),
+            "--await-node",
+            "/root/Main/VFX",
+            "--await-property",
+            "anim",
+            "--await-value",
+            "peak",
+        ),
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert fake.calls[0][1]["await"]["value"] == "peak"
+
+
+def test_await_render_carries_the_predicate_line(monkeypatch, tmp_path):
+    reply = screen_capture_reply(_PNG_B64, width=8, height=8)
+    reply["predicate"] = {
+        "node": "/root/Main/VFX",
+        "property": "frame",
+        "expected": 3,
+        "observed": 3,
+        "engine_frame": 240,
+        "frames_waited": 5,
+    }
+    inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(reply), stderr="", exit_code=0),
+    )
+    out = tmp_path / "shot.png"
+    argv = _await_argv(out, _project(tmp_path))
+    argv.remove("--json")
+
+    result = CliRunner().invoke(app, argv)
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "predicate /root/Main/VFX.frame == 3 held after 5 frames" in result.stdout
+    assert "engine frame 240" in result.stdout
+
+
+def test_await_unmet_predicate_is_the_typed_live_error(monkeypatch, tmp_path):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel(
+                "live_predicate_unmet",
+                "the predicate /root/Main/VFX.frame == 3 did not hold within "
+                "30 frames (last observed: 2)",
+            ),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    out = tmp_path / "shot.png"
+
+    result = CliRunner().invoke(
+        app, _await_argv(out, _project(tmp_path), "--await-frames", "30")
+    )
+
+    assert result.exit_code == EXIT_LIVE
+    data = json.loads(result.stdout)
+    assert data["error"]["code"] == "live_predicate_unmet"
+    assert "last observed: 2" in data["error"]["message"]
+    assert not out.exists()  # no capture reply, no file written
+
+
+def _usage_error_message(result):
+    # The argv path's contract (gda.dispatch.params_or_bad_parameter): a model
+    # refusal is a Click usage error — exit 2, message on stderr — while the
+    # --params-json path surfaces the SAME rule as structured invalid_params.
+    # Click line-wraps and colors the message, so strip ANSI and collapse
+    # whitespace before matching.
+    import re
+
+    assert result.exit_code == 2, result.stdout + result.stderr
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.stderr)
+    plain = re.sub(r"[\u2500-\u257f]", " ", plain)  # rich panel borders
+    return re.sub(r"\s+", " ", plain)
+
+
+def _invalid_params_message(result):
+    assert result.exit_code != 0
+    data = json.loads(result.stdout)
+    assert data["error"]["code"] == "invalid_params"
+    return data["error"]["message"]
+
+
+def test_await_trio_is_all_or_none(monkeypatch, tmp_path):
+    out = tmp_path / "shot.png"
+
+    result = CliRunner().invoke(
+        app,
+        _capture_argv(out, _project(tmp_path), "--await-node", "/root/Main/VFX"),
+    )
+
+    message = _usage_error_message(result)
+    assert "'await_node', 'await_property', and 'await_value' together" in message
+
+
+def test_await_value_null_is_refused_with_the_trio_message(monkeypatch, tmp_path):
+    out = tmp_path / "shot.png"
+
+    result = CliRunner().invoke(
+        app,
+        _capture_argv(
+            out,
+            _project(tmp_path),
+            "--await-node",
+            "/root/Main/VFX",
+            "--await-property",
+            "frame",
+            "--await-value",
+            "null",
+        ),
+    )
+
+    message = _usage_error_message(result)
+    assert "JSON null value is not supported" in message
+
+
+def test_await_events_need_the_predicate(monkeypatch, tmp_path):
+    out = tmp_path / "shot.png"
+
+    result = CliRunner().invoke(
+        app,
+        _capture_argv(
+            out,
+            _project(tmp_path),
+            "--await-events",
+            '[{"type": "key", "key": "Right"}]',
+        ),
+    )
+
+    message = _usage_error_message(result)
+    assert "'await_events' needs the await predicate" in message
+
+
+def test_await_events_refuse_the_physics_clock(monkeypatch, tmp_path):
+    out = tmp_path / "shot.png"
+
+    result = CliRunner().invoke(
+        app,
+        _await_argv(
+            out,
+            _project(tmp_path),
+            "--await-events",
+            '[{"type": "key", "key": "Right", "physics_frame": 1}]',
+        ),
+    )
+
+    message = _usage_error_message(result)
+    assert "process clock" in message
+    assert "physics_frame" in message
+
+
+def test_await_event_offsets_must_fit_the_window(monkeypatch, tmp_path):
+    out = tmp_path / "shot.png"
+
+    result = CliRunner().invoke(
+        app,
+        _await_argv(
+            out,
+            _project(tmp_path),
+            "--await-frames",
+            "10",
+            "--await-events",
+            '[{"type": "key", "key": "Right", "frame": 10}]',
+        ),
+    )
+
+    message = _usage_error_message(result)
+    assert "must be inside the predicate window" in message
+
+
+def test_await_frames_needs_the_predicate(monkeypatch, tmp_path):
+    out = tmp_path / "shot.png"
+
+    result = CliRunner().invoke(
+        app, _capture_argv(out, _project(tmp_path), "--await-frames", "30")
+    )
+
+    message = _usage_error_message(result)
+    assert "'await_frames' needs the await predicate" in message
+
+
+def test_await_params_json_path_rejects_identically(monkeypatch, tmp_path):
+    # ADR-0015: the model is the single validation authority, so the
+    # --params-json path refuses the same malformed predicate the argv path does.
+    out = tmp_path / "shot.png"
+    params = json.dumps(
+        {
+            "output": str(out),
+            "await_node": "/root/Main/VFX",
+            "await_property": "frame",
+            "await_value": 3,
+            "await_events": [{"type": "key", "key": "Right", "physics_frame": 1}],
+        }
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "screen",
+            "capture",
+            "--params-json",
+            params,
+            "--project",
+            str(_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    message = _invalid_params_message(result)
+    assert "process clock" in message
+
+
+def test_await_schema_publishes_the_predicate_contract():
+    schema = ScreenCaptureParams.model_json_schema()
+    frames = schema["properties"]["await_frames"]
+    bounds = {
+        key: value
+        for branch in frames.get("anyOf", [frames])
+        for key, value in branch.items()
+        if key in ("minimum", "maximum")
+    }
+    assert bounds == {"minimum": 1, "maximum": 600}
+    # The events field embeds the SAME input-sequence union (single authority).
+    events = schema["properties"]["await_events"]
+    assert "$defs" in schema and any(
+        "KeySequenceEvent" in str(events) or "KeySequenceEvent" in key
+        for key in schema["$defs"]
+    )

--- a/tests/test_screen_commands.py
+++ b/tests/test_screen_commands.py
@@ -990,6 +990,28 @@ def test_await_schema_and_model_agree_on_the_cross_field_rules():
             },
             False,
         ),
+        # #743 re-review: the REVERSE divergences — the schema says `integer`,
+        # so the model must not quietly coerce strings (strict clock ints).
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": 3,
+                "await_frames": "10",
+            },
+            False,
+        ),
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": 3,
+                "await_events": [{"type": "key", "key": "Right", "frame": "1"}],
+            },
+            False,
+        ),
     ]
     for payload, accepted in corpus:
         schema_ok = validator.is_valid(payload)
@@ -1001,7 +1023,10 @@ def test_await_schema_and_model_agree_on_the_cross_field_rules():
         assert schema_ok == model_ok == accepted, (payload, schema_ok, model_ok)
 
     # The disclosed model-only residual, pinned so it stays a KNOWN divergence:
-    # an event offset outside the window passes the schema but not the model.
+    # an event offset outside the window passes the schema but not the model —
+    # a cross-field numeric bound Draft 2020-12 cannot state. The disclosure is
+    # PUBLIC: the await_events field description (published in the schema) and
+    # the command catalog both name the rule and that it is validation-enforced.
     residual = {
         "output": "x.png",
         "await_node": "/root/N",

--- a/tests/test_screen_commands.py
+++ b/tests/test_screen_commands.py
@@ -486,14 +486,25 @@ def _await_argv(out, project, *extra):
     )
 
 
+def _predicate_report(**overrides):
+    report = {
+        "node": "/root/Main/VFX",
+        "property": "frame",
+        "expected": 3,
+        "observed": 3,
+        "engine_frame": 240,
+        "frames_waited": 5,
+    }
+    report.update(overrides)
+    return report
+
+
 def test_await_predicate_rides_the_wire_with_the_default_ceiling(monkeypatch, tmp_path):
+    reply = screen_capture_reply(_PNG_B64, width=8, height=8)
+    reply["predicate"] = _predicate_report()
     fake = inject_live_runner(
         monkeypatch,
-        RunResult(
-            stdout=sentinel(screen_capture_reply(_PNG_B64, width=8, height=8)),
-            stderr="",
-            exit_code=0,
-        ),
+        RunResult(stdout=sentinel(reply), stderr="", exit_code=0),
     )
     out = tmp_path / "shot.png"
 
@@ -564,13 +575,13 @@ def test_await_events_ride_the_same_window_and_report_surfaces(monkeypatch, tmp_
 
 
 def test_await_bare_word_value_is_a_string_predicate(monkeypatch, tmp_path):
+    reply = screen_capture_reply(_PNG_B64, width=8, height=8)
+    reply["predicate"] = _predicate_report(
+        property="anim", expected="peak", observed="peak"
+    )
     fake = inject_live_runner(
         monkeypatch,
-        RunResult(
-            stdout=sentinel(screen_capture_reply(_PNG_B64, width=8, height=8)),
-            stderr="",
-            exit_code=0,
-        ),
+        RunResult(stdout=sentinel(reply), stderr="", exit_code=0),
     )
     out = tmp_path / "shot.png"
 
@@ -809,3 +820,199 @@ def test_await_schema_publishes_the_predicate_contract():
         "KeySequenceEvent" in str(events) or "KeySequenceEvent" in key
         for key in schema["$defs"]
     )
+
+
+# --- the receipt correlation gate (#743 review, Standards 2 / Spec 2) ----------
+
+
+def _await_capture(monkeypatch, tmp_path, reply, *extra):
+    inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(reply), stderr="", exit_code=0),
+    )
+    out = tmp_path / "shot.png"
+    result = CliRunner().invoke(app, _await_argv(out, _project(tmp_path), *extra))
+    return result, out
+
+
+def _assert_contract_violation(result, out, fragment):
+    data = json.loads(result.stdout)
+    assert data["error"]["code"] == "contract_violation", result.stdout
+    assert fragment in data["error"]["message"]
+    # Refused BEFORE the output file is written.
+    assert not out.exists()
+
+
+def test_gated_request_with_no_predicate_report_is_contract_violation(
+    monkeypatch, tmp_path
+):
+    reply = screen_capture_reply(_PNG_B64, width=8, height=8)
+
+    result, out = _await_capture(monkeypatch, tmp_path, reply)
+
+    _assert_contract_violation(result, out, "no predicate report")
+
+
+def test_predicate_report_naming_another_target_is_contract_violation(
+    monkeypatch, tmp_path
+):
+    reply = screen_capture_reply(_PNG_B64, width=8, height=8)
+    reply["predicate"] = _predicate_report(node="/root/Wrong")
+
+    result, out = _await_capture(monkeypatch, tmp_path, reply)
+
+    _assert_contract_violation(result, out, "does not name the requested predicate")
+
+
+def test_predicate_report_with_unsatisfied_observation_is_contract_violation(
+    monkeypatch, tmp_path
+):
+    reply = screen_capture_reply(_PNG_B64, width=8, height=8)
+    reply["predicate"] = _predicate_report(observed=2)
+
+    result, out = _await_capture(monkeypatch, tmp_path, reply)
+
+    _assert_contract_violation(result, out, "does not satisfy the declared predicate")
+
+
+def test_predicate_report_outside_the_declared_window_is_contract_violation(
+    monkeypatch, tmp_path
+):
+    reply = screen_capture_reply(_PNG_B64, width=8, height=8)
+    reply["predicate"] = _predicate_report(frames_waited=999)
+
+    result, out = _await_capture(monkeypatch, tmp_path, reply)
+
+    _assert_contract_violation(result, out, "outside the declared window")
+
+
+def test_negative_engine_frame_is_contract_violation(monkeypatch, tmp_path):
+    # The wire model bounds the receipt's frames (ge=0), so classify_live
+    # refuses a fabricated negative frame as the standard reply-shape breach.
+    reply = screen_capture_reply(_PNG_B64, width=8, height=8)
+    reply["predicate"] = _predicate_report(engine_frame=-1)
+
+    result, out = _await_capture(monkeypatch, tmp_path, reply)
+
+    data = json.loads(result.stdout)
+    assert data["error"]["code"] == "contract_violation"
+    assert not out.exists()
+
+
+def test_plain_capture_with_unsolicited_predicate_is_contract_violation(
+    monkeypatch, tmp_path
+):
+    reply = screen_capture_reply(_PNG_B64, width=8, height=8)
+    reply["predicate"] = _predicate_report()
+    inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(reply), stderr="", exit_code=0),
+    )
+    out = tmp_path / "shot.png"
+
+    result = CliRunner().invoke(app, _capture_argv(out, _project(tmp_path)))
+
+    _assert_contract_violation(result, out, "declared no --await predicate")
+
+
+# --- schema/model parity (#743 review, Standards 1; ADR-0015) ------------------
+
+
+def test_await_schema_and_model_agree_on_the_cross_field_rules():
+    # A standard Draft 2020-12 validator and the pydantic model must give the
+    # SAME verdict on the cross-field rules the model enforces. One disclosed
+    # exception (stated in the schema helper's docstring): an event offset
+    # outside the window is model-only — a value-dependent relation across two
+    # fields Draft 2020-12 cannot state.
+    import jsonschema
+    import pydantic
+
+    schema = ScreenCaptureParams.model_json_schema()
+    validator = jsonschema.Draft202012Validator(schema)
+    corpus = [
+        ({"output": "x.png"}, True),
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": 3,
+            },
+            True,
+        ),
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": "peak",
+                "await_frames": 30,
+                "await_events": [{"type": "key", "key": "Right", "frame": 1}],
+            },
+            True,
+        ),
+        ({"output": "x.png", "await_node": "/root/N"}, False),
+        ({"output": "x.png", "await_property": "p"}, False),
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": None,
+            },
+            False,
+        ),
+        ({"output": "x.png", "await_frames": 30}, False),
+        (
+            {
+                "output": "x.png",
+                "await_events": [{"type": "key", "key": "Right"}],
+            },
+            False,
+        ),
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": 3,
+                "await_events": [],
+            },
+            False,
+        ),
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": 3,
+                "await_events": [{"type": "key", "key": "Right", "physics_frame": 1}],
+            },
+            False,
+        ),
+    ]
+    for payload, accepted in corpus:
+        schema_ok = validator.is_valid(payload)
+        try:
+            ScreenCaptureParams.model_validate(payload)
+            model_ok = True
+        except pydantic.ValidationError:
+            model_ok = False
+        assert schema_ok == model_ok == accepted, (payload, schema_ok, model_ok)
+
+    # The disclosed model-only residual, pinned so it stays a KNOWN divergence:
+    # an event offset outside the window passes the schema but not the model.
+    residual = {
+        "output": "x.png",
+        "await_node": "/root/N",
+        "await_property": "p",
+        "await_value": 3,
+        "await_frames": 10,
+        "await_events": [{"type": "key", "key": "Right", "frame": 10}],
+    }
+    assert validator.is_valid(residual)
+    try:
+        ScreenCaptureParams.model_validate(residual)
+        assert False, "the model must refuse an offset outside the window"
+    except pydantic.ValidationError:
+        pass

--- a/tests/test_screen_commands.py
+++ b/tests/test_screen_commands.py
@@ -22,6 +22,7 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.exit_codes import EXIT_LIVE
 from gda.commands.screen import ScreenCaptureParams, ScreenFramesParams
+from gda.models import MAX_WINDOW_FRAMES
 from gda.runner import RunResult
 from tests.support import (
     error_sentinel,
@@ -746,12 +747,10 @@ def test_await_events_refuse_the_physics_clock(monkeypatch, tmp_path):
 def test_out_of_window_event_offset_is_accepted_and_rides_the_wire(
     monkeypatch, tmp_path
 ):
-    # #743 second re-review: the offset-inside-window rule was model-only and
-    # JSON Schema cannot state it, so ADR-0015 parity removes it — the model
-    # and the published schema accept EXACTLY the same set. Semantics are
-    # documented instead: the reply waits for every declared event, so an
-    # offset at or beyond the ceiling still fires (it just cannot satisfy the
-    # predicate any more).
+    # #743 second re-review: an event may sit beyond the PREDICATE ceiling and
+    # still drain. That keeps schema/model parity without restoring the old
+    # cross-field rule; the separate per-event maximum below keeps the TOTAL
+    # serialized live window bounded.
     reply = screen_capture_reply(_PNG_B64, width=8, height=8)
     reply["predicate"] = _predicate_report()
     fake = inject_live_runner(
@@ -777,6 +776,46 @@ def test_out_of_window_event_offset_is_accepted_and_rides_the_wire(
     assert params["await"]["frames"] == 10
     (event,) = params["events"]
     assert event["frame"] == 10
+
+
+def test_await_event_offset_must_fit_the_shared_total_window(monkeypatch, tmp_path):
+    # The predicate ceiling and the TOTAL drain ceiling are different: an event
+    # may sit after await_frames, but no accepted event may extend the serialized
+    # live operation beyond the repository-wide MAX_WINDOW_FRAMES bound (#223).
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel(screen_capture_reply(_PNG_B64, width=8, height=8)),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    out = tmp_path / "shot.png"
+
+    result = CliRunner().invoke(
+        app,
+        _await_argv(
+            out,
+            _project(tmp_path),
+            "--await-frames",
+            "10",
+            "--await-events",
+            json.dumps(
+                [
+                    {
+                        "type": "key",
+                        "key": "Right",
+                        "released": True,
+                        "frame": MAX_WINDOW_FRAMES,
+                    }
+                ]
+            ),
+        ),
+    )
+
+    message = _usage_error_message(result)
+    assert str(MAX_WINDOW_FRAMES - 1) in message
+    assert fake.calls == []
 
 
 def test_await_frames_needs_the_predicate(monkeypatch, tmp_path):
@@ -837,6 +876,13 @@ def test_await_schema_publishes_the_predicate_contract():
         "KeySequenceEvent" in str(events) or "KeySequenceEvent" in key
         for key in schema["$defs"]
     )
+    event_frame = schema["$defs"]["KeySequenceEvent"]["properties"]["frame"]
+    maximums = [
+        branch["maximum"]
+        for branch in event_frame.get("anyOf", [event_frame])
+        if "maximum" in branch
+    ]
+    assert maximums == [MAX_WINDOW_FRAMES - 1]
 
 
 # --- the receipt correlation gate (#743 review, Standards 2 / Spec 2) ----------
@@ -937,10 +983,9 @@ def test_plain_capture_with_unsolicited_predicate_is_contract_violation(
 
 def test_await_schema_and_model_agree_on_the_cross_field_rules():
     # A standard Draft 2020-12 validator and the pydantic model must give the
-    # SAME verdict on the cross-field rules the model enforces. One disclosed
-    # exception (stated in the schema helper's docstring): an event offset
-    # outside the window is model-only — a value-dependent relation across two
-    # fields Draft 2020-12 cannot state.
+    # SAME verdict on the public capture contract: cross-field await rules,
+    # imported event scalar/vocabulary constraints, and both predicate and total
+    # window boundaries.
     import jsonschema
     import pydantic
 
@@ -976,6 +1021,22 @@ def test_await_schema_and_model_agree_on_the_cross_field_rules():
                 "await_node": "/root/N",
                 "await_property": "p",
                 "await_value": None,
+            },
+            False,
+        ),
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": 3,
+                "await_events": [
+                    {
+                        "type": "key",
+                        "key": "Right",
+                        "modifiers": ["hyper"],
+                    }
+                ],
             },
             False,
         ),
@@ -1097,6 +1158,22 @@ def test_await_schema_and_model_agree_on_the_cross_field_rules():
                 "await_events": [{"type": "mouse_click", "x": 10, "y": 20}],
             },
             True,
+        ),
+        # The event may be beyond the predicate ceiling, but not beyond the
+        # shared TOTAL live-window ceiling. This keeps the drain bounded while
+        # preserving the both-accept offset-10 case below.
+        (
+            {
+                "output": "x.png",
+                "await_node": "/root/N",
+                "await_property": "p",
+                "await_value": 3,
+                "await_frames": 10,
+                "await_events": [
+                    {"type": "key", "key": "Right", "frame": MAX_WINDOW_FRAMES}
+                ],
+            },
+            False,
         ),
         # The former model-only residual, now a BOTH-ACCEPT case: the
         # offset-inside-window rule was removed for exact parity — the drain


### PR DESCRIPTION
## W5 slice: predicate-gated screen capture with atomic input events (#661)

**The gap (GDA-DF-023):** input and capture are separate live operations, and the ~4 s CLI/daemon round trip lands after a 3–8-frame VFX peak — both commands report success while the PNG shows an already-settled pose. Packages had to author game-side QA galleries that freeze representative frames. `screen frames` does not remove the fixture: it starts after the same round trip and cannot say which frame holds the requested state.

### What shipped

**The synchronization mechanism** (this issue's ownership; #660's receipt echoes it):

- `gda screen capture --await-node <path> --await-property <name> --await-value <json-scalar> [--await-frames N]` holds the capture **game-side**: the harness evaluates `node.property == value` once per PROCESS frame and captures at the first holding frame's boundary. The result carries a `predicate` report — the `observed` value, the absolute `engine_frame`, and the window-relative `frames_waited` — the fields #660's receipt will echo. A gated success is **correlated CLI-side** before the file is written: the report must name this request's predicate, observe a value that satisfies it, and wait inside the declared window — anything else (including an unsolicited report on a plain capture) is `contract_violation`.
- A predicate that never holds within the bound (default 60 frames, ceiling the shared 600) is the new registered **`live_predicate_unmet`**, carrying the last observed value in its message.
- `--await-events <json>` is the **atomic input-and-capture form**: input-sequence events (the same discriminated union `input sequence` takes — single authority, imported not copied) are applied at process-clock `frame` offsets in the same serialized live operation, so a transient triggered by input cannot be missed by a second round trip. **Every declared event fires before the reply** — an early predicate match or an error path never leaves a scheduled release held (proven live for key, mouse-button, and action) — and **a declared event that fails makes the whole capture that typed failure**: the capture payload is discarded, no file is written, and later events still drain.
- The predicate ceiling and total drain ceiling are intentionally distinct: an event may sit at or beyond `await_frames` and still fire, but every event offset is schema-bounded to `0..599`, so the operation drains within the shared 600-frame live-window bound. Such a late event can no longer satisfy the predicate, whose scan ends at `await_frames`. Physics-clock offsets are refused both model-side (ADR-0015) and in the Draft 2020-12 schema.
- **The model and emitted schema accept the same event set**: every scalar field of the sequence union is strict; the modifier vocabulary is a structural enum; the total-window event-offset maximum is structural; and the former model-only offset-inside-predicate-window rule remains removed. A validator/Pydantic parity corpus pins both directions, integer-for-number boundaries, unknown modifiers, the total offset boundary, and the supported beyond-predicate-ceiling case.

- **No new live op and no three-token command**: the predicate rides the existing `screen-capture` op as params, so the op table, `gda-mcp` tool list, and the live contract guards are untouched.

**Mechanism reuse:** the predicate window is the #223 multi-frame base — `_advance_window` gains an early-COMPLETE arm symmetric to its existing early-error arm (`{"complete": payload}` beside `{"error": …}`); the events reuse `_apply_sequence_event` and the offset helpers verbatim; property existence uses the same storage-property + explicit-script-variable two-step `game get` resolves with. Predicate equality is a JSON-scalar contract (numbers numerically, strings against the String rendering, bools strictly) — documented, not a Variant matcher.

**The coherence contract, verified live on both trigger paths:** each window tick EVALUATES BEFORE it injects, so the observed property is always the previously COMPLETED frame's state — exactly the frame the captured texture presents. A `_process`-driven flip is observed with its own presentation (red-pixel e2e, three repeats); a state written by an injected event's synchronous `_input` callback is observed one boundary later, together with its presentation (the same-callback e2e decodes a green Marker pixel). Declared consequences: the predicate sees frame-boundary state only (an intra-frame value is never observable — the typed unmet error, never mismatched pixels); an event's effect is observable from the next boundary; a game-side visual-after-property lag trails by that game frame. Stated in the schema descriptions, help, catalog, SKILL, and the ADR-0020 amendment; ADR-0017 records early completion plus the event-failure reply rule, and ADR-0040 records the fourth one-way group edge (`screen` → `input`).

**Self-description:** `--await-events` is the surface's first nullable-compound single-token option — exactly the case #669's registration guard was built to force — so the argv-binding `json_value` derivation now sees a compound behind `anyOf`/`oneOf`, and the guard's premise comment is updated to "keep the two detectors agreeing".

**Harness identity gate:** `HARNESS_VERSION` 8 → 10 (9 declared multiple bodies during this PR and was retired). The editable in-test history has been removed because it could not enforce history. Instead, the required Python CI job checks the Git merge base against the PR/push head: if `gda_harness.gd` bytes changed, the head must contain a strictly greater numeric `HARNESS_VERSION`. Checkout uses full history, while the current version/hash unit pin still catches accidental snapshot edits and gives the replacement hash.

### Intended public-surface diffs (enumerated)

- `gda screen capture --help`: the five new `--await-*` options.
- `gda schema`: `screen capture` gains five new input properties (`await_frames` bounded 1..600; `await_events` embedding the input-sequence event `$defs`), the `predicate` result field backed by the new `CapturePredicateReport` model, and `json_value: true` on the `--await-events` argv binding. The shared constraint publication also reaches the input group: `input key` / `input tap` emit the modifier vocabulary as an `enum` (the tap result mirrors it), and the sequence-event `$defs` gain `maximum: 599` on `frame` / `physics_frame` with matching descriptions. The complete `gda schema` diff vs the dev tip touches exactly these four commands: `input key`, `input tap`, `input sequence`, `screen capture`.
- SKILL.md `screen` row and the command catalog's `screen` section describe the predicate and the atomic form; ADR-0002's table gains the `live_predicate_unmet` row.

### Acceptance criteria → evidence

| AC | Evidence |
| --- | --- |
| Deterministic capture of a declared transient without game-side fixtures | e2e: `phase == 5` holds for exactly ONE process frame per 8-frame cycle and the rect is RED on that frame alone; the decoded PNG shows the matched frame's pixels, **three times in one session** — and the input-triggered path decodes the same-callback Marker pixel green |
| Never-holding predicate → typed error after the stated bound | e2e: `phase == 99 --await-frames 20` → `live_predicate_unmet`, "did not hold within 20 frames", "last observed" in the message, no file written |
| Result reports frame index + predicate evaluation | unit + e2e: `predicate.{observed, engine_frame, frames_waited}` asserted; renderer prints the predicate line |
| Live regression capturing a short transient reliably across repeated runs | the 3-iteration e2e above, plus the input-triggered form: `--await-events` injects a key press and captures `flash == 1`, a one-frame state ~3 frames later |

### Validation

- Exact delivered head: `402ecb21520fcd6a2fc82cf61eb721a015287b1f`.
- Non-E2E suite: **1850 passed, 2 skipped, 527 deselected**.
- Real-engine windowed E2E: screen **13 passed**, input **16 passed** (**29 passed** total).
- Pyright: 0 errors; repository-wide Ruff check and format: clean (**468 files**); workflow YAML parse and `git diff --check`: clean.
- Harness guard adversarial proof: historical `2270e22f` → `75afef5c` is rejected because the harness body changed while version 9 was reused; dev merge base `85d8a285` → delivered head passes with the legitimate 8 → 10 transition.
- Schema/model probes now both reject `modifiers:["hyper"]` and an event at frame 600, while both accept an event beyond the predicate ceiling when it remains inside the total ceiling.
- Existing red proofs for the original feature and earlier review rounds remain documented in the commit history; no command or live op was added.

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)
