### PR TITLE
fix(gda): one traversal for the four res:// walkers (#764)

### DIFF
--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -71,7 +71,12 @@ they are provenance, not status markers.
 
 **Enumeration** (established by #54): `scene list` walks the project's `res://`
 tree under the same exclusion rule `script list` states below, so the two see the
-same directories and differ only in the extension they collect (#712).
+same directories and differ only in the extension they collect (#712). Since #764 they
+run the same traversal too, and both match the extension **without regard to case**, as
+the engine does — a `Level.TSCN` is a scene to `ResourceLoader`, so `scene list` reports
+it. That case rule is new: the scene walk alone used to compare case-sensitively, which
+made `project statistics` count a `Level.TSCN` as a scene that `scene list` could not
+see.
 
 **Static instance reporting** (established by #400): `scene get` reads the stored
 `SceneState` without instantiating the host scene, but an instanced node is still
@@ -540,6 +545,12 @@ both static-analysis walks (the extension-filtered one behind `find-references`,
 `find-unused-resources` and the `class_name` index, and the unfiltered one `project statistics`
 counts with) — so one project cannot answer two ways. It once did: three of the four compared the
 directory NAME, so `script list` reported a script `project statistics` counted as zero (#712).
+Since #764 the four also share ONE traversal. The scaffolding around the exclusion rule had been
+copied per collector, and the copies drifted a second time — on the extension test, where the
+`scene list` walk alone compared case-sensitively — so each collector is now a single line: the
+shared traversal plus the acceptance test it passes. What they share is the traversal and the
+exclusion rule, **not** a file universe; the two static-analysis walks below still range over
+different files.
 `gda script delete`
 removes a script file and reports the removed script's `class_name`/`extends` (parsed before
 deletion), so the result names the content, not just the path. Delete honors the same addressing
@@ -886,7 +897,10 @@ Two static walks back these, over different file universes: `find-references`,
 creation resolves through) share the extension-filtered one, while `project statistics`
 counts with an unfiltered one that also sees `.import` sidecars and `project.godot` — so
 its file total does not reconcile with the others' candidate set. What is shared is the
-directory exclusion, the rule `script list` states above (#712).
+directory exclusion, the rule `script list` states above (#712), and since #764 the
+traversal itself: the two walks are one recursive walker asked two different acceptance
+questions. A shared traversal is not a shared universe — `project statistics` keeps
+counting the sidecars and the project file the other walk will never see.
 
 ---
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3919,20 +3919,30 @@ func _write_text_file(path: String, source: String, noun: String) -> bool:
 
 # --- project static-analysis reads (issue #116) -----------------------------
 #
-# Four read-only, project-wide reads, all backed by a SINGLE static project scan
-# (_scan_project). The scan reads files as TEXT — it parses each .tscn/.tres for
-# its [ext_resource path="..."] entries and each .gd for its preload/load/extends
-# references — and never instantiates a scene or loads/compiles a script (the
-# read trust boundary of issue #30). Reads still run under --project, so the
-# engine constructs the project's autoloads at startup before _initialize (the
-# residual project-code execution of issue #61); the scan itself adds none.
+# Four read-only, project-wide reads, backed by TWO static scans over different
+# file universes. find-references, dependencies and find-unused-resources share
+# the extension-filtered scan (_collect_resource_paths); statistics counts with
+# the unfiltered one (_collect_all_file_paths), which also sees the .import
+# sidecars and project.godot the other excludes — so its file total does not
+# reconcile with the others' candidate set. The two scans share one traversal
+# (_collect_paths) and one directory-exclusion rule (_should_descend), which is
+# what keeps them from disagreeing about the TREE while ranging over different
+# files within it.
 #
-# All four share one reference graph so they stay consistent (acceptance
-# criterion): find-references reports the incoming references of one target;
-# dependencies reports the outgoing references of every scene/resource;
+# Both scans read files as TEXT — parsing each .tscn/.tres for its
+# [ext_resource path="..."] entries and each .gd for its preload/load/extends
+# references — and never instantiate a scene or load/compile a script (the read
+# trust boundary of issue #30). Reads still run under --project, so the engine
+# constructs the project's autoloads at startup before _initialize (the residual
+# project-code execution of issue #61); the scans themselves add none.
+#
+# The THREE reference-graph reads share one graph so they stay consistent
+# (acceptance criterion): find-references reports the incoming references of one
+# target; dependencies reports the outgoing references of every scene/resource;
 # find-unused-resources reports the resources with no incoming reference (and not
 # an entry point). A resource is "unused" exactly when find-references for it
-# would return empty — the same graph, one truth.
+# would return empty — the same graph, one truth. statistics is not on that graph:
+# it only counts what its own scan reaches.
 
 
 # project-find-references: find every project file that references the target — a
@@ -4172,8 +4182,9 @@ func _resolve_project_class_script(class_token: String) -> Dictionary:
 
 # Build (once per process) the class_name → declaring-.gd-paths index for the
 # resolver's tier-3 static scan (ADR-0032). Walks the full res:// tree skipping
-# the root cache — reusing the shared recursive walker (_collect_resource_paths,
-# which already enumerates .gd among the graph resources) — and parses each .gd's
+# the root cache — reusing the extension-filtered collector
+# (_collect_resource_paths, which already enumerates .gd among the graph
+# resources) — and parses each .gd's
 # class_name from raw source with the existing never-compiled parser
 # (_script_metadata). A class_name declared in more than one .gd maps to multiple
 # paths (sorted, so an ambiguous_class_name error is deterministic regardless of
@@ -4237,51 +4248,71 @@ func _should_descend(child: String) -> bool:
 	return child != ENGINE_CACHE_DIR
 
 
+# The ONE res:// traversal (#764). Open the directory, enumerate hidden entries,
+# loop, ask _should_descend about each child DIRECTORY, and close the listing —
+# the scaffolding that used to be copied into all four collectors below, where
+# the copies were free to drift and one pair already had (see
+# _collect_scene_paths). `accept` is the only thing a caller varies: it is asked
+# about each FILE and decides whether the walk collects it, so the four
+# collectors differ in exactly that predicate and in nothing else.
+#
+# The collectors share this TRAVERSAL, not a file universe. `accept` is what makes
+# _collect_all_file_paths count the import sidecars and project.godot that
+# _collect_resource_paths excludes: one traversal, one exclusion rule, different
+# universes.
+#
+# Navigational entries ('.', '..') stay off, so the recursion cannot loop back on
+# itself (issue #54 review). Hidden entries are enumerated, so a .hidden.tscn, or
+# any file under a dot-prefixed directory, is collected as promised — the dot
+# prefix is not the exclusion test, _should_descend is, and that decision stays
+# its alone (#712).
+#
+# `accept` is asked about the full res:// child path, not the bare entry name: it
+# is the shape the predicates the collectors reuse (_is_scene_path,
+# _is_script_path, _is_graph_resource_path) are written against. The two agree on
+# the extension anyway — String.get_extension() stops at the last '/', so a file
+# with no extension under a dotted directory (res://a.b/README) answers "" either
+# way — but only the full path can carry a test that looks at the directory too.
+func _collect_paths(dir_path: String, accept: Callable, out: Array[String]) -> void:
+	var dir := DirAccess.open(dir_path)
+	if dir == null:
+		return
+	dir.include_hidden = true
+	dir.list_dir_begin()
+	var entry := dir.get_next()
+	while not entry.is_empty():
+		var child := dir_path.path_join(entry)
+		if dir.current_is_dir():
+			if _should_descend(child):
+				_collect_paths(child, accept, out)
+		elif accept.call(child):
+			out.append(child)
+		entry = dir.get_next()
+	dir.list_dir_end()
+
+
+# The unfiltered acceptance test: every file the traversal reaches (#764). A named
+# predicate rather than an inline lambda, so the statistics walk reads as the same
+# one-line shape as the other three collectors and its universe has a name.
+func _accept_any_file(_path: String) -> bool:
+	return true
+
+
 # Recursively collect every RESOURCE-bearing file under res:// — the files that
 # can carry references (.tscn/.tres scenes & resources, .gd scripts) AND the leaf
 # asset resources (everything else except import sidecars, the project file, and
-# the .godot cache). Mirrors _collect_scene_paths: hidden entries enumerated,
-# navigational entries off, directory descent decided by _should_descend. This is
-# the universe the reference graph, find-unused and the class_name index range
-# over.
+# the .godot cache). This is the universe the reference graph, find-unused and the
+# class_name index range over.
 func _collect_resource_paths(dir_path: String, out: Array[String]) -> void:
-	var dir := DirAccess.open(dir_path)
-	if dir == null:
-		return
-	dir.include_hidden = true
-	dir.list_dir_begin()
-	var entry := dir.get_next()
-	while not entry.is_empty():
-		var child := dir_path.path_join(entry)
-		if dir.current_is_dir():
-			if _should_descend(child):
-				_collect_resource_paths(child, out)
-		elif _is_graph_resource_path(child):
-			out.append(child)
-		entry = dir.get_next()
-	dir.list_dir_end()
+	_collect_paths(dir_path, _is_graph_resource_path, out)
 
 
-# Recursively collect EVERY file under res:// (descending per _should_descend)
-# for the statistics counts — unlike _collect_resource_paths this keeps import
-# sidecars, project.godot and every asset, since statistics counts all files. The
-# two walks therefore range over DIFFERENT universes under the same exclusion.
+# Recursively collect EVERY file under res:// for the statistics counts — unlike
+# _collect_resource_paths this keeps import sidecars, project.godot and every
+# asset, since statistics counts all files. The two walks therefore range over
+# DIFFERENT universes under the same traversal and the same exclusion.
 func _collect_all_file_paths(dir_path: String, out: Array[String]) -> void:
-	var dir := DirAccess.open(dir_path)
-	if dir == null:
-		return
-	dir.include_hidden = true
-	dir.list_dir_begin()
-	var entry := dir.get_next()
-	while not entry.is_empty():
-		var child := dir_path.path_join(entry)
-		if dir.current_is_dir():
-			if _should_descend(child):
-				_collect_all_file_paths(child, out)
-		else:
-			out.append(child)
-		entry = dir.get_next()
-	dir.list_dir_end()
+	_collect_paths(dir_path, _accept_any_file, out)
 
 
 # Whether a path names a file the reference graph / find-unused treat as a
@@ -4656,10 +4687,15 @@ func _is_class_name_declaration_of(line: String, target_class: String) -> bool:
 
 
 # Whether a path names a scene file in the TEXT form gda authors and reads: a
-# .tscn. Only scene-validate asks, because it is the only op whose answer comes
-# from the file's own text rather than from the loaded resource — see the refusal
-# it raises. Every other scene op keys on loadability instead, so a .scn that
-# loads is served there as before.
+# .tscn. Two callers ask. scene-validate asks because it is the only op whose
+# answer comes from the file's own text rather than from the loaded resource —
+# see the refusal it raises. The scene walk asks because it lists exactly that
+# universe, and reusing this predicate is what keeps the listing and the refusal
+# from disagreeing about what a scene file is (#764). Every other scene op keys on
+# loadability instead, so a .scn that loads is served there as before.
+#
+# The comparison is case-insensitive because the engine's own recognition is:
+# ResourceFormatLoader::recognize_path matches the extension with nocasecmp_to.
 func _is_scene_path(path: String) -> bool:
 	return path.get_extension().to_lower() == "tscn"
 
@@ -4785,30 +4821,24 @@ func _has_project() -> bool:
 	return DirAccess.dir_exists_absolute("res://") and FileAccess.file_exists("res://project.godot")
 
 
-# Recursively collect every .tscn under res:// (issue #54), descending per
-# _should_descend. The dot prefix is not part of that test, so a legitimately
-# hidden scene (a .hidden.tscn, or one under a dot-prefixed directory) is
-# enumerated as promised (issue #54 review). Paths are returned as res:// paths
-# so they round-trip into other scene commands.
+# Recursively collect every .tscn under res:// (issue #54) over the shared
+# traversal, which enumerates hidden entries and asks _should_descend about every
+# directory. Paths are returned as res:// paths so they round-trip into other
+# scene commands.
+#
+# The acceptance test is _is_scene_path, so the extension is matched WITHOUT
+# regard to case. It used to be matched case-sensitively here and only here, and
+# that made one project answer two ways: `project statistics` counted a Level.TSCN
+# as a scene (it lowercases the extension before classifying) while `scene list`
+# could not see it at all. The engine is the arbiter and it is case-insensitive —
+# ResourceFormatLoader::recognize_path compares the extension with nocasecmp_to
+# (core/io/resource_loader.cpp), ResourceSaver does the same, and the editor's own
+# filesystem scan lowercases every extension before classifying it
+# (editor/file_system/editor_file_system.cpp). A Level.TSCN IS a scene to Godot,
+# so `scene list` now reports it; that listing is the one output this change grew
+# (#764).
 func _collect_scene_paths(dir_path: String, out: Array[String]) -> void:
-	var dir := DirAccess.open(dir_path)
-	if dir == null:
-		return
-	# Hidden entries are off by default; enable them so a .hidden.tscn or a scene
-	# under a dot-prefixed directory is enumerated. Navigational entries ('.',
-	# '..') stay off, so recursion cannot loop back on itself (issue #54 review).
-	dir.include_hidden = true
-	dir.list_dir_begin()
-	var entry := dir.get_next()
-	while not entry.is_empty():
-		var child := dir_path.path_join(entry)
-		if dir.current_is_dir():
-			if _should_descend(child):
-				_collect_scene_paths(child, out)
-		elif entry.get_extension() == "tscn":
-			out.append(child)
-		entry = dir.get_next()
-	dir.list_dir_end()
+	_collect_paths(dir_path, _is_scene_path, out)
 
 
 # Summarize one .tscn for the listing: its path plus the root node's name/type
@@ -4837,26 +4867,14 @@ func _scene_summary(path: String) -> Dictionary:
 	}
 
 
-# Recursively collect every .gd script under res:// (issue #117), descending per
-# _should_descend. Hidden entries are enumerated (a .hidden.gd, or a script under
-# a dot-prefixed directory) and navigational entries stay off. Paths are returned
-# as res:// paths so they round-trip into other script commands.
+# Recursively collect every .gd script under res:// (issue #117) over the shared
+# traversal, which enumerates hidden entries (a .hidden.gd, or a script under a
+# dot-prefixed directory) and asks _should_descend about every directory. Paths
+# are returned as res:// paths so they round-trip into other script commands. The
+# acceptance test is _is_script_path — the same predicate the script group's
+# addressing boundary uses, case-insensitive as the engine is.
 func _collect_script_paths(dir_path: String, out: Array[String]) -> void:
-	var dir := DirAccess.open(dir_path)
-	if dir == null:
-		return
-	dir.include_hidden = true
-	dir.list_dir_begin()
-	var entry := dir.get_next()
-	while not entry.is_empty():
-		var child := dir_path.path_join(entry)
-		if dir.current_is_dir():
-			if _should_descend(child):
-				_collect_script_paths(child, out)
-		elif entry.get_extension().to_lower() == "gd":
-			out.append(child)
-		entry = dir.get_next()
-	dir.list_dir_end()
+	_collect_paths(dir_path, _is_script_path, out)
 
 
 # Summarize one .gd for the listing: its path plus the class_name/extends parsed

--- a/tests/test_e2e_project_walk.py
+++ b/tests/test_e2e_project_walk.py
@@ -1,0 +1,144 @@
+"""S1 (e2e): the shared ``res://`` walk's two behavioural contracts (#764).
+
+The four project-wide collectors in ``operations.gd`` run ONE traversal. These
+tests pin the two things that consolidation had to decide or preserve, against a
+real engine:
+
+* **The acceptance test is case-insensitive.** The scene walk used to compare the
+  extension as written while the script walk lowercased it, so a ``Level.TSCN``
+  counted as a scene in ``project statistics`` (which lowercases) and was
+  invisible to ``scene list``. The engine is the arbiter and is case-insensitive
+  — ``ResourceFormatLoader::recognize_path`` matches the extension with
+  ``nocasecmp_to`` — so the listings match it, and ``scene list`` grew that entry.
+* **The two file universes survive.** A shared traversal is not a shared
+  universe: ``project statistics`` must keep counting the ``.import`` sidecars and
+  ``project.godot`` that the extension-filtered walk behind ``dependencies`` /
+  ``find-unused-resources`` excludes.
+"""
+
+import json
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+from .conftest import project_godot
+from tests.support import GDA_CMD
+
+GODOT = resolve_godot_binary()
+
+PROJECT_GODOT = project_godot(name="gda-walk-fixture")
+
+# Two scenes and two scripts, one of each written with an UPPERCASE extension.
+# The base names differ so the fixture is also valid on a case-insensitive
+# filesystem (macOS APFS preserves case but would collapse main.tscn/MAIN.TSCN).
+MAIN_TSCN = """\
+[gd_scene format=3]
+
+[node name="Main" type="Node2D"]
+"""
+
+LEVEL_TSCN = """\
+[gd_scene format=3]
+
+[node name="Level" type="Node3D"]
+"""
+
+HELPER_GD = """\
+extends RefCounted
+"""
+
+WIDGET_GD = """\
+extends Node
+"""
+
+# An import sidecar for a leaf asset — the engine's own bookkeeping, in the
+# unfiltered universe only.
+ICON_IMPORT = """\
+[remap]
+
+importer="texture"
+type="CompressedTexture2D"
+"""
+
+
+@pytest.fixture
+def walk_project(tmp_path):
+    """A project holding both extension cases and both file universes."""
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "Level.TSCN").write_text(LEVEL_TSCN, encoding="utf-8")
+    (tmp_path / "helper.gd").write_text(HELPER_GD, encoding="utf-8")
+    (tmp_path / "Widget.GD").write_text(WIDGET_GD, encoding="utf-8")
+    (tmp_path / "icon.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+    (tmp_path / "icon.png.import").write_text(ICON_IMPORT, encoding="utf-8")
+    return tmp_path
+
+
+def _gda(project, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _result(project, *args: str) -> dict:
+    proc = _gda(project, *args, "--json")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    return json.loads(proc.stdout)
+
+
+@pytest.mark.e2e
+def test_the_listings_accept_an_extension_in_any_case_as_the_engine_does(walk_project):
+    # AC2 (#764): the case-sensitivity drift is resolved case-INSENSITIVELY, on
+    # both sides. `Level.TSCN` is a scene to the engine (it loads as a
+    # PackedScene, reported below through root_type) so `scene list` reports it;
+    # `Widget.GD` was already accepted by the script walk and stays accepted.
+    scenes = {s["path"]: s for s in _result(walk_project, "scene", "list")["scenes"]}
+    scripts = {s["path"] for s in _result(walk_project, "script", "list")["scripts"]}
+
+    assert set(scenes) == {"res://main.tscn", "res://Level.TSCN"}
+    assert scripts == {"res://helper.gd", "res://Widget.GD"}
+
+    # The engine really reads the uppercase file AS a scene — the listing is not
+    # reporting a path it could not load.
+    assert scenes["res://Level.TSCN"]["root_type"] == "Node3D"
+
+    # And the two ends now agree, which is the point: `project statistics`
+    # classifies by a lowercased extension, so its counts match the listings.
+    # Before this change it counted a scene `scene list` could not see (#712's
+    # failure shape, on the acceptance test instead of the descent decision).
+    stats = _result(walk_project, "project", "statistics")
+    assert stats["scene_count"] == len(scenes)
+    assert stats["script_count"] == len(scripts)
+
+
+@pytest.mark.e2e
+def test_the_two_file_universes_survive_the_shared_traversal(walk_project):
+    # AC4 (#764): one traversal, two universes. `project statistics` counts every
+    # file it reaches — including the `.import` sidecar and `project.godot` — while
+    # the extension-filtered walk behind the reference graph excludes exactly
+    # those, and still sees the leaf asset beside them.
+    stats = _result(walk_project, "project", "statistics")
+    by_ext = {e["extension"]: e["files"] for e in stats["by_extension"]}
+
+    assert by_ext.get("import") == 1, by_ext  # icon.png.import
+    assert by_ext.get("godot") == 1, by_ext  # project.godot
+    assert stats["total_files"] == sum(by_ext.values())
+
+    # The filtered universe: the sidecar and the project file are not resources,
+    # so they are neither unused-resource candidates nor dependency sources...
+    unused = set(_result(walk_project, "project", "find-unused-resources")["unused"])
+    sources = {
+        d["path"]
+        for d in _result(walk_project, "project", "dependencies")["dependencies"]
+    }
+    excluded = {"res://icon.png.import", "res://project.godot"}
+    assert not (unused & excluded), unused
+    assert not (sources & excluded), sources
+
+    # ...while the leaf asset sitting right next to the sidecar still is one, so
+    # the exclusion is the acceptance test's, not an emptied walk.
+    assert "res://icon.png" in unused

--- a/tests/test_project_walk.py
+++ b/tests/test_project_walk.py
@@ -1,0 +1,134 @@
+"""The ``res://`` walk contract: one traversal, four collectors (#764).
+
+``operations.gd`` walks the project's ``res://`` tree for four purposes —
+``scene list``, ``script list``, the extension-filtered static-analysis scan,
+and the unfiltered count behind ``project statistics``. The ``DirAccess``
+scaffolding around that walk used to be copied once per purpose, and the copies
+drifted twice: first on the directory-exclusion decision (#712), then on the
+file-acceptance test, where the scene walk alone compared the extension
+case-sensitively.
+
+These are the source-level guards for the consolidation. The BEHAVIOUR they
+protect — the case rule and the two surviving file universes — is pinned against
+a real engine in ``test_e2e_project_walk.py``.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OPERATIONS_GD = ROOT / "src" / "gda" / "ops" / "operations.gd"
+
+# The four collectors, each of which must be a single delegation to the traversal.
+COLLECTORS = (
+    "_collect_resource_paths",
+    "_collect_all_file_paths",
+    "_collect_scene_paths",
+    "_collect_script_paths",
+)
+
+# The traversal they share, and the DirAccess call only it may make.
+TRAVERSAL = "_collect_paths"
+LISTING_CALL = "list_dir_begin()"
+
+# The section note that documents the two static scans over the one traversal.
+SECTION_HEADER = "# --- project static-analysis reads (issue #116) ---"
+
+# A gda helper named in prose: a ``_``-prefixed identifier that is not the tail of
+# a longer word, so ``ext_resource`` does not read as a mention of ``_resource``.
+HELPER_MENTION = re.compile(r"(?<![A-Za-z0-9_])_[a-z][A-Za-z0-9_]*")
+
+
+def _source() -> str:
+    return OPERATIONS_GD.read_text(encoding="utf-8")
+
+
+def _function_body(source: str, name: str) -> list[str]:
+    """The statement lines of top-level ``func name(...)`` — comments dropped."""
+    lines = source.splitlines()
+    start = next(
+        (i for i, line in enumerate(lines) if line.startswith(f"func {name}(")), None
+    )
+    assert start is not None, f"expected function {name} in operations.gd"
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if line and not line.startswith(("\t", " ")):
+            break  # back at column 0: the function ended
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            body.append(stripped)
+    return body
+
+
+def _comment_block(source: str, header: str) -> list[str]:
+    """The run of comment lines starting at the line that opens with ``header``."""
+    lines = source.splitlines()
+    start = next((i for i, line in enumerate(lines) if line.startswith(header)), None)
+    assert start is not None, f"expected the comment block opening with {header!r}"
+    block: list[str] = []
+    for line in lines[start:]:
+        if not line.startswith("#"):
+            break
+        block.append(line)
+    return block
+
+
+def test_the_four_res_collectors_share_one_traversal():
+    # AC1 (#764): ONE traversal implementation. The DirAccess scaffolding exists
+    # exactly once in the payload, inside the shared walker; each collector is a
+    # single delegation to it and differs only in the acceptance test it passes.
+    source = _source()
+
+    copies = source.count(LISTING_CALL)
+    assert copies == 1, (
+        f"the res:// listing scaffolding must live only in {TRAVERSAL}; "
+        f"found {copies} copies of {LISTING_CALL}"
+    )
+    assert LISTING_CALL in "\n".join(_function_body(source, TRAVERSAL)), (
+        f"{TRAVERSAL} must be the function that holds the listing scaffolding"
+    )
+
+    accepts: dict[str, str] = {}
+    for name in COLLECTORS:
+        body = _function_body(source, name)
+        assert len(body) == 1, f"{name} must be one delegating line, got {body}"
+        call = re.fullmatch(
+            rf"{TRAVERSAL}\(\w+, (?P<accept>_[A-Za-z0-9_]+), \w+\)", body[0]
+        )
+        assert call, f"{name} must delegate to {TRAVERSAL}, got {body[0]!r}"
+        accepts[name] = call.group("accept")
+
+    # The acceptance test is the one thing they vary — four distinct predicates,
+    # each a function this file defines.
+    assert len(set(accepts.values())) == len(COLLECTORS), (
+        f"each collector must pass its own acceptance test, got {accepts}"
+    )
+    for name, accept in accepts.items():
+        assert f"func {accept}(" in source, f"{name} passes undefined {accept}"
+
+
+def test_the_static_analysis_note_names_only_helpers_that_exist():
+    # AC5 (#764): the section note used to claim a SINGLE static project scan
+    # performed by a helper named `_scan_project` — a function this file has
+    # never defined. It now describes the two scans and the traversal they share,
+    # and every gda helper it names must be a function that actually exists, so
+    # the correction cannot rot back into a phantom.
+    source = _source()
+    defined = set(re.findall(r"^func (_[A-Za-z0-9_]+)\(", source, re.MULTILINE))
+
+    assert "_scan_project" not in source, (
+        "operations.gd names _scan_project, which no function defines"
+    )
+
+    note = _comment_block(source, SECTION_HEADER)
+    mentioned = {token for line in note for token in HELPER_MENTION.findall(line)}
+    assert mentioned, "the section note must name the helpers it describes"
+    undefined = sorted(mentioned - defined)
+    assert not undefined, f"the section note names undefined helpers: {undefined}"
+
+    # The corrected fact itself: two scans over different universes, one traversal.
+    assert {
+        "_collect_resource_paths",
+        "_collect_all_file_paths",
+        TRAVERSAL,
+    } <= mentioned


### PR DESCRIPTION
## What

`operations.gd` held four recursive `res://` walkers that were 15-line clones of one another —
open, null-check, enable hidden entries, begin the listing, loop, ask `_should_descend`, advance,
end the listing — differing in exactly one thing: the test that decides whether a FILE is
collected.

They now share ONE traversal, `_collect_paths(dir_path, accept, out)`, which takes the
file-acceptance test as a `Callable`. Each collector is a single delegating line naming its
predicate:

| Collector | Acceptance test | Feeds |
| --- | --- | --- |
| `_collect_resource_paths` | `_is_graph_resource_path` | `find-references`, `dependencies`, `find-unused-resources`, the `class_name` index |
| `_collect_all_file_paths` | `_accept_any_file` | `project statistics` |
| `_collect_scene_paths` | `_is_scene_path` | `scene list` |
| `_collect_script_paths` | `_is_script_path` | `script list`, `script validate --all` |

`_should_descend` keeps its single ownership of the exclusion decision (#712) and is untouched —
this change unifies the *scaffolding* that #712 left copied, not the decision.

## The case-sensitivity decision: case-INSENSITIVE, on both sides

The duplication had already produced a second drift. `_collect_scene_paths` compared
`entry.get_extension() == "tscn"` — the only case-SENSITIVE extension test in the file; every
other one (`_is_scene_path`, `_is_script_path`, `_is_graph_resource_path`, the `project
statistics` classifier) lowercases first. So a `Level.TSCN` counted as a scene in `project
statistics` and was invisible to `scene list`: one project answering two ways, the #712 failure
shape moved from the descent decision onto the acceptance test.

**The engine is the arbiter, and it is case-insensitive.** Verified in the engine source at
`070dc9897e`:

- `core/io/resource_loader.cpp:77` — `ResourceFormatLoader::recognize_path` matches a candidate
  extension with `p_path.right(ext.length()).nocasecmp_to(ext) == 0`.
- `core/io/resource_saver.cpp:86` — `ResourceSaver` recognizes the save extension with
  `nocasecmp_to` too.
- `editor/file_system/editor_file_system.cpp:293, 374, 1241, 1512` — every scan lowercases
  `scan_file.get_extension()` before classifying the file.

Confirmed behaviourally in the new e2e: the engine loads `res://Level.TSCN` as a `PackedScene`
(`scene list` reports its `root_type: "Node3D"`), so it *is* a scene to Godot.

**Output change:** exactly one listing grows. `gda scene list` now reports a scene saved under an
uppercase extension (`Level.TSCN`), which it previously dropped, and its count now agrees with
`project statistics`' `scene_count`. `script list` is unchanged (already case-insensitive); no
other consumer's results change.

## A shared traversal is not a shared universe

`project statistics` keeps counting the `.import` sidecars and `project.godot` that the
extension-filtered walk excludes. That distinction now lives entirely in the acceptance test, and
is pinned by a dedicated e2e (red-proofed by collapsing the statistics walk onto the filtered
predicate).

## Stale comment corrected

The `project static-analysis reads` section note claimed a **SINGLE** static project scan
performed by `_scan_project` — a helper this file has never defined — and that "all four share one
reference graph", which is wrong for `statistics` (it counts; it is not on the graph). Replaced
with the two-scan reality: two universes, one traversal, one exclusion rule, three
reference-graph reads.

## Contract docs

`docs/command-catalog.md` is updated in this slice (code and its published contract land
together): the `scene list` enumeration paragraph now states the case rule and the output change,
the `script list` walk-rule paragraph records the second drift and the consolidation, and the
static-analysis paragraph adds the shared traversal while keeping the two universes explicit.
#760 rebases its exclusion-passage sentence onto these.

## Acceptance tests (all red-proofed)

| AC | Test | Red-proof |
| --- | --- | --- |
| 1 — one traversal | `tests/test_project_walk.py::test_the_four_res_collectors_share_one_traversal` | fails on the pre-change source (4 copies of `list_dir_begin()`) |
| 2 — case drift resolved | `tests/test_e2e_project_walk.py::test_the_listings_accept_an_extension_in_any_case_as_the_engine_does` | fails on the pre-change source (`scene list` misses `res://Level.TSCN`) |
| 4 — two universes survive | `tests/test_e2e_project_walk.py::test_the_two_file_universes_survive_the_shared_traversal` | mutation: point `_collect_all_file_paths` at `_is_graph_resource_path` → the `import`/`godot` extension counts vanish |
| 5 — stale note corrected | `tests/test_project_walk.py::test_the_static_analysis_note_names_only_helpers_that_exist` | fails on the pre-change source (`_scan_project` named, never defined) |

AC 3 (every consumer keeps its current results) is carried by the existing e2e coverage, re-run
below.

## Validation

- `pytest -m "not e2e"` — 2240 passed
- `ruff check .` / `ruff format --check .` / `pyright` — clean (0 errors)
- Targeted real-engine e2e (Godot 4.6.3, macOS), all green:
  - `test_e2e_project_analysis.py` + `test_e2e_project_walk.py` — 17 passed (`statistics`,
    `dependencies`, `find-references`, `find-unused-resources`)
  - `test_e2e_scene.py` — 23 passed (`scene list`, incl. the dot-prefixed / cache-exclusion cases)
  - `test_e2e_script.py` + `test_e2e_classname_resolution.py` — 81 passed (`script list`,
    `script validate --all`, the `class_name` index)
  - `test_e2e_scene_validate.py` — 41 passed (the other `_is_scene_path` caller)

## Not changed

ADR-0032's #712 amendment still describes the descent decision accurately ("all four `res://`
collectors", one predicate); the traversal consolidation is an implementation fact and lives in
the command catalog, not the ADR.

Closes #764
