### PR TITLE
feat(gda): recognize a project-raised push_error as a script diagnostic (#722)

### DIFF
--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -134,9 +134,16 @@ they answer *different* ones:
   engine's error stream. Read `started`: true only when the scene reached `_ready` AND nothing was
   recognized on stderr, which is the distinction the dogfooding note asks for (GDA-DF-030 —
   static validation passed while the first live launch rejected every assembly). Recognition is
-  #651's closed set of engine failure sentences (a runtime error, a failed assertion, a script
-  that could not load, a script binding the engine refused), so project prose written with
-  `push_error()` is not among them.
+  #651's closed set: the engine's own failure sentences (a runtime error, a failed assertion, a
+  script that could not load, a script binding the engine refused) **and a project-raised
+  `push_error()`** (#722), which is the most common way a Godot project reports exactly the
+  invariant violation GDA-DF-030 describes. That one is recognized by its `at:` frame — which
+  the engine fixes as `push_error` — never by its message, which is the project's own prose; its
+  `kind` is `push_error` and its `path`/`line` are the call site named in the engine's GDScript
+  backtrace, or null when it attached none. Everything else the engine prints stays
+  unrecognized: a backtrace alone does not qualify a record, since the engine attaches one to
+  any error raised while GDScript is on the stack, including engine-side failures a script only
+  triggered indirectly.
 
 `scene validate` takes a `.tscn` specifically, and refuses a binary `.scn` with `invalid_path`:
 its dependency set comes from the scene's own TEXT (which is also what attributes each dependency
@@ -626,7 +633,11 @@ alive and did not finish) — so a slow suite is distinguishable from a hang.
 `--completion-marker <line>` declares a liveness contract — the script prints that line when
 its work is done — and a run that hit a recognized error attributable to the entry script, has
 not printed the marker, and then goes silent on both streams is ended in seconds and reported
