### PR TITLE
refactor(gda): single-evaluate script/shader set mode via params model

### DIFF
--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -463,7 +463,9 @@ The lifecycle round-trips: `create` → `list` shows it → `delete` → `list` 
 script as **raw text** — it never compiles or loads the script, so editing one never runs
 project code (the read trust boundary of #30). It edits only a script that exists; a missing
 target is `path_not_found`, never a silent create. Exactly one of three mutually-exclusive
-modes is selected at the CLI (a missing or mixed mode is a usage error, exit 2):
+modes must be selected — derived once by the params model, identically on argv and
+`--params-json` (ADR-0015, #713); a missing or mixed mode is a usage error, exit 2, on argv,
+and structured `invalid_params` on `--params-json`:
 
 - **search-replace** — `--search <old> --replace <new>`: replace **every** literal (not regex)
   occurrence of `<old>` with `<new>`. A search string the source does not contain is refused

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -263,9 +263,13 @@ def resolve_set_mode(
     The single home of the edit-mode rule, shared by ``script set`` and ``shader
     set`` and by BOTH input paths (ADR-0015): exactly one of the three
     mutually-exclusive modes must be supplied. Raises ``ValueError`` on a
-    violation — the CLI wrapper translates it to a usage error (exit 2) for argv,
-    while the params models surface it as the structured ``invalid_params`` for
-    ``--params-json``.
+    violation. Its only callers are the two params models' ``_resolve_mode``
+    ``model_validator``s (:class:`ScriptSetParams` here, :class:`ShaderSetParams`
+    in ``gda.commands.shader``) — so the rule runs exactly ONCE per invocation,
+    on both commands (issue #713). The argv body builds that model through
+    :func:`~gda.dispatch.params_or_bad_parameter`, which turns the raised error
+    into the Click usage error (exit 2); ``--params-json`` builds the same model
+    and surfaces it as the structured ``invalid_params`` instead.
     """
     has_search = search is not None or replace is not None
     has_line_range = start_line is not None or end_line is not None
@@ -2344,12 +2348,16 @@ def set_script(
     project: Optional[str] = project_option(),
 ) -> None:
     """Edit a .gd script via search-replace, line-range, or full overwrite."""
-    mode = parse_set_mode_argv(search, replace, start_line, end_line, content)
+    # The model owns the mode-selection rule and the argv body does not restate
+    # it: the shared builder turns any model-construction failure (resolve_set_mode,
+    # via ScriptSetParams's validator) into the Click usage error (exit 2) — the
+    # same translation an argv-side pre-check used to do by hand — so the rule
+    # runs once per invocation on both input paths (ADR-0015, issue #713).
     dispatch_domain(
         SCRIPT_SET_COMMAND,
-        ScriptSetParams(
+        params_or_bad_parameter(
+            ScriptSetParams,
             path=path,
-            mode=mode,
             search=search,
             replace=replace,
             start_line=start_line,
@@ -2360,27 +2368,6 @@ def set_script(
         godot=godot,
         project=project,
     )
-
-
-def parse_set_mode_argv(
-    search: Optional[str],
-    replace: Optional[str],
-    start_line: Optional[int],
-    end_line: Optional[int],
-    content: Optional[str],
-) -> ScriptSetMode:
-    """Resolve a set command's edit mode for the argv path (issue #133).
-
-    The rule itself lives in :func:`resolve_set_mode` — the single source shared
-    with ``ScriptSetParams`` / ``ShaderSetParams`` (ADR-0015). This thin wrapper
-    translates its ``ValueError`` into a Click usage error (exit 2) so the argv
-    path keeps its usage-error ergonomics, while ``--params-json`` surfaces the
-    same rule as a structured ``invalid_params`` via the model.
-    """
-    try:
-        return resolve_set_mode(search, replace, start_line, end_line, content)
-    except ValueError as exc:
-        raise typer.BadParameter(str(exc)) from exc
 
 
 @_app.command(name="attach", cls=SCRIPT_ATTACH_COMMAND.command_class())

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -1174,17 +1174,24 @@ def _project_scoped_res_path(script: str) -> str | None:
       ``res://`` spellings) — the project is the whole addressable scope, so an
       upward escape names something the ``--project`` contract does not cover.
 
-    The last two are load-bearing for the same reason, and it is not tidiness. The
-    engine answers a root address with ``Can't load script: res://.`` (or
-    ``res://..``), whose address the error parser reads back with the sentence period
-    stripped — ``res://`` for the first, ``res://.`` for the second. Neither matches
-    the entry, so the never-ran verdict misses it and the run reports a PHANTOM
-    SUCCESS. And an escape that RESOLVES (``../outside.gd``) executes a script outside
-    the project entirely, which would widen the Project-code execution surface past
-    ADR-0009's Trusted project — the very consequence the amendment cites for keeping
-    absolute paths refused, so admitting it by the relative spelling would make that
-    reasoning false. Refusing both before the launch closes them without touching the
-    error parser's own res:// handling.
+    The last two are load-bearing, and it is not tidiness. The root-address clause
+    used to ALSO be the fix for a parser bug: the engine answers a root address
+    with ``Can't load script: res://.`` (or ``res://..``), and the pre-#698 error
+    parser read that address back with an assumed sentence period stripped —
+    ``res://`` for the first, ``res://.`` for the second. Neither matched the
+    entry, so the never-ran verdict missed it and the run reported a PHANTOM
+    SUCCESS; refusing the root address here, before any launch, closed that gap.
+    #698 fixed the parser itself to read the address back intact, so that failure
+    mode is now history — the root address stays refused for the plainer reason
+    already given above (it names a directory, not a script), not because the
+    parser still corrupts it. The escape clause is the one still load-bearing for
+    the reason it always was: an escape that RESOLVES (``../outside.gd``)
+    executes a script outside the project entirely, which would widen the
+    Project-code execution surface past ADR-0009's Trusted project — the very
+    consequence the amendment cites for keeping absolute paths refused, so
+    admitting it by the relative spelling would make that reasoning false.
+    Refusing both before the launch keeps this gate, not the error parser, as the
+    one place that decides.
 
     The escape test is on the canonical remainder's first SEGMENT, not a string
     prefix: ``res://..foo.gd`` is a legal file whose name merely starts with two dots,

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -234,10 +234,14 @@ class ScriptDeleteResult(BaseModel):
 class ScriptSetMode(str, Enum):
     """The edit mode of ``gda script set``, the single source of truth (issue #133).
 
-    The CLI resolves exactly one mode from the supplied flags (its mutual-exclusion
-    check) and stamps it here, so the operation dispatches on this explicit
-    discriminator instead of re-inferring the mode from which params are present —
-    the inference precedence can no longer drift from the CLI's exclusivity rule.
+    The params model derives exactly one mode from the supplied fields — via
+    :func:`resolve_set_mode`, run once by the model's own ``_resolve_mode``
+    validator on BOTH the argv and ``--params-json`` paths (ADR-0015, #713) —
+    and stamps it here, so the operation dispatches on this explicit
+    discriminator instead of re-inferring the mode from which params are
+    present. The CLI is a thin argv-to-model adapter; it does not re-derive the
+    mode itself, so the derivation cannot drift from the model's exclusivity
+    rule.
 
     - ``SEARCH_REPLACE`` — ``search``/``replace``: every literal (not regex)
       occurrence of ``search`` is replaced with ``replace``.
@@ -306,9 +310,10 @@ class ScriptSetParams(BaseModel):
     loads the script, so editing one can never run project code (the read trust
     boundary of issue #30). ``path`` addresses the script by its ``res://`` or
     filesystem path. The remaining params carry one of three mutually-exclusive
-    edit modes; the CLI resolves which one and stamps it on ``mode`` (issue #133),
-    so the operation dispatches on that explicit discriminator rather than
-    re-inferring it from which params are present:
+    edit modes; the model derives which one and stamps it on ``mode`` (issue
+    #133, ADR-0015) — the SAME derivation on both the argv and ``--params-json``
+    paths (#713) — so the operation dispatches on that explicit discriminator
+    rather than re-inferring it from which params are present:
 
     - **search-replace** (``mode = search_replace``) — ``search``/``replace`` both
       present: every literal (not regex) occurrence of ``search`` is replaced with
@@ -1175,17 +1180,22 @@ def _project_scoped_res_path(script: str) -> str | None:
       upward escape names something the ``--project`` contract does not cover.
 
     The last two are load-bearing, and it is not tidiness. The root-address clause
-    used to ALSO be the fix for a parser bug: the engine answers a root address
-    with ``Can't load script: res://.`` (or ``res://..``), and the pre-#698 error
-    parser read that address back with an assumed sentence period stripped —
-    ``res://`` for the first, ``res://.`` for the second. Neither matched the
-    entry, so the never-ran verdict missed it and the run reported a PHANTOM
-    SUCCESS; refusing the root address here, before any launch, closed that gap.
-    #698 fixed the parser itself to read the address back intact, so that failure
-    mode is now history — the root address stays refused for the plainer reason
-    already given above (it names a directory, not a script), not because the
-    parser still corrupts it. The escape clause is the one still load-bearing for
-    the reason it always was: an escape that RESOLVES (``../outside.gd``)
+    is ALSO belt-and-suspenders against a parser risk: the engine answers a root
+    address with ``Can't load script: res://.`` (or ``res://..``), a sentence
+    whose trailing dot is part of the ADDRESS, not punctuation. A parser that
+    folds it as though it WERE punctuation — reading ``res://.`` back as
+    ``res://``, ``res://..`` back as ``res://.`` — would miss the launched
+    entry, and the never-ran verdict would report a PHANTOM SUCCESS instead of
+    the refusal it should be. Issue #698 (its fix, PR #756) targets exactly that
+    fold in :mod:`gda.script_errors`'s ``_CANT_LOAD`` regex; this paragraph's own
+    argument does not depend on whether that PR has landed at any point in this
+    branch's history, because THIS guard already closes the gap on its own,
+    independent of the parser's fold either way: a root address is refused
+    HERE, before any launch, so it never reaches the parser at all. The root
+    address therefore stays refused for the plainer reason already given above
+    (it names a directory, not a script). The escape clause is the one still
+    load-bearing for the reason it always was: an escape that RESOLVES
+    (``../outside.gd``)
     executes a script outside the project entirely, which would widen the
     Project-code execution surface past ADR-0009's Trusted project — the very
     consequence the amendment cites for keeping absolute paths refused, so

--- a/src/gda/commands/shader.py
+++ b/src/gda/commands/shader.py
@@ -136,10 +136,11 @@ class ShaderSetParams(BaseModel):
     autoloads at engine startup (ADR-0009). ``path`` addresses the shader by its
     ``res://`` or filesystem path. The remaining params carry the SAME three
     mutually-exclusive edit modes as ``script set`` (issue #118) — the shader
-    group reuses that edit interface rather than re-deriving it. The CLI resolves
-    which mode and stamps it on ``mode`` (issue #133), so the operation dispatches
-    on that explicit discriminator rather than re-inferring it from which params
-    are present:
+    group reuses that edit interface rather than re-deriving it. The model
+    derives which mode and stamps it on ``mode`` (issue #133, ADR-0015) — the
+    SAME derivation on both the argv and ``--params-json`` paths (#713) — so the
+    operation dispatches on that explicit discriminator rather than
+    re-inferring it from which params are present:
 
     - **search-replace** (``mode = search_replace``) — ``search``/``replace`` both
       present: every literal (not regex) occurrence of ``search`` is replaced with

--- a/src/gda/commands/shader.py
+++ b/src/gda/commands/shader.py
@@ -17,8 +17,8 @@ from typing import Optional, Protocol, runtime_checkable
 import typer
 from pydantic import BaseModel, Field, model_validator
 
-from gda.commands.script import ScriptSetMode, parse_set_mode_argv, resolve_set_mode
-from gda.dispatch import dispatch_domain
+from gda.commands.script import ScriptSetMode, resolve_set_mode
+from gda.dispatch import dispatch_domain, params_or_bad_parameter
 from gda.headless import (
     HeadlessCommand,
     godot_option,
@@ -416,12 +416,15 @@ def set_shader(
     """Edit a .gdshader via search-replace, line-range, or full overwrite."""
     # shader set reuses the script set edit-mode interface (issue #115): the same
     # mutual-exclusion resolver decides the single ScriptSetMode discriminator.
-    mode = parse_set_mode_argv(search, replace, start_line, end_line, content)
+    # The model owns that rule and the argv body does not restate it: the shared
+    # builder turns any model-construction failure into the Click usage error
+    # (exit 2), so the rule runs once per invocation on both input paths
+    # (ADR-0015, issue #713).
     dispatch_domain(
         SHADER_SET_COMMAND,
-        ShaderSetParams(
+        params_or_bad_parameter(
+            ShaderSetParams,
             path=path,
-            mode=mode,
             search=search,
             replace=replace,
             start_line=start_line,

--- a/src/gda/dispatch.py
+++ b/src/gda/dispatch.py
@@ -47,11 +47,60 @@ def params_or_bad_parameter(model_cls: type[P], /, **kwargs: Any) -> P:
     usage-error ergonomics — while ``--params-json``, which builds the SAME model
     in the command class, surfaces the same rule as a structured
     ``invalid_params``. Stated here once so no argv body restates it.
+
+    A raw ``ValueError``'s ``str()`` is already the plain sentence a validator
+    wrote, so it passes through as-is. A pydantic ``ValidationError`` is
+    rendered through :func:`_validation_message` instead of its own ``str()`` —
+    which dumps the model's class name, a ``[type=..., input_value=...,
+    input_type=...]`` tag PER ERROR, and a pydantic.dev URL, and can echo back
+    an arbitrary caller value (including a large or sensitive one) inside
+    ``input_value=`` (#713 review).
     """
     try:
         return model_cls(**kwargs)
-    except (ValueError, ValidationError) as exc:
+    except ValidationError as exc:
+        raise typer.BadParameter(_validation_message(exc)) from exc
+    except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
+
+
+def _validation_message(exc: ValidationError) -> str:
+    """Render a ``ValidationError`` as the sentence(s) its checks actually wrote.
+
+    Reads each error's own ``msg`` — already the clean, human-readable text for
+    a built-in pydantic check (a type mismatch, a missing field, an out-of-range
+    value) — rather than ``str(exc)``, which additionally dumps the model class
+    name and a ``[type=..., input_value=..., input_type=...]`` tag per error
+    (the defect: ``input_value`` echoes the caller's raw field value, which can
+    be large or sensitive, e.g. a ``script set --content`` payload).
+
+    For a model or field validator's raised ``ValueError`` (pydantic's
+    ``"value_error"`` type, e.g. :func:`~gda.commands.script.resolve_set_mode`),
+    ``msg`` is pydantic's OWN ``"Value error, "``-prefixed rendering of it; this
+    reads the original exception back out of ``ctx['error']`` instead, so the
+    message is exactly the sentence the validator wrote, unprefixed.
+
+    Each message is tagged with its field path (``loc``, dotted) when the error
+    is field-scoped; a model-level validator's error (``loc == ()``, e.g.
+    ``resolve_set_mode``'s mode-selection rule, which has no single field to
+    name) carries no tag. Multiple errors join on ``"; "`` — a command usually
+    raises exactly one, but pydantic can report several at once (e.g. two
+    independently-invalid fields), and nothing here assumes otherwise.
+    """
+    parts: list[str] = []
+    for err in exc.errors():
+        ctx = err.get("ctx")
+        if err["type"] == "value_error" and isinstance(ctx, dict) and "error" in ctx:
+            message = str(ctx["error"])
+        else:
+            message = err["msg"]
+        loc = err.get("loc") or ()
+        if loc:
+            field = ".".join(str(part) for part in loc)
+            parts.append(f"{field}: {message}")
+        else:
+            parts.append(message)
+    return "; ".join(parts)
 
 
 def make_runner(binary: Path, project: Optional[Path]) -> GodotRunner:

--- a/src/gda/dispatch.py
+++ b/src/gda/dispatch.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, ValidationError
 from gda.errors import (
     Failure,
     invalid_project_failure,
+    validation_error_message,
 )
 from gda.execution import ExecutionKind
 from gda.export_runner import ExportRunner, make_subprocess_export_runner
@@ -50,57 +51,21 @@ def params_or_bad_parameter(model_cls: type[P], /, **kwargs: Any) -> P:
 
     A raw ``ValueError``'s ``str()`` is already the plain sentence a validator
     wrote, so it passes through as-is. A pydantic ``ValidationError`` is
-    rendered through :func:`_validation_message` instead of its own ``str()`` —
-    which dumps the model's class name, a ``[type=..., input_value=...,
-    input_type=...]`` tag PER ERROR, and a pydantic.dev URL, and can echo back
-    an arbitrary caller value (including a large or sensitive one) inside
-    ``input_value=`` (#713 review).
+    rendered through :func:`~gda.errors.validation_error_message` instead of its
+    own ``str()`` — which dumps the model's class name, a ``[type=...,
+    input_value=..., input_type=...]`` tag PER ERROR, and a pydantic.dev URL, and
+    can echo back an arbitrary caller value (including a large or sensitive one)
+    inside ``input_value=`` (#713 review). That renderer is shared with
+    ``--params-json``'s OWN model-construction failure (:mod:`gda.headless`), so
+    the two input channels report the identical sentence for the identical
+    refusal (#713 review, round 3) — not just the same error class.
     """
     try:
         return model_cls(**kwargs)
     except ValidationError as exc:
-        raise typer.BadParameter(_validation_message(exc)) from exc
+        raise typer.BadParameter(validation_error_message(exc)) from exc
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
-
-
-def _validation_message(exc: ValidationError) -> str:
-    """Render a ``ValidationError`` as the sentence(s) its checks actually wrote.
-
-    Reads each error's own ``msg`` — already the clean, human-readable text for
-    a built-in pydantic check (a type mismatch, a missing field, an out-of-range
-    value) — rather than ``str(exc)``, which additionally dumps the model class
-    name and a ``[type=..., input_value=..., input_type=...]`` tag per error
-    (the defect: ``input_value`` echoes the caller's raw field value, which can
-    be large or sensitive, e.g. a ``script set --content`` payload).
-
-    For a model or field validator's raised ``ValueError`` (pydantic's
-    ``"value_error"`` type, e.g. :func:`~gda.commands.script.resolve_set_mode`),
-    ``msg`` is pydantic's OWN ``"Value error, "``-prefixed rendering of it; this
-    reads the original exception back out of ``ctx['error']`` instead, so the
-    message is exactly the sentence the validator wrote, unprefixed.
-
-    Each message is tagged with its field path (``loc``, dotted) when the error
-    is field-scoped; a model-level validator's error (``loc == ()``, e.g.
-    ``resolve_set_mode``'s mode-selection rule, which has no single field to
-    name) carries no tag. Multiple errors join on ``"; "`` — a command usually
-    raises exactly one, but pydantic can report several at once (e.g. two
-    independently-invalid fields), and nothing here assumes otherwise.
-    """
-    parts: list[str] = []
-    for err in exc.errors():
-        ctx = err.get("ctx")
-        if err["type"] == "value_error" and isinstance(ctx, dict) and "error" in ctx:
-            message = str(ctx["error"])
-        else:
-            message = err["msg"]
-        loc = err.get("loc") or ()
-        if loc:
-            field = ".".join(str(part) for part in loc)
-            parts.append(f"{field}: {message}")
-        else:
-            parts.append(message)
-    return "; ".join(parts)
 
 
 def make_runner(binary: Path, project: Optional[Path]) -> GodotRunner:

--- a/src/gda/dispatch.py
+++ b/src/gda/dispatch.py
@@ -49,10 +49,12 @@ def params_or_bad_parameter(model_cls: type[P], /, **kwargs: Any) -> P:
     in the command class, surfaces the same rule as a structured
     ``invalid_params``. Stated here once so no argv body restates it.
 
-    A raw ``ValueError``'s ``str()`` is already the plain sentence a validator
-    wrote, so it passes through as-is. A pydantic ``ValidationError`` is
-    rendered through :func:`~gda.errors.validation_error_message` instead of its
-    own ``str()`` — which dumps the model's class name, a ``[type=...,
+    A custom ``BaseModel.__init__`` can raise a raw ``ValueError`` before
+    pydantic's validation machinery wraps it; its ``str()`` is already the plain
+    refusal sentence, so it passes through as-is. Field/model validators and
+    ``model_post_init`` instead arrive as a pydantic ``ValidationError``, rendered
+    through :func:`~gda.errors.validation_error_message` instead of its own
+    ``str()`` — which dumps the model's class name, a ``[type=...,
     input_value=..., input_type=...]`` tag PER ERROR, and a pydantic.dev URL, and
     can echo back an arbitrary caller value (including a large or sensitive one)
     inside ``input_value=`` (#713 review). That renderer is shared with

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -133,6 +133,55 @@ def _is_too_deep(exc: ValidationError) -> bool:
     return bool(errors) and all(error["type"] == "recursion_loop" for error in errors)
 
 
+def validation_error_message(exc: ValidationError) -> str:
+    """Render a ``ValidationError`` as the sentence(s) its checks actually wrote.
+
+    The shared home for BOTH input channels that build a params model directly
+    from caller-supplied values and must translate a construction failure into a
+    human message (ADR-0015): the argv path's :func:`~gda.dispatch.params_or_bad_parameter`
+    and the ``--params-json`` path's ``invoke()`` (:mod:`gda.headless`). Lives
+    here, below both, because ``gda.dispatch`` imports ``gda.headless`` — a
+    ``gda.headless``-side import of ``gda.dispatch`` would cycle — while both
+    already import :mod:`gda.errors` for their own failure taxonomy (#713
+    review: the two channels must report the SAME sentence for the SAME
+    refusal, not just the same error class).
+
+    Reads each error's own ``msg`` — already the clean, human-readable text for
+    a built-in pydantic check (a type mismatch, a missing field, an out-of-range
+    value) — rather than ``str(exc)``, which additionally dumps the model class
+    name and a ``[type=..., input_value=..., input_type=...]`` tag per error
+    (the defect: ``input_value`` echoes the caller's raw field value, which can
+    be large or sensitive, e.g. a ``script set --content`` payload).
+
+    For a model or field validator's raised ``ValueError`` (pydantic's
+    ``"value_error"`` type, e.g. :func:`~gda.commands.script.resolve_set_mode`),
+    ``msg`` is pydantic's OWN ``"Value error, "``-prefixed rendering of it; this
+    reads the original exception back out of ``ctx['error']`` instead, so the
+    message is exactly the sentence the validator wrote, unprefixed.
+
+    Each message is tagged with its field path (``loc``, dotted) when the error
+    is field-scoped; a model-level validator's error (``loc == ()``, e.g.
+    ``resolve_set_mode``'s mode-selection rule, which has no single field to
+    name) carries no tag. Multiple errors join on ``"; "`` — a command usually
+    raises exactly one, but pydantic can report several at once (e.g. two
+    independently-invalid fields), and nothing here assumes otherwise.
+    """
+    parts: list[str] = []
+    for err in exc.errors():
+        ctx = err.get("ctx")
+        if err["type"] == "value_error" and isinstance(ctx, dict) and "error" in ctx:
+            message = str(ctx["error"])
+        else:
+            message = err["msg"]
+        loc = err.get("loc") or ()
+        if loc:
+            field = ".".join(str(part) for part in loc)
+            parts.append(f"{field}: {message}")
+        else:
+            parts.append(message)
+    return "; ".join(parts)
+
+
 def _operation_error_from_payload(result: RunResult) -> tuple[str, str] | None:
     """Extract a minimal operation error envelope from stdout, if present."""
     try:

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -26,6 +26,7 @@ from gda.errors import (
     conflicting_params_input_failure,
     invalid_params_json_failure,
     unresolvable_binary_failure,
+    validation_error_message,
 )
 from gda.execution import ExecutionKind, live_stack_constraints
 from gda.models import (
@@ -430,7 +431,17 @@ def schema_command_class(
                 try:
                     model = command.input_model.model_validate_json(text)
                 except ValidationError as exc:
-                    emit_failure(invalid_params_json_failure(str(exc)))
+                    # The same clean-sentence extractor the argv path's
+                    # params_or_bad_parameter uses (gda.errors.validation_error_message,
+                    # #713 review round 3), so both input channels report the identical
+                    # refusal for the identical violation — not str(exc)'s dump of the
+                    # model class name, a [type=..., input_value=..., input_type=...]
+                    # tag per error, and a pydantic.dev URL, which used to echo the
+                    # caller's OTHER field values (e.g. a large --content payload) back
+                    # into the structured envelope's message.
+                    emit_failure(
+                        invalid_params_json_failure(validation_error_message(exc))
+                    )
                 if _params_json_dispatch is None:  # pragma: no cover - misconfig
                     raise RuntimeError(
                         "no --params-json dispatcher registered; gda.dispatch must call "

--- a/tests/support.py
+++ b/tests/support.py
@@ -31,6 +31,33 @@ def plain_text(text: str) -> str:
     return ANSI_ESCAPE.sub("", text)
 
 
+# The box-drawing characters Rich uses to frame a Click usage-error panel
+# (``╭─...─╮`` etc.) — a SEPARATE concern from `ANSI_ESCAPE` above, since a
+# usage error's border survives even where color does not.
+_RICH_PANEL_BORDER = re.compile(r"[─-╿]")
+
+
+def usage_error_text(result) -> str:
+    """Normalize a CliRunner ``Result``'s Click usage-error panel to plain text.
+
+    A model refusal on the argv path (``gda.dispatch.params_or_bad_parameter``,
+    ADR-0015) is a Click usage error: exit 2, the message inside a Rich panel on
+    stderr. Rich renders that panel with ANSI color and box-drawing borders even
+    under ``CliRunner`` (colorized state can differ between a local run and CI,
+    issue #671), so a raw ``result.stderr`` can't be matched directly. This
+    normalizes it ONCE — reusing :func:`plain_text` for the ANSI half, folding
+    the box-drawing border to whitespace, then collapsing whitespace runs — and
+    returns the whole collapsed panel (the ``Usage: ...`` preamble, the
+    ``Error`` heading, and the ``Invalid value: <message>`` body), so a caller
+    matches whichever substring it needs, or extracts the message itself.
+    Shared by every test asserting on an argv usage error's text, instead of
+    each redefining the same normalization (#713 review).
+    """
+    assert result.exit_code == 2, result.stdout + result.stderr
+    plain = _RICH_PANEL_BORDER.sub(" ", plain_text(result.stderr))
+    return re.sub(r"\s+", " ", plain).strip()
+
+
 # The gda CLI invocation prefix for e2e subprocess tests. Resolved as the gda
 # MODULE in *this* interpreter's environment — `[sys.executable, "-m", "gda"]` —
 # never a PATH-resolved global. This is the same same-environment resolution

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -15,7 +15,7 @@ field-level validator), and a multi-error ``ValidationError``.
 
 import typer
 import pytest
-from pydantic import BaseModel, ValidationError, field_validator, model_validator
+from pydantic import BaseModel, field_validator, model_validator
 
 from gda.dispatch import params_or_bad_parameter
 

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -23,7 +23,6 @@ report byte-identical sentences for the identical refusal.
 """
 
 import json
-import re
 
 import typer
 import pytest
@@ -32,6 +31,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.dispatch import params_or_bad_parameter
+from tests.support import usage_error_text
 
 # The exact dump fragments str(ValidationError) used to leak (PR #754 review).
 _FORBIDDEN_FRAGMENTS = ("pydantic.dev", "input_value=", "[type=")
@@ -43,13 +43,10 @@ def _assert_clean(message: str) -> None:
 
 
 def _argv_usage_error_message(result) -> str:
-    # Click/Rich renders the usage-error panel with ANSI color and box-drawing
-    # borders even under CliRunner; strip both before matching (mirrors
-    # tests/test_screen_commands.py's `_usage_error_message`).
-    assert result.exit_code == 2, result.stdout + result.stderr
-    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.stderr)
-    plain = re.sub(r"[─-╿]", " ", plain)  # rich panel borders
-    plain = re.sub(r"\s+", " ", plain).strip()
+    # The Rich-panel normalization is shared (tests/support.py,
+    # `usage_error_text`) — the SAME one tests/test_screen_commands.py uses —
+    # so only the "Invalid value: " extraction is specific to this module.
+    plain = usage_error_text(result)
     # The panel is preceded by the "Usage: ..." / "Try '... --help'" preamble
     # and an "Error" heading, so find the marker rather than assume it leads.
     prefix = "Invalid value: "
@@ -151,7 +148,7 @@ def test_multi_error_validation_error_joins_each_fields_own_message():
     _assert_clean(message)
 
 
-def test_no_caller_value_leaks_into_the_refusal(monkeypatch):
+def test_no_caller_value_leaks_into_the_refusal():
     # The concrete leak PR #754's review reproduced: a large/sensitive field
     # value must never ride along in the refusal, even though the refused
     # field itself carries it.

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -98,14 +98,24 @@ class _TwoIndependentFieldsModel(BaseModel):
     b: int
 
 
-class _RawValueErrorModel:
-    """Not a pydantic model: raises a bare ValueError straight out of __init__.
+class _RawValueErrorModel(BaseModel):
+    """A real BaseModel subclass that raises a bare ValueError from __init__.
 
-    Exercises params_or_bad_parameter's OTHER except clause directly — pydantic
-    itself always wraps a validator's ValueError into ValidationError (verified:
-    every mode='before'/'after'/field validator wraps), so this simulates the
-    one caller shape pydantic can never produce, standing in for it.
+    Exercises params_or_bad_parameter's OTHER except clause with a genuine
+    ``P`` (bound to BaseModel) — in contract, not a bypass of it (PR #754
+    review, round 5). A field or model validator can't reach this branch:
+    pydantic always wraps a validator's raised ValueError into
+    ValidationError, and ``model_post_init`` gets the same wrapping
+    (verified). Overriding ``__init__`` is the one route that escapes it —
+    the override runs before pydantic's own validation machinery does, so
+    the plain ValueError it raises here propagates untouched. This is why
+    ``params_or_bad_parameter`` must catch ``ValidationError`` before
+    ``ValueError``: ``ValidationError`` is itself a ``ValueError`` subclass,
+    and this class is the sibling shape a ValidationError-raising validator
+    can never produce.
     """
+
+    a: int = 1
 
     def __init__(self, **kwargs: object) -> None:
         raise ValueError("a plain refusal sentence.")
@@ -113,7 +123,7 @@ class _RawValueErrorModel:
 
 def test_plain_value_error_passes_through_as_the_bare_sentence():
     with pytest.raises(typer.BadParameter) as exc_info:
-        params_or_bad_parameter(_RawValueErrorModel)  # type: ignore[arg-type]
+        params_or_bad_parameter(_RawValueErrorModel)
 
     message = str(exc_info.value)
     assert message == "a plain refusal sentence."

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,0 +1,139 @@
+"""``gda.dispatch.params_or_bad_parameter``'s usage-error rendering (issue #713).
+
+``params_or_bad_parameter`` is the shared argv seam every ``set``/``validate``-style
+params model runs through (ADR-0015): a model-construction failure becomes a Click
+usage error (exit 2). Its rendering used to be ``str(exc)`` on whatever pydantic
+raised, which for a ``ValidationError`` dumps the model's class name, a
+``[type=..., input_value=..., input_type=...]`` tag PER ERROR, and a
+``pydantic.dev`` URL — and can echo an arbitrary caller value (e.g. a
+``script set --content`` payload) back inside ``input_value=`` (found in PR #754's
+review). These tests pin the clean replacement: the validator's own sentence(s),
+with none of that dump noise and no leaked caller value, for a plain
+``ValueError``, a single-error ``ValidationError`` (both a model-level and a
+field-level validator), and a multi-error ``ValidationError``.
+"""
+
+import typer
+import pytest
+from pydantic import BaseModel, ValidationError, field_validator, model_validator
+
+from gda.dispatch import params_or_bad_parameter
+
+# The exact dump fragments str(ValidationError) used to leak (PR #754 review).
+_FORBIDDEN_FRAGMENTS = ("pydantic.dev", "input_value=", "[type=")
+
+
+def _assert_clean(message: str) -> None:
+    for fragment in _FORBIDDEN_FRAGMENTS:
+        assert fragment not in message, f"{fragment!r} leaked into {message!r}"
+
+
+class _ModelLevelRuleModel(BaseModel):
+    """Mirrors ScriptSetParams's shape: a model-level mutual-exclusion rule."""
+
+    search: str | None = None
+    replace: str | None = None
+
+    @model_validator(mode="after")
+    def _check(self) -> "_ModelLevelRuleModel":
+        if (self.search is None) != (self.replace is None):
+            raise ValueError("'search' and 'replace' must be used together.")
+        return self
+
+
+class _FieldLevelRuleModel(BaseModel):
+    """A field-level validator's raised ValueError, the other value_error shape."""
+
+    name: str
+
+    @field_validator("name")
+    @classmethod
+    def _check(cls, value: str) -> str:
+        if not value:
+            raise ValueError("'name' must not be empty.")
+        return value
+
+
+class _TwoIndependentFieldsModel(BaseModel):
+    """Two fields that can each fail independently, for the multi-error join."""
+
+    a: int
+    b: int
+
+
+class _RawValueErrorModel:
+    """Not a pydantic model: raises a bare ValueError straight out of __init__.
+
+    Exercises params_or_bad_parameter's OTHER except clause directly — pydantic
+    itself always wraps a validator's ValueError into ValidationError (verified:
+    every mode='before'/'after'/field validator wraps), so this simulates the
+    one caller shape pydantic can never produce, standing in for it.
+    """
+
+    def __init__(self, **kwargs: object) -> None:
+        raise ValueError("a plain refusal sentence.")
+
+
+def test_plain_value_error_passes_through_as_the_bare_sentence():
+    with pytest.raises(typer.BadParameter) as exc_info:
+        params_or_bad_parameter(_RawValueErrorModel)  # type: ignore[arg-type]
+
+    message = str(exc_info.value)
+    assert message == "a plain refusal sentence."
+    _assert_clean(message)
+
+
+def test_model_level_validation_error_renders_the_validators_own_sentence():
+    with pytest.raises(typer.BadParameter) as exc_info:
+        params_or_bad_parameter(_ModelLevelRuleModel, search="foo", replace=None)
+
+    message = str(exc_info.value)
+    assert message == "'search' and 'replace' must be used together."
+    _assert_clean(message)
+
+
+def test_field_level_validation_error_renders_the_validators_own_sentence():
+    with pytest.raises(typer.BadParameter) as exc_info:
+        params_or_bad_parameter(_FieldLevelRuleModel, name="")
+
+    message = str(exc_info.value)
+    assert message == "name: 'name' must not be empty."
+    _assert_clean(message)
+
+
+def test_multi_error_validation_error_joins_each_fields_own_message():
+    with pytest.raises(typer.BadParameter) as exc_info:
+        params_or_bad_parameter(_TwoIndependentFieldsModel, a="x", b="y")
+
+    message = str(exc_info.value)
+    assert "a: " in message and "b: " in message
+    assert "; " in message  # the stated join separator
+    _assert_clean(message)
+
+
+def test_no_caller_value_leaks_into_the_refusal(monkeypatch):
+    # The concrete leak PR #754's review reproduced: a large/sensitive field
+    # value must never ride along in the refusal, even though the refused
+    # field itself carries it.
+    secret = "SECRET_MARKER_abcdefghijklmnopqrstuvwxyz0123456789_END"
+
+    class _CarriesASecretField(BaseModel):
+        search: str | None = None
+        replace: str | None = None
+        content: str | None = None
+
+        @model_validator(mode="after")
+        def _check(self) -> "_CarriesASecretField":
+            if (self.search is None) != (self.replace is None):
+                raise ValueError("'search' and 'replace' must be used together.")
+            return self
+
+    with pytest.raises(typer.BadParameter) as exc_info:
+        params_or_bad_parameter(
+            _CarriesASecretField, search="foo", replace=None, content=secret
+        )
+
+    message = str(exc_info.value)
+    assert secret not in message
+    assert message == "'search' and 'replace' must be used together."
+    _assert_clean(message)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,22 +1,36 @@
-"""``gda.dispatch.params_or_bad_parameter``'s usage-error rendering (issue #713).
+"""The argv and ``--params-json`` model-refusal rendering (issue #713).
 
-``params_or_bad_parameter`` is the shared argv seam every ``set``/``validate``-style
-params model runs through (ADR-0015): a model-construction failure becomes a Click
-usage error (exit 2). Its rendering used to be ``str(exc)`` on whatever pydantic
-raised, which for a ``ValidationError`` dumps the model's class name, a
-``[type=..., input_value=..., input_type=...]`` tag PER ERROR, and a
-``pydantic.dev`` URL — and can echo an arbitrary caller value (e.g. a
-``script set --content`` payload) back inside ``input_value=`` (found in PR #754's
-review). These tests pin the clean replacement: the validator's own sentence(s),
-with none of that dump noise and no leaked caller value, for a plain
-``ValueError``, a single-error ``ValidationError`` (both a model-level and a
-field-level validator), and a multi-error ``ValidationError``.
+Both input channels construct a command's params model directly from
+caller-supplied values (ADR-0015) and must translate a construction failure
+into a human message: the argv path's
+:func:`~gda.dispatch.params_or_bad_parameter` and the ``--params-json``
+path's ``invoke()`` (:mod:`gda.headless`). Both used to render a pydantic
+``ValidationError`` with its own ``str()``, which dumps the model's class
+name, a ``[type=..., input_value=..., input_type=...]`` tag PER ERROR, and a
+``pydantic.dev`` URL — and echoes an arbitrary caller value (e.g. a
+``script set --content`` payload) back inside ``input_value=`` (found in PR
+#754's review, round 2 for argv, round 3 for ``--params-json``).
+
+Both now go through the ONE shared renderer, :func:`gda.errors.validation_error_message`
+(round 3: moved out of ``gda.dispatch`` to a home below both channels, since
+``gda.dispatch`` imports ``gda.headless`` and the reverse would cycle). These
+tests pin the clean replacement directly against ``params_or_bad_parameter``
+(the validator's own sentence(s), for a plain ``ValueError``, a single-error
+``ValidationError`` — model-level and field-level — and a multi-error
+``ValidationError``), then pin the SAME clean shape end-to-end through an
+actual command's ``--params-json`` route, and finally assert the two channels
+report byte-identical sentences for the identical refusal.
 """
+
+import json
+import re
 
 import typer
 import pytest
 from pydantic import BaseModel, field_validator, model_validator
+from typer.testing import CliRunner
 
+from gda.cli import app
 from gda.dispatch import params_or_bad_parameter
 
 # The exact dump fragments str(ValidationError) used to leak (PR #754 review).
@@ -26,6 +40,32 @@ _FORBIDDEN_FRAGMENTS = ("pydantic.dev", "input_value=", "[type=")
 def _assert_clean(message: str) -> None:
     for fragment in _FORBIDDEN_FRAGMENTS:
         assert fragment not in message, f"{fragment!r} leaked into {message!r}"
+
+
+def _argv_usage_error_message(result) -> str:
+    # Click/Rich renders the usage-error panel with ANSI color and box-drawing
+    # borders even under CliRunner; strip both before matching (mirrors
+    # tests/test_screen_commands.py's `_usage_error_message`).
+    assert result.exit_code == 2, result.stdout + result.stderr
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.stderr)
+    plain = re.sub(r"[─-╿]", " ", plain)  # rich panel borders
+    plain = re.sub(r"\s+", " ", plain).strip()
+    # The panel is preceded by the "Usage: ..." / "Try '... --help'" preamble
+    # and an "Error" heading, so find the marker rather than assume it leads.
+    prefix = "Invalid value: "
+    marker = plain.rfind(prefix)
+    assert marker != -1, plain
+    return plain[marker + len(prefix) :]
+
+
+def _params_json_invalid_params_message(result) -> str:
+    assert result.exit_code != 0, result.stdout
+    data = json.loads(result.stdout)
+    assert data["error"]["code"] == "invalid_params", data
+    message = data["error"]["message"]
+    prefix = "--params-json is not a valid params object: "
+    assert message.startswith(prefix), message
+    return message[len(prefix) :]
 
 
 class _ModelLevelRuleModel(BaseModel):
@@ -137,3 +177,75 @@ def test_no_caller_value_leaks_into_the_refusal(monkeypatch):
     assert secret not in message
     assert message == "'search' and 'replace' must be used together."
     _assert_clean(message)
+
+
+# --- end-to-end: --params-json through an actual command (round 3) ------------
+
+
+def test_params_json_validation_error_is_also_rendered_clean():
+    # script set's search/replace mutual-exclusion rule (resolve_set_mode),
+    # refused via --params-json this time, not argv.
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "set",
+            "--params-json",
+            json.dumps({"path": "/tmp/nonexist.gd", "search": "foo"}),
+            "--json",
+        ],
+    )
+
+    message = _params_json_invalid_params_message(result)
+    assert message == "'search' and 'replace' must be used together."
+    _assert_clean(message)
+
+
+def test_params_json_does_not_leak_the_callers_other_field_value():
+    # The exact channel this round's review caught: --content rode inside
+    # input_value= in the structured envelope's message, secret and all.
+    secret = "SECRET_MARKER_abcdefghijklmnopqrstuvwxyz0123456789_END"
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "set",
+            "--params-json",
+            json.dumps(
+                {"path": "/tmp/nonexist.gd", "search": "foo", "content": secret}
+            ),
+            "--json",
+        ],
+    )
+
+    message = _params_json_invalid_params_message(result)
+    assert secret not in message
+    assert message == "'search' and 'replace' must be used together."
+    _assert_clean(message)
+
+
+def test_argv_and_params_json_report_the_identical_sentence():
+    # #713's own acceptance criterion 2 pairs the two channels ("the same
+    # error class"); this pins them to the same MESSAGE too, not just the
+    # same class, for the identical refusal.
+    argv_result = CliRunner().invoke(
+        app, ["script", "set", "/tmp/nonexist.gd", "--search", "foo", "--json"]
+    )
+    params_json_result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "set",
+            "--params-json",
+            json.dumps({"path": "/tmp/nonexist.gd", "search": "foo"}),
+            "--json",
+        ],
+    )
+
+    argv_message = _argv_usage_error_message(argv_result)
+    params_json_message = _params_json_invalid_params_message(params_json_result)
+    assert (
+        argv_message
+        == params_json_message
+        == ("'search' and 'replace' must be used together.")
+    )

--- a/tests/test_screen_commands.py
+++ b/tests/test_screen_commands.py
@@ -38,6 +38,7 @@ from tests.support import (
     sentinel,
     screen_capture_reply,
     screen_frames_reply,
+    usage_error_text,
 )
 
 # A 1x1 transparent PNG (valid, decodes to real bytes) so a written file starts
@@ -682,14 +683,9 @@ def _usage_error_message(result):
     # The argv path's contract (gda.dispatch.params_or_bad_parameter): a model
     # refusal is a Click usage error — exit 2, message on stderr — while the
     # --params-json path surfaces the SAME rule as structured invalid_params.
-    # Click line-wraps and colors the message, so strip ANSI and collapse
-    # whitespace before matching.
-    import re
-
-    assert result.exit_code == 2, result.stdout + result.stderr
-    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.stderr)
-    plain = re.sub(r"[\u2500-\u257f]", " ", plain)  # rich panel borders
-    return re.sub(r"\s+", " ", plain)
+    # The Rich-panel normalization itself is shared (tests/support.py,
+    # `usage_error_text`, #713 review) rather than redefined here.
+    return usage_error_text(result)
 
 
 def _invalid_params_message(result):


### PR DESCRIPTION
## Summary

`script set` and `shader set` both ran the edit-mode selection rule twice on
the argv route: the CLI body called `parse_set_mode_argv()` by hand and
translated its failure, then the params model's validator called
`resolve_set_mode()` again in `__init__` — `resolve_set_mode`'s own docstring
already named itself the single rule owner, so the second evaluation
contradicted the code's stated design. `shader set` imports both helpers from
the script group and repeats the same pair.

PR #710 removed exactly this pattern from `script validate` by constructing
the params model through the shared `params_or_bad_parameter()` translation
path (ADR-0015: the params model is the input-rule authority). This PR mirrors
that precedent for both `set` commands — no new translation path invented.

- `gda/commands/script.py`'s `set_script` now builds `ScriptSetParams` through
  `params_or_bad_parameter(ScriptSetParams, ...)` instead of calling
  `parse_set_mode_argv()` and passing a pre-resolved `mode` in.
- `gda/commands/shader.py`'s `set_shader` does the same for `ShaderSetParams`,
  keeping the two surfaces in lockstep through the existing shared seam
  (`shader.py` importing from `script.py`, ADR-0040 §5) rather than
  duplicating the fix.
- `parse_set_mode_argv` is **deleted**: its only two callers were the argv
  bodies this PR changes, so it became dead on completion. `resolve_set_mode`'s
  docstring is updated to name its two remaining callers honestly
  (`ScriptSetParams._resolve_mode`, `ShaderSetParams._resolve_mode`) instead of
  describing a CLI-wrapper caller that no longer exists.

## Behavioral parity

- The mode-selection rule now runs exactly **once** per invocation on both
  commands, on both input paths.
- argv and `--params-json` still refuse the same selections with the same
  error class: usage error / exit 2 for argv, structured `invalid_params` for
  `--params-json`.
- `gda script set --help`, `gda shader set --help`, and `gda --help` are
  **byte-identical** to base (verified after every commit). `gda schema` is
  byte-identical to base through round 3; round 4 (below) makes DELIBERATE
  prose-only changes to it, to fix stale ownership language a reviewer found:
  **three docstrings edited, four schema leaves changed** — `input.description`
  and `input.$defs.ScriptSetMode.description`, under BOTH `script set` and
  `shader set` (the `ScriptSetMode` docstring is one source edit that appears
  under each command's `$defs`, so it lands twice). No other schema entry
  changed — verified by diffing the schema as parsed JSON, not raw text, by the
  implementer and again independently by the orchestrator.

## Follow-up (round 2): `params_or_bad_parameter` leaked caller input into the argv refusal

External review of this PR caught a real regression the first commit introduced.
Unifying `script set`/`shader set` onto `params_or_bad_parameter` changed their
argv refusal text from a clean sentence to the raw `str()` of pydantic's
`ValidationError` — a dump carrying the model's class name, a
`[type=..., input_value=..., input_type=...]` tag per error, and a
`pydantic.dev` URL. Concretely:

Before (base, `script set X --search foo`):
```
Invalid value: 'search' and 'replace' must be used together.
```
After the first commit (the regression):
```
Invalid value: 1 validation error for ScriptSetParams
  Value error, 'search' and 'replace' must be used together. [type=value_error,
input_value={'path': 'X', ...}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.13/v/value_error
```
Worse than noise: `input_value=` echoes the caller's OTHER field values back into
the refusal, including large/sensitive ones — `script set X --search foo --content
'SECRET_MARKER_...'` put the secret marker inside the printed refusal.

Root cause was `params_or_bad_parameter` itself (`src/gda/dispatch.py`), the
shared argv seam behind `script set`/`shader set`/`script validate` and every
other params-model construction on the argv path — not this PR's call sites, so
the fix belongs there (`src/gda/dispatch.py` has no owner this wave). Commit
`ae15b38b` fixes it at the seam: instead of `str(exc)` on the whole
`ValidationError`, it reads each error's own `msg` (already clean pydantic text
for a built-in check) or, for a validator's raised `ValueError`
(`resolve_set_mode`, `check_validate_selection`, etc.), the original exception
out of `ctx['error']` — pydantic's own `msg` re-prefixes that with `"Value error,
"`, which this also avoids. Multiple errors join on `"; "`, each tagged with its
dotted field path when field-scoped.

This restored `script set`/`shader set`/`script validate`'s argv wording to the
base clean form and, as the shared seam, also cleaned up the same dump on every
OTHER command's argv usage error (node/input/project/scene/perf/resource/daemon/
game) — grepped `tests/` for `pydantic.dev`, `"validation error for"`,
`input_value=`, `[type=`: zero hits, so no test pinned the old dump text
anywhere in the suite.

## Follow-up (round 3): `--params-json` had the SAME defect, one layer down

Round 2 fixed only the argv (human) channel, on the reviewer's explicit
"dispatch.py:51-54" pointer. A further review measured the OTHER channel:

```
gda script set --params-json '{"path":"...","search":"foo","content":"SECRET_MARKER_..._END"}'
{"error":{"category":"operation","code":"invalid_params","message":"--params-json is not a
valid params object: 1 validation error for ScriptSetParams\n  Value error, 'search' and
'replace' must be used together. [type=value_error, input_value={'path': '/private/tmp/cl
..._MARKER_..._END'}, input_type=dict]\n    For further information visit
https://errors.pydantic.dev/2.13/v/value_error","diagnostics":""}}
```

The structured envelope's OWN `message` field — the one an agent reads — carried
the identical dump, embedded newlines, docs URL, and the caller's `--content`
echoed back inside `input_value=`. After round 2 the human channel was clean and
the machine channel was not, backwards for an agent-facing CLI; #713's AC 2
pairs the two channels on error class, and same class with wildly different
message quality doesn't honour that.

Commit `33630bc0` fixes it by REUSING round 2's extractor rather than
duplicating it: `validation_error_message()` moved out of `gda.dispatch` into
`gda.errors` — a home below BOTH channels (`gda.dispatch` imports
`gda.headless`, so the reverse import would cycle; both already import
`gda.errors` for their own failure taxonomy) — and `headless.py`'s
`--params-json` `ValidationError` handling (`invoke()`) now calls the same
function instead of `str(exc)`. The `"--params-json is not a valid params
object: "` prefix is kept (useful context, not the defect); only the detail
behind it changes.

**Scope of the parity claim.** The two ADR-0015 params-model channels —
argv (`params_or_bad_parameter`) and `--params-json` (`headless.py`'s
`invoke()`) — now report the byte-identical sentence for the identical
model-construction refusal, on `script set`/`shader set`/`script validate` and
every other command built through either path. That is what was verified; it
is NOT a claim that `invalid_params` speaks one sentence everywhere in `gda` —
see "Not touched" below for a known sibling producer outside this scope. For
`script set X --search foo` (no `--replace`):

| channel | rendering |
|---|---|
| argv | `Invalid value: 'search' and 'replace' must be used together.` |
| `--params-json` | `{"error":{"code":"invalid_params","message":"--params-json is not a valid params object: 'search' and 'replace' must be used together.", ...}}` |

Same for the secret-marker repro above: with the fix, `--params-json` now
returns `"--params-json is not a valid params object: 'search' and 'replace'
must be used together."` — no dump, no secret.

`tests/test_dispatch.py` now covers both channels: the original 5 unit tests
against `params_or_bad_parameter` (plain `ValueError`, single-error
`ValidationError` model-level and field-level, multi-error join, the
secret-leak repro), plus 3 more added in round 3 — the `--params-json` channel
pinned clean end-to-end through an actual `script set` invocation, the same
secret-leak repro over `--params-json`, and a parity test asserting the two
channels' extracted sentences are `==`. **Red-proofed both rounds** the same
way: commit the fix, `git checkout <prior-commit> -- <the changed source
files>` (never the tests), observe the new tests fail with the pre-fix dump
text, `git checkout HEAD --` to restore, confirm `git status` is clean and all
tests pass again.

## Follow-up: stale rationale for a sibling slice's parser fix

Sibling slice #698 (`fix/698-script-error-parser-dots`) fixes
`gda.script_errors`' `_CANT_LOAD` regex to stop stripping a trailing period —
the engine never appends one to `Can't load script: <path>`, so the strip was
always wrong. That makes a rationale comment in `script.py`'s
`_project_scoped_res_path` (this PR's owned file) stale once both land: it
justified refusing a root address (`res://.` / `res://..`) partly as
preventing a phantom success caused by the (buggy) parser stripping the
address's own trailing dot. Commit `c3bf1d93` reframed that passage as
history; round 4 below corrects it again — that framing turned out to be
merge-order-fragile.

Routing note: this fix landed here, not in #698's own PR (#756), on the
coordinator's explicit routing call — `commands/script.py` is owned by this
wave under the file-ownership rule for this round of slices, so #756 (which
fixed the underlying parser) was kept out of a file it does not own, and the
now-stale comment was routed to this PR instead. Recorded for the review
record: a routing decision, not scope added on this implementer's own
initiative.

## Follow-up (round 4): stale ownership prose, a merge-order-fragile comment, and test dedup

A further external adversarial review at head `33630bc0` found seven items
(commit `08b74bc5` addresses five; two are declined with reasons):

1. **[P2] Stale ownership prose (fully adopted).** Three docstrings still
   described the pre-#713 world — `script.py`'s `ScriptSetMode` enum and
   `ScriptSetParams` class, `shader.py`'s `ShaderSetParams` class — all said
   "the CLI resolves ... and stamps it on `mode`", when this PR made the
   params model the sole owner of that derivation. Left as-is, a maintainer
   reading them could restore a CLI-side check and reintroduce the double
   evaluation #713 removed. Reworded all three (plus the same claim in
   `docs/command-catalog.md:466`, "modes is selected at the CLI") so the CLI
   reads as a thin argv-to-model adapter and the params model as the
   deriving/stamping owner.

   These three docstrings ARE pydantic model/enum descriptions, so the wording
   change flows into `gda schema`'s `input.description` / `$defs` for
   `script set` and `shader set` — verified by diffing the schema as PARSED
   JSON (not raw text): exactly those two commands' entries differ from base,
   nothing else. `--help` for both commands, and `gda --help`, remain
   byte-identical to base — only `gda schema`'s prose changed, in only the
   three docstrings just listed.

2. **[P2] The `#698` comment asserted a fix not in this branch (partially
   adopted).** `_project_scoped_res_path`'s docstring said "#698 fixed the
   parser itself... so that failure mode is now history", while at the
   reviewed head `src/gda/script_errors.py:92` still holds the OLD regex —
   #698's fix is PR #756, still open. **Adopted:** reworded the paragraph to
   hold regardless of merge order — it now describes the risk hypothetically
   ("a parser that folds it as though it were punctuation WOULD miss...") and
   states explicitly that this guard's own pre-launch refusal already closes
   the gap on its own, independent of whichever PR lands first; #698/#756 are
   named without asserting either PR's landed state. **Not adopted:** moving
   the commit to #756. That routing was the coordinator's own call, not this
   implementer's — `commands/script.py` is this wave's owned file, so routing
   the fix here (rather than letting #756 touch a file it doesn't own) is what
   the file-ownership rule exists for; moving it now would recreate exactly
   the collision that rule prevents (see "Routing note" above).

3. **[P2] Local pytest count reported as if it were CI (fully adopted).** See
   Validation below — local and CI results are now labeled and quoted
   separately, with the two CI-only skips identified.

4. **[P3] Duplicate Rich/ANSI usage-error normalization (adopted).**
   `tests/test_dispatch.py`'s `_argv_usage_error_message` re-implemented the
   same ANSI/box-drawing-border stripping `tests/test_screen_commands.py`'s
   `_usage_error_message` already had. Moved the shared normalization into
   `tests/support.py` as `usage_error_text` (beside the existing `plain_text`);
   both call sites now delegate to it.

5. **[P3] Unused `monkeypatch` parameter (adopted).** Dropped from
   `test_no_caller_value_leaks_into_the_refusal` — the test never used it.

6. **[P3] Remove `_RawValueErrorModel` as speculative (NOT adopted).** The
   branch it covers is real: `params_or_bad_parameter` catches a bare
   `ValueError` SEPARATELY from `ValidationError` (`src/gda/dispatch.py`),
   and something has to pin what that clause does. Deleting the test would
   not delete the branch — it would leave it unverified, which is worse. The
   test's own docstring already answers the `# type: ignore` objection:
   "pydantic itself always wraps a validator's ValueError into
   ValidationError... this simulates the one caller shape pydantic can never
   produce" — no pydantic model can exercise this branch, so the stand-in is
   deliberate, not an oversight.

7. **["Move the shared-renderer message change to its own scoped change"]
   (NOT adopted).** Reverting `headless.py`/`dispatch.py`'s shared rendering
   to the prior global behavior would restore a message that dumps pydantic
   internals and echoes the caller's own `--content` back — that is the exact
   leak measured before this fix was requested (rounds 2/3 above), and is a
   regression this PR will not reintroduce. The transparency half of the
   concern is already met: the "This restored..." paragraph in round 2 and
   the "Scope of the parity claim" paragraph in round 3 (above) each name
   every other affected command and state precisely what was verified, so the
   broader effect is disclosed, not hidden.

## Follow-up (round 5): three P3 residues from re-review

A further re-review at head `08b74bc5` closed the round-4 findings (stale
ownership prose, validation evidence, the merge-order-fragile comment,
duplicate usage-error normalization, unused fixture) and left three P3
judgement calls. New commit: `9c7a7a68`.

1. **[P3] `_RawValueErrorModel` bypasses the declared contract (partially
   adopted).** The reviewer is right that a non-`BaseModel` stand-in needing
   `# type: ignore[arg-type]` to reach `params_or_bad_parameter`'s
   `type[P]` (`P` bound to `BaseModel`) is a real contract bypass, not just
   an odd test double — round 4's "no pydantic model can exercise this
   branch" claim was wrong. It IS reachable from a genuine `BaseModel`
   subclass:

   ```python
   class M(BaseModel):
       a: int = 1
       def __init__(self, **kw):
           raise ValueError("a plain refusal sentence.")
   M(a=1)   # -> propagates a BARE ValueError; issubclass(M, BaseModel) is True
   ```

   (`model_post_init` does NOT work — pydantic wraps that hook's raise as
   `ValidationError` too, same as a field/model validator. Overriding
   `__init__` is the one route that runs before pydantic's own validation
   machinery gets a chance to wrap anything, so the plain `ValueError`
   propagates untouched.)

   So: **not deleted.** `_RawValueErrorModel` now subclasses `BaseModel` and
   raises from an overridden `__init__` instead of faking the shape from
   outside the contract — the `# type: ignore[arg-type]` is gone, the branch
   stays verified, and the docstring is rewritten to state the verified
   in-contract route instead of the "one shape pydantic can never produce"
   framing the evidence above contradicts. Deleting the branch instead would
   turn a clean usage error into an escaping traceback for any future model
   that raises from `__init__` — a safety regression for no gain, since the
   branch is real and in-contract.

2. **[P3] Package the shared-renderer cleanup separately (NOT adopted).**
   The reviewer clarified the actual concern: packaging, not reverting — the
   round-4 reply answered the wrong question by treating the two as
   equivalent. Answering the real concern:

   - The **argv half is not separable**: this PR itself introduced the
     wording regression (round 2) by routing `script set`/`shader set`
     through the params model, so fixing it here is repair of this PR's own
     damage, not an unrelated cleanup riding along.
   - The **`--params-json` half** is an explicit specification amendment
     recorded in [issue #713](https://github.com/aigengame/godot-agent/issues/713):
     shipping a state where the human channel is clean and the machine
     channel — the one an agent actually reads — still dumps pydantic
     internals was judged worse than the wider diff, for an agent-facing CLI.
   - Splitting now costs a new PR, a rebase, and a full re-verification of an
     already twice-reviewed change; the maintainer can still choose to land
     it separately at merge time if they weigh that trade-off differently.

   No code restructured for this item.

3. **[P3] The `#698` rationale edit sits outside issue #713 (fully
   adopted).** The routing decision — `commands/script.py` is this slice's
   owned file, PR #756 fixed the parser that made the old comment false, and
   the file-ownership rule kept #756 out of a file it does not own — is now
   recorded as a stable public specification amendment in
   [issue #713](https://github.com/aigengame/godot-agent/issues/713).
   No runtime code change.

## Validation

**Local** (this machine, `uv run pytest -q -m "not e2e"`, head `9c7a7a68`):
`1909 passed, 539 deselected in 183.41s (0:03:03)` (1901 from the base suite +
8 in `tests/test_dispatch.py`; the wall-clock time is slower than round 4's
105.49s from CPU contention with an unrelated concurrent test run on this
machine, not a behavior change).

**CI**: exact-head run for `33630bc0`
([33079460351](https://github.com/aigengame/godot-agent/actions/runs/33079460351),
`Python unit tests and package build` job) reported `1907 passed, 2 skipped,
539 deselected in 75.96s (0:01:15)`. The two CI-only skips are the two
parametrized cases of
`tests/test_display_probe.py::test_a_real_sandbox_denial_is_classified_as_a_permission_problem`
— each calls `pytest.skip("needs macOS with a working sandbox-exec")` (or the
on-console-session check right after) when `sandbox-exec` or a real desktop
session isn't available, which the GitHub Actions Linux runner never has and
this local macOS dev machine does; confirmed locally (`pytest -k
test_a_real_sandbox_denial... -v` → `2 passed`, not skipped). `1907 + 2 =
1909` reconciles the two counts exactly. Round 4's head `08b74bc5` also went
green on every CI job (run
[33145717067](https://github.com/aigengame/godot-agent/actions/runs/33145717067)).
CI has not yet run against round 5's head `9c7a7a68` at the time of writing.

- `uv run ruff check .` → `All checks passed!`
- `uv run ruff format --check .` → `473 files already formatted`
- `uv run pyright` → `0 errors, 0 warnings, 0 informations`
- `gda script set --help` / `gda shader set --help` / `gda --help` byte-diffed
  against base after every commit: no diff, every time. `gda schema`
  byte-diffed against base after every commit through round 3 (no diff);
  round 4's three intentional deltas are enumerated above and were confirmed
  as the ONLY schema change by diffing the parsed JSON. Round 5 touched only
  `tests/test_dispatch.py` (no `src/` file), so this was re-diffed and
  reconfirmed unchanged — still exactly those four leaves.
- Godot e2e not run for this slice (not needed — no engine-facing behavior
  changed; confirmed via the schema/help evidence and the full unit/
  integration suite above).

Two independent adversarial reviews (code + architecture) passed with no
P1/P2 as of head `33630bc0`. Architecture confirmed the `errors.py` seam
placement against ADR-0040's dependency chain; code probed
`validation_error_message` against pydantic 2.13.4 across nested models,
list-index `loc`s, unions, built-in type errors, `AssertionError`, and a
`PydanticCustomError` with no `ctx['error']` — no crash, no information loss.
A further external adversarial review at that same head produced round 4's
seven findings above; a round-5 re-review at head `08b74bc5` found the three
P3 residues above, closed by commit `9c7a7a68`.

## Not touched (flagged, out of scope)

`gda.errors.classify_run`'s `contract_violation` failure
(`f"structured-output contract violated: {exc}"`) has the same `str(exc)`
shape, but it stringifies the ENGINE's own output-schema mismatch, not
caller-supplied input — a different sensitivity profile and outside what was
asked. Left as-is; noting it here rather than silently leaving it unmentioned.
Both reviews agreed this exclusion is defensible.

`src/gda/commands/perf.py:749-754` is a THIRD `invalid_params` producer, from
another caller-supplied value (`--budget-file`), and it still emits the same
`str(exc)` dump this PR eliminated on the other two channels — found by both
adversarial reviews. It predates this PR, is not an ADR-0015 params-model
construction path, and is out of #713's scope; the coordinator is filing it
separately rather than folding it in here.

Closes #713



## Follow-up (round 6): exact ValueError contract and stable scope authority

Re-review at head `9c7a7a68` found one inaccurate production docstring and two scope decisions whose only claimed authority was the PR/wave record. Commit `264b81d0` and the public issue amendment close all three residues:

1. **Raw `ValueError` route (fully adopted).** `params_or_bad_parameter()` no longer says a raw `ValueError` is a sentence "a validator wrote". The verified in-contract route is a custom `BaseModel.__init__` raising before pydantic wraps the exception. Field/model validators and `model_post_init` are documented as arriving as `ValidationError`.
2. **Shared renderer scope (fully adopted as specification traceability).** [Issue #713](https://github.com/aigengame/godot-agent/issues/713) now explicitly includes the shared ADR-0015 renderer for argv and `--params-json`, states the wider prose-only effect, and preserves the `perf --budget-file` exclusion.
3. **#698 rationale routing (fully adopted as specification traceability).** The same issue amendment records why the merge-safe comment maintenance belongs to this slice without changing #698 runtime behavior.

No renderer code or command behavior changed in this round.

**Round-6 local validation** (head `264b81d0`):

- `pytest -q -p no:cacheprovider tests/test_dispatch.py` → `8 passed`
- `ruff check src/gda/dispatch.py` → passed
- `ruff format --check src/gda/dispatch.py` → passed
- `pyright` → `0 errors, 0 warnings, 0 informations`
- `git diff --check` → clean
