### PR TITLE
feat(gda): accept --json on every command group (#683)

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,7 +643,7 @@ input event.
 
 | Flag       | Description                                                          |
 | ---------- | ------------------------------------------------------------------- |
-| `--json`    | Emit the result as a single JSON object on stdout. Without it, commands print a concise human-readable rendering. Also accepted at the root: `gda --json <group> <command>` means the same as passing it after the command. |
+| `--json`    | Emit the result as a single JSON object on stdout. Without it, commands print a concise human-readable rendering. Accepted before the command too: `gda --json <group> <command>` and `gda <group> --json <command>` mean the same as passing it after the command. |
 | `--schema`  | Emit the command's input/output JSON Schema contract (no Godot spawned). |
 | `--godot`   | Path to the Godot binary (overrides `$GDA_GODOT` and the default). |
 | `--project` | Godot project directory for `res://` resolution (overrides `$GDA_PROJECT`; defaults to the current directory if it is a project). Domain commands only. Resolving a project runs that project's code — see [Project code execution](#configuration). |

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=76e086abf7307138e3a741e6d89aadab413f83570ffdb2a2ad8da2e34e2b992a -->
+<!-- gda-readme-i18n: source=README.md sha256=ff68f26d3fed2c1ef1d07cfd235ba93a282a5a9a6aecb560c6858a90794343e3 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -660,7 +660,7 @@ de entrada.
 
 | Flag       | Descripción                                                        |
 | ---------- | ------------------------------------------------------------------- |
-| `--json`    | Emite el resultado como un único objeto JSON en stdout. Sin él, los comandos imprimen una representación concisa y legible para humanos. También se acepta en la raíz: `gda --json <group> <command>` significa lo mismo que pasarlo después del comando. |
+| `--json`    | Emite el resultado como un único objeto JSON en stdout. Sin él, los comandos imprimen una representación concisa y legible para humanos. También se acepta antes del comando: `gda --json <group> <command>` y `gda <group> --json <command>` significan lo mismo que pasarlo después del comando. |
 | `--schema`  | Emite el contrato JSON Schema de entrada/salida del comando (sin lanzar Godot). |
 | `--godot`   | Ruta al binario de Godot (anula `$GDA_GODOT` y el valor por defecto). |
 | `--project` | Directorio del proyecto de Godot para la resolución de `res://` (anula `$GDA_PROJECT`; por defecto, el directorio actual si es un proyecto). Solo comandos de dominio. Resolver un proyecto ejecuta el código de ese proyecto — consulta [Ejecución del código del proyecto](#configuration). |

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=76e086abf7307138e3a741e6d89aadab413f83570ffdb2a2ad8da2e34e2b992a -->
+<!-- gda-readme-i18n: source=README.md sha256=ff68f26d3fed2c1ef1d07cfd235ba93a282a5a9a6aecb560c6858a90794343e3 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -651,7 +651,7 @@ Godot は daemon セッション内で `get_mouse_position()` /
 
 | フラグ       | 説明                                                          |
 | ---------- | ------------------------------------------------------------------- |
-| `--json`    | 結果を stdout に単一の JSON オブジェクトとして出力します。指定しない場合、コマンドは簡潔な人間可読のレンダリングを出力します。ルートでも受け付けます: `gda --json <group> <command>` はコマンドの後ろに付けた場合と同じ意味です。 |
+| `--json`    | 結果を stdout に単一の JSON オブジェクトとして出力します。指定しない場合、コマンドは簡潔な人間可読のレンダリングを出力します。コマンドの前でも受け付けます: `gda --json <group> <command>` と `gda <group> --json <command>` はコマンドの後ろに付けた場合と同じ意味です。 |
 | `--schema`  | コマンドの入出力 JSON Schema 契約を出力します(Godot は起動されません)。 |
 | `--godot`   | Godot バイナリへのパス(`$GDA_GODOT` とデフォルトを上書きします)。 |
 | `--project` | `res://` 解決のための Godot プロジェクトディレクトリ(`$GDA_PROJECT` を上書き。プロジェクトであればカレントディレクトリがデフォルト)。ドメインコマンドのみ。プロジェクトの解決はそのプロジェクトのコードを実行します — [プロジェクトコードの実行](#configuration) を参照してください。 |

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=76e086abf7307138e3a741e6d89aadab413f83570ffdb2a2ad8da2e34e2b992a -->
+<!-- gda-readme-i18n: source=README.md sha256=ff68f26d3fed2c1ef1d07cfd235ba93a282a5a9a6aecb560c6858a90794343e3 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -612,7 +612,7 @@ Live `game set --property position` 遵循与 `node set` 相同的 `Control` 策
 
 | Flag       | 说明                                                               |
 | ---------- | ------------------------------------------------------------------- |
-| `--json`    | 在 stdout 上把结果作为单个 JSON 对象输出。不加它时，命令会打印一份简洁的、供人阅读的渲染结果。根级同样接受该 flag：`gda --json <group> <command>` 与写在命令之后含义相同。 |
+| `--json`    | 在 stdout 上把结果作为单个 JSON 对象输出。不加它时，命令会打印一份简洁的、供人阅读的渲染结果。命令之前同样接受该 flag：`gda --json <group> <command>` 与 `gda <group> --json <command>` 都与写在命令之后含义相同。 |
 | `--schema`  | 输出该命令的输入/输出 JSON Schema 契约（不会启动 Godot）。 |
 | `--godot`   | Godot 二进制文件的路径（覆盖 `$GDA_GODOT` 和默认值）。 |
 | `--project` | 用于 `res://` 解析的 Godot 项目目录（覆盖 `$GDA_PROJECT`；若当前目录本身是个项目则默认用它）。仅限领域命令。解析一个项目会运行该项目的代码——参见[项目代码执行](#configuration)。 |

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -37,7 +37,7 @@ from gda.commands import (
     theme as theme_commands,
 )
 from gda import hints
-from gda.headless import root_json, set_root_json
+from gda.headless import adopt_group_json, ancestor_json, set_ancestor_json
 from gda.provenance import build_version_provenance, render_version_line
 from gda.runner import USER_DATA_ROOT_ENV, set_user_data_root
 
@@ -87,9 +87,9 @@ def _record_root_json(ctx: typer.Context, value: bool) -> bool:
     Recorded from the option's OWN callback rather than the group-callback body so
     the value is in place before any other root option is processed — which is what
     lets ``--version`` below render either form (#659). How the value travels is the
-    option layer's contract (``gda.headless.set_root_json``), not this module's.
+    option layer's contract (``gda.headless.set_ancestor_json``), not this module's.
     """
-    set_root_json(ctx, value)
+    set_ancestor_json(ctx, value)
     return value
 
 
@@ -103,7 +103,7 @@ def _version_callback(ctx: typer.Context, value: Optional[bool]) -> None:
     """
     if not value or ctx.resilient_parsing:
         return
-    if root_json(ctx):
+    if ancestor_json(ctx):
         typer.echo(build_version_provenance().model_dump_json())
     else:
         typer.echo(render_version_line())
@@ -161,12 +161,13 @@ def main(
     #
     # `--json` is accepted here so the ONE documented rule an agent follows —
     # "always pass --json" — never dies with exit 2 on the discovery surface
-    # (`gda --json --help`, `gda --json <group> <command> …`, #671). It is NOT
+    # (`gda --json --help`, `gda --json <group> <command> …`, #671); every group
+    # takes it for the same reason (`adopt_group_json` below, #683). It is NOT
     # inert: handing it to the shared option layer makes the invoked command's own
-    # `--json` inherit it, so the root and post-command spellings mean the same
-    # thing — accepting a flag that silently returned human text would be worse than
-    # the loud usage error it replaced. The --json hand-over happens in the
-    # option's own callback (`_record_root_json`), so it needs no line here.
+    # `--json` inherit it, so all three spellings mean the same thing — accepting a
+    # flag that silently returned human text would be worse than the loud usage
+    # error it replaced. The --json hand-over happens in the option's own callback
+    # (`_record_root_json`), so it needs no line here.
     # `--user-data-root` is a root option because it is process-wide ENVIRONMENT
     # placement, not an operation parameter: it applies to whichever command runs,
     # on every channel that spawns an engine, and the runner reads it there (#653).
@@ -175,6 +176,13 @@ def main(
 
 
 meta_commands.register(app)
+
+# Every mounted group is given the shared `--json` option, so the flag parses at the
+# THIRD parser site too: `gda <group> --json <command>` (#683). Applied here, once
+# the tree is complete, for the same reason the refusal class below is — it is one
+# property of the whole surface, not something each group module re-declares. The
+# option, and what a group does with it, are `gda.headless`.
+adopt_group_json(app)
 
 # Every group — the root included — is given gda's own click group class LAST, once
 # the tree is complete (#670). It refuses an unrecognized command or option with the

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -86,26 +86,29 @@ def command_constraints(
     )
 
 
-# The context-meta key a root ``--json`` is recorded under (#671). ``ctx.meta`` is
-# ONE dict shared by every context in the tree (click nests it from the parent), so
-# what the root callback records is readable from the invoked command's context.
-# Dotted and package-scoped, per click's documented convention for the namespace.
-ROOT_JSON_META_KEY = "gda.root_json"
+# The context-meta key a ``--json`` given ABOVE the invoked command is recorded
+# under (#671, #683). ``ctx.meta`` is ONE dict shared by every context in the tree
+# (click nests it from the parent), so what an ancestor parser records — the root
+# callback, or a group's — is readable from the invoked command's context. Dotted
+# and package-scoped, per click's documented convention for the namespace.
+ANCESTOR_JSON_META_KEY = "gda.ancestor_json"
 
 
-def set_root_json(ctx: typer.Context, value: bool) -> None:
-    """Record a root ``--json`` for the command the root is about to invoke.
+def set_ancestor_json(ctx: typer.Context, value: bool) -> None:
+    """Record a ``--json`` an ANCESTOR parser bound, for the command it invokes.
 
-    The write half of the root-flag contract, owned HERE next to the options that
-    read it (:func:`_inherit_root_json`, :func:`root_json`), so the knowledge runs
-    downward: the CLI composition root CALLS this to hand the flag over, instead of
-    this module reaching up into that module's private parameter names.
+    The write half of the contract, owned HERE next to the options that read it
+    (:func:`_inherit_ancestor_json`, :func:`ancestor_json`), so the knowledge runs
+    downward: the CLI composition root CALLS this to hand its root flag over,
+    instead of this module reaching up into that module's private parameter names.
+    A group hands its own flag over the same way (:func:`adopt_group_json`), which
+    is what makes the three parser sites one contract rather than three.
     """
-    ctx.meta[ROOT_JSON_META_KEY] = bool(value)
+    ctx.meta[ANCESTOR_JSON_META_KEY] = bool(value)
 
 
-def root_json(ctx: ClickContext) -> bool:
-    """Whether a root ``--json`` was recorded for this invocation (#659).
+def ancestor_json(ctx: ClickContext) -> bool:
+    """Whether a ``--json`` above the invoked command was recorded (#659, #683).
 
     The read half of the same contract, for the readers that are not a command: the
     root's own ``--version``, which renders either a human line or the structured
@@ -118,38 +121,107 @@ def root_json(ctx: ClickContext) -> bool:
     ``typer.Context`` is a subclass, so every existing caller still fits, and this
     function only ever reads ``ctx.meta``.
     """
-    return bool(ctx.meta.get(ROOT_JSON_META_KEY, False))
+    return bool(ctx.meta.get(ANCESTOR_JSON_META_KEY, False))
 
 
-def _inherit_root_json(
+def _inherit_ancestor_json(
     ctx: typer.Context, param: typer.CallbackParam, value: bool
 ) -> bool:
-    """Let a root ``--json`` stand for the command's own (#671).
+    """Let a ``--json`` written above the command stand for the command's own.
 
     The Skill teaches ONE rule — "always pass ``--json``" — and an agent may spell
-    it at the root (``gda --json node get …``) or after the command
-    (``gda node get … --json``). The two must MEAN the same thing, or accepting the
-    root flag would be worse than rejecting it: a silently inert flag returns human
-    text to a caller that asked for JSON, where the old ``No such option`` at least
-    failed loudly.
+    it at the root (``gda --json node get …``), between the group and the command
+    (``gda node --json get …``, #683), or after the command
+    (``gda node get … --json``). All three must MEAN the same thing, or accepting
+    the outer ones would be worse than rejecting them: a silently inert flag returns
+    human text to a caller that asked for JSON, where the old ``No such option`` at
+    least failed loudly.
 
-    A command's own flag wins when given; otherwise the value the root recorded
-    through :func:`set_root_json` applies — click runs the group's callback before
-    it parses the subcommand, so the record is already in place. Living on the
-    shared :func:`json_option` means every call site inherits it with no per-command
-    wiring, including the ``--params-json`` dispatch path, which reads
+    A command's own flag wins when given; otherwise the value an ancestor recorded
+    through :func:`set_ancestor_json` applies — click binds a parser's own options
+    before it parses the subcommand, so the record is already in place. Living on
+    the shared :func:`json_option` means every call site inherits it with no
+    per-command wiring, including the ``--params-json`` dispatch path, which reads
     ``ctx.params`` after this callback has run.
     """
-    return bool(value) or root_json(ctx)
+    return bool(value) or ancestor_json(ctx)
 
 
 def json_option() -> bool:
     return typer.Option(
         False,
         "--json",
-        callback=_inherit_root_json,
+        callback=_inherit_ancestor_json,
         help="Emit the result as a single JSON object.",
     )
+
+
+def _record_group_json(
+    ctx: typer.Context, param: typer.CallbackParam, value: bool
+) -> bool:
+    """Hand a GROUP's ``--json`` down to the command that group is about to run.
+
+    Bound from the option's OWN callback rather than from the group callback's body,
+    so the record is in place before click parses the subcommand no matter what the
+    group body later grows — the shape the root already uses (``gda.cli``).
+
+    Only a GIVEN flag is recorded: the option's ``False`` default must not erase a
+    root ``--json`` the outer parser recorded, or the outer spelling would depend on
+    the inner one.
+    """
+    if value:
+        set_ancestor_json(ctx, True)
+    return value
+
+
+def _group_json(
+    ctx: typer.Context,
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        callback=_record_group_json,
+        help="Emit the invoked command's result as JSON — the same as passing "
+        "--json after the command.",
+    ),
+) -> None:
+    """The callback every command group is given, so ``--json`` parses there too.
+
+    One function shared by all of them: the flag means the same thing under every
+    group, and the same rule written once per group would be that many chances to
+    drift. Its body has nothing to do — the option's own callback did the work — but
+    the function must exist, because a group's options ARE its callback's parameters.
+    """
+
+
+def adopt_group_json(app: typer.Typer) -> None:
+    """Give every group mounted below ``app`` the shared ``--json`` option (#683).
+
+    The third parser site. ``gda --json <group> <command>`` and
+    ``gda <group> <command> --json`` already meant the same thing; the spelling in
+    between died with ``No such option``, so the one rule the Skill teaches broke on
+    a line an agent composes naturally. Applied once from the composition root,
+    AFTER every group has mounted itself, for the reason ``gda.hints.adopt`` is: it
+    is one property of the WHOLE surface, so a group added later inherits the option
+    by being mounted rather than by remembering to declare it. The walk RECURSES for
+    the same reason that one does — a sub-group of a group would otherwise be missed
+    silently.
+
+    Installing the option means installing the callback that carries it, so a group
+    that declares a callback of its own is refused rather than silently replaced:
+    such a group must declare the shared option on that callback itself.
+    """
+    for group in app.registered_groups:
+        instance = group.typer_instance
+        if instance is None:
+            continue
+        if instance.registered_callback is not None:
+            raise RuntimeError(
+                f"command group {group.name!r} declares its own callback; declare "
+                "the shared --json option on it instead of letting "
+                "gda.headless.adopt_group_json replace it."
+            )
+        instance.callback()(_group_json)
+        adopt_group_json(instance)
 
 
 def godot_option() -> Optional[str]:

--- a/src/gda/hints.py
+++ b/src/gda/hints.py
@@ -55,7 +55,7 @@ from typer._click.exceptions import NoSuchOption, UsageError
 from typer._click.globals import get_current_context
 
 from gda.errors import Failure, make_failure
-from gda.headless import emit_failure, root_json
+from gda.headless import ancestor_json, emit_failure
 
 # The two registered codes this module reports (ADR-0002, the `usage` category).
 UNKNOWN_COMMAND = "unknown_command"
@@ -139,28 +139,15 @@ NEAR_MISSES: dict[tuple[str, ...], NearMiss] = {
 }
 
 
-def near_miss(
-    path: tuple[str, ...], token: str, *, on_group: bool
-) -> Optional[NearMiss]:
+def near_miss(path: tuple[str, ...], token: str) -> Optional[NearMiss]:
     """The curated correction for ``token`` under ``path``, or ``None``.
 
-    The table is consulted first. The one rule that is NOT a spelling row follows: a
-    ``--json`` rejected by a GROUP's own parser. Its correction depends on which group
-    was addressed rather than on the group's name, and every group (including any
-    added later) has it, so it is keyed on that SHAPE instead of on fifteen identical
-    rows. It is also the spelling the bundled Skill documents as a usage error, which
-    is how an agent that reads the guidance still ends up here.
+    Table lookups only. A group's ``--json`` was once corrected here by a rule keyed
+    on the tree SHAPE rather than on a spelling; #683 gave every group the option, so
+    the rule went with it — a hint pointing away from an invocation that now works
+    would be worse than none.
     """
-    hit = NEAR_MISSES.get((*path, token))
-    if hit is not None:
-        return hit
-    if on_group and token == "--json" and path:
-        return NearMiss(
-            f"gda {' '.join(path)} <command> --json",
-            "a group's own parser takes only `--help`; `--json` belongs to the "
-            "command, or to the root before it",
-        )
-    return None
+    return NEAR_MISSES.get((*path, token))
 
 
 def _context_path(ctx: ClickContext) -> tuple[str, ...]:
@@ -197,10 +184,11 @@ def _json_in_effect(ctx: ClickContext) -> bool:
 
     1. The command's OWN resolved flag, when the refusal is decided after its parse —
        which is the case for ``gda help <unknown>``. It already carries an inherited
-       root ``--json`` (``gda.headless._inherit_root_json``), so it answers for both
-       spellings wherever it exists.
-    2. The root ``--json``, recorded when the root callback bound it (#671) — the
-       reading available at parse time, before any command's params exist.
+       ancestor ``--json`` (``gda.headless._inherit_ancestor_json``), so it answers
+       for every spelling wherever it exists.
+    2. The ancestor ``--json``, recorded when the root callback (#671) or a group's
+       (#683) bound it — the reading available at parse time, before any command's
+       params exist.
     3. The literal token in the recorded argv. A ``--json`` written AFTER the
        offending token never parses, because the command or option it would have
        belonged to does not exist, so the token itself is the only evidence of the
@@ -209,7 +197,7 @@ def _json_in_effect(ctx: ClickContext) -> bool:
     """
     if bool(ctx.params.get("json_output")):
         return True
-    if root_json(ctx):
+    if ancestor_json(ctx):
         return True
     return "--json" in ctx.meta.get(RAW_ARGV_META_KEY, ())
 
@@ -249,7 +237,7 @@ def unknown_command(path: tuple[str, ...], token: str) -> Refusal:
     two arms agree verbatim even under ``python -m gda``, whose own name is
     ``python -m gda``.
     """
-    hit = near_miss(path, token, on_group=False)
+    hit = near_miss(path, token)
     named = " ".join([CLI_NAME, *path, token])
     return Refusal(
         UNKNOWN_COMMAND,
@@ -261,11 +249,11 @@ def unknown_command(path: tuple[str, ...], token: str) -> Refusal:
 def unknown_option(path: tuple[str, ...], token: str, *, on_group: bool) -> Refusal:
     """The refusal for option ``token`` on the command ``path`` names.
 
-    ``on_group`` picks the remedy, not the wording: a GROUP has only ``--help`` to
-    read, while a leaf command also has ``--schema`` — its machine-readable input
+    ``on_group`` picks the remedy, not the wording: a GROUP is read with ``--help``
+    alone, while a leaf command also has ``--schema`` — its machine-readable input
     contract, which is what an agent should read next.
     """
-    hit = near_miss(path, token, on_group=on_group)
+    hit = near_miss(path, token)
     named = " ".join([CLI_NAME, *path])
     fallback = f"run `{named} --help` for the options it takes"
     if not on_group:

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -90,7 +90,7 @@ class RunResult:
 # The per-invocation user-data root the CLI resolved, or ``None`` for the engine
 # default. Process-wide because it is process-wide CONFIG, not an operation
 # parameter: it is set once from the root ``--user-data-root`` option (the same
-# hand-over shape as ``gda.headless.set_root_json``) and every later launch on any
+# hand-over shape as ``gda.headless.set_ancestor_json``) and every later launch on any
 # channel inherits it, so no channel has to plumb it through the runner seam.
 #
 # ``None`` means the option was ABSENT. An empty string means it was given empty,

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -110,13 +110,14 @@ and re-read the verdict.
 - `gda version --json` — which `gda` is installed and where from; `gda info` — the
   engine's version.
 
-**`--json` placement.** `gda --json <group> <command>` and `gda <group> <command> --json` mean the
-same thing — a root `--json` applies to the command it invokes — so either spelling works, as does
-both at once. `gda schema --json` is accepted too, and idempotent: the manifest is already JSON.
-Two limits: the `--help` FLAG always renders TEXT (`gda --json --help` returns the same help, never
-JSON — use `gda help <command> --json` for a structured payload), and two spellings are still usage
-errors (exit `2`) — `gda <group> --json` (a group's parser takes only `--help`; the structured
-refusal hints the command form) and a bare `gda --json` with no command (`Missing command.`).
+**`--json` placement.** Every parser takes it: `gda --json <group> <command>`,
+`gda <group> --json <command>` and `gda <group> <command> --json` mean the same thing — a `--json`
+written before the command applies to the command it invokes — so any spelling works, as do several
+at once. `gda schema --json` is accepted too, and idempotent: the manifest is already JSON. Two
+limits: the `--help` FLAG always renders TEXT (`gda --json --help` returns the same help, never
+JSON — use `gda help <command> --json` for a structured payload), and the flag is not a command, so
+`gda <group> --json` and a bare `gda --json` with no command are both the usage error
+`Missing command.` (exit `2`).
 
 ## Headless commands (Godot 4.4+, all platforms)
 

--- a/tests/test_json_flag_acceptance.py
+++ b/tests/test_json_flag_acceptance.py
@@ -1,19 +1,21 @@
-"""`--json` is accepted on the discovery surfaces too (issue #671).
+"""`--json` is accepted on the discovery surfaces too (issues #671, #683).
 
 The bundled Skill teaches ONE rule — "always pass `--json`" — so a client that
 follows it must never be answered with a usage error (exit 2). Discovery used to
-break that rule at **two different parser sites**, which is why a root-only fix
+break that rule at **three different parser sites**, which is why a root-only fix
 would be incomplete:
 
 - the ROOT parser (`gda --json --help`, `gda --json <command>`): the root callback
   declared only `--version`, so the flag died before any subcommand was resolved;
 - the `schema` SUBCOMMAND parser (`gda schema --json`): it declared only
-  `--schema`, so the whole-surface JSON manifest rejected the JSON flag.
+  `--schema`, so the whole-surface JSON manifest rejected the JSON flag;
+- every mounted GROUP's parser (`gda scene --json get …`, #683): a group declared no
+  options at all, so the flag written between the group and the command exited 2.
 
-Accepting the root flag is not enough on its own: a root `--json` that parsed but
-did nothing would hand human text to a caller that asked for JSON — worse than the
-loud `No such option` it replaced. So the root flag is INHERITED by the invoked
-command (`gda.headless._inherit_root_json`), and the tests below pin that
+Accepting an outer flag is not enough on its own: a `--json` that parsed but did
+nothing would hand human text to a caller that asked for JSON — worse than the loud
+`No such option` it replaced. So an ancestor's flag is INHERITED by the invoked
+command (`gda.headless._inherit_ancestor_json`), and the tests below pin that
 equivalence, not just the exit code.
 
 The root itself later grew one payload of its own — `--version` (#659) — so the
@@ -27,15 +29,19 @@ import json
 import subprocess
 from importlib.metadata import version
 
+import pytest
+import typer
 from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.commands.meta import read_skill_text
+from gda.headless import adopt_group_json
 from gda.runner import RunResult
 from tests.support import (
     SCENE_GET_RESULT,
     GDA_CMD,
     inject_runner,
+    panel_text,
     plain_text,
     sentinel,
 )
@@ -160,18 +166,129 @@ def test_root_json_reaches_the_params_json_dispatch_path():
     assert json.loads(result.stdout)["name"] == "gda"
 
 
+# --- the GROUP parser site (issue #683) ---------------------------------------
+
+
+def _scene_get(monkeypatch, args: list[str]):
+    """Invoke ``args`` with the runner seam faked, so no Godot is spawned.
+
+    ``scene get`` is the probe for this site because it renders HUMAN text by
+    default: a flag that parsed but did not reach the command would show up here as
+    that text, which is the failure mode acceptance alone would hide.
+    """
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(SCENE_GET_RESULT), stderr="", exit_code=0),
+    )
+    return CliRunner().invoke(app, args)
+
+
+def test_group_json_is_equivalent_to_the_commands_own_json(monkeypatch):
+    # The third parser site: a `--json` between the group and the command used to
+    # die with `No such option`, so the one rule the Skill teaches broke on a line
+    # an agent composes naturally. All three spellings must agree byte for byte.
+    group_spelling = _scene_get(monkeypatch, ["scene", "--json", "get", "/tmp/x.tscn"])
+    command_spelling = _scene_get(
+        monkeypatch, ["scene", "get", "/tmp/x.tscn", "--json"]
+    )
+    root_spelling = _scene_get(monkeypatch, ["--json", "scene", "get", "/tmp/x.tscn"])
+    no_flag = _scene_get(monkeypatch, ["scene", "get", "/tmp/x.tscn"])
+
+    assert group_spelling.exit_code == 0, group_spelling.stdout
+    assert group_spelling.stdout == command_spelling.stdout == root_spelling.stdout
+    assert json.loads(group_spelling.stdout)
+    # …and the default is unchanged: no flag still means human text.
+    assert no_flag.exit_code == 0
+    assert not no_flag.stdout.startswith("{")
+
+
+def test_the_three_spellings_stack_without_conflicting(monkeypatch):
+    # Belt and braces: a client that writes the flag everywhere gets one answer,
+    # not a second output shape to handle.
+    everywhere = _scene_get(
+        monkeypatch, ["--json", "scene", "--json", "get", "/tmp/x.tscn", "--json"]
+    )
+    command_only = _scene_get(monkeypatch, ["scene", "get", "/tmp/x.tscn", "--json"])
+
+    assert everywhere.exit_code == 0, everywhere.stdout
+    assert everywhere.stdout == command_only.stdout
+
+
+def test_group_json_reaches_the_params_json_dispatch_path(monkeypatch):
+    # `--params-json` is intercepted by the command class and dispatched through its
+    # own tail (ADR-0015), which reads `ctx.params` — i.e. after the inherit
+    # callback has run, so a group flag is honored there too.
+    result = _scene_get(
+        monkeypatch,
+        ["scene", "--json", "get", "--params-json", '{"path": "/tmp/x.tscn"}'],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout)["path"]
+
+
+def test_group_json_without_a_command_is_still_a_usage_error():
+    # Acceptance moved the failure to the honest one; it did not invent a payload.
+    # `gda <group> --json` says what a bare `gda --json` says, at the same exit code.
+    result = CliRunner().invoke(app, ["scene", "--json"])
+    bare_root = CliRunner().invoke(app, ["--json"])
+
+    assert result.exit_code == 2
+    assert bare_root.exit_code == 2
+    assert "Missing command." in panel_text(result.stderr)
+    assert "Missing command." in panel_text(bare_root.stderr)
+
+
+def test_every_group_advertises_the_json_option_in_its_help():
+    # The option is installed onto every MOUNTED group at composition
+    # (`gda.headless.adopt_group_json`), so the check walks the live tree rather than
+    # naming the groups: one added later is covered by being mounted. A group is the
+    # node with a `commands` mapping — the duck-type `gda.surface` walks with too.
+    root: object = typer.main.get_command(app)
+    groups = [
+        name
+        for name, command in getattr(root, "commands", {}).items()
+        if getattr(command, "commands", None) is not None
+    ]
+
+    assert groups, "the live tree reported no command groups"
+    for name in groups:
+        rendered = CliRunner().invoke(app, [name, "--help"])
+
+        assert rendered.exit_code == 0, rendered.stdout
+        assert "--json" in plain_text(rendered.stdout), name
+
+
+def test_the_walker_refuses_to_replace_a_groups_own_callback():
+    # Installing the option means installing the callback that carries it. No group
+    # declares one today; one that grows a callback must declare the shared option
+    # on it, so the walker says so instead of dropping that callback silently.
+    root = typer.Typer()
+    group = typer.Typer()
+
+    @group.callback()
+    def _own(ctx: typer.Context) -> None:
+        """A group with business of its own."""
+
+    root.add_typer(group, name="own")
+
+    with pytest.raises(RuntimeError, match="own"):
+        adopt_group_json(root)
+
+
 # --- the shipped guidance states the same contract ----------------------------
 
 
 def test_skill_documents_the_json_placement_contract():
     # The Skill is the guidance an agent actually reads, so the placement rule has
     # to ship WITH the behavior, not only in a PR description. Token-level checks:
-    # the two equivalent spellings are named, and so are the two that still exit 2
-    # (a group's bare parser and a root flag with no command). Prose is free to be
-    # reworded; these tokens are the contract.
+    # the three equivalent spellings are named, and so are the two that still exit 2
+    # (either flavour of "the flag, but no command"). Prose is free to be reworded;
+    # these tokens are the contract.
     text = read_skill_text()
 
     assert "`gda --json <group> <command>`" in text
+    assert "`gda <group> --json <command>`" in text
     assert "`gda <group> <command> --json`" in text
     assert "`gda schema --json`" in text
     assert "`gda --json --help`" in text
@@ -212,8 +329,8 @@ def test_root_version_without_the_flag_stays_text():
 # --- the real out-of-process CLI ---------------------------------------------
 
 
-def test_real_out_of_process_cli_accepts_json_at_both_sites():
-    # Both fixes through a REAL process (`python -m gda`, the same `app` the
+def test_real_out_of_process_cli_accepts_json_at_every_site():
+    # Every fix through a REAL process (`python -m gda`, the same `app` the
     # console script wraps), not only the in-process CliRunner. Deliberately not
     # marked `e2e`: this repo's `e2e` marker means "spawns a real Godot process",
     # and nothing here does.
@@ -236,3 +353,12 @@ def test_real_out_of_process_cli_accepts_json_at_both_sites():
     )
     assert inherited.returncode == 0, inherited.stderr
     assert json.loads(inherited.stdout)["name"] == "gda"
+
+    # The group site needs a command that spawns nothing: `--schema` answers from
+    # the command's own models, so it proves the flag PARSED between the group and
+    # the command without reaching for an engine.
+    on_a_group = subprocess.run(
+        [*GDA_CMD, "scene", "--json", "get", "--schema"], capture_output=True, text=True
+    )
+    assert on_a_group.returncode == 0, on_a_group.stderr
+    assert set(json.loads(on_a_group.stdout)) >= {"input", "output", "error"}

--- a/tests/test_unknown_invocation.py
+++ b/tests/test_unknown_invocation.py
@@ -143,18 +143,6 @@ def test_script_run_script_option_points_at_the_positional_form():
     assert error["hint"] == "gda script run <path>"
 
 
-def test_a_groups_json_flag_points_at_the_command_that_takes_it():
-    # The one refusal keyed on the tree SHAPE rather than on a spelling: a group's own
-    # parser takes only `--help`, so `gda <group> --json` is rejected there — the
-    # spelling the Skill already documents as a usage error. Keyed on shape, so every
-    # group (and any group added later) is covered without a row each.
-    result = CliRunner().invoke(app, ["scene", "--json"])
-
-    error = _envelope(result)
-    assert error["code"] == UNKNOWN_OPTION
-    assert error["hint"] == "gda scene <command> --json"
-
-
 # --- the table is the single authority, and it stays honest -------------------
 
 


### PR DESCRIPTION
## What

`--json` now parses at the **third parser site**: between a command group and its
command. `gda --json <group> <command>`, `gda <group> --json <command>` and
`gda <group> <command> --json` are one invocation, byte for byte.

Before, the middle spelling died with `No such option: --json` (exit 2) — so the one
rule the bundled Skill teaches ("always pass `--json`") broke on a line an agent
composes naturally.

Closes #683

## How

- **`gda.headless.adopt_group_json(app)`** gives every *mounted* group the shared
  option, called once from the composition root after the tree is complete — the same
  whole-surface shape `gda.hints.adopt` already uses, so a group added later inherits
  the flag by being mounted rather than by remembering to declare one. The walk
  recurses, and refuses (loudly) to replace a group that declares a callback of its
  own instead of dropping it silently.
- The group's flag rides the **same context-meta contract the root's does**, which the
  invoked command's own `--json` already inherits (`_inherit_ancestor_json`). Renamed
  `root_json` → `ancestor_json` / `set_root_json` → `set_ancestor_json` /
  `gda.root_json` → `gda.ancestor_json`, because the root is no longer the only writer
  — the old name would have lied as of this change.
- Only a **given** group flag is recorded: the option's `False` default must not
  cancel a root `--json` written outside it.
- `gda <group> --json` with no command stays exit 2 — now with the honest
  `Missing command.` a bare `gda --json` already gets.

### `hints.py`

The group-level `--json` correction was a SHAPE-keyed branch inside `near_miss()` (not
a `NEAR_MISSES` row). It is unreachable once the option parses, and its hint would now
point *away* from an invocation that works, so it is removed together with its test arm
`test_a_groups_json_flag_points_at_the_command_that_takes_it`. `near_miss()` loses its
now-unused `on_group` parameter; `unknown_option()` keeps it (it still picks the
`--schema` half of the fallback sentence). `test_every_curated_hint_names_a_real_invocation`
still passes over the whole table.

## Surface diff — the 15 group helps

`cli.py` has 16 `register()` calls, but the 16th (`meta_commands.register`) registers
the five top-level meta **leaf** commands (`help`/`info`/`schema`/`skill`/`version`),
not a group. Walking the live Typer tree reports **15 groups**, and each one's `--help`
gains exactly this row and nothing else:

```
│ --json          Emit the invoked command's result as JSON — the same as      │
│                 passing --json after the command.                            │
```

| # | Group | help diff |
| - | ----- | --------- |
| 1 | `scene` | `6a7,8` — option row added |
| 2 | `node` | `6a7,8` — option row added |
| 3 | `script` | `6a7,8` — option row added |
| 4 | `resource` | `6a7,8` — option row added |
| 5 | `export` | `6a7,8` — option row added |
| 6 | `project` | `6a7,8` — option row added |
| 7 | `shader` | `6a7,8` — option row added |
| 8 | `theme` | `6a7,8` — option row added |
| 9 | `game` | `6a7,8` — option row added |
| 10 | `diag` | `6a7,8` — option row added |
| 11 | `logger` | `7a8,9` — option row added |
| 12 | `perf` | `6a7,8` — option row added |
| 13 | `input` | `6a7,8` — option row added |
| 14 | `screen` | `7a8,9` — option row added |
| 15 | `daemon` | `6a7,8` — option row added |

Every diff is a pure addition (`NaM,N` — no deleted or changed line): no group's help
prose, usage line, or command list moves.

**Boundary honored (#669):** `gda schema` is **byte-identical** before/after (the
manifest walks leaf commands only), and so is `gda --help`.

## Documentation

- `src/gda/skill/SKILL.md` — the `--json` placement paragraph drops the group-level
  exception; the "flag without a command" limit stays, and now covers `gda <group>
  --json` and bare `gda --json` under the same `Missing command.` sentence.
- `README.md` + the three translations (`docs/README.{zh-CN,es,ja}.md`, re-stamped via
  `scripts/update_readme_i18n.py`): the `--json` global-option row said "Also accepted
  at the root", which now understates the surface.

## Red-proof

Each new guard, shown failing on the code without its fix:

**1. The behavior** — with the wiring line (`adopt_group_json(app)`) commented out in
`cli.py`, i.e. pre-fix parsing:

```
FAILED tests/test_json_flag_acceptance.py::test_group_json_is_equivalent_to_the_commands_own_json
FAILED tests/test_json_flag_acceptance.py::test_the_three_spellings_stack_without_conflicting
FAILED tests/test_json_flag_acceptance.py::test_group_json_reaches_the_params_json_dispatch_path
FAILED tests/test_json_flag_acceptance.py::test_group_json_without_a_command_is_still_a_usage_error
FAILED tests/test_json_flag_acceptance.py::test_every_group_advertises_the_json_option_in_its_help
FAILED tests/test_json_flag_acceptance.py::test_real_out_of_process_cli_accepts_json_at_every_site
6 failed, 14 passed
```

(the out-of-process arm reports the real pre-fix envelope:
`` `gda scene` has no option `--json` ``)

**2. The non-clobbering rule** — mutating `_record_group_json` to record its `False`
default (`set_ancestor_json(ctx, value)` unconditionally), which would let the inner
spelling cancel an outer `--json`:

```
FAILED tests/test_json_flag_acceptance.py::test_root_json_reaches_a_domain_command
FAILED tests/test_json_flag_acceptance.py::test_group_json_is_equivalent_to_the_commands_own_json
3 failed, 17 passed
```

**3. The walker's refusal** — with the `RuntimeError` guard deleted:

```
E       Failed: DID NOT RAISE <class 'RuntimeError'>
FAILED tests/test_json_flag_acceptance.py::test_the_walker_refuses_to_replace_a_groups_own_callback
```

**4. The shipped guidance** — with `SKILL.md` reverted to its pre-fix paragraph:

```
>       assert "`gda <group> --json <command>`" in text
E       AssertionError
FAILED tests/test_json_flag_acceptance.py::test_skill_documents_the_json_placement_contract
```

**5. The removed hint ↔ the removed test** — this is why the two are deleted together.
With the `hints.py` branch removed but its test arm still present:

```
result = <Result SystemExit(2)>
>       assert result.stdout.startswith("{"), result.stdout
E       AssertionError: assert False
FAILED tests/test_unknown_invocation.py::test_a_groups_json_flag_points_at_the_command_that_takes_it
```

## Verification

| Gate | Result |
| ---- | ------ |
| `uv run pytest -m "not e2e" -q` | **2243 passed**, 577 deselected |
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 477 files already formatted |
| `uv run pyright` | 0 errors, 0 warnings |
| `gda schema` before/after | byte-identical |
| `gda --help` before/after | byte-identical |

**Real engine (Godot 4.x, macOS).** This slice is CLI-layer — no launch-backed code
path changed (the only `runner.py` edit is a comment) — but the option layer it touches
is on every headless launch, so the equivalence was verified against a real project as
well as through the faked runner seam:

```
$ gda scene --json get scenes/main.tscn --project <tmp>
{"path":"scenes/main.tscn","root":{"name":"main","type":"Node2D","children":[]}}
$ gda scene get scenes/main.tscn --project <tmp> --json
{"path":"scenes/main.tscn","root":{"name":"main","type":"Node2D","children":[]}}
$ gda scene get scenes/main.tscn --project <tmp>
main (Node2D)
```

Plus `tests/test_e2e_info.py tests/test_e2e_params_json.py` — 6 passed against the
local engine.