-as `script_aborted` with the captured error and phase `aborted_on_error`. The script executes in full, within
+as `script_aborted` with the captured error and phase `aborted_on_error`. A `push_error` never
+arms that abort even though it is recognized (#722): it interrupts nothing — execution
+continues at the next statement — so a script that reports an invariant and then computes
+quietly is alive by construction. It does appear in the run's `diagnostics`, which are advisory:
+a project that uses `push_error` as ordinary logging sees entries on runs that still succeed. The script executes in full, within
 the trusted-project assumption (ADR-0009).
 
 ### `project`

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -66,7 +66,7 @@ they are provenance, not status markers.
 | `gda scene get` | Read a scene's structured tree from its file on disk |
 | `gda scene list` | Enumerate scenes in the project |
 | `gda scene get-exports` | List `@export` properties declared by a scene's nodes |
-| `gda scene validate` | Check statically that a scene and the sub-scenes it instances resolve their dependencies and compile their scripts |
+| `gda scene validate` | Check statically that a scene's dependencies resolve and its scripts compile |
 | `gda scene preflight` | Boot a scene headless and report its startup verdict |
 
 **Enumeration** (established by #54): `scene list` walks the project's `res://`
@@ -115,46 +115,18 @@ they answer *different* ones:
   it binds — the referenced `.gd` files and the embedded `[sub_resource type="GDScript"]`s the
   dependency walk never sees — and checks each script's native base against the node carrying it,
   reporting one problem per file: `missing_resource` (the file is gone), `unloadable_resource`
-  (present on disk but no `ResourceLoader` opens it — typically an asset that was never
-  imported, which a non-editor engine cannot load at all), `script_compile_failed` (the same
-  verdict `script validate` gives that file; an embedded script is named by its `::id`
-  sub-resource path), `incompatible_script` (a binding the engine would refuse — a script on a
-  node outside its native base, the same rule `node script attach` enforces asked
-  statically, or a value bound to a `script` slot that is not a script at all),
-  `cyclic_instance`, or `instance_depth_exceeded` (the last two defined below with the composed
-  walk that finds them). Each problem carries the declared `type` and the node paths referencing
-  it, read from the file's own text because the engine drops an unresolvable reference from what
-  it loads. A path declared twice is one problem with both nodes listed. The verdict is
-  **staged**: unresolved dependencies suppress the load, so the compile and binding problems
-  only the loaded scene can reveal appear after the dependencies are repaired and validate is
-  rerun — the problem list is complete for the stage it reached, not across both stages at once.
-
-  The verdict is **composed**: the scenes a scene instances are validated with it, because a
-  parent whose instanced child is broken is broken too and the parent's own walk cannot see that
-  — `res://child.tscn` resolves, opens, and hands back a usable `PackedScene` with whatever is
-  missing inside it substituted by null. Every problem therefore carries `scene`, the file it
-  was found in, and its `path` and `nodes` are read against THAT file, not against the scene the
-  command was given. The walk descends into instanced `.tscn` files only (a binary `.scn`
-  carries no dependency text — the same reason the command refuses one at the top level),
-  validates each file ONCE however many sites instance it, and reports an instancing cycle
-  rather than following it.
-
-  `cyclic_instance` — a scene instances one that already instances it. Godot refuses a cyclic
-  scene inclusion, so the composition cannot load. Reported against the file that declares the
-  closing edge (`scene`), with `path` naming the ancestor being re-instanced and `nodes` the
-  instancing sites. The walk stops at that edge, so whatever lies beyond it is unreported until
-  the cycle is broken.
-
-  `instance_depth_exceeded` — not a defect in the project but a limit of gda: the walk follows
-  at most 16 levels of instanced sub-scenes below the validated scene, and this edge is past
-  that bound, so the scene named by `path` and everything it instances were UNCHECKED, not
-  judged sound. `scene` names the file holding the declining edge. The verdict is still
-  `valid: false` — a gate must not answer "sound" about what it did not look at — and
-  validating the named scene directly gives it a verdict of its own. The bound covers gda's own
-  walk only: the engine loads the whole chain regardless, and an extremely deep chain overflows
-  the engine's own loader and ends the run with no verdict at all, which this bound does not
-  change.
-
+  (present on disk but no `ResourceLoader` opens it — typically an asset that was never imported,
+  which a non-editor engine cannot load at all), `script_compile_failed` (the same verdict
+  `script validate` gives that file; an embedded script is named by its `::id` sub-resource path)
+  or `incompatible_script` (a binding the engine would refuse — a script on a node outside its
+  native base, the same rule `node script attach` enforces asked statically, or a value bound to
+  a `script` slot that is not a script at all). Each problem carries the declared `type` and
+  the node paths referencing it, read from the file's own text because the engine drops an
+  unresolvable reference from what it loads. A path declared twice is one problem with both nodes
+  listed. The verdict is **staged**: unresolved dependencies suppress the load, so the compile
+  and binding problems only the loaded scene can reveal appear after the dependencies are
+  repaired and validate is rerun — the problem list is complete for the stage it reached, not
+  across both stages at once.
 - `gda scene preflight PATH` is **dynamic**. It instantiates the scene, adds it under a one-shot
   engine's tree root — which runs its `_ready` and the project's autoloads — keeps it alive for
   `--frames` idle frames so startup work landing after `_ready` still prints, and reports
@@ -665,8 +637,8 @@ as `script_aborted` with the captured error and phase `aborted_on_error`. A `pus
 arms that abort even though it is recognized (#722): it interrupts nothing — execution
 continues at the next statement — so a script that reports an invariant and then computes
 quietly is alive by construction. It does appear in the run's `diagnostics`, which are advisory:
-a project that uses `push_error` as ordinary logging sees entries on runs that still succeed. The script executes in full, within
-the trusted-project assumption (ADR-0009).
+a project that uses `push_error` as ordinary logging sees entries on runs that still succeed.
+The script executes in full, within the trusted-project assumption (ADR-0009).
 
 ### `project`
 
@@ -919,7 +891,7 @@ headless is unaffected (4.4+, cross-platform).
   a Dictionary into an `Object` parameter, null into `int`, and any JSON array into a
   typed `Array[int]` are refused with the reason. Without the check `callv` pushes an
   engine error, returns null and writes to the Session log — a failure that would read
-  as a successful null. Three reproduced unsafe argument classes are refused earlier
+  as a successful null. Two reproduced unsafe argument classes are refused earlier
   still, in the params model both invocation paths share (recursively, so a nested
   value counts):
   non-finite numbers (`NaN`/`Infinity`, which JSON has no literals for but Python's
@@ -929,17 +901,11 @@ headless is unaffected (4.4+, cross-platform).
   and a larger integer can arrive as a DIFFERENT value (a call that then succeeds on
   something the caller never sent). Finite floats already are binary64 and do not
   inherit that integer bound; real-engine tests pin the reproduced high-range values
-  `1e17`, `2.5e17`, and `1e300` unchanged.
-  The third class is the small-float one #752 decided: Godot's `built_in_strtod` applies a power
-  of ten it computes as a double, so a literal whose applied exponent is −309 or below is
-  divided by `inf` and arrives as `0.0` — `DBL_MIN`, every subnormal, and normal values such as
-  `1.2345678901234567e-300`. No decimal spelling avoids it (the significand is an integer and
-  the largest finite power the engine's table builds is `1e308`), so those values are REFUSED
-  rather than delivered as a zero the caller never sent; a real-engine corpus
-  (`tests/live_number_corpus.py`) pins the boundary with two same-magnitude values whose only
-  difference is significant-digit count. What crosses can still arrive 1–2 ULP away — disclosed,
-  not refused, since refusing it would reject ordinary game values.
-  Standard JSON Schema cannot distinguish
+  `1e17`, `2.5e17`, and `1e300` unchanged. This is not a full-range preservation
+  guarantee: Godot 4.6.3 parses some small-magnitude normal values, including
+  `1.2345678901234567e-300` and `DBL_MIN`, as `0.0`, and its `JSON.stringify` can
+  also lose small live-result values. [Issue #752](https://github.com/aigengame/godot-agent/issues/752)
+  owns that cross-operation transport defect. Standard JSON Schema cannot distinguish
   an exponent-form float from the equal mathematical integer, so its recursive number
   branch stays broad and discloses that the params model enforces the integer-token
   bound at execution. RFC JSON excludes `NaN` and `Infinity`; some in-memory schema
@@ -953,14 +919,6 @@ headless is unaffected (4.4+, cross-platform).
   chain has at most one declaration owner (a base owner covers its subclasses and need
   not define every method it names); a project that declares in both fails to parse with a message naming the
   member — loud, never a silently wrong allowlist.
-
-  Every live reply is framed with Godot's full-precision JSON writer (#752), so a float a live
-  read returns — `game get`, a `game call` return value, `perf` monitors, a `perf monitor`
-  timeline — reaches the caller as the exact binary64 the running game holds. The default writer
-  it replaced rendered floats fixed-point at 32 decimals, flattening every value below about
-  `1e-32.6` to `0.0` and rounding ordinary values to ~15 significant digits. One residual: a
-  negative zero reads back as `0.0`, decided by the engine before the writer's precision
-  argument applies.
 - **`input` (input simulation):** runtime input injection into the running game
   (shipped, #221). Single-frame ops `input key <KEY> [--modifiers …] [--released]`,
   `input mouse-move <x> <y>`, and `input action <NAME> [--release] [--strength F]`

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -115,19 +115,19 @@ they answer *different* ones:
   it binds — the referenced `.gd` files and the embedded `[sub_resource type="GDScript"]`s the
   dependency walk never sees — and checks each script's native base against the node carrying it,
   reporting one problem per file: `missing_resource` (the file is gone), `unloadable_resource`
-  (present on disk but no `ResourceLoader` opens it — typically an asset that was never imported,
-  which a non-editor engine cannot load at all), `script_compile_failed` (the same verdict
-  `script validate` gives that file; an embedded script is named by its `::id` sub-resource path),
-  `incompatible_script` (a binding the engine would refuse — a script on a node outside its
-  native base, the same rule `node script attach` enforces asked statically, or a value bound to
-  a `script` slot that is not a script at all), or `cyclic_instance` (defined below with the
-  composed walk that finds it). Each problem carries the declared `type` and
-  the node paths referencing it, read from the file's own text because the engine drops an
-  unresolvable reference from what it loads. A path declared twice is one problem with both nodes
-  listed. The verdict is **staged**: unresolved dependencies suppress the load, so the compile
-  and binding problems only the loaded scene can reveal appear after the dependencies are
-  repaired and validate is rerun — the problem list is complete for the stage it reached, not
-  across both stages at once.
+  (present on disk but no `ResourceLoader` opens it — typically an asset that was never
+  imported, which a non-editor engine cannot load at all), `script_compile_failed` (the same
+  verdict `script validate` gives that file; an embedded script is named by its `::id`
+  sub-resource path), `incompatible_script` (a binding the engine would refuse — a script on a
+  node outside its native base, the same rule `node script attach` enforces asked
+  statically, or a value bound to a `script` slot that is not a script at all),
+  `cyclic_instance`, or `instance_depth_exceeded` (the last two defined below with the composed
+  walk that finds them). Each problem carries the declared `type` and the node paths referencing
+  it, read from the file's own text because the engine drops an unresolvable reference from what
+  it loads. A path declared twice is one problem with both nodes listed. The verdict is
+  **staged**: unresolved dependencies suppress the load, so the compile and binding problems
+  only the loaded scene can reveal appear after the dependencies are repaired and validate is
+  rerun — the problem list is complete for the stage it reached, not across both stages at once.
 
   The verdict is **composed**: the scenes a scene instances are validated with it, because a
   parent whose instanced child is broken is broken too and the parent's own walk cannot see that
@@ -144,6 +144,16 @@ they answer *different* ones:
   closing edge (`scene`), with `path` naming the ancestor being re-instanced and `nodes` the
   instancing sites. The walk stops at that edge, so whatever lies beyond it is unreported until
   the cycle is broken.
+
+  `instance_depth_exceeded` — not a defect in the project but a limit of gda: the walk follows
+  at most 16 levels of instanced sub-scenes below the validated scene, and this edge is past
+  that bound, so the scene named by `path` and everything it instances were UNCHECKED, not
+  judged sound. `scene` names the file holding the declining edge. The verdict is still
+  `valid: false` — a gate must not answer "sound" about what it did not look at — and
+  validating the named scene directly gives it a verdict of its own. The bound covers gda's own
+  walk only: the engine loads the whole chain regardless, and an extremely deep chain overflows
+  the engine's own loader and ends the run with no verdict at all, which this bound does not
+  change.
 
 - `gda scene preflight PATH` is **dynamic**. It instantiates the scene, adds it under a one-shot
   engine's tree root — which runs its `_ready` and the project's autoloads — keeps it alive for

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -66,7 +66,7 @@ they are provenance, not status markers.
 | `gda scene get` | Read a scene's structured tree from its file on disk |
 | `gda scene list` | Enumerate scenes in the project |
 | `gda scene get-exports` | List `@export` properties declared by a scene's nodes |
-| `gda scene validate` | Check statically that a scene's dependencies resolve and its scripts compile |
+| `gda scene validate` | Check statically that a scene and the sub-scenes it instances resolve their dependencies and compile their scripts |
 | `gda scene preflight` | Boot a scene headless and report its startup verdict |
 
 **Enumeration** (established by #54): `scene list` walks the project's `res://`
@@ -117,16 +117,34 @@ they answer *different* ones:
   reporting one problem per file: `missing_resource` (the file is gone), `unloadable_resource`
   (present on disk but no `ResourceLoader` opens it — typically an asset that was never imported,
   which a non-editor engine cannot load at all), `script_compile_failed` (the same verdict
-  `script validate` gives that file; an embedded script is named by its `::id` sub-resource path)
-  or `incompatible_script` (a binding the engine would refuse — a script on a node outside its
+  `script validate` gives that file; an embedded script is named by its `::id` sub-resource path),
+  `incompatible_script` (a binding the engine would refuse — a script on a node outside its
   native base, the same rule `node script attach` enforces asked statically, or a value bound to
-  a `script` slot that is not a script at all). Each problem carries the declared `type` and
+  a `script` slot that is not a script at all), or `cyclic_instance` (defined below with the
+  composed walk that finds it). Each problem carries the declared `type` and
   the node paths referencing it, read from the file's own text because the engine drops an
   unresolvable reference from what it loads. A path declared twice is one problem with both nodes
   listed. The verdict is **staged**: unresolved dependencies suppress the load, so the compile
   and binding problems only the loaded scene can reveal appear after the dependencies are
   repaired and validate is rerun — the problem list is complete for the stage it reached, not
   across both stages at once.
+
+  The verdict is **composed**: the scenes a scene instances are validated with it, because a
+  parent whose instanced child is broken is broken too and the parent's own walk cannot see that
+  — `res://child.tscn` resolves, opens, and hands back a usable `PackedScene` with whatever is
+  missing inside it substituted by null. Every problem therefore carries `scene`, the file it
+  was found in, and its `path` and `nodes` are read against THAT file, not against the scene the
+  command was given. The walk descends into instanced `.tscn` files only (a binary `.scn`
+  carries no dependency text — the same reason the command refuses one at the top level),
+  validates each file ONCE however many sites instance it, and reports an instancing cycle
+  rather than following it.
+
+  `cyclic_instance` — a scene instances one that already instances it. Godot refuses a cyclic
+  scene inclusion, so the composition cannot load. Reported against the file that declares the
+  closing edge (`scene`), with `path` naming the ancestor being re-instanced and `nodes` the
+  instancing sites. The walk stops at that edge, so whatever lies beyond it is unreported until
+  the cycle is broken.
+
 - `gda scene preflight PATH` is **dynamic**. It instantiates the scene, adds it under a one-shot
   engine's tree root — which runs its `_ready` and the project's autoloads — keeps it alive for
   `--frames` idle frames so startup work landing after `_ready` still prints, and reports
@@ -891,7 +909,7 @@ headless is unaffected (4.4+, cross-platform).
   a Dictionary into an `Object` parameter, null into `int`, and any JSON array into a
   typed `Array[int]` are refused with the reason. Without the check `callv` pushes an
   engine error, returns null and writes to the Session log — a failure that would read
-  as a successful null. Two reproduced unsafe argument classes are refused earlier
+  as a successful null. Three reproduced unsafe argument classes are refused earlier
   still, in the params model both invocation paths share (recursively, so a nested
   value counts):
   non-finite numbers (`NaN`/`Infinity`, which JSON has no literals for but Python's
@@ -901,11 +919,17 @@ headless is unaffected (4.4+, cross-platform).
   and a larger integer can arrive as a DIFFERENT value (a call that then succeeds on
   something the caller never sent). Finite floats already are binary64 and do not
   inherit that integer bound; real-engine tests pin the reproduced high-range values
-  `1e17`, `2.5e17`, and `1e300` unchanged. This is not a full-range preservation
-  guarantee: Godot 4.6.3 parses some small-magnitude normal values, including
-  `1.2345678901234567e-300` and `DBL_MIN`, as `0.0`, and its `JSON.stringify` can
-  also lose small live-result values. [Issue #752](https://github.com/aigengame/godot-agent/issues/752)
-  owns that cross-operation transport defect. Standard JSON Schema cannot distinguish
+  `1e17`, `2.5e17`, and `1e300` unchanged.
+  The third class is the small-float one #752 decided: Godot's `built_in_strtod` applies a power
+  of ten it computes as a double, so a literal whose applied exponent is −309 or below is
+  divided by `inf` and arrives as `0.0` — `DBL_MIN`, every subnormal, and normal values such as
+  `1.2345678901234567e-300`. No decimal spelling avoids it (the significand is an integer and
+  the largest finite power the engine's table builds is `1e308`), so those values are REFUSED
+  rather than delivered as a zero the caller never sent; a real-engine corpus
+  (`tests/live_number_corpus.py`) pins the boundary with two same-magnitude values whose only
+  difference is significant-digit count. What crosses can still arrive 1–2 ULP away — disclosed,
+  not refused, since refusing it would reject ordinary game values.
+  Standard JSON Schema cannot distinguish
   an exponent-form float from the equal mathematical integer, so its recursive number
   branch stays broad and discloses that the params model enforces the integer-token
   bound at execution. RFC JSON excludes `NaN` and `Infinity`; some in-memory schema
@@ -919,6 +943,14 @@ headless is unaffected (4.4+, cross-platform).
   chain has at most one declaration owner (a base owner covers its subclasses and need
   not define every method it names); a project that declares in both fails to parse with a message naming the
   member — loud, never a silently wrong allowlist.
+
+  Every live reply is framed with Godot's full-precision JSON writer (#752), so a float a live
+  read returns — `game get`, a `game call` return value, `perf` monitors, a `perf monitor`
+  timeline — reaches the caller as the exact binary64 the running game holds. The default writer
+  it replaced rendered floats fixed-point at 32 decimals, flattening every value below about
+  `1e-32.6` to `0.0` and rounding ordinary values to ~15 significant digits. One residual: a
+  negative zero reads back as `0.0`, decided by the engine before the writer's precision
+  argument applies.
 - **`input` (input simulation):** runtime input injection into the running game
   (shipped, #221). Single-frame ops `input key <KEY> [--modifiers …] [--released]`,
   `input mouse-move <x> <y>`, and `input action <NAME> [--release] [--strength F]`

--- a/src/gda/commands/diag.py
+++ b/src/gda/commands/diag.py
@@ -101,8 +101,12 @@ class DiagError(BaseModel):
         default_factory=list,
         description=(
             "The ordered call stack (most-recent-first) when the engine emitted a "
-            "GDScript backtrace; frame [0] equals the top {function,file,line}. "
-            "Empty for an error raised outside any GDScript call stack."
+            "GDScript backtrace, so frame [0] is the innermost GDScript frame. It "
+            "equals the top {function,file,line} only when GDScript itself raised "
+            "the error; when a script called engine code that raised (a push_error, "
+            "say) the top fields name that engine function and file while frame [0] "
+            "names the calling script line. Empty for an error raised outside any "
+            "GDScript call stack."
         ),
     )
 

--- a/src/gda/commands/diag.py
+++ b/src/gda/commands/diag.py
@@ -79,8 +79,10 @@ class DiagError(BaseModel):
     included, told apart by ``level``. The location (``function``/``file``/
     ``line``) is filled from the ``   at:`` follow-on when present; a bare error
     leaves them ``null`` (best-effort, never a parse failure). A runtime GDScript
-    error additionally carries its ordered ``callstack`` of frames (#283); a bare
-    push_error / warning has no backtrace, so ``callstack`` is empty.
+    error additionally carries its ordered ``callstack`` of frames (#283), as does
+    any error — a ``push_error`` included — raised while GDScript was on the call
+    stack; an error raised outside one has no backtrace, so ``callstack`` is
+    empty (#722).
     """
 
     level: str = Field(
@@ -100,7 +102,7 @@ class DiagError(BaseModel):
         description=(
             "The ordered call stack (most-recent-first) when the engine emitted a "
             "GDScript backtrace; frame [0] equals the top {function,file,line}. "
-            "Empty for a bare push_error / warning."
+            "Empty for an error raised outside any GDScript call stack."
         ),
     )
 

--- a/src/gda/commands/scene.py
+++ b/src/gda/commands/scene.py
@@ -566,11 +566,12 @@ class ScenePreflightResult(BaseModel):
         description=(
             "The script errors gda recognized in the engine's error stream during "
             "startup, in emission order; empty when it printed none it recognizes. "
-            "Advisory and best-effort: recognition is a closed set of the engine's "
+            "Advisory and best-effort: recognition is a closed set — the engine's "
             "own failure sentences (a runtime error, a failed assertion, a script "
-            "that could not be loaded), so project prose written with push_error() "
-            "is NOT among them. The verbatim stream is still forwarded to gda's "
-            "stderr."
+            "that could not be loaded), plus a project-raised push_error(), whose "
+            "kind is 'push_error' and whose path/line come from the engine's "
+            "GDScript backtrace. Unrecognized engine prose is not a diagnostic; "
+            "the verbatim stream is still forwarded to gda's stderr."
         ),
     )
     project_root: str | None = Field(

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -1298,6 +1298,16 @@ def _entry_attributable(errors: list[ScriptError], entry: str) -> bool:
       exactly the dogfooded case: an error raised inside the entry's own
       ``_initialize`` aborts it before its ``quit()``.
 
+    ``PUSH_ERROR`` is deliberately NOT here (#722), though it too can name the
+    entry. The watch's whole premise is that something interrupted the run: a
+    GDScript runtime error abandons the function it was raised in, which is why a
+    silence window after one is evidence. A ``push_error`` interrupts nothing —
+    the engine prints it and execution continues at the next statement — so a
+    script that reports an invariant and then computes quietly is alive by
+    construction, and killing it would break the very projects that use
+    ``push_error`` as ordinary logging. Widening recognition (#722) therefore adds
+    diagnostics to what ``script run`` REPORTS without changing when it aborts.
+
     Attribution is what keeps a *survivable* failure from arming the abort at all. A
     running script that merely ``load()``s a missing ``.tres``, or whose helper
     script fails, produces the same engine sentences for a DIFFERENT path — and the

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -1294,7 +1294,7 @@ def _entry_attributable(errors: list[ScriptError], entry: str) -> bool:
       the resource-layer cascade behind those — already matched on the canonical
       ``res://`` identity, on both sides;
     - plus a ``RUNTIME_ERROR`` naming the entry, which that function excludes **by
-      construction** (it is the one kind proving the script DID run) and which is
+      construction** (one of the two kinds proving the script DID run) and which is
       exactly the dogfooded case: an error raised inside the entry's own
       ``_initialize`` aborts it before its ``quit()``.
 

--- a/src/gda/engine_log.py
+++ b/src/gda/engine_log.py
@@ -14,11 +14,13 @@ Godot writes an error as a two-line pair (verified against the engine's
        at: <function> (<file>:<line>)
 
 where ``<TYPE>`` is one of ``ERROR`` / ``WARNING`` / ``SCRIPT ERROR`` /
-``SHADER ERROR``. Print output is plain lines. A runtime GDScript error carries
-a multi-line call stack after the ``at:`` line — a ``GDScript backtrace (most
-recent call first):`` marker then one ``[N] <function> (<file>:<line>)`` frame
-line per stack frame (#283); :func:`parse_errors` folds those frames into the
-error's ordered ``callstack`` (frame ``[0]`` equals the ``at:`` location).
+``SHADER ERROR``. Print output is plain lines. An error raised while GDScript is
+on the call stack carries a multi-line backtrace after the ``at:`` line — a
+``GDScript backtrace (most recent call first):`` marker then one
+``[N] <function> (<file>:<line>)`` frame line per stack frame (#283);
+:func:`parse_errors` folds those frames into the error's ordered ``callstack``.
+Frame ``[0]`` is the innermost GDScript frame, which is NOT always the ``at:``
+location — the ``FRAME_LINE`` comment below carries that contract.
 
 The parsing is **best-effort**: a line that is neither a recognized ``<TYPE>:``
 header nor the ``   at:`` follow-on (a backtrace, an interleaved print line) is
@@ -38,11 +40,31 @@ AT_LINE = re.compile(
     r"^\s*at:\s*(?P<function>.*?)\s*\((?P<file>.*):(?P<line>\d+)\)\s*$"
 )
 
-# After the ``at:`` line, a runtime GDScript error MAY carry a full call stack:
-# a marker line ``GDScript backtrace (most recent call first):`` then one frame
-# line per stack frame, ``       [N] <function> (<file>:<line>)`` (verified
-# against Godot 4.6.3). Frames are ordered most-recent-first; frame ``[0]``
-# equals the ``at:`` location.
+# After the ``at:`` line, an error MAY carry a full call stack: a marker line
+# ``GDScript backtrace (most recent call first):`` then one frame line per stack
+# frame, ``       [N] <function> (<file>:<line>)`` (verified against Godot
+# 4.6.3). Frames are most-recent-first, so frame ``[0]`` is the INNERMOST
+# GDScript frame.
+#
+# Frame ``[0]`` does NOT always equal the ``at:`` location, and the two answer
+# different questions: ``at:`` is where the error was RAISED (the raising C++
+# site's ``__FUNCTION__``/``__FILE__``/``__LINE__``), while the backtrace is
+# where the SCRIPT was. They coincide only when GDScript itself raised the error
+# — its VM reports a runtime error at the failing statement, which is that same
+# innermost frame. When a script CALLS engine code that raises, they differ:
+# ``push_error`` is an ``ERR_PRINT`` inside
+# ``VariantUtilityFunctions::push_error``, so ``at:`` names that C++ function and
+# file while frame ``[0]`` names the ``.gd`` line that called it (reproduced on
+# Godot 4.6.3, #722)::
+#
+#     ERROR: probe: invariant violated
+#        at: push_error (core/variant/variant_utility.cpp:1024)
+#        GDScript backtrace (most recent call first):
+#            [0] _inner (res://main.gd:10)
+#
+# An earlier comment here stated the equality unconditionally; it holds only for
+# the runtime-error class #283 measured it on. This is why ``script_errors``
+# attributes a ``push_error`` from the backtrace and never from ``at:``.
 #
 # A backtrace is attached to ANY error raised while GDScript is on the call stack
 # (`ScriptServer::capture_script_backtraces`) — a `push_error`, a `push_warning`,
@@ -91,11 +113,13 @@ def parse_errors(data: str | bytes, limit: int | None = None) -> list[dict]:
     ``at:`` follow-on fills ``function``/``file``/``line``; absent, they are
     ``None`` (a bare error without a location is not a failure). ``callstack`` is
     the ordered ``{function, file, line}`` frames from the optional ``GDScript
-    backtrace`` block (most-recent-first; frame ``[0]`` equals the ``at:``
-    location); an error raised outside any GDScript call stack carries no
-    backtrace, so ``callstack`` is ``[]``. Unrecognized/continuation lines
-    (interleaved print output) are
-    skipped. ``limit`` tails the most recent ``N`` errors. Empty input -> ``[]``.
+    backtrace`` block (most-recent-first, so frame ``[0]`` is the innermost
+    GDScript frame — equal to the ``at:`` location only when GDScript itself
+    raised the error, not when a script called engine code that raised; see the
+    ``FRAME_LINE`` comment); an error raised outside any GDScript call stack
+    carries no backtrace, so ``callstack`` is ``[]``. Unrecognized/continuation
+    lines (interleaved print output) are skipped. ``limit`` tails the most recent
+    ``N`` errors. Empty input -> ``[]``.
     """
     captured = lines(data)
     errors: list[dict] = []

--- a/src/gda/engine_log.py
+++ b/src/gda/engine_log.py
@@ -42,7 +42,18 @@ AT_LINE = re.compile(
 # a marker line ``GDScript backtrace (most recent call first):`` then one frame
 # line per stack frame, ``       [N] <function> (<file>:<line>)`` (verified
 # against Godot 4.6.3). Frames are ordered most-recent-first; frame ``[0]``
-# equals the ``at:`` location. push_error / warnings carry no backtrace.
+# equals the ``at:`` location.
+#
+# A backtrace is attached to ANY error raised while GDScript is on the call stack
+# (`ScriptServer::capture_script_backtraces`) — a `push_error`, a `push_warning`,
+# and an engine-side error a script triggered indirectly all carry one on the
+# build gda drives. (`godot --headless` is a `target=editor` build, so
+# `DEBUG_ENABLED` is compiled in and `gdscript.cpp` forces
+# `track_call_stack = true` regardless of the project's
+# `debug/settings/gdscript/always_track_call_stacks` setting. An earlier comment
+# here claimed the opposite; it was measured against the wrong build, #722.) So a
+# backtrace's PRESENCE classifies nothing — it is evidence about where, not about
+# what. An error genuinely raised outside any script still carries none.
 BACKTRACE_MARKER = re.compile(r"^\s*GDScript backtrace\b.*:\s*$")
 FRAME_LINE = re.compile(
     r"^\s*\[\d+\]\s*(?P<function>.*?)\s*\((?P<file>.*):(?P<line>\d+)\)\s*$"
@@ -81,8 +92,9 @@ def parse_errors(data: str | bytes, limit: int | None = None) -> list[dict]:
     ``None`` (a bare error without a location is not a failure). ``callstack`` is
     the ordered ``{function, file, line}`` frames from the optional ``GDScript
     backtrace`` block (most-recent-first; frame ``[0]`` equals the ``at:``
-    location); a push_error / warning carries no backtrace, so ``callstack`` is
-    ``[]``. Unrecognized/continuation lines (interleaved print output) are
+    location); an error raised outside any GDScript call stack carries no
+    backtrace, so ``callstack`` is ``[]``. Unrecognized/continuation lines
+    (interleaved print output) are
     skipped. ``limit`` tails the most recent ``N`` errors. Empty input -> ``[]``.
     """
     captured = lines(data)

--- a/src/gda/script_errors.py
+++ b/src/gda/script_errors.py
@@ -261,8 +261,10 @@ class ScriptErrorKind(str, Enum):
     #: A compile failure in the named script (its own syntax error, or a
     #: dependency it preloads that does not resolve). That script never ran.
     PARSE_ERROR = "parse_error"
-    #: A GDScript error raised while the script was already executing. The ONLY
-    #: kind that says the named script ran.
+    #: A GDScript error raised while the script was already executing. One of the
+    #: two kinds that say the named script ran; ``PUSH_ERROR`` below is the other,
+    #: and the two differ in WHOSE claim it is — the engine's here, the project's
+    #: there.
     RUNTIME_ERROR = "runtime_error"
     #: The PROJECT reported its own invariant violation with ``push_error()``
     #: (#722). Like ``RUNTIME_ERROR`` it says the script ran — but it is a

--- a/src/gda/script_errors.py
+++ b/src/gda/script_errors.py
@@ -24,10 +24,29 @@ Consumers (the reason this is a module and not a helper inside one command):
 - the scene-startup preflight (#664) — the same script errors from a scene launch.
 
 Everything here is a **pure function of the stderr text**: no engine, no I/O.
-Recognition is deliberately closed — only the sentences below are classified, so
+Recognition is deliberately closed — only the records below are classified, so
 ``diagnostics`` stays a curated high-signal list rather than a re-encoding of the
 whole error stream (the verbatim stream is preserved separately by each caller).
 An unrecognized error or warning is skipped and never raises.
+
+**What may enter the closed set** (#722, the rule the set is widened by — stated
+once here because widening it changes what EVERY launch-backed channel reports,
+so the criterion has to outlive the record that motivated it):
+
+1. gda keys recognition on a part of the record the ENGINE fixes — a C++ format
+   string's literal prefix, or the ``at:`` frame a builtin always reports — never
+   on text a project authored. Project prose is the payload, not the key;
+2. the record says something specific about a SCRIPT's fate that an agent would
+   branch on, beyond "the engine printed something";
+3. the new kind states, in the enum, whether it proves the script never ran —
+   which is what puts it in (or keeps it out of) ``_ENTRY_FAILURE_PRECEDENCE``.
+
+The rule is what rules out the tempting shortcut for ``push_error``: "any
+``ERROR:`` that carries a GDScript backtrace" fails (1), because
+``ScriptServer::capture_script_backtraces`` attaches a backtrace to ANY error
+raised while GDScript is on the stack — a script's bad ``get_node()`` prints
+``ERROR: Node not found: … / at: get_node (scene/main/node.cpp:1961)`` with a
+full backtrace, and that is the engine's failure, not the project's report.
 
 **Resource identity is canonical, on both sides of every comparison.** Godot
 canonicalizes a ``res://`` path before reporting it, so an entry script invoked as
@@ -50,6 +69,15 @@ The recognized sentences, verbatim from Godot 4.6.3::
     ERROR: Failed loading resource: res://missing.tres.
     ERROR: Script inherits from native type 'Resource', so it can't be assigned to an object of type 'Node2D'.
     ERROR: Cannot set object script. Parameter should be null or a reference to a valid script.
+
+and one record recognized by its FRAME rather than its sentence, because its
+sentence is whatever the project wrote (#722)::
+
+    ERROR: <the project's own message>
+       at: push_error (core/variant/variant_utility.cpp:1024)
+       GDScript backtrace (most recent call first):
+           [0] _inner (res://probe.gd:9)
+           [1] _ready (res://probe.gd:5)
 """
 
 import posixpath
@@ -136,6 +164,25 @@ _NOT_A_SCRIPT_BINDING = re.compile(
     r"valid script"
 )
 
+# The ``at:`` frame function of GDScript's ``push_error()`` builtin (#722). The
+# engine's `at:` line names the C++ function that raised the error, and for this
+# builtin that name IS the API the project called
+# (`VariantUtilityFunctions::push_error` -> `ERR_PRINT`,
+# `core/variant/variant_utility.cpp:1017`, Godot 4.6.3). The MESSAGE is unusable
+# as a key — it is whatever prose the project passed — so the frame is the only
+# engine-fixed part of the record, which is what the closed set's admission rule
+# requires.
+#
+# A project method that happens to be named `push_error` cannot reach this: an
+# error raised from GDScript goes through `ERR_HANDLER_SCRIPT`
+# (`gdscript_vm.cpp:529`/`3988`) and prints as `SCRIPT ERROR`, which `_classify`
+# has already routed elsewhere by the time this is consulted. Only C++ raises the
+# plain `ERROR` level, and only `__FUNCTION__` fills this field. (The builtin is
+# not even shadowable from GDScript in the first place — a `func push_error()` in
+# the same script does not win the unqualified call, verified on 4.6.3 — but the
+# level split is the load-bearing reason, not that.)
+_PUSH_ERROR_FUNCTION = "push_error"
+
 # The two resource-load sentences (#651 review claim 4). Godot emits BOTH for one
 # failed `load()`/`preload()` of a non-script resource, from different layers:
 # `Cannot open file` from the format loader, `Failed loading resource` from
@@ -195,12 +242,14 @@ class ScriptErrorKind(str, Enum):
     """What a recognized engine error line says about the resource it names (#651).
 
     A closed, public enum: it is projected into ``--schema`` through the results
-    that carry :class:`ScriptError`. Every kind except ``RUNTIME_ERROR`` and
-    ``INCOMPATIBLE_SCRIPT`` reports that the named resource could **not be loaded
-    or run**; ``RUNTIME_ERROR`` reports an error raised by a script that was
-    already executing, and ``INCOMPATIBLE_SCRIPT`` reports a binding the engine
-    refused — a compiled script whose base cannot bind its object, or a bound
-    value that is not a Script at all (it names no resource either way).
+    that carry :class:`ScriptError`. Every kind except ``RUNTIME_ERROR``,
+    ``PUSH_ERROR`` and ``INCOMPATIBLE_SCRIPT`` reports that the named resource
+    could **not be loaded or run**; ``RUNTIME_ERROR`` reports an error raised by a
+    script that was already executing, ``PUSH_ERROR`` reports an invariant the
+    project itself rejected while running, and ``INCOMPATIBLE_SCRIPT`` reports a
+    binding the engine refused — a compiled script whose base cannot bind its
+    object, or a bound value that is not a Script at all (it names no resource
+    either way).
 
     Whether such a failure ended the *run* depends on **which** resource it names:
     a load failure naming the entry script means the run never happened, while the
@@ -215,6 +264,13 @@ class ScriptErrorKind(str, Enum):
     #: A GDScript error raised while the script was already executing. The ONLY
     #: kind that says the named script ran.
     RUNTIME_ERROR = "runtime_error"
+    #: The PROJECT reported its own invariant violation with ``push_error()``
+    #: (#722). Like ``RUNTIME_ERROR`` it says the script ran — but it is a
+    #: different claim about the program, which is why it is its own kind: a
+    #: runtime error is the ENGINE saying it could not perform an operation,
+    #: while this is the project saying it does not like what it found. Nothing
+    #: was interrupted: execution continues past a ``push_error`` normally.
+    PUSH_ERROR = "push_error"
     #: The named script does not exist.
     SCRIPT_MISSING = "script_missing"
     #: The named script exists but could not be loaded (an open failure other
@@ -260,8 +316,9 @@ class ScriptErrorKind(str, Enum):
 #: 6. ``NOT_A_MAIN_LOOP`` — last because it is only reachable by a script that
 #:    already existed AND compiled; it is a refusal, not a load failure.
 #:
-#: ``RUNTIME_ERROR`` is absent by construction: it is the one kind that proves the
-#: script DID run.
+#: ``RUNTIME_ERROR`` and ``PUSH_ERROR`` are absent by construction: both prove the
+#: script DID run — the first because the engine raised the error inside it, the
+#: second because the project's own code called ``push_error`` from it.
 _ENTRY_FAILURE_PRECEDENCE = (
     ScriptErrorKind.SCRIPT_MISSING,
     ScriptErrorKind.COMPILE_FAILED,
@@ -283,9 +340,11 @@ class ScriptError(BaseModel):
     kind: ScriptErrorKind = Field(
         description=(
             "Which known engine failure this line reports. Every kind except "
-            "'runtime_error' and 'incompatible_script' means the named resource "
-            "could not be loaded or run; 'runtime_error' means a script was "
-            "already executing when it raised, and 'incompatible_script' means "
+            "'runtime_error', 'push_error' and 'incompatible_script' means the "
+            "named resource could not be loaded or run; 'runtime_error' means a "
+            "script was already executing when it raised; 'push_error' means the "
+            "PROJECT reported its own invariant violation with push_error() and "
+            "kept running; and 'incompatible_script' means "
             "the engine refused a script binding — a compiled script whose base "
             "cannot bind its object, or a bound value that is not a Script at "
             "all (path is null: neither sentence names a file). Whether the RUN "
@@ -313,7 +372,9 @@ class ScriptError(BaseModel):
         default=None,
         description=(
             "The 1-based line in 'path' the engine reported, or null when it "
-            "reported none (engine-side load errors carry no script line)."
+            "reported none (engine-side load errors carry no script line). For a "
+            "'push_error' this is the call site the engine named in its GDScript "
+            "backtrace, never a synthesized number."
         ),
     )
 
@@ -380,7 +441,18 @@ def _classify(record: dict) -> ScriptError | None:
         return _script_error(record, message)
     if level != "error":
         # Warnings and the other engine levels say nothing about a script's fate.
+        # `push_warning` lands here: the project chose the advisory severity, and
+        # gda does not promote it (#722).
         return None
+    # Checked BEFORE the sentence patterns, and kept out of :func:`_engine_error`
+    # on purpose: this record is recognized by its FRAME, while every sentence
+    # below is recognized by its message — mixing the two readings into one
+    # function would break that function's stated invariant, and a project's
+    # `push_error` prose could otherwise coincidentally match a sentence pattern
+    # and be reported as an engine failure it is not.
+    push_error = _push_error(record, message)
+    if push_error is not None:
+        return push_error
     return _engine_error(message)
 
 
@@ -411,6 +483,61 @@ def _script_error(record: dict, message: str) -> ScriptError:
         # C++ source, which is meaningless to an agent — so both travel together.
         line=record.get("line") if path is not None else None,
     )
+
+
+def _push_error(record: dict, message: str) -> ScriptError | None:
+    """A project-raised ``push_error()`` record, or ``None`` if this is not one (#722).
+
+    Recognized by the ``at:`` frame's function (see ``_PUSH_ERROR_FUNCTION``),
+    never by the message — the message is the project's own prose and carries no
+    fixed shape at all.
+
+    **Attribution is backtrace-only, and reported as such.** The ``at:`` frame
+    names the engine's C++ source, which is gda-irrelevant, so the script address
+    comes from the most recent ``res://`` frame of the GDScript backtrace the
+    engine attached — the call site of ``push_error`` itself. That is the engine's
+    own number, not a synthesized one. A record with no backtrace, or one whose
+    frames are all engine-side, honestly carries neither ``path`` nor ``line``
+    rather than a guess.
+
+    The backtrace is present on every build gda drives: ``godot --headless`` is a
+    ``target=editor`` build, so ``DEBUG_ENABLED`` is compiled in and
+    ``gdscript.cpp`` forces ``track_call_stack = true`` regardless of the
+    project's ``always_track_call_stacks`` setting. gda still does not REQUIRE it
+    — losing the backtrace costs the address, not the diagnostic.
+    """
+    if record.get("function") != _PUSH_ERROR_FUNCTION:
+        return None
+    frame = _first_script_frame(record.get("callstack"))
+    if frame is None:
+        return ScriptError(kind=ScriptErrorKind.PUSH_ERROR, message=message)
+    file, line = frame
+    return ScriptError(
+        kind=ScriptErrorKind.PUSH_ERROR,
+        message=message,
+        path=canonical_res_path(file),
+        line=line,
+    )
+
+
+def _first_script_frame(callstack: object) -> tuple[str, int | None] | None:
+    """The most recent ``res://`` frame of a backtrace, as ``(file, line)``.
+
+    Most-recent-first is the engine's own frame order, so the first match is the
+    innermost project frame — the line that made the call. Engine-side frames are
+    skipped for the same reason a diagnostic's ``path`` is only ever a ``res://``
+    address: a C++ source location is noise to an agent.
+    """
+    if not isinstance(callstack, list):
+        return None
+    for frame in callstack:
+        if not isinstance(frame, dict):
+            continue
+        file = frame.get("file")
+        if isinstance(file, str) and file.startswith(_RES_PREFIX):
+            line = frame.get("line")
+            return file, line if isinstance(line, int) else None
+    return None
 
 
 def _engine_error(message: str) -> ScriptError | None:

--- a/tests/support.py
+++ b/tests/support.py
@@ -611,7 +611,11 @@ DIAG_ERRORS_RESULT = {
             "function": "_process",
             "file": "res://main.gd",
             "line": 20,
-            "callstack": [],  # a warning has no backtrace
+            # THIS fixture's warning is a bare one, raised with no GDScript on
+            # the stack. Not a rule about warnings: `push_warning` called from a
+            # script carries a backtrace like any other record, because the engine
+            # attaches one to whatever is raised while GDScript is running (#722).
+            "callstack": [],
         },
         {
             "level": "error",

--- a/tests/test_diag_log_parser.py
+++ b/tests/test_diag_log_parser.py
@@ -104,8 +104,10 @@ def test_parse_errors_empty_input_is_empty_list():
 
 # A real Godot 4.6 runtime GDScript error: the `at:` follow-on is succeeded by a
 # `GDScript backtrace (most recent call first):` marker, then one `[N] func
-# (file:line)` frame line per stack frame (verified against Godot 4.6.3). The
-# `at:` frame equals frame `[0]`; frames are ordered most-recent-first.
+# (file:line)` frame line per stack frame (verified against Godot 4.6.3). Frames
+# are ordered most-recent-first. The `at:` frame equals frame `[0]` FOR THIS
+# CLASS — GDScript itself raised the error, at the failing statement — which is
+# not the general rule; see MIXED_RAISER_LOG below (#722).
 BACKTRACE_LOG = """\
 SCRIPT ERROR: Invalid call. Nonexistent function 'do_thing' in base 'Nil'.
    at: b (res://main.gd:9)
@@ -128,8 +130,10 @@ def test_parse_errors_extracts_the_ordered_callstack_frames():
 
 
 def test_parse_errors_top_frame_fields_match_the_at_line_unchanged():
-    # The existing single-frame {function,file,line} fields stay the top frame —
-    # equal to frame [0] — and are unchanged by the callstack enrichment.
+    # The existing single-frame {function,file,line} fields stay the `at:` location
+    # and are unchanged by the callstack enrichment. They also equal frame [0] here
+    # because GDScript raised this error itself — a property of THIS record, not of
+    # every record (#722).
     error = parse_errors(BACKTRACE_LOG)[0]
     assert error["function"] == "b"
     assert error["file"] == "res://main.gd"
@@ -138,6 +142,62 @@ def test_parse_errors_top_frame_fields_match_the_at_line_unchanged():
         "function": error["function"],
         "file": error["file"],
         "line": error["line"],
+    }
+
+
+# One real Godot 4.6.3 headless capture holding BOTH raiser shapes, so the
+# relation between `at:` and frame `[0]` is pinned by evidence rather than by the
+# assumption the docs used to carry. Reproduced (#722) from a scene whose
+# `_ready` calls `_inner()` (which calls `push_error`) and then `_boom()` (which
+# calls a method on null). The differing indentation is the engine's own
+# ErrorType indent, kept verbatim.
+MIXED_RAISER_LOG = """\
+ERROR: probe: invariant violated
+   at: push_error (core/variant/variant_utility.cpp:1024)
+   GDScript backtrace (most recent call first):
+       [0] _inner (res://main.gd:10)
+       [1] _ready (res://main.gd:5)
+SCRIPT ERROR: Invalid call. Nonexistent function 'do_thing' in base 'Nil'.
+          at: _boom (res://main.gd:15)
+          GDScript backtrace (most recent call first):
+              [0] _boom (res://main.gd:15)
+              [1] _ready (res://main.gd:6)
+"""
+
+
+def test_parse_errors_frame_zero_is_not_the_at_line_for_a_push_error():
+    # The corrected contract (#722): `at:` is where the error was RAISED, the
+    # backtrace is where the SCRIPT was, and for a `push_error` those are two
+    # different places — the engine's own C++ `VariantUtilityFunctions::push_error`
+    # versus the .gd line that called it. An implementation that folded one into
+    # the other (synthesizing frame [0] from `at:`, or overwriting the top fields
+    # from frame [0]) would lose the project's only script attribution.
+    raised_by_engine, raised_by_gdscript = parse_errors(MIXED_RAISER_LOG)
+
+    at_location = {
+        "function": raised_by_engine["function"],
+        "file": raised_by_engine["file"],
+        "line": raised_by_engine["line"],
+    }
+    assert at_location == {
+        "function": "push_error",
+        "file": "core/variant/variant_utility.cpp",
+        "line": 1024,
+    }
+    assert raised_by_engine["callstack"][0] == {
+        "function": "_inner",
+        "file": "res://main.gd",
+        "line": 10,
+    }
+    # The point of the regression: the two locations differ in every field.
+    assert raised_by_engine["callstack"][0] != at_location
+
+    # And the counterpart class in the same capture, where they DO coincide —
+    # which is why the unconditional claim looked true for so long.
+    assert raised_by_gdscript["callstack"][0] == {
+        "function": raised_by_gdscript["function"],
+        "file": raised_by_gdscript["file"],
+        "line": raised_by_gdscript["line"],
     }
 
 

--- a/tests/test_diag_log_parser.py
+++ b/tests/test_diag_log_parser.py
@@ -141,9 +141,11 @@ def test_parse_errors_top_frame_fields_match_the_at_line_unchanged():
     }
 
 
-def test_parse_errors_callstack_is_empty_for_a_bare_push_error():
-    # A plain push_error / warning carries NO GDScript backtrace; its callstack is
-    # an empty list (not an error, not a one-frame synthesis).
+def test_parse_errors_callstack_is_empty_for_a_bare_error():
+    # An error raised outside any GDScript call stack carries NO backtrace; its
+    # callstack is an empty list (not an error, not a one-frame synthesis).
+    # NOT a push_error, which does carry one on the build gda drives (#722) — the
+    # earlier name for this test claimed the opposite.
     errors = parse_errors("ERROR: bare error\n   at: f (res://a.gd:1)\n")
     assert errors[0]["callstack"] == []
 

--- a/tests/test_e2e_scene_preflight.py
+++ b/tests/test_e2e_scene_preflight.py
@@ -305,6 +305,101 @@ def test_a_scene_that_quits_from_ready_still_gets_its_ready_verdict(godot_projec
     assert "handing control back" in preflighted.stderr
 
 
+# GDA-DF-030 in the spelling a Godot project actually writes it in: the scene
+# comes up and reports its own invariant violation with `push_error`. The engine
+# prints an ERROR whose message is entirely the project's prose, so its only
+# script attribution is the GDScript backtrace under it — which is why #722 keys
+# recognition on the `at:` frame the engine fixes as `push_error`.
+#
+# A helper frame between `_ready` and the call keeps the test honest about WHICH
+# line is reported: the innermost project frame, not the outermost.
+PUSH_ERROR_READY_SCRIPT = """\
+extends Node2D
+
+
+func _ready() -> void:
+	_check_encounter()
+
+
+func _check_encounter() -> void:
+	push_error("no spawn point in the encounter")
+	push_warning("and the arena is undersized")
+"""
+
+
+@pytest.mark.e2e
+def test_a_push_error_raised_in_ready_is_reported_as_a_startup_diagnostic(
+    godot_project,
+):
+    # #722, end to end on a real engine: before it, this scene reported
+    # `started: true` with EMPTY diagnostics — the phantom-clean start the
+    # dogfooding note is about, in the most common shape a project writes it.
+    _scene(godot_project, "encounter.tscn", "encounter.gd", PUSH_ERROR_READY_SCRIPT)
+    gda = _gda_project(godot_project)
+
+    # Static validation passes: the scene's dependencies resolve and it compiles.
+    # Only booting it reveals what the project itself thinks of what it found.
+    validated = gda("scene", "validate", "res://encounter.tscn", "--json")
+    assert validated.returncode == 0, validated.stdout + validated.stderr
+    assert json.loads(validated.stdout)["valid"] is True
+
+    preflighted = gda("scene", "preflight", "res://encounter.tscn", "--json")
+
+    assert preflighted.returncode == 0, preflighted.stdout + preflighted.stderr
+    data = json.loads(preflighted.stdout)
+    # The scene DID reach _ready — status and started answer different questions,
+    # and this is exactly the case where they diverge.
+    assert data["status"] == "ready"
+    assert data["started"] is False
+    # Exactly one diagnostic: the push_warning beside it keeps the severity the
+    # project chose for it, and gda does not promote a warning to an error.
+    assert len(data["diagnostics"]) == 1, preflighted.stderr
+    diagnostic = data["diagnostics"][0]
+    assert diagnostic["kind"] == "push_error"
+    assert diagnostic["message"] == "no spawn point in the encounter"
+    # Backtrace-only attribution, resolved to the innermost project frame: the
+    # line that CALLED push_error, which the engine reported and gda did not
+    # invent. Line 9 is the push_error statement in the script above.
+    assert diagnostic["path"] == "res://encounter.gd"
+    assert diagnostic["line"] == 9
+    # The engine's stream is still forwarded verbatim, warning included.
+    assert "and the arena is undersized" in preflighted.stderr
+
+
+# An engine-side error a script only TRIGGERED: raised from the engine's own C++
+# (`get_node`), yet carrying a full GDScript backtrace.
+INDIRECT_ERROR_SCRIPT = """\
+extends Node2D
+
+
+func _ready() -> void:
+	print(get_node("/root/NoSuchThing"))
+"""
+
+
+@pytest.mark.e2e
+def test_an_engine_error_a_script_triggered_is_not_reported_as_the_projects_own(
+    godot_project,
+):
+    # The over-match this recognition could easily have had: the engine attaches a
+    # GDScript backtrace to ANY error raised while a script is on the stack, so a
+    # bad get_node() looks structurally identical to a push_error apart from its
+    # `at:` frame. Keying on that frame is what keeps the engine's own failure out
+    # of the project's diagnostics — the record stays unrecognized, and the
+    # verbatim stream is where a reader still finds it.
+    _scene(godot_project, "indirect.tscn", "indirect.gd", INDIRECT_ERROR_SCRIPT)
+    gda = _gda_project(godot_project)
+
+    preflighted = gda("scene", "preflight", "res://indirect.tscn", "--json")
+
+    assert preflighted.returncode == 0, preflighted.stdout + preflighted.stderr
+    data = json.loads(preflighted.stdout)
+    assert data["status"] == "ready"
+    assert data["diagnostics"] == []
+    assert data["started"] is True
+    assert "NoSuchThing" in preflighted.stderr
+
+
 # The PR #720 review's preflight false positive: a compiled `extends Resource`
 # script on a Node2D. The engine refuses the binding with a deterministic ERROR,
 # the node boots silently script-less, and its `_ready` never runs — so a verdict

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1285,8 +1285,10 @@ def test_diag_errors_result_round_trips_a_multi_frame_callstack():
 
 
 def test_diag_error_callstack_defaults_to_empty_for_a_bare_error():
-    # A bare push_error carries no backtrace: callstack defaults to [] and the
-    # existing single-frame fields stay None — no callstack key required on input.
+    # An error raised outside any GDScript call stack carries no backtrace:
+    # callstack defaults to [] and the existing single-frame fields stay None — no
+    # callstack key required on input. (A push_error is NOT such an error: it does
+    # carry a backtrace on the build gda drives, #722.)
     from gda.commands.diag import DiagError
 
     error = DiagError.model_validate(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1254,8 +1254,10 @@ def test_theme_create_result_round_trips_path_type_and_dirs():
 
 def test_diag_errors_result_round_trips_a_multi_frame_callstack():
     # A runtime GDScript error carries its ordered call stack (#283): each frame
-    # is {function, file, line}, most-recent-first, with frame [0] equal to the
-    # top {function,file,line}. The whole result round-trips byte-identical.
+    # is {function, file, line}, most-recent-first. Frame [0] equals the top
+    # {function,file,line} for THIS class, because GDScript raised the error
+    # itself — see the push_error test below for the class where it does not
+    # (#722). The whole result round-trips byte-identical.
     from gda.commands.diag import DiagErrorsResult
 
     payload = {
@@ -1282,6 +1284,45 @@ def test_diag_errors_result_round_trips_a_multi_frame_callstack():
     assert error.callstack[0].file == "res://main.gd"
     assert error.callstack[0].line == 9
     assert json.loads(result.model_dump_json()) == payload
+
+
+def test_diag_error_keeps_a_push_error_frame_zero_apart_from_the_top_fields():
+    # The model contract `--schema` publishes (#722): frame [0] is the innermost
+    # GDScript frame, NOT necessarily the top {function,file,line}. A push_error is
+    # raised by the engine's own C++ helper, so the top fields name that helper
+    # while frame [0] names the .gd line that called it. Values reproduced from a
+    # real Godot 4.6.3 headless capture (see MIXED_RAISER_LOG in
+    # tests/test_diag_log_parser.py). The model must carry both without collapsing
+    # or cross-filling them.
+    from gda.commands.diag import DiagError
+
+    payload = {
+        "level": "error",
+        "message": "probe: invariant violated",
+        "function": "push_error",
+        "file": "core/variant/variant_utility.cpp",
+        "line": 1024,
+        "callstack": [
+            {"function": "_inner", "file": "res://main.gd", "line": 10},
+            {"function": "_ready", "file": "res://main.gd", "line": 5},
+        ],
+    }
+
+    error = DiagError.model_validate(payload)
+
+    assert error.file == "core/variant/variant_utility.cpp"
+    assert error.callstack[0].file == "res://main.gd"
+    assert error.callstack[0].line == 10
+    assert (
+        error.callstack[0].function,
+        error.callstack[0].file,
+        error.callstack[0].line,
+    ) != (
+        error.function,
+        error.file,
+        error.line,
+    )
+    assert json.loads(error.model_dump_json()) == payload
 
 
 def test_diag_error_callstack_defaults_to_empty_for_a_bare_error():

--- a/tests/test_script_error_parser.py
+++ b/tests/test_script_error_parser.py
@@ -167,14 +167,19 @@ def test_a_parse_error_alone_still_fails_the_entry():
 
 def test_every_never_ran_kind_is_an_entry_failure_candidate():
     # `entry_load_failure` acts on the enum's published promise, so the two must
-    # not drift. Exactly two kinds are excluded, for different reasons the enum
-    # states: `runtime_error` proves the script DID run, and
+    # not drift. Exactly three kinds are excluded, for reasons the enum states:
+    # `runtime_error` and `push_error` both prove the script DID run (the engine
+    # raised inside it; the project's own code called push_error from it), and
     # `incompatible_script` carries no path by construction, so it can never name
     # the entry script and has no place in an entry-verdict precedence.
+    #
+    # Updated deliberately by #722, which is what this assertion is FOR: adding a
+    # kind without deciding whether it can fail an entry fails here by design.
     from gda.script_errors import _ENTRY_FAILURE_PRECEDENCE
 
     assert set(ScriptErrorKind) - set(_ENTRY_FAILURE_PRECEDENCE) == {
         ScriptErrorKind.RUNTIME_ERROR,
+        ScriptErrorKind.PUSH_ERROR,
         ScriptErrorKind.INCOMPATIBLE_SCRIPT,
     }
 
@@ -642,3 +647,137 @@ def test_the_ordinary_sentence_period_still_strips_for_both_sentences():
         (ScriptErrorKind.LOAD_FAILED, "res://plain.gd"),
         (ScriptErrorKind.RESOURCE_LOAD_FAILED, "res://plain.tres"),
     ]
+
+
+# --- A project-raised push_error (#722) ---------------------------------------
+#
+# Captured VERBATIM from `gda scene preflight` on Godot 4.6.3 (macOS), from a
+# scene whose `_ready` calls a helper that push_errors and then push_warnings.
+# This is the GDA-DF-030 shape the recognition set was widened for: the scene
+# comes up, reports its own invariant violation, and the process still exits 0.
+#
+# Note what the record does and does not carry. The `at:` frame names the
+# ENGINE's C++ (`push_error` in `core/variant/variant_utility.cpp`), so the only
+# script attribution in the whole record is the GDScript backtrace under it.
+PUSH_ERROR_STDERR = """\
+ERROR: probe: invariant violated
+   at: push_error (core/variant/variant_utility.cpp:1024)
+   GDScript backtrace (most recent call first):
+       [0] _inner (res://probe.gd:9)
+       [1] _ready (res://probe.gd:5)
+WARNING: probe: a warning
+     at: push_warning (core/variant/variant_utility.cpp:1034)
+     GDScript backtrace (most recent call first):
+         [0] _inner (res://probe.gd:10)
+         [1] _ready (res://probe.gd:5)
+"""
+
+# THE over-match capture, also verbatim from a real preflight: a script whose
+# `_ready` calls `get_node()` on a path that does not exist. The engine raises it
+# from its OWN C++ and attaches a full GDScript backtrace anyway
+# (`ScriptServer::capture_script_backtraces` does that for any error raised while
+# GDScript is on the stack). Keying recognition on "an ERROR: with a backtrace"
+# would swallow this — an engine failure reported as if the project had raised it.
+INDIRECT_ENGINE_ERROR_STDERR = """\
+ERROR: Node not found: "/root/NoSuchThing" (absolute path attempted from "/root/Hero").
+   at: get_node (scene/main/node.cpp:1961)
+   GDScript backtrace (most recent call first):
+       [0] _ready (res://indirect.gd:5)
+"""
+
+
+def test_a_push_error_is_recognized_and_attributed_to_its_call_site():
+    errors = parse_script_errors(PUSH_ERROR_STDERR)
+
+    # One diagnostic, not two: the push_warning beside it is a WARNING, and the
+    # project chose that severity — gda does not promote it.
+    assert [e.kind for e in errors] == [ScriptErrorKind.PUSH_ERROR]
+    error = errors[0]
+    assert error.message == "probe: invariant violated"
+    # Backtrace-only attribution: the most recent res:// frame, which is the line
+    # that CALLED push_error. The engine's own number, not a synthesized one —
+    # the `at:` line's 1024 belongs to variant_utility.cpp and never leaks out.
+    assert error.path == "res://probe.gd"
+    assert error.line == 9
+
+
+def test_a_push_error_does_not_fail_the_entry_script():
+    # It proves the script RAN — the opposite of an entry-load failure — so it must
+    # not flip `script run`'s verdict for the very script that raised it. This is
+    # what keeps the widening additive for the pass-through channel (ADR-0031).
+    errors = parse_script_errors(PUSH_ERROR_STDERR)
+
+    assert entry_load_failure(errors, "res://probe.gd") is None
+
+
+def test_an_engine_error_a_script_triggered_is_not_a_push_error():
+    # The over-match guard: same backtrace shape, different `at:` frame. The
+    # engine could not find the node — that is the engine's failure, not the
+    # project reporting one, and this build's recognized set covers neither, so
+    # the record stays out of `diagnostics` entirely.
+    assert parse_script_errors(INDIRECT_ENGINE_ERROR_STDERR) == []
+
+
+def test_a_push_error_message_that_looks_like_an_engine_sentence_is_still_one():
+    # The project's prose is the PAYLOAD, never the key. A message that happens to
+    # spell an engine load-failure sentence must not be re-reported as that
+    # failure — which would invent a missing script out of a log line and, worse,
+    # fail an entry that ran fine.
+    stderr = (
+        "ERROR: Can't load script: res://not-really-missing.gd\n"
+        "   at: push_error (core/variant/variant_utility.cpp:1024)\n"
+        "   GDScript backtrace (most recent call first):\n"
+        "       [0] _ready (res://liar.gd:3)\n"
+    )
+    errors = parse_script_errors(stderr)
+
+    assert [(e.kind, e.path) for e in errors] == [
+        (ScriptErrorKind.PUSH_ERROR, "res://liar.gd")
+    ]
+    assert entry_load_failure(errors, "res://not-really-missing.gd") is None
+
+
+def test_a_push_error_without_a_backtrace_carries_no_address():
+    # gda does not REQUIRE the backtrace: losing it costs the address, not the
+    # diagnostic. Nothing is synthesized — the engine's C++ `at:` location is not
+    # a script location and never becomes one.
+    stderr = (
+        "ERROR: bare report\n"
+        "   at: push_error (core/variant/variant_utility.cpp:1024)\n"
+    )
+    errors = parse_script_errors(stderr)
+
+    assert [e.kind for e in errors] == [ScriptErrorKind.PUSH_ERROR]
+    assert errors[0].path is None
+    assert errors[0].line is None
+
+
+def test_a_push_error_address_is_canonicalized_like_every_other():
+    # One resource identity everywhere (#651 review claim 1): a backtrace frame
+    # goes through the same canonicalization as a message-derived path, so a
+    # caller comparing addresses cannot be defeated by the spelling.
+    stderr = (
+        "ERROR: report\n"
+        "   at: push_error (core/variant/variant_utility.cpp:1024)\n"
+        "   GDScript backtrace (most recent call first):\n"
+        "       [0] _ready (res://sub/../probe.gd:3)\n"
+    )
+    errors = parse_script_errors(stderr)
+
+    assert errors[0].path == "res://probe.gd"
+
+
+def test_an_engine_side_backtrace_frame_is_skipped_for_the_address():
+    # The address is the first res:// frame, not the first frame: an engine frame
+    # in the backtrace is the same C++ noise the `at:` line is.
+    stderr = (
+        "ERROR: report\n"
+        "   at: push_error (core/variant/variant_utility.cpp:1024)\n"
+        "   GDScript backtrace (most recent call first):\n"
+        "       [0] _native_helper (core/object/object.cpp:1000)\n"
+        "       [1] _ready (res://probe.gd:7)\n"
+    )
+    errors = parse_script_errors(stderr)
+
+    assert errors[0].path == "res://probe.gd"
+    assert errors[0].line == 7

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -1027,6 +1027,30 @@ def test_a_runtime_error_in_a_helper_script_never_arms_the_abort():
     assert verdicts == [False] * 4
 
 
+def test_a_push_error_from_the_entry_never_arms_the_abort():
+    # #722's contract line, pinned where it can regress: `push_error` IS recognized
+    # now, and it names the ENTRY here — so attribution alone would arm the abort.
+    # It must not. The watch's premise is that something interrupted the run; a
+    # push_error interrupts nothing (execution continues at the next statement), so
+    # a script that reports an invariant and then computes quietly is alive by
+    # construction. Widening recognition changed what `script run` REPORTS, not
+    # when it kills.
+    watch = _CompletionMarkerWatch("SUITE DONE", entry=ENTRY, silence=3.0)
+    reported = (
+        "ERROR: logic: 3 of 40 encounters have no spawn point\n"
+        "   at: push_error (core/variant/variant_utility.cpp:1024)\n"
+        "   GDScript backtrace (most recent call first):\n"
+        "       [0] _initialize (res://tests/logic.gd:6)\n"
+    )
+
+    verdicts = _drive(
+        watch,
+        [("", reported, 0.5), ("", "", 3.6), ("", "", 6.7), ("", "", 60.0)],
+    )
+
+    assert verdicts == [False] * 4
+
+
 def test_an_entry_load_failure_arms_the_abort_too():
     # Attribution reuses the EXISTING classification, so every kind that proves the
     # entry never ran arms the abort as well — not just the runtime kind. This is the


### PR DESCRIPTION
## What

Recognize a project-raised `push_error()` as a structured script diagnostic in the #651 parser.

Before this, a scene reporting its own invariant violation from `_ready` came back from
`scene preflight` as `started: true` with **empty** diagnostics — the GDA-DF-030 phantom-clean
start, in the shape a Godot project most often writes it. Reproduced on Godot 4.6.3 against the
merge base, and pinned by the new e2e (its red-proof below is literally `assert True is False`).

Closes #722

## The contract decision

**A new `ScriptErrorKind`, `push_error`** — not a mapping onto `runtime_error` or `assert`.

- The two are **different claims about the program**. A `runtime_error` is the engine saying it
  could not perform an operation; a `push_error` record is the PROJECT saying it does not like
  what it found. Folding them together makes `runtime_error` ambiguous for every current
  consumer, and the distinction is unrecoverable afterwards.
- **Additive**: every existing recognized record is byte-identical, pinned by the existing tests.
  No verdict, error code, or exit status changes anywhere.

**Recognition keys on the `at:` frame function**, which the engine fixes as `push_error`
(`VariantUtilityFunctions::push_error` → `ERR_PRINT`, `core/variant/variant_utility.cpp:1017`) —
never on the message, which is entirely the project's own prose.

Explicitly **not** "any `ERROR:` that carries a backtrace":
`ScriptServer::capture_script_backtraces` attaches one to ANY error raised while GDScript is on
the stack. A script's bad `get_node()` prints `ERROR: Node not found: … / at: get_node
(scene/main/node.cpp:1961)` with a full backtrace, and that is the ENGINE's failure, not the
project's report. Both shapes are pinned by verbatim Godot 4.6.3 captures, and the wrong key is
mutation-proofed red at both the unit and the real-engine level.

A project method named `push_error` cannot reach the branch either: an error raised from GDScript
goes through `ERR_HANDLER_SCRIPT` (`gdscript_vm.cpp:529`/`3988`) and prints as `SCRIPT ERROR`,
which `_classify` has already routed elsewhere. (The builtin is not even shadowable from GDScript
— verified on 4.6.3 — but the level split is the load-bearing reason.)

**Backtrace-only attribution, reported as such.** `path`/`line` come from the most recent
`res://` frame of the engine's backtrace — the call site the engine itself named — canonicalized
like every other address. No backtrace, or an all-engine one → both `null`. Nothing is
synthesized; the `at:` line's C++ location never leaks out.

**Two placements this kind does NOT get**, both recorded where they live:

- **Not in `_ENTRY_FAILURE_PRECEDENCE`** — it proves the script RAN. The lockstep test
  `test_every_never_ran_kind_is_an_entry_failure_candidate` is updated deliberately (it fails by
  design otherwise), and now excludes three kinds with a stated reason each.
- **Does not arm `script run`'s completion-marker abort** (`_entry_attributable`). The watch's
  premise is that something interrupted the run: a runtime error abandons the function it was
  raised in, which is what makes a following silence evidence. A `push_error` interrupts nothing
  — execution continues at the next statement — so a script that reports an invariant and then
  computes quietly is alive **by construction**, and aborting it would break the projects that
  use `push_error` as ordinary logging.

The module docstring now also records **the rule the closed set is widened by**, once, since
widening it changes what every launch-backed channel reports.

## Cross-channel impact

| Channel | Impact |
| --- | --- |
| `gda scene preflight` | The point of the change: `diagnostics` gains the entry, so `started` is `false` for a scene that reports its own invariant violation. |
| `gda script run` | Success-path `diagnostics` gains entries (and so does the timeout/abort prose via `_render_captured_errors`). **A project that uses `push_error` as ordinary logging will now see advisory diagnostics on runs that still succeed — that is intended**, the field is advisory. The verdict, `_ENTRY_FAILURE_CODES` mapping, exit status and abort behaviour are all unchanged. |
| `gda script validate` | **Unaffected** — verified, not assumed. It has its OWN parser (`_SCRIPT_ERROR_LINE` + the `GDScript::reload` frame, `commands/script.py`), which only reads `SCRIPT ERROR:` records; a `push_error` is an `ERROR:`. The issue body's premise that it shares the parser is not accurate. Its e2e passes unchanged (20 passed). |
| `gda diag errors` / `gda logger tail` (daemon) | Unaffected — they read `engine_log.parse_errors` directly, never `parse_script_errors`. |

**No current consumer depended on these records being absent**: the full non-e2e suite (1949
tests) passes untouched, and the daemon/harness `gda_log` path does not reach this parser at all.

## Doc drift corrected in the same PR

- `docs/command-catalog.md` — "`push_error()` is not among them" was false the moment this ships.
  The preflight paragraph now states the widened set, the frame-not-message key, and why a
  backtrace alone does not qualify a record; the `script run` paragraph states the advisory
  diagnostics and the abort carve-out.
- **`ScenePreflightResult.diagnostics`' own published schema description** carried the same
  assertion — corrected (this one is `--schema` output, not a comment).
- `engine_log.py`'s "push_error / warnings carry no backtrace" — wrong for the build gda runs.
  `godot --headless` is a `target=editor` build, so `DEBUG_ENABLED` is compiled in and
  `gdscript.cpp` forces `track_call_stack = true` regardless of
  `debug/settings/gdscript/always_track_call_stacks`. Corrected there, in `diag.py`'s two
  published descriptions carrying the same claim, and in the two test comments that repeated it.
- **"frame `[0]` equals the `at:` location" — false, and found by the round-2 review.** The
  clause retained beside the comment above states it unconditionally in four places, one of them
  published to agents through `--schema`. #722's own captured record disproves it for exactly the
  class this slice started recognizing: a `push_error`'s `at:` is `push_error
  (core/variant/variant_utility.cpp:1024)` while frame `[0]` is the `.gd` line that called it.
  `at:` is where the error was RAISED (the raising C++ site's `__FUNCTION__`/`__FILE__`/
  `__LINE__`); the backtrace is where the SCRIPT was. They coincide only when GDScript itself
  raised the error — the runtime-error class #283 measured the claim on. Corrected in the
  `engine_log` module docstring, the `FRAME_LINE` contract comment, `parse_errors`'s docstring,
  and the `DiagError.callstack` schema description, and pinned by two new regressions built from
  one real Godot 4.6.3 capture holding both shapes.

## Verification

Gates, verbatim:

```
1951 passed, 545 deselected in 55.04s                # uv run pytest -q -m "not e2e"
All checks passed!                                   # uv run ruff check .
473 files already formatted                          # uv run ruff format --check .
0 errors, 0 warnings, 0 informations                 # uv run pyright
```

Real-engine e2e (Godot 4.6.3, macOS), targeted:

```
59 passed in 59.72s                                  # test_e2e_scene_preflight.py + test_e2e_script_run.py
14 passed in 139.20s (0:02:19)                       # tests/test_e2e_scene_validate.py
20 passed, 48 deselected in 253.50s (0:04:13)        # tests/test_e2e_script.py -k validate
```

(The last two are from the round-1 head; nothing since then touches `scene validate` or
`script validate`.)

### Red-proof (every new guard, from committed state)

Source reverted to the merge base `b616e7fb`, tests kept:

- 6 of 9 new unit guards fail (`AttributeError: ... has no attribute 'PUSH_ERROR'`,
  `IndexError: list index out of range`).
- The new e2e fails with `assert True is False` on `started` — the defect itself, reproduced.

Three guards cannot go red against the base (the record is simply dropped there), so they are
mutation-proofed against the plausible wrong implementations instead:

- key on backtrace presence instead of the `at:` frame → the over-match guard fails at both
  levels, reporting the engine's `Node not found` as `kind: push_error`;
- add `PUSH_ERROR` to `_entry_attributable` → the abort guard fails
  (`[False, True, True, True] == [False, False, False, False]`).

The two round-2 regressions are red-proofed the same way, by injecting the discredited
assumption:

- synthesize frame `[0]` from the `at:` line in `parse_errors` → the parser guard fails
  (`{'function': 'push_error'} != {'function': '_inner'}`) and **nothing else does** — all 16
  other parser tests still pass, so no pre-existing test covered this;
- cross-fill `DiagError.callstack[0]` from the top fields → the model guard fails
  (`'core/variant/variant_utility.cpp' == 'res://main.gd'`), again as the sole failure.

## Deliberately out of scope

The second widening candidate recorded on #722 (`Resource file not found:` →
`script_compile_failed` where `script_not_found` is accurate) is **not** taken here. Admitting
that sentence does not by itself fix it: it is the resource layer's generic message for ANY
resource, so it classifies as `RESOURCE_LOAD_FAILED`, whose `_ENTRY_FAILURE_CODES` row already
maps to `script_compile_failed`. Getting `script_not_found` means deciding whether a generic
resource sentence may carry a script-specific verdict — a change to an error CODE on a failure
path, not an advisory diagnostic on a success path, with a different blast radius and no AC or
e2e here. The widening RULE this PR records is what a follow-up should apply to it.

## Notes for integration

**This slice carries only its own catalog contract.** An earlier revision placed #721's and
#752's `docs/command-catalog.md` paragraphs here, to keep one owner per hotspot file for the
wave. The orchestrator reversed that decision after the round-2 review: a slice must not publish
a capability it does not implement, and both siblings are now changing under their own review
rounds, so the routed text was a stale cross-branch read. Commit `4af472ea` removes it — #721
(PR #769) and #752 (PR #770) each take their own catalog contract back, and neither needs to
rebase onto this branch.

What remains in `docs/command-catalog.md` here is #722's own contract, in two paragraphs the
issue and its triage decision name explicitly: the `scene preflight` recognition set (correcting
the now-false "`push_error()` is not among them"), and the `script run` completion-marker
paragraph stating this widening's cross-channel impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



