### PR TITLE
fix(gda): close the res://../ containment bypass in path_outside_project

### DIFF
--- a/src/gda/project.py
+++ b/src/gda/project.py
@@ -22,6 +22,8 @@ import os
 from collections.abc import Mapping
 from pathlib import Path
 
+from gda.script_errors import canonical_res_path
+
 GDA_PROJECT_ENV = "GDA_PROJECT"
 
 # The file Godot uses to mark a directory as a project root.
@@ -44,7 +46,10 @@ def is_engine_virtual_path(path: str) -> bool:
     anywhere in the string. Owned here, in the project-resolution module, and
     read by both callers of the rule: :func:`gda.models.normalize_path` (which
     passes such a path through unexpanded) and :func:`path_outside_project`
-    (which can make no filesystem statement about one).
+    (which still makes no FILESYSTEM statement about a well-formed one, but for
+    a ``res://`` spelling specifically checks it for a lexical escape of the
+    project namespace, #762 — a ``user://``/``uid://`` spelling stays inside by
+    construction, unchanged).
     """
     return path.startswith(ENGINE_VIRTUAL_PREFIXES)
 
@@ -102,6 +107,25 @@ def project_anchored(path: str, project: Path) -> Path:
     return _expand_user(project) / target
 
 
+def _res_escape_remainder(path: str) -> str | None:
+    """The canonical remainder of a ``res://`` address when it escapes upward, else ``None`` (#762).
+
+    Canonicalizes ``path`` the way Godot canonicalizes a ``res://`` address before
+    it resolves or reports one (:func:`gda.script_errors.canonical_res_path`
+    collapses ``.``/``..`` segments), then reads what is left: an exact ``..`` or a
+    leading ``../`` means the address is still climbing above the namespace root
+    AFTER that collapsing, which is genuinely outside. Anything else is not an
+    escape, including a ``res://foo/../bar.gd`` spelling — it collapses to
+    ``res://bar.gd``, net-inside — and a filename that merely STARTS with two dots
+    (``res://..foo.gd`` names a real file, not a traversal; the test is the first
+    PATH SEGMENT, not a string prefix).
+    """
+    remainder = canonical_res_path(path)[len("res://") :]
+    if remainder == ".." or remainder.startswith("../"):
+        return remainder
+    return None
+
+
 def path_outside_project(path: str, project: Path) -> Path | None:
     """The location of ``path`` when it falls OUTSIDE ``project``.
 
@@ -110,9 +134,19 @@ def path_outside_project(path: str, project: Path) -> Path | None:
     project, and otherwise the target's real location, so the caller can name
     *where* it actually is in its diagnostic.
 
