### PR TITLE
fix(gda): one root-cache exclusion for every res:// walk (#712)

### DIFF
--- a/docs/adr/0032-project-local-class-name-resolution-static-fallback.md
+++ b/docs/adr/0032-project-local-class-name-resolution-static-fallback.md
@@ -35,6 +35,22 @@ path` index once per process run. Resolution stays a **static text scan**; the s
 instantiation (and the Node-vs-Resource base-class check) remains **split per site** — only the
 `class_name → path` resolution is unified.
 
+> **Amendment (2026-08-28, #712) — the scan's boundary is the ROOT cache PATH, not the directory
+> name.** "Skipping `.godot/`" above was implemented as a directory-NAME test, which also excluded
+> every `.godot` deeper in the tree. #712 replaced that, in all four `res://` collectors at once,
+> with a lexical comparison of the child's path against `res://.godot`, owned by a single predicate
+> (`_should_descend` in `operations.gd`) so the four cannot drift apart again — three of them
+> disagreed with the fourth, and one project answered two ways: `script list` named a `.gd` whose
+> `class_name` this index could not resolve. For this ADR the boundary is now: the index covers a
+> `.gd` under a **nested** `.godot`, so its `class_name` resolves at all three call sites, and a
+> declaration there can make a name `ambiguous_class_name` that was unambiguous before. The trade
+> is accepted deliberately — a nested `.godot` is usually authored content (an addon vendoring a
+> sample tree), and nothing in the path distinguishes it from a vendored sub-project's own engine
+> cache, whose scripts then enter the index too. The comparison being lexical, it does not resolve
+> filesystem targets: an alias that leads to `res://.godot` is walked and the cache's own scripts
+> are indexed through it. Symlink policy for the `res://` walk is undecided and tracked separately;
+> it is not decided here.
+
 **Explicit contract edges:**
 
 - **Duplicate `class_name`** (declared in more than one `.gd`) is **ambiguous and rejected** with a
@@ -87,6 +103,9 @@ gda's existing boundary); its resolution would need a different mechanism and is
 - **Consistency restored** across the three sites: they now agree on `class_name` resolution in a
   never-opened project, rather than `find-references` reporting "no such class" while a repaired
   `resource create` resolves it.
+- **Scan boundary (amended 2026-08-28, #712).** What the scan skips is the root cache **path**, not
+  every directory named `.godot` — see the Decision amendment for the boundary, the accepted
+  nested-cache trade, and the open symlink question.
 - **Cost.** A never-opened-project miss walks the whole `res://` tree and parses every `.gd`; this is
   acceptable for one-shot ops and is **not** backed by a persistent gda-owned cache — a gda-owned
   cache would re-introduce the very ".godot ownership" complexity the editor-scan option was rejected

--- a/docs/adr/0032-project-local-class-name-resolution-static-fallback.md
+++ b/docs/adr/0032-project-local-class-name-resolution-static-fallback.md
@@ -48,7 +48,7 @@ instantiation (and the Node-vs-Resource base-class check) remains **split per si
 > sample tree), and nothing in the path distinguishes it from a vendored sub-project's own engine
 > cache, whose scripts then enter the index too. The comparison being lexical, it does not resolve
 > filesystem targets: an alias that leads to `res://.godot` is walked and the cache's own scripts
