### PR TITLE
fix(gda): stop the script-error parser eating a genuine trailing dot

### DIFF
--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -99,12 +99,17 @@ status: accepted
 >
 > **What stays refused**, all decided before any launch as `invalid_path`: an **absolute** path;
 > **another engine scheme** (`user://`, `uid://` — lifting one would splice a second scheme into a
-> res:// address and send the engine after a path nobody typed); a path naming the project **root**
-> (`""`, `"."`, `"sub/.."`, and the `res://` / `res://.` spellings — a directory, not a script); and a
-> path **escaping above the root** (`".."`, `"../outside.gd"`, and their `res://` spellings). The ABI
-> edge below names "a non-`res://` **or absolute** script path"; only its first half is lifted here.
+> res:// address and send the engine after a path nobody typed); a leading `~` (a filesystem HOME
+> reference, including an unresolvable one); a path naming the project **root** (`""`, `"."`,
+> `"sub/.."`, and the `res://` / `res://.` spellings — a directory, not a script); a path **escaping
+> above the root** (`".."`, `"../outside.gd"`, and their `res://` spellings); a canonical address
+> ending in a code point at or below **U+0020**, which Godot removes before reporting the path; and a
+> canonical address containing any line boundary recognized by `gda.engine_log`'s line protocol.
+> The ABI edge below names "a non-`res://` **or absolute** script path"; only its first half is lifted
+> here.
 >
-> The last two are refused for a reason beyond tidiness, and both were **verified**. The engine
+> The root and escape shapes are refused for a reason beyond tidiness, and both were **verified**. The
+> engine
 > answers a root or escape address with `Can't load script: res://.` / `res://..`, whose address the
 > error parser reads back with the sentence period stripped — so it never matches the entry, the
 > never-ran verdict misses it, and the run reports a phantom `exit_status: 0`. Worse, an escape that
@@ -115,6 +120,15 @@ status: accepted
 > the widening is what made them reachable from the ordinary project-relative form, so they are closed
 > here. The residual parser weakness (a trailing-period strip that mis-reads `res://..`) is **not**
 > addressed here; it belongs to the error parser and is tracked separately.
