### PR TITLE
fix(gda): report headless float reads at full binary64 precision (#771)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -188,14 +188,18 @@ fallback** for anything else. One projection shared across **every value gda
 emits** — the `get` reads (`project`/`node`/`resource get`), the value echoed by
 `node set`/`resource set`, the per-entry value of `project list` and `scene
 get-exports`, and the live `game get` read — so a value reads the same
-everywhere. That sameness is of SHAPE; numeric FIDELITY is not yet uniform.
-The harness frames every reply with Godot's full-precision JSON writer, so a
-LIVE projected float crosses exactly — the one residual being that a negative
-zero reads back as `0.0` — while the headless writer still flattens small
-floats to `0.0` and rounds ordinary ones (#771). The write-side mirror on the
-live wire is a refusal: a float Godot's parser would read as `0.0` is rejected
-before a request is relayed to the harness, no decimal literal being able to
-deliver it (#752). Two controls keep the shared projection safe on the live
+everywhere. That sameness covers numeric FIDELITY as well as shape: both of
+gda's engine-side payloads frame their reply with Godot's full-precision JSON
+writer — the harness since #752, the headless operations payload since #771 —
+so a projected float is the exact binary64 the subject holds, on either
+channel, with one shared residual the engine decides before the writer is
+consulted: a negative zero reads back as `0.0`. The WRITE sides still differ.
+On the live wire it is a refusal: a float Godot's parser would read as `0.0` is
+rejected before a request is relayed to the harness, no decimal literal being
+able to deliver it (#752). Headless there is no refusal — a `--value` string is
+coerced by that same parser, which still drops the low digits of a
+many-digit literal and reads a `DBL_MIN`-scale one as `0.0` (#772). Two
+controls keep the shared projection safe on the live
 side: the whitelist bounds the Object classes whose storage properties the
 inline kind emits, and the texture kind is safe by construction — a fixed
 getter shape with its one expensive readback behind the explicit digest opt-in

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -89,10 +89,10 @@ address by (`.` for the root) — the `@export` properties the node's attached s
 each a `{name, type, hint, hint_string, value}` entry, where `type` is the export's declared
 Godot type name, `hint`/`hint_string` are the Godot `PropertyHint` enum value and its companion
 string the `@export` annotation produced, and `value` is the export's current value in the same
-JSON projection `node get` uses (its default on a freshly-loaded node) — the property-value
-introspection is reused from `node get` (#55), not re-implemented. An export is detected by its
-usage flags (`PROPERTY_USAGE_SCRIPT_VARIABLE` + `PROPERTY_USAGE_EDITOR`) on the script's own
-property list, so a node's inherited engine properties and a script's plain (non-`@export`)
+JSON projection `node get` uses (its default on a freshly-loaded node), at the same full binary64
+precision (#771) — the property-value introspection is reused from `node get` (#55), not
+re-implemented. An export is detected by its usage flags
+(`PROPERTY_USAGE_SCRIPT_VARIABLE` + `PROPERTY_USAGE_EDITOR`) on the script's own property list, so a node's inherited engine properties and a script's plain (non-`@export`)
 variables are excluded. A node with no script, or whose script declares no exports, is omitted;
 a scene with no exported variables anywhere is a valid, empty listing (`nodes == []`). Like
 `scene get`, get-exports reuses the shared load-failure ladder — a missing file is
@@ -404,6 +404,30 @@ callers can use a follow-up `game get` for domain-specific side effects. Its fai
 LIVE-category `live_unknown_property` / `live_uncoercible_value` (the harness reports them in-band,
 mapped by the live classifier — see
 [Phase 2 — live domain commands](#phase-2--live-domain-commands-served-by-gda-daemon)).
+
+**Number reporting** (#771) — the READ half, shared by every headless command that projects a
+value. `ops/operations.gd` frames each reply with Godot's **full-precision** JSON writer, so a
+projected float is the exact binary64 the project holds: `node get`, `scene get-exports`,
+`project get` / `project list`, `resource get`, and the value each `set` echoes all report
+`1e-300` as `1e-300` and `3.141592653589793` as `3.141592653589793`. They did not before #771 —
+the default writer formats fixed-point with at most 32 decimals, so it reported everything below
+about `1e-32.6` as `0.0` and rounded ordinary values to ~15 significant digits, handing the caller
+a number the project does not hold with nothing marking it approximate. The stored value was never
+the problem: `project.godot` held `3.141592653589793` while the reply said `3.14159265358979`.
+**One residual is disclosed rather than fixed**, and it is the same one the live replies carry: a
+NEGATIVE ZERO reads back as `0.0`, which the engine decides (`JSON::_stringify` returns `"0.0"`
+for anything equal to zero) before the precision argument applies. It is the same engine writer
+the live harness uses, so it is measured against the same corpus and the same partition —
+`gda.live_numbers` is the authority, and `tests/test_e2e_headless_number_reads.py` re-derives the
+verdict from a real engine.
+
+What a `--value` **string** becomes on the way IN is the other half and is **not** covered here:
+the ops coerce it with the engine's own parser (`String.to_float`), which drops the low decimal
+digits of a full-precision literal between `1e-4` and `1e-2` and reads a `DBL_MIN`-scale or
+subnormal literal as `0.0`. Unlike the live wire, headless does not refuse those — see
+[#772](https://github.com/aigengame/godot-agent/issues/772). So a `set` and a following `get`
+agree with each other on the value the project holds; that is what this catalog's round-trip
+claims mean, not that every literal survives coercion.
 
 **Structural edits** (established by #56): three commands restructure the node tree within a
 scene file, each a `load → locate → restructure → pack → save` round-trip that reuses the
@@ -730,7 +754,8 @@ valid result.
 **Reading and writing settings** (established by #111): `gda project get SECTION/KEY` reads one
 setting by its full `section/key` name (e.g. `application/config/name`) and reports it as a
 `{setting, type, value}` triple — `type` is the setting's declared Godot type name and `value` its
-JSON projection, the **same projection** `node get` reports for a node property. Compound values
+JSON projection, the **same projection** `node get` reports for a node property, at the same full
+binary64 precision (#771; see "Number reporting" under [`node`](#node)). Compound values
 arrive **structured** (ADR-0035): a `Dictionary` projects to a JSON object, an `Array` or packed
 array to a JSON array, and an embedded `Object` renders as a **reference projection**
 (`{type, resource_path}` for a Resource with a `res://` path), a **texture projection**
@@ -746,7 +771,11 @@ the CLI value to the setting's **declared type** — read off the setting's curr
 `node set` reads it off the node's property list — using the **same coercion rules** the node group
 established (#55; see "Property value coercion" under [`node`](#node)). It then persists
 `project.godot` (`ProjectSettings.save()`) and reports the coerced value in the same JSON projection
-`project get` uses, so a **`set` round-trips through a `get`**. `set` edits an **existing** setting —
+`project get` uses, so a **`set` round-trips through a `get`**: both report the value
+`ProjectSettings` now holds, at full binary64 precision (#771). The round-trip is of the STORED
+value — what the CLI string coerces to first is the engine's own parser, which can read a
+many-digit or `DBL_MIN`-scale literal as a different double (#772); see "Number reporting" under
+[`node`](#node). `set` edits an **existing** setting —
 an unknown key is `unknown_setting`, never a silent create, so the type to coerce to is always known.
 A value that cannot be coerced to the setting's type is `uncoercible_value` (exit 4, the #55 code,
 `project.godot` left untouched); a failed save is `save_failed`.
@@ -755,9 +784,9 @@ A value that cannot be coerced to the setting's type is `uncoercible_value` (exi
 `ProjectSettings` keys so an agent can **discover** which settings exist — the list half of the
 `list → get → set` workflow (`get`/`set` both require you to already know the `section/key`). Each
 entry reuses the **same** `{setting, type, value}` projection `project get` reports — so a listed
-entry round-trips through `project get` — **plus** an `is_default` boolean: `false` when the key is
-customized (written in `project.godot`), `true` when it is at the engine's built-in default. By
-default the listing is only the project's **customized** settings (small and useful); `--all` widens
+entry round-trips through `project get`, floats included (#771) — **plus** an `is_default`
+boolean: `false` when the key is customized (written in `project.godot`), `true` when it is at
+the engine's built-in default. By default the listing is only the project's **customized** settings (small and useful); `--all` widens
 it to the engine's built-in defaults too, and `--section <prefix>` restricts it to keys whose name
 begins with that `section/` prefix (e.g. `application/`, `display/`) — the two compose. Internal
 engine-bookkeeping settings and the non-setting properties the engine's property list also returns
@@ -947,12 +976,16 @@ re-derives every verdict from a running engine.
   `0.0012345678901234567` arriving 31 doubles away and `0.00014285714285714284` 105.
   Refusing that band would reject ordinary game values, and preserving it would mean not
   sending a JSON number at all, the bespoke transport ADR-0021 rejected.
-- **Headless reads are NOT covered.** `ops/operations.gd` still frames results with the
-  default writer, so a headless `node get` / `scene get-exports` / `project list` /
-  `resource get` can still report a rounded or zeroed float
-  ([#771](https://github.com/aigengame/godot-agent/issues/771)). The live guarantee is
-  therefore stated on the live commands, never on the shared property shape they share
-  with the headless reads.
+- **The headless replies are framed by the same writer since #771.** `ops/operations.gd`
+  made the one-argument change this section describes, so a headless `node get` /
+  `scene get-exports` / `project list` / `resource get` reports the float the project
+  holds and carries the same negative-zero residual (see "Number reporting" under
+  [`node`](#node)). The two channels are still documented separately: the live sentences
+  are published per-field in help and `--schema` and name the WIRE, a leg a headless
+  reply never crosses, so they stay on the live commands rather than moving onto the
+  property shape both share. What differs in substance is the WRITE side — the live wire
+  REFUSES a value its parser would flatten, while a headless `--value` string is coerced
+  by that parser with no refusal ([#772](https://github.com/aigengame/godot-agent/issues/772)).
 
 - **`game` (the running game's scene graph):** `game tree` reads the runtime scene
   tree (shipped — the Phase-2 bootstrap tracer, #7); runtime node property `game get` /

--- a/src/gda/live_numbers.py
+++ b/src/gda/live_numbers.py
@@ -1,5 +1,10 @@
-"""The live wire's NUMBER domain — what a JSON number survives on the way to and
-from an engine session (#752).
+"""The engine's NUMBER domain — what a JSON number survives on the way to and from
+Godot (#752, #771).
+
+Named for the live wire, which is where #752 measured it; the WRITER half is the
+engine's and belongs to both channels. #771 found ``ops/operations.gd`` framing every
+HEADLESS reply with the same default writer described below, and fixed it with the
+same one argument, so the result-direction paragraph now speaks for both.
 
 The live legs carry JSON (ADR-0021): the daemon writes ``{op, params}`` with
 Python's ``json``, the harness reads it with Godot's ``JSON.parse_string``, and the
@@ -28,11 +33,20 @@ rows it split **41 exact / 15 changed / 40 flattened to ``0.0``**, and a
 ``full_precision`` mode instead renders through ``String::num_scientific``
 (grisu2, shortest round-tripping form), which was exact on **95 of the 96** corpus
 rows and on all 5500 of that sweep — the sweep drew no negative zero, and the
-single corpus miss IS that value. The harness therefore stringifies every reply with
-``full_precision`` (``gda_harness.gd``'s ``_json``), and the result direction
-carries full binary64 precision. One residual, kept in the public contract because
-it is an engine early return (``JSON::_stringify`` emits ``"0.0"`` for anything
-equal to zero): a NEGATIVE ZERO reads back as ``0.0``.
+single corpus miss IS that value. BOTH of gda's engine-side payloads therefore
+stringify every reply with ``full_precision`` — the harness (``gda_harness.gd``'s
+``_json``, #752) and the headless operations payload (``ops/operations.gd``'s
+``_json``, #771) — and the result direction carries full binary64 precision on
+either channel. One residual, kept in the public contract because it is an engine
+early return (``JSON::_stringify`` emits ``"0.0"`` for anything equal to zero): a
+NEGATIVE ZERO reads back as ``0.0``.
+
+A headless read needs no separate corpus and gets none: it is measured against the
+same rows and the same ``full_precision`` partition, re-derived from a real engine by
+``tests/test_e2e_headless_number_reads.py``. Its REQUEST half is a different
+question from the live one — a headless ``--value`` is a STRING the operation coerces
+with ``String.to_float``, not a JSON number the parser reads — and it is owned by
+#772, so nothing here is claimed about it.
 
 **The result path has TWO writers, and each float has exactly one of them.** The
 paragraph above is about the engine's: a value the game reports is stringified by
@@ -245,6 +259,17 @@ def find_unrepresentable(value: object, path: str) -> "str | None":
 # property of: the #770 review found the engine sentence inherited by fields the
 # engine never wrote, and a claim that does not say whose value it describes
 # invites exactly that.
+
+# Only the LIVE surfaces publish these. The engine-writer guarantee below became
+# true of headless replies too (#771), but the sentence is not shared onto them: it
+# names the live WIRE, a leg a headless reply never crosses, and it is attached
+# per-field by a guard that walks the LIVE result models. Sharing the string would
+# put a wire claim on a headless read; authoring a headless twin would be the
+# near-duplicate this module exists to prevent. The headless channel therefore states
+# the same fact once, in prose, on the surfaces that document headless behaviour
+# (``docs/command-catalog.md``, ``CONTEXT.md``, the bundled Skill). Publishing it in
+# ``--schema`` needs the derived discipline the live side has — a walk over the
+# headless float-bearing fields — which is a slice of its own, not a rider on #771.
 
 # For a value the ENGINE produced and its full-precision writer serialized.
 LIVE_ENGINE_PRECISION = (

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -6603,10 +6603,32 @@ func _atomic_write_text(path: String, content: String) -> int:
 	return OK
 
 
+# The ONE JSON writer for every headless reply (#771) — the same choice the live
+# harness made in #752, for the same reason, because it is the same engine
+# function. Godot's default JSON.stringify renders a float through String::num,
+# which formats FIXED-POINT with at most MAX_DECIMALS (32) decimals: it flattened
+# every value below ~1e-32.6 to 0.0 and rounded ordinary values to ~15 significant
+# digits (3.141592653589793 came back as 3.14159265358979, and an @export of
+# 1e-300 read back as 0.0). The full_precision argument switches it to
+# String::num_scientific (grisu2, shortest round-tripping form), which loses none
+# of those and still spells every float with a "." or an "e", so a JSON number
+# that was a float stays one. The measured corpus and its counts belong to the one
+# authority that owns them, `gda.live_numbers` (Python side) — not restated here.
+# The other three arguments keep their defaults ("" indent, sort_keys true), so
+# ONLY the number spelling changes. One residual, disclosed in the CLI contract:
+# the engine emits "0.0" for a NEGATIVE ZERO before this argument is consulted.
+#
+# This is the REPORTING half. What a value the caller sends becomes on the way IN
+# — the --value string the ops coerce with String.to_float(), which is the
+# engine's own parser — is a separate question, owned by #772.
+func _json(value: Variant) -> String:
+	return JSON.stringify(value, "", true, true)
+
+
 # Record a successful result: emit it through the sentinel contract and mark
 # the process to exit 0. The single quit() lives in _process.
 func _succeed(payload: Dictionary) -> void:
-	print(RESULT_BEGIN + JSON.stringify(payload) + RESULT_END)
+	print(RESULT_BEGIN + _json(payload) + RESULT_END)
 	_exit_code = 0
 
 
@@ -6617,7 +6639,7 @@ func _diag(message: String) -> void:
 # Record a structured failure through the ADR-0002 sentinel contract. The
 # process is left to exit non-zero via _process.
 func _fail(code: String, message: String) -> void:
-	print(RESULT_BEGIN + JSON.stringify({
+	print(RESULT_BEGIN + _json({
 		"error": {
 			"code": code,
 			"message": message,

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -131,6 +131,8 @@ refusal hints the command form) and a bare `gda --json` with no command (`Missin
 | `shader` | `create`, `get`, `set` (`.gdshader` files) |
 | `theme` | `create` (a loadable `.tres` Theme) |
 
+Every headless reply carries its floats at full binary64 precision, so a value read back through `node get`, `scene get-exports`, `project get`/`project list`, `resource get`, or the echo of a `set` is the exact number the project holds — `1e-300` reads back as `1e-300`, not `0.0`; the one residual belongs to the ENGINE's writer — a negative zero reads back as `0.0` (#771). The `--value` string you send IN is a separate matter and is NOT bounded the way the live wire is: the engine's own parser coerces it, dropping the low digits of a full-precision literal between `1e-4` and `1e-2` and reading a `DBL_MIN`-scale or subnormal literal as `0.0`, with no refusal (#772). Read the `set` echo when the exact bits matter.
+
 ## Live operations (via the daemon; Godot 4.6+, macOS/Linux)
 
 Prerequisites: run `gda daemon start` first (optionally `--scene <res://...>` to boot a

--- a/tests/live_number_corpus.py
+++ b/tests/live_number_corpus.py
@@ -1,22 +1,31 @@
-"""The #752 live-number differential corpus, and the verdicts a real engine gave it.
+"""The #752 number corpus, and the verdicts a real engine gave it.
 
-Both a unit test (``tests/test_live_numbers.py``, which checks gda's model of the
-engine against this table) and an e2e test
-(``tests/test_e2e_live_number_transport.py``, which re-derives the table from a
-real engine) read these rows, so the fast tier and the engine tier can never
-disagree about what the corpus says. It is also the ONE place the published
-counts come from: :data:`PARTITIONS` derives them from the rows below, and
-``tests/test_live_numbers.py`` reads back the two surfaces allowed to state
-them — ``gda.live_numbers``'s module docstring and ``docs/command-catalog.md``
-— requiring the derived strings verbatim, so a hand-edited count cannot
-survive. ADR-0041 and the harness comment quote no count at all; they point at
-``gda.live_numbers`` instead.
+Three tests read these rows, so no tier can disagree with another about what the
+corpus says: a unit test (``tests/test_live_numbers.py``, which checks gda's model
+of the engine against this table) and two e2e tests that re-derive it from a real
+engine — ``tests/test_e2e_live_number_transport.py`` for the live legs, and
+``tests/test_e2e_headless_number_reads.py`` for the headless reply (#771). It is
+also the ONE place the published counts come from: :data:`PARTITIONS` derives them
+from the rows below, and ``tests/test_live_numbers.py`` reads back the two surfaces
+allowed to state them — ``gda.live_numbers``'s module docstring and
+``docs/command-catalog.md`` — requiring the derived strings verbatim, so a
+hand-edited count cannot survive. ADR-0041 and the two engine-side writer comments
+quote no count at all; they point at ``gda.live_numbers`` instead.
+
+The corpus is named for the issue that measured it, not for a leg. The
+``default_stringify`` column records what one ENGINE FUNCTION does to a value, so
+it describes every reply Godot serializes: #752 measured it on the live wire, and
+#771 found the headless reply framed by the same default writer and fixed it with
+the same argument. That is why the headless direction reuses this table instead of
+forking a second one, and why it needs no column of its own — a headless read is
+measured against the same ``full_precision`` partition (:data:`PARTITIONS`).
 
 Measured on Godot 4.6.3.stable.official.7d41c59c4. Not a specification of the
-engine — a recording of it; the e2e test is what keeps the recording true.
+engine — a recording of it; the e2e tests are what keep the recording true.
 """
 
 import math
+import struct
 from typing import Literal, NamedTuple
 
 # What Godot's DEFAULT ``JSON.stringify`` did to a value on the way back. Three
@@ -219,3 +228,32 @@ PARTITIONS: dict[str, Partition] = {
         zero=0,
     ),
 }
+
+
+# --- The verdict helpers both engine tiers read -------------------------------
+# A second definition of "exact" would be a fork of this table's semantics, so the
+# live e2e and the headless e2e share these rather than each spelling their own.
+
+
+def value_bits(value: float) -> str:
+    """One value's IEEE-754 bytes — the only comparison that is not itself lossy."""
+    return struct.pack("<d", value).hex()
+
+
+def stringify_outcome(sent: float, arrived: float) -> DefaultStringify:
+    """The three-state verdict one direction gave one value (cf. LiveNumberCase).
+
+    ``changed`` and ``zero`` are DIFFERENT failures — a rounded value still
+    carries the caller's magnitude, a flattened one does not — so the corpus
+    records which, and the published table reports both.
+    """
+    if value_bits(arrived) == value_bits(sent):
+        return "exact"
+    if arrived == 0.0 and sent != 0.0:
+        return "zero"
+    return "changed"
+
+
+def tally_outcome(counts: list[int], sent: float, arrived: float) -> None:
+    """Add one value's verdict to an ``[exact, changed, zero]`` tally."""
+    counts[("exact", "changed", "zero").index(stringify_outcome(sent, arrived))] += 1

--- a/tests/test_e2e_headless_number_reads.py
+++ b/tests/test_e2e_headless_number_reads.py
@@ -1,0 +1,251 @@
+"""S1 (e2e): the HEADLESS read direction, measured on a real engine (#771).
+
+The live counterpart is ``tests/test_e2e_live_number_transport.py``. This module
+asks the same question of the other channel: does a headless reply report the
+float the project holds, or a rounded — sometimes zeroed — approximation of it?
+
+Both tiers read ONE table, ``tests/live_number_corpus.py``. That is not tidiness:
+the writer under test here is the same engine function #752 measured, so a second
+corpus would be a second opinion about one function. What differs is how the value
+is PLACED: the live tier sends it over the wire, while a headless read must find it
+already in the project. So the probe scene carries every corpus value as its
+IEEE-754 BYTES and reconstructs it in ``_init`` — the only placement that is not
+itself a decimal literal, which is exactly the lossy thing under test. Values such
+as ``DBL_MIN`` and ``5e-324`` cannot be spelled at all for this engine's parser
+(``gda.live_numbers``), so no literal-authored scene could hold them to be read.
+
+What the write path does to a ``--value`` STRING is a separate question, owned by
+[#772](https://github.com/aigengame/godot-agent/issues/772); nothing here claims
+anything about it.
+"""
+
+import json
+import math
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+from tests.live_number_corpus import (
+    LIVE_NUMBER_CORPUS,
+    PARTITIONS,
+    Partition,
+    tally_outcome,
+    value_bits,
+)
+from tests.support import GDA_CMD
+
+GODOT = resolve_godot_binary()
+
+# One exported float per corpus row plus the whole corpus as a packed array, so
+# the scalar arm of the value projection and its element-wise arm are both read
+# through the reply under test. `_init` assigns them: an @export's declared
+# default would have to be a decimal literal.
+_PROBE_BODY = """\
+func _from_hex(h: String) -> float:
+\tvar b := PackedByteArray()
+\tb.resize(8)
+\tfor i in range(8):
+\t\tb[i] = ("0x" + h.substr(i * 2, 2)).hex_to_int()
+\treturn b.decode_double(0)
+
+
+func _init() -> void:
+\tvar packed := PackedFloat64Array()
+\tfor i in range(BITS.size()):
+\t\tvar value := _from_hex(BITS[i])
+\t\tset("v%d" % i, value)
+\t\tpacked.append(value)
+\tall_values = packed
+"""
+
+
+def _probe_source() -> str:
+    """The probe script: the corpus as bit patterns, restored into real exports."""
+    bits = ",\n".join(f'\t"{value_bits(case.value)}"' for case in LIVE_NUMBER_CORPUS)
+    exports = "\n".join(
+        f"@export var v{index}: float = 0.0" for index in range(len(LIVE_NUMBER_CORPUS))
+    )
+    return (
+        "extends Node2D\n\n"
+        f"const BITS := [\n{bits},\n]\n\n"
+        f"{exports}\n"
+        "@export var all_values: PackedFloat64Array = PackedFloat64Array()\n\n\n"
+        f"{_PROBE_BODY}"
+    )
+
+
+PROBE_TSCN = (
+    "[gd_scene load_steps=2 format=3]\n\n"
+    '[ext_resource type="Script" path="res://numbers.gd" id="1"]\n\n'
+    '[node name="Main" type="Node2D"]\n'
+    'script = ExtResource("1")\n'
+)
+
+
+def _gda(project):
+    """A bound ``gda <args> --project <p> --godot <g> --json`` runner."""
+
+    def run(*args):
+        return subprocess.run(
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(project),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+
+    return run
+
+
+def _probe_project(project):
+    """Write the probe scene into ``project`` and return its bound runner."""
+    (project / "numbers.gd").write_text(_probe_source(), encoding="utf-8")
+    (project / "numbers.tscn").write_text(PROBE_TSCN, encoding="utf-8")
+    return _gda(project)
+
+
+def _exports_by_name(run) -> dict:
+    """`scene get-exports` on the probe scene, indexed by export name."""
+    read = run("scene", "get-exports", "numbers.tscn")
+    assert read.returncode == 0, read.stdout + read.stderr
+    nodes = json.loads(read.stdout)["nodes"]
+    assert len(nodes) == 1, nodes
+    return {export["name"]: export["value"] for export in nodes[0]["exports"]}
+
+
+@pytest.mark.e2e
+def test_a_headless_read_reports_every_corpus_value_exactly(godot_project):
+    """The whole corpus, read back through a headless reply, bit for bit.
+
+    Before #771 this reply was framed with Godot's DEFAULT ``JSON.stringify``, so
+    40 of these rows came back as ``0.0`` and 15 more as a different double — the
+    caller was handed a number the project does not hold, unmarked.
+    """
+    run = _probe_project(godot_project)
+    values = _exports_by_name(run)
+
+    measured = [0, 0, 0]
+    for index, case in enumerate(LIVE_NUMBER_CORPUS):
+        arrived = values[f"v{index}"]
+        assert isinstance(arrived, float), (case.label, arrived)
+        tally_outcome(measured, case.value, arrived)
+        if value_bits(case.value) != value_bits(-0.0):
+            assert value_bits(arrived) == value_bits(case.value), (
+                f"{case.label}: the headless reply changed the value the project holds"
+            )
+
+    # The SAME partition the live result direction is measured against, because it
+    # is the same engine writer — derived from the corpus, never transcribed.
+    assert Partition(*measured) == PARTITIONS["full_precision"]
+
+    # The element-wise arm of the value projection reads through the same writer:
+    # a packed array's floats are not a separate spelling.
+    packed = values["all_values"]
+    assert [value_bits(item) for item in packed] == [
+        value_bits(0.0 if value_bits(case.value) == value_bits(-0.0) else case.value)
+        for case in LIVE_NUMBER_CORPUS
+    ]
+
+
+@pytest.mark.e2e
+def test_the_same_values_read_the_same_through_node_get(godot_project):
+    """`node get` and `scene get-exports` report one value, not two.
+
+    The fix is the REPLY's, not one operation's, so two commands that project the
+    same node's properties must agree — including on the rows the default writer
+    used to flatten.
+    """
+    run = _probe_project(godot_project)
+    exported = _exports_by_name(run)
+
+    read = run("node", "get", "numbers.tscn", "--node", ".")
+    assert read.returncode == 0, read.stdout + read.stderr
+    properties = {
+        entry["name"]: entry["value"] for entry in json.loads(read.stdout)["properties"]
+    }
+
+    checked = 0
+    for index, case in enumerate(LIVE_NUMBER_CORPUS):
+        name = f"v{index}"
+        if name not in properties:
+            continue
+        assert value_bits(properties[name]) == value_bits(exported[name]), case.label
+        checked += 1
+    assert checked == len(LIVE_NUMBER_CORPUS), checked
+
+
+@pytest.mark.e2e
+def test_negative_zero_is_the_one_disclosed_headless_residual(godot_project):
+    """`-0.0` reads back as `0.0` — the residual the contract states, not hides.
+
+    Not a gda choice and not fixable by the writer argument: ``JSON::_stringify``
+    returns ``"0.0"`` for anything equal to zero before the precision argument is
+    consulted. The live side discloses the same residual for the same reason.
+    """
+    run = _probe_project(godot_project)
+    values = _exports_by_name(run)
+    index = next(
+        i
+        for i, case in enumerate(LIVE_NUMBER_CORPUS)
+        if value_bits(case.value) == value_bits(-0.0)
+    )
+
+    arrived = values[f"v{index}"]
+    assert arrived == 0.0
+    assert math.copysign(1.0, arrived) > 0
+
+    # And it really is the ONLY row the reply changes.
+    changed = [
+        case.label
+        for i, case in enumerate(LIVE_NUMBER_CORPUS)
+        if value_bits(values[f"v{i}"]) != value_bits(case.value)
+    ]
+    assert changed == ["-zero"], changed
+
+
+@pytest.mark.e2e
+def test_a_project_setting_round_trips_through_set_and_get(godot_project):
+    """The issue's own reproduction: `project set` → `project get`, both exact.
+
+    `project set --value 3.141592653589793` used to answer `3.14159265358979` from
+    the `set` itself and again from the `get`, and `--value 1e-300` answered `0.0`
+    from both — while `project.godot` held the value the caller sent. These are the
+    two literals #771 quotes, and they are the round-trip the catalog promises.
+    """
+    run = _gda(godot_project)
+    setting = "physics/2d/default_gravity"
+
+    for literal, expected in (
+        ("3.141592653589793", 3.141592653589793),
+        ("1e-300", 1e-300),
+    ):
+        was_set = run("project", "set", setting, "--value", literal)
+        assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+        assert value_bits(json.loads(was_set.stdout)["value"]) == value_bits(
+            expected
+        ), literal
+
+        got = run("project", "get", setting)
+        assert got.returncode == 0, got.stdout + got.stderr
+        assert value_bits(json.loads(got.stdout)["value"]) == value_bits(expected), (
+            literal
+        )
+
+        # ...and the setting the enumeration reports is the same value again.
+        listed = run("project", "list", "--section", "physics/")
+        assert listed.returncode == 0, listed.stdout + listed.stderr
+        entry = next(
+            item
+            for item in json.loads(listed.stdout)["settings"]
+            if item["setting"] == setting
+        )
+        assert value_bits(entry["value"]) == value_bits(expected), literal

--- a/tests/test_e2e_live_number_transport.py
+++ b/tests/test_e2e_live_number_transport.py
@@ -27,7 +27,14 @@ import pytest
 from gda.binary import resolve_godot_binary
 from gda.live_numbers import wire_flattens_to_zero
 
-from tests.live_number_corpus import LIVE_NUMBER_CORPUS, PARTITIONS, Partition
+from tests.live_number_corpus import (
+    LIVE_NUMBER_CORPUS,
+    PARTITIONS,
+    Partition,
+    stringify_outcome,
+    tally_outcome,
+    value_bits,
+)
 from tests.support import GDA_CMD, panel_text
 
 GODOT = resolve_godot_binary()
@@ -73,34 +80,11 @@ def _probe_source() -> str:
     """
     rows = ",\n".join(
         '\t["{bits}", "{literal}"]'.format(
-            bits=struct.pack("<d", case.value).hex(), literal=json.dumps(case.value)
+            bits=value_bits(case.value), literal=json.dumps(case.value)
         )
         for case in LIVE_NUMBER_CORPUS
     )
     return f"extends SceneTree\n\nconst CORPUS := [\n{rows},\n]\n\n\n{_PROBE_BODY}"
-
-
-def _bits(value: float) -> str:
-    return struct.pack("<d", value).hex()
-
-
-def _outcome(sent: float, arrived: float) -> str:
-    """The three-state verdict one direction gave one value (cf. LiveNumberCase).
-
-    ``changed`` and ``zero`` are DIFFERENT failures — a rounded value still
-    carries the caller's magnitude, a flattened one does not — so the corpus
-    records which, and the published table reports both.
-    """
-    if _bits(arrived) == _bits(sent):
-        return "exact"
-    if arrived == 0.0 and sent != 0.0:
-        return "zero"
-    return "changed"
-
-
-def _tally(counts: list, sent: float, arrived: float) -> None:
-    """Add one value's verdict to an [exact, changed, zero] tally."""
-    counts[("exact", "changed", "zero").index(_outcome(sent, arrived))] += 1
 
 
 def _ulp_gap(sent: float, arrived: float) -> int:
@@ -160,7 +144,7 @@ def test_the_live_number_corpus_still_describes_this_engine(godot_project):
     measured = {name: [0, 0, 0] for name in PARTITIONS}
     for case in LIVE_NUMBER_CORPUS:
         label, value = case.label, case.value
-        request, default_text, full_text = rows[_bits(value)]
+        request, default_text, full_text = rows[value_bits(value)]
 
         # --- REQUEST direction: what Godot's parser makes of gda's wire literal.
         assert request != "PARSE_NULL", label
@@ -171,7 +155,7 @@ def test_the_live_number_corpus_still_describes_this_engine(godot_project):
         )
         # ...and gda's guard predicts that verdict without asking the engine.
         assert wire_flattens_to_zero(value) is engine_zeroes, label
-        _tally(measured["request"], value, arrived)
+        tally_outcome(measured["request"], value, arrived)
         if engine_zeroes:
             parse_flattened.append(label)
             assert case.request_ulp_gap is None, label
@@ -184,15 +168,17 @@ def test_the_live_number_corpus_still_describes_this_engine(godot_project):
 
         # --- RESULT direction: the writer the harness uses is exact...
         full_arrived = float(json.loads(full_text))
-        assert _bits(full_arrived) == _bits(value) or (
+        assert value_bits(full_arrived) == value_bits(value) or (
             value == 0.0 and math.copysign(1.0, value) < 0
         ), f"{label}: full-precision stringify changed the value"
-        _tally(measured["full_precision"], value, full_arrived)
+        tally_outcome(measured["full_precision"], value, full_arrived)
 
         # ...where the DEFAULT writer, which the harness used before #752, was not.
         default_arrived = float(json.loads(default_text))
-        assert _outcome(value, default_arrived) == case.default_stringify, label
-        _tally(measured["default_stringify"], value, default_arrived)
+        assert stringify_outcome(value, default_arrived) == case.default_stringify, (
+            label
+        )
+        tally_outcome(measured["default_stringify"], value, default_arrived)
         if case.default_stringify != "exact":
             default_lost.append(label)
 
@@ -214,7 +200,7 @@ def test_the_live_number_corpus_still_describes_this_engine(godot_project):
 def test_negative_zero_is_the_one_disclosed_result_residual(godot_project):
     """`-0.0` reads back as `0.0` — the residual the CLI contract states."""
     rows = _engine_rows(godot_project)
-    _, _, full_text = rows[_bits(-0.0)]
+    _, _, full_text = rows[value_bits(-0.0)]
 
     # Not a gda choice: `JSON::_stringify` returns "0.0" for anything equal to
     # zero before the full_precision argument is consulted.
@@ -224,7 +210,8 @@ def test_negative_zero_is_the_one_disclosed_result_residual(godot_project):
     changed = [
         case.label
         for case in LIVE_NUMBER_CORPUS
-        if _bits(float(json.loads(rows[_bits(case.value)][2]))) != _bits(case.value)
+        if value_bits(float(json.loads(rows[value_bits(case.value)][2])))
+        != value_bits(case.value)
     ]
     assert changed == ["-zero"], changed
 
@@ -298,7 +285,7 @@ def test_live_reads_carry_small_and_many_digit_floats_exactly(
         precise = run("game", "get", "/root/Main", "--property", "precise")
         assert precise.returncode == 0, precise.stdout + precise.stderr
         value = json.loads(precise.stdout)["properties"][0]["value"]
-        assert _bits(value) == _bits(3.141592653589793)
+        assert value_bits(value) == value_bits(3.141592653589793)
 
         # The same writer serves a call's RETURN value.
         echoed = run(

--- a/tests/test_harness_coercion_mirror.py
+++ b/tests/test_harness_coercion_mirror.py
@@ -1,4 +1,4 @@
-"""Drift checks for headless/live duplicated property-write policy.
+"""Drift checks for headless/live duplicated policy: property writes, and the reply writer.
 
 ``operations.gd`` (the headless op dispatcher, run via ``godot --headless
 --script <abs-fs-path>``) and ``gda_harness.gd`` (the live res:// autoload) need
@@ -88,3 +88,20 @@ def test_control_position_policy_is_byte_identical_across_the_two_gd_files():
 
     assert operations_policy, "the operations.gd Control-position policy must exist"
     assert operations_policy == harness_policy
+
+
+def test_the_reply_json_writer_is_byte_identical_across_the_two_gd_files():
+    """One writer choice, two payloads (#752 for the harness, #771 for the ops).
+
+    Each file frames its reply with Godot's FULL-PRECISION JSON writer, and that
+    one argument is the whole difference between reporting the float the project
+    holds and reporting a rounded — or, below ~1e-32.6, zeroed — approximation of
+    it. The copies are separate for the same reason the coercion block is, so an
+    edit to one that is not mirrored has a caller-visible cost: the same value
+    read back differently depending on the channel.
+    """
+    operations_writer = _top_level_function(OPERATIONS_GD, "_json")
+    harness_writer = _top_level_function(GDA_HARNESS_GD, "_json")
+
+    assert 'JSON.stringify(value, "", true, true)' in operations_writer
+    assert operations_writer == harness_writer

--- a/tests/test_live_contract_guards.py
+++ b/tests/test_live_contract_guards.py
@@ -295,8 +295,9 @@ def live_float_fields(
     A description covers its own field AND its whole subtree, which is what keeps
     the promise off the shared headless models: ``GameGetResult`` states it on
     ``properties``, so the ``NodeProperty.value`` beneath it is covered without
-    ``NodeProperty`` — which ``node get`` / ``resource get`` also use, and where
-    #771 leaves headless fidelity different — making a live-only claim. Coverage
+    ``NodeProperty`` — which ``node get`` / ``resource get`` also use, and which
+    must not inherit a sentence about the live WIRE (#771) — making a live-only
+    claim. Coverage
     is collected as a SET rather than a boolean because the caller checks it
     against the field's measured writer: a parent that blankets a mixed subtree
     with one writer's sentence is then a failure, not a pass.
@@ -766,10 +767,13 @@ def test_only_the_replies_that_carry_a_gda_number_publish_the_derived_contract(
 
 
 def test_the_headless_property_shape_makes_no_live_precision_promise():
-    # The shared NodeProperty description serves `node get` / `resource get` too,
-    # where #771 leaves the default writer in place. A live-only guarantee stated
-    # there would be false for those reads — so the live commands publish it on
-    # their OWN fields, and the subtree rule above is what lets them.
+    # The shared NodeProperty description serves `node get` / `resource get` too.
+    # Since #771 those reads carry the same full binary64 precision, but not over
+    # the same LEG: both published sentences speak about the live wire (one about
+    # the writer that frames what crosses it, one about a number that never meets
+    # it), and neither is true of a headless read as WORDED. So the live commands
+    # keep publishing them on their OWN fields, and the subtree rule above is what
+    # lets them; `gda.live_numbers` records why no headless twin was authored.
     from gda.models import NodeProperty
 
     schema = json.dumps(NodeProperty.model_json_schema(), ensure_ascii=False)


### PR DESCRIPTION
## What this fixes

Every headless read that projects a float reported a number the project does not hold.
`ops/operations.gd` framed its reply with the DEFAULT `JSON.stringify`, which renders a
float fixed-point with at most 32 decimals: values below ~`1e-32.6` came back as `0.0`
and ordinary ones were rounded to ~15 significant digits — with nothing marking the
result approximate.

**It is REPORTING, not storage.** After `gda project set physics/2d/default_gravity
--value 3.141592653589793` the file held `2d/default_gravity=3.141592653589793` exactly,
while the command's own JSON reply said `3.14159265358979`. No project data was ever
corrupted; callers were shown the wrong number.

## The change

One argument, where the payload frames its reply — the same one #752 applied to the live
harness, on the same engine function (`String::num_scientific` instead of `String::num`).
`operations.gd` gains a `_json()` helper mirroring `gda_harness.gd`'s, used by both
`_succeed` and `_fail`, so the fix reaches `node get`, `scene get-exports`,
`project get` / `project list`, `resource get` and every `set` echo at once.

```
before: gda project set physics/2d/default_gravity --value 3.141592653589793 --json
        -> {"type":"float","value":3.14159265358979}
        gda project set physics/2d/default_gravity --value 1e-300 --json
        -> {"type":"float","value":0.0}

after:  -> {"type":"float","value":3.141592653589793}
        -> {"type":"float","value":1e-300}
```

**One residual is disclosed, not hidden**, and it is the live side's residual too: a
NEGATIVE ZERO reads back as `0.0`, which `JSON::_stringify` decides (it returns `"0.0"`
for anything equal to zero) before the precision argument applies.

**The write half is out of scope.** What a `--value` STRING becomes through the engine's
own parser (`String.to_float`) is #772; every claim in this PR is read-side, and the docs
say so where a round-trip is promised.

## Evidence

`tests/test_e2e_headless_number_reads.py` (new, real engine):

- All 96 rows of `tests/live_number_corpus.py` are placed in a project as **IEEE-754
  bytes** and restored in `_init` — the only placement that is not itself a decimal
  literal, and the only one that can hold `DBL_MIN` or a subnormal at all, since no
  literal can deliver those through this engine's parser. Each is read back through
  `scene get-exports` and compared bit for bit, and the `full_precision` partition is
  re-derived from the reply rather than transcribed.
- `node get` and `scene get-exports` must report one value, not two.
- The negative-zero residual is pinned as the ONLY row the reply changes.
- The issue's own `project set` -> `project get` -> `project list` round-trip, for both
  literals it quotes.

**Red-proof.** Reverting the writer argument fails 3 of the 4 new tests and reproduces
the defect through a real engine:

```
project set --value 3.141592653589793 -> {"type":"float","value":3.14159265358979}
project set --value 1e-300            -> {"type":"float","value":0.0}
scene get-exports (bit-exact corpus)  -> [0.0, 0.0, -0.0, 3.14159265358979, 0.0]
```

The new `_json` drift guard in `tests/test_harness_coercion_mirror.py` was red-proofed the
same way.

**Corpus: reused, not forked.** The headless direction needs no column and gets none — the
writer under test is the same engine function #752 measured, so a second recording would be
a second opinion about one function. The verdict helpers (`value_bits`, `stringify_outcome`,
`tally_outcome`) moved beside the corpus so both e2e tiers read one definition of "exact",
and `PARTITIONS` keeps deriving every published count from the rows.

**Gates:** pytest non-e2e 2239 passed; ruff check / ruff format --check clean; pyright 0
errors. Real-engine e2e run locally: the 4 new tests, plus `test_e2e_live_number_transport`
(5), `node` / `scene_exports` / `project` / `resource` / `object_property` (176), and the
remaining headless suites — scene, preflight, security, validate, script, script_run,
op_robustness, params_json, project_analysis, resource_import, asset_file,
classname_resolution, info, user_data (282). All green.

## Published contracts, in the same change

- `docs/command-catalog.md`: a new **"Number reporting"** paragraph under `node` owns the
  fact (read half guaranteed, write half explicitly not), and the four round-trip sentences
  the issue lists are repaired — `project set` first, since it makes the strongest promise
  and a caller meets it before the others. The Phase-2 bullet that declared headless reads
  uncovered is rewritten.
- `CONTEXT.md` (`Value projection`): the fidelity split is corrected precisely — the read
  side is now uniform across both channels with one shared residual, while the WRITE sides
  still differ (the live wire refuses; headless coerces with no refusal, #772).
- `src/gda/skill/SKILL.md`: the headless section gains the counterpart of the live
  paragraph, including the un-bounded `--value` warning.
- `gda.live_numbers` (the authority) now speaks for both channels, and records the decision
  the issue asked for: `LIVE_ENGINE_PRECISION` is **not** shared onto headless fields. Its
  sentence names the live WIRE — a leg a headless reply never crosses — and it is attached
  per-field by a guard that walks the LIVE result models; sharing the string would put a
  wire claim on a headless read, and a headless twin would be the near-duplicate that module
  exists to prevent. Publishing it in `--schema` needs the same derived discipline (a walk
  over the headless float-bearing fields), which is a slice of its own.

Two stale comments in `tests/test_live_contract_guards.py` that justified a live-only claim
by "#771 leaves headless fidelity different" are corrected to the reason that still holds.

## Follow-up (not in this PR)

Publishing the headless precision contract per-field in `--help` / `--schema`, guarded by a
derived walk over headless float-bearing fields, the way the live side does.

Closes #771