-> are indexed through it. Symlink policy for the `res://` walk is undecided and tracked separately;
+> are indexed through it. Symlink policy for the `res://` walk is undecided and tracked in #760;
 > it is not decided here.
 
 **Explicit contract edges:**

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -70,9 +70,8 @@ they are provenance, not status markers.
 | `gda scene preflight` | Boot a scene headless and report its startup verdict |
 
 **Enumeration** (established by #54): `scene list` walks the project's `res://`
-tree under the one exclusion every `res://` walk applies — the engine's own
-`res://.godot` cache, and only that path, never a directory that merely bears
-that name (stated in full with `script list` below; #712).
+tree under the same exclusion rule `script list` states below, so the two see the
+same directories and differ only in the extension they collect (#712).
 
 **Static instance reporting** (established by #400): `scene get` reads the stored
 `SceneState` without instantiating the host scene, but an instanced node is still
@@ -458,14 +457,15 @@ agent authored. **Only that path**, not every directory named `.godot`: a nested
 authored content, and excluding it hid real scripts from the listing and let `script validate --all`
 report a valid aggregate for a project holding an invalid script (#663 review). Sometimes it is not
 authored content — a vendored sub-project checked out under `res://` and opened once in an editor
-keeps an engine cache of its own, whose import artefacts then count in `project statistics`,
-`find-unused-resources` and `dependencies`. That cost is accepted deliberately: gda cannot tell the
+keeps an engine cache of its own, whose import artefacts then count in `project statistics` and
+become `find-unused-resources` candidates. That cost is accepted deliberately: gda cannot tell the
 two apart from the directory alone, and a false-valid aggregate is the worse failure. Hidden entries
 are otherwise enumerated as promised (#54). **This is the rule for every `res://` walk** — `script
-list`, `scene list`, and the static-analysis scan that backs `project statistics`,
-`find-references`, `dependencies`, `find-unused-resources` and the `class_name` index — so one
-project cannot answer two ways. It once did: three of the four walks compared the directory NAME,
-so `script list` reported a script `project statistics` counted as zero (#712). `gda script delete`
+list`, `scene list`, and both static-analysis walks (the extension-filtered one behind
+`find-references`, `dependencies`, `find-unused-resources` and the `class_name` index, and the
+unfiltered one `project statistics` counts with) — so one project cannot answer two ways. It once
+did: three of the four walks compared the directory NAME, so `script list` reported a script
+`project statistics` counted as zero (#712). `gda script delete`
 removes a script file and reports the removed script's `class_name`/`extends` (parsed before
 deletion), so the result names the content, not just the path. Delete honors the same addressing
 boundary as the rest of the group — only a `.gd` path is removed (a non-`.gd` target is refused
@@ -800,10 +800,12 @@ These create or edit resource files (`.gdshader`, `.tres`) and so are headless.
 | `gda project dependencies` | Map scene → scene references |
 | `gda project statistics` | File/line counts, autoloads, plugins |
 
-One static scan backs all four (and the `class_name` index node/resource creation
-resolves through). It reads the project's `res://` tree under the one exclusion every
-`res://` walk applies — the engine's own `res://.godot` cache, and only that path
-(stated in full with `script list` above; #712).
+Two static walks back these, over different file universes: `find-references`,
+`dependencies`, `find-unused-resources` and the `class_name` index (which node/resource
+creation resolves through) share the extension-filtered one, while `project statistics`
+counts with an unfiltered one that also sees `.import` sidecars and `project.godot` — so
+its file total does not reconcile with the others' candidate set. What is shared is the
+directory exclusion, the rule `script list` states above (#712).
 
 ---
 

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -69,6 +69,11 @@ they are provenance, not status markers.
 | `gda scene validate` | Check statically that a scene's dependencies resolve and its scripts compile |
 | `gda scene preflight` | Boot a scene headless and report its startup verdict |
 
+**Enumeration** (established by #54): `scene list` walks the project's `res://`
+tree under the one exclusion every `res://` walk applies — the engine's own
+`res://.godot` cache, and only that path, never a directory that merely bears
+that name (stated in full with `script list` below; #712).
+
 **Static instance reporting** (established by #400): `scene get` reads the stored
 `SceneState` without instantiating the host scene, but an instanced node is still
 identifiable. Its `type` is resolved to the referenced scene's root node type
@@ -452,7 +457,11 @@ one directory — the engine's own cache at `res://.godot`, whose contents are i
 agent authored. **Only that path**, not every directory named `.godot`: a nested one is authored
 content, and excluding it hid real scripts from the listing and let `script validate --all` report
 a valid aggregate for a project holding an invalid script (#663 review). Hidden entries are
-otherwise enumerated as promised (#54). `gda script delete`
+otherwise enumerated as promised (#54). **This is the rule for every `res://` walk** — `script
+list`, `scene list`, and the static-analysis scan that backs `project statistics`,
+`find-references`, `dependencies`, `find-unused-resources` and the `class_name` index — so one
+project cannot answer two ways. It once did: three of the four walks compared the directory NAME,
+so `script list` reported a script `project statistics` counted as zero (#712). `gda script delete`
 removes a script file and reports the removed script's `class_name`/`extends` (parsed before
 deletion), so the result names the content, not just the path. Delete honors the same addressing
 boundary as the rest of the group — only a `.gd` path is removed (a non-`.gd` target is refused
@@ -786,6 +795,11 @@ These create or edit resource files (`.gdshader`, `.tres`) and so are headless.
 | `gda project find-references` | Find references to a script/class |
 | `gda project dependencies` | Map scene → scene references |
 | `gda project statistics` | File/line counts, autoloads, plugins |
+
+One static scan backs all four (and the `class_name` index node/resource creation
+resolves through). It reads the project's `res://` tree under the one exclusion every
+`res://` walk applies — the engine's own `res://.godot` cache, and only that path
+(stated in full with `script list` above; #712).
 
 ---
 

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -463,8 +463,7 @@ engine cache of its own, whose import artefacts then count in `project statistic
 apart from the directory alone, and a false-valid aggregate is the worse failure. And because the
 test is lexical it compares the path as written, so it does **not** resolve filesystem targets: a
 symlink or alias under another path that leads to `res://.godot` is walked, and the cache's contents
-are then enumerated through that path. Symlink policy for the `res://` walk is undecided — a
-tracked follow-up owns it, together with the symlink CYCLE the same walk descends until the OS path
+are then enumerated through that path. Symlink policy for the `res://` walk is undecided — #760 owns it, together with the symlink CYCLE the same walk descends until the OS path
 limit stops it. Hidden entries are otherwise enumerated as promised (#54). **This rule governs the
 four `res://` collectors in `operations.gd`** — the `script list` walk, the `scene list` walk, and
 both static-analysis walks (the extension-filtered one behind `find-references`, `dependencies`,

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -454,10 +454,14 @@ issue #30) — null when the source declares neither, so the listing names every
 Enumeration needs a project, so projectless it is refused with `project_not_found` (pass
 `--project`); an empty project is a valid, empty listing, not an error. The walk excludes exactly
 one directory — the engine's own cache at `res://.godot`, whose contents are import artefacts no
-agent authored. **Only that path**, not every directory named `.godot`: a nested one is authored
-content, and excluding it hid real scripts from the listing and let `script validate --all` report
-a valid aggregate for a project holding an invalid script (#663 review). Hidden entries are
-otherwise enumerated as promised (#54). **This is the rule for every `res://` walk** — `script
+agent authored. **Only that path**, not every directory named `.godot`: a nested one is usually
+authored content, and excluding it hid real scripts from the listing and let `script validate --all`
+report a valid aggregate for a project holding an invalid script (#663 review). Sometimes it is not
+authored content — a vendored sub-project checked out under `res://` and opened once in an editor
+keeps an engine cache of its own, whose import artefacts then count in `project statistics`,
+`find-unused-resources` and `dependencies`. That cost is accepted deliberately: gda cannot tell the
+two apart from the directory alone, and a false-valid aggregate is the worse failure. Hidden entries
+are otherwise enumerated as promised (#54). **This is the rule for every `res://` walk** — `script
 list`, `scene list`, and the static-analysis scan that backs `project statistics`,
 `find-references`, `dependencies`, `find-unused-resources` and the `class_name` index — so one
 project cannot answer two ways. It once did: three of the four walks compared the directory NAME,

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -453,19 +453,25 @@ issue #30) — null when the source declares neither, so the listing names every
 Enumeration needs a project, so projectless it is refused with `project_not_found` (pass
 `--project`); an empty project is a valid, empty listing, not an error. The walk excludes exactly
 one directory — the engine's own cache at `res://.godot`, whose contents are import artefacts no
-agent authored. **Only that path**, not every directory named `.godot`: a nested one is usually
-authored content, and excluding it hid real scripts from the listing and let `script validate --all`
-report a valid aggregate for a project holding an invalid script (#663 review). Sometimes it is not
-authored content — a vendored sub-project checked out under `res://` and opened once in an editor
-keeps an engine cache of its own, whose import artefacts then count in `project statistics` and
-become `find-unused-resources` candidates. That cost is accepted deliberately: gda cannot tell the
-two apart from the directory alone, and a false-valid aggregate is the worse failure. Hidden entries
-are otherwise enumerated as promised (#54). **This is the rule for every `res://` walk** — `script
-list`, `scene list`, and both static-analysis walks (the extension-filtered one behind
-`find-references`, `dependencies`, `find-unused-resources` and the `class_name` index, and the
-unfiltered one `project statistics` counts with) — so one project cannot answer two ways. It once
-did: three of the four walks compared the directory NAME, so `script list` reported a script
-`project statistics` counted as zero (#712). `gda script delete`
+agent authored. The test is **lexical**: the child's `res://` PATH is compared against that one
+path. Not the directory NAME, so a nested `.godot` is walked — it is usually authored content, and
+excluding it hid real scripts from the listing and let `script validate --all` report a valid
+aggregate for a project holding an invalid script (#663 review). Sometimes it is not authored
+content — a vendored sub-project checked out under `res://` and opened once in an editor keeps an
+engine cache of its own, whose import artefacts then count in `project statistics` and become
+`find-unused-resources` candidates. That cost is accepted deliberately: gda cannot tell the two
+apart from the directory alone, and a false-valid aggregate is the worse failure. And because the
+test is lexical it compares the path as written, so it does **not** resolve filesystem targets: a
+symlink or alias under another path that leads to `res://.godot` is walked, and the cache's contents
+are then enumerated through that path. Symlink policy for the `res://` walk is undecided — a
+tracked follow-up owns it, together with the symlink CYCLE the same walk descends until the OS path
+limit stops it. Hidden entries are otherwise enumerated as promised (#54). **This rule governs the
+four `res://` collectors in `operations.gd`** — the `script list` walk, the `scene list` walk, and
+both static-analysis walks (the extension-filtered one behind `find-references`, `dependencies`,
+`find-unused-resources` and the `class_name` index, and the unfiltered one `project statistics`
+counts with) — so one project cannot answer two ways. It once did: three of the four compared the
+directory NAME, so `script list` reported a script `project statistics` counted as zero (#712).
+`gda script delete`
 removes a script file and reports the removed script's `class_name`/`extends` (parsed before
 deletion), so the result names the content, not just the path. Delete honors the same addressing
 boundary as the rest of the group — only a `.gd` path is removed (a non-`.gd` target is refused

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3722,6 +3722,12 @@ func _ambiguous_class_name_message(class_token: String, paths: Array) -> String:
 # Three of the four walks once compared the NAME, so one project answered two
 # ways: `script list` reported a script `project statistics` counted as zero
 # (#712). One decision, one site — that is what keeps them in agreement.
+#
+# The test is LEXICAL and stays that way here: it does not resolve filesystem
+# targets, so an alias that leads to the root cache is descended into, and a
+# symlink cycle is descended until the OS path limit stops it. Symlink policy for
+# the res:// walk is undecided and tracked separately — do not decide half of it
+# in this predicate.
 func _should_descend(child: String) -> bool:
 	return child != ENGINE_CACHE_DIR
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3726,7 +3726,7 @@ func _ambiguous_class_name_message(class_token: String, paths: Array) -> String:
 # The test is LEXICAL and stays that way here: it does not resolve filesystem
 # targets, so an alias that leads to the root cache is descended into, and a
 # symlink cycle is descended until the OS path limit stops it. Symlink policy for
-# the res:// walk is undecided and tracked separately — do not decide half of it
+# the res:// walk is undecided and tracked in #760 — do not decide half of it
 # in this predicate.
 func _should_descend(child: String) -> bool:
 	return child != ENGINE_CACHE_DIR

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -116,15 +116,8 @@ const SCENE_STARTUP_READY := "ready"
 const SCENE_STARTUP_NOT_READY := "not_ready"
 
 # The ONE directory a res:// walk excludes: the engine's own import/cache tree at
-# the project root. Compared as a full path, never as a directory NAME, because a
-# `.godot` deeper in the tree is not the engine's — it is user content (an addon
-# vendoring a sample project, a test fixture tree) and its files are the
-# project's like any other. Excluding those made `script validate --all` report a
-# valid aggregate for a project holding an invalid script (#663 review), and hid
-# them from `script list` too. Every walk over res:// compares against this one
-# constant (scripts, scenes, graph resources, all files), so one project cannot
-# answer two ways — `script list` reporting a script `project statistics` counts
-# as zero was exactly that (#712).
+# the project root. The VALUE only — the decision that uses it lives in exactly one
+# place, _should_descend, which every walk calls.
 const ENGINE_CACHE_DIR := "res://.godot"
 
 # The project-info settings (issue #111), read with a default so a project that
@@ -3712,13 +3705,34 @@ func _ambiguous_class_name_message(class_token: String, paths: Array) -> String:
 	return "class_name " + class_token + " is declared in more than one script, so it cannot be resolved to a single script; declare it in exactly one .gd. Conflicting scripts: " + ", ".join(PackedStringArray(paths))
 
 
+# Whether a res:// walk descends into this child DIRECTORY. The ONE owner of the
+# exclusion decision: every walk over the project tree (scripts, scenes, graph
+# resources, all files) asks this and nothing else, so the rule cannot drift
+# between them and a new walk inherits it by calling this.
+#
+# The comparison is the full path, never the directory NAME, because a `.godot`
+# deeper in the tree is not this project's engine cache. It is usually authored
+# content (an addon vendoring a sample project, a fixture tree), and excluding it
+# hid real scripts from `script list` and let `script validate --all` report a
+# valid aggregate for a project holding an invalid script (#663 review). Sometimes
+# it is a vendored sub-project's own cache instead, whose artefacts then count in
+# `project statistics` and `find-unused-resources` — accepted deliberately, since
+# nothing in the path tells the two apart and a false-valid aggregate is worse.
+#
+# Three of the four walks once compared the NAME, so one project answered two
+# ways: `script list` reported a script `project statistics` counted as zero
+# (#712). One decision, one site — that is what keeps them in agreement.
+func _should_descend(child: String) -> bool:
+	return child != ENGINE_CACHE_DIR
+
+
 # Recursively collect every RESOURCE-bearing file under res:// — the files that
 # can carry references (.tscn/.tres scenes & resources, .gd scripts) AND the leaf
 # asset resources (everything else except import sidecars, the project file, and
 # the .godot cache). Mirrors _collect_scene_paths: hidden entries enumerated,
-# navigational entries off, the ROOT cache path (ENGINE_CACHE_DIR) skipped — a
-# nested `.godot` is authored content and stays in (#712). This is the universe
-# the reference graph, find-unused and the class_name index range over.
+# navigational entries off, directory descent decided by _should_descend. This is
+# the universe the reference graph, find-unused and the class_name index range
+# over.
 func _collect_resource_paths(dir_path: String, out: Array[String]) -> void:
 	var dir := DirAccess.open(dir_path)
 	if dir == null:
@@ -3729,7 +3743,7 @@ func _collect_resource_paths(dir_path: String, out: Array[String]) -> void:
 	while not entry.is_empty():
 		var child := dir_path.path_join(entry)
 		if dir.current_is_dir():
-			if child != ENGINE_CACHE_DIR:
+			if _should_descend(child):
 				_collect_resource_paths(child, out)
 		elif _is_graph_resource_path(child):
 			out.append(child)
@@ -3737,10 +3751,10 @@ func _collect_resource_paths(dir_path: String, out: Array[String]) -> void:
 	dir.list_dir_end()
 
 
-# Recursively collect EVERY file under res:// (skipping only the root cache at
-# ENGINE_CACHE_DIR, never a nested `.godot`, #712) for the statistics counts —
-# unlike _collect_resource_paths this keeps import sidecars, project.godot and
-# every asset, since statistics counts all files.
+# Recursively collect EVERY file under res:// (descending per _should_descend)
+# for the statistics counts — unlike _collect_resource_paths this keeps import
+# sidecars, project.godot and every asset, since statistics counts all files. The
+# two walks therefore range over DIFFERENT universes under the same exclusion.
 func _collect_all_file_paths(dir_path: String, out: Array[String]) -> void:
 	var dir := DirAccess.open(dir_path)
 	if dir == null:
@@ -3751,7 +3765,7 @@ func _collect_all_file_paths(dir_path: String, out: Array[String]) -> void:
 	while not entry.is_empty():
 		var child := dir_path.path_join(entry)
 		if dir.current_is_dir():
-			if child != ENGINE_CACHE_DIR:
+			if _should_descend(child):
 				_collect_all_file_paths(child, out)
 		else:
 			out.append(child)
@@ -4243,14 +4257,11 @@ func _has_project() -> bool:
 	return DirAccess.dir_exists_absolute("res://") and FileAccess.file_exists("res://project.godot")
 
 
-# Recursively collect every .tscn under res:// (issue #54), skipping only the
-# engine's own res://.godot cache directory (import artifacts, not authored
-# scenes). The skip is the ROOT cache path exactly (ENGINE_CACHE_DIR), not every
-# directory named `.godot` and not every dot-prefixed entry, so legitimately
-# hidden scenes (a .hidden.tscn, a scene under a dot-prefixed directory, a scene
-# under a NESTED `.godot`) are all enumerated as promised (issue #54 review,
-# #712). Paths are returned as res:// paths so they round-trip into other
-# scene commands.
+# Recursively collect every .tscn under res:// (issue #54), descending per
+# _should_descend. The dot prefix is not part of that test, so a legitimately
+# hidden scene (a .hidden.tscn, or one under a dot-prefixed directory) is
+# enumerated as promised (issue #54 review). Paths are returned as res:// paths
+# so they round-trip into other scene commands.
 func _collect_scene_paths(dir_path: String, out: Array[String]) -> void:
 	var dir := DirAccess.open(dir_path)
 	if dir == null:
@@ -4264,7 +4275,7 @@ func _collect_scene_paths(dir_path: String, out: Array[String]) -> void:
 	while not entry.is_empty():
 		var child := dir_path.path_join(entry)
 		if dir.current_is_dir():
-			if child != ENGINE_CACHE_DIR:
+			if _should_descend(child):
 				_collect_scene_paths(child, out)
 		elif entry.get_extension() == "tscn":
 			out.append(child)
@@ -4298,13 +4309,10 @@ func _scene_summary(path: String) -> Dictionary:
 	}
 
 
-# Recursively collect every .gd script under res:// (issue #117), skipping only
-# the engine's own res://.godot cache directory. Hidden entries are enumerated (a
-# .hidden.gd, or a script under a dot-prefixed directory) and navigational entries
-# stay off. The skip is the ROOT cache path exactly (ENGINE_CACHE_DIR), not any
-# directory named `.godot`: an earlier name test also swallowed a nested one,
-# which is authored content — see that const. Paths are returned as res:// paths
-# so they round-trip into other script commands.
+# Recursively collect every .gd script under res:// (issue #117), descending per
+# _should_descend. Hidden entries are enumerated (a .hidden.gd, or a script under
+# a dot-prefixed directory) and navigational entries stay off. Paths are returned
+# as res:// paths so they round-trip into other script commands.
 func _collect_script_paths(dir_path: String, out: Array[String]) -> void:
 	var dir := DirAccess.open(dir_path)
 	if dir == null:
@@ -4315,7 +4323,7 @@ func _collect_script_paths(dir_path: String, out: Array[String]) -> void:
 	while not entry.is_empty():
 		var child := dir_path.path_join(entry)
 		if dir.current_is_dir():
-			if child != ENGINE_CACHE_DIR:
+			if _should_descend(child):
 				_collect_script_paths(child, out)
 		elif entry.get_extension().to_lower() == "gd":
 			out.append(child)

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -118,10 +118,13 @@ const SCENE_STARTUP_NOT_READY := "not_ready"
 # The ONE directory a res:// walk excludes: the engine's own import/cache tree at
 # the project root. Compared as a full path, never as a directory NAME, because a
 # `.godot` deeper in the tree is not the engine's — it is user content (an addon
-# vendoring a sample project, a test fixture tree) and its scripts are the
+# vendoring a sample project, a test fixture tree) and its files are the
 # project's like any other. Excluding those made `script validate --all` report a
 # valid aggregate for a project holding an invalid script (#663 review), and hid
-# them from `script list` too.
+# them from `script list` too. Every walk over res:// compares against this one
+# constant (scripts, scenes, graph resources, all files), so one project cannot
+# answer two ways — `script list` reporting a script `project statistics` counts
+# as zero was exactly that (#712).
 const ENGINE_CACHE_DIR := "res://.godot"
 
 # The project-info settings (issue #111), read with a default so a project that
@@ -3671,8 +3674,8 @@ func _resolve_project_class_script(class_token: String) -> Dictionary:
 
 # Build (once per process) the class_name → declaring-.gd-paths index for the
 # resolver's tier-3 static scan (ADR-0032). Walks the full res:// tree skipping
-# .godot — reusing the shared recursive walker (_collect_resource_paths, which
-# already enumerates .gd among the graph resources) — and parses each .gd's
+# the root cache — reusing the shared recursive walker (_collect_resource_paths,
+# which already enumerates .gd among the graph resources) — and parses each .gd's
 # class_name from raw source with the existing never-compiled parser
 # (_script_metadata). A class_name declared in more than one .gd maps to multiple
 # paths (sorted, so an ambiguous_class_name error is deterministic regardless of
@@ -3713,8 +3716,9 @@ func _ambiguous_class_name_message(class_token: String, paths: Array) -> String:
 # can carry references (.tscn/.tres scenes & resources, .gd scripts) AND the leaf
 # asset resources (everything else except import sidecars, the project file, and
 # the .godot cache). Mirrors _collect_scene_paths: hidden entries enumerated,
-# navigational entries off, res://.godot skipped. This is the universe both the
-# reference graph and find-unused range over.
+# navigational entries off, the ROOT cache path (ENGINE_CACHE_DIR) skipped — a
+# nested `.godot` is authored content and stays in (#712). This is the universe
+# the reference graph, find-unused and the class_name index range over.
 func _collect_resource_paths(dir_path: String, out: Array[String]) -> void:
 	var dir := DirAccess.open(dir_path)
 	if dir == null:
@@ -3725,7 +3729,7 @@ func _collect_resource_paths(dir_path: String, out: Array[String]) -> void:
 	while not entry.is_empty():
 		var child := dir_path.path_join(entry)
 		if dir.current_is_dir():
-			if entry != ".godot":
+			if child != ENGINE_CACHE_DIR:
 				_collect_resource_paths(child, out)
 		elif _is_graph_resource_path(child):
 			out.append(child)
@@ -3733,9 +3737,10 @@ func _collect_resource_paths(dir_path: String, out: Array[String]) -> void:
 	dir.list_dir_end()
 
 
-# Recursively collect EVERY file under res:// (skipping only the .godot cache) for
-# the statistics counts — unlike _collect_resource_paths this keeps import
-# sidecars, project.godot and every asset, since statistics counts all files.
+# Recursively collect EVERY file under res:// (skipping only the root cache at
+# ENGINE_CACHE_DIR, never a nested `.godot`, #712) for the statistics counts —
+# unlike _collect_resource_paths this keeps import sidecars, project.godot and
+# every asset, since statistics counts all files.
 func _collect_all_file_paths(dir_path: String, out: Array[String]) -> void:
 	var dir := DirAccess.open(dir_path)
 	if dir == null:
@@ -3746,7 +3751,7 @@ func _collect_all_file_paths(dir_path: String, out: Array[String]) -> void:
 	while not entry.is_empty():
 		var child := dir_path.path_join(entry)
 		if dir.current_is_dir():
-			if entry != ".godot":
+			if child != ENGINE_CACHE_DIR:
 				_collect_all_file_paths(child, out)
 		else:
 			out.append(child)
@@ -4240,10 +4245,11 @@ func _has_project() -> bool:
 
 # Recursively collect every .tscn under res:// (issue #54), skipping only the
 # engine's own res://.godot cache directory (import artifacts, not authored
-# scenes). The skip is scoped to that one directory name rather than every
-# dot-prefixed entry, so legitimately hidden scenes (a .hidden.tscn, or a scene
-# under a dot-prefixed directory) are still enumerated as promised (issue #54
-# review). Paths are returned as res:// paths so they round-trip into other
+# scenes). The skip is the ROOT cache path exactly (ENGINE_CACHE_DIR), not every
+# directory named `.godot` and not every dot-prefixed entry, so legitimately
+# hidden scenes (a .hidden.tscn, a scene under a dot-prefixed directory, a scene
+# under a NESTED `.godot`) are all enumerated as promised (issue #54 review,
+# #712). Paths are returned as res:// paths so they round-trip into other
 # scene commands.
 func _collect_scene_paths(dir_path: String, out: Array[String]) -> void:
 	var dir := DirAccess.open(dir_path)
@@ -4258,7 +4264,7 @@ func _collect_scene_paths(dir_path: String, out: Array[String]) -> void:
 	while not entry.is_empty():
 		var child := dir_path.path_join(entry)
 		if dir.current_is_dir():
-			if entry != ".godot":
+			if child != ENGINE_CACHE_DIR:
 				_collect_scene_paths(child, out)
 		elif entry.get_extension() == "tscn":
 			out.append(child)

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -1,8 +1,11 @@
 """S1 (e2e): the project static-analysis reads against the real Godot engine (issue #116).
 
 The four read-only, project-wide analysis commands — find-references,
-dependencies, find-unused-resources, statistics — backed by a single static scan
-that parses files as text (no instantiation, issue #30). These tests build a
+dependencies, find-unused-resources, statistics — backed by two static scans
+over different file universes (the first three share the extension-filtered
+walk; statistics counts with an unfiltered one that also sees ``.import``
+sidecars and ``project.godot``) under one shared directory-exclusion rule,
+both parsing files as text (no instantiation, issue #30). These tests build a
 small fixture project WITH cross-references (a main scene that ext_resources a
 sub-scene, a script and an image; a script that preloads a sibling; an autoload;
 an unreferenced resource) and assert each command reports it correctly off the

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -574,3 +574,43 @@ def test_project_walks_agree_on_a_nested_dot_godot_directory(tmp_path):
     )
     assert cached.returncode == 4, cached.stdout + cached.stderr
     assert json.loads(cached.stdout)["error"]["code"] == "invalid_node_type"
+
+    # The three remaining consumers of that same walk. They run AFTER the node
+    # add, which wrote an [ext_resource] to the nested script into
+    # `res://top.tscn` — so the nested content is a real reference target here,
+    # not just an enumerated path.
+    deps_proc = _gda(project, "project", "dependencies", "--json")
+    refs_proc = _gda(
+        project, "project", "find-references", "res://nested/.godot/hidden.gd", "--json"
+    )
+    unused_proc = _gda(project, "project", "find-unused-resources", "--json")
+
+    assert deps_proc.returncode == 0, deps_proc.stdout + deps_proc.stderr
+    assert refs_proc.returncode == 0, refs_proc.stdout + refs_proc.stderr
+    assert unused_proc.returncode == 0, unused_proc.stdout + unused_proc.stderr
+    by_source = {
+        row["path"]: row["depends_on"]
+        for row in json.loads(deps_proc.stdout)["dependencies"]
+    }
+    references = json.loads(refs_proc.stdout)["references"]
+    unused = json.loads(unused_proc.stdout)["unused"]
+
+    # Both nested files are graph sources, and top.tscn's edge to the nested
+    # script is reported from both ends.
+    assert set(by_source) == {
+        "res://top.tscn",
+        "res://nested/.godot/hidden.tscn",
+        "res://nested/.godot/hidden.gd",
+    }
+    assert by_source["res://top.tscn"] == [
+        {"path": "res://nested/.godot/hidden.gd", "kind": "ext_resource"}
+    ]
+    assert [(r["path"], r["kind"]) for r in references] == [
+        ("res://top.tscn", "ext_resource")
+    ]
+    # The nested script is referenced now, so only the two scenes are orphans.
+    assert unused == ["res://nested/.godot/hidden.tscn", "res://top.tscn"]
+    # The root cache is invisible to all three. Its `.gd` and `.tscn` would
+    # otherwise BOTH be dependency source rows and unused candidates, so this
+    # arm fails if the exclusion ever widens past `res://.godot` itself.
+    assert not any(p.startswith("res://.godot/") for p in [*by_source, *unused])

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -482,3 +482,95 @@ def test_dependencies_without_project_is_project_not_found(tmp_path):
     assert proc.returncode == 4, proc.stdout + proc.stderr
     err = json.loads(proc.stdout)["error"]
     assert err["code"] == "project_not_found"
+
+
+# --- every project walk agrees on a nested `.godot` directory (#712) ----------
+
+# A project-local custom Node declared inside a NESTED `.godot` directory — the
+# class the class_name index must find once the resource walk stops excluding
+# that directory by name.
+NESTED_THING_GD = """\
+class_name NestedThing
+extends Node
+"""
+
+# The same declaration authored INTO the engine's own root cache. It must stay
+# invisible, so the correction does not swap one wrong enumeration for another.
+CACHED_THING_GD = """\
+class_name CachedThing
+extends Node
+"""
+
+BARE_TSCN = """\
+[gd_scene format=3]
+
+[node name="Root" type="Node2D"]
+"""
+
+
+@pytest.mark.e2e
+def test_project_walks_agree_on_a_nested_dot_godot_directory(tmp_path):
+    # The exclusion is the engine's ONE cache directory, `res://.godot` — not
+    # every directory that happens to be named `.godot`. A nested one is user
+    # content (an addon vendoring a sample project, a fixture tree). #710 fixed
+    # the SCRIPT walk that way and left three siblings comparing the entry name,
+    # so one project answered two ways: `script list` reported a script that
+    # `project statistics` counted as zero, and `node add --type` could not
+    # resolve a class_name `script list` had just shown (#712). This test is that
+    # cross-command agreement, not four per-walker checks — each command below
+    # rides a different walk over the same tree.
+    project = tmp_path / "nested-cache"
+    (project / "nested" / ".godot").mkdir(parents=True)
+    (project / ".godot").mkdir(parents=True, exist_ok=True)
+    (project / "project.godot").write_text(
+        project_godot("gda-e2e-nested-walks"), encoding="utf-8"
+    )
+    (project / "top.tscn").write_text(BARE_TSCN, encoding="utf-8")
+    (project / "nested" / ".godot" / "hidden.tscn").write_text(
+        BARE_TSCN, encoding="utf-8"
+    )
+    (project / "nested" / ".godot" / "hidden.gd").write_text(
+        NESTED_THING_GD, encoding="utf-8"
+    )
+    (project / ".godot" / "engine_cache.tscn").write_text(BARE_TSCN, encoding="utf-8")
+    (project / ".godot" / "engine_cache.gd").write_text(
+        CACHED_THING_GD, encoding="utf-8"
+    )
+
+    scene_proc = _gda(project, "scene", "list", "--json")
+    script_proc = _gda(project, "script", "list", "--json")
+    stats_proc = _gda(project, "project", "statistics", "--json")
+
+    assert scene_proc.returncode == 0, scene_proc.stdout + scene_proc.stderr
+    assert script_proc.returncode == 0, script_proc.stdout + script_proc.stderr
+    assert stats_proc.returncode == 0, stats_proc.stdout + stats_proc.stderr
+    scenes = {s["path"] for s in json.loads(scene_proc.stdout)["scenes"]}
+    scripts = {s["path"] for s in json.loads(script_proc.stdout)["scripts"]}
+    stats = json.loads(stats_proc.stdout)
+
+    # The nested content is authored content: every walk enumerates it.
+    assert scenes == {"res://top.tscn", "res://nested/.godot/hidden.tscn"}
+    assert scripts == {"res://nested/.godot/hidden.gd"}
+    # The counts and the listings are the same project, so they agree.
+    assert stats["scene_count"] == len(scenes)
+    assert stats["script_count"] == len(scripts)
+    # The root cache stays invisible — in the listings and in the counts alike
+    # (it holds one .gd and one .tscn of its own, which must not be counted).
+    assert not any(p.startswith("res://.godot/") for p in scenes | scripts)
+    by_ext = {e["extension"]: e for e in stats["by_extension"]}
+    assert by_ext["gd"]["files"] == 1
+    assert by_ext["tscn"]["files"] == 2
+
+    # The class_name index rides the resource walk, so node/resource creation
+    # resolves the nested declaration `script list` reports...
+    added = _gda(
+        project, "node", "add", "res://top.tscn", "--type", "NestedThing", "--json"
+    )
+    assert added.returncode == 0, added.stdout + added.stderr
+    assert json.loads(added.stdout)["script_class"] == "NestedThing"
+    # ...and still does not resolve one authored into the engine's own cache.
+    cached = _gda(
+        project, "node", "add", "res://top.tscn", "--type", "CachedThing", "--json"
+    )
+    assert cached.returncode == 4, cached.stdout + cached.stderr
+    assert json.loads(cached.stdout)["error"]["code"] == "invalid_node_type"


### PR DESCRIPTION
## What changed

`operations.gd` holds four sibling walkers over the project's `res://` tree. PR #710 fixed
one of them — `_collect_script_paths` — to compare the full child path against
`ENGINE_CACHE_DIR` (`res://.godot`). The other three still compared the directory NAME:

| walker | before | after |
|---|---|---|
| `_collect_script_paths` | `child != ENGINE_CACHE_DIR` (#710) | `_should_descend(child)` |
| `_collect_scene_paths` | `entry != ".godot"` | `_should_descend(child)` |
| `_collect_resource_paths` | `entry != ".godot"` | `_should_descend(child)` |
| `_collect_all_file_paths` | `entry != ".godot"` | `_should_descend(child)` |

So a user-authored nested `.godot` (an addon vendoring a sample project, a fixture tree)
was invisible to `scene list`, `project find-references`, `project dependencies`,
`project find-unused-resources`, `project statistics`, and the `class_name` index that
`node add --type` / `resource create --type` resolve through — while `script list` saw it.

**One decision, one site.** Unifying only the constant would have left four independent
branches — the exact shape that let #710 fix one walker while three drifted. `_should_descend`
is the single owner of the rule, and it carries the rationale; the const keeps only the value.
A generic walker taking a `Callable` accept-predicate was considered and rejected: the four
accept-tests genuinely differ (extension match, graph-eligibility, unconditional), so it would
buy nothing beyond this helper and cost indirection.

Known consequence, already adjudicated for the script walk by #663/#710 and adopted here
for consistency: if a project vendors a sub-project that WAS opened in an editor, that
sub-project's own `.godot/` artefacts now enter the analysis universe — `project statistics`
counts and `find-unused-resources` candidates. Not `dependencies`: cache artefacts do reach
the graph walk, but `_has_outgoing_references` admits only `.tscn`/`.tres`/`.gd` as source
rows, so they cannot become dependency rows. gda cannot tell that directory from an authored
one, and the alternative — a name test — is what produced the contradiction this PR closes.
The trade lives **in `docs/command-catalog.md` beside the rule**, not only in this PR body,
so a future reader meets it instead of refiling it as a bug.

## The defect, measured (Godot 4.6.3, macOS 15.6 / darwin 25.6.0)

On a project holding `res://top.tscn`, `res://nested/.godot/hidden.tscn`,
`res://nested/.godot/hidden.gd` (`class_name NestedThing`), plus content under the real
`res://.godot`:

**Before** — one project, two answers:

```
scene list        -> {"scenes":[{"path":"res://top.tscn",...}]}
script list       -> {"scripts":[{"path":"res://nested/.godot/hidden.gd","class_name":"NestedThing",...}]}
project statistics-> {"total_files":2,"scene_count":1,"script_count":0,...}
node add res://main.tscn --type NestedThing
                  -> error invalid_node_type: "no .gd script declares class_name NestedThing"
```

**After** — `scene list` returns both scenes, `project statistics` reports
`scene_count: 2` / `script_count: 1` (agreeing with the two listings), and
`node add --type NestedThing` resolves (`script_class: "NestedThing"`). Content under the
real `res://.godot` stays out of all of them **by path**, and `--type CachedThing` (declared
inside that cache) still refuses with `invalid_node_type`.

### What the exclusion does and does not guarantee (#712 AC, qualified)

The rule is **lexical** — the child's `res://` path is compared against `res://.godot`. So:

- **The AC holds for the rule #712 asked to unify.** Root-cache content authored at a
  `res://.godot/...` path is excluded from all four collectors, pinned in both directions by
  the regression.
- **It does not hold for an ALIAS.** With `res://nested/.godot` symlinked to `res://.godot`,
  the cache is enumerated through the alias path — `scene list` and `script list` return
  `res://nested/.godot/root_cache.*` and `node add --type RootCacheThing` resolves.
  Reproduced on this head by the implementing agent, and on the base `04d3e089` by the
  orchestrating agent: `script list` returns the aliased cache script there too, because
  path comparison for that walker shipped under #663/#710. **The gap predates this PR**;
  this PR propagates an already-accepted decision to the three sibling walkers, which is
  what #712 asked for.
- **A symlink CYCLE is worse and equally pre-existing.** `sub/loop -> sub` makes the walk
  descend to the OS path limit and report **33 entries for one real file**, at fabricated
  `res://sub/loop/loop/…/a.gd` paths. Identical on head and base (verified on head here,
  on base by the orchestrator). No hang; garbage output.

Resolving filesystem targets inside `_should_descend` would settle the alias and leave the
cycle standing — half of an undecided policy, decided in a slice about entry-name-versus-path.
It is **deliberately not done here** and is tracked as its own follow-up, with both probes as
evidence. The limitation is stated in `docs/command-catalog.md` beside the rule, on
`_should_descend` itself, and in ADR-0032's amendment.

## Tests / docs that pinned the old behavior

- `tests/test_e2e_scene.py::test_scene_list_enumerates_dot_prefixed_scenes_but_skips_godot_cache`
  — pins `.hidden.tscn`, `.config/deep.tscn` and root-cache invisibility only. It never
  pinned the nested-`.godot` exclusion, so it is unchanged and still passes.
- No other test or doc asserted the old (name-based) rule. `src/gda/commands/resource.py`
  has a Python-side skip (`rel.startswith(".godot/")`) that is already root-anchored and
  correct; untouched.
- **Docs updated deliberately**: `docs/command-catalog.md` stated the exclusion rule only
  inside the `script list` passage (#663). That statement is now generalized to "the rule
  for every `res://` walk" and names the #712 divergence; it also carries the **cost** of
  the rule (a vendored sub-project's own engine cache becoming visible to the analysis
  walks) next to its empirical justification, so the trade is durable rather than
  PR-body-only. The `scene` group and the static-analysis section each get a pointer that
  **refers** to that statement without restating its substance — matching the shape of the
  pre-existing `script validate --all` pointer, so the rule stays in one place.
- **ADR-0032 synced** (`docs/adr/0032-…-static-fallback.md`): its Decision still said the
  class_name static scan walks `res://` "skipping `.godot/`" — the directory-NAME test this
  slice replaced. A dated amendment records the real boundary, what it means for the index
  (a `.gd` under a nested `.godot` is indexed, so its `class_name` resolves at all three call
  sites and can make a name `ambiguous_class_name` that was not), the accepted trade, and the
  open symlink question; a Consequences bullet points at it. The original sentence stays as
  the point-in-time record.
- Two catalog claims corrected while in there: the cost sentence no longer names
  `dependencies` (see above), and "one static scan backs all four" became **two** walks over
  different universes — `find-references`, `dependencies`, `find-unused-resources` and the
  `class_name` index share the extension-filtered walk, `project statistics` counts with the
  unfiltered one (it also sees `.import` sidecars and `project.godot`), so their totals
  cannot reconcile. What is one is the exclusion rule. The same "single scan" claim stood in
  a third place — this test module's own docstring — and was corrected there too.
- After review: the catalog now says the test is **lexical**, names the alias and cycle
  limitations with a pointer to the tracked follow-up, and scopes the rule to **the four
  `res://` collectors in `operations.gd`** rather than "every `res://` walk".
- `operations.gd` comments: the rationale moved onto `_should_descend`; the const keeps only
  the value, and no walker's comment restates the rule any more.

## Test evidence

One **cross-command consistency** regression, not four per-walker tests:
`tests/test_e2e_project_analysis.py::test_project_walks_agree_on_a_nested_dot_godot_directory`
drives all five affected operations plus the two listings on ONE fixture project —
`scene list`, `script list`, `project statistics` (counts and `by_extension`),
`node add --type` (the `class_name` index), then `dependencies`, `find-references` and
`find-unused-resources` — and asserts they agree, in both directions (nested content in,
root-cache content out). The three analysis calls run after the `node add`, so the nested
script is a real reference target: `top.tscn`'s edge to it is reported from both ends, the
nested scene is an orphan candidate, and the root cache — whose own `.gd` and `.tscn` WOULD
otherwise be source rows and candidates — is absent from all three.

**Red-proof** (pre-fix tree, this branch's test): the test failed at its first arm —

```
> assert scenes == {"res://top.tscn", "res://nested/.godot/hidden.tscn"}
E AssertionError: assert {'res://top.tscn'} == {'res://neste...s://top.tscn'}
E   Extra items in the right set: 'res://nested/.godot/hidden.tscn'
1 failed in 5.29s
```

The other arms were red-proofed by the direct CLI repro quoted above (`script_count: 0`
against `script list`'s one script; `invalid_node_type` for `NestedThing`).

## Gates (all run in this worktree; host: local macOS, darwin 25.6.0, Godot 4.6.3)

`10404d7a`, `d7ee3ce3` and `90a4fe11` are behaviourally identical — the commits after the
first two change only comments, a docstring, a doc and an ADR — so an e2e result on any of
them holds for the others.

| gate | command | result | head |
|---|---|---|---|
| unit | `uv run pytest -q -m "not e2e"` | `1901 passed, 540 deselected in 120.97s (0:02:00)` | `90a4fe11` |
| unit (fixed order) | `uv run pytest -q -m "not e2e" -p no:randomly` | `1901 passed, 540 deselected in 132.24s (0:02:12)` | `90a4fe11` |
| doc/skill sync | `uv run pytest -q tests/test_skill_surface_sync.py tests/test_skill_command.py tests/test_readme_i18n_sync.py tests/test_command_descriptor_registry.py tests/test_project.py` | `71 passed in 2.21s` | `1dbfb2cd` |
| e2e (touched file) | `uv run pytest -q -m e2e tests/test_e2e_project_analysis.py -p no:randomly` | `15 passed in 50.80s` | `90a4fe11` |
| e2e (walk consumers) | `uv run pytest -q -m e2e tests/test_e2e_project_analysis.py tests/test_e2e_scene.py tests/test_e2e_project.py tests/test_e2e_classname_resolution.py -p no:randomly` | `77 passed in 127.09s (0:02:07)` | `10404d7a` |
| e2e (script walk) | `uv run pytest -q -m e2e tests/test_e2e_script.py -p no:randomly` | `68 passed in 147.40s (0:02:27)` | `10404d7a` |
| e2e (class-index consumers) | `uv run pytest -q -m e2e tests/test_e2e_node.py tests/test_e2e_resource.py -p no:randomly` | `136 passed in 534.58s (0:08:54)` | `d7ee3ce3` |
| lint | `uv run ruff check .` | `All checks passed!` | `90a4fe11` |
| format | `uv run ruff format --check .` | `472 files already formatted` | `90a4fe11` |
| types | `uv run pyright` | `0 errors, 0 warnings, 0 informations` | `90a4fe11` |

The **class-index consumers** row was produced by the orchestrating agent, not by the
implementing agent, on head `d7ee3ce3` in the same worktree and on the same host — the
implementer had skipped it for its runtime and argued the extraction could not disturb
those paths. The argument was replaced with the run: `136 passed`, the same count as on
the first commit. Every other row was produced by the implementing agent.

One transient: an earlier random-order unit run reported `1900 passed, 540 deselected, 1 error`,
the error at `tests/test_input_commands.py::test_an_explicit_null_button_still_means_the_left_button`
(setup/teardown, not an assertion). That test passes in isolation and the full suite passed
twice afterwards in both orders. The traceback was not captured, so the cause is not proven;
the likely one is temp-directory contention between concurrently running pytest processes in
sibling worktrees, which share the `pytest-of-<user>` base. This change cannot reach that test —
it touches comments, a doc and an ADR only.

Closes #712