+>
+> **Path-identity boundary (2026-08-28, #698 review).** The two character rules above preserve the
+> same canonical identity on both sides of the entry-load verdict. Godot 4.6.3's
+> `String::strip_edges()` removes trailing code points at or below U+0020; Python `str.rstrip()` is
+> intentionally not the rule because it additionally removes Unicode spaces such as NBSP (U+00A0)
+> and EM SPACE (U+2003), which Godot preserves. Separately, `gda.engine_log` parses engine output with
+> `str.splitlines()`. Any address containing one of those line boundaries is therefore impossible to
+> recover from one diagnostic record and is refused before launch. Leading and internal ASCII spaces,
+> and Unicode spaces that Godot preserves, remain valid project-relative characters.
 >
 > **Outcome (2026-08-27, #698):** the error parser's `_CANT_LOAD` regex (`gda.script_errors`) no
 > longer strips a genuine trailing dot. It mirrors `main.cpp:4271`, which never appends sentence
@@ -138,7 +152,8 @@ status: accepted
 >
 > The refusals this decision records stay in place regardless of either parser fix — they are
 > load-bearing for reasons beyond the parser weakness (ADR-0009's Trusted project, above) — but the
-> parser itself no longer mis-reads a dot-terminated or whitespace-containing `res://` address if a
+> parser itself no longer mis-reads a dot-terminated or horizontal-space-containing `res://` address if
+> a
 > future route ever reaches it again.
 >
 > Absolute stays refused for two **verified** reasons, not merely as deferred scope. First, the engine

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -116,16 +116,18 @@ status: accepted
 > here. The residual parser weakness (a trailing-period strip that mis-reads `res://..`) is **not**
 > addressed here; it belongs to the error parser and is tracked separately.
 >
-> **Outcome (2026-08-27, #698):** the error parser's `_CANT_LOAD` and `_FAILED_LOADING_RESOURCE`
-> regexes (`gda.script_errors`) no longer strip a genuine trailing dot. `_CANT_LOAD` mirrors
-> `main.cpp:4366`, which never appends sentence punctuation, so its strip is now unconditional
-> removal — dropped entirely. `_FAILED_LOADING_RESOURCE` mirrors `resource_loader.cpp:317`'s
-> `vformat("Failed loading resource: %s.", p_path)`, which always appends exactly one period, so its
-> strip is now mandatory rather than optional. Both are per-site fixes, not a general
-> longest-candidate heuristic. The refusals this decision records stay in place regardless — they are
-> load-bearing for reasons beyond the parser weakness (ADR-0009's Trusted project, above) — but the
-> parser itself no longer mis-reads a dot-terminated `res://` address if a future route ever reaches
-> it again.
+> **Outcome (2026-08-27, #698):** the error parser's `_CANT_LOAD` regex (`gda.script_errors`) no
+> longer strips a genuine trailing dot. It mirrors `main.cpp:4366`, which never appends sentence
+> punctuation, so any strip was always wrong; the strip is dropped entirely, so `Can't load script:
+> res://..` now round-trips to `res://..` instead of the `res://.` mis-read this paragraph describes.
+> The sibling `_FAILED_LOADING_RESOURCE` regex was tightened too (its strip is now mandatory rather
+> than optional, mirroring `resource_loader.cpp:317`'s guaranteed trailing period), but — verified —
+> its old optional strip never actually mis-read a well-formed captured line, for any dot count; that
+> change is a fail-closed robustness improvement, not a fix for observed corruption. Neither change is
+> a general longest-candidate heuristic. The refusals this decision records stay in place regardless
+> — they are load-bearing for reasons beyond the parser weakness (ADR-0009's Trusted project, above)
+> — but the parser itself no longer mis-reads a dot-terminated `res://` address if a future route
+> ever reaches it again.
 >
 > Absolute stays refused for two **verified** reasons, not merely as deferred scope. First, the engine
 > reports a failed run under the **`res://` spelling even when launched with an absolute in-project

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -117,11 +117,11 @@ status: accepted
 > addressed here; it belongs to the error parser and is tracked separately.
 >
 > **Outcome (2026-08-27, #698):** the error parser's `_CANT_LOAD` regex (`gda.script_errors`) no
-> longer strips a genuine trailing dot. It mirrors `main.cpp:4366`, which never appends sentence
+> longer strips a genuine trailing dot. It mirrors `main.cpp:4271`, which never appends sentence
 > punctuation, so any strip was always wrong; the strip is dropped entirely, so `Can't load script:
 > res://..` now round-trips to `res://..` instead of the `res://.` mis-read this paragraph describes.
 > The sibling `_FAILED_LOADING_RESOURCE` regex was tightened too (its strip is now mandatory rather
-> than optional, mirroring `resource_loader.cpp:317`'s guaranteed trailing period), but — verified —
+> than optional, mirroring `resource_loader.cpp:343`'s guaranteed trailing period), but — verified —
 > its old optional strip never actually mis-read a well-formed captured line, for any dot count; that
 > change is a fail-closed robustness improvement, not a fix for observed corruption. Neither change is
 > a general longest-candidate heuristic. The refusals this decision records stay in place regardless

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -116,6 +116,17 @@ status: accepted
 > here. The residual parser weakness (a trailing-period strip that mis-reads `res://..`) is **not**
 > addressed here; it belongs to the error parser and is tracked separately.
 >
+> **Outcome (2026-08-27, #698):** the error parser's `_CANT_LOAD` and `_FAILED_LOADING_RESOURCE`
+> regexes (`gda.script_errors`) no longer strip a genuine trailing dot. `_CANT_LOAD` mirrors
+> `main.cpp:4366`, which never appends sentence punctuation, so its strip is now unconditional
+> removal — dropped entirely. `_FAILED_LOADING_RESOURCE` mirrors `resource_loader.cpp:317`'s
+> `vformat("Failed loading resource: %s.", p_path)`, which always appends exactly one period, so its
+> strip is now mandatory rather than optional. Both are per-site fixes, not a general
+> longest-candidate heuristic. The refusals this decision records stay in place regardless — they are
+> load-bearing for reasons beyond the parser weakness (ADR-0009's Trusted project, above) — but the
+> parser itself no longer mis-reads a dot-terminated `res://` address if a future route ever reaches
+> it again.
+>
 > Absolute stays refused for two **verified** reasons, not merely as deferred scope. First, the engine
 > reports a failed run under the **`res://` spelling even when launched with an absolute in-project
 > path**, so accepting absolute without also mapping it back to `res://` would break the

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -118,16 +118,28 @@ status: accepted
 >
 > **Outcome (2026-08-27, #698):** the error parser's `_CANT_LOAD` regex (`gda.script_errors`) no
 > longer strips a genuine trailing dot. It mirrors `main.cpp:4271`, which never appends sentence
-> punctuation, so any strip was always wrong; the strip is dropped entirely, so `Can't load script:
-> res://..` now round-trips to `res://..` instead of the `res://.` mis-read this paragraph describes.
-> The sibling `_FAILED_LOADING_RESOURCE` regex was tightened too (its strip is now mandatory rather
-> than optional, mirroring `resource_loader.cpp:343`'s guaranteed trailing period), but — verified —
-> its old optional strip never actually mis-read a well-formed captured line, for any dot count; that
+> punctuation, so any strip was always wrong; the strip is dropped, so `Can't load script: res://..`
+> now round-trips to `res://..` instead of the `res://.` mis-read this paragraph describes. The
+> sibling `_FAILED_LOADING_RESOURCE` regex was tightened too (its strip is now mandatory rather than
+> optional, mirroring `resource_loader.cpp:343`'s guaranteed trailing period), but — verified — its
+> old optional strip never actually mis-read a well-formed captured line, for any dot count; that
 > change is a fail-closed robustness improvement, not a fix for observed corruption. Neither change is
-> a general longest-candidate heuristic. The refusals this decision records stay in place regardless
-> — they are load-bearing for reasons beyond the parser weakness (ADR-0009's Trusted project, above)
-> — but the parser itself no longer mis-reads a dot-terminated `res://` address if a future route
-> ever reaches it again.
+> a general longest-candidate heuristic.
+>
+> Adversarial review of the #698 PR found a second, independent defect in the same two regexes: their
+> path capture was `\S+`, which cannot match a SPACE, so a project-relative path containing one
+> (`res://missing file.`) failed the WHOLE line rather than losing a character — no diagnostic at all,
+> so `entry_load_failure` found nothing and the run reported a phantom success. Pre-existing on `main`
+> before #698 (its `\S+?\.?$` could not match a space either) and masked whenever the path also
+> carried a recognized extension (`_OPEN_FAILED`'s quoted capture is space-safe), so it surfaces only
+> on an extension-less spelling. Both regexes now capture `.+` — `gda.engine_log` has already split
+> stderr into lines before either regex sees one, so `.+` cannot run past the line it belongs to — and
+> genuinely capture to end of line unconditionally, which is what this outcome note now describes.
+>
+> The refusals this decision records stay in place regardless of either parser fix — they are
+> load-bearing for reasons beyond the parser weakness (ADR-0009's Trusted project, above) — but the
+> parser itself no longer mis-reads a dot-terminated or whitespace-containing `res://` address if a
+> future route ever reaches it again.
 >
 > Absolute stays refused for two **verified** reasons, not merely as deferred scope. First, the engine
 > reports a failed run under the **`res://` spelling even when launched with an absolute in-project

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -1150,7 +1150,7 @@ def _project_scoped_res_path(script: str) -> str | None:
     :func:`canonical_res_path`, so the argv, the entry-load verdict and the reported
     path cannot diverge by input spelling.
 
-    Returns ``None`` for the five shapes that are not project-scoped script
+    Returns ``None`` for the six shapes that are not project-scoped script
     addresses. Each must be caught HERE, because each is otherwise launched:
 
     - an **absolute** path — outside the ``--project`` context (the reasons it stays
@@ -1163,6 +1163,16 @@ def _project_scoped_res_path(script: str) -> str | None:
       expand it (an unknown user, #699); a resolvable ``~/x.gd`` was already expanded
       to the absolute path refused above. So both tilde outcomes land on one refusal
       instead of one being refused and the other spliced into ``res://~user/x.gd``;
+    - a path with **trailing whitespace** (``"missing file. "``, ``"missing
+      file.gd "``) — the engine strips trailing whitespace from the ``--script``
+      argv before it ever echoes the path back in a load-failure diagnostic
+      (verified against real Godot 4.6.3), so the address it reports loses
+      whitespace gda's own canonical spelling keeps. The canonical-identity match
+      the never-ran verdict depends on then misses on that one trailing character,
+      and the run reports the same PHANTOM SUCCESS the root/escape refusals below
+      exist to prevent — on a path neither of them admits (#698). Only the
+      TRAILING case is refused: leading and internal whitespace survive the
+      engine's own normalization unchanged and stay accepted;
     - a path that names the project **root** (``""``, ``"."``, ``"sub/.."``) — it names
       a directory, not a script. An unset shell variable makes ``gda script run
       "$SCRIPT"`` exactly this;
@@ -1203,6 +1213,15 @@ def _project_scoped_res_path(script: str) -> str | None:
     if remainder in _ROOT_REMAINDERS:
         return None
     if remainder == ".." or remainder.startswith("../"):
+        return None
+    # Trailing whitespace (#698, adversarial review of PR #756): `canonical_res_path`
+    # is purely lexical (posixpath.normpath) and does NOT strip it, but the engine
+    # DOES — before it ever echoes the path back in a diagnostic — so a canonical
+    # spelling that keeps it can never match what the engine reports. Do NOT
+    # `rstrip()` it off here: silently trimming would launch a DIFFERENT script from
+    # the one the caller named, which is worse than refusing. Refusing is the only
+    # safe answer.
+    if remainder != remainder.rstrip():
         return None
     return canonical
 

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -44,6 +44,7 @@ from gda.errors import (
     script_run_timeout_failure,
     unresolvable_binary_failure,
 )
+from gda.engine_log import lines as engine_log_lines
 from gda.execution import ExecutionKind
 from gda.headless import (
     HeadlessCommand,
@@ -1150,7 +1151,7 @@ def _project_scoped_res_path(script: str) -> str | None:
     :func:`canonical_res_path`, so the argv, the entry-load verdict and the reported
     path cannot diverge by input spelling.
 
-    Returns ``None`` for the six shapes that are not project-scoped script
+    Returns ``None`` for the seven shapes that are not project-scoped script
     addresses. Each must be caught HERE, because each is otherwise launched:
 
     - an **absolute** path — outside the ``--project`` context (the reasons it stays
@@ -1163,16 +1164,17 @@ def _project_scoped_res_path(script: str) -> str | None:
       expand it (an unknown user, #699); a resolvable ``~/x.gd`` was already expanded
       to the absolute path refused above. So both tilde outcomes land on one refusal
       instead of one being refused and the other spliced into ``res://~user/x.gd``;
-    - a path with **trailing whitespace** (``"missing file. "``, ``"missing
-      file.gd "``) — the engine strips trailing whitespace from the ``--script``
-      argv before it ever echoes the path back in a load-failure diagnostic
-      (verified against real Godot 4.6.3), so the address it reports loses
-      whitespace gda's own canonical spelling keeps. The canonical-identity match
-      the never-ran verdict depends on then misses on that one trailing character,
-      and the run reports the same PHANTOM SUCCESS the root/escape refusals below
-      exist to prevent — on a path neither of them admits (#698). Only the
-      TRAILING case is refused: leading and internal whitespace survive the
-      engine's own normalization unchanged and stay accepted;
+    - a path whose canonical address ends in a code point at or below **U+0020** —
+      Godot 4.6.3 removes that exact suffix set (``String::strip_edges``) before it
+      echoes the ``--script`` path in a load-failure diagnostic. The canonical
+      identity then loses a character and the never-ran verdict misses. Python's
+      Unicode ``rstrip`` set is deliberately NOT used: Godot preserves NBSP and EM
+      SPACE, so those remain accepted;
+    - a path containing an **engine-log line boundary** — the engine can emit that
+      character inside its diagnostic, but :mod:`gda.engine_log` necessarily splits
+      the address into separate records. No one record retains the canonical entry
+      identity, so a never-run entry can again report a phantom success. Ordinary
+      leading and internal ASCII spaces remain accepted;
     - a path that names the project **root** (``""``, ``"."``, ``"sub/.."``) — it names
       a directory, not a script. An unset shell variable makes ``gda script run
       "$SCRIPT"`` exactly this;
@@ -1214,14 +1216,16 @@ def _project_scoped_res_path(script: str) -> str | None:
         return None
     if remainder == ".." or remainder.startswith("../"):
         return None
-    # Trailing whitespace (#698, adversarial review of PR #756): `canonical_res_path`
-    # is purely lexical (posixpath.normpath) and does NOT strip it, but the engine
-    # DOES — before it ever echoes the path back in a diagnostic — so a canonical
-    # spelling that keeps it can never match what the engine reports. Do NOT
-    # `rstrip()` it off here: silently trimming would launch a DIFFERENT script from
-    # the one the caller named, which is worse than refusing. Refusing is the only
-    # safe answer.
-    if remainder != remainder.rstrip():
+    # Godot 4.6.3's String::strip_edges() removes trailing code points <= U+0020.
+    # Refuse exactly that engine-normalized suffix set; Python str.rstrip() is wider
+    # and would reject NBSP / EM SPACE even though Godot preserves them. Do not trim:
+    # that would silently launch a different address from the one the caller named.
+    if ord(remainder[-1]) <= 0x20:
+        return None
+    # engine_log owns the line protocol through str.splitlines(). Sentinels make a
+    # boundary at either edge observable (splitlines otherwise suppresses a terminal
+    # empty record), while any ordinary one-line address still produces one record.
+    if len(engine_log_lines(f"x{remainder}x")) != 1:
         return None
     return canonical
 

--- a/src/gda/script_errors.py
+++ b/src/gda/script_errors.py
@@ -87,9 +87,13 @@ _LOAD_FAILED = re.compile(
 )
 
 # `ERROR: Can't load script: <path>` — main.cpp's `start()` giving up on the
-# `--script` entry point. Emitted alongside the more specific sentences above;
-# on its own it is the generic "the entry never became the main loop".
-_CANT_LOAD = re.compile(r"^Can't load script: (?P<path>\S+?)\.?$")
+# `--script` entry point (`main.cpp:4366`, `"Can't load script: " + script`, Godot
+# 4.6.3). The engine concatenates the raw path with NO trailing period — unlike
+# `_FAILED_LOADING_RESOURCE` below, this sentence carries no format-string
+# punctuation to strip. A `\.?$` strip here silently ate a genuine trailing dot
+# off a dot-terminated path (`res://..` parsed back as `res://.`, #698), so the
+# capture runs to end of line unconditionally.
+_CANT_LOAD = re.compile(r"^Can't load script: (?P<path>\S+)$")
 
 # `ERROR: Can't load the script "<path>" as it doesn't inherit from SceneTree or
 # MainLoop.` — the script compiled fine but cannot BE the one-shot entry point.
@@ -132,9 +136,16 @@ _NOT_A_SCRIPT_BINDING = re.compile(
 # verdict is unaffected (see ``_ENTRY_FAILURE_PRECEDENCE``).
 _CANNOT_OPEN_FILE = re.compile(r"^Cannot open file '(?P<path>[^']*)'")
 
-# `ERROR: Failed loading resource: <path>.` — note the sentence-ending period,
-# which is NOT part of the path and is stripped when the address is read out.
-_FAILED_LOADING_RESOURCE = re.compile(r"^Failed loading resource: (?P<path>\S+?)\.?$")
+# `ERROR: Failed loading resource: <path>.` — `resource_loader.cpp:317`,
+# `vformat("Failed loading resource: %s.", p_path)` (Godot 4.6.3). The format
+# string ALWAYS appends exactly one trailing period, so it is sentence
+# punctuation, never part of the path, and the strip is mandatory rather than
+# optional (an optional strip corrupted a genuinely dot-terminated path, e.g.
+# `res://weird..` parsed back as `res://weird.`, #698). The engine's other
+# "Failed loading resource" wording (`resource_loader.cpp:301`, no trailing
+# period) reaches only `print_verbose`, never an `ERROR:` line `parse_errors`
+# recognizes, so it cannot reach this regex.
+_FAILED_LOADING_RESOURCE = re.compile(r"^Failed loading resource: (?P<path>\S+)\.$")
 
 
 def canonical_res_path(path: str) -> str:

--- a/src/gda/script_errors.py
+++ b/src/gda/script_errors.py
@@ -87,7 +87,7 @@ _LOAD_FAILED = re.compile(
 )
 
 # `ERROR: Can't load script: <path>` — main.cpp's `start()` giving up on the
-# `--script` entry point (`main.cpp:4366`, `"Can't load script: " + script`, Godot
+# `--script` entry point (`main.cpp:4271`, `"Can't load script: " + script`, Godot
 # 4.6.3). The engine concatenates the raw path with NO trailing period — unlike
 # `_FAILED_LOADING_RESOURCE` below, this sentence carries no format-string
 # punctuation to strip. A `\.?$` strip here silently ate a genuine trailing dot
@@ -136,15 +136,19 @@ _NOT_A_SCRIPT_BINDING = re.compile(
 # verdict is unaffected (see ``_ENTRY_FAILURE_PRECEDENCE``).
 _CANNOT_OPEN_FILE = re.compile(r"^Cannot open file '(?P<path>[^']*)'")
 
-# `ERROR: Failed loading resource: <path>.` — `resource_loader.cpp:317`,
+# `ERROR: Failed loading resource: <path>.` — `resource_loader.cpp:343`,
 # `vformat("Failed loading resource: %s.", p_path)` (Godot 4.6.3). The format
 # string ALWAYS appends exactly one trailing period, so it is sentence
-# punctuation, never part of the path, and the strip is mandatory rather than
-# optional (an optional strip corrupted a genuinely dot-terminated path, e.g.
-# `res://weird..` parsed back as `res://weird.`, #698). The engine's other
-# "Failed loading resource" wording (`resource_loader.cpp:301`, no trailing
-# period) reaches only `print_verbose`, never an `ERROR:` line `parse_errors`
-# recognizes, so it cannot reach this regex.
+# punctuation, never part of the path. Unlike `_CANT_LOAD` above, an optional
+# strip here never actually mis-read a well-formed captured line, for any
+# number of trailing dots: the lazy quantifier always finds the guaranteed
+# period regardless of how many dots the path itself carries. The strip is
+# mandatory anyway (#698) — a fail-closed hardening that rejects a line
+# lacking the guaranteed period instead of silently accepting the whole
+# remainder as the path, not a fix for observed corruption. The engine's
+# other "Failed loading resource" wording (`resource_loader.cpp:327`, no
+# trailing period) reaches only `print_verbose`, never an `ERROR:` line
+# `parse_errors` recognizes, so it cannot reach this regex.
 _FAILED_LOADING_RESOURCE = re.compile(r"^Failed loading resource: (?P<path>\S+)\.$")
 
 

--- a/src/gda/script_errors.py
+++ b/src/gda/script_errors.py
@@ -90,10 +90,18 @@ _LOAD_FAILED = re.compile(
 # `--script` entry point (`main.cpp:4271`, `"Can't load script: " + script`, Godot
 # 4.6.3). The engine concatenates the raw path with NO trailing period — unlike
 # `_FAILED_LOADING_RESOURCE` below, this sentence carries no format-string
-# punctuation to strip. A `\.?$` strip here silently ate a genuine trailing dot
-# off a dot-terminated path (`res://..` parsed back as `res://.`, #698), so the
-# capture runs to end of line unconditionally.
-_CANT_LOAD = re.compile(r"^Can't load script: (?P<path>\S+)$")
+# punctuation to strip, so the capture now runs to end of line unconditionally.
+# A `\.?$` strip here used to silently eat a genuine trailing dot off a
+# dot-terminated path (`res://..` parsed back as `res://.`, #698). `.+` rather
+# than `\S+`: a project-relative path MAY contain a space (`res://missing
+# file.`), and `\S+` failed to match the line AT ALL for one — a pre-existing
+# phantom success (present on `main` before #698 too, not introduced by the
+# dot fix), which left NO diagnostic behind rather than a corrupted one, and
+# was masked whenever the path also carried a recognized extension (that
+# shape additionally gets `_OPEN_FAILED`'s quoted, space-safe capture).
+# `engine_log` has already split stderr into lines before this regex ever
+# sees one, so `.+` cannot run past the line it belongs to.
+_CANT_LOAD = re.compile(r"^Can't load script: (?P<path>.+)$")
 
 # `ERROR: Can't load the script "<path>" as it doesn't inherit from SceneTree or
 # MainLoop.` — the script compiled fine but cannot BE the one-shot entry point.
@@ -145,11 +153,15 @@ _CANNOT_OPEN_FILE = re.compile(r"^Cannot open file '(?P<path>[^']*)'")
 # period regardless of how many dots the path itself carries. The strip is
 # mandatory anyway (#698) — a fail-closed hardening that rejects a line
 # lacking the guaranteed period instead of silently accepting the whole
-# remainder as the path, not a fix for observed corruption. The engine's
-# other "Failed loading resource" wording (`resource_loader.cpp:327`, no
-# trailing period) reaches only `print_verbose`, never an `ERROR:` line
-# `parse_errors` recognizes, so it cannot reach this regex.
-_FAILED_LOADING_RESOURCE = re.compile(r"^Failed loading resource: (?P<path>\S+)\.$")
+# remainder as the path, not a fix for observed corruption. `.+` rather than
+# `\S+`, for the same reason as `_CANT_LOAD`: a project-relative path MAY
+# contain a space, and `engine_log` has already split stderr into lines
+# before this regex ever sees one, so `.+` cannot run past the line it
+# belongs to. The engine's other "Failed loading resource" wording
+# (`resource_loader.cpp:327`, no trailing period) reaches only
+# `print_verbose`, never an `ERROR:` line `parse_errors` recognizes, so it
+# cannot reach this regex.
+_FAILED_LOADING_RESOURCE = re.compile(r"^Failed loading resource: (?P<path>.+)\.$")
 
 
 def canonical_res_path(path: str) -> str:

--- a/tests/test_e2e_script_run.py
+++ b/tests/test_e2e_script_run.py
@@ -297,6 +297,10 @@ def test_script_run_absolute_path_is_invalid_path(godot_project):
         "../outside.gd",
         "res://..",
         "res://../outside.gd",
+        # Godot preserves the LF in its emitted path, but the line-oriented parser
+        # splits the diagnostic and loses the entry identity. This used to return a
+        # phantom exit-0 success for a script that never ran.
+        "res://missing\nfile.gd",
     ],
 )
 def test_script_run_non_project_scoped_paths_are_refused_before_launch(
@@ -330,6 +334,33 @@ def test_script_run_non_project_scoped_paths_are_refused_before_launch(
     err = data["error"]
     assert err["code"] == "invalid_path"
     assert err["category"] == "operation"
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("suffix", ["\u00a0", "\u2003"])
+def test_script_run_does_not_overreject_unicode_spaces_godot_preserves(
+    godot_project, suffix
+):
+    # Godot's String::strip_edges() trims code points <= U+0020, not Python's
+    # complete Unicode whitespace set. NBSP and EM SPACE remain part of the path,
+    # so the request must launch and reach the ordinary entry-load verdict rather
+    # than fail pre-launch as invalid_path.
+    script = f"res://missing.gd{suffix}"
+    run = _run_gda(
+        "script",
+        "run",
+        script,
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+    )
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "script_compile_failed"
+    assert script in err["message"]
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_script_run.py
+++ b/tests/test_e2e_script_run.py
@@ -304,14 +304,15 @@ def test_script_run_non_project_scoped_paths_are_refused_before_launch(
 ):
     # Accepting the project-relative form must not accept everything merely
     # non-absolute. Against the REAL engine, because these are exactly the cases where
-    # the engine's own report defeats the verdict: `gda script run ""` normalized to
-    # `res://.`, launched, and the engine's `Can't load script: res://.` parsed back
-    # as `res://` — no match, so a run that never happened reported exit 0 SUCCESS.
-    # `..` did the same one level up. The other-scheme cases spawned the engine
-    # against `res://user:/x.gd`, an address the caller never typed. And a RESOLVABLE
-    # escape (`../outside.gd`) actually executed a script outside the project — the
-    # ADR-0009 widening the amendment cites as its reason for refusing absolute paths,
-    # so it must not be reachable by the relative spelling either.
+    # the engine's own report used to defeat the verdict: `gda script run ""`
+    # normalized to `res://.`, launched, and the engine's `Can't load script:
+    # res://.` parsed back as `res://` — no match, so a run that never happened
+    # reported exit 0 SUCCESS (fixed at the parser level by #698; this refusal stays
+    # regardless). `..` did the same one level up. The other-scheme cases spawned the
+    # engine against `res://user:/x.gd`, an address the caller never typed. And a
+    # RESOLVABLE escape (`../outside.gd`) actually executed a script outside the
+    # project — the ADR-0009 widening the amendment cites as its reason for refusing
+    # absolute paths, so it must not be reachable by the relative spelling either.
     run = _run_gda(
         "script",
         "run",

--- a/tests/test_script_error_parser.py
+++ b/tests/test_script_error_parser.py
@@ -437,7 +437,7 @@ def test_a_non_script_binding_never_fails_an_entry_verdict():
     assert entry_load_failure(errors, "res://entry.gd") is None
 
 
-# --- Dot-terminated paths (#698) -----------------------------------------------
+# --- Dot-terminated and whitespace paths (#698) --------------------------------
 #
 # `_CANT_LOAD` and `_FAILED_LOADING_RESOURCE` both used to strip an OPTIONAL
 # trailing period, on the assumption that any trailing "." in the sentence was
@@ -445,7 +445,17 @@ def test_a_non_script_binding_never_fails_an_entry_verdict():
 # real path character: `Can't load script: res://..` parsed back as `res://.`,
 # which then missed the canonical entry `res://..` and reported a phantom
 # success. `res://weird./x.gd` (the issue's ORIGINAL example) does not end in a
-# dot and never triggered this — every fixture below ends in one.
+# dot and never triggered this — every dot-terminated fixture below ends in one.
+#
+# A second, independently-found defect in the same two regexes: `\S+` cannot
+# match a SPACE, so a project-relative path containing one (`res://missing
+# file.`) failed the WHOLE line, not just the trailing character — no
+# diagnostic at all, rather than a corrupted one. Pre-existing on `main` before
+# this issue (base `04d3e089` phantom-succeeds identically; its own `\S+?\.?$`
+# could not match a space either), and MASKED whenever the path also carries a
+# recognized extension — `res://missing file.gd` still gets `SCRIPT_MISSING`
+# from `_OPEN_FAILED`'s quoted, space-safe capture, so testing only the `.gd`
+# shape hides the bug. Both regexes now use `.+` instead of `\S+`.
 
 # `godot --headless --path <proj> --script "res://.."`, captured verbatim (Godot
 # 4.6.3, macOS). `main.cpp:4271` echoes the raw `--script` argv unconditionally —
@@ -473,31 +483,42 @@ ERROR: Can't load script: res://weird..
    at: start (main/main.cpp:4271)
 """
 
+# The whitespace case — `godot --headless --path <proj> --script "res://missing
+# file."`, also captured verbatim. Same shape again (no extension, so `found`
+# stays false and only `_CANT_LOAD` carries the address), but this is the one
+# `\S+` could not match AT ALL: pre-fix, `parse_script_errors` returned `[]` for
+# this capture (no diagnostic, not a corrupted one), and `gda script run
+# "missing file."` reported a phantom exit-0 success with an empty
+# `diagnostics` list.
+WHITESPACE_ROOT_STDERR = """\
+ERROR: Resource file not found: res://missing file. (expected type: unknown)
+   at: _load (core/io/resource_loader.cpp:351)
+ERROR: Can't load script: res://missing file.
+   at: start (main/main.cpp:4271)
+"""
 
-@pytest.mark.parametrize(
-    ("stderr", "path"),
-    [
-        (DOT_TERMINATED_ROOT_STDERR, "res://.."),
-        (DOT_TERMINATED_STEM_STDERR, "res://weird.."),
-    ],
-)
+# One shared matrix for both the parse-level shape and the verdict-level match
+# below — a case belongs here once, not once per test.
+_CANT_LOAD_BOUNDARY_CASES = [
+    (DOT_TERMINATED_ROOT_STDERR, "res://.."),
+    (DOT_TERMINATED_STEM_STDERR, "res://weird.."),
+    (WHITESPACE_ROOT_STDERR, "res://missing file."),
+]
+
+
+@pytest.mark.parametrize(("stderr", "path"), _CANT_LOAD_BOUNDARY_CASES)
 def test_cant_load_round_trips_a_genuinely_dot_terminated_path(stderr, path):
     errors = parse_script_errors(stderr)
 
     assert [(e.kind, e.path) for e in errors] == [(ScriptErrorKind.LOAD_FAILED, path)]
 
 
-@pytest.mark.parametrize(
-    ("stderr", "path"),
-    [
-        (DOT_TERMINATED_ROOT_STDERR, "res://.."),
-        (DOT_TERMINATED_STEM_STDERR, "res://weird.."),
-    ],
-)
+@pytest.mark.parametrize(("stderr", "path"), _CANT_LOAD_BOUNDARY_CASES)
 def test_cant_load_still_matches_the_entry_when_dot_terminated(stderr, path):
     # Acceptance: the verdict logic's canonical-identity match must not phantom-
     # succeed if an entry route ever reaches this parser with a genuinely
-    # dot-terminated path again (#693 closed the CLI entry route; this covers the
+    # dot-terminated or whitespace-containing path again (#693 closed gda's
+    # pre-launch entry-path refusal for the root/escape shapes; this covers the
     # parser itself, independent of that guard).
     errors = parse_script_errors(stderr)
     verdict = entry_load_failure(errors, path)
@@ -574,6 +595,36 @@ def test_failed_loading_resource_still_matches_the_entry_when_dot_terminated():
     assert verdict is not None
     assert verdict.kind is ScriptErrorKind.RESOURCE_LOAD_FAILED
     assert verdict.path == "res://weird.."
+
+
+# The same whitespace fix, for `_FAILED_LOADING_RESOURCE` — `godot --headless
+# --path <proj> --script "res://missing file.gd"`, captured verbatim. The `.gd`
+# extension is what makes `found=true` reachable at all: unlike `_CANT_LOAD`,
+# this sentence only fires when a loader recognizes the path's extension (see
+# the probe note above `DOT_TERMINATED_RESOURCE_STDERR`), so the no-extension
+# whitespace shape (`WHITESPACE_ROOT_STDERR` above) cannot exercise it. This is
+# the masking case in miniature: `SCRIPT_MISSING` from `_OPEN_FAILED` already
+# carries the correct verdict here regardless of this regex, but the
+# diagnostic itself must still round-trip rather than silently vanishing —
+# pre-fix, `\S+?\.?$` could not match this line at all.
+WHITESPACE_RESOURCE_STDERR = """\
+ERROR: Attempt to open script 'res://missing file.gd' resulted in error 'File not found'.
+   at: load_source_code (modules/gdscript/gdscript.cpp:1127)
+ERROR: Failed loading resource: res://missing file.gd.
+   at: _load (core/io/resource_loader.cpp:343)
+ERROR: Can't load script: res://missing file.gd
+   at: start (main/main.cpp:4271)
+"""
+
+
+def test_failed_loading_resource_round_trips_a_whitespace_path():
+    errors = parse_script_errors(WHITESPACE_RESOURCE_STDERR)
+
+    assert [(e.kind, e.path) for e in errors] == [
+        (ScriptErrorKind.SCRIPT_MISSING, "res://missing file.gd"),
+        (ScriptErrorKind.RESOURCE_LOAD_FAILED, "res://missing file.gd"),
+        (ScriptErrorKind.LOAD_FAILED, "res://missing file.gd"),
+    ]
 
 
 def test_the_ordinary_sentence_period_still_strips_for_both_sentences():

--- a/tests/test_script_error_parser.py
+++ b/tests/test_script_error_parser.py
@@ -448,7 +448,7 @@ def test_a_non_script_binding_never_fails_an_entry_verdict():
 # dot and never triggered this — every fixture below ends in one.
 
 # `godot --headless --path <proj> --script "res://.."`, captured verbatim (Godot
-# 4.6.3, macOS). `main.cpp:4366` echoes the raw `--script` argv unconditionally —
+# 4.6.3, macOS). `main.cpp:4271` echoes the raw `--script` argv unconditionally —
 # "Can't load script: " + script, no format-string punctuation — so the sentence
 # is real evidence for `_CANT_LOAD`'s fix regardless of what else in the engine
 # rejects the address. (The "Resource file not found" sentence is not in this
@@ -507,7 +507,7 @@ def test_cant_load_still_matches_the_entry_when_dot_terminated(stderr, path):
     assert verdict.path == path
 
 
-# `_FAILED_LOADING_RESOURCE` mirrors `resource_loader.cpp:317`'s format string
+# `_FAILED_LOADING_RESOURCE` mirrors `resource_loader.cpp:343`'s format string
 # (`vformat("Failed loading resource: %s.", p_path)`, Godot 4.6.3), which ALWAYS
 # appends exactly one period. For `p_path == "res://weird.."` the sentence carries
 # three trailing dots — two are the path's own, the third is the format string's.
@@ -542,7 +542,7 @@ def test_cant_load_still_matches_the_entry_when_dot_terminated(stderr, path):
 # pin the documented contract, not a red-proofed regression.
 DOT_TERMINATED_RESOURCE_STDERR = (
     "ERROR: Failed loading resource: res://weird...\n"
-    "   at: _load (core/io/resource_loader.cpp:317)\n"
+    "   at: _load (core/io/resource_loader.cpp:343)\n"
 )
 
 
@@ -562,7 +562,7 @@ def test_failed_loading_resource_requires_the_guaranteed_period():
     # an un-punctuated remainder as if it were a resource address.
     errors = parse_script_errors(
         "ERROR: Failed loading resource: res://plain.tres\n"
-        "   at: _load (core/io/resource_loader.cpp:317)\n"
+        "   at: _load (core/io/resource_loader.cpp:343)\n"
     )
     assert errors == []
 
@@ -583,7 +583,7 @@ def test_the_ordinary_sentence_period_still_strips_for_both_sentences():
         "ERROR: Can't load script: res://plain.gd\n"
         "   at: start (main/main.cpp:4271)\n"
         "ERROR: Failed loading resource: res://plain.tres.\n"
-        "   at: _load (core/io/resource_loader.cpp:317)\n"
+        "   at: _load (core/io/resource_loader.cpp:343)\n"
     )
     errors = parse_script_errors(stderr)
 

--- a/tests/test_script_error_parser.py
+++ b/tests/test_script_error_parser.py
@@ -435,3 +435,159 @@ def test_a_non_script_binding_is_a_recognized_diagnostic():
 def test_a_non_script_binding_never_fails_an_entry_verdict():
     errors = parse_script_errors(NOT_A_SCRIPT_BINDING_STDERR)
     assert entry_load_failure(errors, "res://entry.gd") is None
+
+
+# --- Dot-terminated paths (#698) -----------------------------------------------
+#
+# `_CANT_LOAD` and `_FAILED_LOADING_RESOURCE` both used to strip an OPTIONAL
+# trailing period, on the assumption that any trailing "." in the sentence was
+# punctuation. For a res:// address that genuinely ends in a dot, that stripped a
+# real path character: `Can't load script: res://..` parsed back as `res://.`,
+# which then missed the canonical entry `res://..` and reported a phantom
+# success. `res://weird./x.gd` (the issue's ORIGINAL example) does not end in a
+# dot and never triggered this — every fixture below ends in one.
+
+# `godot --headless --path <proj> --script "res://.."`, captured verbatim (Godot
+# 4.6.3, macOS). `main.cpp:4366` echoes the raw `--script` argv unconditionally —
+# "Can't load script: " + script, no format-string punctuation — so the sentence
+# is real evidence for `_CANT_LOAD`'s fix regardless of what else in the engine
+# rejects the address. (The "Resource file not found" sentence is not in this
+# module's recognized closed set and is correctly skipped; `ResourceLoader::
+# recognize_path`'s suffix-extension match never reaches "Failed loading
+# resource" for an address with no registered extension, which is why that
+# sentence cannot come from THIS particular capture — see the synthetic fixture
+# below for that regex instead.)
+DOT_TERMINATED_ROOT_STDERR = """\
+ERROR: Resource file not found: res://.. (expected type: unknown)
+   at: _load (core/io/resource_loader.cpp:351)
+ERROR: Can't load script: res://..
+   at: start (main/main.cpp:4271)
+"""
+
+# Same capture shape with a stem before the trailing dots — `godot --headless
+# --path <proj> --script "res://weird.."`, also captured verbatim.
+DOT_TERMINATED_STEM_STDERR = """\
+ERROR: Resource file not found: res://weird.. (expected type: unknown)
+   at: _load (core/io/resource_loader.cpp:351)
+ERROR: Can't load script: res://weird..
+   at: start (main/main.cpp:4271)
+"""
+
+
+@pytest.mark.parametrize(
+    ("stderr", "path"),
+    [
+        (DOT_TERMINATED_ROOT_STDERR, "res://.."),
+        (DOT_TERMINATED_STEM_STDERR, "res://weird.."),
+    ],
+)
+def test_cant_load_round_trips_a_genuinely_dot_terminated_path(stderr, path):
+    errors = parse_script_errors(stderr)
+
+    assert [(e.kind, e.path) for e in errors] == [(ScriptErrorKind.LOAD_FAILED, path)]
+
+
+@pytest.mark.parametrize(
+    ("stderr", "path"),
+    [
+        (DOT_TERMINATED_ROOT_STDERR, "res://.."),
+        (DOT_TERMINATED_STEM_STDERR, "res://weird.."),
+    ],
+)
+def test_cant_load_still_matches_the_entry_when_dot_terminated(stderr, path):
+    # Acceptance: the verdict logic's canonical-identity match must not phantom-
+    # succeed if an entry route ever reaches this parser with a genuinely
+    # dot-terminated path again (#693 closed the CLI entry route; this covers the
+    # parser itself, independent of that guard).
+    errors = parse_script_errors(stderr)
+    verdict = entry_load_failure(errors, path)
+
+    assert verdict is not None
+    assert verdict.kind is ScriptErrorKind.LOAD_FAILED
+    assert verdict.path == path
+
+
+# `_FAILED_LOADING_RESOURCE` mirrors `resource_loader.cpp:317`'s format string
+# (`vformat("Failed loading resource: %s.", p_path)`, Godot 4.6.3), which ALWAYS
+# appends exactly one period. For `p_path == "res://weird.."` the sentence carries
+# three trailing dots — two are the path's own, the third is the format string's.
+#
+# Hand-authored, not captured: this exact combination cannot come from a real
+# run. `ResourceFormatLoader::recognize_path` (resource_loader.cpp:62)
+# suffix-matches a REGISTERED extension before "Failed loading resource" is
+# reachable at all, and no registered extension is itself a bare "." — probed
+# directly (a running script's `load("res://weird..")`) and confirmed it instead
+# hits the `#ifdef TOOLS_ENABLED` file-not-found branch, the same unrecognized
+# sentence `DOT_TERMINATED_STEM_STDERR` carries above. The format string itself
+# is exercised for real by the ordinary sentence-period fixtures elsewhere in
+# this file (e.g. ``MISSING_STDERR``'s ``res://nope.gd.``); only the dot-count
+# at the tail is synthesized here.
+#
+# NOTE ON THE FIX: unlike `_CANT_LOAD`, this regex's old OPTIONAL strip
+# (`\S+?\.?$`) was never actually corrupted by ANY number of trailing dots on a
+# WELL-FORMED sentence. The lazy quantifier always finds the SMALLEST capture
+# whose remainder is 0 or 1 characters; because the format string guarantees
+# the message's last character is always the appended period, that smallest
+# split is always at `len(message) - 1`, which always strips exactly the
+# guaranteed period and nothing else — for `p_path` ending in 0, 1, 2, or any
+# other number of dots alike (verified exhaustively for every fixture below,
+# both the old and the fixed regex agree byte-for-byte). The mandatory strip
+# below is still correct and adopted per the issue: it makes the regex FAIL
+# CLOSED (no match) on a line that lacks the guaranteed trailing period,
+# instead of silently accepting the whole remainder the way the optional
+# strip did — see `test_failed_loading_resource_requires_the_guaranteed_period`
+# for that one real behavioral difference. But it is not a corruption fix on
+# any genuine engine capture, so — unlike the `_CANT_LOAD` tests above — the
+# round-trip tests below do NOT distinguish pre-fix from post-fix code; they
+# pin the documented contract, not a red-proofed regression.
+DOT_TERMINATED_RESOURCE_STDERR = (
+    "ERROR: Failed loading resource: res://weird...\n"
+    "   at: _load (core/io/resource_loader.cpp:317)\n"
+)
+
+
+def test_failed_loading_resource_round_trips_a_genuinely_dot_terminated_path():
+    errors = parse_script_errors(DOT_TERMINATED_RESOURCE_STDERR)
+
+    assert [(e.kind, e.path) for e in errors] == [
+        (ScriptErrorKind.RESOURCE_LOAD_FAILED, "res://weird.."),
+    ]
+
+
+def test_failed_loading_resource_requires_the_guaranteed_period():
+    # THE one genuine pre/post-fix divergence for this regex: a line that lacks
+    # the format string's guaranteed trailing period. Never produced by the real
+    # engine (the format string always appends it) — this pins the FAIL-CLOSED
+    # contract the mandatory strip now enforces, rather than silently treating
+    # an un-punctuated remainder as if it were a resource address.
+    errors = parse_script_errors(
+        "ERROR: Failed loading resource: res://plain.tres\n"
+        "   at: _load (core/io/resource_loader.cpp:317)\n"
+    )
+    assert errors == []
+
+
+def test_failed_loading_resource_still_matches_the_entry_when_dot_terminated():
+    errors = parse_script_errors(DOT_TERMINATED_RESOURCE_STDERR)
+    verdict = entry_load_failure(errors, "res://weird..")
+
+    assert verdict is not None
+    assert verdict.kind is ScriptErrorKind.RESOURCE_LOAD_FAILED
+    assert verdict.path == "res://weird.."
+
+
+def test_the_ordinary_sentence_period_still_strips_for_both_sentences():
+    # Non-regression: an address that does NOT itself end in a dot must still
+    # have the engine's sentence-ending period stripped, for both fixed regexes.
+    stderr = (
+        "ERROR: Can't load script: res://plain.gd\n"
+        "   at: start (main/main.cpp:4271)\n"
+        "ERROR: Failed loading resource: res://plain.tres.\n"
+        "   at: _load (core/io/resource_loader.cpp:317)\n"
+    )
+    errors = parse_script_errors(stderr)
+
+    assert [(e.kind, e.path) for e in errors] == [
+        (ScriptErrorKind.LOAD_FAILED, "res://plain.gd"),
+        (ScriptErrorKind.RESOURCE_LOAD_FAILED, "res://plain.tres"),
+    ]

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -232,18 +232,33 @@ def test_both_path_forms_reach_one_canonical_address(script):
 @pytest.mark.parametrize(
     ("script", "canonical"),
     [
-        # LEADING and INTERNAL whitespace are unaffected by the engine's own argv
-        # normalization (verified against real Godot 4.6.3) — unlike TRAILING
-        # whitespace (#698, see
-        # test_a_non_project_scoped_path_is_invalid_path_before_any_launch), they
-        # never desync gda's canonical spelling from what the engine echoes back, so
-        # they must stay accepted rather than widening the refusal beyond the
-        # evidence.
+        # LEADING and INTERNAL ASCII SPACES are unaffected by the engine's own argv
+        # normalization (verified against real Godot 4.6.3). Keep this claim narrow:
+        # line-breaking whitespace is unsafe for the line-oriented diagnostic
+        # protocol and is refused separately below.
         (" tests/logic.gd", "res:// tests/logic.gd"),
         ("tests/log ic.gd", "res://tests/log ic.gd"),
     ],
 )
-def test_leading_and_internal_whitespace_are_accepted(script, canonical):
+def test_leading_and_internal_ascii_spaces_are_accepted(script, canonical):
+    outcome, launch = _run(
+        RunResult(stdout="ok\n", stderr="", exit_code=0), script=script
+    )
+
+    assert isinstance(outcome, ScriptRunResult), getattr(outcome, "error", None)
+    (_binary, args, _cwd, _timeout, _label, _watch) = launch.calls[0]
+    assert args == ["--path", str(PROJECT), "--script", canonical]
+    assert outcome.path == canonical
+
+
+@pytest.mark.parametrize("suffix", ["\u00a0", "\u2003"])
+def test_trailing_unicode_spaces_that_godot_preserves_are_accepted(suffix):
+    # Godot 4.6.3's String::strip_edges() removes only code points <= U+0020.
+    # NBSP and EM SPACE therefore survive the --script path and its diagnostic;
+    # Python str.rstrip() is wider and must not define this engine-facing ABI.
+    script = f"tests/logic.gd{suffix}"
+    canonical = f"res://{script}"
+
     outcome, launch = _run(
         RunResult(stdout="ok\n", stderr="", exit_code=0), script=script
     )
@@ -287,18 +302,28 @@ def test_leading_and_internal_whitespace_are_accepted(script, canonical):
         # absolute path, refused above. Both tilde outcomes end on ONE refusal.
         "~nosuchuser/x.gd",
         "~/x.gd",
-        # TRAILING whitespace (#698, adversarial review of PR #756, reproduced on
-        # real Godot 4.6.3): the engine strips it from the `--script` argv before
-        # echoing the path in its own diagnostic, so gda's canonical spelling (which
-        # keeps it) can never match the entry-load verdict's canonical-identity
-        # comparison. That is a PHANTOM SUCCESS again — exit 0, empty diagnostics,
-        # for a script that never ran — on a path the root/escape refusals above do
-        # not catch. Both accepted forms, both with and without a resolved
-        # extension, and a non-space whitespace character too.
+        # A TRAILING code point <= U+0020 (#698 review, reproduced on real Godot
+        # 4.6.3): Godot strips it from the `--script` path before echoing the path in
+        # its diagnostic, so the canonical identity cannot match. Both accepted
+        # forms, with and without an extension, and two members of the engine's
+        # actual trim set.
         "missing file. ",
         "missing file.gd ",
         "res://missing file. ",
         "tests/logic.gd\t",
+        # engine_log splits these characters into separate records. If one appears
+        # anywhere in the path, the emitted address cannot round-trip through the
+        # line-oriented diagnostic protocol and a never-run entry can phantom-pass.
+        "tests/missing\nfile.gd",
+        "tests/missing\rfile.gd",
+        "tests/missing\vfile.gd",
+        "tests/missing\ffile.gd",
+        "tests/missing\x1cfile.gd",
+        "tests/missing\x1dfile.gd",
+        "tests/missing\x1efile.gd",
+        "tests/missing\x85file.gd",
+        "tests/missing\u2028file.gd",
+        "tests/missing\u2029file.gd",
     ],
 )
 def test_a_non_project_scoped_path_is_invalid_path_before_any_launch(script):
@@ -310,9 +335,9 @@ def test_a_non_project_scoped_path_is_invalid_path_before_any_launch(script):
     # PHANTOM SUCCESS (exit 0). This refusal stays regardless of the parser's own fix
     # — a resolvable escape is worse: `../outside.gd` RAN a script outside the
     # project, which is exactly the ADR-0009 widening the amendment cites as its
-    # reason for refusing absolute paths. The trailing-whitespace case is the same
-    # phantom-success failure mode again, via a different mechanism (the engine's
-    # own argv normalization, not the parser) — see #698 / PR #756.
+    # reason for refusing absolute paths. The trailing-engine-trim and embedded-line-
+    # boundary cases are the same phantom-success failure mode through two other
+    # identity-loss mechanisms — see #698 / PR #756.
     outcome, launch = _run(RunResult(stdout="", stderr="", exit_code=0), script=script)
 
     assert isinstance(outcome, Failure)

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -230,6 +230,31 @@ def test_both_path_forms_reach_one_canonical_address(script):
 
 
 @pytest.mark.parametrize(
+    ("script", "canonical"),
+    [
+        # LEADING and INTERNAL whitespace are unaffected by the engine's own argv
+        # normalization (verified against real Godot 4.6.3) — unlike TRAILING
+        # whitespace (#698, see
+        # test_a_non_project_scoped_path_is_invalid_path_before_any_launch), they
+        # never desync gda's canonical spelling from what the engine echoes back, so
+        # they must stay accepted rather than widening the refusal beyond the
+        # evidence.
+        (" tests/logic.gd", "res:// tests/logic.gd"),
+        ("tests/log ic.gd", "res://tests/log ic.gd"),
+    ],
+)
+def test_leading_and_internal_whitespace_are_accepted(script, canonical):
+    outcome, launch = _run(
+        RunResult(stdout="ok\n", stderr="", exit_code=0), script=script
+    )
+
+    assert isinstance(outcome, ScriptRunResult), getattr(outcome, "error", None)
+    (_binary, args, _cwd, _timeout, _label, _watch) = launch.calls[0]
+    assert args == ["--path", str(PROJECT), "--script", canonical]
+    assert outcome.path == canonical
+
+
+@pytest.mark.parametrize(
     "script",
     [
         # Absolute: outside the --project context (#675 keeps this refusal).
@@ -262,6 +287,18 @@ def test_both_path_forms_reach_one_canonical_address(script):
         # absolute path, refused above. Both tilde outcomes end on ONE refusal.
         "~nosuchuser/x.gd",
         "~/x.gd",
+        # TRAILING whitespace (#698, adversarial review of PR #756, reproduced on
+        # real Godot 4.6.3): the engine strips it from the `--script` argv before
+        # echoing the path in its own diagnostic, so gda's canonical spelling (which
+        # keeps it) can never match the entry-load verdict's canonical-identity
+        # comparison. That is a PHANTOM SUCCESS again — exit 0, empty diagnostics,
+        # for a script that never ran — on a path the root/escape refusals above do
+        # not catch. Both accepted forms, both with and without a resolved
+        # extension, and a non-space whitespace character too.
+        "missing file. ",
+        "missing file.gd ",
+        "res://missing file. ",
+        "tests/logic.gd\t",
     ],
 )
 def test_a_non_project_scoped_path_is_invalid_path_before_any_launch(script):
@@ -273,7 +310,9 @@ def test_a_non_project_scoped_path_is_invalid_path_before_any_launch(script):
     # PHANTOM SUCCESS (exit 0). This refusal stays regardless of the parser's own fix
     # — a resolvable escape is worse: `../outside.gd` RAN a script outside the
     # project, which is exactly the ADR-0009 widening the amendment cites as its
-    # reason for refusing absolute paths.
+    # reason for refusing absolute paths. The trailing-whitespace case is the same
+    # phantom-success failure mode again, via a different mechanism (the engine's
+    # own argv normalization, not the parser) — see #698 / PR #756.
     outcome, launch = _run(RunResult(stdout="", stderr="", exit_code=0), script=script)
 
     assert isinstance(outcome, Failure)

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -379,6 +379,45 @@ def test_missing_entry_script_is_a_failure_despite_the_zero_exit():
     assert outcome.error.diagnostics == MISSING_STDERR
 
 
+# Independent finding, same #698 fix: a project-relative path containing a SPACE
+# reached `_CANT_LOAD`'s old `\S+` capture and failed to match the WHOLE line —
+# no diagnostic at all, not a corrupted one — so `entry_load_failure` found
+# nothing and this operation fell through to the SUCCESS branch: a phantom
+# `ScriptRunResult` with `exit_status: 0` and an empty `diagnostics` list, for a
+# script that never ran. Captured verbatim from `godot --headless --path <proj>
+# --script "res://missing file."` (Godot 4.6.3, macOS) — same shape as
+# MISSING_STDERR above, minus the extension (so only `_CANT_LOAD` carries the
+# address; the `.gd` spelling MASKS this bug via `_OPEN_FAILED`'s quoted,
+# space-safe capture, so testing only that shape would wrongly conclude there
+# is no defect — see tests/test_script_error_parser.py for the parser-level
+# coverage of both this and the extension-masked shape).
+WHITESPACE_STDERR = """\
+ERROR: Resource file not found: res://missing file. (expected type: unknown)
+   at: _load (core/io/resource_loader.cpp:351)
+ERROR: Can't load script: res://missing file.
+   at: start (main/main.cpp:4271)
+"""
+
+
+def test_a_whitespace_entry_path_is_a_failure_despite_the_zero_exit():
+    # Public-verdict regression: assert the OPERATION's outcome flips from a
+    # phantom success to the registered failure end-to-end, through the SAME
+    # validate -> launch -> classify recipe every other verdict test here drives
+    # — not that the parser's regex captures the path correctly in isolation
+    # (that is asserted separately, at the parser level, in
+    # tests/test_script_error_parser.py).
+    outcome, _ = _run(
+        RunResult(stdout="", stderr=WHITESPACE_STDERR, exit_code=0),
+        script="missing file.",
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "script_compile_failed"
+    assert outcome.exit_code == EXIT_OPERATION
+    assert "res://missing file." in outcome.error.message
+    assert outcome.error.diagnostics == WHITESPACE_STDERR
+
+
 def test_entry_parse_error_is_a_failure_despite_the_zero_exit():
     # GDA-DF-007: a non-compiling entry script also leaves exit 0 behind. The
     # engine's own sentence is carried in the message so the reason is readable

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -246,9 +246,10 @@ def test_both_path_forms_reach_one_canonical_address(script):
         "sub/..",
         "res://",
         "res://.",
-        # Escapes ABOVE the root, in both spellings. `..` phantom-succeeded (the
-        # engine's `Can't load script: res://..` parses back as `res://.`), and
-        # `../outside.gd` actually EXECUTED a script outside the project.
+        # Escapes ABOVE the root, in both spellings. `..` phantom-succeeded before
+        # #698 fixed the parser (the engine's `Can't load script: res://..` used to
+        # parse back as `res://.`), and `../outside.gd` actually EXECUTED a script
+        # outside the project — refused regardless of the parser's own fix.
         "..",
         "sub/../..",
         "../outside.gd",
@@ -267,9 +268,10 @@ def test_a_non_project_scoped_path_is_invalid_path_before_any_launch(script):
     # The path ABI edge (ADR-0031, narrowed by #675): accepting the project-relative
     # form must not accept everything ELSE that is merely non-absolute. The root and
     # escape cases are load-bearing — the engine answers `Can't load script: res://.`
-    # / `res://..`, whose address the parser reads back with the sentence period
-    # stripped, so it never matches the entry and the run reported a PHANTOM SUCCESS
-    # (exit 0). A resolvable escape is worse: `../outside.gd` RAN a script outside the
+    # / `res://..`, and before #698 fixed the parser that address came back with the
+    # sentence period stripped, so it never matched the entry and the run reported a
+    # PHANTOM SUCCESS (exit 0). This refusal stays regardless of the parser's own fix
+    # — a resolvable escape is worse: `../outside.gd` RAN a script outside the
     # project, which is exactly the ADR-0009 widening the amendment cites as its
     # reason for refusing absolute paths.
     outcome, launch = _run(RunResult(stdout="", stderr="", exit_code=0), script=script)


### PR DESCRIPTION
## Summary

`gda.script_errors`'s `_CANT_LOAD` and `_FAILED_LOADING_RESOURCE` regexes carried two independent defects for a `res://` address with an unusual shape.

**1. `_CANT_LOAD` corrupted a genuinely dot-terminated path.** It stripped an optional trailing period on the assumption it was always sentence punctuation:

```
>>> _CANT_LOAD.match("Can't load script: res://..").group("path")
'res://.'
```

That mismatches the canonical entry `res://..`, so an entry route reaching this parser would report a phantom success (exit 0) for a run that never happened. `#693` already closed gda's pre-launch refusal for the root/escape shapes that could trigger this for `script run`, but the parser weakness itself remained for the other live consumers: dependency/diagnostic paths in `script run` results, the timeout path (#655), and scene-preflight (#664).

**2. Both regexes rejected a path containing whitespace — found by external adversarial review of this PR, reproduced independently on real Godot 4.6.3.** `\S+` cannot match a space, so a project-relative path containing one (`res://missing file.`) failed the WHOLE line, not just the trailing character:

```
$ gda script run "missing file." --project <p> --json
{"path":"res://missing file.","exit_status":0,...,"diagnostics":[]}
```

No diagnostic was produced at all, so `entry_load_failure` found nothing and the run reported a phantom exit-0 success with empty diagnostics — the same class of defect as (1), on a different boundary. **Pre-existing, not introduced by this PR**: base `04d3e089` phantom-succeeds identically, since its original `\S+?\.?$` could not match a space either. **Masked whenever the path also carries a recognized extension** — `res://missing file.gd` still resolves correctly via `_OPEN_FAILED`'s quoted, space-safe capture (`'res://missing file.gd' resulted in error 'File not found'`) — so a check that only exercises the `.gd` shape concludes there is no bug.

Per-site fixes, verified against Godot **4.6.3-stable** (an earlier pass in this PR mis-cited a local `../godot` checkout that turned out to be a development tree 3260 commits past 4.6.3-stable; corrected to match the fixtures, which are captured against the real 4.6.3 binary), not a general longest-candidate heuristic (explicitly declined for this issue):

- `_CANT_LOAD` mirrors `main.cpp:4271` — `"Can't load script: " + script`, which **never** appends a period. Now `re.compile(r"^Can't load script: (?P<path>.+)$")` — the optional period strip is dropped, and `.+` replaces `\S+` so a space no longer fails the whole match.
- `_FAILED_LOADING_RESOURCE` mirrors `resource_loader.cpp:343` — `vformat("Failed loading resource: %s.", p_path)`, which **always** appends exactly one period. Now `re.compile(r"^Failed loading resource: (?P<path>.+)\.$")` — the strip is mandatory (fails closed on a line lacking the guaranteed period) and `.+` replaces `\S+` for the same whitespace reason. `gda.engine_log` already splits stderr into lines before either regex sees one, so `.+` cannot run past the line it belongs to.

Confirmed `resource_loader.cpp:327`'s unpunctuated `print_verbose` variant of the same sentence cannot reach this parser: it emits no `ERROR:` record, and `gda.engine_log.parse_errors` only recognizes `ERROR:`/`WARNING:`/`SCRIPT ERROR:`/`SHADER ERROR:` headers.

### A finding worth flagging

Unlike `_CANT_LOAD`, `_FAILED_LOADING_RESOURCE`'s old *optional* period strip was never actually corrupted on any well-formed captured line, for any number of trailing dots — verified both mathematically and by exhaustive check. The lazy `\S+?\.?$` quantifier always finds the smallest capture whose remainder is 0-or-1 chars; since the format string guarantees the message's last character is the appended period, that smallest split always lands exactly on the guaranteed period, regardless of how many dots `p_path` itself ends in. The mandatory strip is still correct and adopted per this issue — it makes the regex fail closed on a line that lacks the guaranteed period, and makes the invariant explicit rather than relying on an accidental-but-correct quantifier interaction — but it is not fixing a live corruption bug the way the `_CANT_LOAD` dot-strip was. (The whitespace defect above is a separate, independent bug that *does* affect both regexes equally — the mathematical argument here is about the period strip only.)

## Test plan

- [x] `uv run pytest -q -m "not e2e"` — `1913 passed, 539 deselected in 70.46s (0:01:10)`
- [x] `uv run ruff check .` — `All checks passed!`
- [x] `uv run ruff format --check .` — `472 files already formatted`
- [x] `uv run pyright` — `0 errors, 0 warnings, 0 informations`
- [x] Red-proof (dot-termination): stashed the source fix, reran the parser tests — 5 failed against pre-fix code (4 `_CANT_LOAD` dot-terminated regressions + 1 `_FAILED_LOADING_RESOURCE` fail-closed regression); popped the stash and confirmed all pass again.
- [x] Red-proof (whitespace): stashed the source fix again after adding the whitespace fixtures and the public-verdict test — 4 failed against pre-fix code (2 parser-level `_CANT_LOAD` whitespace cases, 1 `_FAILED_LOADING_RESOURCE` whitespace round-trip, and `test_a_whitespace_entry_path_is_a_failure_despite_the_zero_exit`, which reproduced the exact phantom-success shape from the live repro: `ScriptRunResult(exit_status=0, diagnostics=[])` instead of a `Failure`); popped the stash and confirmed all pass again.
- [ ] Godot e2e — not run; not needed for this parser-level slice per the dispatch brief (the fix has no other CLI-surface change; `#693` already owns the entry-route e2e coverage).

New regression fixtures for `_CANT_LOAD` (`res://..`, `res://weird..`, and `res://missing file.`) and the whitespace `_FAILED_LOADING_RESOURCE` case (`res://missing file.gd`) are captured verbatim from real `godot --headless --script "..."` runs (Godot 4.6.3, macOS), per the file's fixture convention. The dot-terminated `_FAILED_LOADING_RESOURCE` fixture is hand-authored (a real run cannot produce that exact combination — `ResourceFormatLoader::recognize_path` suffix-matches a registered extension before that sentence is reachable, and no registered extension is itself a bare `.`; probed directly and confirmed), documented as such in the test comments.

Also adds a **public-verdict** regression at the operation level (`tests/test_script_run_operation.py::test_a_whitespace_entry_path_is_a_failure_despite_the_zero_exit`) that drives `run_script_run_operation` end-to-end through its real validate → launch → classify recipe and asserts the outcome flips from a phantom `ScriptRunResult` success to the registered `script_compile_failed` `Failure` — not inferred from the regex matching alone. Merges the `_CANT_LOAD` dot-terminated parametrize matrix (previously duplicated across two test functions) into one shared list, folding the new whitespace case in rather than adding a third copy.

The ADR-0031 outcome note is updated to describe what the code now does (captures to end of line unconditionally, via `.+`) and records the whitespace hole as pre-existing rather than introduced by this PR.

## Consumers checked for a pin on the old behavior

Searched every consumer named in the issue (`gda script run`, its timeout path, scene-preflight) plus every test file referencing `Can't load script:` / `Failed loading resource:`. No test asserts the corrupted (pre-fix) parse as expected behavior. Three explanatory comments described the old `_CANT_LOAD` dot-strip corruption as the *reason* `script run` refuses root/escape paths before any launch, and went stale after that fix:

- `src/gda/commands/script.py` (~1174-1177) — inside `#713`'s ownership; left untouched, routed to that slice instead of edited here.
- `tests/test_script_run_operation.py` (two spots) and `tests/test_e2e_script_run.py` (one spot, caught in a follow-up pass) — unowned by any slice this wave, so rewritten in place to read as history (`#698 fixed the parser …`) without implying the parser still corrupts; the refusal itself is unchanged and stays load-bearing regardless, independent of the parser (ADR-0009's Trusted project).

## Update: a fourth defect, one layer above the parser (trailing whitespace)

External adversarial review of this PR found a fourth defect, reproduced independently on real Godot 4.6.3, one level up from the parser fixes above. It survives the `.+` capture fix: it is not a parsing gap, it is a canonical-identity mismatch.

```
$ gda script run "missing file. " --project <p> --json
{"path":"res://missing file. ","exit_status":0,"stdout":"...","diagnostics":[]}
   stderr contains: ERROR: Can't load script: res://missing file.
```

Godot strips trailing whitespace from the `--script` argv *before* it ever echoes the path back in a load-failure diagnostic, so the engine's address (`res://missing file.`) loses what gda's own canonical spelling keeps (`res://missing file. `, since `canonical_res_path` is purely lexical `posixpath.normpath` and does not strip it). The canonical-identity comparison the never-ran verdict depends on then misses on that one trailing character, and the run reports the same phantom success (exit 0, empty `diagnostics`) the root/escape refusals in `_project_scoped_res_path` already exist to prevent — on a path neither of them admits. `missing file.gd ` has the same shape (masked from the parser-level fixture work above by `_OPEN_FAILED`'s quoted, space-safe capture, but not from this mismatch).

`_project_scoped_res_path` (`src/gda/commands/script.py`) now refuses exactly the suffix set Godot 4.6.3 removes before reporting the path: a trailing code point at or below U+0020. It does not trim the caller's address, because that would launch a different script. It also refuses any canonical address containing a line boundary recognized by `gda.engine_log`; such a character splits the emitted address across records, so no diagnostic retains the entry identity.

Scoped to the two verified identity-loss mechanisms: trailing U+0000..U+0020 and engine-log line boundaries are refused. Leading and internal ASCII spaces remain accepted. NBSP (U+00A0) and EM SPACE (U+2003) also remain accepted because Godot preserves them; this explicitly avoids Python `str.rstrip()`, whose Unicode whitespace set is wider than the engine's.

- [x] Public-operation regressions: the no-launch matrix covers the engine-trim suffixes and all line-boundary characters recognized by Python `splitlines`; separate unit and real-engine cases prove NBSP/EM SPACE are not over-rejected.
- [x] `uv run pytest -q -m "not e2e"` — `1919 passed, 539 deselected in 152.96s (0:02:32)`
- [x] `uv run ruff check .` — `All checks passed!`
- [x] `uv run ruff format --check .` — `472 files already formatted`
- [x] `uv run pyright` — `0 errors, 0 warnings, 0 informations`
- [x] Red-proof: committed the fix (`feff4381`), reverted only `src/gda/commands/script.py` to the parent commit, reran — 4 failed, each reproducing a real phantom `ScriptRunResult` (e.g. `ScriptRunResult(path='res://tests/logic.gd\t', exit_status=0, ..., diagnostics=[])`) instead of the expected `Failure`; restored the fix and confirmed all pass again.
- [x] Manual repro against real Godot 4.6.3 (`gda script run`, both path forms, with and without a `.gd` extension) before and after the fix, plus leading/internal-whitespace non-regression.

This defect also exists on the base (`origin/feat/gda-dogfooding-dev`, unaffected by the parser fixes above), but it is the same class as the whitespace P1 this PR already closes, so it closes here too.

Closes #698


## Update: exact Godot trim set and engine-log line boundaries

The round-3 re-review found that Python `str.rstrip()` both under-specified the diagnostic boundary and over-rejected Unicode spaces. Commit `517a3071` replaces it with the exact Godot 4.6.3 trailing rule (code point <= U+0020) and reuses `gda.engine_log.lines` to reject any address that cannot remain one diagnostic record. ADR-0031 now owns the complete pre-launch refusal set and the exact terminology.

Validation at `517a3071`:

- `tests/test_script_error_parser.py tests/test_script_run_operation.py tests/test_script_run_commands.py`: **203 passed**.
- Real Godot 4.6.3 regressions for the internal-LF refusal and NBSP/EM SPACE non-overreach: **13 passed**.
- Ruff check/format: pass.
- Pyright: **0 errors, 0 warnings, 0 informations**.

This section supersedes the earlier broad "trailing whitespace" and "leading/internal whitespace" wording. The implemented contract is expressed only in terms of Godot's exact trim set and the engine-log line protocol.
