### PR TITLE
fix(gda): route an invalid budget entry through the shared refusal renderer (#759)

### DIFF
--- a/src/gda/commands/perf.py
+++ b/src/gda/commands/perf.py
@@ -42,7 +42,12 @@ from pydantic import (
 
 from gda import dispatch
 from gda.dispatch import dispatch_domain, dispatch_recipe, params_or_bad_parameter
-from gda.errors import Failure, classify_live, make_failure
+from gda.errors import (
+    Failure,
+    classify_live,
+    make_failure,
+    validation_error_message,
+)
 from gda.execution import ExecutionKind
 from gda.headless import (
     HeadlessCommand,
@@ -808,8 +813,19 @@ def _load_budgets(path: Path) -> "dict[str, PerfBudget] | Failure":
         try:
             budgets[name] = PerfBudget.model_validate(entry)
         except ValidationError as exc:
+            # The SHARED renderer (#713/#754), not ``str(exc)``: the raw dump
+            # names the model class, tags each error with
+            # ``[type=..., input_value=..., input_type=...]`` — echoing the
+            # caller's own budget-file content back — and appends a
+            # ``pydantic.dev`` URL, so one ``invalid_params`` code would speak
+            # two languages depending on which surface produced it (#759).
+            # ``name`` stays in the message because it is what the caller must
+            # fix, and it is already bounded by ``PERF_MONITOR_NAMES`` above —
+            # a known monitor name, never arbitrary caller content.
             return make_failure(
-                "invalid_params", f"budget entry {name!r} is invalid: {exc}", ""
+                "invalid_params",
+                f"budget entry {name!r} is invalid: {validation_error_message(exc)}",
+                "",
             )
     return budgets
 

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -136,10 +136,14 @@ def _is_too_deep(exc: ValidationError) -> bool:
 def validation_error_message(exc: ValidationError) -> str:
     """Render a ``ValidationError`` as the sentence(s) its checks actually wrote.
 
-    The shared home for BOTH input channels that build a params model directly
-    from caller-supplied values and must translate a construction failure into a
-    human message (ADR-0015): the argv path's :func:`~gda.dispatch.params_or_bad_parameter`
-    and the ``--params-json`` path's ``invoke()`` (:mod:`gda.headless`). Lives
+    The shared home for every channel that builds a model directly from
+    caller-supplied values and must translate a construction failure into a
+    human message: the two ADR-0015 input channels — the argv path's
+    :func:`~gda.dispatch.params_or_bad_parameter` and the ``--params-json``
+    path's ``invoke()`` (:mod:`gda.headless`) — and the caller-supplied FILE
+    channel, ``perf --budget``'s per-entry refusal (#759, the third consumer;
+    ``tests/support.py``'s leak-fragment guard treats this function as the
+    authority for all of them). Lives
     here, below both, because ``gda.dispatch`` imports ``gda.headless`` — a
     ``gda.headless``-side import of ``gda.dispatch`` would cycle — while both
     already import :mod:`gda.errors` for their own failure taxonomy (#713

--- a/tests/support.py
+++ b/tests/support.py
@@ -66,6 +66,25 @@ def usage_error_text(result) -> str:
     return panel_text(result.stderr)
 
 
+# The exact fragments a pydantic ``ValidationError`` rendered with its own
+# ``str()`` adds around the checks' real sentences: the ``[type=...,
+# input_value=..., input_type=...]`` tag per error — whose ``input_value``
+# echoes the caller's own value back — and the ``errors.pydantic.dev`` URL.
+# ONE authority for every producer that must render such an error as the
+# sentence its check wrote (``gda.errors.validation_error_message``, #713/#754)
+# and for every test asserting the dump does not leak: the argv and
+# ``--params-json`` channels (tests/test_dispatch.py) and the ``perf
+# --budget-file`` loader (#759). A single home keeps a later pydantic dump
+# format from silently weakening half the assertions.
+PYDANTIC_DUMP_FRAGMENTS = ("pydantic.dev", "input_value=", "[type=")
+
+
+def assert_no_pydantic_dump(message: str) -> None:
+    """Assert no ``str(ValidationError)`` dump fragment reached ``message``."""
+    for fragment in PYDANTIC_DUMP_FRAGMENTS:
+        assert fragment not in message, f"{fragment!r} leaked into {message!r}"
+
+
 # The gda CLI invocation prefix for e2e subprocess tests. Resolved as the gda
 # MODULE in *this* interpreter's environment — `[sys.executable, "-m", "gda"]` —
 # never a PATH-resolved global. This is the same same-environment resolution

--- a/tests/support.py
+++ b/tests/support.py
@@ -74,7 +74,7 @@ def usage_error_text(result) -> str:
 # sentence its check wrote (``gda.errors.validation_error_message``, #713/#754)
 # and for every test asserting the dump does not leak: the argv and
 # ``--params-json`` channels (tests/test_dispatch.py) and the ``perf
-# --budget-file`` loader (#759). A single home keeps a later pydantic dump
+# --budget`` loader (#759). A single home keeps a later pydantic dump
 # format from silently weakening half the assertions.
 PYDANTIC_DUMP_FRAGMENTS = ("pydantic.dev", "input_value=", "[type=")
 

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -31,15 +31,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.dispatch import params_or_bad_parameter
-from tests.support import usage_error_text
-
-# The exact dump fragments str(ValidationError) used to leak (PR #754 review).
-_FORBIDDEN_FRAGMENTS = ("pydantic.dev", "input_value=", "[type=")
-
-
-def _assert_clean(message: str) -> None:
-    for fragment in _FORBIDDEN_FRAGMENTS:
-        assert fragment not in message, f"{fragment!r} leaked into {message!r}"
+from tests.support import assert_no_pydantic_dump, usage_error_text
 
 
 def _argv_usage_error_message(result) -> str:
@@ -127,7 +119,7 @@ def test_plain_value_error_passes_through_as_the_bare_sentence():
 
     message = str(exc_info.value)
     assert message == "a plain refusal sentence."
-    _assert_clean(message)
+    assert_no_pydantic_dump(message)
 
 
 def test_model_level_validation_error_renders_the_validators_own_sentence():
@@ -136,7 +128,7 @@ def test_model_level_validation_error_renders_the_validators_own_sentence():
 
     message = str(exc_info.value)
     assert message == "'search' and 'replace' must be used together."
-    _assert_clean(message)
+    assert_no_pydantic_dump(message)
 
 
 def test_field_level_validation_error_renders_the_validators_own_sentence():
@@ -145,7 +137,7 @@ def test_field_level_validation_error_renders_the_validators_own_sentence():
 
     message = str(exc_info.value)
     assert message == "name: 'name' must not be empty."
-    _assert_clean(message)
+    assert_no_pydantic_dump(message)
 
 
 def test_multi_error_validation_error_joins_each_fields_own_message():
@@ -155,7 +147,7 @@ def test_multi_error_validation_error_joins_each_fields_own_message():
     message = str(exc_info.value)
     assert "a: " in message and "b: " in message
     assert "; " in message  # the stated join separator
-    _assert_clean(message)
+    assert_no_pydantic_dump(message)
 
 
 def test_no_caller_value_leaks_into_the_refusal():
@@ -183,7 +175,7 @@ def test_no_caller_value_leaks_into_the_refusal():
     message = str(exc_info.value)
     assert secret not in message
     assert message == "'search' and 'replace' must be used together."
-    _assert_clean(message)
+    assert_no_pydantic_dump(message)
 
 
 # --- end-to-end: --params-json through an actual command (round 3) ------------
@@ -205,7 +197,7 @@ def test_params_json_validation_error_is_also_rendered_clean():
 
     message = _params_json_invalid_params_message(result)
     assert message == "'search' and 'replace' must be used together."
-    _assert_clean(message)
+    assert_no_pydantic_dump(message)
 
 
 def test_params_json_does_not_leak_the_callers_other_field_value():
@@ -228,7 +220,7 @@ def test_params_json_does_not_leak_the_callers_other_field_value():
     message = _params_json_invalid_params_message(result)
     assert secret not in message
     assert message == "'search' and 'replace' must be used together."
-    _assert_clean(message)
+    assert_no_pydantic_dump(message)
 
 
 def test_argv_and_params_json_report_the_identical_sentence():

--- a/tests/test_perf_commands.py
+++ b/tests/test_perf_commands.py
@@ -21,6 +21,7 @@ from tests.support import (
     PERF_MONITOR_SIGNAL_RESULT,
     PERF_MONITORS_RESULT,
     PERF_SAMPLE_REPLY,
+    assert_no_pydantic_dump,
     error_sentinel,
     inject_live_runner,
     perf_sample_reply_all_monitors,
@@ -722,6 +723,67 @@ def test_perf_monitors_window_budget_file_problems_are_invalid_params(
         # Each case must fail for ITS OWN reason — this is what the aliased
         # single-file table could not prove (#735 recheck 2).
         assert fragment in error["message"], (name, error["message"])
+    assert fake.calls == []
+
+
+def test_perf_monitors_window_budget_entry_refusal_leaks_no_pydantic_dump(
+    monkeypatch, tmp_path
+):
+    # A broken budget ENTRY is refused by the `PerfBudget` model, and the
+    # loader used to interpolate the raw `ValidationError` (#759): the message
+    # an agent reads carried the model class name, a `[type=...,
+    # input_value=..., input_type=...]` tag echoing the caller's own budget-file
+    # content, embedded newlines, and a `pydantic.dev` URL. It now goes through
+    # the SAME shared renderer the argv and --params-json channels use
+    # (`gda.errors.validation_error_message`, #713/#754), so one
+    # `invalid_params` code speaks one language on every surface.
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(PERF_SAMPLE_REPLY), stderr="", exit_code=0),
+    )
+    # A distinctive bound value: only pydantic's own dump echoes a rejected
+    # input back, so finding it in the message proves the leak directly.
+    secret = "NOT-A-NUMBER-4d9f21"
+    cases = [
+        # A built-in check (strict float) — the message is pydantic's own `msg`.
+        (
+            "leak-builtin.json",
+            '{"fps": {"stat": "p50", "min": "%s"}}' % secret,
+            "min: Input should be a valid number",
+        ),
+        # A field-scoped enum check — the field path survives the rendering.
+        (
+            "leak-enum.json",
+            '{"fps": {"stat": "%s", "min": 60}}' % secret,
+            "stat: Input should be",
+        ),
+        # A model-level validator's own ValueError — unprefixed, untagged.
+        (
+            "leak-validator.json",
+            '{"fps": {"stat": "p50"}}',
+            "a budget entry needs 'min' and/or 'max'.",
+        ),
+    ]
+    for name, content, sentence in cases:
+        budget = _budget_file(tmp_path, name, content)
+        result = _window(tmp_path, "--frames", "5", "--budget", str(budget))
+
+        error = json.loads(result.stdout)["error"]
+        assert error["code"] == "invalid_params", (name, result.stdout)
+        assert_no_pydantic_dump(error["message"])
+        # The dump's other two tells: the model class name, and the newlines it
+        # embeds to lay one error out over three lines.
+        assert "PerfBudget" not in error["message"], (name, error["message"])
+        assert "\n" not in error["message"], (name, error["message"])
+        # The caller's own budget-file content is not echoed back...
+        assert secret not in error["message"], (name, error["message"])
+        # ...while the entry NAME — bounded by PERF_MONITOR_NAMES, and what the
+        # caller must fix — and the check's own sentence both survive.
+        assert error["message"].startswith("budget entry 'fps' is invalid: "), (
+            name,
+            error["message"],
+        )
+        assert sentence in error["message"], (name, error["message"])
     assert fake.calls == []
 
 


### PR DESCRIPTION
## What

`perf --budget` rejected a broken budget entry by interpolating the pydantic
`ValidationError` with its own `str()`. The `invalid_params` envelope's `message` — the
field an agent reads — therefore carried pydantic's internal dump instead of the rule
that was broken.

Before (real CLI, `{"fps": {"stat": "p50", "min": "60"}}`):

```json
{"error":{"category":"operation","code":"invalid_params","message":"budget entry 'fps' is invalid: 1 validation error for PerfBudget\nmin\n  Input should be a valid number [type=float_type, input_value='60', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.13/v/float_type","diagnostics":""}}
```

After:

```json
{"error":{"category":"operation","code":"invalid_params","message":"budget entry 'fps' is invalid: min: Input should be a valid number","diagnostics":""}}
```

The one-line change reuses `gda.errors.validation_error_message` — the public extractor
PR #754 added for the two ADR-0015 params-model channels (argv and `--params-json`). This
was the third producer of the same public code from another caller-supplied value, so one
`invalid_params` code no longer speaks two languages depending on which surface produced it.

The entry NAME stays in the message: it is what the caller must fix, and it is already
bounded by `PERF_MONITOR_NAMES` upstream in the same loop, so it is a known monitor name
rather than arbitrary caller content.

More after-state probes (all real CLI, no engine — see "Verification"):

| budget entry | message |
| --- | --- |
| `{"fps": {"stat": "p50"}}` | `budget entry 'fps' is invalid: a budget entry needs 'min' and/or 'max'.` |
| `{"fps": {"stat": "count", "min": 1}}` | `budget entry 'fps' is invalid: stat: Input should be 'min', 'max', 'mean', 'p50' or 'p95'` |
| `{"fps": {"stat": "p50", "min": 100, "max": 50}}` | `budget entry 'fps' is invalid: budget bounds form an impossible interval: min 100.0 > max 50.0.` |
| `{"fps": {"stat": "p50", "min": 60, "top": 1}}` | `budget entry 'fps' is invalid: top: Extra inputs are not permitted` |

## Regression

`test_perf_monitors_window_budget_entry_refusal_leaks_no_pydantic_dump` walks three entry
shapes — a built-in strict-number check, a field-scoped enum check, and a model-level
validator's own `ValueError` — and pins both halves of the contract:

- ABSENCE: no `pydantic.dev`, no `input_value=`, no `[type=`, no `PerfBudget` class name,
  no embedded newline, and no occurrence of a distinctive sentinel value planted in the
  budget file (only pydantic's dump echoes a rejected input back, so finding it proves
  the leak directly).
- PRESENCE: the message still starts `budget entry 'fps' is invalid: ` and still carries
  the check's own sentence, so the fix cannot be satisfied by emptying the message.

The leaked-fragment list moved from a private constant in `tests/test_dispatch.py` into
`tests/support.py` (`PYDANTIC_DUMP_FRAGMENTS` / `assert_no_pydantic_dump`), so this
regression and the two channel regressions assert against ONE list rather than two copies
that could drift apart as pydantic's dump format changes. This is the only file this slice
touches outside `commands/perf.py` and its own test module; a wave-mate appending to
`tests/support.py` would conflict on that hunk.

## Sweep: remaining `ValidationError` → public-failure producers

A whole-repo scan (`src/`, `libs/`, `examples/`, `scripts/`) confirms the issue's premise —
this was the last one in `src/gda`. Every other site, and why it is left alone:

| Site | Why not changed |
| --- | --- |
| `src/gda/headless.py:443`, `src/gda/dispatch.py:68` | Already route through `validation_error_message` (#754). |
| `src/gda/errors.py:361` (`classify_run`'s `contract_violation`) | The issue's declared exclusion: it validates the ENGINE's output against gda's result schema, not caller input — a different origin and a different failure consequence. |
| `src/gda/errors.py:193`, `src/gda/errors.py:408` | Swallow the `ValidationError` (`return None`); no message is produced. |
| `libs/gda-balancing/.../interfaces/cli/dispatch.py:208` | A separate package with its own error taxonomy, and it already renders through its own equivalent clean summarizer (`_summarize`: `loc` + `msg`, never `str(exc)`). Nothing leaks. |
| `libs/gda-balancing/.../schema/funnel/__init__.py:79` | Interpolates into an INTERNAL `RuntimeError` flagged as an engine-parity bug, not a public failure envelope. |
| `libs/gda-balancing/.../interfaces/http/api_v1.py:81` | Discards the exception (`raise InvalidHttpRequest from error`). |

## Verification

- Red-proofed: with `f"...: {exc}"` restored, the new regression fails on the first
  assertion, reporting the full leak (`PerfBudget` class name, embedded newlines,
  `[type=float_type, input_value='NOT-A-NUMBER-4d9f21', input_type=str]`, the
  `errors.pydantic.dev` URL). With the fix, it passes.
- Real CLI probe (`uv run gda perf monitors --frames 5 --budget ... --project ... --json`)
  for both the before and after state, on a bare project directory. NO engine and NO
  daemon are needed: `_load_budgets` runs before the first `runner.run(...)` in
  `run_perf_monitors_operation`, so the refusal never reaches the live channel — which is
  also what the existing `assert fake.calls == []` pins.
- Gates: `pytest -m "not e2e"` 2239 passed / 577 deselected; `ruff check` clean;
  `ruff format --check` clean; `pyright` 0 errors.
- `test_e2e_perf`'s budget case exercises a VALID budget (the happy path), which this
  change does not touch.

Closes #759

