### PR TITLE
fix(gda): one canonical identity for the project reference graph (#774)

### DIFF
--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -902,6 +902,21 @@ traversal itself: the two walks are one recursive walker asked two different acc
 questions. A shared traversal is not a shared universe — `project statistics` keeps
 counting the sidecars and the project file the other walk will never see.
 
+**One graph node per file, whatever a declaration spells it (#774).** A `res://` address has
+many lexical spellings for one file, and the three graph reads key on the file the engine
+resolves rather than on the spelling: every harvested path — an `[ext_resource]` line, a
+`preload()`/`load()`/`extends` argument, and `project.godot`'s own main scene and autoload
+entries — is folded through the engine's `simplify_path`, and so is the `find-references`
+target. `res://sub/../leaf.tscn` and `res://leaf.tscn` are therefore ONE node:
+`dependencies` reports the resolved path, `find-references` matches whichever side is
+aliased (aliased declaration with a canonical query, and the reverse), and
+`find-unused-resources` never reports a resource that something references under an alias.
+`project statistics` reads `project.godot` through the same accessor, so the autoload paths
+it lists are canonical too. The echoed `target` keeps the caller's own spelling — only the
+matching is canonical, and a `class_name` target is no path at all. Keying on the raw
+spellings broke all three at once: `find-unused-resources` listed an instanced scene, which
+is wrong advice with a destructive follow-up.
+
 ---
 
 ## Phase 2 — live domain commands (served by `gda-daemon`)

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -902,20 +902,31 @@ traversal itself: the two walks are one recursive walker asked two different acc
 questions. A shared traversal is not a shared universe — `project statistics` keeps
 counting the sidecars and the project file the other walk will never see.
 
-**One graph node per file, whatever a declaration spells it (#774).** A `res://` address has
-many lexical spellings for one file, and the three graph reads key on the file the engine
-resolves rather than on the spelling: every harvested path — an `[ext_resource]` line, a
-`preload()`/`load()`/`extends` argument, and `project.godot`'s own main scene and autoload
-entries — is folded through the engine's `simplify_path`, and so is the `find-references`
-target. `res://sub/../leaf.tscn` and `res://leaf.tscn` are therefore ONE node:
-`dependencies` reports the resolved path, `find-references` matches whichever side is
-aliased (aliased declaration with a canonical query, and the reverse), and
-`find-unused-resources` never reports a resource that something references under an alias.
-`project statistics` reads `project.godot` through the same accessor, so the autoload paths
-it lists are canonical too. The echoed `target` keeps the caller's own spelling — only the
-matching is canonical, and a `class_name` target is no path at all. Keying on the raw
-spellings broke all three at once: `find-unused-resources` listed an instanced scene, which
-is wrong advice with a destructive follow-up.
+**One graph node per file, whatever a declaration spells it (#774).** One file has many
+spellings, and the three graph reads key on the file the engine resolves rather than on the
+spelling. Two spellings reach the same file, and each needs its own fold:
+
+- an **alias** of an absolute address — `res://sub/../leaf.tscn` for `res://leaf.tscn` —
+  which the engine's `simplify_path` folds;
+- a **relative** address, which the engine resolves against the directory of the file that
+  DECLARES it. `path="../shared/leaf.tscn"` in `res://scenes/main.tscn` loads
+  `res://shared/leaf.tscn`, and `preload("../shared/x.gd")` in `res://scripts/user.gd` loads
+  `res://shared/x.gd`. Such a path is anchored to that directory first, then simplified.
+
+Every harvested path is folded this way — an `[ext_resource]` line and a
+`preload()`/`load()`/`extends` argument by the rule above; `project.godot`'s main scene and
+autoload entries, and the `find-references` target, are absolute already and are only
+simplified. So `dependencies` reports the resolved path (never a bare `../…` that names no
+file), `find-references` matches whichever side is aliased or relative (a folded declaration
+with a canonical query, and the reverse), and `find-unused-resources` never reports a
+resource that something references under another spelling. `project statistics` reads
+`project.godot` through the same accessor, so the autoload paths it lists are canonical too.
+
+The echoed `target` keeps the caller's own spelling, and each reference's `context` keeps the
+line as written — only the matching is folded, so an agent still sees the text it must edit.
+A `class_name` target is no path at all. Keying on the raw spelling broke all three reads at
+once: `find-unused-resources` listed an instanced scene, which is wrong advice with a
+destructive follow-up.
 
 ---
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3944,18 +3944,30 @@ func _write_text_file(path: String, source: String, noun: String) -> bool:
 # would return empty — the same graph, one truth. statistics is not on that graph:
 # it only counts what its own scan reaches.
 #
-# ONE graph needs ONE identity per file. Every path that enters it — harvested
-# from an [ext_resource] line, from a preload/load/extends argument, or from
-# project.godot's main scene and autoloads — AND the caller's find-references
-# query pass through _canonical_resource_path, the engine's own simplify_path. A
-# file is one node however a declaration spells it: res://leaf.tscn and
-# res://sub/../leaf.tscn are the same node, not two. Keying on the raw spellings
-# broke all three reads at once (#774): dependencies named a node no file on disk
-# answers to, find-references for the canonical path missed the aliased
-# declaration, and find-unused-resources therefore advised DELETING a scene the
-# project instances — wrong advice with a destructive follow-up. The other side
-# of every comparison is canonical by construction: the walk builds each path by
-# joining directory entries, never by echoing a declaration.
+# ONE graph needs ONE identity per file, and that identity is the path the ENGINE
+# resolves a declaration to — not the string the declaration spells. Two spellings
+# reach the same file:
+#
+# - an ALIAS of an absolute address (res://leaf.tscn and res://sub/../leaf.tscn),
+#   folded by _canonical_resource_path, the engine's own simplify_path;
+# - a RELATIVE address, which the engine resolves against the DECLARING file's
+#   own directory — `path="../shared/leaf.tscn"` in res://scenes/main.tscn loads
+#   res://shared/leaf.tscn (measured on 4.6.3), and `preload("../shared/x.gd")`
+#   in res://scripts/user.gd loads res://shared/x.gd (measured likewise).
+#
+# So every path that enters the graph is folded by the owner that knows its base
+# directory: _normalize_ext_resource_path for an [ext_resource] line,
+# _resolve_ref_path for a preload/load/extends argument. Only two entrants have no
+# declaring file to anchor to and are absolute by construction — project.godot's
+# main scene and autoloads, and the caller's find-references query — and those go
+# straight to _canonical_resource_path.
+#
+# Keying on the raw spelling broke all three reads at once (#774): dependencies
+# named a node no file on disk answers to, find-references for the resolved path
+# missed the declaration, and find-unused-resources therefore advised DELETING a
+# scene the project instances — wrong advice with a destructive follow-up. The
+# other side of every comparison is canonical by construction: the walk builds each
+# path by joining directory entries, never by echoing a declaration.
 
 
 # project-find-references: find every project file that references the target — a
@@ -4389,20 +4401,26 @@ func _outgoing_references_of(path: String) -> Array:
 # The res:// paths an [ext_resource ... path="res://..."] line names in a
 # .tscn/.tres file — the file's external dependencies. Parsed by text: each
 # ext_resource line carries a path="..." attribute (Godot 4 also carries a uid,
-# but always the path too). Returns res:// paths in line order, each canonical
-# (#774) so a file is one graph node however the line spells it.
+# but always the path too). Returns res:// paths in line order, each under the
+# ONE graph identity (#774) so a file is one graph node however the line spells
+# it: _normalize_ext_resource_path anchors a relative declaration to the
+# DECLARING file's directory before it canonicalizes, because the engine resolves
+# it that way — `path="../shared/leaf.tscn"` in res://scenes/main.tscn loads
+# res://shared/leaf.tscn (measured on 4.6.3). Canonicalizing without anchoring
+# left the relative spelling as its own graph node.
 func _ext_resource_paths(path: String) -> Array[String]:
 	var out: Array[String] = []
 	var text := FileAccess.get_file_as_string(path)
 	if text.is_empty():
 		return out
+	var base_dir := path.get_base_dir()
 	for line in text.split("\n"):
 		var stripped := line.strip_edges()
 		if not stripped.begins_with("[ext_resource"):
 			continue
 		var ref := _quoted_attr(stripped, "path=")
 		if not ref.is_empty():
-			out.append(_canonical_resource_path(ref))
+			out.append(_normalize_ext_resource_path(ref, base_dir))
 	return out
 
 
@@ -4457,15 +4475,18 @@ func _collect_references_from(path: String, target_paths: Dictionary, target_cla
 	if text.is_empty():
 		return
 	if ext == "tscn" or ext == "tres":
+		var ext_base_dir := path.get_base_dir()
 		for line in text.split("\n"):
 			var stripped := line.strip_edges()
 			if not stripped.begins_with("[ext_resource"):
 				continue
 			var ref := _quoted_attr(stripped, "path=")
-			# Canonical on BOTH sides: target_paths is seeded canonical, and the
-			# declared spelling is folded here, so an aliased declaration matches
-			# a canonical query and the reverse (#774).
-			if target_paths.has(_canonical_resource_path(ref)):
+			# One identity on BOTH sides: target_paths is seeded canonical, and the
+			# declared spelling is folded here through the SAME owner the harvest
+			# side uses (_normalize_ext_resource_path — anchor to the declaring
+			# file's directory, then canonicalize), so an aliased OR relative
+			# declaration matches a canonical query and the reverse (#774).
+			if target_paths.has(_normalize_ext_resource_path(ref, ext_base_dir)):
 				references.append({"path": path, "kind": "ext_resource", "context": stripped})
 	elif ext == "gd":
 		var base_dir := path.get_base_dir()

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3943,6 +3943,19 @@ func _write_text_file(path: String, source: String, noun: String) -> bool:
 # an entry point). A resource is "unused" exactly when find-references for it
 # would return empty — the same graph, one truth. statistics is not on that graph:
 # it only counts what its own scan reaches.
+#
+# ONE graph needs ONE identity per file. Every path that enters it — harvested
+# from an [ext_resource] line, from a preload/load/extends argument, or from
+# project.godot's main scene and autoloads — AND the caller's find-references
+# query pass through _canonical_resource_path, the engine's own simplify_path. A
+# file is one node however a declaration spells it: res://leaf.tscn and
+# res://sub/../leaf.tscn are the same node, not two. Keying on the raw spellings
+# broke all three reads at once (#774): dependencies named a node no file on disk
+# answers to, find-references for the canonical path missed the aliased
+# declaration, and find-unused-resources therefore advised DELETING a scene the
+# project instances — wrong advice with a destructive follow-up. The other side
+# of every comparison is canonical by construction: the walk builds each path by
+# joining directory entries, never by echoing a declaration.
 
 
 # project-find-references: find every project file that references the target — a
@@ -3971,7 +3984,11 @@ func _op_project_find_references(params: Dictionary) -> void:
 	var target_paths := {}  # res:// paths a reference may name the target by
 	var target_class := ""  # class_name token a .gd reference may name it by
 	if target.begins_with("res://"):
-		target_paths[target] = true
+		# The query is canonicalized like every harvested path (#774), so a caller
+		# that spells the target res://sub/../leaf.tscn asks about the same node
+		# the graph keys res://leaf.tscn under. The echoed "target" keeps the
+		# caller's own spelling — it also carries a class_name, which is no path.
+		target_paths[_canonical_resource_path(target)] = true
 	else:
 		# Resolve the class_name through the SAME unified resolver node add /
 		# resource create use (ADR-0032), so find-references and resource create
@@ -3981,7 +3998,7 @@ func _op_project_find_references(params: Dictionary) -> void:
 		match resolution["status"]:
 			"resolved":
 				target_class = target
-				target_paths[resolution["path"]] = true
+				target_paths[_canonical_resource_path(String(resolution["path"]))] = true
 			"ambiguous":
 				_fail(OP_ERROR_AMBIGUOUS_CLASS_NAME, _ambiguous_class_name_message(target, resolution["paths"]))
 				return
@@ -4372,7 +4389,8 @@ func _outgoing_references_of(path: String) -> Array:
 # The res:// paths an [ext_resource ... path="res://..."] line names in a
 # .tscn/.tres file — the file's external dependencies. Parsed by text: each
 # ext_resource line carries a path="..." attribute (Godot 4 also carries a uid,
-# but always the path too). Returns res:// paths in line order.
+# but always the path too). Returns res:// paths in line order, each canonical
+# (#774) so a file is one graph node however the line spells it.
 func _ext_resource_paths(path: String) -> Array[String]:
 	var out: Array[String] = []
 	var text := FileAccess.get_file_as_string(path)
@@ -4384,7 +4402,7 @@ func _ext_resource_paths(path: String) -> Array[String]:
 			continue
 		var ref := _quoted_attr(stripped, "path=")
 		if not ref.is_empty():
-			out.append(ref)
+			out.append(_canonical_resource_path(ref))
 	return out
 
 
@@ -4405,15 +4423,18 @@ func _script_outgoing_references(path: String) -> Array:
 	return out
 
 
-# Resolve a reference-path argument to a res:// path: a res:// (or uid://) path is
-# already absolute; a relative path is joined onto the referencing file's base
-# directory and simplified, so "../shared/util.gd" from res://a/b.gd becomes
-# res://shared/util.gd. uid:// references are left as-is (they round-trip through
-# Godot's UID system, not the path graph).
+# Resolve a reference-path argument to a canonical res:// path: a relative path is
+# joined onto the referencing file's base directory first, so "../shared/util.gd"
+# from res://a/b.gd becomes res://shared/util.gd. An ALREADY-prefixed argument is
+# canonicalized too and that half is the #774 fix: it used to be returned verbatim,
+# so preload("res://sub/../util.gd") and preload("res://util.gd") were two graph
+# nodes for one file. simplify_path leaves a scheme it does not own alone, so a
+# uid:// reference still passes through unchanged (it round-trips through Godot's
+# UID system, not the path graph).
 func _resolve_ref_path(ref: String, base_dir: String) -> String:
 	if ref.begins_with("res://") or ref.begins_with("uid://") or ref.begins_with("user://"):
-		return ref
-	return base_dir.path_join(ref).simplify_path()
+		return _canonical_resource_path(ref)
+	return _canonical_resource_path(base_dir.path_join(ref))
 
 
 # Find every reference to the target inside one file, appending {path, kind,
@@ -4441,7 +4462,10 @@ func _collect_references_from(path: String, target_paths: Dictionary, target_cla
 			if not stripped.begins_with("[ext_resource"):
 				continue
 			var ref := _quoted_attr(stripped, "path=")
-			if target_paths.has(ref):
+			# Canonical on BOTH sides: target_paths is seeded canonical, and the
+			# declared spelling is folded here, so an aliased declaration matches
+			# a canonical query and the reverse (#774).
+			if target_paths.has(_canonical_resource_path(ref)):
 				references.append({"path": path, "kind": "ext_resource", "context": stripped})
 	elif ext == "gd":
 		var base_dir := path.get_base_dir()
@@ -4529,13 +4553,20 @@ func _project_entry_points() -> Array[String]:
 # ProjectSettings — never run.
 func _main_scene_path() -> String:
 	var value: Variant = ProjectSettings.get_setting("application/run/main_scene", "")
-	return String(value)
+	# Canonical like every other path in the graph (#774): an aliased
+	# run/main_scene left the project's entry point matching nothing the walk
+	# found, so find-unused-resources reported the MAIN SCENE as unused.
+	# simplify_path("") is "", so an unset main scene stays the empty "none".
+	return _canonical_resource_path(String(value))
 
 
 # The project's autoload singletons as {name, path} entries, read from
 # ProjectSettings's autoload/* keys (never executed). The stored value carries a
 # leading "*" enable marker for an enabled singleton; it is stripped so the path
-# is the bare res:// path the rest of the graph compares against.
+# is the bare res:// path the rest of the graph compares against, then
+# canonicalized like every other path in the graph (#774). Order matters: the
+# marker must come off FIRST, because simplify_path does not recognize a scheme
+# behind it and folds "*res://a/../b.gd" to the broken "*res:/b.gd".
 func _project_autoloads() -> Array:
 	var out: Array = []
 	for setting in ProjectSettings.get_property_list():
@@ -4544,7 +4575,7 @@ func _project_autoloads() -> Array:
 			continue
 		var autoload_name: String = key.substr("autoload/".length())
 		var value := String(ProjectSettings.get_setting(key, ""))
-		out.append({"name": autoload_name, "path": value.trim_prefix("*")})
+		out.append({"name": autoload_name, "path": _canonical_resource_path(value.trim_prefix("*"))})
 	return out
 
 

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -617,3 +617,215 @@ def test_project_walks_agree_on_a_nested_dot_godot_directory(tmp_path):
     # otherwise BOTH be dependency source rows and unused candidates, so this
     # arm fails if the exclusion ever widens past `res://.godot` itself.
     assert not any(p.startswith("res://.godot/") for p in [*by_source, *unused])
+
+
+# --- alias spellings are one graph node (#774) -------------------------------
+#
+# A `res://` address has many lexical spellings for one file: `res://leaf.tscn`
+# and `res://sub/../leaf.tscn` are the SAME file to the engine, which folds every
+# address through `simplify_path` before it resolves one. The three graph reads
+# used to key on the raw spelling instead, so an aliased declaration made a graph
+# node no file on disk answered to, `find-references` for the real path missed the
+# reference, and `find-unused-resources` therefore advised deleting a scene the
+# project instances. These tests pin the identity on BOTH sides of the comparison
+# — the harvested declaration and the caller's query — over every harvest site:
+# an `[ext_resource]` line, a `preload()` argument, and `project.godot`'s own
+# main-scene and autoload entries.
+
+ALIAS_PROJECT_GODOT = project_godot(
+    name="gda-alias-fixture",
+    extra="""\
+run/main_scene="res://sub/../parent.tscn"
+
+[autoload]
+
+Hud="*res://sub/../hud.tscn"
+""",
+)
+
+# The aliased [ext_resource] declaration: parent.tscn really instances leaf.tscn,
+# the engine resolves the spelling, and the graph must agree that it does.
+ALIAS_PARENT_TSCN = """\
+[gd_scene load_steps=2 format=3 uid="uid://baliasparent"]
+
+[ext_resource type="PackedScene" path="res://sub/../leaf.tscn" id="1_leaf"]
+
+[node name="Parent" type="Node2D"]
+
+[node name="Leaf" parent="." instance=ExtResource("1_leaf")]
+"""
+
+ALIAS_LEAF_TSCN = """\
+[gd_scene format=3 uid="uid://baliasleaf"]
+
+[node name="Leaf" type="Node2D"]
+"""
+
+# The autoload scene, named by project.godot under an aliased spelling.
+ALIAS_HUD_TSCN = """\
+[gd_scene format=3 uid="uid://baliashud"]
+
+[node name="Hud" type="Node"]
+"""
+
+# The reverse direction: a CANONICAL declaration the query aliases.
+ALIAS_CANONICAL_TSCN = """\
+[gd_scene load_steps=2 format=3 uid="uid://baliascanon"]
+
+[ext_resource type="Texture2D" path="res://icon.png" id="1_icon"]
+
+[node name="Canonical" type="Sprite2D"]
+texture = ExtResource("1_icon")
+"""
+
+# The script-side harvest site: an already-prefixed, aliased preload argument.
+ALIAS_USER_GD = """\
+extends Node
+
+const Helper = preload("res://sub/../helper.gd")
+"""
+
+ALIAS_HELPER_GD = """\
+extends RefCounted
+"""
+
+ALIAS_ORPHAN_TRES = """\
+[gd_resource type="Resource" format=3]
+
+[resource]
+"""
+
+
+@pytest.fixture
+def alias_project(tmp_path):
+    """A project whose references are declared under alias spellings (#774).
+
+    Every reference here names a file that really exists and that the engine
+    really resolves; only the SPELLING is aliased. ``sub/`` is a real directory
+    (it holds the orphan) so the aliases read as something an agent would
+    plausibly write, not as a synthetic string.
+    """
+    (tmp_path / "project.godot").write_text(ALIAS_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "parent.tscn").write_text(ALIAS_PARENT_TSCN, encoding="utf-8")
+    (tmp_path / "leaf.tscn").write_text(ALIAS_LEAF_TSCN, encoding="utf-8")
+    (tmp_path / "hud.tscn").write_text(ALIAS_HUD_TSCN, encoding="utf-8")
+    (tmp_path / "canonical.tscn").write_text(ALIAS_CANONICAL_TSCN, encoding="utf-8")
+    (tmp_path / "user.gd").write_text(ALIAS_USER_GD, encoding="utf-8")
+    (tmp_path / "helper.gd").write_text(ALIAS_HELPER_GD, encoding="utf-8")
+    (tmp_path / "icon.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "orphan.tres").write_text(ALIAS_ORPHAN_TRES, encoding="utf-8")
+    return tmp_path
+
+
+@pytest.mark.e2e
+def test_dependencies_keys_an_aliased_declaration_canonically(alias_project):
+    proc = _gda(alias_project, "project", "dependencies", "--json")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    by_source = {
+        row["path"]: row["depends_on"]
+        for row in json.loads(proc.stdout)["dependencies"]
+    }
+
+    # The aliased [ext_resource] and the aliased preload both report the file the
+    # engine resolves, not the spelling the declaration used.
+    assert by_source["res://parent.tscn"] == [
+        {"path": "res://leaf.tscn", "kind": "ext_resource"}
+    ]
+    assert by_source["res://user.gd"] == [
+        {"path": "res://helper.gd", "kind": "preload"}
+    ]
+    # No graph node names a path that no file on disk answers to.
+    named = {dep["path"] for deps in by_source.values() for dep in deps}
+    assert not any(".." in path.split("/") for path in named), named
+
+
+@pytest.mark.e2e
+def test_find_references_matches_an_aliased_declaration_from_a_canonical_query(
+    alias_project,
+):
+    scene = _gda(
+        alias_project, "project", "find-references", "res://leaf.tscn", "--json"
+    )
+    script = _gda(
+        alias_project, "project", "find-references", "res://helper.gd", "--json"
+    )
+
+    assert scene.returncode == 0, scene.stdout + scene.stderr
+    assert script.returncode == 0, script.stdout + script.stderr
+    assert [(r["path"], r["kind"]) for r in json.loads(scene.stdout)["references"]] == [
+        ("res://parent.tscn", "ext_resource")
+    ]
+    assert [
+        (r["path"], r["kind"]) for r in json.loads(script.stdout)["references"]
+    ] == [("res://user.gd", "preload")]
+
+
+@pytest.mark.e2e
+def test_find_references_matches_a_canonical_declaration_from_an_aliased_query(
+    alias_project,
+):
+    proc = _gda(
+        alias_project,
+        "project",
+        "find-references",
+        "res://sub/../icon.png",
+        "--json",
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    data = json.loads(proc.stdout)
+    # The echoed target keeps the caller's own spelling; the MATCHING does not.
+    assert data["target"] == "res://sub/../icon.png"
+    assert [(r["path"], r["kind"]) for r in data["references"]] == [
+        ("res://canonical.tscn", "ext_resource")
+    ]
+
+
+@pytest.mark.e2e
+def test_find_references_matches_an_aliased_project_level_entry(alias_project):
+    # project.godot is a harvest site too: its main scene and autoloads name a
+    # resource by path the way an ext_resource line does.
+    main = _gda(
+        alias_project, "project", "find-references", "res://parent.tscn", "--json"
+    )
+    autoload = _gda(
+        alias_project, "project", "find-references", "res://hud.tscn", "--json"
+    )
+
+    assert main.returncode == 0, main.stdout + main.stderr
+    assert autoload.returncode == 0, autoload.stdout + autoload.stderr
+    assert ("project.godot", "main_scene") in {
+        (r["path"], r["kind"]) for r in json.loads(main.stdout)["references"]
+    }
+    assert ("project.godot", "autoload") in {
+        (r["path"], r["kind"]) for r in json.loads(autoload.stdout)["references"]
+    }
+
+
+@pytest.mark.e2e
+def test_find_unused_resources_never_lists_an_aliased_reference(alias_project):
+    proc = _gda(alias_project, "project", "find-unused-resources", "--json")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    unused = json.loads(proc.stdout)["unused"]
+
+    # The destructive advice this issue is about: leaf.tscn is instanced by
+    # parent.tscn, and parent.tscn/hud.tscn are project entry points — all three
+    # under alias spellings. None of them is deletable.
+    assert "res://leaf.tscn" not in unused
+    assert "res://parent.tscn" not in unused
+    assert "res://hud.tscn" not in unused
+    assert "res://icon.png" not in unused
+    # The report still works: the genuinely unreferenced resource is reported.
+    assert "res://sub/orphan.tres" in unused
+
+    # The consistency criterion holds under alias spellings too: unused means
+    # exactly "find-references returns empty".
+    for path in unused:
+        refs = json.loads(
+            _gda(alias_project, "project", "find-references", path, "--json").stdout
+        )["references"]
+        assert refs == [], f"{path} reported unused but has references {refs}"

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -644,21 +644,47 @@ Hud="*res://sub/../hud.tscn"
 )
 
 # The aliased [ext_resource] declaration: parent.tscn really instances leaf.tscn,
-# the engine resolves the spelling, and the graph must agree that it does.
+# the engine resolves the spelling, and the graph must agree that it does. It also
+# instances nested.tscn under a RELATIVE spelling — no `res://` prefix at all, which
+# the engine resolves against parent.tscn's own directory (the project root here).
 ALIAS_PARENT_TSCN = """\
-[gd_scene load_steps=2 format=3 uid="uid://baliasparent"]
+[gd_scene load_steps=3 format=3 uid="uid://baliasparent"]
 
 [ext_resource type="PackedScene" path="res://sub/../leaf.tscn" id="1_leaf"]
+[ext_resource type="PackedScene" path="scenes/nested.tscn" id="2_nested"]
 
 [node name="Parent" type="Node2D"]
 
 [node name="Leaf" parent="." instance=ExtResource("1_leaf")]
+
+[node name="Nested" parent="." instance=ExtResource("2_nested")]
 """
 
 ALIAS_LEAF_TSCN = """\
 [gd_scene format=3 uid="uid://baliasleaf"]
 
 [node name="Leaf" type="Node2D"]
+"""
+
+# The relative declaration that ESCAPES its own directory: nested.tscn lives in
+# res://scenes/, and the engine resolves `../shared/deep.tscn` from there to
+# res://shared/deep.tscn (measured on 4.6.3). Canonicalizing this spelling without
+# first anchoring it to the DECLARING file's directory leaves `../shared/deep.tscn`
+# unchanged — a graph node no file on disk answers to.
+ALIAS_NESTED_TSCN = """\
+[gd_scene load_steps=2 format=3 uid="uid://baliasnested"]
+
+[ext_resource type="PackedScene" path="../shared/deep.tscn" id="1_deep"]
+
+[node name="Nested" type="Node2D"]
+
+[node name="Deep" parent="." instance=ExtResource("1_deep")]
+"""
+
+ALIAS_DEEP_TSCN = """\
+[gd_scene format=3 uid="uid://baliasdeep"]
+
+[node name="Deep" type="Node2D"]
 """
 
 # The autoload scene, named by project.godot under an aliased spelling.
@@ -704,6 +730,12 @@ def alias_project(tmp_path):
     really resolves; only the SPELLING is aliased. ``sub/`` is a real directory
     (it holds the orphan) so the aliases read as something an agent would
     plausibly write, not as a synthetic string.
+
+    Two families of spelling are covered, because they need two different folds:
+    an ALIAS of an absolute address (``res://sub/../leaf.tscn``), which only needs
+    simplifying, and a RELATIVE address (``scenes/nested.tscn`` from the root,
+    ``../shared/deep.tscn`` from ``res://scenes/``), which must first be anchored
+    to the DECLARING file's own directory — the way the engine resolves it.
     """
     (tmp_path / "project.godot").write_text(ALIAS_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "parent.tscn").write_text(ALIAS_PARENT_TSCN, encoding="utf-8")
@@ -716,6 +748,12 @@ def alias_project(tmp_path):
     sub = tmp_path / "sub"
     sub.mkdir()
     (sub / "orphan.tres").write_text(ALIAS_ORPHAN_TRES, encoding="utf-8")
+    scenes = tmp_path / "scenes"
+    scenes.mkdir()
+    (scenes / "nested.tscn").write_text(ALIAS_NESTED_TSCN, encoding="utf-8")
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    (shared / "deep.tscn").write_text(ALIAS_DEEP_TSCN, encoding="utf-8")
     return tmp_path
 
 
@@ -730,16 +768,28 @@ def test_dependencies_keys_an_aliased_declaration_canonically(alias_project):
     }
 
     # The aliased [ext_resource] and the aliased preload both report the file the
-    # engine resolves, not the spelling the declaration used.
+    # engine resolves, not the spelling the declaration used. parent.tscn's second
+    # reference is spelled RELATIVE ("scenes/nested.tscn") and must be anchored to
+    # the declaring file's directory before it is canonicalized.
     assert by_source["res://parent.tscn"] == [
-        {"path": "res://leaf.tscn", "kind": "ext_resource"}
+        {"path": "res://leaf.tscn", "kind": "ext_resource"},
+        {"path": "res://scenes/nested.tscn", "kind": "ext_resource"},
+    ]
+    # The relative reference that ESCAPES its own directory, resolved from the
+    # declaring file rather than from the project root.
+    assert by_source["res://scenes/nested.tscn"] == [
+        {"path": "res://shared/deep.tscn", "kind": "ext_resource"}
     ]
     assert by_source["res://user.gd"] == [
         {"path": "res://helper.gd", "kind": "preload"}
     ]
-    # No graph node names a path that no file on disk answers to.
+    # No graph node names a path that no file on disk answers to. Both arms are
+    # load-bearing: `..` catches an unanchored `../shared/deep.tscn`, and the
+    # `res://` prefix catches an unanchored `scenes/nested.tscn`, which carries no
+    # `..` to be caught by.
     named = {dep["path"] for deps in by_source.values() for dep in deps}
     assert not any(".." in path.split("/") for path in named), named
+    assert all(path.startswith("res://") for path in named), named
 
 
 @pytest.mark.e2e
@@ -761,6 +811,40 @@ def test_find_references_matches_an_aliased_declaration_from_a_canonical_query(
     assert [
         (r["path"], r["kind"]) for r in json.loads(script.stdout)["references"]
     ] == [("res://user.gd", "preload")]
+
+
+@pytest.mark.e2e
+def test_find_references_matches_a_relative_declaration(alias_project):
+    # The reference is declared `../shared/deep.tscn` from res://scenes/nested.tscn;
+    # the engine loads res://shared/deep.tscn, so a query for that path must find
+    # the declaring site. Reported empty before the declaring file's directory was
+    # used to anchor the spelling.
+    deep = _gda(
+        alias_project, "project", "find-references", "res://shared/deep.tscn", "--json"
+    )
+    # And the prefix-less relative form, declared `scenes/nested.tscn` from the
+    # project root — a spelling with no `..` in it at all.
+    nested = _gda(
+        alias_project,
+        "project",
+        "find-references",
+        "res://scenes/nested.tscn",
+        "--json",
+    )
+
+    assert deep.returncode == 0, deep.stdout + deep.stderr
+    assert nested.returncode == 0, nested.stdout + nested.stderr
+    assert [(r["path"], r["kind"]) for r in json.loads(deep.stdout)["references"]] == [
+        ("res://scenes/nested.tscn", "ext_resource")
+    ]
+    assert [
+        (r["path"], r["kind"]) for r in json.loads(nested.stdout)["references"]
+    ] == [("res://parent.tscn", "ext_resource")]
+    # The context is the line as written, so the agent still sees the spelling it
+    # must edit — only the MATCHING is normalized.
+    assert (
+        '"../shared/deep.tscn"' in json.loads(deep.stdout)["references"][0]["context"]
+    )
 
 
 @pytest.mark.e2e
@@ -819,6 +903,11 @@ def test_find_unused_resources_never_lists_an_aliased_reference(alias_project):
     assert "res://parent.tscn" not in unused
     assert "res://hud.tscn" not in unused
     assert "res://icon.png" not in unused
+    # Same advice, reached through the RELATIVE spellings: nested.tscn is instanced
+    # by the main scene and deep.tscn by nested.tscn. Before the anchor, both were
+    # reported deletable — including a scene the project's own main scene loads.
+    assert "res://scenes/nested.tscn" not in unused
+    assert "res://shared/deep.tscn" not in unused
     # The report still works: the genuinely unreferenced resource is reported.
     assert "res://sub/orphan.tres" in unused
 


### PR DESCRIPTION
Closes #774

## What was wrong

The three project-analysis graph reads keyed their shared reference graph on the **raw spelling** each declaration used, while the walk that supplies the other side of every comparison builds its paths by joining directory entries — so the two sides could never meet on an aliased declaration.

Reproduced on this PR's base (`9122e03e`, Godot 4.6.3), a parent scene instancing `res://leaf.tscn` under the spelling `res://sub/../leaf.tscn`:

```
project dependencies       → parent depends_on "res://sub/../leaf.tscn"   (a node no file on disk answers to)
find-references res://leaf.tscn → references: []                          (the reference is real; the query never matches)
find-unused-resources      → unused: ["res://leaf.tscn"]                  (advises deleting a scene that is instanced)
```

## What changed

Every path that enters the graph — and the caller's query — now passes through `_canonical_resource_path`, the deep adapter the composed `scene validate` walk already uses (a direct `simplify_path()`, so it cannot drift from the engine). Both sides of every comparison carry one identity.

The harvest and query sites, all in `src/gda/ops/operations.gd`:

| site | was |
| --- | --- |
| `_ext_resource_paths` | appended the literal `path="…"` attribute |
| `_resolve_ref_path` | returned an already-prefixed reference unchanged |
| `_collect_references_from`'s `[ext_resource]` scan | compared the declared spelling |
| `_op_project_find_references`' `target_paths` seeding | used the caller's query verbatim |
| `_main_scene_path` / `_project_autoloads` | returned the literal `project.godot` value |

**The last row was not in the reported repro but carries the same defect on the project's entry points.** Reproduced separately: an aliased `run/main_scene="res://sub/../parent.tscn"` and an aliased autoload made `find-unused-resources` report the **main scene and the autoload scene themselves** as deletable, and `find-references res://parent.tscn` return empty. Same graph, same one-call fix, same destructive advice — so it is fixed here and red-proofed with the rest. The `*` enable marker comes off an autoload value **before** the fold: `simplify_path` does not recognize a scheme behind it and folds `*res://a/../b.gd` to the broken `*res:/b.gd` (measured on 4.6.3).

Two deliberate non-changes:

- The echoed `target` keeps the caller's own spelling — only the matching is canonical, and a `class_name` target is no path at all.
- `project statistics` reads the autoloads through the same accessor, so the paths it lists are canonical too. Identical output for any normally-spelled project; documented in the catalog.

**Scope boundary honored.** Identity only — the duplicated scene-text scans themselves are untouched; that is #775.

## Published contract

`docs/command-catalog.md`'s static-analysis section said nothing about spelling identity. It now states the alias-invariance as a contract: one graph node per file whatever a declaration spells it, matching in both directions, and the `target`-echo/`statistics` caveats. `SKILL.md` needed nothing — its `project` row is a bare command list, and the README rows are one-line descriptions that make no spelling claim.

## Stale comment corrected

The section note near `_op_project_find_references` named a `_scan_project` function that does not exist and claimed "All four share one reference graph". Both are now true: there are **two** walks (`_collect_resource_paths` and `_collect_all_file_paths`), and the graph is shared by **three** reads — `statistics` is not a graph read. The consistency claim itself is what this PR makes true again.

## Validation

Gates green on `a1297a33`:

- `uv run pytest -m "not e2e"` → **2238 passed**
- `uv run ruff check .` → clean · `uv run ruff format --check .` → clean · `uv run pyright` → **0 errors**

Real-engine e2e (Godot 4.6.3, macOS), 5 new tests in `tests/test_e2e_project_analysis.py` against one `alias_project` fixture whose references all name files the engine really resolves — only the spelling is aliased:

| test | covers |
| --- | --- |
| `test_dependencies_keys_an_aliased_declaration_canonically` | aliased `[ext_resource]` **and** aliased `preload` report the resolved path; no graph node names a `..` component |
| `test_find_references_matches_an_aliased_declaration_from_a_canonical_query` | direction 1, scene + script |
| `test_find_references_matches_a_canonical_declaration_from_an_aliased_query` | direction 2 |
| `test_find_references_matches_an_aliased_project_level_entry` | `project.godot` main scene + autoload |
| `test_find_unused_resources_never_lists_an_aliased_reference` | the instanced scene and both entry points are not listed; the real orphan still is; the unused ⇔ empty-find-references criterion still holds |

**Red-proofed**: with `src/gda/ops/operations.gd` reverted to the pre-fix source and the tests unchanged, all 5 fail. Pre-fix `find-unused-resources` returned `['res://canonical.tscn', 'res://hud.tscn', 'res://leaf.tscn', 'res://parent.tscn', 'res://sub/orphan.tres']` — the instanced scene, the autoload scene and the main scene all offered for deletion.

Regression sweep, run serially: `test_e2e_project_analysis` (20), plus `test_e2e_project`, `test_e2e_script`, `test_e2e_classname_resolution`, `test_e2e_scene_validate`, `test_e2e_scene` → **191 e2e passed**. That set covers every consumer of the five changed functions, including the script attach/save missing-dependency guard that shares `_resolve_ref_path`.
