### PR TITLE
test(gda): pin the ADR-0002 error-description column (#701)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -219,8 +219,8 @@ The `Meaning` column is pinned too (#701): it must match the registry's
 `description` once markup and wrapping are normalized. A trailing parenthetical
 that cites at least one ADR or issue — a `Phase N` label may ride along inside
 it — is a citation rather than part of the code's meaning, so it is not compared.
-41 rows here carry one; so do 5 registry descriptions, which is allowed, not a
-mistake to tidy away. A bare `(Phase N)` is *not* a citation and IS compared,
+Many rows here carry one, and some registry descriptions do too: that is allowed,
+not a mistake to tidy away. A bare `(Phase N)` is *not* a citation and IS compared,
 which is why the live rows below state their phase through the `Category` column
 instead. `tests/test_error_registry.py` is the single home of that rule.
 

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -217,9 +217,12 @@ source and is checked by tests. GDScript mirrors only the rows whose source is
 
 The `Meaning` column is pinned too (#701): it must match the registry's
 `description` once markup and wrapping are normalized. A trailing parenthetical
-naming the deciding ADR or issue is provenance for *this* record rather than part
-of the code's meaning, so it rides these rows only and is not compared —
-`tests/test_error_registry.py` is the single home of that rule.
+that cites at least one ADR or issue — a `Phase N` label may ride along inside
+it — is a citation rather than part of the code's meaning, so it is not compared.
+41 rows here carry one; so do 5 registry descriptions, which is allowed, not a
+mistake to tidy away. A bare `(Phase N)` is *not* a citation and IS compared,
+which is why the live rows below state their phase through the `Category` column
+instead. `tests/test_error_registry.py` is the single home of that rule.
 
 Each row carries the process `Exit Code` a shell consumer keys on. It is
 per-code, not per-category: within `environment`, `binary_not_found` exits `127`
@@ -295,9 +298,9 @@ operation, and parse codes the CLI assigns).
 | `contract_violation` | `parse` | `parser` | `5` | The process claimed success but violated the structured-output contract. |
 | `tree_too_deep` | `parse` | `classifier` | `5` | The engine emitted a valid result tree that nests past gda's recursion limit; the payload is contract-conformant, the limit is wrapper-side (shares the `parse` exit code; the `code` distinguishes it from `contract_violation`). |
 | `daemon_not_running` | `live` | `classifier` | `6` | A live command found no running gda-daemon for the project; start one with `gda daemon start` (Phase 2, ADR-0017 / ADR-0021). |
-| `engine_session_not_running` | `live` | `classifier` | `6` | The daemon is running but holds no live engine session to serve the live operation (Phase 2). |
-| `engine_disconnected` | `live` | `classifier` | `6` | The engine session disconnected before the live operation returned — the game crashed or the harness connection dropped (Phase 2). |
-| `live_timeout` | `live` | `classifier` | `6` | A live operation did not return from the engine session before the daemon's timeout. The session is discarded: its reply is no longer attributable, so the next operation relaunches it and runtime state does not survive (Phase 2). |
+| `engine_session_not_running` | `live` | `classifier` | `6` | The daemon is running but holds no live engine session to serve the live operation. |
+| `engine_disconnected` | `live` | `classifier` | `6` | The engine session disconnected before the live operation returned — the game crashed or the harness connection dropped. |
+| `live_timeout` | `live` | `classifier` | `6` | A live operation did not return from the engine session before the daemon's timeout. The session is discarded: its reply is no longer attributable, so the next operation relaunches it and runtime state does not survive. |
 | `daemon_running` | `live` | `classifier` | `6` | A daemon-lifecycle command was refused because a gda-daemon is running for the project; stop it first with `gda daemon stop` (Phase 2, #225). |
 | `daemon_already_running` | `live` | `classifier` | `6` | A `gda daemon start --scene` was refused because a gda-daemon is already running for the project; `--scene` only takes effect at start, so stop it with `gda daemon stop` then start again with `--scene` (Phase 2, #278). |
 | `live_node_not_found` | `live` | `classifier` | `6` | A live game operation's node path does not resolve to a node in the running scene tree (Phase 2, #220). |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -215,6 +215,12 @@ the Python registry in `src/gda/error_codes.py`; the table below mirrors that
 source and is checked by tests. GDScript mirrors only the rows whose source is
 `operation`, because only those codes can be reported by headless operations.
 
+The `Meaning` column is pinned too (#701): it must match the registry's
+`description` once markup and wrapping are normalized. A trailing parenthetical
+naming the deciding ADR or issue is provenance for *this* record rather than part
+of the code's meaning, so it rides these rows only and is not compared —
+`tests/test_error_registry.py` is the single home of that rule.
+
 Each row carries the process `Exit Code` a shell consumer keys on. It is
 per-code, not per-category: within `environment`, `binary_not_found` exits `127`
 but `launch_timeout` exits `124`. The `exit_codes.py` registry defines the
@@ -224,7 +230,7 @@ operation, and parse codes the CLI assigns).
 | Code | Category | Source | Exit Code | Meaning |
 | --- | --- | --- | --- | --- |
 | `binary_not_found` | `environment` | `runner` | `127` | The Godot binary could not be launched. |
-| `launch_timeout` | `environment` | `runner` | `124` | Godot launched but did not return before the runner timeout. One command does not report it — see the 2026-08-19 scope note (#664). |
+| `launch_timeout` | `environment` | `runner` | `124` | Godot launched but did not return before the runner timeout. One command does not report it: `scene preflight` reports its own `timeout` status instead (#664). |
 | `user_data_unwritable` | `environment` | `runner` | `127` | The log or user-data placement for the launch could not be made usable, so the launch was refused. |
 | `unknown_command` | `usage` | `classifier` | `2` | gda has no such command; discover the surface with `gda schema` or `gda --help`. A recognized near miss also carries the supported invocation in the envelope's `hint`. |
 | `unknown_option` | `usage` | `classifier` | `2` | The command exists but has no such option; read its options with `--help` or its input contract with `--schema`. A recognized near miss also carries the supported invocation in the envelope's `hint`. |
@@ -265,7 +271,7 @@ operation, and parse codes the CLI assigns).
 | `no_search_match` | `operation` | `operation` | `4` | A search-replace script edit found no occurrence of the search string. |
 | `invalid_line_range` | `operation` | `operation` | `4` | A line-range script edit specified lines outside the script's bounds, or end before start. |
 | `script_compile_failed` | `operation` | `operation` | `4` | A script does not compile, so the requested work could not proceed: `script attach` refuses to bind it to a node, and `script run` reports that the entry script (or a dependency it preloads) never ran (#651). |
-| `script_not_found` | `operation` | `classifier` | `4` | A `script run` entry script does not exist in the project, so the engine never ran it — read from stderr, since the engine still exits 0 (#651). |
+| `script_not_found` | `operation` | `classifier` | `4` | A `script run` entry script does not exist in the project, so the engine never ran it — it still exits 0, and gda reads the failure from stderr (#651). |
 | `script_failed` | `operation` | `classifier` | `4` | A `script run --strict` script ran to completion and chose a non-zero exit status; strict mode maps that opted-in failure onto the uniform error envelope. Never reported without `--strict` (ADR-0031 amendment, #651). |
 | `script_aborted` | `operation` | `classifier` | `4` | A `script run` was ended early, before its `--timeout`: a script error appeared on stderr, the caller's declared `--completion-marker` did not, and the run then went silent. Reported only when `--completion-marker` is declared (ADR-0031 amendment, #655). |
 | `incompatible_script_type` | `operation` | `operation` | `4` | A script compiles but its base type is incompatible with the requested use: `script attach`'s target node type, or `script run`'s requirement that a one-shot entry script extend `SceneTree`/`MainLoop` (#651). |
@@ -276,9 +282,9 @@ operation, and parse codes the CLI assigns).
 | `export_presets_not_found` | `operation` | `operation` | `4` | The project has no export_presets.cfg, so it defines no export presets. |
 | `export_preset_not_found` | `operation` | `operation` | `4` | No export preset with the requested name exists in export_presets.cfg. |
 | `export_path_unset` | `operation` | `classifier` | `4` | An export run has no destination — neither a `--output` override nor a configured `export_path` (#170). |
-| `export_templates_missing` | `operation` | `classifier` | `4` | A release/debug export needs the export templates for the running engine version, which are not installed (pack needs no platform templates and is exempt; #170). |
+| `export_templates_missing` | `operation` | `classifier` | `4` | A release/debug export needs the export templates for the running engine version, which are not installed; `pack` needs no platform templates and is exempt (#170). |
 | `export_output_parent_failed` | `operation` | `classifier` | `4` | An export run could not create the output parent directory before native export (#402). |
-| `stdout_spill_failed` | `operation` | `classifier` | `4` | A `script run` stdout exceeded the cap but the complete-stream spill file could not be written, so the bounded result cannot be delivered (#665). |
+| `stdout_spill_failed` | `operation` | `classifier` | `4` | A `script run`'s stdout exceeded the cap but the complete-stream spill file could not be written, so the bounded result cannot be delivered (#665). |
 | `export_failed` | `operation` | `classifier` | `4` | A native Godot export run failed (the engine reported the export did not complete). |
 | `invalid_uid` | `operation` | `operation` | `4` | A requested `uid://` value is not a syntactically valid resource UID. |
 | `unknown_uid` | `operation` | `operation` | `4` | A syntactically valid resource UID is not registered in the engine's UID cache. |
@@ -291,7 +297,7 @@ operation, and parse codes the CLI assigns).
 | `daemon_not_running` | `live` | `classifier` | `6` | A live command found no running gda-daemon for the project; start one with `gda daemon start` (Phase 2, ADR-0017 / ADR-0021). |
 | `engine_session_not_running` | `live` | `classifier` | `6` | The daemon is running but holds no live engine session to serve the live operation (Phase 2). |
 | `engine_disconnected` | `live` | `classifier` | `6` | The engine session disconnected before the live operation returned — the game crashed or the harness connection dropped (Phase 2). |
-| `live_timeout` | `live` | `classifier` | `6` | A live operation did not return from the engine session before the daemon's timeout (Phase 2). |
+| `live_timeout` | `live` | `classifier` | `6` | A live operation did not return from the engine session before the daemon's timeout. The session is discarded: its reply is no longer attributable, so the next operation relaunches it and runtime state does not survive (Phase 2). |
 | `daemon_running` | `live` | `classifier` | `6` | A daemon-lifecycle command was refused because a gda-daemon is running for the project; stop it first with `gda daemon stop` (Phase 2, #225). |
 | `daemon_already_running` | `live` | `classifier` | `6` | A `gda daemon start --scene` was refused because a gda-daemon is already running for the project; `--scene` only takes effect at start, so stop it with `gda daemon stop` then start again with `--scene` (Phase 2, #278). |
 | `live_node_not_found` | `live` | `classifier` | `6` | A live game operation's node path does not resolve to a node in the running scene tree (Phase 2, #220). |
@@ -299,8 +305,8 @@ operation, and parse codes the CLI assigns).
 | `live_unknown_property` | `live` | `classifier` | `6` | A live game get or set targeted a property name the running node does not expose as an addressable runtime, storage, or attached-script property (Phase 2, #220, #422). |
 | `live_uncoercible_value` | `live` | `classifier` | `6` | A live game set value cannot be coerced to the addressed runtime property's or script variable's Godot type (Phase 2, #220, #422). |
 | `live_unknown_method` | `live` | `classifier` | `6` | A live game call named a method the addressed running node does not have (Phase 2, #673). |
-| `live_method_not_allowlisted` | `live` | `classifier` | `6` | A live game call named a method the addressed running node has but its class never declared gda-callable (Phase 2, #673, ADR-0041). |
-| `live_invalid_call_args` | `live` | `classifier` | `6` | A live game call supplied arguments the declared method cannot take — a count outside its accepted range, or a value the declared parameter type cannot convert from (Phase 2, #673). |
+| `live_method_not_allowlisted` | `live` | `classifier` | `6` | A live game call named a method the addressed running node has but its attached-script chain never declared gda-callable (Phase 2, #673, ADR-0041). |
+| `live_invalid_call_args` | `live` | `classifier` | `6` | A live game call supplied arguments the declared method cannot take: a count outside its accepted range, or a value the declared parameter type cannot convert from (Phase 2, #673). |
 | `live_log_unavailable` | `live` | `classifier` | `6` | A live engine session was launched but its diagnostics log file is missing or unreadable, so `gda diag` cannot read the running game's errors/output (Phase 2, #224). |
 | `live_scene_not_found` | `live` | `classifier` | `6` | A `gda daemon start --scene` selector did not load: the launched session ran a different scene (Godot silently falls back to main_scene for a missing/invalid path or UID), verified by the harness at launch — gda never falls back (Phase 2, #278). |
 | `live_perf_node_not_found` | `live` | `classifier` | `6` | A live perf monitor's node path does not resolve to a node in the running scene tree (Phase 2, #223). |
@@ -309,11 +315,11 @@ operation, and parse codes the CLI assigns).
 | `live_invalid_key` | `live` | `classifier` | `6` | A live input key event named a key the engine could not resolve to a keycode (Phase 2, #221). |
 | `live_unknown_action` | `live` | `classifier` | `6` | A live input action targeted an action the running game's InputMap does not declare (Phase 2, #221). |
 | `live_invalid_event_spec` | `live` | `classifier` | `6` | A live input sequence event has a type the harness does not recognize (Phase 2, #221). |
-| `live_predicate_unmet` | `live` | `classifier` | `6` | A live `screen capture` predicate (`--await-*`, #661) did not hold within its declared frame bound (Phase 2). |
+| `live_predicate_unmet` | `live` | `classifier` | `6` | A live `screen capture` predicate (`--await-*`) did not hold within its declared frame bound (Phase 2, #661). |
 | `live_display_unavailable` | `live` | `classifier` | `6` | A live `screen` capture ran on a headless engine session (the dummy DisplayServer cannot read pixels); start the daemon windowed with `gda daemon start --windowed` (Phase 2, #222). |
-| `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
-| `live_windowed_unavailable` | `environment` | `classifier` | `127` | A windowed Engine session (`gda daemon start --windowed`) was requested but the host has no usable DisplayServer (no on-console GUI session / no `$DISPLAY`), so the session cannot come up; refused before spawning Godot (Phase 2, #345). |
-| `live_windowed_permission_denied` | `environment` | `classifier` | `127` | A windowed Engine session (`gda daemon start --windowed`) was requested but this process is denied the window-server lookup (e.g. a sandbox), so gda cannot tell whether the host has one; re-run outside the restriction to find out rather than recording the host as display-less (Phase 2, #667). |
+| `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, which are unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
+| `live_windowed_unavailable` | `environment` | `classifier` | `127` | A windowed Engine session was requested (`gda daemon start --windowed`) but the host has no usable DisplayServer (no on-console GUI session / no `$DISPLAY`), so the session cannot come up; refused before spawning Godot (Phase 2, #345). |
+| `live_windowed_permission_denied` | `environment` | `classifier` | `127` | A windowed Engine session was requested (`gda daemon start --windowed`) but this process is denied the window-server lookup (e.g. a sandbox), so gda cannot tell whether the host has one; re-run outside the restriction to find out rather than recording the host as display-less (Phase 2, #667). |
 
 ## Considered options
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -3,6 +3,12 @@
 The registry is the machine-readable companion to ADR-0002's table. Every code
 emitted in a public ``GdaError`` must be declared here.
 
+**Editing a ``description``.** Its wording is pinned against that ADR's ``Meaning``
+column, so a change here needs the same change there (#701). What the pin
+normalizes away — markup, wrapping, and a trailing ADR/issue citation — is stated
+with its reasoning in ``tests/test_error_registry.py``, the single home of that
+rule.
+
 **What ``source`` means.** It names a code's *authoritative origin channel* — the
 layer that defines the failure and owns reporting it — and it governs **GDScript
 mirror membership**: ``operations.gd`` declares exactly the ``operation``-source

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -85,7 +85,13 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.ENVIRONMENT,
         EXIT_TIMEOUT,
         ErrorCodeSource.RUNNER,
-        "Godot launched but did not return before the runner timeout.",
+        # The scope caveat is not decoration (#701): `scene preflight` owns a
+        # wall-clock bound of its own and reports exceeding it as a `timeout`
+        # STATUS on a successful result, so an agent that branches on this code
+        # alone would never see that command's timeout.
+        "Godot launched but did not return before the runner timeout. One command "
+        "does not report it: `scene preflight` reports its own `timeout` status "
+        "instead.",
     ),
     ErrorCodeSpec(
         "user_data_unwritable",
@@ -437,7 +443,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         EXIT_OPERATION,
         ErrorCodeSource.CLASSIFIER,
         "A `script run` entry script does not exist in the project, so the engine "
-        "never ran it (it still exits 0; gda reads the failure from stderr).",
+        "never ran it — it still exits 0, and gda reads the failure from stderr.",
     ),
     ErrorCodeSpec(
         "script_failed",
@@ -530,14 +536,24 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.CLASSIFIER,
-        "An export run targeted a preset that has no configured export_path.",
+        # Both producing conditions, not just the configured one (#701): the
+        # destination is `--output` if given, else the preset's `export_path`, so
+        # the failure needs BOTH to be absent — a reader told only about
+        # `export_path` would not know the override exists.
+        "An export run has no destination — neither a `--output` override nor a "
+        "configured `export_path`.",
     ),
     ErrorCodeSpec(
         "export_templates_missing",
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.CLASSIFIER,
-        "An export run needs the export templates for the running engine version, which are not installed.",
+        # Scoped to the modes that actually need templates (#701): `pack` produces
+        # project data only, so the preflight skips the check for it. "An export
+        # run" claimed the code can fire for a mode it never fires for.
+        "A release/debug export needs the export templates for the running engine "
+        "version, which are not installed; `pack` needs no platform templates and "
+        "is exempt.",
     ),
     ErrorCodeSpec(
         "export_output_parent_failed",
@@ -616,7 +632,9 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         EXIT_PARSE,
         ErrorCodeSource.CLASSIFIER,
         "The engine emitted a valid result tree that nests past gda's recursion"
-        " limit; the payload is contract-conformant, the limit is wrapper-side.",
+        " limit; the payload is contract-conformant, the limit is wrapper-side"
+        " (shares the `parse` exit code; the `code` distinguishes it from"
+        " `contract_violation`).",
     ),
     # Phase-2 live execution channel (ADR-0017, ADR-0021). Classifier-source —
     # surfaced by the daemon IPC client / the daemon, never by a headless
@@ -643,8 +661,8 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.LIVE,
         EXIT_LIVE,
         ErrorCodeSource.CLASSIFIER,
-        "The engine session disconnected before the live operation returned"
-        " (the game crashed or the harness connection dropped).",
+        "The engine session disconnected before the live operation returned —"
+        " the game crashed or the harness connection dropped.",
     ),
     ErrorCodeSpec(
         "live_timeout",
@@ -841,7 +859,8 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.LIVE,
         EXIT_LIVE,
         ErrorCodeSource.CLASSIFIER,
-        "A live capture predicate did not hold within its declared frame bound.",
+        "A live `screen capture` predicate (`--await-*`) did not hold within its "
+        "declared frame bound.",
     ),
     # The `screen` capture failure the gda harness reports for #222. Same shape as
     # the other per-op LIVE codes (LIVE-category, classifier-source, exit_code
@@ -856,8 +875,8 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         EXIT_LIVE,
         ErrorCodeSource.CLASSIFIER,
         "A live screen capture ran on a headless engine session (the dummy "
-        "DisplayServer cannot read pixels); start the daemon with `gda daemon start "
-        "--windowed`.",
+        "DisplayServer cannot read pixels); start the daemon windowed with "
+        "`gda daemon start --windowed`.",
     ),
     # A pre-launch platform precondition, not a live-runtime failure: live needs
     # Unix domain sockets, which are UNIX-only, so it is an ENVIRONMENT-category
@@ -869,7 +888,8 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         EXIT_NOT_FOUND,
         ErrorCodeSource.CLASSIFIER,
         "Live operations require a UNIX platform (macOS/Linux); they use Unix"
-        " domain sockets, which are unavailable here.",
+        " domain sockets, which are unavailable here. Phase-1 headless is"
+        " unaffected.",
     ),
     # A pre-launch DISPLAY precondition, not a live-runtime failure: a windowed
     # engine session needs a usable host DisplayServer, and a host with none makes a

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -100,39 +100,59 @@ HARNESS_LIVE_ERROR_CODES = (
 #    one space, and a trailing period is ignored — so a reflow or a code-span
 #    added on one side is never a failure. Every other character must match.
 #
-# 2. **Provenance references are not part of a code's meaning.** 41 rows end with
-#    a parenthetical naming when, and under which decision, the row entered the
+# 2. **A citation is not part of a code's meaning.** 41 of the ADR's 91 rows end
+#    with a parenthetical citing the decision or issue that put the row in the
 #    contract: `(Phase 2, ADR-0017 / ADR-0021)`, `(ADR-0033, #363)`, `(#170)`.
 #    Saying which decision added a row is the ADR's job as a decision record; the
 #    registry's `description` is the code's MEANING — the sentence a caller reads
 #    next to the code, where an unresolvable issue number is noise. So a trailing
-#    parenthetical made of nothing but provenance tokens is stripped and not
-#    compared. It is stripped on BOTH sides, not just the ADR's: the two artifacts
-#    cite decisions for different readers, and five registry rows already carry a
-#    pointer (`invalid_params` -> ADR-0015) that is worth keeping where it is.
+#    parenthetical is stripped and not compared when it CITES at least one ADR or
+#    issue and contains nothing but citation tokens. It is stripped on BOTH sides,
+#    not just the ADR's: the two artifacts cite for different readers, and 5
+#    registry descriptions carry one too (`usage_error`, `invalid_params`,
+#    `ambiguous_class_name`, `script_failed`, `script_aborted` — each a pointer to
+#    the ADR that governs it, worth keeping where it is).
 #    Rejected alternative: have the registry adopt the ADR's refs. That copies 41
 #    references an agent cannot resolve into the public code descriptions and makes
 #    appending an issue number a standing obligation for every new code.
 #
+#    **Why a reference is REQUIRED, not merely allowed** (#755 review): a bare
+#    `(Phase N)` is domain content, not a citation — CONTEXT.md defines Phase 1 /
+#    Phase 2 as the order capabilities are delivered in. An earlier form of this
+#    rule stripped any parenthetical built from the token set, so `(Phase 2)` and
+#    `(Phase 1)` normalized alike and a mislabelled row would have passed the pin
+#    silently — the exact drift class #701 exists to catch. A `Phase N` may still
+#    ride INSIDE a citation cluster, because dropping it from the token set would
+#    unstrip `(Phase 2, ADR-0017 / ADR-0021)` and turn a third of the cited rows
+#    into false divergences.
+#
+#    Residual, stated rather than overclaimed: a `Phase N` riding inside a cluster
+#    is stripped with it and so is not compared. What actually pins those rows is
+#    the `Category` column beside them — `live` exists only in Phase 2 (ADR-0021),
+#    and that column IS compared. The three rows that used to end in a bare
+#    `(Phase 2)` no longer carry one at all; see the ADR-side note.
+#
 # The rule is deliberately narrow. A parenthetical that MIXES prose with a ref is
-# not provenance and is compared verbatim, so content can never hide behind the
+# not a citation and is compared verbatim, so content can never hide behind the
 # rule. #701 found exactly that: `(pack needs no platform templates and is
 # exempt; #170)` — a real exemption the registry had lost. It was reconciled into
 # both artifacts, not normalized away.
 #
-# A new provenance form (a date, a PR link) will fail this pin rather than being
-# silently accepted. That is intended: widening PROVENANCE_TOKEN is a conscious
-# edit.
-PROVENANCE_TOKEN = r"(?:Phase \d+|ADR-\d{4}(?: amendment)?|#\d+)"
-TRAILING_PROVENANCE = re.compile(
-    rf"\s*\({PROVENANCE_TOKEN}(?:\s*[,/]\s*{PROVENANCE_TOKEN})*\)\.?\s*$"
+# A new citation form (a date, a PR link) will fail this pin rather than being
+# silently accepted. That is intended: widening the token set is a conscious edit.
+CITATION_REF = r"(?:ADR-\d{4}(?: amendment)?|#\d+)"
+CITATION_TOKEN = rf"(?:Phase \d+|{CITATION_REF})"
+TRAILING_CITATION = re.compile(
+    # The lookahead is the "at least one ADR or issue reference" requirement.
+    rf"\s*\((?=[^()]*{CITATION_REF})"
+    rf"{CITATION_TOKEN}(?:\s*[,/]\s*{CITATION_TOKEN})*\)\.?\s*$"
 )
 
 
 def _normalized_description(text: str) -> str:
     """The comparable part of a description — see the rule above."""
     flattened = " ".join(text.replace("`", "").split()).rstrip(". ")
-    return TRAILING_PROVENANCE.sub("", flattened).rstrip(". ")
+    return TRAILING_CITATION.sub("", flattened).rstrip(". ")
 
 
 class ErrorRow(NamedTuple):
@@ -200,12 +220,12 @@ def test_adr_registry_matches_python_authoritative_registry():
     assert _adr_registry() == _python_registry()
 
 
-def test_description_normalization_ignores_only_provenance_refs():
+def test_description_normalization_ignores_only_citations():
     # Pins the boundary of the rule stated above, so widening it stays a conscious
     # edit rather than a side effect of a regex tweak.
     #
     # Ignored: markup, wrapping, a trailing period, and a trailing parenthetical
-    # that is nothing but provenance tokens.
+    # that cites an ADR or issue and holds nothing else.
     assert _normalized_description("A `code` span.") == "A code span"
     assert _normalized_description("Wrapped\n  text") == "Wrapped text"
     assert _normalized_description("Meaning (Phase 2, ADR-0017 / ADR-0021).") == (
@@ -217,10 +237,27 @@ def test_description_normalization_ignores_only_provenance_refs():
     assert _normalized_description("Meaning (pack is exempt; #170).") == (
         "Meaning (pack is exempt; #170)"
     )
-    # NOT ignored: a provenance-looking parenthetical mid-sentence.
+    # NOT ignored: a citation-looking parenthetical mid-sentence.
     assert _normalized_description("Meaning (#170) and more.") == (
         "Meaning (#170) and more"
     )
+
+
+def test_a_bare_phase_label_is_compared_not_stripped():
+    # #755 review: `Phase N` is domain content (CONTEXT.md — the order capabilities
+    # are delivered in), so a parenthetical holding ONLY a phase label is not a
+    # citation and must survive normalization. Before the fix both sides normalized
+    # to the same string and a row mislabelled Phase 1 passed the pin silently.
+    assert _normalized_description("Meaning (Phase 2).") == "Meaning (Phase 2)"
+    assert _normalized_description("Meaning (Phase 2).") != (
+        _normalized_description("Meaning (Phase 1).")
+    )
+    # The other direction, which is why `Phase \d+` stays in the token set: a phase
+    # label riding inside a real citation is stripped with it. Removing the token
+    # would unstrip these and turn a third of the cited rows into false
+    # divergences.
+    assert _normalized_description("Meaning (Phase 2, #220).") == "Meaning"
+    assert _normalized_description("Meaning (Phase 2, ADR-0021).") == "Meaning"
 
 
 def test_gdscript_operation_error_codes_mirror_python_operation_subset():

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -2,6 +2,7 @@
 
 import re
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 
@@ -46,7 +47,9 @@ ADR_0002 = ROOT / "docs" / "adr" / "0002-headless-structured-output-contract.md"
 OPERATIONS_GD = ROOT / "src" / "gda" / "ops" / "operations.gd"
 GDA_HARNESS_GD = ROOT / "src" / "gda" / "harness" / "gda_harness.gd"
 
-ADR_REGISTRY_ROW = re.compile(r"^\| `([^`]+)` \| `([^`]+)` \| `([^`]+)` \| `(\d+)` \|")
+ADR_REGISTRY_ROW = re.compile(
+    r"^\| `([^`]+)` \| `([^`]+)` \| `([^`]+)` \| `(\d+)` \| (.+?) \|$"
+)
 GDSCRIPT_OPERATION_CODE = re.compile(
     r'^const OP_ERROR_[A-Z_]+ := "([a-z_]+)"$', re.MULTILINE
 )
@@ -84,19 +87,83 @@ HARNESS_LIVE_ERROR_CODES = (
 )
 
 
-def _adr_registry() -> dict[str, tuple[str, str, int]]:
-    rows: dict[str, tuple[str, str, int]] = {}
+# --- How a code's DESCRIPTION is compared across the two artifacts (#701) -----
+#
+# ADR-0002's table and `gda.error_codes` carry the same per-code description, and
+# the equality pin below compares it. Two normalizations run first. Both are
+# decisions with a stated reason, because a rule buried in a regex is a rule the
+# next reader cannot tell from a bug.
+#
+# 1. **Markdown prose vs a Python string.** The ADR cell is Markdown (`code
+#    spans`, one long line); the registry is an implicitly-concatenated,
+#    formatter-wrapped string. Backticks are dropped, whitespace runs collapse to
+#    one space, and a trailing period is ignored — so a reflow or a code-span
+#    added on one side is never a failure. Every other character must match.
+#
+# 2. **Provenance references are not part of a code's meaning.** 41 rows end with
+#    a parenthetical naming when, and under which decision, the row entered the
+#    contract: `(Phase 2, ADR-0017 / ADR-0021)`, `(ADR-0033, #363)`, `(#170)`.
+#    Saying which decision added a row is the ADR's job as a decision record; the
+#    registry's `description` is the code's MEANING — the sentence a caller reads
+#    next to the code, where an unresolvable issue number is noise. So a trailing
+#    parenthetical made of nothing but provenance tokens is stripped and not
+#    compared. It is stripped on BOTH sides, not just the ADR's: the two artifacts
+#    cite decisions for different readers, and five registry rows already carry a
+#    pointer (`invalid_params` -> ADR-0015) that is worth keeping where it is.
+#    Rejected alternative: have the registry adopt the ADR's refs. That copies 41
+#    references an agent cannot resolve into the public code descriptions and makes
+#    appending an issue number a standing obligation for every new code.
+#
+# The rule is deliberately narrow. A parenthetical that MIXES prose with a ref is
+# not provenance and is compared verbatim, so content can never hide behind the
+# rule. #701 found exactly that: `(pack needs no platform templates and is
+# exempt; #170)` — a real exemption the registry had lost. It was reconciled into
+# both artifacts, not normalized away.
+#
+# A new provenance form (a date, a PR link) will fail this pin rather than being
+# silently accepted. That is intended: widening PROVENANCE_TOKEN is a conscious
+# edit.
+PROVENANCE_TOKEN = r"(?:Phase \d+|ADR-\d{4}(?: amendment)?|#\d+)"
+TRAILING_PROVENANCE = re.compile(
+    rf"\s*\({PROVENANCE_TOKEN}(?:\s*[,/]\s*{PROVENANCE_TOKEN})*\)\.?\s*$"
+)
+
+
+def _normalized_description(text: str) -> str:
+    """The comparable part of a description — see the rule above."""
+    flattened = " ".join(text.replace("`", "").split()).rstrip(". ")
+    return TRAILING_PROVENANCE.sub("", flattened).rstrip(". ")
+
+
+class ErrorRow(NamedTuple):
+    """One code's full public shape, as both artifacts must state it."""
+
+    category: str
+    source: str
+    exit_code: int
+    description: str
+
+
+def _adr_registry() -> dict[str, ErrorRow]:
+    rows: dict[str, ErrorRow] = {}
     for line in ADR_0002.read_text(encoding="utf-8").splitlines():
         match = ADR_REGISTRY_ROW.match(line)
         if match:
-            code, category, source, exit_code = match.groups()
-            rows[code] = (category, source, int(exit_code))
+            code, category, source, exit_code, description = match.groups()
+            rows[code] = ErrorRow(
+                category, source, int(exit_code), _normalized_description(description)
+            )
     return rows
 
 
-def _python_registry() -> dict[str, tuple[str, str, int]]:
+def _python_registry() -> dict[str, ErrorRow]:
     return {
-        spec.code: (spec.category.value, spec.source.value, spec.exit_code)
+        spec.code: ErrorRow(
+            spec.category.value,
+            spec.source.value,
+            spec.exit_code,
+            _normalized_description(spec.description),
+        )
         for spec in ERROR_CODES
     }
 
@@ -123,7 +190,37 @@ def test_failure_builder_rejects_unregistered_public_codes():
 
 
 def test_adr_registry_matches_python_authoritative_registry():
+    # Every column of a code's public shape, the `Meaning` prose included (#701).
+    # The description used to be parsed out of the ADR row and thrown away, so the
+    # two artifacts could describe the same code differently and nothing noticed —
+    # wave 2 shipped three PRs whose description edits had to be checked by eye,
+    # and 15 rows had already drifted apart in substance (a producing condition the
+    # registry omitted, an exemption it had lost, a remedy it stated incompletely).
+    # Comparison rule: see `_normalized_description` above.
     assert _adr_registry() == _python_registry()
+
+
+def test_description_normalization_ignores_only_provenance_refs():
+    # Pins the boundary of the rule stated above, so widening it stays a conscious
+    # edit rather than a side effect of a regex tweak.
+    #
+    # Ignored: markup, wrapping, a trailing period, and a trailing parenthetical
+    # that is nothing but provenance tokens.
+    assert _normalized_description("A `code` span.") == "A code span"
+    assert _normalized_description("Wrapped\n  text") == "Wrapped text"
+    assert _normalized_description("Meaning (Phase 2, ADR-0017 / ADR-0021).") == (
+        _normalized_description("Meaning.")
+    )
+    assert _normalized_description("Meaning (ADR-0031 amendment, #655).") == "Meaning"
+    # NOT ignored: a parenthetical carrying prose, even when a ref rides along —
+    # that is content, and dropping it is how a real divergence would hide.
+    assert _normalized_description("Meaning (pack is exempt; #170).") == (
+        "Meaning (pack is exempt; #170)"
+    )
+    # NOT ignored: a provenance-looking parenthetical mid-sentence.
+    assert _normalized_description("Meaning (#170) and more.") == (
+        "Meaning (#170) and more"
+    )
 
 
 def test_gdscript_operation_error_codes_mirror_python_operation_subset():

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -92,7 +92,8 @@ HARNESS_LIVE_ERROR_CODES = (
 # ADR-0002's table and `gda.error_codes` carry the same per-code description, and
 # the equality pin below compares it. Two normalizations run first. Both are
 # decisions with a stated reason, because a rule buried in a regex is a rule the
-# next reader cannot tell from a bug.
+# next reader cannot tell from a bug. Counts below are a 2026-08-28 snapshot, not
+# a contract — only the pin itself is asserted.
 #
 # 1. **Markdown prose vs a Python string.** The ADR cell is Markdown (`code
 #    spans`, one long line); the registry is an implicitly-concatenated,

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -126,11 +126,15 @@ HARNESS_LIVE_ERROR_CODES = (
 #    unstrip `(Phase 2, ADR-0017 / ADR-0021)` and turn a third of the cited rows
 #    into false divergences.
 #
-#    Residual, stated rather than overclaimed: a `Phase N` riding inside a cluster
-#    is stripped with it and so is not compared. What actually pins those rows is
-#    the `Category` column beside them — `live` exists only in Phase 2 (ADR-0021),
-#    and that column IS compared. The three rows that used to end in a bare
-#    `(Phase 2)` no longer carry one at all; see the ADR-side note.
+#    Residual, stated exactly: a `Phase N` riding inside a citation cluster is
+#    stripped with it and so is not compared. For 20 of the 23 rows carrying a
+#    phase label the compared `Category` column pins the distinction indirectly —
+#    `live` exists only in Phase 2 (ADR-0021) — but the other three are
+#    ENVIRONMENT-category (`live_unsupported_platform`, `live_windowed_unavailable`,
+#    `live_windowed_permission_denied`), so for those a phase mislabel inside a
+#    citation cluster is caught by neither mechanism. Left that way deliberately:
+#    three docs-only rows in a field with no runtime consumer do not justify the
+#    27 rows of churn that closing the riding case would cost.
 #
 # The rule is deliberately narrow. A parenthetical that MIXES prose with a ref is
 # not a citation and is compared verbatim, so content can never hide behind the


### PR DESCRIPTION
Closes #701

## What changed

`tests/test_error_registry.py`'s registry↔ADR-0002 equality pin parsed the table's
`Meaning` cell and threw it away, comparing only `(category, source, exit_code)`. The pin
now compares all four columns, and the divergences it surfaced are reconciled.

The comparison reuses the existing `_adr_registry()` / `_python_registry()` helpers — they
now return a 4-field `ErrorRow` and the one existing equality assertion covers the
description too. No parallel parser was added.

## Derived measurement (reproduced, not quoted)

Comparing `gda.error_codes.ERROR_CODES` against the ADR-0002 table at the fork point
(`04d3e089`):

| | |
|---|---|
| codes compared | 91 (91 ADR rows, 91 registry entries; no row missing on either side) |
| differ after markup / whitespace / trailing-period normalization | **42** |
| — trailing provenance reference only | 27 |
| — **substantive content** | **15** |

This matches the issue's pre-dispatch measurement once the provenance grammar admits
`ADR-0031 amendment` as a token (`script_failed` and `script_aborted` differ by nothing
else). With a narrower grammar the split reads 25 / 17.

### After reconciliation, at head `3d035725`

Three counts, three different populations — an earlier version of this line conflated the
first two, which is the one defect a PR about measurement accuracy cannot afford:

| Count | Value | What it is |
|---|---|---|
| differ after backtick / whitespace / trailing-period normalization | **38** | every one explained by a trailing citation |
| ADR descriptions carrying a strippable citation | **41** | a property of the ADR side alone |
| differ after the citation rule | **0** | what the pin asserts |

41 and 38 are not the same population and neither is a subset relation by luck: **3** of the
41 (`ambiguous_class_name`, `invalid_params`, `usage_error`) carry the *same* citation on the
registry side and match otherwise, so they were never in the 38. Two more registry
descriptions carry a citation (`script_aborted`, `script_failed`) but a *different* one from
their ADR row — `(#655)` vs `(ADR-0031 amendment, #655)` — so those two do stay in the 38 and
are resolved by the rule, not by already matching. That is 5 registry descriptions with a
citation, of which only 3 subtract.

These are a dated snapshot, not a contract: the pin asserts row-for-row equality, never a
count, so a legitimate new citation moves these numbers and breaks nothing.

## Decision 1 — the citation rule, and why

**A trailing parenthetical is stripped, on both sides, and not compared — but only when
it CITES at least one ADR or issue and holds nothing else.** Stated with its reasoning in
`tests/test_error_registry.py` above `_normalized_description`.

Why this and not "the registry adopts the refs":

- Saying which decision added a row is the ADR's job as a decision record. The registry's
  `description` is the code's *meaning* — the sentence read next to the code, where an
  unresolvable issue number is noise.
- Adopting them means copying 41 references into the public code descriptions and making
  "append an issue number" a standing obligation for every new code.
- Stripped on **both** sides rather than the ADR's only, because the two artifacts cite for
  different readers and 5 registry descriptions carry a pointer worth keeping where it is
  (`usage_error`, `invalid_params`, `ambiguous_class_name`, `script_failed`,
  `script_aborted`).

**Why a reference is required, not merely allowed** (from the #755 review). The first form
of this rule stripped any parenthetical built from the token set, and `Phase N` was in that
set — so `(Phase 2)` and `(Phase 1)` normalized alike and a mislabelled row would have
passed the guard silently. Phase is domain content, not a citation: `CONTEXT.md` defines
Phase 1 / Phase 2 as the order capabilities are delivered in. `Phase N` stays in the token
set so it can ride *inside* a cluster — removing it would unstrip
`(Phase 2, ADR-0017 / ADR-0021)` and turn a third of the cited rows into false divergences.

**Residual, stated exactly:** a `Phase N` riding inside a citation cluster is stripped with
it and so is not compared. For 20 of the 23 rows carrying a phase label the compared
`Category` column pins the distinction indirectly — `live` exists only in Phase 2
(ADR-0021) — but the other three are `environment`-category
(`live_unsupported_platform`, `live_windowed_unavailable`,
`live_windowed_permission_denied`), so for those a phase mislabel inside a citation cluster
is caught by neither mechanism. Left that way deliberately and not taken as a follow-up:
three docs-only rows in a field with no runtime consumer do not justify the 27 rows of
churn that closing the riding case would cost.

The rule stays deliberately narrow, and that narrowness is load-bearing: a parenthetical
that **mixes prose with a ref is not a citation** and is compared verbatim. #701 contains
exactly that case — `export_templates_missing`'s `(pack needs no platform templates and is
exempt; #170)`, a real exemption the registry had lost. It was reconciled into both
artifacts, not normalized away. Two boundary tests
(`test_description_normalization_ignores_only_citations`,
`test_a_bare_phase_label_is_compared_not_stripped`) pin both directions, so widening the
token set stays a conscious edit.

The ADR carries a short summary of the rule above its table, since that is where a human
edits a row — including the fact that a registry description may carry a citation too, so
nobody "tidies away" one of the five.

## Decision 2 — a verdict per substantive divergence

18 divergences, 18 verdicts — the original 15, plus 3 more surfaced by the tightened
citation rule. Seven fix the **registry**, nine fix the **ADR**, two are phrasing with no
correctness winner. The registry is the authoritative source (ADR-0002
says so), so the default direction is "the ADR adopts the registry" — overridden wherever
the ADR's text was the more correct or more complete one.

| Code | Verdict | Why |
|---|---|---|
| `export_path_unset` | **registry was wrong** → adopts ADR | Registry named only the configured `export_path`; `export_path_unset_failure`'s own docstring says the destination is `--output` if given, else `export_path`, and the code fires only when **both** are absent. A reader of the registry would not know the override exists. |
| `export_templates_missing` | **registry was wrong** → adopts ADR | Registry said "an export run"; `export_templates_missing_failure` skips the check for `--mode pack` entirely. The registry claimed the code can fire for a mode it never fires for, and had lost the `pack` exemption. |
| `launch_timeout` | **registry was wrong** → adopts ADR (reworded) | ADR carried "one command does not report it — see the 2026-08-19 scope note"; the registry carried no caveat. `scene preflight` reports exceeding its own bound as a `timeout` **status on a success result**, so an agent branching on this code alone never sees that command's timeout. Both sides now name the command instead of pointing at a note, so the sentence stands on its own in the registry. |
| `live_display_unavailable` | **registry was wrong** → adopts ADR | Registry's remedy read "start the daemon with `gda daemon start --windowed`", dropping *windowed* — the word that says what is being fixed. The registry's own code comment already called it "the self-revealing remediation (start the daemon windowed)". |
| `live_predicate_unmet` | **registry was wrong** → adopts ADR | Registry said "a live capture predicate"; the ADR names the command and flag (`screen capture`, `--await-*`). The code exists for exactly one surface and naming it costs nothing. (`#661` moved out of the inline parenthetical into the row's trailing provenance, where it belongs.) |
| `live_unsupported_platform` | **registry was incomplete** → adopts ADR | The ADR's "Phase-1 headless is unaffected" is the scope a reader hitting this on Windows most needs; the registry dropped it. |
| `tree_too_deep` | **registry was incomplete** → adopts ADR | The ADR explains that it shares `contract_violation`'s exit code and is told apart by `code`. That is precisely the branching advice a registry entry should carry. |
| `live_timeout` | **ADR was incomplete** → adopts registry | The registry documents that the session is discarded and runtime state does not survive. Verified in `daemon/session.py`: the timeout latches `_channel_stale` because the protocol has no request id and a late frame would be read as the *next* op's reply. A live-op consumer must know this; the ADR omitted it. |
| `live_method_not_allowlisted` | **ADR was wrong** → adopts registry | ADR said "its **class** never declared gda-callable". ADR-0041 resolves `GDA_CALLABLE` along the addressed node's **attached script's** base chain — a node's engine class never declares anything. The registry was accurate. |
| `live_invalid_call_args` | **ADR adopts registry** | Em-dash vs colon before an enumeration; no correctness difference. Default direction. |
| `live_windowed_unavailable` | **ADR adopts registry** | Word order only (`A windowed Engine session (…) was requested` vs `was requested (…)`). Default direction. |
| `live_windowed_permission_denied` | **ADR adopts registry** | Same word-order difference as its sibling; kept consistent with it. |
| `stdout_spill_failed` | **ADR adopts registry** | `A script run stdout` → `A script run's stdout`. Grammar. |
| `engine_disconnected` | **phrasing; registry adopts the ADR's em-dash** | Same content (parenthetical vs em-dash). Direction flipped from the default here for one reason: the registry's form ends in a parenthetical, and the ADR row appends `(Phase 2)` after it — adopting the registry text would stack two parentheticals at the end of the cell. |
| `script_not_found` | **phrasing; both adopt one form** | Same content, different phrasing. Reworded to `— it still exits 0, and gda reads the failure from stderr` for the same reason: the registry's parenthetical form would stack against the ADR row's `(#651)`. |
| `engine_session_not_running` | **ADR carried a redundant label** → dropped | Surfaced by the tightened rule. The bare `(Phase 2)` duplicates the row's own `Category` column, which reads `live` — a category that exists only in Phase 2 (ADR-0021) and that the pin already compares. Dropped rather than copied into the registry: a delivery-phase label is not part of a code's meaning, and 24 sibling live codes carry none. |
| `engine_disconnected` | **ADR carried a redundant label** → dropped | Same, and the same reasoning. |
| `live_timeout` | **ADR carried a redundant label** → dropped | Same, and the same reasoning. |

## On the "an agent reading `gda schema`" framing

Worth correcting for the record: `ErrorCodeSpec.description` reaches **no** gda output
today. It is not in `gda schema`, not in a per-command `--schema` (the uniform `error` key
carries the `GdaErrorEnvelope` shape, not a code enum with prose), and not in an emitted
envelope — a failure's `message` comes from the failure builder, not the registry row.
Proof: `gda schema` is **byte-identical** before and after this change, despite seven
registry descriptions being rewritten.

So the description column is documentation, in two places: the ADR table and
`error_codes.py` itself. That does not weaken the case for the pin — both are read by
humans and by agents reading the source, and #701's substantive findings are real
inaccuracies in a public-ABI reference — but the divergences were not silently degrading
`gda schema` output, and the claim should not be repeated as if they were.

## Validation

| Gate | Command | Result |
|---|---|---|
| Suite | `uv run pytest -q -m "not e2e"` | `1903 passed, 539 deselected in 111.29s (0:01:51)` |
| Lint | `uv run ruff check .` | `All checks passed!` |
| Format | `uv run ruff format --check .` | `472 files already formatted` |
| Types | `uv run pyright` | `0 errors, 0 warnings, 0 informations` |
| Schema | `gda schema` before vs after | no difference (see above) |

**Red-proof, two ways.** Perturbing one registry description (`path_not_found`: "does not
exist" -> "does not exist anywhere") fails the equality pin with a readable diff, and
passes again once reverted:

```
E         Differing items:
E         {'path_not_found': ErrorRow(..., description='A requested file does not exist')} !=
          {'path_not_found': ErrorRow(..., description='A requested file does not exist anywhere')}
1 failed in 0.52s
```

And the case the review found — writing a bare `(Phase 1)` onto a `live` ADR row — now
fails too, where before it normalized away silently:

```
E         {'engine_session_not_running': ErrorRow(..., description='...to serve the live operation (Phase 1)')} !=
          {'engine_session_not_running': ErrorRow(..., description='...to serve the live operation')}
1 failed in 0.14s
```

**Godot e2e was not run** — it is not needed for this slice: no engine-facing behavior,
no GDScript, and no emitted output changes.

## Review round (PR #755)

All four findings fully adopted, in `56126712`:

1. **P2 — a bare `(Phase N)` was stripped.** Reproduced against my own function before
   fixing. Rule tightened to require a citation; the 3 rows it surfaced reconciled with
   verdicts in the table above; boundary pinned in both directions by a new test.
2. **P2 — the ADR claimed the trailing reference "rides these rows only".** False; derived
   the real figures (41 ADR rows, 5 registry descriptions) and stated both, so nobody
   removes one of the five as noise.
3. **P3 — the ADR's stated scope ("naming the deciding ADR or issue") was narrower than the
   implementation.** Rewritten in the same edit to describe what the rule now does,
   including the bare-`Phase N` exclusion.
4. **P3 — no pointer on the authoritative side.** `error_codes.py`'s module docstring now
   says the wording is pinned and where the rule lives.

Not re-litigated: generating the table instead of guarding it. Agreed with the architecture
lens — ADR-0002 is a narrative record with the table embedded in prose, so generation buys a
marker-based partial-file generator plus a CI step and reproduces the same drift class at
"forgot to regenerate".

## Remainder

None for #701's acceptance criteria. Two judgement calls worth a reviewer's eye. The
`Phase N`-inside-a-citation residual is described under Decision 1 — including the three
`environment`-category rows it leaves genuinely uncaught. And the
`launch_timeout` row now names `scene preflight` instead of pointing at ADR-0002's
2026-08-19 scope note, so the sentence works in both artifacts. The scope note still
explains the *why* and is findable — its bullet is titled "The launch bound as a verdict,
not `launch_timeout`".