-    An engine-virtual path is inside by construction: it addresses the project
-    the engine was launched with, and gda can make no filesystem statement
-    about one.
+    A ``res://`` address is checked LEXICALLY against the namespace it names,
+    rather than trusted by construction: :func:`_res_escape_remainder`
+    canonicalizes it the way the engine does and refuses one that still steps
+    above the namespace root after that collapsing (``res://../outside.gd``).
+    gda still makes no FILESYSTEM statement about a well-formed ``res://``
+    path — it is the engine's own launch ``--path`` that owns resolving one,
+    and this check never touches the filesystem to decide — but a spelling
+    that lexically escapes the namespace is not well-formed, and admitting it
+    here defeated the very refusal this function exists to make (#762). The
+    other two engine-virtual schemes are unaffected and stay inside by
+    construction: ``user://`` addresses the engine's own data directory, not a
+    child of the project tree, and ``uid://`` is an opaque identifier with no
+    path structure to escape through.
 
     A filesystem path is first anchored the way the engine will address it
     (:func:`project_anchored`), then read in up to two ways — it belongs to the
@@ -149,7 +183,12 @@ def path_outside_project(path: str, project: Path) -> Path | None:
     location it would occupy rather than raising.
     """
     if is_engine_virtual_path(path):
-        return None
+        if not path.startswith("res://"):
+            return None
+        escape = _res_escape_remainder(path)
+        if escape is None:
+            return None
+        return (_expand_user(project) / escape).resolve()
     root = _expand_user(project)
     candidate = project_anchored(path, project)
     location = candidate.resolve()

--- a/src/gda/project.py
+++ b/src/gda/project.py
@@ -111,12 +111,16 @@ def _res_escape_remainder(path: str) -> str | None:
     """The canonical remainder of a ``res://`` address when it escapes upward, else ``None`` (#762).
 
     Canonicalizes ``path`` the way Godot canonicalizes a ``res://`` address before
-    it resolves or reports one (:func:`gda.script_errors.canonical_res_path`
-    collapses ``.``/``..`` segments), then reads what is left: an exact ``..`` or a
-    leading ``../`` means the address is still climbing above the namespace root
-    AFTER that collapsing, which is genuinely outside. Anything else is not an
-    escape, including a ``res://foo/../bar.gd`` spelling — it collapses to
-    ``res://bar.gd``, net-inside — and a filename that merely STARTS with two dots
+    it resolves or reports one — :func:`gda.script_errors.canonical_res_path` folds
+    ``\\`` to ``/`` and collapses ``.``/``..`` segments, and its docstring is where
+    that correspondence to ``String::simplify_path`` is audited step by step — then
+    reads what is left: an exact ``..`` or a leading ``../`` means the address is
+    still climbing above the namespace root AFTER that collapsing, which is
+    genuinely outside. The fold is what makes ``res://..\\outside.gd`` reach this
+    test as the escape the engine treats it as, rather than as an in-project
+    filename (PR #766 review). Anything else is not an escape, including a
+    ``res://foo/../bar.gd`` spelling — it collapses to ``res://bar.gd``,
+    net-inside — and a filename that merely STARTS with two dots
     (``res://..foo.gd`` names a real file, not a traversal; the test is the first
     PATH SEGMENT, not a string prefix).
     """

--- a/src/gda/script_errors.py
+++ b/src/gda/script_errors.py
@@ -173,18 +173,49 @@ def canonical_res_path(path: str) -> str:
     engine's spelling against the caller's raw one missed the match and let a
     failed run report success.
 
-    Collapses ``.``/``..`` segments and duplicate slashes on the path part only
-    (posixpath semantics), leaving the ``res://`` scheme intact. Purely lexical —
-    no filesystem access — so it is safe on a path that does not exist, which is
-    exactly the missing-entry-script case. A non-``res://`` string is returned
-    unchanged: this normalizes an address, it does not validate one.
+    Purely lexical — no filesystem access — so it is safe on a path that does not
+    exist, which is exactly the missing-entry-script case. A non-``res://`` string
+    is returned unchanged: this normalizes an address, it does not validate one.
+
+    **Against ``String::simplify_path``** (``core/string/ustring.cpp:4149-4233``,
+    Godot ``4.6-stable-3260-g070dc9897e``), the engine function every ``res://``
+    address passes through before the engine resolves or reports it
+    (``ProjectSettings::localize_path``, ``core/config/project_settings.cpp:158``).
+    Which of its steps this reproduces, in the engine's own order:
+
+    - **scheme extraction** (4153-4168: first ``://`` whose prefix is all ASCII
+      alphanumerics becomes the "drive") — reproduced NARROWLY, for an exact
+      ``res://`` prefix only. The engine's other two drive branches (network share,
+      Windows ``C:``) are deliberately NOT reproduced: they are unreachable once the
+      scheme branch matched, and a non-``res://`` string leaves here untouched anyway.
+    - **``\\`` → ``/`` across the whole remainder** (4192) — reproduced, and it must
+      run BEFORE the leading-slash strip below, exactly as the engine runs it before
+      its own empty-segment split: ``res://\\a.gd`` folds to ``res://a.gd``, which is
+      no longer possible once the strip has already passed over a backslash. Without
+      this step ``res://..\\outside.gd`` read as an ordinary in-project filename
+      while the engine loaded the file one directory ABOVE the project and reported
+      it back as ``res://../outside.gd`` (#762).
+    - **repeated-``//`` collapse and ``split("/", false)``** (4193-4201) — reproduced
+      by the leading-slash strip plus ``posixpath.normpath``, which collapses runs of
+      separators and drops a trailing one. The strip is what covers POSIX's one
+      divergence: it gives exactly two leading slashes a special meaning (``//a``
+      stays ``//a``), so ``res:////a.gd`` would otherwise stay uncanonicalized.
+    - **``.``/``..`` collapse with the leading-``..`` strip DISABLED for ``res://``**
+      (4204-4221) — reproduced: ``normpath`` on a RELATIVE remainder keeps a leading
+      ``..`` for the same reason the engine keeps it, and that is what lets a caller
+      of this function see an escape at all rather than have it silently swallowed.
+
+    One stated gap, in the join (4223-4232): when every segment collapses away the
+    engine yields the bare ``res://`` while ``normpath`` yields ``.``, so
+    ``res://a/..`` canonicalizes here to ``res://.``. Both spellings name the project
+    root and every consumer already treats the pair alike — ``script run``'s gate
+    tests the pair explicitly (``_ROOT_REMAINDERS``) and a ``.`` is not an upward
+    escape — so closing it would only churn a deliberate accommodation that #763
+    owns reconciling.
     """
     if not path.startswith(_RES_PREFIX):
         return path
-    # Strip leading slashes before normpath: POSIX gives exactly two leading
-    # slashes a special meaning ("//a" stays "//a"), which would leave a
-    # `res:////a.gd` spelling uncanonicalized.
-    remainder = path[len(_RES_PREFIX) :].lstrip("/")
+    remainder = path[len(_RES_PREFIX) :].replace("\\", "/").lstrip("/")
     if not remainder:
         return _RES_PREFIX
     # normpath("") is ".", so the empty case is handled above rather than here.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -92,10 +92,12 @@ def test_path_in_a_sibling_tree_is_outside_and_reports_its_location(tmp_path):
     assert path_outside_project(str(script), proj) == script.resolve()
 
 
-def test_engine_virtual_paths_are_never_outside(tmp_path):
+def test_well_formed_engine_virtual_paths_are_not_outside(tmp_path):
     # res:// (and its user:// / uid:// siblings) address the project the engine
-    # was launched with, so they are inside by construction — gda makes no
-    # filesystem statement about them (ADR-0006).
+    # was launched with, so gda makes no filesystem statement about them
+    # (ADR-0006). WELL-FORMED is the qualifier the name carries: a res:// spelling
+    # that lexically escapes the namespace is not inside by construction and IS
+    # refused — see test_a_res_dotdot_escape_is_outside below (#762).
     proj = _make_project(tmp_path / "game")
 
     assert path_outside_project("res://hero.gd", proj) is None
@@ -120,6 +122,36 @@ def test_a_res_dotdot_escape_is_outside(tmp_path):
     )
     # The bare escape, with no filename after it, is refused the same way.
     assert path_outside_project("res://..", proj) == tmp_path.resolve()
+
+
+def test_a_backslash_spelled_res_escape_is_outside(tmp_path):
+    # The separator bypass (PR #766 round-2 review): Godot folds `\` to `/` across
+    # a res:// address before it collapses anything (ustring.cpp:4192), so
+    # `res://..\outside.gd` IS the escaping address to the engine — a real 4.6.3
+    # run loads the file one directory above the project and reports it back as
+    # `res://../outside.gd`. Reading the backslash as a filename character let this
+    # spelling through the very check the slash spelling above is refused by.
+    proj = _make_project(tmp_path / "game")
+
+    assert (
+        path_outside_project("res://..\\outside.gd", proj)
+        == (tmp_path / "outside.gd").resolve()
+    )
+    # Mixed separators collapse together, exactly as the engine collapses them
+    # after the fold: `a\..\..\outside.gd` is `a/../../outside.gd`, net one level up.
+    assert (
+        path_outside_project("res://a\\..\\..\\outside.gd", proj)
+        == (tmp_path / "outside.gd").resolve()
+    )
+
+
+def test_a_backslash_in_a_filesystem_path_is_not_a_separator(tmp_path):
+    # The fold is the ENGINE's res:// rule, not the filesystem's: `\` is a legal
+    # POSIX filename character, so an ordinary path keeps it and is anchored under
+    # the project as the single-segment name it is.
+    proj = _make_project(tmp_path / "game")
+
+    assert path_outside_project("..\\outside.gd", proj) is None
 
 
 def test_a_res_path_that_collapses_back_inside_is_not_outside(tmp_path):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -103,6 +103,56 @@ def test_engine_virtual_paths_are_never_outside(tmp_path):
     assert path_outside_project("uid://abc123", proj) is None
 
 
+# --- a res:// spelling that LEXICALLY escapes the namespace (#762) ------------
+
+
+def test_a_res_dotdot_escape_is_outside(tmp_path):
+    # #762: `path_outside_project` used to short-circuit EVERY res:// string as
+    # inside, so `res://../outside.gd` bypassed containment even though it names
+    # a file one directory above the project root — exactly what the absolute
+    # spelling of the same file is already refused for. The reported location
+    # lets a caller compare the two spellings' refusals directly.
+    proj = _make_project(tmp_path / "game")
+
+    assert (
+        path_outside_project("res://../outside.gd", proj)
+        == (tmp_path / "outside.gd").resolve()
+    )
+    # The bare escape, with no filename after it, is refused the same way.
+    assert path_outside_project("res://..", proj) == tmp_path.resolve()
+
+
+def test_a_res_path_that_collapses_back_inside_is_not_outside(tmp_path):
+    # A `..` a lexical collapse cancels out stays inside: `res://foo/../bar.gd`
+    # normalizes to `res://bar.gd`, net-inside the namespace, exactly as Godot
+    # itself would canonicalize the address. `resource import`'s own res://
+    # gate (`_asset_res_path`) is stricter — it refuses ANY literal `..`
+    # component regardless of net effect — and #763 tracks reconciling the two;
+    # this authority's rule is decided here.
+    proj = _make_project(tmp_path / "game")
+
+    assert path_outside_project("res://foo/../bar.gd", proj) is None
+
+
+def test_a_res_path_starting_with_two_dots_is_not_an_escape(tmp_path):
+    # `res://..foo.gd` names a real file whose name merely starts with two dots,
+    # not a traversal — the escape test is the first PATH SEGMENT, not a string
+    # prefix.
+    proj = _make_project(tmp_path / "game")
+
+    assert path_outside_project("res://..foo.gd", proj) is None
+
+
+def test_user_and_uid_paths_stay_inside_even_with_a_dotdot(tmp_path):
+    # Only res:// gets the lexical escape check (#762): user:// and uid:// stay
+    # inside by construction, unchanged — gda still cannot make a filesystem
+    # statement about where either one really resolves.
+    proj = _make_project(tmp_path / "game")
+
+    assert path_outside_project("user://../outside.gd", proj) is None
+    assert path_outside_project("uid://../abc123", proj) is None
+
+
 def test_a_colon_bearing_filesystem_path_is_not_treated_as_virtual(tmp_path):
     # A colon is a legal POSIX filename character, so "contains ://" is not a
     # scheme test: `/work/outside://deck.gd` is an ordinary filesystem path that

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 import pytest
 
-from gda.script_errors import canonical_res_path
 from gda.project import (
     GDA_PROJECT_ENV,
     PROJECT_MARKER,
@@ -145,15 +144,6 @@ def test_a_backslash_spelled_res_escape_is_outside(tmp_path):
         path_outside_project("res://a\\..\\..\\outside.gd", proj)
         == (tmp_path / "outside.gd").resolve()
     )
-
-
-def test_the_fold_does_not_reach_a_non_res_string():
-    # The fold is the ENGINE's res:// rule, so the canonicalizer must not apply it
-    # to anything else. This is the PLATFORM-INDEPENDENT half of that boundary: the
-    # string is returned untouched wherever gda runs. What the resulting filesystem
-    # path then MEANS is the platform's business, asserted separately below.
-    assert canonical_res_path("..\\outside.gd") == "..\\outside.gd"
-    assert canonical_res_path("a\\b.gd") == "a\\b.gd"
 
 
 @pytest.mark.skipif(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -7,10 +7,12 @@ when it holds one, otherwise gda runs projectless (filesystem paths only) — th
 behaviour before project context existed.
 """
 
+import os
 from pathlib import Path
 
 import pytest
 
+from gda.script_errors import canonical_res_path
 from gda.project import (
     GDA_PROJECT_ENV,
     PROJECT_MARKER,
@@ -145,10 +147,25 @@ def test_a_backslash_spelled_res_escape_is_outside(tmp_path):
     )
 
 
-def test_a_backslash_in_a_filesystem_path_is_not_a_separator(tmp_path):
-    # The fold is the ENGINE's res:// rule, not the filesystem's: `\` is a legal
-    # POSIX filename character, so an ordinary path keeps it and is anchored under
-    # the project as the single-segment name it is.
+def test_the_fold_does_not_reach_a_non_res_string():
+    # The fold is the ENGINE's res:// rule, so the canonicalizer must not apply it
+    # to anything else. This is the PLATFORM-INDEPENDENT half of that boundary: the
+    # string is returned untouched wherever gda runs. What the resulting filesystem
+    # path then MEANS is the platform's business, asserted separately below.
+    assert canonical_res_path("..\\outside.gd") == "..\\outside.gd"
+    assert canonical_res_path("a\\b.gd") == "a\\b.gd"
+
+
+@pytest.mark.skipif(
+    os.name != "posix", reason="`\\` is a filename character on POSIX only"
+)
+def test_a_backslash_in_a_filesystem_path_is_not_a_separator_on_posix(tmp_path):
+    # The consequence of the boundary above, on THIS platform: `\` is a legal POSIX
+    # filename character, so an ordinary path keeps it and is anchored under the
+    # project as the single-segment name it is. Native Windows `pathlib` reads the
+    # same string as a parent-directory escape and `path_outside_project` reports it
+    # outside — correctly, by that platform's own rule. The claim under test is that
+    # gda defers to the platform here, not that the string is inert everywhere.
     proj = _make_project(tmp_path / "game")
 
     assert path_outside_project("..\\outside.gd", proj) is None

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -594,6 +594,54 @@ def test_script_validate_refusal_is_identical_on_the_params_json_path(
     assert fake.calls == []
 
 
+def test_script_validate_refuses_a_res_dotdot_escape_the_same_as_the_absolute_spelling(
+    monkeypatch, tmp_path
+):
+    # #762: `path_outside_project` used to short-circuit EVERY res:// spelling as
+    # inside, so the SAME file, addressed as `res://../outside.gd`, bypassed the
+    # refusal the absolute spelling above already gets. Pinning both spellings in
+    # one test — not two separate ones — is deliberate: it is exactly the
+    # invariant that broke (same file, same command, opposite verdicts), so a
+    # future change that fixes one spelling without the other fails HERE.
+    proj = _project(tmp_path, "game")
+    outsider = tmp_path / "outside.gd"  # one directory above the project root
+
+    fake_abs = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    )
+    result_abs = CliRunner().invoke(
+        app,
+        ["script", "validate", str(outsider), "--project", str(proj), "--json"],
+    )
+
+    fake_res = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    )
+    result_res = CliRunner().invoke(
+        app,
+        [
+            "script",
+            "validate",
+            "res://../outside.gd",
+            "--project",
+            str(proj),
+            "--json",
+        ],
+    )
+
+    error_abs = json.loads(result_abs.stdout)["error"]
+    error_res = json.loads(result_res.stdout)["error"]
+    assert result_abs.exit_code == result_res.exit_code == 4
+    assert error_abs["code"] == error_res["code"] == "project_not_found"
+    assert error_abs["category"] == error_res["category"] == "operation"
+    # Both spellings name the SAME underlying location in their message.
+    assert str(outsider.resolve()) in error_abs["message"]
+    assert str(outsider.resolve()) in error_res["message"]
+    # Neither spelling reached the engine.
+    assert fake_abs.calls == []
+    assert fake_res.calls == []
+
+
 def test_script_validate_reports_the_resolved_project_root(monkeypatch, tmp_path):
     # The result names the root its res:// dependencies resolved against, so a
     # reader can tell a real compile error from a wrong-project one without
@@ -642,8 +690,11 @@ def test_script_validate_reports_a_null_project_root_when_projectless(
 
 
 def test_script_validate_does_not_refuse_a_res_path(monkeypatch, tmp_path):
-    # A res:// path addresses the resolved project by construction (ADR-0006), so
-    # containment makes no filesystem claim about it — it is never refused.
+    # A WELL-FORMED res:// path addresses the resolved project by construction
+    # (ADR-0006), so containment makes no filesystem claim about it and it is not
+    # refused. That is no longer true of every res:// spelling (#762): one that
+    # lexically escapes the namespace, e.g. `res://../outside.gd`, is refused —
+    # see test_script_validate_refuses_a_res_dotdot_escape_the_same_as_the_absolute_spelling.
     proj = _project(tmp_path, "game")
     fake = inject_runner(
         monkeypatch,

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -10,6 +10,7 @@ import json
 import re
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from gda.cli import app
@@ -594,8 +595,22 @@ def test_script_validate_refusal_is_identical_on_the_params_json_path(
     assert fake.calls == []
 
 
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        "res://../outside.gd",
+        # Godot folds `\\` to `/` across a res:// address before it collapses
+        # anything (`String::simplify_path`, ustring.cpp:4192), so these name the
+        # SAME file to the engine — a real 4.6.3 run loads it and reports back
+        # `res://../outside.gd`. They bypassed the check the slash spelling is
+        # refused by until the shared canonicalizer learned the fold (PR #766
+        # round-2 review).
+        "res://..\\outside.gd",
+        "res://a\\..\\..\\outside.gd",
+    ],
+)
 def test_script_validate_refuses_a_res_dotdot_escape_the_same_as_the_absolute_spelling(
-    monkeypatch, tmp_path
+    monkeypatch, tmp_path, spelling
 ):
     # #762: `path_outside_project` used to short-circuit EVERY res:// spelling as
     # inside, so the SAME file, addressed as `res://../outside.gd`, bypassed the
@@ -622,7 +637,7 @@ def test_script_validate_refuses_a_res_dotdot_escape_the_same_as_the_absolute_sp
         [
             "script",
             "validate",
-            "res://../outside.gd",
+            spelling,
             "--project",
             str(proj),
             "--json",

--- a/tests/test_script_error_parser.py
+++ b/tests/test_script_error_parser.py
@@ -239,9 +239,24 @@ ERROR: Can't load script: res://sub//..//gone.gd
         # collapsed further without escaping the project root.
         ("res://", "res://"),
         ("res://../outside.gd", "res://../outside.gd"),
-        # Not a res:// address: normalizing an address is not validating one.
+        # A BACKSLASH is a separator inside a res:// address, not a filename
+        # character: Godot folds `\` to `/` across the whole address before it
+        # collapses anything (`String::simplify_path`, ustring.cpp:4192), so the
+        # engine loads — and reports back — the slash spelling. Reading these as
+        # ordinary filenames let `res://..\outside.gd` past the containment check
+        # that already refuses `res://../outside.gd` (#762).
+        ("res://a\\b.gd", "res://a/b.gd"),
+        ("res://..\\outside.gd", "res://../outside.gd"),
+        ("res://a\\..\\..\\outside.gd", "res://../outside.gd"),
+        # The fold must run BEFORE the leading-slash strip, as the engine runs it
+        # before its own empty-segment split — otherwise this one stays `res:///a.gd`.
+        ("res://\\a.gd", "res://a.gd"),
+        # Not a res:// address: normalizing an address is not validating one. A
+        # filesystem path keeps its backslashes — POSIX allows `\` in a filename,
+        # and the fold is the ENGINE's res:// rule, not the filesystem's.
         ("/abs/path.gd", "/abs/path.gd"),
         ("relative.gd", "relative.gd"),
+        ("/abs/we\\ird.gd", "/abs/we\\ird.gd"),
     ],
 )
 def test_canonical_res_path_collapses_lexically(spelling, canonical):

--- a/tests/test_script_error_parser.py
+++ b/tests/test_script_error_parser.py
@@ -257,6 +257,11 @@ ERROR: Can't load script: res://sub//..//gone.gd
         ("/abs/path.gd", "/abs/path.gd"),
         ("relative.gd", "relative.gd"),
         ("/abs/we\\ird.gd", "/abs/we\\ird.gd"),
+        # The same two strings as the res:// rows above, MINUS the scheme, so the
+        # contrast is one row apart: with `res://` the backslash is a separator the
+        # engine folds, without it the string is a filename gda must not rewrite.
+        ("a\\b.gd", "a\\b.gd"),
+        ("..\\outside.gd", "..\\outside.gd"),
     ],
 )
 def test_canonical_res_path_collapses_lexically(spelling, canonical):

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -296,6 +296,16 @@ def test_trailing_unicode_spaces_that_godot_preserves_are_accepted(suffix):
         "res://..",
         "res://../outside.gd",
         "../../etc/passwd",
+        # The SAME escape spelled with the engine's other separator. Godot folds
+        # `\\` to `/` across a res:// address before it collapses anything
+        # (`String::simplify_path`, ustring.cpp:4192), and this gate lifts a
+        # project-relative path onto a res:// address first, so both of these
+        # named the file one level above the project and were LAUNCHED — the
+        # widest form of the containment bypass PR #766's round-2 review found,
+        # closed here by the shared canonicalizer learning the fold.
+        "res://..\\outside.gd",
+        "..\\outside.gd",
+        "res://a\\..\\..\\outside.gd",
         # A leading `~` is a HOME reference — a filesystem address form. It reaches
         # the operation unexpanded only when the shared normalizer could not resolve
         # the user (#699); a resolvable `~/x.gd` arrives already expanded to an


### PR DESCRIPTION
## Summary

- `path_outside_project` (the ADR-0006 containment authority, `src/gda/project.py`) short-circuited **every** `res://` string as inside the project. Its docstring's own reasoning — "an engine-virtual path is inside by construction... gda can make no filesystem statement about one" — is true for a well-formed `res://a/b.gd` but false for one that lexically escapes the namespace: `res://../outside.gd` still names a file above the project root after Godot's own `.`/`..` collapsing, and nothing checked for that.
- `script validate` trusts this authority directly (`_script_validate_recipe`), so the same file got opposite verdicts by spelling: refused as `/abs/path/outside.gd`, accepted as `res://../outside.gd`. Per `CONTEXT.md`'s Project-code execution surface, `validate` compiles the target, so the bypass admitted code outside the `Trusted project` through a refusal that exists precisely to prevent that.
- Fix, part 1: a `res://` path is now canonicalized through the shared `gda.script_errors.canonical_res_path` and refused only when it still climbs above the namespace root after that collapsing (`res://..`, `res://../outside.gd`, `res://../../x`).
- Fix, part 2 (round-2 review): **the canonicalizer itself did not match the engine on separators.** Godot folds `\` to `/` across a `res://` address *before* it collapses anything (`String::simplify_path`, `core/string/ustring.cpp:4192`, `4.6-stable-3260-g070dc9897e`), so `res://..\outside.gd` **is** the escaping `res://../outside.gd` to the engine. The fold now lives in `canonical_res_path`, where the engine puts it, so all three consumers get the engine's own identity. Applied only to a `res://` string: `\` is a legal POSIX filename character, and the fold is the engine's rule, not the filesystem's.
- A path that lexically contains `..` but collapses back inside (`res://foo/../bar.gd` → `res://bar.gd`) stays accepted — it is net-inside the namespace, exactly as Godot itself would canonicalize the address. A filename that merely starts with two dots (`res://..foo.gd`) is unaffected (checked by path segment, not string prefix). `user://` and `uid://` are untouched: gda still cannot make a filesystem statement about either.

## Engine parity of `canonical_res_path`

The round-2 review asked that the claim "canonicalized the way the engine canonicalizes one" be true or the gap be stated. `canonical_res_path`'s docstring now audits `String::simplify_path` (`core/string/ustring.cpp:4149-4233`) step by step. Reproduced: the scheme/"drive" extraction (narrowly, for an exact `res://` prefix); the `\` → `/` fold (4192); the repeated-`//` collapse and `split("/", false)` (4193-4201); the `.`/`..` collapse **with the leading-`..` strip disabled for `res://`** (4204-4221, the engine's own `FIXME`-marked exception), which is what lets an escape survive to be detected at all.

**One stated gap**, in the join (4223-4232): when every segment collapses away the engine yields the bare `res://`, `posixpath.normpath` yields `.`, so `res://a/..` canonicalizes here to `res://.`. Both spellings name the project root and every consumer already treats the pair alike — `script run`'s gate tests the pair explicitly (`_ROOT_REMAINDERS = {"", "."}`) and a `.` is not an upward escape — so the divergence is unobservable. Closing it would churn a deliberate accommodation in another command's gate, which #763 owns reconciling.

## Real-engine evidence (Godot 4.6.3, `4.6-stable-3260-g070dc9897e`)

All three spellings are one address to the engine, and it loads the file one directory above the project:

```
spelling=res://../outside.gd
  simplify_path -> res://../outside.gd
  load          -> (res://../outside.gd):<GDScript#-9223372010883643985>
spelling=res://..\outside.gd
  simplify_path -> res://../outside.gd
  load          -> (res://../outside.gd):<GDScript#-9223372010883643985>
spelling=res://a\..\..\outside.gd
  simplify_path -> res://../outside.gd
  load          -> (res://../outside.gd):<GDScript#-9223372010883643985>
```

The separator bypass was **wider than `script validate`**. At the previous head (`e6e8cd0b`), against the real engine:

| command | previous head | this head |
|---|---|---|
| `gda script validate 'res://..\outside.gd'` | `valid=true`, exit 0 | `project_not_found`, exit 4 |
| `gda script run '..\outside.gd'` | exit 0, stdout `<<<OUTSIDE-SCRIPT-RAN>>>` — **it executed a script outside the project** | `invalid_path`, exit 4, no launch |

`script run`'s gate lifts a project-relative path onto a `res://` address before canonicalizing, so the un-folded backslash reached the engine as a real traversal. That is exactly the ADR-0009 `Trusted project` widening the gate exists to prevent, and it is closed by the same one-line fold because all three gates share the canonicalizer.

## Scope discipline (per #762)

Three commands answer "is this target inside the resolved project", each its own way:

| command | `res://../outside.gd` | `res://..\outside.gd` | decided by |
|---|---|---|---|
| `script validate` | now refused (was accepted — the bug) | now refused (was accepted) | `gda.project.path_outside_project` (fixed here) |
| `script run` | refused | now refused (was **launched**) | its own `_project_scoped_res_path` (`src/gda/commands/script.py`) — its refusal *rules* are unchanged; it shares `canonical_res_path`, so the fold fixed its separator blind spot too |
| `resource import` | refused | refused on POSIX, by the later `is_file()` check rather than by its `..` gate | its own `..`-in-parts check in `_asset_res_path` (`src/gda/commands/resource.py`) — unchanged |

Neither `script run`'s nor `resource import`'s private gate becomes redundant by this fix: neither ever delegated the `res://` case to `path_outside_project` — that's exactly the "three answers" problem #763 (blocked on this PR) is scoped to unify. This PR makes the authority answer correctly, fixes the one caller (`script validate`) that trusted it, and corrects the shared canonicalizer that all three read.

`res://foo/../bar.gd` (net-inside, contains a literal `..`): the script-validate gate **accepts** it (canonicalizes first, matching Godot's own address identity), while `resource import`'s gate **rejects** it (its parts-based check refuses any literal `..` regardless of net effect). That divergence already existed before this PR and is left in place — reconciling it is explicitly #763's job, not this one's.

**Disclosed residual risk (unchanged by this PR, for #763):** `_asset_res_path` splits with `PurePosixPath`, so `res://..\x.png` is one segment and its `..` gate does not fire. On POSIX the request is still refused, one step later, by `source.is_file()` on the literal-backslash name; a Windows-native `Path` join would treat `\` as a separator and could reach the parent directory. Not reproducible on this platform, so it is reported rather than changed — `resource import` is a different command with its own gate, and #763 owns unifying them.

## Test plan

- [x] `tests/test_script_error_parser.py` — the canonicalization matrix gains `res://a\b.gd`, `res://..\outside.gd`, `res://a\..\..\outside.gd` (all folding to the engine's spelling), `res://\a.gd` (pins that the fold runs **before** the leading-slash strip, as the engine runs it before its own split), and `/abs/we\ird.gd` (a filesystem path keeps its backslashes).
- [x] `tests/test_project.py` pins the authority directly: `res://../outside.gd` and `res://..` are outside (with the resolved location reported); the new `test_a_backslash_spelled_res_escape_is_outside` covers `res://..\outside.gd` and the mixed `res://a\..\..\outside.gd`; `test_a_backslash_in_a_filesystem_path_is_not_a_separator_on_posix` pins that `..\outside.gd` as a *filesystem* path stays inside **on POSIX**, where `\` is a legal filename character — native Windows `pathlib` reads the same string as a parent escape and gda reports it outside, correctly by that platform's rule, so the test carries the repository's `os.name != "posix"` skip. The platform-independent half of that boundary — that the fold is the engine's `res://` rule and never rewrites another string — is pinned where it is already owned, in `tests/test_script_error_parser.py`'s `canonical_res_path` matrix, which now carries `a\b.gd` and `..\outside.gd` one row away from their `res://` twins; `res://foo/../bar.gd` and `res://..foo.gd` stay inside; `user://../outside.gd` / `uid://../abc123` stay inside (untouched).
- [x] `tests/test_script_commands.py` — `test_script_validate_refuses_a_res_dotdot_escape_the_same_as_the_absolute_spelling` is now parametrized over the slash, backslash and mixed spellings, each paired **in one test** with the absolute path of the same file: identical `project_not_found` verdict, identical reported location, neither reaching the engine.
- [x] `tests/test_script_run_operation.py` — the `_project_scoped_res_path` refusal matrix gains `res://..\outside.gd`, `..\outside.gd` and `res://a\..\..\outside.gd`, the spellings that previously launched.
- [x] Existing `test_script_validate_does_not_refuse_a_res_path` (well-formed `res://deck.gd`) still passes; its comment cross-references the new escape test.
- [x] `test_engine_virtual_paths_are_never_outside` renamed to `test_well_formed_engine_virtual_paths_are_not_outside`, its comment qualified — the old name asserted an absolute that the sibling escape test disproves (round-2 Standards finding).
- [x] Red-proofed: with the committed head's `src/` restored over the new tests, **10 cases failed** — 4 canonicalizer cases, `test_a_backslash_spelled_res_escape_is_outside`, 2 CLI-parity cases, 3 `script run` gate cases (the last reporting `ScriptRunResult(path='res://a\\..\\..\\outside.gd', exit_status=0)`, i.e. the pre-fix build launched the escape). With the fix restored, all 246 tests in those four files pass.
- [x] Real-engine severity check run both ways (table above), plus a legitimate in-project `gda script run inside.gd` still succeeding (exit 0).

Gates (verbatim, at `0c926509`):
```
$ uv run pytest -q -m "not e2e"
1958 passed, 543 deselected in 55.49s

$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
473 files already formatted

$ uv run pyright
0 errors, 0 warnings, 0 informations

$ uv run pytest -q -m e2e -rs tests/test_e2e_script.py tests/test_e2e_script_run.py tests/test_e2e_project.py
141 passed in 160.48s (0:02:40)

$ uv run pytest -q -m e2e -rs tests/test_e2e_scene_preflight.py tests/test_e2e_scene_validate.py tests/test_e2e_scene_security.py
30 passed in 22.88s
```

The second e2e batch is there because `canonical_res_path` is shared with the script-error parser, which the scene preflight also reads.

## Sweep (AC bullet 4)

Every remaining site that answers "is this target inside the resolved project", confirmed by grep across `src/gda`:

1. `gda.project.path_outside_project` — the declared ADR-0006 authority (fixed here).
2. `gda.commands.script._project_scoped_res_path` — `script run`'s own gate, independent rules, unchanged; shares `canonical_res_path`, so it inherits the separator fold.
3. `gda.commands.resource._asset_res_path` — `resource import`'s own gate: reuses the authority for filesystem paths, but has its own inline check for `res://` inputs, unchanged.

Still three answers, not one — #763 is the tracked follow-up to unify them.

Closes #762

