### PR TITLE
fix(gda): dogfooding phase-2 P1 — parser, walk, and input-authority fixes (dev→main promotion)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -215,6 +215,15 @@ the Python registry in `src/gda/error_codes.py`; the table below mirrors that
 source and is checked by tests. GDScript mirrors only the rows whose source is
 `operation`, because only those codes can be reported by headless operations.
 
+The `Meaning` column is pinned too (#701): it must match the registry's
+`description` once markup and wrapping are normalized. A trailing parenthetical
+that cites at least one ADR or issue — a `Phase N` label may ride along inside
+it — is a citation rather than part of the code's meaning, so it is not compared.
+Many rows here carry one, and some registry descriptions do too: that is allowed,
+not a mistake to tidy away. A bare `(Phase N)` is *not* a citation and IS compared,
+which is why the live rows below state their phase through the `Category` column
+instead. `tests/test_error_registry.py` is the single home of that rule.
+
 Each row carries the process `Exit Code` a shell consumer keys on. It is
 per-code, not per-category: within `environment`, `binary_not_found` exits `127`
 but `launch_timeout` exits `124`. The `exit_codes.py` registry defines the
@@ -224,7 +233,7 @@ operation, and parse codes the CLI assigns).
 | Code | Category | Source | Exit Code | Meaning |
 | --- | --- | --- | --- | --- |
 | `binary_not_found` | `environment` | `runner` | `127` | The Godot binary could not be launched. |
