### PR TITLE
test(gda): deflake the streaming-launch timeout test's fake-engine startup race

### DIFF
--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -319,12 +320,11 @@ def test_streaming_timeout_preserves_the_output_the_child_already_wrote(
     # the real child's startup, narrowed only by a cheap shell engine (see
     # ``_fast_fake_engine``) — a residual race, later removed outright by
     # controlling the CLOCK the runner's poll loop reads instead of the runner's
-    # behaviour: ``gda.runner`` does a plain ``import time`` and calls
-    # ``time.monotonic()``, so patching ``runner.time.monotonic`` redirects just
-    # that one lookup. ``subprocess`` and ``threading`` instead bind their own
-    # ``_time = monotonic`` reference at import time, so the child's real
-    # ``proc.wait()`` grace period and the reader-thread ``join()`` are untouched —
-    # only the poll loop's idea of "how much time has passed" is fake.
+    # behaviour: ``gda.runner`` does a plain ``import time``, so replacing that
+    # module binding with a runner-local proxy redirects its ``monotonic`` lookup
+    # without mutating the process-global stdlib module. The proxy delegates
+    # ``sleep`` to the real function, so only the poll loop's idea of "how much
+    # time has passed" is fake.
     #
     # The fake reports elapsed 0.0 until the watch's accumulated capture actually
     # contains both lines the assertions below check, then jumps past any timeout
@@ -343,8 +343,9 @@ def test_streaming_timeout_preserves_the_output_the_child_already_wrote(
     engine = _fast_fake_engine(tmp_path, "SUITE START", "boom")
     watch = _RecordingWatch()
 
-    # Captured BEFORE patching — calling this (not ``time.monotonic``) inside the
-    # fake avoids the fake recursing into itself.
+    # Captured BEFORE replacing the runner's module binding. The stdlib module
+    # itself stays untouched, and the fake uses the saved function for its
+    # independent real-time safety ceiling.
     real_monotonic = time.monotonic
     real_deadline = real_monotonic() + 15.0  # generous real-time safety ceiling
 
@@ -358,7 +359,13 @@ def test_streaming_timeout_preserves_the_output_the_child_already_wrote(
         both_lines_seen = "SUITE START" in watch.stdout and "boom" in watch.stderr
         return 100.0 if both_lines_seen else 0.0
 
-    monkeypatch.setattr(runner.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(
+        runner,
+        "time",
+        SimpleNamespace(monotonic=fake_monotonic, sleep=time.sleep),
+    )
+    assert runner.time is not time
+    assert time.monotonic is real_monotonic
 
     result = launch(engine, [], cwd=None, timeout=1.0, watch=watch, timeout_label="X")
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -249,15 +249,21 @@ def _fast_fake_engine(tmp_path: Path, stdout_line: str, stderr_line: str) -> Pat
     """A ``/bin/sh`` stand-in, for the one test where startup latency IS the point (#728).
 
     Diverges from ``_fake_engine`` on purpose: that one pays a fresh Python
-    interpreter's startup (measured at #728: ~25-30ms typical, spiking past
-    900ms under load — plenty of margin for every other streaming test here,
-    which race nothing) before it writes a byte. The timeout-preserves-output
-    test needs the real child to have ALREADY written before ``launch``'s
-    timeout elapses, so shrinking that head start is the fix: a shell has no
-    interpreter to load, so it typically writes within single-digit
-    milliseconds (measured at #728: ~6-10ms, worst observed under 12-way CPU
-    load ~0.5s) — two-plus orders of magnitude below the caller's timeout
-    instead of the same order of magnitude it used to be.
+    interpreter's startup before it writes a byte — plenty of margin for
+    every other streaming test here, which race nothing. ``/bin/sh`` is an
+    interpreter too, but a far cheaper one to start than Python's, and that
+    gap is what the timeout-preserves-output test needs, since its child must
+    have ALREADY written before ``launch``'s timeout elapses. The measurements
+    and the margin they justify live in that ONE test's own comment, next to
+    the timeout value they argue for — not restated here, so there is a single
+    place to update rather than two copies that can silently drift apart (a
+    real defect an earlier #728 review round caught).
+
+    ``printf '%s\\n'``, not ``echo``: XSI ``echo`` interprets backslash
+    escapes in its operand on this platform's ``/bin/sh``, so a payload
+    containing ``\\n`` or similar would print something other than what was
+    passed in. ``printf`` with a literal ``'%s\\n'`` format leaves the
+    (``shlex.quote``-escaped, so shell-syntax-safe) argument untouched.
 
     It always ``sleep``s afterward, past any timeout this suite uses, via
     ``exec`` — not a trailing background job. Without ``exec`` SIGTERM only
@@ -269,7 +275,7 @@ def _fast_fake_engine(tmp_path: Path, stdout_line: str, stderr_line: str) -> Pat
     out = shlex.quote(stdout_line)
     err = shlex.quote(stderr_line)
     script.write_text(
-        f"#!/bin/sh\necho {out}\necho {err} 1>&2\nexec sleep 30\n",
+        f"#!/bin/sh\nprintf '%s\\n' {out}\nprintf '%s\\n' {err} 1>&2\nexec sleep 30\n",
         encoding="utf-8",
     )
     script.chmod(0o755)
@@ -307,19 +313,17 @@ def test_streaming_timeout_preserves_the_output_the_child_already_wrote(tmp_path
     #
     # THE #728 FIX: proving that means the child must ALREADY have written before
     # the timeout below elapses — a real race against a real process's startup.
-    # ``_fast_fake_engine`` (not the shared ``_fake_engine``) keeps that race from
-    # being a coin flip: no interpreter to load means the write typically lands in
-    # single-digit milliseconds, two-plus orders of magnitude inside the deadline
-    # instead of sharing its order of magnitude (see its docstring for the
-    # measurements this margin is based on, not asserted from). The timeout is
-    # also doubled from the pre-#728 1.5s to 3.0s: steady state is tight (180
-    # measured runs, ~4ms typical, max 5.1ms), but isolated FIRST-invocation
-    # outliers of 312ms and 1110ms were observed across independent
-    # measurement runs — and this test spawns the engine exactly once per
-    # suite, so that cold start IS its normal path, not a rare one the steady
-    # state can stand in for. Against the worst observed outlier, 1.5s leaves
-    # only ~1.35x headroom; 3.0s leaves ~2.7x, cheaply (the fake engine never
-    # exits on its own, so this is the test's own wall-clock cost either way).
+    # ``_fast_fake_engine`` (not the shared ``_fake_engine``) narrows that race:
+    # starting ``/bin/sh`` is far cheaper than starting a Python interpreter (see
+    # its docstring), so the write lands sooner. The timeout is ALSO doubled from
+    # the pre-#728 1.5s to 3.0s, because "sooner" still has a tail: steady state is
+    # tight (180 measured runs, ~4ms typical, max 5.1ms), but isolated
+    # FIRST-invocation outliers of 312ms and 1110ms were observed across
+    # independent measurement runs — and this test spawns the engine exactly once
+    # per suite, so that cold start IS its normal path, not a rare one the steady
+    # state can stand in for. Against the worst observed outlier, 1.5s leaves only
+    # ~1.35x headroom; 3.0s leaves ~2.7x. This is the ONE place these numbers are
+    # recorded; nothing else in this file restates them (#728 review).
     engine = _fast_fake_engine(tmp_path, "SUITE START", "boom")
 
     result = launch(

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -312,14 +312,14 @@ def test_streaming_timeout_preserves_the_output_the_child_already_wrote(tmp_path
     # single-digit milliseconds, two-plus orders of magnitude inside the deadline
     # instead of sharing its order of magnitude (see its docstring for the
     # measurements this margin is based on, not asserted from). The timeout is
-    # also doubled from the pre-#728 1.5s to 3.0s: across 40 measured runs the
-    # observed worst-case time-to-first-output was ~312ms, and that max came
-    # from an UNLOADED run (12-way CPU load's own max was only ~20ms) — the
-    # tail is not purely load-driven, so reasoning from the typical case alone
-    # would repeat the error that produced the original flake. 1.5s leaves
-    # only ~4.8x headroom over that observed tail; 3.0s leaves ~9.6x, cheaply
-    # (the fake engine never exits on its own, so this is the test's own
-    # wall-clock cost either way).
+    # also doubled from the pre-#728 1.5s to 3.0s: steady state is tight (180
+    # measured runs, ~4ms typical, max 5.1ms), but isolated FIRST-invocation
+    # outliers of 312ms and 1110ms were observed across independent
+    # measurement runs — and this test spawns the engine exactly once per
+    # suite, so that cold start IS its normal path, not a rare one the steady
+    # state can stand in for. Against the worst observed outlier, 1.5s leaves
+    # only ~1.35x headroom; 3.0s leaves ~2.7x, cheaply (the fake engine never
+    # exits on its own, so this is the test's own wall-clock cost either way).
     engine = _fast_fake_engine(tmp_path, "SUITE START", "boom")
 
     result = launch(

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -13,6 +13,7 @@ suite.
 import shlex
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -246,18 +247,18 @@ def _fake_engine(tmp_path: Path, body: str) -> Path:
 
 
 def _fast_fake_engine(tmp_path: Path, stdout_line: str, stderr_line: str) -> Path:
-    """A ``/bin/sh`` stand-in, for the one test where startup latency IS the point (#728).
+    """A ``/bin/sh`` stand-in, kept for WALL-CLOCK SPEED, not correctness (#728).
 
     Diverges from ``_fake_engine`` on purpose: that one pays a fresh Python
-    interpreter's startup before it writes a byte — plenty of margin for
-    every other streaming test here, which race nothing. ``/bin/sh`` is an
-    interpreter too, but a far cheaper one to start than Python's, and that
-    gap is what the timeout-preserves-output test needs, since its child must
-    have ALREADY written before ``launch``'s timeout elapses. The measurements
-    and the margin they justify live in that ONE test's own comment, next to
-    the timeout value they argue for — not restated here, so there is a single
-    place to update rather than two copies that can silently drift apart (a
-    real defect an earlier #728 review round caught).
+    interpreter's startup before it writes a byte. The one test that uses this
+    (``test_streaming_timeout_preserves_the_output_the_child_already_wrote``)
+    used to race that startup against a real deadline; that race is gone —
+    the test now controls the runner's clock directly, so a slower child could
+    no longer flip the result. ``/bin/sh`` stays anyway: the test still waits,
+    in real wall-clock time, for this REAL child to actually write its output
+    before the (now fake) deadline is allowed to cross, and a cheap shell keeps
+    that wait — and the suite — fast rather than paying a Python interpreter's
+    startup for no reason.
 
     ``printf '%s\\n'``, not ``echo``: XSI ``echo`` interprets backslash
     escapes in its operand on this platform's ``/bin/sh``, so a payload
@@ -305,30 +306,61 @@ class _RecordingWatch:
         return bool(self.abort_when and self.abort_when(self.stderr))
 
 
-def test_streaming_timeout_preserves_the_output_the_child_already_wrote(tmp_path):
+def test_streaming_timeout_preserves_the_output_the_child_already_wrote(
+    monkeypatch, tmp_path
+):
     # THE #655 DEFECT: a buffered capture discards everything on a timeout, so a
     # script error Godot had ALREADY printed was lost (GDA-DF-012). With a watch the
     # capture survives, on BOTH streams, and no gda prose is mixed into either — the
     # watching channel composes its own diagnostics from this.
     #
-    # THE #728 FIX: proving that means the child must ALREADY have written before
-    # the timeout below elapses — a real race against a real process's startup.
-    # ``_fast_fake_engine`` (not the shared ``_fake_engine``) narrows that race:
-    # starting ``/bin/sh`` is far cheaper than starting a Python interpreter (see
-    # its docstring), so the write lands sooner. The timeout is ALSO doubled from
-    # the pre-#728 1.5s to 3.0s, because "sooner" still has a tail: steady state is
-    # tight (180 measured runs, ~4ms typical, max 5.1ms), but isolated
-    # FIRST-invocation outliers of 312ms and 1110ms were observed across
-    # independent measurement runs — and this test spawns the engine exactly once
-    # per suite, so that cold start IS its normal path, not a rare one the steady
-    # state can stand in for. Against the worst observed outlier, 1.5s leaves only
-    # ~1.35x headroom; 3.0s leaves ~2.7x. This is the ONE place these numbers are
-    # recorded; nothing else in this file restates them (#728 review).
+    # THE #728 FIX: proving that needs the child to have ALREADY written before the
+    # deadline. An earlier version of this test raced a real 3.0s deadline against
+    # the real child's startup, narrowed only by a cheap shell engine (see
+    # ``_fast_fake_engine``) — a residual race, later removed outright by
+    # controlling the CLOCK the runner's poll loop reads instead of the runner's
+    # behaviour: ``gda.runner`` does a plain ``import time`` and calls
+    # ``time.monotonic()``, so patching ``runner.time.monotonic`` redirects just
+    # that one lookup. ``subprocess`` and ``threading`` instead bind their own
+    # ``_time = monotonic`` reference at import time, so the child's real
+    # ``proc.wait()`` grace period and the reader-thread ``join()`` are untouched —
+    # only the poll loop's idea of "how much time has passed" is fake.
+    #
+    # The fake reports elapsed 0.0 until the watch's accumulated capture actually
+    # contains both lines the assertions below check, then jumps past any timeout
+    # in one step — so the loop keeps making REAL polls, on a REAL process, in REAL
+    # wall-clock time, until the REAL output arrives, and only then does the
+    # deadline "elapse". A real-clock safety ceiling (independent of the fake)
+    # fails the test loudly, with whatever was captured so far, if that output
+    # never arrives at all — a hang becomes an assertion, not a stuck suite.
+    #
+    # ``timeout`` below is consequently INERT: the loop only ever observes elapsed
+    # 0.0 or the fake's post-observation jump, so any positive value under that
+    # jump behaves identically. It is kept small (1.0) to say so — the 1.5s/3.0s
+    # cold-start margin math it used to carry (measured outliers of 312ms/1110ms
+    # against a real deadline) no longer applies now that nothing races it, and is
+    # deleted rather than kept as unused history.
     engine = _fast_fake_engine(tmp_path, "SUITE START", "boom")
+    watch = _RecordingWatch()
 
-    result = launch(
-        engine, [], cwd=None, timeout=3.0, watch=_RecordingWatch(), timeout_label="X"
-    )
+    # Captured BEFORE patching — calling this (not ``time.monotonic``) inside the
+    # fake avoids the fake recursing into itself.
+    real_monotonic = time.monotonic
+    real_deadline = real_monotonic() + 15.0  # generous real-time safety ceiling
+
+    def fake_monotonic() -> float:
+        now = real_monotonic()
+        if now > real_deadline:
+            raise AssertionError(
+                "safety ceiling: the child's output never arrived "
+                f"(stdout={watch.stdout!r} stderr={watch.stderr!r})"
+            )
+        both_lines_seen = "SUITE START" in watch.stdout and "boom" in watch.stderr
+        return 100.0 if both_lines_seen else 0.0
+
+    monkeypatch.setattr(runner.time, "monotonic", fake_monotonic)
+
+    result = launch(engine, [], cwd=None, timeout=1.0, watch=watch, timeout_label="X")
 
     assert result.launch_failure is LaunchFailure.TIMEOUT
     assert result.exit_code == EXIT_TIMEOUT

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -10,6 +10,7 @@ channel-specific argv tail / export-only cwd stay tested in each runner's own
 suite.
 """
 
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -265,8 +266,10 @@ def _fast_fake_engine(tmp_path: Path, stdout_line: str, stderr_line: str) -> Pat
     on every single launch (#728).
     """
     script = tmp_path / "fast-fake-engine"
+    out = shlex.quote(stdout_line)
+    err = shlex.quote(stderr_line)
     script.write_text(
-        f"#!/bin/sh\necho '{stdout_line}'\necho '{stderr_line}' 1>&2\nexec sleep 30\n",
+        f"#!/bin/sh\necho {out}\necho {err} 1>&2\nexec sleep 30\n",
         encoding="utf-8",
     )
     script.chmod(0o755)
@@ -309,10 +312,14 @@ def test_streaming_timeout_preserves_the_output_the_child_already_wrote(tmp_path
     # single-digit milliseconds, two-plus orders of magnitude inside the deadline
     # instead of sharing its order of magnitude (see its docstring for the
     # measurements this margin is based on, not asserted from). The timeout is
-    # also doubled from the pre-#728 1.5s to 3.0s: cheap (the child never exits
-    # on its own, so this is the test's own wall-clock cost either way) real extra
-    # headroom against a sustained-contention tail the measurements still show
-    # is non-zero, on top of — not instead of — the margin the faster engine buys.
+    # also doubled from the pre-#728 1.5s to 3.0s: across 40 measured runs the
+    # observed worst-case time-to-first-output was ~312ms, and that max came
+    # from an UNLOADED run (12-way CPU load's own max was only ~20ms) — the
+    # tail is not purely load-driven, so reasoning from the typical case alone
+    # would repeat the error that produced the original flake. 1.5s leaves
+    # only ~4.8x headroom over that observed tail; 3.0s leaves ~9.6x, cheaply
+    # (the fake engine never exits on its own, so this is the test's own
+    # wall-clock cost either way).
     engine = _fast_fake_engine(tmp_path, "SUITE START", "boom")
 
     result = launch(

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -244,6 +244,35 @@ def _fake_engine(tmp_path: Path, body: str) -> Path:
     return script
 
 
+def _fast_fake_engine(tmp_path: Path, stdout_line: str, stderr_line: str) -> Path:
+    """A ``/bin/sh`` stand-in, for the one test where startup latency IS the point (#728).
+
+    Diverges from ``_fake_engine`` on purpose: that one pays a fresh Python
+    interpreter's startup (measured at #728: ~25-30ms typical, spiking past
+    900ms under load — plenty of margin for every other streaming test here,
+    which race nothing) before it writes a byte. The timeout-preserves-output
+    test needs the real child to have ALREADY written before ``launch``'s
+    timeout elapses, so shrinking that head start is the fix: a shell has no
+    interpreter to load, so it typically writes within single-digit
+    milliseconds (measured at #728: ~6-10ms, worst observed under 12-way CPU
+    load ~0.5s) — two-plus orders of magnitude below the caller's timeout
+    instead of the same order of magnitude it used to be.
+
+    It always ``sleep``s afterward, past any timeout this suite uses, via
+    ``exec`` — not a trailing background job. Without ``exec`` SIGTERM only
+    ends the shell; the orphaned ``sleep`` keeps the captured pipe open and
+    the reader-thread join in ``launch``'s teardown runs to its own timeout
+    on every single launch (#728).
+    """
+    script = tmp_path / "fast-fake-engine"
+    script.write_text(
+        f"#!/bin/sh\necho '{stdout_line}'\necho '{stderr_line}' 1>&2\nexec sleep 30\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    return script
+
+
 class _RecordingWatch:
     """A ``LaunchWatch`` that records what it was fed and can ask for an abort.
 
@@ -272,15 +301,22 @@ def test_streaming_timeout_preserves_the_output_the_child_already_wrote(tmp_path
     # script error Godot had ALREADY printed was lost (GDA-DF-012). With a watch the
     # capture survives, on BOTH streams, and no gda prose is mixed into either — the
     # watching channel composes its own diagnostics from this.
-    engine = _fake_engine(
-        tmp_path,
-        "print('SUITE START', flush=True)\n"
-        "print('boom', file=sys.stderr, flush=True)\n"
-        "time.sleep(30)\n",
-    )
+    #
+    # THE #728 FIX: proving that means the child must ALREADY have written before
+    # the timeout below elapses — a real race against a real process's startup.
+    # ``_fast_fake_engine`` (not the shared ``_fake_engine``) keeps that race from
+    # being a coin flip: no interpreter to load means the write typically lands in
+    # single-digit milliseconds, two-plus orders of magnitude inside the deadline
+    # instead of sharing its order of magnitude (see its docstring for the
+    # measurements this margin is based on, not asserted from). The timeout is
+    # also doubled from the pre-#728 1.5s to 3.0s: cheap (the child never exits
+    # on its own, so this is the test's own wall-clock cost either way) real extra
+    # headroom against a sustained-contention tail the measurements still show
+    # is non-zero, on top of — not instead of — the margin the faster engine buys.
+    engine = _fast_fake_engine(tmp_path, "SUITE START", "boom")
 
     result = launch(
-        engine, [], cwd=None, timeout=1.5, watch=_RecordingWatch(), timeout_label="X"
+        engine, [], cwd=None, timeout=3.0, watch=_RecordingWatch(), timeout_label="X"
     )
 
     assert result.launch_failure is LaunchFailure.TIMEOUT


### PR DESCRIPTION
## Summary

`tests/test_launch.py::test_streaming_timeout_preserves_the_output_the_child_already_wrote` proves the #655/GDA-DF-012 guarantee: a streaming `Headless launch` that hits its timeout still returns the child's already-written stdout/stderr verbatim. Earlier rounds on this branch reduced — but did not remove — a real race between the launch's timeout deadline and a real child process's startup, using a cheaper fake engine and a widened timeout (1.5s -> 3.0s). A reviewer then demonstrated a working probe that removes the race outright by controlling only the clock the runner's poll loop reads, while still exercising a real child, real pipes, and the real timeout/teardown path. **This PR adopts that probe and reverses this branch's own earlier decline of the same recommendation** — see "Reversed decision" below.

**No production code changed.** `src/gda/runner.py` is untouched.

## Reversed decision: clock-controlled determinism

A prior review round on this branch proposed monkeypatching `gda.runner.time.monotonic` instead of racing a real deadline. The author declined it (commit `fb2d027f`'s reply) on three grounds: (1) `runner.py` has no injectable clock seam and adding one would be a forbidden production-code change; (2) faking the module's clock would "prove the capture/teardown logic given a clock the test controls, not that the real race resolves correctly" — treated as weakening the test; (3) the issue's own acceptance criteria already passed via the typical-margin branch, so nothing required the change.

All three turned out to be wrong, or at least not decisive:

1. No seam needed to be added. `runner.py` already does a plain `import time` and calls `time.monotonic()`; that module-level attribute lookup **is** an injectable seam, unused rather than absent.
2. The reviewer's probe (and this PR's adaptation of it) keeps the real child process, real pipes, real reader threads, and the real timeout/SIGTERM/reap/join teardown — only the poll loop's read of "how much time has passed" is faked, and only until the watch has actually observed the child's real output. The final implementation replaces `gda.runner`'s module binding with a small proxy instead of mutating the process-global stdlib `time` module; the proxy delegates `sleep` to the real function and overrides only `monotonic`. Nothing about what the test proves is weakened, and unrelated code in the pytest process continues to see the real stdlib clock.
3. The acceptance criteria's typical-margin branch passing was never the concern; the residual cold-start race (worst observed outlier 1110ms, ~2.7x headroom at 3.0s) was. Removing it outright is strictly stronger than measuring it more precisely.

## The fix

- The test now monkeypatches the `gda.runner.time` binding with a runner-local `SimpleNamespace` proxy. Its fake `monotonic` reports elapsed `0.0` until the watch's accumulated capture contains both expected lines (`"SUITE START"` in stdout, `"boom"` in stderr), then jumps past any timeout in one step. Its `sleep` is the real stdlib function, so the poll loop keeps making real, `0.05s`-spaced polls against the real child until its real output arrives, and only then does the deadline "elapse". The test pins that `time.monotonic` itself remains the original function.
- A real-clock safety ceiling (15s), independent of the fake, fails the test loudly — with whatever was captured so far — if the child's output never arrives at all. A hang becomes an assertion, not a stuck suite.
- The `timeout` argument passed to `launch()` is now inert: the loop only ever observes elapsed `0.0` or the fake's post-observation jump, so any positive value under that jump behaves identically. It is `1.0` now, a plain placeholder — the 1.5s/3.0s cold-start margin math it used to carry no longer applies to anything and is deleted rather than kept as unused history.
- `_fast_fake_engine` (the `/bin/sh` stand-in) is kept, but its docstring is rewritten: it no longer narrows a race (there is none), it just keeps the still-real startup wait — and the suite — fast rather than paying a Python interpreter's startup for no reason.

## On the previous margin/probability language — superseded, not corrected in place

The prior PR body claimed the fix "reduces flake probability by two-plus orders of magnitude" and discussed a "cold start" tail (312ms/1110ms outliers) sized against a 3.0s deadline. Both statements described the now-removed probabilistic-margin approach:

- The "two-plus orders of magnitude" phrasing was itself inaccurate for that approach — the evidence only supported a **margin** change (~54x -> ~750x typical time-to-first-output vs. deadline, i.e. ~13.9x), never an estimate of `P(first_output > deadline)`.
- "Cold start" conflated two different things — a freshly spawned interpreter process, and the first use of a newly generated script path — without saying which was measured.

This PR does not restate either number correctly, because there is no more margin or probability left to state: the guarantee is now unconditional, up to the 15s real-clock safety ceiling — which exists to fail loudly rather than hang, not to bound a race. The old measurement tables and margin math are removed from this body rather than kept as historical color; that narrative stays on the PR's review thread for anyone who wants it.

## Evidence

Target test alone, 25 consecutive runs (`uv run pytest -q tests/test_launch.py::test_streaming_timeout_preserves_the_output_the_child_already_wrote`), each a fresh process: **25/25 passed**.

| | pytest-reported test duration | full process wall clock |
| --- | --- | --- |
| min | 0.53s | 0.91s |
| max | 0.97s | 1.52s |
| avg | 0.59s | 1.03s |

For comparison, every run of the previous (race-narrowed) version paid the full `3.0s` timeout, because the fake engine never exits on its own — the deterministic version instead ends as soon as the real child's real output has actually arrived, typically well under 1s.

## Validation commands

Run BEFORE any number above was written, against exact head `b907bce7`:

- `uv run pytest -q tests/test_launch.py` -> `24 passed in 7.39s`
- `uv run pytest -q -m "not e2e"` -> `1901 passed, 539 deselected in 179.01s (0:02:59)`
- `uv run ruff check .` -> `All checks passed!`
- `uv run ruff format --check .` -> `472 files already formatted`
- `uv run pyright` -> `0 errors, 0 warnings, 0 informations`
- CI at exact head `b907bce7` ([run 33162103207](https://github.com/aigengame/godot-agent/actions/runs/33162103207)): `Python unit tests and package build` job -> `1899 passed, 2 skipped, 539 deselected in 71.15s (0:01:11)`; `tests/test_launch.py` shows 0 skips in that run (the 2-skip delta is the same pre-existing macOS-local-vs-Linux-CI environment difference noted in earlier rounds, unrelated to this change). Lint, format, and pyright CI jobs also pass at this head.
- Godot e2e: not run — not needed for this slice (test-suite-only change, no engine-facing behavior touched).

## Scope

Touches only `tests/test_launch.py`.

Closes #728


## Follow-up: isolate the fake clock from the process-global stdlib module

Re-review at head `b907bce7` found that `runner.time is time`: patching `runner.time.monotonic` therefore changed `time.monotonic` for the entire pytest process, contrary to the PR's "just that one lookup" claim. Fully adopted in commit `b8706b5b`.

The test now replaces only `gda.runner`'s module binding with a `SimpleNamespace(monotonic=fake_monotonic, sleep=time.sleep)` proxy. A regression assertion pins `time.monotonic is real_monotonic`. Red proof against the previous implementation failed exactly on that assertion; the isolated proxy then passed.

Latest local validation at head `b8706b5b`:

- target test → **1 passed**, then **10/10** fresh pytest runs passed
- `tests/test_launch.py` → **24 passed**
- Ruff check/format → **passed**
- Pyright → **0 errors, 0 warnings, 0 informations**
- `git diff --check` → **clean**