-| `launch_timeout` | `environment` | `runner` | `124` | Godot launched but did not return before the runner timeout. One command does not report it — see the 2026-08-19 scope note (#664). |
+| `launch_timeout` | `environment` | `runner` | `124` | Godot launched but did not return before the runner timeout. One command does not report it: `scene preflight` reports its own `timeout` status instead (#664). |
 | `user_data_unwritable` | `environment` | `runner` | `127` | The log or user-data placement for the launch could not be made usable, so the launch was refused. |
 | `unknown_command` | `usage` | `classifier` | `2` | gda has no such command; discover the surface with `gda schema` or `gda --help`. A recognized near miss also carries the supported invocation in the envelope's `hint`. |
 | `unknown_option` | `usage` | `classifier` | `2` | The command exists but has no such option; read its options with `--help` or its input contract with `--schema`. A recognized near miss also carries the supported invocation in the envelope's `hint`. |
@@ -265,7 +274,7 @@ operation, and parse codes the CLI assigns).
 | `no_search_match` | `operation` | `operation` | `4` | A search-replace script edit found no occurrence of the search string. |
 | `invalid_line_range` | `operation` | `operation` | `4` | A line-range script edit specified lines outside the script's bounds, or end before start. |
 | `script_compile_failed` | `operation` | `operation` | `4` | A script does not compile, so the requested work could not proceed: `script attach` refuses to bind it to a node, and `script run` reports that the entry script (or a dependency it preloads) never ran (#651). |
-| `script_not_found` | `operation` | `classifier` | `4` | A `script run` entry script does not exist in the project, so the engine never ran it — read from stderr, since the engine still exits 0 (#651). |
+| `script_not_found` | `operation` | `classifier` | `4` | A `script run` entry script does not exist in the project, so the engine never ran it — it still exits 0, and gda reads the failure from stderr (#651). |
 | `script_failed` | `operation` | `classifier` | `4` | A `script run --strict` script ran to completion and chose a non-zero exit status; strict mode maps that opted-in failure onto the uniform error envelope. Never reported without `--strict` (ADR-0031 amendment, #651). |
 | `script_aborted` | `operation` | `classifier` | `4` | A `script run` was ended early, before its `--timeout`: a script error appeared on stderr, the caller's declared `--completion-marker` did not, and the run then went silent. Reported only when `--completion-marker` is declared (ADR-0031 amendment, #655). |
 | `incompatible_script_type` | `operation` | `operation` | `4` | A script compiles but its base type is incompatible with the requested use: `script attach`'s target node type, or `script run`'s requirement that a one-shot entry script extend `SceneTree`/`MainLoop` (#651). |
@@ -276,9 +285,9 @@ operation, and parse codes the CLI assigns).
 | `export_presets_not_found` | `operation` | `operation` | `4` | The project has no export_presets.cfg, so it defines no export presets. |
 | `export_preset_not_found` | `operation` | `operation` | `4` | No export preset with the requested name exists in export_presets.cfg. |
 | `export_path_unset` | `operation` | `classifier` | `4` | An export run has no destination — neither a `--output` override nor a configured `export_path` (#170). |
-| `export_templates_missing` | `operation` | `classifier` | `4` | A release/debug export needs the export templates for the running engine version, which are not installed (pack needs no platform templates and is exempt; #170). |
+| `export_templates_missing` | `operation` | `classifier` | `4` | A release/debug export needs the export templates for the running engine version, which are not installed; `pack` needs no platform templates and is exempt (#170). |
 | `export_output_parent_failed` | `operation` | `classifier` | `4` | An export run could not create the output parent directory before native export (#402). |
-| `stdout_spill_failed` | `operation` | `classifier` | `4` | A `script run` stdout exceeded the cap but the complete-stream spill file could not be written, so the bounded result cannot be delivered (#665). |
+| `stdout_spill_failed` | `operation` | `classifier` | `4` | A `script run`'s stdout exceeded the cap but the complete-stream spill file could not be written, so the bounded result cannot be delivered (#665). |
 | `export_failed` | `operation` | `classifier` | `4` | A native Godot export run failed (the engine reported the export did not complete). |
 | `invalid_uid` | `operation` | `operation` | `4` | A requested `uid://` value is not a syntactically valid resource UID. |
 | `unknown_uid` | `operation` | `operation` | `4` | A syntactically valid resource UID is not registered in the engine's UID cache. |
@@ -289,9 +298,9 @@ operation, and parse codes the CLI assigns).
 | `contract_violation` | `parse` | `parser` | `5` | The process claimed success but violated the structured-output contract. |
 | `tree_too_deep` | `parse` | `classifier` | `5` | The engine emitted a valid result tree that nests past gda's recursion limit; the payload is contract-conformant, the limit is wrapper-side (shares the `parse` exit code; the `code` distinguishes it from `contract_violation`). |
 | `daemon_not_running` | `live` | `classifier` | `6` | A live command found no running gda-daemon for the project; start one with `gda daemon start` (Phase 2, ADR-0017 / ADR-0021). |
-| `engine_session_not_running` | `live` | `classifier` | `6` | The daemon is running but holds no live engine session to serve the live operation (Phase 2). |
-| `engine_disconnected` | `live` | `classifier` | `6` | The engine session disconnected before the live operation returned — the game crashed or the harness connection dropped (Phase 2). |
-| `live_timeout` | `live` | `classifier` | `6` | A live operation did not return from the engine session before the daemon's timeout (Phase 2). |
+| `engine_session_not_running` | `live` | `classifier` | `6` | The daemon is running but holds no live engine session to serve the live operation. |
+| `engine_disconnected` | `live` | `classifier` | `6` | The engine session disconnected before the live operation returned — the game crashed or the harness connection dropped. |
+| `live_timeout` | `live` | `classifier` | `6` | A live operation did not return from the engine session before the daemon's timeout. The session is discarded: its reply is no longer attributable, so the next operation relaunches it and runtime state does not survive. |
 | `daemon_running` | `live` | `classifier` | `6` | A daemon-lifecycle command was refused because a gda-daemon is running for the project; stop it first with `gda daemon stop` (Phase 2, #225). |
 | `daemon_already_running` | `live` | `classifier` | `6` | A `gda daemon start --scene` was refused because a gda-daemon is already running for the project; `--scene` only takes effect at start, so stop it with `gda daemon stop` then start again with `--scene` (Phase 2, #278). |
 | `live_node_not_found` | `live` | `classifier` | `6` | A live game operation's node path does not resolve to a node in the running scene tree (Phase 2, #220). |
@@ -299,8 +308,8 @@ operation, and parse codes the CLI assigns).
 | `live_unknown_property` | `live` | `classifier` | `6` | A live game get or set targeted a property name the running node does not expose as an addressable runtime, storage, or attached-script property (Phase 2, #220, #422). |
 | `live_uncoercible_value` | `live` | `classifier` | `6` | A live game set value cannot be coerced to the addressed runtime property's or script variable's Godot type (Phase 2, #220, #422). |
 | `live_unknown_method` | `live` | `classifier` | `6` | A live game call named a method the addressed running node does not have (Phase 2, #673). |
-| `live_method_not_allowlisted` | `live` | `classifier` | `6` | A live game call named a method the addressed running node has but its class never declared gda-callable (Phase 2, #673, ADR-0041). |
-| `live_invalid_call_args` | `live` | `classifier` | `6` | A live game call supplied arguments the declared method cannot take — a count outside its accepted range, or a value the declared parameter type cannot convert from (Phase 2, #673). |
+| `live_method_not_allowlisted` | `live` | `classifier` | `6` | A live game call named a method the addressed running node has but its attached-script chain never declared gda-callable (Phase 2, #673, ADR-0041). |
+| `live_invalid_call_args` | `live` | `classifier` | `6` | A live game call supplied arguments the declared method cannot take: a count outside its accepted range, or a value the declared parameter type cannot convert from (Phase 2, #673). |
 | `live_log_unavailable` | `live` | `classifier` | `6` | A live engine session was launched but its diagnostics log file is missing or unreadable, so `gda diag` cannot read the running game's errors/output (Phase 2, #224). |
 | `live_scene_not_found` | `live` | `classifier` | `6` | A `gda daemon start --scene` selector did not load: the launched session ran a different scene (Godot silently falls back to main_scene for a missing/invalid path or UID), verified by the harness at launch — gda never falls back (Phase 2, #278). |
 | `live_perf_node_not_found` | `live` | `classifier` | `6` | A live perf monitor's node path does not resolve to a node in the running scene tree (Phase 2, #223). |
@@ -309,11 +318,11 @@ operation, and parse codes the CLI assigns).
 | `live_invalid_key` | `live` | `classifier` | `6` | A live input key event named a key the engine could not resolve to a keycode (Phase 2, #221). |
 | `live_unknown_action` | `live` | `classifier` | `6` | A live input action targeted an action the running game's InputMap does not declare (Phase 2, #221). |
 | `live_invalid_event_spec` | `live` | `classifier` | `6` | A live input sequence event has a type the harness does not recognize (Phase 2, #221). |
-| `live_predicate_unmet` | `live` | `classifier` | `6` | A live `screen capture` predicate (`--await-*`, #661) did not hold within its declared frame bound (Phase 2). |
+| `live_predicate_unmet` | `live` | `classifier` | `6` | A live `screen capture` predicate (`--await-*`) did not hold within its declared frame bound (Phase 2, #661). |
 | `live_display_unavailable` | `live` | `classifier` | `6` | A live `screen` capture ran on a headless engine session (the dummy DisplayServer cannot read pixels); start the daemon windowed with `gda daemon start --windowed` (Phase 2, #222). |
-| `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
-| `live_windowed_unavailable` | `environment` | `classifier` | `127` | A windowed Engine session (`gda daemon start --windowed`) was requested but the host has no usable DisplayServer (no on-console GUI session / no `$DISPLAY`), so the session cannot come up; refused before spawning Godot (Phase 2, #345). |
-| `live_windowed_permission_denied` | `environment` | `classifier` | `127` | A windowed Engine session (`gda daemon start --windowed`) was requested but this process is denied the window-server lookup (e.g. a sandbox), so gda cannot tell whether the host has one; re-run outside the restriction to find out rather than recording the host as display-less (Phase 2, #667). |
+| `live_unsupported_platform` | `environment` | `classifier` | `127` | Live operations require a UNIX platform (macOS/Linux); they use Unix domain sockets, which are unavailable here. Phase-1 headless is unaffected (Phase 2, ADR-0021). |
+| `live_windowed_unavailable` | `environment` | `classifier` | `127` | A windowed Engine session was requested (`gda daemon start --windowed`) but the host has no usable DisplayServer (no on-console GUI session / no `$DISPLAY`), so the session cannot come up; refused before spawning Godot (Phase 2, #345). |
+| `live_windowed_permission_denied` | `environment` | `classifier` | `127` | A windowed Engine session was requested (`gda daemon start --windowed`) but this process is denied the window-server lookup (e.g. a sandbox), so gda cannot tell whether the host has one; re-run outside the restriction to find out rather than recording the host as display-less (Phase 2, #667). |
 
 ## Considered options
 

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -99,12 +99,17 @@ status: accepted
 >
 > **What stays refused**, all decided before any launch as `invalid_path`: an **absolute** path;
 > **another engine scheme** (`user://`, `uid://` — lifting one would splice a second scheme into a
-> res:// address and send the engine after a path nobody typed); a path naming the project **root**
-> (`""`, `"."`, `"sub/.."`, and the `res://` / `res://.` spellings — a directory, not a script); and a
-> path **escaping above the root** (`".."`, `"../outside.gd"`, and their `res://` spellings). The ABI
-> edge below names "a non-`res://` **or absolute** script path"; only its first half is lifted here.
+> res:// address and send the engine after a path nobody typed); a leading `~` (a filesystem HOME
+> reference, including an unresolvable one); a path naming the project **root** (`""`, `"."`,
+> `"sub/.."`, and the `res://` / `res://.` spellings — a directory, not a script); a path **escaping
+> above the root** (`".."`, `"../outside.gd"`, and their `res://` spellings); a canonical address
+> ending in a code point at or below **U+0020**, which Godot removes before reporting the path; and a
+> canonical address containing any line boundary recognized by `gda.engine_log`'s line protocol.
+> The ABI edge below names "a non-`res://` **or absolute** script path"; only its first half is lifted
+> here.
 >
-> The last two are refused for a reason beyond tidiness, and both were **verified**. The engine
+> The root and escape shapes are refused for a reason beyond tidiness, and both were **verified**. The
+> engine
 > answers a root or escape address with `Can't load script: res://.` / `res://..`, whose address the
 > error parser reads back with the sentence period stripped — so it never matches the entry, the
 > never-ran verdict misses it, and the run reports a phantom `exit_status: 0`. Worse, an escape that
@@ -115,6 +120,41 @@ status: accepted
 > the widening is what made them reachable from the ordinary project-relative form, so they are closed
 > here. The residual parser weakness (a trailing-period strip that mis-reads `res://..`) is **not**
 > addressed here; it belongs to the error parser and is tracked separately.
+>
+> **Path-identity boundary (2026-08-28, #698 review).** The two character rules above preserve the
+> same canonical identity on both sides of the entry-load verdict. Godot 4.6.3's
+> `String::strip_edges()` removes trailing code points at or below U+0020; Python `str.rstrip()` is
+> intentionally not the rule because it additionally removes Unicode spaces such as NBSP (U+00A0)
+> and EM SPACE (U+2003), which Godot preserves. Separately, `gda.engine_log` parses engine output with
+> `str.splitlines()`. Any address containing one of those line boundaries is therefore impossible to
+> recover from one diagnostic record and is refused before launch. Leading and internal ASCII spaces,
+> and Unicode spaces that Godot preserves, remain valid project-relative characters.
+>
+> **Outcome (2026-08-27, #698):** the error parser's `_CANT_LOAD` regex (`gda.script_errors`) no
+> longer strips a genuine trailing dot. It mirrors `main.cpp:4271`, which never appends sentence
+> punctuation, so any strip was always wrong; the strip is dropped, so `Can't load script: res://..`
+> now round-trips to `res://..` instead of the `res://.` mis-read this paragraph describes. The
+> sibling `_FAILED_LOADING_RESOURCE` regex was tightened too (its strip is now mandatory rather than
+> optional, mirroring `resource_loader.cpp:343`'s guaranteed trailing period), but — verified — its
+> old optional strip never actually mis-read a well-formed captured line, for any dot count; that
+> change is a fail-closed robustness improvement, not a fix for observed corruption. Neither change is
+> a general longest-candidate heuristic.
+>
+> Adversarial review of the #698 PR found a second, independent defect in the same two regexes: their
+> path capture was `\S+`, which cannot match a SPACE, so a project-relative path containing one
+> (`res://missing file.`) failed the WHOLE line rather than losing a character — no diagnostic at all,
+> so `entry_load_failure` found nothing and the run reported a phantom success. Pre-existing on `main`
+> before #698 (its `\S+?\.?$` could not match a space either) and masked whenever the path also
+> carried a recognized extension (`_OPEN_FAILED`'s quoted capture is space-safe), so it surfaces only
+> on an extension-less spelling. Both regexes now capture `.+` — `gda.engine_log` has already split
+> stderr into lines before either regex sees one, so `.+` cannot run past the line it belongs to — and
+> genuinely capture to end of line unconditionally, which is what this outcome note now describes.
+>
+> The refusals this decision records stay in place regardless of either parser fix — they are
+> load-bearing for reasons beyond the parser weakness (ADR-0009's Trusted project, above) — but the
+> parser itself no longer mis-reads a dot-terminated or horizontal-space-containing `res://` address if
+> a
+> future route ever reaches it again.
 >
 > Absolute stays refused for two **verified** reasons, not merely as deferred scope. First, the engine
 > reports a failed run under the **`res://` spelling even when launched with an absolute in-project

--- a/docs/adr/0032-project-local-class-name-resolution-static-fallback.md
+++ b/docs/adr/0032-project-local-class-name-resolution-static-fallback.md
@@ -35,6 +35,22 @@ path` index once per process run. Resolution stays a **static text scan**; the s
 instantiation (and the Node-vs-Resource base-class check) remains **split per site** — only the
 `class_name → path` resolution is unified.
 
+> **Amendment (2026-08-28, #712) — the scan's boundary is the ROOT cache PATH, not the directory
+> name.** "Skipping `.godot/`" above was implemented as a directory-NAME test, which also excluded
+> every `.godot` deeper in the tree. #712 replaced that, in all four `res://` collectors at once,
+> with a lexical comparison of the child's path against `res://.godot`, owned by a single predicate
+> (`_should_descend` in `operations.gd`) so the four cannot drift apart again — three of them
+> disagreed with the fourth, and one project answered two ways: `script list` named a `.gd` whose
+> `class_name` this index could not resolve. For this ADR the boundary is now: the index covers a
+> `.gd` under a **nested** `.godot`, so its `class_name` resolves at all three call sites, and a
+> declaration there can make a name `ambiguous_class_name` that was unambiguous before. The trade
+> is accepted deliberately — a nested `.godot` is usually authored content (an addon vendoring a
+> sample tree), and nothing in the path distinguishes it from a vendored sub-project's own engine
+> cache, whose scripts then enter the index too. The comparison being lexical, it does not resolve
+> filesystem targets: an alias that leads to `res://.godot` is walked and the cache's own scripts
+> are indexed through it. Symlink policy for the `res://` walk is undecided and tracked in #760;
+> it is not decided here.
+
 **Explicit contract edges:**
 
 - **Duplicate `class_name`** (declared in more than one `.gd`) is **ambiguous and rejected** with a
@@ -87,6 +103,9 @@ gda's existing boundary); its resolution would need a different mechanism and is
 - **Consistency restored** across the three sites: they now agree on `class_name` resolution in a
   never-opened project, rather than `find-references` reporting "no such class" while a repaired
   `resource create` resolves it.
+- **Scan boundary (amended 2026-08-28, #712).** What the scan skips is the root cache **path**, not
+  every directory named `.godot` — see the Decision amendment for the boundary, the accepted
+  nested-cache trade, and the open symlink question.
 - **Cost.** A never-opened-project miss walks the whole `res://` tree and parses every `.gd`; this is
   acceptable for one-shot ops and is **not** backed by a persistent gda-owned cache — a gda-owned
   cache would re-introduce the very ".godot ownership" complexity the editor-scan option was rejected

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -69,6 +69,10 @@ they are provenance, not status markers.
 | `gda scene validate` | Check statically that a scene's dependencies resolve and its scripts compile |
 | `gda scene preflight` | Boot a scene headless and report its startup verdict |
 
+**Enumeration** (established by #54): `scene list` walks the project's `res://`
+tree under the same exclusion rule `script list` states below, so the two see the
+same directories and differ only in the extension they collect (#712).
+
 **Static instance reporting** (established by #400): `scene get` reads the stored
 `SceneState` without instantiating the host scene, but an instanced node is still
 identifiable. Its `type` is resolved to the referenced scene's root node type
@@ -449,10 +453,24 @@ issue #30) — null when the source declares neither, so the listing names every
 Enumeration needs a project, so projectless it is refused with `project_not_found` (pass
 `--project`); an empty project is a valid, empty listing, not an error. The walk excludes exactly
 one directory — the engine's own cache at `res://.godot`, whose contents are import artefacts no
-agent authored. **Only that path**, not every directory named `.godot`: a nested one is authored
-content, and excluding it hid real scripts from the listing and let `script validate --all` report
-a valid aggregate for a project holding an invalid script (#663 review). Hidden entries are
-otherwise enumerated as promised (#54). `gda script delete`
+agent authored. The test is **lexical**: the child's `res://` PATH is compared against that one
+path. Not the directory NAME, so a nested `.godot` is walked — it is usually authored content, and
+excluding it hid real scripts from the listing and let `script validate --all` report a valid
+aggregate for a project holding an invalid script (#663 review). Sometimes it is not authored
+content — a vendored sub-project checked out under `res://` and opened once in an editor keeps an
+engine cache of its own, whose import artefacts then count in `project statistics` and become
+`find-unused-resources` candidates. That cost is accepted deliberately: gda cannot tell the two
+apart from the directory alone, and a false-valid aggregate is the worse failure. And because the
+test is lexical it compares the path as written, so it does **not** resolve filesystem targets: a
+symlink or alias under another path that leads to `res://.godot` is walked, and the cache's contents
+are then enumerated through that path. Symlink policy for the `res://` walk is undecided — #760 owns it, together with the symlink CYCLE the same walk descends until the OS path
+limit stops it. Hidden entries are otherwise enumerated as promised (#54). **This rule governs the
+four `res://` collectors in `operations.gd`** — the `script list` walk, the `scene list` walk, and
+both static-analysis walks (the extension-filtered one behind `find-references`, `dependencies`,
+`find-unused-resources` and the `class_name` index, and the unfiltered one `project statistics`
+counts with) — so one project cannot answer two ways. It once did: three of the four compared the
+directory NAME, so `script list` reported a script `project statistics` counted as zero (#712).
+`gda script delete`
 removes a script file and reports the removed script's `class_name`/`extends` (parsed before
 deletion), so the result names the content, not just the path. Delete honors the same addressing
 boundary as the rest of the group — only a `.gd` path is removed (a non-`.gd` target is refused
@@ -786,6 +804,13 @@ These create or edit resource files (`.gdshader`, `.tres`) and so are headless.
 | `gda project find-references` | Find references to a script/class |
 | `gda project dependencies` | Map scene → scene references |
 | `gda project statistics` | File/line counts, autoloads, plugins |
+
+Two static walks back these, over different file universes: `find-references`,
+`dependencies`, `find-unused-resources` and the `class_name` index (which node/resource
+creation resolves through) share the extension-filtered one, while `project statistics`
+counts with an unfiltered one that also sees `.import` sidecars and `project.godot` — so
+its file total does not reconcile with the others' candidate set. What is shared is the
+directory exclusion, the rule `script list` states above (#712).
 
 ---
 

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -481,7 +481,9 @@ The lifecycle round-trips: `create` → `list` shows it → `delete` → `list` 
 script as **raw text** — it never compiles or loads the script, so editing one never runs
 project code (the read trust boundary of #30). It edits only a script that exists; a missing
 target is `path_not_found`, never a silent create. Exactly one of three mutually-exclusive
-modes is selected at the CLI (a missing or mixed mode is a usage error, exit 2):
+modes must be selected — derived once by the params model, identically on argv and
+`--params-json` (ADR-0015, #713); a missing or mixed mode is a usage error, exit 2, on argv,
+and structured `invalid_params` on `--params-json`:
 
 - **search-replace** — `--search <old> --replace <new>`: replace **every** literal (not regex)
   occurrence of `<old>` with `<new>`. A search string the source does not contain is refused

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -44,6 +44,7 @@ from gda.errors import (
     script_run_timeout_failure,
     unresolvable_binary_failure,
 )
+from gda.engine_log import lines as engine_log_lines
 from gda.execution import ExecutionKind
 from gda.headless import (
     HeadlessCommand,
@@ -1150,7 +1151,7 @@ def _project_scoped_res_path(script: str) -> str | None:
     :func:`canonical_res_path`, so the argv, the entry-load verdict and the reported
     path cannot diverge by input spelling.
 
-    Returns ``None`` for the five shapes that are not project-scoped script
+    Returns ``None`` for the seven shapes that are not project-scoped script
     addresses. Each must be caught HERE, because each is otherwise launched:
 
     - an **absolute** path — outside the ``--project`` context (the reasons it stays
@@ -1163,6 +1164,17 @@ def _project_scoped_res_path(script: str) -> str | None:
       expand it (an unknown user, #699); a resolvable ``~/x.gd`` was already expanded
       to the absolute path refused above. So both tilde outcomes land on one refusal
       instead of one being refused and the other spliced into ``res://~user/x.gd``;
+    - a path whose canonical address ends in a code point at or below **U+0020** —
+      Godot 4.6.3 removes that exact suffix set (``String::strip_edges``) before it
+      echoes the ``--script`` path in a load-failure diagnostic. The canonical
+      identity then loses a character and the never-ran verdict misses. Python's
+      Unicode ``rstrip`` set is deliberately NOT used: Godot preserves NBSP and EM
+      SPACE, so those remain accepted;
+    - a path containing an **engine-log line boundary** — the engine can emit that
+      character inside its diagnostic, but :mod:`gda.engine_log` necessarily splits
+      the address into separate records. No one record retains the canonical entry
+      identity, so a never-run entry can again report a phantom success. Ordinary
+      leading and internal ASCII spaces remain accepted;
     - a path that names the project **root** (``""``, ``"."``, ``"sub/.."``) — it names
       a directory, not a script. An unset shell variable makes ``gda script run
       "$SCRIPT"`` exactly this;
@@ -1203,6 +1215,17 @@ def _project_scoped_res_path(script: str) -> str | None:
     if remainder in _ROOT_REMAINDERS:
         return None
     if remainder == ".." or remainder.startswith("../"):
+        return None
+    # Godot 4.6.3's String::strip_edges() removes trailing code points <= U+0020.
+    # Refuse exactly that engine-normalized suffix set; Python str.rstrip() is wider
+    # and would reject NBSP / EM SPACE even though Godot preserves them. Do not trim:
+    # that would silently launch a different address from the one the caller named.
+    if ord(remainder[-1]) <= 0x20:
+        return None
+    # engine_log owns the line protocol through str.splitlines(). Sentinels make a
+    # boundary at either edge observable (splitlines otherwise suppresses a terminal
+    # empty record), while any ordinary one-line address still produces one record.
+    if len(engine_log_lines(f"x{remainder}x")) != 1:
         return None
     return canonical
 

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -235,10 +235,14 @@ class ScriptDeleteResult(BaseModel):
 class ScriptSetMode(str, Enum):
     """The edit mode of ``gda script set``, the single source of truth (issue #133).
 
-    The CLI resolves exactly one mode from the supplied flags (its mutual-exclusion
-    check) and stamps it here, so the operation dispatches on this explicit
-    discriminator instead of re-inferring the mode from which params are present —
-    the inference precedence can no longer drift from the CLI's exclusivity rule.
+    The params model derives exactly one mode from the supplied fields — via
+    :func:`resolve_set_mode`, run once by the model's own ``_resolve_mode``
+    validator on BOTH the argv and ``--params-json`` paths (ADR-0015, #713) —
+    and stamps it here, so the operation dispatches on this explicit
+    discriminator instead of re-inferring the mode from which params are
+    present. The CLI is a thin argv-to-model adapter; it does not re-derive the
+    mode itself, so the derivation cannot drift from the model's exclusivity
+    rule.
 
     - ``SEARCH_REPLACE`` — ``search``/``replace``: every literal (not regex)
       occurrence of ``search`` is replaced with ``replace``.
@@ -264,9 +268,13 @@ def resolve_set_mode(
     The single home of the edit-mode rule, shared by ``script set`` and ``shader
     set`` and by BOTH input paths (ADR-0015): exactly one of the three
     mutually-exclusive modes must be supplied. Raises ``ValueError`` on a
-    violation — the CLI wrapper translates it to a usage error (exit 2) for argv,
-    while the params models surface it as the structured ``invalid_params`` for
-    ``--params-json``.
+    violation. Its only callers are the two params models' ``_resolve_mode``
+    ``model_validator``s (:class:`ScriptSetParams` here, :class:`ShaderSetParams`
+    in ``gda.commands.shader``) — so the rule runs exactly ONCE per invocation,
+    on both commands (issue #713). The argv body builds that model through
+    :func:`~gda.dispatch.params_or_bad_parameter`, which turns the raised error
+    into the Click usage error (exit 2); ``--params-json`` builds the same model
+    and surfaces it as the structured ``invalid_params`` instead.
     """
     has_search = search is not None or replace is not None
     has_line_range = start_line is not None or end_line is not None
@@ -303,9 +311,10 @@ class ScriptSetParams(BaseModel):
     loads the script, so editing one can never run project code (the read trust
     boundary of issue #30). ``path`` addresses the script by its ``res://`` or
     filesystem path. The remaining params carry one of three mutually-exclusive
-    edit modes; the CLI resolves which one and stamps it on ``mode`` (issue #133),
-    so the operation dispatches on that explicit discriminator rather than
-    re-inferring it from which params are present:
+    edit modes; the model derives which one and stamps it on ``mode`` (issue
+    #133, ADR-0015) — the SAME derivation on both the argv and ``--params-json``
+    paths (#713) — so the operation dispatches on that explicit discriminator
+    rather than re-inferring it from which params are present:
 
     - **search-replace** (``mode = search_replace``) — ``search``/``replace`` both
       present: every literal (not regex) occurrence of ``search`` is replaced with
@@ -1182,17 +1191,29 @@ def _project_scoped_res_path(script: str) -> str | None:
       ``res://`` spellings) — the project is the whole addressable scope, so an
       upward escape names something the ``--project`` contract does not cover.
 
-    The last two are load-bearing for the same reason, and it is not tidiness. The
-    engine answers a root address with ``Can't load script: res://.`` (or
-    ``res://..``), whose address the error parser reads back with the sentence period
-    stripped — ``res://`` for the first, ``res://.`` for the second. Neither matches
-    the entry, so the never-ran verdict misses it and the run reports a PHANTOM
-    SUCCESS. And an escape that RESOLVES (``../outside.gd``) executes a script outside
-    the project entirely, which would widen the Project-code execution surface past
-    ADR-0009's Trusted project — the very consequence the amendment cites for keeping
-    absolute paths refused, so admitting it by the relative spelling would make that
-    reasoning false. Refusing both before the launch closes them without touching the
-    error parser's own res:// handling.
+    The last two are load-bearing, and it is not tidiness. The root-address clause
+    is ALSO belt-and-suspenders against a parser risk: the engine answers a root
+    address with ``Can't load script: res://.`` (or ``res://..``), a sentence
+    whose trailing dot is part of the ADDRESS, not punctuation. A parser that
+    folds it as though it WERE punctuation — reading ``res://.`` back as
+    ``res://``, ``res://..`` back as ``res://.`` — would miss the launched
+    entry, and the never-ran verdict would report a PHANTOM SUCCESS instead of
+    the refusal it should be. Issue #698 (its fix, PR #756) targets exactly that
+    fold in :mod:`gda.script_errors`'s ``_CANT_LOAD`` regex; this paragraph's own
+    argument does not depend on whether that PR has landed at any point in this
+    branch's history, because THIS guard already closes the gap on its own,
+    independent of the parser's fold either way: a root address is refused
+    HERE, before any launch, so it never reaches the parser at all. The root
+    address therefore stays refused for the plainer reason already given above
+    (it names a directory, not a script). The escape clause is the one still
+    load-bearing for the reason it always was: an escape that RESOLVES
+    (``../outside.gd``)
+    executes a script outside the project entirely, which would widen the
+    Project-code execution surface past ADR-0009's Trusted project — the very
+    consequence the amendment cites for keeping absolute paths refused, so
+    admitting it by the relative spelling would make that reasoning false.
+    Refusing both before the launch keeps this gate, not the error parser, as the
+    one place that decides.
 
     The escape test is on the canonical remainder's first SEGMENT, not a string
     prefix: ``res://..foo.gd`` is a legal file whose name merely starts with two dots,
@@ -2367,12 +2388,16 @@ def set_script(
     project: Optional[str] = project_option(),
 ) -> None:
     """Edit a .gd script via search-replace, line-range, or full overwrite."""
-    mode = parse_set_mode_argv(search, replace, start_line, end_line, content)
+    # The model owns the mode-selection rule and the argv body does not restate
+    # it: the shared builder turns any model-construction failure (resolve_set_mode,
+    # via ScriptSetParams's validator) into the Click usage error (exit 2) — the
+    # same translation an argv-side pre-check used to do by hand — so the rule
+    # runs once per invocation on both input paths (ADR-0015, issue #713).
     dispatch_domain(
         SCRIPT_SET_COMMAND,
-        ScriptSetParams(
+        params_or_bad_parameter(
+            ScriptSetParams,
             path=path,
-            mode=mode,
             search=search,
             replace=replace,
             start_line=start_line,
@@ -2383,27 +2408,6 @@ def set_script(
         godot=godot,
         project=project,
     )
-
-
-def parse_set_mode_argv(
-    search: Optional[str],
-    replace: Optional[str],
-    start_line: Optional[int],
-    end_line: Optional[int],
-    content: Optional[str],
-) -> ScriptSetMode:
-    """Resolve a set command's edit mode for the argv path (issue #133).
-
-    The rule itself lives in :func:`resolve_set_mode` — the single source shared
-    with ``ScriptSetParams`` / ``ShaderSetParams`` (ADR-0015). This thin wrapper
-    translates its ``ValueError`` into a Click usage error (exit 2) so the argv
-    path keeps its usage-error ergonomics, while ``--params-json`` surfaces the
-    same rule as a structured ``invalid_params`` via the model.
-    """
-    try:
-        return resolve_set_mode(search, replace, start_line, end_line, content)
-    except ValueError as exc:
-        raise typer.BadParameter(str(exc)) from exc
 
 
 @_app.command(name="attach", cls=SCRIPT_ATTACH_COMMAND.command_class())

--- a/src/gda/commands/shader.py
+++ b/src/gda/commands/shader.py
@@ -17,8 +17,8 @@ from typing import Optional, Protocol, runtime_checkable
 import typer
 from pydantic import BaseModel, Field, model_validator
 
-from gda.commands.script import ScriptSetMode, parse_set_mode_argv, resolve_set_mode
-from gda.dispatch import dispatch_domain
+from gda.commands.script import ScriptSetMode, resolve_set_mode
+from gda.dispatch import dispatch_domain, params_or_bad_parameter
 from gda.headless import (
     HeadlessCommand,
     godot_option,
@@ -136,10 +136,11 @@ class ShaderSetParams(BaseModel):
     autoloads at engine startup (ADR-0009). ``path`` addresses the shader by its
     ``res://`` or filesystem path. The remaining params carry the SAME three
     mutually-exclusive edit modes as ``script set`` (issue #118) — the shader
-    group reuses that edit interface rather than re-deriving it. The CLI resolves
-    which mode and stamps it on ``mode`` (issue #133), so the operation dispatches
-    on that explicit discriminator rather than re-inferring it from which params
-    are present:
+    group reuses that edit interface rather than re-deriving it. The model
+    derives which mode and stamps it on ``mode`` (issue #133, ADR-0015) — the
+    SAME derivation on both the argv and ``--params-json`` paths (#713) — so the
+    operation dispatches on that explicit discriminator rather than
+    re-inferring it from which params are present:
 
     - **search-replace** (``mode = search_replace``) — ``search``/``replace`` both
       present: every literal (not regex) occurrence of ``search`` is replaced with
@@ -416,12 +417,15 @@ def set_shader(
     """Edit a .gdshader via search-replace, line-range, or full overwrite."""
     # shader set reuses the script set edit-mode interface (issue #115): the same
     # mutual-exclusion resolver decides the single ScriptSetMode discriminator.
-    mode = parse_set_mode_argv(search, replace, start_line, end_line, content)
+    # The model owns that rule and the argv body does not restate it: the shared
+    # builder turns any model-construction failure into the Click usage error
+    # (exit 2), so the rule runs once per invocation on both input paths
+    # (ADR-0015, issue #713).
     dispatch_domain(
         SHADER_SET_COMMAND,
-        ShaderSetParams(
+        params_or_bad_parameter(
+            ShaderSetParams,
             path=path,
-            mode=mode,
             search=search,
             replace=replace,
             start_line=start_line,

--- a/src/gda/dispatch.py
+++ b/src/gda/dispatch.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, ValidationError
 from gda.errors import (
     Failure,
     invalid_project_failure,
+    validation_error_message,
 )
 from gda.execution import ExecutionKind
 from gda.export_runner import ExportRunner, make_subprocess_export_runner
@@ -47,10 +48,25 @@ def params_or_bad_parameter(model_cls: type[P], /, **kwargs: Any) -> P:
     usage-error ergonomics — while ``--params-json``, which builds the SAME model
     in the command class, surfaces the same rule as a structured
     ``invalid_params``. Stated here once so no argv body restates it.
+
+    A custom ``BaseModel.__init__`` can raise a raw ``ValueError`` before
+    pydantic's validation machinery wraps it; its ``str()`` is already the plain
+    refusal sentence, so it passes through as-is. Field/model validators and
+    ``model_post_init`` instead arrive as a pydantic ``ValidationError``, rendered
+    through :func:`~gda.errors.validation_error_message` instead of its own
+    ``str()`` — which dumps the model's class name, a ``[type=...,
+    input_value=..., input_type=...]`` tag PER ERROR, and a pydantic.dev URL, and
+    can echo back an arbitrary caller value (including a large or sensitive one)
+    inside ``input_value=`` (#713 review). That renderer is shared with
+    ``--params-json``'s OWN model-construction failure (:mod:`gda.headless`), so
+    the two input channels report the identical sentence for the identical
+    refusal (#713 review, round 3) — not just the same error class.
     """
     try:
         return model_cls(**kwargs)
-    except (ValueError, ValidationError) as exc:
+    except ValidationError as exc:
+        raise typer.BadParameter(validation_error_message(exc)) from exc
+    except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
 
 

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -3,6 +3,12 @@
 The registry is the machine-readable companion to ADR-0002's table. Every code
 emitted in a public ``GdaError`` must be declared here.
 
+**Editing a ``description``.** Its wording is pinned against that ADR's ``Meaning``
+column, so a change here needs the same change there (#701). What the pin
+normalizes away — markup, wrapping, and a trailing ADR/issue citation — is stated
+with its reasoning in ``tests/test_error_registry.py``, the single home of that
+rule.
+
 **What ``source`` means.** It names a code's *authoritative origin channel* — the
 layer that defines the failure and owns reporting it — and it governs **GDScript
 mirror membership**: ``operations.gd`` declares exactly the ``operation``-source
@@ -85,7 +91,13 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.ENVIRONMENT,
         EXIT_TIMEOUT,
         ErrorCodeSource.RUNNER,
-        "Godot launched but did not return before the runner timeout.",
+        # The scope caveat is not decoration (#701): `scene preflight` owns a
+        # wall-clock bound of its own and reports exceeding it as a `timeout`
+        # STATUS on a successful result, so an agent that branches on this code
+        # alone would never see that command's timeout.
+        "Godot launched but did not return before the runner timeout. One command "
+        "does not report it: `scene preflight` reports its own `timeout` status "
+        "instead.",
     ),
     ErrorCodeSpec(
         "user_data_unwritable",
@@ -437,7 +449,7 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         EXIT_OPERATION,
         ErrorCodeSource.CLASSIFIER,
         "A `script run` entry script does not exist in the project, so the engine "
-        "never ran it (it still exits 0; gda reads the failure from stderr).",
+        "never ran it — it still exits 0, and gda reads the failure from stderr.",
     ),
     ErrorCodeSpec(
         "script_failed",
@@ -530,14 +542,24 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.CLASSIFIER,
-        "An export run targeted a preset that has no configured export_path.",
+        # Both producing conditions, not just the configured one (#701): the
+        # destination is `--output` if given, else the preset's `export_path`, so
+        # the failure needs BOTH to be absent — a reader told only about
+        # `export_path` would not know the override exists.
+        "An export run has no destination — neither a `--output` override nor a "
+        "configured `export_path`.",
     ),
     ErrorCodeSpec(
         "export_templates_missing",
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.CLASSIFIER,
-        "An export run needs the export templates for the running engine version, which are not installed.",
+        # Scoped to the modes that actually need templates (#701): `pack` produces
+        # project data only, so the preflight skips the check for it. "An export
+        # run" claimed the code can fire for a mode it never fires for.
+        "A release/debug export needs the export templates for the running engine "
+        "version, which are not installed; `pack` needs no platform templates and "
+        "is exempt.",
     ),
     ErrorCodeSpec(
         "export_output_parent_failed",
@@ -616,7 +638,9 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         EXIT_PARSE,
         ErrorCodeSource.CLASSIFIER,
         "The engine emitted a valid result tree that nests past gda's recursion"
-        " limit; the payload is contract-conformant, the limit is wrapper-side.",
+        " limit; the payload is contract-conformant, the limit is wrapper-side"
+        " (shares the `parse` exit code; the `code` distinguishes it from"
+        " `contract_violation`).",
     ),
     # Phase-2 live execution channel (ADR-0017, ADR-0021). Classifier-source —
     # surfaced by the daemon IPC client / the daemon, never by a headless
@@ -643,8 +667,8 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.LIVE,
         EXIT_LIVE,
         ErrorCodeSource.CLASSIFIER,
-        "The engine session disconnected before the live operation returned"
-        " (the game crashed or the harness connection dropped).",
+        "The engine session disconnected before the live operation returned —"
+        " the game crashed or the harness connection dropped.",
     ),
     ErrorCodeSpec(
         "live_timeout",
@@ -841,7 +865,8 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.LIVE,
         EXIT_LIVE,
         ErrorCodeSource.CLASSIFIER,
-        "A live capture predicate did not hold within its declared frame bound.",
+        "A live `screen capture` predicate (`--await-*`) did not hold within its "
+        "declared frame bound.",
     ),
     # The `screen` capture failure the gda harness reports for #222. Same shape as
     # the other per-op LIVE codes (LIVE-category, classifier-source, exit_code
@@ -856,8 +881,8 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         EXIT_LIVE,
         ErrorCodeSource.CLASSIFIER,
         "A live screen capture ran on a headless engine session (the dummy "
-        "DisplayServer cannot read pixels); start the daemon with `gda daemon start "
-        "--windowed`.",
+        "DisplayServer cannot read pixels); start the daemon windowed with "
+        "`gda daemon start --windowed`.",
     ),
     # A pre-launch platform precondition, not a live-runtime failure: live needs
     # Unix domain sockets, which are UNIX-only, so it is an ENVIRONMENT-category
@@ -869,7 +894,8 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         EXIT_NOT_FOUND,
         ErrorCodeSource.CLASSIFIER,
         "Live operations require a UNIX platform (macOS/Linux); they use Unix"
-        " domain sockets, which are unavailable here.",
+        " domain sockets, which are unavailable here. Phase-1 headless is"
+        " unaffected.",
     ),
     # A pre-launch DISPLAY precondition, not a live-runtime failure: a windowed
     # engine session needs a usable host DisplayServer, and a host with none makes a

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -133,6 +133,55 @@ def _is_too_deep(exc: ValidationError) -> bool:
     return bool(errors) and all(error["type"] == "recursion_loop" for error in errors)
 
 
+def validation_error_message(exc: ValidationError) -> str:
+    """Render a ``ValidationError`` as the sentence(s) its checks actually wrote.
+
+    The shared home for BOTH input channels that build a params model directly
+    from caller-supplied values and must translate a construction failure into a
+    human message (ADR-0015): the argv path's :func:`~gda.dispatch.params_or_bad_parameter`
+    and the ``--params-json`` path's ``invoke()`` (:mod:`gda.headless`). Lives
+    here, below both, because ``gda.dispatch`` imports ``gda.headless`` — a
+    ``gda.headless``-side import of ``gda.dispatch`` would cycle — while both
+    already import :mod:`gda.errors` for their own failure taxonomy (#713
+    review: the two channels must report the SAME sentence for the SAME
+    refusal, not just the same error class).
+
+    Reads each error's own ``msg`` — already the clean, human-readable text for
+    a built-in pydantic check (a type mismatch, a missing field, an out-of-range
+    value) — rather than ``str(exc)``, which additionally dumps the model class
+    name and a ``[type=..., input_value=..., input_type=...]`` tag per error
+    (the defect: ``input_value`` echoes the caller's raw field value, which can
+    be large or sensitive, e.g. a ``script set --content`` payload).
+
+    For a model or field validator's raised ``ValueError`` (pydantic's
+    ``"value_error"`` type, e.g. :func:`~gda.commands.script.resolve_set_mode`),
+    ``msg`` is pydantic's OWN ``"Value error, "``-prefixed rendering of it; this
+    reads the original exception back out of ``ctx['error']`` instead, so the
+    message is exactly the sentence the validator wrote, unprefixed.
+
+    Each message is tagged with its field path (``loc``, dotted) when the error
+    is field-scoped; a model-level validator's error (``loc == ()``, e.g.
+    ``resolve_set_mode``'s mode-selection rule, which has no single field to
+    name) carries no tag. Multiple errors join on ``"; "`` — a command usually
+    raises exactly one, but pydantic can report several at once (e.g. two
+    independently-invalid fields), and nothing here assumes otherwise.
+    """
+    parts: list[str] = []
+    for err in exc.errors():
+        ctx = err.get("ctx")
+        if err["type"] == "value_error" and isinstance(ctx, dict) and "error" in ctx:
+            message = str(ctx["error"])
+        else:
+            message = err["msg"]
+        loc = err.get("loc") or ()
+        if loc:
+            field = ".".join(str(part) for part in loc)
+            parts.append(f"{field}: {message}")
+        else:
+            parts.append(message)
+    return "; ".join(parts)
+
+
 def _operation_error_from_payload(result: RunResult) -> tuple[str, str] | None:
     """Extract a minimal operation error envelope from stdout, if present."""
     try:

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -26,6 +26,7 @@ from gda.errors import (
     conflicting_params_input_failure,
     invalid_params_json_failure,
     unresolvable_binary_failure,
+    validation_error_message,
 )
 from gda.execution import ExecutionKind, live_stack_constraints
 from gda.models import (
@@ -430,7 +431,17 @@ def schema_command_class(
                 try:
                     model = command.input_model.model_validate_json(text)
                 except ValidationError as exc:
-                    emit_failure(invalid_params_json_failure(str(exc)))
+                    # The same clean-sentence extractor the argv path's
+                    # params_or_bad_parameter uses (gda.errors.validation_error_message,
+                    # #713 review round 3), so both input channels report the identical
+                    # refusal for the identical violation — not str(exc)'s dump of the
+                    # model class name, a [type=..., input_value=..., input_type=...]
+                    # tag per error, and a pydantic.dev URL, which used to echo the
+                    # caller's OTHER field values (e.g. a large --content payload) back
+                    # into the structured envelope's message.
+                    emit_failure(
+                        invalid_params_json_failure(validation_error_message(exc))
+                    )
                 if _params_json_dispatch is None:  # pragma: no cover - misconfig
                     raise RuntimeError(
                         "no --params-json dispatcher registered; gda.dispatch must call "

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -116,12 +116,8 @@ const SCENE_STARTUP_READY := "ready"
 const SCENE_STARTUP_NOT_READY := "not_ready"
 
 # The ONE directory a res:// walk excludes: the engine's own import/cache tree at
-# the project root. Compared as a full path, never as a directory NAME, because a
-# `.godot` deeper in the tree is not the engine's — it is user content (an addon
-# vendoring a sample project, a test fixture tree) and its scripts are the
-# project's like any other. Excluding those made `script validate --all` report a
-# valid aggregate for a project holding an invalid script (#663 review), and hid
-# them from `script list` too.
+# the project root. The VALUE only — the decision that uses it lives in exactly one
+# place, _should_descend, which every walk calls.
 const ENGINE_CACHE_DIR := "res://.godot"
 
 # The project-info settings (issue #111), read with a default so a project that
@@ -3671,8 +3667,8 @@ func _resolve_project_class_script(class_token: String) -> Dictionary:
 
 # Build (once per process) the class_name → declaring-.gd-paths index for the
 # resolver's tier-3 static scan (ADR-0032). Walks the full res:// tree skipping
-# .godot — reusing the shared recursive walker (_collect_resource_paths, which
-# already enumerates .gd among the graph resources) — and parses each .gd's
+# the root cache — reusing the shared recursive walker (_collect_resource_paths,
+# which already enumerates .gd among the graph resources) — and parses each .gd's
 # class_name from raw source with the existing never-compiled parser
 # (_script_metadata). A class_name declared in more than one .gd maps to multiple
 # paths (sorted, so an ambiguous_class_name error is deterministic regardless of
@@ -3709,12 +3705,40 @@ func _ambiguous_class_name_message(class_token: String, paths: Array) -> String:
 	return "class_name " + class_token + " is declared in more than one script, so it cannot be resolved to a single script; declare it in exactly one .gd. Conflicting scripts: " + ", ".join(PackedStringArray(paths))
 
 
+# Whether a res:// walk descends into this child DIRECTORY. The ONE owner of the
+# exclusion decision: every walk over the project tree (scripts, scenes, graph
+# resources, all files) asks this and nothing else, so the rule cannot drift
+# between them and a new walk inherits it by calling this.
+#
+# The comparison is the full path, never the directory NAME, because a `.godot`
+# deeper in the tree is not this project's engine cache. It is usually authored
+# content (an addon vendoring a sample project, a fixture tree), and excluding it
+# hid real scripts from `script list` and let `script validate --all` report a
+# valid aggregate for a project holding an invalid script (#663 review). Sometimes
+# it is a vendored sub-project's own cache instead, whose artefacts then count in
+# `project statistics` and `find-unused-resources` — accepted deliberately, since
+# nothing in the path tells the two apart and a false-valid aggregate is worse.
+#
+# Three of the four walks once compared the NAME, so one project answered two
+# ways: `script list` reported a script `project statistics` counted as zero
+# (#712). One decision, one site — that is what keeps them in agreement.
+#
+# The test is LEXICAL and stays that way here: it does not resolve filesystem
+# targets, so an alias that leads to the root cache is descended into, and a
+# symlink cycle is descended until the OS path limit stops it. Symlink policy for
+# the res:// walk is undecided and tracked in #760 — do not decide half of it
+# in this predicate.
+func _should_descend(child: String) -> bool:
+	return child != ENGINE_CACHE_DIR
+
+
 # Recursively collect every RESOURCE-bearing file under res:// — the files that
 # can carry references (.tscn/.tres scenes & resources, .gd scripts) AND the leaf
 # asset resources (everything else except import sidecars, the project file, and
 # the .godot cache). Mirrors _collect_scene_paths: hidden entries enumerated,
-# navigational entries off, res://.godot skipped. This is the universe both the
-# reference graph and find-unused range over.
+# navigational entries off, directory descent decided by _should_descend. This is
+# the universe the reference graph, find-unused and the class_name index range
+# over.
 func _collect_resource_paths(dir_path: String, out: Array[String]) -> void:
 	var dir := DirAccess.open(dir_path)
 	if dir == null:
@@ -3725,7 +3749,7 @@ func _collect_resource_paths(dir_path: String, out: Array[String]) -> void:
 	while not entry.is_empty():
 		var child := dir_path.path_join(entry)
 		if dir.current_is_dir():
-			if entry != ".godot":
+			if _should_descend(child):
 				_collect_resource_paths(child, out)
 		elif _is_graph_resource_path(child):
 			out.append(child)
@@ -3733,9 +3757,10 @@ func _collect_resource_paths(dir_path: String, out: Array[String]) -> void:
 	dir.list_dir_end()
 
 
-# Recursively collect EVERY file under res:// (skipping only the .godot cache) for
-# the statistics counts — unlike _collect_resource_paths this keeps import
-# sidecars, project.godot and every asset, since statistics counts all files.
+# Recursively collect EVERY file under res:// (descending per _should_descend)
+# for the statistics counts — unlike _collect_resource_paths this keeps import
+# sidecars, project.godot and every asset, since statistics counts all files. The
+# two walks therefore range over DIFFERENT universes under the same exclusion.
 func _collect_all_file_paths(dir_path: String, out: Array[String]) -> void:
 	var dir := DirAccess.open(dir_path)
 	if dir == null:
@@ -3746,7 +3771,7 @@ func _collect_all_file_paths(dir_path: String, out: Array[String]) -> void:
 	while not entry.is_empty():
 		var child := dir_path.path_join(entry)
 		if dir.current_is_dir():
-			if entry != ".godot":
+			if _should_descend(child):
 				_collect_all_file_paths(child, out)
 		else:
 			out.append(child)
@@ -4238,13 +4263,11 @@ func _has_project() -> bool:
 	return DirAccess.dir_exists_absolute("res://") and FileAccess.file_exists("res://project.godot")
 
 
-# Recursively collect every .tscn under res:// (issue #54), skipping only the
-# engine's own res://.godot cache directory (import artifacts, not authored
-# scenes). The skip is scoped to that one directory name rather than every
-# dot-prefixed entry, so legitimately hidden scenes (a .hidden.tscn, or a scene
-# under a dot-prefixed directory) are still enumerated as promised (issue #54
-# review). Paths are returned as res:// paths so they round-trip into other
-# scene commands.
+# Recursively collect every .tscn under res:// (issue #54), descending per
+# _should_descend. The dot prefix is not part of that test, so a legitimately
+# hidden scene (a .hidden.tscn, or one under a dot-prefixed directory) is
+# enumerated as promised (issue #54 review). Paths are returned as res:// paths
+# so they round-trip into other scene commands.
 func _collect_scene_paths(dir_path: String, out: Array[String]) -> void:
 	var dir := DirAccess.open(dir_path)
 	if dir == null:
@@ -4258,7 +4281,7 @@ func _collect_scene_paths(dir_path: String, out: Array[String]) -> void:
 	while not entry.is_empty():
 		var child := dir_path.path_join(entry)
 		if dir.current_is_dir():
-			if entry != ".godot":
+			if _should_descend(child):
 				_collect_scene_paths(child, out)
 		elif entry.get_extension() == "tscn":
 			out.append(child)
@@ -4292,13 +4315,10 @@ func _scene_summary(path: String) -> Dictionary:
 	}
 
 
-# Recursively collect every .gd script under res:// (issue #117), skipping only
-# the engine's own res://.godot cache directory. Hidden entries are enumerated (a
-# .hidden.gd, or a script under a dot-prefixed directory) and navigational entries
-# stay off. The skip is the ROOT cache path exactly (ENGINE_CACHE_DIR), not any
-# directory named `.godot`: an earlier name test also swallowed a nested one,
-# which is authored content — see that const. Paths are returned as res:// paths
-# so they round-trip into other script commands.
+# Recursively collect every .gd script under res:// (issue #117), descending per
+# _should_descend. Hidden entries are enumerated (a .hidden.gd, or a script under
+# a dot-prefixed directory) and navigational entries stay off. Paths are returned
+# as res:// paths so they round-trip into other script commands.
 func _collect_script_paths(dir_path: String, out: Array[String]) -> void:
 	var dir := DirAccess.open(dir_path)
 	if dir == null:
@@ -4309,7 +4329,7 @@ func _collect_script_paths(dir_path: String, out: Array[String]) -> void:
 	while not entry.is_empty():
 		var child := dir_path.path_join(entry)
 		if dir.current_is_dir():
-			if child != ENGINE_CACHE_DIR:
+			if _should_descend(child):
 				_collect_script_paths(child, out)
 		elif entry.get_extension().to_lower() == "gd":
 			out.append(child)

--- a/src/gda/script_errors.py
+++ b/src/gda/script_errors.py
@@ -87,9 +87,21 @@ _LOAD_FAILED = re.compile(
 )
 
 # `ERROR: Can't load script: <path>` — main.cpp's `start()` giving up on the
-# `--script` entry point. Emitted alongside the more specific sentences above;
-# on its own it is the generic "the entry never became the main loop".
-_CANT_LOAD = re.compile(r"^Can't load script: (?P<path>\S+?)\.?$")
+# `--script` entry point (`main.cpp:4271`, `"Can't load script: " + script`, Godot
+# 4.6.3). The engine concatenates the raw path with NO trailing period — unlike
+# `_FAILED_LOADING_RESOURCE` below, this sentence carries no format-string
+# punctuation to strip, so the capture now runs to end of line unconditionally.
+# A `\.?$` strip here used to silently eat a genuine trailing dot off a
+# dot-terminated path (`res://..` parsed back as `res://.`, #698). `.+` rather
+# than `\S+`: a project-relative path MAY contain a space (`res://missing
+# file.`), and `\S+` failed to match the line AT ALL for one — a pre-existing
+# phantom success (present on `main` before #698 too, not introduced by the
+# dot fix), which left NO diagnostic behind rather than a corrupted one, and
+# was masked whenever the path also carried a recognized extension (that
+# shape additionally gets `_OPEN_FAILED`'s quoted, space-safe capture).
+# `engine_log` has already split stderr into lines before this regex ever
+# sees one, so `.+` cannot run past the line it belongs to.
+_CANT_LOAD = re.compile(r"^Can't load script: (?P<path>.+)$")
 
 # `ERROR: Can't load the script "<path>" as it doesn't inherit from SceneTree or
 # MainLoop.` — the script compiled fine but cannot BE the one-shot entry point.
@@ -132,9 +144,24 @@ _NOT_A_SCRIPT_BINDING = re.compile(
 # verdict is unaffected (see ``_ENTRY_FAILURE_PRECEDENCE``).
 _CANNOT_OPEN_FILE = re.compile(r"^Cannot open file '(?P<path>[^']*)'")
 
-# `ERROR: Failed loading resource: <path>.` — note the sentence-ending period,
-# which is NOT part of the path and is stripped when the address is read out.
-_FAILED_LOADING_RESOURCE = re.compile(r"^Failed loading resource: (?P<path>\S+?)\.?$")
+# `ERROR: Failed loading resource: <path>.` — `resource_loader.cpp:343`,
+# `vformat("Failed loading resource: %s.", p_path)` (Godot 4.6.3). The format
+# string ALWAYS appends exactly one trailing period, so it is sentence
+# punctuation, never part of the path. Unlike `_CANT_LOAD` above, an optional
+# strip here never actually mis-read a well-formed captured line, for any
+# number of trailing dots: the lazy quantifier always finds the guaranteed
+# period regardless of how many dots the path itself carries. The strip is
+# mandatory anyway (#698) — a fail-closed hardening that rejects a line
+# lacking the guaranteed period instead of silently accepting the whole
+# remainder as the path, not a fix for observed corruption. `.+` rather than
+# `\S+`, for the same reason as `_CANT_LOAD`: a project-relative path MAY
+# contain a space, and `engine_log` has already split stderr into lines
+# before this regex ever sees one, so `.+` cannot run past the line it
+# belongs to. The engine's other "Failed loading resource" wording
+# (`resource_loader.cpp:327`, no trailing period) reaches only
+# `print_verbose`, never an `ERROR:` line `parse_errors` recognizes, so it
+# cannot reach this regex.
+_FAILED_LOADING_RESOURCE = re.compile(r"^Failed loading resource: (?P<path>.+)\.$")
 
 
 def canonical_res_path(path: str) -> str:

--- a/tests/support.py
+++ b/tests/support.py
@@ -31,6 +31,33 @@ def plain_text(text: str) -> str:
     return ANSI_ESCAPE.sub("", text)
 
 
+# The box-drawing characters Rich uses to frame a Click usage-error panel
+# (``╭─...─╮`` etc.) — a SEPARATE concern from `ANSI_ESCAPE` above, since a
+# usage error's border survives even where color does not.
+_RICH_PANEL_BORDER = re.compile(r"[─-╿]")
+
+
+def usage_error_text(result) -> str:
+    """Normalize a CliRunner ``Result``'s Click usage-error panel to plain text.
+
+    A model refusal on the argv path (``gda.dispatch.params_or_bad_parameter``,
+    ADR-0015) is a Click usage error: exit 2, the message inside a Rich panel on
+    stderr. Rich renders that panel with ANSI color and box-drawing borders even
+    under ``CliRunner`` (colorized state can differ between a local run and CI,
+    issue #671), so a raw ``result.stderr`` can't be matched directly. This
+    normalizes it ONCE — reusing :func:`plain_text` for the ANSI half, folding
+    the box-drawing border to whitespace, then collapsing whitespace runs — and
+    returns the whole collapsed panel (the ``Usage: ...`` preamble, the
+    ``Error`` heading, and the ``Invalid value: <message>`` body), so a caller
+    matches whichever substring it needs, or extracts the message itself.
+    Shared by every test asserting on an argv usage error's text, instead of
+    each redefining the same normalization (#713 review).
+    """
+    assert result.exit_code == 2, result.stdout + result.stderr
+    plain = _RICH_PANEL_BORDER.sub(" ", plain_text(result.stderr))
+    return re.sub(r"\s+", " ", plain).strip()
+
+
 # The gda CLI invocation prefix for e2e subprocess tests. Resolved as the gda
 # MODULE in *this* interpreter's environment — `[sys.executable, "-m", "gda"]` —
 # never a PATH-resolved global. This is the same same-environment resolution

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,0 +1,258 @@
+"""The argv and ``--params-json`` model-refusal rendering (issue #713).
+
+Both input channels construct a command's params model directly from
+caller-supplied values (ADR-0015) and must translate a construction failure
+into a human message: the argv path's
+:func:`~gda.dispatch.params_or_bad_parameter` and the ``--params-json``
+path's ``invoke()`` (:mod:`gda.headless`). Both used to render a pydantic
+``ValidationError`` with its own ``str()``, which dumps the model's class
+name, a ``[type=..., input_value=..., input_type=...]`` tag PER ERROR, and a
+``pydantic.dev`` URL — and echoes an arbitrary caller value (e.g. a
+``script set --content`` payload) back inside ``input_value=`` (found in PR
+#754's review, round 2 for argv, round 3 for ``--params-json``).
+
+Both now go through the ONE shared renderer, :func:`gda.errors.validation_error_message`
+(round 3: moved out of ``gda.dispatch`` to a home below both channels, since
+``gda.dispatch`` imports ``gda.headless`` and the reverse would cycle). These
+tests pin the clean replacement directly against ``params_or_bad_parameter``
+(the validator's own sentence(s), for a plain ``ValueError``, a single-error
+``ValidationError`` — model-level and field-level — and a multi-error
+``ValidationError``), then pin the SAME clean shape end-to-end through an
+actual command's ``--params-json`` route, and finally assert the two channels
+report byte-identical sentences for the identical refusal.
+"""
+
+import json
+
+import typer
+import pytest
+from pydantic import BaseModel, field_validator, model_validator
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.dispatch import params_or_bad_parameter
+from tests.support import usage_error_text
+
+# The exact dump fragments str(ValidationError) used to leak (PR #754 review).
+_FORBIDDEN_FRAGMENTS = ("pydantic.dev", "input_value=", "[type=")
+
+
+def _assert_clean(message: str) -> None:
+    for fragment in _FORBIDDEN_FRAGMENTS:
+        assert fragment not in message, f"{fragment!r} leaked into {message!r}"
+
+
+def _argv_usage_error_message(result) -> str:
+    # The Rich-panel normalization is shared (tests/support.py,
+    # `usage_error_text`) — the SAME one tests/test_screen_commands.py uses —
+    # so only the "Invalid value: " extraction is specific to this module.
+    plain = usage_error_text(result)
+    # The panel is preceded by the "Usage: ..." / "Try '... --help'" preamble
+    # and an "Error" heading, so find the marker rather than assume it leads.
+    prefix = "Invalid value: "
+    marker = plain.rfind(prefix)
+    assert marker != -1, plain
+    return plain[marker + len(prefix) :]
+
+
+def _params_json_invalid_params_message(result) -> str:
+    assert result.exit_code != 0, result.stdout
+    data = json.loads(result.stdout)
+    assert data["error"]["code"] == "invalid_params", data
+    message = data["error"]["message"]
+    prefix = "--params-json is not a valid params object: "
+    assert message.startswith(prefix), message
+    return message[len(prefix) :]
+
+
+class _ModelLevelRuleModel(BaseModel):
+    """Mirrors ScriptSetParams's shape: a model-level mutual-exclusion rule."""
+
+    search: str | None = None
+    replace: str | None = None
+
+    @model_validator(mode="after")
+    def _check(self) -> "_ModelLevelRuleModel":
+        if (self.search is None) != (self.replace is None):
+            raise ValueError("'search' and 'replace' must be used together.")
+        return self
+
+
+class _FieldLevelRuleModel(BaseModel):
+    """A field-level validator's raised ValueError, the other value_error shape."""
+
+    name: str
+
+    @field_validator("name")
+    @classmethod
+    def _check(cls, value: str) -> str:
+        if not value:
+            raise ValueError("'name' must not be empty.")
+        return value
+
+
+class _TwoIndependentFieldsModel(BaseModel):
+    """Two fields that can each fail independently, for the multi-error join."""
+
+    a: int
+    b: int
+
+
+class _RawValueErrorModel(BaseModel):
+    """A real BaseModel subclass that raises a bare ValueError from __init__.
+
+    Exercises params_or_bad_parameter's OTHER except clause with a genuine
+    ``P`` (bound to BaseModel) — in contract, not a bypass of it (PR #754
+    review, round 5). A field or model validator can't reach this branch:
+    pydantic always wraps a validator's raised ValueError into
+    ValidationError, and ``model_post_init`` gets the same wrapping
+    (verified). Overriding ``__init__`` is the one route that escapes it —
+    the override runs before pydantic's own validation machinery does, so
+    the plain ValueError it raises here propagates untouched. This is why
+    ``params_or_bad_parameter`` must catch ``ValidationError`` before
+    ``ValueError``: ``ValidationError`` is itself a ``ValueError`` subclass,
+    and this class is the sibling shape a ValidationError-raising validator
+    can never produce.
+    """
+
+    a: int = 1
+
+    def __init__(self, **kwargs: object) -> None:
+        raise ValueError("a plain refusal sentence.")
+
+
+def test_plain_value_error_passes_through_as_the_bare_sentence():
+    with pytest.raises(typer.BadParameter) as exc_info:
+        params_or_bad_parameter(_RawValueErrorModel)
+
+    message = str(exc_info.value)
+    assert message == "a plain refusal sentence."
+    _assert_clean(message)
+
+
+def test_model_level_validation_error_renders_the_validators_own_sentence():
+    with pytest.raises(typer.BadParameter) as exc_info:
+        params_or_bad_parameter(_ModelLevelRuleModel, search="foo", replace=None)
+
+    message = str(exc_info.value)
+    assert message == "'search' and 'replace' must be used together."
+    _assert_clean(message)
+
+
+def test_field_level_validation_error_renders_the_validators_own_sentence():
+    with pytest.raises(typer.BadParameter) as exc_info:
+        params_or_bad_parameter(_FieldLevelRuleModel, name="")
+
+    message = str(exc_info.value)
+    assert message == "name: 'name' must not be empty."
+    _assert_clean(message)
+
+
+def test_multi_error_validation_error_joins_each_fields_own_message():
+    with pytest.raises(typer.BadParameter) as exc_info:
+        params_or_bad_parameter(_TwoIndependentFieldsModel, a="x", b="y")
+
+    message = str(exc_info.value)
+    assert "a: " in message and "b: " in message
+    assert "; " in message  # the stated join separator
+    _assert_clean(message)
+
+
+def test_no_caller_value_leaks_into_the_refusal():
+    # The concrete leak PR #754's review reproduced: a large/sensitive field
+    # value must never ride along in the refusal, even though the refused
+    # field itself carries it.
+    secret = "SECRET_MARKER_abcdefghijklmnopqrstuvwxyz0123456789_END"
+
+    class _CarriesASecretField(BaseModel):
+        search: str | None = None
+        replace: str | None = None
+        content: str | None = None
+
+        @model_validator(mode="after")
+        def _check(self) -> "_CarriesASecretField":
+            if (self.search is None) != (self.replace is None):
+                raise ValueError("'search' and 'replace' must be used together.")
+            return self
+
+    with pytest.raises(typer.BadParameter) as exc_info:
+        params_or_bad_parameter(
+            _CarriesASecretField, search="foo", replace=None, content=secret
+        )
+
+    message = str(exc_info.value)
+    assert secret not in message
+    assert message == "'search' and 'replace' must be used together."
+    _assert_clean(message)
+
+
+# --- end-to-end: --params-json through an actual command (round 3) ------------
+
+
+def test_params_json_validation_error_is_also_rendered_clean():
+    # script set's search/replace mutual-exclusion rule (resolve_set_mode),
+    # refused via --params-json this time, not argv.
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "set",
+            "--params-json",
+            json.dumps({"path": "/tmp/nonexist.gd", "search": "foo"}),
+            "--json",
+        ],
+    )
+
+    message = _params_json_invalid_params_message(result)
+    assert message == "'search' and 'replace' must be used together."
+    _assert_clean(message)
+
+
+def test_params_json_does_not_leak_the_callers_other_field_value():
+    # The exact channel this round's review caught: --content rode inside
+    # input_value= in the structured envelope's message, secret and all.
+    secret = "SECRET_MARKER_abcdefghijklmnopqrstuvwxyz0123456789_END"
+    result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "set",
+            "--params-json",
+            json.dumps(
+                {"path": "/tmp/nonexist.gd", "search": "foo", "content": secret}
+            ),
+            "--json",
+        ],
+    )
+
+    message = _params_json_invalid_params_message(result)
+    assert secret not in message
+    assert message == "'search' and 'replace' must be used together."
+    _assert_clean(message)
+
+
+def test_argv_and_params_json_report_the_identical_sentence():
+    # #713's own acceptance criterion 2 pairs the two channels ("the same
+    # error class"); this pins them to the same MESSAGE too, not just the
+    # same class, for the identical refusal.
+    argv_result = CliRunner().invoke(
+        app, ["script", "set", "/tmp/nonexist.gd", "--search", "foo", "--json"]
+    )
+    params_json_result = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "set",
+            "--params-json",
+            json.dumps({"path": "/tmp/nonexist.gd", "search": "foo"}),
+            "--json",
+        ],
+    )
+
+    argv_message = _argv_usage_error_message(argv_result)
+    params_json_message = _params_json_invalid_params_message(params_json_result)
+    assert (
+        argv_message
+        == params_json_message
+        == ("'search' and 'replace' must be used together.")
+    )

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -1,8 +1,11 @@
 """S1 (e2e): the project static-analysis reads against the real Godot engine (issue #116).
 
 The four read-only, project-wide analysis commands — find-references,
-dependencies, find-unused-resources, statistics — backed by a single static scan
-that parses files as text (no instantiation, issue #30). These tests build a
+dependencies, find-unused-resources, statistics — backed by two static scans
+over different file universes (the first three share the extension-filtered
+walk; statistics counts with an unfiltered one that also sees ``.import``
+sidecars and ``project.godot``) under one shared directory-exclusion rule,
+both parsing files as text (no instantiation, issue #30). These tests build a
 small fixture project WITH cross-references (a main scene that ext_resources a
 sub-scene, a script and an image; a script that preloads a sibling; an autoload;
 an unreferenced resource) and assert each command reports it correctly off the
@@ -482,3 +485,135 @@ def test_dependencies_without_project_is_project_not_found(tmp_path):
     assert proc.returncode == 4, proc.stdout + proc.stderr
     err = json.loads(proc.stdout)["error"]
     assert err["code"] == "project_not_found"
+
+
+# --- every project walk agrees on a nested `.godot` directory (#712) ----------
+
+# A project-local custom Node declared inside a NESTED `.godot` directory — the
+# class the class_name index must find once the resource walk stops excluding
+# that directory by name.
+NESTED_THING_GD = """\
+class_name NestedThing
+extends Node
+"""
+
+# The same declaration authored INTO the engine's own root cache. It must stay
+# invisible, so the correction does not swap one wrong enumeration for another.
+CACHED_THING_GD = """\
+class_name CachedThing
+extends Node
+"""
+
+BARE_TSCN = """\
+[gd_scene format=3]
+
+[node name="Root" type="Node2D"]
+"""
+
+
+@pytest.mark.e2e
+def test_project_walks_agree_on_a_nested_dot_godot_directory(tmp_path):
+    # The exclusion is the engine's ONE cache directory, `res://.godot` — not
+    # every directory that happens to be named `.godot`. A nested one is user
+    # content (an addon vendoring a sample project, a fixture tree). #710 fixed
+    # the SCRIPT walk that way and left three siblings comparing the entry name,
+    # so one project answered two ways: `script list` reported a script that
+    # `project statistics` counted as zero, and `node add --type` could not
+    # resolve a class_name `script list` had just shown (#712). This test is that
+    # cross-command agreement, not four per-walker checks — each command below
+    # rides a different walk over the same tree.
+    project = tmp_path / "nested-cache"
+    (project / "nested" / ".godot").mkdir(parents=True)
+    (project / ".godot").mkdir(parents=True, exist_ok=True)
+    (project / "project.godot").write_text(
+        project_godot("gda-e2e-nested-walks"), encoding="utf-8"
+    )
+    (project / "top.tscn").write_text(BARE_TSCN, encoding="utf-8")
+    (project / "nested" / ".godot" / "hidden.tscn").write_text(
+        BARE_TSCN, encoding="utf-8"
+    )
+    (project / "nested" / ".godot" / "hidden.gd").write_text(
+        NESTED_THING_GD, encoding="utf-8"
+    )
+    (project / ".godot" / "engine_cache.tscn").write_text(BARE_TSCN, encoding="utf-8")
+    (project / ".godot" / "engine_cache.gd").write_text(
+        CACHED_THING_GD, encoding="utf-8"
+    )
+
+    scene_proc = _gda(project, "scene", "list", "--json")
+    script_proc = _gda(project, "script", "list", "--json")
+    stats_proc = _gda(project, "project", "statistics", "--json")
+
+    assert scene_proc.returncode == 0, scene_proc.stdout + scene_proc.stderr
+    assert script_proc.returncode == 0, script_proc.stdout + script_proc.stderr
+    assert stats_proc.returncode == 0, stats_proc.stdout + stats_proc.stderr
+    scenes = {s["path"] for s in json.loads(scene_proc.stdout)["scenes"]}
+    scripts = {s["path"] for s in json.loads(script_proc.stdout)["scripts"]}
+    stats = json.loads(stats_proc.stdout)
+
+    # The nested content is authored content: every walk enumerates it.
+    assert scenes == {"res://top.tscn", "res://nested/.godot/hidden.tscn"}
+    assert scripts == {"res://nested/.godot/hidden.gd"}
+    # The counts and the listings are the same project, so they agree.
+    assert stats["scene_count"] == len(scenes)
+    assert stats["script_count"] == len(scripts)
+    # The root cache stays invisible — in the listings and in the counts alike
+    # (it holds one .gd and one .tscn of its own, which must not be counted).
+    assert not any(p.startswith("res://.godot/") for p in scenes | scripts)
+    by_ext = {e["extension"]: e for e in stats["by_extension"]}
+    assert by_ext["gd"]["files"] == 1
+    assert by_ext["tscn"]["files"] == 2
+
+    # The class_name index rides the resource walk, so node/resource creation
+    # resolves the nested declaration `script list` reports...
+    added = _gda(
+        project, "node", "add", "res://top.tscn", "--type", "NestedThing", "--json"
+    )
+    assert added.returncode == 0, added.stdout + added.stderr
+    assert json.loads(added.stdout)["script_class"] == "NestedThing"
+    # ...and still does not resolve one authored into the engine's own cache.
+    cached = _gda(
+        project, "node", "add", "res://top.tscn", "--type", "CachedThing", "--json"
+    )
+    assert cached.returncode == 4, cached.stdout + cached.stderr
+    assert json.loads(cached.stdout)["error"]["code"] == "invalid_node_type"
+
+    # The three remaining consumers of that same walk. They run AFTER the node
+    # add, which wrote an [ext_resource] to the nested script into
+    # `res://top.tscn` — so the nested content is a real reference target here,
+    # not just an enumerated path.
+    deps_proc = _gda(project, "project", "dependencies", "--json")
+    refs_proc = _gda(
+        project, "project", "find-references", "res://nested/.godot/hidden.gd", "--json"
+    )
+    unused_proc = _gda(project, "project", "find-unused-resources", "--json")
+
+    assert deps_proc.returncode == 0, deps_proc.stdout + deps_proc.stderr
+    assert refs_proc.returncode == 0, refs_proc.stdout + refs_proc.stderr
+    assert unused_proc.returncode == 0, unused_proc.stdout + unused_proc.stderr
+    by_source = {
+        row["path"]: row["depends_on"]
+        for row in json.loads(deps_proc.stdout)["dependencies"]
+    }
+    references = json.loads(refs_proc.stdout)["references"]
+    unused = json.loads(unused_proc.stdout)["unused"]
+
+    # Both nested files are graph sources, and top.tscn's edge to the nested
+    # script is reported from both ends.
+    assert set(by_source) == {
+        "res://top.tscn",
+        "res://nested/.godot/hidden.tscn",
+        "res://nested/.godot/hidden.gd",
+    }
+    assert by_source["res://top.tscn"] == [
+        {"path": "res://nested/.godot/hidden.gd", "kind": "ext_resource"}
+    ]
+    assert [(r["path"], r["kind"]) for r in references] == [
+        ("res://top.tscn", "ext_resource")
+    ]
+    # The nested script is referenced now, so only the two scenes are orphans.
+    assert unused == ["res://nested/.godot/hidden.tscn", "res://top.tscn"]
+    # The root cache is invisible to all three. Its `.gd` and `.tscn` would
+    # otherwise BOTH be dependency source rows and unused candidates, so this
+    # arm fails if the exclusion ever widens past `res://.godot` itself.
+    assert not any(p.startswith("res://.godot/") for p in [*by_source, *unused])

--- a/tests/test_e2e_script_run.py
+++ b/tests/test_e2e_script_run.py
@@ -297,6 +297,10 @@ def test_script_run_absolute_path_is_invalid_path(godot_project):
         "../outside.gd",
         "res://..",
         "res://../outside.gd",
+        # Godot preserves the LF in its emitted path, but the line-oriented parser
+        # splits the diagnostic and loses the entry identity. This used to return a
+        # phantom exit-0 success for a script that never ran.
+        "res://missing\nfile.gd",
     ],
 )
 def test_script_run_non_project_scoped_paths_are_refused_before_launch(
@@ -304,14 +308,15 @@ def test_script_run_non_project_scoped_paths_are_refused_before_launch(
 ):
     # Accepting the project-relative form must not accept everything merely
     # non-absolute. Against the REAL engine, because these are exactly the cases where
-    # the engine's own report defeats the verdict: `gda script run ""` normalized to
-    # `res://.`, launched, and the engine's `Can't load script: res://.` parsed back
-    # as `res://` — no match, so a run that never happened reported exit 0 SUCCESS.
-    # `..` did the same one level up. The other-scheme cases spawned the engine
-    # against `res://user:/x.gd`, an address the caller never typed. And a RESOLVABLE
-    # escape (`../outside.gd`) actually executed a script outside the project — the
-    # ADR-0009 widening the amendment cites as its reason for refusing absolute paths,
-    # so it must not be reachable by the relative spelling either.
+    # the engine's own report used to defeat the verdict: `gda script run ""`
+    # normalized to `res://.`, launched, and the engine's `Can't load script:
+    # res://.` parsed back as `res://` — no match, so a run that never happened
+    # reported exit 0 SUCCESS (fixed at the parser level by #698; this refusal stays
+    # regardless). `..` did the same one level up. The other-scheme cases spawned the
+    # engine against `res://user:/x.gd`, an address the caller never typed. And a
+    # RESOLVABLE escape (`../outside.gd`) actually executed a script outside the
+    # project — the ADR-0009 widening the amendment cites as its reason for refusing
+    # absolute paths, so it must not be reachable by the relative spelling either.
     run = _run_gda(
         "script",
         "run",
@@ -329,6 +334,33 @@ def test_script_run_non_project_scoped_paths_are_refused_before_launch(
     err = data["error"]
     assert err["code"] == "invalid_path"
     assert err["category"] == "operation"
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("suffix", ["\u00a0", "\u2003"])
+def test_script_run_does_not_overreject_unicode_spaces_godot_preserves(
+    godot_project, suffix
+):
+    # Godot's String::strip_edges() trims code points <= U+0020, not Python's
+    # complete Unicode whitespace set. NBSP and EM SPACE remain part of the path,
+    # so the request must launch and reach the ordinary entry-load verdict rather
+    # than fail pre-launch as invalid_path.
+    script = f"res://missing.gd{suffix}"
+    run = _run_gda(
+        "script",
+        "run",
+        script,
+        "--project",
+        str(godot_project),
+        "--godot",
+        str(GODOT),
+        "--json",
+    )
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "script_compile_failed"
+    assert script in err["message"]
 
 
 @pytest.mark.e2e

--- a/tests/test_error_registry.py
+++ b/tests/test_error_registry.py
@@ -2,6 +2,7 @@
 
 import re
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 
@@ -46,7 +47,9 @@ ADR_0002 = ROOT / "docs" / "adr" / "0002-headless-structured-output-contract.md"
 OPERATIONS_GD = ROOT / "src" / "gda" / "ops" / "operations.gd"
 GDA_HARNESS_GD = ROOT / "src" / "gda" / "harness" / "gda_harness.gd"
 
-ADR_REGISTRY_ROW = re.compile(r"^\| `([^`]+)` \| `([^`]+)` \| `([^`]+)` \| `(\d+)` \|")
+ADR_REGISTRY_ROW = re.compile(
+    r"^\| `([^`]+)` \| `([^`]+)` \| `([^`]+)` \| `(\d+)` \| (.+?) \|$"
+)
 GDSCRIPT_OPERATION_CODE = re.compile(
     r'^const OP_ERROR_[A-Z_]+ := "([a-z_]+)"$', re.MULTILINE
 )
@@ -84,19 +87,108 @@ HARNESS_LIVE_ERROR_CODES = (
 )
 
 
-def _adr_registry() -> dict[str, tuple[str, str, int]]:
-    rows: dict[str, tuple[str, str, int]] = {}
+# --- How a code's DESCRIPTION is compared across the two artifacts (#701) -----
+#
+# ADR-0002's table and `gda.error_codes` carry the same per-code description, and
+# the equality pin below compares it. Two normalizations run first. Both are
+# decisions with a stated reason, because a rule buried in a regex is a rule the
+# next reader cannot tell from a bug. Counts below are a 2026-08-28 snapshot, not
+# a contract — only the pin itself is asserted.
+#
+# 1. **Markdown prose vs a Python string.** The ADR cell is Markdown (`code
+#    spans`, one long line); the registry is an implicitly-concatenated,
+#    formatter-wrapped string. Backticks are dropped, whitespace runs collapse to
+#    one space, and a trailing period is ignored — so a reflow or a code-span
+#    added on one side is never a failure. Every other character must match.
+#
+# 2. **A citation is not part of a code's meaning.** 41 of the ADR's 91 rows end
+#    with a parenthetical citing the decision or issue that put the row in the
+#    contract: `(Phase 2, ADR-0017 / ADR-0021)`, `(ADR-0033, #363)`, `(#170)`.
+#    Saying which decision added a row is the ADR's job as a decision record; the
+#    registry's `description` is the code's MEANING — the sentence a caller reads
+#    next to the code, where an unresolvable issue number is noise. So a trailing
+#    parenthetical is stripped and not compared when it CITES at least one ADR or
+#    issue and contains nothing but citation tokens. It is stripped on BOTH sides,
+#    not just the ADR's: the two artifacts cite for different readers, and 5
+#    registry descriptions carry one too (`usage_error`, `invalid_params`,
+#    `ambiguous_class_name`, `script_failed`, `script_aborted` — each a pointer to
+#    the ADR that governs it, worth keeping where it is).
+#    Rejected alternative: have the registry adopt the ADR's refs. That copies 41
+#    references an agent cannot resolve into the public code descriptions and makes
+#    appending an issue number a standing obligation for every new code.
+#
+#    **Why a reference is REQUIRED, not merely allowed** (#755 review): a bare
+#    `(Phase N)` is domain content, not a citation — CONTEXT.md defines Phase 1 /
+#    Phase 2 as the order capabilities are delivered in. An earlier form of this
+#    rule stripped any parenthetical built from the token set, so `(Phase 2)` and
+#    `(Phase 1)` normalized alike and a mislabelled row would have passed the pin
+#    silently — the exact drift class #701 exists to catch. A `Phase N` may still
+#    ride INSIDE a citation cluster, because dropping it from the token set would
+#    unstrip `(Phase 2, ADR-0017 / ADR-0021)` and turn a third of the cited rows
+#    into false divergences.
+#
+#    Residual, stated exactly: a `Phase N` riding inside a citation cluster is
+#    stripped with it and so is not compared. For 20 of the 23 rows carrying a
+#    phase label the compared `Category` column pins the distinction indirectly —
+#    `live` exists only in Phase 2 (ADR-0021) — but the other three are
+#    ENVIRONMENT-category (`live_unsupported_platform`, `live_windowed_unavailable`,
+#    `live_windowed_permission_denied`), so for those a phase mislabel inside a
+#    citation cluster is caught by neither mechanism. Left that way deliberately:
+#    three docs-only rows in a field with no runtime consumer do not justify the
+#    27 rows of churn that closing the riding case would cost.
+#
+# The rule is deliberately narrow. A parenthetical that MIXES prose with a ref is
+# not a citation and is compared verbatim, so content can never hide behind the
+# rule. #701 found exactly that: `(pack needs no platform templates and is
+# exempt; #170)` — a real exemption the registry had lost. It was reconciled into
+# both artifacts, not normalized away.
+#
+# A new citation form (a date, a PR link) will fail this pin rather than being
+# silently accepted. That is intended: widening the token set is a conscious edit.
+CITATION_REF = r"(?:ADR-\d{4}(?: amendment)?|#\d+)"
+CITATION_TOKEN = rf"(?:Phase \d+|{CITATION_REF})"
+TRAILING_CITATION = re.compile(
+    # The lookahead is the "at least one ADR or issue reference" requirement.
+    rf"\s*\((?=[^()]*{CITATION_REF})"
+    rf"{CITATION_TOKEN}(?:\s*[,/]\s*{CITATION_TOKEN})*\)\.?\s*$"
+)
+
+
+def _normalized_description(text: str) -> str:
+    """The comparable part of a description — see the rule above."""
+    flattened = " ".join(text.replace("`", "").split()).rstrip(". ")
+    return TRAILING_CITATION.sub("", flattened).rstrip(". ")
+
+
+class ErrorRow(NamedTuple):
+    """One code's full public shape, as both artifacts must state it."""
+
+    category: str
+    source: str
+    exit_code: int
+    description: str
+
+
+def _adr_registry() -> dict[str, ErrorRow]:
+    rows: dict[str, ErrorRow] = {}
     for line in ADR_0002.read_text(encoding="utf-8").splitlines():
         match = ADR_REGISTRY_ROW.match(line)
         if match:
-            code, category, source, exit_code = match.groups()
-            rows[code] = (category, source, int(exit_code))
+            code, category, source, exit_code, description = match.groups()
+            rows[code] = ErrorRow(
+                category, source, int(exit_code), _normalized_description(description)
+            )
     return rows
 
 
-def _python_registry() -> dict[str, tuple[str, str, int]]:
+def _python_registry() -> dict[str, ErrorRow]:
     return {
-        spec.code: (spec.category.value, spec.source.value, spec.exit_code)
+        spec.code: ErrorRow(
+            spec.category.value,
+            spec.source.value,
+            spec.exit_code,
+            _normalized_description(spec.description),
+        )
         for spec in ERROR_CODES
     }
 
@@ -123,7 +215,54 @@ def test_failure_builder_rejects_unregistered_public_codes():
 
 
 def test_adr_registry_matches_python_authoritative_registry():
+    # Every column of a code's public shape, the `Meaning` prose included (#701).
+    # The description used to be parsed out of the ADR row and thrown away, so the
+    # two artifacts could describe the same code differently and nothing noticed —
+    # wave 2 shipped three PRs whose description edits had to be checked by eye,
+    # and 15 rows had already drifted apart in substance (a producing condition the
+    # registry omitted, an exemption it had lost, a remedy it stated incompletely).
+    # Comparison rule: see `_normalized_description` above.
     assert _adr_registry() == _python_registry()
+
+
+def test_description_normalization_ignores_only_citations():
+    # Pins the boundary of the rule stated above, so widening it stays a conscious
+    # edit rather than a side effect of a regex tweak.
+    #
+    # Ignored: markup, wrapping, a trailing period, and a trailing parenthetical
+    # that cites an ADR or issue and holds nothing else.
+    assert _normalized_description("A `code` span.") == "A code span"
+    assert _normalized_description("Wrapped\n  text") == "Wrapped text"
+    assert _normalized_description("Meaning (Phase 2, ADR-0017 / ADR-0021).") == (
+        _normalized_description("Meaning.")
+    )
+    assert _normalized_description("Meaning (ADR-0031 amendment, #655).") == "Meaning"
+    # NOT ignored: a parenthetical carrying prose, even when a ref rides along —
+    # that is content, and dropping it is how a real divergence would hide.
+    assert _normalized_description("Meaning (pack is exempt; #170).") == (
+        "Meaning (pack is exempt; #170)"
+    )
+    # NOT ignored: a citation-looking parenthetical mid-sentence.
+    assert _normalized_description("Meaning (#170) and more.") == (
+        "Meaning (#170) and more"
+    )
+
+
+def test_a_bare_phase_label_is_compared_not_stripped():
+    # #755 review: `Phase N` is domain content (CONTEXT.md — the order capabilities
+    # are delivered in), so a parenthetical holding ONLY a phase label is not a
+    # citation and must survive normalization. Before the fix both sides normalized
+    # to the same string and a row mislabelled Phase 1 passed the pin silently.
+    assert _normalized_description("Meaning (Phase 2).") == "Meaning (Phase 2)"
+    assert _normalized_description("Meaning (Phase 2).") != (
+        _normalized_description("Meaning (Phase 1).")
+    )
+    # The other direction, which is why `Phase \d+` stays in the token set: a phase
+    # label riding inside a real citation is stripped with it. Removing the token
+    # would unstrip these and turn a third of the cited rows into false
+    # divergences.
+    assert _normalized_description("Meaning (Phase 2, #220).") == "Meaning"
+    assert _normalized_description("Meaning (Phase 2, ADR-0021).") == "Meaning"
 
 
 def test_gdscript_operation_error_codes_mirror_python_operation_subset():

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -10,9 +10,12 @@ channel-specific argv tail / export-only cwd stay tested in each runner's own
 suite.
 """
 
+import shlex
 import subprocess
 import sys
+import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -244,6 +247,43 @@ def _fake_engine(tmp_path: Path, body: str) -> Path:
     return script
 
 
+def _fast_fake_engine(tmp_path: Path, stdout_line: str, stderr_line: str) -> Path:
+    """A ``/bin/sh`` stand-in, kept for WALL-CLOCK SPEED, not correctness (#728).
+
+    Diverges from ``_fake_engine`` on purpose: that one pays a fresh Python
+    interpreter's startup before it writes a byte. The one test that uses this
+    (``test_streaming_timeout_preserves_the_output_the_child_already_wrote``)
+    used to race that startup against a real deadline; that race is gone —
+    the test now controls the runner's clock directly, so a slower child could
+    no longer flip the result. ``/bin/sh`` stays anyway: the test still waits,
+    in real wall-clock time, for this REAL child to actually write its output
+    before the (now fake) deadline is allowed to cross, and a cheap shell keeps
+    that wait — and the suite — fast rather than paying a Python interpreter's
+    startup for no reason.
+
+    ``printf '%s\\n'``, not ``echo``: XSI ``echo`` interprets backslash
+    escapes in its operand on this platform's ``/bin/sh``, so a payload
+    containing ``\\n`` or similar would print something other than what was
+    passed in. ``printf`` with a literal ``'%s\\n'`` format leaves the
+    (``shlex.quote``-escaped, so shell-syntax-safe) argument untouched.
+
+    It always ``sleep``s afterward, past any timeout this suite uses, via
+    ``exec`` — not a trailing background job. Without ``exec`` SIGTERM only
+    ends the shell; the orphaned ``sleep`` keeps the captured pipe open and
+    the reader-thread join in ``launch``'s teardown runs to its own timeout
+    on every single launch (#728).
+    """
+    script = tmp_path / "fast-fake-engine"
+    out = shlex.quote(stdout_line)
+    err = shlex.quote(stderr_line)
+    script.write_text(
+        f"#!/bin/sh\nprintf '%s\\n' {out}\nprintf '%s\\n' {err} 1>&2\nexec sleep 30\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    return script
+
+
 class _RecordingWatch:
     """A ``LaunchWatch`` that records what it was fed and can ask for an abort.
 
@@ -267,21 +307,67 @@ class _RecordingWatch:
         return bool(self.abort_when and self.abort_when(self.stderr))
 
 
-def test_streaming_timeout_preserves_the_output_the_child_already_wrote(tmp_path):
+def test_streaming_timeout_preserves_the_output_the_child_already_wrote(
+    monkeypatch, tmp_path
+):
     # THE #655 DEFECT: a buffered capture discards everything on a timeout, so a
     # script error Godot had ALREADY printed was lost (GDA-DF-012). With a watch the
     # capture survives, on BOTH streams, and no gda prose is mixed into either — the
     # watching channel composes its own diagnostics from this.
-    engine = _fake_engine(
-        tmp_path,
-        "print('SUITE START', flush=True)\n"
-        "print('boom', file=sys.stderr, flush=True)\n"
-        "time.sleep(30)\n",
-    )
+    #
+    # THE #728 FIX: proving that needs the child to have ALREADY written before the
+    # deadline. An earlier version of this test raced a real 3.0s deadline against
+    # the real child's startup, narrowed only by a cheap shell engine (see
+    # ``_fast_fake_engine``) — a residual race, later removed outright by
+    # controlling the CLOCK the runner's poll loop reads instead of the runner's
+    # behaviour: ``gda.runner`` does a plain ``import time``, so replacing that
+    # module binding with a runner-local proxy redirects its ``monotonic`` lookup
+    # without mutating the process-global stdlib module. The proxy delegates
+    # ``sleep`` to the real function, so only the poll loop's idea of "how much
+    # time has passed" is fake.
+    #
+    # The fake reports elapsed 0.0 until the watch's accumulated capture actually
+    # contains both lines the assertions below check, then jumps past any timeout
+    # in one step — so the loop keeps making REAL polls, on a REAL process, in REAL
+    # wall-clock time, until the REAL output arrives, and only then does the
+    # deadline "elapse". A real-clock safety ceiling (independent of the fake)
+    # fails the test loudly, with whatever was captured so far, if that output
+    # never arrives at all — a hang becomes an assertion, not a stuck suite.
+    #
+    # ``timeout`` below is consequently INERT: the loop only ever observes elapsed
+    # 0.0 or the fake's post-observation jump, so any positive value under that
+    # jump behaves identically. It is kept small (1.0) to say so — the 1.5s/3.0s
+    # cold-start margin math it used to carry (measured outliers of 312ms/1110ms
+    # against a real deadline) no longer applies now that nothing races it, and is
+    # deleted rather than kept as unused history.
+    engine = _fast_fake_engine(tmp_path, "SUITE START", "boom")
+    watch = _RecordingWatch()
 
-    result = launch(
-        engine, [], cwd=None, timeout=1.5, watch=_RecordingWatch(), timeout_label="X"
+    # Captured BEFORE replacing the runner's module binding. The stdlib module
+    # itself stays untouched, and the fake uses the saved function for its
+    # independent real-time safety ceiling.
+    real_monotonic = time.monotonic
+    real_deadline = real_monotonic() + 15.0  # generous real-time safety ceiling
+
+    def fake_monotonic() -> float:
+        now = real_monotonic()
+        if now > real_deadline:
+            raise AssertionError(
+                "safety ceiling: the child's output never arrived "
+                f"(stdout={watch.stdout!r} stderr={watch.stderr!r})"
+            )
+        both_lines_seen = "SUITE START" in watch.stdout and "boom" in watch.stderr
+        return 100.0 if both_lines_seen else 0.0
+
+    monkeypatch.setattr(
+        runner,
+        "time",
+        SimpleNamespace(monotonic=fake_monotonic, sleep=time.sleep),
     )
+    assert runner.time is not time
+    assert time.monotonic is real_monotonic
+
+    result = launch(engine, [], cwd=None, timeout=1.0, watch=watch, timeout_label="X")
 
     assert result.launch_failure is LaunchFailure.TIMEOUT
     assert result.exit_code == EXIT_TIMEOUT

--- a/tests/test_screen_commands.py
+++ b/tests/test_screen_commands.py
@@ -38,6 +38,7 @@ from tests.support import (
     sentinel,
     screen_capture_reply,
     screen_frames_reply,
+    usage_error_text,
 )
 
 # A 1x1 transparent PNG (valid, decodes to real bytes) so a written file starts
@@ -682,14 +683,9 @@ def _usage_error_message(result):
     # The argv path's contract (gda.dispatch.params_or_bad_parameter): a model
     # refusal is a Click usage error — exit 2, message on stderr — while the
     # --params-json path surfaces the SAME rule as structured invalid_params.
-    # Click line-wraps and colors the message, so strip ANSI and collapse
-    # whitespace before matching.
-    import re
-
-    assert result.exit_code == 2, result.stdout + result.stderr
-    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.stderr)
-    plain = re.sub(r"[\u2500-\u257f]", " ", plain)  # rich panel borders
-    return re.sub(r"\s+", " ", plain)
+    # The Rich-panel normalization itself is shared (tests/support.py,
+    # `usage_error_text`, #713 review) rather than redefined here.
+    return usage_error_text(result)
 
 
 def _invalid_params_message(result):

--- a/tests/test_script_error_parser.py
+++ b/tests/test_script_error_parser.py
@@ -435,3 +435,210 @@ def test_a_non_script_binding_is_a_recognized_diagnostic():
 def test_a_non_script_binding_never_fails_an_entry_verdict():
     errors = parse_script_errors(NOT_A_SCRIPT_BINDING_STDERR)
     assert entry_load_failure(errors, "res://entry.gd") is None
+
+
+# --- Dot-terminated and whitespace paths (#698) --------------------------------
+#
+# `_CANT_LOAD` and `_FAILED_LOADING_RESOURCE` both used to strip an OPTIONAL
+# trailing period, on the assumption that any trailing "." in the sentence was
+# punctuation. For a res:// address that genuinely ends in a dot, that stripped a
+# real path character: `Can't load script: res://..` parsed back as `res://.`,
+# which then missed the canonical entry `res://..` and reported a phantom
+# success. `res://weird./x.gd` (the issue's ORIGINAL example) does not end in a
+# dot and never triggered this — every dot-terminated fixture below ends in one.
+#
+# A second, independently-found defect in the same two regexes: `\S+` cannot
+# match a SPACE, so a project-relative path containing one (`res://missing
+# file.`) failed the WHOLE line, not just the trailing character — no
+# diagnostic at all, rather than a corrupted one. Pre-existing on `main` before
+# this issue (base `04d3e089` phantom-succeeds identically; its own `\S+?\.?$`
+# could not match a space either), and MASKED whenever the path also carries a
+# recognized extension — `res://missing file.gd` still gets `SCRIPT_MISSING`
+# from `_OPEN_FAILED`'s quoted, space-safe capture, so testing only the `.gd`
+# shape hides the bug. Both regexes now use `.+` instead of `\S+`.
+
+# `godot --headless --path <proj> --script "res://.."`, captured verbatim (Godot
+# 4.6.3, macOS). `main.cpp:4271` echoes the raw `--script` argv unconditionally —
+# "Can't load script: " + script, no format-string punctuation — so the sentence
+# is real evidence for `_CANT_LOAD`'s fix regardless of what else in the engine
+# rejects the address. (The "Resource file not found" sentence is not in this
+# module's recognized closed set and is correctly skipped; `ResourceLoader::
+# recognize_path`'s suffix-extension match never reaches "Failed loading
+# resource" for an address with no registered extension, which is why that
+# sentence cannot come from THIS particular capture — see the synthetic fixture
+# below for that regex instead.)
+DOT_TERMINATED_ROOT_STDERR = """\
+ERROR: Resource file not found: res://.. (expected type: unknown)
+   at: _load (core/io/resource_loader.cpp:351)
+ERROR: Can't load script: res://..
+   at: start (main/main.cpp:4271)
+"""
+
+# Same capture shape with a stem before the trailing dots — `godot --headless
+# --path <proj> --script "res://weird.."`, also captured verbatim.
+DOT_TERMINATED_STEM_STDERR = """\
+ERROR: Resource file not found: res://weird.. (expected type: unknown)
+   at: _load (core/io/resource_loader.cpp:351)
+ERROR: Can't load script: res://weird..
+   at: start (main/main.cpp:4271)
+"""
+
+# The whitespace case — `godot --headless --path <proj> --script "res://missing
+# file."`, also captured verbatim. Same shape again (no extension, so `found`
+# stays false and only `_CANT_LOAD` carries the address), but this is the one
+# `\S+` could not match AT ALL: pre-fix, `parse_script_errors` returned `[]` for
+# this capture (no diagnostic, not a corrupted one), and `gda script run
+# "missing file."` reported a phantom exit-0 success with an empty
+# `diagnostics` list.
+WHITESPACE_ROOT_STDERR = """\
+ERROR: Resource file not found: res://missing file. (expected type: unknown)
+   at: _load (core/io/resource_loader.cpp:351)
+ERROR: Can't load script: res://missing file.
+   at: start (main/main.cpp:4271)
+"""
+
+# One shared matrix for both the parse-level shape and the verdict-level match
+# below — a case belongs here once, not once per test.
+_CANT_LOAD_BOUNDARY_CASES = [
+    (DOT_TERMINATED_ROOT_STDERR, "res://.."),
+    (DOT_TERMINATED_STEM_STDERR, "res://weird.."),
+    (WHITESPACE_ROOT_STDERR, "res://missing file."),
+]
+
+
+@pytest.mark.parametrize(("stderr", "path"), _CANT_LOAD_BOUNDARY_CASES)
+def test_cant_load_round_trips_a_genuinely_dot_terminated_path(stderr, path):
+    errors = parse_script_errors(stderr)
+
+    assert [(e.kind, e.path) for e in errors] == [(ScriptErrorKind.LOAD_FAILED, path)]
+
+
+@pytest.mark.parametrize(("stderr", "path"), _CANT_LOAD_BOUNDARY_CASES)
+def test_cant_load_still_matches_the_entry_when_dot_terminated(stderr, path):
+    # Acceptance: the verdict logic's canonical-identity match must not phantom-
+    # succeed if an entry route ever reaches this parser with a genuinely
+    # dot-terminated or whitespace-containing path again (#693 closed gda's
+    # pre-launch entry-path refusal for the root/escape shapes; this covers the
+    # parser itself, independent of that guard).
+    errors = parse_script_errors(stderr)
+    verdict = entry_load_failure(errors, path)
+
+    assert verdict is not None
+    assert verdict.kind is ScriptErrorKind.LOAD_FAILED
+    assert verdict.path == path
+
+
+# `_FAILED_LOADING_RESOURCE` mirrors `resource_loader.cpp:343`'s format string
+# (`vformat("Failed loading resource: %s.", p_path)`, Godot 4.6.3), which ALWAYS
+# appends exactly one period. For `p_path == "res://weird.."` the sentence carries
+# three trailing dots — two are the path's own, the third is the format string's.
+#
+# Hand-authored, not captured: this exact combination cannot come from a real
+# run. `ResourceFormatLoader::recognize_path` (resource_loader.cpp:62)
+# suffix-matches a REGISTERED extension before "Failed loading resource" is
+# reachable at all, and no registered extension is itself a bare "." — probed
+# directly (a running script's `load("res://weird..")`) and confirmed it instead
+# hits the `#ifdef TOOLS_ENABLED` file-not-found branch, the same unrecognized
+# sentence `DOT_TERMINATED_STEM_STDERR` carries above. The format string itself
+# is exercised for real by the ordinary sentence-period fixtures elsewhere in
+# this file (e.g. ``MISSING_STDERR``'s ``res://nope.gd.``); only the dot-count
+# at the tail is synthesized here.
+#
+# NOTE ON THE FIX: unlike `_CANT_LOAD`, this regex's old OPTIONAL strip
+# (`\S+?\.?$`) was never actually corrupted by ANY number of trailing dots on a
+# WELL-FORMED sentence. The lazy quantifier always finds the SMALLEST capture
+# whose remainder is 0 or 1 characters; because the format string guarantees
+# the message's last character is always the appended period, that smallest
+# split is always at `len(message) - 1`, which always strips exactly the
+# guaranteed period and nothing else — for `p_path` ending in 0, 1, 2, or any
+# other number of dots alike (verified exhaustively for every fixture below,
+# both the old and the fixed regex agree byte-for-byte). The mandatory strip
+# below is still correct and adopted per the issue: it makes the regex FAIL
+# CLOSED (no match) on a line that lacks the guaranteed trailing period,
+# instead of silently accepting the whole remainder the way the optional
+# strip did — see `test_failed_loading_resource_requires_the_guaranteed_period`
+# for that one real behavioral difference. But it is not a corruption fix on
+# any genuine engine capture, so — unlike the `_CANT_LOAD` tests above — the
+# round-trip tests below do NOT distinguish pre-fix from post-fix code; they
+# pin the documented contract, not a red-proofed regression.
+DOT_TERMINATED_RESOURCE_STDERR = (
+    "ERROR: Failed loading resource: res://weird...\n"
+    "   at: _load (core/io/resource_loader.cpp:343)\n"
+)
+
+
+def test_failed_loading_resource_round_trips_a_genuinely_dot_terminated_path():
+    errors = parse_script_errors(DOT_TERMINATED_RESOURCE_STDERR)
+
+    assert [(e.kind, e.path) for e in errors] == [
+        (ScriptErrorKind.RESOURCE_LOAD_FAILED, "res://weird.."),
+    ]
+
+
+def test_failed_loading_resource_requires_the_guaranteed_period():
+    # THE one genuine pre/post-fix divergence for this regex: a line that lacks
+    # the format string's guaranteed trailing period. Never produced by the real
+    # engine (the format string always appends it) — this pins the FAIL-CLOSED
+    # contract the mandatory strip now enforces, rather than silently treating
+    # an un-punctuated remainder as if it were a resource address.
+    errors = parse_script_errors(
+        "ERROR: Failed loading resource: res://plain.tres\n"
+        "   at: _load (core/io/resource_loader.cpp:343)\n"
+    )
+    assert errors == []
+
+
+def test_failed_loading_resource_still_matches_the_entry_when_dot_terminated():
+    errors = parse_script_errors(DOT_TERMINATED_RESOURCE_STDERR)
+    verdict = entry_load_failure(errors, "res://weird..")
+
+    assert verdict is not None
+    assert verdict.kind is ScriptErrorKind.RESOURCE_LOAD_FAILED
+    assert verdict.path == "res://weird.."
+
+
+# The same whitespace fix, for `_FAILED_LOADING_RESOURCE` — `godot --headless
+# --path <proj> --script "res://missing file.gd"`, captured verbatim. The `.gd`
+# extension is what makes `found=true` reachable at all: unlike `_CANT_LOAD`,
+# this sentence only fires when a loader recognizes the path's extension (see
+# the probe note above `DOT_TERMINATED_RESOURCE_STDERR`), so the no-extension
+# whitespace shape (`WHITESPACE_ROOT_STDERR` above) cannot exercise it. This is
+# the masking case in miniature: `SCRIPT_MISSING` from `_OPEN_FAILED` already
+# carries the correct verdict here regardless of this regex, but the
+# diagnostic itself must still round-trip rather than silently vanishing —
+# pre-fix, `\S+?\.?$` could not match this line at all.
+WHITESPACE_RESOURCE_STDERR = """\
+ERROR: Attempt to open script 'res://missing file.gd' resulted in error 'File not found'.
+   at: load_source_code (modules/gdscript/gdscript.cpp:1127)
+ERROR: Failed loading resource: res://missing file.gd.
+   at: _load (core/io/resource_loader.cpp:343)
+ERROR: Can't load script: res://missing file.gd
+   at: start (main/main.cpp:4271)
+"""
+
+
+def test_failed_loading_resource_round_trips_a_whitespace_path():
+    errors = parse_script_errors(WHITESPACE_RESOURCE_STDERR)
+
+    assert [(e.kind, e.path) for e in errors] == [
+        (ScriptErrorKind.SCRIPT_MISSING, "res://missing file.gd"),
+        (ScriptErrorKind.RESOURCE_LOAD_FAILED, "res://missing file.gd"),
+        (ScriptErrorKind.LOAD_FAILED, "res://missing file.gd"),
+    ]
+
+
+def test_the_ordinary_sentence_period_still_strips_for_both_sentences():
+    # Non-regression: an address that does NOT itself end in a dot must still
+    # have the engine's sentence-ending period stripped, for both fixed regexes.
+    stderr = (
+        "ERROR: Can't load script: res://plain.gd\n"
+        "   at: start (main/main.cpp:4271)\n"
+        "ERROR: Failed loading resource: res://plain.tres.\n"
+        "   at: _load (core/io/resource_loader.cpp:343)\n"
+    )
+    errors = parse_script_errors(stderr)
+
+    assert [(e.kind, e.path) for e in errors] == [
+        (ScriptErrorKind.LOAD_FAILED, "res://plain.gd"),
+        (ScriptErrorKind.RESOURCE_LOAD_FAILED, "res://plain.tres"),
+    ]

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -230,6 +230,46 @@ def test_both_path_forms_reach_one_canonical_address(script):
 
 
 @pytest.mark.parametrize(
+    ("script", "canonical"),
+    [
+        # LEADING and INTERNAL ASCII SPACES are unaffected by the engine's own argv
+        # normalization (verified against real Godot 4.6.3). Keep this claim narrow:
+        # line-breaking whitespace is unsafe for the line-oriented diagnostic
+        # protocol and is refused separately below.
+        (" tests/logic.gd", "res:// tests/logic.gd"),
+        ("tests/log ic.gd", "res://tests/log ic.gd"),
+    ],
+)
+def test_leading_and_internal_ascii_spaces_are_accepted(script, canonical):
+    outcome, launch = _run(
+        RunResult(stdout="ok\n", stderr="", exit_code=0), script=script
+    )
+
+    assert isinstance(outcome, ScriptRunResult), getattr(outcome, "error", None)
+    (_binary, args, _cwd, _timeout, _label, _watch) = launch.calls[0]
+    assert args == ["--path", str(PROJECT), "--script", canonical]
+    assert outcome.path == canonical
+
+
+@pytest.mark.parametrize("suffix", ["\u00a0", "\u2003"])
+def test_trailing_unicode_spaces_that_godot_preserves_are_accepted(suffix):
+    # Godot 4.6.3's String::strip_edges() removes only code points <= U+0020.
+    # NBSP and EM SPACE therefore survive the --script path and its diagnostic;
+    # Python str.rstrip() is wider and must not define this engine-facing ABI.
+    script = f"tests/logic.gd{suffix}"
+    canonical = f"res://{script}"
+
+    outcome, launch = _run(
+        RunResult(stdout="ok\n", stderr="", exit_code=0), script=script
+    )
+
+    assert isinstance(outcome, ScriptRunResult), getattr(outcome, "error", None)
+    (_binary, args, _cwd, _timeout, _label, _watch) = launch.calls[0]
+    assert args == ["--path", str(PROJECT), "--script", canonical]
+    assert outcome.path == canonical
+
+
+@pytest.mark.parametrize(
     "script",
     [
         # Absolute: outside the --project context (#675 keeps this refusal).
@@ -246,9 +286,10 @@ def test_both_path_forms_reach_one_canonical_address(script):
         "sub/..",
         "res://",
         "res://.",
-        # Escapes ABOVE the root, in both spellings. `..` phantom-succeeded (the
-        # engine's `Can't load script: res://..` parses back as `res://.`), and
-        # `../outside.gd` actually EXECUTED a script outside the project.
+        # Escapes ABOVE the root, in both spellings. `..` phantom-succeeded before
+        # #698 fixed the parser (the engine's `Can't load script: res://..` used to
+        # parse back as `res://.`), and `../outside.gd` actually EXECUTED a script
+        # outside the project — refused regardless of the parser's own fix.
         "..",
         "sub/../..",
         "../outside.gd",
@@ -261,17 +302,42 @@ def test_both_path_forms_reach_one_canonical_address(script):
         # absolute path, refused above. Both tilde outcomes end on ONE refusal.
         "~nosuchuser/x.gd",
         "~/x.gd",
+        # A TRAILING code point <= U+0020 (#698 review, reproduced on real Godot
+        # 4.6.3): Godot strips it from the `--script` path before echoing the path in
+        # its diagnostic, so the canonical identity cannot match. Both accepted
+        # forms, with and without an extension, and two members of the engine's
+        # actual trim set.
+        "missing file. ",
+        "missing file.gd ",
+        "res://missing file. ",
+        "tests/logic.gd\t",
+        # engine_log splits these characters into separate records. If one appears
+        # anywhere in the path, the emitted address cannot round-trip through the
+        # line-oriented diagnostic protocol and a never-run entry can phantom-pass.
+        "tests/missing\nfile.gd",
+        "tests/missing\rfile.gd",
+        "tests/missing\vfile.gd",
+        "tests/missing\ffile.gd",
+        "tests/missing\x1cfile.gd",
+        "tests/missing\x1dfile.gd",
+        "tests/missing\x1efile.gd",
+        "tests/missing\x85file.gd",
+        "tests/missing\u2028file.gd",
+        "tests/missing\u2029file.gd",
     ],
 )
 def test_a_non_project_scoped_path_is_invalid_path_before_any_launch(script):
     # The path ABI edge (ADR-0031, narrowed by #675): accepting the project-relative
     # form must not accept everything ELSE that is merely non-absolute. The root and
     # escape cases are load-bearing — the engine answers `Can't load script: res://.`
-    # / `res://..`, whose address the parser reads back with the sentence period
-    # stripped, so it never matches the entry and the run reported a PHANTOM SUCCESS
-    # (exit 0). A resolvable escape is worse: `../outside.gd` RAN a script outside the
+    # / `res://..`, and before #698 fixed the parser that address came back with the
+    # sentence period stripped, so it never matched the entry and the run reported a
+    # PHANTOM SUCCESS (exit 0). This refusal stays regardless of the parser's own fix
+    # — a resolvable escape is worse: `../outside.gd` RAN a script outside the
     # project, which is exactly the ADR-0009 widening the amendment cites as its
-    # reason for refusing absolute paths.
+    # reason for refusing absolute paths. The trailing-engine-trim and embedded-line-
+    # boundary cases are the same phantom-success failure mode through two other
+    # identity-loss mechanisms — see #698 / PR #756.
     outcome, launch = _run(RunResult(stdout="", stderr="", exit_code=0), script=script)
 
     assert isinstance(outcome, Failure)
@@ -375,6 +441,45 @@ def test_missing_entry_script_is_a_failure_despite_the_zero_exit():
     assert "res://tests/logic.gd" in outcome.error.message
     # The raw stderr is preserved as secondary evidence on the envelope.
     assert outcome.error.diagnostics == MISSING_STDERR
+
+
+# Independent finding, same #698 fix: a project-relative path containing a SPACE
+# reached `_CANT_LOAD`'s old `\S+` capture and failed to match the WHOLE line —
+# no diagnostic at all, not a corrupted one — so `entry_load_failure` found
+# nothing and this operation fell through to the SUCCESS branch: a phantom
+# `ScriptRunResult` with `exit_status: 0` and an empty `diagnostics` list, for a
+# script that never ran. Captured verbatim from `godot --headless --path <proj>
+# --script "res://missing file."` (Godot 4.6.3, macOS) — same shape as
+# MISSING_STDERR above, minus the extension (so only `_CANT_LOAD` carries the
+# address; the `.gd` spelling MASKS this bug via `_OPEN_FAILED`'s quoted,
+# space-safe capture, so testing only that shape would wrongly conclude there
+# is no defect — see tests/test_script_error_parser.py for the parser-level
+# coverage of both this and the extension-masked shape).
+WHITESPACE_STDERR = """\
+ERROR: Resource file not found: res://missing file. (expected type: unknown)
+   at: _load (core/io/resource_loader.cpp:351)
+ERROR: Can't load script: res://missing file.
+   at: start (main/main.cpp:4271)
+"""
+
+
+def test_a_whitespace_entry_path_is_a_failure_despite_the_zero_exit():
+    # Public-verdict regression: assert the OPERATION's outcome flips from a
+    # phantom success to the registered failure end-to-end, through the SAME
+    # validate -> launch -> classify recipe every other verdict test here drives
+    # — not that the parser's regex captures the path correctly in isolation
+    # (that is asserted separately, at the parser level, in
+    # tests/test_script_error_parser.py).
+    outcome, _ = _run(
+        RunResult(stdout="", stderr=WHITESPACE_STDERR, exit_code=0),
+        script="missing file.",
+    )
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "script_compile_failed"
+    assert outcome.exit_code == EXIT_OPERATION
+    assert "res://missing file." in outcome.error.message
+    assert outcome.error.diagnostics == WHITESPACE_STDERR
 
 
 def test_entry_parse_error_is_a_failure_despite_the_zero_exit():


### PR DESCRIPTION
## What

The **phase-2 P1** promotion from `feat/gda-dogfooding-dev` to `main`, per the milestone branch model: slices land on the dev branch one squashed commit each; this PR promotes the wave via **merge commit** (never squash — squashing would collapse the per-issue `fix:`/`test:`/`refactor:` commits release-please derives the changelog from).

P1 was the first phase-2 wave: five independent slices, dispatched in parallel to isolated worktrees, merged in the order below. Every slice went through independent adversarial review on up to three lenses (code / document / architecture), and each was re-verified in the main loop against its own gates before merge.

## Merged slices

| Slice | Issue | dev commit | Slice PR |
| --- | --- | --- | --- |
| pin the ADR-0002 error-description column and reconcile the drift it surfaces | #701 | `fa441c91` | #755 (3 review rounds) |
| script-error parser: dot-terminated paths, whitespace grammar, engine-exact trailing rule | #698 | `78d17f19` | #756 (4 review rounds) |
| one root-cache exclusion for every `res://` walk | #712 | `8d445e63` | #758 (5 review rounds) |
| `script set` / `shader set`: one mode-selection authority | #713 | `55b85291` | #754 (5 review rounds) |
| deflake the streaming-launch timeout test | #728 | `708578d0` | #757 (4 review rounds) |

### What #701 shipped

The registry↔ADR-0002 equality pin covered `(category, source, exit_code)` but silently ignored the `description` column, so the two artifacts had drifted for 91 codes with nobody noticing.

- Measured at the fork point: **38 of 91 rows differed** after backtick/whitespace/period normalization; **41 ADR descriptions carry a trailing citation**, three of which match their registry counterpart exactly and so never entered the 38. All three populations are now stated separately rather than conflated.
- The pin extends to the description column, with one **decided** normalization rule: a trailing parenthetical is excluded from comparison only when it contains at least one real `ADR-NNNN`/`#N` reference. A bare `(Phase N)` is domain content (`CONTEXT.md` defines Phase 1/2 as a delivery concept), so it **is** compared — an earlier form of the rule let `(Phase 2)` and `(Phase 1)` normalize alike, which is the exact drift class this issue exists to catch.
- **18 substantive divergences** reconciled with a per-code verdict: 7 fixed the registry (e.g. `export_path_unset` had lost the `--output` producing condition; `live_display_unavailable` had lost the word "windowed"), 9 fixed the ADR (e.g. `live_method_not_allowlisted` said "its class" where ADR-0041 resolves along the attached-script chain), 2 were phrasing with no correctness winner.
- Residual stated exactly rather than papered over: a `Phase N` riding **inside** a citation cluster stays uncompared; for 20 of 23 phase-labelled rows the compared `Category` column pins the distinction indirectly, and the other three (`live_unsupported_platform`, `live_windowed_unavailable`, `live_windowed_permission_denied`) are `environment`-category, so for those it is caught by neither mechanism.

### What #698 shipped

Three defects in the script-error parser, each closing a path to **phantom success** — a run reporting `exit_status: 0` for a script that never executed.

- **The dot-terminated address.** `_CANT_LOAD` stripped an optional trailing period, but `main/main.cpp:4271` emits `"Can't load script: " + script` and never appends one — so `res://..` parsed back as `res://.`, missed the canonical-identity match, and the never-ran verdict was lost. The strip is dropped. `_FAILED_LOADING_RESOURCE` mirrors `resource_loader.cpp:343`, which **always** appends exactly one period, so its strip became mandatory — fail-closed hardening, **not** a fix for observed corruption (the old lazy quantifier never mis-read a well-formed line; the issue's original example was mis-constructed and was corrected).
- **The whitespace grammar.** `\S+` could not match a path containing a space, so `gda script run "missing file."` returned a success shape while the engine printed `Can't load script:`. Both patterns now capture the full line remainder. The `.gd` spelling masks this — with an extension the engine additionally emits a quoted `Attempt to open script '…'` that survives whitespace — so testing only that shape shows no bug.
- **The trailing-normalization boundary.** A first fix used Python `str.rstrip()` as a proxy; Godot's `String::strip_edges()` trims code points `<= U+0020` (`ustring.cpp:4073`), while Python's Unicode set is wider. The guard now encodes the engine's actual rule — trailing NBSP and EM SPACE reach the engine as before, trailing space/tab are refused pre-launch, and a path containing a line break is refused because it cannot round-trip through the line-oriented diagnostic protocol. Refusal, never `rstrip()`: silently trimming would launch a *different* script than the caller named. ADR-0031 records the complete pre-launch refusal set.

### What #712 shipped

`gda` answered two ways about one project. PR #710 had fixed `_collect_script_paths` to compare the full path against the root cache; the other three walkers still compared the directory **name**, so a user-authored nested `.godot` was invisible to them and visible to it.

- Reproduced as a cross-command contradiction: on one project, `script list` returned a script that `project statistics` counted as `script_count: 0`, and `node add --type NestedThing` refused a `class_name` the listing had just reported.
- All four walkers now route through a single `_should_descend()` — the PR's own review noted that unifying the *constant* while leaving four independent branches is the shape that produced the bug, so the **decision** has one owner too.
- The rule is documented as **lexical** in the command catalog, with its accepted cost (a vendored sub-project's own cache becomes visible to the analysis walks) stated beside it rather than left in a PR body, and ADR-0032 synchronized.
- **Issue #712's acceptance criterion was formally amended**, not silently reinterpreted: a symlink alias re-admits the root cache, which no path comparison can prevent. Measured base-vs-head, that exposure is only partly pre-existing. The guarantee is now stated as lexical-path-only, with **#760** owning filesystem identity and cycle termination together as one symlink policy.

### What #713 shipped

`script set` and `shader set` evaluated their mode-selection rule twice — a hand-rolled argv pre-check plus the params model's own validator — contradicting ADR-0015, which makes the model the input-rule authority.

- Both commands now build their params model through `params_or_bad_parameter()`; `parse_set_mode_argv` is deleted. The rule runs exactly once per invocation, verified across an instrumented script/shader × argv/JSON matrix.
- That routing exposed a real regression the slice then repaired at its seam: `str()` on a pydantic `ValidationError` dumps the model class name, a `[type=…, input_value=…]` tag per error, a pydantic.dev URL — and **echoes the caller's own value back**, including a `--content` payload. A shared `validation_error_message()` in `gda.errors` now renders the validator's own sentence, used by **both** ADR-0015 channels, so argv and `--params-json` report the identical sentence for the identical refusal.
- Public surface: `--help` byte-identical; `gda schema` differs at exactly four description leaves under `script set`/`shader set`, all deliberate.

### What #728 shipped

The streaming-launch timeout test raced its own fake engine's startup against a real deadline, with an observed tail that crossed it.

- The race is now **removed, not narrowed**: the test replaces `gda.runner`'s `time` binding with a runner-local proxy whose clock crosses the deadline only after the watch has observed both expected lines. The real child, real pipes, real reader threads, the real timeout branch and real SIGTERM/reap/join all still run; only the incidental startup timing is controlled, and a real-clock safety ceiling turns a hang into a loud assertion.
- The proxy replaces the module **binding**, not the module: an earlier form mutated process-global `time.monotonic`, which the test now pins against (`time.monotonic is real_monotonic`).
- Runtime fell from a fixed 3.05 s per run to ~0.6 s, and the timeout constant lost its purpose and its obsolete cold-start margin arithmetic.

## Follow-ups filed

- **#759** — `perf --budget-file`'s `invalid_params` still renders a `ValidationError` via `str(exc)`, leaking pydantic internals and caller content. Third producer of the defect class #713 fixed for the two ADR-0015 channels; a one-line reuse of the new extractor.
- **#760** — the `res://` walk has no symlink policy: an alias re-admits the engine cache, and a cycle emits fabricated duplicate paths to the OS path limit. Both reproduced on 4.6.3, both present pre-#712.

## Validation

- Every slice re-verified in the main loop against its own gates before merge, not on the implementer's report alone.
- **Integration check before merging:** all five branches merged onto a scratch tree and the full suite run there — `1941 passed, 543 deselected`, ruff and pyright clean. Two cross-slice file overlaps (`docs/command-catalog.md`, `src/gda/commands/script.py`) were trial-merged and content-checked in both directions, since a silent keep-both merge is the hazard this wave's parallel shape creates.
- After #755 landed, the remaining four were re-merged onto the new dev tip and **#701's new description pin re-run** (`18 passed`) — a pin installed mid-wave has to be re-checked against the slices that follow it.
- Full CI with `run-e2e=true` dispatched on this branch tip: run [33171526977](https://github.com/aigengame/godot-agent/actions/runs/33171526977).
